### PR TITLE
[codex] Add HITL recovery for unregistered keeper repos

### DIFF
--- a/.github/actions/install-ocaml-deps/install.sh
+++ b/.github/actions/install-ocaml-deps/install.sh
@@ -18,8 +18,13 @@ install_os_packages() {
   local started_at
   started_at="$(date +%s)"
   echo "Refreshing apt package index..."
-  sudo apt-get update -qq
-  log_elapsed "Refreshed apt package index" "${started_at}"
+  if sudo apt-get update -qq; then
+    log_elapsed "Refreshed apt package index" "${started_at}"
+  else
+    echo \
+      "::warning::apt package index refresh failed; attempting install with existing package index" \
+      >&2
+  fi
 
   started_at="$(date +%s)"
   declare -a package_args=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
 
       - name: Install meta shell dependencies
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
 
       - name: Guard pending release tag on main PRs
@@ -503,7 +503,7 @@ jobs:
 
       - name: Install health shell dependencies
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep bc
 
       - name: Setup OCaml toolchain

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -25,7 +25,7 @@ jobs:
 
 
       - name: Refresh apt index
-        run: sudo apt-get update
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -352,7 +352,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y -qq ripgrep
+        run: |
+          bash scripts/ci/apt-refresh.sh
+          sudo apt-get install -y -qq ripgrep
       - name: Run path SSOT audit
         run: bash scripts/audit-path-ssot.sh
 

--- a/.github/workflows/main-nightly-health.yml
+++ b/.github/workflows/main-nightly-health.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install ripgrep
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
 
       - name: Check doc truth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Refresh apt index
         if: runner.os == 'Linux'
-        run: sudo apt-get update -qq
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install ripgrep
         run: |
           if ! command -v rg >/dev/null 2>&1; then
-            sudo apt-get update -qq
+            bash scripts/ci/apt-refresh.sh
             sudo apt-get install -y ripgrep
           fi
 

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '22'
 
       - name: Refresh system package index
-        run: sudo apt-get update -qq
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install OS dependencies
         run: sudo apt-get install -y jq

--- a/docs/superpowers/plans/2026-07-06-repo-claim-hitl-plan.html
+++ b/docs/superpowers/plans/2026-07-06-repo-claim-hitl-plan.html
@@ -134,10 +134,11 @@
     <section>
       <h2>Decision</h2>
       <p>
-        Keep the strict repo access gate as the default authority. Add an
-        explicit HITL claim path for the narrow case where a repository is
-        registered and identity-validated, but the keeper's selected mapping
-        does not include it.
+        Keep the strict repo access gate as the default authority. Add explicit
+        HITL recovery paths for sandbox clones that are physically present but
+        not authorized by the repository catalog. Registered repositories remain
+        allowed because keeper mappings are advisory/default-scope metadata, not
+        access caps.
       </p>
       <div class="grid">
         <div class="tile">
@@ -150,15 +151,17 @@
         <div class="tile">
           <h3 class="warn">HITL Pending</h3>
           <p>
-            Repository identity is valid, but the keeper mapping excludes it.
-            Queue an approval request and do not block the keeper fiber.
+            A sandbox clone has auditable Git metadata but is missing from
+            <code>repositories.toml</code>, or its sandbox name should become an
+            explicit alias of an existing catalog repository.
           </p>
         </div>
         <div class="tile">
           <h3 class="danger">Denied</h3>
           <p>
-            Repository is unregistered, mapping file is malformed, repository
-            store load failed, or identity mismatched. No claim request is made.
+            Repository store load failed, Git metadata is incomplete, or identity
+            evidence is insufficient for an automatic approved mutation. The
+            keeper remains fail-closed.
           </p>
         </div>
       </div>
@@ -167,11 +170,11 @@
     <section>
       <h2>Implementation Slice</h2>
       <ul>
-        <li>Add a typed access decision in <code>Keeper_repo_mapping</code> so callers can distinguish not-in-mapping from load/store/identity errors.</li>
-        <li>Add a keeper-side HITL bridge that calls <code>Keeper_approval_queue.submit_pending</code> for repository-claim requests.</li>
-        <li>On operator approve, update <code>keeper_repo_mappings.toml</code> through the existing <code>save_mapping</code> SSOT.</li>
-        <li>On reject or edit, persist no mapping change and emit an explicit log path.</li>
-        <li>Wire read/write filesystem paths to return a structured <code>approval_pending</code> response instead of a plain policy reject for the claimable case.</li>
+        <li>Keep <code>Keeper_repo_mapping</code> as the pure policy/enforcement boundary.</li>
+        <li>Add a keeper-side HITL bridge that calls <code>Keeper_approval_queue.submit_pending</code> for sandbox clone registration requests.</li>
+        <li>On operator approve, update <code>repositories.toml</code> through <code>Repo_store.add</code> for new repositories, or <code>Repo_store.update</code> for approved aliases.</li>
+        <li>On reject, edit, or incomplete evidence, persist no catalog mutation and emit an explicit log path.</li>
+        <li>Wire read/write filesystem paths to return a structured <code>approval_pending</code> response instead of a plain policy reject for claimable sandbox clones.</li>
       </ul>
     </section>
 
@@ -179,7 +182,8 @@
       <h2>Non Goals</h2>
       <ul>
         <li>No OAS API or provider behavior change.</li>
-        <li>No automatic repo registration for unregistered or identity-mismatched paths.</li>
+        <li>No automatic repo registration without an operator approval decision.</li>
+        <li>No duplicate catalog entry when the clone remote matches an existing registered repository; use an approved alias instead.</li>
         <li>No heuristic matching from free text, branch names, or command strings.</li>
         <li>No background mutation without an approval decision.</li>
       </ul>
@@ -197,19 +201,19 @@
         </thead>
         <tbody>
           <tr>
-            <td>Keeper mapping excludes registered repo</td>
-            <td>HITL pending approval is created</td>
-            <td>Focused Alcotest for repo claim bridge</td>
+              <td>Unregistered sandbox clone with valid origin metadata</td>
+              <td>HITL pending approval is created; approve registers the repo in <code>repositories.toml</code></td>
+              <td>Focused Alcotest for repo registration bridge</td>
           </tr>
           <tr>
-            <td>Operator approves claim</td>
-            <td>Mapping file gains the repository id through <code>save_mapping</code></td>
-            <td>Resolve pending approval and reload mapping</td>
+              <td>Clone name differs but origin remote matches an existing repo</td>
+              <td>HITL pending approval is created; approve adds the clone segment as an alias</td>
+              <td>Resolve pending approval and reload repository catalog</td>
           </tr>
           <tr>
-            <td>Unregistered repo id</td>
-            <td>Fail closed; no HITL request</td>
-            <td>Repo mapping decision test</td>
+              <td>Unregistered repo id without sandbox clone evidence</td>
+              <td>Fail closed; no HITL request</td>
+              <td>Repo access decision test</td>
           </tr>
           <tr>
             <td>Malformed mapping or repository store</td>

--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -143,13 +143,13 @@ let apply_record path c json =
 let state_of_counters c =
   if c.stale_source_snapshot_count > 0
   then Source_snapshot_stale
-  else if c.artifact_missing_count > 0
-  then Artifact_missing
   else if c.missing_source_snapshot_count > 0
           || c.artifact_unknown_count > 0
           || c.artifact_not_verified_count > 0
           || c.rejected_count > 0
   then Needs_evidence
+  else if c.artifact_missing_count > 0
+  then Artifact_missing
   else Verified
 ;;
 

--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -323,6 +323,7 @@ let append_record ~tool_name ~author ~target_post_id ~content ~claims ~snapshot 
        | None -> [])
   in
   let path = Board_claim_evidence.sidecar_path () in
