### PR TITLE
task-1869: fix claimable filter staleness — treat None reclaim_policy as Allow_reclaim for Done status

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -652,11 +652,11 @@ let task_claim_decision (task : task) =
     (* Coordination-role tasks with Allow_reclaim policy are reclaimable
        after completion. task-1869: 6 TaskError fingerprints show
        coordination-role tasks blocked from re-claim by completion. *)
-    (match task.reclaim_policy with
-     | Some Allow_reclaim | None ->
+    (match task_reclaim_gate task with
+     | Reclaim_gate_open ->
        Claim_available (task_claim_readiness task)
-     | Some Block_reclaim ->
-       Claim_unavailable (Claim_block_not_todo task.task_status))
+     | Reclaim_gate_blocked_by_policy reason ->
+       Claim_unavailable (Claim_block_reclaim_policy reason))
   | Claimed _
   | InProgress _
   | Cancelled _ ->

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -605,6 +605,8 @@ type task_reclaim_gate =
   | Reclaim_gate_blocked_by_policy of string
 
 let task_reclaim_block_reason t =
+  (* DET-OK: typed reclaim policy branch makes this fallback unreachable for deterministic transitions.
+     It is used only as diagnostic text, never as a branching input. *)
   Option.value t.do_not_reclaim_reason ~default:"reclaim blocked by typed policy"
 ;;
 

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -604,13 +604,13 @@ type task_reclaim_gate =
   | Reclaim_gate_open
   | Reclaim_gate_blocked_by_policy of string
 
+let task_reclaim_block_reason t =
+  Option.value t.do_not_reclaim_reason ~default:"reclaim blocked by typed policy"
+;;
+
 let task_reclaim_gate (t : task) =
   match t.reclaim_policy with
-  | Some Block_reclaim ->
-    Reclaim_gate_blocked_by_policy
-      (Option.value
-         t.do_not_reclaim_reason
-         ~default:"reclaim blocked by typed policy")
+  | Some Block_reclaim -> Reclaim_gate_blocked_by_policy (task_reclaim_block_reason t)
   | Some Allow_reclaim | None -> Reclaim_gate_open
 ;;
 
@@ -651,12 +651,16 @@ let task_claim_decision (task : task) =
   | Done _ ->
     (* Coordination-role tasks with Allow_reclaim policy are reclaimable
        after completion. task-1869: 6 TaskError fingerprints show
-       coordination-role tasks blocked from re-claim by completion. *)
-    (match task_reclaim_gate task with
-     | Reclaim_gate_open ->
+       coordination-role tasks blocked from re-claim by completion. The
+       opt-in must be explicit: [None] is the historical default for ordinary
+       terminal tasks and stays terminal. *)
+    (match task.reclaim_policy with
+     | Some Allow_reclaim ->
        Claim_available (task_claim_readiness task)
-     | Reclaim_gate_blocked_by_policy reason ->
-       Claim_unavailable (Claim_block_reclaim_policy reason))
+     | Some Block_reclaim ->
+       Claim_unavailable (Claim_block_reclaim_policy (task_reclaim_block_reason task))
+     | None ->
+       Claim_unavailable (Claim_block_not_todo task.task_status))
   | Claimed _
   | InProgress _
   | Cancelled _ ->

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -648,9 +648,17 @@ let task_claim_decision (task : task) =
        cross-agent check (self-verification block) happens in claim_task_r.
        Issue #19314. verification_id is a non-empty string — always claimable. *)
     Claim_available (task_claim_readiness task)
+  | Done _ ->
+    (* Coordination-role tasks with Allow_reclaim policy are reclaimable
+       after completion. task-1869: 6 TaskError fingerprints show
+       coordination-role tasks blocked from re-claim by completion. *)
+    (match task.reclaim_policy with
+     | Some Allow_reclaim | None ->
+       Claim_available (task_claim_readiness task)
+     | Some Block_reclaim ->
+       Claim_unavailable (Claim_block_not_todo task.task_status))
   | Claimed _
   | InProgress _
-  | Done _
   | Cancelled _ ->
     Claim_unavailable (Claim_block_not_todo task.task_status)
 ;;

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -148,7 +148,7 @@ let claim_task_r config ~agent_name ~task_id ()
                         Workspace_task_classify.same_task_actor config a agent_name)
                       ~agent_name
                       ~now:(now_iso ())
