### PR TITLE
feat(keeper): LLM compaction summarizer with structured plan (W2)

### DIFF
--- a/lib/keeper/compaction_llm_summarizer.ml
+++ b/lib/keeper/compaction_llm_summarizer.ml
@@ -159,6 +159,11 @@ let validate_partition ~message_count ~kept ~summarized ~dropped =
          "indices not covered: %s"
          (String.concat "," (List.rev_map string_of_int xs)))
 
+let validate_non_empty_output ~message_count ~kept ~summarized =
+  if message_count > 0 && kept = [] && summarized = [] then
+    Error "plan would produce empty compaction output"
+  else Ok ()
+
 let plan_of_json ~message_count json =
   let* summary = string_field Schema.compaction_plan_field_summary json in
   let summary = String.trim summary in
@@ -169,6 +174,7 @@ let plan_of_json ~message_count json =
   let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
   let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
+  let* () = validate_non_empty_output ~message_count ~kept ~summarized in
   Ok { summary; kept; summarized; dropped }
 
 (* Marker prefix so the folded summary is recognizable in the transcript and

--- a/lib/keeper/compaction_llm_summarizer.ml
+++ b/lib/keeper/compaction_llm_summarizer.ml
@@ -1,0 +1,303 @@
+(** LLM-backed keeper context compaction (RFC-0313-adjacent W2).
+    See compaction_llm_summarizer.mli. Structure mirrors
+    Keeper_memory_llm_summary: opt-in gate + fiber-local Eio capture +
+    schema-capable provider filter + timeout + fail-closed [None]. *)
+
+module Schema = Keeper_structured_output_schema
+module Int_set = Set.Make (Int)
+
+(* Bound the summary output. Larger than the memory-bank 512 because a
+   compaction summary stands in for many messages, but still capped so the
+   emergency path (a near-full context) cannot request an unbounded reply. *)
+let summary_max_tokens = 1024
+
+(* Bound the serialized working set handed to the model. A compaction fires
+   near the context limit, so the notes text must itself be bounded well below
+   the window; the model classifies by index, so truncation loses tail detail
+   but never the index mapping (the tail simply lands in [kept]). *)
+let max_notes_bytes = 24_000
+
+type compaction_plan =
+  { summary : string
+  ; kept : int list
+  ; summarized : int list
+  ; dropped : int list
+  }
+
+type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan option
+
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:Eio_context.eio_net ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+let default_complete ~sw ~net ?clock ~config ~messages () =
+  Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
+
+let is_direct_completion_provider (provider_cfg : Llm_provider.Provider_config.t) : bool =
+  match provider_cfg.kind with
+  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
+
+let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
+  let max_tokens =
+    match provider_cfg.max_tokens with
+    | Some n when n > 0 -> Some (min n summary_max_tokens)
+    | _ -> Some summary_max_tokens
+  in
+  { provider_cfg with
+    max_tokens
+  ; temperature = Some 0.0
+  ; tool_choice = None
+  ; disable_parallel_tool_use = true
+  }
+  |> Schema.apply_to_provider_config Schema.compaction_plan_output_schema
+
+let plan_schema_supported provider_cfg =
+  Schema.provider_config_accepts_schema Schema.compaction_plan_output_schema provider_cfg
+
+let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
+
+(* One indexed line per message: "[i] role: <text>". The model must classify
+   every [i] into exactly one of kept/summarized/dropped. *)
+let indexed_messages_text (messages : Agent_sdk.Types.message list) =
+  messages
+  |> List.mapi (fun idx (m : Agent_sdk.Types.message) ->
+    let role =
+      match m.role with
+      | Agent_sdk.Types.System -> "system"
+      | Agent_sdk.Types.User -> "user"
+      | Agent_sdk.Types.Assistant -> "assistant"
+      | Agent_sdk.Types.Tool -> "tool"
+    in
+    let text = Agent_sdk.Types.text_of_message m |> String.trim in
+    Printf.sprintf "[%d] %s: %s" idx role text)
+  |> String.concat "\n"
+  |> String_util.utf8_safe ~max_bytes:max_notes_bytes ~suffix:"..."
+  |> String_util.to_string
+
+let messages_for_plan ~(messages : Agent_sdk.Types.message list) =
+  let count = List.length messages in
+  let system =
+    "You compact a keeper's working context. Classify EVERY message, by its \
+     0-based index, into exactly one of: kept (verbatim, still load-bearing), \
+     summarized (folded into the summary), or dropped (low value, discard). \
+     Every index in range must appear in exactly one list; do not invent \
+     indices. Prefer keeping recent messages and any with concrete code paths, \
+     commands, decisions, or unresolved blockers. Write one durable [summary] \
+     prose block that stands in for the summarized messages. Do not invent \
+     facts. Do not include [STATE] blocks or markdown fences."
+  in
+  let user =
+    Printf.sprintf
+      "message_count: %d\nmessages:\n%s\n\nReturn a JSON object with fields \
+       summary, kept_indices, summarized_indices, dropped_indices covering \
+       every index in [0, %d) exactly once."
+      count
+      (indexed_messages_text messages)
+      count
+  in
+  [ message Agent_sdk.Types.System system; message Agent_sdk.Types.User user ]
+
+(* -- structured plan parsing + validation (Parse, don't validate) -- *)
+
+let int_list_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`List items) ->
+       List.fold_right
+         (fun item acc ->
+           match acc, item with
+           | Ok xs, `Int n -> Ok (n :: xs)
+           | Ok _, _ -> Error (Printf.sprintf "%s must contain only integers" key)
+           | Error _, _ -> acc)
+         items
+         (Ok [])
+     | Some _ -> Error (Printf.sprintf "%s must be an array" key)
+     | None -> Error (Printf.sprintf "missing %s" key))
+  | _ -> Error "plan must be a JSON object"
+
+let string_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) -> Ok s
+     | Some _ -> Error (Printf.sprintf "%s must be a string" key)
+     | None -> Error (Printf.sprintf "missing %s" key))
+  | _ -> Error "plan must be a JSON object"
+
+let ( let* ) = Result.bind
+
+(* The three index lists must together partition [0, message_count) exactly:
+   every index in range, no out-of-range, no negatives, no duplicates across
+   the union. A violation yields [Error] (caller falls back to deterministic),
+   not a silent repair — an LLM that miscounts must not drop real messages. *)
+let validate_partition ~message_count ~kept ~summarized ~dropped =
+  let all = kept @ summarized @ dropped in
+  let seen = Array.make message_count false in
+  let rec check = function
+    | [] -> Ok ()
+    | idx :: rest ->
+      if idx < 0 || idx >= message_count then
+        Error (Printf.sprintf "index %d out of range [0, %d)" idx message_count)
+      else if seen.(idx) then Error (Printf.sprintf "index %d appears more than once" idx)
+      else begin
+        seen.(idx) <- true;
+        check rest
+      end
+  in
+  let* () = check all in
+  let missing = ref [] in
+  Array.iteri (fun idx covered -> if not covered then missing := idx :: !missing) seen;
+  match !missing with
+  | [] -> Ok ()
+  | xs ->
+    Error
+      (Printf.sprintf
+         "indices not covered: %s"
+         (String.concat "," (List.rev_map string_of_int xs)))
+
+let plan_of_json ~message_count json =
+  let* summary = string_field Schema.compaction_plan_field_summary json in
+  let summary = String.trim summary in
+  let* () =
+    if summary = "" then Error "summary must be non-empty" else Ok ()
+  in
+  let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
+  let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
+  let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
+  let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
+  Ok { summary; kept; summarized; dropped }
+
+(* Marker prefix so the folded summary is recognizable in the transcript and
+   by downstream tooling, matching the memory-bank [MEMORY_SUMMARY] convention. *)
+let summary_marker = "[COMPACTION_SUMMARY]"
+
+let apply (plan : compaction_plan) ~(messages : Agent_sdk.Types.message list) =
+  let summarized = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.summarized in
+  let dropped = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.dropped in
+  let first_summarized =
+    List.fold_left min max_int plan.summarized
+  in
+  let summary_msg =
+    message Agent_sdk.Types.Assistant (summary_marker ^ " " ^ plan.summary)
+  in
+  messages
+  |> List.mapi (fun idx m -> idx, m)
+  |> List.filter_map (fun (idx, m) ->
+    if Int_set.mem idx dropped then None
+    else if Int_set.mem idx summarized then
+      (* Emit the single summary message at the position of the first
+         summarized index; the rest of the summarized indices collapse away. *)
+      if idx = first_summarized then Some summary_msg else None
+    else Some m)
+
+let plan_of_response ~message_count response =
+  match
+    Agent_sdk_response.structured_json_of_response
+      ~schema_name:"keeper_compaction_plan"
+      response
+  with
+  | Ok json -> plan_of_json ~message_count json
+  | Error detail -> Error ("invalid structured response: " ^ detail)
+
+type 'a timeout_result =
+  | Completed of 'a
+  | Timed_out
+  | Clock_unavailable
+
+let with_timeout ?clock ~timeout_sec f =
+  match clock with
+  | None -> Clock_unavailable
+  | Some clock ->
+    (try Completed (Eio.Time.with_timeout_exn clock timeout_sec f) with
+     | Eio.Time.Timeout -> Timed_out)
+
+let run_plan
+    ?(complete : complete_fn = default_complete)
+    ?clock
+    ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
+    ~(keeper_name : string)
+    ~(runtime_id : string)
+    ~sw
+    ~net
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    ~(messages : Agent_sdk.Types.message list)
+    () : compaction_plan option =
+  let message_count = List.length messages in
+  let provider_cfg = provider_for_plan provider_cfg in
+  let request = messages_for_plan ~messages in
+  match
+    with_timeout ?clock ~timeout_sec (fun () ->
+      complete ~sw ~net ?clock ~config:provider_cfg ~messages:request ())
+  with
+  | Timed_out ->
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM plan timed out runtime=%s timeout_sec=%.1f"
+      runtime_id timeout_sec;
+    None
+  | Clock_unavailable ->
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM plan clock unavailable runtime=%s — refusing provider \
+       call without enforcing timeout"
+      runtime_id;
+    None
+  | Completed (Error err) ->
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM plan failed runtime=%s: %s"
+      runtime_id (Provider_http_error.to_message err);
+    None
+  | Completed (Ok response) ->
+    (match plan_of_response ~message_count response with
+     | Ok plan -> Some plan
+     | Error detail ->
+       Log.Keeper.warn ~keeper_name
+         "compaction LLM plan rejected runtime=%s: %s"
+         runtime_id detail;
+       None)
+
+let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) ()
+  : summarizer option
+  =
+  if not (Keeper_memory_bank.memory_llm_summary_enabled ()) then None
+  else
+    match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+    | Some sw, Some net ->
+      let clock = Eio_context.get_clock_opt () in
+      let provider_runtime_id =
+        Keeper_memory_runtime_resolution.runtime_id_for_librarian ~runtime_id
+      in
+      (match
+         Keeper_memory_runtime_resolution.provider_for_runtime
+           ~runtime_id:provider_runtime_id
+       with
+       | Error err ->
+         Log.Keeper.warn ~keeper_name
+           "compaction LLM summarizer provider resolution failed runtime=%s: %s"
+           provider_runtime_id err;
+         None
+       | Ok provider ->
+         let providers =
+           [ provider ]
+           |> List.filter is_direct_completion_provider
+           |> List.filter plan_schema_supported
+         in
+         (match providers with
+          | [] ->
+            Log.Keeper.warn ~keeper_name
+              "compaction LLM summarizer has no schema-capable direct completion \
+               provider runtime=%s"
+              provider_runtime_id;
+            None
+          | provider_cfg :: _ ->
+            Some
+              (fun ~messages ->
+                run_plan ?complete ?clock ?timeout_sec ~keeper_name
+                  ~runtime_id:provider_runtime_id ~sw ~net ~provider_cfg ~messages ())))
+    | _ ->
+      Log.Keeper.warn ~keeper_name
+        "compaction LLM summarizer skipped: Eio context unavailable runtime=%s"
+        runtime_id;
+      None

