### PR TITLE
refactor(dashboard): keeper 런타임 카드 read-only化 — 설정 모달이 runtime_id SSOT

### DIFF
--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -142,6 +142,15 @@ export type KeeperConfigControlInventoryItem = {
 
 const kcfTab = signal<KcfTabId>('identity')
 
+// Deep-link entry point: focus a specific config tab before the modal opens.
+// `kcfTab` is reset to 'identity' only on panel teardown (see
+// resetKeeperConfigPanelDrafts), never on mount, so a value set here survives the
+// next open. Used by the read-only runtime card (keeper-runtime-model-editor) to
+// land the operator on the 런타임 tab where runtime_id is actually edited.
+export function focusKeeperConfigTab(tab: KcfTabId): void {
+  kcfTab.value = tab
+}
+
 // ── State ────────────────────────────────────────────────
 
 const goalOptionsResource = createAsyncResource<GoalTreeNode[]>()

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -81,6 +81,9 @@ export interface KeeperDetailBodyProps {
   onPreserveToggle: (preserve: boolean) => void
   onClearSubmit: () => void
   onSocialSweep: () => void
+  // Deep-link the read-only runtime card to the 설정(.kcf) 런타임 tab (the single
+  // write path for runtime_id). Optional so isolated renders degrade gracefully.
+  onOpenRuntimeConfig?: () => void
 }
 
 export function KeeperDetailBody({
@@ -101,6 +104,7 @@ export function KeeperDetailBody({
   onPreserveToggle,
   onClearSubmit,
   onSocialSweep,
+  onOpenRuntimeConfig,
 }: KeeperDetailBodyProps) {
   return html`
     <div class="kw-detail-body mx-auto flex w-full max-w-[1180px] flex-col gap-5 v2-monitoring-surface">
@@ -191,8 +195,8 @@ export function KeeperDetailBody({
           title="진단 / 운영"
           defaultCollapsed=${true}
         >
-          ${'' /* ── 런타임 model 편집 (RFC-0207 persona runtime_id) — surfaced here so it is one expand away, not buried under 설정 → Keeper 설정 → 소스 ── */}
-          <${KeeperRuntimeModelEditor} keeperName=${keeper.name} />
+          ${'' /* ── 런타임 model (RFC-0207 persona runtime_id) — read-only card surfaced here one expand away; edits deep-link to the 설정(.kcf) 런타임 tab, the single write path ── */}
+          <${KeeperRuntimeModelEditor} keeperName=${keeper.name} onOpenRuntimeConfig=${onOpenRuntimeConfig} />
           <${KeeperToolTelemetry} keeperName=${keeper.name} />
           <${KeeperSecretProjectionPanel} keeperName=${keeper.name} projection=${compositeSnapshot?.secret_projection} />
           <${KeeperGithubAppConfigPanel} keeperName=${keeper.name} projection=${compositeSnapshot?.secret_projection} />

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -394,6 +394,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
           onPreserveToggle=${setPreserveSystemPrompt}
           onClearSubmit=${submitClearContext}
           onSocialSweep=${() => { void runSocialSweep() }}
+          onOpenRuntimeConfig=${() => openKeeperConfig()}
         />
       <//>
     </div>

--- a/dashboard/src/components/keeper-runtime-model-editor.test.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.test.ts
@@ -8,23 +8,26 @@ import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 const refs = vi.hoisted(() => ({
   config: null as unknown,
   status: 'loaded' as string,
-  patch: vi.fn(),
   providers: vi.fn(),
-  applied: vi.fn(),
   load: vi.fn(),
+  // Spy for the deep-link tab focus. The card is read-only; it no longer writes
+  // runtime_id — it only opens the config modal pre-focused on the 런타임 tab.
+  focusTab: vi.fn(),
 }))
 
-// Only [patchKeeperConfig] is exercised; the other two satisfy keeper-config-panel's
-// real module-level imports when [vi.importActual] loads it below.
+// [patchKeeperConfig] is no longer exercised by this card (the write path moved to
+// the config modal), but keeper-config-panel — loaded below via [vi.importActual] —
+// still imports it at module scope, so the mock must provide it.
 vi.mock('../api/dashboard', () => ({
-  patchKeeperConfig: refs.patch,
+  patchKeeperConfig: vi.fn(),
   fetchRuntimeProviders: refs.providers,
   fetchKeeperConfig: vi.fn(),
   fetchDashboardGoalsTree: vi.fn(),
 }))
 
-// Keep the real [InlineSelectRow] (via ...actual); override the shared-config
-// accessors so each test drives the loaded config directly.
+// Keep the real keeper-config-panel (via ...actual) so [keeperRuntimeConfigCanWrite]
+// gates on the driven config; override the shared-config accessors and the tab
+// focus so each test drives state directly and can assert the deep-link target.
 vi.mock('./keeper-config-panel', async () => {
   const actual = await vi.importActual<typeof import('./keeper-config-panel')>('./keeper-config-panel')
   return {
@@ -32,19 +35,19 @@ vi.mock('./keeper-config-panel', async () => {
     peekLoadedKeeperConfig: (_name: string) => refs.config as KeeperConfig | null,
     peekKeeperConfigLoadStatus: (_name: string) => refs.status as KeeperConfigLoadStatus,
     loadKeeperConfig: refs.load,
-    applyKeeperConfigUpdate: refs.applied,
+    focusKeeperConfigTab: refs.focusTab,
   }
 })
 
 vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
 
-import { KeeperRuntimeModelEditor, canEditRuntime, uniqueNonEmpty } from './keeper-runtime-model-editor'
+import { KeeperRuntimeModelEditor } from './keeper-runtime-model-editor'
 
 async function flush() {
   await new Promise(resolve => setTimeout(resolve, 0))
 }
 
-// Partial config carrying only the fields the editor reads. The single cast is
+// Partial config carrying only the fields the card reads. The single cast is
 // confined to this helper; the component never sees an untyped value.
 function makeConfig(
   execution: Partial<KeeperConfig['execution']> = {},
@@ -265,31 +268,7 @@ function makeRuntimeProvider(runtimeId: string, providerName: string, modelName:
   }
 }
 
-describe('uniqueNonEmpty', () => {
-  it('drops empties and dedupes, preserving first-seen order', () => {
-    expect(uniqueNonEmpty(['a.one', '', '  ', 'b.two', 'a.one', ' b.two '])).toEqual(['a.one', 'b.two'])
-  })
-
-  it('returns [] for all-empty input', () => {
-    expect(uniqueNonEmpty(['', '   '])).toEqual([])
-  })
-})
-
-describe('canEditRuntime', () => {
-  it('is true only for a toml source with a manifest path', () => {
-    expect(canEditRuntime(makeConfig({}, { default_source_kind: 'toml', default_manifest_path: '/x.toml' }))).toBe(true)
-  })
-
-  it('is false for a persona source', () => {
-    expect(canEditRuntime(makeConfig({}, { default_source_kind: 'persona', default_manifest_path: '/x.toml' }))).toBe(false)
-  })
-
-  it('is false when the toml manifest path is missing', () => {
-    expect(canEditRuntime(makeConfig({}, { default_source_kind: 'toml', default_manifest_path: null }))).toBe(false)
-  })
-})
-
-describe('KeeperRuntimeModelEditor', () => {
+describe('KeeperRuntimeModelEditor (read-only card)', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
@@ -297,7 +276,6 @@ describe('KeeperRuntimeModelEditor', () => {
     document.body.appendChild(container)
     refs.config = null
     refs.status = 'loaded'
-    refs.patch.mockReset()
     refs.providers.mockReset()
     refs.providers.mockResolvedValue({
       providers: [
@@ -305,8 +283,8 @@ describe('KeeperRuntimeModelEditor', () => {
         makeRuntimeProvider('b.two', 'Provider B', 'model-b'),
       ],
     })
-    refs.applied.mockReset()
     refs.load.mockReset()
+    refs.focusTab.mockReset()
   })
 
   afterEach(() => {
@@ -314,105 +292,83 @@ describe('KeeperRuntimeModelEditor', () => {
     container.remove()
   })
 
-  it('renders an editable model selector for a toml-sourced keeper', async () => {
-    refs.config = makeConfig({ selected_runtime_id: 'a.one', runtime_options: ['a.one', 'b.two'] })
-    render(html`<${KeeperRuntimeModelEditor} keeperName="editable-keeper" />`, container)
+  it('renders the current runtime + catalog summary read-only, with no editable <select>', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="editable-keeper" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
+    await flush()
     await flush()
 
+    // Regression guard: the duplicate write UI (a runtime <select> that patched
+    // runtime_id) must be gone. The config modal now owns the single write path.
+    expect(container.querySelector('select[aria-label="runtime"]')).toBeNull()
+    expect(Array.from(container.querySelectorAll('button')).some(b => b.textContent?.includes('저장'))).toBe(false)
+
+    // Still surfaces the current assignment + read-only catalog facts.
     expect(container.textContent).toContain('런타임')
     expect(container.textContent).toContain('a.one')
-    const select = container.querySelector('select[aria-label="runtime"]') as HTMLSelectElement | null
-    expect(select).not.toBeNull()
-    expect(select!.value).toBe('a.one')
-    await flush()
     expect(container.textContent).toContain('Provider A')
     expect(container.textContent).toContain('claude')
     expect(container.textContent).toContain('caps:declared')
-    expect(container.textContent).toContain('source:oas-provider-config-model')
-    expect(container.textContent).toContain('input:multimodal,image,audio')
-    expect(container.textContent).toContain('wire:chat-template-kwargs')
-    expect(container.textContent).toContain('reasoning-stream:delta-reasoning-field:reasoning_content')
-    expect(container.textContent).toContain('format:json,schema')
-    expect(container.textContent).toContain('prompt-cache@1024')
-    expect(container.textContent).toContain('declared')
     expect(container.textContent).toContain('api:chat-completions')
-    expect(container.textContent).toContain('behavior:inline-tools,keeper-bridge')
-    expect(container.textContent).toContain('match:claude-')
-    expect(container.textContent).toContain('concurrency:4')
-    expect(container.textContent).toContain('wire:responses.reasoning')
-    expect(container.textContent).toContain('tool-call-replay:required')
-    expect(container.textContent).toContain('responses-api')
-    expect(container.textContent).toContain('budget:4096')
   })
 
-  it('patches runtime_id with the selected runtime and updates shared config', async () => {
-    refs.config = makeConfig({ selected_runtime_id: 'a.one', runtime_options: ['a.one', 'b.two'] })
-    refs.patch.mockResolvedValueOnce(makeConfig({ selected_runtime_id: 'b.two', runtime_options: ['a.one', 'b.two'] }))
-
-    render(html`<${KeeperRuntimeModelEditor} keeperName="patch-keeper" />`, container)
+  it('deep-links to the 설정 런타임 tab: focuses runtime then invokes onOpenRuntimeConfig', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    const onOpen = vi.fn()
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="deeplink-keeper" onOpenRuntimeConfig=${onOpen} />`,
+      container,
+    )
     await flush()
 
-    const select = container.querySelector('select[aria-label="runtime"]') as HTMLSelectElement
-    select.value = 'b.two'
-    select.dispatchEvent(new Event('change', { bubbles: true }))
+    const link = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('설정에서 변경'),
+    )
+    expect(link).toBeTruthy()
+    link!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flush()
 
-    const saveButton = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('저장'))
-    expect(saveButton).toBeTruthy()
-    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await flush()
-    await flush()
-
-    expect(refs.patch).toHaveBeenCalledWith('patch-keeper', { runtime_id: 'b.two' })
-    expect(refs.applied).toHaveBeenCalledTimes(1)
+    // The card owns the tab target (런타임) and delegates opening to the host.
+    expect(refs.focusTab).toHaveBeenCalledWith('runtime')
+    expect(onOpen).toHaveBeenCalledTimes(1)
   })
 