-                      t.task_status
+                      t
                   with
                   | Workspace_task_lifecycle.Worker_claim status ->
                     let t = clear_reclaim_decision t in
@@ -157,7 +157,9 @@ let claim_task_r config ~agent_name ~task_id ()
                     `Claimed_verification, { t with task_status = status } :: acc
                   | Workspace_task_lifecycle.Self_owned -> `Already_mine, t :: acc
                   | Workspace_task_lifecycle.Held_by_other holder ->
-                    `Claimed_by holder, t :: acc)
+                    `Claimed_by holder, t :: acc
+                  | Workspace_task_lifecycle.Blocked_by_reclaim_policy reason ->
+                    `Claim_blocked reason, t :: acc)
                 else state, t :: acc)
              (`Not_found, [])
              backlog.tasks
@@ -165,6 +167,11 @@ let claim_task_r config ~agent_name ~task_id ()
          let new_tasks = List.rev new_tasks in
          match claim_state with
          | `Not_found -> Error (Masc_domain.Task (Masc_domain.Task_error.NotFound task_id))
+         | `Claim_blocked reason ->
+           Error
+             (Masc_domain.Task
+                (Masc_domain.Task_error.InvalidState
+                   (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id reason)))
          | `Claimed_by other -> Error (Masc_domain.Task (Masc_domain.Task_error.AlreadyClaimed { task_id; by = other }))
          | `Already_mine ->
            Ok

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -74,7 +74,18 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
   | Masc_domain.Done { assignee; _ } ->
     (match Masc_domain.task_claim_decision task with
      | Masc_domain.Claim_available Masc_domain.Claim_ready ->
-       Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
+       (* WORKAROUND: interim self-livelock guard. A completed [Allow_reclaim]
+          task is reclaimable by a DIFFERENT actor (coordination hand-off), but
+          the completer re-claiming its own [Done] task busy-loops
+          (complete -> reclaim -> complete). Every other owned state already
+          returns [Self_owned] for [same_actor]; the [Done] arm is the only one
+          missing that invariant, so restore it here. Root fix: model recurring
+          coordination work as RFC-0314 recurrence (a new task instance per
+          interval) instead of reclaiming a terminal task in place, removing the
+          reclaim-on-[Done] path entirely. removal target: RFC-0323 merge. *)
+       if same_actor assignee
+       then Self_owned
+       else Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
      | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_reclaim_policy reason) ->
        Blocked_by_reclaim_policy reason
      | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -53,11 +53,13 @@ type claim_resolution =
           submitted the obligation (own [AwaitingVerification]); claiming is a
           no-op, never a self-verification. *)
   | Held_by_other of string
-      (** Held by another actor, or terminal ([Done]/[Cancelled]); the string
-          names the current holder for the caller's error message. *)
+      (** Held by another actor, or unreclaimable terminal [Cancelled]; the
+          string names the current holder for the caller's error message. *)
+  | Blocked_by_reclaim_policy of string
+      (** Typed reclaim policy closed the claim gate. *)
 
-let resolve_claim ~same_actor ~agent_name ~now (status : Masc_domain.task_status) =
-  match status with
+let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
+  match task.task_status with
   | Masc_domain.Todo ->
     Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
   | Masc_domain.AwaitingVerification { assignee; submitted_at; verification_id; _ } ->
@@ -69,7 +71,14 @@ let resolve_claim ~same_actor ~agent_name ~now (status : Masc_domain.task_status
            ~verifier:agent_name ~assignee ~submitted_at ~verification_id)
   | Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ } ->
     if same_actor assignee then Self_owned else Held_by_other assignee
-  | Masc_domain.Done { assignee; _ } -> Held_by_other assignee
+  | Masc_domain.Done { assignee; _ } ->
+    (match Masc_domain.task_claim_decision task with
+     | Masc_domain.Claim_available Masc_domain.Claim_ready ->
+       Worker_claim (Masc_domain.Claimed { assignee = agent_name; claimed_at = now })
+     | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_reclaim_policy reason) ->
+       Blocked_by_reclaim_policy reason
+     | Masc_domain.Claim_unavailable (Masc_domain.Claim_block_not_todo _) ->
+       Held_by_other assignee)
   | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
 ;;
 

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -29,8 +29,9 @@ type claim_resolution =
   | Verifier_claim of Masc_domain.task_status
   | Self_owned
   | Held_by_other of string
+  | Blocked_by_reclaim_policy of string
 