--- a/lib/keeper/compaction_llm_summarizer.mli
+++ b/lib/keeper/compaction_llm_summarizer.mli
@@ -1,0 +1,76 @@
+(** LLM-backed keeper context compaction (RFC-0313-adjacent W2).
+
+    Opt-in per-keeper alternative to the deterministic extractive strategy
+    chain. Requests a structured {!compaction_plan} from a librarian-lane
+    provider that classifies each working-set message (by 0-based index) into
+    kept / summarized / dropped, plus one [summary] prose block standing in
+    for the summarized indices.
+
+    Fail-closed by construction: {!make} returns [None] (caller falls back to
+    the deterministic chain) whenever the opt-in gate is off, the Eio context
+    is unavailable, no schema-capable direct-completion provider resolves, or
+    the produced plan is structurally invalid. This mirrors
+    {!Keeper_memory_llm_summary.make}; it never lies about effects — the
+    provider call happens inside the fiber-local Eio context captured at
+    construction, and the summarizer type stays synchronous+total. *)
+
+(** A validated compaction plan over a working set of [n] messages. Every
+    index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
+    pairwise disjoint, and together they cover every index exactly once. *)
+type compaction_plan = private
+  { summary : string
+  ; kept : int list
+  ; summarized : int list
+  ; dropped : int list
+  }
+
+(** [summarizer ~messages] returns [Some plan] when the LLM produced a valid
+    plan over [messages], or [None] on any failure (timeout, http error, empty
+    or invalid structured response). Total and synchronous; the effect is
+    hidden in the closure captured by {!make}. *)
+type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan option
+
+(** The low-level provider completion the summarizer drives. Defaulted to
+    {!Llm_provider.Complete.complete}; overridable in tests. *)
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:Eio_context.eio_net ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+(** [make ~runtime_id ~keeper_name ()] builds a summarizer bound to the
+    librarian lane resolved from [runtime_id], or [None] if the opt-in gate is
+    off / Eio context or a schema-capable provider is unavailable. The caller
+    treats [None] as "use the deterministic chain". [complete]/[timeout_sec]
+    override the provider call and deadline (tests). *)
+val make
+  :  ?complete:complete_fn
+  -> ?timeout_sec:float
+  -> runtime_id:string
+  -> keeper_name:string
+  -> unit
+  -> summarizer option
+
+(** Parse+validate a raw structured response into a plan over [message_count]
+    messages. Exposed for tests. Returns [Error] with a reason on any
+    structural violation (out-of-range / negative / duplicate / non-covering
+    indices, or a missing/empty summary). *)
+val plan_of_json
+  :  message_count:int
+  -> Yojson.Safe.t
+  -> (compaction_plan, string) result
+
+(** [apply plan ~messages] rebuilds the working set from a validated [plan]:
+    [kept] indices survive verbatim, the [summarized] indices are replaced by a
+    single assistant memory-summary message ([plan.summary]), and [dropped]
+    indices are removed. Original message order is preserved; the summary is
+    inserted at the position of the first summarized index. [plan] is assumed
+    to have been validated against [List.length messages] (it partitions the
+    index space), so this is total. *)
+val apply
+  :  compaction_plan
+  -> messages:Agent_sdk.Types.message list
+  -> Agent_sdk.Types.message list

