### PR TITLE
feat(dashboard): restore Monitor to the v2 rail + align order to 2026-07 export (v2 delta slice 3)

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1051,9 +1051,11 @@ describe('SideRail v2 chrome', () => {
     expect(container.querySelector('.nav-link.active')?.textContent).toContain('Work')
     expect(container.querySelector('.nav-link.active')?.textContent).not.toContain('Settings')
 
+    // Multiple surfaces render sublists (any surface with 2+ sections), so
+    // anchor on the globally-unique active sublink instead of the first list.
     const sublist = container.querySelector('.nav-sublist')
     expect(sublist).not.toBeNull()
-    const activeSublink = sublist?.querySelector('.nav-sublink.active')
+    const activeSublink = container.querySelector('.nav-sublink.active')
     expect(activeSublink).not.toBeNull()
     expect(activeSublink?.textContent).toContain('Work')
     expect(container.querySelector('.nav-footer .nav-footer-settings')?.textContent).toContain('Settings')

--- a/dashboard/src/components/v2/nav-rail-v2.test.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.test.ts
@@ -46,4 +46,27 @@ describe('NavRailV2 schedule badge', () => {
 
     expect(scheduleNavItem(container)?.querySelector('.nav-badge')).toBeNull()
   })
+
+  // Rail order + group breaks mirror the 2026-07 keeper-v2 standalone export.
+  it('renders the v2 export rail order with Monitor after Keepers', () => {
+    render(html`<${NavRailV2} />`, container)
+
+    const rail = container.querySelector('.v2-nav')
+    const walk = Array.from(rail?.children ?? []).map(el => {
+      if (el.className.includes('nav-div')) return '|'
+      if (el.className.includes('nav-brand')) return 'brand'
+      if (el.className.includes('nav-spacer')) return 'spacer'
+      return el.getAttribute('title')
+    })
+    expect(walk).toEqual([
+      'brand',
+      '개요', '|',
+      'Keepers', 'Monitor', '|',
+      '작업', '승인', '예약', '|',
+      '보드', 'Fusion', '로그', '|',
+      'IDE', '커넥터',
+      'spacer',
+      '설정',
+    ])
+  })
 })

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -18,20 +18,25 @@ type NavEntry = SurfaceEntry | 'sep'
 
 // Prototype SURFACES order/labels/icons, mapped to live TabIds.
 //   prototype work→workspace, monitor→monitoring, ide→code; rest 1:1.
+// Groups mirror the 2026-07 standalone export's rail DOM: 개요 |
+// Keepers · Monitor | 작업 · 승인 · 예약 | 보드 · Fusion · 로그 |
+// IDE · 커넥터 (설정 stays in the footer slot below the spacer).
 const SURFACES: readonly NavEntry[] = [
   { tab: 'overview', label: '개요', icon: 'grid' },
   'sep',
-  { tab: 'workspace', label: '작업', icon: 'target' },
   { tab: 'keepers', label: 'Keepers', icon: 'users' },
+  { tab: 'monitoring', label: 'Monitor', icon: 'monitor' },
+  'sep',
+  { tab: 'workspace', label: '작업', icon: 'target' },
+  { tab: 'approvals', label: '승인', icon: 'shield' },
+  { tab: 'schedule', label: '예약', icon: 'clock' },
   'sep',
   { tab: 'board', label: '보드', icon: 'board' },
-  { tab: 'schedule', label: '예약', icon: 'clock' },
-  { tab: 'approvals', label: '승인', icon: 'shield' },
   { tab: 'fusion', label: 'Fusion', icon: 'fusion' },
+  { tab: 'logs', label: '로그', icon: 'logs' },
   'sep',
   { tab: 'code', label: 'IDE', icon: 'code' },
   { tab: 'connectors', label: '커넥터', icon: 'plug' },
-  { tab: 'logs', label: '로그', icon: 'logs' },
 ]
 
 export interface NavBadges {

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -60,32 +60,34 @@ describe('dashboard surface navigation', () => {
     expect(workspace?.defaultTab).toBe('workspace')
   })
 
-  it('keeps the v2 primary shell aligned to the prototype surface set plus the operator-restored Logs surface', () => {
+  it('keeps the v2 primary shell aligned to the 2026-07 keeper-v2 export rail order', () => {
     expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
       'overview',
-      'workspace',
       'keepers',
-      'board',
-      'schedule',
+      'monitoring',
+      'workspace',
       'approvals',
+      'schedule',
+      'board',
       'fusion',
+      'logs',
       'code',
       'connectors',
       'settings',
-      'logs',
     ])
     expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
       'Overview',
-      'Work',
       'Keepers',
-      'Board',
-      'Schedule',
+      'Monitor',
+      'Work',
       'Approvals',
+      'Schedule',
+      'Board',
       'Fusion',
+      'Logs',
       'IDE',
       'Connectors',
       'Settings',
-      'Logs',
     ])
   })
 

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -110,23 +110,25 @@ export interface DashboardSectionNavItem {
   hidden?: boolean
 }
 
