### PR TITLE
fix(test): realign Keeper_metrics.all tripwire to 252 (#23539 follow-up)

### DIFF
--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 251
+  check int "Keeper_metrics.all covers every constructor" 252
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
## 무엇

main red 1건 — `test_otel_zero_fill` `module-init #3`:

```
FAIL Keeper_metrics.all covers every constructor — Expected: 251 / Received: 252
```

트립와이어 리터럴 251 → 252.

## 왜

#23539가 `MemoryOsReobserveEchoSuppressed` constructor + `to_string` 매핑 + `all` 엔트리를 추가하면서 zero-fill 드리프트 트립와이어를 미갱신. #23539의 CI 런이 머지 시각에 취소(merge-before-green)되어 main에서 처음 발현. constructor/매핑/all은 이미 정합(injective 체크 통과 대상)이고 트립와이어 숫자만 stale — 1줄.

RFC-WAIVED: test-only tripwire literal realignment; no subsystem code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>