+  Fs_compat.invalidate_cached_writer path;
   Fs_compat.append_jsonl path json;
   (* Mirror sibling sidecars (board_posts/comments/reactions/sub_boards), which
      rotate at [Board_paths.max_jsonl_bytes]. Without this the claim-evidence
@@ -332,16 +333,18 @@ let append_record ~tool_name ~author ~target_post_id ~content ~claims ~snapshot 
 ;;
 
 let evaluate ~target_post_id ~claims ~snapshot ~artifact_refs ~resolutions =
-  match snapshot with
-  | Some source ->
-    (match target_post_id with
-     | None -> Reject "source_post_snapshot_without_target_post"
-     | Some target_post_id ->
-       (match validate_source_snapshot ~target_post_id source with
-     | Error reason -> Reject reason
-        | Ok () -> Allow))
-  | None -> Allow
-  |> function
+  let snapshot_decision =
+    match snapshot with
+    | Some source ->
+      (match target_post_id with
+       | None -> Reject "source_post_snapshot_without_target_post"
+       | Some target_post_id ->
+         (match validate_source_snapshot ~target_post_id source with
+          | Error reason -> Reject reason
+          | Ok () -> Allow))
+    | None -> Allow
+  in
+  match snapshot_decision with
   | Reject _ as reject -> reject
   | Allow ->
     let requires_artifact = List.exists claim_requires_existing_artifact claims in

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -267,10 +267,10 @@ let test_ledger () =
   Alcotest.(check int) "corpus size" 32 (List.length corpus);
   (* W4/G-9 delta vs W1: the 9 policy-as-risk cases moved R2->R1 (repo
      create/fork, discussion create/comment/edit/close, graphql create x3), so
-     R1 5->14, R2 20->11, and policy_as_risk 9->0 — the #23362 defect is closed. *)
+     R1 6->15, R2 19->10, and policy_as_risk 9->0 — the #23362 defect is closed. *)
   Alcotest.(check int) "R0 count" 7 r0;
-  Alcotest.(check int) "R1 count" 14 r1;
-  Alcotest.(check int) "R2 count" 11 r2;
+  Alcotest.(check int) "R1 count" 15 r1;
+  Alcotest.(check int) "R2 count" 10 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
   Alcotest.(check int) "defect: policy-as-risk (CLOSED by W4)" 0 policy_as_risk;
   (* Was 1 (unknown-repo-action). CLOSED: the auto-run gap moved to the

--- a/lib/exec_policy/exec_policy_paths.ml
+++ b/lib/exec_policy/exec_policy_paths.ml
@@ -99,7 +99,7 @@ let keeper_registered_repo_path_allowed ?keeper_id ?base_path path =
       | Keeper_repo_mapping.Repository_identity_mismatch _
       | Keeper_repo_mapping.Repository_store_error _ ->
           false
-      | Keeper_repo_mapping.Repository repository_id -> (
+      | Keeper_repo_mapping.Repository { repository_id; _ } -> (
           match
             Keeper_repo_mapping.validate_access ~keeper_id ~repository_id
               ~base_path

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -12,6 +12,7 @@ let repository_registration_next_action = "wait_for_operator_approval"
 type registration_candidate =
   { repository_id : Repo_manager_types.repository_id
   ; repo_root : string
+  ; expected_repo_root : string option
   ; origin_url : string
   ; default_branch : string
   }
@@ -64,6 +65,34 @@ let canonical_url_equal left right =
 
 let origin_url_matches left right = String.equal left right || canonical_url_equal left right
 
+let normalized_root_for_compare path =
+  let trimmed = String.trim path in
+  let trimmed =
+    if String.ends_with ~suffix:"/" trimmed
+    then String.sub trimmed 0 (String.length trimmed - 1)
+    else trimmed
+  in
+  try Unix.realpath trimmed with
+  | Unix.Unix_error _ | Sys_error _ -> trimmed
+;;
+
+let candidate_expected_repo_root_mismatch candidate =
+  match candidate.expected_repo_root with
+  | None -> None
+  | Some expected_repo_root ->
+    if
+      String.equal
+        (normalized_root_for_compare candidate.repo_root)
+        (normalized_root_for_compare expected_repo_root)
+    then None
+    else
+      Some
+        (Printf.sprintf
+           "git worktree root %s does not match expected playground repository root %s"
+           candidate.repo_root
+           expected_repo_root)
+;;
+
 let revalidate_registration_candidate candidate =
   match Repo_git.worktree_root ~local_path:candidate.repo_root with
   | Error reason -> Error ("worktree root recheck failed: " ^ reason)
@@ -76,6 +105,9 @@ let revalidate_registration_candidate candidate =
            candidate.repo_root
            repo_root)
     else (
+      match candidate_expected_repo_root_mismatch { candidate with repo_root } with
+      | Some reason -> Error reason
+      | None ->
       match Repo_git.get_origin_url ~local_path:repo_root with
       | Error reason -> Error ("origin recheck failed: " ^ reason)
       | Ok origin_url ->
@@ -124,6 +156,9 @@ let log_stale_approved_candidate ~keeper_id candidate detail =
 ;;
 
 let registration_operation ~keeper_id ~base_path candidate =
+  match candidate_expected_repo_root_mismatch candidate with
+  | Some reason -> Manual_catalog_review { reason; candidate }
+  | None -> (
   match find_existing_repository_by_origin ~base_path candidate.origin_url with
   | Error reason -> Manual_catalog_review { reason; candidate }
   | Ok (Some existing) ->
@@ -135,7 +170,7 @@ let registration_operation ~keeper_id ~base_path candidate =
       Manual_catalog_review
         { reason = "origin URL basename does not match requested repository id"
         ; candidate
-        }
+        })
 ;;
 
 let operation_candidate = function
@@ -295,11 +330,15 @@ let registration_operation_input ~keeper_id ~base_path operation =
      ; "repository_id", `String candidate.repository_id
      ; "policy_source", `String Config_dir_resolver.repositories_toml_basename
      ; "requested_action", `String (operation_name operation)
-     ; "base_path", `String base_path
-     ; "repo_root", `String candidate.repo_root
-     ; "origin_url", `String candidate.origin_url
-     ; "default_branch", `String candidate.default_branch
-     ; "identity_valid", `Bool (candidate_identity_is_valid ~keeper_id candidate)
+	     ; "base_path", `String base_path
+	     ; "repo_root", `String candidate.repo_root
+     ; ( "expected_repo_root"
+       , match candidate.expected_repo_root with
+         | None -> `Null
+         | Some expected_repo_root -> `String expected_repo_root )
+	     ; "origin_url", `String candidate.origin_url
+	     ; "default_branch", `String candidate.default_branch
+	     ; "identity_valid", `Bool (candidate_identity_is_valid ~keeper_id candidate)
      ]
      @ operation_fields)
 ;;
@@ -323,7 +362,7 @@ let path_for_git_probe path =
   | Sys_error _ -> Filename.dirname path
 ;;
 
-let registration_candidate_of_path ~repository_id ~path =
+let registration_candidate_of_path ~repository_id ~expected_repo_root ~path =
   let probe_path = path_for_git_probe path in
   match Repo_git.worktree_root ~local_path:probe_path with
   | Error reason -> Error reason
@@ -333,7 +372,8 @@ let registration_candidate_of_path ~repository_id ~path =
     | Ok origin_url -> (
       match Repo_git.origin_head_branch ~local_path:repo_root with
       | Error reason -> Error reason
-      | Ok default_branch -> Ok { repository_id; repo_root; origin_url; default_branch }))
+      | Ok default_branch ->
+        Ok { repository_id; repo_root; expected_repo_root; origin_url; default_branch }))
 ;;
 
 let pending_operator_action_message detail =
@@ -375,10 +415,10 @@ let request_repository_access ~keeper_id ~base_path ~repository_id =
 let request_path_access ~keeper_id ~base_path ~path =
   match Keeper_repo_mapping.repository_resolution_of_path ~base_path ~path with
   | Keeper_repo_mapping.No_repository -> Access_allowed
-  | Keeper_repo_mapping.Repository repository_id ->
+  | Keeper_repo_mapping.Repository { repository_id; repo_root = expected_repo_root } ->
     (match request_repository_access ~keeper_id ~base_path ~repository_id with
      | Access_denied detail ->
-       (match registration_candidate_of_path ~repository_id ~path with
+       (match registration_candidate_of_path ~repository_id ~expected_repo_root ~path with
         | Ok candidate ->
           let operation = registration_operation ~keeper_id ~base_path candidate in
           let approval_id = submit_registration_hitl ~keeper_id ~base_path operation in

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -1,6 +1,272 @@
 type access_result =
   | Access_allowed
   | Access_denied of string
+  | Access_denied_hitl_pending of { detail : string; approval_id : string }
+
+let repository_registration_tool_name = "keeper_repository_registration"
+let repository_registration_kind = "repository_registration"
+let repository_registration_disposition = "operator_action_required"
+let repository_registration_reason = "repository_unregistered"
+
+type registration_candidate =
+  { repository_id : Repo_manager_types.repository_id
+  ; repo_root : string
+  ; origin_url : string
+  ; default_branch : string
+  }
+
+type registration_operation =
+  | Register_new of registration_candidate
+  | Add_alias_to_existing of
+      { existing_repository_id : Repo_manager_types.repository_id
+      ; alias : string
+      ; candidate : registration_candidate
+      }
+  | Manual_catalog_review of
+      { reason : string
+      ; candidate : registration_candidate
+      }
+
+let repository_record_of_candidate ~keeper_id candidate =
+  { Repo_manager_types.id = candidate.repository_id
+  ; name = candidate.repository_id
+  ; url = candidate.origin_url
+  ; local_path = candidate.repo_root
+  ; aliases = []
+  ; default_branch = candidate.default_branch
+  ; keepers = [ keeper_id ]
+  ; status = Repo_manager_types.Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = Int64.zero
+  ; updated_at = Int64.zero
+  }
+;;
+
+let candidate_identity_is_valid ~keeper_id candidate =
+  let repo = repository_record_of_candidate ~keeper_id candidate in
+  Keeper_repo_mapping.repository_url_basename_matches_identity repo
+;;
+
+let add_string_once value values =
+  if List.exists (String.equal value) values then values else values @ [ value ]
+;;
+
+let canonical_url_equal left right =
+  match
+    ( Agent_observation.canonical_url_of_remote left
+    , Agent_observation.canonical_url_of_remote right )
+  with
+  | Some left, Some right -> String.equal left right
+  | _ -> false
+;;
+
+let find_existing_repository_by_origin ~base_path origin_url =
+  match Repo_store.load_all ~base_path with
+  | Error detail -> Error detail
+  | Ok repos ->
+    Ok
+      (List.find_opt
+         (fun (repo : Repo_manager_types.repository) ->
+            canonical_url_equal repo.url origin_url)
+         repos)
+;;
+
+let registration_operation ~keeper_id ~base_path candidate =
+  match find_existing_repository_by_origin ~base_path candidate.origin_url with
+  | Error reason -> Manual_catalog_review { reason; candidate }
+  | Ok (Some existing) ->
+    Add_alias_to_existing
+      { existing_repository_id = existing.id; alias = candidate.repository_id; candidate }
+  | Ok None ->
+    if candidate_identity_is_valid ~keeper_id candidate then Register_new candidate
+    else
+      Manual_catalog_review
+        { reason = "origin URL basename does not match requested repository id"
+        ; candidate
+        }
+;;
+
+let operation_candidate = function
+  | Register_new candidate
+  | Add_alias_to_existing { candidate; _ }
+  | Manual_catalog_review { candidate; _ } -> candidate
+;;
+
+let operation_name = function
+  | Register_new _ -> "register_repository"
+  | Add_alias_to_existing _ -> "add_repository_alias"
+  | Manual_catalog_review _ -> "review_repository_catalog"
+;;
+
+let approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias =
+  match Repo_store.find ~base_path existing_repository_id with
+  | Error detail ->
+    Log.Keeper.warn
+      "keeper repo alias approved but catalog read failed keeper=%s \
+       repository=%s alias=%s source=%s error=%s"
+      keeper_id
+      existing_repository_id
+      alias
+      Config_dir_resolver.repositories_toml_basename
+      detail
+  | Ok existing ->
+    let updated =
+      { existing with
+        aliases = add_string_once alias existing.aliases
+      ; keepers = add_string_once keeper_id existing.keepers
+      }
+    in
+    (match Repo_store.update ~base_path existing.id updated with
+     | Ok _ ->
+       Log.Keeper.info
+         "keeper repo alias approved keeper=%s repository=%s alias=%s source=%s"
+         keeper_id
+         existing.id
+         alias
+         Config_dir_resolver.repositories_toml_basename
+     | Error detail ->
+       Log.Keeper.warn
+         "keeper repo alias approved but catalog update failed keeper=%s \
+          repository=%s alias=%s source=%s error=%s"
+         keeper_id
+         existing.id
+         alias
+         Config_dir_resolver.repositories_toml_basename
+         detail)
+;;
+
+let approve_new_registration ~keeper_id ~base_path candidate =
+  match find_existing_repository_by_origin ~base_path candidate.origin_url with
+  | Error detail ->
+    Log.Keeper.warn
+      "keeper repo registration approved but catalog recheck failed keeper=%s \
+       repository=%s source=%s error=%s"
+      keeper_id
+      candidate.repository_id
+      Config_dir_resolver.repositories_toml_basename
+      detail
+  | Ok (Some existing) ->
+    approve_alias
+      ~keeper_id
+      ~base_path
+      ~existing_repository_id:existing.id
+      ~alias:candidate.repository_id
+  | Ok None ->
+    if candidate_identity_is_valid ~keeper_id candidate then (
+      let repo = repository_record_of_candidate ~keeper_id candidate in
+      match Repo_store.add ~base_path repo with
+      | Ok _ ->
+        Log.Keeper.info
+          "keeper repo registration approved keeper=%s repository=%s source=%s"
+          keeper_id
+          candidate.repository_id
+          Config_dir_resolver.repositories_toml_basename
+      | Error detail ->
+        Log.Keeper.warn
+          "keeper repo registration approved but catalog update failed keeper=%s \
+           repository=%s source=%s error=%s"
+          keeper_id
+          candidate.repository_id
+          Config_dir_resolver.repositories_toml_basename
+          detail)
+    else
+      Log.Keeper.warn
+        "keeper repo registration approved but identity check failed keeper=%s \
+         repository=%s url=%s"
+        keeper_id
+        candidate.repository_id
+        candidate.origin_url
+;;
+
+let apply_approved_operation ~keeper_id ~base_path = function
+  | Register_new candidate -> approve_new_registration ~keeper_id ~base_path candidate
+  | Add_alias_to_existing { existing_repository_id; alias; _ } ->
+    approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias
+  | Manual_catalog_review { reason; candidate } ->
+    Log.Keeper.warn
+      "keeper repo catalog review approved but no automatic mutation is safe \
+       keeper=%s repository=%s reason=%s"
+      keeper_id
+      candidate.repository_id
+      reason
+;;
+
+let register_candidate_on_approval ~keeper_id ~base_path operation decision =
+  let candidate = operation_candidate operation in
+  match decision with
+  | Agent_sdk.Hooks.Approve ->
+    apply_approved_operation ~keeper_id ~base_path operation
+  | Agent_sdk.Hooks.Reject reason ->
+    Log.Keeper.info
+      "keeper repo registration rejected keeper=%s repository=%s reason=%s"
+      keeper_id
+      candidate.repository_id
+      reason
+  | Agent_sdk.Hooks.Edit _ ->
+    Log.Keeper.warn
+      "keeper repo registration edit decision ignored keeper=%s repository=%s; \
+       dashboard approval resolver supports approve/reject only"
+      keeper_id
+      candidate.repository_id
+;;
+
+let registration_operation_input ~keeper_id ~base_path operation =
+  let candidate = operation_candidate operation in
+  let operation_fields =
+    match operation with
+    | Register_new _ -> []
+    | Add_alias_to_existing { existing_repository_id; alias; _ } ->
+      [ "target_repository_id", `String existing_repository_id; "alias", `String alias ]
+    | Manual_catalog_review { reason; _ } -> [ "manual_review_reason", `String reason ]
+  in
+  `Assoc
+    ([ "kind", `String repository_registration_kind
+     ; "keeper_id", `String keeper_id
+     ; "repository_id", `String candidate.repository_id
+     ; "policy_source", `String Config_dir_resolver.repositories_toml_basename
+     ; "requested_action", `String (operation_name operation)
+     ; "base_path", `String base_path
+     ; "repo_root", `String candidate.repo_root
+     ; "origin_url", `String candidate.origin_url
+     ; "default_branch", `String candidate.default_branch
+     ; "identity_valid", `Bool (candidate_identity_is_valid ~keeper_id candidate)
+     ]
+     @ operation_fields)
+;;
+
+let submit_registration_hitl ~keeper_id ~base_path operation =
+  Keeper_approval_queue.submit_pending
+    ~keeper_name:keeper_id
+    ~tool_name:repository_registration_tool_name
+    ~input:(registration_operation_input ~keeper_id ~base_path operation)
+    ~risk_level:Keeper_approval_queue.High
+    ~base_path
+    ~sandbox_target:"repository_catalog"
+    ~disposition:repository_registration_disposition
+    ~disposition_reason:repository_registration_reason
+    ~on_resolution:(register_candidate_on_approval ~keeper_id ~base_path operation)
+    ()
+;;
+
+let path_for_git_probe path =
+  try if Sys.file_exists path && Sys.is_directory path then path else Filename.dirname path with
+  | Sys_error _ -> Filename.dirname path
+;;
+
+let registration_candidate_of_path ~repository_id ~path =
+  let probe_path = path_for_git_probe path in
+  match Repo_git.worktree_root ~local_path:probe_path with
+  | Error reason -> Error reason
+  | Ok repo_root ->
+    (match Repo_git.get_origin_url ~local_path:repo_root with
+     | Error reason -> Error reason
+     | Ok origin_url ->
+       (match Repo_git.origin_head_branch ~local_path:repo_root with
+        | Error reason -> Error reason
+        | Ok default_branch ->
+          Ok { repository_id; repo_root; origin_url; default_branch }))
+;;
 
 let request_repository_access ~keeper_id ~base_path ~repository_id =
   match Keeper_repo_mapping.access_decision ~keeper_id ~repository_id ~base_path with
@@ -13,7 +279,23 @@ let request_path_access ~keeper_id ~base_path ~path =
   match Keeper_repo_mapping.repository_resolution_of_path ~base_path ~path with
   | Keeper_repo_mapping.No_repository -> Access_allowed
   | Keeper_repo_mapping.Repository repository_id ->
-    request_repository_access ~keeper_id ~base_path ~repository_id
+    (match request_repository_access ~keeper_id ~base_path ~repository_id with
+     | Access_denied detail ->
+       (match registration_candidate_of_path ~repository_id ~path with
+        | Ok candidate ->
+          let operation = registration_operation ~keeper_id ~base_path candidate in
+          let approval_id = submit_registration_hitl ~keeper_id ~base_path operation in
+          Access_denied_hitl_pending { detail; approval_id }
+        | Error reason ->
+          Log.Keeper.warn
+            "keeper repo registration candidate unavailable keeper=%s repository=%s \
+             path=%s error=%s"
+            keeper_id
+            repository_id
+            path
+            reason;
+          Access_denied detail)
+     | (Access_allowed | Access_denied_hitl_pending _) as result -> result)
   | Keeper_repo_mapping.Repository_identity_mismatch mismatch ->
     Access_denied (Keeper_repo_mapping.repository_identity_mismatch_message mismatch)
   | Keeper_repo_mapping.Repository_store_error detail ->
@@ -33,6 +315,23 @@ let tool_response_json ~path = function
       [ "ok", `Bool false
       ; "error", `String detail
       ; "path", `String path
+      ; ( "deterministic_retry"
+        , `Assoc
+            [ "reason", `String "policy_blocked"
+            ; "retry_same_args", `Bool false
+            ] )
+      ]
+  | Access_denied_hitl_pending { detail; approval_id } ->
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String detail
+      ; "path", `String path
+      ; ( "approval_pending"
+        , `Assoc
+            [ "id", `String approval_id
+            ; "kind", `String repository_registration_kind
+            ; "non_blocking", `Bool true
+            ] )
       ; ( "deterministic_retry"
         , `Assoc
             [ "reason", `String "policy_blocked"

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -7,6 +7,7 @@ let repository_registration_tool_name = "keeper_repository_registration"
 let repository_registration_kind = "repository_registration"
 let repository_registration_disposition = "operator_action_required"
 let repository_registration_reason = "repository_unregistered"
+let repository_registration_next_action = "wait_for_operator_approval"
 
 type registration_candidate =
   { repository_id : Repo_manager_types.repository_id
@@ -326,14 +327,42 @@ let registration_candidate_of_path ~repository_id ~path =
   let probe_path = path_for_git_probe path in
   match Repo_git.worktree_root ~local_path:probe_path with
   | Error reason -> Error reason
-  | Ok repo_root ->
-    (match Repo_git.get_origin_url ~local_path:repo_root with
-     | Error reason -> Error reason
-     | Ok origin_url ->
-       (match Repo_git.origin_head_branch ~local_path:repo_root with
-        | Error reason -> Error reason
-        | Ok default_branch ->
-          Ok { repository_id; repo_root; origin_url; default_branch }))
+  | Ok repo_root -> (
+    match Repo_git.get_origin_url ~local_path:repo_root with
+    | Error reason -> Error reason
+    | Ok origin_url -> (
+      match Repo_git.origin_head_branch ~local_path:repo_root with
+      | Error reason -> Error reason
+      | Ok default_branch -> Ok { repository_id; repo_root; origin_url; default_branch }))
+;;
+
+let pending_operator_action_message detail =
+  Printf.sprintf
+    "%s; operator approval pending for %s"
+    detail
+    repository_registration_kind
+;;
+
+let deterministic_policy_blocked_fields =
+  Keeper_tool_deterministic_error.(deterministic_retry_fields Policy_blocked)
+;;
+
+let repository_registration_action_fields =
+  [ "operator_action_required", `Bool true
+  ; "operator_action_kind", `String repository_registration_kind
+  ; "operator_action_reason", `String repository_registration_reason
+  ; "recoverability", `String repository_registration_disposition
+  ; "next_action", `String repository_registration_next_action
+  ]
+;;
+
+let approval_pending_json approval_id =
+  `Assoc
+    [ "id", `String approval_id
+    ; "kind", `String repository_registration_kind
+    ; "reason", `String repository_registration_reason
+    ; "non_blocking", `Bool true
+    ]
 ;;
 
 let request_repository_access ~keeper_id ~base_path ~repository_id =
@@ -380,30 +409,19 @@ let tool_response_json ~path = function
     `Assoc [ "ok", `Bool true; "path", `String path ]
   | Access_denied detail ->
     `Assoc
-      [ "ok", `Bool false
-      ; "error", `String detail
-      ; "path", `String path
-      ; ( "deterministic_retry"
-        , `Assoc
-            [ "reason", `String "policy_blocked"
-            ; "retry_same_args", `Bool false
-            ] )
-      ]
+      ([ "ok", `Bool false
+       ; "error", `String detail
+       ; "path", `String path
+       ]
+       @ deterministic_policy_blocked_fields)
   | Access_denied_hitl_pending { detail; approval_id } ->
     `Assoc
-      [ "ok", `Bool false
-      ; "error", `String detail
-      ; "path", `String path
-      ; ( "approval_pending"
-        , `Assoc
-            [ "id", `String approval_id
-            ; "kind", `String repository_registration_kind
-            ; "non_blocking", `Bool true
-            ] )
-      ; ( "deterministic_retry"
-        , `Assoc
-            [ "reason", `String "policy_blocked"
-            ; "retry_same_args", `Bool false
-            ] )
-      ]
+      ([ "ok", `Bool false
+       ; "error", `String (pending_operator_action_message detail)
+       ; "policy_error", `String detail
+       ; "path", `String path
+       ; "approval_pending", approval_pending_json approval_id
+       ]
+       @ repository_registration_action_fields
+       @ deterministic_policy_blocked_fields)
 ;;

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -61,6 +61,44 @@ let canonical_url_equal left right =
   | _ -> false
 ;;
 
+let origin_url_matches left right = String.equal left right || canonical_url_equal left right
+
+let revalidate_registration_candidate candidate =
+  match Repo_git.worktree_root ~local_path:candidate.repo_root with
+  | Error reason -> Error ("worktree root recheck failed: " ^ reason)
+  | Ok repo_root ->
+    if not (String.equal repo_root candidate.repo_root)
+    then
+      Error
+        (Printf.sprintf
+           "worktree root changed from %s to %s"
+           candidate.repo_root
+           repo_root)
+    else (
+      match Repo_git.get_origin_url ~local_path:repo_root with
+      | Error reason -> Error ("origin recheck failed: " ^ reason)
+      | Ok origin_url ->
+        if not (origin_url_matches candidate.origin_url origin_url)
+        then
+          Error
+            (Printf.sprintf
+               "origin changed from %s to %s"
+               candidate.origin_url
+               origin_url)
+        else (
+          match Repo_git.origin_head_branch ~local_path:repo_root with
+          | Error reason -> Error ("origin HEAD recheck failed: " ^ reason)
+          | Ok default_branch ->
+            if not (String.equal default_branch candidate.default_branch)
+            then
+              Error
+                (Printf.sprintf
+                   "default branch changed from %s to %s"
+                   candidate.default_branch
+                   default_branch)
+            else Ok { candidate with repo_root; origin_url; default_branch }))
+;;
+
 let find_existing_repository_by_origin ~base_path origin_url =
   match Repo_store.load_all ~base_path with
   | Error detail -> Error detail
@@ -70,6 +108,18 @@ let find_existing_repository_by_origin ~base_path origin_url =
          (fun (repo : Repo_manager_types.repository) ->
             canonical_url_equal repo.url origin_url)
          repos)
+;;
+
+let log_stale_approved_candidate ~keeper_id candidate detail =
+  Log.Keeper.warn
+    "keeper repo registration approved but git metadata recheck failed; \
+     skipping catalog mutation keeper=%s repository=%s repo_root=%s \
+     source=%s error=%s"
+    keeper_id
+    candidate.repository_id
+    candidate.repo_root
+    Config_dir_resolver.repositories_toml_basename
+    detail
 ;;
 
 let registration_operation ~keeper_id ~base_path candidate =
@@ -99,8 +149,37 @@ let operation_name = function
   | Manual_catalog_review _ -> "review_repository_catalog"
 ;;
 
-let approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias =
-  match Repo_store.find ~base_path existing_repository_id with
+let persist_alias ~keeper_id ~base_path ~(existing : Repo_manager_types.repository) ~alias =
+  let updated =
+    { existing with
+      aliases = add_string_once alias existing.aliases
+    ; keepers = add_string_once keeper_id existing.keepers
+    }
+  in
+  match Repo_store.update ~base_path existing.id updated with
+  | Ok _ ->
+    Log.Keeper.info
+      "keeper repo alias approved keeper=%s repository=%s alias=%s source=%s"
+      keeper_id
+      existing.id
+      alias
+      Config_dir_resolver.repositories_toml_basename
+  | Error detail ->
+    Log.Keeper.warn
+      "keeper repo alias approved but catalog update failed keeper=%s \
+       repository=%s alias=%s source=%s error=%s"
+      keeper_id
+      existing.id
+      alias
+      Config_dir_resolver.repositories_toml_basename
+      detail
+;;
+
+let approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias ~candidate =
+  match revalidate_registration_candidate candidate with
+  | Error detail -> log_stale_approved_candidate ~keeper_id candidate detail
+  | Ok current_candidate -> (
+    match Repo_store.find ~base_path existing_repository_id with
   | Error detail ->
     Log.Keeper.warn
       "keeper repo alias approved but catalog read failed keeper=%s \
@@ -111,32 +190,25 @@ let approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias =
       Config_dir_resolver.repositories_toml_basename
       detail
   | Ok existing ->
-    let updated =
-      { existing with
-        aliases = add_string_once alias existing.aliases
-      ; keepers = add_string_once keeper_id existing.keepers
-      }
-    in
-    (match Repo_store.update ~base_path existing.id updated with
-     | Ok _ ->
-       Log.Keeper.info
-         "keeper repo alias approved keeper=%s repository=%s alias=%s source=%s"
-         keeper_id
-         existing.id
-         alias
-         Config_dir_resolver.repositories_toml_basename
-     | Error detail ->
-       Log.Keeper.warn
-         "keeper repo alias approved but catalog update failed keeper=%s \
-          repository=%s alias=%s source=%s error=%s"
-         keeper_id
-         existing.id
-         alias
-         Config_dir_resolver.repositories_toml_basename
-         detail)
+    if not (origin_url_matches existing.url current_candidate.origin_url)
+    then
+      Log.Keeper.warn
+        "keeper repo alias approved but current clone origin does not match \
+         target repository; skipping catalog mutation keeper=%s repository=%s \
+         alias=%s source=%s target_origin=%s current_origin=%s"
+        keeper_id
+        existing.id
+        alias
+        Config_dir_resolver.repositories_toml_basename
+        existing.url
+        current_candidate.origin_url
+    else persist_alias ~keeper_id ~base_path ~existing ~alias)
 ;;
 
 let approve_new_registration ~keeper_id ~base_path candidate =
+  match revalidate_registration_candidate candidate with
+  | Error detail -> log_stale_approved_candidate ~keeper_id candidate detail
+  | Ok candidate -> (
   match find_existing_repository_by_origin ~base_path candidate.origin_url with
   | Error detail ->
     Log.Keeper.warn
@@ -147,11 +219,7 @@ let approve_new_registration ~keeper_id ~base_path candidate =
       Config_dir_resolver.repositories_toml_basename
       detail
   | Ok (Some existing) ->
-    approve_alias
-      ~keeper_id
-      ~base_path
-      ~existing_repository_id:existing.id
-      ~alias:candidate.repository_id
+    persist_alias ~keeper_id ~base_path ~existing ~alias:candidate.repository_id
   | Ok None ->
     if candidate_identity_is_valid ~keeper_id candidate then (
       let repo = repository_record_of_candidate ~keeper_id candidate in
@@ -176,13 +244,13 @@ let approve_new_registration ~keeper_id ~base_path candidate =
          repository=%s url=%s"
         keeper_id
         candidate.repository_id
-        candidate.origin_url
+        candidate.origin_url)
 ;;
 
 let apply_approved_operation ~keeper_id ~base_path = function
   | Register_new candidate -> approve_new_registration ~keeper_id ~base_path candidate
-  | Add_alias_to_existing { existing_repository_id; alias; _ } ->
-    approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias
+  | Add_alias_to_existing { existing_repository_id; alias; candidate } ->
+    approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias ~candidate
   | Manual_catalog_review { reason; candidate } ->
     Log.Keeper.warn
       "keeper repo catalog review approved but no automatic mutation is safe \

--- a/lib/keeper/keeper_repo_claim_hitl.mli
+++ b/lib/keeper/keeper_repo_claim_hitl.mli
@@ -2,15 +2,16 @@
 
     [Keeper_repo_mapping] remains a pure policy/enforcement module and does
     not depend on keeper tool surfaces. This module is the composition layer
-    that turns fail-closed repository denials into tool-facing responses.
+    that turns fail-closed repository denials into tool-facing responses and
+    non-blocking operator registration requests when a sandbox clone provides
+    enough structured evidence.
     Keeper repository mappings are advisory/default-scope metadata and are not
-    claimable access caps. The module name is retained for compatibility with
-    the former repo-claim path; selected-scope misses no longer submit HITL
-    approvals. *)
+    claimable access caps. *)
 
 type access_result =
   | Access_allowed
   | Access_denied of string
+  | Access_denied_hitl_pending of { detail : string; approval_id : string }
 
 val request_repository_access :
   keeper_id:string ->

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -373,7 +373,7 @@ let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
     Keeper_repo_mapping.repository_resolution_of_path_from_catalog ~base_path
       ~path:repo_path repos
   with
-  | Keeper_repo_mapping.Repository repository_id -> Ok repository_id
+  | Keeper_repo_mapping.Repository { repository_id; _ } -> Ok repository_id
   | Keeper_repo_mapping.No_repository -> Ok repo_name
   | Keeper_repo_mapping.Repository_identity_mismatch _ ->
     Error

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -35,6 +35,12 @@ let validate_rg_inputs ~pattern:_ ~file_type =
   | Error _ as e -> e
   | Ok () -> Ok ()
 ;;
+
+type read_target_result =
+  | Read_target of string
+  | Read_target_error of string
+  | Read_target_policy_response of string
+
 let try_handle
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Workspace.config)
@@ -48,19 +54,25 @@ let try_handle
     Keeper_sandbox_containment.check_read_target ~config ~meta ~target
   in
   let repo_check target =
-    Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
-      ~base_path:root ~path:target
+    match
+      Keeper_repo_claim_hitl.request_path_access
+        ~keeper_id:meta.name
+        ~base_path:root
+        ~path:target
+    with
+    | Keeper_repo_claim_hitl.Access_allowed -> Read_target target
+    | access_result ->
+      Read_target_policy_response
+        (Yojson.Safe.to_string
+           (Keeper_repo_claim_hitl.tool_response_json ~path:target access_result))
   in
   let read_target () =
     match Keeper_tool_execute_path.resolve_tool_read_path ~config ~meta ~args with
-    | Error _ as e -> e
+    | Error e -> Read_target_error e
     | Ok target ->
       (match containment_check target with
-       | Error msg -> Error msg
-       | Ok () ->
-         match repo_check target with
-         | Error msg -> Error msg
-         | Ok () -> Ok target)
+       | Error msg -> Read_target_error msg
+       | Ok () -> repo_check target)
   in
   let path_error e =
     actionable_path_error ~op ~meta ~raw_path ~error:e
@@ -138,8 +150,9 @@ let try_handle
          | Error msg -> error_json ~fields:[ "op", `String op ] msg
          | Ok () -> (
            match read_target () with
-           | Error e -> path_error e
-           | Ok target ->
+           | Read_target_error e -> path_error e
+           | Read_target_policy_response response -> response
+           | Read_target target ->
              let limit = shell_readonly_limit args in
              let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
              if Keeper_sandbox_read_runner.should_route_read ~meta then

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -636,14 +636,21 @@ let repository_matches_token ~base_path token (repo : repository) =
 
 type repository_resolution =
   | No_repository
-  | Repository of repository_id
+  | Repository of repository_match
   | Repository_identity_mismatch of repository_identity_mismatch
   | Repository_store_error of string
+
+and repository_match =
+  { repository_id : repository_id
+  ; repo_root : string option
+  }
+
+let repository_match ?repo_root repository_id = { repository_id; repo_root }
 
 let repository_resolution_of_repo ?repo_root ~segment repo =
   match repository_identity_mismatch ?repo_root ~segment repo with
   | Some mismatch -> Repository_identity_mismatch mismatch
-  | None -> Repository repo.id
+  | None -> Repository (repository_match ?repo_root repo.id)
 
 let repository_identity_mismatch_for_url_basename_token ?repo_root ~segment
     token repos =
@@ -665,7 +672,7 @@ let unresolved_repository_segment_resolution ?repo_root ~segment repos =
       segment repos
   with
   | Some mismatch -> Repository_identity_mismatch mismatch
-  | None -> Repository segment
+  | None -> Repository (repository_match ?repo_root segment)
 
 let resolve_repository_id_segment_from_catalog ~base_path ?repo_root segment repos =
   match List.find_opt (repository_matches_token ~base_path segment) repos with
@@ -729,7 +736,7 @@ let repository_resolution_of_path ~base_path ~path =
     if the path is not under any registered repository. *)
 let repository_id_of_path ~base_path ~path =
   match repository_resolution_of_path ~base_path ~path with
-  | Repository repo_id -> Some repo_id
+  | Repository { repository_id; _ } -> Some repository_id
   | No_repository | Repository_identity_mismatch _ | Repository_store_error _ -> None
 
 (** [validate_path_access ~keeper_id ~base_path ~path] checks that [path]
@@ -741,7 +748,8 @@ let repository_id_of_path ~base_path ~path =
 let validate_path_access ~keeper_id ~base_path ~path =
   match repository_resolution_of_path ~base_path ~path with
   | No_repository -> Ok ()
-  | Repository repo_id -> validate_access ~keeper_id ~repository_id:repo_id ~base_path
+  | Repository { repository_id; _ } ->
+      validate_access ~keeper_id ~repository_id ~base_path
   | Repository_identity_mismatch mismatch ->
       Error (repository_identity_mismatch_message mismatch)
   | Repository_store_error msg ->

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -124,6 +124,12 @@ type repository_identity_mismatch
 
 val repository_identity_mismatch_message : repository_identity_mismatch -> string
 
+val repository_url_basename_matches_identity : repository -> bool
+(** [repository_url_basename_matches_identity repo] is the catalog identity
+    SSOT used before authorizing a playground repository path. Registration
+    flows reuse it so operator-approved catalog additions do not grow a second
+    URL/name matching rule. *)
+
 type repository_resolution =
   | No_repository
   | Repository of repository_id

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -130,9 +130,14 @@ val repository_url_basename_matches_identity : repository -> bool
     flows reuse it so operator-approved catalog additions do not grow a second
     URL/name matching rule. *)
 
+type repository_match =
+  { repository_id : repository_id
+  ; repo_root : string option
+  }
+
 type repository_resolution =
   | No_repository
-  | Repository of repository_id
+  | Repository of repository_match
   | Repository_identity_mismatch of repository_identity_mismatch
   | Repository_store_error of string
 

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -141,13 +141,26 @@ let worktree_root ~local_path =
   | Error msg -> Stdlib.Error msg
 
 let branch_of_origin_head_ref refname =
-  match List.rev (String.split_on_char '/' (String.trim refname)) with
-  | branch :: _ when String.trim branch <> "" -> Stdlib.Ok (String.trim branch)
-  | _ ->
+  let refname = String.trim refname in
+  let prefix = "refs/remotes/origin/" in
+  if String.starts_with ~prefix refname
+  then
+    let branch =
+      String.sub refname (String.length prefix) (String.length refname - String.length prefix)
+      |> String.trim
+    in
+    if String.equal branch ""
+    then
       Stdlib.Error
         (Printf.sprintf
            "git symbolic-ref refs/remotes/origin/HEAD returned invalid ref: %S"
            refname)
+    else Stdlib.Ok branch
+  else
+    Stdlib.Error
+      (Printf.sprintf
+         "git symbolic-ref refs/remotes/origin/HEAD returned invalid ref: %S"
+         refname)
 ;;
 
 let origin_head_branch ~local_path =

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -124,6 +124,44 @@ let get_origin_url ~local_path =
   | Ok [] -> Error "git remote get-url origin returned no output"
   | Error msg -> Error msg
 
+let worktree_root ~local_path =
+  match
+    run_git
+      ~cwd:local_path
+      ~env:read_only_git_env
+      ~timeout_sec:status_summary_timeout_sec
+      [ "rev-parse"; "--show-toplevel" ]
+  with
+  | Ok (root :: _) ->
+    let root = String.trim root in
+    if String.equal root ""
+    then Stdlib.Error "git rev-parse --show-toplevel returned blank"
+    else Stdlib.Ok root
+  | Ok [] -> Stdlib.Error "git rev-parse --show-toplevel returned no output"
+  | Error msg -> Stdlib.Error msg
+
+let branch_of_origin_head_ref refname =
+  match List.rev (String.split_on_char '/' (String.trim refname)) with
+  | branch :: _ when String.trim branch <> "" -> Stdlib.Ok (String.trim branch)
+  | _ ->
+      Stdlib.Error
+        (Printf.sprintf
+           "git symbolic-ref refs/remotes/origin/HEAD returned invalid ref: %S"
+           refname)
+;;
+
+let origin_head_branch ~local_path =
+  match
+    run_git
+      ~cwd:local_path
+      ~env:read_only_git_env
+      ~timeout_sec:status_summary_timeout_sec
+      [ "symbolic-ref"; "-q"; "refs/remotes/origin/HEAD" ]
+  with
+  | Ok (refname :: _) -> branch_of_origin_head_ref refname
+  | Ok [] -> Stdlib.Error "git symbolic-ref refs/remotes/origin/HEAD returned no output"
+  | Error msg -> Stdlib.Error msg
+
 let inspect_timeout_sec = status_summary_timeout_sec
 
 let current_branch ~repository =

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -42,6 +42,17 @@ val get_origin_url : local_path:string -> (string, string) result
 (** [get_origin_url ~local_path] returns the configured [origin] remote URL
     for the repository at [local_path]. *)
 
+val worktree_root : local_path:string -> (string, string) result
+(** [worktree_root ~local_path] returns Git's [--show-toplevel] path for
+    [local_path]. It is read-only and bounded; callers use it to avoid treating
+    an arbitrary file's dirname as a repository root. *)
+
+val origin_head_branch : local_path:string -> (string, string) result
+(** [origin_head_branch ~local_path] returns the branch named by
+    [refs/remotes/origin/HEAD]. It does not fall back to guessed branch names;
+    callers that need an auditable repository-registration candidate should
+    surface [Error _] to the operator instead of inventing a default branch. *)
+
 val current_branch : repository:repository -> (string, string) result
 (** [current_branch ~repository] returns the short name of the checked-out
     branch via [git rev-parse --abbrev-ref HEAD]. A detached HEAD returns

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -21,6 +21,9 @@ let parse_task_contract args =
            "contract must be an object when provided (received %s)"
            (Json_util.kind_name other))
 
+let handoff_example_evidence_ref =
+  Filename.concat Common.masc_dirname "harness-evidence/proof.json"
+
 let is_internal_marker key =
   String.length key > 0 && Char.equal key.[0] '_'
 
@@ -123,11 +126,12 @@ let parse_handoff_context ~(agent_name : string)
                    "handoff_context.summary is required for action=%s \
                     (non-empty string). Example: {\"summary\": \"tests \
                     green, local proof saved\", \"next_step\": \"wait \
-                    for CI\", \"evidence_refs\": [\".masc/harness-evidence/proof.json\"]}. \
+                    for CI\", \"evidence_refs\": [\"%s\"]}. \
                     Alternatively pass a non-empty top-level 'notes' or \
                     'reason' and it will be synthesized into summary \
                     automatically."
-                   (Masc_domain.task_action_to_string action))
+                   (Masc_domain.task_action_to_string action)
+                   handoff_example_evidence_ref)
             else
               (* Entry-class action (claim/start) with an empty
                  handoff_context object. The summary is meaningless at

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -24,6 +24,22 @@ module Float = Stdlib.Float
 let masc_add_task_name =
   Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
 
+let handoff_example_evidence_ref =
+  Filename.concat Common.masc_dirname "harness-evidence/proof.json"
+
+let handoff_context_description =
+  Printf.sprintf
+    "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class \
+     actions (done / submit_for_verification / release / cancel). On \
+     action='done' or 'submit_for_verification', include 'evidence_refs' with \
+     at least one locally validated reference: an existing base-path artifact \
+     file/file:// URI, a commit hash present in the local git repo, or a %s \
+     trace/turn/receipt ref that resolves on disk. Completion notes, URLs, PR \
+     numbers, and trace-shaped labels alone do NOT satisfy the gate. Example: \
+     {\"summary\": \"tests green, local proof saved\", \"evidence_refs\": [\"%s\"]}."
+    Common.masc_dirname
+    handoff_example_evidence_ref
+
 let schemas : Masc_domain.tool_schema list = [
   {
     name = masc_add_task_name;
@@ -253,7 +269,7 @@ they do not route normal completion through the verifier agent."
         ]);
         ("handoff_context", `Assoc [
           ("type", `String "object");
-          ("description", `String "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class actions (done / submit_for_verification / release / cancel). On action='done' or 'submit_for_verification', include 'evidence_refs' with at least one locally validated reference: an existing base-path artifact file/file:// URI, a commit hash present in the local git repo, or a .masc trace/turn/receipt ref that resolves on disk. Completion notes, URLs, PR numbers, and trace-shaped labels alone do NOT satisfy the gate. Example: {\"summary\": \"tests green, local proof saved\", \"evidence_refs\": [\".masc/harness-evidence/proof.json\"]}.");
+          ("description", `String handoff_context_description);
           ("properties", `Assoc [
             ("summary", `Assoc [
               ("type", `String "string");

--- a/scripts/ci/apt-refresh.sh
+++ b/scripts/ci/apt-refresh.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if sudo apt-get update -qq; then
+  echo "Refreshed apt package index."
+else
+  echo "::warning::apt package index refresh failed; using existing package index" >&2
+fi

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -24,7 +24,7 @@ lib/keeper/keeper_sandbox_control.ml:224  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:477  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:196  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:589  # argv_keeper
-lib/keeper/keeper_sandbox_read_backend.ml:184  # argv_keeper
+lib/keeper/keeper_sandbox_read_backend.ml:185  # argv_keeper
 lib/keeper/keeper_sandbox_runner.ml:167  # argv_keeper
 lib/keeper/keeper_sandbox_runtime_setup.ml:51  # argv_keeper
 lib/keeper/keeper_tools_oas_handler_exec.ml:76  # argv_keeper

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -98,6 +98,13 @@ let init_git_repo dir url =
        |])
 ;;
 
+let set_git_origin_url dir url =
+  Alcotest.(check int)
+    "git remote set-url"
+    0
+    (run_git_quiet [| "git"; "-C"; dir; "remote"; "set-url"; "origin"; url |])
+;;
+
 let with_temp_base_path f =
   let dir = Filename.temp_file "repo_claim_hitl" "" in
   Sys.remove dir;
@@ -274,6 +281,37 @@ let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
         repo.local_path)
 ;;
 
+let test_registration_approval_rechecks_clone_origin () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-register-stale-origin" in
+    write_repositories base_path [];
+    let repo_root =
+      Filename.concat
+        base_path
+        (Filename.concat ".masc/playground" (keeper_id ^ "/repos/not-registered"))
+    in
+    let target = Filename.concat repo_root "README.md" in
+    init_git_repo repo_root "https://github.com/test/not-registered.git";
+    write_file target "hello\n";
+    (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
+     | Claim.Access_denied_hitl_pending _ -> ()
+     | Claim.Access_allowed -> Alcotest.fail "expected registration HITL denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected registration HITL pending denial, got: " ^ detail));
+    let pending = require_one_pending ~keeper_id in
+    set_git_origin_url repo_root "https://github.com/test/renamed.git";
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    match Repo_store.find ~base_path "not-registered" with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.fail "stale approved registration must not persist")
+;;
+
 let test_unregistered_clone_matching_existing_remote_requests_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
@@ -322,6 +360,45 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
         (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
 
+let test_alias_approval_rechecks_clone_origin () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-alias-stale-origin" in
+    let registered = sample_repo ~base_path "masc" in
+    let registered =
+      { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
+    in
+    write_repositories base_path [ registered ];
+    let repo_root =
+      Filename.concat
+        base_path
+        (Filename.concat ".masc/playground" (keeper_id ^ "/repos/masc-mcp"))
+    in
+    let target = Filename.concat repo_root "README.md" in
+    init_git_repo repo_root registered.url;
+    write_file target "hello\n";
+    (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
+     | Claim.Access_denied_hitl_pending _ -> ()
+     | Claim.Access_allowed -> Alcotest.fail "expected alias HITL denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected alias HITL pending denial, got: " ^ detail));
+    let pending = require_one_pending ~keeper_id in
+    set_git_origin_url repo_root "https://github.com/jeong-sik/not-masc.git";
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    match Repo_store.find ~base_path "masc" with
+    | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
+    | Ok repo ->
+      Alcotest.(check bool)
+        "stale alias not persisted"
+        false
+        (List.exists (String.equal "masc-mcp") repo.aliases))
+;;
+
 let () =
   Alcotest.run
     "Keeper_repo_claim_hitl"
@@ -339,8 +416,16 @@ let () =
             `Quick
             test_unregistered_clone_requests_hitl_and_approval_registers_repo
         ; Alcotest.test_case
+            "registration approval rechecks clone origin"
+            `Quick
+            test_registration_approval_rechecks_clone_origin
+        ; Alcotest.test_case
             "clone name mismatch queues alias HITL"
             `Quick
             test_unregistered_clone_matching_existing_remote_requests_alias
+        ; Alcotest.test_case
+            "alias approval rechecks clone origin"
+            `Quick
+            test_alias_approval_rechecks_clone_origin
         ] )
     ]

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -354,9 +354,60 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
+	      Alcotest.(check bool)
+	        "alias persisted"
+	        true
+	        (List.exists (String.equal "masc-mcp") repo.aliases))
+	;;
+
+let test_nested_git_root_queues_manual_review_without_alias () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-nested-root" in
+    let registered = sample_repo ~base_path "masc" in
+    let registered =
+      { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
+    in
+    write_repositories base_path [ registered ];
+    let expected_repo_root =
+      Filename.concat
+        base_path
+        (Filename.concat ".masc/playground" (keeper_id ^ "/repos/masc-mcp"))
+    in
+    let nested_root = Filename.concat expected_repo_root "nested" in
+    let target = Filename.concat nested_root "README.md" in
+    init_git_repo nested_root registered.url;
+    write_file target "nested\n";
+    (match Claim.request_path_access ~keeper_id ~base_path ~path:target with
+     | Claim.Access_denied_hitl_pending _ -> ()
+     | Claim.Access_allowed -> Alcotest.fail "expected manual review HITL denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected manual review HITL pending denial, got: " ^ detail));
+    let pending = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "requested action"
+      "review_repository_catalog"
+      (string_field "requested_action" pending.input);
+    Alcotest.(check string)
+      "expected repo root"
+      expected_repo_root
+      (string_field "expected_repo_root" pending.input);
+    Alcotest.(check string)
+      "git root"
+      (canonical_path nested_root)
+      (string_field "repo_root" pending.input);
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    match Repo_store.find ~base_path "masc" with
+    | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
+    | Ok repo ->
       Alcotest.(check bool)
