### PR TITLE
fix(dashboard): hide duplicate ns sublabel in overview attention rows (v2 delta slice 2)

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -24,6 +24,7 @@ import {
   Overview,
 } from './overview'
 import type { FusionRunRecord, TelemetryEntry, TelemetrySourceSummary } from '../../api/dashboard'
+import { keepers } from '../../store'
 import type { Goal } from '../../types/core'
 
 // bar-seg ratio helper (mirrors FunnelCard inline logic)
@@ -991,5 +992,24 @@ describe('Overview prototype surface', () => {
     const btn = tel?.querySelector('button.ov-link')
     expect(btn).not.toBeNull()
     expect(btn?.textContent).toBe('로그 보기 →')
+  })
+
+  // The attention row's mono sublabel exists to show the wire name next to a
+  // localized display name; when they are identical it printed "base base".
+  it('attention row hides the ns sublabel when display name equals keeper name', () => {
+    keepers.value = [
+      makeKeeper({ name: 'base', needs_attention: true }),
+      makeKeeper({ name: 'nick0cave', koreanName: '닉케이브', needs_attention: true }),
+    ]
+    try {
+      const { container } = render(h(Overview, null))
+      const plain = container.querySelector('[data-testid="attention-row-base"] .ov-attn-name')
+      expect(plain?.textContent?.trim()).toBe('base')
+      expect(plain?.querySelector('.ov-attn-ns')).toBeNull()
+      const localized = container.querySelector('[data-testid="attention-row-nick0cave"] .ov-attn-name')
+      expect(localized?.querySelector('.ov-attn-ns')?.textContent).toBe('nick0cave')
+    } finally {
+      keepers.value = []
+    }
   })
 })

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -997,6 +997,7 @@ describe('Overview prototype surface', () => {
   // The attention row's mono sublabel exists to show the wire name next to a
   // localized display name; when they are identical it printed "base base".
   it('attention row hides the ns sublabel when display name equals keeper name', () => {
+    const previousKeepers = keepers.value
     keepers.value = [
       makeKeeper({ name: 'base', needs_attention: true }),
       makeKeeper({ name: 'nick0cave', koreanName: '닉케이브', needs_attention: true }),
@@ -1009,7 +1010,7 @@ describe('Overview prototype surface', () => {
       const localized = container.querySelector('[data-testid="attention-row-nick0cave"] .ov-attn-name')
       expect(localized?.querySelector('.ov-attn-ns')?.textContent).toBe('nick0cave')
     } finally {
-      keepers.value = []
+      keepers.value = previousKeepers
     }
   })
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -796,7 +796,9 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
               <div class="ov-attn-meta">
                 <div class="ov-attn-name">
                   ${displayName}
-                  <span class="ov-attn-ns mono">${k.name}</span>
+                  ${displayName === k.name
+                    ? null
+                    : html`<span class="ov-attn-ns mono">${k.name}</span>`}
                 </div>
                 <div class=${`ov-attn-reason sev-${reason.sev}`}>
                   <span class="inline-block size-1.5 rounded-full ${attentionToneClass(reason.sev)}"></span>


### PR DESCRIPTION
## 무엇

keeper-v2 목업 ↔ 실 대시보드 UI 델타 슬라이스 2 — 개요 "주의 필요" 행의 이름 이중 표기 제거.

## 왜

행 구조가 `display name + mono 서브라벨(wire name)`인데, `koreanName`이 없는 keeper는 display name == wire name이라 **"base base"** 처럼 같은 이름이 두 번 렌더됨. 목업(Keeper Agent v2 standalone)의 동일 행은 이름 하나만 표시.

## 수리

`displayName === k.name`이면 서브라벨 생략 (다르면 기존대로 병기 — 로컬라이즈 이름 옆 wire name은 유용).

## 검증

- vitest: overview.test.ts 95 passed (신규 케이스: base → 서브라벨 없음 / 닉케이브 → `nick0cave` 병기 유지)
- tsc --noEmit 0 / eslint 0

RFC-WAIVED: 표시 조건 1분기 수정 (visual-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
