### PR TITLE
Allow keeper playground clone reads

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -364,7 +364,11 @@ let playground_repo_policy ~(base_path : string) ~(keeper_name : string) =
     r
   | r -> r
 
-let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+type playground_policy_repository =
+  | Policy_registered_repository of string
+  | Policy_sandbox_local
+
+let playground_repo_policy_repository ~base_path ~repo_catalog ~repo_name
     ~repo_path =
   match repo_catalog with
   | Error msg -> Error (`Store_error msg)
@@ -373,8 +377,9 @@ let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
     Keeper_repo_mapping.repository_resolution_of_path_from_catalog ~base_path
       ~path:repo_path repos
   with
-  | Keeper_repo_mapping.Repository { repository_id; _ } -> Ok repository_id
-  | Keeper_repo_mapping.No_repository -> Ok repo_name
+  | Keeper_repo_mapping.Repository { repository_id; _ } ->
+    Ok (Policy_registered_repository repository_id)
+  | Keeper_repo_mapping.No_repository -> Ok Policy_sandbox_local
   | Keeper_repo_mapping.Repository_identity_mismatch _ ->
     Error
       (`Identity_mismatch
@@ -384,7 +389,7 @@ let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
 let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       ~repo_name ~repo_path =
   let field status allowed ?repository_id ?error ?mapping_error
-        ?(default_scope = false) () =
+        ?policy_scope ?(default_scope = false) () =
     let status_text = playground_policy_status_to_string status in
     let reason_fields =
       match playground_policy_reason status with
@@ -409,11 +414,16 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     let default_scope_fields =
       if default_scope then [ ("policy_default_scope", `Bool true) ] else []
     in
+    let policy_scope_fields =
+      match policy_scope with
+      | None -> []
+      | Some scope -> [ ("policy_scope", `String scope) ]
+    in
     ( "policy_source"
     , `String (policy_source_basename_of_status status) )
     :: ("policy_status", `String status_text)
     :: ("policy_allowed", `Bool allowed)
-    :: (default_scope_fields @ repository_id_fields @ reason_fields
+    :: (policy_scope_fields @ default_scope_fields @ repository_id_fields @ reason_fields
         @ error_fields @ mapping_error_fields)
   in
   let repository_id_in_catalog repository_id =
@@ -428,7 +438,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
   in
   let field_resolved_registered ?mapping_error ~default_scope () =
     match
-      playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+      playground_repo_policy_repository ~base_path ~repo_catalog ~repo_name
         ~repo_path
     with
     | Error (`Identity_mismatch msg) ->
@@ -437,7 +447,9 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     | Error (`Store_error msg) ->
       field Policy_repository_store_error false ~repository_id:repo_name
         ~error:msg ()
-    | Ok repository_id ->
+    | Ok Policy_sandbox_local ->
+      field Policy_allowed true ?mapping_error ~policy_scope:"sandbox_local" ()
+    | Ok (Policy_registered_repository repository_id) ->
       (match repository_id_in_catalog repository_id with
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id ~error:msg ()
@@ -452,7 +464,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       field_resolved_registered ~default_scope:true ()
   | Keeper_repo_mapping.Mapping_found mapping ->
       (match
-       playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+       playground_repo_policy_repository ~base_path ~repo_catalog ~repo_name
          ~repo_path
        with
        | Error (`Identity_mismatch msg) ->
@@ -461,7 +473,9 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id:repo_name
            ~error:msg ()
-       | Ok repository_id ->
+       | Ok Policy_sandbox_local ->
+         field Policy_allowed true ~policy_scope:"sandbox_local" ()
+       | Ok (Policy_registered_repository repository_id) ->
          (match repository_id_in_catalog repository_id with
           | Error (`Store_error msg) ->
             field Policy_repository_store_error false ~repository_id ~error:msg ()

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -672,7 +672,7 @@ let unresolved_repository_segment_resolution ?repo_root ~segment repos =
       segment repos
   with
   | Some mismatch -> Repository_identity_mismatch mismatch
-  | None -> Repository (repository_match ?repo_root segment)
+  | None -> No_repository
 
 let resolve_repository_id_segment_from_catalog ~base_path ?repo_root segment repos =
   match List.find_opt (repository_matches_token ~base_path segment) repos with
@@ -703,8 +703,12 @@ let path_under_repo ~base_path repo path =
 (** [repository_resolution_of_path ~base_path ~path] returns the registered
     repository for [path], or an identity mismatch when the path points at a
     declared repository whose URL basename contradicts its declared identity.
-    Repository store load failures remain explicit so access callers can deny
-    instead of treating an unknown repository catalog as "not a repository". *)
+    Playground clone paths that do not resolve to a registered repository are
+    treated like other sandbox-local paths after the identity-mismatch check;
+    the repository catalog is not an authorization cap for a keeper's own
+    playground. Repository store load failures remain explicit so access
+    callers can deny instead of treating an unknown repository catalog as "not
+    a repository". *)
 let repository_resolution_of_path_from_catalog ~base_path ~path repos =
   match playground_path_of_path ~base_path ~path with
   | Some Playground_internal | Some Playground_repos_root -> No_repository
@@ -741,10 +745,11 @@ let repository_id_of_path ~base_path ~path =
 
 (** [validate_path_access ~keeper_id ~base_path ~path] checks that [path]
     either is outside registered repositories or resolves to a valid
-    registered repository. Per-keeper mappings are advisory/default-scope
-    metadata and do not cap access. This is the integration point for keeper
-    execution paths that operate on filesystem paths rather than explicit
-    repository IDs. *)
+    registered repository. A sandbox-local playground clone that is absent from
+    the repository catalog is outside registered repositories, not a policy
+    denial. Per-keeper mappings are advisory/default-scope metadata and do not
+    cap access. This is the integration point for keeper execution paths that
+    operate on filesystem paths rather than explicit repository IDs. *)
 let validate_path_access ~keeper_id ~base_path ~path =
   match repository_resolution_of_path ~base_path ~path with
   | No_repository -> Ok ()

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -145,7 +145,10 @@ val repository_resolution_of_path :
   base_path:string -> path:string -> repository_resolution
 (** [repository_resolution_of_path ~base_path ~path] returns the repository
     resolution for [path]. Use this for access decisions so identity mismatches
-    and repository-store load failures stay explicit and fail closed. *)
+    and repository-store load failures stay explicit and fail closed.
+    Playground clone paths that do not resolve to a registered repository are
+    classified as [No_repository], so containment remains the access boundary
+    for sandbox-local files. *)
 
 val repository_resolution_of_path_from_catalog :
   base_path:string -> path:string -> repository list -> repository_resolution
@@ -168,5 +171,4 @@ val validate_path_access :
 (** [validate_path_access ~keeper_id ~base_path ~path] returns [Ok ()] if
     [path] resolves outside registered repositories or to a registered
     repository. Per-keeper mappings do not cap access. Returns [Error msg] for
-    unregistered playground repositories, identity mismatches, and
-    repository-store load failures. *)
+    identity mismatches and repository-store load failures. *)

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -73,11 +73,6 @@ let run_git_quiet argv =
 
 let git_available () = run_git_quiet [| "git"; "--version" |] = 0
 
-let canonical_path path =
-  try Unix.realpath path with
-  | Unix.Unix_error _ | Sys_error _ -> path
-;;
-
 let init_git_repo dir url =
   ensure_dir dir;
   Alcotest.(check int) "git init" 0 (run_git_quiet [| "git"; "init"; "-q"; dir |]);
@@ -206,31 +201,7 @@ let test_unregistered_repository_does_not_request_hitl () =
   Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
 ;;
 
-let require_one_pending ~keeper_id =
-  match
-    AQ.list_pending_entries ()
-    |> List.filter (fun (entry : AQ.pending_approval) ->
-      String.equal entry.keeper_name keeper_id)
-  with
-  | [ entry ] -> entry
-  | entries ->
-    Alcotest.failf
-      "expected one pending approval for %s, got %d"
-      keeper_id
-      (List.length entries)
-;;
-
-let string_field key json =
-  match Yojson.Safe.Util.member key json with
-  | `String value -> value
-  | other ->
-    Alcotest.failf
-      "expected string field %s, got %s"
-      key
-      (Yojson.Safe.to_string other)
-;;
-
-let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
+let test_unregistered_clone_path_is_sandbox_local_allowed () =
   if not (git_available ()) then Alcotest.skip ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -249,39 +220,18 @@ let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
     let pending_before = AQ.pending_count () in
     let result = Claim.request_path_access ~keeper_id ~base_path ~path:target in
     (match result with
-     | Claim.Access_denied_hitl_pending { detail; approval_id } ->
-       Alcotest.(check bool)
-         "denial mentions unregistered repository"
-         true
-         (contains_substring detail "not-registered");
-       Alcotest.(check bool) "approval id nonempty" true (String.trim approval_id <> "")
-     | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
+     | Claim.Access_allowed -> ()
      | Claim.Access_denied detail ->
-       Alcotest.fail ("expected HITL pending denial, got: " ^ detail));
-    Alcotest.(check int) "pending count increments" (pending_before + 1) (AQ.pending_count ());
-    let pending = require_one_pending ~keeper_id in
-    Alcotest.(check string)
-      "requested action"
-      "register_repository"
-      (string_field "requested_action" pending.input);
-    Alcotest.(check string)
-      "policy source"
-      Config_dir_resolver.repositories_toml_basename
-      (string_field "policy_source" pending.input);
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
-     | Ok () -> ()
-     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.fail ("sandbox-local clone path denied: " ^ detail)
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "sandbox-local clone path must not create HITL");
+    Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ());
     match Repo_store.find ~base_path "not-registered" with
-    | Error detail -> Alcotest.fail ("approved registration did not persist: " ^ detail)
-    | Ok repo ->
-      Alcotest.(check string) "registered url" "https://github.com/test/not-registered.git" repo.url;
-      Alcotest.(check string)
-        "registered local path"
-        (canonical_path repo_root)
-        repo.local_path)
+    | Error _ -> ()
+    | Ok _ -> Alcotest.fail "sandbox-local access must not mutate repositories.toml")
 ;;
 