-        "alias persisted"
-        true
+        "manual review approval does not persist alias"
+        false
         (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
 
@@ -419,13 +470,17 @@ let () =
             "registration approval rechecks clone origin"
             `Quick
             test_registration_approval_rechecks_clone_origin
+	        ; Alcotest.test_case
+	            "clone name mismatch queues alias HITL"
+	            `Quick
+	            test_unregistered_clone_matching_existing_remote_requests_alias
         ; Alcotest.test_case
-            "clone name mismatch queues alias HITL"
+            "nested git root queues manual review without alias"
             `Quick
-            test_unregistered_clone_matching_existing_remote_requests_alias
-        ; Alcotest.test_case
-            "alias approval rechecks clone origin"
-            `Quick
+            test_nested_git_root_queues_manual_review_without_alias
+	        ; Alcotest.test_case
+	            "alias approval rechecks clone origin"
+	            `Quick
             test_alias_approval_rechecks_clone_origin
         ] )
     ]

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -57,6 +57,47 @@ let write_file path content =
     (fun () -> output_string oc content)
 ;;
 
+let run_git_quiet argv =
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close devnull)
+    (fun () ->
+       try
+         let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
+         match Unix.waitpid [] pid with
+         | _, Unix.WEXITED code -> code
+         | _, (Unix.WSIGNALED _ | Unix.WSTOPPED _) -> 1
+       with
+       | Unix.Unix_error _ -> 1)
+;;
+
+let git_available () = run_git_quiet [| "git"; "--version" |] = 0
+
+let canonical_path path =
+  try Unix.realpath path with
+  | Unix.Unix_error _ | Sys_error _ -> path
+;;
+
+let init_git_repo dir url =
+  ensure_dir dir;
+  Alcotest.(check int) "git init" 0 (run_git_quiet [| "git"; "init"; "-q"; dir |]);
+  Alcotest.(check int)
+    "git remote add"
+    0
+    (run_git_quiet [| "git"; "-C"; dir; "remote"; "add"; "origin"; url |]);
+  Alcotest.(check int)
+    "git origin HEAD"
+    0
+    (run_git_quiet
+       [| "git"
+        ; "-C"
+        ; dir
+        ; "symbolic-ref"
+        ; "refs/remotes/origin/HEAD"
+        ; "refs/remotes/origin/main"
+       |])
+;;
+
 let with_temp_base_path f =
   let dir = Filename.temp_file "repo_claim_hitl" "" in
   Sys.remove dir;
@@ -125,11 +166,15 @@ let test_registered_repo_outside_advisory_mapping_is_allowed () =
   (match result with
    | Claim.Access_allowed -> ()
    | Claim.Access_denied detail ->
-     Alcotest.fail ("registered repo outside advisory mapping denied: " ^ detail));
+     Alcotest.fail ("registered repo outside advisory mapping denied: " ^ detail)
+   | Claim.Access_denied_hitl_pending _ ->
+     Alcotest.fail "registered repo must not create HITL");
   Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
 ;;
 
 let test_unregistered_repository_does_not_request_hitl () =
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
   with_temp_base_path @@ fun base_path ->
   let keeper_id = "keeper-repo-unregistered" in
   let repo_a = sample_repo ~base_path "repo-a" in
@@ -148,8 +193,133 @@ let test_unregistered_repository_does_not_request_hitl () =
        "denial mentions unregistered repository"
        true
        (contains_substring detail "not-registered")
-   | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial");
+   | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
+   | Claim.Access_denied_hitl_pending _ ->
+     Alcotest.fail "direct repository id request must not create HITL");
   Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
+;;
+
+let require_one_pending ~keeper_id =
+  match
+    AQ.list_pending_entries ()
+    |> List.filter (fun (entry : AQ.pending_approval) ->
+      String.equal entry.keeper_name keeper_id)
+  with
+  | [ entry ] -> entry
+  | entries ->
+    Alcotest.failf
+      "expected one pending approval for %s, got %d"
+      keeper_id
+      (List.length entries)
+;;
+
+let string_field key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value -> value
+  | other ->
+    Alcotest.failf
+      "expected string field %s, got %s"
+      key
+      (Yojson.Safe.to_string other)
+;;
+
+let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-register-clone" in
+    write_repositories base_path [];
+    let repo_root =
+      Filename.concat
+        base_path
+        (Filename.concat ".masc/playground" (keeper_id ^ "/repos/not-registered"))
+    in
+    let target = Filename.concat repo_root "README.md" in
+    init_git_repo repo_root "https://github.com/test/not-registered.git";
+    write_file target "hello\n";
+    let pending_before = AQ.pending_count () in
+    let result = Claim.request_path_access ~keeper_id ~base_path ~path:target in
+    (match result with
+     | Claim.Access_denied_hitl_pending { detail; approval_id } ->
+       Alcotest.(check bool)
+         "denial mentions unregistered repository"
+         true
+         (contains_substring detail "not-registered");
+       Alcotest.(check bool) "approval id nonempty" true (String.trim approval_id <> "")
+     | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected HITL pending denial, got: " ^ detail));
+    Alcotest.(check int) "pending count increments" (pending_before + 1) (AQ.pending_count ());
+    let pending = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "requested action"
+      "register_repository"
+      (string_field "requested_action" pending.input);
+    Alcotest.(check string)
+      "policy source"
+      Config_dir_resolver.repositories_toml_basename
+      (string_field "policy_source" pending.input);
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    match Repo_store.find ~base_path "not-registered" with
+    | Error detail -> Alcotest.fail ("approved registration did not persist: " ^ detail)
+    | Ok repo ->
+      Alcotest.(check string) "registered url" "https://github.com/test/not-registered.git" repo.url;
+      Alcotest.(check string)
+        "registered local path"
+        (canonical_path repo_root)
+        repo.local_path)
+;;
+
+let test_unregistered_clone_matching_existing_remote_requests_alias () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-alias-clone" in
+    let registered = sample_repo ~base_path "masc" in
+    let registered =
+      { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
+    in
+    write_repositories base_path [ registered ];
+    let repo_root =
+      Filename.concat
+        base_path
+        (Filename.concat ".masc/playground" (keeper_id ^ "/repos/masc-mcp"))
+    in
+    let target = Filename.concat repo_root "README.md" in
+    init_git_repo repo_root registered.url;
+    write_file target "hello\n";
+    let result = Claim.request_path_access ~keeper_id ~base_path ~path:target in
+    (match result with
+     | Claim.Access_denied_hitl_pending _ -> ()
+     | Claim.Access_allowed -> Alcotest.fail "expected alias HITL denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected alias HITL pending denial, got: " ^ detail));
+    let pending = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "requested action"
+      "add_repository_alias"
+      (string_field "requested_action" pending.input);
+    Alcotest.(check string)
+      "target repository"
+      "masc"
+      (string_field "target_repository_id" pending.input);
+    Alcotest.(check string) "alias" "masc-mcp" (string_field "alias" pending.input);
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    match Repo_store.find ~base_path "masc" with
+    | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
+    | Ok repo ->
+      Alcotest.(check bool)
+        "alias persisted"
+        true
+        (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
 
 let () =
@@ -164,5 +334,13 @@ let () =
             "unregistered repository remains fail-closed"
             `Quick
             test_unregistered_repository_does_not_request_hitl
+        ; Alcotest.test_case
+            "unregistered sandbox clone queues registration HITL"
+            `Quick
+            test_unregistered_clone_requests_hitl_and_approval_registers_repo
+        ; Alcotest.test_case
+            "clone name mismatch queues alias HITL"
+            `Quick
+            test_unregistered_clone_matching_existing_remote_requests_alias
         ] )
     ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -16,8 +16,11 @@ module Keeper_tool_execute_path = Masc.Keeper_tool_execute_path
 module Keeper_types = Keeper_types
 module Keeper_alerting_path = Masc.Keeper_alerting_path
 module Keeper_tool_policy = Masc.Keeper_tool_policy
