### PR TITLE
feat(exec): gh pr merge를 Ask(Requires_approval)로 — deny floor에서 제거 (운영자 결정)

### DIFF
--- a/docs/rfc/RFC-0309-typed-gh-capability-gating.md
+++ b/docs/rfc/RFC-0309-typed-gh-capability-gating.md
@@ -243,21 +243,27 @@ say approval enables the action.
 
 ### 3.5 What #23362 got right and keeps
 
-The genuine irreversibles stay floored exactly as before: `pr merge`,
+The genuine irreversibles stay floored exactly as before:
 `repo delete/archive/transfer/rename`, `release delete`, `secret delete`,
 `gh api -X DELETE`, `delete*` graphql mutations, `discussion delete`. The
-catastrophic floor (`Deny`) remains trust-independent. This RFC widens the
-space *between* Allow and Deny; it does not soften Deny.
+catastrophic floor (`Deny`) remains trust-independent for these. This RFC widens
+the space *between* Allow and Deny; for these ops it does not soften Deny.
 
-> **W4/G-9 follow-up (`pr ready` reclassified):** `pr ready` was originally
-> listed here alongside `pr merge`, but it toggles a PR between draft and
-> ready-for-review and is reversible via `gh pr ready --undo`. Its CI/notification
-> side-effects are an externality shared with `pr create` (already Allowed on the
-> capability axis), not a reversibility fact — the same policy-as-risk conflation
-> W4/G-9 closed for repo create/fork/discussion. It now classifies R1 in
-> `repo_hosting_cli_reversible_mutations` and, on the non-durable `Pr` family, the
-> capability axis leaves it `Allowed`. The `test_shell_ir_gh_capability_baseline`
-> corpus and `test_gh_capability_policy` dispositions were updated to match.
+> **W4/G-9 follow-up — `pr ready` and `pr merge` reclassified:** both were
+> originally floored here. `pr ready` toggles a PR between draft and
+> ready-for-review and is reversible via `gh pr ready --undo`; `pr merge` writes
+> the base branch but is reversible via `git revert` (the tree is restored,
+> exactly as a created repo can be deleted). Their high-stakes nature —
+> CI/notifications for `ready`, base-branch/deploy effects for `merge` — is a
+> durable-remote *externality* on the capability axis, not a reversibility fact
+> (the same policy-as-risk conflation W4/G-9 closed for repo
+> create/fork/discussion). Both now classify R1 in
+> `repo_hosting_cli_reversible_mutations`. On the capability axis `pr ready` (not
+> a durable-remote surface) stays `Allowed`, while `pr merge` (writes the shared
+> base branch, `creates_durable_remote_surface`) is `Requires_approval` — routed
+> to non-blocking human approval, mirroring `gh repo create` (2026-07-08 operator
+> decision: merge asks, not denies). The baseline corpus, `test_gh_capability_policy`
+> dispositions, and the destructive-floor regression tests were updated to match.
 
 ---
 

--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -342,11 +342,10 @@ let ask_of policy ~caps ~bin : Verdict.t =
    risk and to the overlay: a gh verb whose [Gh_capability_policy.disposition]
    is [Requires_approval] produces [Ask] even under the autonomous (all-Observe)
    overlay, because the non-blocking HITL queue is the resolver the overlay
-   comment (approval_config.ml) said did not exist. [Allowed]/[Denied] verbs are
-   left to the existing risk grading ([Denied] verbs are R2/Destructive, already
-   floored or Ask-graded; [Allowed] verbs fall through to the overlay), so this
-   layer only ADDS an approval requirement, never removes one. Non-gh commands
-   are unaffected. *)
+   comment (approval_config.ml) said did not exist. [Allowed] verbs fall through
+   to the existing risk grading. [Denied] gh capability rules are handled by
+   [gh_capability_policy_deny_rule] before this approval path, so they cannot
+   fall through to the autonomous overlay. Non-gh commands are unaffected. *)
 let gh_capability_of_simple (simple : Shell_ir.simple)
   : Gh_capability_policy.disposition option
   =
@@ -358,7 +357,7 @@ let gh_capability_of_simple (simple : Shell_ir.simple)
 let gh_capability_policy_deny_rule_of_simple (simple : Shell_ir.simple)
   : string option
   =
-  Gh_capability_policy.repo_create_contract_rule_of_simple simple
+  Gh_capability_policy.policy_deny_rule_of_simple simple
 
 let gh_capability_policy_deny_rule (caps : Capability.t list) : string option =
   let rec scan = function

--- a/lib/exec/approval_policy.mli
+++ b/lib/exec/approval_policy.mli
@@ -30,19 +30,21 @@ val decide :
        - any [Destructive] git op → [Deny Destructive_git];
        - a redirect [Write_path] whose scope is [Outside_workspace] or
          [Absolute_unknown] → [Deny Path_escape];
