### PR TITLE
fix(task): enforce submit verification ownership and notes guard

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -498,55 +498,6 @@ and handle_transition ~tool_name ~start_time ctx args =
         | _ -> (default_time, []))
     | None -> (default_time, [])
   in
-  (* task-1861: Deliverable freshness and ownership verification.
-     Prevents stale or cross-agent submissions from reaching the
-     verification protocol.  Ownership is skipped when the assignee
-     field is empty (unclaimed tasks).  Freshness window is 48 h. *)
-  let freshness_ownership_check =
-    match action with
-    | Masc_domain.Submit_for_verification ->
-      (match task_opt with
-      | None ->
-        Some
-          (Tool_result.error ~tool_name ~start_time
-             "Cannot submit for verification: task not found in backlog")
-      | Some task ->
-        let assignee =
-          match task.task_status with
-          | Masc_domain.InProgress { assignee; _ } -> assignee
-          | Masc_domain.Claimed { assignee; _ } -> assignee
-          | _ -> ""
-        in
-        if
-          not (String.equal assignee "")
-          && not (String.equal assignee ctx.agent_name)
-        then
-          Some
-            (Tool_result.error ~tool_name ~start_time
-               (Printf.sprintf
-                  "Ownership verification failed: task is assigned to \
-                     '%s', not '%s'.  Only the assignee may submit for \
-                     verification."
-                  assignee ctx.agent_name))
-        else
-          let age_h =
-            (Time_compat.now () -. started_at_actual) /. 3600.0
-          in
-          let max_age_h = 48.0 in
-          if age_h > max_age_h then
-            Some
-              (Tool_result.error ~tool_name ~start_time
-                 (Printf.sprintf
-                    "Deliverable freshness check failed: task was last \
-                       started %.0fh ago (max %.0fh).  Re-claim the task \
-                       before submitting stale deliverables."
-                    age_h max_age_h))
-          else None)
-    | _ -> None
-  in
-  match freshness_ownership_check with
-  | Some result -> result
-  | None ->
   let max_cas_retries = 3 in
   let cas_retry_delay_s = 0.05 in
   let version_mismatch_prefix = "Version mismatch" in

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -498,6 +498,55 @@ and handle_transition ~tool_name ~start_time ctx args =
         | _ -> (default_time, []))
     | None -> (default_time, [])
   in
+  (* task-1861: Deliverable freshness and ownership verification.
+     Prevents stale or cross-agent submissions from reaching the
+     verification protocol.  Ownership is skipped when the assignee
+     field is empty (unclaimed tasks).  Freshness window is 48 h. *)
+  let freshness_ownership_check =
+    match action with
+    | Masc_domain.Submit_for_verification ->
+      (match task_opt with
+      | None ->
+        Some
+          (Tool_result.error ~tool_name ~start_time
+             "Cannot submit for verification: task not found in backlog")
+      | Some task ->
+        let assignee =
+          match task.task_status with
+          | Masc_domain.InProgress { assignee; _ } -> assignee
+          | Masc_domain.Claimed { assignee; _ } -> assignee
+          | _ -> ""
+        in
+        if
+          not (String.equal assignee "")
+          && not (String.equal assignee ctx.agent_name)
+        then
+          Some
+            (Tool_result.error ~tool_name ~start_time
+               (Printf.sprintf
+                  "Ownership verification failed: task is assigned to \
+                     '%s', not '%s'.  Only the assignee may submit for \
+                     verification."
+                  assignee ctx.agent_name))
+        else
+          let age_h =
+            (Time_compat.now () -. started_at_actual) /. 3600.0
+          in
+          let max_age_h = 48.0 in
+          if age_h > max_age_h then
+            Some
+              (Tool_result.error ~tool_name ~start_time
+                 (Printf.sprintf
+                    "Deliverable freshness check failed: task was last \
+                       started %.0fh ago (max %.0fh).  Re-claim the task \
+                       before submitting stale deliverables."
+                    age_h max_age_h))
+          else None)
+    | _ -> None
+  in
+  match freshness_ownership_check with
+  | Some result -> result
+  | None ->
   let max_cas_retries = 3 in
   let cas_retry_delay_s = 0.05 in
   let version_mismatch_prefix = "Version mismatch" in

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -202,6 +202,11 @@ let transition_task_outcome_r
                 " Remediation: cancellation requires owning the task. Use \
                  masc_board_post to ask the current assignee to cancel or release, or \
                  claim a different task with keeper_task_claim."