+module AQ = Masc.Keeper_approval_queue
 module Fs_compat = Fs_compat
 module Json = Yojson.Safe.Util
+
+open Repo_manager_types
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
@@ -109,6 +112,60 @@ let write_executable path content =
 let normalize_realpath path =
   try Unix.realpath path with
   | _ -> path
+
+let run_git_quiet argv =
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close devnull)
+    (fun () ->
+       try
+         let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
+         match Unix.waitpid [] pid with
+         | _, Unix.WEXITED code -> code
+         | _, (Unix.WSIGNALED _ | Unix.WSTOPPED _) -> 1
+       with
+       | Unix.Unix_error _ -> 1)
+
+let git_available () = run_git_quiet [| "git"; "--version" |] = 0
+
+let init_git_repo dir url =
+  ensure_dir dir;
+  Alcotest.(check int) "git init" 0 (run_git_quiet [| "git"; "init"; "-q"; dir |]);
+  Alcotest.(check int)
+    "git remote add"
+    0
+    (run_git_quiet [| "git"; "-C"; dir; "remote"; "add"; "origin"; url |]);
+  Alcotest.(check int)
+    "git origin HEAD"
+    0
+    (run_git_quiet
+       [| "git"
+        ; "-C"
+        ; dir
+        ; "symbolic-ref"
+        ; "refs/remotes/origin/HEAD"
+        ; "refs/remotes/origin/main"
+       |])
+
+let sample_repo ~base_path id =
+  { id
+  ; name = id
+  ; url = "https://github.com/jeong-sik/" ^ id ^ ".git"
+  ; local_path = Filename.concat base_path (Filename.concat ".masc/repos" id)
+  ; aliases = []
+  ; default_branch = "main"
+  ; keepers = []
+  ; status = Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = Int64.zero
+  ; updated_at = Int64.zero
+  }
+
+let save_repositories base_path repos =
+  match Repo_store.save_all ~base_path repos with
+  | Ok () -> ()
+  | Error detail -> Alcotest.fail ("save repositories failed: " ^ detail)
 
 let test_shell_command_available_uses_path_without_shell () =
   let dir = temp_dir () in
