### PR TITLE
feat(keeper): enumerate registered repositories in the keeper system prompt

### DIFF
--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -318,6 +318,7 @@ val build_keeper_system_prompt
   -> ?keeper_name:string
   -> ?home_ground:string
   -> ?active_goals:(string * string) list
+  -> ?registered_repos:string list
   -> unit
   -> string
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -318,7 +318,7 @@ val build_keeper_system_prompt
   -> ?keeper_name:string
   -> ?home_ground:string
   -> ?active_goals:(string * string) list
-  -> ?registered_repos:string list
+  -> ?registered_repositories:Keeper_prompt.registered_repositories
   -> unit
   -> string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -61,6 +61,7 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?home_ground:string ->
   ?active_goals:(string * string) list ->
+  ?registered_repos:string list ->
   unit ->
   string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -61,7 +61,7 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?home_ground:string ->
   ?active_goals:(string * string) list ->
-  ?registered_repos:string list ->
+  ?registered_repositories:Keeper_prompt.registered_repositories ->
   unit ->
   string
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -175,10 +175,15 @@ let behavior_prompt_block name =
         name
 
 
+type registered_repositories =
+  | Registered_repository_ids of string list
+  | Registered_repositories_unavailable of string
+
 let build_keeper_system_prompt
     ~goal
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
-    ?(home_ground = "") ?(active_goals = []) ?(registered_repos = []) () =
+    ?(home_ground = "") ?(active_goals = [])
+    ?(registered_repositories = Registered_repository_ids []) () =
   let goal = normalize_goal_text goal in
   (* Behavior prompt blocks live under
      [<prompts_dir>/behavior/<name>.md] and are read once per process via
@@ -236,15 +241,25 @@ let build_keeper_system_prompt
         (String_util.escape_xml home_ground)
   in
   let registered_repositories_block =
-    (* Enumerate the keeper's registered repository ids from
-       [repositories.toml] so the keeper has the closed set of valid
+    (* Enumerate the globally registered repository ids from [repositories.toml]
+       so the keeper has the closed set of valid
        [repos/<name>] segments rather than guessing (org-prefixed, renamed,
-       or invented names are rejected as unregistered). Empty list renders
-       nothing — a failed/empty catalog read degrades to silence, never a
-       fabricated name. *)
-    match registered_repos with
-    | [] -> ""
-    | repos ->
+       or invented names are rejected as unregistered). Empty catalog renders
+       nothing. Catalog read failure renders a fail-closed block so the keeper
+       does not silently fall back to guessing. *)
+    match registered_repositories with
+    | Registered_repository_ids [] -> ""
+    | Registered_repositories_unavailable reason ->
+        Printf.sprintf
+          "\n\
+           <registered_repositories>\n\
+           Repository catalog unavailable: %s\n\
+           Do not guess repos/<name> segments while the catalog is unavailable. \
+           Refresh repositories.toml or ask the operator for the correct \
+           registered repository id before using repository-scoped tools.\n\
+           </registered_repositories>\n"
+          (String_util.escape_xml reason)
+    | Registered_repository_ids repos ->
         let lines =
           List.map
             (fun id -> Printf.sprintf "- repos/%s" (String_util.escape_xml id))