-let test_registration_approval_rechecks_clone_origin () =
+let test_unregistered_clone_origin_change_stays_sandbox_local () =
   if not (git_available ()) then Alcotest.skip ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -297,22 +247,21 @@ let test_registration_approval_rechecks_clone_origin () =
     let target = Filename.concat repo_root "README.md" in
     init_git_repo repo_root "https://github.com/test/not-registered.git";
     write_file target "hello\n";
+    let pending_before = AQ.pending_count () in
     (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
-     | Claim.Access_denied_hitl_pending _ -> ()
-     | Claim.Access_allowed -> Alcotest.fail "expected registration HITL denial"
+     | Claim.Access_allowed -> ()
      | Claim.Access_denied detail ->
-       Alcotest.fail ("expected registration HITL pending denial, got: " ^ detail));
-    let pending = require_one_pending ~keeper_id in
+       Alcotest.fail ("sandbox-local clone path denied: " ^ detail)
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "sandbox-local clone path must not create HITL");
     set_git_origin_url repo_root "https://github.com/test/renamed.git";
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
-     | Ok () -> ()
-     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ());
     match Repo_store.find ~base_path "not-registered" with
     | Error _ -> ()
-    | Ok _ -> Alcotest.fail "stale approved registration must not persist")
+    | Ok _ -> Alcotest.fail "sandbox-local access must not mutate repositories.toml")
 ;;
 
