### PR TITLE
fix(test): realign Keeper_metrics.all drift tripwire to 253

### DIFF
--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 252
+  check int "Keeper_metrics.all covers every constructor" 253
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"


### PR DESCRIPTION
## 문제

main red: `test_otel_zero_fill` "keeper all complete" — tripwire 하드코딩 카운트(252)와 `Keeper_metrics.all` 실제 크기(253) 불일치.

## 원인

오늘 constructor 추가 커밋 2건이 tripwire bump를 누락:
- #23539 `MemoryOsReobserveEchoSuppressed` (본인 PR — Build and Test가 머지 시점 Closed PR CI Cleanup으로 취소되며 이 테스트까지 도달하지 못함)
- #23556 RFC-0315 P2a counter

둘 다 `all` 리스트에는 존재하며 (type 253 = all 253, missing 0 정적 대조 확인), 카운트만 뒤처짐.

## 수정

`test/test_otel_zero_fill.ml` 1줄: 252 → 253.

## 검증

- `dune build --root . test/test_otel_zero_fill.exe` 후 실행: 6/6 OK ("keeper all complete" 포함)
- 정적 대조: type constructors 253 = all entries 253, missing []

## 참고

오늘 하루에만 이 tripwire 재정렬이 5번째 (fcf1f69acb, 933316935b, 912c41fc1e 구간 desync 포함). 반복 드리프트의 근본 수정(정적 CI 체크)은 별도 이슈로 등록.
