### PR TITLE
fix(keeper): arm Goal_stagnation fire-once gate (RFC-0310 §3.3 re-fire P0)

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -196,6 +196,20 @@ let consume_single_heartbeat_stimulus
       gs.gs_goal_id
       gs.gs_stale_since
       meta_after_triage.name;
+    (* Arm [Keeper_goal_stagnation_wake]'s fire-once-per-episode gate. The
+       producer skips re-enqueue only when [turn_started_seen] is true for the
+       episode stimulus id; that flag is set solely from a [Turn_started]
+       reaction row. Without recording it here the gate stays inert, so once
+       [ack_consumed] drops the stimulus the next scan re-detects the same
+       stale episode ((goal_id, updated_at) unchanged) and re-wakes every tick
+       — the blind cadence RFC-0303 forbids and RFC-0310 §3.3 exists to avoid.
+       [stim] carries the episode-pinned [arrived_at], so this row stamps the
+       exact stimulus id the producer recomputes next scan. Mirrors the
+       No_progress_recovery arm below. *)
+    record_event_queue_stimulus_turn_started
+      ~ctx
+      ~keeper_name:meta_after_triage.name
+      stim;
     pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
   | Keeper_event_queue.Failure_judgment fj ->
     (* RFC-0313 W2: a deterministic turn failure awaits an LLM-boundary

--- a/test/test_keeper_goal_stagnation_wake.ml
+++ b/test/test_keeper_goal_stagnation_wake.ml
@@ -1,10 +1,14 @@
-(** RFC-0310 §3.3 — Goal_stagnation detection core.
+(** RFC-0310 §3.3 — Goal_stagnation detection and fire-once dedup.
 
-    Pins [Keeper_goal_stagnation_wake.stagnation_of_goal], the pure predicate
-    that decides whether a goal earns a one-shot stagnation wake. The full
-    enqueue path (event queue + reaction-ledger episode dedup) rides on the
-    same [Goal_store.goal] input; this file fixes the decision so a phase or
-    threshold regression is caught without a base-path fixture. *)
+    Two layers:
+    - [stagnation_of_goal], the pure predicate that decides whether a goal
+      earns a one-shot stagnation wake (phase gate, threshold, fail-closed
+      parse). Pinned without a base-path fixture.
+    - [enqueue_goal_stagnation_wakes], the producer whose fire-once-per-episode
+      invariant depends on the reaction-ledger [turn_started_seen] gate.
+      [test_episode_fires_once_across_rescans] drives it against a real
+      base-path fixture to prove it re-fires while the episode is unattended
+      and goes silent once the [Turn_started] reaction is on the ledger. *)
 
 open Alcotest
 
@@ -46,6 +50,25 @@ let stale_ts = "2026-07-07T23:00:00Z"
 let fresh_ts = "2026-07-08T01:55:00Z"
 
 let is_some = function Some _ -> true | None -> false
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_goal_stagnation_refire_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+  in
+  try rm dir with
+  | _ -> ()
+
+let keeper_name = "goal-stagnation-keeper"
 
 let test_stale_executing_goal_wakes () =
   let result =
@@ -108,6 +131,90 @@ let test_phase_predicate_exhaustive () =
         (Goal_phase.admits_self_directed_progress phase))
     Goal_phase.all
 
