### PR TITLE
fix(test): pin outcome-positive category in eligible staleness case (#23534 follow-up)

### DIFF
--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -583,10 +583,17 @@ let () =
                Alcotest.(check bool) "young unverified" true (Consolidator.not_stale ~now young))
         ; Alcotest.test_case "eligible ~now filters stale Durable_knowledge" `Quick
             (fun () ->
-               let stale_dk = fact ~last_verified_at:(now -. 90000.)
+               (* [eligible] also gates on category
+                  ([is_outcome_positive_for_shared_promotion]): the fixture
+                  default [Fact] is rejected there, which would mask the
+                  staleness axis this case isolates. Pin an outcome-positive
+                  category so only [not_stale] varies between the two facts. *)
+               let stale_dk = fact ~category:Types.Validated_approach
+                 ~last_verified_at:(now -. 90000.)
                  ~claim_kind:(Some Types.Durable_knowledge) "stale_dk" in
                Alcotest.(check bool) "stale dk" false (Consolidator.eligible ~now stale_dk);
-               let fresh_dk = fact ~last_verified_at:(now -. 10.0)
+               let fresh_dk = fact ~category:Types.Validated_approach
+                 ~last_verified_at:(now -. 10.0)
                  ~claim_kind:(Some Types.Durable_knowledge) "fresh_dk" in
                Alcotest.(check bool) "fresh dk" true (Consolidator.eligible ~now fresh_dk))
         ; Alcotest.test_case "not_stale delegates to fact_effective_valid_until first" `Quick


### PR DESCRIPTION
## 무엇

main red 1건 — `test_keeper_memory_os_consolidation` `staleness_gate #3`:

```
FAIL fresh dk — Expected: `true' / Received: `false'
```

#23534가 추가한 "eligible ~now filters stale Durable_knowledge" 케이스의 fixture 수리 (테스트 2 fact에 `~category:Types.Validated_approach` 명시).

## 왜 (의미론 판정: 테스트 오류, 코드 회귀 아님)

`Consolidator.eligible`은 staleness 외에 category 게이트를 먼저 통과해야 한다:

```ocaml
let eligible ~now fact =
  is_promotable fact.category
  && is_outcome_positive_for_shared_promotion fact.category  (* Validated_approach | Lesson만 true *)
  && not_stale ~now fact
  && ...
```

- 테스트 fixture 기본 category = `Fact` → `is_outcome_positive_for_shared_promotion Fact = false` (RFC-0247 §6: 반복된 plain fact는 outcome 평가 전까지 keeper-local).
- 따라서 `fresh_dk`(10초 전 verified)도 staleness와 무관하게 `eligible=false` — 결정론적 FAIL.
- `stale_dk`의 expected false는 **staleness가 아니라 category 때문에** 우연히 통과 — 케이스가 증명하려던 축(staleness 관통)을 전혀 검증하지 못하는 상태였다.

수리 후 두 fact 모두 category 게이트를 통과하고 `not_stale`만 분기: stale(90000s > 86400s) → false, fresh(10s) → true. 케이스가 원래 의도대로 staleness 축을 분리 검증한다.

## 왜 main에서야 발견됐나

#23534의 CI가 머지 시각에 완주하지 못한 채 착지 (merge-before-green). 같은 런(7ca672d15f, job 85616608933)의 다른 red 계열은 별도 수리됨: tripwire #23561(MERGED), auto-pause blocker #23560(MERGED). 잔여는 board coverage 계열(별도 이슈 예정).

## 검증

- 로컬 dune 실행 없음 (repo 규칙: dune은 CI에서만). 정적 판정 근거:
  - `~category:Types.Lesson` 동일 패턴이 같은 파일 164행 등에서 기존 사용.
  - `Validated_approach`는 `keeper_memory_os_types.mli:87` 노출 variant.
  - `max_consensus_staleness = 86400.` (policy SSOT) 기준 90000 > 86400, 10 ≤ 86400.
- 판정은 이 PR CI의 Build and Test로 확인한다.

RFC-WAIVED: test-only fixture fix; no subsystem code touched.

Refs: #23534 (원인), task-1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