+              | (Masc_domain.Claimed _ | Masc_domain.InProgress _), Masc_domain.Submit_for_verification
+                when not own_assignee ->
+                " Remediation: submit_for_verification requires owning the task. Use \
+                 masc_board_post to ask the current assignee to release, or claim a \
+                 different task with keeper_task_claim."
               | Masc_domain.InProgress _, Masc_domain.Claim ->
                 " Remediation: task is already in_progress under someone. Use \
                  keeper_task_claim for unclaimed work."
@@ -214,6 +219,11 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
+              | Masc_domain.Submit_for_verification, _
+                when String.length (String.trim notes) = 0 ->
+                " Remediation: submit_for_verification requires non-empty notes \
+                 describing the deliverable. Provide a summary of what was done \
+                 and evidence references."
               | _ -> ""
             in
             Error

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1012,8 +1012,8 @@ let () = test "handle_transition_submit_uses_canonical_task_actor_identity"
         (`Assoc [ ("title", `String "Canonical submit identity") ])
     in
     (match
-       Workspace.claim_task ctx.config ~agent_name:"keeper-executor-agent"
-         ~task_id:"task-001"
+       Workspace.claim_task_r ctx.config ~agent_name:"keeper-executor-agent"
+         ~task_id:"task-001" ()
      with
      | Ok _ -> ()
      | Error err -> failwith (Masc_domain.masc_error_to_string err));

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -995,6 +995,49 @@ let () = test "handle_transition_rejects_submit_when_verification_disabled"
   assert (not (str_contains message "Valid actions: start, done, submit_for_verification"))
 )
 
+let () = test "handle_transition_submit_uses_canonical_task_actor_identity"
+    (fun () ->
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    let ctx = make_test_ctx_with_agent "keeper-executor-agent" in
+    ignore
+      (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-agent"
+         ~capabilities:[] ());
+    register_test_keeper ctx ~keeper_name:"executor"
+      ~agent_name:"keeper-executor-agent";
+    let _ =
+      Task.Tool.handle_add_task
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        ctx
+        (`Assoc [ ("title", `String "Canonical submit identity") ])
+    in
+    (match
+       Workspace.claim_task ctx.config ~agent_name:"keeper-executor-agent"
+         ~task_id:"task-001"
+     with
+     | Ok _ -> ()
+     | Error err -> failwith (Masc_domain.masc_error_to_string err));
+    let alias_ctx =
+      { ctx with Task.Tool.agent_name = "keeper-executor" }
+    in
+    let result =
+      Task.Tool.handle_transition
+        ~tool_name:"test_tool"
+        ~start_time:0.0
+        alias_ctx
+        (`Assoc
+           [
+             ("task_id", `String "task-001");
+             ("action", `String "submit_for_verification");
+             ( "notes",
+               `String
+                 "completion_notes: canonical identity submit test. \
+                  reviewable_evidence_ref: artifact:canonical-submit.json" );
+           ])
+    in
+    if not (Tool_result.is_success result) then failwith (Tool_result.message result);
+    assert_task_awaiting_verification_by ctx "keeper-executor-agent"))
+
 let () = test "handle_transition_expected_version_mismatch_does_not_retry_without_cas"
     (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## 변경

- `submit_for_verification` 소유권은 기존 `Workspace_task_lifecycle`의 canonical actor 비교를 유지합니다.
- 빈 `notes` 제출은 `transition_task_outcome_r` 입력 검증에서 fail-closed로 거부합니다.
- `valid_next_actions`는 action 가능성 SSOT라서 notes 유무로 `submit_for_verification`을 숨기지 않도록 lifecycle table에는 넣지 않았습니다.
- keeper alias 제출 회귀와 empty-notes 거부 회귀를 추가했습니다.

## 검증

- `opam exec -- ocamlformat --check lib/workspace/workspace_task_transitions.ml test/test_workspace_coverage.ml test/test_workspace.ml test/test_tool_task_coverage.ml`
- `git diff --check`
- `python3 scripts/check_test_coverage.py`
- `bash scripts/ci/check-determinism-contract.sh`
- `bash scripts/hardening-ratchet.sh --check --fail-on-critical --json-out /tmp/hardening-ratchet-23598-submit-notes.json`

로컬 Dune은 현재 switch가 OCaml 5.4.1이라 repo의 OCaml 5.5 guard에서 중단되었습니다. guard는 우회하지 않았고, 빌드 판정은 CI 기준입니다.