### PR TITLE
fix(dashboard): main red — monitoring-as-primary breaks app chrome tests (#23578 regression)

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -342,8 +342,10 @@ describe('App v2 header chrome', () => {
 
   it('keeps floating status and focus chrome on operational surfaces', () => {
     window.innerWidth = 1280
-    window.location.hash = '#monitoring/agents'
-    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+    // `command` is a non-primary operational surface; `monitoring` moved into
+    // V2_PRIMARY_SURFACE_IDS (#23578) so it now suppresses floating chrome.
+    window.location.hash = '#command/operations'
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null }
     renderApp()
 
     expect(container.querySelector('[data-testid="dashboard-status-tray"]')).not.toBeNull()
@@ -352,8 +354,8 @@ describe('App v2 header chrome', () => {
 
   it('focus mode does not permanently hide the rail', async () => {
     window.innerWidth = 1280
-    window.location.hash = '#monitoring/agents'
-    route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
+    window.location.hash = '#command/operations'
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null }
     renderApp()
 
     // Rail (now `nav.v2-nav`) should be visible initially.
@@ -430,16 +432,22 @@ describe('shouldSuppressFloatingChrome', () => {
       keeperDetailMode: false,
       mobileDrawerOpen: false,
     })).toBe(true)
-  })
-
-  it('keeps floating chrome for operational surfaces unless a shell overlay is active', () => {
+    // monitoring joined V2_PRIMARY_SURFACE_IDS in #23578 (Monitor in the v2 rail).
     expect(shouldSuppressFloatingChrome({
       currentTab: 'monitoring',
       keeperDetailMode: false,
       mobileDrawerOpen: false,
+    })).toBe(true)
+  })
+
+  it('keeps floating chrome for operational surfaces unless a shell overlay is active', () => {
+    expect(shouldSuppressFloatingChrome({
+      currentTab: 'command',
+      keeperDetailMode: false,
+      mobileDrawerOpen: false,
     })).toBe(false)
     expect(shouldSuppressFloatingChrome({
-      currentTab: 'monitoring',
+      currentTab: 'command',
       keeperDetailMode: false,
       mobileDrawerOpen: true,
     })).toBe(true)


### PR DESCRIPTION
## 목적

main red 복구. #23578(Monitor를 v2 rail에 복원)이 `monitoring`을 `V2_PRIMARY_SURFACE_IDS`에 추가했는데, 이 리스트는 rail/shell 게이트뿐 아니라 `isPrimaryDashboardSurface → shouldSuppressFloatingChrome`도 구동한다. 결과적으로 monitoring이 이제 다른 v2 primary surface처럼 legacy floating chrome(status tray + focus toggle)을 억제한다. `app.test.ts`는 #23578 이전 가정("monitoring = operational surface → chrome 유지")을 인코딩하고 있어 3개 테스트가 깨졌다.

## 실패 지점 (origin/main, run 28875930148 · commit 3e62e8b488)

- `app.test.ts:349` — monitoring에서 status-tray가 null이 아님을 기대 (이제 억제되어 null)
- `app.test.ts:363` — 같은 케이스 focus-toggle
- `app.test.ts:440` — `shouldSuppressFloatingChrome({currentTab:'monitoring'})`가 false 기대 (이제 true)

## 변경

- "operational surface keeps chrome" 케이스를 여전히 non-primary인 `command`(intervention/governance)로 이동
- monitoring은 이제 chrome을 억제한다고 어서트

동작 변화는 없다 — #23578에서 이미 결정된 동작을 테스트 기대치만 갱신한다. v2 primary surface는 자체 shell chrome을 제공하므로 legacy floating chrome 억제가 설계 의도와 일치한다.

## 근본 원인

#23578 CI가 cancelled-at-merge라 pre-merge에 app.test.ts breakage가 관측되지 않았다. RFC-0316(#23570, merged)이 겨냥하는 enforce_admins 게이팅 부재의 실사례.

## 로컬 검증 (pnpm@10.31.0, CI 동일)

- `pnpm test` 전체: 637 files / 8690 tests passed
- `pnpm run typecheck`: clean
- `pnpm run lint`: clean

## 미검증

- 없음 (전체 스위트 로컬 green)