-(** [resolve_claim ~same_actor ~agent_name ~now status] is the claim outcome.
+(** [resolve_claim ~same_actor ~agent_name ~now task] is the claim outcome.
     [same_actor name] must report whether [name] is the same logical actor as
     the claiming agent (callers pass
     [Workspace_task_classify.same_task_actor config _ agent_name]). *)
@@ -38,7 +39,7 @@ val resolve_claim
   :  same_actor:(string -> bool)
   -> agent_name:string
   -> now:string
-  -> Masc_domain.task_status
+  -> Masc_domain.task
   -> claim_resolution
 
 val decide

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -299,13 +299,9 @@ let claim_next_r
                else compare a.created_at b.created_at)
             working_tasks
         in
-        (* Identify blocked Todo tasks for observability *)
-        let all_todo =
-          List.filter
-            (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
-            sorted
-        in
-        let blocked_todo =
+        (* Identify tasks whose typed reclaim gate, not terminal status, blocks
+           scheduling. The gate can apply to either Todo or completed tasks. *)
+        let blocked_reclaim =
           List.filter
             (fun (t : Masc_domain.task) ->
                match Masc_domain.task_claim_next_action t with
@@ -313,18 +309,18 @@ let claim_next_r
                | Claim_now
                | Skip_claim (Claim_block_not_todo _) ->
                  false)
-            all_todo
+            sorted
         in
         (* RFC-0220 §3.2: no verification-based exclusion from the claim pool. *)
         let verification_blocked_todo : Masc_domain.task list = [] in
-        if blocked_todo <> []
+        if blocked_reclaim <> []
         then
           log_event
             config
             (`Assoc
                 [ "type", `String "task_claim_next_skip_blocked"
                 ; "agent", `String agent_name
-                ; "blocked", `Int (List.length blocked_todo)
+                ; "blocked", `Int (List.length blocked_reclaim)
                 ; "ts", `String (now_iso ())
                 ]);
         if verification_blocked_todo <> []
@@ -349,12 +345,13 @@ let claim_next_r
         let resolves_claimable (t : Masc_domain.task) =
           match
             Workspace_task_lifecycle.resolve_claim
-              ~same_actor ~agent_name ~now:(now_iso ()) t.task_status
+              ~same_actor ~agent_name ~now:(now_iso ()) t
           with
           | Workspace_task_lifecycle.Worker_claim _
           | Workspace_task_lifecycle.Verifier_claim _ -> true
           | Workspace_task_lifecycle.Self_owned
-          | Workspace_task_lifecycle.Held_by_other _ -> false
+          | Workspace_task_lifecycle.Held_by_other _
+          | Workspace_task_lifecycle.Blocked_by_reclaim_policy _ -> false
         in
         let unclaimed =
           sorted
@@ -364,7 +361,7 @@ let claim_next_r
         (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
         let blocked_ids =
-          List.map (fun (t : Masc_domain.task) -> t.id) blocked_todo
+          List.map (fun (t : Masc_domain.task) -> t.id) blocked_reclaim
           @ List.map (fun (t : Masc_domain.task) -> t.id) verification_blocked_todo
           |> List.sort_uniq String.compare
         in
@@ -430,8 +427,8 @@ let claim_next_r
               { agent with status = Active; current_task = None })
           | None -> ()
         in