@@ -540,6 +597,67 @@ let test_readonly_execute_omitted_cwd_does_not_create_write_root () =
       false
       (Sys.file_exists playground)
 
+let test_rg_unregistered_clone_queues_repository_hitl () =
+  if not (git_available ()) then ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    setup ~keeper_name:"analyst" ~sandbox:Keeper_types_profile_sandbox.Local
+    @@ fun ~base ~config ~meta ~playground ->
+    let registered = sample_repo ~base_path:base "masc" in
+    save_repositories base [ registered ];
+    let repo_root = Filename.concat playground "repos/masc-mcp" in
+    init_git_repo repo_root registered.url;
+    let raw =
+      Keeper_tool_command_runtime.handle_tool_search_files
+        ~turn_sandbox_factory:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:
+          (`Assoc
+            [ "op", `String "rg"
+            ; "pattern", `String "Repository"
+            ; "path", `String "repos/masc-mcp"
+            ])
+    in
+    let json = Yojson.Safe.from_string raw in
+    Alcotest.(check (option bool)) "policy response denies access" (Some false)
+      (Json.member "ok" json |> Json.to_bool_option);
+    Alcotest.(check (option string)) "policy response keeps original error"
+      (Some "Repository masc-mcp is not registered; access not allowed")
+      (Json.member "error" json |> Json.to_string_option);
+    Alcotest.(check (option string)) "approval kind"
+      (Some "repository_registration")
+      (Json.member "approval_pending" json |> Json.member "kind" |> Json.to_string_option);
+    Alcotest.(check (option bool)) "approval is non-blocking"
+      (Some true)
+      (Json.member "approval_pending" json |> Json.member "non_blocking"
+       |> Json.to_bool_option);
+    match
+      AQ.list_pending_entries ()
+      |> List.filter (fun (entry : AQ.pending_approval) ->
+        String.equal entry.keeper_name meta.name)
+    with
+    | [ pending ] ->
+      Alcotest.(check string)
+        "requested alias action"
+        "add_repository_alias"
+        (Json.member "requested_action" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias target"
+        "masc"
+        (Json.member "target_repository_id" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias"
+        "masc-mcp"
+        (Json.member "alias" pending.input |> Json.to_string)
+    | entries ->
+      Alcotest.failf
+        "expected one pending repository registration approval, got %d; raw=%s"
+        (List.length entries)
+        raw)
+
 
 let () =
   Alcotest.run "Keeper_tool_search_files_containment"
@@ -582,5 +700,9 @@ let () =
             "read-only Execute omitted cwd does not create write root"
             `Quick
             test_readonly_execute_omitted_cwd_does_not_create_write_root;
+          Alcotest.test_case
+            "rg unregistered clone queues repository HITL"
+            `Quick
+            test_rg_unregistered_clone_queues_repository_hitl;
         ] );
     ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -13,6 +13,7 @@ module Keeper_sandbox = Masc.Keeper_sandbox
 module Keeper_sandbox_factory = Masc.Keeper_sandbox_factory
 module Keeper_sandbox_repo_path = Masc.Keeper_sandbox_repo_path
 module Keeper_tool_execute_path = Masc.Keeper_tool_execute_path