-let test_unregistered_clone_matching_existing_remote_requests_alias () =
+let test_unknown_clone_matching_existing_remote_is_sandbox_local () =
   if not (git_available ()) then Alcotest.skip ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -332,35 +281,25 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
     let target = Filename.concat repo_root "README.md" in
     init_git_repo repo_root registered.url;
     write_file target "hello\n";
+    let pending_before = AQ.pending_count () in
     let result = Claim.request_path_access ~keeper_id ~base_path ~path:target in
     (match result with
-     | Claim.Access_denied_hitl_pending _ -> ()
-     | Claim.Access_allowed -> Alcotest.fail "expected alias HITL denial"
+     | Claim.Access_allowed -> ()
      | Claim.Access_denied detail ->
-       Alcotest.fail ("expected alias HITL pending denial, got: " ^ detail));
-    let pending = require_one_pending ~keeper_id in
-    Alcotest.(check string)
-      "requested action"
-      "add_repository_alias"
-      (string_field "requested_action" pending.input);
-    Alcotest.(check string)
-      "target repository"
-      "masc"
-      (string_field "target_repository_id" pending.input);
-    Alcotest.(check string) "alias" "masc-mcp" (string_field "alias" pending.input);
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
-     | Ok () -> ()
-     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.fail ("sandbox-local clone path denied: " ^ detail)
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "sandbox-local clone path must not create HITL");
+    Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ());
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
 	      Alcotest.(check bool)