--- a/lib/keeper/compaction_llm_summarizer.mli
+++ b/lib/keeper/compaction_llm_summarizer.mli
@@ -16,7 +16,9 @@
 
 (** A validated compaction plan over a working set of [n] messages. Every
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
-    pairwise disjoint, and together they cover every index exactly once. *)
+    pairwise disjoint, and together they cover every index exactly once. For
+    non-empty inputs, at least one [kept] or [summarized] index is required so
+    applying the plan cannot erase the entire working set. *)
 type compaction_plan = private
   { summary : string
   ; kept : int list
@@ -57,7 +59,8 @@ val make
 (** Parse+validate a raw structured response into a plan over [message_count]
     messages. Exposed for tests. Returns [Error] with a reason on any
     structural violation (out-of-range / negative / duplicate / non-covering
-    indices, or a missing/empty summary). *)
+    indices, empty output for a non-empty working set, or a missing/empty
+    summary). *)
 val plan_of_json
   :  message_count:int
   -> Yojson.Safe.t

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -396,11 +396,40 @@ let compact_if_needed_typed
          ~context_ratio:ratio
          ~message_count:msg_count);
     let messages, pair_repair_stats =
-      let msgs_after_compact =
+      let deterministic_compact () =
         (* Issue #8597 #1: dropped [~system_prompt] arg — compact
                ignored it (system prompt already present in messages
                when role=System). *)
         Context_compact_oas.compact ~messages:(messages_of_context ctx) ~strategies ()
