### PR TITLE
fix(keeper): migrate auto-pause blocker tests to RFC-0313 W3 pacing modes

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -965,6 +965,7 @@ dominant source of the observed CAS race exhaustion after
                     ~meta
                     ~updated_meta
                     ~is_auto_recoverable
+                    ~pacing_enforced:(Keeper_pacing_shadow.pacing_enforced ())
                     ~err
                     ~error_text:e_str;
                   (* RFC-0221 §3.4: emit turn_completed telemetry on all exit paths

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -40,6 +40,7 @@ let record_failure_and_maybe_escalate
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(updated_meta : Keeper_meta_contract.keeper_meta)
       ~is_auto_recoverable
+      ~pacing_enforced
       ~err
       ~error_text
   =
@@ -76,8 +77,10 @@ let record_failure_and_maybe_escalate
      [paused=true] — the failure was already recorded as pacing (revisit
      widening) and, for judgment classes, as a [Failure_judgment] stimulus at
      the routing site in [Keeper_unified_turn]. The three auto-pause flags
-     below stay reachable only in shadow mode (kill-switch, removed in W4). *)
-  let pacing_enforced = Keeper_pacing_shadow.pacing_enforced () in
+     below stay reachable only in shadow mode (kill-switch, removed in W4).
+     [pacing_enforced] is injected by the caller (production wires
+     [Keeper_pacing_shadow.pacing_enforced ()]) so the mode is an explicit
+     input at the boundary, not a hidden config read inside policy code. *)
   let runtime_auto_paused =
     (not pacing_enforced)
     && EC.is_runtime_exhausted_error err

--- a/lib/keeper/keeper_unified_turn_failure.mli
+++ b/lib/keeper/keeper_unified_turn_failure.mli
@@ -5,6 +5,13 @@ val record_failure_and_maybe_escalate
   -> meta:Keeper_meta_contract.keeper_meta
   -> updated_meta:Keeper_meta_contract.keeper_meta
   -> is_auto_recoverable:bool
+  -> pacing_enforced:bool
   -> err:Agent_sdk.Error.sdk_error
   -> error_text:string
   -> unit
+(** [pacing_enforced] is the RFC-0313 W3 mode, read once by the caller
+    (production wires [Keeper_pacing_shadow.pacing_enforced ()]).  When
+    [true] (default runtime config), the three legacy auto-pause flags are
+    inert — the failure is expressed as pacing plus a judgment stimulus at
+    the routing site; when [false] (shadow kill-switch, removed in W4), the
+    legacy [paused=true] writes run. *)

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -1161,6 +1161,7 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
            ~meta
            ~updated_meta:meta
            ~is_auto_recoverable:false
+           ~pacing_enforced:false
            ~err
            ~error_text:(Agent_sdk.Error.to_string err)
        done;
@@ -1212,6 +1213,7 @@ let test_read_only_no_progress_pause_uses_backoff_auto_resume () =
            ~meta
            ~updated_meta:meta
            ~is_auto_recoverable:false
+           ~pacing_enforced:false
            ~err
            ~error_text:(Agent_sdk.Error.to_string err)
        done;
@@ -1257,6 +1259,7 @@ let test_mutating_no_progress_pause_stays_manual_resume () =
            ~meta
            ~updated_meta:meta
            ~is_auto_recoverable:false
+           ~pacing_enforced:false
            ~err
            ~error_text:(Agent_sdk.Error.to_string err)
        done;
@@ -1295,6 +1298,7 @@ let test_runtime_pause_threshold_override_controls_idle_auto_pause () =
          ~meta
          ~updated_meta:meta
          ~is_auto_recoverable:false
+         ~pacing_enforced:false
          ~err
          ~error_text:(Agent_sdk.Error.to_string err);
        (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
@@ -1307,6 +1311,7 @@ let test_runtime_pause_threshold_override_controls_idle_auto_pause () =
          ~meta
          ~updated_meta:meta
          ~is_auto_recoverable:false
+         ~pacing_enforced:false
          ~err
          ~error_text:(Agent_sdk.Error.to_string err);
        match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
@@ -1314,6 +1319,52 @@ let test_runtime_pause_threshold_override_controls_idle_auto_pause () =
          check bool "paused at runtime threshold" true
            entry.Masc.Keeper_registry.meta.paused
        | None -> fail "expected registered keeper after threshold")
