### PR TITLE
fix(test): use repo mapping module in policy source test

### DIFF
--- a/test/test_policy_source_of_status.ml
+++ b/test/test_policy_source_of_status.ml
@@ -17,7 +17,7 @@ open Alcotest
 module Ksc = Masc.Keeper_sandbox_control
 
 let catalog = Config_dir_resolver.repositories_toml_basename
-let mapping = Masc.Keeper_repo_mapping.mappings_toml_basename
+let mapping = Keeper_repo_mapping.mappings_toml_basename
 
 let source_of s = Ksc.policy_source_basename_of_status s
 


### PR DESCRIPTION
## Summary

Fix the post-merge Health compile failure from #23571.

`test/test_policy_source_of_status.ml` links `Keeper_repo_mapping` as a direct test dependency, matching existing tests such as `test_playground_repo_readiness.ml`. The merged test still referenced `Masc.Keeper_repo_mapping`, which fails with `Unbound module Masc.Keeper_repo_mapping` in Health job `85649534235`.

## Verification

- `ocamlformat --check test/test_policy_source_of_status.ml`
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- `rg -n "Masc\\.Keeper_repo_mapping" test/test_policy_source_of_status.ml` returned no matches

No local Dune build/test run; CI remains the build authority for the compile failure.

[근거] GitHub Actions Health job `85649534235` on PR #23571, checked 2026-07-07 23:54 KST, confidence High.
