### PR TITLE
fix(exec): gh pr ready를 reversible(R1/Allowed)로 재분류 — keeper Draft→Ready 차단 해소

### DIFF
--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -243,11 +243,21 @@ say approval enables the action.
 
 ### 3.5 What #23362 got right and keeps
 
-The genuine irreversibles stay floored exactly as before: `pr merge/ready`,
+The genuine irreversibles stay floored exactly as before: `pr merge`,
 `repo delete/archive/transfer/rename`, `release delete`, `secret delete`,
 `gh api -X DELETE`, `delete*` graphql mutations, `discussion delete`. The
 catastrophic floor (`Deny`) remains trust-independent. This RFC widens the
 space *between* Allow and Deny; it does not soften Deny.
+
+> **W4/G-9 follow-up (`pr ready` reclassified):** `pr ready` was originally
+> listed here alongside `pr merge`, but it toggles a PR between draft and
+> ready-for-review and is reversible via `gh pr ready --undo`. Its CI/notification
+> side-effects are an externality shared with `pr create` (already Allowed on the
+> capability axis), not a reversibility fact — the same policy-as-risk conflation
+> W4/G-9 closed for repo create/fork/discussion. It now classifies R1 in
+> `repo_hosting_cli_reversible_mutations` and, on the non-durable `Pr` family, the
+> capability axis leaves it `Allowed`. The `test_shell_ir_gh_capability_baseline`
+> corpus and `test_gh_capability_policy` dispositions were updated to match.
 
 ---
 

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -364,7 +364,15 @@ let classify_write_detail (words : string list) : risk_class option =
 
 let repo_hosting_cli_irreversible_ops =
   [
-    ("pr", [ "merge"; "ready" ]);
+    (* RFC-0309 W4/G-9 (completing the deferred [pr ready] case): only [merge]
+       is factually irreversible (it writes the base branch history). [ready]
+       toggles a PR between draft and ready-for-review and is reversible via
+       [gh pr ready --undo], so it moves to the reversible table below. Its
+       CI/notification side-effects are an externality (a capability concern,
+       identical to [pr create] which is already Allowed), NOT a reversibility
+       fact — encoding them as R2 here was the same policy-as-risk mistake W4/G-9
+       closed for repo create/fork/discussion. *)
+    ("pr", [ "merge" ]);
     (* RFC-0309 W4/G-9: repo create/fork are factually REVERSIBLE (a created or
        forked repo can be deleted), so they move to the reversible table below.
        Only the genuinely irreversible repo ops stay here. This restores the
@@ -390,7 +398,7 @@ let repo_hosting_cli_reversible_mutations =
   [
     ("pr",
      [ "create"; "close"; "reopen"; "edit"; "comment"; "review"; "lock"; "checkout";
-       "unlock" ]);
+       "unlock"; "ready" ]);
     ("issue",
      [ "create"; "close"; "reopen"; "edit"; "comment"; "lock"; "unlock";
        "develop"; "pin"; "unpin" ]);

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -394,6 +394,50 @@ let test_gh_reversible_repo_hosting_ops_allowed_under_autonomous () =
   | Verdict.Allow t -> assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
   | _ -> Alcotest.fail "gh pr create should remain allowed under autonomous"
 
+(* RFC-0309 W4/G-9 (deferred [pr ready] case resolved): [gh pr ready] toggles a
+   PR draft<->ready-for-review and is reversible ([--undo]). On the [Pr] family
+   it does not touch a durable remote surface, so the capability axis leaves it
+   [Allowed] and the autonomous overlay runs it — matching [gh pr create]. Covers
+   the plain form and the keeper house-style trailing [--repo] flag. *)
+let test_gh_pr_ready_allowed_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Allow t ->
+         assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
+       | _ -> Alcotest.failf "%s: gh pr ready must be allowed under autonomous" label)
+    [ "gh pr ready 123", [ "pr"; "ready"; "123" ]
+    ; "gh pr ready 123 --repo o/r", [ "pr"; "ready"; "123"; "--repo"; "o/r" ]
+    ]
+
+(* Documents a KNOWN residual asymmetry, not an endorsement: the disposition
+   axis ([Gh_capability_policy.disposition_of_simple]) locates the gh subcommand
+   with the word-list [Gh_verb.classify], which reads a leading value-taking
+   global flag's value ("o/r") as the subcommand -> [Gh_verb.Other] ->
+   [Requires_approval] -> [Ask]. The risk floor is already flag-robust (typed
+   lowering), so this is strictly better than the prior [Deny] and non-blocking.
+   The floor-aligned fix (a flag-robust verb extractor shared with the floor)
+   is tracked as a follow-up; when it lands, this expectation flips to [Allow]. *)
+let test_gh_pr_ready_leading_flag_asks_under_autonomous () =
+  let s =
+    simple (bin_ok "gh")
+      ~args:(List.map lit [ "--repo"; "o/r"; "pr"; "ready"; "123" ])
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps
+      ~simple:s
+  with
+  | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+  | _ ->
+    Alcotest.fail
+      "leading-flag gh pr ready currently asks (known disposition asymmetry)"
+
 (* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
    pr merge]) must not slip the destructive op past the floor. gh (Cobra)
    accepts flags before the subcommand and consumes their values, so the
