### PR TITLE
feat(keeper): RFC-0315 P2a — interruption note for no-[STATE] turns (erased-past repair)

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -452,6 +452,38 @@ let no_state_interruption_note =
    backlog, and messages against live state, then act or defer with a \
    stated reason."
 
+type interruption_progress_snapshot =
+  | No_existing_progress_snapshot
+  | Existing_progress_snapshot of Keeper_memory_policy.keeper_state_snapshot
+  | Existing_progress_snapshot_read_failed of string
+  | Existing_progress_snapshot_parse_failed
+
+let read_existing_interruption_progress_snapshot ~(progress_path : string) =
+  if not (Fs_compat.file_exists progress_path) then
+    No_existing_progress_snapshot
+  else
+    match Fs_compat.load_file progress_path with
+    | exception Eio.Cancel.Cancelled _ as e -> raise e
+    | exception exn ->
+        Existing_progress_snapshot_read_failed (Printexc.to_string exn)
+    | text -> (
+        match Keeper_memory_policy.progress_snapshot_cache_of_text text with
+        | Some (cache : Keeper_memory_policy.progress_snapshot_cache) ->
+            Existing_progress_snapshot cache.snapshot
+        | None -> Existing_progress_snapshot_parse_failed)
+
+let record_interruption_progress_snapshot_read_failure
+    ~(keeper_name : string)
+    ~(reason : string)
+    ~(detail : string) : unit =
+  Log.Keeper.warn
+    "keeper:%s interruption-note snapshot read failed (%s): %s"
+    keeper_name reason detail;
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string SnapshotReadFailures)
+    ~labels:[("keeper", keeper_name); ("phase", "interruption_note"); ("reason", reason)]
+    ()
+
 (* RFC-0315 P2a: a no-[STATE] turn is exactly the turn whose replay suffix
    the checkpoint layer prunes (synthetic-empty / requires-attention), and
    it also writes zero memory-bank notes — so without a note the next turn
@@ -465,54 +497,57 @@ let augment_progress_with_interruption_note
     ~(generation : int)
     ~(updated_at : string)
     ~(keeper_name : string) : unit =
-  let existing_snapshot =
-    if Fs_compat.file_exists progress_path then (
-      try
-        Option.map
-          (fun (cache : Keeper_memory_policy.progress_snapshot_cache) ->
-            cache.snapshot)
-          (Keeper_memory_policy.progress_snapshot_cache_of_text
-             (Fs_compat.load_file progress_path))
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> None)
-    else None
-  in
   let base_snapshot =
-    match existing_snapshot with
-    | Some snapshot -> snapshot
-    | None -> Keeper_memory_policy.empty_keeper_state_snapshot
+    match read_existing_interruption_progress_snapshot ~progress_path with
+    | No_existing_progress_snapshot ->
+        Some Keeper_memory_policy.empty_keeper_state_snapshot
+    | Existing_progress_snapshot snapshot -> Some snapshot
+    | Existing_progress_snapshot_read_failed detail ->
+        record_interruption_progress_snapshot_read_failure
+          ~keeper_name
+          ~reason:"read_failed"
+          ~detail;
+        None
+    | Existing_progress_snapshot_parse_failed ->
+        record_interruption_progress_snapshot_read_failure
+          ~keeper_name
+          ~reason:"parse_failed"
+          ~detail:progress_path;
+        None
   in
-  if
-    not
-      (List.mem no_state_interruption_note
-         base_snapshot.Keeper_memory_policy.open_questions)
-  then (
-    let augmented =
-      Keeper_memory_policy.cap_snapshot
-        {
-          base_snapshot with
-          Keeper_memory_policy.open_questions =
-            no_state_interruption_note
-            :: base_snapshot.Keeper_memory_policy.open_questions;
-        }
-    in
-    match
-      Keeper_memory_policy.write_progress_snapshot_path
-        ~path:progress_path
-        ~generation
-        ~updated_at
-        (Keeper_memory_policy.forward_looking_snapshot augmented)
-    with
-    | Ok () -> ()
-    | Error err ->
-        Log.Keeper.warn
-          "keeper:%s interruption-note snapshot write failed: %s"
-          keeper_name err;
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string SnapshotWriteFailures)
-          ~labels:[("keeper", keeper_name)]
-          ())
+  match base_snapshot with
+  | None -> ()
+  | Some base_snapshot ->
+      if
+        not
+          (List.mem no_state_interruption_note
+             base_snapshot.Keeper_memory_policy.open_questions)
+      then (
+        let augmented =
+          Keeper_memory_policy.cap_snapshot
+            {
+              base_snapshot with
+              Keeper_memory_policy.open_questions =
+                no_state_interruption_note
+                :: base_snapshot.Keeper_memory_policy.open_questions;
+            }
+        in
+        match
+          Keeper_memory_policy.write_progress_snapshot_path
+            ~path:progress_path
+            ~generation
+            ~updated_at
+            (Keeper_memory_policy.forward_looking_snapshot augmented)
+        with
+        | Ok () -> ()
+        | Error err ->
+            Log.Keeper.warn
+              "keeper:%s interruption-note snapshot write failed: %s"
+              keeper_name err;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string SnapshotWriteFailures)
+              ~labels:[("keeper", keeper_name)]
+              ())
 
 let apply_post_turn_lifecycle_with_resilience_handles
     ~(resilience_audit_store : Shared_audit.Store.t option)

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -452,7 +452,7 @@ let no_state_interruption_note =
    backlog, and messages against live state, then act or defer with a \
    stated reason."
 