-	        "alias persisted"
-	        true
+	        "alias not persisted"
+	        false
 	        (List.exists (String.equal "masc-mcp") repo.aliases))
 	;;
 
-let test_nested_git_root_queues_manual_review_without_alias () =
+let test_nested_git_root_stays_sandbox_local_without_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -381,27 +320,14 @@ let test_nested_git_root_queues_manual_review_without_alias () =
     let target = Filename.concat nested_root "README.md" in
     init_git_repo nested_root registered.url;
     write_file target "nested\n";
+    let pending_before = AQ.pending_count () in
     (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
-     | Claim.Access_denied_hitl_pending _ -> ()
-     | Claim.Access_allowed -> Alcotest.fail "expected manual review HITL denial"
+     | Claim.Access_allowed -> ()
      | Claim.Access_denied detail ->
-       Alcotest.fail ("expected manual review HITL pending denial, got: " ^ detail));
-    let pending = require_one_pending ~keeper_id in
-    Alcotest.(check string)
-      "requested action"
-      "review_repository_catalog"
-      (string_field "requested_action" pending.input);
-    Alcotest.(check string)
-      "expected repo root"
-      expected_repo_root
-      (string_field "expected_repo_root" pending.input);
-    Alcotest.(check string)
-      "git root"
-      (canonical_path nested_root)
-      (string_field "repo_root" pending.input);
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
-     | Ok () -> ()
-     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.fail ("sandbox-local nested git root denied: " ^ detail)
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "sandbox-local nested git root must not create HITL");
+    Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ());
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
@@ -411,7 +337,7 @@ let test_nested_git_root_queues_manual_review_without_alias () =
         (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
 
-let test_alias_approval_rechecks_clone_origin () =
+let test_unknown_clone_origin_change_does_not_persist_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -431,16 +357,15 @@ let test_alias_approval_rechecks_clone_origin () =
     let target = Filename.concat repo_root "README.md" in
     init_git_repo repo_root registered.url;
     write_file target "hello\n";
+    let pending_before = AQ.pending_count () in
     (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
-     | Claim.Access_denied_hitl_pending _ -> ()
-     | Claim.Access_allowed -> Alcotest.fail "expected alias HITL denial"
+     | Claim.Access_allowed -> ()
      | Claim.Access_denied detail ->
-       Alcotest.fail ("expected alias HITL pending denial, got: " ^ detail));
-    let pending = require_one_pending ~keeper_id in
+       Alcotest.fail ("sandbox-local clone path denied: " ^ detail)
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "sandbox-local clone path must not create HITL");
     set_git_origin_url repo_root "https://github.com/jeong-sik/not-masc.git";
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
-     | Ok () -> ()
-     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ());
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
@@ -463,24 +388,24 @@ let () =
             `Quick
             test_unregistered_repository_does_not_request_hitl
         ; Alcotest.test_case
-            "unregistered sandbox clone queues registration HITL"
+            "unregistered sandbox clone path is sandbox-local allowed"
             `Quick
-            test_unregistered_clone_requests_hitl_and_approval_registers_repo
+            test_unregistered_clone_path_is_sandbox_local_allowed
         ; Alcotest.test_case
-            "registration approval rechecks clone origin"
+            "unregistered clone origin changes stay sandbox-local"
             `Quick
-            test_registration_approval_rechecks_clone_origin
+            test_unregistered_clone_origin_change_stays_sandbox_local
 	        ; Alcotest.test_case
-	            "clone name mismatch queues alias HITL"
+	            "clone name mismatch stays sandbox-local"
 	            `Quick
