### PR TITLE
fix(dashboard): roster ⋮ hidden until hover (v2 mock fidelity)

### DIFF
--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -438,6 +438,7 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     // where hover is unavailable.
     expect(baseRuleDecls('.kw-kp-more').opacity).toBe('0')
     expect(baseRuleDecls('.kw-kp-row:hover .kw-kp-more').opacity).toBe('1')
+    expect(baseRuleDecls('.kw-kp-row:focus-within .kw-kp-more').opacity).toBe('1')
     expect(mobileRuleDecls('.kw-kp-more').opacity).toBe('1')
   })
 

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -432,6 +432,15 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(mobileRuleDecls('.kw-kp-menu')['max-width']).toContain('env(safe-area-inset-right, 0px)')
   })
 
+  it('hides the roster ⋮ action until hover/focus on desktop, keeps it for touch', () => {
+    // v2 mock (.kp-more) is opacity:0 at rest and reveals on row hover/focus, so
+    // the card reads as identity + status. The 860px block restores it for touch
+    // where hover is unavailable.
+    expect(baseRuleDecls('.kw-kp-more').opacity).toBe('0')
+    expect(baseRuleDecls('.kw-kp-row:hover .kw-kp-more').opacity).toBe('1')
+    expect(mobileRuleDecls('.kw-kp-more').opacity).toBe('1')
+  })
+
   it('keeps the mobile context drawer close to the v2 rail without prototype-local state', () => {
     expect(keeperWorkspaceRailSource).toContain('keeper.context_ratio')
     expect(keeperWorkspaceRailSource).toContain('tasks.value.filter')

--- a/dashboard/src/styles/keeper-workspace-v23.test.ts
+++ b/dashboard/src/styles/keeper-workspace-v23.test.ts
@@ -36,12 +36,16 @@ describe('keeper-workspace v2.3 fleet surface CSS', () => {
     expect(rightRail['align-items']).toBe('flex-end')
   })
 
-  it('keeps roster rows to one always discoverable command target', () => {
+  it('keeps roster rows to one hover/focus command target', () => {
     const menuButton = baseDeclarationsForSelector('.kw-kp-more')
+    const hoverButton = baseDeclarationsForSelector('.kw-kp-row:hover .kw-kp-more')
+    const focusButton = baseDeclarationsForSelector('.kw-kp-row:focus-within .kw-kp-more')
 
     expect(menuButton.position).toBe('absolute')
-    expect(menuButton.opacity).toBe('0.72')
+    expect(menuButton.opacity).toBe('0')
     expect(menuButton.width).toBe('26px')
+    expect(hoverButton.opacity).toBe('1')
+    expect(focusButton.opacity).toBe('1')
     expect(css).not.toContain('.kw-kp-chat')
     expect(css).not.toContain('.kw-kp-inline-actions')
     expect(css).not.toContain('.kw-kp-inline-action')

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -456,7 +456,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   justify-content: center;
   padding: 0;
   transform: translateY(-50%);
-  opacity: 0.72;
+  /* v2 mock (.kp-more) keeps the ⋮ hidden until the row is hovered/focused so
+     the roster reads as identity + status; the row:hover / :focus-within rule
+     below reveals it. The 860px block keeps it always visible for touch. */
+  opacity: 0;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-panel-alt);


### PR DESCRIPTION
## 목적

디자인 충실도 사이클 — 확정된 로스터 델타 #6. 목업은 카드의 overflow(⋮) 컨트롤을 opacity:0로 두고 row hover/focus 시에만 노출해 카드를 정체성+상태로 읽히게 한다. 라이브는 0.72로 모든 카드에 ⋮ 상시 노출.

## 실측 (CSSOM ground truth)

| | 목업 `.kp-more` | 라이브 `.kw-kp-more` |
|---|---|---|
| opacity (rest) | **0** | **0.72** |
| hover | reveal | reveal |

## 변경

- 데스크톱 `.kw-kp-more` opacity 0.72 → **0**. 기존 `.kw-kp-row:hover/:focus-within .kw-kp-more { opacity: 1 }`가 hover·키보드 포커스 노출 처리, `@media (max-width:860px)` 블록이 터치용 opacity:1 유지(hover 불가 환경).
- 드리프트 가드 추가: 데스크톱 숨김 / hover 노출 / 터치 노출 계약.

## 검증

- `keeper-workspace-mobile.test.ts` 19 green (신규 케이스 포함)
- dev 서버 캡처: 정지 상태 카드에서 ⋮ 사라짐 확인

## 참고

독립 PR #23611(카드 밀도: ctx/tool 제거+간결시간)과 병행. 둘 다 머지되면 로스터가 목업의 깔끔한 2행 카드 + hover-kebab로 수렴.

## 미검증

- 없음 (CSS 계약 테스트 + 시각 확인). CI Dashboard job이 최종 판정.