-  it('does not patch when the selection equals the current value', async () => {
-    refs.config = makeConfig({ selected_runtime_id: 'a.one', runtime_options: ['a.one', 'b.two'] })
-    render(html`<${KeeperRuntimeModelEditor} keeperName="noop-keeper" />`, container)
+  it('hides the deep-link when no host wires onOpenRuntimeConfig (still read-only)', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    render(html`<${KeeperRuntimeModelEditor} keeperName="unwired-keeper" />`, container)
     await flush()
 
-    // No selection change → save button is disabled and patch is never called.
-    const saveButton = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('저장'))
-    expect((saveButton as HTMLButtonElement).disabled).toBe(true)
-    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await flush()
-    expect(refs.patch).not.toHaveBeenCalled()
+    expect(Array.from(container.querySelectorAll('button')).some(b =>
+      b.textContent?.includes('설정에서 변경'),
+    )).toBe(false)
+    // Content is still there — the card degrades to pure display.
+    expect(container.textContent).toContain('a.one')
+    expect(container.querySelector('select[aria-label="runtime"]')).toBeNull()
   })
 
-  it('shows an actionable read-only hint for a non-toml keeper', async () => {
+  it('shows an actionable read-only hint (no deep-link) for a non-toml keeper', async () => {
     refs.config = makeConfig({ selected_runtime_id: 'a.one' }, { default_source_kind: 'persona', default_manifest_path: null })
-    render(html`<${KeeperRuntimeModelEditor} keeperName="persona-keeper" />`, container)
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="persona-keeper" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
     await flush()
 
     expect(container.querySelector('select[aria-label="runtime"]')).toBeNull()
+    // Non-toml sources cannot be written from the config modal either, so the
+    // card explains the runtime.toml path instead of deep-linking.
     expect(container.textContent).toContain('편집 가능한 TOML 소스가 아니')
-    // Hint names the runtime assignment surface so the operator can unlock editing.
     expect(container.textContent).toContain('runtime.toml')
     expect(container.textContent).toContain('[runtime.assignments]')
+    expect(Array.from(container.querySelectorAll('button')).some(b =>
+      b.textContent?.includes('설정에서 변경'),
+    )).toBe(false)
+    // Catalog facts still render for observability.
     expect(container.textContent).toContain('caps:declared')
     expect(container.textContent).toContain('api:chat-completions')
-    expect(container.textContent).toContain('behavior:inline-tools,keeper-bridge')
-    expect(container.textContent).toContain('responses-api')
-  })
-
-  it('clears a pending selection when the viewed keeper changes', async () => {
-    refs.config = makeConfig({ selected_runtime_id: 'a.one', runtime_options: ['a.one', 'b.two'] })
-    render(html`<${KeeperRuntimeModelEditor} keeperName="keeper-alpha" />`, container)
-    await flush()
-
-    const select = container.querySelector('select[aria-label="runtime"]') as HTMLSelectElement
-    select.value = 'b.two'
-    select.dispatchEvent(new Event('change', { bubbles: true }))
-    await flush()
-    expect((container.querySelector('select[aria-label="runtime"]') as HTMLSelectElement).value).toBe('b.two')
-
-    // Navigate to a different keeper: the stale pending 'b.two' must not leak.
-    refs.config = makeConfig({ selected_runtime_id: 'c.three', runtime_options: ['c.three', 'b.two'] })
-    render(html`<${KeeperRuntimeModelEditor} keeperName="keeper-beta" />`, container)
-    await flush()
-
-    expect((container.querySelector('select[aria-label="runtime"]') as HTMLSelectElement).value).toBe('c.three')
   })
 
   it('renders a loading state until the config is available', async () => {

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -1,30 +1,31 @@
-// Keeper runtime editor — a prominent, one-expand-away card that lets an
-// operator change which runtime lane a keeper dispatches on.
+// Keeper runtime model card — a prominent, one-expand-away card that shows which
+// runtime lane a keeper dispatches on, at the top of the keeper detail's 진단/운영
+// section so it is discoverable without digging.
 //
 // RFC-0207: a keeper's runtime selection lives in a SINGLE surface —
-// runtime.toml [runtime.assignments]. The detailed view of that assignment is
-// buried under 설정 → Keeper 설정 → 소스. This card surfaces the same assignment
-// at the top of the keeper detail's 진단/운영 section so it is discoverable
-// without digging.
+// runtime.toml [runtime.assignments], edited through the 설정(.kcf) config modal's
+// 런타임 tab. This card is READ-ONLY: it surfaces the current assignment + catalog
+// facts and deep-links to the config modal for changes. It does NOT write.
 //
-// State is SHARED with keeper-config-panel via [configState]/[loadKeeperConfig]
-// (read) and [applyKeeperConfigUpdate] (write) so the two surfaces never show
-// divergent values for the same keeper. No second fetch, no drift.
+// History: runtime_id used to be editable here AND in the config modal — two
+// write paths for one field (both PATCH /config {runtime_id}) with two mirrored
+// edit gates kept in sync by hand. The write now lives only in the config modal,
+// so there is one SSOT, one edit gate (keeperRuntimeConfigCanWrite), and no drift.
+//
+// State is SHARED with keeper-config-panel via [loadKeeperConfig] /
+// [peekLoadedKeeperConfig] so the two surfaces never show divergent values for the
+// same keeper. No second fetch, no drift.
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
-import { patchKeeperConfig, type DashboardRuntimeProviderSnapshot } from '../api/dashboard'
-import type { KeeperConfig } from '../types'
+import type { DashboardRuntimeProviderSnapshot } from '../api/dashboard'
 import {
-  InlineSelectRow,
-  applyKeeperConfigUpdate,
+  focusKeeperConfigTab,
+  keeperRuntimeConfigCanWrite,
   loadKeeperConfig,
   peekKeeperConfigLoadStatus,
   peekLoadedKeeperConfig,
 } from './keeper-config-panel'
-import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
-import { BTN_FILLED_BASE } from './common/button-filled-base'
 import { MISSING_DATA_DASH } from '../lib/format-string'
 import { formatContextTokens } from '../lib/format-number'
 import {
@@ -39,38 +40,6 @@ import {
   runtimeCatalogRequestConfig,
   runtimeCatalogSnapshotFacts,
 } from '../lib/runtime-provider-summary'
-import { refreshKeeperRuntimeStatus } from '../store'
-
-// Pending dropdown selection before save. `null` = no pending change (show the
-// server's current value). Module-level singleton: at most one editor renders at
-// a time (one keeper detail page), mirroring keeper-config-panel's draft signals.
-const modelDraft = signal<string | null>(null)
-// Which keeper [modelDraft] belongs to. Guards against a stale pending selection
-// leaking across keeper navigation (A's dropdown choice showing up on B).
-const modelDraftKeeper = signal<string>('')
-const modelSaving = signal(false)
-
-/** Dedupe + drop empty, preserving first-seen order. */
-export function uniqueNonEmpty(values: readonly string[]): string[] {
-  const out: string[] = []
-  const seen = new Set<string>()
-  for (const raw of values) {
-    const v = raw.trim()
-    if (v === '' || seen.has(v)) continue
-    seen.add(v)
-    out.push(v)
-  }
-  return out
-}
-
-/**
- * Editable only when the keeper has a writable TOML-backed config source.
- * persona-only / generated keepers have no manifest to patch. Mirrors the
- * `runtimeCanEdit` gate in keeper-config-panel so the two surfaces agree.
- */
-export function canEditRuntime(c: KeeperConfig): boolean {
-  return c.sources.default_source_kind === 'toml' && Boolean(c.sources.default_manifest_path)
-}
 
 function RuntimeCapabilityPill({ label, value }: { label: string; value: boolean | undefined }) {
   const enabled = value === true
@@ -179,13 +148,17 @@ function EditorHeader() {
   `
 }
 
-export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string }) {
-  // Reset the pending selection whenever the viewed keeper changes.
-  if (modelDraftKeeper.value !== keeperName) {
-    if (modelDraft.value !== null) modelDraft.value = null
-    modelDraftKeeper.value = keeperName
-  }
-
+export function KeeperRuntimeModelEditor({
+  keeperName,
+  onOpenRuntimeConfig,
+}: {
+  keeperName: string
+  // Opens the 설정(.kcf) config modal for this keeper (the card pre-focuses the
+  // 런타임 tab, which owns the single write path for runtime_id). Optional so the
+  // card degrades to read-only display when no host wires it (e.g. isolated
+  // renders/tests); the deep-link button then hides.
+  onOpenRuntimeConfig?: () => void
+}) {
   // Lazy-load the shared config. This card only mounts when the 진단/운영
   // section is expanded; loadKeeperConfig dedupes by name internally.
   const status = peekKeeperConfigLoadStatus(keeperName)
@@ -202,32 +175,31 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
 
   const current = config.execution.selected_runtime_id.trim()
   const canonical = config.execution.selected_runtime_canonical.trim()
-  const effective = (modelDraft.value ?? current).trim()
-  const hasChange = modelDraft.value !== null && effective !== current
-  const isSaving = modelSaving.value
   loadRuntimeCatalog()
   const catalogState = runtimeCatalogState.value
   const catalog = catalogState.status === 'loaded' ? catalogState.data : []
-  const runtimeEntry = findRuntimeCatalogEntry(catalog, effective || current)
+  const runtimeEntry = findRuntimeCatalogEntry(catalog, current)
 
-  if (!canEditRuntime(config)) {
-    // Actionable read-only: explain WHY it is locked and HOW to unlock it, so
-    // the operator is not left at the same dead-end the card exists to fix.
+  const canonicalRow =
+    canonical && canonical !== current
+      ? html`<div class="text-2xs text-[var(--color-fg-muted)]">정규화: ${canonical}</div>`
+      : null
+  const summary = html`
+    <${RuntimeCatalogSummary} runtimeId=${current} entry=${runtimeEntry} status=${catalogState.status} />
+  `
+
+  if (!keeperRuntimeConfigCanWrite(config)) {
+    // Non-TOML source: the config modal cannot write this either, so there is no
+    // deep-link — explain WHY it is locked and HOW to unlock it via runtime.toml.
     const kind = config.sources.default_source_kind ?? 'unknown'
     return html`
       <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--color-border-default)]/60 bg-[var(--color-bg-surface)]/35 px-4 py-3">
         <${EditorHeader} />
         <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</div>
-        ${canonical && canonical !== current
-          ? html`<div class="text-2xs text-[var(--color-fg-muted)]">정규화: ${canonical}</div>`
-          : null}
-        <${RuntimeCatalogSummary}
-          runtimeId=${current}
-          entry=${findRuntimeCatalogEntry(catalog, current)}
-          status=${catalogState.status}
-        />
+        ${canonicalRow}
+        ${summary}
         <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-status-warn)]">
-          이 keeper는 편집 가능한 TOML 소스가 아니라(소스: ${kind}) 여기서 model을 바꿀 수 없습니다.
+          이 keeper는 편집 가능한 TOML 소스가 아니라(소스: ${kind}) model을 바꿀 수 없습니다.
           편집하려면 <code>.masc/config/runtime.toml</code> 의
           <code>[runtime.assignments]</code> 에 keeper 배정을 추가하고 서버를 재시작하세요.
         </div>
@@ -235,69 +207,31 @@ export function KeeperRuntimeModelEditor({ keeperName }: { keeperName: string })
     `
   }
 
-  const options = uniqueNonEmpty([
-    effective,
-    current,
-    canonical,
-    ...config.execution.runtime_options,
-  ])
-
-  async function save() {
-    const next = (modelDraft.value ?? '').trim()
-    if (next === '' || next === current) return
-    modelSaving.value = true
-    try {
-      const updated = await patchKeeperConfig(keeperName, { runtime_id: next })
-      applyKeeperConfigUpdate(keeperName, updated)
-      void refreshKeeperRuntimeStatus().catch(err => {
-        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
-        showToast(message, 'warning')
-      })
-      modelDraft.value = null
-      showToast('런타임 저장 완료', 'success')
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : '저장 실패', 'error')
-    } finally {
-      modelSaving.value = false
-    }
-  }
-
-  function reset() {
-    modelDraft.value = null
-  }
-
+  // TOML-backed: read-only display + deep-link to the 설정(.kcf) 런타임 tab, which
+  // owns the single write path for runtime_id.
   return html`
     <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-4 py-3">
       <${EditorHeader} />
       <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</span></div>
-      <${InlineSelectRow}
-        label="runtime"
-        value=${effective}
-        options=${options}
-        onChange=${(value: string) => { modelDraft.value = value }}
-      />
-      <${RuntimeCatalogSummary}
-        runtimeId=${effective}
-        entry=${runtimeEntry}
-        status=${catalogState.status}
-      />
-      <div class="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)]"
-          onClick=${save}
-          disabled=${!hasChange || isSaving}
-        >${isSaving ? '저장 중...' : '저장'}</button>
-        <button
-          type="button"
-          class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
-          onClick=${reset}
-          disabled=${!hasChange || isSaving}
-        >되돌리기</button>
-        ${hasChange
-          ? html`<span class="text-2xs text-[var(--color-fg-muted)]">저장 시 runtime.toml assignment 갱신</span>`
-          : null}
-      </div>
+      ${canonicalRow}
+      ${summary}
+      ${onOpenRuntimeConfig
+        ? html`
+            <div class="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--color-bg-surface)] px-3 py-1 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--color-bg-hover)] cursor-pointer v2-monitoring-action"
+                onClick=${() => {
+                  // Pre-focus the 런타임 tab before the modal opens; kcfTab is not
+                  // reset on mount, so this value survives the open.
+                  focusKeeperConfigTab('runtime')
+                  onOpenRuntimeConfig()
+                }}
+              >설정에서 변경 ↗</button>
+              <span class="text-2xs text-[var(--color-fg-muted)]">런타임 배정은 설정 → 런타임에서 편집합니다</span>
+            </div>
+          `
+        : null}
     </div>
   `
 }


### PR DESCRIPTION
## 목표

Keeper 상세에서 런타임 모델(`runtime_id`) 편집이 **운영 상세**와 **설정(.kcf) 모달** 두 곳에 중복 존재하던 것을 통합합니다. 설정 모달을 유일한 편집(SSOT)으로 두고, 운영 상세의 카드는 읽기전용 + "설정에서 변경" 딥링크로 강등합니다.

## 배경 (중복 근거)

- 두 표면이 같은 필드를 같은 엔드포인트(`PATCH /api/v1/keepers/:name/config {runtime_id}`)로 **둘 다 쓰기**했습니다.
  - 설정 모달: `InlineSelectRow` → `saveRuntimeConfig`
  - 운영 상세: `KeeperRuntimeModelEditor`의 `<select>` + 저장 버튼
- 편집 게이트가 두 벌(`canEditRuntime` / `keeperRuntimeConfigCanWrite`)로 **손으로 동기화** — 편집기 주석이 `Mirrors ... so the two surfaces agree`로 자백.
- 중복 조사 매트릭스: 두 표면 각 항목 중 하드 중복은 `runtime_id` 1건. 나머지(프롬프트 어셈블리 / tool allowlist / runtime drift)는 읽기전용 소프트 오버랩이라 쓰기 충돌 없음.

## 변경

- `keeper-runtime-model-editor.ts` — write path 제거(`modelDraft` / `save` / `InlineSelectRow` / `patchKeeperConfig`), 미러 게이트 `canEditRuntime` 삭제 → config-panel의 `keeperRuntimeConfigCanWrite` 재사용. 읽기전용 표시(현재 런타임 + 카탈로그 요약) + "설정에서 변경 ↗" 딥링크.
- `keeper-config-panel.ts` — `focusKeeperConfigTab(tab)` export. `kcfTab`은 teardown에서만 리셋되므로 open 직전 포커스가 유지됨.
- `keeper-detail-body.ts` / `keeper-detail-page.ts` — `onOpenRuntimeConfig` prop threading (KeeperDetailContent → KeeperDetailBody → 카드).
- non-toml keeper는 기존 읽기전용 안내 유지(설정 모달도 쓰기 불가).

## 검증

- 로컬 `tsc --noEmit` 0 에러, eslint 0 에러.
- vitest: 편집기 테스트 5/5 — 읽기전용 렌더 / 딥링크 타깃(`focusKeeperConfigTab('runtime')` + `onOpenRuntimeConfig`) / **런타임 `<select>` 부재 회귀가드**. 인접(config-panel / detail / detail-page) 97/97.
- 딥링크 착지: reset 핸들러는 keeper 전환 시에만 발화(`loadKeeperConfig`의 `configKeeperName !== name`). 동일 keeper 설정 open은 early-return이라 `kcfTab='runtime'` 생존.

## 남은 미검증 / 후속

- export명 `KeeperRuntimeModelEditor`는 read-only가 됐지만 blast radius 최소화를 위해 유지(후속 rename 후보: `KeeperRuntimeModelCard`).
- CI의 dune/전체 vitest 결과.

## 설계 노트

워크어라운드를 추가하지 않습니다. 중복 write 경로 하나를 **제거**하여 SSOT를 확립합니다(net −96 lines). counter / cap / string 분류기 / N-of-M 패치 없음.

RFC-WAIVED: dashboard 런타임 카드 UI 통합. credential/identity/operator/keeper-sandbox/dashboard-credential/hooks/workflow 어느 gated subsystem에도 해당하지 않음 (runtime 모델 카드 read-only화 + config SSOT).
