### PR TITLE
test(gate): evidence gate blocks fake ref and recovers (RFC-0311 reject-path)

### DIFF
--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -23,6 +23,10 @@
        notes below the substance floor ([min_notes_length] = 10) are rejected
        before Gate 3 ever calls an LLM. Reachable only when the caller owns the
        task (otherwise gate 1 above intercepts first).
+    3. [Task_completion_gate] — done attempts with substantive notes but no
+       trusted, reviewer-inspectable [handoff_context.evidence_refs] are
+       rejected, and a later retry with a trusted ref can still complete the
+       same task.
 
     Each reject asserts a gate-SPECIFIC signal (distinct rule_id / substring /
     failure_class), not merely outcome=failure — a tool-not-allowed or unknown-tool
@@ -30,17 +34,11 @@
     so the gate-specific assertion is what proves the *intended* gate fired. Each
     reject also asserts the task FSM was NOT mutated (anti-vacuity).
 
-    Deliberately NOT covered here, with rationale:
-    - A legitimate *completion* success: once notes clear the length floor, the
-      anti-rationalization review reaches its Gate-3 LLM branch, whose
-      unavailable-LLM verdict is governed by operator fail-mode config and is not
-      deterministic in a no-LLM CI fixture. The deterministic success anchor is
-      therefore the *claim* (Test D), which has no review gate.
-    - An evidence-gate rejection on keeper_task_done: the deterministic evidence
-      evaluator is wired into the *claim* auto-complete path, not the done path
-      (a Phase-3 / RFC-0199 gap). Asserting a done-evidence reject here would
-      assert a gate that does not exist. The evaluator's Indeterminate-dominates
-      determinism is already covered by test_keeper_deterministic_evidence_probe.ml.
+    Completion success and evidence-gate recovery are covered with a trusted
+    evidence reference ([PR#123]), keeping the no-LLM fixture deterministic while
+    proving the gate is selective rather than reject-everything. The evaluator's
+    Indeterminate-dominates determinism remains covered by
+    test_keeper_deterministic_evidence_probe.ml.
 
     The fixture helpers below are intentionally a local copy of the minimal subset
     used by test_keeper_tool_dispatch_runtime.ml (Eio workspace + a registered
@@ -320,10 +318,10 @@ let test_completion_with_evidence_refs_succeeds () =
 
 (* Test E — the evidence gate BLOCKS an untrusted (fake) reference on the *done*
    path, and the block is RECOVERABLE. This closes the reject-path proof gap the
-   docstring above left open ("asserting a done-evidence reject here would assert
-   a gate that does not exist"): the deterministic evidence gate DOES run on
-   Done_action (tool_task.ml: needs_gate = Done_action -> true), so a done attempt
-   whose evidence_refs hold no trusted Evidence_ref shape is rejected here.
+   old harness docstring left open ("asserting a done-evidence reject here would
+   assert a gate that does not exist"): the deterministic evidence gate DOES run
+   on Done_action (tool_task.ml: needs_gate = Done_action -> true), so a done
+   attempt whose evidence_refs hold no trusted Evidence_ref shape is rejected here.
 
    Two properties in one flow, mirroring test_completion_with_evidence_refs so the
    ONLY changed variable is trusted-vs-untrusted evidence:

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -318,6 +318,88 @@ let test_completion_with_evidence_refs_succeeds () =
          ^ Masc_domain.task_status_to_string task.task_status)
     | None -> fail "task-001 missing after completion")
 
+(* Test E — the evidence gate BLOCKS an untrusted (fake) reference on the *done*
+   path, and the block is RECOVERABLE. This closes the reject-path proof gap the
+   docstring above left open ("asserting a done-evidence reject here would assert
+   a gate that does not exist"): the deterministic evidence gate DOES run on
+   Done_action (tool_task.ml: needs_gate = Done_action -> true), so a done attempt
+   whose evidence_refs hold no trusted Evidence_ref shape is rejected here.
+
+   Two properties in one flow, mirroring test_completion_with_evidence_refs so the
+   ONLY changed variable is trusted-vs-untrusted evidence:
+   1. block:    substantive result (clears the anti-rationalization length floor)
+                + a prose "reference" a keeper might paste to fake completion
+                -> workflow rejection, FSM unchanged (anti-vacuity).
+   2. recover:  the SAME work re-submitted with a trusted reference (PR#123)
+                completes. The keeper is not frozen — this is the property the
+                CDAL redesign had to preserve: block fake-done without stalling. *)
+let test_untrusted_evidence_denied_then_recovers () =
+  with_ws "completion_trust_untrusted_then_recover" (fun ~config ~meta ~ctx_work ->
+    ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
+    ignore
+      (Workspace.add_task config ~title:"complete with a fake reference" ~priority:1
+         ~description:"claimed by the caller, first faked then legitimately proven");
+    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    check string "self-claim precondition succeeds" "success" (outcome_label claim.KET.outcome);
+    (* block: notes are substantive but the reference is untrusted prose. *)
+    let faked =
+      attempt_done
+        ~config
+        ~meta
+        ~ctx_work
+        ~task_id:"task-001"
+        ~result:"Completed the deliverable and verified it end to end."
+        ~evidence_refs:[ "trust me, it is done" ]
+        ()
+    in
+    check string "faked completion outcome" "failure" (outcome_label faked.KET.outcome);
+    check string "faked completion payload shape" "structured_error"
+      (payload_kind faked.KET.payload_shape);
+    let faked_json = parse_json faked.KET.raw_output in
+    check string "evidence reject is a workflow rejection" "workflow_rejection"
+      Yojson.Safe.Util.(member "failure_class" faked_json |> to_string);
+    check bool "reject names the trusted-evidence requirement (gate-specific signal)" true
+      (contains_substring faked.KET.raw_output
+         "no trusted, reviewer-inspectable evidence reference");
+    (* anti-vacuity: the faked attempt did NOT advance the FSM. *)
+    (match assignee_of config "task-001" with
+     | Some assignee ->
+       check string "task still owned by caller after the faked completion"
+         meta.agent_name assignee
+     | None ->
+       fail "task-001 must remain Claimed/InProgress after the rejected fake completion");
+    (* recover: same work, now with a trusted reference, completes. *)
+    let recovered =
+      attempt_done
+        ~config
+        ~meta
+        ~ctx_work
+        ~task_id:"task-001"
+        ~result:"Completed the deliverable and verified it end to end."
+        ~evidence_refs:[ "PR#123" ]
+        ()
+    in
+    check string "recovery completion outcome" "success" (outcome_label recovered.KET.outcome);
+    check string "recovery payload shape" "structured_success"
+      (payload_kind recovered.KET.payload_shape);
+    match
+      List.find_opt
+        (fun (t : Masc_domain.task) -> String.equal t.id "task-001")
+        (Workspace.get_tasks_raw config)
+    with
+    | Some
+        { task_status = Masc_domain.Done { assignee; _ }
+        ; handoff_context = Some handoff
+        ; _
+        } ->
+      check string "recovered done assignee" meta.agent_name assignee;
+      check (list string) "recovered handoff evidence_refs" [ "PR#123" ] handoff.evidence_refs
+    | Some task ->
+      fail
+        ("expected task-001 Done after recovery, got "
+         ^ Masc_domain.task_status_to_string task.task_status)
+    | None -> fail "task-001 missing after recovery completion")
+
 (* Test D — positive control: the gates are SELECTIVE, not reject-everything.
    A keeper claiming its own backlog task is accepted on the same dispatch path. *)
 let test_legitimate_claim_succeeds () =
@@ -354,6 +436,8 @@ let () =
             `Quick test_completion_denied_for_thin_notes
         ; test_case "completion with evidence_refs succeeds"
             `Quick test_completion_with_evidence_refs_succeeds
+        ; test_case "untrusted evidence is denied then a trusted retry recovers"
+            `Quick test_untrusted_evidence_denied_then_recovers
         ; test_case "legitimate self-claim is accepted (selectivity control)" `Quick
             test_legitimate_claim_succeeds
         ] )

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -49,6 +49,7 @@ open Alcotest
 
 module KET = Masc.Keeper_tool_dispatch_runtime
 module Workspace = Masc.Workspace
+module Task_completion_gate = Masc.Task_completion_gate
 
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
@@ -424,6 +425,22 @@ let () =
      deterministic: notes below [min_notes_length] short-circuit before the
      Gate-3 LLM call, so no model runtime is ever invoked. *)
   Atomic.set Workspace_hooks.get_default_runtime_id_fn (fun () -> "test-evaluator-runtime");
+  (* Wire the REAL evidence gate into the completion hook. The hook defaults to a
+     permissive stub (workspace_hooks.ml: always Pass); the running server swaps
+     in the deterministic gate at boot via Workspace_metric_hooks. Left unwired,
+     every done attempt passes the gate vacuously — a completion-with-evidence
+     test would go green without the gate ever running, and a fake-evidence
+     reject could never be observed. This replicates the boot adapter so the
+     reject/recover oracle (and the evidence_refs-success test) exercise the
+     gate itself rather than the stub. *)
+  Atomic.set Workspace_hooks.task_completion_gate_decide_fn
+    (fun ~task_id ~task_opt ~notes ~handoff () ->
+      match
+        Task_completion_gate.decide ~task_id ~task_opt ~notes ~handoff_context:handoff ()
+      with
+      | Task_completion_gate.Pass -> Workspace_hooks.Pass
+      | Task_completion_gate.Reject { reason; rule_id; hint; payload_json } ->
+        Workspace_hooks.Reject { reason; rule_id; hint; payload_json });
   run "Completion_trust_harness"
     [ ( "completion_trust_dispatch_oracle"
       , [ test_case "non-owner completion is denied (ownership gate)" `Quick


### PR DESCRIPTION
## 목표

RFC-0311 evidence gate의 **거부 경로**를 실증하고, 그 과정에서 드러난 **테스트 공백**을 메운다.

#23538(L1 게이트)은 "trusted evidence_refs가 있으면 완료"(happy path)만 테스트로 덮은 것처럼 보였다. 실제로는 그 테스트조차 **게이트를 태우지 않았다**(아래 참조). 게이트의 존재 이유인 **fake-done 차단 + keeper 무정지(회복)** 는 미검증이었다.

## 발견 (핵심)

`test_completion_trust_harness.ml`는 `Workspace_hooks.task_completion_gate_decide_fn`을 배선하지 않았다. 이 hook의 **기본값은 permissive stub(항상 `Pass`)** 이고, 실제 게이트는 서버 부팅 시 `Workspace_metric_hooks`가 교체한다. harness는 `get_default_runtime_id_fn`만 배선하고 게이트는 두지 않았다.

결과: harness에서 evidence 게이트가 **완전히 inert**였다. 기존 `completion with evidence_refs succeeds`(`PR#123`→success) 테스트는 **게이트를 증명한 게 아니라 no-op stub Pass를 통과한 vacuous green**이었다. 새로 추가한 untrusted 테스트가 이 vacuity를 폭로했다(inert 게이트가 fake 참조 `"trust me, it is done"`를 통과시켜 test가 실패 → 실제 게이트 배선 후 통과).

## 변경

- `test/test_completion_trust_harness.ml`:
  - `test_untrusted_evidence_denied_then_recovers` 추가(block + recover).
  - `Workspace_hooks.task_completion_gate_decide_fn`에 **실제 게이트 배선**(부팅 adapter 복제). 이걸로 evidence_refs-success 테스트도 non-vacuous가 된다.
  - docstring 정렬(fleet `agent@masc.local` 협업 커밋 `ae2250ba90` 위에 rebase).
- **production 코드 미변경, test-only.**

## 무엇을 증명하나

`test_completion_with_evidence_refs_succeeds`를 미러링하되 **trusted↔untrusted 증거만** 바꿔 통제변수 하나로 고정:

1. **block** — substantive notes(anti-rationalization 길이 floor 통과) + untrusted prose 참조(`"trust me, it is done"`, 어떤 trusted `Evidence_ref` shape에도 파싱 안 됨) → `workflow_rejection`(게이트 고유 사유 `"no trusted, reviewer-inspectable evidence reference"`), task FSM 미변경(anti-vacuity).
2. **recover** — 같은 작업 + trusted 참조(`PR#123`) → `Done` 완료, ref가 `handoff_context`에 실림. **keeper 무정지** — CDAL 재설계가 보존해야 했던 속성.

## 검증

- **로컬 실행 (masc 정상, #23566 머지 후): 6/6 통과**, untrusted-then-recover 포함. 배선 전엔 test #4 실패 → 배선 후 통과 = 테스트가 게이트 유무를 **구별**함(non-vacuous).
- CI에서 재확인.
- 선행 블로커였던 main 컴파일 브레이크(`keeper_post_turn.ml:466`, #23556)는 **#23566 머지로 해소**됨.

## 설계 노트

워크어라운드 아님 — production 로직 0 변경. 기존 게이트 동작을 **증명**하고, 그 증명을 무력화하던 harness 배선 공백을 메운다. 이 세션에서 #23538의 shape-only 게이트가 keeper 전원 락아웃됐던 사고(fleet `5331d1e114` 해소)의 후속 — "동작한다"의 미검증 절반(차단+회복)을 닫는다.

Refs #18840. RFC-0311. #23538 후속.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: MASC Agent <agent@masc.local>