+(* Fire-once-per-episode (RFC-0310 §3.3) — the invariant the edge redesign
+   exists to hold, and the one the pure-predicate cases above cannot reach. The
+   re-fire loop lives in [enqueue_goal_stagnation_wakes], whose only durable
+   fire-once gate is the reaction ledger's [turn_started_seen]. That flag is
+   armed by the [Turn_started] reaction the stagnation turn records when it
+   consumes the stimulus (keeper_heartbeat_stimulus_intake, Goal_stagnation
+   arm — mirroring No_progress_recovery). Without that reaction the queue-level
+   identity dedup collapses duplicate queue *entries* but does not stop the
+   *wake*: the producer keeps returning the goal id and re-waking every scan —
+   the blind cadence RFC-0303 forbids. This test drives the producer across
+   scans against a real base-path fixture and asserts it re-fires while no
+   reaction exists, then goes silent once the episode reaction is recorded. *)
+let test_episode_fires_once_across_rescans () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_path in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let persisted =
+        match
+          Goal_store.upsert_goal config ~title:"Advance the wake redesign"
+            ~phase:Goal_phase.Executing ()
+        with
+        | Ok (goal_rec, _) -> goal_rec
+        | Error err -> Alcotest.failf "goal upsert failed: %s" err
+      in
+      let goal_id = persisted.Goal_store.id in
+      (* [upsert_goal] stamps [updated_at] at persist time; pick a [now] past
+         the threshold so the goal reads as stale without a hand-computed
+         epoch. *)
+      let updated_ts =
+        match Masc_domain.parse_iso8601_opt persisted.Goal_store.updated_at with
+        | Some ts -> ts
+        | None ->
+          Alcotest.failf "persisted updated_at did not parse: %s"
+            persisted.Goal_store.updated_at
+      in
+      let now = updated_ts +. threshold_sec +. 1.0 in
+      let scan () =
+        SW.enqueue_goal_stagnation_wakes ~config ~keeper_name
+          ~active_goal_ids:[ goal_id ] ~now ~threshold_sec ()
+      in
+      check (list string) "first scan fires the stale episode" [ goal_id ]
+        (scan ());
+      (* No turn has recorded a Turn_started reaction yet, so the producer must
+         re-fire. This is the defect the intake fix closes: queue dedup alone
+         does not stop the wake. *)
+      check (list string)
+        "re-fires while the episode has no turn_started reaction" [ goal_id ]
+        (scan ());
+      (* Record the reaction exactly as the fixed intake arm does: same episode
+         [gs], [arrived_at] pinned to the episode timestamp so the stimulus id
+         matches what the producer recomputes on the next scan. *)
+      let gs =
+        match SW.stagnation_of_goal ~now ~threshold_sec persisted with
+        | Some gs -> gs
+        | None ->
+          Alcotest.fail "the persisted goal must be stale for this fixture"
+      in
+      let stimulus : Keeper_event_queue.stimulus =
+        { post_id = Keeper_event_queue.goal_stagnation_post_id gs
+        ; urgency = Keeper_event_queue.Normal
+        ; arrived_at = updated_ts
+        ; payload = Keeper_event_queue.Goal_stagnation gs
+        }
+      in
+      Masc.Keeper_reaction_ledger.record_event_queue_reaction ~base_path
+        ~keeper_name ~reaction_kind:Masc.Keeper_reaction_ledger.Turn_started
+        stimulus;
+      let evidence =
+        Masc.Keeper_reaction_ledger.event_queue_reaction_evidence ~base_path
+          ~keeper_name
+          ~stimulus_id:
+            (Masc.Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus)
+      in
+      check bool "turn_started_seen arms after the episode reaction" true
+        evidence.Masc.Keeper_reaction_ledger.turn_started_seen;
+      check (list string) "silent after the episode has been attended" []
+        (scan ()))
+
 let () =
   run
     "keeper goal stagnation wake"
@@ -122,5 +229,9 @@ let () =
             test_unparseable_timestamp_silent
         ; test_case "phase predicate exhaustive" `Quick
             test_phase_predicate_exhaustive
+        ] )
+    ; ( "enqueue_goal_stagnation_wakes"
+      , [ test_case "episode fires once across re-scans" `Quick
+            test_episode_fires_once_across_rescans
         ] )
     ]


### PR DESCRIPTION
## 문제 (P0)

`#23605`(RFC-0310 §3.3 Goal_stagnation edge, MERGED)의 fire-once-per-episode 불변식이 깨져 있었다. 머지 후 적대 검증 4개 렌즈(refire / detector-placement / exhaustive-boundary / cost-scope)가 **전원 동일 P0로 수렴**해 발견.

