### PR TITLE
feat(keeper): connector-aware wake continuation W1-W2 (RFC-0320)

### DIFF
--- a/.github/actions/install-ocaml-deps/install.sh
+++ b/.github/actions/install-ocaml-deps/install.sh
@@ -18,8 +18,13 @@ install_os_packages() {
   local started_at
   started_at="$(date +%s)"
   echo "Refreshing apt package index..."
-  sudo apt-get update -qq
-  log_elapsed "Refreshed apt package index" "${started_at}"
+  if sudo apt-get update -qq; then
+    log_elapsed "Refreshed apt package index" "${started_at}"
+  else
+    echo \
+      "::warning::apt package index refresh failed; attempting install with existing package index" \
+      >&2
+  fi
 
   started_at="$(date +%s)"
   declare -a package_args=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
 
       - name: Install meta shell dependencies
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
 
       - name: Guard pending release tag on main PRs
@@ -503,7 +503,7 @@ jobs:
 
       - name: Install health shell dependencies
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep bc
 
       - name: Setup OCaml toolchain

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -25,7 +25,7 @@ jobs:
 
 
       - name: Refresh apt index
-        run: sudo apt-get update
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -352,7 +352,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y -qq ripgrep
+        run: |
+          bash scripts/ci/apt-refresh.sh
+          sudo apt-get install -y -qq ripgrep
       - name: Run path SSOT audit
         run: bash scripts/audit-path-ssot.sh
 

--- a/.github/workflows/main-nightly-health.yml
+++ b/.github/workflows/main-nightly-health.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install ripgrep
         run: |
-          sudo apt-get update -qq
+          bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
 
       - name: Check doc truth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Refresh apt index
         if: runner.os == 'Linux'
-        run: sudo apt-get update -qq
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install ripgrep
         run: |
           if ! command -v rg >/dev/null 2>&1; then
-            sudo apt-get update -qq
+            bash scripts/ci/apt-refresh.sh
             sudo apt-get install -y ripgrep
           fi
 

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '22'
 
       - name: Refresh system package index
-        run: sudo apt-get update -qq
+        run: bash scripts/ci/apt-refresh.sh
 
       - name: Install OS dependencies
         run: sudo apt-get install -y jq

--- a/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
+++ b/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
@@ -153,6 +153,7 @@ and connector_attention =
 - **W1** — G1 provenance capture. `continuation_channel` 타입 + 승인 제출/mention 접수 시 캡처. 순수 추가, 소비자 없음(무행동). payload 필드는 `option`으로 추가해 기존 직렬화 하위호환.
 - **W2** — G2 carry-through. resolve/완료 hook이 채널을 wake payload에 실음. 직렬화 왕복 + audit.
 - **W3** — G3 re-engagement. intake가 채널로 대화 재개. HITL 먼저(가장 명확한 계기), 그다음 `Connector_attention`(G4).
+  - **구현 노트 (2026-07-08 조사)**: `Connector_attention`은 `keeper_heartbeat_stimulus_intake.ml:226-269`에서 `external_attention` item(surface_ref 포함)을 turn observation으로 이미 주입한다. 따라서 Connector 계열의 실제 gap은 wake payload가 아니라 **turn 결과를 channel로 delivery하는 라우팅**이다(현재 heartbeat turn 결과가 원 채널로 가지 않음). `Hitl_resolved`는 `external_attention`이 없어 wake payload의 `channel`이 유일한 provenance이며, 그 provenance 캡처가 W2b다. 즉 W3의 핵심 난도는 delivery 라우팅(keeper turn 아키텍처)이고 W2b는 approval entry provenance 배선이다 — 두 축이 독립적으로 진행 가능.
 - **W4** — G5 observability + G6 safety invariant + TLA+ + regression 픽스처. `Bg`/`Fusion`/`Schedule`로 채널 확장 및 Dashboard streaming/패널-drop caveat(§1.4)은 opt-in follow-up.
 
 ## 10. Open questions

--- a/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
+++ b/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
@@ -154,6 +154,12 @@ and connector_attention =
 - **W2** — G2 carry-through. resolve/완료 hook이 채널을 wake payload에 실음. 직렬화 왕복 + audit.
 - **W3** — G3 re-engagement. intake가 채널로 대화 재개. HITL 먼저(가장 명확한 계기), 그다음 `Connector_attention`(G4).
   - **구현 노트 (2026-07-08 조사)**: `Connector_attention`은 `keeper_heartbeat_stimulus_intake.ml:226-269`에서 `external_attention` item(surface_ref 포함)을 turn observation으로 이미 주입한다. 따라서 Connector 계열의 실제 gap은 wake payload가 아니라 **turn 결과를 channel로 delivery하는 라우팅**이다(현재 heartbeat turn 결과가 원 채널로 가지 않음). `Hitl_resolved`는 `external_attention`이 없어 wake payload의 `channel`이 유일한 provenance이며, 그 provenance 캡처가 W2b다. 즉 W3의 핵심 난도는 delivery 라우팅(keeper turn 아키텍처)이고 W2b는 approval entry provenance 배선이다 — 두 축이 독립적으로 진행 가능.
+  - **W3 delivery 청사진 (Explore 조사, SMALL-to-MEDIUM — from-scratch 아님)**:
+    - **송신 인프라는 이미 존재·재사용**: `keeper_surface_post` 도구(`keeper_tool_in_process_runtime.ml:205-265`, `keeper_tool_runtime.ml:184`)가 Discord(`Channel_gate_discord_state.send_message`)/Slack(`Keeper_chat_slack.send_message_with_blocks`)로 send + `Keeper_chat_store` persist + `Keeper_chat_broadcast`한다. 표준 keeper 도구라 autonomous/wake turn에서 호출 가능.
+    - **현재 자동 미전달 이유**: chat 경로(`Keeper_chat_consumer` → `handle_turn`)는 `Keeper_chat_events` stream + adapter로 커넥터에 전달하지만, wake 경로 `Keeper_unified_turn.run_keeper_cycle`(`keeper_unified_turn.mli:199-209`)은 **events/channel/connector 파라미터가 없다**. wake-turn `response_text`는 `keeper_agent_run_finalize_response.ml:418,447,528`에서 checkpoint/session + post-turn memory로만 가고, autonomous prose는 `keeper_unified_turn_success.ml:129-131`에서 `Internal_prose`로 분류된다.
+    - **구현 seam**: `keeper_agent_run_finalize_response.finalize`(response_text 생산) 또는 `Keeper_unified_turn_success` 성공 핸들러에 post-turn routing seam을 추가. wake의 `continuation_channel`(routable일 때)과 `response_text`를 기존 send 인프라로 전달. Unrouted면 기존대로 internal 유지(fail-closed).
+    - **관통 필요**: `continuation_channel`을 wake stimulus → `run_keeper_cycle`(현재 param 없음) → `finalize`까지 전파. `run_keeper_cycle` 시그니처 변경이 호출자 관통을 유발(컴파일러가 강제). 정책: routable channel일 때만 delivery, autonomous internal prose는 그대로.
+    - **두 해석**: (a) "keeper가 채널로 답할 수 있다" = `keeper_surface_post`로 이미 가능(SMALL, self-description에 channel + 지시만); (b) "결정론적 auto-deliver(모델이 도구 안 골라도)" = MEDIUM(위 seam). RFC-0320 §2 "라우팅=결정론적" 원칙상 (b)가 정합.
 - **W4** — G5 observability + G6 safety invariant + TLA+ + regression 픽스처. `Bg`/`Fusion`/`Schedule`로 채널 확장 및 Dashboard streaming/패널-drop caveat(§1.4)은 opt-in follow-up.
 
 ## 10. Open questions

--- a/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
+++ b/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
@@ -1,0 +1,167 @@
+---
+rfc: "0320"
+title: "Keeper connector-aware continuation: carry the originating channel through wake so a resumed keeper replies where the conversation started"
+status: Draft
+created: 2026-07-08
+updated: 2026-07-08
+author: vincent (+ Claude Opus 4.8)
+supersedes: []
+superseded_by: null
+related: ["0315", "0304", "0303", "connector-deferred-reply-via-chat-queue", "connector-ambient-attention-wake"]
+implementation_prs: []
+---
+
+# RFC-0320: Keeper connector-aware continuation
+
+wake는 발화되지만 keeper가 **어느 대화를 이어가야 하는지**를 모른다. 승인이 풀리고 mention이 와도 keeper가 자기 상태로만 진행하고 발화했던 채널로 돌아오지 않는 근원을, 직교하는 wake 계열 전체 관점에서 닫는다.
+
+## 1. Problem — connector-blind wake
+
+keeper 이벤트 큐의 wake payload는 id + 결과만 싣는다. 어느 커넥터(대시보드 채팅 / Discord / Slack 스레드)에서 대화가 시작됐는지가 제출 시점에 캡처되지 않아 resolve→wake까지 전달할 수가 없다. 그래서 keeper는 깨어나도 "proceed on its own state" — 발화했던 대화로 돌아오지 못한다.
+
+### 1.1 실측 체인 (30초 내 승인했는데도 keeper가 채팅에서 멈춘 사례, `appr_7bf611289364`)
+
+1. keeper가 대시보드 채팅 턴에서 gated tool(`gh repo create`, audited/privileged)을 호출.
+2. 승인 큐에 제출 — entry는 `turn_id` / `task_id` / `goal_id`만 캡처. chat connector / thread는 캡처 안 함.
+3. keeper 턴이 "승인 대기 중" narration을 하고 종료.
+4. operator가 30초 뒤 승인 → `resolve_entry` → composition-root hook이 `Hitl_resolved{approval_id, decision}`를 keeper 큐에 enqueue. wake는 분명히 발화됨.
+5. keeper가 `Hitl_resolved`로 깨어남 — 그러나 payload에 커넥터가 없고, intake가 "unblock → proceed on its own state"로 처리. "채팅 스레드로 대화 이어가라"가 아님.
+6. → keeper는 대시보드 채팅에 답하지 않고 자율 사이클로 진행. **채팅 관점에선 멈춘 것.**
+
+### 1.2 증거 (adversarial 검증 완료, file:line)
+
+| 사실 | 위치 | 확인 |
+|---|---|---|
+| wake payload에 커넥터 없음 | `lib/keeper_runtime/keeper_event_queue.ml:39-92` | 11개 wake variant 전수. `hitl_resolution={approval_id;decision}` (:119-126), `connector_attention={event_id}` (:132). 어느 payload도 outbound reply channel을 first-class 필드로 갖지 않음. |
+| Hitl_resolved intake = 자기상태 | `keeper_heartbeat_stimulus_intake.ml:104-115` | `event_queue_trigger_of_stimulus`가 `None` 반환. 주석: "proceeds on its own state". |
+| Hitl_resolved consume = 빈 관찰 | `keeper_heartbeat_stimulus_intake.ml:259-271` | `[]` 반환, reply-channel 라우팅 없음 ("no observation to inject"). |
+| approval entry에 커넥터 없음 | `keeper_approval_queue` (`create_entry`) | `turn_id`/`task_id`/`goal_id`(+sandbox/runtime/model)만. chat connector/thread 필드 부재. |
+| resolve→wake hook에 채널 없음 | `server_bootstrap_loops.ml:509-526` | `Hitl_resolved{approval_id,decision}` enqueue. entry 타입에도 hook에도 전달할 channel 필드 자체가 없음. |
+| 커넥터 좌표는 존재하나 wake에 안 실림 | `keeper_external_attention.mli:15-29` | `surface_ref`가 Discord{channel_id;thread_id}/Slack{channel_id;thread_ts}/Webhook을 이미 모델링. `Connector_attention`은 `{event_id}` 포인터로 간접 참조만, 좌표는 store에서 재조회. |
+
+### 1.3 유일한 예외 = 살아있는 turn의 in-place 재개
+
+채널에 답이 도달하는 **단 하나의 경로**는 fast-approval resolver가 **원래 suspended turn을 in-place로 재개**할 때다 (원래 turn이 아직 살아있어야 함). 이는 wake path가 아니며, 턴이 종료된 뒤에는 성립하지 않는다. 턴이 끝나면 woken keeper는 자기 상태로 진행하고 발화 채널로 답하지 않는다.
+
+### 1.4 인접 사실 — Dashboard continuation은 이미 push된다 (별개 개선)
+
+adversarial 검증에서 교정된 사실: 대시보드-소스 queued 턴의 결과는 `process_single_turn`이 `Keeper_chat_broadcast.chat_appended`를 호출해 실시간 전달된다 (`server_routes_http_keeper_stream.ml:1288-1289` → `keeper_chat_broadcast.ml:82` → `sse.ml:1011`; 대시보드 `sse-store.ts:637` → `hydrateKeeperChatHistory(force)` `keeper-actions.ts:741-762`). 즉 **이 RFC의 주 대상이 아니다.** 남는 caveat 둘: (a) live token streaming은 유실되고 final message만 재-fetch로 나타남, (b) 해당 keeper 패널이 hydrate/active 상태일 때만 도착, 아니면 client-side drop되어 다음 open 시 보임. 이 둘은 §9 follow-up으로 분리한다. **이 RFC의 코어는 event-queue wake의 outbound continuation이다** (Dashboard chat inbound가 아니라).
+
+### 1.5 기존 RFC와의 경계
+
+- `RFC-connector-deferred-reply-via-chat-queue` — busy-path connector 메시지를 chat queue로 drain (구현: #22798/#23446, stale Draft/[] 메타에도 실질 구현됨). **Discord inbound 한정.**
+- `RFC-connector-ambient-attention-wake` — idle keeper가 ambient connector 메시지 인지 (구현: #22818/#22825). **Discord ambient 한정.**
+- 두 RFC 모두 **inbound** dispatch/ambient를 다루며, `Hitl_resolved` 및 나머지 event-queue wake의 **outbound continuation connector-blindness는 어느 쪽도 닫지 않는다.** 이 RFC가 그 gap을 닫는다.
+
+## 2. 원칙 — continuation channel을 일급으로
+
+깨우는 것(stimulus)과 어디로 답할지(continuation channel)를 분리된 두 개념으로 두지 말고, wake가 originating channel을 실어나른다. 판단(무엇을 말할지)은 LLM 경계에 남기고, 라우팅(어디로 답할지)은 결정론적으로 stimulus에 태워 보낸다. 커넥터를 지어내지 않는다 — 없으면 `Unrouted`로 표면화(fail-closed).
+
+## 3. 직교 wake 계열 매트릭스
+
+이 gap은 HITL만이 아니다. keeper 이벤트 큐의 wake 계열 전체가 같은 결함을 공유한다 — "누가 특정 채널에서 응답/이어짐을 기다림"인데 채널이 안 실린다.
+
+| Wake stimulus | 계기 | continuation 대상 | 현재 payload | 커넥터 필요 | 현재 동작 |
+|---|---|---|---|---|---|
+| `Hitl_resolved` | operator 승인/거부 | 발화했던 채팅 스레드 | `{approval_id, decision}` | 필수 | 자기상태 진행 |
+| `Connector_attention` | keeper/유저 @mention·메시지 | 부른 채널·상대 | `{event_id}` | 필수 | 응답 루프 안 닫힘 |
+| `Bg_completed` | 백그라운드 잡 완료 (RFC-0290) | 요청한 대화/보고처 | `{bg_run_id;…}` | 권장 | 보고처 유실 가능 |
+| `Fusion_completed` | fusion 완료 | 요청 맥락 | `{run_id;…}` | 권장 | 동상 |
+| `Schedule_due` | 예약 wake | 예약이 지정한 대상 | `{schedule_id;…}` | 선택 | 대상별 상이 |
+| `Goal_assigned` | 목표 배정 (RFC-0315) | 배정자 | `{ga_goal_id;…}` | 선택 | self-desc 있음 |
+| `Board_signal` | 보드 포스트 | 보드 스레드 | `{…author;hearth}` | 선택 | 보드 한정 |
+| `Bootstrap` / `No_progress_recovery` | 내부 복구/부팅 | (대화 아님) | — | 불필요 | 해당 없음 |
+
+→ continuation channel이 필요한 5계열(`Hitl_resolved`, `Connector_attention`, `Bg_completed`/`Fusion_completed`, `Schedule_due`)이 동일한 구조 수정으로 함께 닫힌다. 이것이 이 설계를 단발 패치가 아니라 직교 매트릭스로 다루는 이유다.
+
+## 4. Goal Matrix
+
+각 Goal은 독립 검증 가능한 슬라이스.
+
+| Goal | 현재 | Gap | 목표 (측정 가능) | 접점 (파일) | 검증 | 경계·리스크 |
+|---|---|---|---|---|---|---|
+| **G1** provenance capture | entry/stimulus가 turn/task/goal만 | originating connector 미캡처 | typed `continuation_channel`(Dashboard{thread}\|Discord{ch,user}\|Slack{ch,user}\|Unrouted{reason})를 승인 제출·mention 접수 시점에 캡처 | `keeper_approval_queue`(create_entry), `keeper_chat_queue`, `connector_attention` | 제출 시 커넥터 왕복 테스트; 없으면 Unrouted | 커넥터 지어내기 금지 → Unrouted (fail-closed) |
+| **G2** carry-through | resolve→`Hitl_resolved{id,decision}` | wake payload에 채널 없음 | resolve/완료 hook이 `continuation_channel`을 wake payload에 실어 enqueue | `server_bootstrap_loops`(hitl hook), `keeper_event_queue`(payload 확장) | resolve→enqueue payload에 채널 보존; 직렬화 왕복 | payload 확장은 exhaustive; 미매핑 variant 컴파일 에러 |
+| **G3** re-engagement | 깨면 "proceed on its own state" | 발화 대화로 복귀 안 함 | wake 턴이 `continuation_channel`의 대화를 재개 — 채팅 스레드/부른 상대에게 응답. RFC-0315 self-description에 "continuation channel" 차원 추가 | `keeper_heartbeat_stimulus_intake`, `keeper_unified_prompt`(self-desc) | 승인→해당 스레드에 응답 도착; Unrouted면 자율진행 | 재개는 대화만; 새 privileged 행동은 재-게이팅(RFC-0319) |
+| **G4** keeper↔keeper | `Connector_attention` wake만 존재 | 부른 채널로 응답 루프 안 닫힘 → "서로 안 도와줌" | A가 B를 mention→B가 A가 부른 채널에서 응답. G1–G3를 mention 경로에 적용 | `connector_attention`, reactive wake 경로 | A@B→B가 같은 채널 응답 관측; 무응답률 지표 하락 | 과잉 wake 방지(RFC-0303 throttle 유지) |
+| **G5** observability | resolve만 audit | wake→continuation 전달/누락 불가시 | 모든 wake→continuation을 attributed; Unrouted·dropped-continuation을 대시보드에 표면화(silent 금지) | `audit_approval_event`, `agent_timeline`, dashboard | continuation 전달률·Unrouted 카운트 노출 | telemetry-as-fix 금지 — 카운트는 알람이지 fix 아님 |
+| **G6** safety invariant | — | 재개 시 gated 행동 자동실행 위험 | 재개는 대화 계속일 뿐: 새 privileged tool은 다시 승인 큐로. continuation이 중복 실행/자동승인으로 새지 않음 | `governance_pipeline` / `runtime_agent_context.ml:491-493`(재-게이팅 경로) | TLA+ must-fail: `ContinuationNeverAutoExecutesGated` | RFC-0319 직무분리와 정합; 이중 실행 방지 |
+
+## 5. 데이터 모델 델타
+
+커넥터 provenance를 closed variant로. bool/string 금지 — 미분류는 `Unrouted`로 표현 가능해야 하고(fail-closed), 새 커넥터 추가 시 라우팅 지점이 컴파일 에러가 나야 한다.
+
+```ocaml
+(* NOW — id만: wake payload에 대화 채널이 없다 *)
+and hitl_resolution = { approval_id : string; decision : hitl_resolution_decision }
+and connector_attention = { event_id : string }
+(* 승인 entry: turn/task/goal만, chat connector 필드 없음 *)
+
+(* TO-BE — continuation_channel 관통 *)
+type continuation_channel =
+  | Dashboard of { thread_id : string }
+  | Discord   of { channel_id : string; user_id : string }
+  | Slack     of { channel : string; user_id : string }
+  | Unrouted  of { reason : string }   (* fail-closed: 커넥터 미상 *)
+
+and hitl_resolution =
+  { approval_id : string; decision : hitl_resolution_decision; channel : continuation_channel }
+and connector_attention =
+  { event_id : string; channel : continuation_channel }
+(* create_entry … ~turn_id ~task_id ~goal_id ~channel  (제출 시점 캡처, resolve까지 관통) *)
+```
+
+## 6. Wake 턴 재개 — before / after
+
+```ocaml
+(* NOW — heartbeat intake *)
+| Hitl_resolved _ ->
+  (* approval left the queue; keeper no longer skips on
+     Approval_pending and proceeds ON ITS OWN STATE *)
+  []   (* → 발화 대화로 안 돌아옴 *)
+
+(* TO-BE — connector-aware *)
+| Hitl_resolved r ->
+  (match r.channel with
+   | Dashboard { thread_id } -> resume_conversation ~thread_id ~note:(approval_outcome r)
+   | Discord _ | Slack _     -> resume_conversation ~channel:r.channel ~note:(approval_outcome r)
+   | Unrouted { reason }      -> log_unrouted reason; proceed_on_own_state ())
+  (* exhaustive: 새 채널 = 컴파일 에러 *)
+```
+
+판단(무엇을 말할지)=LLM. 라우팅(어디로)=결정론적 channel 매치. 둘의 경계가 이 설계의 핵심.
+
+## 7. 불변식 & 검증
+
+- **Fail-closed 라우팅**: 커넥터를 결정 못 하면 `Unrouted` — 임의 채널로 보내지 않고 자율진행 + 표면화.
+- **Exhaustive 매치**: `continuation_channel`·wake variant는 catch-all(`_ ->`) 금지. 새 커넥터/새 wake는 라우팅 지점에서 컴파일 에러.
+- **No double-execute (G6)**: 재개는 대화 계속일 뿐. 재개 턴의 새 privileged tool은 다시 승인 큐. TLA+ `ContinuationNeverAutoExecutesGated` must-fail 모델(clean 만족 / buggy 위반). 현재 wiring(`runtime_agent_context.ml:491-493`)은 resumed 턴을 fresh 턴과 같은 governance callback으로 보내나 재-invocation 실행 의미론은 외부 Agent SDK에 있어 in-repo 미검증 — TLA+로 invariant를 못박는다.
+- **At-most-once continuation**: 한 resolution이 두 번 재개하지 않음(중복 wake 멱등).
+- **Observable**: continuation 전달률 + Unrouted 카운트가 대시보드에 노출 — dropped continuation이 silent가 아님.
+- **Regression**: `appr_7bf611289364` 시나리오 재현 — 대시보드 채팅 발화→gated→30초 승인→같은 스레드에 응답 도착.
+
+## 8. 경계
+
+- **MASC 전용** — OAS 무관.
+- **LLM 경계** = 재개 턴에서 무엇을 말할지. 라우팅(어디로)은 typed channel로 결정론적. 커넥터를 LLM/문자열로 추론하지 않음.
+- **No fabrication** — 커넥터 미상은 `Unrouted`. 편의 기본값(예: 항상 Dashboard) 금지.
+- **RFC-0319와 직교** — 이건 continuation 라우팅, 저건 auto-approval 모드. G6에서 직무분리·재게이팅으로 만난다.
+- **과잉 wake 금지** — RFC-0303 reactive-wake throttle / No_signal 게이트 유지. continuation은 이미 있던 대화의 재개이지 새 wake 소스가 아니다.
+
+## 9. 롤아웃 웨이브
+
+- **W1** — G1 provenance capture. `continuation_channel` 타입 + 승인 제출/mention 접수 시 캡처. 순수 추가, 소비자 없음(무행동). payload 필드는 `option`으로 추가해 기존 직렬화 하위호환.
+- **W2** — G2 carry-through. resolve/완료 hook이 채널을 wake payload에 실음. 직렬화 왕복 + audit.
+- **W3** — G3 re-engagement. intake가 채널로 대화 재개. HITL 먼저(가장 명확한 계기), 그다음 `Connector_attention`(G4).
+- **W4** — G5 observability + G6 safety invariant + TLA+ + regression 픽스처. `Bg`/`Fusion`/`Schedule`로 채널 확장 및 Dashboard streaming/패널-drop caveat(§1.4)은 opt-in follow-up.
+
+## 10. Open questions
+
+- 재개 타이밍: resolve 즉시 wake vs 다음 heartbeat 틱? (throttle와의 상호작용)
+- 턴 종료 후 재개: `submit_and_await`가 여전히 블로킹이면 fiber 재개 vs 새 continuation 턴 — 어느 것이 SSOT?
+- 커넥터 만료: 대화 스레드가 닫힌 뒤 승인되면? (`Unrouted` + 보드 fallback?)
+- 다중 대기: 한 keeper가 여러 채널에서 대기 시 continuation 우선순위.
+
+---
+
+근거: `keeper_approval_queue.ml` · `keeper_event_queue.ml` · `keeper_heartbeat_stimulus_intake.ml` · `server_bootstrap_loops.ml` · `keeper_external_attention.mli` · `server_routes_http_keeper_stream.ml` · `runtime_agent_context.ml`. 인접 RFC-0315 / RFC-0304 / RFC-0290 / RFC-0303. 설계 원본: `reports/masc-keeper-connector-aware-continuation-goal-matrix.html`. 근본원인 매핑 및 adversarial 검증(H1 교정 / H2 확정)은 7-agent understand workflow(2026-07-08)로 수행.

--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -143,13 +143,13 @@ let apply_record path c json =
 let state_of_counters c =
   if c.stale_source_snapshot_count > 0
   then Source_snapshot_stale
-  else if c.artifact_missing_count > 0
-  then Artifact_missing
   else if c.missing_source_snapshot_count > 0
           || c.artifact_unknown_count > 0
           || c.artifact_not_verified_count > 0
           || c.rejected_count > 0
   then Needs_evidence
+  else if c.artifact_missing_count > 0
+  then Artifact_missing
   else Verified
 ;;
 

--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -323,6 +323,7 @@ let append_record ~tool_name ~author ~target_post_id ~content ~claims ~snapshot 
        | None -> [])
   in
   let path = Board_claim_evidence.sidecar_path () in
+  Fs_compat.invalidate_cached_writer path;
   Fs_compat.append_jsonl path json;
   (* Mirror sibling sidecars (board_posts/comments/reactions/sub_boards), which
      rotate at [Board_paths.max_jsonl_bytes]. Without this the claim-evidence
@@ -332,16 +333,18 @@ let append_record ~tool_name ~author ~target_post_id ~content ~claims ~snapshot 
 ;;
 
 let evaluate ~target_post_id ~claims ~snapshot ~artifact_refs ~resolutions =
-  match snapshot with
-  | Some source ->
-    (match target_post_id with
-     | None -> Reject "source_post_snapshot_without_target_post"
-     | Some target_post_id ->
-       (match validate_source_snapshot ~target_post_id source with
-     | Error reason -> Reject reason
-        | Ok () -> Allow))
-  | None -> Allow
-  |> function
+  let snapshot_decision =
+    match snapshot with
+    | Some source ->
+      (match target_post_id with
+       | None -> Reject "source_post_snapshot_without_target_post"
+       | Some target_post_id ->
+         (match validate_source_snapshot ~target_post_id source with
+          | Error reason -> Reject reason
+          | Ok () -> Allow))
+    | None -> Allow
+  in
+  match snapshot_decision with
   | Reject _ as reject -> reject
   | Allow ->
     let requires_artifact = List.exists claim_requires_existing_artifact claims in

--- a/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
+++ b/lib/exec/test/test_shell_ir_gh_capability_baseline.ml
@@ -270,10 +270,10 @@ let test_ledger () =
   Alcotest.(check int) "corpus size" 32 (List.length corpus);
   (* W4/G-9 delta vs W1: the 9 policy-as-risk cases moved R2->R1 (repo
      create/fork, discussion create/comment/edit/close, graphql create x3), so
-     R1 5->14, R2 20->11, and policy_as_risk 9->0 — the #23362 defect is closed. *)
+     R1 6->15, R2 19->10, and policy_as_risk 9->0 — the #23362 defect is closed. *)
   Alcotest.(check int) "R0 count" 7 r0;
-  Alcotest.(check int) "R1 count" 14 r1;
-  Alcotest.(check int) "R2 count" 11 r2;
+  Alcotest.(check int) "R1 count" 15 r1;
+  Alcotest.(check int) "R2 count" 10 r2;
   Alcotest.(check int) "Destructive count" 0 dp;
   Alcotest.(check int) "defect: policy-as-risk (CLOSED by W4)" 0 policy_as_risk;
   (* Was 1 (unknown-repo-action). CLOSED: the auto-run gap moved to the

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -24,7 +24,8 @@
   keeper_runtime_failure_route
   keeper_latched_reason
   keeper_event_queue
-  keeper_event_queue_persistence)
+  keeper_event_queue_persistence
+  keeper_continuation_channel)
  (libraries
   agent_sdk
   agent_sdk.llm_provider

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -1,0 +1,88 @@
+type t =
+  | Dashboard of { thread_id : string }
+  | Discord of { channel_id : string; user_id : string }
+  | Slack of { channel : string; user_id : string }
+  | Unrouted of { reason : string }
+
+let unrouted reason = Unrouted { reason }
+
+let is_routable = function
+  | Unrouted _ -> false
+  | Dashboard _ | Discord _ | Slack _ -> true
+
+let kind_label = function
+  | Dashboard _ -> "dashboard"
+  | Discord _ -> "discord"
+  | Slack _ -> "slack"
+  | Unrouted _ -> "unrouted"
+
+let describe = function
+  | Dashboard { thread_id } -> Printf.sprintf "dashboard thread=%s" thread_id
+  | Discord { channel_id; user_id } ->
+    Printf.sprintf "discord channel=%s user=%s" channel_id user_id
+  | Slack { channel; user_id } -> Printf.sprintf "slack channel=%s user=%s" channel user_id
+  | Unrouted { reason } -> Printf.sprintf "unrouted (%s)" reason
+
+let same_route a b =
+  match a, b with
+  | Dashboard x, Dashboard y -> String.equal x.thread_id y.thread_id
+  | Discord x, Discord y ->
+    String.equal x.channel_id y.channel_id && String.equal x.user_id y.user_id
+  | Slack x, Slack y ->
+    String.equal x.channel y.channel && String.equal x.user_id y.user_id
+  | Unrouted _, Unrouted _ -> false
+  (* Distinct-constructor pairs share no route. Listing the constructors
+     explicitly (not [_]) keeps this exhaustive: a new variant forces a
+     compile error here rather than silently defaulting to [false]. *)
+  | (Dashboard _ | Discord _ | Slack _ | Unrouted _), (Dashboard _ | Discord _ | Slack _ | Unrouted _)
+    -> false
+
+let to_yojson = function
+  | Dashboard { thread_id } ->
+    `Assoc [ ("kind", `String "dashboard"); ("thread_id", `String thread_id) ]
+  | Discord { channel_id; user_id } ->
+    `Assoc
+      [ ("kind", `String "discord")
+      ; ("channel_id", `String channel_id)
+      ; ("user_id", `String user_id)
+      ]
+  | Slack { channel; user_id } ->
+    `Assoc
+      [ ("kind", `String "slack")
+      ; ("channel", `String channel)
+      ; ("user_id", `String user_id)
+      ]
+  | Unrouted { reason } ->
+    `Assoc [ ("kind", `String "unrouted"); ("reason", `String reason) ]
+
+let ( let* ) = Result.bind
+
+let assoc_fields = function
+  | `Assoc fields -> Ok fields
+  | _ -> Error "continuation_channel must be a JSON object"
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String s) -> Ok s
+  | Some _ -> Error (Printf.sprintf "continuation_channel: field %s must be a string" name)
+  | None -> Error (Printf.sprintf "continuation_channel: missing field %s" name)
+
+let of_yojson json =
+  let* fields = assoc_fields json in
+  let* kind = string_field "kind" fields in
+  match kind with
+  | "dashboard" ->
+    let* thread_id = string_field "thread_id" fields in
+    Ok (Dashboard { thread_id })
+  | "discord" ->
+    let* channel_id = string_field "channel_id" fields in
+    let* user_id = string_field "user_id" fields in
+    Ok (Discord { channel_id; user_id })
+  | "slack" ->
+    let* channel = string_field "channel" fields in
+    let* user_id = string_field "user_id" fields in
+    Ok (Slack { channel; user_id })
+  | "unrouted" ->
+    let* reason = string_field "reason" fields in
+    Ok (Unrouted { reason })
+  | other -> Error (Printf.sprintf "continuation_channel: unknown kind: %s" other)

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -52,11 +52,47 @@ let describe = function
       user_id
   | Unrouted { reason } -> Printf.sprintf "unrouted (%s)" reason
 
+let same_string_option = Option.equal String.equal
+
 let same_route a b =
   match a, b with
-  | Dashboard x, Dashboard y -> String.equal x.thread_id y.thread_id
-  | Discord x, Discord y -> x = y
-  | Slack x, Slack y -> x = y
+  | Dashboard { thread_id = left }, Dashboard { thread_id = right } ->
+    String.equal left right
+  | ( Discord
+        { guild_id = left_guild
+        ; channel_id = left_channel
+        ; parent_channel_id = left_parent
+        ; thread_id = left_thread
+        ; user_id = left_user
+        }
+    , Discord
+        { guild_id = right_guild
+        ; channel_id = right_channel
+        ; parent_channel_id = right_parent
+        ; thread_id = right_thread
+        ; user_id = right_user
+        } ) ->
+    same_string_option left_guild right_guild
+    && String.equal left_channel right_channel
+    && same_string_option left_parent right_parent
+    && same_string_option left_thread right_thread
+    && String.equal left_user right_user
+  | ( Slack
+        { team_id = left_team
+        ; channel_id = left_channel
+        ; thread_ts = left_thread
+        ; user_id = left_user
+        }
+    , Slack
+        { team_id = right_team
+        ; channel_id = right_channel
+        ; thread_ts = right_thread
+        ; user_id = right_user
+        } ) ->
+    same_string_option left_team right_team
+    && String.equal left_channel right_channel
+    && same_string_option left_thread right_thread
+    && String.equal left_user right_user
   | Unrouted _, Unrouted _ -> false
   (* Distinct-constructor pairs share no route. Listing the constructors
      explicitly (not [_]) keeps this exhaustive: a new variant forces a

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -1,7 +1,18 @@
 type t =
   | Dashboard of { thread_id : string }
-  | Discord of { channel_id : string; user_id : string }
-  | Slack of { channel : string; user_id : string }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+      user_id : string;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+      user_id : string;
+    }
   | Unrouted of { reason : string }
 
 let unrouted reason = Unrouted { reason }
@@ -18,18 +29,34 @@ let kind_label = function
 
 let describe = function
   | Dashboard { thread_id } -> Printf.sprintf "dashboard thread=%s" thread_id
-  | Discord { channel_id; user_id } ->
-    Printf.sprintf "discord channel=%s user=%s" channel_id user_id
-  | Slack { channel; user_id } -> Printf.sprintf "slack channel=%s user=%s" channel user_id
+  | Discord { guild_id; channel_id; parent_channel_id; thread_id; user_id } ->
+    let opt label = function
+      | None -> ""
+      | Some value -> Printf.sprintf " %s=%s" label value
+    in
+    Printf.sprintf "discord%s channel=%s%s%s user=%s"
+      (opt "guild" guild_id)
+      channel_id
+      (opt "parent_channel" parent_channel_id)
+      (opt "thread" thread_id)
+      user_id
+  | Slack { team_id; channel_id; thread_ts; user_id } ->
+    let opt label = function
+      | None -> ""
+      | Some value -> Printf.sprintf " %s=%s" label value
+    in
+    Printf.sprintf "slack%s channel=%s%s user=%s"
+      (opt "team" team_id)
+      channel_id
+      (opt "thread_ts" thread_ts)
+      user_id
   | Unrouted { reason } -> Printf.sprintf "unrouted (%s)" reason
 
 let same_route a b =
   match a, b with
   | Dashboard x, Dashboard y -> String.equal x.thread_id y.thread_id
-  | Discord x, Discord y ->
-    String.equal x.channel_id y.channel_id && String.equal x.user_id y.user_id
-  | Slack x, Slack y ->
-    String.equal x.channel y.channel && String.equal x.user_id y.user_id
+  | Discord x, Discord y -> x = y
+  | Slack x, Slack y -> x = y
   | Unrouted _, Unrouted _ -> false
   (* Distinct-constructor pairs share no route. Listing the constructors
      explicitly (not [_]) keeps this exhaustive: a new variant forces a
@@ -37,21 +64,32 @@ let same_route a b =
   | (Dashboard _ | Discord _ | Slack _ | Unrouted _), (Dashboard _ | Discord _ | Slack _ | Unrouted _)
     -> false
 
+let option_string_fields fields =
+  List.filter_map
+    (fun (name, value) -> Option.map (fun value -> name, `String value) value)
+    fields
+
 let to_yojson = function
   | Dashboard { thread_id } ->
     `Assoc [ ("kind", `String "dashboard"); ("thread_id", `String thread_id) ]
-  | Discord { channel_id; user_id } ->
+  | Discord { guild_id; channel_id; parent_channel_id; thread_id; user_id } ->
     `Assoc
-      [ ("kind", `String "discord")
-      ; ("channel_id", `String channel_id)
-      ; ("user_id", `String user_id)
-      ]
-  | Slack { channel; user_id } ->
+      ([ ("kind", `String "discord")
+       ; ("channel_id", `String channel_id)
+       ; ("user_id", `String user_id)
+       ]
+       @ option_string_fields
+           [ ("guild_id", guild_id)
+           ; ("parent_channel_id", parent_channel_id)
+           ; ("thread_id", thread_id)
+           ])
+  | Slack { team_id; channel_id; thread_ts; user_id } ->
     `Assoc
-      [ ("kind", `String "slack")
-      ; ("channel", `String channel)
-      ; ("user_id", `String user_id)
-      ]
+      ([ ("kind", `String "slack")
+       ; ("channel_id", `String channel_id)
+       ; ("user_id", `String user_id)
+       ]
+       @ option_string_fields [ ("team_id", team_id); ("thread_ts", thread_ts) ])
   | Unrouted { reason } ->
     `Assoc [ ("kind", `String "unrouted"); ("reason", `String reason) ]
 
@@ -67,6 +105,12 @@ let string_field name fields =
   | Some _ -> Error (Printf.sprintf "continuation_channel: field %s must be a string" name)
   | None -> Error (Printf.sprintf "continuation_channel: missing field %s" name)
 
+let optional_string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String s) when String.trim s <> "" -> Some s
+  | Some (`String _) | Some `Null | None -> None
+  | Some _ -> None
+
 let of_yojson json =
   let* fields = assoc_fields json in
   let* kind = string_field "kind" fields in
@@ -77,11 +121,28 @@ let of_yojson json =
   | "discord" ->
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
-    Ok (Discord { channel_id; user_id })
+    Ok
+      (Discord
+         { guild_id = optional_string_field "guild_id" fields
+         ; channel_id
+         ; parent_channel_id = optional_string_field "parent_channel_id" fields
+         ; thread_id = optional_string_field "thread_id" fields
+         ; user_id
+         })
   | "slack" ->
-    let* channel = string_field "channel" fields in
+    let* channel_id =
+      match string_field "channel_id" fields with
+      | Ok value -> Ok value
+      | Error _ -> string_field "channel" fields
+    in
     let* user_id = string_field "user_id" fields in
-    Ok (Slack { channel; user_id })
+    Ok
+      (Slack
+         { team_id = optional_string_field "team_id" fields
+         ; channel_id
+         ; thread_ts = optional_string_field "thread_ts" fields
+         ; user_id
+         })
   | "unrouted" ->
     let* reason = string_field "reason" fields in
     Ok (Unrouted { reason })

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -1,0 +1,48 @@
+(** Keeper_continuation_channel — the connector/channel a wake or approval
+    should continue the conversation on (RFC-0320).
+
+    Captured at submission time (approval create, mention intake) and, in later
+    waves, carried through the wake payload so a resumed keeper replies where
+    the conversation started instead of proceeding on its own state.
+
+    [Unrouted] is the fail-closed value: when the originating connector cannot
+    be determined it is represented explicitly rather than defaulting to a
+    convenience channel. The variant is closed and matches are exhaustive so a
+    new connector forces a compile error at every routing site.
+
+    This module is a pure data type with no consumers yet (RFC-0320 W1). *)
+
+type t =
+  | Dashboard of { thread_id : string }
+  | Discord of { channel_id : string; user_id : string }
+  | Slack of { channel : string; user_id : string }
+  | Unrouted of { reason : string }
+
+(** [unrouted reason] is the fail-closed channel carrying a diagnostic
+    [reason] explaining why no connector could be determined. *)
+val unrouted : string -> t
+
+(** [is_routable t] is [false] only for [Unrouted]; a routable channel has a
+    concrete reply destination. *)
+val is_routable : t -> bool
+
+(** [kind_label t] is a stable lowercase tag for metrics / observability:
+    ["dashboard"] | ["discord"] | ["slack"] | ["unrouted"]. *)
+val kind_label : t -> string
+
+(** [describe t] is a human-readable one-line summary for logs. *)
+val describe : t -> string
+
+(** [same_route a b] is [true] when two channels denote the same reply
+    destination, used to coalesce continuations without losing routing. Two
+    [Unrouted] values are never the same route (an unroutable value has no
+    destination to share). *)
+val same_route : t -> t -> bool
+
+(** [to_yojson t] serializes to a tagged object [{ "kind": <tag>; ... }]. *)
+val to_yojson : t -> Yojson.Safe.t
+
+(** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
+    missing or unknown ["kind"], or a missing field, is an [Error]; there is
+    no permissive default (RFC-0320 §2 fail-closed). *)
+val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -10,12 +10,25 @@
     convenience channel. The variant is closed and matches are exhaustive so a
     new connector forces a compile error at every routing site.
 
-    This module is a pure data type with no consumers yet (RFC-0320 W1). *)
+    This module is a pure data type. It lives below the main [masc] library, so
+    connector constructors carry the lossless coordinate fields used by
+    [Surface_ref] without depending on that higher-level module. *)
 
 type t =
   | Dashboard of { thread_id : string }
-  | Discord of { channel_id : string; user_id : string }
-  | Slack of { channel : string; user_id : string }
+  | Discord of {
+      guild_id : string option;
+      channel_id : string;
+      parent_channel_id : string option;
+      thread_id : string option;
+      user_id : string;
+    }
+  | Slack of {
+      team_id : string option;
+      channel_id : string;
+      thread_ts : string option;
+      user_id : string;
+    }
   | Unrouted of { reason : string }
 
 (** [unrouted reason] is the fail-closed channel carrying a diagnostic

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -131,19 +131,26 @@ and hitl_resolution = {
   approval_id : string;
   (* the resolved pending-approval id; correlates to the queue entry. *)
   decision : hitl_resolution_decision;
-  (* resolved decision label carried for observability, not control flow — the
-     keeper re-evaluates from its own state once the approval is gone from the
-     queue. *)
+  (* resolved decision label carried for observability. *)
+  channel : Keeper_continuation_channel.t;
+  (* RFC-0320: the connector the resolved conversation started on, captured at
+     approval-submission time and carried through so a woken keeper can reply
+     into it. [Unrouted] when no originating connector was captured. *)
 }
 
 and bg_job_outcome =
   | Bg_ok of string  (* result payload *)
   | Bg_failed of string  (* failure label *)
 
-and connector_attention = { event_id : string }
+and connector_attention = {
+  event_id : string;
       (* RFC-connector-ambient-attention-wake: pointer into
          [Keeper_external_attention] for the ambient message; content/surface
          read from that store on the turn path. *)
+  channel : Keeper_continuation_channel.t;
+      (* RFC-0320: the connector that raised this attention, so a woken keeper
+         replies into the same channel. [Unrouted] when unknown. *)
+}
 
 and scheduled_wake = {
   schedule_id : string;
@@ -559,12 +566,14 @@ let payload_to_yojson = function
     `Assoc
       [ "kind", `String "connector_attention"
       ; "event_id", `String ca.event_id
+      ; "channel", Keeper_continuation_channel.to_yojson ca.channel
       ]
   | Hitl_resolved r ->
     `Assoc
       [ "kind", `String "hitl_resolved"
       ; "approval_id", `String r.approval_id
       ; "decision", `String (hitl_resolution_decision_to_string r.decision)
+      ; "channel", Keeper_continuation_channel.to_yojson r.channel
       ]
   | Goal_verification_failed failure ->
     `Assoc
@@ -601,6 +610,14 @@ let payload_to_yojson = function
       ; "stale_since", `String gs.gs_stale_since
       ; "goal_title", `String gs.gs_goal_title
       ]
+
+let continuation_channel_field fields =
+  match List.assoc_opt "channel" fields with
+  | None ->
+    (* Backward compat: pre-RFC-0320 persisted stimuli carry no channel; a
+       replayed legacy wake is [Unrouted] rather than a parse failure. *)
+    Ok (Keeper_continuation_channel.unrouted "legacy: channel not captured")
+  | Some json -> Keeper_continuation_channel.of_yojson json
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -655,12 +672,14 @@ let payload_of_yojson json =
     Ok (Schedule_due { schedule_id; due_at; payload_digest; title; message })
   | "connector_attention" ->
     let* event_id = string_field ~context "event_id" fields in
-    Ok (Connector_attention { event_id })
+    let* channel = continuation_channel_field fields in
+    Ok (Connector_attention { event_id; channel })
   | "hitl_resolved" ->
     let* approval_id = string_field ~context "approval_id" fields in
     let* decision_s = string_field ~context "decision" fields in
     let* decision = hitl_resolution_decision_of_string decision_s in
-    Ok (Hitl_resolved { approval_id; decision })
+    let* channel = continuation_channel_field fields in
+    Ok (Hitl_resolved { approval_id; decision; channel })
   | "goal_verification_failed" ->
     let* goal_id = string_field ~context "goal_id" fields in
     let* request_id = string_field ~context "request_id" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -162,6 +162,10 @@ and hitl_resolution_decision =
 and hitl_resolution = {
   approval_id : string;
   decision : hitl_resolution_decision;
+  channel : Keeper_continuation_channel.t;
+      (** RFC-0320: the connector this resolution should continue the
+          conversation on. [Unrouted] when no originating connector was
+          captured at approval-submission time. *)
 }
 (** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
     pending-approval queue entry; [decision] is the resolved label
@@ -169,7 +173,12 @@ and hitl_resolution = {
     re-evaluates from its own state once the approval leaves the queue, so the
     decision is not itself control flow. *)
 
-and connector_attention = { event_id : string }
+and connector_attention = {
+  event_id : string;
+  channel : Keeper_continuation_channel.t;
+      (** RFC-0320: the connector that raised this attention, so a woken keeper
+          replies into the same channel. [Unrouted] when unknown. *)
+}
 (** RFC-connector-ambient-attention-wake payload for [Connector_attention]:
     [event_id] is the pointer into [Keeper_external_attention] for the ambient
     message; content/surface are read from that store on the turn path. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -513,7 +513,21 @@ let start_keeper_loops
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun ~base_path ~keeper_name ~approval_id ~decision ->
-       let resolution = Keeper_event_queue.{ approval_id; decision } in
+       let resolution =
+         Keeper_event_queue.
+           { approval_id
+           ; decision
+           (* WORKAROUND (RFC-0320 W2): the approval-submission connector is not
+              yet captured on the queue entry, so a HITL resolution cannot route
+              back to the originating chat thread and is [Unrouted]. 근본 해결:
+              W2b threads a continuation_channel through
+              [Keeper_approval_queue.create_entry] and the resolution wake hook
+              so this becomes [entry.channel] instead. *)
+           ; channel =
+               Keeper_continuation_channel.unrouted
+                 "hitl provenance capture pending (RFC-0320 W2b)"
+           }
+       in
        let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
        let stimulus : Keeper_event_queue.stimulus =
          { Keeper_event_queue.post_id = Keeper_event_queue.hitl_resolution_post_id resolution

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -636,7 +636,15 @@ let handle_ambient ~base_dir
            ; urgency = Keeper_event_queue.Low
            ; arrived_at = Unix.gettimeofday ()
              (* NDT-OK: stimulus receipt time, used only for ordering/age *)
-           ; payload = Keeper_event_queue.Connector_attention { event_id }
+           ; payload =
+               (* RFC-0320: carry the originating Discord channel+author so a
+                  woken keeper replies into the same thread, not its own state. *)
+               Keeper_event_queue.Connector_attention
+                 { event_id
+                 ; channel =
+                     Keeper_continuation_channel.Discord
+                       { channel_id; user_id = author_id }
+                 }
            }
          in
          Keeper_registry_event_queue.enqueue ~base_path:base_dir keeper_name stimulus;

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -589,6 +589,8 @@ let handle_ambient ~base_dir
       Discord_observability.record_ambient
         Discord_observability.Ambient_dropped_too_long
     else begin
+      let parent_channel_id = State.parent_channel_of_thread ~channel_id in
+      let thread_id = Option.map (fun _ -> channel_id) parent_channel_id in
       let attention_event_id =
         record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
           ~message_id ~author_id ~author_name ~content:trimmed
@@ -602,8 +604,8 @@ let handle_ambient ~base_dir
              {
                guild_id;
                channel_id;
-               parent_channel_id = None;
-               thread_id = None;
+               parent_channel_id;
+               thread_id;
              })
         ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
         ~external_message_id:message_id
@@ -643,7 +645,12 @@ let handle_ambient ~base_dir
                  { event_id
                  ; channel =
                      Keeper_continuation_channel.Discord
-                       { channel_id; user_id = author_id }
+                       { guild_id
+                       ; channel_id
+                       ; parent_channel_id
+                       ; thread_id
+                       ; user_id = author_id
+                       }
                  }
            }
          in

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -21,6 +21,9 @@ let parse_task_contract args =
            "contract must be an object when provided (received %s)"
            (Json_util.kind_name other))
 
+let handoff_example_evidence_ref =
+  Filename.concat Common.masc_dirname "harness-evidence/proof.json"
+
 let is_internal_marker key =
   String.length key > 0 && Char.equal key.[0] '_'
 
@@ -123,11 +126,12 @@ let parse_handoff_context ~(agent_name : string)
                    "handoff_context.summary is required for action=%s \
                     (non-empty string). Example: {\"summary\": \"tests \
                     green, local proof saved\", \"next_step\": \"wait \
-                    for CI\", \"evidence_refs\": [\".masc/harness-evidence/proof.json\"]}. \
+                    for CI\", \"evidence_refs\": [\"%s\"]}. \
                     Alternatively pass a non-empty top-level 'notes' or \
                     'reason' and it will be synthesized into summary \
                     automatically."
-                   (Masc_domain.task_action_to_string action))
+                   (Masc_domain.task_action_to_string action)
+                   handoff_example_evidence_ref)
             else
               (* Entry-class action (claim/start) with an empty
                  handoff_context object. The summary is meaningless at

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -24,6 +24,22 @@ module Float = Stdlib.Float
 let masc_add_task_name =
   Tool_name.Task_name.to_string Tool_name.Task_name.Add_task
 
+let handoff_example_evidence_ref =
+  Filename.concat Common.masc_dirname "harness-evidence/proof.json"
+
+let handoff_context_description =
+  Printf.sprintf
+    "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class \
+     actions (done / submit_for_verification / release / cancel). On \
+     action='done' or 'submit_for_verification', include 'evidence_refs' with \
+     at least one locally validated reference: an existing base-path artifact \
+     file/file:// URI, a commit hash present in the local git repo, or a %s \
+     trace/turn/receipt ref that resolves on disk. Completion notes, URLs, PR \
+     numbers, and trace-shaped labels alone do NOT satisfy the gate. Example: \
+     {\"summary\": \"tests green, local proof saved\", \"evidence_refs\": [\"%s\"]}."
+    Common.masc_dirname
+    handoff_example_evidence_ref
+
 let schemas : Masc_domain.tool_schema list = [
   {
     name = masc_add_task_name;
@@ -253,7 +269,7 @@ they do not route normal completion through the verifier agent."
         ]);
         ("handoff_context", `Assoc [
           ("type", `String "object");
-          ("description", `String "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class actions (done / submit_for_verification / release / cancel). On action='done' or 'submit_for_verification', include 'evidence_refs' with at least one locally validated reference: an existing base-path artifact file/file:// URI, a commit hash present in the local git repo, or a .masc trace/turn/receipt ref that resolves on disk. Completion notes, URLs, PR numbers, and trace-shaped labels alone do NOT satisfy the gate. Example: {\"summary\": \"tests green, local proof saved\", \"evidence_refs\": [\".masc/harness-evidence/proof.json\"]}.");
+          ("description", `String handoff_context_description);
           ("properties", `Assoc [
             ("summary", `Assoc [
               ("type", `String "string");

--- a/scripts/ci/apt-refresh.sh
+++ b/scripts/ci/apt-refresh.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if sudo apt-get update -qq; then
+  echo "Refreshed apt package index."
+else
+  echo "::warning::apt package index refresh failed; using existing package index" >&2
+fi

--- a/test/keeper_continuation_channel/dune
+++ b/test/keeper_continuation_channel/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_continuation_channel)
+ (libraries masc.keeper_runtime yojson))

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -1,0 +1,85 @@
+(* Unit tests for [Keeper_continuation_channel] (RFC-0320 W1).
+
+   Covers the closed-variant contract:
+     - codec round-trips for every constructor,
+     - fail-closed parsing (unknown kind / missing field / non-object -> Error),
+     - the routing helpers (is_routable, kind_label, same_route). *)
+
+open Keeper_continuation_channel
+
+let roundtrip ch =
+  match of_yojson (to_yojson ch) with
+  | Ok ch' -> assert (ch' = ch)
+  | Error e -> failwith ("continuation_channel roundtrip failed: " ^ e)
+
+let test_codec_roundtrip () =
+  roundtrip (Dashboard { thread_id = "thread-42" });
+  roundtrip (Discord { channel_id = "C123"; user_id = "U9" });
+  roundtrip (Slack { channel = "general"; user_id = "U1" });
+  roundtrip (unrouted "connector not captured at submission")
+
+let expect_error label json =
+  match of_yojson json with
+  | Error _ -> ()
+  | Ok _ -> failwith ("expected Error for " ^ label)
+
+let test_unknown_kind_is_error () =
+  expect_error "unknown kind"
+    (`Assoc [ ("kind", `String "webhook"); ("url", `String "https://x") ])
+
+let test_missing_field_is_error () =
+  (* dashboard requires thread_id *)
+  expect_error "missing thread_id" (`Assoc [ ("kind", `String "dashboard") ]);
+  (* discord requires user_id *)
+  expect_error "missing discord user_id"
+    (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
+
+let test_missing_kind_is_error () =
+  expect_error "missing kind" (`Assoc [ ("thread_id", `String "t") ])
+
+let test_non_object_is_error () =
+  expect_error "non-object string" (`String "nope");
+  expect_error "non-object list" (`List [ `String "a" ])
+
+let test_is_routable () =
+  assert (is_routable (Dashboard { thread_id = "t" }));
+  assert (is_routable (Discord { channel_id = "c"; user_id = "u" }));
+  assert (is_routable (Slack { channel = "c"; user_id = "u" }));
+  assert (not (is_routable (unrouted "x")))
+
+let test_kind_label () =
+  assert (String.equal (kind_label (Dashboard { thread_id = "t" })) "dashboard");
+  assert (String.equal (kind_label (Discord { channel_id = "c"; user_id = "u" })) "discord");
+  assert (String.equal (kind_label (Slack { channel = "c"; user_id = "u" })) "slack");
+  assert (String.equal (kind_label (unrouted "x")) "unrouted")
+
+let test_same_route () =
+  (* same destination *)
+  assert (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t1" }));
+  assert (
+    same_route
+      (Discord { channel_id = "c"; user_id = "u" })
+      (Discord { channel_id = "c"; user_id = "u" }));
+  (* differing coordinate -> different route *)
+  assert (not (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t2" })));
+  assert (
+    not
+      (same_route
+         (Discord { channel_id = "c"; user_id = "u" })
+         (Discord { channel_id = "c"; user_id = "u2" })));
+  (* different constructor -> different route *)
+  assert (
+    not (same_route (Dashboard { thread_id = "t" }) (Slack { channel = "c"; user_id = "u" })));
+  (* two Unrouted values never share a route (no destination to share) *)
+  assert (not (same_route (unrouted "a") (unrouted "a")))
+
+let () =
+  test_codec_roundtrip ();
+  test_unknown_kind_is_error ();
+  test_missing_field_is_error ();
+  test_missing_kind_is_error ();
+  test_non_object_is_error ();
+  test_is_routable ();
+  test_kind_label ();
+  test_same_route ();
+  print_endline "Keeper_continuation_channel: all tests passed"

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -14,8 +14,21 @@ let roundtrip ch =
 
 let test_codec_roundtrip () =
   roundtrip (Dashboard { thread_id = "thread-42" });
-  roundtrip (Discord { channel_id = "C123"; user_id = "U9" });
-  roundtrip (Slack { channel = "general"; user_id = "U1" });
+  roundtrip
+    (Discord
+       { guild_id = Some "G1"
+       ; channel_id = "C123"
+       ; parent_channel_id = Some "P1"
+       ; thread_id = Some "T1"
+       ; user_id = "U9"
+       });
+  roundtrip
+    (Slack
+       { team_id = Some "TEAM1"
+       ; channel_id = "general"
+       ; thread_ts = Some "1710000000.000001"
+       ; user_id = "U1"
+       });
   roundtrip (unrouted "connector not captured at submission")
 
 let expect_error label json =
@@ -43,14 +56,38 @@ let test_non_object_is_error () =
 
 let test_is_routable () =
   assert (is_routable (Dashboard { thread_id = "t" }));
-  assert (is_routable (Discord { channel_id = "c"; user_id = "u" }));
-  assert (is_routable (Slack { channel = "c"; user_id = "u" }));
+  assert (
+    is_routable
+      (Discord
+         { guild_id = None
+         ; channel_id = "c"
+         ; parent_channel_id = None
+         ; thread_id = None
+         ; user_id = "u"
+         }));
+  assert (
+    is_routable
+      (Slack { team_id = None; channel_id = "c"; thread_ts = None; user_id = "u" }));
   assert (not (is_routable (unrouted "x")))
 
 let test_kind_label () =
   assert (String.equal (kind_label (Dashboard { thread_id = "t" })) "dashboard");
-  assert (String.equal (kind_label (Discord { channel_id = "c"; user_id = "u" })) "discord");
-  assert (String.equal (kind_label (Slack { channel = "c"; user_id = "u" })) "slack");
+  assert (
+    String.equal
+      (kind_label
+         (Discord
+            { guild_id = None
+            ; channel_id = "c"
+            ; parent_channel_id = None
+            ; thread_id = None
+            ; user_id = "u"
+            }))
+      "discord");
+  assert (
+    String.equal
+      (kind_label
+         (Slack { team_id = None; channel_id = "c"; thread_ts = None; user_id = "u" }))
+      "slack");
   assert (String.equal (kind_label (unrouted "x")) "unrouted")
 
 let test_same_route () =
@@ -58,18 +95,50 @@ let test_same_route () =
   assert (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t1" }));
   assert (
     same_route
-      (Discord { channel_id = "c"; user_id = "u" })
-      (Discord { channel_id = "c"; user_id = "u" }));
+      (Discord
+         { guild_id = Some "g"
+         ; channel_id = "c"
+         ; parent_channel_id = Some "p"
+         ; thread_id = Some "t"
+         ; user_id = "u"
+         })
+      (Discord
+         { guild_id = Some "g"
+         ; channel_id = "c"
+         ; parent_channel_id = Some "p"
+         ; thread_id = Some "t"
+         ; user_id = "u"
+         }));
   (* differing coordinate -> different route *)
   assert (not (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t2" })));
   assert (
     not
       (same_route
-         (Discord { channel_id = "c"; user_id = "u" })
-         (Discord { channel_id = "c"; user_id = "u2" })));
+         (Discord
+            { guild_id = Some "g"
+            ; channel_id = "c"
+            ; parent_channel_id = Some "p"
+            ; thread_id = Some "t"
+            ; user_id = "u"
+            })
+         (Discord
+            { guild_id = Some "g"
+            ; channel_id = "c"
+            ; parent_channel_id = Some "p"
+            ; thread_id = Some "t2"
+            ; user_id = "u"
+            })));
   (* different constructor -> different route *)
   assert (
-    not (same_route (Dashboard { thread_id = "t" }) (Slack { channel = "c"; user_id = "u" })));
+    not
+      (same_route
+         (Dashboard { thread_id = "t" })
+         (Slack
+            { team_id = None
+            ; channel_id = "c"
+            ; thread_ts = None
+            ; user_id = "u"
+            })));
   (* two Unrouted values never share a route (no destination to share) *)
   assert (not (same_route (unrouted "a") (unrouted "a")))
 

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -24,7 +24,7 @@ lib/keeper/keeper_sandbox_control.ml:224  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:477  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:196  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:589  # argv_keeper
-lib/keeper/keeper_sandbox_read_backend.ml:184  # argv_keeper
+lib/keeper/keeper_sandbox_read_backend.ml:185  # argv_keeper
 lib/keeper/keeper_sandbox_runner.ml:167  # argv_keeper
 lib/keeper/keeper_sandbox_runtime_setup.ml:51  # argv_keeper
 lib/keeper/keeper_tools_oas_handler_exec.ml:76  # argv_keeper

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -171,15 +171,30 @@ let test_connector_attention_codec_roundtrips () =
           { event_id = "evt-77"
           ; channel =
               Keeper_continuation_channel.Discord
-                { channel_id = "chan-77"; user_id = "user-77" }
+                { guild_id = Some "guild-77"
+                ; channel_id = "chan-77"
+                ; parent_channel_id = Some "parent-77"
+                ; thread_id = Some "thread-77"
+                ; user_id = "user-77"
+                }
           }
     }
   in
   match Q.stimulus_of_yojson (Q.stimulus_to_yojson s) with
   | Ok s' -> (
     match s'.Q.payload with
-    | Q.Connector_attention { event_id } ->
-      check string "event_id survives the JSON round-trip" "evt-77" event_id
+    | Q.Connector_attention { event_id; channel } ->
+      check string "event_id survives the JSON round-trip" "evt-77" event_id;
+      check bool "connector coordinates survive the JSON round-trip" true
+        (Keeper_continuation_channel.same_route
+           channel
+           (Keeper_continuation_channel.Discord
+              { guild_id = Some "guild-77"
+              ; channel_id = "chan-77"
+              ; parent_channel_id = Some "parent-77"
+              ; thread_id = Some "thread-77"
+              ; user_id = "user-77"
+              }))
     | _ -> check bool "round-trip payload stays Connector_attention" true false)
   | Error e -> check bool ("round-trip decode failed: " ^ e) true false
 

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -166,7 +166,13 @@ let test_connector_attention_codec_roundtrips () =
     { Q.post_id = "evt-77"
     ; urgency = Q.Normal
     ; arrived_at = 1.0
-    ; payload = Q.Connector_attention { event_id = "evt-77" }
+    ; payload =
+        Q.Connector_attention
+          { event_id = "evt-77"
+          ; channel =
+              Keeper_continuation_channel.Discord
+                { channel_id = "chan-77"; user_id = "user-77" }
+          }
     }
   in
   match Q.stimulus_of_yojson (Q.stimulus_to_yojson s) with

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -250,10 +250,10 @@ let () =
        (stimulus_to_yojson
           { post_id =
               hitl_resolution_post_id
-                { approval_id = "appr-9"; decision = Hitl_approved }
+                { approval_id = "appr-9"; decision = Hitl_approved; channel = Keeper_continuation_channel.unrouted "test" }
           ; urgency = Immediate
           ; arrived_at = 4.0
-          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = Hitl_approved }
+          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = Hitl_approved; channel = Keeper_continuation_channel.unrouted "test" }
           })
    with
    | Ok s ->
@@ -960,5 +960,46 @@ let () =
         | None -> Alcotest.fail "original second stimulus should remain queued"
       in
       assert (String.equal second.post_id "bootstrap"));
+
+  (* RFC-0320 backward compat: pre-W2 persisted stimuli have no [channel] in
+     their payload and must replay as [Unrouted], not fail — a restart
+     replaying a legacy wake queue must not break. Simulate by serializing a W2
+     stimulus then stripping the [channel] field before parsing back. *)
+  (let strip_channel json =
+     match json with
+     | `Assoc top ->
+       `Assoc
+         (List.map
+            (fun (k, v) ->
+              if String.equal k "payload" then
+                ( k
+                , match v with
+                  | `Assoc p ->
+                    `Assoc
+                      (List.filter (fun (pk, _) -> not (String.equal pk "channel")) p)
+                  | other -> other )
+              else (k, v))
+            top)
+     | other -> other
+   in
+   let hitl_stim =
+     { post_id = "p-legacy"
+     ; urgency = Immediate
+     ; arrived_at = 1.0
+     ; payload =
+         Hitl_resolved
+           { approval_id = "a"
+           ; decision = Hitl_approved
+           ; channel = Keeper_continuation_channel.unrouted "seed"
+           }
+     }
+   in
+   match stimulus_of_yojson (strip_channel (stimulus_to_yojson hitl_stim)) with
+   | Ok s ->
+     (match s.payload with
+      | Hitl_resolved r ->
+        assert (not (Keeper_continuation_channel.is_routable r.channel))
+      | _ -> assert false)
+   | Error _ -> assert false);
 
   print_endline "test_keeper_event_queue: all passed"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -38,6 +38,8 @@ let cleanup () =
   Board_dispatch.reset_for_test ();
   Board_curation.reset_for_test ();
   Board_moderation.reset_for_test ();
+  Fs_compat.reset_fd_cache_for_testing ();
+  Fs_compat.reset_mkdir_memo_for_testing ();
   remove_path (Filename.concat _test_base_path Common.masc_dirname);
   Board_dispatch.init_jsonl ()
 
@@ -1417,8 +1419,11 @@ let test_dispatch_delete_success () =
     |> Yojson.Safe.Util.member "id"
     |> Yojson.Safe.Util.to_string
   in
-  let ok_del, msg_del = dispatch "masc_board_delete"
-    (make_args [("post_id", `String post_id)]) in
+  let ok_del, msg_del =
+    dispatch
+      "masc_board_delete"
+      (make_args [ ("post_id", `String post_id); ("author", `String "tester") ])
+  in
   Alcotest.(check bool) "delete ok" true ok_del;
   Alcotest.(check bool) "delete msg contains id" true
     (contains_substring msg_del post_id)
@@ -1427,11 +1432,14 @@ let test_dispatch_delete_not_found () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let ok, body = dispatch "masc_board_delete"
-    (make_args [("post_id", `String "nonexistent-id")]) in
+  let ok, body =
+    dispatch
+      "masc_board_delete"
+      (make_args [ ("post_id", `String "nonexistent-id"); ("author", `String "tester") ])
+  in
   Alcotest.(check bool) "delete not found" false ok;
   Alcotest.(check bool) "error message present" true
-    (contains_substring body "Delete failed")
+    (contains_substring body "Post not found" || contains_substring body "nonexistent-id")
 
 let test_dispatch_delete_empty_id () =
   with_eio @@ fun env ->
@@ -2993,7 +3001,7 @@ let () =
             let json = parse_create_response_json create_msg in
             let post_id = Yojson.Safe.Util.(json |> member "id" |> to_string) in
             let (_ok, _msg) = dispatch "masc_board_delete" (make_args [
-              ("post_id", `String post_id)
+              ("post_id", `String post_id); ("author", `String "tester")
             ]) in
             let (_ok2, body2) = dispatch "masc_board_list" args in
             Alcotest.(check bool) "cache invalidated after delete" true

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1788,10 +1788,15 @@ let claim_gate_sidecar_path () =
 
 let claim_gate_posts_path () = Board.persist_path ()
 
+let claim_gate_source_post_seq = ref 0
+
 let create_claim_gate_source_post () =
+  incr claim_gate_source_post_seq;
   let correction =
-    "Correction: I did not create the PoC claimed here. \
-     repos/masc/scratch/task-1746-poc.ml does not exist."
+    Printf.sprintf
+      "Correction %d: I did not create the PoC claimed here. \
+       repos/masc/scratch/task-1746-poc.ml does not exist."
+      !claim_gate_source_post_seq
   in
   let ok, body =
     dispatch
@@ -1934,7 +1939,7 @@ let test_comment_claim_gate_allows_missing_artifact_block () =
   cleanup ();
   let source = create_claim_gate_source_post () in
   let post_id = Yojson.Safe.Util.(source |> member "id" |> to_string) in
-  let ok, body =
+  let ok, _body =
     dispatch
       "masc_board_comment"
       (make_args
@@ -1947,7 +1952,12 @@ let test_comment_claim_gate_allows_missing_artifact_block () =
          ])
   in
   Alcotest.(check bool) "missing-artifact block allowed" true ok;
-  Alcotest.(check bool) "comment added" true (contains_substring body "Comment added");
+  let comments =
+    match Board_dispatch.get_comments ~post_id with
+    | Ok comments -> comments
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  Alcotest.(check int) "comment persisted" 1 (List.length comments);
   let sidecar_body =
     In_channel.with_open_text (claim_gate_sidecar_path ()) In_channel.input_all
   in
@@ -1995,6 +2005,8 @@ let test_post_create_claim_gate_rolls_back_on_sidecar_failure () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
   let sidecar = claim_gate_sidecar_path () in
+  let parent = Filename.dirname sidecar in
+  if not (Sys.file_exists parent) then Unix.mkdir parent 0o755;
   Unix.mkdir sidecar 0o755;
   let result =
     dispatch_result


### PR DESCRIPTION
## 목적

keeper가 busy일 때 말 걸면 `"executor is busy; your message is queued"` ack 후, turn이 끝나도 **발화했던 채널로 돌아와 대화를 이어가지 않는** 문제(RFC-0320)를 닫습니다. 이 PR은 W1(타입) + W2(wake payload 관통)입니다.

## 근본원인 (adversarial 검증 완료)

event-queue wake payload(`Hitl_resolved` 등)가 originating connector를 안 실어서, 깨어난 keeper가 "proceed on its own state"로 진행하고 발화 채널로 답하지 않습니다.

- `keeper_event_queue.ml` — 11개 wake variant, 어느 payload도 reply channel을 first-class 필드로 갖지 않았음
- `keeper_heartbeat_stimulus_intake.ml:104-115` — `Hitl_resolved` intake가 `None` → "proceeds on its own state"
- `keeper_approval_queue` (`create_entry`) — `turn_id`/`task_id`/`goal_id`만, chat connector/thread 부재

7-agent understand workflow로 진단·adversarial 검증(H1 dashboard-push 가설은 교정: 대시보드는 `Keeper_chat_broadcast`로 push되므로 주 대상 아님 / H2 wake connector-blindness는 확정).

## W1 — continuation_channel 타입 (G1 기반)

`Keeper_continuation_channel` closed variant. `Dashboard | Discord | Slack | Unrouted`. `Unrouted`=fail-closed(편의 기본값 금지), exhaustive match(catch-all 없음 → 새 커넥터=컴파일 에러), tagged yojson codec(unknown/missing→Error).

## W2 — wake payload 관통 (G2)

`hitl_resolution`과 `connector_attention`에 `channel : Keeper_continuation_channel.t` 추가.

- **Connector_attention**: ambient gateway가 **진짜 Discord channel+author**를 실음 (`server_discord_in_process_gateway.ml`).
- **Hitl_resolved**: 지금은 `Unrouted` — approval-submission connector가 아직 queue entry에 캡처되지 않음. `WORKAROUND` 주석 명시, **W2b**가 `create_entry` + resolution wake hook에 channel을 배선(이 슬라이스는 approval hook 계약을 건드리지 않음).
- **하위호환**: pre-W2 persisted stimuli는 channel 필드가 없고 `Unrouted`로 파싱(파싱 실패 아님) → 재시작 시 legacy wake 큐 replay 안 깨짐. `continuation_channel_field` helper + regression test.

## 검증

- `test_keeper_continuation_channel`: codec round-trip, fail-closed 파싱, 라우팅 헬퍼. 8/8.
- `test_keeper_event_queue`: channel codec round-trip + **legacy-no-channel → Unrouted** 회귀 테스트. all passed.
- `test_keeper_connector_attention_wake`: Discord connector_attention codec/projection. 4 tests.
- 전체 빌드 green, `ocamlformat --check` clean.

## 남은 웨이브 (RFC-0320, 이 PR 범위 밖)

- **W2b** — HITL provenance capture: `create_entry ~channel` + resolution wake hook 계약 확장 (approval subsystem, 신중한 별도 PR).
- **W3** — re-engagement: intake가 channel로 **turn 결과를 delivery**. 조사 결과 Connector_attention은 `external_attention`이 이미 surface를 나르므로, 실제 gap은 turn-result delivery 라우팅(keeper turn 아키텍처 통합).
- **W4** — observability + G6 safety invariant(TLA+ `ContinuationNeverAutoExecutesGated`).

RFC: `docs/rfc/RFC-0320-keeper-connector-aware-continuation.md` (이 PR에 포함)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
