### PR TITLE
fix(dashboard): pin logs column header while the stream scrolls (sticky)

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -639,4 +639,19 @@ describe('logs vendored stylesheet', () => {
     expect(css).toContain('grid-template-areas')
     expect(css).toContain('.lg-colhd { display: none; }')
   })
+
+  it('pins the column header while the event stream scrolls', () => {
+    // Sticky column header stays visible over a multi-thousand-row stream. This
+    // only works while .v2-logs-panel does not clip: an overflow:hidden there
+    // pins the sticky element to a non-scrolling ancestor and it scrolls away.
+    const css = readFileSync(resolve(__dirname, '../styles/v2-logs.css'), 'utf8')
+    const headerRule = css.match(/\.v2-logs-table-header\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(headerRule).toContain('position: sticky')
+    expect(headerRule).toContain('top: 0')
+    const panelRule = css.match(/\.v2-logs-panel\s*\{([^}]*)\}/)?.[1] ?? ''
+    // overflow: visible (not hidden) keeps the sticky header pinned to the page
+    // scroller. Match the declaration, not the rationale comment above it.
+    expect(panelRule).toMatch(/overflow:\s*visible\s*;/)
+    expect(panelRule).not.toMatch(/overflow:\s*hidden\s*;/)
+  })
 })

--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -29,7 +29,12 @@
   flex: 1;
   flex-direction: column;
   min-height: 0;
-  overflow: hidden;
+  /* overflow must stay visible: the panel grows to its full content height and
+     the page scrolls at .dashboard-main-scroll, so it never actually clips. An
+     `overflow: hidden` here only created a sticky containing block that pinned
+     .v2-logs-table-header's `position: sticky` to a non-scrolling ancestor,
+     making the column header scroll away with the rows. */
+  overflow: visible;
   background: transparent;
   box-shadow: inset 0 1px 0 var(--v2-logs-top-glow);
 }
@@ -272,6 +277,12 @@
   display: grid;
   grid-template-columns: var(--v2-logs-cols);
   flex: none;
+  /* Sticky column header: the event stream can be thousands of rows tall, so the
+     시각/keeper/유형/이벤트 labels stay pinned to the top of the scroll while the
+     rows move under them (opaque --bg-panel below covers the scrolled rows). */
+  position: sticky;
+  top: 0;
+  z-index: 3;
   align-items: center;
   gap: 14px;
   padding: 10px 26px;


### PR DESCRIPTION
## 목적

사용자 지적: "Sticky 하는 부분도 있고 ... 개선". 이벤트 로그를 스크롤하면 컬럼 헤더(시각/keeper/유형/이벤트)가 화면 밖으로 밀려나 수천 행 중간에서 어느 컬럼인지 알 수 없다. sticky 프로브로 `.dashboard-main-scroll`에 sticky 요소가 0개임을 확인.

## 근본 원인 (실측)

`.v2-logs-panel { overflow: hidden }`. 패널은 콘텐츠 전체 높이로 자라 실제로는 클리핑하지 않지만(스크롤은 패널이 아니라 페이지 `.dashboard-main-scroll`에서 발생), 그 overflow가 **sticky containing block**을 만들어 `position: sticky` 자식을 스크롤하지 않는 패널에 고정 → 헤더가 행과 함께 사라짐. 브라우저 주입 테스트로 `overflow: visible` + 헤더 sticky가 고정을 복원함을 확인.

## 변경

- `.v2-logs-panel`: `overflow: hidden` → `visible` (클리핑한 적 없어 시각 변화 없음) — sticky가 페이지 스크롤러 기준으로 해석되도록.
- `.v2-logs-table-header`: `position: sticky; top: 0; z-index: 3` 추가. 이미 불투명 `--bg-panel` 배경이 있어 아래로 스크롤되는 행을 덮음.
- 모바일(`@640px`)은 vendored `keeper-v2/logs.css`가 `.lg-colhd { display: none }`로 헤더를 숨겨 스택 카드 레이아웃과 충돌 없음.
- CSS 드리프트 가드(sticky 헤더 + 비클리핑 패널 계약) 추가.

## 검증

- dev 서버 캡처: 스크롤된 스트림 위에 헤더 고정 확인
- `pnpm test` 637파일/8687 green, typecheck/lint clean

## 참고

`.dashboard-main-scroll`의 `p-4` 상단 패딩으로 헤더 위 ~16px에 이전 행 슬라이버가 비칠 수 있음 — 코드베이스의 기존 `deck-table thead { top: 0 }` 패턴과 동일한 관용. 같은 근본 원인(중간 overflow:hidden)이 approvals `.ap-detail-panel-rail` sticky도 깨뜨림 — 후속 PR로 분리.

## 미검증

- 없음 (전체 스위트 + 시각 확인). CI Dashboard job이 최종 판정.