### PR TITLE
fix(keeper): Execute tool guidance — no shell, use Edit, do not retry same argv

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -554,7 +554,12 @@ let public_descriptors =
          the executable, or pipeline. Do not repeat executable as argv[0]. \
          Examples: executable='git' argv=['status', '--short']; executable='gh' \
          argv=['pr', 'list', '--repo', 'owner/name']. Use cwd for repo-scoped \
-         operations."
+         operations. Each command runs as a single typed argv with no shell: \
+         there is no pipe, redirect, glob, or VAR=value env prefix unless you \
+         build them as an explicit pipeline. To EDIT a file, use the Edit \
+         tool, not 'sed -i' or 'cat >' — in-place shell edits fail here. If a \
+         command fails, do not repeat the same argv: fix the invocation or use \
+         a different tool (Edit for edits, Read/Grep for inspection)."
       ~input_schema:execute_schema
       ~policy:
         (policy

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -554,12 +554,14 @@ let public_descriptors =
          the executable, or pipeline. Do not repeat executable as argv[0]. \
          Examples: executable='git' argv=['status', '--short']; executable='gh' \
          argv=['pr', 'list', '--repo', 'owner/name']. Use cwd for repo-scoped \
-         operations. Each command runs as a single typed argv with no shell: \
-         there is no pipe, redirect, glob, or VAR=value env prefix unless you \
-         build them as an explicit pipeline. To EDIT a file, use the Edit \
-         tool, not 'sed -i' or 'cat >' — in-place shell edits fail here. If a \
-         command fails, do not repeat the same argv: fix the invocation or use \
-         a different tool (Edit for edits, Read/Grep for inspection)."
+         operations. Each Execute call is typed, not shell-parsed: use \
+         pipeline=[...] for pipelines, typed stdin/stdout/stderr fields for \
+         redirection-like I/O, typed env for environment variables, and \
+         explicit argv/path literals instead of shell glob expansion. To EDIT a \
+         file, use the Edit tool, not 'sed -i' or 'cat >' — in-place shell \
+         edits fail here. If a command fails, do not repeat the same argv: fix \
+         the invocation or use a different tool (Edit for edits, Read/Grep for \
+         inspection)."
       ~input_schema:execute_schema
       ~policy:
         (policy


### PR DESCRIPTION
## 목적

Keeper Tools 실패 감소. 라이브 로그(2026-07-07, 최근 40k줄) 분류 결과 keeper가 Execute 도구를 반복적으로 오용:

| 실패 유형 | 건수 | 프롬프트-fixable |
|---|---|---|
| 반복 동일-인자 재시도 ("failed N times with same arguments") | 12 | ✅ |
| 잘못된 셸 문법 (`sed: can't read s/...`, `find -rn`, `cat: sed`) | 34 | ✅ |
| gh/graphql 스키마 오용 (`Unknown JSON field`) | 20 | ✅ |
| 대화형 도구 오용 (`Terminal is dumb, EDITOR unset`) | 5 | ✅ |
| Execute 인자 스키마 오류 (`must include exactly one of executable\|pipeline`) | — | ✅ |

핵심: Execute는 shell이 아니라 typed argv인데(pipe/redirect/glob/env prefix 없음), keeper가 `sed -i`·`cat >`·`VAR=v cmd` 같은 shell 관용구를 시도. 그리고 실패 시 같은 argv를 반복. 도구 설명(매 턴 주입)에 이 제약과 대안이 없었음.

## 변경

`keeper_tool_descriptor.ml` Execute 도구 설명에 4줄 추가:
- shell 없음 명시 (pipe/redirect/glob/env prefix는 explicit pipeline으로만)
- 파일 편집은 `sed -i`/`cat >` 대신 **Edit 도구**
- 실패 시 같은 argv 반복 금지 → invocation 수정 or 다른 도구

간결하게(토큰 절약) 핵심만. 기존 예시(git/gh/rg)와 "Do not repeat executable as argv[0]" substring 유지.

## 검증

- `dune build lib/keeper` clean.
- `test_keeper_tool_descriptor_registry_integrity` 32 tests pass (drift-guard substring 유지).
- ocamlformat clean.

## 성격 (반복 개선)

이건 프롬프트 개선의 첫 iteration입니다. 효과는 관찰지표(Execute 오용 건수 감소)로 사후 검증. 남은 것: gh/graphql 스키마 안내(별도), Shell IR env 미지원(기능 갭, 프롬프트 아니라 구현 or 별도 안내).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


WORKAROUND-WAIVED: false positive — this PR adds prose guidance to a tool description string; it introduces no string-matching classifier in code. The flagged tokens are error signatures quoted in the diagnosis table, not a classifier.