-	            test_unregistered_clone_matching_existing_remote_requests_alias
+	            test_unknown_clone_matching_existing_remote_is_sandbox_local
         ; Alcotest.test_case
-            "nested git root queues manual review without alias"
+            "nested git root stays sandbox-local without alias"
             `Quick
-            test_nested_git_root_queues_manual_review_without_alias
+            test_nested_git_root_stays_sandbox_local_without_alias
 	        ; Alcotest.test_case
-	            "alias approval rechecks clone origin"
+	            "origin change does not persist alias"
 	            `Quick
-            test_alias_approval_rechecks_clone_origin
+            test_unknown_clone_origin_change_does_not_persist_alias
         ] )
     ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -88,6 +88,11 @@ let write_mapping base_path keeper_id repo_ids =
   | Ok () -> ()
   | Error e -> Alcotest.fail ("write_mapping failed: " ^ e)
 
+let expect_path_access_ok ~label ~keeper_id ~base_path ~path =
+  match Keeper_repo_mapping.validate_path_access ~keeper_id ~base_path ~path with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail (label ^ ", got: " ^ msg)
+
 let write_repositories base_path repos =
   let path = Filename.concat base_path ".masc/config/repositories.toml" in
   let repo_block (r : repository) =
@@ -628,7 +633,7 @@ let test_validate_path_access_rejects_empty_url_basename () =
             "mentions identity mismatch" true
             (contains_substring msg "Repository identity mismatch"))
 
-let test_validate_path_access_playground_rejects_git_remote_only_identity () =
+let test_validate_path_access_playground_allows_git_remote_only_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -649,17 +654,13 @@ let test_validate_path_access_playground_rejects_git_remote_only_identity () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc.git";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected git remote-only identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected git remote-only sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_exact_remote_url_identity () =
+let test_validate_path_access_playground_allows_exact_remote_url_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -680,17 +681,13 @@ let test_validate_path_access_playground_rejects_exact_remote_url_identity () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc-mcp";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected exact remote URL identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected exact-remote sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_secondary_remote_url_spoof ()
+let test_validate_path_access_playground_allows_secondary_remote_url_clone ()
   =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -715,17 +712,13 @@ let test_validate_path_access_playground_rejects_secondary_remote_url_spoof ()
           ("origin", Filename.concat base_path "workspace/yousleepwhen/masc-mcp");
           ("github", "https://github.com/jeong-sik/masc.git");
         ];
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected secondary remote spoof to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected secondary-remote sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_gitdir_remote_identity () =
+let test_validate_path_access_playground_allows_gitdir_remote_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -750,17 +743,13 @@ let test_validate_path_access_playground_rejects_gitdir_remote_identity () =
         ~gitdir_ref:"../linked-worktree-gitdir"
         ~gitdir_path
         ~url:"https://github.com/jeong-sik/masc.git";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected gitdir remote identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected gitdir sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_large_git_config_denied () =
