### PR TITLE
fix(dashboard): make the approvals detail rail actually stick (sticky)

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import * as Vitest from 'vitest'
@@ -113,7 +115,11 @@ describe('ApprovalsSurface', () => {
     render(html`<${ApprovalsSurface} />`, container)
     await flushUi()
 
-    expect(container.querySelector('[data-testid="approvals-surface"]')).not.toBeNull()
+    const surface = container.querySelector('[data-testid="approvals-surface"]')
+    expect(surface).not.toBeNull()
+    // ap-surface scopes the .ov-scroll overflow override that lets the sticky
+    // detail rail work; without the class the CSS rule below never matches.
+    expect(surface?.className).toContain('ap-surface')
     const cards = container.querySelectorAll('[data-testid="approval-card"]')
     expect(cards.length).toBe(4)
     expect(container.textContent).toContain('masc-improver')
@@ -674,5 +680,15 @@ describe('ApprovalsSurface', () => {
       expect(el.tagName).toBe('BUTTON')
       expect(el.textContent).not.toContain('sandbox')
     }
+  })
+
+  it('keeps the sticky detail rail working by un-clipping the approvals .ov-scroll', () => {
+    // The rail is position: sticky, but the shared .ov-scroll wrapper's
+    // overflow formed a non-scrolling sticky containing block. approvals-v2.css
+    // must restore overflow:visible on the approvals-scoped wrapper only.
+    const css = readFileSync(resolve(__dirname, '../../styles/approvals-v2.css'), 'utf8')
+    expect(css).toMatch(/\.ap-surface\s*>\s*\.ov-scroll\s*\{[^}]*overflow:\s*visible/)
+    const railRule = css.match(/\.ap-detail-panel\s*\{([^}]*)\}/)?.[1] ?? ''
+    expect(railRule).toContain('position: sticky')
   })
 })

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -569,7 +569,7 @@ export function ApprovalsSurface() {
   }, [items])
 
   return html`
-    <main class="ov ov-2col ss-surface bg-surface-page text-text-primary" data-screen-label="승인 큐" data-testid="approvals-surface">
+    <main class="ov ov-2col ss-surface ap-surface bg-surface-page text-text-primary" data-screen-label="승인 큐" data-testid="approvals-surface">
       <div class="ov-scroll">
         <header class="ov-head">
           <div>

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -100,6 +100,16 @@
 .ap-act.deny:hover:not(:disabled) { background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
 .ap-act.ghost:hover:not(:disabled) { color: var(--volt-strong); }
 
+/* The shared .ov-scroll wrapper is declared overflow-y:auto, but on the
+   approvals surface it grows to its full content height and never scrolls (the
+   page scrolls at .dashboard-main-scroll). That non-scrolling overflow still
+   formed a sticky containing block, pinning .ap-detail-panel-rail's
+   `position: sticky` to the static wrapper so the detail panel scrolled away
+   with the queue. Restoring overflow:visible here (approvals only) lets the
+   rail stick against the page scroller. Scoped to .ap-surface so the other
+   .ov-scroll surfaces are untouched. */
+.ap-surface > .ov-scroll { overflow: visible; }
+
 /* Request-detail rail / inline dossier (live surface). */
 .ap-detail-panel { position: sticky; top: 14px; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 14px; min-width: 0; }
 .ap-detail-panel-inline { display: none; }


### PR DESCRIPTION
## 목적

사용자 지시: "approvals rail sticky부터 고쳐라". `.ap-detail-panel-rail`은 `position:sticky; top:14px`가 선언됐는데 상세 패널이 큐와 함께 스크롤돼 사라진다.

## 근본 원인 (로그 #23619와 동일 계열)

공유 `.ov-scroll`(overview/schedule/approvals/work 4표면)은 `overflow-y:auto`지만 approvals에서 콘텐츠 전체 높이로 자라 실제로는 스크롤하지 않는다(스크롤은 페이지 `.dashboard-main-scroll`). 그 비스크롤 overflow가 여전히 **sticky containing block**을 만들어 rail의 sticky를 정적 wrapper에 고정 → 스크롤과 1:1 이동(실측: 1002px 스크롤에 rail top −669).

## 변경

- `.ov-scroll`이 4표면 공유라 전역 변경 대신, 표면 root에 `ap-surface` 클래스를 추가하고 **approvals-scoped `overflow: visible`** 복원(`.ap-surface > .ov-scroll`). rail sticky가 페이지 스크롤러 기준으로 해석됨.
- 브라우저 ap_probe로 `.ov-scroll`이 유일한 sticky-killer임을 확인(4건 있을 때 측정).

## 범위/안전

- 모바일(≤980px)에서는 `.ap-detail-panel` `position:static` + rail `display:none`이라 이 CSS는 도달 불가 — 데스크톱만 영향.
- ownership 드리프트 가드(`approvals-css-ownership.test.ts`) 통과: compound `.ap-surface > .ov-scroll`는 bare `.ov-scroll` base rule 재정의 아님.
- sticky 계약 드리프트 가드 추가(overflow:visible + rail position:sticky + ap-surface 클래스).

## 검증

- `pnpm test` 637파일/8694 green, typecheck/lint clean
- dev 서버: `.ap-surface > .ov-scroll` computed `overflow: visible` 확인
- **미검증**: rail이 실제 붙는 라이브 시각은 HITL 큐에 항목이 있어야 가능(현재 0건, transient). CSS/마크업 계약 + 로그 #23619에서 증명된 동일 메커니즘으로 대체 검증.

## 후속

`.ov-scroll`의 "내부 스크롤러가 높이 제약을 못 받아 페이지 스크롤 + sticky 파괴" 패턴은 overview/schedule/work에도 남아 있음. 근본 해결(높이 제약 체인 복원 또는 `.ov-scroll` overflow 재설계)은 아키텍처 변경이라 별도 RFC/PR로 분리.