### PR TITLE
RFC-0320 W2b HITL approval provenance capture

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -376,7 +376,14 @@ let reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta () 
   decision
 ;;
 
-let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock ()
+let to_oas_approval_callback
+      ~config
+      ~governance_level
+      ~keeper_name
+      ?meta
+      ?clock
+      ?continuation_channel
+      ()
   : Agent_sdk.Hooks.approval_callback
   =
   fun ~tool_name ~input ->
@@ -559,6 +566,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                   (Operator_approval.approval_mode_queue_reason_to_string reason)
                 ~risk_level
                 ?clock
+                ?continuation_channel
                 ()
             in
             (match Operator_approval.decide_approval_mode ~mode ~band with

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -143,6 +143,7 @@ val to_oas_approval_callback :
   keeper_name:string ->
   ?meta:Keeper_meta_contract.keeper_meta ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   unit ->
   Agent_sdk.Hooks.approval_callback
 (** Build an OAS approval callback with genuine HITL fiber suspension.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -218,6 +218,7 @@ let run_turn
       ?shared_context
       ?event_bus
       ?trace_link
+      ?continuation_channel
       ?yield_to_chat_waiting
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
@@ -772,6 +773,7 @@ let run_turn
                          ~keeper_name:meta.name
                          ~meta
                          ?clock:(Eio_context.get_clock_opt ())
+                         ?continuation_channel
                          ())
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
                       (* Mutation-boundary is native to OAS now; [exit_condition]

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -155,6 +155,7 @@ val run_turn
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?trace_link:string * string
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?yield_to_chat_waiting:(unit -> bool)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
           (the same guard point as [max_idle_turns], before the next model

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -184,6 +184,7 @@ let audit_approval_event
       ?approval_mode
       ?authorizing_band
       ?decision
+      ?continuation_channel
       ()
   =
   let decision, decision_kind, decision_reason =
@@ -247,6 +248,10 @@ let audit_approval_event
             | None -> [])
          @ (match authorizing_band with
             | Some value -> [ "authorizing_band", `String value ]
+            | None -> [])
+         @ (match continuation_channel with
+            | Some channel ->
+              [ "continuation_channel", Keeper_continuation_channel.to_yojson channel ]
             | None -> [])
          @
          match auto_approved with
@@ -389,6 +394,7 @@ let resolved_approval_json_of_audit_event json =
     ; "approval_mode", json_member_or_null "approval_mode" json
     ; "authorizing_band", json_member_or_null "authorizing_band" json
     ; "auto_approved", json_member_or_null "auto_approved" json
+    ; "continuation_channel", json_member_or_null "continuation_channel" json
     ]
 ;;
 
@@ -495,6 +501,8 @@ let create_entry
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?(continuation_channel =
+        Keeper_continuation_channel.unrouted "no originating connector")
       ~audit_base_path
       ~resolver
       ~on_resolution
@@ -531,6 +539,7 @@ let create_entry
   ; disposition
   ; disposition_reason
   ; phase = Awaiting_operator
+  ; continuation_channel
   ; audit_base_path
   ; resolver
   ; on_resolution
@@ -584,6 +593,7 @@ let pending_entry_json_fields
   ; "selected_model", `Null
   ; "disposition", Json_util.string_opt_to_json entry.disposition
   ; "disposition_reason", Json_util.string_opt_to_json entry.disposition_reason
+  ; "continuation_channel", Keeper_continuation_channel.to_yojson entry.continuation_channel
   ]
   @ (if include_requested_at_iso
      then
@@ -671,6 +681,7 @@ let record_pending (entry : pending_approval) =
     ?selected_model:entry.selected_model
     ?disposition:entry.disposition
     ?disposition_reason:entry.disposition_reason
+    ~continuation_channel:entry.continuation_channel
     ();
   broadcast_pending entry
 ;;
@@ -847,14 +858,30 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
+     continuation_channel:Keeper_continuation_channel.t ->
      unit)
     ref =
-  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ())
+  ref
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~continuation_channel:_ ->
+       ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
-let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision =
-  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision with
+let wake_keeper_on_approval_resolution
+      ~base_path
+      ~keeper_name
+      ~approval_id
+      ~decision
+      ~continuation_channel
+  =
+  try
+    !approval_resolution_wake_hook
+      ~base_path
+      ~keeper_name
+      ~approval_id
+      ~decision
+      ~continuation_channel
+  with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.warn
@@ -895,6 +922,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ?disposition:entry.disposition
     ?disposition_reason:entry.disposition_reason
     ~decision:(Approval_resolved decision)
+    ~continuation_channel:entry.continuation_channel
     ();
   (match entry.resolver with
    | Some resolver -> Eio.Promise.resolve resolver decision
@@ -920,7 +948,8 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ~base_path
     ~keeper_name:entry.keeper_name
     ~approval_id:entry.id
-    ~decision:(hitl_resolution_decision_of_approval_decision decision);
+    ~decision:(hitl_resolution_decision_of_approval_decision decision)
+    ~continuation_channel:entry.continuation_channel;
   try
     Sse.broadcast
       (`Assoc
@@ -1041,6 +1070,7 @@ let submit_and_await
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
       ?(critical_escalation_after_s = default_critical_approval_escalation_after_s)
+      ?continuation_channel
       ()
   : Agent_sdk.Hooks.approval_decision
   =
@@ -1064,6 +1094,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
       ~on_resolution:None
@@ -1112,6 +1143,7 @@ let submit_and_await
            ?runtime_contract
            ?selected_model
            ~decision:(Approval_expired reason)
+           ~continuation_channel:entry.continuation_channel
            ();
          (* Mirror expire_stale's teardown, but preserve any concurrent
             operator decision that wins the promise resolution race. *)
@@ -1142,6 +1174,7 @@ let submit_and_await
            ?runtime_contract
            ?selected_model
            ~audit_disposition:(Approval_escalated reason)
+           ~continuation_channel:entry.continuation_channel
            ();
          (match update_pending_phase ~id Escalated with
           | Some escalated_entry -> broadcast_pending escalated_entry
@@ -1175,6 +1208,7 @@ let submit_and_await
               ?disposition
               ?disposition_reason
               ~decision:(Approval_expired reason)
+              ~continuation_channel:entry.continuation_channel
               ()
           with
           | Eio.Cancel.Cancelled _ -> ()
@@ -1208,6 +1242,7 @@ let submit_pending
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~on_resolution
       ()
   : string
@@ -1253,6 +1288,7 @@ let submit_pending
           ?selected_model
           ?disposition
           ?disposition_reason
+          ?continuation_channel
           ~audit_base_path:base_path
           ~resolver:None
           ~on_resolution:(Some on_resolution)
@@ -1515,6 +1551,7 @@ let expire_stale ~max_wait_s =
          ?disposition:entry.disposition
          ?disposition_reason:entry.disposition_reason
          ~decision:(Approval_expired reason)
+         ~continuation_channel:entry.continuation_channel
          ();
        (* Expiry clears the [Approval_pending] skip just like a resolution, so
           the keeper needs the same wake or it stays stalled until an unrelated
@@ -1524,7 +1561,8 @@ let expire_stale ~max_wait_s =
          ~base_path:entry.audit_base_path
          ~keeper_name:entry.keeper_name
          ~approval_id:id
-         ~decision:Keeper_event_queue.Hitl_rejected;
+         ~decision:Keeper_event_queue.Hitl_rejected
+         ~continuation_channel:entry.continuation_channel;
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -78,6 +78,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
@@ -207,6 +208,7 @@ val audit_approval_event :
   ?approval_mode:string ->
   ?authorizing_band:string ->
   ?decision:approval_audit_decision ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   unit ->
   unit
 
@@ -282,6 +284,7 @@ val submit_and_await :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
   ?critical_escalation_after_s:float ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   unit ->
   Agent_sdk.Hooks.approval_decision
 
@@ -306,6 +309,7 @@ val submit_pending :
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
   unit ->
   string
@@ -324,6 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
+   continuation_channel:Keeper_continuation_channel.t ->
    unit) ->
   unit
 

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -23,9 +23,19 @@ type queued_message = {
   source : message_source;
 }
 
+let dashboard_queue_default_thread_id = "dashboard"
+
+let dashboard_thread_id_or_default = function
+  | Some thread_id -> thread_id
+  | None ->
+    (* DET-OK: queued dashboard messages without AG-UI thread metadata are routed
+       to the documented singleton dashboard lane, not inferred from runtime
+       state. *)
+    dashboard_queue_default_thread_id
+
 let continuation_channel_of_message_source ?dashboard_thread_id = function
   | Dashboard ->
-    let thread_id = Option.value ~default:"dashboard" dashboard_thread_id in
+    let thread_id = dashboard_thread_id_or_default dashboard_thread_id in
     Keeper_continuation_channel.Dashboard { thread_id }
   | Discord { channel_id; user_id } ->
     Keeper_continuation_channel.Discord

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -23,6 +23,22 @@ type queued_message = {
   source : message_source;
 }
 
+let continuation_channel_of_message_source ?dashboard_thread_id = function
+  | Dashboard ->
+    let thread_id = Option.value ~default:"dashboard" dashboard_thread_id in
+    Keeper_continuation_channel.Dashboard { thread_id }
+  | Discord { channel_id; user_id } ->
+    Keeper_continuation_channel.Discord
+      { guild_id = None
+      ; channel_id
+      ; parent_channel_id = None
+      ; thread_id = None
+      ; user_id
+      }
+  | Slack { channel; user_id } ->
+    Keeper_continuation_channel.Slack
+      { team_id = None; channel_id = channel; thread_ts = None; user_id }
+
 type queue_entry = {
   mutex : Eio.Mutex.t;
   q : queued_message Queue.t;

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -32,6 +32,13 @@ type queued_message = {
   source : message_source;
 }
 
+(** [continuation_channel_of_message_source source] converts queued chat
+    provenance into the RFC-0320 continuation-channel type. Dashboard queue
+    sources may supply [dashboard_thread_id] from the local AG-UI thread; when
+    omitted the dashboard surface is preserved as a single route. *)
+val continuation_channel_of_message_source :
+  ?dashboard_thread_id:string -> message_source -> Keeper_continuation_channel.t
+
 (** {1 Queue operations} *)
 
 (** [configure_persistence base_path] enables durable per-keeper queue

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -691,7 +691,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ?continuation_channel ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -699,7 +699,11 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_create_from_persona" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_create_from_persona ctx args))
   | "masc_keeper_up" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_up ctx args))
   | "masc_keeper_status" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_status ctx args))
-  | "masc_keeper_msg" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg ctx args))
+  | "masc_keeper_msg" ->
+      Some
+        (tool_result_with_tool_name
+           ~tool_name:name
+           (handle_keeper_msg ?continuation_channel ctx args))
   | "masc_keeper_msg_result" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_result ctx args))
   | "masc_keeper_msg_cancel" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_cancel ctx args))
   | "masc_keeper_msg_queue" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_queue ctx args))
@@ -721,7 +725,15 @@ let dispatch ctx ~name ~args : tool_result option =
 (** Streaming dispatch: only handles keeper_msg with text delta forwarding.
     Returns None for all other tool names.
     Called from server_routes_http_keeper_stream. *)
-let dispatch_stream ?on_text_delta ?on_event ctx ~name ~args : tool_result option =
+let dispatch_stream
+      ?on_text_delta
+      ?on_event
+      ?continuation_channel
+      ctx
+      ~name
+      ~args
+  : tool_result option
+  =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -729,7 +741,12 @@ let dispatch_stream ?on_text_delta ?on_event ctx ~name ~args : tool_result optio
       Some
         (tool_result_with_tool_name
            ~tool_name:name
-           (handle_keeper_msg_stream ?on_text_delta ?on_event ctx args))
+           (handle_keeper_msg_stream
+              ?on_text_delta
+              ?on_event
+              ?continuation_channel
+              ctx
+              args))
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -15,6 +15,7 @@ type tool_result = Keeper_types_profile.tool_result
 val schemas : Masc_domain.tool_schema list
 
 val dispatch :
+  ?continuation_channel:Keeper_continuation_channel.t ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 module For_testing : sig
@@ -33,4 +34,5 @@ end
 val dispatch_stream :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -694,7 +694,7 @@ let keeper_msg_body
   | Error err -> tool_result_error err
 ;;
 
-let handle_keeper_msg ctx args : tool_result =
+let handle_keeper_msg ?continuation_channel ctx args : tool_result =
   match
     let* name = resolve_keeper_name ctx args in
     let resolved_args = with_keeper_name args name in
@@ -711,7 +711,9 @@ let handle_keeper_msg ctx args : tool_result =
         ~base_path:ctx.config.base_path
         ~keeper_name:name
         ~f:(fun ?event_bus () ->
-          let result = Turn.handle_keeper_msg ?event_bus ctx resolved_args in
+          let result =
+            Turn.handle_keeper_msg ?event_bus ?continuation_channel ctx resolved_args
+          in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply
@@ -802,7 +804,14 @@ let keeper_msg_queue_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_msg_queue ctx args : tool_result =
   keeper_msg_queue_body ~config:ctx.config args
 
-let handle_keeper_msg_stream ?on_text_delta ?on_event ctx args : tool_result =
+let handle_keeper_msg_stream
+      ?on_text_delta
+      ?on_event
+      ?continuation_channel
+      ctx
+      args
+  : tool_result
+  =
   match
     let* name = resolve_keeper_name ctx args in
     let resolved_args = with_keeper_name args name in
@@ -811,7 +820,13 @@ let handle_keeper_msg_stream ?on_text_delta ?on_event ctx args : tool_result =
        fallback lookup in the turn body. *)
     let event_bus = Keeper_event_bus.get () in
     let result =
-      Turn.handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx resolved_args
+      Turn.handle_keeper_msg
+        ?on_text_delta
+        ?on_event
+        ?event_bus
+        ?continuation_channel
+        ctx
+        resolved_args
     in
     if not (tool_result_success result) then
       Ok result

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -571,7 +571,15 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    [handle_keeper_msg] calls this directly because the validation guard
    below exits first). Do not add keeper-state mutation ahead of the
    validation guards without moving it behind the slot. *)
-let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : tool_result =
+let run_keeper_msg_turn_admitted
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ctx
+      args
+  : tool_result
+  =
   with_span
     ~name:"keeper_turn"
     ~attrs:[
@@ -1169,10 +1177,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                ~trajectory_acc
 		                                ?degraded_retry_runtime
 		                                ?fallback_reason
-		                                ~runtime_rotation_attempts
-		                                ~is_retry
-		                                ?event_bus
-		                                ())
+                                ~runtime_rotation_attempts
+                                ~is_retry
+                                ?event_bus
+                                ?continuation_channel
+                                ())
 		                         ()))
 		            in
 		            match run_result with
@@ -1375,7 +1384,15 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 
 ))))))))
 
-let handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx args : tool_result =
+let handle_keeper_msg
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ctx
+      args
+  : tool_result
+  =
   let event_bus =
     match event_bus with
     | Some _ -> event_bus
@@ -1385,14 +1402,26 @@ let handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx args : tool_result
   if not (validate_name name) then
     (* Invalid input cannot reach run_turn; let the admitted body produce
        its precise validation error without holding the slot. *)
-    run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args
+    run_keeper_msg_turn_admitted
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ctx
+      args
   else
     match
       Keeper_turn_admission.run_serialized
         ~base_path:ctx.config.base_path
         ~keeper_name:name
         (fun () ->
-          run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)
+          run_keeper_msg_turn_admitted
+            ?on_text_delta
+            ?on_event
+            ?event_bus
+            ?continuation_channel
+            ctx
+            args)
     with
     | `Ran result -> result
     | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
@@ -1413,7 +1442,14 @@ let handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx args : tool_result
              waiting
              in_flight_text)
 
-let handle_keeper_msg_if_free ?on_text_delta ?on_event ?event_bus ctx args =
+let handle_keeper_msg_if_free
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ctx
+      args
+  =
   let event_bus =
     match event_bus with
     | Some _ -> event_bus
@@ -1421,10 +1457,23 @@ let handle_keeper_msg_if_free ?on_text_delta ?on_event ?event_bus ctx args =
   in
   let name = get_string args "name" "" in
   if not (validate_name name) then
-    `Ran (run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)
+    `Ran
+      (run_keeper_msg_turn_admitted
+         ?on_text_delta
+         ?on_event
+         ?event_bus
+         ?continuation_channel
+         ctx
+         args)
   else
     Keeper_turn_admission.run_chat_if_free
       ~base_path:ctx.config.base_path
       ~keeper_name:name
       (fun () ->
-        run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)
+        run_keeper_msg_turn_admitted
+          ?on_text_delta
+          ?on_event
+          ?event_bus
+          ?continuation_channel
+          ctx
+          args)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -138,6 +138,7 @@ val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?event_bus:Agent_sdk.Event_bus.t ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 (** [event_bus] is captured at the handler boundary and reused by the admitted
     turn body. Callers that omit it keep the legacy process/domain fallback, but
@@ -148,6 +149,7 @@ val handle_keeper_msg_if_free :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?event_bus:Agent_sdk.Event_bus.t ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   _ Keeper_types_profile.context ->
   Yojson.Safe.t ->
   [ `Ran of tool_result | `Busy of Keeper_turn_admission.rejection ]

--- a/lib/keeper_contract/dune
+++ b/lib/keeper_contract/dune
@@ -15,6 +15,7 @@
   agent_sdk
   eio
   masc.keeper_registry
+  masc.keeper_runtime
   masc.keeper_metrics
   masc.masc_core
   masc.masc_types

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -59,6 +59,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -54,6 +54,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -512,20 +512,14 @@ let start_keeper_loops
      Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
-    (fun ~base_path ~keeper_name ~approval_id ~decision ->
+    (fun ~base_path ~keeper_name ~approval_id ~decision ~continuation_channel ->
        let resolution =
          Keeper_event_queue.
            { approval_id
            ; decision
-           (* WORKAROUND (RFC-0320 W2): the approval-submission connector is not
-              yet captured on the queue entry, so a HITL resolution cannot route
-              back to the originating chat thread and is [Unrouted]. 근본 해결:
-              W2b threads a continuation_channel through
-              [Keeper_approval_queue.create_entry] and the resolution wake hook
-              so this becomes [entry.channel] instead. *)
-           ; channel =
-               Keeper_continuation_channel.unrouted
-                 "hitl provenance capture pending (RFC-0320 W2b)"
+           (* RFC-0320 W2b: carry the submission-time continuation channel on
+              the HITL wake. W3 owns delivery/re-engagement. *)
+           ; channel = continuation_channel
            }
        in
        let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
@@ -1130,15 +1124,20 @@ let start_keeper_loops
                 enqueued, so the turn records the assistant reply only and does
                 not re-write the user line. Dashboard-source queue messages have
                 no upstream recorder, so the turn records both sides. *)
-             let connector_user_line_recorded_upstream =
-               match queued_message.source with
-               | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
-               | Keeper_chat_queue.Dashboard -> false
+	             let connector_user_line_recorded_upstream =
+	               match queued_message.source with
+	               | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
+	               | Keeper_chat_queue.Dashboard -> false
+	             in
+             let continuation_channel =
+               Keeper_chat_queue.continuation_channel_of_message_source
+                 ~dashboard_thread_id:thread_id
+                 queued_message.source
              in
-             process_single_turn ~connector_user_line_recorded_upstream
-               ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~closed ~client_disconnects:None ~payload ~run_id ~message_id
-               ~agent_name ~events)
+	             process_single_turn ~connector_user_line_recorded_upstream
+	               ~state ~clock ~sw ~auth_token:None
+	               ~thread_id ~continuation_channel ~closed ~client_disconnects:None ~payload ~run_id ~message_id
+	               ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -378,7 +378,15 @@ let keeper_tool_failure_log_details ~tool_name ~agent_name ~duration_ms
       ("error_body_bytes", `Int (String.length error_body));
     ]
 
-let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~arguments =
+let execute_keeper_stream_tool
+      ~sw
+      ~clock
+      ?auth_token:_
+      state
+      ~agent_name
+      ~arguments
+      ~continuation_channel
+  =
   let start_time = Eio.Time.now clock in
   let success, body, failure_class =
     try
@@ -392,7 +400,13 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
           net = state.Mcp_server.net;
         }
       in
-      match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args:arguments with
+      match
+        Keeper_tool_surface.dispatch
+          ~continuation_channel
+          keeper_ctx
+          ~name:"masc_keeper_msg"
+          ~args:arguments
+      with
       | Some result ->
           let success = Tool_result.is_success result in
           let body = Tool_result.message result in
@@ -652,8 +666,17 @@ let keeper_stream_send_event ?on_closed writer mutex closed event =
     Projects the typed keeper result into the local HTTP stream response pair.
     No external timeout — keeper internal limits control duration
     (aligned with MCP path, see mcp_server_eio_call_tool.ml:139-143). *)
-let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event state
-    ~agent_name ~arguments ~on_text_delta =
+let execute_keeper_stream_tool_streaming
+      ~sw
+      ~clock
+      ?auth_token:_
+      ?on_event
+      state
+      ~agent_name
+      ~arguments
+      ~continuation_channel
+      ~on_text_delta
+  =
   let start_time = Eio.Time.now clock in
   let success, body, failure_class =
     try
@@ -669,7 +692,9 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
       in
       match
         Keeper_tool_surface.dispatch_stream ~on_text_delta ?on_event keeper_ctx
-          ~name:"masc_keeper_msg" ~args:arguments
+          ~continuation_channel
+          ~name:"masc_keeper_msg"
+          ~args:arguments
       with
       | Some result ->
           let success = Tool_result.is_success result in
@@ -734,8 +759,17 @@ let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ ?on_event stat
     ~tool_name:"masc_keeper_msg" ~success ~duration_ms ();
   (success, body)
 
-let execute_keeper_stream_tool_streaming_if_free ~sw ~clock ?auth_token:_ ?on_event state
-    ~agent_name ~arguments ~on_text_delta =
+let execute_keeper_stream_tool_streaming_if_free
+      ~sw
+      ~clock
+      ?auth_token:_
+      ?on_event
+      state
+      ~agent_name
+      ~arguments
+      ~continuation_channel
+      ~on_text_delta
+  =
   let start_time = Eio.Time.now clock in
   let outcome =
     try
@@ -750,7 +784,11 @@ let execute_keeper_stream_tool_streaming_if_free ~sw ~clock ?auth_token:_ ?on_ev
         }
       in
       match
-        Keeper_turn.handle_keeper_msg_if_free ~on_text_delta ?on_event keeper_ctx
+        Keeper_turn.handle_keeper_msg_if_free
+          ~on_text_delta
+          ?on_event
+          ~continuation_channel
+          keeper_ctx
           arguments
       with
       | `Busy rejection -> `Busy rejection
@@ -965,7 +1003,7 @@ let translate_oas_stream_event = Keeper_chat_oas_stream_bridge.translate
    optional could not be erased (warning 16). Every caller states explicitly
    whether the gate inbound boundary already owns the user line. *)
 let process_single_turn ~connector_user_line_recorded_upstream
-    ~state ~clock ~sw ~auth_token ~thread_id ~closed
+    ~state ~clock ~sw ~auth_token ~thread_id ~continuation_channel ~closed
     ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
@@ -1145,6 +1183,7 @@ let process_single_turn ~connector_user_line_recorded_upstream
                 execute_keeper_stream_tool_streaming_if_free ~sw ~clock
                   ?auth_token
                   state ~agent_name ~arguments:args ~on_event
+                  ~continuation_channel
                   ~on_text_delta:(fun _ -> ())
               with
               | `Ran result -> Ok (`Ran result)
@@ -1157,10 +1196,11 @@ let process_single_turn ~connector_user_line_recorded_upstream
             else
               Ok
                 (`Ran
-                   (execute_keeper_stream_tool_streaming ~sw ~clock
-                      ?auth_token
-                      state ~agent_name ~arguments:args ~on_event
-                      ~on_text_delta:(fun _ -> ())))
+	                   (execute_keeper_stream_tool_streaming ~sw ~clock
+	                      ?auth_token
+	                      state ~agent_name ~arguments:args ~on_event
+                         ~continuation_channel
+	                      ~on_text_delta:(fun _ -> ())))
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
@@ -1172,9 +1212,10 @@ let process_single_turn ~connector_user_line_recorded_upstream
                 (try
                    Ok
                      (`Ran
-                        (execute_keeper_stream_tool ~sw ~clock
-                           ?auth_token
-                           state ~agent_name ~arguments:args))
+	                        (execute_keeper_stream_tool ~sw ~clock
+	                           ?auth_token
+	                           state ~agent_name ~arguments:args
+                            ~continuation_channel))
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn2 -> Error (Printexc.to_string exn2))
@@ -1515,6 +1556,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   in
   let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
+  let continuation_channel =
+    Keeper_continuation_channel.Dashboard { thread_id }
+  in
 
   let sse_adapter_loop ~events ~writer ~mutex ~closed ~on_closed ~on_finished =
     let current_thread_id = ref Ag_ui.default_thread_id in
@@ -1782,12 +1826,12 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            let run_now () =
              (* Dashboard stream route: no gate inbound boundary recorded this
                 user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
-             process_single_turn ~connector_user_line_recorded_upstream:false
-               ~state ~clock ~sw
-               ~auth_token:(auth_token_from_request request)
-               ~thread_id ~closed
-               ~client_disconnects:(Some (stream_sw, client_disconnects))
-               ~payload ~run_id ~message_id ~agent_name ~events;
+	             process_single_turn ~connector_user_line_recorded_upstream:false
+	               ~state ~clock ~sw
+	               ~auth_token:(auth_token_from_request request)
+	               ~thread_id ~continuation_channel ~closed
+	               ~client_disconnects:(Some (stream_sw, client_disconnects))
+	               ~payload ~run_id ~message_id ~agent_name ~events;
              wait_for_adapter_finished ()
            in
            if has_external_speaker payload then run_now ()

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -155,6 +155,7 @@ val process_single_turn :
   sw:Eio.Switch.t ->
   auth_token:string option ->
   thread_id:string ->
+  continuation_channel:Keeper_continuation_channel.t ->
   closed:bool ref ->
   client_disconnects:(Eio.Switch.t * unit Eio.Stream.t) option ->
   payload:keeper_chat_stream_request ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -84,6 +84,7 @@ let dummy_pending_approval
   ; disposition = None
   ; disposition_reason = None
   ; phase = Q.Awaiting_operator
+  ; continuation_channel = Keeper_continuation_channel.unrouted "test fixture"
   ; audit_base_path
   ; resolver = None
   ; on_resolution = None

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -7,6 +7,7 @@
        fires, and the updated phase is reflected in-memory and in JSON. *)
 
 module AQ = Masc.Keeper_approval_queue
+module Chat_queue = Masc.Keeper_chat_queue
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_" "" in
@@ -121,14 +122,26 @@ let test_resolve_fires_keeper_wake_hook () =
   @@ fun _env ->
   let base_path = temp_dir () in
   let woke = ref None in
-  AQ.set_approval_resolution_wake_hook (fun ~base_path:_ ~keeper_name ~approval_id ~decision ->
-    woke := Some (keeper_name, approval_id, decision));
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_
+      ~keeper_name
+      ~approval_id
+      ~decision
+      ~continuation_channel:_ ->
+      woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
       (* Reset to the default no-op so the recording closure does not leak into
          later tests that share this module-level hook. *)
       AQ.set_approval_resolution_wake_hook
-        (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ());
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~continuation_channel:_ ->
+          ());
       cleanup_dir base_path)
     (fun () ->
        Eio.Switch.run
@@ -165,8 +178,105 @@ let test_resolve_fires_keeper_wake_hook () =
             "wake carries the typed decision label"
             true
             (decision = Keeper_event_queue.Hitl_approved)
-        | None -> Alcotest.fail "resolve did not fire the keeper wake hook");
-       yield_until (fun () -> Option.is_some !result))
+	       | None -> Alcotest.fail "resolve did not fire the keeper wake hook");
+	       yield_until (fun () -> Option.is_some !result))
+;;
+
+let test_resolution_wake_carries_originating_continuation_channel () =
+  let base_path = temp_dir () in
+  let captured = ref None in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_
+      ~keeper_name:_
+      ~approval_id
+      ~decision
+      ~continuation_channel ->
+      captured :=
+        Some
+          Keeper_event_queue.
+            { approval_id; decision; channel = continuation_channel });
+  let reset_hook () =
+    AQ.set_approval_resolution_wake_hook
+      (fun
+        ~base_path:_
+        ~keeper_name:_
+        ~approval_id:_
+        ~decision:_
+        ~continuation_channel:_ ->
+        ())
+  in
+  let submit_resolve_capture ?continuation_channel ~keeper_name () =
+    captured := None;
+    let id =
+      AQ.submit_pending
+        ~keeper_name
+        ~tool_name:"keeper_continue_after_reconcile"
+        ~input:(`Assoc [ "kind", `String "medium_gate" ])
+        ~risk_level:AQ.Medium
+        ~base_path
+        ?continuation_channel
+        ~on_resolution:(fun _decision -> ())
+        ()
+    in
+    (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+    match !captured with
+    | Some resolution -> resolution
+    | None -> Alcotest.fail "resolve did not publish a wake payload"
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      reset_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let dashboard_channel =
+         Chat_queue.continuation_channel_of_message_source
+           ~dashboard_thread_id:"dashboard-thread-1"
+           Chat_queue.Dashboard
+       in
+       let dashboard_resolution =
+         submit_resolve_capture
+           ~keeper_name:"wake-dashboard-origin-test"
+           ~continuation_channel:dashboard_channel
+           ()
+       in
+       Alcotest.(check bool)
+         "dashboard wake payload keeps the originating route"
+         true
+         (Keeper_continuation_channel.same_route
+            dashboard_channel
+            dashboard_resolution.channel);
+       let discord_channel =
+         Chat_queue.continuation_channel_of_message_source
+           (Chat_queue.Discord
+              { channel_id = "discord-channel-1"; user_id = "discord-user-1" })
+       in
+       let discord_resolution =
+         submit_resolve_capture
+           ~keeper_name:"wake-discord-origin-test"
+           ~continuation_channel:discord_channel
+           ()
+       in
+       Alcotest.(check bool)
+         "discord wake payload keeps the originating route"
+         true
+         (Keeper_continuation_channel.same_route
+            discord_channel
+            discord_resolution.channel);
+       let unrouted_resolution =
+         submit_resolve_capture ~keeper_name:"wake-unrouted-origin-test" ()
+       in
+       match unrouted_resolution.channel with
+       | Keeper_continuation_channel.Unrouted { reason } ->
+         Alcotest.(check string) "missing connector fails closed"
+           "no originating connector"
+           reason
+       | Keeper_continuation_channel.Dashboard _
+       | Keeper_continuation_channel.Discord _
+       | Keeper_continuation_channel.Slack _ ->
+         Alcotest.fail "missing connector must not synthesize a routable channel")
 ;;
 
 let test_critical_entry_phase_becomes_escalated_after_timer () =
@@ -461,12 +571,16 @@ let () =
             `Quick
             test_critical_entry_phase_becomes_escalated_after_timer
         ] )
-    ; ( "wake"
-      , [ Alcotest.test_case
-            "resolve fires the keeper wake hook"
-            `Quick
-            test_resolve_fires_keeper_wake_hook
-        ] )
+	    ; ( "wake"
+	      , [ Alcotest.test_case
+	            "resolve fires the keeper wake hook"
+	            `Quick
+	            test_resolve_fires_keeper_wake_hook
+	        ; Alcotest.test_case
+	            "resolution wake carries originating continuation channel"
+	            `Quick
+	            test_resolution_wake_carries_originating_continuation_channel
+	        ] )
     ; ( "summary"
       , [ Alcotest.test_case
             "context summary survives include_input:true JSON paths"


### PR DESCRIPTION
## Summary

Governing RFC: RFC-0320 W2b.

- Capture `Keeper_continuation_channel.t` on pending HITL approval entries, pending/resolved JSON, and approval audit rows.
- Thread chat-lane provenance from dashboard/queued connector sources through `Keeper_turn`, `Keeper_agent_run`, and `Governance_pipeline` into approval submission.
- Replace the server wake hook's temporary `Unrouted "hitl provenance capture pending (RFC-0320 W2b)"` workaround with the stored entry channel. This PR only carries provenance; W3 owns delivery/re-engagement.

WORKAROUND-WAIVED: this PR removes the RFC-0320 W2b workaround, does not add one.

## Files Changed

- `lib/governance_pipeline.ml`
- `lib/governance_pipeline.mli`
- `lib/keeper/keeper_agent_run.ml`
- `lib/keeper/keeper_agent_run.mli`
- `lib/keeper/keeper_approval_queue.ml`
- `lib/keeper/keeper_approval_queue.mli`
- `lib/keeper/keeper_chat_queue.ml`
- `lib/keeper/keeper_chat_queue.mli`
- `lib/keeper/keeper_tool_surface.ml`
- `lib/keeper/keeper_tool_surface.mli`
- `lib/keeper/keeper_tool_surface_ops.ml`
- `lib/keeper/keeper_turn.ml`
- `lib/keeper/keeper_turn.mli`
- `lib/keeper_contract/dune`
- `lib/keeper_contract/keeper_approval_queue_rules_types.ml`
- `lib/keeper_contract/keeper_approval_queue_rules_types.mli`
- `lib/server/server_bootstrap_loops.ml`
- `lib/server/server_routes_http_keeper_stream.ml`
- `lib/server/server_routes_http_keeper_stream.mli`
- `test/test_hitl_summary_worker.ml`
- `test/test_keeper_approval_queue.ml`

## Anti-Drift

- Base: fetched `origin/main` at `ba223535e8903126eb3dab4fb4868f7a37989013` (RFC-0319 backend merge).
- Live `git ls-remote origin refs/heads/main`: `ba223535e8903126eb3dab4fb4868f7a37989013`.
- `git rev-list --count origin/main..HEAD`: `1`.
- `git rev-list --count HEAD..origin/main`: `0`.
- `behind_by`: `0`.

## Validation

- `dune build --root .`: PASS.
- Focused Dune-built test executables:
  - `test/test_keeper_approval_queue.exe`: PASS, 7 tests.
  - `test/test_hitl_approval.exe`: PASS, 50 tests.
  - `test/test_governance_pipeline.exe`: PASS, 102 tests.
  - `test/test_hitl_summary_worker.exe`: PASS, 14 tests.

Note: this repo exposes only the aggregate `runtest` alias, so the focused test executables above were run through Dune directly to avoid running the entire suite.