+module Keeper_tool_filesystem_runtime = Masc.Keeper_tool_filesystem_runtime
 module Keeper_types = Keeper_types
 module Keeper_alerting_path = Masc.Keeper_alerting_path
 module Keeper_tool_policy = Masc.Keeper_tool_policy
@@ -104,6 +105,49 @@ let parse_field raw field =
 
 let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
+
+let unregistered_masc_mcp_policy_error =
+  "Repository masc-mcp is not registered; access not allowed"
+
+let assert_repository_registration_policy_response ~raw =
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check (option bool)) "policy response denies access" (Some false)
+    (Json.member "ok" json |> Json.to_bool_option);
+  Alcotest.(check (option string)) "policy error keeps original denial"
+    (Some unregistered_masc_mcp_policy_error)
+    (Json.member "policy_error" json |> Json.to_string_option);
+  Alcotest.(check bool) "visible error changes from bare denial" true
+    (not
+       (String.equal
+          (Json.member "error" json |> Json.to_string_option |> Option.value ~default:"")
+          unregistered_masc_mcp_policy_error));
+  Alcotest.(check (option bool)) "operator action required" (Some true)
+    (Json.member "operator_action_required" json |> Json.to_bool_option);
+  Alcotest.(check (option string)) "operator action kind"
+    (Some "repository_registration")
+    (Json.member "operator_action_kind" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "operator action reason"
+    (Some "repository_unregistered")
+    (Json.member "operator_action_reason" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "next action"
+    (Some "wait_for_operator_approval")
+    (Json.member "next_action" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "approval kind"
+    (Some "repository_registration")
+    (Json.member "approval_pending" json |> Json.member "kind"
+   |> Json.to_string_option);
+  Alcotest.(check (option string)) "approval reason"
+    (Some "repository_unregistered")
+    (Json.member "approval_pending" json |> Json.member "reason"
+   |> Json.to_string_option);
+  Alcotest.(check (option bool)) "approval is non-blocking"
+    (Some true)
+    (Json.member "approval_pending" json |> Json.member "non_blocking"
+   |> Json.to_bool_option);
+  Alcotest.(check (option string)) "deterministic retry reason"
+    (Some "policy_blocked")
+    (Json.member "deterministic_retry" json |> Json.member "reason"
+   |> Json.to_string_option)
 
 let write_executable path content =
   ignore (Fs_compat.save_file_atomic path content);
@@ -621,19 +665,54 @@ let test_rg_unregistered_clone_queues_repository_hitl () =
             ; "path", `String "repos/masc-mcp"
             ])
     in
-    let json = Yojson.Safe.from_string raw in
-    Alcotest.(check (option bool)) "policy response denies access" (Some false)
-      (Json.member "ok" json |> Json.to_bool_option);
-    Alcotest.(check (option string)) "policy response keeps original error"
-      (Some "Repository masc-mcp is not registered; access not allowed")
-      (Json.member "error" json |> Json.to_string_option);
-    Alcotest.(check (option string)) "approval kind"
-      (Some "repository_registration")
-      (Json.member "approval_pending" json |> Json.member "kind" |> Json.to_string_option);
-    Alcotest.(check (option bool)) "approval is non-blocking"
-      (Some true)
-      (Json.member "approval_pending" json |> Json.member "non_blocking"
-       |> Json.to_bool_option);
+    assert_repository_registration_policy_response ~raw;
+    match
+      AQ.list_pending_entries ()
+      |> List.filter (fun (entry : AQ.pending_approval) ->
+        String.equal entry.keeper_name meta.name)
+    with
+    | [ pending ] ->
+      Alcotest.(check string)
+        "requested alias action"
+        "add_repository_alias"
+        (Json.member "requested_action" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias target"
+        "masc"
+        (Json.member "target_repository_id" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias"
+        "masc-mcp"
+        (Json.member "alias" pending.input |> Json.to_string)
+    | entries ->
+      Alcotest.failf
+        "expected one pending repository registration approval, got %d; raw=%s"
+        (List.length entries)
+        raw)
+
+let test_read_unregistered_clone_surfaces_repository_hitl () =
+  if not (git_available ()) then ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    setup ~keeper_name:"reader" ~sandbox:Keeper_types_profile_sandbox.Local
+    @@ fun ~base ~config ~meta ~playground ->
+    ignore (Keeper_registry.register ~base_path:base meta.name meta);
+    let registered = sample_repo ~base_path:base "masc" in
+    save_repositories base [ registered ];
+    let repo_root = Filename.concat playground "repos/masc-mcp" in
+    init_git_repo repo_root registered.url;
+    ignore (Fs_compat.save_file_atomic (Filename.concat repo_root "README.md") "Repository\n");
+    let raw =
+      Keeper_tool_filesystem_runtime.handle_read_file
+        ~turn_sandbox_factory:None
+        ~config
+        ~keeper_name:meta.name
+        ~args:
+          (`Assoc
+            [ "path", `String "repos/masc-mcp/README.md"; "max_bytes", `Int 4096 ])
+    in
+    assert_repository_registration_policy_response ~raw;
     match
       AQ.list_pending_entries ()
       |> List.filter (fun (entry : AQ.pending_approval) ->
@@ -704,5 +783,9 @@ let () =
             "rg unregistered clone queues repository HITL"
             `Quick
             test_rg_unregistered_clone_queues_repository_hitl;
+          Alcotest.test_case
+            "Read unregistered clone surfaces repository HITL"
+            `Quick
+            test_read_unregistered_clone_surfaces_repository_hitl;
         ] );
     ]

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -231,9 +231,38 @@ let test_status_summary_uses_read_only_git_conventions () =
               Alcotest.(check bool)
                 "uses --no-optional-locks" true
                 (contains_substring joined "--no-optional-locks");