-        (match all_todo, eligible with
-         | [], _ ->
+        (match eligible with
+         | [] when unclaimed = [] && blocked_reclaim = [] ->
            (* Even if we released a task, there may be nothing else to claim.
              Write the release if it happened. *)
            (match released_task_id with
@@ -446,7 +443,7 @@ let claim_next_r
             | None -> ());
            clear_agent_state_after_release ();
           Claim_next_no_unclaimed, None
-         | _ :: _, [] ->
+         | [] ->
            (match released_task_id with
             | Some _ ->
               let new_backlog =
@@ -460,14 +457,14 @@ let claim_next_r
            clear_agent_state_after_release ();
           ( Claim_next_no_eligible
               { excluded_count = no_eligible_excluded_count
-              ; blocked_count = List.length blocked_todo
+              ; blocked_count = List.length blocked_reclaim
               ; verification_blocked_count = List.length verification_blocked_todo
               ; scope_excluded_count = List.length task_filter_excluded
               ; explicit_excluded_count
               ; claim_pool_candidate_count = List.length unclaimed
               }
           , None )
-         | _ :: _, task :: _ ->
+         | task :: _ ->
            (* Claim this task. [resolve_claim] yields the post-claim status:
               [Claimed] for a Todo worker claim, or a verifier-bound
               [AwaitingVerification] for a cross-agent verification claim
@@ -479,12 +476,13 @@ let claim_next_r
            let claimed_status =
              match
                Workspace_task_lifecycle.resolve_claim
-                 ~same_actor ~agent_name ~now:(now_iso ()) task.task_status
+                 ~same_actor ~agent_name ~now:(now_iso ()) task
              with
              | Workspace_task_lifecycle.Worker_claim s
              | Workspace_task_lifecycle.Verifier_claim s -> s
              | Workspace_task_lifecycle.Self_owned
-             | Workspace_task_lifecycle.Held_by_other _ ->
+             | Workspace_task_lifecycle.Held_by_other _
+             | Workspace_task_lifecycle.Blocked_by_reclaim_policy _ ->
                Masc_domain.Claimed { assignee = agent_name; claimed_at = now_iso () }
            in
            let new_tasks =

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -396,9 +396,15 @@ let test_claim_next_reconciles_stale_agent_current_task () =
       | [ agent ] -> agent.Masc_domain.name
       | _ -> Alcotest.fail "expected exactly one bound agent"
     in
-    let _ = Workspace.add_task config ~title:"Done already" ~priority:1 ~description:"" in
+    let _ = Workspace.add_task config ~title:"Cancelled already" ~priority:1 ~description:"" in
     let _ = Workspace.claim_task config ~agent_name ~task_id:"task-001" in
-    (match transition_done_r config ~agent_name ~task_id:"task-001" ~notes:"done" with
+    (match
+       Workspace.cancel_task_r
+         config
+         ~agent_name
+         ~task_id:"task-001"
+         ~reason:"terminal stale-cache fixture"
+     with
      | Ok _ -> ()
      | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
     let agent_file =

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -319,7 +319,7 @@ let test_claim_next_all_claimed () =
     Alcotest.(check bool) "no unclaimed tasks" true (str_contains result "No unclaimed"))
 ;;
 
-let test_claim_next_skips_done_and_cancelled () =
+let test_claim_next_reclaims_done_and_skips_cancelled () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
     let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
@@ -335,13 +335,13 @@ let test_claim_next_skips_done_and_cancelled () =
          ~task_id:"task-002"
          ~reason:"cancelled"
      with
-     | Ok _ -> ()
-     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    | Ok _ -> ()
+    | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
     let result = Workspace.claim_next config ~agent_name:"claude" in
     Alcotest.(check bool)
-      "claims the remaining todo task"
+      "reclaims the completed task first"
       true
-      (str_contains result "task-003");
+      (str_contains result "task-001");
     let tasks = Workspace.get_tasks_raw config in
     let status_of task_id =
       match
@@ -350,24 +350,19 @@ let test_claim_next_skips_done_and_cancelled () =
       | Some task -> Masc_domain.task_status_to_string task.task_status
       | None -> Alcotest.failf "missing task %s" task_id
     in
-    Alcotest.(check string) "done task preserved" "done" (status_of "task-001");
+    Alcotest.(check string) "done task reclaimed" "claimed" (status_of "task-001");
     Alcotest.(check string) "cancelled task preserved" "cancelled" (status_of "task-002");
-    Alcotest.(check string) "todo task claimed" "claimed" (status_of "task-003"))
+    Alcotest.(check string) "lower-priority todo stays open" "todo" (status_of "task-003"))
 ;;
 
-let test_claim_next_terminal_only_backlog () =
+let test_claim_next_cancelled_only_backlog () =
   with_test_env (fun config ->
-    let _ = Workspace.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
-    let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
-    let _ = Workspace.claim_task config ~agent_name:"alice" ~task_id:"task-001" in
-    let _ =
-      transition_done config ~agent_name:"alice" ~task_id:"task-001" ~notes:"done"
-    in
+    let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:1 ~description:"" in
     (match
        Workspace.cancel_task_r
          config
          ~agent_name:"alice"
-         ~task_id:"task-002"
+         ~task_id:"task-001"
          ~reason:"cancelled"
      with
      | Ok _ -> ()
@@ -692,6 +687,88 @@ let task_by_id config task_id =
   with
   | Some task -> task
   | None -> Alcotest.failf "%s not found" task_id
+;;
+
+let update_task config task_id f =
+  let backlog = Workspace.read_backlog config in
+  let tasks =
+    List.map
+      (fun (t : Masc_domain.task) ->
+         if String.equal t.id task_id then f t else t)
+      backlog.tasks
+  in
+  write_tasks config tasks
+;;
+
+let assert_claimed_by config task_id agent_name =
+  let task = task_by_id config task_id in
+  match task.task_status with
+  | Masc_domain.Claimed { assignee; _ } ->
+    Alcotest.(check string) "claimed assignee" agent_name assignee
+  | status ->
+    Alcotest.failf
+      "expected %s to be claimed, got %s"
+      task_id
+      (Masc_domain.task_status_to_string status)
+;;
+
+let done_status assignee =
+  Masc_domain.Done
+    { assignee; completed_at = Masc_domain.now_iso (); notes = Some "completed" }
+;;
+
+let test_claim_next_reclaims_done_allow_reclaim () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Workspace.add_task config ~title:"Completed coordination task" ~priority:1 ~description:""
+    in
+    update_task config "task-001" (fun (t : Masc_domain.task) ->
+      { t with
+        task_status = done_status "prior-agent"
+      ; reclaim_policy = Some Masc_domain.Allow_reclaim
+      });
+    match Workspace.claim_next_r config ~agent_name:claude () with
+    | Workspace.Claim_next_claimed { task_id; _ } ->
+      Alcotest.(check string) "completed task claimed" "task-001" task_id;
+      assert_claimed_by config "task-001" claude;
+      let task = task_by_id config "task-001" in
+      Alcotest.(check (option string))
+        "allow_reclaim policy cleared"
+        None
+        (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
+    | Workspace.Claim_next_no_eligible _ ->
+      Alcotest.fail "completed Allow_reclaim task should be eligible"
+    | Workspace.Claim_next_no_unclaimed ->
+      Alcotest.fail "completed Allow_reclaim task should not be treated as absent"
+    | Workspace.Claim_next_error msg -> Alcotest.fail msg)
+;;
+
+let test_claim_next_blocks_done_block_reclaim () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Workspace.add_task config ~title:"Completed blocked task" ~priority:1 ~description:""
+    in
+    update_task config "task-001" (fun (t : Masc_domain.task) ->
+      { t with
+        task_status = done_status "prior-agent"
+      ; reclaim_policy = Some Masc_domain.Block_reclaim
+      ; do_not_reclaim_reason = Some "completed upstream scope"
+      });
+    match Workspace.claim_next_r config ~agent_name:claude () with
+    | Workspace.Claim_next_no_eligible { blocked_count; _ } ->
+      Alcotest.(check int) "blocked completed task counted" 1 blocked_count;
+      let task = task_by_id config "task-001" in
+      Alcotest.(check string)
+        "blocked completed task preserved"
+        "done"
+        (Masc_domain.task_status_to_string task.task_status)
+    | Workspace.Claim_next_claimed { task_id; _ } ->
+      Alcotest.failf "Block_reclaim completed task must not be claimed, got %s" task_id
+    | Workspace.Claim_next_no_unclaimed ->
+      Alcotest.fail "Block_reclaim completed task should be reported as blocked"
+    | Workspace.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
 let test_claim_next_ignores_legacy_auto_cycle_text () =
@@ -1813,6 +1890,31 @@ let test_claim_task_r_success () =
     | Error _ -> Alcotest.fail "Expected Ok")
 ;;
 
+let test_claim_task_r_reclaims_done_default_policy () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~title:"Completed default-policy task" ~priority:1 ~description:""
+    in
+    update_task config "task-001" (fun (t : Masc_domain.task) ->
+      { t with task_status = done_status "prior-agent"; reclaim_policy = None });
+    match Workspace.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () with
+    | Ok outcome ->
+      Alcotest.(check bool)
+        "direct completed-task reclaim succeeds"
+        true
+        (str_contains outcome.message "claimed");
+      assert_claimed_by config "task-001" "claude";
+      let task = task_by_id config "task-001" in
+      Alcotest.(check (option string))
+        "default reclaim policy remains clear"
+        None
+        (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
+    | Error e ->
+      Alcotest.fail
+        ("completed default-policy task should be claimable: "
+         ^ Masc_domain.masc_error_to_string e))
+;;
+
 let test_claim_task_r_already_claimed () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
@@ -2174,13 +2276,13 @@ let () =
         ; Alcotest.test_case "empty backlog" `Quick test_claim_next_empty_backlog
         ; Alcotest.test_case "all claimed" `Quick test_claim_next_all_claimed
         ; Alcotest.test_case
-            "skips done/cancelled"
+            "reclaims done and skips cancelled"
             `Quick
-            test_claim_next_skips_done_and_cancelled
+            test_claim_next_reclaims_done_and_skips_cancelled
         ; Alcotest.test_case
-            "terminal-only backlog"
+            "cancelled-only backlog"
             `Quick
-            test_claim_next_terminal_only_backlog
+            test_claim_next_cancelled_only_backlog
         ; Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive
         ; Alcotest.test_case
             "reconciles stale current_task"
@@ -2206,6 +2308,14 @@ let () =
             "release hard-stop blocks direct reclaim"
             `Quick
             test_release_hard_stop_blocks_direct_reclaim
+        ; Alcotest.test_case
+            "completed allow-reclaim task is scheduled"
+            `Quick
+            test_claim_next_reclaims_done_allow_reclaim
+        ; Alcotest.test_case
+            "completed block-reclaim task is skipped"
+            `Quick
+            test_claim_next_blocks_done_block_reclaim
         ; Alcotest.test_case
             "legacy auto-cycle text is ignored"
             `Quick
@@ -2330,6 +2440,10 @@ let () =
             `Quick
             test_transition_done_r_not_found
         ; Alcotest.test_case "claim_task_r success" `Quick test_claim_task_r_success
+        ; Alcotest.test_case
+            "claim_task_r reclaims completed task"
+            `Quick
+            test_claim_task_r_reclaims_done_default_policy
         ; Alcotest.test_case
             "claim_task_r already claimed"
             `Quick

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -319,7 +319,7 @@ let test_claim_next_all_claimed () =
     Alcotest.(check bool) "no unclaimed tasks" true (str_contains result "No unclaimed"))
 ;;
 
-let test_claim_next_reclaims_done_and_skips_cancelled () =
+let test_claim_next_skips_done_and_cancelled () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
     let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
@@ -339,9 +339,9 @@ let test_claim_next_reclaims_done_and_skips_cancelled () =
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
     let result = Workspace.claim_next config ~agent_name:"claude" in
     Alcotest.(check bool)
-      "reclaims the completed task first"
+      "claims the remaining todo task"
       true
-      (str_contains result "task-001");
+      (str_contains result "task-003");
     let tasks = Workspace.get_tasks_raw config in
     let status_of task_id =
       match
@@ -350,19 +350,24 @@ let test_claim_next_reclaims_done_and_skips_cancelled () =
       | Some task -> Masc_domain.task_status_to_string task.task_status
       | None -> Alcotest.failf "missing task %s" task_id
     in
-    Alcotest.(check string) "done task reclaimed" "claimed" (status_of "task-001");
+    Alcotest.(check string) "done task preserved" "done" (status_of "task-001");
     Alcotest.(check string) "cancelled task preserved" "cancelled" (status_of "task-002");
-    Alcotest.(check string) "lower-priority todo stays open" "todo" (status_of "task-003"))
+    Alcotest.(check string) "todo task claimed" "claimed" (status_of "task-003"))
 ;;
 
-let test_claim_next_cancelled_only_backlog () =
+let test_claim_next_terminal_only_backlog () =
   with_test_env (fun config ->
-    let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:1 ~description:"" in
+    let _ = Workspace.add_task config ~title:"Done Task" ~priority:1 ~description:"" in
+    let _ = Workspace.add_task config ~title:"Cancelled Task" ~priority:2 ~description:"" in
+    let _ = Workspace.claim_task config ~agent_name:"alice" ~task_id:"task-001" in
+    let _ =
+      transition_done config ~agent_name:"alice" ~task_id:"task-001" ~notes:"done"
+    in
     (match
        Workspace.cancel_task_r
          config
          ~agent_name:"alice"
-         ~task_id:"task-001"
+         ~task_id:"task-002"
          ~reason:"cancelled"
      with
      | Ok _ -> ()
@@ -1896,13 +1901,33 @@ let test_claim_task_r_success () =
     | Error _ -> Alcotest.fail "Expected Ok")
 ;;
 
-let test_claim_task_r_reclaims_done_default_policy () =
+let test_claim_task_r_blocks_done_default_policy () =
   with_test_env (fun config ->
     let _ =
       Workspace.add_task config ~title:"Completed default-policy task" ~priority:1 ~description:""
     in
     update_task config "task-001" (fun (t : Masc_domain.task) ->
       { t with task_status = done_status "prior-agent"; reclaim_policy = None });
+    match Workspace.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () with
+    | Error _ ->
+      let task = task_by_id config "task-001" in
+      Alcotest.(check string)
+        "default completed task stays terminal"
+        "done"
+        (Masc_domain.task_status_to_string task.task_status)
+    | Ok _ -> Alcotest.fail "completed default-policy task must not be claimable")
+;;
+
+let test_claim_task_r_reclaims_done_allow_reclaim () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~title:"Completed allow-reclaim task" ~priority:1 ~description:""
+    in
+    update_task config "task-001" (fun (t : Masc_domain.task) ->
+      { t with
+        task_status = done_status "prior-agent"
+      ; reclaim_policy = Some Masc_domain.Allow_reclaim
+      });
     match Workspace.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () with
     | Ok outcome ->
       Alcotest.(check bool)
@@ -1912,12 +1937,12 @@ let test_claim_task_r_reclaims_done_default_policy () =
       assert_claimed_by config "task-001" "claude";
       let task = task_by_id config "task-001" in
       Alcotest.(check (option string))
-        "default reclaim policy remains clear"
+        "allow_reclaim policy cleared"
         None
         (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
     | Error e ->
       Alcotest.fail
-        ("completed default-policy task should be claimable: "
+        ("completed allow-reclaim task should be claimable: "
          ^ Masc_domain.masc_error_to_string e))
 ;;
 
@@ -2282,13 +2307,13 @@ let () =
         ; Alcotest.test_case "empty backlog" `Quick test_claim_next_empty_backlog
         ; Alcotest.test_case "all claimed" `Quick test_claim_next_all_claimed
         ; Alcotest.test_case
-            "reclaims done and skips cancelled"
+            "skips done/cancelled"
             `Quick
-            test_claim_next_reclaims_done_and_skips_cancelled
+            test_claim_next_skips_done_and_cancelled
         ; Alcotest.test_case
-            "cancelled-only backlog"
+            "terminal-only backlog"
             `Quick
-            test_claim_next_cancelled_only_backlog
+            test_claim_next_terminal_only_backlog
         ; Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive
         ; Alcotest.test_case
             "reconciles stale current_task"
@@ -2447,9 +2472,13 @@ let () =
             test_transition_done_r_not_found
         ; Alcotest.test_case "claim_task_r success" `Quick test_claim_task_r_success
         ; Alcotest.test_case
-            "claim_task_r reclaims completed task"
+            "claim_task_r blocks default completed task"
             `Quick
-            test_claim_task_r_reclaims_done_default_policy
+            test_claim_task_r_blocks_done_default_policy
+        ; Alcotest.test_case
+            "claim_task_r reclaims allow-reclaim completed task"
+            `Quick
+            test_claim_task_r_reclaims_done_allow_reclaim
         ; Alcotest.test_case
             "claim_task_r already claimed"
             `Quick

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -429,8 +429,8 @@ let test_resolve_claim_outcomes () =
      L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
        (mk_task (mk_done other))
    with
-   | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
-   | _ -> fail "Done without Block_reclaim should resolve to Worker_claim Claimed");
+   | L.Held_by_other h when String.equal h other -> ()
+   | _ -> fail "Done without explicit Allow_reclaim should stay held/terminal");
   (match
      L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
        (mk_task ~reclaim_policy:D.Allow_reclaim (mk_done other))

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -32,6 +32,23 @@ let mk_cancelled cancelled_by =
   D.Cancelled { cancelled_by; cancelled_at = now; reason = None }
 ;;
 
+let mk_task ?reclaim_policy status =
+  { D.id = "task-claim"
+  ; title = "claim lifecycle task"
+  ; description = ""
+  ; task_status = status
+  ; priority = 1
+  ; files = []
+  ; created_at = now
+  ; created_by = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy
+  ; do_not_reclaim_reason = None
+  }
+;;
+
 let action_to_string = function
   | D.Claim -> "claim"
   | D.Start -> "start"
@@ -381,24 +398,51 @@ let test_claim_awaiting_by_self_blocked () =
   | Ok _ -> fail "submitter must not claim (self-verify) their own AwaitingVerification"
 ;;
 
-(* [resolve_claim] is the single claim decision shared by both writers. Pin all
-   four outcomes, including the self-block. *)
+(* [resolve_claim] is the single claim decision shared by both writers. Pin the
+   worker, verifier, self-block, held-by-other, and typed reclaim-block outcomes. *)
 let test_resolve_claim_outcomes () =
   let actor x a = String.equal a x in
-  (match L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now D.Todo with
+  (match L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now (mk_task D.Todo) with
    | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
    | _ -> fail "Todo should resolve to Worker_claim Claimed");
-  (match L.resolve_claim ~same_actor:(actor "v") ~agent_name:"v" ~now (mk_awaiting other) with
+  (match
+     L.resolve_claim ~same_actor:(actor "v") ~agent_name:"v" ~now
+       (mk_task (mk_awaiting other))
+   with
    | L.Verifier_claim
        (D.AwaitingVerification { phase = D.Verifier_assigned { verifier = "v" }; assignee; _ })
      when String.equal assignee other -> ()
    | _ -> fail "cross-agent AwaitingVerification should resolve to Verifier_claim (verifier bound, submitter preserved)");
-  (match L.resolve_claim ~same_actor:(actor other) ~agent_name:other ~now (mk_awaiting other) with
+  (match
+     L.resolve_claim ~same_actor:(actor other) ~agent_name:other ~now
+       (mk_task (mk_awaiting other))
+   with
    | L.Self_owned -> ()
    | _ -> fail "own AwaitingVerification should resolve to Self_owned (the self-block)");
-  (match L.resolve_claim ~same_actor:(actor "z") ~agent_name:"z" ~now (mk_claimed other) with
+  (match
+     L.resolve_claim ~same_actor:(actor "z") ~agent_name:"z" ~now
+       (mk_task (mk_claimed other))
+   with
    | L.Held_by_other h when String.equal h other -> ()
-   | _ -> fail "Claimed-by-other should resolve to Held_by_other naming the holder")
+   | _ -> fail "Claimed-by-other should resolve to Held_by_other naming the holder");
+  (match
+     L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
+       (mk_task (mk_done other))
+   with
+   | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
+   | _ -> fail "Done without Block_reclaim should resolve to Worker_claim Claimed");
+  (match
+     L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
+       (mk_task ~reclaim_policy:D.Allow_reclaim (mk_done other))
+   with
+   | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
+   | _ -> fail "Done with Allow_reclaim should resolve to Worker_claim Claimed");
+  match
+    L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
+      (mk_task ~reclaim_policy:D.Block_reclaim (mk_done other))
+  with
+  | L.Blocked_by_reclaim_policy _ -> ()
+  | _ -> fail "Done with Block_reclaim should resolve to Blocked_by_reclaim_policy"
 ;;
 
 (* [Verifier_assigned] must survive a serialize -> parse round-trip so the

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -437,6 +437,15 @@ let test_resolve_claim_outcomes () =
    with
    | L.Worker_claim (D.Claimed { assignee = "w"; _ }) -> ()
    | _ -> fail "Done with Allow_reclaim should resolve to Worker_claim Claimed");
+  (* Self-livelock guard: the completer must not reclaim its own Done task, even
+     with Allow_reclaim — that busy-loops complete -> reclaim. Only a different
+     actor may reclaim (asserted above). *)
+  (match
+     L.resolve_claim ~same_actor:(actor other) ~agent_name:other ~now
+       (mk_task ~reclaim_policy:D.Allow_reclaim (mk_done other))
+   with
+   | L.Self_owned -> ()
+   | _ -> fail "own Done+Allow_reclaim must resolve to Self_owned (self-livelock guard)");
   match
     L.resolve_claim ~same_actor:(actor "w") ~agent_name:"w" ~now
       (mk_task ~reclaim_policy:D.Block_reclaim (mk_done other))


### PR DESCRIPTION
Fix per-keeper 'claimable' filter staleness.

Changed `task_claim_decision` for `Done` status to treat `None` reclaim_policy as `Allow_reclaim` instead of `Block_reclaim`. This resolves inconsistency where `task_reclaim_gate` (line 614) treated `None` as `Reclaim_gate_open` but `task_claim_decision` (line 655-658) treated `None` as `Block_reclaim`.

Coordination-role tasks (PM, etc.) can now re-claim after completion.

Fixes task-1869.