### PR TITLE
feat(dashboard): GitHub App 자격증명 패널을 keeper 설정 access 탭에 노출

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -985,6 +985,9 @@ const mocks = vi.hoisted(() => {
     pauseKeeper: vi.fn(async () => ({ ok: true, action: 'pause', name: 'keeper-sangsu' })),
     resumeKeeper: vi.fn(async () => ({ ok: true, action: 'resume', name: 'keeper-sangsu' })),
     wakeKeeper: vi.fn(async () => ({ ok: true, action: 'wakeup', name: 'keeper-sangsu' })),
+    // access tab surfaces the GitHub App panel, which reads secret_projection
+    // from the keeper composite; no existing config in the default fixture.
+    fetchKeeperComposite: vi.fn(async () => ({ secret_projection: null })),
   }
 })
 
@@ -1003,6 +1006,7 @@ vi.mock('../api/keeper', () => ({
   pauseKeeper: mocks.pauseKeeper,
   resumeKeeper: mocks.resumeKeeper,
   wakeKeeper: mocks.wakeKeeper,
+  fetchKeeperComposite: mocks.fetchKeeperComposite,
 }))
 
 import {
@@ -1050,6 +1054,7 @@ describe('KeeperConfigPanel', () => {
     mocks.pauseKeeper.mockClear()
     mocks.resumeKeeper.mockClear()
     mocks.wakeKeeper.mockClear()
+    mocks.fetchKeeperComposite.mockClear()
   })
 
   afterEach(() => {
@@ -1057,6 +1062,25 @@ describe('KeeperConfigPanel', () => {
     container.remove()
     resetKeeperConfig()
     resetRuntimeCatalog()
+  })
+
+  it('surfaces the GitHub App credentials panel under the access tab', async () => {
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    // The credentials panel is scoped to the access tab, so the default
+    // (identity) tab must not render it.
+    expect(container.querySelector('[data-testid="keeper-github-app-config-panel"]')).toBeNull()
+
+    // 권한·샌드박스 (access) is where operators look for credentials; the panel
+    // is surfaced here in addition to the monitoring detail's 진단/운영 copy.
+    selectKcfTab(container, '권한·샌드박스')
+    await flush()
+    expect(container.querySelector('[data-testid="keeper-github-app-config-panel"]')).not.toBeNull()
+    expect(container.textContent).toContain('GitHub App 자격증명')
+    // The panel's initial projection is loaded from the keeper composite.
+    expect(mocks.fetchKeeperComposite).toHaveBeenCalledWith('keeper-sangsu', expect.anything())
   })
 
   it('separates editable prompt controls from read-only runtime metadata', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -11,7 +11,9 @@ import {
   patchKeeperConfig,
   setKeeperToolPolicy,
 } from '../api/dashboard'
-import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
+import { fetchKeeperComposite, pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
+import { KeeperGithubAppConfigPanel } from './keeper-github-app-config'
+import type { KeeperSecretProjection } from '../api/schemas/keeper-composite'
 import type { DashboardRuntimeProviderSnapshot, DashboardToolInventoryItem, KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import { formatTokens, formatPct, formatCost } from '../lib/format-number'
@@ -1681,6 +1683,23 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
   useEffect(() => retainKeeperConfigPanelSubscriptions(), [])
 
+  // GitHub App credentials live in the keeper secret projection, which the
+  // config payload does not carry. Fetch it once per keeper (same source the
+  // monitoring detail reads via composite.secret_projection) so the access-tab
+  // panel can detect existing config; mutations return the fresh projection and
+  // update this state without a refetch.
+  const [secretProjection, setSecretProjection] = useState<KeeperSecretProjection | null>(null)
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchKeeperComposite(keeperName, { signal: controller.signal })
+      .then((snapshot) => setSecretProjection(snapshot.secret_projection ?? null))
+      .catch(() => {
+        // A failed/aborted secret fetch leaves the panel in its empty-projection
+        // state (save still works); it must not break the rest of the config UI.
+      })
+    return () => controller.abort()
+  }, [keeperName])
+
   // Trigger load on first render or name change
   if (configKeeperName.value !== keeperName || state.status === 'idle') {
     void loadKeeperConfig(keeperName)
@@ -2346,6 +2365,17 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       <${SectionHeader} size="xs" class="mb-1">참여 네임스페이스</${SectionHeader}>
       <${ModelList} models=${c.workspace.bound_workspace_ids} />
     </div>
+
+    ${'' /* GitHub App per-keeper credentials — surfaced here in 설정 → 권한·샌드박스
+       alongside the monitoring detail's 진단/운영 copy, because credentials are a
+       settings concept and this is where operators look for them. Both call sites
+       render the same KeeperGithubAppConfigPanel against secret_projection. */}
+    <${MajorSectionHeader} title="GitHub App 자격증명" />
+    <${KeeperGithubAppConfigPanel}
+      keeperName=${keeperName}
+      projection=${secretProjection}
+      onProjectionChange=${setSecretProjection}
+    />
   `
 
   // goals ◎ — assigned goal-store bindings (active_goal_ids picker)


### PR DESCRIPTION
## 목표
GitHub App 자격증명 설정을 keeper **설정 오버레이(권한·샌드박스 탭)** 에도 노출. 기존엔 모니터링 detail의 "진단/운영" 섹션에만 있어 credential을 설정 화면에서 찾던 operator에게 "어디에도 안 보이는" 문제였음.

## 변경
- `keeper-config-panel.ts`: access 탭에 `KeeperGithubAppConfigPanel` 추가. `fetchKeeperComposite`로 secret_projection을 mount 시 1회 로드(모니터링 detail과 동일 SSOT 소스), AbortController 정리, fetch 실패는 swallow(설정 UI 무영향). 뮤테이션은 fresh projection 반환→refetch 없이 state 갱신.
- 테스트: identity 탭엔 없고 access 탭엔 있음 + composite fetch 호출 검증.

## 검증
- tsc --noEmit: 0 errors
- eslint: clean
- vitest: keeper-config-panel 73 pass (신규 surface 테스트 포함), keeper-github-app-config 5 pass

## RFC
기존 패널 surface 추가(새 credential 로직 없음). pr-rfc-check PASS. 참고 RFC-0236 §10 / #23528(GitHub App token) / #23547(패널 최초 추가).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
