### PR TITLE
fix(workspace): repair submit verification remediation pattern

### DIFF
--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -219,7 +219,7 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
-              | Masc_domain.Submit_for_verification, _
+              | _, Masc_domain.Submit_for_verification
                 when String.length (String.trim notes) = 0 ->
                 " Remediation: submit_for_verification requires non-empty notes \
                  describing the deliverable. Provide a summary of what was done \


### PR DESCRIPTION
## Summary
- fix the submit_for_verification remediation pattern to match on the action slot, not task_status
- unblock current main CI compile failures in workspace_task_transitions.ml

## Verification
- git diff --check
- ocamlformat --check lib/workspace/workspace_task_transitions.ml
- local dune build intentionally not run; CI is the build authority for this repo