### PR TITLE
fix(exec): share gh approval rationale summary

### DIFF
--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -165,6 +165,26 @@ let gh_gating_detail ir =
             (Masc_exec.Shell_ir_risk.gh_verb_class_to_string verb_class)))
 ;;
 
+let approval_required_summary ir bin =
+  let bin_text = Masc_exec.Exec_program.to_string bin in
+  match Masc_exec.Exec_program.known bin with
+  | Some Masc_exec.Exec_program.Gh ->
+    (match gh_gating_detail ir with
+     | Some detail ->
+       Printf.sprintf
+         "command '%s' requires approval — %s (audited/privileged risk class)"
+         bin_text
+         detail
+     | None ->
+       Printf.sprintf
+         "command '%s' requires approval (audited/privileged risk class)"
+         bin_text)
+  | Some _ | None ->
+    Printf.sprintf
+      "command '%s' requires approval (audited/privileged risk class)"
+      bin_text
+;;
+
 let gh_capability_policy_result ir ~caps =
   match last_simple_of_ir ir with
   | None -> Gh_policy_noop
@@ -218,19 +238,8 @@ let dispatch_classified
     (match gh_capability_policy_result ir ~caps with
      | Gh_policy_denied reason -> Error (Policy_denied { reason })
      | Gh_policy_approval_required bin ->
+       let summary = approval_required_summary ir bin in
        let bin = Masc_exec.Exec_program.to_string bin in
-       let summary =
-         match gh_gating_detail ir with
-         | Some detail ->
-           Printf.sprintf
-             "command '%s' requires approval — %s (audited/privileged risk class)"
-             bin
-             detail
-         | None ->
-           Printf.sprintf
-             "command '%s' requires approval (audited/privileged risk class)"
-             bin
-       in
        Error
          (Approval_required
             { summary; bin; kind = Gh_capability_requires_approval })
@@ -352,16 +361,10 @@ let dispatch_classified_with_approval
          | Some _ | None -> Privileged_program_floor
        in
        let bin = Masc_exec.Exec_program.to_string request_bin in
+       let summary = approval_required_summary ir request_bin in
        Error
          (Approval_required
-            { summary =
-                Printf.sprintf
-                  "command '%s' requires approval (audited/privileged risk \
-                   class)"
-                  bin
-            ; bin
-            ; kind
-            })
+            { summary; bin; kind })
      | Deny { reason; caps = _ } ->
        Error
          (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason }))

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1006,7 +1006,11 @@ let () =
      A flip to Policy_denied (e.g. risk-class regression) must fail the test. *)
   | Error
       (Keeper_tool_execute_shell_ir.Approval_required
-         { kind = Keeper_tool_execute_shell_ir.Privileged_program_floor; _ }) -> ()
+         { summary; kind = Keeper_tool_execute_shell_ir.Privileged_program_floor; _ }) ->
+    assert (
+      String.equal
+        summary
+        "command 'rm' requires approval (audited/privileged risk class)")
   | Error _ -> assert false
 
 let () =
@@ -1076,8 +1080,13 @@ let () =
   with
   | Ok _ -> assert false
   | Error
-      (Keeper_tool_execute_shell_ir.Approval_required { summary = _; bin; kind }) ->
+      (Keeper_tool_execute_shell_ir.Approval_required { summary; bin; kind }) ->
     assert (String.equal bin "gh");
+    assert (
+      String.equal
+        summary
+        "command 'gh' requires approval — gh repo create: reversible mutation \
+         (audited/privileged risk class)");
     assert (kind = Keeper_tool_execute_shell_ir.Gh_capability_requires_approval)
   | Error _ -> assert false
 


### PR DESCRIPTION
## Summary

- Fixes the post-23583 gap where dispatch_classified_with_approval still returned the generic gh approval summary.
- Shares the gh rationale summary between the bare dispatch path and the approval-enabled path.
- Keeps non-gh privileged approvals on the old generic summary so rm or unknown privileged commands do not get fabricated gh details.
- Pins both paths in test/test_exec_dispatch.ml.

## Validation

- opam exec -- ocamlformat --check lib/keeper_tooling/keeper_tool_execute_shell_ir.ml test/test_exec_dispatch.ml
- git diff --check origin/main...HEAD
- No local Dune run; Dune build remains CI authority.

[근거] Compared against origin/main at 4d95e2d8bd on 2026-07-08 00:15 KST; confidence High for source diff/local non-Dune checks, CI pending.