+
+(* RFC-0313 W3 enforce twin: under the production default ([pacing]
+   mode = "enforce"), repeated IdleDetected failures past the runtime
+   threshold must NOT write [paused=true] — the failure is expressed as
+   pacing plus a judgment stimulus at the routing site instead.  The
+   legacy tests above pass [~pacing_enforced:false] to pin the shadow
+   kill-switch semantics until W4 deletes the auto-pause flags. *)
+let test_enforced_pacing_keeps_idle_detected_unpaused () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_runtime_config (runtime_toml_with_pause_threshold 2) @@ fun () ->
+  let base_path = temp_dir "masc-idle-detected-enforced-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "idle-detected-enforced" in
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let err =
+         Agent_sdk.Error.Agent
+           (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 4 })
+       in
+       for _ = 1 to 3 do
+         Masc.Keeper_unified_turn_failure.record_failure_and_maybe_escalate
+           ~config
+           ~meta
+           ~updated_meta:meta
+           ~is_auto_recoverable:false
+           ~pacing_enforced:true
+           ~err
+           ~error_text:(Agent_sdk.Error.to_string err)
+       done;
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check bool "not paused past threshold under enforce" false
+           entry.Masc.Keeper_registry.meta.paused;
+         check
+           (option (float 0.001))
+           "no auto-resume timer under enforce"
+           None
+           entry.Masc.Keeper_registry.meta.auto_resume_after_sec
+       | None -> fail "expected registered keeper under enforce")
 
 let test_legacy_last_blocker_pair_rejected () =
   let legacy_json =
@@ -1437,5 +1488,7 @@ let () =
             test_idle_detected_repeated_failure_pauses_keeper;
           test_case "runtime [pause] threshold controls idle auto-pause" `Quick
             test_runtime_pause_threshold_override_controls_idle_auto_pause;
+          test_case "enforced pacing keeps IdleDetected unpaused (RFC-0313 W3)" `Quick
+            test_enforced_pacing_keeps_idle_detected_unpaused;
         ] );
     ]


### PR DESCRIPTION
## 무엇

main `Build and Test` quick suite red 잔여 — `7ca672d15f` 런의 `test_keeper_auto_pause_blocker_persist_12683` 4건:

- `idle-detected loop #0/#1` (repeated IdleDetected pause / runtime [pause] threshold)
- `no_progress loop #13/#14` (read-only backoff auto-resume / mutating manual resume)

전부 `meta.paused = true`를 단언하는 **legacy auto-pause 계약**.

## 왜

RFC-0313 W3(#23524)가 `keeper_unified_turn_failure`의 auto-pause 플래그 3종을 `(not pacing_enforced) &&`로 게이트했는데 이 테스트 파일은 마이그레이션되지 않았고, #23524의 CI 런이 머지 시각에 취소되어 main에서 발현. 테스트 fixture TOML(`runtime_toml_with_pause_threshold`)에 `[pacing]` 섹션이 없어 숨은 `Keeper_pacing_shadow` read가 의도와 무관하게 enforce 기본으로 낙하하는 이중 구조 — #23552(supervisor sweep)와 동일 병리.

## 어떻게 — #23552와 같은 경계 주입 패턴

1. `record_failure_and_maybe_escalate`에 **필수** `~pacing_enforced:bool` 추가, 내부 숨은 read 제거. 프로덕션 유일 호출자(`keeper_unified_turn.ml` failure path)가 `Keeper_pacing_shadow.pacing_enforced ()` 배선.
2. legacy pause 테스트 4건(5사이트)은 `~pacing_enforced:false` 명시 — shadow kill-switch 의미론 핀 (W4가 auto-pause 플래그와 함께 일괄 삭제 예정).
3. **enforce 트윈 신설**: threshold 초과 반복 IdleDetected에서 `meta.paused = false` + auto-resume 타이머 없음 — W3 불변식(turn failure는 존재를 못 바꾼다)을 이 유닛 레벨에서 핀.

## 검증

- ocamlformat --check 4파일 통과. dune 빌드는 CI 위임(운영 규칙).
- 같은 런의 나머지 red는 별도 축: board claim gate 11건(#23527 추적, 플릿), otel_zero_fill 트립와이어(#23539 누락 → hotfix PR 별도), staleness_gate(#23534 자체 테스트, 작성자 축).

RFC-0313 (W3 flip #23524의 테스트 마이그레이션 누락분 — #23552와 동일 계열, 다른 소비자).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
