### PR TITLE
fix(librarian): re-extraction must not advance last_verified_at (RFC-0285 §3.3)

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -243,7 +243,7 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          ; observed_by = []
          ; first_seen = now
          ; valid_until = fact_valid_until ~now ~external_ref ~claim_kind category
-         ; last_verified_at = Some now
+         ; last_verified_at = None (* RFC-0285 §3.3 / RFC-0259 P7: re-extraction must not advance last_verified_at *)
          ; schema_version
          ; claim_id
          }


### PR DESCRIPTION
## Summary

`fact_of_json` in keeper_librarian.ml was advancing `last_verified_at = Some now` during recall re-extraction, violating RFC-0285 §3.3 and RFC-0259 P7.

## Change

- `keeper_librarian.ml:246` — changed `last_verified_at = Some now` → `last_verified_at = None`
- Added inline RFC citation comment
- Only actual verification (not re-extraction) should advance `last_verified_at`

## Evidence

- Commit: cd905118a
- Branch: rondo/task-1864-librarian-last-verified-at-fix
- Task: task-1864