### PR TITLE
fix(keeper): policy_source 라벨을 실제 판정 config 파일에서 파생 (task-1865)

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -534,8 +534,11 @@ let locks_dir ~base_path =
 let data_dir ~base_path =
   Filename.concat base_path "data"
 
+let repositories_toml_basename = "repositories.toml"
+
 let repositories_toml_path ~base_path =
-  Filename.concat (masc_root ~base_path) "config/repositories.toml"
+  Filename.concat (masc_root ~base_path)
+    (Filename.concat "config" repositories_toml_basename)
 
 let keeper_repo_mappings_toml_path ~base_path =
   Filename.concat (masc_root ~base_path) "config/keeper_repo_mappings.toml"

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -156,6 +156,12 @@ val data_dir : base_path:string -> string
 
 (** {2 Config-rooted file accessors} *)
 
+val repositories_toml_basename : string
+(** ["repositories.toml"]. SSOT basename of the repository catalog file, so
+    callers that surface *which* config file gated a decision (e.g. the
+    playground repo [policy_source] field) label it from one constant instead
+    of a scattered literal. [repositories_toml_path] derives from this. *)
+
 val repositories_toml_path : base_path:string -> string
 (** [<base_path>/.masc/config/repositories.toml]. Backwards-compatible
     direct derivation from [base_path]. A future RFC may extend this to

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -340,6 +340,23 @@ let playground_policy_reason = function
       Some
         "repository catalog could not be loaded; access is denied fail-closed"
 
+(* Which config file actually decided this status. The binding allow/deny gate
+   is the repository catalog (repositories.toml): a repo is usable iff it is
+   registered there, and [access_decision] never denies on the mapping — per
+   RFC-0312 the keeper_repo_mappings.toml scope is advisory. So every
+   catalog-sourced verdict (allowed / unregistered / identity mismatch / store
+   load error) is labelled with the catalog basename; only the
+   mapping-file-load failure is sourced from the advisory mapping. Exhaustive
+   so a new status cannot silently inherit the wrong source. *)
+let policy_source_basename_of_status : playground_policy_status -> string
+  = function
+  | Policy_allowed
+  | Policy_unregistered_repository
+  | Policy_repository_identity_mismatch
+  | Policy_repository_store_error ->
+      Config_dir_resolver.repositories_toml_basename
+  | Policy_mapping_load_error -> Keeper_repo_mapping.mappings_toml_basename
+
 let playground_repo_policy ~(base_path : string) ~(keeper_name : string) =
   match Keeper_repo_mapping.lookup_mapping ~base_path ~keeper_id:keeper_name with
   | Keeper_repo_mapping.Mapping_load_error msg as r ->
@@ -393,7 +410,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       if default_scope then [ ("policy_default_scope", `Bool true) ] else []
     in
     ( "policy_source"
-    , `String Keeper_repo_mapping.mappings_toml_basename )
+    , `String (policy_source_basename_of_status status) )
     :: ("policy_status", `String status_text)
     :: ("policy_allowed", `Bool allowed)
     :: (default_scope_fields @ repository_id_fields @ reason_fields

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -59,6 +59,15 @@ val playground_policy_status_to_string : playground_policy_status -> string
     tests and callers can assert against the same strings the JSON response
     uses without duplicating them. *)
 
+val policy_source_basename_of_status : playground_policy_status -> string
+(** Basename of the config file that actually decided a status: the repository
+    catalog ([repositories.toml]) for every allow/deny verdict, since that is
+    the binding gate, and the advisory mapping ([keeper_repo_mappings.toml])
+    only for its own load failure (RFC-0312). Exposed so the [policy_source]
+    field's source-of-truth is asserted against the same mapping the JSON uses,
+    rather than a hardcoded basename that misreported catalog denials as
+    mapping denials. *)
+
 val playground_repos_json :
   config:Workspace.config ->
   meta:keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,7 @@
   test_advisory_only_affordance_never_drives_wake
   test_keeper_failed_task_orphan_does_not_livelock
   test_broadcast_wakeup_policy
+  test_policy_source_of_status
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_keeper_librarian_retry
@@ -400,6 +401,7 @@
   test_advisory_only_affordance_never_drives_wake
   test_keeper_failed_task_orphan_does_not_livelock
   test_broadcast_wakeup_policy
+  test_policy_source_of_status
   test_keeper_mention_scope
   test_keeper_lane_mentions
   test_keeper_librarian_retry

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -216,7 +216,7 @@ let test_playground_repos_mark_missing_mapping_default_scope_allowed () =
   check bool "policy marks default scope" true
     (json_bool "policy_default_scope" json);
   check string "policy source"
-    Masc.Config_dir_resolver.repositories_toml_basename
+    Config_dir_resolver.repositories_toml_basename
     (json_string "policy_source" json)
 
 let test_playground_repos_mark_registered_repo_outside_mapping_allowed () =

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -216,7 +216,7 @@ let test_playground_repos_mark_missing_mapping_default_scope_allowed () =
   check bool "policy marks default scope" true
     (json_bool "policy_default_scope" json);
   check string "policy source"
-    Keeper_repo_mapping.mappings_toml_basename
+    Masc.Config_dir_resolver.repositories_toml_basename
     (json_string "policy_source" json)
 
 let test_playground_repos_mark_registered_repo_outside_mapping_allowed () =

--- a/test/test_policy_source_of_status.ml
+++ b/test/test_policy_source_of_status.ml
@@ -16,7 +16,7 @@
 open Alcotest
 module Ksc = Masc.Keeper_sandbox_control
 
-let catalog = Masc.Config_dir_resolver.repositories_toml_basename
+let catalog = Config_dir_resolver.repositories_toml_basename
 let mapping = Masc.Keeper_repo_mapping.mappings_toml_basename
 
 let source_of s = Ksc.policy_source_basename_of_status s

--- a/test/test_policy_source_of_status.ml
+++ b/test/test_policy_source_of_status.ml
@@ -1,0 +1,62 @@
+(** Regression for the playground repo [policy_source] label
+    ({!Masc.Keeper_sandbox_control.policy_source_basename_of_status}).
+
+    The field previously hardcoded the advisory mapping basename
+    (keeper_repo_mappings.toml) for every verdict, so a catalog-sourced denial
+    (repo not registered in repositories.toml) reported the wrong config file
+    as its source. Keepers then recorded that false cause as durable knowledge
+    and stopped touching the registered repo entirely (task-1865 / task-1866).
+
+    The binding allow/deny gate is the catalog (RFC-0312 makes the mapping
+    advisory), so every catalog verdict must be sourced from repositories.toml;
+    only the mapping-file load failure is sourced from the mapping. Assertions
+    compare against the SSOT basenames, not literals, so a rename of either
+    config file cannot silently pass a stale expectation. *)
+
+open Alcotest
+module Ksc = Masc.Keeper_sandbox_control
+
+let catalog = Masc.Config_dir_resolver.repositories_toml_basename
+let mapping = Masc.Keeper_repo_mapping.mappings_toml_basename
+
+let source_of s = Ksc.policy_source_basename_of_status s
+
+let test_catalog_sourced () =
+  (* Allow and every deny that the catalog decides are sourced from the
+     catalog file, not the advisory mapping. *)
+  check string "allowed -> catalog" catalog (source_of Ksc.Policy_allowed);
+  check string "unregistered -> catalog" catalog
+    (source_of Ksc.Policy_unregistered_repository);
+  check string "identity mismatch -> catalog" catalog
+    (source_of Ksc.Policy_repository_identity_mismatch);
+  check string "store error -> catalog" catalog
+    (source_of Ksc.Policy_repository_store_error)
+;;
+
+let test_mapping_sourced () =
+  (* Only the advisory mapping's own load failure is sourced from the mapping
+     file. *)
+  check string "mapping load error -> mapping" mapping
+    (source_of Ksc.Policy_mapping_load_error)
+;;
+
+let test_catalog_and_mapping_are_distinct () =
+  (* The bug was invisible because both once resolved to the mapping basename;
+     pin that the two sources are different files so a regression that collapses
+     them fails here. *)
+  check bool "catalog basename differs from mapping basename" true
+    (not (String.equal catalog mapping))
+;;
+
+let () =
+  run "policy_source_of_status"
+    [ ( "source-of-truth",
+        [ test_case "catalog verdicts are sourced from repositories.toml" `Quick
+            test_catalog_sourced
+        ; test_case "mapping load failure is sourced from keeper_repo_mappings.toml"
+            `Quick test_mapping_sourced
+        ; test_case "catalog and mapping basenames are distinct files" `Quick
+            test_catalog_and_mapping_are_distinct
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표
playground repo policy JSON의 `policy_source` 필드가 실제 판정한 config 파일을 정직하게 가리키도록 수정. 기존엔 모든 verdict에 advisory mapping basename(`keeper_repo_mappings.toml`)을 하드코딩 → catalog(`repositories.toml`) 미등록으로 인한 차단인데도 mapping이 원인인 것처럼 표기.

## 근본원인 (task-1865 / task-1866)
1. repo명 masc-mcp→masc 전환. catalog는 `masc`만 등록, 구 `masc-mcp`는 06-25 deregister.
2. keeper가 stale `masc-mcp` 참조 → `ensure_ready.find_repo_url` None(미등록) → 차단.
3. 차단 라벨이 `policy_source=keeper_repo_mappings.toml`로 **거짓 원인** 표기.
4. keeper들이 "mappings 미등록이 원인"을 RFC-0259 durable knowledge로 학습(10 keeper ~60 claims, base 템플릿 20건) → 등록된 `masc`를 영영 회피 → fleet PR 3% 정체.

이 PR은 (4)의 재발원인인 code root(거짓 라벨)를 제거한다. 오염된 durable memory 정정은 task-1866(operator 승인 필요).

## 변경
- `Keeper_sandbox_control.policy_source_basename_of_status`: typed status → 실제 결정 config 파일의 exhaustive 매핑. catalog verdict(allowed/unregistered/identity mismatch/store error) → `repositories.toml`; mapping 파일 로드 실패만 → `keeper_repo_mappings.toml`. catch-all 없음(새 variant는 컴파일 에러).
- `Config_dir_resolver.repositories_toml_basename` SSOT 상수 추가, path를 여기서 파생.
- 방출 site(`playground_repo_policy_fields`)를 하드코딩 → 함수 호출로 교체.
- `.mli` 2곳 노출, 단위 테스트 추가.

## RFC
RFC-0312 (`docs/rfc/RFC-0312-keeper-repo-mapping-advisory-scope.md`) — keeper_repo_mappings.toml scope는 advisory이고 binding gate는 catalog. 본 라벨링이 그 의미론을 그대로 반영.

## 로컬 검증
- dune 빌드는 CI에서 (워크스페이스 정책). 변경은 exhaustive match + SSOT 상수라 타입 레벨에서 강제됨.
- 테스트 `test_policy_source_of_status`: catalog verdict 4종 → repositories.toml, mapping load 실패 → keeper_repo_mappings.toml, 두 basename 상이 guard.

## 미검증
- CI 빌드/테스트 green (push 후 확인).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
