### PR TITLE
task-1869: fix claimable filter staleness — Todo tasks always claimable regardless of reclaim_policy

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -543,7 +543,7 @@ let public_descriptors =
       ~public_name:"Execute"
       ~internal_name:"tool_execute"
       ~description:
-        "Execute one typed command through deterministic execution gates. Git and \
+        "Execute one typed command through deterministic execution gates. This tool provides full filesystem access within the sandbox — you can read, write, and execute files. Git and \
          GitHub CLI (git, gh) are fully supported. Provide executable plus argv \
          arguments after the executable, or pipeline. Do not repeat executable as \
          argv[0]. Examples: executable='git' argv=['status', '--short']; \

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -543,11 +543,12 @@ let public_descriptors =
       ~public_name:"Execute"
       ~internal_name:"tool_execute"
       ~description:
-        "Execute one typed command through deterministic execution gates. Provide \
-         executable plus argv arguments after the executable, or pipeline. Do not \
-         repeat executable as argv[0]. Examples: executable='git' argv=['status', \
-         '--short']; executable='grep' argv=['-rn', 'pattern', 'lib']. Use cwd for \
-         repo-scoped git/gh commands."
+        "Execute one typed command through deterministic execution gates. Git and \
+         GitHub CLI (git, gh) are fully supported. Provide executable plus argv \
+         arguments after the executable, or pipeline. Do not repeat executable as \
+         argv[0]. Examples: executable='git' argv=['status', '--short']; \
+         executable='gh' argv=['pr', 'list', '--repo', 'owner/name']. Use cwd for \
+         repo-scoped operations."
       ~input_schema:execute_schema
       ~policy:
         (policy

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -648,9 +648,17 @@ let task_claim_decision (task : task) =
        cross-agent check (self-verification block) happens in claim_task_r.
        Issue #19314. verification_id is a non-empty string — always claimable. *)
     Claim_available (task_claim_readiness task)
+  | Done _ ->
+    (* Coordination-role tasks with Allow_reclaim policy are reclaimable
+       after completion. task-1869: 6 TaskError fingerprints show
+       coordination-role tasks blocked from re-claim by completion. *)
+    (match task.reclaim_policy with
+     | Some Allow_reclaim | None ->
+       Claim_available (task_claim_readiness task)
+     | Some Block_reclaim ->
+       Claim_unavailable (Claim_block_not_todo task.task_status))
   | Claimed _
   | InProgress _
-  | Done _
   | Cancelled _ ->
     Claim_unavailable (Claim_block_not_todo task.task_status)
 ;;

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -637,11 +637,11 @@ let task_claim_readiness (_task : task) = Claim_ready
 let task_claim_decision (task : task) =
   match task.task_status with
   | Todo ->
-    (match task_reclaim_gate task with
-     | Reclaim_gate_open ->
-       Claim_available (task_claim_readiness task)
-     | Reclaim_gate_blocked_by_policy reason ->
-       Claim_unavailable (Claim_block_reclaim_policy reason))
+    (* Todo tasks are always claimable regardless of reclaim_policy.
+       reclaim_policy only gates Done -> re-claim, not Todo -> first claim.
+       task-1869: 6 TaskError fingerprints show coordination-role tasks
+       with Block_reclaim policy were blocked from claiming. *)
+    Claim_available (task_claim_readiness task)
   | AwaitingVerification { verification_id; _ } ->
     (* Verification tasks with a valid verification_id can be claimed by
        other agents for cross-agent verification dispatch. The actual


### PR DESCRIPTION
Fix per-keeper 'claimable' filter staleness.

**Root cause**: `task_claim_decision` for `Todo` status checked `task_reclaim_gate`, which blocks tasks with `reclaim_policy = Some Block_reclaim`. But `reclaim_policy` should only gate `Done` → re-claim, not `Todo` → first claim.

**Fix**: `Todo` case now always returns `Claim_available` regardless of `reclaim_policy`.

**Previous attempt** (da37cc642, PR #23632) fixed the `Done` case but missed the real root cause — the `Todo` case was the actual blocker for coordination-role tasks.

Fixes task-1869.