### PR TITLE
fix(dashboard): guard goal undefined crash in Topbar and App.jsx

### DIFF
--- a/dashboard/design-system/ui_kits/cockpit/App.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/App.jsx
@@ -59,7 +59,7 @@ function App() {
       </div>
     );
   }
-  const activeGoal = D.goals.find(g => g.id === selGoal) || D.goals[0];
+  const activeGoal = D.goals.find(g => g.id === selGoal) || D.goals[0] || null;
 
   const toggleKeeper = useCallback((id) => {
     setSelectedKeepers(prev => {

--- a/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/Chrome.jsx
@@ -52,11 +52,13 @@ function Topbar({ goal, goals, mode, setMode, density, setDensity, branch, setBr
         </div>
       )}
       <span className="tb-sep"></span>
-      <div className="tb-goal" title={goal.id}>
-        <span className="chip active"><span className="d"></span>{goal.id.replace("goal-","")}</span>
-        <span>{goal.title}</span>
-        <span className="chev">▾</span>
-      </div>
+      {goal && (
+        <div className="tb-goal" title={goal.id || ""}>
+          <span className="chip active"><span className="d"></span>{(goal.id || "").replace("goal-","")}</span>
+          <span>{goal.title || ""}</span>
+          <span className="chev">▾</span>
+        </div>
+      )}
       <span className="tb-sep"></span>
       <div className="tb-modes">
         {PLANES.map(m => (


### PR DESCRIPTION
## Summary

Fixes two crash bugs in the cockpit dashboard where an undefined `goal` prop causes a TypeError in the Topbar component.

### Changes

1. **Chrome.jsx:38-39** — Added null guard (`{goal && (...)}`) around the `tb-goal` div in the Topbar component. When `goal` is undefined (e.g. empty goals array), the goal chip section is now safely omitted instead of crashing on `goal.id`.

2. **App.jsx:62** — Added explicit `|| null` fallback for `activeGoal` to prevent `undefined` from being passed to Topbar when `D.goals.find(...)` returns undefined (empty array case).

### Root Cause

`D.goals.find(g => g.id === selGoal) || D.goals[0]` returns `undefined` when `D.goals` is an empty array. This `undefined` flows into `Topbar` as the `goal` prop, where `goal.id.replace(...)` throws a TypeError.

### Evidence

- Branch: `rondo/task-1846-dashboard-ux-fixes`
- Commit: 314be04e2
- Task: task-1846 (Dashboard UX audit)