### PR TITLE
feat(keeper): document keeper tool descriptor constraints (Grep multiline, Edit byte-exact, board length)

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1576,7 +1576,7 @@ let internal_descriptors : t list =
     (* ── board cluster (RFC-0179 PR-3, 15 tools) ──────────────── *)
   ; board_descriptor
       "keeper_board_comment"
-      "Comment on one board post. Requires an exact post_id from board activity, keeper_board_list, keeper_board_search, or keeper_board_post_get."
+      "Comment on one board post. Requires an exact post_id from board activity, keeper_board_list, keeper_board_search, or keeper_board_post_get. Board content has a maximum length; keep comments concise — summarize and link rather than pasting long output."
       ~readonly:false
   ; board_descriptor
       "keeper_board_comment_vote"
@@ -1600,7 +1600,10 @@ let internal_descriptors : t list =
       ~readonly:true
   ; board_descriptor
       "keeper_board_post"
-      "Post a new board entry. Quantitative claims require code-anchor evidence."
+      "Post a new board entry. Quantitative claims require code-anchor \
+       evidence. Board content has a maximum length; keep entries concise — \
+       post a short summary of the key points and reference a file path, PR, \
+       or issue link instead of pasting full logs, diffs, or analyses."
       ~readonly:false
   ; board_descriptor
       "keeper_board_search"

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -611,7 +611,9 @@ let public_descriptors =
         "Search file contents with ripgrep: provide a regex `pattern` (and \
          optionally path/glob/type). To list a directory, read a file, or run \
          git status/log/diff, use the Execute tool (e.g. executable='ls' \
-         argv=['-la','<path>'])."
+         argv=['-la','<path>']). Patterns match within a single line; a \
+         literal newline in `pattern` is rejected. To match across lines, run \
+         `rg -U` through the Execute tool."
       ~input_schema:search_files_schema
       ~policy:
         (policy
@@ -656,7 +658,12 @@ let public_descriptors =
       ~id:"agent.edit_file"
       ~public_name:"Edit"
       ~internal_name:"tool_edit_file"
-      ~description:"Patch an existing file by replacing an exact string."
+      ~description:
+        "Patch an existing file by replacing an exact string. Read the file \
+         first and copy old_string verbatim from its current bytes, including \
+         leading whitespace, indentation, and newlines; the match is exact and \
+         byte-sensitive. On 'old_string not found', re-Read the file to get the \
+         current text instead of retrying the same string."
       ~input_schema:edit_file_schema
       ~policy:
         (policy

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -472,6 +472,28 @@ let test_edit_descriptor_requires_read_first () =
     descriptor.description
 ;;
 
+let test_board_descriptors_steer_concise_content () =
+  (* board_post/comment content-length rejects (53/day): keepers pasted full
+     logs/analyses (up to 8186 chars) past the max_content_length limit. The
+     descriptors now steer concise summaries + links. No hardcoded number —
+     the limit is env-configurable (Board_types.Limits.max_content_length),
+     and the rejection error already reports the actual count. *)
+  let post = required_internal_descriptor "keeper_board_post" in
+  let comment = required_internal_descriptor "keeper_board_comment" in
+  check_contains
+    "board_post description names the length limit"
+    ~sub:"maximum length"
+    post.description;
+  check_contains
+    "board_post description steers summary + link"
+    ~sub:"reference a file path, PR, or issue link"
+    post.description;
+  check_contains
+    "board_comment description names the length limit"
+    ~sub:"maximum length"
+    comment.description
+;;
+
 let test_board_descriptions_disambiguate_post_id_flow () =
   let get_descriptor = required_internal_descriptor "keeper_board_post_get" in
   let get_schema = required_board_schema "keeper_board_post_get" in
@@ -1183,6 +1205,10 @@ let () =
             "Edit requires Read-first and byte-exact old_string"
             `Quick
             test_edit_descriptor_requires_read_first
+        ; test_case
+            "Board post/comment steer concise content"
+            `Quick
+            test_board_descriptors_steer_concise_content
         ; test_case
             "Board get/list descriptions disambiguate post_id flow"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -443,6 +443,35 @@ let test_execute_descriptor_spells_out_argv_and_filesystem_basis () =
     argv_description
 ;;
 
+let test_grep_descriptor_documents_multiline () =
+  (* Keepers passed a literal newline in `pattern` (11 rejects); the runtime
+     error referenced a --multiline flag Grep does not expose. Document single-
+     line matching and route cross-line matches to the working Execute rg -U. *)
+  let descriptor = required_public_descriptor "Grep" in
+  check_contains
+    "Grep description says patterns match within a single line"
+    ~sub:"match within a single line"
+    descriptor.description;
+  check_contains
+    "Grep description routes cross-line matches to rg -U"
+    ~sub:"rg -U"
+    descriptor.description
+;;
+
+let test_edit_descriptor_requires_read_first () =
+  (* old_string mismatch (31 rejects): keepers edited without Read or blind-
+     retried a non-matching string. Document byte-sensitivity + re-Read. *)
+  let descriptor = required_public_descriptor "Edit" in
+  check_contains
+    "Edit description says the match is byte-sensitive"
+    ~sub:"byte-sensitive"
+    descriptor.description;
+  check_contains
+    "Edit description directs re-Read on a missed match"
+    ~sub:"re-Read the file"
+    descriptor.description
+;;
+
 let test_board_descriptions_disambiguate_post_id_flow () =
   let get_descriptor = required_internal_descriptor "keeper_board_post_get" in
   let get_schema = required_board_schema "keeper_board_post_get" in
@@ -1146,6 +1175,14 @@ let () =
             "Execute argv/filesystem basis is explicit"
             `Quick
             test_execute_descriptor_spells_out_argv_and_filesystem_basis
+        ; test_case
+            "Grep documents single-line match and rg -U"
+            `Quick
+            test_grep_descriptor_documents_multiline
+        ; test_case
+            "Edit requires Read-first and byte-exact old_string"
+            `Quick
+            test_edit_descriptor_requires_read_first
         ; test_case
             "Board get/list descriptions disambiguate post_id flow"
             `Quick


### PR DESCRIPTION
## 목적

keeper tool 실패 중 prose로 교정 가능한 세 근본을 tool descriptor에 반영합니다 (실측 `system_log_2026-07-07.jsonl`):

- **Grep (11건)**: `pattern`에 리터럴 newline → 거부. 런타임 에러가 Grep이 노출하지 않는 `--multiline` 플래그를 언급해 오도. → 단일 라인 매칭 명시 + cross-line은 Execute `rg -U`로 라우팅.
- **Edit (31건)**: "exact string 교체"라는 한 줄 설명뿐 — Read-first도, `old_string not found` 복구 안내도 없음. → byte-sensitivity + 실패 시 re-Read 명시.
- **board_post/comment (53건)**: content-length 초과 거부(최대 8186 > 4000자). keeper가 전체 로그/분석을 board에 덤핑. → **drift-free** 요약+링크 지침 (숫자 하드코딩 안 함 — 제한은 env-configurable `Board_types.Limits.max_content_length`이고 거부 에러가 실제 카운트를 이미 보고).

## 검증

- `test_keeper_tool_descriptor_registry_integrity`: Grep(single-line + `rg -U`), Edit(byte-sensitive + re-Read), Board(요약+링크) drift-guard 3건 추가. **35 tests green.**

## 설계 원칙

세 델타 모두 **제약을 전달**하되 **drift를 피합니다**: repo-name의 정적 `repos/masc` 예시 drift 교훈(#23600)을 board 제한에도 적용 — 하드코딩된 숫자 대신 행동 지침(요약+링크)을 주고, 정확한 값은 런타임 에러에 맡깁니다.

## 범위 · 의도적 제외

destructive-git retry(44건)는 prose로 **패치하지 않습니다** — 런타임이 이미 `keeper_guards.ml:238`에서 승인 안내를 내보내는데 루프가 지속됐고, catastrophic-floor deny라 승인 경로가 없어 더 많은 prose는 telemetry-as-fix. 구조적 safe-branch-delete affordance로 이슈 **#23602** 승격.

masc_transition rejection(40건)은 정상 FSM/소유권 게이트(에러가 이미 "claim a different task"로 actionable) — 수정 대상 아님.

iter-2 주력(repo-name ~780, 68%)은 #23600.

WORKAROUND-WAIVED: false positive — tool descriptor에 prose 안내를 추가할 뿐 코드에 문자열 분류기를 도입하지 않으며, "telemetry-as-fix"는 destructive-git 델타를 *거부*하고 구조적 이슈로 승격하는 근거로만 언급됩니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