producer `Keeper_goal_stagnation_wake`는 episode stimulus id에 대해 reaction ledger의 `turn_started_seen`이 true일 때만 재enqueue를 건너뛴다. 그런데 이 플래그는 오직 `Turn_started` reaction row로만 set되는데, `consume_single_heartbeat_stimulus`의 `Goal_stagnation` arm은 이 reaction을 **한 번도 기록하지 않았다** — 로그 + pending observation 승격만 수행.

결과: gate가 영구 inert. `ack_consumed`가 stimulus를 큐에서 제거하면, 다음 heartbeat 스캔이 같은 stale episode(`(goal_id, updated_at)` 불변)를 재감지 → `turn_started_seen=false` → 매 tick 재enqueue + 재wake. **미진행 Executing goal이 영원히 재발화** — RFC-0303이 금지하고 edge 재설계가 없애려던 blind cadence의 부활.

큐 레벨 identity dedup(gate a)은 중복 **큐 항목**만 막을 뿐 **wake 신호**는 막지 못한다(producer가 goal_id를 계속 반환하고 wakeup을 계속 호출). 유일한 내구적 정지선은 gate (b) `turn_started_seen`인데, 그게 arm되지 않았다.

## 근거 (검증됨)

- `lib/keeper/keeper_goal_stagnation_wake.ml`: `if evidence.turn_started_seen then None else (enqueue; ...)` — 유일한 post-consume gate
- `lib/keeper/keeper_heartbeat_stimulus_intake.ml:190` (fix 전): `Goal_stagnation` arm = 로그 + `pending_board_event_of_stimulus`만, recorder 호출 없음
- `record_recovery_stimulus_turn_started`는 `No_progress_recovery` arm에서만 호출(intake.ml:221)
- `record_schedule_due_turn_started_reactions`의 `Goal_stagnation` arm은 `-> ()` (기록 안 함)
- `turn_started_seen`은 `Turn_started` reaction row에서만 set → Goal_stagnation엔 그 row가 없어 영구 false

## 수정

`Goal_stagnation` intake arm에 `record_event_queue_stimulus_turn_started` 호출 추가 — **`No_progress_recovery` arm과 완전히 대칭**. stimulus는 episode-pinned `arrived_at`을 담고 있어, 이 reaction이 producer가 다음 스캔에 재계산하는 stimulus id를 정확히 stamp한다. 이후 `turn_started_seen`이 true → goal이 진행될 때까지(새 updated_at → 새 episode) episode 침묵.

producer 주석과 `.mli` 계약이 이미 "ledger gate가 재스캔을 막는다"고 선언했으나 기록하는 쪽이 비어 계약이 거짓이었다. 이 fix로 코드가 문서와 일치.

## 테스트

`test_episode_fires_once_across_rescans` 추가: base-path fixture에서 `enqueue_goal_stagnation_wakes`를 스캔 2회 이상 구동.
- reaction 없을 때 재발화(`[goal_id]`) — 결함 재현
- `Turn_started` reaction 기록 후 침묵(`[]`) — fire-once 성립
- `turn_started_seen` arm 직접 검증

기존 테스트는 순수 predicate `stagnation_of_goal`만 커버해 결함이 사는 재발화 경로가 비어 있었다(적대 검증 P2).

## 검증

- `dune build --root . test/test_keeper_goal_stagnation_wake.exe` green
- 테스트 6/6 통과 (`Test Successful in 0.175s`)
- `ocamlformat --check` clean (두 파일)

## 후속 (별도 이슈 예정)

producer가 `turn_started_seen` gate를 쓰기로 하는 것과 intake가 `Turn_started`를 기록해야 하는 것 사이의 결합이 암묵적·비강제다. Goal_stagnation이 정확히 이 갭에 빠졌다. 구조적 방지(gated producer마다 recording arm 존재를 강제하는 테스트/lint, 또는 공용 dispatch)를 별도 이슈로 escalate — 이 PR은 P0만 닫는다.

## 메타

- 근거: post-merge 적대 검증 워크플로 (4 lenses 수렴). `#23605` 후속.
- RFC: RFC-0310 §3.3 (Goal convergence loop). credential/operator/sandbox/hooks 미변경 — RFC gate 대상 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