+      in
+      (* RFC-0313-adjacent W2: [Llm] mode asks a librarian-lane summarizer for a
+         structured kept/summarized/dropped plan and applies it; any failure
+         (opt-in off, no Eio context, no schema provider, invalid plan) yields
+         [None] and falls back to the deterministic chain — the [Deterministic]
+         floor is always the guaranteed result. Emergency compaction (a
+         near-full context, [emergency] above) never calls the LLM: the reply
+         itself needs headroom and the cooldown is bypassed, so it stays on the
+         cheap deterministic path. *)
+      let msgs_after_compact =
+        match meta.compaction.mode with
+        | Keeper_config.Deterministic -> deterministic_compact ()
+        | Keeper_config.Llm ->
+          let emergency = ratio >= emergency_compact_ratio_threshold in
+          let runtime_id =
+            try Keeper_meta_contract.runtime_id_of_meta meta with Failure _ -> ""
+          in
+          if emergency || String.equal runtime_id "" then deterministic_compact ()
+          else begin
+            match
+              Compaction_llm_summarizer.make ~runtime_id ~keeper_name:meta.name ()
+            with
+            | None -> deterministic_compact ()
+            | Some summarizer ->
+              let msgs = messages_of_context ctx in
+              (match summarizer ~messages:msgs with
+               | Some plan -> Compaction_llm_summarizer.apply plan ~messages:msgs
+               | None -> deterministic_compact ())
+          end
       in
       (* Apply keeper-private fold after standard strategies *)
       let msgs_after_fold =

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -213,6 +213,30 @@ let memory_bank_summary_output_schema =
   object_schema ~required:(List.map fst fields) fields
 ;;
 
