### PR TITLE
fix(workspace): submit_for_verification match 위치 교정 (main 컴파일 붕괴 해소)

### DIFF
--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -219,7 +219,7 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
-              | Masc_domain.Submit_for_verification, _
+              | _, Masc_domain.Submit_for_verification
                 when String.length (String.trim notes) = 0 ->
                 " Remediation: submit_for_verification requires non-empty notes \
                  describing the deliverable. Provide a summary of what was done \


### PR DESCRIPTION
## 증상

`#23598`(2b568cebd6) 머지 이후 **main이 컴파일 붕괴** — Build 스텝이 다음으로 실패:

```
File "lib/workspace/workspace_task_transitions.ml", line 222:
Error: The constructor Masc_domain.Submit_for_verification
       belongs to the variant type task_action
       but a constructor was expected belonging to task_status
```

이후 머지된 모든 PR(#23603, #23610 등)이 이 붕괴를 상속해 Build 실패. main이 배포 불가 상태.

## 근본 원인

`transition_task_outcome_r`의 remediation match는 `(task_status, task_action)` 튜플입니다. #23598이 추가한 arm이 `Masc_domain.Submit_for_verification`(task_**action**)를 **첫째 슬롯(task_status 자리)** 에 뒀습니다:

```ocaml
| Masc_domain.Submit_for_verification, _   (* ← action in status slot *)
  when String.length (String.trim notes) = 0 -> ...
```

같은 PR이 추가한 위 형제 arm은 올바르게 둘째 슬롯을 씁니다: `(Claimed|InProgress), Submit_for_verification`.

## 수정

빈-notes 가드는 **action이 submit_for_verification일 때** 발동해야 하므로, 생성자를 둘째 슬롯으로 이동:

```ocaml
| _, Masc_domain.Submit_for_verification
  when String.length (String.trim notes) = 0 -> ...
```

`Done _, _`/`Cancelled _, _` status arm 뒤 위치를 유지해 terminal-state 메시지가 우선합니다. 컴파일되고 의도한 arm이 매칭되는 것 외 동작 변화 없음. ocamlformat 통과.

RFC-WAIVED: 1줄 컴파일 오류 교정(변형 위치 스왑), 아키텍처 변경 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
