### PR TITLE
fix(exec): gh capability disposition을 flag-robust하게 (typed subcommand, #23599)

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -660,7 +660,18 @@ let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
       Exec_program.to_string simple.Shell_ir.bin
       :: List.map arg_word simple.Shell_ir.args
     in
-    let verb = Gh_verb.classify words in
+    (* Flag-robust verb (RFC-0309 W3, #23599): the typed lowering locates the
+       subcommand past leading value-taking global flags, so [gh --repo O/R pr
+       view] is read as [Pr/view] (Allowed) rather than [Gh_verb.Other] (Ask).
+       Falls back to the word-list [Gh_verb.classify] only for the [Generic]
+       escape hatch (non-literal argv), preserving prior behavior there. The
+       typed parser preserves the [Api]/[gh api graphql] identity, so the graphql
+       opacity fail-closed below still fires (RFC-0208). *)
+    let verb =
+      match Shell_ir_risk.gh_verb_of_simple simple with
+      | Some v -> v
+      | None -> Gh_verb.classify words
+    in
     if is_graphql_api verb && graphql_query_body_is_opaque simple.Shell_ir.args
     then Some Requires_approval
     else Some (disposition_of_words words verb))

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -728,6 +728,28 @@ let gh_verb_class_to_string = function
   | Gh_string_borne -> "string-borne (word-list floor)"
   | Gh_unrecognized_family -> "unrecognized family (fail-closed)"
 
+(* Flag-robust gh verb identity for the capability axis (RFC-0309 W3, #23599).
+   The word-list [Gh_verb.classify] reads a leading value-taking global flag's
+   value as the subcommand ([gh --repo O/R pr view] -> [Gh_verb.Other "O/R"]),
+   which routes reversible reads/mutations to [Requires_approval]. The typed
+   lowering ([Shell_ir_typed.of_simple], whose gh parser consumes gh global
+   value-flags exactly like gh) locates the real subcommand/action, so this is
+   the same source the enforcement floor ([repo_hosting_cli_floor_risk]) already
+   trusts — the risk and capability axes cannot disagree on the subcommand.
+
+   [None] when the command does not lower to a typed [Gh] (the [Generic] escape
+   hatch for non-literal argv, e.g. [gh $CMD]); the caller then keeps its
+   word-list fallback, preserving today's behavior for that case. The [Api]
+   family is preserved by the typed parser ([gh api graphql] lowers to
+   [subcommand="api"; action="graphql"], including the leading-flag form), so the
+   caller's [gh api graphql] opacity fail-closed (RFC-0208) is not weakened. *)
+let gh_verb_of_simple (simple : Shell_ir.simple) : Gh_verb.t option =
+  match Shell_ir_typed.of_simple simple with
+  | Shell_ir_typed.W (Shell_ir_typed_types.Gh { subcommand; action; _ }) ->
+    Some (Gh_verb.of_fields ~subcommand ~action)
+  | Shell_ir_typed.W _ -> None
+[@@warning "-4"]
+
 (* --- Stage-word extraction (local copy; dependency direction prevents
     reference to Exec_policy_mutation_classifier in the top-level lib). --- *)
 

--- a/lib/exec/shell_ir_risk.mli
+++ b/lib/exec/shell_ir_risk.mli
@@ -142,6 +142,17 @@ val risk_of_gh_verb : Gh_verb.t -> risk_class
     axis (an unrecognized action's reversibility is genuinely unknown — the
     capability axis, not risk, gates it). Never returns [Destructive_protected]. *)
 
+val gh_verb_of_simple : Shell_ir.simple -> Gh_verb.t option
+(** Flag-robust gh verb identity from the typed lowering ([Shell_ir_typed]),
+    used by the capability axis ([Gh_capability_policy.disposition_of_simple]) so
+    a leading value-taking global flag ([gh --repo O/R pr view]) does not shadow
+    the real subcommand as the word-list [Gh_verb.classify] does. [None] when the
+    command does not lower to a typed [Gh] (the [Generic] escape hatch for
+    non-literal argv); the caller keeps its word-list fallback. Shares the
+    subcommand-location logic the enforcement floor already trusts, and preserves
+    the [Api]/[gh api graphql] identity so the caller's RFC-0208 graphql opacity
+    fail-closed is not weakened. *)
+
 val gh_api_graphql_creates_durable_remote : string list -> bool
 (** True when [words] is a [gh api graphql ...] invocation whose (comment-
     stripped) body contains a durable-remote repository/discussion create/mutate

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -415,15 +415,13 @@ let test_gh_pr_ready_allowed_under_autonomous () =
     ; "gh pr ready 123 --repo o/r", [ "pr"; "ready"; "123"; "--repo"; "o/r" ]
     ]
 
-(* Documents a KNOWN residual asymmetry, not an endorsement: the disposition
-   axis ([Gh_capability_policy.disposition_of_simple]) locates the gh subcommand
-   with the word-list [Gh_verb.classify], which reads a leading value-taking
-   global flag's value ("o/r") as the subcommand -> [Gh_verb.Other] ->
-   [Requires_approval] -> [Ask]. The risk floor is already flag-robust (typed
-   lowering), so this is strictly better than the prior [Deny] and non-blocking.
-   The floor-aligned fix (a flag-robust verb extractor shared with the floor)
-   is tracked as a follow-up; when it lands, this expectation flips to [Allow]. *)
-let test_gh_pr_ready_leading_flag_asks_under_autonomous () =
+(* RFC-0309 W3 (#23599 fix): the disposition axis now locates the gh subcommand
+   with the flag-robust typed lowering ([Shell_ir_risk.gh_verb_of_simple]), so a
+   leading value-taking global flag no longer shadows the subcommand as the
+   word-list [Gh_verb.classify] did. [gh --repo O/R pr ready] reads as [Pr/ready]
+   -> Allowed, matching the plain and trailing-flag forms. (Before #23599 this
+   asked; before #23597 it was denied.) *)
+let test_gh_pr_ready_leading_flag_allowed_under_autonomous () =
   let s =
     simple (bin_ok "gh")
       ~args:(List.map lit [ "--repo"; "o/r"; "pr"; "ready"; "123" ])
@@ -433,10 +431,55 @@ let test_gh_pr_ready_leading_flag_asks_under_autonomous () =
     Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps
       ~simple:s
   with
+  | Verdict.Allow t ->
+    assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
+  | _ ->
+    Alcotest.fail
+      "leading-flag gh pr ready must be allowed after the #23599 flag-robust fix"
+
+(* #23599: leading-flag reads must not be over-gated. Before the fix
+   [gh --repo O/R pr view] -> [Gh_verb.Other] -> [Ask]; now it reads as a known
+   read and is Allowed like the plain form. *)
+let test_gh_leading_flag_read_allowed_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Allow t ->
+         assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
+       | _ ->
+         Alcotest.failf "%s: leading-flag gh read must be allowed" label)
+    [ "gh --repo o/r pr view 123", [ "--repo"; "o/r"; "pr"; "view"; "123" ]
+    ; "gh --repo o/r pr list", [ "--repo"; "o/r"; "pr"; "list" ]
+    ]
+
+(* #23599 fail-closed preservation: making the disposition flag-robust must NOT
+   weaken the RFC-0208 graphql boundary. A leading-flag literal durable-remote
+   graphql mutation still reaches the capability Ask, because the typed lowering
+   preserves the [Api]/[graphql] identity (subcommand="api", action="graphql")
+   and the durable-remote body scan runs on the argv words. *)
+let test_gh_leading_flag_graphql_durable_remote_asks_under_autonomous () =
+  let s =
+    simple (bin_ok "gh")
+      ~args:
+        (List.map lit
+           [ "--repo"; "o/r"; "api"; "graphql"; "-f"
+           ; "query=mutation{createRepository}"
+           ])
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps
+      ~simple:s
+  with
   | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
   | _ ->
     Alcotest.fail
-      "leading-flag gh pr ready currently asks (known disposition asymmetry)"
+      "leading-flag durable-remote graphql must still ask (fail-closed preserved)"
 
 (* Issue #23390 regression: a leading value-taking global flag ([gh --repo o/r
    pr merge]) must not slip the destructive op past the floor. gh (Cobra)
@@ -459,7 +502,7 @@ let test_gh_leading_flag_destructive_floored_under_autonomous () =
     [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
       (* [pr ready] moved off this floor (RFC-0309 W4/G-9: reversible via --undo);
          its leading-flag disposition is covered by
-         [test_gh_pr_ready_leading_flag_asks_under_autonomous]. *)
+         [test_gh_pr_ready_leading_flag_allowed_under_autonomous]. *)
     ; "gh --repo o/r repo delete"
       , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
     ]
@@ -940,7 +983,9 @@ let () =
   test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
   test_gh_pr_ready_allowed_under_autonomous ();
-  test_gh_pr_ready_leading_flag_asks_under_autonomous ();
+  test_gh_pr_ready_leading_flag_allowed_under_autonomous ();
+  test_gh_leading_flag_read_allowed_under_autonomous ();
+  test_gh_leading_flag_graphql_durable_remote_asks_under_autonomous ();
   test_gh_leading_flag_destructive_floored_under_autonomous ();
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();


### PR DESCRIPTION
## 목적

keeper의 gh 명령이 **leading global value-flag**를 쓸 때 capability disposition 축이 subcommand를 오독해 과잉 게이팅되던 문제를 근본 교정합니다 (#23599). `#23597`(gh pr ready reversible)에서 발견해 pin으로 남긴 축 비대칭을 닫습니다.

## 근본 원인

`Gh_capability_policy.disposition_of_simple`이 subcommand를 word-list `Gh_verb.classify`(drop_flags)로 찾습니다. 이 방식은 leading value-flag의 **값**을 subcommand로 오독합니다:

```
gh <flag> OWNER pr view   -> classify: subcommand="OWNER" -> Gh_verb.Other -> Requires_approval -> Ask
```

즉 leading-flag를 쓴 **모든 gh 명령**(단순 read 포함)이 HITL 큐로 과잉 라우팅됐습니다. risk floor(`repo_hosting_cli_floor_risk`)는 이미 typed lowering으로 flag-robust인데 capability 축만 뒤처진 **축 비대칭**입니다.

## 변경

- `Shell_ir_risk.gh_verb_of_simple` 신설: floor가 이미 신뢰하는 typed lowering(`Shell_ir_typed.of_simple`, gh 파서가 global value-flag를 gh와 동일하게 소비)으로 gh verb를 도출. 두 축이 동일 subcommand를 읽습니다.
- `disposition_of_simple`이 이를 사용, Generic escape hatch(비-literal argv)만 word-list fallback.

## fail-closed 보존 (RFC-0208) — 소스 실측 검증

가장 중요한 안전 요건: graphql opacity fail-closed가 약화되면 안 됩니다. `bin/gen_shell_ir_walkers.ml`(gh 파서, 4141-4256행)을 직접 확인했습니다 — gh 파서가 `--repo`/`-R`/`--hostname` 등 global value-flag를 소비(4236-4242행)한 뒤 첫 non-flag=subcommand, 둘째=action. 따라서 `gh api graphql`은 leading-flag 포함 항상 `{subcommand="api", action="graphql"}`로 lowering → `is_graphql_api` true 유지 → opacity 검사 발동. 게다가 opacity 검사는 `simple.args`를 직접 보므로 verb 도출 방식과 무관합니다.

## 결과 (autonomous overlay)

| 명령 | 이전 | 이후 |
|---|---|---|
| leading-flag gh reads (`... pr view/list`) | Ask | **Allow** |
| leading-flag `gh ... pr ready` | Ask (#23597 pin) | **Allow** |
| leading-flag 리터럴 durable-remote graphql | Ask | **Ask** (fail-closed 보존) |
| leading-flag `pr merge` / `repo delete` | Deny | Deny (불변, floor) |
| opaque graphql query (기존 테스트) | Requires_approval | Requires_approval (불변) |

## 테스트

- leading-flag `pr ready` Allowed, leading-flag reads Allowed, leading-flag durable-remote graphql 여전히 Ask.
- 기존 `test_graphql_opaque_query_simple`(RFC-0208) 전 케이스 케이스별로 추적해 불변 확인 — opacity 검사가 verb-무관(`simple.args` 직접)이라 두 경로(typed/fallback) 모두 동일 판정.
- `#23597`의 leading-flag Ask pin을 Allow로 뒤집음(그 테스트 주석이 예고한 대로).
- 4파일 ocamlformat 통과. full build/test는 CI.

## RFC

Governing RFC: RFC-0309 (typed gh capability gating) W3. 신규 RFC 불필요.

Closes #23599

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
