### PR TITLE
fix(workspace): main red — Submit_for_verification 튜플 위치 오타 교정 (#23598 회귀)

### DIFF
--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -219,7 +219,7 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
-              | Masc_domain.Submit_for_verification, _
+              | _, Masc_domain.Submit_for_verification
                 when String.length (String.trim notes) = 0 ->
                 " Remediation: submit_for_verification requires non-empty notes \
                  describing the deliverable. Provide a summary of what was done \


### PR DESCRIPTION
## 문제

main이 Build and Test compile error로 red다. `#23598`(2b568cebd6, merge-before-green)가 `workspace_task_transitions.ml`의 transition-remediation match에 arm을 추가하면서 **튜플 위치를 틀렸다**.

이 match의 scrutinee는 `(task_status, task_action)`다:

```
| (Masc_domain.Claimed _ | Masc_domain.InProgress _), Masc_domain.Submit_for_verification  (* line 205: status, action — 올바름 *)
    when not own_assignee -> ...
| Masc_domain.Submit_for_verification, _                                                    (* line 222: action이 status 자리 — 타입 오류 *)
    when String.length (String.trim notes) = 0 -> ...
```

line 222는 `Submit_for_verification`(= `task_action` 생성자)를 첫(= `task_status`) 자리에 놓아 컴파일러가 거부한다:

```
Error: The constructor Masc_domain.Submit_for_verification
       belongs to the variant type Masc_domain.task_action = Types_core.task_action
       but a constructor was expected belonging to [task_status]
```

## 변경

action을 두 번째 자리로 옮긴다 (sibling arm line 205와 remediation 텍스트가 가리키는 의도):

```
| _, Masc_domain.Submit_for_verification when notes empty -> ...
```

- `Done _, _` / `Cancelled _, _` arm이 line 222보다 앞에 있어 terminal 상태는 이미 소진 → `_, Submit_for_verification`이 나머지(Claimed/InProgress with own_assignee=true) + 빈 notes를 정확히 잡는다.
- 순수 위치 교정. 로직/동작 변화 없음.

## 검증

- `dune build --root . lib/workspace` green (에러 해소)
- ocamlformat clean

근본: merge-before-green (RFC-0316 게이팅 대상). 이 hotfix는 컴파일만 복구한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
