### PR TITLE
feat(dashboard): align HITL approvals with keeper v2

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import * as Vitest from 'vitest'
-import type { DashboardGovernanceResponse, KeeperApprovalQueueItem, KeeperResolvedApprovalItem } from '../../types'
+import type { DashboardGovernanceResponse, KeeperApprovalQueueItem, KeeperApprovalRule, KeeperResolvedApprovalItem } from '../../types'
 
 const { afterEach, beforeEach, describe, expect, it, vi } = Vitest
 
@@ -27,6 +27,7 @@ function queueItem(overrides: Partial<KeeperApprovalQueueItem> & { id: string })
 function responseWithQueue(
   approval_queue: KeeperApprovalQueueItem[],
   recent_resolved: KeeperResolvedApprovalItem[] = [],
+  approval_rules: KeeperApprovalRule[] = [],
 ): DashboardGovernanceResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
@@ -37,6 +38,8 @@ function responseWithQueue(
     pending_actions: [],
     approval_queue,
     recent_resolved,
+    approval_rules,
+    hitl: { enabled: true, disabled_by_env: false, env_name: 'MASC_DISABLE_HITL', default_enabled: true },
   } as DashboardGovernanceResponse
 }
 
@@ -45,6 +48,7 @@ function responseWithQueue(
 async function loadSurface(
   approval_queue: KeeperApprovalQueueItem[],
   recent_resolved: KeeperResolvedApprovalItem[] = [],
+  approval_rules: KeeperApprovalRule[] = [],
 ) {
   vi.resetModules()
   const resolveGovernanceApproval = vi
@@ -52,7 +56,7 @@ async function loadSurface(
     .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
   vi.doMock('../../api', () => ({
     decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved)),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved, approval_rules)),
     fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
     resolveGovernanceApproval,
     deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
@@ -61,7 +65,7 @@ async function loadSurface(
   }))
   vi.doMock('../../api/dashboard-governance', () => ({
     decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved)),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved, approval_rules)),
     fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
     resolveGovernanceApproval,
     deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