+(* Compaction plan (RFC-0313-adjacent W2). The LLM classifies each working-set
+   message by 0-based index into kept / summarized / dropped, and returns one
+   [summary] prose block that stands in for the summarized indices. Index-based
+   (not free-text rewrite) so the original messages are never fabricated — the
+   consumer reconstructs the context by index, matching the
+   [consolidation_plan] member_indices/drop_indices precedent. Field names are
+   exported as constants so the parser shares this SSOT. *)
+let compaction_plan_field_summary = "summary"
+let compaction_plan_field_kept_indices = "kept_indices"
+let compaction_plan_field_summarized_indices = "summarized_indices"
+let compaction_plan_field_dropped_indices = "dropped_indices"
+
+let compaction_plan_output_schema =
+  let int_array = `Assoc [ "type", `String "array"; "items", integer_schema ] in
+  let fields =
+    [ compaction_plan_field_summary, string_schema
+    ; compaction_plan_field_kept_indices, int_array
+    ; compaction_plan_field_summarized_indices, int_array
+    ; compaction_plan_field_dropped_indices, int_array
+    ]
+  in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let vision_analyze_output_schema =
   let fields = [ "text", string_schema ] in
   object_schema ~required:(List.map fst fields) fields

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -14,6 +14,18 @@ val consolidation_plan_output_schema : Yojson.Safe.t
 val memory_bank_summary_output_schema : Yojson.Safe.t
 (** JSON object the memory-bank summary provider must return. *)
 
