### PR TITLE
feat(keeper): steer connector continuation reply on wake (RFC-0320 W3a)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -281,12 +281,19 @@ let board_reaction_note (reaction : Keeper_world_observation.board_reaction_even
 let board_event_note = function
   | Keeper_world_observation.Board_reaction_changed reaction ->
     board_reaction_note reaction
+  | Keeper_world_observation.External_attention ->
+    (* RFC-0320 W3(a): steer a woken keeper to answer back into the connector
+       conversation this attention came from (via keeper_surface_post), instead
+       of only proceeding on its own state. The routing target is deterministic
+       — it is the conversation surface already on this observation; the LLM
+       decides only what to say. *)
+    " [continuation: someone is waiting in this conversation — reply to them \
+     with keeper_surface_post, do not only proceed on your own state]"
   | Keeper_world_observation.Board_post_created
   | Keeper_world_observation.Board_comment_added
   | Keeper_world_observation.Fusion_completed
   | Keeper_world_observation.Bg_completed
   | Keeper_world_observation.Schedule_due
-  | Keeper_world_observation.External_attention
   | Keeper_world_observation.Goal_verification_failed
   | Keeper_world_observation.Failure_judgment
   | Keeper_world_observation.Goal_assigned

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -11,6 +11,11 @@ val state_block_instruction_text : string
 (** Generic STATE formatting instruction for normal keeper turns. Turn-level
     output guards can override this when continuity is runtime-managed. *)
 
+val format_board_event_text : Keeper_world_observation.pending_board_event -> string
+(** Render a single pending board event as its prompt line. Exposed for tests:
+    RFC-0320 W3(a) verifies that an [External_attention] event steers the woken
+    keeper to reply into the originating conversation via keeper_surface_post. *)
+
 (** Build unified system prompt and user message from keeper state.
 
     Returns [(system_prompt, user_message)] where:

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -215,6 +215,19 @@ let test_external_attention_projects_to_prompt_event () =
      | WO.Unknown -> true
      | _ -> false)
 
+let test_external_attention_prompt_steers_continuation () =
+  (* RFC-0320 W3(a): the rendered prompt line for an external-attention wake must
+     steer the keeper to answer back into the originating conversation via
+     keeper_surface_post, instead of only proceeding on its own state. *)
+  let meta = make_meta "conn-keeper" in
+  let item = external_attention_item () in
+  let ev = WO.pending_board_event_of_external_attention ~meta item in
+  let line = Masc.Keeper_unified_prompt.format_board_event_text ev in
+  check bool "prompt line steers a keeper_surface_post reply" true
+    (contains ~needle:"keeper_surface_post" line);
+  check bool "prompt line marks a waiting continuation" true
+    (contains ~needle:"continuation" line)
+
 let () =
   init_runtime_default_for_tests ();
   run "connector_attention_wake"
@@ -231,5 +244,7 @@ let () =
     ; ( "projection",
         [ test_case "external attention becomes prompt event" `Quick
             test_external_attention_projects_to_prompt_event
+        ; test_case "external attention prompt steers continuation reply" `Quick
+            test_external_attention_prompt_steers_continuation
         ] )
     ]


### PR DESCRIPTION
## 목적

RFC-0320 continuation의 W3(a) 슬라이스입니다. keeper가 `External_attention`(커넥터 mention/메시지) stimulus로 깨어날 때, **원 대화로 돌아가 답하도록** 프롬프트로 유도합니다. W1+W2(#23623)에 이어집니다.

## 배경

W1(`continuation_channel` 타입)+W2(wake payload 관통)는 #23623으로 main 착지했습니다. 하지만 keeper가 wake 후 **발화 채널로 돌아오는 실제 동작**은 아직이었습니다 — wake turn(`Keeper_unified_turn.run_keeper_cycle`)은 응답을 checkpoint/memory에만 남기고(`Internal_prose`), 커넥터로 자동 전달하지 않습니다.

Explore 조사로 확인: `keeper_surface_post` 도구가 **이미 Discord/Slack로 send+persist+broadcast**하며 wake turn에서 호출 가능합니다. 즉 송신 인프라는 존재하고, keeper가 그것을 쓰도록 **유도**만 하면 됩니다.

## 이 PR (W3a — prompt 유도, turn 파이프라인 미관통)

`keeper_unified_prompt.ml`의 `board_event_note`에서 `External_attention` arm을 분리해 continuation 지시를 prompt line에 추가합니다:

```
[continuation: someone is waiting in this conversation — reply to them with
 keeper_surface_post, do not only proceed on your own state]
```

- **라우팅(어디로)은 결정론적** — 대화 surface는 이미 observation에 실려 있습니다.
- **판단(무엇을 말할지)은 LLM** — RFC-0320 §2 경계와 정합.
- 기존 `keeper_surface_post` send 인프라 재사용, keeper turn 파이프라인 변경 없음.

## 범위 밖 (RFC-0320 후속)

- **W2b** — HITL(`Hitl_resolved`) provenance: approval entry에 커넥터 캡처 + resolve wake hook 계약(approval subsystem 관통). HITL은 `external_attention` surface가 없어 이 prompt 경로 밖입니다.
- **W3b** — 결정론적 auto-delivery: `keeper_agent_run_finalize_response.finalize` seam에서 response_text를 채널로 전달(모델이 도구를 안 골라도).

## 검증

- `test_keeper_connector_attention_wake` projection: External_attention prompt line이 `keeper_surface_post` + `continuation`을 포함. 5/5 pass.
- `format_board_event_text`를 mli에 노출(prompt-line 단언용).

RFC: `docs/rfc/RFC-0320-keeper-connector-aware-continuation.md` (#23623에서 main 착지)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