@@ -413,7 +457,9 @@ let test_gh_leading_flag_destructive_floored_under_autonomous () =
        | _ ->
          Alcotest.failf "%s: leading-flag destructive op must be floored" label)
     [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
-    ; "gh --repo o/r pr ready", [ "--repo"; "o/r"; "pr"; "ready"; "123" ]
+      (* [pr ready] moved off this floor (RFC-0309 W4/G-9: reversible via --undo);
+         its leading-flag disposition is covered by
+         [test_gh_pr_ready_leading_flag_asks_under_autonomous]. *)
     ; "gh --repo o/r repo delete"
       , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
     ]
@@ -893,6 +939,8 @@ let () =
   test_gh_irreversible_repo_hosting_ops_denied_under_autonomous ();
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
+  test_gh_pr_ready_allowed_under_autonomous ();
+  test_gh_pr_ready_leading_flag_asks_under_autonomous ();
   test_gh_leading_flag_destructive_floored_under_autonomous ();
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -72,6 +72,9 @@ let test_current_dispositions () =
   (* local / in-repo reversible mutations: Allowed *)
   check "pr create" (verb ~sub:"pr" ~act:"create" ()) Pol.Allowed;
   check "pr comment" (verb ~sub:"pr" ~act:"comment" ()) Pol.Allowed;
+  (* RFC-0309 W4/G-9: [pr ready] is a reversible in-repo mutation (draft<->ready,
+     [--undo]); the [Pr] family is not a durable remote surface, so Allowed. *)
+  check "pr ready" (verb ~sub:"pr" ~act:"ready" ()) Pol.Allowed;
   check "issue create" (verb ~sub:"issue" ~act:"create" ()) Pol.Allowed;
   check "release create" (verb ~sub:"release" ~act:"create" ()) Pol.Allowed;
   (* genuinely irreversible (also risk-floored): Denied *)

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -96,6 +96,13 @@ let corpus : (string * string * expectation) list =
      Stable Shell_ir_risk.R1_Reversible_mutation);
     ("pr-comment", "gh pr comment 123 --body B",
      Stable Shell_ir_risk.R1_Reversible_mutation);