-              Alcotest.(check bool)
-                "sets GIT_OPTIONAL_LOCKS env key" true
-                (contains_substring joined "\"GIT_OPTIONAL_LOCKS\"")))
+	              Alcotest.(check bool)
+	                "sets GIT_OPTIONAL_LOCKS env key" true
+	                (contains_substring joined "\"GIT_OPTIONAL_LOCKS\"")))
+
+let test_origin_head_branch_preserves_slash_branch () =
+  with_temp_dir (fun tmp ->
+      let source = Filename.concat tmp "source" in
+      init_local_repo source;
+      (match run_cmd ~cwd:source [ "git"; "branch"; "release/v1" ] with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("git branch release/v1 failed: " ^ e));
+      (match
+         run_cmd
+           ~cwd:source
+           [ "git"; "update-ref"; "refs/remotes/origin/release/v1"; "HEAD" ]
+       with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("git update-ref origin/release/v1 failed: " ^ e));
+      (match
+         run_cmd
+           ~cwd:source
+           [ "git"
+           ; "symbolic-ref"
+           ; "refs/remotes/origin/HEAD"
+           ; "refs/remotes/origin/release/v1"
+           ]
+       with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("git origin HEAD failed: " ^ e));
+      match Repo_git.origin_head_branch ~local_path:source with
+      | Ok branch -> Alcotest.(check string) "origin HEAD branch" "release/v1" branch
+      | Error e -> Alcotest.fail ("origin_head_branch failed: " ^ e))
 
 let () =
   Alcotest.run "Repo_git"
