### PR TITLE
fix(keeper): accept empty compaction summary when nothing is summarized (W2 self-review)

### DIFF
--- a/lib/keeper/compaction_llm_summarizer.ml
+++ b/lib/keeper/compaction_llm_summarizer.ml
@@ -167,12 +167,20 @@ let validate_non_empty_output ~message_count ~kept ~summarized =
 let plan_of_json ~message_count json =
   let* summary = string_field Schema.compaction_plan_field_summary json in
   let summary = String.trim summary in
-  let* () =
-    if summary = "" then Error "summary must be non-empty" else Ok ()
-  in
   let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
   let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
   let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
+  (* The summary stands in for the [summarized] messages; it is consumed by
+     [apply] only when [summarized] is non-empty. Requiring it non-empty
+     unconditionally would reject a legitimate "keep everything, nothing to
+     summarize" plan (summary="") and spuriously fall back to the
+     deterministic chain. So the summary must be non-empty iff it will be
+     used. *)
+  let* () =
+    if summarized <> [] && summary = ""
+    then Error "summary must be non-empty when summarized indices are present"
+    else Ok ()
+  in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
   let* () = validate_non_empty_output ~message_count ~kept ~summarized in
   Ok { summary; kept; summarized; dropped }

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -80,10 +80,21 @@ let test_all_dropped_rejected () =
     true
     (is_error (C.plan_of_json ~message_count:2 json))
 
-let test_empty_summary_rejected () =
+(* The summary is only consumed when there are summarized indices. A blank
+   summary with an empty [summarized] set is a legitimate "keep everything"
+   plan and must be accepted — rejecting it spuriously falls back to the
+   deterministic chain. *)
+let test_empty_summary_accepted_when_nothing_summarized () =
   let json = plan_json ~summary:"   " ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
-    "a blank summary is rejected"
+    "a blank summary is accepted when nothing is summarized"
+    true
+    (is_ok (C.plan_of_json ~message_count:2 json))
+
+let test_empty_summary_rejected_when_summarizing () =
+  let json = plan_json ~summary:"   " ~kept:[ 1 ] ~summarized:[ 0 ] ~dropped:[] in
+  Alcotest.(check bool)
+    "a blank summary is rejected when there are summarized indices to fold"
     true
     (is_error (C.plan_of_json ~message_count:2 json))
 
@@ -153,7 +164,10 @@ let () =
         ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
         ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
         ; Alcotest.test_case "all dropped rejected" `Quick test_all_dropped_rejected
-        ; Alcotest.test_case "empty summary rejected" `Quick test_empty_summary_rejected
+        ; Alcotest.test_case "empty summary accepted when nothing summarized" `Quick
+            test_empty_summary_accepted_when_nothing_summarized
+        ; Alcotest.test_case "empty summary rejected when summarizing" `Quick
+            test_empty_summary_rejected_when_summarizing
         ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
         ] )
     ; ( "apply"


### PR DESCRIPTION
## 목적

W2(#23558, 머지됨)의 컴팩션 plan 검증 결함 수정. **적대적 셀프 리뷰로 발견** (W2가 codex 리뷰 credit 소진으로 봇 리뷰 없이 머지됨).

## 결함 (P2)

`plan_of_json`이 `summary`를 **무조건 non-empty** 요구했는데, `apply`는 `summarized` 인덱스가 있을 때만 summary를 사용합니다. 결과: LLM이 "전부 kept, 요약할 것 없음"이라는 **정당한 plan**(`summary=""`, `summarized=[]`)을 주면 parser가 거부 → `None` → deterministic fallback. 데이터 손실은 없으나(summary가 0개 메시지 대표) **정당한 LLM 응답이 버려져 LLM 경로가 불필요하게 fallback**합니다.

## 변경

- `compaction_llm_summarizer.ml plan_of_json`: summary 검증을 조건부로 — `summarized <> [] && summary = "" → Error`. summarized가 비면 빈 summary 허용.
- `test_compaction_llm_summarizer.ml`: 기존 `test_empty_summary_rejected`가 **틀린 계약을 인코딩**(blank summary + summarized=[] 거부를 정상으로 못박음). 두 케이스로 분리 — accepted-when-nothing-summarized + rejected-when-summarizing.

## 검증

`dune build lib/keeper` + test 13 tests green. ocamlformat clean.

## 부수 (같은 셀프 리뷰에서 확인)

W2의 미검증 blind spot 2개를 코드로 반증: (1) Eio 컨텍스트는 turn 스코프(`keeper_agent_run.ml:310 Eio.Switch.run + with_turn_switch`)에서 available → Llm 경로 dead 아님. (2) `with_timeout`가 `Eio.Time.Timeout`만 잡아 `Eio.Cancel.Cancelled`는 전파 → cancellation 안전. 둘 다 결함 없음.

## Workaround-bar self-check

검증 로직 완화(과잉 엄격 → 정확). string classifier/telemetry-as-fix/N-of-M 아님. 오히려 잘못된 테스트 계약을 정정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