@@ -253,7 +268,8 @@ let build_keeper_system_prompt
         Printf.sprintf
           "\n\
            <registered_repositories>\n\
-           Only these repository names resolve under repos/<name>/. Any other \
+           Only these globally registered repository names resolve under \
+           repos/<name>/. Any other \
            name (org-prefixed, renamed, or invented) is rejected as \
            unregistered.\n\
            %s\n\

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -178,7 +178,7 @@ let behavior_prompt_block name =
 let build_keeper_system_prompt
     ~goal
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
-    ?(home_ground = "") ?(active_goals = []) () =
+    ?(home_ground = "") ?(active_goals = []) ?(registered_repos = []) () =
   let goal = normalize_goal_text goal in
   (* Behavior prompt blocks live under
      [<prompts_dir>/behavior/<name>.md] and are read once per process via
@@ -235,6 +235,31 @@ let build_keeper_system_prompt
          </home_ground>\n"
         (String_util.escape_xml home_ground)
   in
+  let registered_repositories_block =
+    (* Enumerate the keeper's registered repository ids from
+       [repositories.toml] so the keeper has the closed set of valid
+       [repos/<name>] segments rather than guessing (org-prefixed, renamed,
+       or invented names are rejected as unregistered). Empty list renders
+       nothing — a failed/empty catalog read degrades to silence, never a
+       fabricated name. *)
+    match registered_repos with
+    | [] -> ""
+    | repos ->
+        let lines =
+          List.map
+            (fun id -> Printf.sprintf "- repos/%s" (String_util.escape_xml id))
+            repos
+        in
+        Printf.sprintf
+          "\n\
+           <registered_repositories>\n\
+           Only these repository names resolve under repos/<name>/. Any other \
+           name (org-prefixed, renamed, or invented) is rejected as \
+           unregistered.\n\
+           %s\n\
+           </registered_repositories>\n"
+          (String.concat "\n" lines)
+  in
   (* Prefix ordering: common blocks first for LLM KV cache sharing.
      All keepers share the same autonomous-behavior, policy, continuity,
      and most of <world>/<capabilities> text.  Keeper-specific blocks
@@ -285,6 +310,8 @@ let build_keeper_system_prompt
       identity_anchor;
       (* ── Home ground (CWD anchor) ───────────────────────────── *)
       home_ground_block;
+      (* ── Registered repositories (valid repos/<name> segments) ─ *)
+      registered_repositories_block;
       (* ── Keeper-specific blocks ─────────────────────────────── *)
       persona_block;
       "<identity>\n\

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -36,8 +36,13 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?home_ground:string ->
   ?active_goals:(string * string) list ->
+  ?registered_repos:string list ->
   unit ->
   string
+(** [registered_repos] lists the keeper's registered repository ids (from
+    [repositories.toml]). When non-empty it renders a [<registered_repositories>]
+    block enumerating the valid [repos/<name>] segments, so the keeper does not
+    guess org-prefixed / renamed / invented names that fail as unregistered. *)
 
 val append_direct_reply_mode_prompt :
   base_prompt:string ->

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -29,6 +29,10 @@ val state_block_output_guard_text : string
     synthesize and persist STATE metadata, so direct/no-state turns should not
     ask the model to emit raw STATE markers in visible text. *)
 
+type registered_repositories =
+  | Registered_repository_ids of string list
+  | Registered_repositories_unavailable of string
+
 val build_keeper_system_prompt :
   goal:string ->
   instructions:string ->
@@ -36,13 +40,14 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?home_ground:string ->
   ?active_goals:(string * string) list ->
-  ?registered_repos:string list ->
+  ?registered_repositories:registered_repositories ->
   unit ->
   string
-(** [registered_repos] lists the keeper's registered repository ids (from
-    [repositories.toml]). When non-empty it renders a [<registered_repositories>]
-    block enumerating the valid [repos/<name>] segments, so the keeper does not
-    guess org-prefixed / renamed / invented names that fail as unregistered. *)
+(** [registered_repositories] lists the globally registered repository ids from
+    [repositories.toml], or carries the catalog read error. A non-empty id list
+    renders the valid [repos/<name>] segments; an unavailable catalog renders a
+    fail-closed [<registered_repositories>] block that tells the keeper not to
+    guess org-prefixed / renamed / invented names. *)
 
 val append_direct_reply_mode_prompt :
   base_prompt:string ->

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -58,6 +58,14 @@ let build_base_system_prompt
          | None -> None)
       meta.active_goal_ids
   in
+  let registered_repos =
+    (* Enumerate registered repository ids so the system prompt can list the
+       valid [repos/<name>] segments. A failed catalog read yields [] (no
+       block), matching the empty-goals/empty-home degrade-to-silence policy. *)
+    match Repo_store.load_all ~base_path:config.base_path with
+    | Ok repos -> List.map (fun (r : Repo_manager_types.repository) -> r.id) repos
+    | Error _ -> []
+  in
   Keeper_prompt.build_keeper_system_prompt
     ~goal:(prompt_profile_default profile_defaults.goal meta.goal)
     ~instructions:
@@ -66,6 +74,7 @@ let build_base_system_prompt
     ~keeper_name:meta.name
     ~active_goals
     ~home_ground:config.base_path
+    ~registered_repos
     ()
 
 let max_tokens_fallback ~keeper_name profile_defaults () =

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -58,13 +58,18 @@ let build_base_system_prompt
          | None -> None)
       meta.active_goal_ids
   in