+let test_validate_path_access_playground_large_git_config_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -784,17 +773,13 @@ let test_validate_path_access_playground_large_git_config_denied () =
       write_file (Filename.concat repo_root ".git/config")
         (String.make (70 * 1024) 'x'
          ^ "\n[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc.git\n");
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected oversized git config to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected oversized-git-config sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_denied () =
+let test_validate_path_access_playground_unknown_repo_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -816,17 +801,13 @@ let test_validate_path_access_playground_unknown_repo_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected unknown playground repo to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_wildcard_denied () =
+let test_validate_path_access_playground_unknown_repo_wildcard_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -848,19 +829,13 @@ let test_validate_path_access_playground_unknown_repo_wildcard_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () ->
-          Alcotest.fail
-            "expected unknown playground repo under wildcard to be denied as unregistered"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo under wildcard to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_no_mapping_denied () =
+let test_validate_path_access_playground_unknown_repo_no_mapping_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -881,17 +856,11 @@ let test_validate_path_access_playground_unknown_repo_no_mapping_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () ->
-          Alcotest.fail
-            "expected unknown playground repo without mapping to be denied as unregistered"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo without mapping to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
 let test_apply_mapping_explicit () =
   with_temp_base_path (fun base_path ->
@@ -1019,22 +988,22 @@ let () =
             test_validate_path_access_wildcard_rejects_mismatched_url_basename;
           Alcotest.test_case "empty URL basename is identity mismatch" `Quick
             test_validate_path_access_rejects_empty_url_basename;
-          Alcotest.test_case "playground rejects git remote-only identity" `Quick
-            test_validate_path_access_playground_rejects_git_remote_only_identity;
-          Alcotest.test_case "playground rejects exact remote URL identity" `Quick
-            test_validate_path_access_playground_rejects_exact_remote_url_identity;
-          Alcotest.test_case "playground rejects secondary remote URL spoof" `Quick
-            test_validate_path_access_playground_rejects_secondary_remote_url_spoof;
-          Alcotest.test_case "playground rejects gitdir remote identity" `Quick
-            test_validate_path_access_playground_rejects_gitdir_remote_identity;
-          Alcotest.test_case "playground large git config is denied" `Quick
-            test_validate_path_access_playground_large_git_config_denied;
-          Alcotest.test_case "playground unknown repo denied as unregistered" `Quick
-            test_validate_path_access_playground_unknown_repo_denied;
-          Alcotest.test_case "playground unknown repo under wildcard denied as unregistered" `Quick
-            test_validate_path_access_playground_unknown_repo_wildcard_denied;
-          Alcotest.test_case "playground unknown repo no mapping denied" `Quick
-            test_validate_path_access_playground_unknown_repo_no_mapping_denied;
+          Alcotest.test_case "playground allows git remote-only clone" `Quick
+            test_validate_path_access_playground_allows_git_remote_only_clone;
+          Alcotest.test_case "playground allows exact remote URL clone" `Quick
+            test_validate_path_access_playground_allows_exact_remote_url_clone;
+          Alcotest.test_case "playground allows secondary remote URL clone" `Quick
+            test_validate_path_access_playground_allows_secondary_remote_url_clone;
+          Alcotest.test_case "playground allows gitdir remote clone" `Quick
+            test_validate_path_access_playground_allows_gitdir_remote_clone;
+          Alcotest.test_case "playground large git config is allowed" `Quick
+            test_validate_path_access_playground_large_git_config_allowed;
+          Alcotest.test_case "playground unknown repo allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_allowed;
+          Alcotest.test_case "playground unknown repo under wildcard allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_wildcard_allowed;
+          Alcotest.test_case "playground unknown repo no mapping allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_no_mapping_allowed;
         ] );
       ( "apply_mapping",
         [

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -108,6 +108,15 @@ let parse_bool_field raw field =
 
 let assert_sandbox_local_search_response ~raw =
   let json = Yojson.Safe.from_string raw in
+  let deterministic_retry_reason =
+    match Json.member "deterministic_retry" json with
+    | `Null -> None
+    | `Assoc _ as retry -> Json.member "reason" retry |> Json.to_string_option
+    | other ->
+      Alcotest.failf
+        "unexpected deterministic_retry shape: %s"
+        (Yojson.Safe.to_string other)
+  in
   Alcotest.(check (option bool)) "sandbox-local search succeeds" (Some true)
     (Json.member "ok" json |> Json.to_bool_option);
   Alcotest.(check (option string)) "no policy error" None
@@ -117,8 +126,7 @@ let assert_sandbox_local_search_response ~raw =
   Alcotest.(check (option bool)) "no operator action" None
     (Json.member "operator_action_required" json |> Json.to_bool_option);
   Alcotest.(check (option string)) "no deterministic policy retry" None
-    (Json.member "deterministic_retry" json |> Json.member "reason"
-     |> Json.to_string_option)
+    deterministic_retry_reason
 
 let assert_no_repository_registration_pending ~keeper_name =
   let pending =

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -106,48 +106,27 @@ let parse_field raw field =
 let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
-let unregistered_masc_mcp_policy_error =
-  "Repository masc-mcp is not registered; access not allowed"
-
-let assert_repository_registration_policy_response ~raw =
+let assert_sandbox_local_search_response ~raw =
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check (option bool)) "policy response denies access" (Some false)
+  Alcotest.(check (option bool)) "sandbox-local search succeeds" (Some true)
     (Json.member "ok" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "policy error keeps original denial"
-    (Some unregistered_masc_mcp_policy_error)
+  Alcotest.(check (option string)) "no policy error" None
     (Json.member "policy_error" json |> Json.to_string_option);
-  Alcotest.(check bool) "visible error changes from bare denial" true
-    (not
-       (String.equal
-          (Json.member "error" json |> Json.to_string_option |> Option.value ~default:"")
-          unregistered_masc_mcp_policy_error));
-  Alcotest.(check (option bool)) "operator action required" (Some true)
+  Alcotest.(check (option string)) "no visible error" None
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check (option bool)) "no operator action" None
     (Json.member "operator_action_required" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "operator action kind"
-    (Some "repository_registration")
-    (Json.member "operator_action_kind" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "operator action reason"
-    (Some "repository_unregistered")
-    (Json.member "operator_action_reason" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "next action"
-    (Some "wait_for_operator_approval")
-    (Json.member "next_action" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "approval kind"
-    (Some "repository_registration")
-    (Json.member "approval_pending" json |> Json.member "kind"
-   |> Json.to_string_option);
-  Alcotest.(check (option string)) "approval reason"
-    (Some "repository_unregistered")
-    (Json.member "approval_pending" json |> Json.member "reason"
-   |> Json.to_string_option);
-  Alcotest.(check (option bool)) "approval is non-blocking"
-    (Some true)
-    (Json.member "approval_pending" json |> Json.member "non_blocking"
-   |> Json.to_bool_option);
-  Alcotest.(check (option string)) "deterministic retry reason"
-    (Some "policy_blocked")
+  Alcotest.(check (option string)) "no deterministic policy retry" None
     (Json.member "deterministic_retry" json |> Json.member "reason"
-   |> Json.to_string_option)
+     |> Json.to_string_option)
+
+let assert_no_repository_registration_pending ~keeper_name =
+  let pending =
+    AQ.list_pending_entries ()
+    |> List.filter (fun (entry : AQ.pending_approval) ->
+      String.equal entry.keeper_name keeper_name)
+  in
+  Alcotest.(check int) "no repository registration pending" 0 (List.length pending)
 
 let write_executable path content =
   ignore (Fs_compat.save_file_atomic path content);
@@ -641,7 +620,7 @@ let test_readonly_execute_omitted_cwd_does_not_create_write_root () =
       false
       (Sys.file_exists playground)
 
-let test_rg_unregistered_clone_queues_repository_hitl () =
+let test_rg_unknown_playground_clone_is_sandbox_local () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -665,32 +644,10 @@ let test_rg_unregistered_clone_queues_repository_hitl () =
             ; "path", `String "repos/masc-mcp"
             ])
     in
-    assert_repository_registration_policy_response ~raw;
-    match
-      AQ.list_pending_entries ()
-      |> List.filter (fun (entry : AQ.pending_approval) ->
-        String.equal entry.keeper_name meta.name)
-    with
-    | [ pending ] ->
-      Alcotest.(check string)
-        "requested alias action"
-        "add_repository_alias"
-        (Json.member "requested_action" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias target"
-        "masc"
-        (Json.member "target_repository_id" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias"
-        "masc-mcp"
-        (Json.member "alias" pending.input |> Json.to_string)
-    | entries ->
-      Alcotest.failf
-        "expected one pending repository registration approval, got %d; raw=%s"
-        (List.length entries)
-        raw)
+    assert_sandbox_local_search_response ~raw;
+    assert_no_repository_registration_pending ~keeper_name:meta.name)
 
-let test_read_unregistered_clone_surfaces_repository_hitl () =
+let test_read_unknown_playground_clone_is_sandbox_local () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -712,30 +669,15 @@ let test_read_unregistered_clone_surfaces_repository_hitl () =
           (`Assoc
             [ "path", `String "repos/masc-mcp/README.md"; "max_bytes", `Int 4096 ])
     in
-    assert_repository_registration_policy_response ~raw;
-    match
-      AQ.list_pending_entries ()
-      |> List.filter (fun (entry : AQ.pending_approval) ->
-        String.equal entry.keeper_name meta.name)
-    with
-    | [ pending ] ->
-      Alcotest.(check string)
-        "requested alias action"
-        "add_repository_alias"
-        (Json.member "requested_action" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias target"
-        "masc"
-        (Json.member "target_repository_id" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias"
-        "masc-mcp"
-        (Json.member "alias" pending.input |> Json.to_string)
-    | entries ->
-      Alcotest.failf
-        "expected one pending repository registration approval, got %d; raw=%s"
-        (List.length entries)
-        raw)
+    let json = Yojson.Safe.from_string raw in
+    Alcotest.(check (option bool)) "sandbox-local read succeeds" (Some true)
+      (Json.member "ok" json |> Json.to_bool_option);
+    Alcotest.(check (option string)) "read content"
+      (Some "Repository\n")
+      (Json.member "content" json |> Json.to_string_option);
+    Alcotest.(check (option string)) "no policy error" None
+      (Json.member "policy_error" json |> Json.to_string_option);
+    assert_no_repository_registration_pending ~keeper_name:meta.name)
 
 
 let () =
@@ -780,12 +722,12 @@ let () =
             `Quick
             test_readonly_execute_omitted_cwd_does_not_create_write_root;
           Alcotest.test_case
-            "rg unregistered clone queues repository HITL"
+            "rg unknown playground clone is sandbox-local"
             `Quick
-            test_rg_unregistered_clone_queues_repository_hitl;
+            test_rg_unknown_playground_clone_is_sandbox_local;
           Alcotest.test_case
-            "Read unregistered clone surfaces repository HITL"
+            "Read unknown playground clone is sandbox-local"
             `Quick
-            test_read_unregistered_clone_surfaces_repository_hitl;
+            test_read_unknown_playground_clone_is_sandbox_local;
         ] );
     ]

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -242,6 +242,23 @@ let test_playground_repos_mark_registered_repo_outside_mapping_allowed () =
   check string "policy repository id" "masc"
     (json_string "policy_repository_id" json)
 
+let test_playground_repos_mark_unknown_clone_sandbox_local_allowed () =
+  let base_path = temp_dir "masc-playground-repo-policy" in
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  save_repositories base_path [];
+  create_playground_repo_marker ~config ~meta "masc-mcp";
+  let json = playground_repo_entry ~config ~meta ~repo_name:"masc-mcp" in
+  check bool "policy allows sandbox-local clone" true
+    (json_bool "policy_allowed" json);
+  check string "policy status"
+    (Keeper_sandbox_control.playground_policy_status_to_string Policy_allowed)
+    (json_string "policy_status" json);
+  check string "policy scope" "sandbox_local"
+    (json_string "policy_scope" json);
+  check (option string) "no catalog repository id" None
+    (json_string_opt "policy_repository_id" json)
+
 let test_playground_repos_mark_wildcard_mapping_allowed () =
   let base_path = temp_dir "masc-playground-repo-policy" in
   let config = Masc.Workspace.default_config base_path in
@@ -727,6 +744,8 @@ let () =
         test_case "registered filesystem repo outside mapping is marked allowed"
           `Quick
           test_playground_repos_mark_registered_repo_outside_mapping_allowed;
+        test_case "unknown filesystem repo is sandbox-local allowed" `Quick
+          test_playground_repos_mark_unknown_clone_sandbox_local_allowed;
         test_case "filesystem repo under wildcard mapping is marked allowed"
           `Quick test_playground_repos_mark_wildcard_mapping_allowed;
         test_case "filesystem repo policy uses registered repository id"


### PR DESCRIPTION
Fixes live keeper tool errors where Read and Grep rejected paths under a keeper playground clone just because the clone was absent from repositories.toml. Keeps sandbox containment and registered-repository identity mismatch failures explicit. Validation run locally: git diff --check, opam exec -- ocamlformat --check on touched OCaml files, opam exec -- ocamlc -stop-after parsing on touched OCaml files. Full dune build is left to CI.