+(** Wire field names for {!compaction_plan_output_schema}; shared with the
+    W2 compaction-plan parser as the single source of truth. *)
+val compaction_plan_field_summary : string
+
+val compaction_plan_field_kept_indices : string
+val compaction_plan_field_summarized_indices : string
+val compaction_plan_field_dropped_indices : string
+
+val compaction_plan_output_schema : Yojson.Safe.t
+(** JSON object the LLM compaction summarizer must return: a [summary] prose
+    block plus kept / summarized / dropped 0-based message indices. *)
+
 val vision_analyze_output_schema : Yojson.Safe.t
 (** JSON object the one-shot vision analyzer provider must return. *)
 

--- a/test/dune
+++ b/test/dune
@@ -235,6 +235,7 @@
   test_workspace_telemetry_drop_non_eio
   test_keeper_contract_classifier_pure
   test_keeper_compact_policy_pure
+  test_compaction_llm_summarizer
   test_keeper_pacing
   test_keeper_pacing_replay
   test_keeper_runtime_failure_route
@@ -589,6 +590,7 @@
   test_workspace_telemetry_drop_non_eio
   test_keeper_contract_classifier_pure
   test_keeper_compact_policy_pure
+  test_compaction_llm_summarizer
   test_keeper_pacing
   test_keeper_pacing_replay
   test_keeper_runtime_failure_route

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -36,6 +36,13 @@ let test_all_kept_accepted () =
     true
     (is_ok (C.plan_of_json ~message_count:3 json))
 
+let test_drop_only_with_kept_accepted () =
+  let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
+  Alcotest.(check bool)
+    "drop-only plans are valid when at least one message remains"
+    true
+    (is_ok (C.plan_of_json ~message_count:2 json))
+
 (* -- plan_of_json: structural violations rejected (no silent repair) -- *)
 
 let test_out_of_range_rejected () =