+    (* W4/G-9 FIXED (deferred [pr ready] case resolved): [pr ready] is reversible
+       ([--undo] toggles back to draft). Its CI/notification side-effects are an
+       externality shared with [pr create] (already R1/Allowed), not a
+       reversibility fact — the G-4 externality axis this comment previously
+       deferred to is the capability axis, and [pr ready] on the [Pr] family does
+       not touch a durable remote surface, so it stays Allowed there. *)
+    ("pr-ready", "gh pr ready 123", Stable Shell_ir_risk.R1_Reversible_mutation);
     ("issue-create", "gh issue create --title T",
      Stable Shell_ir_risk.R1_Reversible_mutation);
     ("issue-edit", "gh issue edit 123",
@@ -105,10 +112,6 @@ let corpus : (string * string * expectation) list =
     (* --- genuinely irreversible: stable R2 (floor stands, RFC-0309
        does not soften Deny) ------------------------------------------- *)
     ("pr-merge", "gh pr merge 123 --squash", Stable Shell_ir_risk.R2_Irreversible);
-    (* pre-existing floor: `pr ready --undo` exists, but ready triggers
-       external side-effects (CI, notifications). Revisit under the G-4
-       externality axis; out of W0 scope. *)
-    ("pr-ready", "gh pr ready 123", Stable Shell_ir_risk.R2_Irreversible);
     ("repo-delete", "gh repo delete owner/repo --yes",
      Stable Shell_ir_risk.R2_Irreversible);
     ("repo-archive", "gh repo archive owner/repo",

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -224,6 +224,12 @@ let test_gh_r1_reversible () =
   check "gh pr create" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr close 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh --repo owner/repo pr close 123" Shell_ir_risk.R1_Reversible_mutation;
+  (* RFC-0309 W4/G-9: [pr ready] is reversible ([--undo] toggles back to draft),
+     so the risk axis is R1 like [pr create]. The floor stays flag-robust for the
+     leading-global-flag form. *)
+  check "gh pr ready 123" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh pr ready 123 --undo" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh --repo owner/repo pr ready 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr checkout 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr reopen 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue create" Shell_ir_risk.R1_Reversible_mutation;
@@ -265,7 +271,6 @@ let test_gh_r1_reversible () =
 
 let test_gh_r2_irreversible () =
   check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
-  check "gh pr ready 123" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo archive owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo transfer owner/repo" Shell_ir_risk.R2_Irreversible;


### PR DESCRIPTION
## 목적

키퍼가 자기 PR을 **Draft → Ready로 전환할 수 없던** 문제를 근본 교정합니다. `gh pr ready`가 `gh pr merge`와 같은 irreversible 테이블에 묶여 리스크 R2 → capability `Denied`로 차단돼 있었습니다.

## 근본 원인 (분류 오류, 워크어라운드 아님)

`gh pr ready`는 `gh pr ready --undo`로 draft로 되돌릴 수 있는 **가역(reversible) 작업**입니다. R2로 둔 근거는 코드/테스트 주석에 "CI·알림 side-effect" 때문이라고 명시돼 있었으나, 이는 가역성(risk)이 아니라 **externality(capability)** 사안입니다. 동일한 side-effect를 가진 `gh pr create`는 이미 `Allowed`입니다 — 같은 시스템 논리 안에서 `pr ready`만 차단할 일관된 근거가 없습니다.

이는 #23362의 policy-as-risk 실수를 W4/G-9가 repo create/fork/discussion에 대해 이미 교정한 것과 동일한 패턴이며, `pr ready`가 그 마이그레이션에서 빠진 **마지막 잔재**입니다. `test_shell_ir_gh_capability_baseline.ml`에 이 케이스를 "G-4 externality 축에서 재검토, W0 범위 밖"으로 명시 유예한 TODO가 있었고, 이 PR이 그 유예를 해소합니다.

## 변경

- **SSOT 한 곳**: `repo_hosting_cli_irreversible_ops`의 `("pr", [ "merge"; "ready" ])` → `("pr", [ "merge" ])`, `("pr", ...)` reversible 테이블에 `"ready"` 추가. 리스크 테이블이 SSOT이므로 floor·typed·capability 세 소비 층이 동시에 올바르게 읽습니다.
- **RFC-0309 §3.5** 문서 교정: `pr ready`를 "genuine irreversibles" 목록에서 제거하고 재분류 근거를 W4/G-9 follow-up 노트로 추가.

## 결과 (판정 실측)

| 명령 | 이전 | 이후 |
|---|---|---|
| `gh pr ready 123` | Deny | **Allow** |
| `gh pr ready 123 --repo o/r` (키퍼 관용형) | Deny | **Allow** |
| `gh --repo o/r pr ready 123` (leading-flag) | Deny | **Ask** (개선, 아래 참조) |
| `gh pr merge` | Deny | Deny (불변) |

leading-flag 형태는 disposition 축(`Gh_verb.classify`)이 leading value-flag를 subcommand로 오독해 `Other` → `Requires_approval`(Ask)로 갑니다. 리스크 floor는 이미 flag-robust(typed lowering)라 이건 별개의 기존 비대칭입니다. Deny → Ask로 개선됐고 non-blocking HITL로 해소 가능합니다. floor-정렬 근본 수정은 후속 이슈로 분리합니다 (`test_gh_pr_ready_leading_flag_asks_under_autonomous`가 현재 동작을 pin).

## 테스트

- `test_shell_ir_risk`: `gh pr ready`(평문·`--undo`·leading-flag) R1 단언 추가, R2 제거.
- `test_gh_capability_policy`: `pr ready` → `Allowed` disposition 단언.
- `test_shell_ir_gh_capability_baseline`: R1 corpus로 이동, 유예 TODO 해소.
- `test_approval_policy`: `pr ready` autonomous overlay Allow 단언 + leading-flag Ask pin, destructive-floor 회귀 리스트에서 제거.
- 로컬: 4+1 파일 `ocamlformat --check` 통과. full build/test는 CI.

## RFC

Governing RFC: **RFC-0309** (typed gh capability gating). 이 변경은 RFC-0309 자신의 W4/G-9 "risk 축은 사실만 진술" 마이그레이션을 완결하며, §3.5를 그에 맞게 갱신합니다. 신규 RFC 불필요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