-  let registered_repos =
+  let registered_repositories =
     (* Enumerate registered repository ids so the system prompt can list the
-       valid [repos/<name>] segments. A failed catalog read yields [] (no
-       block), matching the empty-goals/empty-home degrade-to-silence policy. *)
+       valid [repos/<name>] segments. A failed catalog read is rendered as a
+       fail-closed prompt block instead of silently falling back to guessing. *)
     match Repo_store.load_all ~base_path:config.base_path with
-    | Ok repos -> List.map (fun (r : Repo_manager_types.repository) -> r.id) repos
-    | Error _ -> []
+    | Ok repos ->
+        Keeper_prompt.Registered_repository_ids
+          (List.map (fun (r : Repo_manager_types.repository) -> r.id) repos)
+    | Error err ->
+        Log.Keeper.warn ~keeper_name:meta.name
+          "registered repository catalog unavailable: %s" err;
+        Keeper_prompt.Registered_repositories_unavailable err
   in
   Keeper_prompt.build_keeper_system_prompt
     ~goal:(prompt_profile_default profile_defaults.goal meta.goal)
@@ -74,7 +79,7 @@ let build_base_system_prompt
     ~keeper_name:meta.name
     ~active_goals
     ~home_ground:config.base_path
-    ~registered_repos
+    ~registered_repositories
     ()
 
 let max_tokens_fallback ~keeper_name profile_defaults () =

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -230,6 +230,35 @@ let test_keeper_prompt_preserves_snapshot_delta_anchors () =
     (has_in prompt "State block template");
   check bool "world anchor present" true (has_in prompt "<world>")
 
+let test_registered_repositories_block_lists_valid_repos () =
+  (* ~780 wrong-repo-name failures: keepers guess org-prefixed / stale /
+     invented names. The block hands them the closed set of valid segments. *)
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Work on the registered repositories"
+      ~instructions:""
+      ~registered_repos:[ "masc"; "oas" ]
+      ()
+  in
+  check bool "block header present" true
+    (has_in prompt "<registered_repositories>");
+  check bool "lists repos/masc" true (has_in prompt "- repos/masc");
+  check bool "lists repos/oas" true (has_in prompt "- repos/oas");
+  check bool "states unregistered names are rejected" true
+    (has_in prompt "rejected as")
+
+let test_registered_repositories_block_empty_renders_nothing () =
+  (* Empty / failed catalog read degrades to silence, never a fabricated
+     name — same policy as empty active_goals / empty home_ground. *)
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"No registered repositories"
+      ~instructions:""
+      ()
+  in
+  check bool "no block when list empty" false
+    (has_in prompt "<registered_repositories>")
+
 let test_prompt_recovery_guard_restores_missing_anchors () =
   let prompt =
     KP.ensure_critical_prompt_anchors
@@ -519,6 +548,10 @@ let () =
             test_direct_reply_prompt_matches_server_managed_heartbeat_policy;
           test_case "keeper prompt preserves snapshot delta anchors" `Quick
             test_keeper_prompt_preserves_snapshot_delta_anchors;
+          test_case "registered_repositories block lists valid repos" `Quick
+            test_registered_repositories_block_lists_valid_repos;
+          test_case "registered_repositories block empty renders nothing" `Quick
+            test_registered_repositories_block_empty_renders_nothing;
           test_case "prompt recovery guard restores missing anchors" `Quick
             test_prompt_recovery_guard_restores_missing_anchors;
           test_case "prompt recovery guard survives empty registry value"

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -232,12 +232,12 @@ let test_keeper_prompt_preserves_snapshot_delta_anchors () =
 
 let test_registered_repositories_block_lists_valid_repos () =
   (* ~780 wrong-repo-name failures: keepers guess org-prefixed / stale /
-     invented names. The block hands them the closed set of valid segments. *)
+     invented names. The block hands them the global registered id set. *)
   let prompt =
     KP.build_keeper_system_prompt
       ~goal:"Work on the registered repositories"
       ~instructions:""
-      ~registered_repos:[ "masc"; "oas" ]
+      ~registered_repositories:(KP.Registered_repository_ids [ "masc"; "oas" ])
       ()
   in
   check bool "block header present" true
@@ -248,8 +248,8 @@ let test_registered_repositories_block_lists_valid_repos () =
     (has_in prompt "rejected as")
 
 let test_registered_repositories_block_empty_renders_nothing () =
-  (* Empty / failed catalog read degrades to silence, never a fabricated
-     name — same policy as empty active_goals / empty home_ground. *)
+  (* Empty catalog still degrades to silence, never a fabricated name — same
+     policy as empty active_goals / empty home_ground. *)
   let prompt =
     KP.build_keeper_system_prompt
       ~goal:"No registered repositories"
