### PR TITLE
fix(exec): gate destructive/opaque gh api HTTP methods (RFC-0309, #23451)

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -650,6 +650,60 @@ let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
   scan args
 ;;
 
+let is_rest_api (v : Gh_verb.t) : bool =
+  match v.Gh_verb.family with
+  | Gh_verb.Api -> not (is_graphql_api v)
+  | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+  | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
+  | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
+  | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ -> false
+;;
+
+let is_method_flag = function
+  | "-X" | "--method" -> true
+  | _ -> false
+;;
+
+(* Leading literal of an attached/opaque method arg: [-X$M] ([Concat [Lit "-X";
+   Var _]] -> "-X"), [-XDELETE...$M], or [--method=$M]. Distinguishes a method
+   flag from other gh flags (none of which share the [-X] short form). *)
+let attached_method_prefix prefix =
+  let lower = String.lowercase_ascii prefix in
+  String.starts_with ~prefix:"-x" lower
+  || String.starts_with ~prefix:"--method" lower
+;;
+
+(* [gh api] REST HTTP method opacity (#23451). The method ([-X]/[--method])
+   decides read (GET) vs durable/destructive write (POST/PUT/PATCH/DELETE). When
+   the method VALUE is opaque (Shell IR Var/Concat), the literal method
+   classifier ([Shell_ir_risk]'s floor) cannot see it, defaults to GET/R0, and a
+   [$METHOD]-carried DELETE/POST silently downgrades to [Allow] under the
+   autonomous overlay. Mirror the graphql body-opacity fail-closed: an opaque
+   method on a REST [gh api] routes to [Requires_approval]. Literal methods are
+   unaffected — the floor classifies them precisely (DELETE -> R2 Deny,
+   POST/PUT/PATCH -> R1, GET -> R0 Allow). The value/file is never read (no
+   TOCTOU); opacity alone gates. *)
+let gh_api_method_is_opaque (args : Shell_ir.arg list) : bool =
+  let rec scan = function
+    | [] -> false
+    | arg :: rest ->
+      (match arg_literal arg with
+       | Some tok when is_method_flag tok ->
+         (* separate value form: [-X <VALUE>] / [--method <VALUE>] *)
+         (match rest with
+          | value :: tail -> Option.is_none (arg_literal value) || scan tail
+          | [] -> false)
+       | Some _ -> scan rest
+       | None ->
+         (* opaque arg (has a Var): attached method flag with opaque value, e.g.
+            [-X$M] or [--method=$M]. Its leading literal chunk names the flag. *)
+         (match arg_leading_literal arg with
+          | Some prefix when attached_method_prefix prefix -> true
+          | Some _ | None -> scan rest))
+  in
+  scan args
+;;
+
 let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
   match Exec_program.known simple.Shell_ir.bin with
   | Some Exec_program.Gh ->
@@ -673,6 +727,8 @@ let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
       | None -> Gh_verb.classify words
     in
     if is_graphql_api verb && graphql_query_body_is_opaque simple.Shell_ir.args
+    then Some Requires_approval
+    else if is_rest_api verb && gh_api_method_is_opaque simple.Shell_ir.args
     then Some Requires_approval
     else Some (disposition_of_words words verb))
   | Some _ | None -> None

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -593,7 +593,17 @@ let classify_repo_hosting_cli (words : string list) : risk_class =
     if in_table repo_hosting_cli_irreversible_ops command sub
        || positional_dangerous_hit
     then R2_Irreversible
-    else if command = "api" then
+      (* [command = "api"] locates the subcommand at [words[1]]; [sub = "api"]
+         additionally catches a method flag placed BEFORE the subcommand
+         ([gh -XDELETE api /repos/o/r]), which gh's Cobra parser accepts as a
+         leading flag. Without [sub], the method token sits in the command slot
+         ([command = "-xdelete"]), the api branch is skipped, and the literal
+         DELETE (extracted from the full word list below) never fires the floor
+         — an autonomous DELETE bypass (#23451 form 1). Same leading-flag
+         positional class as #23390 (global flags). A spurious [sub = "api"]
+         without a real method stays [R0_Read] (no [-X] -> GET), so reads are
+         not over-blocked. *)
+    else if command = "api" || sub = "api" then
       let method_ =
         match extract_method_from_parts words with
         | Some m -> m

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -953,7 +953,88 @@ let test_worktree_remove_floored_under_autonomous () =
   | Verdict.Deny { reason = Destructive_git (Git_op.Destructive `Worktree_remove); _ } -> ()
   | _ -> assert false
 
+(* RFC-0309 #23451 form 1: a method flag placed BEFORE the [api] subcommand
+   ([gh -XDELETE api /repos/o/r]) is accepted by gh's Cobra parser as a leading
+   flag, so the literal DELETE executes. Before the fix the method token sat in
+   the command slot, the api branch was skipped, and the DELETE never reached the
+   catastrophic floor — an autonomous auto-run DELETE. The floor now locates the
+   api subcommand past the leading flag and Denies. *)
+let test_gh_api_leading_method_flag_delete_floored_under_autonomous () =
+  let s = simple (bin_ok "gh") ~args:(List.map lit [ "-XDELETE"; "api"; "/repos/o/r" ]) in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps
+      ~simple:s
+  with
+  | Verdict.Deny { reason = Destructive_repo_hosting_cli bin; _ } ->
+    assert (Exec_program.to_string bin = "gh")
+  | _ ->
+    Alcotest.failf "leading attached -XDELETE before api must be floored (Deny)"
+
+(* The spaced leading form ([gh -X DELETE api ...]) is already gated (not a
+   silent Allow); pin that it stays gated so a future parser change cannot
+   regress it to Allow. *)
+let test_gh_api_spaced_leading_method_delete_not_allowed_under_autonomous () =
+  let s =
+    simple (bin_ok "gh") ~args:(List.map lit [ "-X"; "DELETE"; "api"; "/repos/o/r" ])
+  in
+  let caps = Capability_check.of_simple s in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous ~caps
+      ~simple:s
+  with
+  | Verdict.Allow _ ->
+    Alcotest.failf "spaced leading -X DELETE api must not auto-run (Allow)"
+  | Verdict.Ask _ | Verdict.Deny _ | Verdict.Suggest_confirm _ -> ()
+
+(* RFC-0309 #23451 form 2: an opaque method value ([gh api -X $METHOD /path])
+   defeats the literal method classifier, which defaults to GET/R0 and would
+   silently Allow a runtime DELETE/POST. The capability axis fails closed to Ask
+   on method opacity, mirroring the graphql body-opacity gate. Covers separate,
+   long-flag, and attached forms. *)
+let test_gh_api_opaque_method_asks_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Ask { bin; _ } -> assert (Exec_program.to_string bin = "gh")
+       | _ -> Alcotest.failf "%s: opaque gh api method must Ask under autonomous" label)
+    [ ( "gh api -X $METHOD /path"
+      , [ lit "api"; lit "-X"; var "METHOD"; lit "/repos/o/r" ] )
+    ; ( "gh api --method $METHOD /path"
+      , [ lit "api"; lit "--method"; var "METHOD"; lit "/repos/o/r" ] )
+    ; ( "gh api -X$METHOD /path (attached)"
+      , [ lit "api"; concat [ lit "-X"; var "METHOD" ]; lit "/repos/o/r" ] )
+    ]
+
+(* Control: a literal read ([gh api /path] default GET, [gh api -X GET /path])
+   must NOT be over-blocked by the method-opacity gate — only opaque or
+   destructive methods escalate. *)
+let test_gh_api_literal_read_not_over_blocked_under_autonomous () =
+  List.iter
+    (fun (label, args) ->
+       let s = simple (bin_ok "gh") ~args:(List.map lit args) in
+       let caps = Capability_check.of_simple s in
+       match
+         Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+           ~caps ~simple:s
+       with
+       | Verdict.Allow t ->
+         assert (Exec_program.to_string (Verdict.Trusted_argv.bin t) = "gh")
+       | _ -> Alcotest.failf "%s: literal gh api read must stay Allow" label)
+    [ "gh api /repos/o/r (default GET)", [ "api"; "/repos/o/r" ]
+    ; "gh api -X GET /repos/o/r", [ "api"; "-X"; "GET"; "/repos/o/r" ]
+    ]
+
 let () =
+  test_gh_api_leading_method_flag_delete_floored_under_autonomous ();
+  test_gh_api_spaced_leading_method_delete_not_allowed_under_autonomous ();
+  test_gh_api_opaque_method_asks_under_autonomous ();
+  test_gh_api_literal_read_not_over_blocked_under_autonomous ();
   test_safe_bin_strict_asks ();
   test_safe_bin_allowed_with_overlay ();
   test_privileged_bin_asks ();


### PR DESCRIPTION
## 목표

RFC-0309(typed-gh capability gating)의 잔여 우회 **#23451**을 닫습니다. autonomous keeper가 `gh api`의 파괴적 HTTP method를 두 형태로 무승인 실행할 수 있었습니다:

1. **leading method flag** — `gh -XDELETE api /repos/o/r` (gh Cobra 파서가 서브커맨드 앞 flag를 허용)
2. **opaque method value** — `gh api -X "$METHOD" /repos/o/r` (`$METHOD`=DELETE 등)

## 재현 (fix 전, empirical)

`Approval_policy.decide … ~overlay:autonomous`로 실측한 현재 verdict:

| 명령 | 현재 verdict | 판정 |
|------|------|------|
| `gh -XDELETE api /repos/o/r` | **Allow** | 우회 (form 1) |
| `gh -X DELETE api /repos/o/r` (spaced leading) | Ask | 이미 gated |
| `gh api -X $METHOD /repos/o/r` (opaque) | **Allow** | 우회 (form 2) |
| `gh api --method $METHOD /repos/o/r` | **Allow** | 우회 |
| `gh api -X$METHOD /repos/o/r` (attached opaque) | **Allow** | 우회 |
| `gh api -X DELETE /repos/o/r` (literal) | Deny | 정확 (대조군) |

`gh -XDELETE api … --help`가 exit 0으로 api 서브커맨드에 라우팅됨을 실제 gh 바이너리로 확인 — form 1은 실행 가능한 exploit입니다.

## 변경 (축 분리 유지, string 분류기 아님)

두 결함 모두 **위치/불투명성 robustness** 문제이지 위험 op의 wordlist 문제가 아닙니다.

- **(a) `lib/exec/shell_ir_risk.ml` — floor 위치 robustness**: `classify_repo_hosting_cli`의 api 판정을 `command = "api"`에서 `command = "api" || sub = "api"`로 확장. leading method flag가 서브커맨드를 밀어내도(`command = "-xdelete"`) `sub`가 `api`를 잡아 method 추출이 발동 → literal DELETE는 R2 → **catastrophic floor Deny**. #23390(leading global flag)과 동일한 위치 robustness 계열. `sub = "api"`가 우연히 참이어도 `-X`가 없으면 GET/R0라 read는 over-block되지 않음.

- **(b) `lib/exec/gh_capability_policy.ml` — capability opacity fail-closed**: `gh_api_method_is_opaque`를 신설해 REST `gh api`의 method 값이 opaque(Shell IR Var/Concat)이면 `Requires_approval` → **Ask**. graphql body-opacity 게이트(#23449)와 동형. literal method는 floor가 정확 분류(DELETE→R2 Deny, POST/PUT/PATCH→R1, GET→R0 Allow)하므로 영향 없음. 파일/값을 읽지 않음(TOCTOU 없음), 불투명성만으로 게이팅.

## 범위 밖 (별개 이슈)

`gh api -X POST /user/repos`(REST durable-remote 생성)는 여전히 Allow이며 이는 **#23445**입니다. method+path 조합 기반 REST 리소스 타이핑이 필요해(RFC-0042 신규 string 분류기 금지) 별도 RFC-scoped 설계로 남깁니다. 본 PR은 method **파괴성/불투명성**만 다룹니다.

## 검증

- 신규 테스트 4종(`test_approval_policy.ml`): form 1 → Deny · spaced leading → not-Allow · opaque method 3형태 → Ask · literal read(GET/기본) → Allow(over-block 회귀가드).
- 전체 `@lib/exec/test/runtest` green(warn-error). baseline 하네스(G-0) ledger 불변(corpus에 leading-flag-before-api 케이스 없음). differential/oracle/top-level risk PASS.
- 전체 `dune build --root .` green(다운스트림 keeper lib 포함). ocamlformat --check 3파일 clean.

## 근거

RFC-0309 §3.1 string-borne 경계 + 적대 감사 후속(`project-gh-gating-adversarial-audit-followup-20260707`). typed 게이팅에서 string-borne 동등경로(leading flag/opaque value)를 빠뜨리면 우회가 생긴다는 교훈의 연장.

RFC: RFC-0309 확장 (Shell IR approval gate / containment). 워크어라운드 아님 — 우회를 typed/구조적 수단(위치·불투명성 robustness)으로 제거하며 counter/cap/string-classifier/N-of-M 없음.

Closes #23451.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