@@ -248,11 +277,16 @@ let () =
       ( "fetch", [ Alcotest.test_case "returns remotes" `Quick test_fetch ] );
       ( "get_recent_commits",
         [ Alcotest.test_case "returns commits" `Quick test_get_recent_commits ] );
-      ( "status_summary",
-        [
-          Alcotest.test_case "counts porcelain rows" `Quick
-            test_status_summary_counts_porcelain_rows;
-          Alcotest.test_case "uses read-only git conventions" `Quick
-            test_status_summary_uses_read_only_git_conventions;
-        ] );
-    ]
+	      ( "status_summary",
+	        [
+	          Alcotest.test_case "counts porcelain rows" `Quick
+	            test_status_summary_counts_porcelain_rows;
+	          Alcotest.test_case "uses read-only git conventions" `Quick
+	            test_status_summary_uses_read_only_git_conventions;
+	        ] );
+	      ( "origin_head_branch",
+	        [
+	          Alcotest.test_case "preserves slash branch" `Quick
+	            test_origin_head_branch_preserves_slash_branch;
+	        ] );
+	    ]

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -38,6 +38,8 @@ let cleanup () =
   Board_dispatch.reset_for_test ();
   Board_curation.reset_for_test ();
   Board_moderation.reset_for_test ();
+  Fs_compat.reset_fd_cache_for_testing ();
+  Fs_compat.reset_mkdir_memo_for_testing ();
   remove_path (Filename.concat _test_base_path Common.masc_dirname);
   Board_dispatch.init_jsonl ()
 
@@ -1417,8 +1419,11 @@ let test_dispatch_delete_success () =
     |> Yojson.Safe.Util.member "id"
     |> Yojson.Safe.Util.to_string
   in
-  let ok_del, msg_del = dispatch "masc_board_delete"
-    (make_args [("post_id", `String post_id)]) in
+  let ok_del, msg_del =
+    dispatch
+      "masc_board_delete"
+      (make_args [ ("post_id", `String post_id); ("author", `String "tester") ])
+  in
   Alcotest.(check bool) "delete ok" true ok_del;
   Alcotest.(check bool) "delete msg contains id" true
     (contains_substring msg_del post_id)
@@ -1427,11 +1432,14 @@ let test_dispatch_delete_not_found () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let ok, body = dispatch "masc_board_delete"
-    (make_args [("post_id", `String "nonexistent-id")]) in
+  let ok, body =
+    dispatch
+      "masc_board_delete"
+      (make_args [ ("post_id", `String "nonexistent-id"); ("author", `String "tester") ])
+  in
   Alcotest.(check bool) "delete not found" false ok;
   Alcotest.(check bool) "error message present" true
-    (contains_substring body "Delete failed")
+    (contains_substring body "Post not found" || contains_substring body "nonexistent-id")
 
 let test_dispatch_delete_empty_id () =
   with_eio @@ fun env ->
@@ -2993,7 +3001,7 @@ let () =
             let json = parse_create_response_json create_msg in
             let post_id = Yojson.Safe.Util.(json |> member "id" |> to_string) in
             let (_ok, _msg) = dispatch "masc_board_delete" (make_args [
-              ("post_id", `String post_id)
+              ("post_id", `String post_id); ("author", `String "tester")
             ]) in
             let (_ok2, body2) = dispatch "masc_board_list" args in
             Alcotest.(check bool) "cache invalidated after delete" true

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1788,10 +1788,15 @@ let claim_gate_sidecar_path () =
 
 let claim_gate_posts_path () = Board.persist_path ()
 
+let claim_gate_source_post_seq = ref 0
+
 let create_claim_gate_source_post () =
+  incr claim_gate_source_post_seq;
   let correction =
-    "Correction: I did not create the PoC claimed here. \
-     repos/masc/scratch/task-1746-poc.ml does not exist."
+    Printf.sprintf
+      "Correction %d: I did not create the PoC claimed here. \
+       repos/masc/scratch/task-1746-poc.ml does not exist."
+      !claim_gate_source_post_seq
   in
   let ok, body =
     dispatch
@@ -1934,7 +1939,7 @@ let test_comment_claim_gate_allows_missing_artifact_block () =
   cleanup ();
   let source = create_claim_gate_source_post () in
   let post_id = Yojson.Safe.Util.(source |> member "id" |> to_string) in
-  let ok, body =
+  let ok, _body =
     dispatch
       "masc_board_comment"
       (make_args
@@ -1947,7 +1952,12 @@ let test_comment_claim_gate_allows_missing_artifact_block () =
          ])
   in
   Alcotest.(check bool) "missing-artifact block allowed" true ok;
-  Alcotest.(check bool) "comment added" true (contains_substring body "Comment added");
+  let comments =
+    match Board_dispatch.get_comments ~post_id with
+    | Ok comments -> comments
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  Alcotest.(check int) "comment persisted" 1 (List.length comments);
   let sidecar_body =
     In_channel.with_open_text (claim_gate_sidecar_path ()) In_channel.input_all
   in
@@ -1995,6 +2005,8 @@ let test_post_create_claim_gate_rolls_back_on_sidecar_failure () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let sidecar = claim_gate_sidecar_path () in
+  let parent = Filename.dirname sidecar in
+  if not (Sys.file_exists parent) then Unix.mkdir parent 0o755;
   Unix.mkdir sidecar 0o755;
   let result =
     dispatch_result


### PR DESCRIPTION
## Summary

- Keep unregistered keeper repository access fail-closed, but surface a non-blocking HITL recovery request when a sandbox clone provides auditable Git metadata.
- On approval, register a new repository through `Repo_store.add`, or add a clone-name alias to an existing repository with the same canonical remote through `Repo_store.update`.
- Update the repo claim HITL plan and add focused coverage for direct-deny, registration approval, and alias approval paths.

## Root Cause

Physical clones under a keeper sandbox were visible on disk, but `repositories.toml` remained the authorization SSOT. The old path returned only `Repository <id> is not registered; access not allowed`, leaving the keeper with no operator recovery path.

## Validation

- `ocamlformat --check lib/keeper/keeper_repo_claim_hitl.ml lib/keeper/keeper_repo_claim_hitl.mli lib/repo_manager/repo_git.ml lib/repo_manager/repo_git.mli lib/repo_manager/keeper_repo_mapping.mli test/test_keeper_repo_claim_hitl.ml`
- `env MASC_SKIP_OCAML_VERSION_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_repo_claim_hitl.exe`
- `./_build/default/test/test_keeper_repo_claim_hitl.exe`

Note: local switch reports OCaml 5.4 while the repo wrapper requires 5.5, so the focused local build used `MASC_SKIP_OCAML_VERSION_CHECK=1`; CI remains the build authority.