@@ -63,6 +70,13 @@ let test_missing_index_rejected () =
   let json = plan_json ~summary:"x" ~kept:[ 0 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
     "a partition that omits an in-range index is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_all_dropped_rejected () =
+  let json = plan_json ~summary:"S" ~kept:[] ~summarized:[] ~dropped:[ 0; 1 ] in
+  Alcotest.(check bool)
+    "a non-empty working set must not compact to empty output"
     true
     (is_error (C.plan_of_json ~message_count:2 json))
 
@@ -132,10 +146,13 @@ let () =
     [ ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
         ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
+        ; Alcotest.test_case "drop-only with kept accepted" `Quick
+            test_drop_only_with_kept_accepted
         ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected
         ; Alcotest.test_case "negative rejected" `Quick test_negative_rejected
         ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
         ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
+        ; Alcotest.test_case "all dropped rejected" `Quick test_all_dropped_rejected
         ; Alcotest.test_case "empty summary rejected" `Quick test_empty_summary_rejected
         ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
         ] )

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -1,0 +1,146 @@
+(** Unit tests for [Compaction_llm_summarizer] (RFC-0313-adjacent W2).
+
+    Covers the pure surface: structured-plan parsing/validation
+    ([plan_of_json]) and plan application ([apply]). The provider call in
+    [make] needs an Eio context + live provider and is exercised by
+    integration, not here. *)
+
+open Masc
+module C = Compaction_llm_summarizer
+
+let plan_json ~summary ~kept ~summarized ~dropped : Yojson.Safe.t =
+  let ints xs = `List (List.map (fun i -> `Int i) xs) in
+  `Assoc
+    [ "summary", `String summary
+    ; "kept_indices", ints kept
+    ; "summarized_indices", ints summarized
+    ; "dropped_indices", ints dropped
+    ]
+
+let is_ok = function Ok _ -> true | Error _ -> false
+let is_error = function Ok _ -> false | Error _ -> true
+
+(* -- plan_of_json: valid partition accepted -- *)
+
+let test_valid_partition_accepted () =
+  let json = plan_json ~summary:"folded" ~kept:[ 3; 4 ] ~summarized:[ 0; 1 ] ~dropped:[ 2 ] in
+  Alcotest.(check bool)
+    "a full disjoint partition of [0,5) parses"
+    true
+    (is_ok (C.plan_of_json ~message_count:5 json))
+
+let test_all_kept_accepted () =
+  let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
+  Alcotest.(check bool)
+    "kept covering everything parses (summary unused but required non-empty)"
+    true
+    (is_ok (C.plan_of_json ~message_count:3 json))
+
+(* -- plan_of_json: structural violations rejected (no silent repair) -- *)
+
+let test_out_of_range_rejected () =
+  let json = plan_json ~summary:"x" ~kept:[ 0; 1 ] ~summarized:[ 5 ] ~dropped:[] in
+  Alcotest.(check bool)
+    "an index >= message_count is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_negative_rejected () =
+  let json = plan_json ~summary:"x" ~kept:[ -1; 0 ] ~summarized:[ 1 ] ~dropped:[] in
+  Alcotest.(check bool)
+    "a negative index is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_duplicate_rejected () =
+  let json = plan_json ~summary:"x" ~kept:[ 0; 1 ] ~summarized:[ 1 ] ~dropped:[] in
+  Alcotest.(check bool)
+    "an index appearing in two lists is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_missing_index_rejected () =
+  let json = plan_json ~summary:"x" ~kept:[ 0 ] ~summarized:[] ~dropped:[] in
+  Alcotest.(check bool)
+    "a partition that omits an in-range index is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_empty_summary_rejected () =
+  let json = plan_json ~summary:"   " ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[] in
+  Alcotest.(check bool)
+    "a blank summary is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:2 json))
+
+let test_missing_field_rejected () =
+  let json = `Assoc [ "summary", `String "x"; "kept_indices", `List [] ] in
+  Alcotest.(check bool)
+    "a plan missing summarized_indices/dropped_indices is rejected"
+    true
+    (is_error (C.plan_of_json ~message_count:0 json))
+
+(* -- apply: reconstruction honours the plan -- *)
+
+let msg role text = Agent_sdk.Types.text_message role text
+let texts (ms : Agent_sdk.Types.message list) =
+  List.map (fun m -> Agent_sdk.Types.text_of_message m) ms
+
+let sample =
+  [ msg Agent_sdk.Types.User "u0"
+  ; msg Agent_sdk.Types.Assistant "a1"
+  ; msg Agent_sdk.Types.Tool "t2"
+  ; msg Agent_sdk.Types.User "u3"
+  ]
+
+let test_apply_keeps_summarizes_drops () =
+  (* kept: 3 ; summarized: 0,1 ; dropped: 2 *)
+  let json = plan_json ~summary:"S" ~kept:[ 3 ] ~summarized:[ 0; 1 ] ~dropped:[ 2 ] in
+  match C.plan_of_json ~message_count:4 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    let out = C.apply plan ~messages:sample in
+    let out_texts = texts out in
+    (* summary replaces indices 0,1 at position of first summarized (0);
+       index 2 dropped; index 3 kept. Result: [summary; u3]. *)
+    Alcotest.(check int) "two messages remain" 2 (List.length out);
+    Alcotest.(check bool)
+      "first is the compaction summary"
+      true
+      (match out_texts with
+       | s :: _ -> Astring.String.is_infix ~affix:"S" s
+                   && Astring.String.is_prefix ~affix:"[COMPACTION_SUMMARY]" s
+       | [] -> false);
+    Alcotest.(check (list string))
+      "kept message survives verbatim after the summary"
+      [ "u3" ]
+      (List.tl out_texts)
+
+let test_apply_all_kept_is_identity () =
+  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2; 3 ] ~summarized:[] ~dropped:[] in
+  match C.plan_of_json ~message_count:4 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    let out = C.apply plan ~messages:sample in
+    Alcotest.(check (list string))
+      "all-kept leaves the working set unchanged"
+      (texts sample)
+      (texts out)
+
+let () =
+  Alcotest.run "compaction_llm_summarizer"
+    [ ( "plan_of_json"
+      , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
+        ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
+        ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected
+        ; Alcotest.test_case "negative rejected" `Quick test_negative_rejected
+        ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
+        ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
+        ; Alcotest.test_case "empty summary rejected" `Quick test_empty_summary_rejected
+        ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
+        ] )
+    ; ( "apply"
+      , [ Alcotest.test_case "keeps/summarizes/drops" `Quick test_apply_keeps_summarizes_drops
+        ; Alcotest.test_case "all-kept is identity" `Quick test_apply_all_kept_is_identity
+        ] )
+    ]


### PR DESCRIPTION
## 목적

LLM 컴팩션 이니셔티브 **W2 (LLM summarizer 구현)**. W1(#23548, stacked base)이 놓은 `compaction_mode = Deterministic | Llm`의 `Llm` arm을 실제 librarian-lane LLM 요약으로 구현한다.

**default off 유지** — opt-in keeper만 LLM 경로. deterministic은 항상 보장된 fallback floor.

## 변경

### 1. `compaction_llm_summarizer.ml/.mli` (신규)
`Keeper_memory_llm_summary.make` 패턴을 복제한 컴팩션 전용 summarizer:
- **opt-in gate** (`memory_llm_summary_enabled`) + **fiber-local Eio capture** (`Eio_context.get_switch_opt`) + **librarian lane 해석** (`runtime_id_for_librarian`) + **schema-capable direct-completion provider 필터** → 하나라도 실패 시 `None` (fail-closed).
- 요약 요청은 **structured output** — LLM이 각 메시지를 0-based index로 kept/summarized/dropped 분류 + `summary` prose 1블록.
- **Parse, don't validate**: `plan_of_json`이 index partition을 검증 — 범위 초과/음수/중복/미커버/빈 summary는 조용히 고치지 않고 **거부** (→ `None` → deterministic fallback). LLM이 miscount해도 실제 메시지를 잃지 않음.
- `apply`: kept 원문 유지, summarized→summary 메시지 1개로 대체(첫 summarized 위치), dropped 제거, 순서 보존.

### 2. `keeper_structured_output_schema.ml`: `compaction_plan_output_schema` (신규)
`{ summary, kept_indices, summarized_indices, dropped_indices }`. `consolidation_plan`의 member/drop-indices 선례를 따른 index 모델. wire field는 상수로 export해 파서와 SSOT 공유.

### 3. `keeper_compact_policy.ml`: `compact_if_needed_typed` 통합
`Applied` 분기의 messages 계산에 mode 갈래:
- `Deterministic` → 기존 OAS strategy chain (불변).
- `Llm` → **emergency(ratio≥0.8)면 deterministic만** (요약 응답도 headroom 필요 + cooldown 우회 밴드), 아니면 summarizer 시도 → 실패 시 deterministic fallback.
- fold_reducer(tool-result stub) + pair-repair는 mode 무관하게 동일 적용.

## 검증

- `dune build lib/keeper lib/config` clean.
- `test_compaction_llm_summarizer` 10 tests: partition 파싱(valid 2 + 거부 6) + apply(재구성 2). ocamlformat clean.
- provider 호출 경로(`make`)는 Eio+live provider 필요라 integration 소관, 이 PR은 pure surface + fail-closed 구조.

## 잔여 (별도 슬라이스)
- **W2b 대시보드 배선**: plan.kept/summarized/dropped를 pre_compact snapshot에 노출 → 빈 대시보드 컬럼 채움.
- **W3 가드레일**: budget cap, noop/divergence guard 강화.
- **W4**: opt-in 활성 + shadow 측정.

## Workaround-bar self-check
- structured output = typed schema (string classifier 아님).
- fail-closed fallback = 기존 deterministic 재사용 (신규 suppression 아님).
- 단일 통합 지점(`compact_if_needed_typed`) — N-of-M 아님.
- plan 검증은 reject(고침 아님) — telemetry-as-fix 아님.

Stacked on #23548 (W1). W1 머지 후 main으로 retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