-(* RFC-0314 P2a: a no-[STATE] turn is exactly the turn whose replay suffix
+(* RFC-0315 P2a: a no-[STATE] turn is exactly the turn whose replay suffix
    the checkpoint layer prunes (synthetic-empty / requires-attention), and
    it also writes zero memory-bank notes — so without a note the next turn
    opens on "No continuity snapshot available." and re-derives the world

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -442,6 +442,78 @@ let apply_multimodal_wirein
             ();
           lifecycle)
 
+(* Must stay under [Keeper_memory_policy.default_max_item_chars] (200) and
+   contain no ';' — open questions round-trip through progress.md as a
+   single "; "-joined line, so a longer or semicolon-bearing note would be
+   truncated or split and the dedupe-by-membership check below would stop
+   holding. Pinned by test_keeper_post_turn_interruption_note. *)
+let no_state_interruption_note =
+  "Previous turn left no persisted [STATE] snapshot. Re-verify held task, \
+   backlog, and messages against live state, then act or defer with a \
+   stated reason."
+
+(* RFC-0314 P2a: a no-[STATE] turn is exactly the turn whose replay suffix
+   the checkpoint layer prunes (synthetic-empty / requires-attention), and
+   it also writes zero memory-bank notes — so without a note the next turn
+   opens on "No continuity snapshot available." and re-derives the world
+   from scratch. Augment progress.md in place: keep whatever forward-looking
+   snapshot already exists and add one open question stating that the
+   previous turn left no persisted state. Constant text + membership check
+   keep consecutive no-[STATE] turns from stacking duplicates. *)
+let augment_progress_with_interruption_note
+    ~(progress_path : string)
+    ~(generation : int)
+    ~(updated_at : string)
+    ~(keeper_name : string) : unit =
+  let existing_snapshot =
+    if Fs_compat.file_exists progress_path then (
+      try
+        Option.map
+          (fun (cache : Keeper_memory_policy.progress_snapshot_cache) ->
+            cache.snapshot)
+          (Keeper_memory_policy.progress_snapshot_cache_of_text
+             (Fs_compat.load_file progress_path))
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> None)
+    else None
+  in
+  let base_snapshot =
+    match existing_snapshot with
+    | Some snapshot -> snapshot
+    | None -> Keeper_memory_policy.empty_keeper_state_snapshot
+  in
+  if
+    not
+      (List.mem no_state_interruption_note
+         base_snapshot.Keeper_memory_policy.open_questions)
+  then (
+    let augmented =
+      Keeper_memory_policy.cap_snapshot
+        {
+          base_snapshot with
+          Keeper_memory_policy.open_questions =
+            no_state_interruption_note
+            :: base_snapshot.Keeper_memory_policy.open_questions;
+        }
+    in
+    match
+      Keeper_memory_policy.write_progress_snapshot_path
+        ~path:progress_path
+        ~generation
+        ~updated_at
+        (Keeper_memory_policy.forward_looking_snapshot augmented)
+    with
+    | Ok () -> ()
+    | Error err ->
+        Log.Keeper.warn
+          "keeper:%s interruption-note snapshot write failed: %s"
+          keeper_name err;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string SnapshotWriteFailures)
+          ~labels:[("keeper", keeper_name)]
+          ())
+
 let apply_post_turn_lifecycle_with_resilience_handles
     ~(resilience_audit_store : Shared_audit.Store.t option)
     ~(resilience_strategy_executor : Resilience.Recovery.strategy_executor option)
