### PR TITLE
[codex] dashboard v2 projection gaps

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1029,6 +1029,53 @@ describe('createPost', () => {
       hearth: 'ops',
     })
   })
+
+  it('passes typed metadata through to the board post tool', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createPost('Plan', 'Body', 'dashboard-user', {
+      meta: {
+        attachments: [{
+          id: 'att-1',
+          kind: 'external_link',
+          origin_url: 'https://example.test/trace.log',
+          origin_name: 'trace.log',
+          origin_size_bytes: 4,
+          mime_type: 'text/plain',
+          width: null,
+          height: null,
+          created_at: 1_799_000_000,
+        }],
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      title: 'Plan',
+      content: 'Body',
+      author: 'dashboard-user',
+      meta: {
+        attachments: [{
+          id: 'att-1',
+          kind: 'external_link',
+          origin_url: 'https://example.test/trace.log',
+          origin_name: 'trace.log',
+          origin_size_bytes: 4,
+          mime_type: 'text/plain',
+          width: null,
+          height: null,
+          created_at: 1_799_000_000,
+        }],
+      },
+    })
+  })
 })
 
 describe('SubBoard API helpers', () => {

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1097,19 +1097,25 @@ export async function requestBoardContextInference(
   return normalized
 }
 
+export interface CreateBoardPostOptions {
+  hearth?: string
+  meta?: Record<string, unknown>
+}
+
 export function createPost(
   title: string,
   content: string,
   author: string,
-  options: { hearth?: string } = {},
+  options: CreateBoardPostOptions = {},
 ): Promise<unknown> {
-  const body: Record<string, string> = {
+  const body: Record<string, unknown> = {
     title,
     content,
     author,
   }
   const hearth = options.hearth?.trim()
   if (hearth) body.hearth = hearth
+  if (options.meta && Object.keys(options.meta).length > 0) body.meta = options.meta
   return post(`/api/v1/tools/masc_board_post`, body)
 }
 

--- a/dashboard/src/api/schemas/gate-connectors.test.ts
+++ b/dashboard/src/api/schemas/gate-connectors.test.ts
@@ -26,6 +26,13 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors[0].capabilities).toEqual([])
     expect(result.connectors[0].available).toBe(false)
     expect(result.connectors[0].guild_count).toBe(0)
+    expect(result.connectors[0].source_health).toEqual({
+      storage_paths: 'fallback',
+      runtime_summary: 'fallback',
+      binding_summary: 'fallback',
+      names: 'fallback',
+      observed_channel: 'missing',
+    })
     expect(result.total).toBe(1)
     expect(result.active_count).toBe(1)
     expect(result.generated_at).toBe('2024-01-01T00:00:00Z')
@@ -177,6 +184,7 @@ describe('parseGateConnectorsData', () => {
       audit_path: '/audit',
       names_path: '/names',
     })
+    expect(result.connectors[0].source_health.storage_paths).toBe('present')
   })
 
   it('parses runtime_summary with defaults when missing', () => {
@@ -236,6 +244,7 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors[0].runtime_summary.connected).toBe(true)
     expect(result.connectors[0].runtime_summary.stale_after_sec).toBe(300)
     expect(result.connectors[0].runtime_summary.gate_healthy).toBe(true)
+    expect(result.connectors[0].source_health.runtime_summary).toBe('present')
   })
 
   it('parses binding_summary with cross-field default for configured_bindings_count', () => {
@@ -280,11 +289,13 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors[0].binding_summary.configured_bindings_count).toBe(5)
     expect(result.connectors[0].binding_summary.binding_source).toBe('config')
     expect(result.connectors[0].binding_summary.runtime_bindings_count).toBe(3)
+    expect(result.connectors[0].source_health.binding_summary).toBe('present')
   })
 
   it('parses observed_channel as null when missing', () => {
     const result = parseGateConnectorsData(minimalOuter)
     expect(result.connectors[0].observed_channel).toBeNull()
+    expect(result.connectors[0].source_health.observed_channel).toBe('missing')
   })
 
   it('filters names via filteredStringMap (drops empty strings and non-strings)', () => {
@@ -308,6 +319,7 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors[0].names.channel_names).toEqual({ c1: 'Channel One' })
     expect(result.connectors[0].names.channel_to_guild).toEqual({ c1: 'g1' })
     expect(result.connectors[0].names.updated_at).toBe('2024-01-01')
+    expect(result.connectors[0].source_health.names).toBe('present')
   })
 
   it('returns default names when names field is missing', () => {

--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -190,6 +190,16 @@ const ConnectorBindingSummarySchema = object({
 
 export type ConnectorBindingSummary = InferOutput<typeof ConnectorBindingSummarySchema>
 
+export type ConnectorSourceHealthState = 'present' | 'fallback' | 'missing'
+
+export interface ConnectorSourceHealth {
+  storage_paths: ConnectorSourceHealthState
+  runtime_summary: ConnectorSourceHealthState
+  binding_summary: ConnectorSourceHealthState
+  names: ConnectorSourceHealthState
+  observed_channel: ConnectorSourceHealthState
+}
+
 // --- Connector info ---
 
 const GateConnectorInfoRawSchema = object({
@@ -271,6 +281,7 @@ export interface GateConnectorInfo {
   storage_paths: ConnectorStoragePaths
   runtime_summary: ConnectorRuntimeSummary
   binding_summary: ConnectorBindingSummary
+  source_health: ConnectorSourceHealth
   observed_channel?: ChannelInfo | null
   names_path: string
   names: ConnectorNames
@@ -320,6 +331,16 @@ function parseObservedChannel(raw: unknown): ChannelInfo | null {
   if (raw === undefined || raw === null) return null
   const parsed = safeParseChannelInfo(raw)
   return parsed.success ? parsed.output : null
+}
+
+function sourceHealthForObject(raw: unknown): ConnectorSourceHealthState {
+  return isRecord(raw) ? 'present' : 'fallback'
+}
+
+function sourceHealthForObservedChannel(raw: unknown): ConnectorSourceHealthState {
+  if (raw === undefined || raw === null) return 'missing'
+  const parsed = safeParseChannelInfo(raw)
+  return parsed.success ? 'present' : 'fallback'
 }
 
 function parseGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
@@ -372,6 +393,13 @@ function parseGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
       outer.output.binding_summary,
       configured_bindings.length,
     ),
+    source_health: {
+      storage_paths: sourceHealthForObject(outer.output.storage_paths),
+      runtime_summary: sourceHealthForObject(outer.output.runtime_summary),
+      binding_summary: sourceHealthForObject(outer.output.binding_summary),
+      names: sourceHealthForObject(outer.output.names),
+      observed_channel: sourceHealthForObservedChannel(outer.output.observed_channel),
+    },
     observed_channel: parseObservedChannel(outer.output.observed_channel),
     names_path: outer.output.names_path,
     names: parseConnectorNames(outer.output.names),

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -20,6 +20,14 @@ import type { BoardPost, OperatorSnapshot } from '../../types'
 
 import '@testing-library/jest-dom'
 
+const voiceStartMock = vi.hoisted(() => vi.fn())
+const voiceStopMock = vi.hoisted(() => vi.fn())
+const voiceInputState = vi.hoisted(() => ({
+  state: 'idle' as 'idle' | 'recording' | 'transcribing',
+  supported: true,
+  transcript: '스케줄러 결과 확인 바람',
+}))
+
 vi.mock('../../store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../store')>()
   return {
@@ -61,6 +69,18 @@ vi.mock('../../operator-store', async (importOriginal) => {
     dispatchOperatorAction: vi.fn(),
   }
 })
+
+vi.mock('../chat/voice-input', () => ({
+  useVoiceInput: (options: { onTranscribed: (text: string) => void }) => ({
+    state: voiceInputState.state,
+    supported: voiceInputState.supported,
+    start: voiceStartMock.mockImplementation(() => {
+      options.onTranscribed(voiceInputState.transcript)
+      return Promise.resolve()
+    }),
+    stop: voiceStopMock,
+  }),
+}))
 
 vi.mock('./board-state', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('./board-state')
@@ -189,6 +209,11 @@ describe('BoardSurface Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    voiceStartMock.mockReset()
+    voiceStopMock.mockReset()
+    voiceInputState.state = 'idle'
+    voiceInputState.supported = true
+    voiceInputState.transcript = '스케줄러 결과 확인 바람'
     clearLocalStorage()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ posts: [] }), {
@@ -914,7 +939,7 @@ describe('BoardSurface Component', () => {
     expect(screen.getByLabelText('Mobile mention target')).toHaveValue('keeper:sangsu')
   })
 
-  it('serializes compact mobile mention attachment and voice drafts before sending', () => {
+  it('blocks compact mobile mention attachments until block transport is available', () => {
     const dispatchMock = vi.mocked(dispatchOperatorAction)
     render(h(BoardSurface, null))
 
@@ -926,36 +951,20 @@ describe('BoardSurface Component', () => {
     fireEvent.change(fileInput, {
       target: { files: [new File(['trace'], 'trace.log', { type: 'text/plain' })] },
     })
-    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice'))
-    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice-stop'))
     fireEvent.input(screen.getByTestId('bd-composer-mobile-body'), {
-      target: { value: 'check trace' },
+      target: { value: 'check trace\n\n스케줄러 결과 확인 바람' },
     })
 
     expect(screen.getByTestId('bd-composer-mobile-draft-tray')).toHaveTextContent('trace.log')
-    expect(screen.getByTestId('bd-composer-mobile-draft-tray')).toHaveTextContent('받아쓰기')
+    expect(screen.getByTestId('bd-composer-mobile-draft-tray')).toHaveTextContent('transport unavailable')
+    expect(screen.getByTestId('bd-composer-mobile-body')).toHaveValue('check trace\n\n스케줄러 결과 확인 바람')
+    expect(screen.getByTestId('bd-composer-mobile-send')).toBeDisabled()
     fireEvent.click(screen.getByTestId('bd-composer-mobile-send'))
 
-    expect(dispatchMock).toHaveBeenCalledWith({
-      actor: 'dashboard-test',
-      action_type: 'keeper_message',
-      target_type: 'keeper',
-      target_id: 'sangsu',
-      payload: {
-        message: [
-          'Attachments:',
-          '- trace.log (5 B · file)',
-          '',
-          'Voice memo 0:12 (40 KB)',
-          '스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.',
-          '',
-          'check trace',
-        ].join('\n'),
-      },
-    })
+    expect(dispatchMock).not.toHaveBeenCalled()
   })
 
-  it('removes compact mobile mention multimodal drafts and re-disables send', () => {
+  it('removes compact mobile mention attachment drafts', () => {
     render(h(BoardSurface, null))
 
     fireEvent.click(screen.getByTestId('bd-comp-tab-mention'))
@@ -966,16 +975,8 @@ describe('BoardSurface Component', () => {
     fireEvent.change(screen.getByTestId('bd-composer-mobile-file-input'), {
       target: { files: [new File(['trace'], 'trace.log', { type: 'text/plain' })] },
     })
-    expect(send).not.toBeDisabled()
-    fireEvent.click(screen.getByLabelText('Remove mobile attachment trace.log'))
-    expect(screen.queryByTestId('bd-composer-mobile-draft-tray')).not.toBeInTheDocument()
     expect(send).toBeDisabled()
-
-    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice'))
-    expect(screen.getByTestId('bd-composer-mobile-recorder')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('bd-composer-mobile-voice-stop'))
-    expect(send).not.toBeDisabled()
-    fireEvent.click(screen.getByLabelText('Remove mobile voice draft'))
+    fireEvent.click(screen.getByLabelText('Remove mobile attachment trace.log'))
     expect(screen.queryByTestId('bd-composer-mobile-draft-tray')).not.toBeInTheDocument()
     expect(send).toBeDisabled()
   })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -31,13 +31,17 @@ import { ReactionBar } from './reaction-bar'
 import { PostShareActions } from './post-share-actions'
 import { StateBlockMessages } from './state-block-messages'
 import {
+  appendVoiceTranscriptDraft,
+  composerAttachmentDeliveryReason,
+  composerAttachmentTrayMeta,
   ComposerV2,
-  createComposerVoiceDraft,
-  formatClock,
   formatFileSize,
   serializeComposerBody,
+  uniqueComposerAttachmentId,
 } from './composer-v2'
-import type { ComposerAttachmentDraft, ComposerV2Mode, ComposerVoiceDraft } from './composer-v2'
+import type { ComposerAttachmentDraft, ComposerV2Mode } from './composer-v2'
+import { stableAttachmentId } from '../chat/attachments'
+import { useVoiceInput } from '../chat/voice-input'
 import { ensureStateBlockDraft, stateBlockKeys } from '../ops/ops-state'
 import { navigateBoard } from './board-route'
 import {
@@ -825,10 +829,17 @@ function BdComposer() {
   const [mobileKeeperTarget, setMobileKeeperTarget] = useState('')
   const [mobileOpen, setMobileOpen] = useState(false)
   const [mobileAttachments, setMobileAttachments] = useState<ComposerAttachmentDraft[]>([])
-  const [mobileVoiceDraft, setMobileVoiceDraft] = useState<ComposerVoiceDraft | null>(null)
-  const [mobileRecording, setMobileRecording] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const mobileFileInputRef = useRef<HTMLInputElement>(null)
+  const mobileVoice = useVoiceInput({
+    onTranscribed: (text) => {
+      setLocalBody(current => appendVoiceTranscriptDraft(current, text))
+      showToast('Voice transcribed.', 'success')
+    },
+    onError: (message) => {
+      showToast(message, 'error')
+    },
+  })
 
   useEffect(() => {
     if (boardHearthFilter.value !== localHearth) {
@@ -879,11 +890,16 @@ function BdComposer() {
     && mobileMentionOptions.length > 0
   const mobileStateKeys = mode === 'state' ? stateBlockKeys(localBody) : []
   const mobileQuickBusy = submitting || operatorActionBusy.value
+  const mobileAttachmentDeliveryReason = mode === 'mention'
+    ? composerAttachmentDeliveryReason(mobileAttachments)
+    : null
   const mobileMentionHasDraft = mode === 'mention'
-    && (localBody.trim() !== '' || mobileAttachments.length > 0 || mobileVoiceDraft !== null)
+    && (localBody.trim() !== '' || mobileAttachments.length > 0)
   const mobileQuickHasDraft = mode === 'mention' ? mobileMentionHasDraft : localBody.trim() !== ''
   const mobileQuickDisabled = mobileQuickBusy
+    || mobileVoice.state !== 'idle'
     || !mobileQuickHasDraft
+    || mobileAttachmentDeliveryReason !== null
     || (mode === 'mention' && (!mobileMentionTarget || mobileMentionUnresolved))
     || (mode === 'state' && mobileStateKeys.length === 0)
 
@@ -924,26 +940,31 @@ function BdComposer() {
   function attachMobileMentionFiles(files: FileList | File[]): void {
     const nextFiles = Array.from(files).slice(0, 6)
     if (nextFiles.length === 0) return
-    setMobileAttachments(current => [
-      ...current,
-      ...nextFiles.map((file, index): ComposerAttachmentDraft => ({
-        id: `mobile-${Date.now()}-${index}-${file.name}`,
-        kind: file.type.startsWith('image/') ? 'image' : 'file',
-        name: file.name,
-        size: formatFileSize(file.size),
-      })),
-    ].slice(0, 6))
-  }
-
-  function stopMobileVoiceDraft(): void {
-    setMobileRecording(false)
-    setMobileVoiceDraft(createComposerVoiceDraft())
+    setMobileAttachments(current => {
+      const pending: ComposerAttachmentDraft[] = []
+      for (const file of nextFiles) {
+        const kind = file.type.startsWith('image/') ? 'image' : 'file'
+        const baseId = stableAttachmentId({
+          name: file.name,
+          type: kind,
+          mimeType: file.type || null,
+          size: file.size,
+        })
+        pending.push({
+          id: uniqueComposerAttachmentId(baseId, current, pending),
+          kind,
+          name: file.name,
+          size: formatFileSize(file.size),
+          sizeBytes: file.size,
+          mime: file.type || null,
+        })
+      }
+      return [...current, ...pending].slice(0, 6)
+    })
   }
 
   function resetMobileMentionDrafts(): void {
     setMobileAttachments([])
-    setMobileVoiceDraft(null)
-    setMobileRecording(false)
   }
 
   async function submitPost(event?: Event, options: { compactMobile?: boolean } = {}): Promise<void> {
@@ -979,10 +1000,11 @@ function BdComposer() {
 
     event?.stopPropagation()
     const body = localBody.trim()
+    if (mobileQuickDisabled) return
     const message = mode === 'mention'
-      ? serializeComposerBody({ text: localBody, attachments: mobileAttachments, voice: mobileVoiceDraft })
+      ? serializeComposerBody({ text: localBody, attachments: [], voice: null })
       : body
-    if (!message || mobileQuickDisabled) return
+    if (!message) return
     setSubmitting(true)
     try {
       if (mode === 'mention') {
@@ -1098,7 +1120,7 @@ function BdComposer() {
               </div>
             `
             : null}
-          ${mobileAttachments.length > 0 || mobileVoiceDraft
+          ${mobileAttachments.length > 0
             ? html`
               <div class="bd-mobile-draft-tray composer-tray" data-testid="bd-composer-mobile-draft-tray">
                 ${mobileAttachments.map(attachment => html`
@@ -1108,7 +1130,7 @@ function BdComposer() {
                     </div>
                     <div class="cdraft-meta">
                       <span class="cdraft-name mono">${attachment.name}</span>
-                      <span class="cdraft-sub mono">${[attachment.size, attachment.kind, attachment.dims].filter(Boolean).join(' · ')}</span>
+                      <span class="cdraft-sub mono">${composerAttachmentTrayMeta(attachment)} · transport unavailable</span>
                     </div>
                     <button
                       type="button"
@@ -1122,55 +1144,22 @@ function BdComposer() {
                     </button>
                   </div>
                 `)}
-                ${mobileVoiceDraft
-                  ? html`
-                    <div class="cdraft voice">
-                      <span class="cdraft-glyph mic">◌</span>
-                      <div class="cdraft-wave" aria-hidden="true">
-                        ${mobileVoiceDraft.wave.map((height, index) => html`<span class="vbar" key=${index} style=${{ height: `${Math.round(4 + height * 18)}px` }} />`)}
-                      </div>
-                      <span class="cdraft-dur mono">${formatClock(mobileVoiceDraft.secs)}</span>
-                      <div class="cdraft-tx">
-                        <span class="cdraft-tx-k">받아쓰기</span>
-                        <span class="cdraft-tx-v">${mobileVoiceDraft.transcript}</span>
-                      </div>
-                      <button
-                        type="button"
-                        class="cdraft-x"
-                        title="음성 제거"
-                        aria-label="Remove mobile voice draft"
-                        onClick=${() => { setMobileVoiceDraft(null) }}
-                        disabled=${mobileQuickBusy}
-                      >
-                        <${X} size=${10} aria-hidden="true" />
-                      </button>
-                    </div>
-                  `
-                  : null}
               </div>
             `
             : null}
-          ${mobileRecording
+          ${mobileVoice.state !== 'idle'
             ? html`
               <div class="bd-mobile-rec-bar rec-bar" data-testid="bd-composer-mobile-recorder">
                 <span class="rec-dot" aria-hidden="true"></span>
-                <span class="rec-lbl">녹음 중</span>
-                <span class="rec-clock mono">0:12</span>
+                <span class="rec-lbl">${mobileVoice.state === 'recording' ? '녹음 중' : '전사 중'}</span>
                 <div class="rec-wave" aria-hidden="true">
                   ${[0.4, 0.8, 0.5, 0.9, 0.45, 0.75, 0.52, 0.84, 0.48, 0.7].map((height, index) => html`<span class="rbar" key=${index} style=${{ height: `${Math.round(3 + height * 20)}px` }} />`)}
                 </div>
                 <button
                   type="button"
-                  class="rec-btn cancel"
-                  onClick=${() => { setMobileRecording(false) }}
-                  disabled=${mobileQuickBusy}
-                  data-testid="bd-composer-mobile-voice-cancel"
-                >취소</button>
-                <button
-                  type="button"
                   class="rec-btn stop"
-                  onClick=${stopMobileVoiceDraft}
-                  disabled=${mobileQuickBusy}
+                  onClick=${mobileVoice.stop}
+                  disabled=${mobileQuickBusy || mobileVoice.state !== 'recording'}
                   data-testid="bd-composer-mobile-voice-stop"
                 >
                   <${Square} size=${11} aria-hidden="true" />
@@ -1262,9 +1251,9 @@ function BdComposer() {
               type="button"
               class="bd-mobile-compose-tool"
               title="음성 입력"
-              aria-label="Start mobile mention voice draft"
-              disabled=${mobileQuickBusy || mobileRecording}
-              onClick=${() => { setMobileRecording(true) }}
+              aria-label="Start mobile mention voice input"
+              disabled=${mobileQuickBusy || mobileVoice.state !== 'idle' || !mobileVoice.supported}
+              onClick=${() => { void mobileVoice.start() }}
               data-testid="bd-composer-mobile-voice"
             >
               <${Mic} size=${15} strokeWidth=${2.2} aria-hidden="true" />

--- a/dashboard/src/components/board/composer-v2.test.ts
+++ b/dashboard/src/components/board/composer-v2.test.ts
@@ -15,6 +15,13 @@ const currentDashboardActorMock = vi.hoisted(() => vi.fn(() => 'dashboard-test')
 const sendBroadcastMock = vi.hoisted(() => vi.fn())
 const dispatchOperatorActionMock = vi.hoisted(() => vi.fn())
 const showToastMock = vi.hoisted(() => vi.fn())
+const voiceStartMock = vi.hoisted(() => vi.fn())
+const voiceStopMock = vi.hoisted(() => vi.fn())
+const voiceInputState = vi.hoisted(() => ({
+  state: 'idle' as 'idle' | 'recording' | 'transcribing',
+  supported: true,
+  transcript: '스케줄러 결과 확인 바람',
+}))
 
 vi.mock('../../api', () => ({
   currentDashboardActor: currentDashboardActorMock,
@@ -31,6 +38,18 @@ vi.mock('../../operator-store', async (importOriginal) => {
 
 vi.mock('../common/toast', () => ({
   showToast: showToastMock,
+}))
+
+vi.mock('../chat/voice-input', () => ({
+  useVoiceInput: (options: { onTranscribed: (text: string) => void }) => ({
+    state: voiceInputState.state,
+    supported: voiceInputState.supported,
+    start: voiceStartMock.mockImplementation(() => {
+      options.onTranscribed(voiceInputState.transcript)
+      return Promise.resolve()
+    }),
+    stop: voiceStopMock,
+  }),
 }))
 
 function snapshotWithKeepers(keepers: Array<{
@@ -118,6 +137,11 @@ describe('ComposerV2', () => {
       result: 'sent',
     })
     showToastMock.mockReset()
+    voiceStartMock.mockReset()
+    voiceStopMock.mockReset()
+    voiceInputState.state = 'idle'
+    voiceInputState.supported = true
+    voiceInputState.transcript = '스케줄러 결과 확인 바람'
     operatorActionBusy.value = false
     operatorSnapshot.value = snapshotWithKeepers([
       { name: 'keeper-a', status: 'online' },
@@ -157,7 +181,7 @@ describe('ComposerV2', () => {
     expect((screen.getByLabelText('Composer v2 message') as HTMLTextAreaElement).value).toBe('')
   })
 
-  it('sends attachment-only drafts through the current text transport', async () => {
+  it('blocks attachment-only drafts until block transport is available', () => {
     render(h(ComposerV2, { workspaceId: 'ops' }))
 
     fireEvent.change(screen.getByTestId('composer-v2-file-input'), {
@@ -166,39 +190,28 @@ describe('ComposerV2', () => {
 
     expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('trace.log')
     expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('text/plain')
+    expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('transport unavailable')
     expect(screen.getByTestId('composer-v2-command-rail')).toHaveTextContent('1 file')
+    expect(screen.getByTestId('composer-v2-command-rail')).toHaveTextContent('blocked · attachment transport unavailable')
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-    await waitFor(() => {
-      expect(sendBroadcastMock).toHaveBeenCalledWith(
-        'dashboard-test',
-        'Attachments:\n- trace.log (4 B · file)',
-      )
-    })
-    expect(screen.queryByTestId('composer-v2-tray')).not.toBeInTheDocument()
+    expect(sendBroadcastMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId('composer-v2-tray')).toBeInTheDocument()
   })
 
-  it('captures a voice draft and serializes it into the current text transport', async () => {
+  it('transcribes voice input into the current text transport', async () => {
     render(h(ComposerV2, { workspaceId: 'ops' }))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start voice draft' }))
-    expect(screen.getByTestId('composer-v2-recorder')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /완료/ }))
-    expect(screen.getByTestId('composer-v2-tray')).toHaveTextContent('받아쓰기')
+    fireEvent.click(screen.getByRole('button', { name: 'Start voice input' }))
+    expect(voiceStartMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText('Composer v2 message')).toHaveValue('스케줄러 결과 확인 바람')
 
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
     await waitFor(() => {
-      expect(sendBroadcastMock).toHaveBeenCalledWith(
-        'dashboard-test',
-        expect.stringContaining('Voice memo 0:12 (40 KB)'),
-      )
+      expect(sendBroadcastMock).toHaveBeenCalledWith('dashboard-test', '스케줄러 결과 확인 바람')
     })
-    expect(sendBroadcastMock).toHaveBeenCalledWith(
-      'dashboard-test',
-      expect.stringContaining('스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.'),
-    )
   })
 
   it('sends keeper DMs through the operator keeper-message action', async () => {

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -21,6 +21,8 @@ import {
   replaceTrailingMentionDraft,
 } from '../../lib/mention-utils'
 import { useOperatorMentionContext } from '../common/use-operator-mention-context'
+import { stableAttachmentId } from '../chat/attachments'
+import { useVoiceInput } from '../chat/voice-input'
 
 export type ComposerV2Mode = 'broadcast' | 'dm' | 'state-block'
 
@@ -40,6 +42,7 @@ export interface ComposerAttachmentDraft {
   kind: 'image' | 'file'
   name: string
   size: string
+  sizeBytes?: number | null
   mime?: string | null
   dims?: string | null
 }
@@ -89,16 +92,33 @@ function composeBodyText(body: ComposerV2Request['compose']['body']): string {
   return typeof body === 'string' ? body : body.raw
 }
 
-function attachmentTransportMeta(attachment: ComposerAttachmentDraft): string {
-  return [attachment.size, attachment.kind, attachment.dims].filter(Boolean).join(' · ')
-}
-
-function attachmentTrayMeta(attachment: ComposerAttachmentDraft): string {
+export function composerAttachmentTrayMeta(attachment: ComposerAttachmentDraft): string {
   return [attachment.size, attachment.mime, attachment.kind, attachment.dims].filter(Boolean).join(' · ')
 }
 
 function plural(count: number, singular: string, pluralLabel: string): string {
   return `${count} ${count === 1 ? singular : pluralLabel}`
+}
+
+export function composerAttachmentTransportUnavailable(attachments: ComposerAttachmentDraft[]): boolean {
+  return attachments.length > 0
+}
+
+export function composerAttachmentDeliveryReason(attachments: ComposerAttachmentDraft[]): string | null {
+  return composerAttachmentTransportUnavailable(attachments) ? 'attachment transport unavailable' : null
+}
+
+export function uniqueComposerAttachmentId(
+  baseId: string,
+  existing: ComposerAttachmentDraft[],
+  pending: ComposerAttachmentDraft[],
+): string {
+  const used = new Set([...existing, ...pending].map(attachment => attachment.id))
+  if (!used.has(baseId)) return baseId
+
+  let suffix = 2
+  while (used.has(`${baseId}-${suffix}`)) suffix += 1
+  return `${baseId}-${suffix}`
 }
 
 export function buildComposerV2Request(input: {
@@ -139,13 +159,11 @@ export function formatClock(seconds: number): string {
   return `${Math.floor(whole / 60)}:${String(whole % 60).padStart(2, '0')}`
 }
 
-export function createComposerVoiceDraft(): ComposerVoiceDraft {
-  return {
-    secs: 12,
-    size: formatFileSize(12 * 3400),
-    wave: [0.35, 0.72, 0.48, 0.9, 0.42, 0.66, 0.58, 0.8, 0.5, 0.7, 0.38, 0.62],
-    transcript: '스케줄러 p99 스파이크와 compact 타이밍을 비교해서 결과만 알려줘.',
-  }
+export function appendVoiceTranscriptDraft(current: string, transcript: string): string {
+  const text = transcript.trim()
+  if (!text) return current
+  const body = current.trim()
+  return body ? `${body}\n\n${text}` : text
 }
 
 export function serializeComposerBody(input: {
@@ -153,16 +171,10 @@ export function serializeComposerBody(input: {
   attachments: ComposerAttachmentDraft[]
   voice: ComposerVoiceDraft | null
 }): string {
-  const blocks: string[] = []
   if (input.attachments.length > 0) {
-    blocks.push([
-      'Attachments:',
-      ...input.attachments.map(attachment => {
-        const meta = attachmentTransportMeta(attachment)
-        return `- ${attachment.name}${meta ? ` (${meta})` : ''}`
-      }),
-    ].join('\n'))
+    throw new Error('Composer attachments require block transport and must not be serialized into text body')
   }
+  const blocks: string[] = []
   if (input.voice) {
     blocks.push([
       `Voice memo ${formatClock(input.voice.secs)} (${input.voice.size})`,
@@ -200,13 +212,20 @@ export function ComposerV2({
   const [draft, setDraft] = useState('')
   const [keeperTarget, setKeeperTarget] = useState('')
   const [attachments, setAttachments] = useState<ComposerAttachmentDraft[]>([])
-  const [voiceDraft, setVoiceDraft] = useState<ComposerVoiceDraft | null>(null)
-  const [recording, setRecording] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const workspace = normalizeWorkspaceId(workspaceId)
   const busy = submitting || operatorActionBusy.value
+  const voice = useVoiceInput({
+    onTranscribed: (text) => {
+      setDraft(current => appendVoiceTranscriptDraft(current, text))
+      showToast('Voice transcribed.', 'success')
+    },
+    onError: (message) => {
+      showToast(message, 'error')
+    },
+  })
   const mention = useOperatorMentionContext({
     message: draft,
     target: keeperTarget,
@@ -232,9 +251,12 @@ export function ComposerV2({
     setDismissedMentionQuery,
   } = mention
   const stateKeys = mode === 'state-block' ? stateBlockKeys(draft) : []
-  const hasDraftContent = draft.trim() !== '' || attachments.length > 0 || voiceDraft !== null
+  const attachmentDeliveryReason = composerAttachmentDeliveryReason(attachments)
+  const hasDraftContent = draft.trim() !== '' || attachments.length > 0
   const sendDisabled = busy
+    || voice.state !== 'idle'
     || !hasDraftContent
+    || attachmentDeliveryReason !== null
     || (mode === 'dm' && (!effectiveKeeperOnline || unresolvedTrailingMention))
     || (mode === 'state-block' && stateKeys.length === 0)
   const targetLabel = mode === 'dm'
@@ -244,26 +266,32 @@ export function ComposerV2({
     : `#${workspace}`
   const mediaLabel = [
     attachments.length > 0 ? plural(attachments.length, 'file', 'files') : 'no files',
-    voiceDraft ? 'voice' : null,
+    voice.state !== 'idle' ? voice.state : null,
   ].filter(Boolean).join(' · ')
   const deliveryState = busy
     ? 'sending'
-    : sendDisabled
+    : voice.state !== 'idle' || sendDisabled
       ? 'blocked'
       : 'ready'
   const deliveryReason = busy
     ? 'transport busy'
-    : !hasDraftContent
-      ? 'draft empty'
-      : mode === 'dm' && unresolvedTrailingMention
-        ? 'resolve mention'
-        : mode === 'dm' && !effectiveKeeperOnline
-          ? 'keeper unavailable'
-          : mode === 'state-block' && stateKeys.length === 0
-            ? 'state block required'
-            : mode === 'dm'
-              ? 'keeper message'
-              : 'workspace broadcast'
+    : voice.state === 'recording'
+      ? 'recording voice'
+      : voice.state === 'transcribing'
+        ? 'transcribing voice'
+        : !hasDraftContent
+          ? 'draft empty'
+          : attachmentDeliveryReason
+            ? attachmentDeliveryReason
+            : mode === 'dm' && unresolvedTrailingMention
+              ? 'resolve mention'
+              : mode === 'dm' && !effectiveKeeperOnline
+                ? 'keeper unavailable'
+                : mode === 'state-block' && stateKeys.length === 0
+                  ? 'state block required'
+                  : mode === 'dm'
+                    ? 'keeper message'
+                    : 'workspace broadcast'
   const deliveryToneClass = deliveryState === 'ready'
     ? 'border-[var(--color-status-ok)] text-[var(--color-status-ok)]'
     : deliveryState === 'sending'
@@ -299,33 +327,38 @@ export function ComposerV2({
   function attachFiles(files: FileList | File[]): void {
     const nextFiles = Array.from(files).slice(0, 6)
     if (nextFiles.length === 0) return
-    setAttachments(current => [
-      ...current,
-      ...nextFiles.map((file, index): ComposerAttachmentDraft => ({
-        id: `${Date.now()}-${index}-${file.name}`,
-        kind: file.type.startsWith('image/') ? 'image' : 'file',
-        name: file.name,
-        size: formatFileSize(file.size),
-        mime: file.type || null,
-      })),
-    ].slice(0, 6))
-  }
-
-  function stopVoiceDraft(): void {
-    setRecording(false)
-    setVoiceDraft(createComposerVoiceDraft())
+    setAttachments(current => {
+      const pending: ComposerAttachmentDraft[] = []
+      for (const file of nextFiles) {
+        const kind = file.type.startsWith('image/') ? 'image' : 'file'
+        const baseId = stableAttachmentId({
+          name: file.name,
+          type: kind,
+          mimeType: file.type || null,
+          size: file.size,
+        })
+        pending.push({
+          id: uniqueComposerAttachmentId(baseId, current, pending),
+          kind,
+          name: file.name,
+          size: formatFileSize(file.size),
+          sizeBytes: file.size,
+          mime: file.type || null,
+        })
+      }
+      return [...current, ...pending].slice(0, 6)
+    })
   }
 
   function resetDraft(): void {
     setDraft('')
     setAttachments([])
-    setVoiceDraft(null)
-    setRecording(false)
   }
 
   async function submit(): Promise<void> {
-    const message = serializeComposerBody({ text: draft, attachments, voice: voiceDraft })
-    if (!message || sendDisabled) return
+    if (sendDisabled) return
+    const message = serializeComposerBody({ text: draft, attachments: [], voice: null })
+    if (!message) return
     const keeperId = mode === 'dm'
       ? trailingMentionTarget ?? keeperNameFromTarget(keeperTarget)
       : null
@@ -421,7 +454,7 @@ export function ComposerV2({
           </div>
         </div>
 
-        ${attachments.length > 0 || voiceDraft
+        ${attachments.length > 0
           ? html`
               <div class="composer-tray" data-testid="composer-v2-tray">
                 ${attachments.map(attachment => html`
@@ -431,7 +464,7 @@ export function ComposerV2({
                     </div>
                     <div class="cdraft-meta">
                       <span class="cdraft-name mono">${attachment.name}</span>
-                      <span class="cdraft-sub mono">${attachmentTrayMeta(attachment)}</span>
+                      <span class="cdraft-sub mono">${composerAttachmentTrayMeta(attachment)} · transport unavailable</span>
                     </div>
                     <button
                       type="button"
@@ -445,31 +478,6 @@ export function ComposerV2({
                     </button>
                   </div>
                 `)}
-                ${voiceDraft
-                  ? html`
-                      <div class="cdraft voice">
-                        <span class="cdraft-glyph mic">◌</span>
-                        <div class="cdraft-wave" aria-hidden="true">
-                          ${voiceDraft.wave.map((height, index) => html`<span class="vbar" key=${index} style=${{ height: `${Math.round(4 + height * 18)}px` }} />`)}
-                        </div>
-                        <span class="cdraft-dur mono">${formatClock(voiceDraft.secs)}</span>
-                        <div class="cdraft-tx">
-                          <span class="cdraft-tx-k">받아쓰기</span>
-                          <span class="cdraft-tx-v">${voiceDraft.transcript}</span>
-                        </div>
-                        <button
-                          type="button"
-                          class="cdraft-x"
-                          title="음성 제거"
-                          aria-label="Remove voice draft"
-                          onClick=${() => { setVoiceDraft(null) }}
-                          disabled=${busy}
-                        >
-                          <${X} size=${10} aria-hidden="true" />
-                        </button>
-                      </div>
-                    `
-                  : null}
               </div>
             `
           : null}
@@ -523,17 +531,15 @@ export function ComposerV2({
             `
           : null}
 
-        ${recording
+        ${voice.state !== 'idle'
           ? html`
               <div class="rec-bar" data-testid="composer-v2-recorder">
                 <span class="rec-dot" aria-hidden="true"></span>
-                <span class="rec-lbl">녹음 중</span>
-                <span class="rec-clock mono">0:12</span>
+                <span class="rec-lbl">${voice.state === 'recording' ? '녹음 중' : '전사 중'}</span>
                 <div class="rec-wave" aria-hidden="true">
                   ${[0.4, 0.8, 0.5, 0.9, 0.45, 0.75, 0.52, 0.84, 0.48, 0.7].map((height, index) => html`<span class="rbar" key=${index} style=${{ height: `${Math.round(3 + height * 20)}px` }} />`)}
                 </div>
-                <button type="button" class="rec-btn cancel" onClick=${() => { setRecording(false) }} disabled=${busy}>취소</button>
-                <button type="button" class="rec-btn stop" onClick=${stopVoiceDraft} disabled=${busy}>
+                <button type="button" class="rec-btn stop" onClick=${voice.stop} disabled=${busy || voice.state !== 'recording'}>
                   <${Square} size=${11} aria-hidden="true" />
                   완료
                 </button>
@@ -619,9 +625,9 @@ export function ComposerV2({
               type="button"
               class="ctool"
               title="음성 입력"
-              aria-label="Start voice draft"
-              onClick=${() => { setRecording(true) }}
-              disabled=${busy || recording}
+              aria-label="Start voice input"
+              onClick=${() => { void voice.start() }}
+              disabled=${busy || voice.state !== 'idle' || !voice.supported}
               data-testid="composer-v2-voice"
             >
               <${Mic} size=${15} aria-hidden="true" />

--- a/dashboard/src/components/chat/attachments.test.ts
+++ b/dashboard/src/components/chat/attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MAX_FILE_SIZE,
   MAX_IMAGE_SIZE,
+  stableAttachmentId,
   validateFile,
 } from './attachments'
 
@@ -49,5 +50,32 @@ describe('validateFile', () => {
 
   it('rejects oversized files', () => {
     expect(validateFile(fileOfSize('a.txt', 'text/plain', MAX_FILE_SIZE + 1))).toContain('파일 크기 초과')
+  })
+})
+
+describe('stableAttachmentId', () => {
+  it('derives a deterministic id from attachment identity and content', () => {
+    const input = {
+      name: 'trace.log',
+      type: 'file',
+      mimeType: 'text/plain',
+      size: 12,
+      data: 'data:text/plain;base64,QUJD',
+    }
+
+    expect(stableAttachmentId(input)).toBe(stableAttachmentId({ ...input }))
+    expect(stableAttachmentId(input)).toMatch(/^att-[0-9a-z]+$/)
+  })
+
+  it('changes when the attachment content reference changes', () => {
+    const base = {
+      name: 'trace.log',
+      type: 'file',
+      mimeType: 'text/plain',
+      size: 12,
+    }
+
+    expect(stableAttachmentId({ ...base, data: 'data:text/plain;base64,QUJD' }))
+      .not.toBe(stableAttachmentId({ ...base, data: 'data:text/plain;base64,REVG' }))
   })
 })

--- a/dashboard/src/components/chat/attachments.ts
+++ b/dashboard/src/components/chat/attachments.ts
@@ -73,6 +73,51 @@ export interface CollectAttachmentsResult {
   errors: string[]
 }
 
+export interface StableAttachmentIdentity {
+  name: string
+  type?: string | null
+  kind?: string | null
+  mimeType?: string | null
+  size?: number | null
+  dims?: string | null
+  data?: string | null
+  src?: string | null
+}
+
+function stableAttachmentHash(value: string): string {
+  let hash = 5381
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36)
+}
+
+export function stableAttachmentId(input: StableAttachmentIdentity): string {
+  const payload = [
+    input.name,
+    input.type ?? '',
+    input.kind ?? '',
+    input.mimeType ?? '',
+    String(input.size ?? ''),
+    input.dims ?? '',
+    input.data ?? input.src ?? '',
+  ].join('\x1f')
+  return `att-${stableAttachmentHash(payload)}`
+}
+
+function uniqueStableAttachmentId(
+  baseId: string,
+  existing: KeeperConversationAttachment[],
+  pending: KeeperConversationAttachment[],
+): string {
+  const used = new Set([...existing, ...pending].map(att => att.id))
+  if (!used.has(baseId)) return baseId
+
+  let suffix = 2
+  while (used.has(`${baseId}-${suffix}`)) suffix += 1
+  return `${baseId}-${suffix}`
+}
+
 /** Validate, resize, and encode [files] into attachments, respecting the
  *  per-file rules plus the total-payload and count budgets relative to
  *  [existing]. Validation failures are collected, not thrown, so the
@@ -113,8 +158,16 @@ export async function collectAttachments(
       break
     }
     const dims = resized.type.startsWith('image/') ? await readImageDimensions(resized) : null
+    const baseId = stableAttachmentId({
+      name: resized.name,
+      type: resized.type.startsWith('image/') ? 'image' : 'file',
+      mimeType: resized.type,
+      size: base64Size,
+      data: dataUrl,
+      dims,
+    })
     attachments.push({
-      id: `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      id: uniqueStableAttachmentId(baseId, existing, attachments),
       type: resized.type.startsWith('image/') ? 'image' : 'file',
       name: resized.name,
       size: base64Size,

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -121,6 +121,13 @@ function sampleConnectorsResponse(overrides?: Partial<Record<string, unknown>>) 
         binding_source: 'persisted',
         runtime_bindings_count: 1,
         pid: 4242,
+        source_health: {
+          storage_paths: 'fallback',
+          runtime_summary: 'fallback',
+          binding_summary: 'fallback',
+          names: 'fallback',
+          observed_channel: 'missing',
+        },
         configured_bindings: [
           {
             channel_id: '123456',
@@ -307,6 +314,10 @@ describe('ConnectorStatusPanel', () => {
     const detailPanels = container.querySelectorAll('[data-testid="connector-detail-panel"]')
     expect(detailPanels.length).toBe(1)
     expect(detailPanels[0]?.textContent).toContain('Discord')
+    const sourceHealth = detailPanels[0]?.querySelector('[data-testid="connector-source-health"]')
+    expect(sourceHealth?.textContent).toContain('source health')
+    expect(sourceHealth?.querySelector('[data-connector-source-health="storage_paths"]')?.getAttribute('data-connector-source-health-state')).toBe('fallback')
+    expect(sourceHealth?.querySelector('[data-connector-source-health="observed_channel"]')?.getAttribute('data-connector-source-health-state')).toBe('missing')
     expect(container.querySelectorAll('button[aria-label="toggle header details"]').length).toBe(1)
   })
 

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -499,6 +499,13 @@ function placeholderConnector(connectorId: KnownConnectorId): GateConnectorInfo 
       runtime_bindings_count: 0,
       configured_bindings_count: 0,
     },
+    source_health: {
+      storage_paths: 'fallback',
+      runtime_summary: 'fallback',
+      binding_summary: 'fallback',
+      names: 'fallback',
+      observed_channel: 'missing',
+    },
     observed_channel: null,
     names_path: '',
     names: {
@@ -508,6 +515,51 @@ function placeholderConnector(connectorId: KnownConnectorId): GateConnectorInfo 
       updated_at: '',
     },
   }
+}
+
+type ConnectorSourceHealthKey = keyof GateConnectorInfo['source_health']
+
+const CONNECTOR_SOURCE_HEALTH_ROWS: Array<{ key: ConnectorSourceHealthKey; label: string }> = [
+  { key: 'storage_paths', label: 'storage paths' },
+  { key: 'runtime_summary', label: 'runtime summary' },
+  { key: 'binding_summary', label: 'binding summary' },
+  { key: 'names', label: 'names' },
+  { key: 'observed_channel', label: 'observed channel' },
+]
+
+function connectorSourceHealthClass(state: GateConnectorInfo['source_health'][ConnectorSourceHealthKey]): string {
+  switch (state) {
+    case 'present':
+      return 'border-[var(--color-status-ok)] text-[var(--color-status-ok)]'
+    case 'missing':
+      return 'border-[var(--color-border-default)] text-[var(--color-fg-disabled)]'
+    case 'fallback':
+      return 'border-[var(--color-status-warn)] text-[var(--color-status-warn)]'
+  }
+}
+
+function ConnectorSourceHealthStrip({ connector }: { connector: GateConnectorInfo | null }) {
+  const sourceHealth = connector?.source_health
+  return html`
+    <div
+      class="mt-2 flex flex-wrap items-center gap-1.5 text-3xs"
+      data-testid="connector-source-health"
+      aria-label="Connector source health"
+    >
+      <span class="uppercase tracking-4 text-[var(--color-fg-disabled)]">source health</span>
+      ${CONNECTOR_SOURCE_HEALTH_ROWS.map(row => {
+        const state = sourceHealth?.[row.key] ?? 'missing'
+        return html`
+          <span
+            key=${row.key}
+            class=${`rounded-[var(--r-0)] border px-1.5 py-0.5 ${connectorSourceHealthClass(state)}`}
+            data-connector-source-health=${row.key}
+            data-connector-source-health-state=${state}
+          >${row.label} ${state}</span>
+        `
+      })}
+    </div>
+  `
 }
 
 // Native lifecycle hits the new /api/v1/sidecar/{start,stop} endpoints
@@ -857,6 +909,7 @@ function ConnectorLivePanel({
           getRailInflight(connectorId),
         )}
       />
+      <${ConnectorSourceHealthStrip} connector=${connector} />
 
       <${StartupCheckBanner} connectorId=${connectorId} sidecarUp=${connector?.available === true} />
 

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -366,9 +366,12 @@ describe('FusionSurface', () => {
     // 3 first-tier nodes become cards (meta is not a card); the failed one is isolated
     expect(grid?.querySelectorAll('.fus-jnode')).toHaveLength(3)
 
-    // decision badges are mapped from the free-form wire decision via the shared spec
-    expect(grid?.textContent).toContain('권고') // skeptic -> Recommend
-    expect(grid?.textContent).toContain('심의 무효') // literalist -> Insufficient
+    // Free-form wire decisions are not substring-promoted into semantic badges.
+    // They stay raw/neutral so protocol drift remains visible.
+    expect(grid?.textContent).toContain('recommend — patch first')
+    expect(grid?.textContent).toContain('insufficient — missing: benchmarks')
+    expect(grid?.textContent).not.toContain('권고')
+    expect(grid?.textContent).not.toContain('심의 무효')
     // resolved-answer gist as the card summary
     expect(grid?.textContent).toContain('Skeptic: patch the isolation first')
 
@@ -816,6 +819,29 @@ describe('FusionSurface', () => {
     expect(cards[0]?.classList.contains('answered')).toBe(true)
     expect(cards[0]?.classList.contains('failed')).toBe(false)
     expect(cards[1]?.classList.contains('failed')).toBe(true)
+  })
+
+  it('does not derive judge run status from status substrings', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-judge-status-substring',
+        title: 'Fusion deliberation (run fus-judge-status-substring): pending',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-judge-status-substring',
+          question: 'Judge status edge cases?',
+          panel: [{ model: 'm1', status: 'answered', answer: 'Panel answer.' }],
+          judge: { status: 'failover' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).toContain('running')
+    expect(container.querySelector('.fus-rdot.run')).not.toBeNull()
+    expect(container.querySelector('.fus-rdot.deny')).toBeNull()
   })
 
   it('renders the panel reason_code as a category chip on a failed panel card', () => {

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -41,11 +41,24 @@ import {
 
 type FusionRunStatus = 'complete' | 'failed' | 'running'
 type FusionTone = 'ok' | 'warn' | 'bad' | 'volt' | 'muted'
+type FusionDecisionKey = 'Answer' | 'Recommend' | 'Insufficient'
 
 const FAILED_PANEL_STATUSES: readonly string[] = ['failed', 'error']
+const FAILED_JUDGE_STATUSES: readonly string[] = ['failed', 'error']
+const COMPLETE_JUDGE_STATUSES: readonly string[] = ['synthesized', 'complete', 'completed']
+const DECISION_KEY_BY_TOKEN: Readonly<Record<string, FusionDecisionKey>> = {
+  answer: 'Answer',
+  recommend: 'Recommend',
+  insufficient: 'Insufficient',
+}
 
 function isPanelFailure(status: string): status is 'failed' | 'error' {
   return FAILED_PANEL_STATUSES.includes(status)
+}
+
+function normalizedWireToken(value: string | null): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed.toLowerCase() : null
 }
 
 const FUSION_BOARD_SOURCE = 'fusion'
@@ -271,37 +284,47 @@ function normalizeParams(meta: Record<string, unknown>): FusionRunParams {
 }
 
 function statusFor(judge: FusionJudge, panel: FusionPanelEntry[]): FusionRunStatus {
-  const status = judge.status?.toLowerCase() ?? ''
-  if (status.includes('fail')) return 'failed'
+  const status = normalizedWireToken(judge.status)
+  if (status && FAILED_JUDGE_STATUSES.includes(status)) return 'failed'
   if (judge.error) return 'failed'
-  if (judge.resolvedAnswer || judge.synthesis || judge.decision || status.includes('synth')) return 'complete'
+  if (judge.resolvedAnswer || judge.synthesis || judge.decision) return 'complete'
+  if (status && COMPLETE_JUDGE_STATUSES.includes(status)) return 'complete'
   if (panel.length > 0 && panel.every(entry => isPanelFailure(entry.status))) return 'failed'
   return 'running'
 }
 
+interface ParsedFusionDecision {
+  raw: string
+  key: FusionDecisionKey | null
+}
+
+function parseFusionDecision(decision: string | null): ParsedFusionDecision | null {
+  const raw = decision?.trim()
+  if (!raw) return null
+  const token = normalizedWireToken(raw)
+  return {
+    raw,
+    key: token ? DECISION_KEY_BY_TOKEN[token] ?? null : null,
+  }
+}
+
 function toneFor(status: FusionRunStatus, decision: string | null): FusionTone {
   if (status === 'failed') return 'bad'
-  const lower = decision?.toLowerCase() ?? ''
-  if (lower.includes('answer')) return 'ok'
-  if (lower.includes('recommend')) return 'volt'
-  if (lower.includes('insufficient') || lower.includes('uncertain')) return 'warn'
+  const parsed = parseFusionDecision(decision)
+  if (parsed?.key === 'Answer') return 'ok'
+  if (parsed?.key === 'Recommend') return 'volt'
+  if (parsed?.key === 'Insufficient') return 'warn'
+  if (parsed && status === 'complete') return 'warn'
   return status === 'running' ? 'muted' : 'ok'
 }
 
-// Wire `decision` is a free-form string (`fusion_sink.render_decision` emits
-// `"answer — …"` / `"recommend — …"` / `"insufficient — missing: …"`), not the
-// clean OCaml variant. Map it to the canonical key the SSOT `fusionDecisionSpec`
-// understands, then defer label/glyph/tone to that shared spec (no inline
-// label/colour drift). Unknown / running / failed decisions fall through to the
-// spec's neutral fallback. This mirrors the existing `toneFor` substring logic —
-// the typed variant lives backend-side and is flattened to a string on the wire.
+// Only exact wire decision tokens are elevated to semantic badges. Description
+// strings remain raw/neutral so protocol drift is visible instead of silently
+// inheriting the wrong label, glyph, or tone.
 function decisionSpecFor(decision: string | null): FusionDecisionSpec | null {
-  if (!decision) return null
-  const lower = decision.toLowerCase()
-  if (lower.includes('answer')) return fusionDecisionSpec('Answer')
-  if (lower.includes('recommend')) return fusionDecisionSpec('Recommend')
-  if (lower.includes('insufficient') || lower.includes('uncertain')) return fusionDecisionSpec('Insufficient')
-  return fusionDecisionSpec(decision)
+  const parsed = parseFusionDecision(decision)
+  if (!parsed) return null
+  return fusionDecisionSpec(parsed.key ?? parsed.raw)
 }
 
 function keeperNameFor(post: BoardPost): string {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -62,6 +62,7 @@ import {
   removeQueuedMessage,
   type QueuedMessage,
 } from '../keeper-chat-store'
+import { stableAttachmentId } from './chat/attachments'
 import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize, type ChatComposerCommand, type ChatComposerSendPayload } from './chat/primitives'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
@@ -287,17 +288,32 @@ export function filterConversationEntries(
 }
 
 function blocksToAttachments(blocks: ChatBlock[]): KeeperConversationAttachment[] {
+  const generatedCounts = new Map<string, number>()
   return blocks
     .filter((b): b is ChatAttachBlock => b.t === 'attach')
-    .map((b) => ({
-      id: b.id ?? `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      type: b.kind === 'image' || b.src?.startsWith('data:image/') ? 'image' : 'file',
-      name: b.name,
-      size: b.sizeBytes ?? 0,
-      mimeType: b.mimeType ?? 'application/octet-stream',
-      data: b.data ?? b.src ?? '',
-      dims: b.dims,
-    }))
+    .map((b) => {
+      const baseId = stableAttachmentId({
+        name: b.name,
+        type: b.kind === 'image' || b.src?.startsWith('data:image/') ? 'image' : 'file',
+        kind: b.kind,
+        mimeType: b.mimeType,
+        size: b.sizeBytes,
+        dims: b.dims,
+        data: b.data ?? b.svg ?? b.ph,
+        src: b.src,
+      })
+      const count = generatedCounts.get(baseId) ?? 0
+      generatedCounts.set(baseId, count + 1)
+      return {
+        id: b.id ?? (count === 0 ? baseId : `${baseId}-${count + 1}`),
+        type: b.kind === 'image' || b.src?.startsWith('data:image/') ? 'image' : 'file',
+        name: b.name,
+        size: b.sizeBytes ?? 0,
+        mimeType: b.mimeType ?? 'application/octet-stream',
+        data: b.data ?? b.src ?? '',
+        dims: b.dims,
+      }
+    })
 }
 
 function blocksToDisplayBlocks(blocks: ChatBlock[]): ChatBlock[] | undefined {

--- a/dashboard/src/components/runtime-environment-editor.test.ts
+++ b/dashboard/src/components/runtime-environment-editor.test.ts
@@ -229,10 +229,43 @@ price-output = 0.28
 [ollama_cloud.flash-nojson]
 `
 
-function mountSection(container: HTMLElement, section: 'models' | 'routing' | 'bindings') {
+const sourceWithUnknownLaneCapabilities = `[runtime]
+default = "ollama_cloud.minimax-m3"
+librarian = "ollama_cloud.flash-unknown"
+cross_verifier = "ollama_cloud.missing-binding"
+
+[providers.ollama_cloud]
+display-name = "Ollama Cloud"
+protocol = "openai-compatible-http"
+endpoint = "https://ollama.example/v1"
+
+[models.minimax-m3]
+api-name = "minimax-m3"
+max-context = 524288
+tools-support = true
+thinking-support = true
+streaming = true
+
+[models.flash-unknown]
+api-name = "flash-unknown"
+max-context = 1048576
+tools-support = true
+thinking-support = true
+streaming = true
+
+[ollama_cloud.minimax-m3]
+
+[ollama_cloud.flash-unknown]
+`
+
+function mountSection(
+  container: HTMLElement,
+  section: 'models' | 'routing' | 'bindings',
+  sourceText = sourceWithCapabilities,
+) {
   render(
     html`<${RuntimeEnvironmentEditor}
-      sourceText=${sourceWithCapabilities}
+      sourceText=${sourceText}
       section=${section}
       onRoutingChange=${() => {}}
       onAssignmentChange=${() => {}}
@@ -259,6 +292,26 @@ describe('RuntimeEnvironmentEditor capability projection', () => {
     render(null, container)
   })
 
+  it('renders supported capability state for a JSON-required lane with declared support', () => {
+    const container = document.createElement('div')
+    mountSection(
+      container,
+      'routing',
+      sourceWithCapabilities.replace(
+        'librarian = "ollama_cloud.flash-nojson"',
+        'librarian = "ollama_cloud.minimax-m3"',
+      ),
+    )
+
+    const badge = container.querySelector('[data-testid="runtime-lane-librarian-capability"]')
+    expect(badge?.getAttribute('data-runtime-lane-capability')).toBe('supported')
+    expect(badge?.classList.contains('rt-ok')).toBe(true)
+    expect(badge?.textContent).toContain('JSON 모드 필요')
+    expect(badge?.textContent).toContain('minimax-m3 지원')
+
+    render(null, container)
+  })
+
   it('warns when a JSON-required lane targets a model without response-format-json', () => {
     const container = document.createElement('div')
     mountSection(container, 'routing')
@@ -279,6 +332,44 @@ describe('RuntimeEnvironmentEditor capability projection', () => {
     expect(warnings.some(w => w.includes('structured output 필요') && w.includes('deepseek-v4-flash 미지원'))).toBe(true)
     // and it does not mislabel the structured requirement as a JSON-mode one
     expect(warnings.every(w => !(w.includes('structured output 필요') && w.includes('JSON 모드')))).toBe(true)
+
+    render(null, container)
+  })
+
+  it('renders unknown capability state without green OK styling when required capability is not declared', () => {
+    const container = document.createElement('div')
+    mountSection(container, 'routing', sourceWithUnknownLaneCapabilities)
+
+    const librarian = container.querySelector('[data-testid="runtime-lane-librarian-capability"]')
+    expect(librarian?.getAttribute('data-runtime-lane-capability')).toBe('unknown')
+    expect(librarian?.classList.contains('rt-unknown')).toBe(true)
+    expect(librarian?.classList.contains('rt-ok')).toBe(false)
+    expect(librarian?.textContent).toContain('JSON 모드 필요')
+    expect(librarian?.textContent).toContain('flash-unknown capability 미확인')
+
+    const crossVerifier = container.querySelector('[data-testid="runtime-lane-cross_verifier-capability"]')
+    expect(crossVerifier?.getAttribute('data-runtime-lane-capability')).toBe('unknown')
+    expect(crossVerifier?.classList.contains('rt-unknown')).toBe(true)
+    expect(crossVerifier?.textContent).toContain('runtime binding 없음: ollama_cloud.missing-binding')
+
+    render(null, container)
+  })
+
+  it('renders unconfigured capability state for an unset optional required-capability lane', () => {
+    const container = document.createElement('div')
+    mountSection(
+      container,
+      'routing',
+      sourceWithUnknownLaneCapabilities.replace(
+        'librarian = "ollama_cloud.flash-unknown"\n',
+        '',
+      ),
+    )
+
+    const badge = container.querySelector('[data-testid="runtime-lane-librarian-capability"]')
+    expect(badge?.getAttribute('data-runtime-lane-capability')).toBe('unconfigured')
+    expect(badge?.classList.contains('rt-unknown')).toBe(true)
+    expect(badge?.textContent).toContain('lane 미설정')
 
     render(null, container)
   })

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -271,6 +271,14 @@ function keeperDotTone(status: string): string {
   return 'bg-[var(--color-status-err)]'
 }
 
+type RuntimeLaneCapabilityState = 'supported' | 'unsupported' | 'unknown' | 'unconfigured'
+
+interface RuntimeLaneCapabilityBadge {
+  readonly state: RuntimeLaneCapabilityState
+  readonly className: 'rt-ok' | 'rt-warn' | 'rt-unknown'
+  readonly label: string
+}
+
 export function RuntimeEnvironmentEditor({
   sourceText,
   section,
@@ -490,10 +498,8 @@ export function RuntimeEnvironmentEditor({
     setBindingFormError(null)
   }
 
-  // rt-select — runtime.css:43. Inline width cap so the 248px min-width never
-  // Layout is now handled by keeper-v2/runtime.css (.rt-lane/.rt-lane-c/.rt-select)
-  // so the narrow Settings embed stacks label above control instead of squeezing
-  // the label to one-word-per-line.
+  // Layout is handled by keeper-v2/runtime.css (.rt-lane/.rt-lane-c/.rt-select)
+  // so the narrow Settings embed can wrap labels, controls, and capability badges.
 
   function laneRow(
     lane: 'default' | 'librarian' | 'structured_judge' | 'hitl_summary' | 'cross_verifier',
@@ -519,14 +525,44 @@ export function RuntimeEnvironmentEditor({
           ? (typeof model.structuredOutput === 'boolean' ? model.structuredOutput : null)
           : (typeof model.jsonSupport === 'boolean' ? model.jsonSupport : null)
     const capLabel = requirement === 'structured' ? 'structured output 필요' : 'JSON 모드 필요'
-    const capWarning =
+    const capBadge: RuntimeLaneCapabilityBadge | null =
       requirement === 'none'
         ? null
-        : capValue === false && model
-          ? html`<span class="rt-warn">${capLabel} · ${model.apiName} 미지원</span>`
-          : (capValue === null && model) || !model
-            ? html`<span class="rt-ok">${capLabel} · 모델 capability 미확인</span>`
-            : null
+        : value === ''
+          ? {
+              state: 'unconfigured',
+              className: 'rt-unknown',
+              label: `${capLabel} · lane 미설정`,
+            }
+          : !binding
+            ? {
+                state: 'unknown',
+                className: 'rt-unknown',
+                label: `${capLabel} · runtime binding 없음: ${value}`,
+              }
+            : !model
+              ? {
+                  state: 'unknown',
+                  className: 'rt-unknown',
+                  label: `${capLabel} · model 정의 없음: ${binding.modelId}`,
+                }
+              : capValue === true
+                ? {
+                    state: 'supported',
+                    className: 'rt-ok',
+                    label: `${capLabel} · ${model.apiName} 지원`,
+                  }
+                : capValue === false
+                  ? {
+                      state: 'unsupported',
+                      className: 'rt-warn',
+                      label: `${capLabel} · ${model.apiName} 미지원`,
+                    }
+                  : {
+                      state: 'unknown',
+                      className: 'rt-unknown',
+                      label: `${capLabel} · ${model.apiName} capability 미확인`,
+                    }
 
     return html`
       <div class="rt-lane">
@@ -545,7 +581,14 @@ export function RuntimeEnvironmentEditor({
             ${canUnset ? html`<option value="">미설정</option>` : null}
             ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
           </select>
-          ${capWarning}
+          ${capBadge ? html`
+            <span
+              class=${capBadge.className}
+              data-testid=${`runtime-lane-${lane}-capability`}
+              data-runtime-lane=${lane}
+              data-runtime-lane-capability=${capBadge.state}
+            >${capBadge.label}</span>
+          ` : null}
         </div>
       </div>
     `

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -190,11 +190,11 @@ describe('ScheduleSurface', () => {
     expect(summary?.textContent).not.toContain('승인 차단')
     // The wake-signal feed header is renamed in v2.
     expect(container.textContent).toContain('wake signal 피드 · schedule_runner.tick')
-    expect(container.querySelector('[data-testid="schedule-waiting-inventory"]')?.textContent)
-      .toContain('Keeper Waiting Inventory')
-    expect(container.querySelector('[data-testid="schedule-waiting-inventory"]')?.textContent)
+    expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)
+      .toContain('Keeper Lanes · wake evidence')
+    expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)
       .toContain('sangsu')
-    expect(container.querySelector('[data-testid="schedule-waiting-inventory"]')?.textContent)
+    expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)
       .toContain('masc.board_post')
     // REMOVED: '출처 <signal_source>' feed attribution line is not rendered on
     // the v2 surface (it is diagnostics-only); no equivalent element exists to

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -11,7 +11,7 @@ import { ConnectionStatus } from '../dashboard-shell'
 import type { DashboardScheduledAutomation } from '../../api'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { StatusChip } from '../common/status-chip'
-import { KeeperWaitingInventoryPanel } from '../tools/keeper-waiting-inventory-panel'
+import { KeeperLaneInventoryPanel } from '../tools/keeper-waiting-inventory-panel'
 import { ScheduleAside, ScheduledAutomationPanel, normalizedScheduleStatus, scheduledPendingApprovalCount } from '../tools/scheduled-automation-panel'
 import {
   loadTools,
@@ -100,9 +100,9 @@ export function ScheduleSurface() {
           </div>
         </section>
 
-        <section class="ov-card mt-4" aria-label="Keeper waiting inventory" data-testid="schedule-waiting-inventory">
-          <div class="ov-card-h"><h3>Keeper Waiting Inventory</h3></div>
-          <${KeeperWaitingInventoryPanel} inventory=${waitingInventory} />
+        <section class="ov-card mt-4" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
+          <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
+          <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
         </section>
 
         ${loading && !automation

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
@@ -3,7 +3,7 @@ import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { DashboardKeeperWaitingInventory } from '../../api'
-import { KeeperWaitingInventoryPanel } from './keeper-waiting-inventory-panel'
+import { KeeperLaneInventoryPanel, KeeperWaitingInventoryPanel } from './keeper-waiting-inventory-panel'
 
 function inventoryFixture(): DashboardKeeperWaitingInventory {
   return {
@@ -166,5 +166,65 @@ describe('KeeperWaitingInventoryPanel', () => {
     expect(container.textContent).toContain('keepersunknown')
     expect(container.textContent).toContain('keeper_meta_store')
     expect(container.textContent).toContain('repair keeper meta store')
+  })
+})
+
+describe('KeeperLaneInventoryPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders one lane card per projected keeper, including idle lanes', () => {
+    render(html`<${KeeperLaneInventoryPanel} inventory=${inventoryFixture()} />`, container)
+
+    const cards = container.querySelectorAll('[data-testid="keeper-lane-card"]')
+    expect(cards).toHaveLength(3)
+    expect(container.querySelector('[data-keeper-lane="sangsu"]')?.textContent).toContain('event queue pending')
+    expect(container.querySelector('[data-keeper-lane="busy-one"]')?.textContent).toContain('turn admission waiting')
+    expect(container.querySelector('[data-keeper-lane="idle-one"]')?.textContent).toContain('no keeper-specific waiting rows')
+    expect(container.textContent).toContain('Global lane evidence')
+    expect(container.textContent).toContain('producer schedule runner')
+  })
+
+  it('surfaces missing wake producer and next action evidence explicitly', () => {
+    const inventory = inventoryFixture()
+    inventory.keepers = [
+      {
+        keeper_name: 'partial-lane',
+        state: 'waiting',
+        waiting_count: 1,
+        waiting_on: [
+          {
+            keeper_name: 'partial-lane',
+            source: 'external_message',
+            waiting_on: 'discord:ops',
+            wake_producer: null,
+            next_action: '',
+          },
+        ],
+      },
+    ]
+
+    render(html`<${KeeperLaneInventoryPanel} inventory=${inventory} />`, container)
+
+    expect(container.textContent).toContain('partial-lane')
+    expect(container.textContent).toContain('discord:ops')
+    expect(container.textContent).toContain('producer wake producer missing')
+    expect(container.textContent).toContain('next action missing')
+  })
+
+  it('renders unavailable lane evidence without inventing fallback rows', () => {
+    render(html`<${KeeperLaneInventoryPanel} inventory=${null} />`, container)
+
+    expect(container.textContent).toContain('keeper lane evidence unavailable')
+    expect(container.querySelector('[data-testid="keeper-lane-card"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
@@ -15,6 +15,12 @@ export function enumLabel(value: string | null | undefined): string {
   return value.replace(/_/g, ' ')
 }
 
+function evidenceLabel(value: string | null | undefined, missingLabel: string): string {
+  if (!value) return missingLabel
+  const trimmed = value.trim()
+  return trimmed ? enumLabel(trimmed) : missingLabel
+}
+
 export function stateTone(state: string | null | undefined): StatusChipTone {
   switch (state) {
     case 'waiting':
@@ -83,6 +89,8 @@ function SourceCounts({ counts }: { counts: Record<string, number> | null | unde
 }
 
 function WaitingRow({ row }: { row: DashboardKeeperWaitingRow }) {
+  const wakeProducer = evidenceLabel(row.wake_producer, 'wake producer missing')
+  const nextAction = evidenceLabel(row.next_action, 'next action missing')
   return html`
     <div class="grid gap-1 border-t border-[var(--color-border-subtle)] py-2 first:border-t-0">
       <div class="flex min-w-0 flex-wrap items-center gap-2">
@@ -92,8 +100,8 @@ function WaitingRow({ row }: { row: DashboardKeeperWaitingRow }) {
       <div class="grid gap-1 text-2xs text-[var(--color-fg-muted)] sm:grid-cols-4">
         <span>since ${timeLabel(row.since_iso)}</span>
         <span>due ${timeLabel(row.due_at_iso)}</span>
-        <span class="font-mono">producer ${enumLabel(row.wake_producer)}</span>
-        <span class="font-mono">${enumLabel(row.next_action)}</span>
+        <span class="font-mono">producer ${wakeProducer}</span>
+        <span class="font-mono">${nextAction}</span>
       </div>
     </div>
   `
@@ -174,6 +182,119 @@ export function KeeperWaitingInventoryPanel({
         ? html`
             <div class="border-t border-[var(--color-border-subtle)] pt-3">
               <div class="mb-1 text-xs font-medium text-[var(--color-fg-secondary)]">Global waiting</div>
+              ${globalRows.map((row, index) => html`<${WaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />`)}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
+function laneSummary(keeper: DashboardKeeperWaitingKeeper): string {
+  const nextAction = evidenceLabel(keeper.next_action, 'next action unavailable')
+  const dueAt = timeLabel(keeper.due_at_iso)
+  const since = timeLabel(keeper.since_iso)
+  return [
+    `state ${enumLabel(keeper.state)}`,
+    `waiting ${keeper.waiting_count.toLocaleString()}`,
+    `since ${since}`,
+    `due ${dueAt}`,
+    nextAction,
+  ].join(' · ')
+}
+
+function LaneEvidenceCard({ keeper }: { keeper: DashboardKeeperWaitingKeeper }) {
+  const rows = (keeper.waiting_on ?? []).slice(0, 6)
+  const truncatedSources = Object.entries(keeper.truncated_sources ?? {})
+    .filter(([, truncated]) => truncated)
+    .map(([source]) => enumLabel(source))
+  return html`
+    <article
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      data-testid="keeper-lane-card"
+      data-keeper-lane=${keeper.keeper_name}
+    >
+      <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
+        <div class="min-w-0">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <span class="min-w-0 truncate font-mono text-sm font-semibold text-[var(--color-fg-primary)]">${keeper.keeper_name}</span>
+            <${StatusChip} tone=${stateTone(keeper.state)} uppercase=${false}>${enumLabel(keeper.state)}<//>
+          </div>
+          <div class="mt-1 text-2xs text-[var(--color-fg-muted)]" title=${laneSummary(keeper)}>
+            <span class="font-mono">since ${timeLabel(keeper.since_iso)}</span>
+            <span aria-hidden="true"> · </span>
+            <span class="font-mono">due ${timeLabel(keeper.due_at_iso)}</span>
+          </div>
+        </div>
+        <div class="text-right text-2xs text-[var(--color-fg-muted)]">
+          <div><span class="font-mono text-[var(--color-fg-primary)]">${keeper.waiting_count.toLocaleString()}</span> lane rows</div>
+          ${keeper.next_action
+            ? html`<div class="font-mono">${enumLabel(keeper.next_action)}</div>`
+            : html`<div class="font-mono text-[var(--color-status-warn)]">next action unavailable</div>`}
+        </div>
+      </div>
+      <div class="mt-2">
+        <${SourceCounts} counts=${keeper.sources} />
+      </div>
+      ${keeper.waiting_count_truncated
+        ? html`
+            <div class="mt-2 text-2xs text-[var(--color-status-warn)]">
+              truncated ${truncatedSources.length > 0 ? truncatedSources.join(', ') : 'waiting rows'}
+            </div>
+          `
+        : null}
+      <div class="mt-2">
+        ${rows.length > 0
+          ? rows.map((row, index) => html`<${WaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />`)
+          : html`<div class="border-t border-[var(--color-border-subtle)] pt-2 text-xs text-[var(--color-fg-muted)]">no keeper-specific waiting rows</div>`}
+        ${keeper.waiting_count > rows.length
+          ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]">+${keeper.waiting_count - rows.length} more</div>`
+          : null}
+      </div>
+    </article>
+  `
+}
+
+export function KeeperLaneInventoryPanel({
+  inventory,
+}: {
+  inventory: DashboardKeeperWaitingInventory | null | undefined
+}) {
+  if (!inventory) {
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">keeper lane evidence unavailable</div>`
+  }
+  const lanes = inventory.keepers ?? []
+  const globalRows = (inventory.global_waiting_on ?? []).slice(0, 6)
+  const keeperCount =
+    inventory.keeper_count_known === false ? 'unknown' : inventory.keeper_count
+  const pendingConfirmCount =
+    inventory.global_pending_confirm_count_known === false
+      ? 'unknown'
+      : inventory.global_pending_confirm_count ?? 0
+  return html`
+    <div class="grid gap-3" data-testid="keeper-lane-inventory">
+      <div class="flex flex-wrap gap-1.5">
+        <${CountPill} label="keeper lanes" value=${keeperCount} />
+        <${CountPill} label="waiting lanes" value=${inventory.waiting_keeper_count} />
+        <${CountPill} label="lane rows" value=${inventory.row_count} />
+        <${CountPill} label="global rows" value=${inventory.global_row_count ?? 0} />
+        <${CountPill} label="unmapped confirms" value=${pendingConfirmCount} />
+      </div>
+      <${SourceCounts} counts=${inventory.source_counts} />
+      ${lanes.length > 0
+        ? html`<div class="grid gap-2 lg:grid-cols-2">${lanes.map(keeper => html`<${LaneEvidenceCard} key=${keeper.keeper_name} keeper=${keeper} />`)}</div>`
+        : html`<div class="text-xs text-[var(--color-fg-muted)]">no keeper lane rows in projection</div>`}
+      ${inventory.row_count_truncated
+        ? html`
+            <div class="text-2xs text-[var(--color-status-warn)]">
+              lane projection truncated at ${inventory.external_attention_row_limit ?? 'unknown'} rows
+            </div>
+          `
+        : null}
+      ${globalRows.length > 0
+        ? html`
+            <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
+              <div class="mb-1 text-xs font-medium text-[var(--color-fg-secondary)]">Global lane evidence</div>
               ${globalRows.map((row, index) => html`<${WaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />`)}
             </div>
           `

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -682,6 +682,17 @@ describe('ScheduledAutomationPanel', () => {
     doneFilter.click()
     await Promise.resolve()
 
+    const cardWakeSummary = container.querySelector('[data-schedule-wake-evidence-summary="sched-keeper-wake"]')
+    expect(cardWakeSummary).not.toBeNull()
+    expect(cardWakeSummary?.getAttribute('data-schedule-wake-evidence-receipt')).toBe('recognized')
+    expect(cardWakeSummary?.getAttribute('data-schedule-wake-evidence-queue')).toBe('matched_pending')
+    expect(cardWakeSummary?.getAttribute('data-schedule-wake-evidence-reaction')).toBe('matched_stimulus')
+    expect(cardWakeSummary?.textContent).toContain('wake evidence')
+    expect(cardWakeSummary?.textContent).toContain('receipt recognized')
+    expect(cardWakeSummary?.textContent).toContain('queue matched pending')
+    expect(cardWakeSummary?.textContent).toContain('reaction matched stimulus')
+    expect(cardWakeSummary?.textContent).toContain('post schedule-due:sched-keeper-wake')
+
     const openDetail = container.querySelector('[data-schedule-detail="sched-keeper-wake"]') as HTMLButtonElement
     openDetail.click()
     await Promise.resolve()
@@ -804,6 +815,142 @@ describe('ScheduledAutomationPanel', () => {
     expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_seen')
     expect(ackReactionEvidence?.textContent).toContain('true')
     expect(ackReactionEvidence?.textContent).toContain('event_queue_ack_recorded_at')
+  })
+
+  it('shows missing wake evidence explicitly for keeper wake cards', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-keeper-wake-missing',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        approval_required: false,
+        payload_kind: 'masc.keeper_wake',
+        payload_support: 'supported',
+        payload_target: 'keeper:schedule-keeper',
+        payload_summary: 'Scheduled wake without projection evidence yet',
+      }),
+    ])
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const scheduledFilter = container.querySelector('[data-schedule-filter="scheduled"]') as HTMLButtonElement
+    scheduledFilter.click()
+    await Promise.resolve()
+
+    const summary = container.querySelector('[data-schedule-wake-evidence-summary="sched-keeper-wake-missing"]')
+    expect(summary).not.toBeNull()
+    expect(summary?.getAttribute('data-schedule-wake-evidence-receipt')).toBe('missing')
+    expect(summary?.getAttribute('data-schedule-wake-evidence-queue')).toBe('missing')
+    expect(summary?.getAttribute('data-schedule-wake-evidence-reaction')).toBe('missing')
+    expect(summary?.textContent).toContain('receipt missing')
+    expect(summary?.textContent).toContain('queue missing')
+    expect(summary?.textContent).toContain('reaction missing')
+  })
+
+  it('surfaces cadence counts and filters exact recurrence kinds in v2', async () => {
+    const auto = automation([
+      request({
+        schedule_id: 'sched-poll-live',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        recurrence: { kind: 'interval', interval_sec: 60 },
+        recurrence_kind: 'interval',
+        payload_kind: 'keeper.poll',
+        payload_summary: 'Poll live queue',
+        due_at_iso: '2026-06-21T00:01:00Z',
+      }),
+      request({
+        schedule_id: 'sched-poll-terminal',
+        status: 'succeeded',
+        effective_status: 'succeeded',
+        execution_readiness: 'terminal',
+        recurrence: { kind: 'interval', interval_sec: 300 },
+        recurrence_kind: 'interval',
+        payload_kind: 'keeper.poll',
+        payload_summary: 'Terminal poll history',
+      }),
+      request({
+        schedule_id: 'sched-daily',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        recurrence: { kind: 'daily', hour: 9, minute: 0, timezone: 'Asia/Seoul' },
+        recurrence_kind: 'daily',
+        payload_kind: 'keeper.daily',
+        payload_summary: 'Daily keeper check',
+      }),
+      request({
+        schedule_id: 'sched-one-shot',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        recurrence: { kind: 'one_shot' },
+        recurrence_kind: 'one_shot',
+        payload_kind: 'keeper.once',
+        payload_summary: 'One shot keeper check',
+      }),
+      request({
+        schedule_id: 'sched-cron',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        recurrence: { kind: 'cron', expression: '0 9 * * 1-5', timezone: 'Asia/Seoul' },
+        recurrence_kind: 'cron',
+        payload_kind: 'keeper.cron',
+        payload_summary: 'Cron keeper check',
+      }),
+      request({
+        schedule_id: 'sched-unknown-cadence',
+        status: 'scheduled',
+        effective_status: 'scheduled',
+        execution_readiness: 'scheduled',
+        payload_kind: 'keeper.unknown',
+        payload_summary: 'Missing recurrence projection',
+      }),
+    ])
+
+    render(html`<${ScheduledAutomationPanel} automation=${auto} variant="v2" />`, container)
+
+    const summary = container.querySelector('[data-schedule-cadence-summary]')
+    expect(summary).not.toBeNull()
+    expect(container.querySelector('[data-schedule-cadence-filter="interval"]')?.getAttribute('data-schedule-cadence-count')).toBe('2')
+    expect(container.querySelector('[data-schedule-cadence-filter="daily"]')?.getAttribute('data-schedule-cadence-count')).toBe('1')
+    expect(container.querySelector('[data-schedule-cadence-filter="oneshot"]')?.getAttribute('data-schedule-cadence-count')).toBe('1')
+    expect(container.querySelector('[data-schedule-cadence-filter="cron"]')?.getAttribute('data-schedule-cadence-count')).toBe('1')
+    expect(container.querySelector('[data-schedule-cadence-filter="unknown"]')?.getAttribute('data-schedule-cadence-count')).toBe('1')
+    expect(container.querySelector('[data-schedule-polling-strip]')?.getAttribute('data-schedule-polling-count')).toBe('1')
+    expect(container.querySelector('[data-schedule-polling-card="sched-poll-live"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-polling-card="sched-poll-terminal"]')).toBeNull()
+
+    const scheduledFilter = container.querySelector('[data-schedule-filter="scheduled"]') as HTMLButtonElement
+    scheduledFilter.click()
+    await flush()
+
+    const intervalFilter = container.querySelector('[data-schedule-cadence-filter="interval"]') as HTMLButtonElement
+    intervalFilter.click()
+    await flush()
+
+    expect(container.querySelector('[data-schedule-id="sched-poll-live"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-daily"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-one-shot"]')).toBeNull()
+    expect(container.querySelector('[data-schedule-cadence-card="sched-poll-live"]')?.getAttribute('data-schedule-cadence')).toBe('interval')
+
+    const dailyFilter = container.querySelector('[data-schedule-cadence-filter="daily"]') as HTMLButtonElement
+    dailyFilter.click()
+    await flush()
+
+    expect(container.querySelector('[data-schedule-polling-strip]')).toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-daily"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-id="sched-poll-live"]')).toBeNull()
+
+    const unknownFilter = container.querySelector('[data-schedule-cadence-filter="unknown"]') as HTMLButtonElement
+    unknownFilter.click()
+    await flush()
+
+    expect(container.querySelector('[data-schedule-id="sched-unknown-cadence"]')).not.toBeNull()
+    expect(container.querySelector('[data-schedule-cadence-card="sched-unknown-cadence"]')?.getAttribute('data-schedule-cadence')).toBe('unknown')
   })
 
   it('filters schedule cards without filtering the wake signal feed', async () => {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -625,6 +625,96 @@ function ReactionEvidenceBlock({
   `
 }
 
+function wakeEvidenceStatus(value: { projection_status?: string | null } | null | undefined): string {
+  const status = value?.projection_status?.trim()
+  return status && status.length > 0 ? status : 'missing'
+}
+
+function wakeEvidenceTone(
+  value: { projection_status?: string | null } | null | undefined,
+  tone: StatusChipTone,
+): StatusChipTone {
+  return value ? tone : 'warn'
+}
+
+function isKeeperWakePayload(request: DashboardScheduledAutomationRequest): boolean {
+  return request.payload_kind === 'masc.keeper_wake'
+}
+
+function hasWakeEvidenceSummary(request: DashboardScheduledAutomationRequest): boolean {
+  return isKeeperWakePayload(request) ||
+    request.dispatch_receipt != null ||
+    request.keeper_queue_evidence != null ||
+    request.keeper_reaction_evidence != null
+}
+
+function wakeEvidenceJoinKey(request: DashboardScheduledAutomationRequest): string | null {
+  const candidates = [
+    request.dispatch_receipt?.post_id,
+    request.keeper_queue_evidence?.post_id,
+    request.keeper_reaction_evidence?.post_id,
+    request.dispatch_receipt?.stimulus_id,
+    request.keeper_reaction_evidence?.stimulus_id,
+  ]
+  for (const candidate of candidates) {
+    const value = candidate?.trim()
+    if (value) return value
+  }
+  return null
+}
+
+function WakeEvidenceSummary({ request }: { request: DashboardScheduledAutomationRequest }) {
+  if (!hasWakeEvidenceSummary(request)) return null
+  const receiptStatus = wakeEvidenceStatus(request.dispatch_receipt)
+  const queueStatus = wakeEvidenceStatus(request.keeper_queue_evidence)
+  const reactionStatus = wakeEvidenceStatus(request.keeper_reaction_evidence)
+  const joinKey = wakeEvidenceJoinKey(request)
+  const items: ReadonlyArray<{
+    key: string
+    label: string
+    status: string
+    tone: StatusChipTone
+  }> = [
+    {
+      key: 'receipt',
+      label: 'receipt',
+      status: receiptStatus,
+      tone: wakeEvidenceTone(request.dispatch_receipt, dispatchReceiptTone(request.dispatch_receipt)),
+    },
+    {
+      key: 'queue',
+      label: 'queue',
+      status: queueStatus,
+      tone: wakeEvidenceTone(request.keeper_queue_evidence, queueEvidenceTone(request.keeper_queue_evidence)),
+    },
+    {
+      key: 'reaction',
+      label: 'reaction',
+      status: reactionStatus,
+      tone: wakeEvidenceTone(request.keeper_reaction_evidence, reactionEvidenceTone(request.keeper_reaction_evidence)),
+    },
+  ]
+  return html`
+    <div
+      class="sch-wake-evidence"
+      data-schedule-wake-evidence-summary=${request.schedule_id}
+      data-schedule-wake-evidence-receipt=${receiptStatus}
+      data-schedule-wake-evidence-queue=${queueStatus}
+      data-schedule-wake-evidence-reaction=${reactionStatus}
+    >
+      <span class="sch-wake-title">wake evidence</span>
+      ${items.map(item => html`
+        <span class="sch-wake-item" data-schedule-wake-evidence-item=${item.key}>
+          ${item.label} <${StatusChip} tone=${item.tone} uppercase=${false}>${enumLabel(item.status)}<//>
+        </span>
+      `)}
+      ${joinKey
+        ? html`<span class="sch-wake-join mono" title=${joinKey}>post ${joinKey}</span>`
+        : null}
+    </div>
+  `
+}
+
 function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
@@ -1572,23 +1662,178 @@ function cardRailTone(cls: string): string {
 
 // Prototype filter tabs (audit P0 #3): 5 tabs, prototype labels/ordering.
 type SchTabKey = 'pending' | 'scheduled' | 'active' | 'done' | 'all'
+type SchCadenceKey = 'oneshot' | 'interval' | 'daily' | 'cron' | 'unknown'
 interface SchTabDef {
   readonly key: SchTabKey
   readonly label: string
   // Effective-status values (live, normalized) this tab includes; null = all.
   readonly statuses: readonly string[] | null
 }
+interface SchCadenceDef {
+  readonly key: SchCadenceKey
+  readonly label: string
+  readonly shortLabel: string
+  readonly glyph: string
+  readonly cls: string
+}
+const SCH_TERMINAL_STATUSES = ['succeeded', 'failed', 'rejected', 'cancelled', 'canceled', 'expired'] as const
 const SCH_TABS: readonly SchTabDef[] = [
   { key: 'pending', label: '승인 대기', statuses: ['pending_approval', 'awaiting_approval', 'blocked_approval'] },
   { key: 'scheduled', label: '예약됨', statuses: ['scheduled'] },
   { key: 'active', label: 'due · 실행', statuses: ['due', 'due_pending_refresh', 'running'] },
-  { key: 'done', label: '완료 · 종료', statuses: ['succeeded', 'failed', 'rejected', 'cancelled', 'canceled', 'expired'] },
+  { key: 'done', label: '완료 · 종료', statuses: SCH_TERMINAL_STATUSES },
   { key: 'all', label: '전체', statuses: null },
+]
+const SCH_TERMINAL_STATUS_SET: ReadonlySet<string> = new Set(SCH_TERMINAL_STATUSES)
+const SCH_CADENCES: readonly SchCadenceDef[] = [
+  { key: 'daily', label: '정기 · 매일', shortLabel: '정기', glyph: '◈', cls: 'ok' },
+  { key: 'interval', label: '폴링 · 주기', shortLabel: '폴링', glyph: '↻', cls: 'volt' },
+  { key: 'oneshot', label: '1회 · ad-hoc', shortLabel: '1회', glyph: '•', cls: 'info' },
+  { key: 'cron', label: 'cron', shortLabel: 'cron', glyph: '⌁', cls: 'warn' },
+  { key: 'unknown', label: 'unknown', shortLabel: 'unknown', glyph: '?', cls: 'dim' },
 ]
 
 function schTabMatches(tab: SchTabDef, request: DashboardScheduledAutomationRequest): boolean {
   if (tab.statuses === null) return true
   return tab.statuses.includes(normalized(effectiveStatus(request)))
+}
+
+function recurrenceKind(request: DashboardScheduledAutomationRequest): string | null {
+  const kind = request.recurrence?.kind ?? request.recurrence_kind ?? null
+  const value = normalized(kind)
+  return value === '' ? null : value
+}
+
+function scheduleCadence(request: DashboardScheduledAutomationRequest): SchCadenceKey {
+  switch (recurrenceKind(request)) {
+    case 'one_shot':
+    case 'oneshot':
+      return 'oneshot'
+    case 'interval':
+      return 'interval'
+    case 'daily':
+      return 'daily'
+    case 'cron':
+      return 'cron'
+    case null:
+    default:
+      return 'unknown'
+  }
+}
+
+function schCadenceDef(key: SchCadenceKey): SchCadenceDef {
+  return SCH_CADENCES.find(definition => definition.key === key) ?? SCH_CADENCES[SCH_CADENCES.length - 1]!
+}
+
+function SchCadenceTag({ request }: { request: DashboardScheduledAutomationRequest }) {
+  const cadence = scheduleCadence(request)
+  const definition = schCadenceDef(cadence)
+  return html`
+    <span
+      class=${`sch-cad ${definition.cls}`}
+      data-schedule-cadence-card=${request.schedule_id}
+      data-schedule-cadence=${cadence}
+      title=${`recurrence.kind = ${recurrenceKind(request) ?? 'missing'}`}
+    >${definition.glyph} ${definition.shortLabel}</span>
+  `
+}
+
+function SchCadenceSummary({
+  requests,
+  active,
+  onSelect,
+}: {
+  requests: readonly DashboardScheduledAutomationRequest[]
+  active: SchCadenceKey | null
+  onSelect: (key: SchCadenceKey | null) => void
+}) {
+  const counts = new Map<SchCadenceKey, number>(SCH_CADENCES.map(definition => [definition.key, 0]))
+  for (const request of requests) {
+    const cadence = scheduleCadence(request)
+    counts.set(cadence, (counts.get(cadence) ?? 0) + 1)
+  }
+  return html`
+    <div
+      class="sch-cadsum"
+      data-schedule-cadence-summary
+      data-schedule-cadence-active=${active ?? 'all'}
+    >
+      ${SCH_CADENCES.map(definition => {
+        const selected = active === definition.key
+        const count = counts.get(definition.key) ?? 0
+        return html`
+          <button
+            type="button"
+            class=${`sch-cadsum-i ${definition.cls} ${selected ? 'on' : ''} ${active && !selected ? 'off' : ''}`}
+            aria-pressed=${selected ? 'true' : 'false'}
+            data-schedule-cadence-filter=${definition.key}
+            data-schedule-cadence-count=${count}
+            onClick=${() => { onSelect(selected ? null : definition.key) }}
+          >
+            <span class="sch-cadsum-gl">${definition.glyph}</span>
+            <span class="sch-cadsum-n mono">${count.toLocaleString()}</span>
+            <span class="sch-cadsum-l">${definition.label}</span>
+          </button>
+        `
+      })}
+    </div>
+  `
+}
+
+function isTerminalSchedule(request: DashboardScheduledAutomationRequest): boolean {
+  return SCH_TERMINAL_STATUS_SET.has(normalized(effectiveStatus(request)))
+}
+
+function SchPollingStrip({
+  requests,
+  onOpen,
+}: {
+  requests: readonly DashboardScheduledAutomationRequest[]
+  onOpen: (request: DashboardScheduledAutomationRequest) => void
+}) {
+  const polls = requests.filter(request => scheduleCadence(request) === 'interval' && !isTerminalSchedule(request))
+  return html`
+    <section
+      class="sch-poll"
+      data-schedule-polling-strip
+      data-schedule-polling-count=${polls.length}
+    >
+      <div class="sch-poll-h">
+        <span class="sch-cad volt">↻ 상시 폴링</span>
+        <span class="sch-poll-sub">recurrence.kind=interval · terminal 상태 제외</span>
+      </div>
+      ${polls.length === 0
+        ? html`<div class="sch-day-empty mono">활성 폴링 없음</div>`
+        : html`
+            <div class="sch-poll-list">
+              ${polls.map(request => {
+                const payload = schedPayloadSpec(request.payload_kind)
+                const status = statusSpecForLive(effectiveStatus(request))
+                const dueIso = request.next_due_at_iso ?? request.due_at_iso ?? null
+                return html`
+                  <button
+                    type="button"
+                    class=${`sch-poll-card st-${cardRailTone(status.cls)}`}
+                    data-schedule-polling-card=${request.schedule_id}
+                    onClick=${() => { onOpen(request) }}
+                  >
+                    <div class="sch-poll-top">
+                      <span class="sch-poll-int mono">↻ ${recurrenceText(request)}</span>
+                      <${SchStatusPill} status=${effectiveStatus(request)} />
+                    </div>
+                    <div class="sch-poll-title">${payload.glyph} ${request.payload_summary?.trim() || request.payload_kind || request.schedule_id}</div>
+                    <div class="sch-poll-foot">
+                      <${SchKeeperMeta} actor=${request.scheduled_by} />
+                      <${SchRiskChip} risk=${request.risk_class} />
+                      <span class="sch-poll-next mono" title="next_due_at">${formatDateTimeKo(dueIso)}</span>
+                    </div>
+                  </button>
+                `
+              })}
+            </div>
+          `}
+    </section>
+  `
 }
 
 function recurrenceText(request: DashboardScheduledAutomationRequest): string {
@@ -1648,6 +1893,7 @@ function SchCard({
         >
           <span class="sch-kind">${payload.glyph} ${payload.lbl}</span>
           <span class="sch-id mono">${request.schedule_id}</span>
+          <${SchCadenceTag} request=${request} />
           <${SchRiskChip} risk=${request.risk_class} />
           ${request.payload_support && request.payload_support !== 'supported'
             ? html`<${SchPayloadSupportChip} support=${request.payload_support} />`
@@ -1666,6 +1912,7 @@ function SchCard({
             ? html`<span class="sch-need mono" title="별도 사람(operator) 승인 필요">⊙ 승인 필요</span>`
             : null}
         </div>
+        <${WakeEvidenceSummary} request=${request} />
       </div>
     </article>
   `
@@ -1913,13 +2160,17 @@ function SchedulePrototypeSurface({
   onSelectSchedule?: (scheduleId: string | null) => void
 }) {
   const [tab, setTab] = useState<SchTabKey>('pending')
+  const [cadenceFilter, setCadenceFilter] = useState<SchCadenceKey | null>(null)
   const [internalSelectedId, setInternalSelectedId] = useState<string | null>(null)
   const selectedScheduleId = controlledSelectedId !== undefined ? controlledSelectedId : internalSelectedId
   const setSelectedScheduleId = onSelectSchedule ?? setInternalSelectedId
 
   const rows = automation.requests ?? []
   const tabDef = SCH_TABS.find(definition => definition.key === tab) ?? SCH_TABS[0]!
-  const filtered = rows.filter(request => schTabMatches(tabDef, request))
+  const cadenceRows = cadenceFilter
+    ? rows.filter(request => scheduleCadence(request) === cadenceFilter)
+    : rows
+  const filtered = cadenceRows.filter(request => schTabMatches(tabDef, request))
   // Durable runner signals (real source). Keep one feed (audit P0/P1 #9).
   const durableSignalContract = durableWakeSignalContract(automation)
   const durableSignals = durableSignalContract.visibleSignals
@@ -1940,11 +2191,26 @@ function SchedulePrototypeSurface({
         onOpen=${setSelectedScheduleId}
       />
 
+      <${SchCadenceSummary}
+        requests=${rows}
+        active=${cadenceFilter}
+        onSelect=${setCadenceFilter}
+      />
+
+      ${cadenceFilter === null || cadenceFilter === 'interval'
+        ? html`
+            <${SchPollingStrip}
+              requests=${rows}
+              onOpen=${(next: DashboardScheduledAutomationRequest) => { setSelectedScheduleId(next.schedule_id) }}
+            />
+          `
+        : null}
+
       <div class="sch-tabs" role="tablist" aria-label="예약 필터">
         ${SCH_TABS.map(definition => {
           const count = definition.statuses === null
-            ? rows.length
-            : rows.filter(request => schTabMatches(definition, request)).length
+            ? cadenceRows.length
+            : cadenceRows.filter(request => schTabMatches(definition, request)).length
           const active = definition.key === tab
           return html`
             <button

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -62,7 +62,7 @@ import { goalTreeData } from '../goal-tree-state'
 import { selectedTask } from './goals/task-detail-selection'
 import { showGoalCreate } from './goals/goal-create-state'
 import { Work } from './work'
-import type { GoalTreeNode, GoalTreeTask, GoalTreeSummary } from '../types'
+import type { GoalTreeNode, GoalTreeTask, GoalTreeSummary, GoalVerificationRequest } from '../types'
 
 const GOAL_FIXTURE_OK_COLOR = '#4ade80'
 
@@ -173,6 +173,24 @@ function goalTreeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     blocking_reason: '',
     created_at: '2026-01-01',
     updated_at: '2026-01-02',
+    ...overrides,
+  }
+}
+
+function goalVerificationRequest(overrides: Partial<GoalVerificationRequest> = {}): GoalVerificationRequest {
+  return {
+    id: 'VR-1',
+    goal_id: 'G-1',
+    target_phase: 'awaiting_approval',
+    requested_by: { id: 'operator' },
+    policy_snapshot: {
+      principals: [{ id: 'keeper-reviewer' }, { id: 'operator' }],
+      eligible_principals: [{ id: 'keeper-reviewer' }, { id: 'operator' }],
+      required_verdicts: 2,
+    },
+    votes: [],
+    status: 'open',
+    created_at: '2026-01-03',
     ...overrides,
   }
 }
@@ -316,7 +334,7 @@ describe('Work', () => {
 
       const section = screen.getByTestId('work-board-section')
       expect(section.textContent).toContain('칸반 · 상태별')
-      expect(section.textContent).toContain('todo → claimed → in_progress → verify → done')
+      expect(section.textContent).toContain('todo → claimed → in_progress → verify → blocked/paused/unknown → done')
 
       const todoCol = screen.getByTestId('kanban-col-todo')
       const claimedCol = screen.getByTestId('kanban-col-claimed')
@@ -493,6 +511,58 @@ describe('Work', () => {
       expect(detail?.textContent).toContain('unit tests pass')
       expect(detail?.textContent).toContain('Handoff summary text')
       expect(detail?.textContent).toContain('Deploy to staging')
+    })
+
+    it('expands inline task detail for execution links and contract evidence without synthetic lineage', () => {
+      goals.value = [
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = [
+        {
+          id: 'J-ledger',
+          title: 'Ledger job',
+          goal_id: 'G-1',
+          status: 'in_progress',
+          created_at: '2026-01-02T00:00:00Z',
+          updated_at: '2026-01-02T01:00:00Z',
+          execution_links: {
+            session_id: 'sess-ledger',
+            operation_id: 'op-ledger',
+          },
+          contract: {
+            strict: true,
+            completion_contract: ['merge-ready proof'],
+            required_evidence: ['typed test evidence'],
+            links: {
+              session_id: null,
+              operation_id: 'op-contract',
+            },
+          },
+          handoff_context: {
+            summary: '',
+            evidence_refs: ['receipt-1'],
+            updated_by: 'sangsu',
+            updated_at: '2026-01-02T02:00:00Z',
+          },
+        },
+      ]
+
+      const { container } = render(html`<${Work} />`)
+
+      fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+      fireEvent.click(container.querySelector('[data-job-id="J-ledger"] .wk-task-main')!)
+
+      const ledger = within(screen.getByTestId('job-row')).getByTestId('task-evidence-ledger')
+      expect(ledger.textContent).toContain('sess-ledger')
+      expect(ledger.textContent).toContain('op-ledger')
+      expect(ledger.textContent).toContain('strict')
+      expect(ledger.textContent).toContain('op-contract')
+      expect(ledger.textContent).toContain('merge-ready proof')
+      expect(ledger.textContent).toContain('typed test evidence')
+      expect(ledger.textContent).toContain('receipt-1')
+      expect(ledger.textContent).toContain('sangsu')
+      expect(ledger.textContent).toContain('2026-01-02T00:00:00Z')
+      expect(ledger.textContent).not.toContain('활동 흐름')
     })
 
     it('renders all defined gate evaluations including verify_to_review', () => {
@@ -1278,8 +1348,144 @@ describe('Work', () => {
         expect(screen.getByTestId('work-backlog').textContent).toContain('Tree Only Goal')
       })
 
-      it('maps unknown Goal Store task statuses to a fallback instead of dropping them', () => {
+      it('renders Goal Store projection dossier evidence on matching goal cards', () => {
+        const openRequest = goalVerificationRequest()
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, status: 'active', phase: 'awaiting_approval', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              title: 'Goal One',
+              priority: 5,
+              phase: 'awaiting_approval',
+              goal_fsm: {
+                state: 'awaiting_approval',
+                source: 'goal.phase',
+                next_actions: ['request operator approval'],
+                activity_observation: 'approval',
+                stagnation_status: 'stalled',
+              },
+              verification_summary: {
+                effective_policy: openRequest.policy_snapshot,
+                open_request: openRequest,
+                latest_request: null,
+                approve_count: 1,
+                reject_count: 0,
+                remaining_possible: 1,
+              },
+              effective_verifier_policy: openRequest.policy_snapshot,
+              active_verification_request: openRequest,
+              pending_verification_count: 1,
+              completion_summary: {
+                state: 'awaiting_approval',
+                pct: 75,
+                pct_source: 'goal_store',
+                attainment_state: 'in_progress',
+                attainment_basis: 'linked_tasks',
+                metric_evaluation: 'absent',
+                task_total: 4,
+                task_done: 3,
+                task_open: 1,
+                is_complete: false,
+                is_terminal: false,
+                ready_to_request_completion: false,
+                gate: 'approval',
+                requires_verifier: true,
+                requires_completion_approval: true,
+                active_verification_request: true,
+                blocking_source: 'approval',
+                blocking_reason: 'awaiting human approval',
+              },
+              timeline_events: [{ kind: 'turn' }],
+              last_activity_at: '2026-01-04T10:00:00Z',
+              stagnation_seconds: 3600,
+              linked_keeper_names: ['sangsu'],
+              pending_approval_count: 2,
+              infra_risk_count: 1,
+              blocking_source: 'approval',
+              blocking_reason: 'awaiting human approval',
+              latest_keeper_ref: 'sangsu',
+              latest_turn_ref: 42,
+              stalled_since: '2026-01-04T09:00:00Z',
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+
+        const goalCard = screen.getByTestId('goal-card')
+        fireEvent.click(goalCard.querySelector('.wk-goal-h')!)
+
+        const dossier = within(goalCard).getByTestId('goal-dossier')
+        expect(dossier).toHaveAttribute('data-goal-dossier', 'G-1')
+        expect(dossier).toHaveAttribute('data-goal-dossier-fsm-state', 'awaiting_approval')
+        expect(dossier).toHaveAttribute('data-goal-dossier-verification', 'open_request')
+        expect(dossier).toHaveAttribute('data-goal-dossier-blocking-source', 'approval')
+        expect(dossier).toHaveAttribute('data-goal-dossier-timeline-count', '1')
+        expect(dossier.textContent).toContain('state awaiting_approval')
+        expect(dossier.textContent).toContain('request operator approval')
+        expect(dossier.textContent).toContain('open_request VR-1')
+        expect(dossier.textContent).toContain('approve 1')
+        expect(dossier.textContent).toContain('remaining 1')
+        expect(dossier.textContent).toContain('state awaiting_approval')
+        expect(dossier.textContent).toContain('gate approval')
+        expect(dossier.textContent).toContain('tasks 3/4')
+        expect(dossier.textContent).toContain('keeper sangsu')
+        expect(dossier.textContent).toContain('turn 42')
+        expect(dossier.textContent).toContain('infra risk 1')
+        expect(dossier.textContent).toContain('awaiting human approval')
+      })
+
+      it('renders tree-only Goal Store goals in the list without an execution goal mirror', () => {
         goals.value = []
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-tree',
+              title: 'Tree Only Goal',
+              priority: 4,
+              status: 'active',
+              phase: 'blocked',
+              goal_fsm: {
+                state: 'blocked',
+                source: 'goal.phase',
+                next_actions: ['unblock linked task'],
+                activity_observation: 'task',
+                stagnation_status: 'stalled',
+              },
+              tasks: [goalTreeTask({ id: 'T-tree', goal_id: 'G-tree', status: 'todo' })],
+              blocking_source: 'task_fsm',
+              blocking_reason: 'linked task blocked',
+              stalled_since: '2026-01-05T09:00:00Z',
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1, total_tasks: 1 }),
+        }
+
+        render(html`<${Work} />`)
+
+        const goalCard = screen.getByTestId('goal-card')
+        expect(goalCard).toHaveAttribute('data-goal-id', 'G-tree')
+        expect(goalCard.textContent).toContain('Tree Only Goal')
+        fireEvent.click(goalCard.querySelector('.wk-goal-h')!)
+
+        const dossier = within(goalCard).getByTestId('goal-dossier')
+        expect(dossier).toHaveAttribute('data-goal-dossier-fsm-state', 'blocked')
+        expect(dossier).toHaveAttribute('data-goal-dossier-blocking-source', 'task_fsm')
+        expect(dossier.textContent).toContain('unblock linked task')
+        expect(dossier.textContent).toContain('linked task blocked')
+        expect(screen.getByTestId('work-backlog').textContent).toContain('Tree Only Goal')
+      })
+
+      it('preserves blocked and unknown Goal Store task statuses instead of remapping them', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
         tasks.value = []
         goalTreeData.value = {
           tree: [
@@ -1296,8 +1502,12 @@ describe('Work', () => {
 
         render(html`<${Work} />`)
 
-        expect(screen.getByTestId('kpi-wip')).toHaveTextContent('1')
-        expect(screen.getByTestId('kpi-backlog')).toHaveTextContent('1')
+        expect(screen.getByTestId('kpi-wip')).toHaveTextContent('0')
+        expect(screen.getByTestId('kpi-backlog')).toHaveTextContent('0')
+        const goalCard = screen.getByTestId('goal-card')
+        expect(within(goalCard).getByText('차단')).toBeTruthy()
+        expect(within(goalCard).getByText('상태 미확인')).toBeTruthy()
+        expect(goalCard.textContent).toContain('unknown status: weird_status')
       })
 
       it('falls back to Goal Store fields when execution fields are empty strings', () => {

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -37,20 +37,17 @@ function isWorkSection(v: string | undefined): v is WorkSection {
 
 // Bucket = progress-aggregation axis (done/wip/verify/blocked/todo).
 // cls    = the prototype's CSS modifier on .wk-task-dot/.wk-task-state.
-// They differ on purpose: the vendored v2.css defines dot/state variants
-// `done|wip|verify|claimed|cancelled|todo` (v2.css:832-850) but NOT
-// `review` or `blocked`, so emitting the prototype's exact class names is
-// what gets the row styled. `claimed` keeps its own (info-blue) color
-// instead of folding into wip; `cancelled` keeps the struck-through grey.
+// They differ on purpose: `claimed`, `blocked`, `paused`, and `unknown`
+// preserve protocol truth instead of folding into broader progress states.
 type JobBucket = 'done' | 'wip' | 'verify' | 'blocked' | 'todo'
-type JobStateCls = 'done' | 'wip' | 'verify' | 'claimed' | 'cancelled' | 'todo'
+type JobStateCls = 'done' | 'wip' | 'verify' | 'claimed' | 'cancelled' | 'todo' | 'blocked' | 'paused' | 'unknown'
 
 // ── Kanban view columns ─────────────────────────────────────────────────────
 // Closed tuple — cancelled is excluded by design (it has its own aside panel).
 // Each entry: [task.status value, Korean column label, CSS modifier cls].
 // The cls values come directly from JobStateCls so KanbanCard can reuse the
 // same .wk-kcard.<cls> and .wk-kcol-dot.<cls> rules without extra mapping.
-type KanbanStatus = 'todo' | 'claimed' | 'in_progress' | 'awaiting_verification' | 'done'
+type KanbanStatus = 'todo' | 'claimed' | 'in_progress' | 'awaiting_verification' | 'blocked' | 'paused' | 'unknown' | 'done'
 type KanbanColumn = readonly [status: KanbanStatus, label: string, cls: JobStateCls]
 
 const KANBAN_COLUMNS: ReadonlyArray<KanbanColumn> = [
@@ -58,6 +55,9 @@ const KANBAN_COLUMNS: ReadonlyArray<KanbanColumn> = [
   ['claimed',               '클레임', 'claimed'],
   ['in_progress',           '진행',   'wip'],
   ['awaiting_verification', '검증',   'verify'],
+  ['blocked',               '차단',   'blocked'],
+  ['paused',                '정지',   'paused'],
+  ['unknown',               '미확인', 'unknown'],
   ['done',                  '완료',   'done'],
 ] as const
 
@@ -73,6 +73,9 @@ function jobStateForTask(task: Task): JobState {
     case 'in_progress': return { label: '진행 중', bucket: 'wip', cls: 'wip' }
     case 'claimed': return { label: '클레임', bucket: 'wip', cls: 'claimed' }
     case 'awaiting_verification': return { label: '검증 대기', bucket: 'verify', cls: 'verify' }
+    case 'blocked': return { label: '차단', bucket: 'blocked', cls: 'blocked' }
+    case 'paused': return { label: '일시정지', bucket: 'blocked', cls: 'paused' }
+    case 'unknown': return { label: '상태 미확인', bucket: 'blocked', cls: 'unknown' }
     case 'cancelled': return { label: '취소', bucket: 'blocked', cls: 'cancelled' }
     case 'todo':
     default: return { label: '대기', bucket: 'todo', cls: 'todo' }
@@ -84,6 +87,19 @@ function blockerNoteForTask(task: Task): string | null {
     return task.handoff_context?.reason
       ?? task.handoff_context?.failure_mode
       ?? 'cancelled'
+  }
+  if (task.status === 'blocked') {
+    return task.handoff_context?.reason
+      ?? task.handoff_context?.failure_mode
+      ?? 'blocked'
+  }
+  if (task.status === 'paused') {
+    return task.handoff_context?.reason
+      ?? task.handoff_context?.failure_mode
+      ?? 'paused'
+  }
+  if (task.status === 'unknown') {
+    return task.status_raw ? `unknown status: ${task.status_raw}` : 'unknown status'
   }
   if (task.status === 'awaiting_verification') {
     return task.handoff_context?.reason ?? '검증 대기'
@@ -209,13 +225,23 @@ const GOAL_STORE_TASK_STATUS: Readonly<Record<string, NonNullable<Task['status']
   completed: 'done',
   done: 'done',
   cancelled: 'cancelled',
-  blocked: 'in_progress',
-  paused: 'in_progress',
+  blocked: 'blocked',
+  paused: 'paused',
+  unknown: 'unknown',
 }
 
-function normalizeGoalStoreTaskStatus(value: unknown): Task['status'] {
-  const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
-  return GOAL_STORE_TASK_STATUS[raw]
+interface GoalStoreTaskStatus {
+  readonly status: NonNullable<Task['status']>
+  readonly status_raw: string | null
+}
+
+function normalizeGoalStoreTaskStatus(value: unknown): GoalStoreTaskStatus {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  const token = raw.toLowerCase()
+  const status = GOAL_STORE_TASK_STATUS[token]
+  return status
+    ? { status, status_raw: status === 'unknown' ? raw : null }
+    : { status: 'unknown', status_raw: raw || null }
 }
 
 function goalProgressCounts(goalTasks: Task[]): GoalProgressCounts {
@@ -232,17 +258,11 @@ function goalProgressCounts(goalTasks: Task[]): GoalProgressCounts {
 }
 
 function taskFromGoalTreeTask(task: GoalTreeTask): Task | null {
-  let status = normalizeGoalStoreTaskStatus(task.status)
-  if (!status) {
-    console.warn('[Work] unknown Goal Store task status, falling back to todo', {
-      id: task.id,
-      status: task.status,
-    })
-    status = 'todo'
-  }
+  const status = normalizeGoalStoreTaskStatus(task.status)
   const normalized = normalizeTask({
     ...task,
-    status,
+    status: status.status,
+    status_raw: status.status_raw,
   })
   if (!normalized) {
     console.warn('[Work] dropped Goal Store task', {
@@ -285,6 +305,28 @@ function flattenGoalTreeNodes(nodes: readonly GoalTreeNode[]): GoalTreeNode[] {
   }
   walk(nodes)
   return acc
+}
+
+function goalFromGoalTreeNode(node: GoalTreeNode): Goal {
+  return {
+    id: node.id,
+    title: node.title,
+    metric: node.metric,
+    target_value: node.target_value,
+    due_date: node.due_date,
+    priority: node.priority,
+    status: node.status,
+    phase: node.phase,
+    require_completion_approval: node.require_completion_approval,
+    active_verification_request_id:
+      node.active_verification_request?.id
+      ?? node.verification_summary.open_request?.id
+      ?? null,
+    parent_goal_id: node.parent_goal_id,
+    last_review_note: node.status_reason || null,
+    created_at: node.created_at,
+    updated_at: node.updated_at,
+  }
 }
 
 function mergeTaskRecord(goalStoreTask: Task, executionTask: Task): Task {
@@ -356,13 +398,222 @@ function TaskGate({ rows }: { rows: ReturnType<typeof taskGateRows> }) {
   `
 }
 
+interface TaskEvidenceLedgerRow {
+  readonly key: string
+  readonly label: string
+  readonly value: string
+  readonly tone?: 'ok' | 'warn'
+}
+
+function appendEvidenceList(
+  rows: TaskEvidenceLedgerRow[],
+  label: string,
+  values: readonly string[] | undefined,
+  keyPrefix: string,
+) {
+  for (const value of values ?? []) {
+    if (value.trim() === '') continue
+    rows.push({ key: `${keyPrefix}:${value}`, label, value })
+  }
+}
+
+function taskEvidenceLedgerRows(task: Task): TaskEvidenceLedgerRow[] {
+  const rows: TaskEvidenceLedgerRow[] = []
+  const links = task.execution_links
+  if (links?.session_id) rows.push({ key: 'execution:session', label: 'session', value: links.session_id })
+  if (links?.operation_id) rows.push({ key: 'execution:operation', label: 'operation', value: links.operation_id })
+
+  const contract = task.contract
+  if (contract?.strict !== undefined) {
+    rows.push({
+      key: 'contract:strict',
+      label: 'contract',
+      value: contract.strict ? 'strict' : 'advisory',
+      tone: contract.strict ? 'warn' : undefined,
+    })
+  }
+  if (contract?.links?.session_id) {
+    rows.push({ key: 'contract:session', label: 'contract session', value: contract.links.session_id })
+  }
+  if (contract?.links?.operation_id) {
+    rows.push({ key: 'contract:operation', label: 'contract operation', value: contract.links.operation_id })
+  }
+  appendEvidenceList(rows, 'completion', contract?.completion_contract, 'completion')
+  appendEvidenceList(rows, 'required evidence', contract?.required_evidence, 'required')
+  appendEvidenceList(rows, 'inspect evidence', contract?.inspect_gate_evidence, 'inspect')
+  appendEvidenceList(rows, 'verify evidence', contract?.verify_gate_evidence, 'verify')
+
+  const handoff = task.handoff_context
+  appendEvidenceList(rows, 'handoff evidence', handoff?.evidence_refs, 'handoff-evidence')
+  if (handoff?.updated_by) rows.push({ key: 'handoff:updated-by', label: 'handoff by', value: handoff.updated_by })
+  if (handoff?.updated_at) rows.push({ key: 'handoff:updated-at', label: 'handoff at', value: handoff.updated_at })
+
+  if (rows.length > 0) {
+    if (task.created_at) rows.push({ key: 'task:created', label: 'created', value: task.created_at })
+    if (task.updated_at) rows.push({ key: 'task:updated', label: 'updated', value: task.updated_at })
+    if (task.completed_at) rows.push({ key: 'task:completed', label: 'completed', value: task.completed_at, tone: 'ok' })
+  }
+  return rows
+}
+
+function TaskEvidenceLedger({ rows }: { rows: readonly TaskEvidenceLedgerRow[] }) {
+  if (rows.length === 0) return null
+
+  return html`
+    <div
+      class="wk-evidence"
+      data-testid="task-evidence-ledger"
+      data-task-evidence-row-count=${rows.length}
+    >
+      <div class="wk-evidence-h">실행 · 계약 · 증거 링크</div>
+      <div class="wk-evidence-rows">
+        ${rows.map(row => html`
+          <div key=${row.key} class=${`wk-evidence-row ${row.tone ?? ''}`}>
+            <span class="wk-evidence-k mono">${row.label}</span>
+            <span class="wk-evidence-v mono">${row.value}</span>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+function verificationSourceForGoal(node: GoalTreeNode): 'open_request' | 'latest_request' | 'policy' | 'none' {
+  if (node.active_verification_request || node.verification_summary.open_request) return 'open_request'
+  if (node.verification_summary.latest_request) return 'latest_request'
+  if (node.effective_verifier_policy || node.verification_summary.effective_policy) return 'policy'
+  return 'none'
+}
+
+function hasGoalBlockingEvidence(node: GoalTreeNode): boolean {
+  return node.blocking_source !== 'none'
+    || node.blocking_reason.trim().length > 0
+    || (node.stalled_since ?? '').trim().length > 0
+}
+
+function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined }) {
+  if (!node) return null
+
+  const verification = node.verification_summary
+  const verificationSource = verificationSourceForGoal(node)
+  const verificationRequest =
+    node.active_verification_request
+    ?? verification.open_request
+    ?? verification.latest_request
+    ?? null
+  const verifierPolicy = node.effective_verifier_policy ?? verification.effective_policy ?? null
+  const completion = node.completion_summary ?? null
+  const showBlocking = hasGoalBlockingEvidence(node)
+
+  return html`
+    <div
+      class="wk-dossier"
+      data-testid="goal-dossier"
+      data-goal-dossier=${node.id}
+      data-goal-dossier-fsm-state=${node.goal_fsm.state}
+      data-goal-dossier-verification=${verificationSource}
+      data-goal-dossier-blocking-source=${node.blocking_source}
+      data-goal-dossier-timeline-count=${node.timeline_events.length}
+    >
+      <div class="wk-dossier-row">
+        <span class="wk-dossier-k">FSM</span>
+        <span class="wk-dossier-chip mono">state ${node.goal_fsm.state}</span>
+        <span class="wk-dossier-chip mono">source ${node.goal_fsm.source}</span>
+        <span class="wk-dossier-chip mono">activity ${node.goal_fsm.activity_observation}</span>
+        <span class="wk-dossier-chip mono">stagnation ${node.goal_fsm.stagnation_status}</span>
+      </div>
+
+      ${node.goal_fsm.next_actions.length > 0 ? html`
+        <div class="wk-dossier-row">
+          <span class="wk-dossier-k">next actions</span>
+          ${node.goal_fsm.next_actions.map((action) => html`
+            <span key=${action} class="wk-dossier-chip mono">${action}</span>
+          `)}
+        </div>
+      ` : null}
+
+      <div class="wk-dossier-row">
+        <span class="wk-dossier-k">verification</span>
+        ${verificationRequest ? html`
+          <span class="wk-dossier-chip mono">${verificationSource} ${verificationRequest.id}</span>
+          <span class="wk-dossier-chip mono">status ${verificationRequest.status}</span>
+          <span class="wk-dossier-chip mono">target ${verificationRequest.target_phase}</span>
+        ` : verifierPolicy ? html`
+          <span class="wk-dossier-chip mono">policy ${verifierPolicy.required_verdicts}/${verifierPolicy.principals.length}</span>
+        ` : html`
+          <span class="wk-dossier-chip mono">none</span>
+        `}
+        <span class="wk-dossier-chip mono">approve ${verification.approve_count}</span>
+        <span class="wk-dossier-chip mono">reject ${verification.reject_count}</span>
+        <span class="wk-dossier-chip mono">remaining ${verification.remaining_possible}</span>
+        ${node.pending_verification_count > 0 ? html`
+          <span class="wk-dossier-chip warn mono">pending ${node.pending_verification_count}</span>
+        ` : null}
+      </div>
+
+      ${completion ? html`
+        <div class="wk-dossier-row">
+          <span class="wk-dossier-k">completion</span>
+          <span class="wk-dossier-chip mono">state ${completion.state}</span>
+          <span class="wk-dossier-chip mono">gate ${completion.gate}</span>
+          <span class="wk-dossier-chip mono">tasks ${completion.task_done}/${completion.task_total}</span>
+          <span class="wk-dossier-chip mono">pct ${completion.pct == null ? 'unmeasured' : `${completion.pct}%`}</span>
+          ${completion.ready_to_request_completion ? html`
+            <span class="wk-dossier-chip ok mono">ready to request</span>
+          ` : null}
+          ${completion.active_verification_request ? html`
+            <span class="wk-dossier-chip warn mono">active verification</span>
+          ` : null}
+        </div>
+      ` : null}
+
+      <div class="wk-dossier-row">
+        <span class="wk-dossier-k">activity</span>
+        ${node.last_activity_at ? html`
+          <span class="wk-dossier-chip mono">last ${node.last_activity_at}</span>
+        ` : html`
+          <span class="wk-dossier-chip mono">last unavailable</span>
+        `}
+        <span class="wk-dossier-chip mono">events ${node.timeline_events.length}</span>
+        <span class="wk-dossier-chip mono">stagnation ${node.stagnation_seconds}s</span>
+        ${node.latest_keeper_ref ? html`<span class="wk-dossier-chip mono">keeper ${node.latest_keeper_ref}</span>` : null}
+        ${node.latest_turn_ref != null ? html`<span class="wk-dossier-chip mono">turn ${node.latest_turn_ref}</span>` : null}
+        ${node.linked_keeper_names.map((name) => html`
+          <span key=${name} class="wk-dossier-chip mono">linked ${name}</span>
+        `)}
+        ${node.pending_approval_count > 0 ? html`
+          <span class="wk-dossier-chip warn mono">approvals ${node.pending_approval_count}</span>
+        ` : null}
+        ${node.infra_risk_count > 0 ? html`
+          <span class="wk-dossier-chip bad mono">infra risk ${node.infra_risk_count}</span>
+        ` : null}
+      </div>
+
+      ${showBlocking ? html`
+        <div class="wk-dossier-row">
+          <span class="wk-dossier-k">blocking</span>
+          <span class="wk-dossier-chip bad mono">source ${node.blocking_source}</span>
+          ${node.blocking_reason ? html`<span class="wk-dossier-text">${node.blocking_reason}</span>` : null}
+          ${node.stalled_since ? html`<span class="wk-dossier-chip warn mono">stalled ${node.stalled_since}</span>` : null}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void }) {
   const state = jobStateForTask(task)
   const keeper = keeperByName(task.assignee)
   const blocker = blockerNoteForTask(task)
   const gateRows = taskGateRows(task)
   const handoff = task.handoff_context
-  const hasDetail = gateRows.length > 0 || !!handoff?.summary || !!handoff?.next_step || !!handoff?.failure_mode
+  const evidenceRows = taskEvidenceLedgerRows(task)
+  const hasDetail =
+    gateRows.length > 0
+    || evidenceRows.length > 0
+    || !!handoff?.summary
+    || !!handoff?.next_step
+    || !!handoff?.failure_mode
   const [open, setOpen] = useState(false)
 
   const toggle = () => {
@@ -411,6 +662,7 @@ function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void 
       ${open && hasDetail ? html`
         <div class="wk-task-detail">
           ${gateRows.length > 0 ? html`<${TaskGate} rows=${gateRows} />` : null}
+          ${evidenceRows.length > 0 ? html`<${TaskEvidenceLedger} rows=${evidenceRows} />` : null}
           ${handoff ? html`
             <div class="wk-handoff">
               <div class="wk-handoff-h">핸드오프 컨텍스트</div>
@@ -431,12 +683,14 @@ function GoalCard({
   onToggle,
   goalTasks,
   onClaim,
+  goalNode,
 }: {
   goal: Goal
   open: boolean
   onToggle: () => void
   goalTasks: Task[]
   onClaim: (id: string) => void
+  goalNode?: GoalTreeNode | null
 }) {
   const progress = goalProgressCounts(goalTasks)
   const leadName = leadNameForGoal(goal)
@@ -477,6 +731,7 @@ function GoalCard({
       ${open ? html`
         <div class="wk-jobs">
           ${goal.last_review_note ? html`<div class="wk-note">${goal.last_review_note}</div>` : null}
+          <${GoalProjectionDossier} node=${goalNode} />
           ${goal.require_completion_approval && goal.verifier_policy?.principals.length ? html`
             <div class="wk-verifier">
               완료 승인 정책 · 검증자
@@ -780,7 +1035,7 @@ function KanbanView({
         <span class="wk-sec-glyph" aria-hidden="true">▦</span>
         <span class="wk-sec-t">칸반 · 상태별</span>
         <span class="wk-sec-n mono">${total}</span>
-        <span class="wk-sec-sub mono">todo → claimed → in_progress → verify → done</span>
+        <span class="wk-sec-sub mono">todo → claimed → in_progress → verify → blocked/paused/unknown → done</span>
       </div>
       <div class="wk-kanban" data-testid="work-kanban">
         ${KANBAN_COLUMNS.map(([status, label, cls]) => {
@@ -1093,6 +1348,17 @@ function WorkSurfaceV2() {
     () => flattenGoalTreeNodes(goalTreeSnapshot?.tree ?? []),
     [goalTreeSnapshot],
   )
+  const goalTreeNodeById = useMemo(() => {
+    const map = new Map<string, GoalTreeNode>()
+    for (const node of treeGoals) map.set(node.id, node)
+    return map
+  }, [treeGoals])
+  const displayGoals = useMemo(() => {
+    const map = new Map<string, Goal>()
+    for (const node of treeGoals) map.set(node.id, goalFromGoalTreeNode(node))
+    for (const goal of goalList) map.set(goal.id, goal)
+    return Array.from(map.values())
+  }, [goalList, treeGoals])
 
   const [view, setView] = useState<WorkView>(readStoredWorkView)
   const [openSet, setOpenSet] = useState<Set<string>>(new Set())
@@ -1101,7 +1367,7 @@ function WorkSurfaceV2() {
   useEffect(() => {
     setOpenSet(prev => {
       const next = new Set(prev)
-      for (const g of goalList) {
+      for (const g of displayGoals) {
         const progress = goalProgressCounts(allTasks.filter(t => t.goal_id === g.id))
         // Prototype auto-expands attention goals (priority >= 7 || at_risk ||
         // verifying, work.jsx:138). The live priority scale (1=top vs 9=top)
@@ -1112,7 +1378,7 @@ function WorkSurfaceV2() {
       }
       return next
     })
-  }, [goalList, allTasks])
+  }, [displayGoals, allTasks])
 
   const claimTask = (taskId: string) => {
     setClaimed(prev => {
@@ -1156,7 +1422,7 @@ function WorkSurfaceV2() {
 
   const tasksByGoalId = useMemo(() => {
     const map = new Map<string, Task[]>()
-    for (const g of goalList) map.set(g.id, [])
+    for (const g of displayGoals) map.set(g.id, [])
     for (const g of treeGoals) {
       if (!map.has(g.id)) map.set(g.id, [])
     }
@@ -1167,7 +1433,7 @@ function WorkSurfaceV2() {
       }
     }
     return map
-  }, [goalList, treeGoals, claimedTasks])
+  }, [displayGoals, treeGoals, claimedTasks])
 
   const backlogTasks = useMemo(() => {
     return claimedTasks
@@ -1424,9 +1690,9 @@ function WorkSurfaceV2() {
 
           ${view === 'list'
             ? /* RFC-0294: flat priority-sorted list replaces horizon grouping */
-              goalList.length > 0 ? html`
+              displayGoals.length > 0 ? html`
                 <div class="wk-list" data-testid="work-goal-list">
-                  ${[...goalList]
+                  ${[...displayGoals]
                     .sort((a, b) => (a.priority ?? GOAL_PRIORITY_MAX) - (b.priority ?? GOAL_PRIORITY_MAX) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
                     .map(g => html`
                     <${GoalCard}
@@ -1436,6 +1702,7 @@ function WorkSurfaceV2() {
                       onToggle=${() => toggleGoal(g.id)}
                       goalTasks=${tasksByGoalId.get(g.id) ?? []}
                       onClaim=${claimTask}
+                      goalNode=${goalTreeNodeById.get(g.id) ?? null}
                     />
                   `)}
                 </div>

--- a/dashboard/src/lib/core-parsers.ts
+++ b/dashboard/src/lib/core-parsers.ts
@@ -27,6 +27,9 @@ export const TASK_STATUS_VALUES = [
   'awaiting_verification',
   'done',
   'cancelled',
+  'blocked',
+  'paused',
+  'unknown',
 ] as const satisfies ReadonlyArray<TaskStatus>
 export type _TaskStatusComplete = NoMissingVariant<
   Exclude<TaskStatus, (typeof TASK_STATUS_VALUES)[number]>

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -166,6 +166,62 @@ describe('normalizeTaskStatus', () => {
       status: 'done',
     })
   })
+
+  it('preserves task gate snapshots from execution task payloads', () => {
+    expect(normalizeTask({
+      id: 'task-gate',
+      title: 'Execution task with gate',
+      status: 'awaiting_verification',
+      gate: {
+        strict: true,
+        completion_contract: ['unit tests pass'],
+        unmet_completion_contract: ['manual approval'],
+        done: {
+          status: 'blocked',
+          checks: [
+            { evidence: 'unit tests pass', outcome: 'satisfied', detail: 'vitest green' },
+            { evidence: 'manual approval', outcome: 'missing', detail: 'operator pending' },
+          ],
+          reasons: ['operator approval pending'],
+        },
+        inspect_to_implement: {
+          status: 'inconclusive',
+          checks: [
+            { evidence: 'diff review', outcome: 'unsupported', detail: 'not collected' },
+          ],
+        },
+        verify_to_review: {
+          status: 'not-a-known-status',
+          reasons: ['backend drift fixture'],
+        },
+      },
+    })).toMatchObject({
+      gate: {
+        strict: true,
+        completion_contract: ['unit tests pass'],
+        unmet_completion_contract: ['manual approval'],
+        done: {
+          status: 'blocked',
+          checks: [
+            { evidence: 'unit tests pass', outcome: 'satisfied', detail: 'vitest green' },
+            { evidence: 'manual approval', outcome: 'missing', detail: 'operator pending' },
+          ],
+          reasons: ['operator approval pending'],
+        },
+        inspect_to_implement: {
+          status: 'inconclusive',
+          checks: [
+            { evidence: 'diff review', outcome: 'unsupported', detail: 'not collected' },
+          ],
+        },
+        verify_to_review: {
+          status: 'unknown',
+          status_raw: 'not-a-known-status',
+          reasons: ['unknown gate status: not-a-known-status', 'backend drift fixture'],
+        },
+      },
+    })
+  })
 })
 
 describe('normalizeMessage', () => {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -1,4 +1,4 @@
-import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
+import { isRecord, asString, asNumber, asBoolean, asStringArray, asRecordArray, toIsoTimestamp } from './components/common/normalize'
 import {
   parseTaskStatus,
   parseExecutionTone,
@@ -9,7 +9,7 @@ import { normalizeKeeperTrust } from './keeper-store-normalize'
 import { normalizeStopCause } from './lib/stop-cause'
 import { parseAgentStatus } from './lib/agent-status'
 import type {
-  Agent, Task, Message, ServerStatus,
+  Agent, Task, TaskGateEvaluation, Message, ServerStatus,
   DashboardExecutionSummary, DashboardExecutionHandoff,
   DashboardExecutionQueueItem, DashboardExecutionSessionBrief,
   DashboardExecutionWorkerSupportBrief,
@@ -54,6 +54,79 @@ export function normalizeAgentStatus(value: unknown): Agent['status'] {
 
 export function normalizeTaskStatus(value: unknown): Task['status'] {
   return parseTaskStatus(value)
+}
+
+function normalizeTaskGateStatus(value: unknown): {
+  readonly status: TaskGateEvaluation['status']
+  readonly raw: string | null
+} {
+  const raw = asString(value)?.trim() ?? null
+  if (raw === 'ready' || raw === 'blocked' || raw === 'inconclusive') {
+    return { status: raw, raw: null }
+  }
+  return { status: 'unknown', raw }
+}
+
+function normalizeTaskGateCheckOutcome(value: unknown): 'satisfied' | 'missing' | 'failed' | 'unsupported' | null {
+  const raw = asString(value)?.trim()
+  if (raw === 'satisfied' || raw === 'missing' || raw === 'failed' || raw === 'unsupported') return raw
+  return null
+}
+
+function normalizeTaskGateCheck(raw: unknown): NonNullable<TaskGateEvaluation['checks']>[number] | null {
+  if (!isRecord(raw)) return null
+  const outcome = normalizeTaskGateCheckOutcome(raw.outcome)
+  if (!outcome) return null
+  const evidence = asString(raw.evidence, '')
+  const detail = asString(raw.detail, '')
+  if (!evidence && !detail) return null
+  return { evidence, outcome, detail }
+}
+
+function normalizeTaskGateEvaluation(raw: unknown): TaskGateEvaluation | null {
+  if (!isRecord(raw)) return null
+  const statusInput = asString(raw.status)
+  const { status, raw: statusRaw } = normalizeTaskGateStatus(raw.status)
+  const checks = asRecordArray(raw.checks)
+    .map(normalizeTaskGateCheck)
+    .filter((check): check is NonNullable<TaskGateEvaluation['checks']>[number] => check !== null)
+  const reasons = asStringArray(raw.reasons)
+  if (statusRaw) reasons.unshift(`unknown gate status: ${statusRaw}`)
+  if (!statusInput && checks.length === 0 && reasons.length === 0) return null
+  return {
+    status,
+    status_raw: statusRaw,
+    checks,
+    reasons,
+  }
+}
+
+function normalizeTaskGateSnapshot(raw: unknown): Task['gate'] {
+  if (!isRecord(raw)) return null
+  const done = normalizeTaskGateEvaluation(raw.done)
+  const inspect = normalizeTaskGateEvaluation(raw.inspect_to_implement)
+  const verify = normalizeTaskGateEvaluation(raw.verify_to_review)
+  const completionContract = asStringArray(raw.completion_contract)
+  const unmetCompletionContract = asStringArray(raw.unmet_completion_contract)
+  const strict = asBoolean(raw.strict)
+  if (
+    done === null
+    && inspect === null
+    && verify === null
+    && completionContract.length === 0
+    && unmetCompletionContract.length === 0
+    && strict === undefined
+  ) {
+    return null
+  }
+  return {
+    strict,
+    completion_contract: completionContract,
+    unmet_completion_contract: unmetCompletionContract,
+    done: done ?? undefined,
+    inspect_to_implement: inspect,
+    verify_to_review: verify,
+  }
 }
 
 export function normalizeAgent(raw: unknown): Agent | null {
@@ -117,11 +190,13 @@ export function normalizeTask(raw: unknown): Task | null {
         session_id: asString(raw.execution_links.session_id) ?? null,
       }
     : null
+  const gate = normalizeTaskGateSnapshot(raw.gate)
   return {
     id,
     title,
     goal_id: asString(raw.goal_id) ?? null,
     status: normalizeTaskStatus(raw.status),
+    status_raw: asString(raw.status_raw) ?? null,
     priority: asNumber(raw.priority),
     assignee: asString(raw.assignee),
     assignee_kind: asString(raw.assignee_kind) ?? null,
@@ -131,6 +206,7 @@ export function normalizeTask(raw: unknown): Task | null {
     completed_at: asString(raw.completed_at),
     contract,
     handoff_context: handoffContext,
+    gate,
     execution_links: executionLinks,
   }
 }

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -37,14 +37,15 @@
 /* routing lanes */
 .rt-lane { display: flex; align-items: center; flex-wrap: wrap; gap: 10px 16px; padding: 14px 0; border-top: 1px solid var(--border-soft); }
 .rt-lane:first-of-type { border-top: 0; }
-.rt-lane-l { flex: 1 1 140px; min-width: 0; }
+.rt-lane-l { flex: 1 1 140px; min-width: 0; overflow-wrap: anywhere; }
 .rt-lane-lbl { font-size: var(--fs-13); color: var(--text-primary); }
-.rt-lane-hint { font-size: var(--fs-11); color: var(--text-dim); margin-top: 3px; }
+.rt-lane-hint { font-size: var(--fs-11); color: var(--text-dim); margin-top: 3px; overflow-wrap: anywhere; }
 .rt-lane-c { display: flex; align-items: center; gap: 10px; flex: 1 1 200px; min-width: 0; }
-.rt-select { background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 10px; color: var(--text-bright); font-size: var(--fs-12); cursor: pointer; min-width: 0; width: 100%; max-width: 320px; }
+.rt-select { background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 10px; color: var(--text-bright); font-size: var(--fs-12); cursor: pointer; min-width: 0; width: 100%; max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .rt-select:focus { outline: none; border-color: var(--volt-dim); }
-.rt-warn { font-size: var(--fs-11); color: var(--status-bad); white-space: nowrap; }
-.rt-ok { font-size: var(--fs-11); color: var(--status-ok); white-space: nowrap; }
+.rt-warn { font-size: var(--fs-11); color: var(--status-bad); overflow-wrap: anywhere; }
+.rt-ok { font-size: var(--fs-11); color: var(--status-ok); overflow-wrap: anywhere; }
+.rt-unknown { font-size: var(--fs-11); color: var(--status-warn); overflow-wrap: anywhere; }
 
 /* provider cards */
 .rt-cards { display: flex; flex-direction: column; gap: 12px; }

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -50,6 +50,43 @@
 .sch-payload-row { border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-sunken); color: var(--text-mid); cursor: pointer; font-size: var(--fs-10); padding: 2px 8px; }
 .sch-payload-row:hover { border-color: var(--volt-dim); color: var(--volt); }
 
+/* ── cadence axis ── */
+.sch-cad { display: inline-flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.02em; padding: 1px 8px; border-radius: var(--radius-pill); white-space: nowrap; color: var(--tone, var(--text-dim)); border: 1px solid color-mix(in oklab, var(--tone, var(--text-dim)) 34%, transparent); background: color-mix(in oklab, var(--tone, var(--text-dim)) 9%, transparent); }
+.sch-cad.ok { --tone: var(--status-ok); }
+.sch-cad.info { --tone: var(--info); }
+.sch-cad.volt { --tone: var(--volt-strong); }
+.sch-cad.warn { --tone: var(--status-warn); }
+.sch-cad.dim { --tone: var(--text-dim); }
+.sch-cadsum { display: flex; gap: 8px; flex-wrap: wrap; margin: 14px 0 12px; }
+.sch-cadsum-i { display: inline-flex; align-items: center; gap: 7px; padding: 5px 12px 5px 10px; border-radius: var(--radius-sm); border: 1px solid color-mix(in oklab, var(--tone) 28%, transparent); background: color-mix(in oklab, var(--tone) 6%, transparent); color: var(--text-mid); cursor: pointer; transition: 0.14s; --tone: var(--text-dim); }
+.sch-cadsum-i.ok { --tone: var(--status-ok); }
+.sch-cadsum-i.info { --tone: var(--info); }
+.sch-cadsum-i.volt { --tone: var(--volt-strong); }
+.sch-cadsum-i.warn { --tone: var(--status-warn); }
+.sch-cadsum-i.dim { --tone: var(--text-dim); }
+.sch-cadsum-i:hover { border-color: color-mix(in oklab, var(--tone) 55%, transparent); }
+.sch-cadsum-i.on { background: color-mix(in oklab, var(--tone) 15%, transparent); border-color: var(--tone); color: var(--text-bright); }
+.sch-cadsum-i.off { opacity: 0.5; }
+.sch-cadsum-gl { color: var(--tone); font-size: var(--fs-12); }
+.sch-cadsum-n { font-size: var(--fs-13); color: var(--tone); }
+.sch-cadsum-l { font-size: var(--fs-11); }
+.sch-poll { margin: 0 0 14px; padding: 14px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: color-mix(in oklab, var(--volt-strong) 4%, var(--bg-card)); }
+.sch-poll-h { display: flex; align-items: baseline; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; }
+.sch-poll-sub { font-size: var(--fs-11); color: var(--text-dim); }
+.sch-poll-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
+.sch-poll-card { text-align: left; display: flex; flex-direction: column; gap: 8px; padding: 11px 12px; border: 1px solid var(--border-main); border-left: 3px solid var(--tone, var(--volt-strong)); border-radius: var(--radius-sm); background: var(--bg-card); cursor: pointer; transition: 0.14s; --tone: var(--border-highlight); }
+.sch-poll-card.st-ok { --tone: var(--status-ok); }
+.sch-poll-card.st-warn { --tone: var(--status-warn); }
+.sch-poll-card.st-bad { --tone: var(--status-bad); }
+.sch-poll-card.st-info { --tone: var(--info); }
+.sch-poll-card.st-dim { --tone: var(--border-highlight); }
+.sch-poll-card:hover { border-color: var(--border-highlight); border-left-color: var(--tone); }
+.sch-poll-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.sch-poll-int { font-size: var(--fs-11); color: var(--volt-strong); }
+.sch-poll-title { font-size: 12.5px; line-height: 1.45; color: var(--text-primary); text-wrap: pretty; }
+.sch-poll-foot { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.sch-poll-next { margin-left: auto; font-size: 10.5px; color: var(--text-dim); }
+
 /* ── schedule cards ── */
 .sch-list { display: flex; flex-direction: column; gap: 11px; }
 .sch-card { display: flex; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-card); overflow: hidden; }
@@ -91,6 +128,10 @@
 .sch-due { display: inline-flex; align-items: baseline; gap: 4px; color: var(--text-mid); }
 .sch-need { color: var(--status-warn); }
 .sch-grant { color: var(--status-ok); }
+.sch-wake-evidence { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--border-soft); color: var(--text-dim); font-size: var(--fs-11); }
+.sch-wake-title { flex: none; font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+.sch-wake-item { display: inline-flex; align-items: center; gap: 5px; min-width: 0; color: var(--text-mid); white-space: nowrap; }
+.sch-wake-join { overflow: hidden; min-width: 0; max-width: 100%; text-overflow: ellipsis; color: var(--text-dim); }
 
 .sch-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 13px; }
 .sch-act { font-family: var(--font-ui); font-size: var(--fs-12); padding: 6px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.16s; }

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -201,25 +201,28 @@ html[data-skin="v2"] .rt-input:focus { outline: none; border-color: var(--volt-d
 html[data-skin="v2"] .rt-lane {
   display: flex;
   align-items: center;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 10px 16px;
   padding: 14px 0;
   border-top: 1px solid var(--border-soft);
 }
 html[data-skin="v2"] .rt-lane:first-of-type { border-top: 0; } /* runtime.css:38 */
-html[data-skin="v2"] .rt-lane-l { flex: 1; min-width: 0; } /* runtime.css:39 */
+html[data-skin="v2"] .rt-lane-l { flex: 1 1 140px; min-width: 0; overflow-wrap: anywhere; } /* runtime.css:39 */
 html[data-skin="v2"] .rt-lane-lbl { font-size: var(--fs-13); color: var(--text-primary); } /* runtime.css:40 */
 html[data-skin="v2"] .rt-lane-hint {
   /* runtime.css:41 */
   font-size: var(--fs-11);
   color: var(--text-dim);
   margin-top: 3px;
+  overflow-wrap: anywhere;
 }
 html[data-skin="v2"] .rt-lane-c {
   /* runtime.css:42 */
   display: flex;
   align-items: center;
   gap: 10px;
-  flex: none;
+  flex: 1 1 200px;
+  min-width: 0;
 }
 html[data-skin="v2"] .rt-select {
   /* runtime.css:43 */
@@ -230,11 +233,17 @@ html[data-skin="v2"] .rt-select {
   color: var(--text-bright);
   font-size: var(--fs-12);
   cursor: pointer;
-  min-width: 248px;
+  min-width: 0;
+  width: 100%;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 html[data-skin="v2"] .rt-select:focus { outline: none; border-color: var(--volt-dim); } /* runtime.css:44 */
-html[data-skin="v2"] .rt-warn { font-size: var(--fs-11); color: var(--status-bad); white-space: nowrap; } /* runtime.css:45 */
-html[data-skin="v2"] .rt-ok { font-size: var(--fs-11); color: var(--status-ok); white-space: nowrap; } /* runtime.css:46 */
+html[data-skin="v2"] .rt-warn { font-size: var(--fs-11); color: var(--status-bad); overflow-wrap: anywhere; } /* runtime.css:45 */
+html[data-skin="v2"] .rt-ok { font-size: var(--fs-11); color: var(--status-ok); overflow-wrap: anywhere; } /* runtime.css:46 */
+html[data-skin="v2"] .rt-unknown { font-size: var(--fs-11); color: var(--status-warn); overflow-wrap: anywhere; }
 
 /* provider cards — runtime.css:49 */
 html[data-skin="v2"] .rt-cards { display: flex; flex-direction: column; gap: 12px; }
@@ -536,5 +545,5 @@ html[data-skin="v2"] .set-card-b-wide .rt-shell {
   html[data-skin="v2"] .rt-nav { flex-direction: row; overflow-x: auto; }
   html[data-skin="v2"] .rt-nav-h,
   html[data-skin="v2"] .rt-nav-foot { display: none; }
-  html[data-skin="v2"] .rt-select { min-width: 160px; }
+  html[data-skin="v2"] .rt-select { min-width: 0; }
 }

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -251,6 +251,8 @@
 .wk-seg.verify { background: var(--volt-strong); }
 .wk-seg.wip { background: var(--volt); }
 .wk-seg.blocked { background: var(--status-bad); }
+.wk-seg.paused { background: var(--status-warn); }
+.wk-seg.unknown { background: var(--text-dim); }
 
 .wk-prog-lbl {
   flex: none;
@@ -283,6 +285,69 @@
   padding: 2px 0 10px;
   border-bottom: 1px dashed var(--border-soft);
   margin-bottom: 8px;
+}
+
+.wk-dossier {
+  display: grid;
+  gap: 6px;
+  padding: 2px 0 10px;
+  border-bottom: 1px dashed var(--border-soft);
+  margin-bottom: 8px;
+}
+
+.wk-dossier-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.wk-dossier-k {
+  flex: 0 0 78px;
+  font-size: var(--fs-10);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.wk-dossier-chip {
+  max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: var(--fs-10);
+  color: var(--text-mid);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs);
+  padding: 1px 6px;
+  background: var(--surface-1);
+}
+
+.wk-dossier-chip.ok {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 30%, transparent);
+  background: color-mix(in oklab, var(--status-ok) 8%, transparent);
+}
+
+.wk-dossier-chip.warn {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 32%, transparent);
+  background: color-mix(in oklab, var(--status-warn) 9%, transparent);
+}
+
+.wk-dossier-chip.bad {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 32%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 8%, transparent);
+}
+
+.wk-dossier-text {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  font-size: var(--fs-11);
+  color: var(--text-mid);
+  line-height: 1.4;
 }
 
 .wk-verifier {
@@ -424,6 +489,8 @@
 .wk-task-dot.wip { background: var(--volt); }
 .wk-task-dot.review { background: var(--status-warn); }
 .wk-task-dot.blocked { background: var(--status-bad); }
+.wk-task-dot.paused { background: var(--status-warn); }
+.wk-task-dot.unknown { background: var(--text-dim); }
 
 .wk-task-id {
   flex: none;
@@ -470,6 +537,8 @@
 .wk-task-state.wip { color: var(--volt-strong); }
 .wk-task-state.review { color: var(--status-warn); }
 .wk-task-state.blocked { color: var(--status-bad); }
+.wk-task-state.paused { color: var(--status-warn); }
+.wk-task-state.unknown { color: var(--text-dim); }
 
 .wk-task-kp {
   flex: none;
@@ -645,6 +714,64 @@
   text-transform: uppercase;
   color: var(--text-dim);
   min-width: 36px;
+}
+
+.wk-evidence {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+}
+
+.wk-evidence-h {
+  font-size: var(--fs-10);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.wk-evidence-rows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.wk-evidence-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 3px 7px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-soft);
+  background: var(--bg-panel);
+  color: var(--text-mid);
+  font-size: var(--fs-11);
+}
+
+.wk-evidence-row.ok {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 30%, transparent);
+}
+
+.wk-evidence-row.warn {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 30%, transparent);
+}
+
+.wk-evidence-k {
+  flex: none;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.wk-evidence-v {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* ── Footer / new goal button ─────────────────────────────────────────────── */
@@ -1550,6 +1677,9 @@
 .wk-kcol-dot.claimed { background: var(--color-fg-muted); }
 .wk-kcol-dot.wip { background: var(--volt-strong); }
 .wk-kcol-dot.verify { background: var(--color-status-info, var(--color-info)); }
+.wk-kcol-dot.blocked { background: var(--color-status-err, var(--status-bad)); }
+.wk-kcol-dot.paused { background: var(--color-status-warn, var(--status-warn)); }
+.wk-kcol-dot.unknown { background: var(--color-fg-disabled); }
 .wk-kcol-dot.done { background: var(--color-status-ok); }
 
 .wk-kcol-title {
@@ -1604,6 +1734,9 @@
 .wk-kcard.claimed { border-left-color: var(--color-fg-muted); }
 .wk-kcard.wip { border-left-color: var(--volt-strong); }
 .wk-kcard.verify { border-left-color: var(--color-status-info, var(--color-info)); }
+.wk-kcard.blocked { border-left-color: var(--color-status-err, var(--status-bad)); }
+.wk-kcard.paused { border-left-color: var(--color-status-warn, var(--status-warn)); }
+.wk-kcard.unknown { border-left-color: var(--color-fg-disabled); }
 .wk-kcard.done {
   border-left-color: var(--color-status-ok);
   opacity: 0.86;

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -53,7 +53,8 @@ export interface Task {
   id: string
   title: string
   goal_id?: string | null
-  status?: 'todo' | 'in_progress' | 'claimed' | 'awaiting_verification' | 'done' | 'cancelled'
+  status?: 'todo' | 'in_progress' | 'claimed' | 'awaiting_verification' | 'done' | 'cancelled' | 'blocked' | 'paused' | 'unknown'
+  status_raw?: string | null
   priority?: number
   assignee?: string
   assignee_kind?: string | null
@@ -98,7 +99,8 @@ interface TaskGateCheck {
 }
 
 export interface TaskGateEvaluation {
-  status: 'ready' | 'blocked' | 'inconclusive'
+  status: 'ready' | 'blocked' | 'inconclusive' | 'unknown'
+  status_raw?: string | null
   checks?: TaskGateCheck[]
   reasons?: string[]
 }

--- a/reports/dashboard-v2-reference-gap-matrix-2026-07-07.html
+++ b/reports/dashboard-v2-reference-gap-matrix-2026-07-07.html
@@ -1,0 +1,424 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MASC Dashboard v2 Reference Gap Matrix - 2026-07-07</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #101113;
+      --panel: #17191d;
+      --panel-2: #1f2228;
+      --line: #343944;
+      --line-2: #46505f;
+      --text: #eef1f5;
+      --muted: #a7afba;
+      --soft: #d1d6de;
+      --green: #7ddc9a;
+      --amber: #f0c36a;
+      --red: #ff8d8d;
+      --blue: #88b8ff;
+      --violet: #bba1ff;
+      --cyan: #7ed6dc;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { max-width: 1480px; margin: 0 auto; padding: 28px 22px 48px; }
+    header {
+      border: 1px solid var(--line);
+      background: linear-gradient(180deg, #1a1d23, #14161a);
+      border-radius: 8px;
+      padding: 22px;
+    }
+    h1 { margin: 0; font-size: 25px; letter-spacing: 0; }
+    h2 { margin: 28px 0 12px; font-size: 18px; letter-spacing: 0; }
+    h3 { margin: 0 0 8px; font-size: 15px; letter-spacing: 0; }
+    p { margin: 8px 0; }
+    code, .mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      font-size: 12px;
+    }
+    code {
+      color: #e8eefb;
+      background: #20242c;
+      border: 1px solid #343b47;
+      border-radius: 4px;
+      padding: 1px 5px;
+      white-space: nowrap;
+    }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border: 1px solid var(--line);
+      background: #20242b;
+      border-radius: 999px;
+      padding: 4px 9px;
+    }
+    .grid { display: grid; gap: 12px; }
+    .grid.cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .grid.cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .card {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .card strong { color: var(--soft); }
+    .note {
+      border: 1px solid #5a4d2a;
+      background: #211c13;
+      border-radius: 8px;
+      padding: 12px 14px;
+      color: #f4dfaa;
+    }
+    .danger {
+      border-color: #6f3737;
+      background: #251819;
+      color: #ffd1d1;
+    }
+    .ok { color: var(--green); }
+    .warn { color: var(--amber); }
+    .bad { color: var(--red); }
+    .info { color: var(--blue); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    th, td {
+      border-bottom: 1px solid var(--line);
+      border-right: 1px solid var(--line);
+      padding: 10px;
+      vertical-align: top;
+    }
+    th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background: #20242b;
+      color: #f5f7fb;
+      text-align: left;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+    td { color: #dfe3ea; }
+    tr:last-child td { border-bottom: 0; }
+    th:last-child, td:last-child { border-right: 0; }
+    .id { width: 52px; color: var(--cyan); font-weight: 700; }
+    .surface { min-width: 155px; font-weight: 700; color: #f0f4fa; }
+    .risk { min-width: 265px; }
+    .slice { min-width: 260px; }
+    .score { width: 88px; text-align: center; }
+    .pct {
+      display: inline-flex;
+      min-width: 54px;
+      justify-content: center;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-weight: 700;
+      background: #222831;
+    }
+    .sev {
+      display: inline-flex;
+      border-radius: 4px;
+      border: 1px solid var(--line);
+      padding: 1px 6px;
+      margin-bottom: 5px;
+      font-size: 11px;
+      font-weight: 700;
+    }
+    .sev.p0 { color: #ffd5d5; border-color: #844545; background: #2a1717; }
+    .sev.p1 { color: #ffe9b8; border-color: #725b2b; background: #261f12; }
+    .sev.p2 { color: #cfe5ff; border-color: #3d587a; background: #172033; }
+    .sev.p3 { color: #d8d1ff; border-color: #5a4c85; background: #211c31; }
+    ul, ol { margin: 8px 0 0; padding-left: 18px; }
+    li { margin: 5px 0; }
+    .ledger {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .ledger .card { min-height: 100%; }
+    .evidence-list li { margin: 6px 0; }
+    .small { font-size: 12px; color: var(--muted); }
+    @media (max-width: 1000px) {
+      .grid.cols-4, .grid.cols-3, .ledger { grid-template-columns: 1fr; }
+      main { padding: 18px 12px 36px; }
+      table { font-size: 12px; }
+      th, td { padding: 8px; }
+      code { white-space: normal; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>MASC Dashboard v2 Reference Gap Matrix</h1>
+      <p>
+        최신 기준은 <code>/Users/dancer/Downloads/v2 (29)</code>의 <code>keeper-v2/*.jsx</code> 소스 번들이다.
+        이 문서는 레퍼런스 의도를 현재 <code>~/me/workspace/yousleepwhen/masc/dashboard</code> 구현과 대조해
+        PR로 쪼갤 수 있는 미비점만 증거 기반으로 정리한다.
+      </p>
+      <div class="meta">
+        <span class="pill">작성일 2026-07-07</span>
+        <span class="pill">대상 MASC dashboard</span>
+        <span class="pill">OAS 경계: MASC -> OAS 단방향만 허용</span>
+        <span class="pill">dune build: CI 권한</span>
+      </div>
+    </header>
+
+    <h2>판독 규칙</h2>
+    <div class="grid cols-4">
+      <div class="card"><strong>레퍼런스 샘플은 truth가 아니다.</strong><br />모델명, 토큰, 비용, fixture transcript는 화면 형태와 데이터 계약의 힌트로만 본다.</div>
+      <div class="card"><strong>Activation %는 완료율이 아니다.</strong><br />현재 증거만으로 해당 PR slice를 바로 시작할 수 있는 준비도다.</div>
+      <div class="card"><strong>판단은 LLM 경계로 둔다.</strong><br />멘션/관련글/wake 판단을 regex, substring, 임의 점수로 확정하지 않는다.</div>
+      <div class="card"><strong>없으면 없음으로 보여준다.</strong><br />빈 문자열, 0, unknown default가 운영 정상처럼 보이면 silent failure로 본다.</div>
+    </div>
+
+    <h2>우선순위 결론</h2>
+    <div class="grid cols-3">
+      <div class="card">
+        <h3>P0 - protocol hardening 먼저</h3>
+        <p>상태를 다른 상태로 접거나, free-form string을 의미판정하거나, 임시 id를 만드는 지점부터 제거한다.</p>
+        <p class="small">대표: task status fallback, fusion decision substring, connector fallback default, attachment Math.random fallback.</p>
+      </div>
+      <div class="card">
+        <h3>P1 - wake evidence</h3>
+        <p>Scheduler/HITL/Board/Connector가 keeper lane을 깨웠다는 durable event와 UI join key가 필요하다.</p>
+        <p class="small">UI가 관측 전용이라고 말하는 지점은 정직하지만, 스펙상 wake plane의 끝은 아니다.</p>
+      </div>
+      <div class="card">
+        <h3>P1 - multimodal transport</h3>
+        <p>Keeper chat은 block 구조가 강하지만 board composer는 attachment/voice를 텍스트로 접는다.</p>
+        <p class="small">Board와 Chat이 같은 multimodal block transport를 공유해야 한다.</p>
+      </div>
+    </div>
+
+    <h2>Goal Matrix</h2>
+    <table>
+      <thead>
+        <tr>
+          <th class="id">ID</th>
+          <th class="surface">Surface</th>
+          <th>Reference evidence</th>
+          <th>Current evidence</th>
+          <th class="risk">Gap / risk</th>
+          <th class="slice">First PR slice</th>
+          <th class="score">Activation</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="id">G01</td>
+          <td class="surface">Keeper chat, turn transcript</td>
+          <td><code>messages.jsx:80-127</code>, <code>messages.jsx:175-203</code>, <code>turn-inspector.jsx:152-194</code></td>
+          <td><code>chat/primitives.ts:1534-1678</code>, <code>chat/primitives.ts:3031-3158</code>, <code>tool-call-output-store.ts:176-205</code>, <code>keeper-turn-inspector.ts:1087-1228</code></td>
+          <td><span class="sev p1">P1</span><br />Interleaving은 강하다. 남은 리스크는 tool output join coverage와 attachment id 안정성이다. <code>tool_use_id</code> 없는 출력은 skip되고, 일부 attachment id는 fallback 생성된다.</td>
+          <td>Turn bundle join coverage badge, unlinked tool output warning, stable block id contract. No timestamp/order heuristic beyond provider sequence.</td>
+          <td class="score"><span class="pct ok">80%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G02</td>
+          <td class="surface">Multimodal composer</td>
+          <td><code>composer.jsx:1-3</code>, <code>composer.jsx:164-171</code>, <code>messages.jsx:96-98</code></td>
+          <td><code>board/composer-v2.ts:151-175</code>, <code>board/composer-v2.ts:326-364</code>, <code>chat/primitives.ts:3976-4008</code>, <code>chat/primitives.ts:4176-4246</code></td>
+          <td><span class="sev p1">P1</span><br />Keeper chat has block transport. Board composer serializes attachment/voice into text and has a fixed voice draft. This violates multimodal parity and can hide missing blob transport.</td>
+          <td>Extract shared <code>ComposerBlocks</code> transport for chat/board, persist attachment ids/content refs, remove fixed voice draft path.</td>
+          <td class="score"><span class="pct warn">52%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G03</td>
+          <td class="surface">Board social workflow</td>
+          <td><code>board.jsx:33-67</code>, <code>board.jsx:69-112</code>, <code>board.jsx:115-186</code></td>
+          <td><code>api/board.ts:887-1083</code>, <code>board/post-detail.ts:78-185</code>, <code>board/reaction-bar.ts:31-83</code>, <code>board/mention-inbox.ts:27-121</code></td>
+          <td><span class="sev p2">P2</span><br />Write/edit/comment/vote/reaction surface is mostly wired. Mention inbox is content-derived UI, not reactive/proactive keeper wake. Emoji set is static UI vocabulary, acceptable only if backend reaction contract is explicit.</td>
+          <td>Board mention/context inference -> LLM wake decision queue with explicit outcome event: ignored, queued, woke, or failed.</td>
+          <td class="score"><span class="pct ok">78%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G04</td>
+          <td class="surface">HITL approvals</td>
+          <td><code>approvals.jsx:24-58</code>, <code>approvals.jsx:60-65</code>, <code>approvals.jsx:134-214</code></td>
+          <td><code>approvals/approvals-surface.ts:1-12</code>, <code>approvals/approvals-surface.ts:165-225</code>, <code>approvals/approvals-surface.ts:228-327</code></td>
+          <td><span class="sev p1">P1</span><br />Current UI honestly omits defer/undo because live endpoint only supports approve/reject/always. Missing piece is the non-blocking path from decision to keeper wake/job queue evidence.</td>
+          <td>Add approval decision receipt and wake/job correlation row. Do not add fake defer UI until endpoint exists.</td>
+          <td class="score"><span class="pct ok">82%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G05</td>
+          <td class="surface">Scheduler wake plane</td>
+          <td><code>schedule.jsx:1-5</code>, <code>schedule.jsx:33-83</code>, <code>schedule.jsx:205-259</code></td>
+          <td><code>schedule/schedule-surface.ts:64-77</code>, <code>tools/scheduled-automation-panel.ts:194-241</code>, <code>tools/scheduled-automation-panel.ts:299-320</code></td>
+          <td><span class="sev p1">P1</span><br />The surface is explicitly observation-only. That is honest, but the spec needs a durable runner signal to keeper lane, plus terminal outcome. UI currently proves visibility, not execution.</td>
+          <td>Backend wake receipt -> dashboard lane event -> schedule detail join. Show supported/blocked/unknown payload state without data-stub wording.</td>
+          <td class="score"><span class="pct warn">60%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G06</td>
+          <td class="surface">Fusion quorum, judges, sink</td>
+          <td><code>fusion.jsx:1-5</code>, <code>fusion.jsx:63-144</code>, <code>fusion.jsx:146-179</code>, <code>fusion.jsx:189-260</code></td>
+          <td><code>api/dashboard-fusion.ts:8-70</code>, <code>fusion/fusion-surface.ts:130-252</code>, <code>fusion/fusion-surface.ts:273-305</code></td>
+          <td><span class="sev p1">P1</span><br />Judge fields and async registry exist. The weak point is mapping free-form decision text by substring, which is exactly the kind of semantic heuristic the project rules reject.</td>
+          <td>Wire typed <code>fusion_decision</code> variant from backend and render only typed arms. Preserve unknown as protocol drift, not failed decision.</td>
+          <td class="score"><span class="pct warn">68%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G07</td>
+          <td class="surface">Goal / Task work graph</td>
+          <td><code>work.jsx:1-9</code>, <code>work.jsx:25-61</code>, <code>work.jsx:63-87</code>, <code>work.jsx:136-227</code></td>
+          <td><code>api/dashboard-goals.ts:151-249</code>, <code>api/dashboard-goals.ts:263-305</code>, <code>work.ts:202-260</code>, <code>work.ts:290-319</code></td>
+          <td><span class="sev p0">P0</span><br /><code>blocked</code>/<code>paused</code> collapse into <code>in_progress</code>, and unknown task status falls back to <code>todo</code>. This can alter operator truth.</td>
+          <td>Introduce typed dashboard task status union with <code>blocked</code>, <code>paused</code>, <code>unknown(raw)</code>. Render protocol warnings instead of remapping.</td>
+          <td class="score"><span class="pct warn">58%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G08</td>
+          <td class="surface">Lane per Keeper, busy/deferred</td>
+          <td><code>data.jsx:12-16</code>, <code>data.jsx:51-85</code>, <code>data.jsx:103-110</code></td>
+          <td><code>keeper-workspace-chat.ts:72-141</code>, <code>keeper-workspace-chat.ts:187-203</code>, <code>keeper-shared.ts:210-254</code></td>
+          <td><span class="sev p1">P1</span><br />Lifecycle actions and queued input rows exist, but the dashboard still needs a first-class per-keeper lane panel: busy now, queued inputs, deferred external messages, wake cause, and next action.</td>
+          <td>Add lane timeline projection per keeper. Every external event must land as seen, queued, replied-busy, woke, or failed.</td>
+          <td class="score"><span class="pct warn">55%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G09</td>
+          <td class="surface">Memory OS / librarian</td>
+          <td><code>memory.jsx:1-6</code>, <code>memory.jsx:28-74</code>, <code>memory.jsx:76-144</code>, <code>memory.jsx:147-232</code></td>
+          <td><code>memory-inspector.ts:1-17</code>, <code>memory-inspector.ts:116-128</code>, <code>memory-inspector.ts:170-206</code>, <code>memory-inspector.ts:475-479</code>, <code>memory-inspector.ts:660-679</code></td>
+          <td><span class="sev p2">P2</span><br />This is one of the better-aligned surfaces: real bytes, typed categories, no salience/uses fabrication. Gap is explicit: compaction keep/summarize/drop diff is Phase 3, and wake/recall causality needs stronger linking.</td>
+          <td>Memory compaction diff view from backend projection, plus wake cause -> recall block -> fact provenance link.</td>
+          <td class="score"><span class="pct ok">72%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G10</td>
+          <td class="surface">Runtime provider/model catalog</td>
+          <td><code>runtime-data.jsx:1-6</code>, <code>runtime-data.jsx:17-38</code>, <code>runtime-data.jsx:40-60</code>, <code>runtime-data.jsx:69-94</code></td>
+          <td><code>api/dashboard-runtime.ts:19-210</code>, <code>api/dashboard-runtime.ts:1044-1141</code>, <code>runtime-panel.ts:136-183</code>, <code>runtime-toml-editor.ts:244-289</code></td>
+          <td><span class="sev p1">P1</span><br />The dashboard has rich runtime contracts and config editing. Do not copy prototype model lists as current truth. Model capability changes require official docs/OAS source verification before implementation.</td>
+          <td>Runtime capability provenance view: declared spec, effective capability, OAS provider source, latest official-doc verification timestamp where applicable.</td>
+          <td class="score"><span class="pct ok">76%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G11</td>
+          <td class="surface">Connectors and context separation</td>
+          <td><code>connectors.jsx:1-3</code>, <code>connectors.jsx:4-75</code>, <code>connectors.jsx:78-194</code>, <code>messages.jsx:149-171</code></td>
+          <td><code>api/schemas/gate-connectors.ts:1-21</code>, <code>api/schemas/gate-connectors.ts:195-238</code>, <code>api/schemas/gate-connectors.ts:298-383</code>, <code>connector-flow.ts:1-8</code>, <code>connector-flow.ts:78-190</code></td>
+          <td><span class="sev p1">P1</span><br />Connector flow and audit are useful. However the schema intentionally returns shaped defaults for missing nested data. That can be okay for partial availability, but the UI must expose partial/missing provenance instead of making empty records look normal.</td>
+          <td>Connector source-health strip per nested object: storage paths, names, runtime summary, binding summary, observed channel. No invisible fallback.</td>
+          <td class="score"><span class="pct warn">62%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G12</td>
+          <td class="surface">Observability / inspector</td>
+          <td><code>turn-inspector.jsx:1-4</code>, <code>turn-inspector.jsx:62-115</code>, <code>turn-inspector.jsx:118-249</code></td>
+          <td><code>dashboard-turn-records.ts:37-69</code>, <code>dashboard-turn-records.ts:101-161</code>, <code>keeper-turn-inspector.ts:41-87</code>, <code>keeper-turn-inspector.ts:1361-1370</code>, <code>observatory.ts:164-202</code></td>
+          <td><span class="sev p2">P2</span><br />Current implementation explicitly avoids fabricated model/cost/duration. Remaining debt: 30-minute timestamp fallback for legacy rows and approximate context token labels. Both are labeled, but should be retired once exact refs are backfilled.</td>
+          <td>Backfill <code>turn_ref</code> on persisted rows, then remove timestamp attribution fallback. Replace approximate context token labels with backend bytes/tokens only.</td>
+          <td class="score"><span class="pct ok">74%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G13</td>
+          <td class="surface">Layout / pixel parity</td>
+          <td><code>fleet.jsx</code>, <code>keeper-v2/*.jsx</code>, <code>keeper-v2/Keeper Agent v2 (standalone).html</code></td>
+          <td><code>dashboard/src/components/**</code>, existing v2 CSS/classes, multiple migrated surfaces</td>
+          <td><span class="sev p3">P3</span><br />Many surfaces are functionally migrated, but the reference bundle is a denser, integrated workspace. Visual parity should be checked after protocol slices, not before data truth.</td>
+          <td>Playwright screenshot loop after functional slices: desktop/mobile, non-overlap, drawer widths, side rails, table density.</td>
+          <td class="score"><span class="pct warn">48%</span></td>
+        </tr>
+        <tr>
+          <td class="id">G14</td>
+          <td class="surface">False-field elimination</td>
+          <td>Prototype explicitly contains fixture-only values in <code>composer.jsx</code>, <code>runtime-data.jsx</code>, <code>turn-inspector.jsx</code>.</td>
+          <td><code>keeper-shared.ts:289-300</code>, <code>board/composer-v2.ts:142-149</code>, <code>fusion/fusion-surface.ts:291-305</code>, <code>work.ts:202-260</code>, <code>gate-connectors.ts:66-70</code></td>
+          <td><span class="sev p0">P0</span><br />Cross-cutting source of future regressions. These are small enough to fix first and unblock stricter review of every later feature.</td>
+          <td>Single hardening PR: stable ids, no fixed draft voice, typed decisions, no status remap, explicit partial-source UI.</td>
+          <td class="score"><span class="pct ok">90%</span></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>PR Slice Order</h2>
+    <ol>
+      <li><strong>P0 protocol hardening:</strong> task status typed union, fusion decision typed wire, stable attachment ids, connector partial-source disclosures.</li>
+      <li><strong>Multimodal block transport:</strong> share chat/board composer block contract and stop serializing rich media into plain body text.</li>
+      <li><strong>Scheduler wake evidence:</strong> durable runner receipt, lane event, terminal outcome, and dashboard join.</li>
+      <li><strong>Fusion async surface:</strong> typed Judge/Judge-of-Judges graph, sink receipt, and failed-panel isolation without free-form parsing.</li>
+      <li><strong>Lane per Keeper:</strong> one lane timeline per keeper showing busy, queued, deferred, wake cause, current run, and next action.</li>
+      <li><strong>Board reactive/proactive path:</strong> board mention/context inference -> LLM judgment -> wake or queue with explicit ignored reason.</li>
+      <li><strong>Connector context memory:</strong> Discord/Slack/iMessage server/channel/user context as scoped facts and turn source badges.</li>
+      <li><strong>Memory compaction diff:</strong> backend projection for keep/summarize/drop and librarian diagnostic rows.</li>
+      <li><strong>Visual parity loop:</strong> only after truth contracts are stable, run Playwright screenshots against the latest reference bundle.</li>
+    </ol>
+
+    <h2>Do Not Copy As Truth</h2>
+    <div class="note">
+      <p><strong>Runtime/model names in <code>runtime-data.jsx</code> are not current capability truth.</strong> Provider/model support changes quickly. Any implementation around Thinking, Reasoning, Tools, Multiturn, Multimodal, or pricing must first read the latest official docs and then bind the result to OAS/runtime schema evidence.</p>
+      <p><strong>Prototype fixture values must stay out of production:</strong> synthetic turn cost/tokens, hardcoded voice transcript/duration, sample Discord messages, and demo model catalogs are design scaffolding only.</p>
+    </div>
+
+    <h2>Acceptance Rules For Every Slice</h2>
+    <div class="grid cols-3">
+      <div class="card"><strong>Boundary</strong><br />MASC can consume OAS runtime/provider truth; OAS must not import or assume MASC dashboard concepts.</div>
+      <div class="card"><strong>No silent failure</strong><br />Malformed, missing, stale, unsupported, and partial data must render as explicit source health or protocol drift.</div>
+      <div class="card"><strong>No fake judgment</strong><br />Human-like judgment paths go through an LLM boundary or an explicit typed rule. Regex/substrings may extract candidates only, not decide meaning.</div>
+      <div class="card"><strong>Lane isolation</strong><br />One keeper blocked/busy must not freeze global dashboard behavior or other keepers' lanes.</div>
+      <div class="card"><strong>Immutable UI transforms</strong><br />Prefer pure transforms over in-place mutation; preserve raw tokens for unknown variants.</div>
+      <div class="card"><strong>Verification</strong><br />Frontend changes run targeted typecheck/tests. OCaml/dune full build remains CI authority unless explicitly requested.</div>
+    </div>
+
+    <h2>Evidence Ledger</h2>
+    <div class="ledger">
+      <div class="card">
+        <h3>Latest reference bundle</h3>
+        <ul class="evidence-list">
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/messages.jsx:37-52</code> trace groups and tool duration.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/messages.jsx:80-127</code> rich chat block taxonomy including fusion/media.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/board.jsx:33-186</code> board posts, replies, reactions, mention inbox, composer modes.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/schedule.jsx:1-259</code> scheduler approval/detail/run payload surface.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/approvals.jsx:1-214</code> HITL queue and auto policy shape.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/fusion.jsx:1-260</code> panel fanout, judge fields, Judge-of-Judges, sink.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/memory.jsx:1-232</code> real-memory inspector shape, no salience/uses/pins.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/connectors.jsx:1-194</code> gate/connectors/bindings/audit surface.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/runtime-data.jsx:1-94</code> runtime config/catalog shape, treated as design shape only.</li>
+          <li><code>/Users/dancer/Downloads/v2 (29)/keeper-v2/turn-inspector.jsx:1-249</code> turn detail intent; synthetic fixture values excluded from truth.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Current MASC dashboard</h3>
+        <ul class="evidence-list">
+          <li><code>dashboard/src/api/board.ts:887-1157</code> board API, context inference, reactions, sub-board operations.</li>
+          <li><code>dashboard/src/components/board/composer-v2.ts:142-175</code> fixed voice draft and body serialization gap.</li>
+          <li><code>dashboard/src/components/approvals/approvals-surface.ts:1-483</code> live approval queue, approve/reject/always, no fake defer.</li>
+          <li><code>dashboard/src/components/schedule/schedule-surface.ts:64-77</code> current scheduler page states observation-only.</li>
+          <li><code>dashboard/src/components/fusion/fusion-surface.ts:291-305</code> current decision normalization from free-form text.</li>
+          <li><code>dashboard/src/components/work.ts:202-260</code> task status remapping and unknown fallback risk.</li>
+          <li><code>dashboard/src/components/memory-inspector.ts:1-17</code> real-data-only memory inspector contract.</li>
+          <li><code>dashboard/src/api/dashboard-runtime.ts:19-210</code> runtime capability and config surface types.</li>
+          <li><code>dashboard/src/api/schemas/gate-connectors.ts:66-70</code> shaped fallback contract for nested connector objects.</li>
+          <li><code>dashboard/src/components/keeper-turn-inspector.ts:1361-1370</code> exact turn_ref match with legacy timestamp fallback.</li>
+        </ul>
+      </div>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Close the next set of keeper-v2 dashboard parity gaps against the latest local `v2 (29)` reference.
- Harden Work/Goal task projection rendering with explicit blocked/paused/unknown status preservation, Goal Store dossiers, task gate preservation, and execution/contract/evidence ledgers.
- Add projection-backed detail for schedule keeper lanes, wake evidence, connector health, runtime lane capability state, board/composer attachment behavior, and fusion surface evidence.
- Add `reports/dashboard-v2-reference-gap-matrix-2026-07-07.html` as the gap matrix artifact used to drive this slice.

## Why

The dashboard was still hiding or flattening several projection details that should be visible to operators. The most important root-cause fix in this slice is that execution task `gate` snapshots were parsed by the backend but dropped at the dashboard normalization boundary, which made gate evidence silently unavailable in the Work UI.

## Validation

- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/board.test.ts src/api/schemas/gate-connectors.test.ts src/components/board/board-surface.test.ts src/components/board/composer-v2.test.ts src/components/chat/attachments.test.ts src/components/connector-status.test.ts src/components/fusion/fusion-surface.test.ts src/components/runtime-environment-editor.test.ts src/components/schedule/schedule-surface.test.ts src/components/tools/keeper-waiting-inventory-panel.test.ts src/components/tools/scheduled-automation-panel.test.ts src/components/work.test.ts src/store-normalizers.test.ts --no-file-parallelism --maxWorkers=1` (13 files, 385 tests)
- `git diff --check HEAD~1..HEAD`
- Rendered Playwright smoke via `/private/tmp/masc_work_task_evidence_smoke.py` against `http://127.0.0.1:5186/dashboard/#workspace?section=work`
  - desktop screenshot: `/private/tmp/masc-work-task-evidence-smoke.png`
  - mobile screenshot: `/private/tmp/masc-work-task-evidence-smoke-mobile.png`

Dune build was intentionally not run locally; CI remains the build authority for OCaml/dune.