+// Order mirrors the 2026-07 keeper-v2 standalone export's rail: 개요 · Keepers ·
+// Monitor · 작업 · 승인 · 예약 · 보드 · Fusion · 로그 · IDE · 커넥터 · 설정.
+// That export restored Monitor to the primary rail and moved Logs before IDE,
+// so the earlier #21525 operator-restored-Logs deviation is now the design
+// itself. Settings stays pinned in the rail footer, so it renders outside the
+// main list even though it closes this set.
 const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'overview',
-  'workspace',
   'keepers',
-  'board',
-  'schedule',
+  'monitoring',
+  'workspace',
   'approvals',
+  'schedule',
+  'board',
   'fusion',
+  'logs',
   'code',
   'connectors',
   'settings',
-  // 'logs' is kept in the primary surface set by operator request. #21525 dropped it
-  // from the desktop side rail (reachable only via Settings/command palette); operators
-  // still want the standalone Logs surface in the rail, so this deviates from the codex
-  // v2 prototype set on purpose. Settings is pinned in the rail footer, so logs renders
-  // as the last regular surface in the main list.
-  'logs',
 ]
 
 export function isPrimaryDashboardSurface(tabId: TabId): boolean {


### PR DESCRIPTION
## 무엇

keeper-v2 목업 ↔ 실 대시보드 UI 델타 슬라이스 3 — **Monitor를 v2 rail에 복원**하고 rail 순서/그룹을 2026-07 standalone export와 정렬.

## 왜

최신 목업 rail DOM (렌더해서 추출):

```
M | 개요 | Keepers · Monitor | 작업 · 승인 · 예약 | 보드 · Fusion · 로그 | IDE · 커넥터 ‖ 설정
```

live rail(`nav-rail-v2.ts` SURFACES)은 구버전 세트: **Monitor 항목 자체가 없어** KEEPER FLEET 표면(운영판정·컨텍스트 게이지·keeper 액션·런타임 패널이 이미 완전 구현됨)이 rail에서 도달 불가였고, 순서/그룹도 다름 (`개요 | 작업 · Keepers | 보드 · 예약 · 승인 · Fusion | IDE · 커넥터 · 로그`). 아이콘(`monitor` 파형)과 라우팅(`monitoring` tab)은 이미 존재 — 목록 누락만이 문제.

## 변경

- `nav-rail-v2.ts`: monitoring 삽입 + 그룹/순서를 export rail DOM과 1:1 정렬. rail 전체를 걷는 회귀 테스트 추가 (BRAND/SEP/spacer 위치 포함 exact match).
- `navigation.ts` `V2_PRIMARY_SURFACE_IDS`: 동일 멤버십/순서 — `isPrimaryDashboardSurface`가 monitoring 라우트를 v2 shell로 태우고 SideRail도 같은 순서 유지. (#21525 "operator-restored Logs" 주석은 최신 export가 로그를 rail에 포함하므로 deviation 아님 — 주석 갱신.)
- `dashboard-shell.test.ts`: 첫 `.nav-sublist` == 활성 표면이라는 취약 가정 수정 (monitoring도 sublist를 렌더하므로) — 전역 유일 `.nav-sublink.active`로 앵커.

## 검증

- 목업 rail DOM walk와 live rail DOM walk **완전 일치** (구분선 위치 포함)
- vite dev 스크린샷: Monitor 클릭 → KEEPER FLEET가 v2 크롬으로 렌더
- vitest: nav-rail-v2 3/3 (순서 회귀 테스트 신규), navigation 54/54, dashboard-shell 40/40
- tsc --noEmit 0 / `eslint src` clean
- nav allowlist(`dashboard_nav_event.ml`): `monitoring` 기등재 — 서버 동기화 불필요

RFC-WAIVED: 기존 표면의 rail 노출/순서 정렬 (navigation-only, 신규 표면/라우트 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