@@ -507,6 +579,11 @@ let apply_post_turn_lifecycle_with_resilience_handles
           Keeper_metrics.(to_string StateSnapshotSkippedNoState)
           ~labels:[("keeper", meta.name)]
           ();
+        augment_progress_with_interruption_note
+          ~progress_path
+          ~generation:meta.runtime.generation
+          ~updated_at:(now_iso ())
+          ~keeper_name:meta.name;
         {
           meta with
           runtime =

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -140,7 +140,7 @@ val augment_progress_with_interruption_note :
   updated_at:string ->
   keeper_name:string ->
   unit
-(** RFC-0314 P2a. Called on a turn that produced no [STATE] snapshot (the
+(** RFC-0315 P2a. Called on a turn that produced no [STATE] snapshot (the
     same turns whose checkpoint replay suffix is pruned and whose memory
     writes are suppressed): preserves the existing forward-looking
     progress.md snapshot and adds {!no_state_interruption_note} to its

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -129,6 +129,25 @@ val recover_latest_checkpoint_for_overflow_retry :
   primary_model_max_tokens:int ->
   overflow_retry_recovery option
 
+val no_state_interruption_note : string
+(** Open-question text recorded by
+    {!augment_progress_with_interruption_note}. Constant so repeated
+    no-[STATE] turns dedupe by membership instead of stacking. *)
+
+val augment_progress_with_interruption_note :
+  progress_path:string ->
+  generation:int ->
+  updated_at:string ->
+  keeper_name:string ->
+  unit
+(** RFC-0314 P2a. Called on a turn that produced no [STATE] snapshot (the
+    same turns whose checkpoint replay suffix is pruned and whose memory
+    writes are suppressed): preserves the existing forward-looking
+    progress.md snapshot and adds {!no_state_interruption_note} to its
+    open questions, so the next turn's Continuity layer states that the
+    previous turn left no persisted state instead of rendering nothing.
+    Write failures are logged and counted, never raised. *)
+
 module For_testing : sig
   val invalid_snapshot_goal_fingerprint : string -> string
 

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -126,6 +126,7 @@ type t =
   | ProviderTimeoutLoopPaused
   | TurnFailureStreakPaused
   | CycleExceptions
+  | SnapshotReadFailures
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
   | StateSnapshotInvalidGoal
@@ -394,6 +395,7 @@ let to_string = function
   | ProviderTimeoutLoopPaused -> "masc_keeper_provider_timeout_loop_paused_total"
   | TurnFailureStreakPaused -> "masc_keeper_turn_failure_streak_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
+  | SnapshotReadFailures -> "masc_keeper_snapshot_read_failures_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
   | StateSnapshotSkippedNoState ->
     "masc_keeper_state_snapshot_skipped_no_state_total"
@@ -587,7 +589,7 @@ let all : t list =
     ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
     PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
     TurnFailureStreakPaused;
-    CycleExceptions; SnapshotWriteFailures; StateSnapshotSkippedNoState; StateSnapshotInvalidGoal; PromptUnknownToolTokens;
+    CycleExceptions; SnapshotReadFailures; SnapshotWriteFailures; StateSnapshotSkippedNoState; StateSnapshotInvalidGoal; PromptUnknownToolTokens;
     PromptTokenStripped;
     ProgressUpdatedLineFailures;
     SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -117,6 +117,7 @@ type t =
   | ProviderTimeoutLoopPaused
   | TurnFailureStreakPaused
   | CycleExceptions
+  | SnapshotReadFailures
   | SnapshotWriteFailures
   | StateSnapshotSkippedNoState
   | StateSnapshotInvalidGoal

--- a/test/dune
+++ b/test/dune
@@ -260,6 +260,7 @@
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
+  test_keeper_post_turn_interruption_note
   test_keeper_unified_verification_surface
   test_keeper_observation_provenance
   test_keeper_fsm_guard_actions
@@ -614,6 +615,7 @@
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
+  test_keeper_post_turn_interruption_note
   test_keeper_unified_verification_surface
   test_keeper_observation_provenance
   test_keeper_fsm_guard_actions

--- a/test/test_keeper_post_turn_interruption_note.ml
+++ b/test/test_keeper_post_turn_interruption_note.ml
@@ -1,4 +1,4 @@
-(* RFC-0314 P2a — interruption note for no-[STATE] turns.
+(* RFC-0315 P2a — interruption note for no-[STATE] turns.
 
    A turn that produces no [STATE] snapshot is the same turn whose checkpoint
    replay suffix gets pruned and whose memory-bank writes are suppressed, so

--- a/test/test_keeper_post_turn_interruption_note.ml
+++ b/test/test_keeper_post_turn_interruption_note.ml
@@ -1,0 +1,97 @@
+(* RFC-0314 P2a — interruption note for no-[STATE] turns.
+
+   A turn that produces no [STATE] snapshot is the same turn whose checkpoint
+   replay suffix gets pruned and whose memory-bank writes are suppressed, so
+   before this change it left the next turn with an empty continuity surface.
+   These tests pin the repair: progress.md gains one forward-looking open
+   question, existing forward content survives, and consecutive no-[STATE]
+   turns do not stack duplicates. *)
+
+open Alcotest
+module P = Masc.Keeper_post_turn
+module MP = Masc.Keeper_memory_policy
+
+let tmp_progress_path () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-interruption-note-%d" (Unix.getpid ()))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Filename.concat dir "progress.md"
+
+let remove_if_exists path = if Sys.file_exists path then Sys.remove path
+
+let read_snapshot path =
+  match MP.progress_snapshot_cache_of_text (In_channel.with_open_text path In_channel.input_all) with
+  | Some cache -> cache.MP.snapshot
+  | None -> Alcotest.fail "progress.md did not parse back into a snapshot"
+
+let augment path =
+  P.augment_progress_with_interruption_note
+    ~progress_path:path
+    ~generation:3
+    ~updated_at:"2026-07-07T12:00:00Z"
+    ~keeper_name:"note-keeper"
+
+let test_note_written_when_no_progress_file () =
+  let path = tmp_progress_path () in
+  remove_if_exists path;
+  augment path;
+  let snapshot = read_snapshot path in
+  check bool "note recorded as open question" true
+    (List.mem P.no_state_interruption_note snapshot.MP.open_questions)
+
+let test_existing_forward_content_survives () =
+  let path = tmp_progress_path () in
+  remove_if_exists path;
+  let prior =
+    {
+      MP.empty_keeper_state_snapshot with
+      MP.next_summary = Some "wire parser to store";
+      MP.open_questions = [ "is the fixture stable?" ];
+    }
+  in
+  (match
+     MP.write_progress_snapshot_path ~path ~generation:3
+       ~updated_at:"2026-07-07T11:00:00Z" prior
+   with
+  | Ok () -> ()
+  | Error e -> Alcotest.fail ("fixture write failed: " ^ e));
+  augment path;
+  let snapshot = read_snapshot path in
+  check (option string) "prior next summary preserved"
+    (Some "wire parser to store") snapshot.MP.next_summary;
+  check bool "prior open question preserved" true
+    (List.mem "is the fixture stable?" snapshot.MP.open_questions);
+  check bool "note added" true
+    (List.mem P.no_state_interruption_note snapshot.MP.open_questions)
+
+let test_consecutive_turns_do_not_stack_duplicates () =
+  let path = tmp_progress_path () in
+  remove_if_exists path;
+  augment path;
+  augment path;
+  augment path;
+  let snapshot = read_snapshot path in
+  let occurrences =
+    List.length
+      (List.filter
+         (String.equal P.no_state_interruption_note)
+         snapshot.MP.open_questions)
+  in
+  check int "note appears exactly once" 1 occurrences
+
+let () =
+  run "keeper_post_turn_interruption_note"
+    [
+      ( "interruption note",
+        [
+          test_case "written when no progress file exists" `Quick
+            test_note_written_when_no_progress_file;
+          test_case "existing forward content survives" `Quick
+            test_existing_forward_content_survives;
+          test_case "consecutive no-STATE turns dedupe" `Quick
+            test_consecutive_turns_do_not_stack_duplicates;
+        ] );
+    ]

--- a/test/test_keeper_post_turn_interruption_note.ml
+++ b/test/test_keeper_post_turn_interruption_note.ml
@@ -22,6 +22,9 @@ let tmp_progress_path () =
 
 let remove_if_exists path = if Sys.file_exists path then Sys.remove path
 
+let write_text path text =
+  Out_channel.with_open_text path (fun oc -> output_string oc text)
+
 let read_snapshot path =
   match MP.progress_snapshot_cache_of_text (In_channel.with_open_text path In_channel.input_all) with
   | Some cache -> cache.MP.snapshot
@@ -82,6 +85,15 @@ let test_consecutive_turns_do_not_stack_duplicates () =
   in
   check int "note appears exactly once" 1 occurrences
 
+let test_malformed_progress_is_not_overwritten () =
+  let path = tmp_progress_path () in
+  remove_if_exists path;
+  let malformed = "not a progress snapshot\n" in
+  write_text path malformed;
+  augment path;
+  check string "malformed progress left untouched" malformed
+    (In_channel.with_open_text path In_channel.input_all)
+
 let () =
   run "keeper_post_turn_interruption_note"
     [
@@ -93,5 +105,7 @@ let () =
             test_existing_forward_content_survives;
           test_case "consecutive no-STATE turns dedupe" `Quick
             test_consecutive_turns_do_not_stack_duplicates;
+          test_case "malformed progress is not overwritten" `Quick
+            test_malformed_progress_is_not_overwritten;
         ] );
     ]


### PR DESCRIPTION
## 문제 (RFC-0315 §1 D3 — Erased past)

[STATE] 스냅샷 없이 끝난 턴은 ①체크포인트 replay suffix가 턴 이전 prefix로 prune되고(synthetic-empty / contract requires-attention, `keeper_agent_run_finalize_response.ml`) ②memory-bank note 0건 + progress snapshot 미갱신이라, 다음 wake의 Continuity 표면이 "No continuity snapshot available."로 비어 keeper가 매번 백지에서 세계를 재유도합니다 — 사용자가 관측한 "길 잃음"의 D3 축.

## 변경 (P2a — checkpoint 의미론 불변)

prune 자체는 유지합니다(오염된 replay suffix 방역은 정당). 손실은 기존 continuity 파이프로 복구합니다:

- `apply_continuity_summary`의 no-snapshot 분기에서 progress.md를 **제자리 증강**: 기존 forward-looking 스냅샷(Goal/Next/OpenQuestions/Constraints)을 보존하고, "이전 턴이 상태를 남기지 못했다 — 라이브 상태 재검증 후 행동 또는 사유 명시 defer" open question 1개 추가.
- 노트는 상수 텍스트(200자 미만·세미콜론 없음 — progress.md가 open questions를 `"; "`로 join하므로) + membership 검사로 연속 no-[STATE] 턴에서 중복 누적 방지.
- 실패는 log + `SnapshotWriteFailures` 카운터, raise 없음.

다음 턴의 Continuity 레이어(읽기 체인 1순위 = progress snapshot)가 이 노트를 렌더하므로, PR #23546(P1)의 Current Task 레이어와 결합하면 "무엇을 하다 끊겼고 무엇을 쥐고 있는지"가 wake 턴에 복원됩니다.

## 검증

- 신규 `test_keeper_post_turn_interruption_note` 3케이스: 파일 부재 시 기록 / 기존 forward 내용 라운드트립 보존 / 연속 호출 dedupe. (라운드트립 테스트가 초기 노트 텍스트의 max_item_chars 초과 + join 구분자 포함 버그를 실제로 잡음)
- `dune build --root .` lib+bin+test green (worktree)

## 스코프 외 (RFC-0315 Phase 2 잔여, 후속)

- replay prune reason의 typed 관통(현재 manifest 텔레메트리에서 소멸) 및 노트의 reason별 구체화
- ~~working_state sidecar restore의 write-only theater~~ → P1 #23546의 P1e(Open Loops 레이어)로 해소됨
- generation bump 시 short-term 드랍 정책, corrupt checkpoint 관측화

RFC: RFC-0315 (`docs/rfc/RFC-0315-wake-turn-self-description.md`, PR #23546에 포함) §3 Phase 2.

MASC: task-1856 (Phase 2 슬라이스)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
