### PR TITLE
feat(exec): surface gh gating rationale on approval prompts (RFC-0309 visibility)

### DIFF
--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -709,6 +709,17 @@ let risk_of_gh_verb (v : Gh_verb.t) : risk_class =
   (* Risk genuinely unknown; capability axis gates it. Not fabricated to R1/R2. *)
   | Gh_unrecognized_action -> R0_Read
 
+(* Human-readable label for the gh verb classification, for surfacing the
+   gating rationale on operator approval prompts (why this gh command needs
+   approval). *)
+let gh_verb_class_to_string = function
+  | Gh_read -> "read"
+  | Gh_reversible_mutation -> "reversible mutation"
+  | Gh_irreversible_mutation -> "irreversible mutation"
+  | Gh_unrecognized_action -> "unrecognized action (capability-gated)"
+  | Gh_string_borne -> "string-borne (word-list floor)"
+  | Gh_unrecognized_family -> "unrecognized family (fail-closed)"
+
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)
 

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -128,6 +128,10 @@ type gh_verb_class =
 val classify_gh_verb : Gh_verb.t -> gh_verb_class
 (** Classify a gh verb. See {!gh_verb_class}. *)
 
+val gh_verb_class_to_string : gh_verb_class -> string
+(** Human-readable label for an operator approval rationale (why a gh command
+    is gated). *)
+
 val risk_of_gh_verb : Gh_verb.t -> risk_class
 (** RFC-0309 §3.1 (W1): the typed-family risk opinion for a gh command,
     projected from [classify_gh_verb]. Reads the same subcommand tables as

--- a/lib/exec/test/test_gh_verb.ml
+++ b/lib/exec/test/test_gh_verb.ml
@@ -144,6 +144,41 @@ let test_api_left_to_floor () =
     Alcotest.failf "floor should still catch api -X DELETE: got %s" (rc f)
 ;;
 
+(* The gating rationale surfaced on operator approval prompts (RFC-0309
+   visibility): each verb class maps to a distinct human-readable label, and a
+   real irreversible command (pr merge) yields the mutation label. *)
+let test_verb_class_to_string () =
+  let label words =
+    Shell_ir_risk.gh_verb_class_to_string
+      (Shell_ir_risk.classify_gh_verb (Gh_verb.classify words))
+  in
+  Alcotest.(check string)
+    "pr merge is an irreversible mutation"
+    "irreversible mutation"
+    (label [ "gh"; "pr"; "merge" ]);
+  Alcotest.(check string)
+    "pr view is a read"
+    "read"
+    (label [ "gh"; "pr"; "view"; "1" ]);
+  (* every class label is non-empty and distinct *)
+  let classes =
+    [ Shell_ir_risk.Gh_read
+    ; Shell_ir_risk.Gh_reversible_mutation
+    ; Shell_ir_risk.Gh_irreversible_mutation
+    ; Shell_ir_risk.Gh_unrecognized_action
+    ; Shell_ir_risk.Gh_string_borne
+    ; Shell_ir_risk.Gh_unrecognized_family
+    ]
+  in
+  let labels = List.map Shell_ir_risk.gh_verb_class_to_string classes in
+  List.iter
+    (fun s -> if s = "" then Alcotest.fail "verb class label must be non-empty")
+    labels;
+  Alcotest.(check int)
+    "all six labels distinct"
+    (List.length classes)
+    (List.length (List.sort_uniq String.compare labels))
+
 let () =
   Alcotest.run "gh_verb"
     [
@@ -153,6 +188,8 @@ let () =
           Alcotest.test_case "of_fields (real pipeline)" `Quick test_of_fields;
           Alcotest.test_case "family_token round-trip" `Quick
             test_family_token_round_trip;
+          Alcotest.test_case "verb class to_string labels" `Quick
+            test_verb_class_to_string;
         ] );
       ( "risk-agreement",
         [

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -141,6 +141,30 @@ type gh_capability_policy_result =
   | Gh_policy_approval_required of Masc_exec.Exec_program.t
   | Gh_policy_denied of string
 
+(* Surface WHY a gh command is gated on the operator approval prompt: the gh
+   family/action and its verb classification (read / reversible / irreversible
+   mutation / …). Returns [None] when the command's words are not literally
+   recoverable (env/redirect/$VAR present) so no rationale is fabricated. *)
+let gh_gating_detail ir =
+  match last_simple_of_ir ir with
+  | None -> None
+  | Some simple ->
+    (match Masc_exec.Shell_ir_risk.literal_words_of_simple simple with
+     | None -> None
+     | Some words ->
+       let verb = Masc_exec.Gh_verb.classify words in
+       let verb_class = Masc_exec.Shell_ir_risk.classify_gh_verb verb in
+       let family = Masc_exec.Gh_verb.string_of_family verb.Masc_exec.Gh_verb.family in
+       let action = Option.value ~default:"" verb.Masc_exec.Gh_verb.action in
+       let subject = String.trim (family ^ " " ^ action) in
+       let subject = if subject = "" then "gh" else "gh " ^ subject in
+       Some
+         (Printf.sprintf
+            "%s: %s"
+            subject
+            (Masc_exec.Shell_ir_risk.gh_verb_class_to_string verb_class)))
+;;
+
 let gh_capability_policy_result ir ~caps =
   match last_simple_of_ir ir with
   | None -> Gh_policy_noop
@@ -195,15 +219,21 @@ let dispatch_classified
      | Gh_policy_denied reason -> Error (Policy_denied { reason })
      | Gh_policy_approval_required bin ->
        let bin = Masc_exec.Exec_program.to_string bin in
+       let summary =
+         match gh_gating_detail ir with
+         | Some detail ->
+           Printf.sprintf
+             "command '%s' requires approval — %s (audited/privileged risk class)"
+             bin
+             detail
+         | None ->
+           Printf.sprintf
+             "command '%s' requires approval (audited/privileged risk class)"
+             bin
+       in
        Error
          (Approval_required
-            { summary =
-                Printf.sprintf
-                  "command '%s' requires approval (audited/privileged risk class)"
-                  bin
-            ; bin
-            ; kind = Gh_capability_requires_approval
-            })
+            { summary; bin; kind = Gh_capability_requires_approval })
      | Gh_policy_noop ->
        (match first_privileged_program caps with
         | Some bin ->


### PR DESCRIPTION
## 목적

gh gating 판정 상세를 운영자 승인 프롬프트에 노출(#6). 지금은 gh 명령이 승인을 탈 때 `command 'gh' requires approval (audited/privileged risk class)`라는 **일반 문구만** 보임 — 운영자가 "왜 이 gh 명령이 R2인지"(어떤 verb/family/action)를 알 수 없음. RFC-0309에서 강화한 gating 로직(`classify_gh_verb`)은 그 근거를 이미 계산하지만 approval summary로 전달 안 됨.

## 변경 (additive)

- `Shell_ir_risk.gh_verb_class_to_string` 신설 — gh verb class(read / reversible mutation / irreversible mutation / unrecognized action / string-borne / unrecognized family)의 사람이 읽는 라벨.
- `keeper_tool_execute_shell_ir.gh_gating_detail` — 승인 대상 gh 명령의 `literal_words_of_simple` → `Gh_verb.classify` → family/action + verb class를 `"gh {family} {action}: {class}"`로 조립. words가 literal 복구 불가(env/redirect/$VAR)면 `None`(근거 날조 안 함).
- `Gh_policy_approval_required` summary에 이 상세를 삽입: `command 'gh' requires approval — gh pr merge: irreversible mutation (audited/privileged risk class)`.

이 summary는 approval item의 disposition으로 흘러 approvals-surface에 표시됨.

## 경계

exec 계층(`shell_ir_risk`)이 verb 분류·stringify를 소유, keeper는 조립·소비만. 판정 로직 변경 없음 — 순수하게 기존 판정 근거를 노출.

## 검증

- `dune build lib/exec lib/keeper_tooling` clean.
- `test_gh_verb` 7 tests: `pr merge → irreversible mutation`, `pr view → read`, 6 라벨 non-empty·distinct.
- ocamlformat clean.

## RFC

RFC-0309(gh capability gating, 이 세션 W4 #23424) 가시성 후속. 판정 로직은 불변, approval rationale 노출만 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
