### PR TITLE
fix(dashboard): restore pixel-avatar base grid CSS lost in #3912 dedup (v2 delta slice 1)

### DIFF
--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -137,7 +137,7 @@ export function AgentAvatar({
     : 'pixel-avatar-name'
 
   return html`
-    <div class="v2-overview-avatar pixel-avatar rounded-wrap">
+    <div class="v2-overview-avatar pixel-avatar-wrap">
       ${avatar}
       <span class=${nameClass}>${name}</span>
     </div>

--- a/dashboard/src/styles/pixel-avatar.css
+++ b/dashboard/src/styles/pixel-avatar.css
@@ -2,7 +2,34 @@
 
 /* ═══ Pixel Avatars ═══ */
 
+/* Base container — the 8x8 cell grid needs an explicit box or the empty
+   cells collapse it to 0x0 and every AgentAvatar surface renders blank.
+   Sizes restored verbatim from the original pixel-avatars.css (#1403);
+   the base rules were dropped in the #3912 CSS dedup and never re-extracted.
+   Corner radius comes from the markup's rounded-* utility, not here. */
+.pixel-avatar {
+  display: grid;
+  grid-template: repeat(8, 1fr) / repeat(8, 1fr);
+  width: 48px;
+  height: 48px;
+  overflow: hidden;
+  flex-shrink: 0;
+  image-rendering: pixelated;
+}
+
+@utility pixel-avatar--sm {
+  width: 32px;
+  height: 32px;
+}
+
+@utility pixel-avatar--lg {
+  width: 64px;
+  height: 64px;
+}
+
 @utility pixel-avatar--xl {
+  width: 96px;
+  height: 96px;
   box-shadow:
     0 0 0 2px var(--color-bg-page),
     0 0 0 3px var(--brass-1),


### PR DESCRIPTION
## 무엇

keeper-v2 목업 ↔ 실 대시보드 UI 델타 극복 작업 슬라이스 1 — `AgentAvatar`(픽셀 아바타)가 모든 표면에서 0×0으로 collapse해 **아예 렌더되지 않던** 버그 수리.

## 왜 (근본 원인)

`.pixel-avatar`의 base 규칙(8×8 grid + 크기)이 CSS 정리 과정에서 유실:

1. #1403 `pixel-avatars.css`: base 48px + sm 32 / lg 64 / xl 96 정의 (원본)
2. #2321: global.css로 통합
3. #3912 CSS dedup: **base 규칙 삭제** ← 유실 지점
4. #3915 재추출(`pixel-avatar.css`): 상태 애니메이션·activity dot·speech bubble만 살아남음

이후 64개 빈 `span` 셀이 크기 없는 컨테이너 안에서 0×0으로 collapse. 영향 표면 5곳: overview 주의 필요 리스트, approvals, fusion, agent-roster, agent-profile.

목업(Keeper Agent v2 standalone)과의 스크린샷 대조에서 "주의 필요 행에 아바타 부재"로 발견 → DOM 검사로 `offsetWidth/Height = 0` 확인 → git 히스토리로 유실 커밋 특정.

## 수리

- 원본 #1403 규칙 verbatim 복원 (base 48 / sm 32 / lg 64 / xl 96). 발명 값 없음.
- corner radius는 마크업의 `rounded-[var(--r-1)]` 유틸에 위임 (이중 정의 회피).
- `showName` 래퍼에서 `pixel-avatar` 클래스 제거 — base box 복원 시 라벨 스택에 grid가 오적용되는 것 방지 (호출자 0인 dead 경로지만 클래스만 정정).

## 검증

- before: live(8935) 스크린샷 — 주의 필요 행 아바타 자리 공백 (DOM엔 존재, 0×0)
- after: worktree vite dev(proxy→8935) 스크린샷 — base/issue_king 픽셀 아바타 정상 렌더
- `tsc --noEmit` 0 / `eslint` (변경 파일) 0

RFC-WAIVED: CSS 유실 복원 (test-only급 시각 수리, subsystem 로직 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