-       - an irreversible repository-hosting CLI operation ([gh pr merge],
-         [gh repo delete], [gh api -X DELETE]) → [Deny
+       - an irreversible repository-hosting CLI operation ([gh repo delete],
+         [gh api -X DELETE]) → [Deny
          Destructive_repo_hosting_cli];
        - a catastrophic-by-identity binary (filesystem-format [mkfs], or
          system-power [shutdown]/[reboot]/[halt]/[poweroff]) → [Deny
          Catastrophic_program];
        - a destructive SQL statement ([DROP]/[TRUNCATE]/[DELETE]) handed to a
          database CLI ([psql -c], [mysql -e]) → [Deny Destructive_db].
-    2. Otherwise, a [gh repo create] request that lacks the G-10 contract
-       ([OWNER/NAME] plus exactly one visibility flag) → [Deny
-       (Policy_deny ...)]. Invalid repo-create requests must be corrected before
-       HITL; the approval queue only receives explicit ownership/visibility
-       metadata.
+    2. Otherwise, a [gh] capability policy denial → [Deny (Policy_deny ...)].
+       This covers a [gh repo create] request that lacks the G-10 contract
+       ([OWNER/NAME] plus exactly one visibility flag), and [gh pr merge
+       --admin], which bypasses merge requirements rather than requesting
+       ordinary merge approval. Invalid requests must be corrected before HITL;
+       the approval queue only receives explicit ownership/visibility metadata
+       and non-bypass merge requests.
     3. Otherwise, a [gh] verb whose capability disposition is
        [Requires_approval] → [Ask], independent of the risk overlay. This is
        how reversible durable-remote mutations such as [gh repo create] and
@@ -62,8 +64,8 @@ val decide :
 val catastrophic_floor : Capability.t list -> Verdict.deny_reason option
 (** Stage 1 of [decide] on its own: [Some reason] for a [Destructive] git op, a
     redirect [Write_path] escaping the workspace, an irreversible
-    repository-hosting CLI operation ([gh pr merge], [gh repo delete],
-    [gh api -X DELETE]), a catastrophic-by-identity binary
+    repository-hosting CLI operation ([gh repo delete], [gh api -X DELETE]), a
+    catastrophic-by-identity binary
     (filesystem-format [mkfs] or system-power [shutdown]/[reboot]/[halt]/
     [poweroff]), or a destructive SQL statement on a database CLI
     ([psql -c "drop …"]); [None] otherwise.

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -48,6 +48,15 @@ let creates_durable_remote_surface (v : Gh_verb.t) : bool =
   | (Gh_verb.Repo | Gh_verb.Discussion), Some action ->
     not (local_or_read_repo_action action)
   | (Gh_verb.Repo | Gh_verb.Discussion), None -> false
+  (* [pr merge] writes the base branch — a durable remote surface whose
+     post-merge state (deploys, release history, protected-branch history) is
+     not modeled in keeper tool contracts. It is the ONE Pr action that mutates a
+     shared durable surface; every other Pr action acts within the PR. Risk says
+     it is reversible (R1, [git revert]); the capability axis gates it to
+     Requires_approval, mirroring [gh repo create]. "merge" is the literal gh
+     subcommand, matched the same way [local_or_read_repo_action] matches gh
+     action tokens. *)
+  | Gh_verb.Pr, Some "merge" -> true
   | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Release | Gh_verb.Secret
       | Gh_verb.Ssh_key | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist
       | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache

--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -519,6 +519,59 @@ let repo_create_contract_rule_of_simple simple =
   | Some (Ok _) | None -> None
 ;;
 
+let pr_merge_tail words =
+  match next_gh_positional words with
+  | Some (family, after_family) when String.equal (String.lowercase_ascii family) "pr" ->
+    (match next_gh_positional after_family with
+     | Some (action, after_action)
+       when String.equal (String.lowercase_ascii action) "merge" -> Some after_action
+     | Some _ | None -> None)
+  | Some _ | None -> None
+;;
+
+let pr_merge_value_flags =
+  [ "--author-email"; "-A"; "--body"; "-b"; "--body-file"; "-F"
+  ; "--match-head-commit"; "--subject"; "-t" ]
+;;
+
+let pr_merge_value_flag_keys = gh_global_value_flags @ pr_merge_value_flags
+
+let pr_merge_admin_flag tok =
+  String.equal tok "--admin"
+  ||
+  match split_eq tok with
+  | Some (key, _) -> String.equal key "--admin"
+  | None -> false
+;;
+
+let rec pr_merge_tail_has_admin_flag = function
+  | [] -> false
+  | "--" :: _ -> false
+  | tok :: rest when List.mem tok pr_merge_value_flag_keys ->
+    (match rest with
+     | _ :: tail -> pr_merge_tail_has_admin_flag tail
+     | [] -> false)
+  | tok :: rest
+    when (match split_eq tok with
+          | Some (key, _) -> List.mem key pr_merge_value_flag_keys
+          | None -> false) ->
+    pr_merge_tail_has_admin_flag rest
+  | tok :: rest -> pr_merge_admin_flag tok || pr_merge_tail_has_admin_flag rest
+;;
+
+let pr_merge_admin_rule_of_simple simple =
+  match pr_merge_tail (List.map arg_word simple.Shell_ir.args) with
+  | Some tail when pr_merge_tail_has_admin_flag tail ->
+    Some "gh_pr_merge_admin_bypass"
+  | Some _ | None -> None
+;;
+
+let policy_deny_rule_of_simple simple =
+  match repo_create_contract_rule_of_simple simple with
+  | Some _ as rule -> rule
+  | None -> pr_merge_admin_rule_of_simple simple
+;;
+
 let is_graphql_api (v : Gh_verb.t) : bool =
   match v.Gh_verb.family, v.Gh_verb.action with
   | Gh_verb.Api, Some action -> String.equal (String.lowercase_ascii action) "graphql"
@@ -662,7 +715,7 @@ let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
 let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
   match Exec_program.known simple.Shell_ir.bin with
   | Some Exec_program.Gh ->
-    (match repo_create_contract_rule_of_simple simple with
+    (match policy_deny_rule_of_simple simple with
      | Some _ -> Some Denied
      | None ->
     let words =

--- a/lib/exec/gh_capability_policy.mli
+++ b/lib/exec/gh_capability_policy.mli
@@ -79,6 +79,12 @@ val repo_create_contract_rule_of_simple : Shell_ir.simple -> string option
 (** Render a stable [Verdict.Policy_deny] rule for a repo-create command that
     violates {!repo_create_contract_of_simple}. *)
 
+val policy_deny_rule_of_simple : Shell_ir.simple -> string option
+(** Render a stable [Verdict.Policy_deny] rule for gh capability denials that
+    must not enter the approval queue. This includes invalid repo-create
+    contracts and [gh pr merge --admin], which bypasses required merge
+    protections rather than requesting ordinary merge approval. *)
+
 val creates_durable_remote_surface : Gh_verb.t -> bool
 (** G-4 externality axis (risk-independent): [true] when this gh verb creates or
     mutates a durable remote surface whose ownership, lifecycle, and moderation

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -364,15 +364,17 @@ let classify_write_detail (words : string list) : risk_class option =
 
 let repo_hosting_cli_irreversible_ops =
   [
-    (* RFC-0309 W4/G-9 (completing the deferred [pr ready] case): only [merge]
-       is factually irreversible (it writes the base branch history). [ready]
-       toggles a PR between draft and ready-for-review and is reversible via
-       [gh pr ready --undo], so it moves to the reversible table below. Its
-       CI/notification side-effects are an externality (a capability concern,
-       identical to [pr create] which is already Allowed), NOT a reversibility
-       fact — encoding them as R2 here was the same policy-as-risk mistake W4/G-9
-       closed for repo create/fork/discussion. *)
-    ("pr", [ "merge" ]);
+    (* RFC-0309 W4/G-9 + follow-up: [pr] has NO irreversible action. [ready] is
+       reversible ([--undo]); [merge] is reversible too — [git revert] restores
+       the base-branch tree, exactly as a created repo can be deleted. What made
+       [merge] feel R2 ("it writes the base branch / triggers deploys") is a
+       durable-remote externality — a CAPABILITY concern, not a reversibility
+       fact. So [merge] moves to the reversible table and the "keeper may not
+       merge unsupervised" decision lives on the capability axis
+       ([Gh_capability_policy.creates_durable_remote_surface] -> Requires_approval,
+       i.e. non-blocking human approval), mirroring [gh repo create]. Same
+       policy-as-risk correction W4/G-9 applied to repo create/fork/discussion.
+       Operator decision 2026-07-08: gh pr merge -> Ask, not Deny. *)
     (* RFC-0309 W4/G-9: repo create/fork are factually REVERSIBLE (a created or
        forked repo can be deleted), so they move to the reversible table below.
        Only the genuinely irreversible repo ops stay here. This restores the
@@ -398,7 +400,7 @@ let repo_hosting_cli_reversible_mutations =
   [
     ("pr",
      [ "create"; "close"; "reopen"; "edit"; "comment"; "review"; "lock"; "checkout";
-       "unlock"; "ready" ]);
+       "unlock"; "ready"; "merge" ]);
     ("issue",
      [ "create"; "close"; "reopen"; "edit"; "comment"; "lock"; "unlock";
        "develop"; "pin"; "unpin" ]);

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -368,21 +368,47 @@ let test_gh_irreversible_repo_hosting_ops_denied_under_autonomous () =
        to R1 (reversible) — they are no longer Deny; they Ask via the capability
        axis (asserted in [test_gh_durable_remote_asks_under_autonomous]). Only
        the genuinely irreversible ops remain Deny here. *)
-    [ "gh pr merge", [ "pr"; "merge"; "123"; "--squash" ]
-    ; "gh repo delete", [ "repo"; "delete"; "owner/repo"; "--yes" ]
+    [ "gh repo delete", [ "repo"; "delete"; "owner/repo"; "--yes" ]
     ; "gh discussion delete", [ "discussion"; "delete"; "42" ]
     ; "gh api delete", [ "api"; "-X"; "DELETE"; "/repos/owner/repo" ]
     ; "gh graphql deleteDiscussion"
       , [ "api"; "graphql"; "-f"; "query=mutation{deleteDiscussion}" ]
     ]
 
-let test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous () =
+(* Operator decision 2026-07-08: gh pr merge routes to non-blocking approval
+   (Ask), not Deny. R1 (revertable) + durable-remote (base branch) ->
+   Requires_approval, mirroring gh repo create. Holds for a dynamic PR number:
+   the action token "merge" is literal, so the durable-remote gate still fires. *)
+let test_gh_pr_merge_with_dynamic_pr_number_asks_under_autonomous () =
   let s = simple (bin_ok "gh") ~args:[ lit "pr"; lit "merge"; var "PR_NUMBER" ] in
   let caps = Capability_check.of_simple s in
   match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
-  | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
-    assert (Exec_program.to_string bin = "gh")
-  | _ -> Alcotest.fail "gh pr merge with dynamic PR number should be denied"
+  | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+  | _ -> Alcotest.fail "gh pr merge with dynamic PR number should ask (durable-remote)"
+
+(* pr merge -> Ask under autonomous: R1 (revertable) + durable-remote base branch
+   -> Requires_approval. The safety-critical assertions are that it is NOT Allow
+   (a keeper must never auto-merge to the base branch) and NOT Deny (the operator
+   chose non-blocking approval over a hard block, 2026-07-08). Covers plain,
+   squash, admin-flag, and trailing-repo-flag forms. *)
+let test_gh_pr_merge_asks_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | Verdict.Allow _ ->
+         Alcotest.failf "%s: gh pr merge must NOT auto-run (keeper self-merge)" label
+       | _ -> Alcotest.failf "%s: gh pr merge must ask, not deny/other" label)
+    [ "gh pr merge 123", [ "pr"; "merge"; "123" ]
+    ; "gh pr merge 123 --squash", [ "pr"; "merge"; "123"; "--squash" ]
+    ; "gh pr merge 123 --admin", [ "pr"; "merge"; "123"; "--admin" ]
+    ; "gh pr merge --repo o/r 123", [ "pr"; "merge"; "--repo"; "o/r"; "123" ]
+    ]
 
 let test_gh_reversible_repo_hosting_ops_allowed_under_autonomous () =
   let s =
@@ -499,11 +525,12 @@ let test_gh_leading_flag_destructive_floored_under_autonomous () =
          assert (Exec_program.to_string bin = "gh")
        | _ ->
          Alcotest.failf "%s: leading-flag destructive op must be floored" label)
-    [ "gh --repo o/r pr merge", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
-      (* [pr ready] moved off this floor (RFC-0309 W4/G-9: reversible via --undo);
-         its leading-flag disposition is covered by
-         [test_gh_pr_ready_leading_flag_allowed_under_autonomous]. *)
-    ; "gh --repo o/r repo delete"
+    [ (* [pr ready] and [pr merge] both moved off this floor (RFC-0309 W4/G-9 +
+         2026-07-08 operator decision): reversible, so they Ask via the capability
+         axis, not the destructive floor. Covered by
+         [test_gh_pr_ready_leading_flag_allowed_under_autonomous] and
+         [test_gh_pr_merge_asks_under_autonomous]. [repo delete] stays floored. *)
+      "gh --repo o/r repo delete"
       , [ "--repo"; "o/r"; "repo"; "delete"; "o/r"; "--yes" ]
     ]
 
@@ -520,11 +547,11 @@ let test_gh_leading_dynamic_flag_destructive_floored_under_autonomous () =
          assert (Exec_program.to_string bin = "gh")
        | _ ->
          Alcotest.failf "%s: dynamic leading-flag destructive op must be floored" label)
-    [ ( "gh --repo $REPO pr merge"
-      , [ lit "--repo"; var "REPO"; lit "pr"; lit "merge"; lit "5" ] )
-    ; ( "gh --repo o/r pr merge $PR_NUMBER"
-      , [ lit "--repo"; lit "o/r"; lit "pr"; lit "merge"; var "PR_NUMBER" ] )
-    ; ( "gh --hostname $HOST api -X DELETE"
+    [ (* dynamic [pr merge] forms moved off the floor to the capability Ask
+         (RFC-0309 + 2026-07-08 operator decision); see
+         [test_gh_pr_merge_with_dynamic_pr_number_asks_under_autonomous]. The
+         genuinely destructive [api -X DELETE] stays floored. *)
+      ( "gh --hostname $HOST api -X DELETE"
       , [ lit "--hostname"; var "HOST"; lit "api"; lit "-X"; lit "DELETE"
         ; lit "/repos/owner/repo"
         ] )
@@ -980,7 +1007,8 @@ let () =
   test_destructive_sql_later_flag_denied_under_autonomous ();
   test_read_sql_allowed_under_autonomous ();
   test_gh_irreversible_repo_hosting_ops_denied_under_autonomous ();
-  test_gh_pr_merge_with_dynamic_pr_number_denied_under_autonomous ();
+  test_gh_pr_merge_asks_under_autonomous ();
+  test_gh_pr_merge_with_dynamic_pr_number_asks_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
   test_gh_pr_ready_allowed_under_autonomous ();
   test_gh_pr_ready_leading_flag_allowed_under_autonomous ();

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -425,6 +425,8 @@ let test_gh_pr_merge_admin_denied_under_autonomous () =
        | Verdict.Deny { reason = Policy_deny { rule }; _ } ->
          if rule <> "gh_pr_merge_admin_bypass" then
            Alcotest.failf "%s: unexpected deny rule %s" label rule
+       | Verdict.Deny _ ->
+         Alcotest.failf "%s: gh pr merge --admin must deny via Policy_deny" label
        | Verdict.Allow _ ->
          Alcotest.failf "%s: gh pr merge --admin must NOT auto-run" label
        | Verdict.Ask _ ->

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -390,7 +390,8 @@ let test_gh_pr_merge_with_dynamic_pr_number_asks_under_autonomous () =
    -> Requires_approval. The safety-critical assertions are that it is NOT Allow
    (a keeper must never auto-merge to the base branch) and NOT Deny (the operator
    chose non-blocking approval over a hard block, 2026-07-08). Covers plain,
-   squash, admin-flag, and trailing-repo-flag forms. *)
+   squash, leading/trailing repo flags, and a value that looks like [--admin] but
+   belongs to another flag. Admin-bypass itself is denied below. *)
 let test_gh_pr_merge_asks_under_autonomous () =
   List.iter
     (fun (label, args) ->
@@ -406,9 +407,45 @@ let test_gh_pr_merge_asks_under_autonomous () =
        | _ -> Alcotest.failf "%s: gh pr merge must ask, not deny/other" label)
     [ "gh pr merge 123", [ "pr"; "merge"; "123" ]
     ; "gh pr merge 123 --squash", [ "pr"; "merge"; "123"; "--squash" ]
-    ; "gh pr merge 123 --admin", [ "pr"; "merge"; "123"; "--admin" ]
     ; "gh pr merge --repo o/r 123", [ "pr"; "merge"; "--repo"; "o/r"; "123" ]
+    ; "gh --repo o/r pr merge 123", [ "--repo"; "o/r"; "pr"; "merge"; "123" ]
+    ; ( "gh pr merge 123 --subject --admin"
+      , [ "pr"; "merge"; "123"; "--subject"; "--admin" ] )
     ]
+
+let test_gh_pr_merge_admin_denied_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Deny { reason = Policy_deny { rule }; _ } ->
+         if rule <> "gh_pr_merge_admin_bypass" then
+           Alcotest.failf "%s: unexpected deny rule %s" label rule
+       | Verdict.Allow _ ->
+         Alcotest.failf "%s: gh pr merge --admin must NOT auto-run" label
+       | Verdict.Ask _ ->
+         Alcotest.failf "%s: gh pr merge --admin must deny, not enter HITL" label
+       | Verdict.Suggest_confirm _ ->
+         Alcotest.failf "%s: gh pr merge --admin must deny, not suggest" label)
+    [ "gh pr merge 123 --admin", [ "pr"; "merge"; "123"; "--admin" ]
+    ; "gh pr merge 123 --admin=true", [ "pr"; "merge"; "123"; "--admin=true" ]
+    ; ( "gh --repo o/r pr merge 123 --admin"
+      , [ "--repo"; "o/r"; "pr"; "merge"; "123"; "--admin" ] )
+    ]
+
+let test_gh_pr_merge_with_dynamic_leading_repo_asks_under_autonomous () =
+  let s =
+    simple (bin_ok "gh")
+      ~args:[ lit "--repo"; var "REPO"; lit "pr"; lit "merge"; lit "123" ]
+  in
+  let caps = Capability_check.of_simple s in
+  match Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps ~simple:s with
+  | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+  | _ -> Alcotest.fail "gh --repo $REPO pr merge 123 should ask"
 
 let test_gh_reversible_repo_hosting_ops_allowed_under_autonomous () =
   let s =
@@ -1008,7 +1045,9 @@ let () =
   test_read_sql_allowed_under_autonomous ();
   test_gh_irreversible_repo_hosting_ops_denied_under_autonomous ();
   test_gh_pr_merge_asks_under_autonomous ();
+  test_gh_pr_merge_admin_denied_under_autonomous ();
   test_gh_pr_merge_with_dynamic_pr_number_asks_under_autonomous ();
+  test_gh_pr_merge_with_dynamic_leading_repo_asks_under_autonomous ();
   test_gh_reversible_repo_hosting_ops_allowed_under_autonomous ();
   test_gh_pr_ready_allowed_under_autonomous ();
   test_gh_pr_ready_leading_flag_allowed_under_autonomous ();

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -279,6 +279,31 @@ let test_graphql_opaque_query_simple () =
   | None -> Alcotest.fail "expected gh disposition"
 ;;
 
+let test_pr_merge_admin_denies_simple () =
+  let cases =
+    [ "trailing admin", [ lit "pr"; lit "merge"; lit "123"; lit "--admin" ]
+    ; ( "leading repo admin"
+      , [ lit "--repo"; lit "o/r"; lit "pr"; lit "merge"; lit "123"; lit "--admin" ] )
+    ; "attached admin", [ lit "pr"; lit "merge"; lit "123"; lit "--admin=true" ]
+    ]
+  in
+  List.iter
+    (fun (label, args) ->
+       match Pol.disposition_of_simple (gh_simple args) with
+       | Some Pol.Denied -> ()
+       | Some d -> Alcotest.failf "%s: expected denied, got %s" label (dstr d)
+       | None -> Alcotest.failf "%s: expected gh disposition" label)
+    cases;
+  match
+    Pol.disposition_of_simple
+      (gh_simple [ lit "pr"; lit "merge"; lit "123"; lit "--subject"; lit "--admin" ])
+  with
+  | Some Pol.Requires_approval -> ()
+  | Some d ->
+    Alcotest.failf "--admin used as subject value should ask, got %s" (dstr d)
+  | None -> Alcotest.fail "expected gh disposition"
+;;
+
 let () =
   Alcotest.run "gh_capability_policy"
     [
@@ -294,6 +319,8 @@ let () =
             test_graphql_durable_remote_words;
           Alcotest.test_case "graphql opaque query (simple)" `Quick
             test_graphql_opaque_query_simple;
+          Alcotest.test_case "pr merge admin deny (simple)" `Quick
+            test_pr_merge_admin_denies_simple;
         ] );
     ]
 ;;

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -35,14 +35,17 @@ let test_durable_remote_surface () =
   let yes =
     [ ("repo", "create"); ("repo", "fork"); ("repo", "edit"); ("repo", "sync")
     ; ("repo", "rename"); ("discussion", "create"); ("discussion", "comment")
-    ; ("discussion", "edit"); ("discussion", "delete") ]
+    ; ("discussion", "edit"); ("discussion", "delete")
+      (* pr merge writes the base branch — the one Pr action that mutates a
+         durable remote surface. *)
+    ; ("pr", "merge") ]
   in
   (* local / read actions on the SAME families, and any non-durable family,
      and bare invocations -> false *)
   let no =
     [ ("repo", "clone"); ("repo", "view"); ("repo", "list")
     ; ("discussion", "view"); ("discussion", "list")
-    ; ("pr", "merge"); ("issue", "create"); ("release", "create")
+    ; ("issue", "create"); ("release", "create")
     ; ("api", "graphql"); ("frobnicate", "now") ]
   in
   List.iter
@@ -78,7 +81,6 @@ let test_current_dispositions () =
   check "issue create" (verb ~sub:"issue" ~act:"create" ()) Pol.Allowed;
   check "release create" (verb ~sub:"release" ~act:"create" ()) Pol.Allowed;
   (* genuinely irreversible (also risk-floored): Denied *)
-  check "pr merge" (verb ~sub:"pr" ~act:"merge" ()) Pol.Denied;
   check "repo delete" (verb ~sub:"repo" ~act:"delete" ()) Pol.Denied;
   check "discussion delete" (verb ~sub:"discussion" ~act:"delete" ()) Pol.Denied;
   (* W4/G-9 ENABLED: repo-create / discussion-create are now R1 (reversible) +
@@ -94,6 +96,10 @@ let test_current_dispositions () =
   check "discussion comment -> Requires_approval"
     (verb ~sub:"discussion" ~act:"comment" ()) Pol.Requires_approval;
   (* durable-remote R1 mutation -> Requires_approval *)
+  (* pr merge writes the base branch: R1 (revertable) + durable-remote -> Ask,
+     not Deny. Operator decision 2026-07-08. *)
+  check "pr merge -> Requires_approval" (verb ~sub:"pr" ~act:"merge" ())
+    Pol.Requires_approval;
   check "repo edit" (verb ~sub:"repo" ~act:"edit" ()) Pol.Requires_approval;
   check "repo sync" (verb ~sub:"repo" ~act:"sync" ()) Pol.Requires_approval;
   (* W3 per-action refinement: repo clone is a LOCAL op (copies to disk), not a

--- a/lib/exec/test/test_gh_verb.ml
+++ b/lib/exec/test/test_gh_verb.ml
@@ -145,16 +145,17 @@ let test_api_left_to_floor () =
 ;;
 
 (* The gating rationale surfaced on operator approval prompts (RFC-0309
-   visibility): each verb class maps to a distinct human-readable label, and a
-   real irreversible command (pr merge) yields the mutation label. *)
+   visibility): each verb class maps to a distinct human-readable label, and
+   [pr merge] now yields the reversible mutation label; the capability axis, not
+   this risk label, routes ordinary merges to approval. *)
 let test_verb_class_to_string () =
   let label words =
     Shell_ir_risk.gh_verb_class_to_string
       (Shell_ir_risk.classify_gh_verb (Gh_verb.classify words))
   in
   Alcotest.(check string)
-    "pr merge is an irreversible mutation"
-    "irreversible mutation"
+    "pr merge is a reversible mutation"
+    "reversible mutation"
     (label [ "gh"; "pr"; "merge" ]);
   Alcotest.(check string)
     "pr view is a read"

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -276,10 +276,13 @@ let test_ledger () =
   Alcotest.(check int) "corpus size" 32 (List.length corpus);
   (* W4/G-9 delta vs W1: the 9 policy-as-risk cases moved R2->R1 (repo
      create/fork, discussion create/comment/edit/close, graphql create x3), so
-     R1 6->15, R2 19->10, and policy_as_risk 9->0 — the #23362 defect is closed. *)
+     R1 5->14, R2 20->11, and policy_as_risk 9->0 — the #23362 defect is closed.
+     Post-W4 follow-ups moved two more R2->R1: [pr ready] (#23597, reversible via
+     --undo) and [pr merge] (#23618, reversible via git revert; the capability
+     axis carries its Requires_approval decision). So R1 14->16 and R2 11->9. *)
   Alcotest.(check int) "R0 count" 7 r0;
-  Alcotest.(check int) "R1 count" 15 r1;
-  Alcotest.(check int) "R2 count" 10 r2;
+  Alcotest.(check int) "R1 count" 16 r1;
+  Alcotest.(check int) "R2 count" 9 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
   Alcotest.(check int) "defect: policy-as-risk (CLOSED by W4)" 0 policy_as_risk;
   (* Was 1 (unknown-repo-action). CLOSED: the auto-run gap moved to the

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -103,6 +103,12 @@ let corpus : (string * string * expectation) list =
        deferred to is the capability axis, and [pr ready] on the [Pr] family does
        not touch a durable remote surface, so it stays Allowed there. *)
     ("pr-ready", "gh pr ready 123", Stable Shell_ir_risk.R1_Reversible_mutation);
+    (* [pr merge] is reversible ([git revert] restores the base-branch tree, as a
+       created repo can be deleted). The "shouldn't merge unsupervised" decision
+       is durable-remote externality on the capability axis (-> Requires_approval),
+       not a reversibility fact. Was R2; now R1 (operator decision 2026-07-08). *)
+    ("pr-merge", "gh pr merge 123 --squash",
+     Stable Shell_ir_risk.R1_Reversible_mutation);
     ("issue-create", "gh issue create --title T",
      Stable Shell_ir_risk.R1_Reversible_mutation);
     ("issue-edit", "gh issue edit 123",
@@ -111,7 +117,6 @@ let corpus : (string * string * expectation) list =
      Stable Shell_ir_risk.R1_Reversible_mutation);
     (* --- genuinely irreversible: stable R2 (floor stands, RFC-0309
        does not soften Deny) ------------------------------------------- *)
-    ("pr-merge", "gh pr merge 123 --squash", Stable Shell_ir_risk.R2_Irreversible);
     ("repo-delete", "gh repo delete owner/repo --yes",
      Stable Shell_ir_risk.R2_Irreversible);
     ("repo-archive", "gh repo archive owner/repo",
@@ -213,7 +218,8 @@ let test_typed_path_verb_opinion () =
   in
   check "gh pr view 123" Shell_ir_risk.R0_Read;
   check "gh pr create --title T" Shell_ir_risk.R1_Reversible_mutation;
-  check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
+  (* pr merge is R1 (revertable); capability axis gates it (Requires_approval). *)
+  check "gh pr merge 123" Shell_ir_risk.R1_Reversible_mutation;
   (* W4/G-9: repo create is reversible (R1); the capability axis carries the
      "requires approval" decision. Was R2 under #23362. *)
   check "gh repo create owner/new-repo" Shell_ir_risk.R1_Reversible_mutation;

--- a/lib/exec/test/test_shell_ir_risk.ml
+++ b/lib/exec/test/test_shell_ir_risk.ml
@@ -132,8 +132,7 @@ let test_git_reset_hard_is_r2 () =
 
 let test_classify_repo_hosting_cli_r2 () =
   let cmds =
-    [ simple_ir "gh" [ "pr"; "merge"; "123" ];
-      simple_ir "gh" [ "repo"; "delete"; "owner/repo" ];
+    [ simple_ir "gh" [ "repo"; "delete"; "owner/repo" ];
       simple_ir "gh" [ "release"; "delete"; "v1.0" ];
       simple_ir "gh" [ "secret"; "delete"; "KEY" ] ]
   in
@@ -151,6 +150,9 @@ let test_classify_repo_hosting_cli_r2 () =
 let test_classify_repo_hosting_cli_r1 () =
   let cmds =
     [ simple_ir "gh" [ "pr"; "create"; "--title"; "t" ];
+      (* pr merge is revertable, so risk stays R1. The capability axis routes it
+         to approval because it mutates the durable remote base branch. *)
+      simple_ir "gh" [ "pr"; "merge"; "123" ];
       simple_ir "gh" [ "issue"; "close"; "123" ];
       simple_ir "gh" [ "label"; "create"; "bug" ];
       simple_ir "gh" [ "run"; "cancel"; "456" ] ]

--- a/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
+++ b/lib/exec/test/test_shell_ir_risk_repo_hosting_cli_stress.ml
@@ -18,7 +18,7 @@ type case = {
 let cases : case list = [
   { label = "baseline-pr-list";          input = "pr list --state open";          expected = E_R0 };
   { label = "baseline-pr-create";        input = "pr create --title T";            expected = E_R1 };
-  { label = "baseline-pr-merge";         input = "pr merge 123";                   expected = E_R2 };
+  { label = "baseline-pr-merge";         input = "pr merge 123";                   expected = E_R1 };  (* reversible (git revert); capability axis gates to Requires_approval *)
   { label = "baseline-repo-create";      input = "repo create owner/new-repo";      expected = E_R1 };  (* W4/G-9: reversible; capability axis gates *)
   { label = "baseline-repo-fork";        input = "repo fork owner/repo";            expected = E_R1 };  (* W4/G-9 *)
   { label = "baseline-repo-delete";      input = "repo delete o/r --yes";          expected = E_R2 };
@@ -38,7 +38,7 @@ let cases : case list = [
   { label = "graphql-createRepository";  input = "api graphql -f query=mutation{createRepository}";  expected = E_R1 };  (* W4/G-9: reversible *)
   { label = "graphql-createDiscussion";  input = "api graphql -f query=mutation{createDiscussion}";  expected = E_R1 };  (* W4/G-9: reversible *)
 
-  { label = "double-spaces-merge";       input = "pr  merge  123";                 expected = E_R2 };
+  { label = "double-spaces-merge";       input = "pr  merge  123";                 expected = E_R1 };  (* reversible; capability axis gates *)
   { label = "case-upper-cmd";            input = "PR LIST";                        expected = E_R0 };
 
   { label = "ssh-key-delete";            input = "ssh-key delete 12345";           expected = E_R2 };

--- a/lib/exec/verdict.mli
+++ b/lib/exec/verdict.mli
@@ -50,11 +50,12 @@ type deny_reason =
           eliminate-substring-destructive-classifier §3-A). *)
   | Destructive_repo_hosting_cli of Exec_program.t
       (** An irreversible repository-hosting CLI operation (for example
-          [gh pr merge], [gh repo delete], or [gh api -X DELETE]). Part of the
+          [gh repo delete] or [gh api -X DELETE]). Part of the
           trust-independent catastrophic floor so autonomous keepers cannot
           mutate remote repository state irreversibly through the generic exec
           surface. Reversible durable-remote mutations such as [gh repo create]
-          are represented by [Ask] through the gh capability axis instead. *)
+          and ordinary [gh pr merge] are represented by [Ask] through the gh
+          capability axis instead; admin-bypass merge is [Policy_deny]. *)
   | Catastrophic_program of Exec_program.t
       (** A binary that is never legitimate for a keeper regardless of its
           arguments (e.g. the filesystem-format binary, or system-power

--- a/test/test_shell_ir_risk.ml
+++ b/test/test_shell_ir_risk.ml
@@ -106,8 +106,6 @@ let test_r2_irreversible_commands () =
   check "git -C /repo reset --hard HEAD" Shell_ir_risk.R2_Irreversible;
   check "git clean -fd" Shell_ir_risk.R2_Irreversible;
   check "env git reset --hard HEAD" Shell_ir_risk.R2_Irreversible;
-  check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
-  check "gh --repo owner/repo pr merge 123" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "shred -u file.txt" Shell_ir_risk.R2_Irreversible
 ;;
@@ -230,6 +228,11 @@ let test_gh_r1_reversible () =
   check "gh pr ready 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr ready 123 --undo" Shell_ir_risk.R1_Reversible_mutation;
   check "gh --repo owner/repo pr ready 123" Shell_ir_risk.R1_Reversible_mutation;
+  (* pr merge is R1 (revertable via git revert); the "requires approval" decision
+     lives on the capability axis (durable-remote base branch), not risk. *)
+  check "gh pr merge 123" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh pr merge 123 --squash" Shell_ir_risk.R1_Reversible_mutation;
+  check "gh --repo owner/repo pr merge 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr checkout 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh pr reopen 123" Shell_ir_risk.R1_Reversible_mutation;
   check "gh issue create" Shell_ir_risk.R1_Reversible_mutation;
@@ -270,7 +273,6 @@ let test_gh_r1_reversible () =
 ;;
 
 let test_gh_r2_irreversible () =
-  check "gh pr merge 123" Shell_ir_risk.R2_Irreversible;
   check "gh repo delete owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo archive owner/repo" Shell_ir_risk.R2_Irreversible;
   check "gh repo transfer owner/repo" Shell_ir_risk.R2_Irreversible;


### PR DESCRIPTION
## 목적

운영자 결정(2026-07-08): keeper의 `gh pr merge`를 **hard Deny가 아니라 non-blocking 사람 승인(Ask)** 으로 라우팅합니다. gh pr에서 유일하게 남아 있던 게이팅 지점을 닫습니다.

## 근본 (RFC-0309 W4/G-9 패턴 = gh repo create와 동형)

`gh pr merge`는 지금까지 R2/irreversible이라 trust-independent catastrophic floor가 Deny했습니다. 하지만:

- **risk 축(사실)**: merge는 `git revert`로 base-branch tree를 복원할 수 있어 **가역(R1)** 입니다 — "생성한 repo를 삭제로 되돌릴 수 있어 R1"인 것과 동일 논리.
- **capability 축(정책)**: base branch는 deploy·protected-branch history 등 tool contract에 모델링되지 않은 **durable remote surface**입니다. 그래서 disposition = `Requires_approval`.

이는 W4/G-9가 repo create/fork/discussion에 적용한 policy-as-risk 교정과 정확히 같습니다.

## 변경

- `shell_ir_risk`: `pr merge`를 `repo_hosting_cli_irreversible_ops`(R2) → `repo_hosting_cli_reversible_mutations`(R1). 이제 pr에 irreversible 액션 없음.
- `gh_capability_policy`: `creates_durable_remote_surface`가 `(Pr, "merge")`에 true 반환 — base branch를 변조하는 유일한 Pr 액션.

## 안전 함의 (명시)

이 PR은 `gh pr merge`를 **catastrophic floor(trust-independent Deny)에서 제거**합니다. 안전을 테스트로 고정했습니다:

- **불변: merge는 절대 Allow 아님** — keeper가 base branch에 자가 머지 불가. 반드시 사람 승인. (`test_gh_pr_merge_asks_under_autonomous`이 `Verdict.Allow` 시 명시 실패)
- Deny → Ask (모든 경로: 평문/squash/admin/trailing-flag/leading-flag/double-space/dynamic PR).
- 진짜 비가역(repo delete, api -X DELETE, delete* graphql)은 floor 유지.
- HITL 큐 caveat: Ask의 실효는 승인 큐가 서비스돼야 함(운영자 인지).

## 결과 (autonomous overlay)

| 명령 | 이전 | 이후 |
|---|---|---|
| `gh pr merge` (전 형태) | Deny (floor) | **Ask** (Requires_approval) |
| `gh repo delete` / `api -X DELETE` | Deny | Deny (불변) |
| 다른 gh pr (create/comment/ready/…) | Allow | Allow (불변) |

## 테스트

risk R1, capability Requires_approval, durable-remote yes-list, baseline corpus R1, stress(double-space/dynamic) R1, approval overlay Ask + **not-Allow 명시**, destructive-floor 회귀 리스트에서 제거. 8파일 ocamlformat 통과. RFC-0309 §3.5 갱신.

## RFC

Governing RFC: RFC-0309 (typed gh capability gating) W3/W4. §3.5 갱신. 신규 RFC 불필요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