@@ -133,6 +137,10 @@ describe('ApprovalsSurface', () => {
     expect(container.textContent).not.toContain('처리이력')
     // KPI strip counts the queue
     expect(container.querySelector('[data-testid="approvals-queue"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="approvals-aside"]')?.textContent)
+      .toContain('HITL 상태')
+    expect(container.querySelector('[data-testid="approvals-aside"]')?.textContent)
+      .toContain('enabled')
   }, 20000)
 
   it('renders the HITL context summary (available) inside the pending card', async () => {
@@ -337,7 +345,7 @@ describe('ApprovalsSurface', () => {
     expect(container.textContent).not.toContain('처리이력')
   }, 20000)
 
-  it('keeps prototype-only defer, undo, and history controls out of the live surface', async () => {
+  it('keeps prototype-only defer and undo controls out while exposing backed queue/history tabs', async () => {
     const { ApprovalsSurface } = await loadSurface([
       queueItem({ id: 'appr-no-fake-controls', keeper_name: 'masc-improver' }),
     ])
@@ -346,7 +354,8 @@ describe('ApprovalsSurface', () => {
     await flushUi()
 
     expect(container.querySelector('.ap-act.defer')).toBeNull()
-    expect(container.querySelector('.ap-history')).toBeNull()
+    expect(container.querySelector('.ap-viewseg')).not.toBeNull()
+    expect(container.textContent).toContain('이력')
     expect(container.textContent).not.toContain('보류')
     expect(container.textContent).not.toContain('되돌리기')
     expect(container.textContent).not.toContain('처리이력')
@@ -371,9 +380,12 @@ describe('ApprovalsSurface', () => {
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
-    const history = container.querySelector('[data-testid="approvals-history"]')
+    container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
+    await flushUi()
+
+    const history = container.querySelector('[data-testid="approvals-history-view"]')
     expect(history).not.toBeNull()
-    expect(history?.textContent).toContain('최근 처리 (1)')
+    expect(history?.querySelector('.ap-hist-summary')?.getAttribute('aria-label')).toBe('승인 이력 요약')
     expect(history?.textContent).toContain('거부')
     expect(history?.textContent).toContain('fs_write')
     expect(history?.textContent).toContain('masc-improver')
@@ -381,6 +393,64 @@ describe('ApprovalsSurface', () => {
     expect(history?.querySelector('.ap-history-decision')?.className).toContain('decision-reject')
     expect(history?.querySelector('.ap-history-decision')?.className).not.toContain('operator denied')
     expect(history?.querySelector('.ap-history-at')?.textContent).toContain('2026')
+  }, 20000)
+
+  it('filters resolved approval history and surfaces Always-rule evidence', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [
+        {
+          id: 'appr-approved',
+          keeper_name: 'keeper-a',
+          tool_name: 'fs_write',
+          risk_level: 'medium',
+          decision: 'approve',
+          resolved_at: '2026-06-27T02:02:03Z',
+          rule_match: { rule_id: 'rule-1', matched_by: 'fingerprint' },
+        },
+        {
+          id: 'appr-rejected',
+          keeper_name: 'keeper-b',
+          tool_name: 'shell',
+          risk_level: 'critical',
+          decision: 'reject',
+          resolved_at: '2026-06-27T01:02:03Z',
+        },
+      ],
+      [
+        {
+          id: 'rule-1',
+          keeper_name: 'keeper-a',
+          tool_name: 'fs_write',
+          max_risk: 'medium',
+          match_count: 3,
+        },
+      ],
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const aside = container.querySelector('[data-testid="approvals-aside"]')
+    expect(aside?.textContent).toContain('Always Rules')
+    expect(aside?.textContent).toContain('keeper-a')
+    expect(aside?.textContent).toContain('fs_write')
+    expect(aside?.textContent).toContain('match 3')
+
+    container.querySelector<HTMLButtonElement>('.ap-viewbtn:not(.on)')?.click()
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approvals-history-view"]')?.textContent)
+      .toContain('rule rule-1')
+
+    const rejectFilter = Array.from(container.querySelectorAll<HTMLButtonElement>('.ap-hist-f'))
+      .find(button => button.textContent === '거부')
+    rejectFilter?.click()
+    await flushUi()
+
+    const history = container.querySelector('[data-testid="approvals-history-view"]')
+    expect(history?.textContent).toContain('appr-rejected')
+    expect(history?.textContent).not.toContain('appr-approved')
   }, 20000)
 
   it('shows the empty state when no approvals are pending', async () => {

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -8,14 +8,16 @@
 // Data source: governanceData.value?.approval_queue (KeeperApprovalQueueItem[]).
 // Actions: respondToKeeperApproval(id, 'approve' | 'reject', rememberRule).
 // The live decision model is the closed set {approve, reject} (+ rememberRule);
-// there is no defer/undo endpoint, so the prototype's 보류/되돌리기/처리이력 are
-// intentionally not rendered. Visual layout ports the keeper-v2 .ap-* design.
+// there is no defer/undo endpoint, so the prototype's 보류/되돌리기 controls are
+// intentionally not rendered. History is read-only from recent_resolved.
+// Visual layout ports the keeper-v2 .ap-* design.
 
 import { html } from 'htm/preact'
 import { Fragment } from 'preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import type {
   KeeperApprovalQueueItem,
+  KeeperApprovalRule,
   KeeperResolvedApprovalItem,
   HitlContextSummary,
   HitlSummaryStatus,
@@ -31,6 +33,7 @@ import {
 import {
   keeperResolvedApprovalDecisionClass,
   keeperResolvedApprovalDecisionLabel,
+  type KeeperResolvedApprovalDecision,
 } from '../../lib/keeper-approval-decision'
 import { navigate } from '../../router'
 import { AgentAvatar } from '../overview/agent-avatar'
@@ -43,6 +46,23 @@ import {
   refreshGovernance,
   respondToKeeperApproval,
 } from '../governance-store'
+
+type ApprovalsView = 'queue' | 'history'
+type ApprovalHistoryFilter = 'all' | KeeperResolvedApprovalDecision | 'rule'
+
+const APPROVAL_HISTORY_FILTERS: ReadonlyArray<{
+  id: ApprovalHistoryFilter
+  label: string
+  predicate: (item: KeeperResolvedApprovalItem) => boolean
+}> = [
+  { id: 'all', label: '전체', predicate: () => true },
+  { id: 'approve', label: '승인', predicate: item => item.decision === 'approve' },
+  { id: 'reject', label: '거부', predicate: item => item.decision === 'reject' },
+  { id: 'edit', label: '수정됨', predicate: item => item.decision === 'edit' },
+  { id: 'unknown', label: '처리됨', predicate: item => item.decision === 'unknown' },
+  { id: 'rule', label: 'Always 규칙', predicate: item => item.rule_match != null },
+]
+const DEFAULT_APPROVAL_HISTORY_FILTER = APPROVAL_HISTORY_FILTERS[0]!
 
 function apSev(riskLevel: string | null | undefined): KeeperApprovalRiskVisualBand {
   return keeperApprovalRiskVisualBand(riskLevel)
@@ -133,10 +153,70 @@ function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
       <span class="ap-history-tool mono">${item.tool_name}</span>
       <span class="ap-history-keeper">${item.keeper_name}</span>
       <span class="ap-history-id mono">${item.id}</span>
+      ${item.rule_match?.rule_id
+        ? html`<span class="ap-history-rule mono" title=${item.rule_match.matched_by ?? ''}>rule ${item.rule_match.rule_id}</span>`
+        : null}
       ${item.resolved_at
         ? html`<span class="ap-history-at">${formatDateTimeKo(item.resolved_at)}</span>`
         : null}
     </li>
+  `
+}
+
+function resolvedAtMs(item: KeeperResolvedApprovalItem): number {
+  const parsed = item.resolved_at ? Date.parse(item.resolved_at) : Number.NaN
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function ApHistory({ items }: { items: KeeperResolvedApprovalItem[] }) {
+  const [filter, setFilter] = useState<ApprovalHistoryFilter>('all')
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a)),
+    [items],
+  )
+  const activeFilter = APPROVAL_HISTORY_FILTERS.find(item => item.id === filter)
+    ?? DEFAULT_APPROVAL_HISTORY_FILTER
+  const shown = sorted.filter(activeFilter.predicate)
+  const counts = useMemo(() => ({
+    approve: sorted.filter(item => item.decision === 'approve').length,
+    reject: sorted.filter(item => item.decision === 'reject').length,
+    rule: sorted.filter(item => item.rule_match != null).length,
+    keepers: new Set(sorted.map(item => item.keeper_name)).size,
+  }), [sorted])
+
+  return html`
+    <section class="ap-hist" data-testid="approvals-history-view">
+      <div class="ap-hist-summary" aria-label="승인 이력 요약">
+        <div class="ap-hist-stat"><b class="mono ok">${counts.approve}</b> 승인</div>
+        <div class="ap-hist-stat"><b class="mono bad">${counts.reject}</b> 거부</div>
+        <div class="ap-hist-stat"><b class="mono">${counts.rule}</b> Rule</div>
+        <div class="ap-hist-stat"><b class="mono">${counts.keepers}</b> 관련 키퍼</div>
+      </div>
+      <div class="ap-hist-filters" role="tablist" aria-label="승인 이력 필터">
+        ${APPROVAL_HISTORY_FILTERS.map(option => html`
+          <button
+            key=${option.id}
+            type="button"
+            class=${`ap-hist-f ${filter === option.id ? 'on' : ''}`}
+            aria-pressed=${filter === option.id}
+            onClick=${() => setFilter(option.id)}
+          >${option.label}</button>
+        `)}
+      </div>
+      ${shown.length > 0
+        ? html`
+            <ul class="ap-history-list ap-hist-list">
+              ${shown.map(item => html`<${ResolvedApprovalItem} key=${item.id} item=${item} />`)}
+            </ul>
+          `
+        : html`
+            <div class="ap-clear compact" data-testid="approvals-history-empty">
+              <div class="ico">${'✓'}</div>
+              <h3>해당 필터의 처리 이력이 없습니다</h3>
+              <div class="ap-clear-sub">최근 처리 projection에 일치하는 항목이 없습니다.</div>
+            </div>
+          `}
+    </section>
   `
 }
 
@@ -363,6 +443,98 @@ function ApprovalDetailPanel({
   `
 }
 
+function ApprovalRuleRow({ rule }: { rule: KeeperApprovalRule }) {
+  return html`
+    <li class="ap-rule-row" data-testid="approval-rule-row">
+      <span class="ap-rule-keeper mono">${rule.keeper_name}</span>
+      <span class="ap-rule-tool mono">${rule.tool_name}</span>
+      ${rule.max_risk ? html`<span class="ap-rule-risk">${keeperApprovalRiskLabel(rule.max_risk)}</span>` : null}
+      ${typeof rule.match_count === 'number' ? html`<span class="ap-rule-match mono">match ${rule.match_count}</span>` : null}
+    </li>
+  `
+}
+
+function ApAside({
+  openCount,
+  resolvedItems,
+  rules,
+}: {
+  openCount: number
+  resolvedItems: KeeperResolvedApprovalItem[]
+  rules: KeeperApprovalRule[]
+}) {
+  const hitl = governanceData.value?.hitl
+  const enabled = hitl?.enabled ?? null
+  const recent = [...resolvedItems]
+    .sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a))
+    .slice(0, 5)
+  return html`
+    <aside class="ap-aside" data-testid="approvals-aside">
+      <section class="wka-card ap-auto-card">
+        <div class="wka-h">
+          <h3>HITL 상태</h3>
+          <span class=${`ap-hitl-state ${enabled === false ? 'bad' : enabled === true ? 'ok' : ''}`}>
+            ${enabled === null ? 'unknown' : enabled ? 'enabled' : 'disabled'}
+          </span>
+        </div>
+        <div class="wka-auto">
+          <div class="wka-auto-top">
+            <span class="wka-auto-lbl">
+              자동 승인
+              <b>${rules.length > 0 ? 'Always 규칙 기반' : '수동 결재 중'}</b>
+            </span>
+            <span class=${`wka-switch ${rules.length > 0 ? 'on' : ''}`} aria-hidden="true"></span>
+          </div>
+          <div class="wka-auto-stat">${rules.length.toLocaleString()}개 Always 규칙 · 열린 승인 ${openCount.toLocaleString()}건</div>
+          <div class="wka-auto-note">
+            <b>비가역·파괴적 요청은 수동 결재</b> · 규칙 생성은 카드의 “항상 승인” 액션으로만 수행됩니다.
+          </div>
+          ${hitl?.disabled_by_env
+            ? html`<div class="ap-env-warn mono">${hitl.env_name} disables HITL</div>`
+            : null}
+        </div>
+      </section>
+
+      <section class="wka-card">
+        <div class="wka-h">
+          <h3>Always Rules</h3>
+          <span class="mono">${rules.length}</span>
+        </div>
+        ${rules.length > 0
+          ? html`<ul class="ap-rule-list">${rules.slice(0, 6).map(rule => html`<${ApprovalRuleRow} key=${rule.id} rule=${rule} />`)}</ul>`
+          : html`<div class="ap-side-empty">저장된 Always 규칙 없음</div>`}
+      </section>
+
+      <section class="wka-card">
+        <div class="wka-h">
+          <h3>최근 처리</h3>
+          <span class="mono">${resolvedItems.length}</span>
+        </div>
+        ${recent.length > 0
+          ? html`
+              <ul class="ap-recent-list">
+                ${recent.map(item => html`
+                  <li class="ap-recent-row" key=${item.id}>
+                    <span class=${`ap-history-decision ${keeperResolvedApprovalDecisionClass(item.decision)}`}>
+                      ${keeperResolvedApprovalDecisionLabel(item.decision)}
+                    </span>
+                    <span class="ap-recent-body">
+                      <span class="ap-recent-top">
+                        <span class="mono">${item.tool_name}</span>
+                        <span>${item.keeper_name}</span>
+                      </span>
+                      <span class="ap-recent-sub mono">${item.id}</span>
+                    </span>
+                  </li>
+                `)}
+              </ul>
+            `
+          : html`<div class="ap-side-empty">최근 처리 projection 없음</div>`}
+      </section>
+    </aside>
+  `
+}
+
 export function ApprovalsSurface() {
   useEffect(() => {
     void refreshGovernance()
@@ -374,12 +546,14 @@ export function ApprovalsSurface() {
 
   const items = governanceData.value?.approval_queue ?? []
   const resolvedItems = governanceData.value?.recent_resolved ?? []
+  const rules = governanceData.value?.approval_rules ?? []
   const error = governanceError.value
   // First load only: governanceResource is stale-while-revalidate, so a refetch
   // keeps the previous data — governanceData is null ONLY before the first load
   // resolves. Show a loading state then, instead of asserting the empty queue.
   const firstLoad = governanceLoading.value && governanceData.value === null
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [view, setView] = useState<ApprovalsView>('queue')
   const selectedItem = items.find(item => item.id === selectedId) ?? items[0] ?? null
 
   const stats = useMemo(() => {
@@ -395,7 +569,7 @@ export function ApprovalsSurface() {
   }, [items])
 
   return html`
-    <main class="ov ss-surface bg-surface-page text-text-primary" data-screen-label="승인 큐" data-testid="approvals-surface">
+    <main class="ov ov-2col ss-surface bg-surface-page text-text-primary" data-screen-label="승인 큐" data-testid="approvals-surface">
       <div class="ov-scroll">
         <header class="ov-head">
           <div>
@@ -406,15 +580,35 @@ export function ApprovalsSurface() {
               <span title="감독자가 보는 단일 결재 지점">operator가 직접 승인·거부</span>
             </p>
           </div>
-          ${items.length > 0
-            ? html`<span class="ap-sla mono" title="가장 오래 대기 중인 건">최장 대기 ${apAge(stats.longest)}</span>`
-            : null}
+          <div class="ap-head-actions">
+            <div class="ap-viewseg" role="tablist" aria-label="승인 큐 보기">
+              <button
+                type="button"
+                class=${`ap-viewbtn ${view === 'queue' ? 'on' : ''}`}
+                aria-selected=${view === 'queue'}
+                onClick=${() => setView('queue')}
+              >
+                큐${items.length > 0 ? html`<span class="ap-viewbtn-n mono">${items.length}</span>` : null}
+              </button>
+              <button
+                type="button"
+                class=${`ap-viewbtn ${view === 'history' ? 'on' : ''}`}
+                aria-selected=${view === 'history'}
+                onClick=${() => setView('history')}
+              >이력</button>
+            </div>
+            ${view === 'queue' && items.length > 0
+              ? html`<span class="ap-sla mono" title="가장 오래 대기 중인 건">최장 대기 ${apAge(stats.longest)}</span>`
+              : null}
+          </div>
         </header>
 
         ${error ? html`<div class="ap-error" role="alert" data-testid="approvals-error">${error}</div>` : null}
 
         ${firstLoad
           ? html`<${LoadingState}>승인 큐 불러오는 중...<//>`
+          : view === 'history'
+            ? html`<${ApHistory} items=${resolvedItems} />`
           : html`
         <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
           <div class="ov-kpi">
@@ -426,12 +620,12 @@ export function ApprovalsSurface() {
             <div class=${`ov-kpi-v ${stats.irreversible ? 'bad' : ''}`} data-testid="approvals-kpi-irreversible">${stats.irreversible}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">최장 대기</div>
-            <div class="ov-kpi-v">${items.length ? apAge(stats.longest) : '—'}</div>
+            <div class="ov-kpi-k">Always 규칙</div>
+            <div class="ov-kpi-v">${rules.length}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">관련 키퍼</div>
-            <div class="ov-kpi-v volt">${stats.keepers}</div>
+            <div class="ov-kpi-k">처리 완료</div>
+            <div class="ov-kpi-v volt">${resolvedItems.length}</div>
           </div>
         </section>
 
@@ -465,20 +659,15 @@ export function ApprovalsSurface() {
               </div>
             `
           : null}
-        ${resolvedItems.length > 0
-          ? html`
-              <section class="ap-history" data-testid="approvals-history">
-                <h2 class="ap-history-title">최근 처리 (${resolvedItems.length})</h2>
-                <ul class="ap-history-list">
-                  ${resolvedItems.map(item => html`
-                    <${ResolvedApprovalItem} key=${item.id} item=${item} />
-                  `)}
-                </ul>
-              </section>
-            `
-          : null}
       `}
       </div>
+      ${!firstLoad ? html`
+        <${ApAside}
+          openCount=${items.length}
+          resolvedItems=${resolvedItems}
+          rules=${rules}
+        />
+      ` : null}
     </main>
   `
 }

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -771,7 +771,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
           </h5>
           ${judge.consensus.map((claim, index) => html`
             <div class="fus-claim" key=${`consensus-${index}`}>
-              <p><${RichContent} text=${claim.text} previewLimit=${0} /></p>
+              <div class="fus-claim-text"><${RichContent} text=${claim.text} previewLimit=${0} /></div>
               <${FusionModelChips} models=${claim.models} />
             </div>
           `)}
@@ -787,7 +787,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                     ${contradiction.positions.map(position => html`
                       <div class="fus-pos" key=${`${contradiction.topic}:${position.model}`}>
                         <span class="fus-pos-m mono">${position.model}</span>
-                        <span class="fus-pos-s"><${RichContent} text=${position.stance} previewLimit=${0} /></span>
+                        <div class="fus-pos-s"><${RichContent} text=${position.stance} previewLimit=${0} /></div>
                       </div>
                     `)}
                   </div>
@@ -809,7 +809,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                     </div>
                     <div class="fus-gap-row">
                       <span class="k">누락</span>
-                      <span class="fus-gap-miss"><${RichContent} text=${gap.missing} previewLimit=${0} /></span>
+                      <div class="fus-gap-miss"><${RichContent} text=${gap.missing} previewLimit=${0} /></div>
                     </div>
                   </div>
                 `)}
@@ -823,7 +823,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                 <h5><span class="fus-jglyph">✦</span>고유 통찰 <span class="n">${judge.uniqueInsights.length}</span></h5>
                 ${judge.uniqueInsights.map((insight, index) => html`
                   <div class="fus-insight" key=${`insight-${index}`}>
-                    <p><${RichContent} text=${insight.text} previewLimit=${0} /></p>
+                    <div class="fus-insight-text"><${RichContent} text=${insight.text} previewLimit=${0} /></div>
                     ${insight.model ? html`<span class="fus-mchip mono">${insight.model}</span>` : null}
                   </div>
                 `)}
@@ -1108,7 +1108,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
         <div class="fus-resolved-lbl">resolved_answer</div>
         <${FusionResolvedBody} text=${resolved} />
         ${run.judge.recommendation?.rationale
-          ? html`<p class="fus-rec-rationale"><span class="k">근거</span><${RichContent} text=${run.judge.recommendation.rationale} previewLimit=${0} /></p>`
+          ? html`<div class="fus-rec-rationale"><span class="k">근거</span><${RichContent} text=${run.judge.recommendation.rationale} previewLimit=${0} /></div>`
           : null}
         ${run.judge.missingInputs.length > 0
           ? html`

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -8,6 +8,8 @@
 
    This file therefore carries ONLY what the live approvals surface adds on top
    of that SSOT and surfaces.css does NOT define:
+     - the queue↔history view switch and right HITL state aside (.ap-view*,
+       .ap-hist*, .ap-aside*, .ap-rule*, .ap-recent*)
      - the queue↔detail-rail workspace grid (.ap-workspace, .ap-detail-panel*,
        .ap-dossier*) and the live "상세" toggle (.ap-detail-toggle)
      - the live decision set: disabled state + the "항상 승인" Approve+Always
@@ -26,10 +28,16 @@
    shadowed those values — leaving them dead and divergent from the design SSOT.
    They are removed here so the file no longer redefines surfaces.css-owned
    selectors. The no-overlap invariant is guarded by approvals-css-ownership.test.ts.
-   The prototype's defer / undo / resolved-history rules stay omitted: the live
-   decision model is the closed {approve, reject}(+rule) set with no backing
-   endpoint for those.
+   The prototype's defer / undo controls stay omitted: the live decision model
+   is the closed {approve, reject}(+rule) set with no backing endpoint for those.
    ════════════════════════════════════════════════════════════════ */
+
+.ap-head-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 10px; min-width: 0; }
+.ap-viewseg { display: inline-flex; align-items: center; gap: 4px; padding: 3px; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-sunken); }
+.ap-viewbtn { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; padding: 0 10px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-dim); font-size: var(--fs-12); font-family: var(--font-ui); cursor: pointer; }
+.ap-viewbtn:hover { color: var(--text-primary); background: var(--bg-panel); }
+.ap-viewbtn.on { color: var(--text-bright); background: var(--volt-wash); box-shadow: inset 0 0 0 1px var(--volt-dim); }
+.ap-viewbtn-n { min-width: 16px; padding: 1px 5px; border-radius: var(--radius-pill); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
 
 /* Queue ↔ detail-rail two-column workspace (live surface; not in the prototype,
    which uses a right operations aside instead). */
@@ -119,17 +127,70 @@
   .ap-detail-panel-inline { display: block; }
   .ap-h { flex-wrap: wrap; }
   .ap-id { margin-left: 0; }
+  .ap-aside { position: static; }
+  .ap-head-actions { justify-content: flex-start; width: 100%; }
 }
 
-/* Recent resolved approvals history (live surface augmentation). */
+/* Queue/history view, audit list, and HITL aside (live surface augmentation). */
+.ap-hist { display: flex; flex-direction: column; gap: 14px; }
+.ap-hist-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.ap-hist-stat { min-width: 0; padding: 12px; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-panel); color: var(--text-dim); font-size: var(--fs-12); }
+.ap-hist-stat b { display: block; margin-bottom: 2px; color: var(--text-bright); font-size: var(--fs-18); }
+.ap-hist-stat b.ok { color: var(--status-ok); }
+.ap-hist-stat b.bad { color: var(--status-bad); }
+.ap-hist-filters { display: flex; flex-wrap: wrap; gap: 6px; }
+.ap-hist-f { border: 1px solid var(--border-soft); border-radius: var(--radius-xs); background: var(--bg-sunken); color: var(--text-dim); padding: 6px 9px; font-size: var(--fs-11); cursor: pointer; }
+.ap-hist-f:hover { color: var(--text-primary); border-color: var(--border-main); }
+.ap-hist-f.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
 .ap-history { margin-top: 24px; padding-top: 24px; border-top: 1px solid var(--border-soft); }
 .ap-history-title { font-size: var(--fs-14); font-weight: 600; color: var(--text-dim); margin: 0 0 12px; }
 .ap-history-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
-.ap-history-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--radius-sm); background: var(--bg-panel); border: 1px solid var(--border-soft); font-size: var(--fs-12); }
+.ap-hist-list { margin-top: 0; }
+.ap-history-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--radius-sm); background: var(--bg-panel); border: 1px solid var(--border-soft); font-size: var(--fs-12); min-width: 0; }
 .ap-history-decision { flex: none; min-width: 48px; text-align: center; padding: 2px 8px; border-radius: var(--radius-xs); font-weight: 600; text-transform: uppercase; font-size: var(--fs-10); }
 .ap-history-decision.decision-approve { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 12%, transparent); }
 .ap-history-decision.decision-reject { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ap-history-decision.decision-edit { color: var(--volt-strong); background: var(--volt-wash); }
+.ap-history-decision.decision-unknown { color: var(--text-dim); background: var(--bg-sunken); }
 .ap-history-tool { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
 .ap-history-keeper { flex: 1 1 120px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); }
 .ap-history-id { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); font-size: 10.5px; }
+.ap-history-rule { flex: 0 1 130px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--volt-strong); font-size: var(--fs-10); }
 .ap-history-at { flex: none; color: var(--text-dim); font-size: 10.5px; }
+.ap-clear.compact { min-height: 190px; }
+
+.ap-aside { position: sticky; top: 14px; display: flex; flex-direction: column; gap: 12px; align-self: start; min-width: 0; }
+.ap-aside .wka-card { border: 1px solid var(--border-soft); border-radius: var(--radius-md); background: var(--bg-panel); padding: 14px; box-shadow: var(--shadow-1); }
+.ap-aside .wka-h { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+.ap-aside .wka-h h3 { margin: 0; color: var(--text-bright); font-size: var(--fs-13); font-family: var(--font-display); font-weight: 600; }
+.ap-hitl-state { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--text-dim); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); padding: 2px 7px; }
+.ap-hitl-state.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 38%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.ap-hitl-state.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 38%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
+.ap-auto-card .wka-auto { display: flex; flex-direction: column; gap: 8px; }
+.wka-auto-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.wka-auto-lbl { display: flex; flex-direction: column; gap: 2px; color: var(--text-dim); font-size: var(--fs-11); }
+.wka-auto-lbl b { color: var(--text-bright); font-size: var(--fs-13); }
+.wka-switch { position: relative; width: 34px; height: 18px; flex: none; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); background: var(--bg-sunken); }
+.wka-switch::after { content: ""; position: absolute; top: 3px; left: 3px; width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim); transition: transform 120ms ease, background 120ms ease; }
+.wka-switch.on { border-color: var(--volt-dim); background: var(--volt-wash); }
+.wka-switch.on::after { transform: translateX(15px); background: var(--volt-strong); }
+.wka-auto-stat { color: var(--text-primary); font-size: var(--fs-12); }
+.wka-auto-note { color: var(--text-dim); font-size: var(--fs-11); line-height: 1.45; }
+.wka-auto-note b { color: var(--text-bright); }
+.ap-env-warn { color: var(--status-bad); font-size: var(--fs-10); }
+.ap-rule-list, .ap-recent-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.ap-rule-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 4px 8px; padding: 8px; border: 1px solid var(--border-soft); border-radius: var(--radius-xs); background: var(--bg-sunken); font-size: var(--fs-11); }
+.ap-rule-keeper, .ap-rule-tool { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ap-rule-tool { color: var(--text-bright); }
+.ap-rule-risk, .ap-rule-match { color: var(--text-dim); font-size: var(--fs-10); }
+.ap-recent-row { display: flex; gap: 8px; align-items: flex-start; min-width: 0; }
+.ap-recent-body { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.ap-recent-top { min-width: 0; display: flex; flex-wrap: wrap; gap: 6px; color: var(--text-primary); font-size: var(--fs-11); }
+.ap-recent-sub { color: var(--text-dim); font-size: var(--fs-10); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ap-side-empty { color: var(--text-dim); font-size: var(--fs-12); padding: 8px 0; }
+
+@media (max-width: 720px) {
+  .ap-hist-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ap-history-item { flex-wrap: wrap; }
+  .ap-history-at { flex-basis: 100%; }
+}

--- a/dashboard/src/styles/keeper-v2/fusion.css
+++ b/dashboard/src/styles/keeper-v2/fusion.css
@@ -142,9 +142,21 @@
 
 .fus-claim, .fus-insight { padding: 8px 0; border-top: 1px solid var(--border-soft); }
 .fus-claim:first-of-type, .fus-insight:first-of-type { border-top: 0; padding-top: 0; }
-.fus-claim p, .fus-insight p { margin: 0 0 6px; font-size: 12.5px; color: var(--text-primary); line-height: 1.5; }
+.fus-claim p,
+.fus-insight p,
+.fus-claim-text,
+.fus-insight-text {
+  margin: 0 0 6px;
+  font-size: 12.5px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
 .fus-insight { display: flex; align-items: flex-start; gap: 10px; }
-.fus-insight p { flex: 1; margin: 0; }
+.fus-insight p,
+.fus-insight-text {
+  flex: 1;
+  margin: 0;
+}
 
 .fus-mchips { display: inline-flex; flex-wrap: wrap; gap: 4px; }
 .fus-mchip { font-size: var(--fs-9); color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 1px 6px; background: var(--bg-sunken); white-space: nowrap; }


### PR DESCRIPTION
## Summary

- Align the live HITL approvals surface with the Keeper Agent v2 reference:
  queue/history segmented view, read-only resolved history filters, HITL state aside, Always-rule evidence, and recent-resolution rail.
- Keep live approval semantics strict: only backed `approve`, `reject`, and `approve + remember rule` actions are rendered. Prototype-only defer/undo controls remain omitted because there is no live endpoint.
- Fix Fusion structured judge evidence wrappers so `RichContent` is not nested inside paragraph/inline-only elements, removing runtime Preact improper-nesting console errors.

## Validation

- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/approvals/approvals-surface.test.ts src/components/schedule/schedule-surface.test.ts src/components/schedule/schedule-agenda.test.ts src/components/fusion/fusion-surface.test.ts src/components/work.test.ts src/config/navigation.test.ts --no-file-parallelism --maxWorkers=1`
- Render smoke with Python Playwright against `http://127.0.0.1:5176/dashboard/`:
  desktop/mobile `#approvals`, `#schedule`, `#workspace`, `#fusion`; no page errors, no console errors, no failed responses, no page-level horizontal overflow.

## Screenshots

- `/private/tmp/masc-dashboard-v2-shots/desktop-approvals.png`
- `/private/tmp/masc-dashboard-v2-shots/mobile-approvals.png`
- `/private/tmp/masc-dashboard-v2-shots/desktop-schedule.png`
- `/private/tmp/masc-dashboard-v2-shots/mobile-schedule.png`
- `/private/tmp/masc-dashboard-v2-shots/desktop-workspace.png`
- `/private/tmp/masc-dashboard-v2-shots/mobile-workspace.png`
- `/private/tmp/masc-dashboard-v2-shots/desktop-fusion.png`
- `/private/tmp/masc-dashboard-v2-shots/mobile-fusion.png`
