### PR TITLE
fix(keeper): unbreak main — parenthesize exception-as pattern in keeper_post_turn

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -463,7 +463,7 @@ let read_existing_interruption_progress_snapshot ~(progress_path : string) =
     No_existing_progress_snapshot
   else
     match Fs_compat.load_file progress_path with
-    | exception Eio.Cancel.Cancelled _ as e -> raise e
+    | exception (Eio.Cancel.Cancelled _ as e) -> raise e
     | exception exn ->
         Existing_progress_snapshot_read_failed (Printexc.to_string exn)
     | text -> (


### PR DESCRIPTION
## 목적

main(`6a1325beac`)의 컴파일 red 복구. `dune build lib/keeper` 실패.

## 원인

#23556(RFC-0315 P2a)가 `lib/keeper/keeper_post_turn.ml:466`에 exception pattern + `as` 바인딩을 괄호 없이 넣어 OCaml 문법 오류:

```
| exception Eio.Cancel.Cancelled _ as e -> raise e
Error: Exception patterns are not allowed in this position.
```

`exception P as e`는 파싱되지 않습니다 — `exception (P as e)`로 괄호가 필요합니다.

## 변경

`keeper_post_turn.ml:466` 1줄: `exception (Eio.Cancel.Cancelled _ as e)`. Cancelled를 re-raise하는 의도는 그대로 보존.

## 검증

`dune build lib/keeper` clean.

merge-before-green (PR 빌드가 머지 시 cancel돼 main에서 첫 발현). required check=CI Gate aggregate 구조의 반복 산물.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