@@ -258,6 +258,23 @@ let test_registered_repositories_block_empty_renders_nothing () =
   in
   check bool "no block when list empty" false
     (has_in prompt "<registered_repositories>")
+
+let test_registered_repositories_block_failure_renders_fail_closed () =
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Repository catalog unavailable"
+      ~instructions:""
+      ~registered_repositories:
+        (KP.Registered_repositories_unavailable "repositories.toml parse error")
+      ()
+  in
+  check bool "block header present" true
+    (has_in prompt "<registered_repositories>");
+  check bool "catalog unavailable visible" true
+    (has_in prompt "Repository catalog unavailable");
+  check bool "tells keeper not to guess" true (has_in prompt "Do not guess");
+  check bool "carries parse error" true
+    (has_in prompt "repositories.toml parse error")
 
 let test_prompt_recovery_guard_restores_missing_anchors () =
   let prompt =
@@ -552,6 +569,8 @@ let () =
             test_registered_repositories_block_lists_valid_repos;
           test_case "registered_repositories block empty renders nothing" `Quick
             test_registered_repositories_block_empty_renders_nothing;
+          test_case "registered_repositories failure block is fail closed" `Quick
+            test_registered_repositories_block_failure_renders_fail_closed;
           test_case "prompt recovery guard restores missing anchors" `Quick
             test_prompt_recovery_guard_restores_missing_anchors;
           test_case "prompt recovery guard survives empty registry value"


### PR DESCRIPTION
## 목적

keeper가 하루에 **~780회** 잘못된 repository 이름을 추측해 `Repository X is not registered`로 실패합니다 (실측: `system_log_2026-07-07.jsonl`). 내역:
- `jeong-sik-masc` 392 (GitHub org-prefixed 전체명)
- `masc-mcp` 230 (폐기된 옛 이름, stale durable memory 유래)
- `masc-verify` 44 / `anyang-keepers-masc-workbench` 39 / `verifier-lab` 17 / `masc-workbench-full` 5 등 (지어낸 이름)

원인은 정보 부재입니다. system prompt는 sandbox root와 정적 `repos/masc` 예시 하나(모든 keeper 공유)만 줄 뿐, 유효한 `repos/<name>` 세그먼트의 닫힌 집합을 알려주지 않습니다.

## 변경

spawn 시 `repositories.toml`에서 읽은 **global registered repository ids**를 `<registered_repositories>` 블록으로 system prompt에 주입합니다 (기존 `<available_goals>`/`<home_ground>` 블록 패턴 미러).

- `keeper_run_context.ml`: `Repo_store.load_all` 결과를 `Keeper_prompt.registered_repositories` variant로 전달합니다.
- `keeper_prompt.ml`/`.mli`: `?registered_repositories` param + `<registered_repositories>` 블록 렌더.
- catalog read 실패는 더 이상 `[]`로 접지 않습니다. `Repository catalog unavailable ... Do not guess repos/<name>` fail-closed 블록을 렌더하고 `Log.Keeper.warn`을 남깁니다.
- 빈 catalog는 기존 empty goals/home과 같이 무렌더합니다.

## 근거 · 검증

- `keeper_prompt_metrics`: repo id 블록 렌더, 빈 목록 무렌더, catalog-unavailable fail-closed 블록 테스트 추가.
- Local checks passed: `opam exec -- ocamlformat --check ...`, `git diff --check`, `python3 scripts/check_test_coverage.py`, `bash scripts/ci/check-determinism-contract.sh`, `bash scripts/hardening-ratchet.sh --check --fail-on-critical --json-out /tmp/hardening-ratchet-23600-repo-prompt.json`.
- Local focused Dune build blocked by existing bare Dune process (`dune build --root . lib` PID 78273); CI is the compile authority for this run.

## 범위

편집 파일은 RFC-gated `lib/repo_manager/` 밖입니다. `keeper_run_context`는 catalog를 read만 합니다. “keeper별 authorization cap” 변경이 아니라 prompt display/default-scope 안내이며, closed set은 현재 global registered repository ids입니다.

[근거] 명령: `gh pr view 23600 --json headRefOid,mergeable,statusCheckRollup,title,body`, `git diff --stat origin/main...HEAD`, listed local checks; 확인일시: 2026-07-08 01:06:45 KST; 신뢰도: High

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>