### PR TITLE
fix(keeper): align playground repo access errors

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -364,11 +364,7 @@ let playground_repo_policy ~(base_path : string) ~(keeper_name : string) =
     r
   | r -> r
 
-type playground_repo_policy_resolution =
-  | Registered_repository_id of Repo_manager_types.repository_id
-  | Sandbox_local_clone
-
-let playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
+let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
     ~repo_path =
   match repo_catalog with
   | Error msg -> Error (`Store_error msg)
@@ -378,8 +374,8 @@ let playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
       ~path:repo_path repos
   with
   | Keeper_repo_mapping.Repository { repository_id; _ } ->
-    Ok (Registered_repository_id repository_id)
-  | Keeper_repo_mapping.No_repository -> Ok Sandbox_local_clone
+    Ok repository_id
+  | Keeper_repo_mapping.No_repository -> Ok repo_name
   | Keeper_repo_mapping.Repository_identity_mismatch _ ->
     Error
       (`Identity_mismatch
@@ -389,7 +385,7 @@ let playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
 let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       ~repo_name ~repo_path =
   let field status allowed ?repository_id ?error ?mapping_error
-        ?policy_scope ?(default_scope = false) () =
+        ?(default_scope = false) () =
     let status_text = playground_policy_status_to_string status in
     let reason_fields =
       match playground_policy_reason status with
@@ -414,16 +410,11 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     let default_scope_fields =
       if default_scope then [ ("policy_default_scope", `Bool true) ] else []
     in
-    let scope_fields =
-      match policy_scope with
-      | None -> []
-      | Some scope -> [ ("policy_scope", `String scope) ]
-    in
     ( "policy_source"
     , `String (policy_source_basename_of_status status) )
     :: ("policy_status", `String status_text)
     :: ("policy_allowed", `Bool allowed)
-    :: (scope_fields @ default_scope_fields @ repository_id_fields @ reason_fields
+    :: (default_scope_fields @ repository_id_fields @ reason_fields
         @ error_fields @ mapping_error_fields)
   in
   let repository_id_in_catalog repository_id =
@@ -438,7 +429,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
   in
   let field_resolved_registered ?mapping_error ~default_scope () =
     match
-      playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
+      playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
         ~repo_path
     with
     | Error (`Identity_mismatch msg) ->
@@ -447,10 +438,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     | Error (`Store_error msg) ->
       field Policy_repository_store_error false ~repository_id:repo_name
         ~error:msg ()
-    | Ok Sandbox_local_clone ->
-      field Policy_allowed true ?mapping_error ~default_scope
-        ~policy_scope:"sandbox_local" ()
-    | Ok (Registered_repository_id repository_id) ->
+    | Ok repository_id ->
       (match repository_id_in_catalog repository_id with
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id ~error:msg ()
@@ -465,7 +453,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       field_resolved_registered ~default_scope:true ()
   | Keeper_repo_mapping.Mapping_found mapping ->
       (match
-       playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
+       playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
          ~repo_path
        with
        | Error (`Identity_mismatch msg) ->
@@ -474,9 +462,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id:repo_name
            ~error:msg ()
-       | Ok Sandbox_local_clone ->
-         field Policy_allowed true ~policy_scope:"sandbox_local" ()
-       | Ok (Registered_repository_id repository_id) ->
+       | Ok repository_id ->
          (match repository_id_in_catalog repository_id with
           | Error (`Store_error msg) ->
             field Policy_repository_store_error false ~repository_id ~error:msg ()

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -364,7 +364,11 @@ let playground_repo_policy ~(base_path : string) ~(keeper_name : string) =
     r
   | r -> r
 
-let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+type playground_repo_policy_resolution =
+  | Registered_repository_id of Repo_manager_types.repository_id
+  | Sandbox_local_clone
+
+let playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
     ~repo_path =
   match repo_catalog with
   | Error msg -> Error (`Store_error msg)
@@ -373,8 +377,9 @@ let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
     Keeper_repo_mapping.repository_resolution_of_path_from_catalog ~base_path
       ~path:repo_path repos
   with
-  | Keeper_repo_mapping.Repository { repository_id; _ } -> Ok repository_id
-  | Keeper_repo_mapping.No_repository -> Ok repo_name
+  | Keeper_repo_mapping.Repository { repository_id; _ } ->
+    Ok (Registered_repository_id repository_id)
+  | Keeper_repo_mapping.No_repository -> Ok Sandbox_local_clone
   | Keeper_repo_mapping.Repository_identity_mismatch _ ->
     Error
       (`Identity_mismatch
@@ -384,7 +389,7 @@ let playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
 let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       ~repo_name ~repo_path =
   let field status allowed ?repository_id ?error ?mapping_error
-        ?(default_scope = false) () =
+        ?policy_scope ?(default_scope = false) () =
     let status_text = playground_policy_status_to_string status in
     let reason_fields =
       match playground_policy_reason status with
@@ -409,11 +414,16 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     let default_scope_fields =
       if default_scope then [ ("policy_default_scope", `Bool true) ] else []
     in
+    let scope_fields =
+      match policy_scope with
+      | None -> []
+      | Some scope -> [ ("policy_scope", `String scope) ]
+    in
     ( "policy_source"
     , `String (policy_source_basename_of_status status) )
     :: ("policy_status", `String status_text)
     :: ("policy_allowed", `Bool allowed)
-    :: (default_scope_fields @ repository_id_fields @ reason_fields
+    :: (scope_fields @ default_scope_fields @ repository_id_fields @ reason_fields
         @ error_fields @ mapping_error_fields)
   in
   let repository_id_in_catalog repository_id =
@@ -428,7 +438,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
   in
   let field_resolved_registered ?mapping_error ~default_scope () =
     match
-      playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+      playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
         ~repo_path
     with
     | Error (`Identity_mismatch msg) ->
@@ -437,7 +447,10 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
     | Error (`Store_error msg) ->
       field Policy_repository_store_error false ~repository_id:repo_name
         ~error:msg ()
-    | Ok repository_id ->
+    | Ok Sandbox_local_clone ->
+      field Policy_allowed true ?mapping_error ~default_scope
+        ~policy_scope:"sandbox_local" ()
+    | Ok (Registered_repository_id repository_id) ->
       (match repository_id_in_catalog repository_id with
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id ~error:msg ()
@@ -452,7 +465,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
       field_resolved_registered ~default_scope:true ()
   | Keeper_repo_mapping.Mapping_found mapping ->
       (match
-       playground_repo_policy_repository_id ~base_path ~repo_catalog ~repo_name
+       playground_repo_policy_resolution ~base_path ~repo_catalog ~repo_name
          ~repo_path
        with
        | Error (`Identity_mismatch msg) ->
@@ -461,7 +474,9 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
        | Error (`Store_error msg) ->
          field Policy_repository_store_error false ~repository_id:repo_name
            ~error:msg ()
-       | Ok repository_id ->
+       | Ok Sandbox_local_clone ->
+         field Policy_allowed true ~policy_scope:"sandbox_local" ()
+       | Ok (Registered_repository_id repository_id) ->
          (match repository_id_in_catalog repository_id with
           | Error (`Store_error msg) ->
             field Policy_repository_store_error false ~repository_id ~error:msg ()

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -77,6 +77,24 @@ let actionable_path_action_for_class
       Printf.sprintf "Check the path. Your playground: %s" playground)
 ;;
 
+let deterministic_retry_fields_for_path_class
+      (cls : Keeper_failure_circuit_breaker.error_class)
+  =
+  match cls with
+  | Keeper_failure_circuit_breaker.Path_not_found ->
+    Keeper_tool_deterministic_error.deterministic_retry_fields
+      Keeper_tool_deterministic_error.Path_not_found
+  | Keeper_failure_circuit_breaker.Path_not_allowed ->
+    Keeper_tool_deterministic_error.deterministic_retry_fields
+      Keeper_tool_deterministic_error.Path_outside_sandbox
+  | Keeper_failure_circuit_breaker.Cwd_not_directory ->
+    Keeper_tool_deterministic_error.deterministic_retry_fields
+      Keeper_tool_deterministic_error.Cwd_not_directory
+  | Keeper_failure_circuit_breaker.Shell_exit_nonzero
+  | Keeper_failure_circuit_breaker.Other ->
+    []
+;;
+
 (** Actionable error for path resolution failures.
     Follows Samchon harness pattern: field-level diagnostics with
     exact path, expected constraint, and concrete next action.
@@ -104,13 +122,14 @@ let actionable_path_error
   let action = actionable_path_action_for_class ~playground ~raw_path cls in
   Yojson.Safe.to_string
     (`Assoc
-        [ "ok", `Bool false
-        ; "op", `String op
-        ; "error", `String error
-        ; "tried", `String raw_path
-        ; "your_playground", `String playground
-        ; "action", `String action
-        ])
+        ([ "ok", `Bool false
+         ; "op", `String op
+         ; "error", `String error
+         ; "tried", `String raw_path
+         ; "your_playground", `String playground
+         ; "action", `String action
+         ]
+         @ deterministic_retry_fields_for_path_class cls))
 ;;
 
 let file_not_found_prefix = "File not found:"

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -672,7 +672,7 @@ let unresolved_repository_segment_resolution ?repo_root ~segment repos =
       segment repos
   with
   | Some mismatch -> Repository_identity_mismatch mismatch
-  | None -> Repository (repository_match ?repo_root segment)
+  | None -> No_repository
 
 let resolve_repository_id_segment_from_catalog ~base_path ?repo_root segment repos =
   match List.find_opt (repository_matches_token ~base_path segment) repos with
@@ -703,8 +703,11 @@ let path_under_repo ~base_path repo path =
 (** [repository_resolution_of_path ~base_path ~path] returns the registered
     repository for [path], or an identity mismatch when the path points at a
     declared repository whose URL basename contradicts its declared identity.
-    Repository store load failures remain explicit so access callers can deny
-    instead of treating an unknown repository catalog as "not a repository". *)
+    A visible playground clone that is absent from the catalog is not an
+    authorization failure: playground containment owns read access, and the
+    catalog remains metadata/alias state. Repository store load failures remain
+    explicit so access callers can deny instead of treating an unreadable
+    repository catalog as "not a repository". *)
 let repository_resolution_of_path_from_catalog ~base_path ~path repos =
   match playground_path_of_path ~base_path ~path with
   | Some Playground_internal | Some Playground_repos_root -> No_repository
@@ -742,7 +745,9 @@ let repository_id_of_path ~base_path ~path =
 (** [validate_path_access ~keeper_id ~base_path ~path] checks that [path]
     either is outside registered repositories or resolves to a valid
     registered repository. Per-keeper mappings are advisory/default-scope
-    metadata and do not cap access. This is the integration point for keeper
+    metadata and do not cap access; visible playground clones that are not in
+    the catalog are outside repo-policy authorization and stay governed by the
+    sandbox containment boundary. This is the integration point for keeper
     execution paths that operate on filesystem paths rather than explicit
     repository IDs. *)
 let validate_path_access ~keeper_id ~base_path ~path =

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -302,6 +302,57 @@ let filter_repos_by_mapping (mapping : keeper_repo_mapping)
       (fun (r : repository) -> String_set.mem r.id mapping_id_set)
       repos
 
+(* Path normalization for prefix comparison. *)
+let normalize_path_for_prefix_check path =
+  let p = String.trim path in
+  if String.ends_with ~suffix:"/" p then
+    String.sub p 0 (String.length p - 1)
+  else p
+
+let basename_of_path path =
+  normalize_path_for_prefix_check path |> Filename.basename
+
+let repository_url_basename url =
+  let stripped = normalize_path_for_prefix_check url in
+  if stripped = "" then ""
+  else
+    let base = Filename.basename stripped in
+    if Filename.check_suffix base ".git" then
+      String.sub base 0 (String.length base - 4)
+    else base
+
+let repository_identity_tokens (repo : repository) =
+  repo.id :: repo.name :: repo.aliases
+  |> List.map String.trim
+  |> List.filter (fun token -> not (String.equal token ""))
+
+(** [token_matches_url_basename ~basename token] is a case-insensitive
+    comparison between a repository identity token and the basename extracted
+    from a URL. Identity drift in the wild (e.g. [masc] vs [Masc]) should not
+    cause a fail-closed rejection. *)
+let token_matches_url_basename ~basename token =
+  String.equal (String.lowercase_ascii basename) (String.lowercase_ascii token)
+
+(** [repository_url_basename_matches_identity repo] returns [true] when the
+    repository's URL basename can be matched against one of the repository's
+    declared identity tokens. An empty basename (missing/empty URL or
+    unparseable URL) is treated as [false]: fail-closed, not "matches by
+    default". *)
+let repository_url_basename_matches_identity repo =
+  let basename = repository_url_basename repo.url in
+  (not (String.equal basename ""))
+  && List.exists (token_matches_url_basename ~basename) (repository_identity_tokens repo)
+
+let repository_matches_token ~base_path token (repo : repository) =
+  String.equal repo.id token
+  || String.equal repo.name token
+  || List.exists (String.equal token) repo.aliases
+  || (repository_url_basename_matches_identity repo
+      && token_matches_url_basename ~basename:(repository_url_basename repo.url) token)
+  || String.equal
+       (basename_of_path (Repo_store.local_path ~base_path repo))
+       token
+
 let repository_registered ~base_path ~repository_id : (bool, string) result =
   match Repo_store.load_all ~base_path with
   | Stdlib.Error msg ->
@@ -313,7 +364,7 @@ let repository_registered ~base_path ~repository_id : (bool, string) result =
   | Stdlib.Ok repos ->
     Stdlib.Ok
       (List.exists
-         (fun (repo : repository) -> String.equal repo.id repository_id)
+         (repository_matches_token ~base_path repository_id)
          repos)
 
 let log_mapping_load_error_if_new ~keeper_id msg =
@@ -485,13 +536,6 @@ let apply_mapping ~keeper_id ~base_path ~repositories =
   | Mapping_found mapping ->
       filter_repos_by_mapping mapping repositories
 
-(* Path normalization for prefix comparison. *)
-let normalize_path_for_prefix_check path =
-  let p = String.trim path in
-  if String.ends_with ~suffix:"/" p then
-    String.sub p 0 (String.length p - 1)
-  else p
-
 let relative_under ~root path =
   let root_norm = normalize_path_for_prefix_check root in
   let path_norm = normalize_path_for_prefix_check path in
@@ -538,40 +582,6 @@ let playground_path_of_path ~base_path ~path =
       | _keeper :: ["repos"] ->
           Some Playground_repos_root
       | _ -> Some Playground_internal)
-
-let basename_of_path path =
-  normalize_path_for_prefix_check path |> Filename.basename
-
-let repository_url_basename url =
-  let stripped = normalize_path_for_prefix_check url in
-  if stripped = "" then ""
-  else
-    let base = Filename.basename stripped in
-    if Filename.check_suffix base ".git" then
-      String.sub base 0 (String.length base - 4)
-    else base
-
-let repository_identity_tokens (repo : repository) =
-  repo.id :: repo.name :: repo.aliases
-  |> List.map String.trim
-  |> List.filter (fun token -> not (String.equal token ""))
-
-(** [token_matches_url_basename ~basename token] is a case-insensitive
-    comparison between a repository identity token and the basename extracted
-    from a URL. Identity drift in the wild (e.g. [masc] vs [Masc]) should not
-    cause a fail-closed rejection. *)
-let token_matches_url_basename ~basename token =
-  String.equal (String.lowercase_ascii basename) (String.lowercase_ascii token)
-
-(** [repository_url_basename_matches_identity repo] returns [true] when the
-    repository's URL basename can be matched against one of the repository's
-    declared identity tokens. An empty basename (missing/empty URL or
-    unparseable URL) is treated as [false]: fail-closed, not "matches by
-    default". *)
-let repository_url_basename_matches_identity repo =
-  let basename = repository_url_basename repo.url in
-  (not (String.equal basename ""))
-  && List.exists (token_matches_url_basename ~basename) (repository_identity_tokens repo)
 
 type repository_identity_mismatch = {
   repository_id : string;
@@ -623,16 +633,6 @@ let repository_identity_mismatch_message
      url_basename=%S url=%S repo_root=%S. Add the URL basename as an explicit \
      alias, or fix repositories.toml before keeper repository access."
     segment repository_id repository_name url_basename repository_url repo_root
-
-let repository_matches_token ~base_path token (repo : repository) =
-  String.equal repo.id token
-  || String.equal repo.name token
-  || List.exists (String.equal token) repo.aliases
-  || (repository_url_basename_matches_identity repo
-      && token_matches_url_basename ~basename:(repository_url_basename repo.url) token)
-  || String.equal
-       (basename_of_path (Repo_store.local_path ~base_path repo))
-       token
 
 type repository_resolution =
   | No_repository

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -672,7 +672,7 @@ let unresolved_repository_segment_resolution ?repo_root ~segment repos =
       segment repos
   with
   | Some mismatch -> Repository_identity_mismatch mismatch
-  | None -> No_repository
+  | None -> Repository (repository_match ?repo_root segment)
 
 let resolve_repository_id_segment_from_catalog ~base_path ?repo_root segment repos =
   match List.find_opt (repository_matches_token ~base_path segment) repos with
@@ -703,11 +703,11 @@ let path_under_repo ~base_path repo path =
 (** [repository_resolution_of_path ~base_path ~path] returns the registered
     repository for [path], or an identity mismatch when the path points at a
     declared repository whose URL basename contradicts its declared identity.
-    A visible playground clone that is absent from the catalog is not an
-    authorization failure: playground containment owns read access, and the
-    catalog remains metadata/alias state. Repository store load failures remain
-    explicit so access callers can deny instead of treating an unreadable
-    repository catalog as "not a repository". *)
+    A visible playground clone under [repos/<segment>] is still treated as a
+    repository-scoped path; unknown segments become synthetic repository IDs so
+    access remains fail-closed through the repository-registration/HITL path.
+    Repository store load failures remain explicit so access callers can deny
+    instead of treating an unreadable repository catalog as "not a repository". *)
 let repository_resolution_of_path_from_catalog ~base_path ~path repos =
   match playground_path_of_path ~base_path ~path with
   | Some Playground_internal | Some Playground_repos_root -> No_repository
@@ -746,10 +746,9 @@ let repository_id_of_path ~base_path ~path =
     either is outside registered repositories or resolves to a valid
     registered repository. Per-keeper mappings are advisory/default-scope
     metadata and do not cap access; visible playground clones that are not in
-    the catalog are outside repo-policy authorization and stay governed by the
-    sandbox containment boundary. This is the integration point for keeper
-    execution paths that operate on filesystem paths rather than explicit
-    repository IDs. *)
+    the catalog still resolve to their path segment and must pass repository
+    registration policy. This is the integration point for keeper execution
+    paths that operate on filesystem paths rather than explicit repository IDs. *)
 let validate_path_access ~keeper_id ~base_path ~path =
   match repository_resolution_of_path ~base_path ~path with
   | No_repository -> Ok ()

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -170,4 +170,5 @@ val validate_path_access :
     repository. Per-keeper mappings do not cap access. Returns [Error msg] for
     registered-repository identity mismatches and repository-store load
     failures. A visible playground clone that is absent from the catalog is
-    treated as sandbox-local and remains governed by path containment. *)
+    treated as a synthetic repository id so access remains fail-closed through
+    repository registration policy instead of sandbox containment alone. *)

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -168,5 +168,6 @@ val validate_path_access :
 (** [validate_path_access ~keeper_id ~base_path ~path] returns [Ok ()] if
     [path] resolves outside registered repositories or to a registered
     repository. Per-keeper mappings do not cap access. Returns [Error msg] for
-    unregistered playground repositories, identity mismatches, and
-    repository-store load failures. *)
+    registered-repository identity mismatches and repository-store load
+    failures. A visible playground clone that is absent from the catalog is
+    treated as sandbox-local and remains governed by path containment. *)

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -9,10 +9,26 @@
 
 open Masc.Keeper_tool_shared_runtime
 module CB = Masc.Keeper_failure_circuit_breaker
+module Json = Yojson.Safe.Util
 
 let r = Alcotest.(check string)
 
 let pg = ".masc/playground/test"
+
+let make_meta () =
+  let json =
+    `Assoc
+      [ "name", `String "test"
+      ; "agent_name", `String "keeper-test-agent"
+      ; "trace_id", `String "trace-test"
+      ; "goal", `String "actionable path test"
+      ; "sandbox_profile", `String "local"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+;;
 
 let test_path_not_found () =
   let action =
@@ -93,6 +109,25 @@ let test_empty_raw_path_overrides_class () =
        true
      with Not_found -> false)
 
+let test_actionable_path_error_marks_path_not_found_deterministic () =
+  let raw =
+    actionable_path_error
+      ~op:"rg"
+      ~meta:(make_meta ())
+      ~raw_path:"repos/masc-mcp/lib"
+      ~error:"path_not_found_under_allowed_roots: repos/masc-mcp/lib"
+  in
+  let json = Yojson.Safe.from_string raw in
+  let retry = Json.member "deterministic_retry" json in
+  Alcotest.(check (option string))
+    "retry reason"
+    (Some "path_not_found")
+    (Json.member "reason" retry |> Json.to_string_option);
+  Alcotest.(check (option bool))
+    "same args retry disabled"
+    (Some false)
+    (Json.member "retry_same_args" retry |> Json.to_bool_option)
+
 let () =
   Alcotest.run "actionable_path_action"
     [
@@ -110,5 +145,12 @@ let () =
         [
           Alcotest.test_case "empty raw_path -> Provide a path" `Quick
             test_empty_raw_path_overrides_class;
+        ] );
+      ( "error_json",
+        [
+          Alcotest.test_case
+            "path not found marks deterministic retry boundary"
+            `Quick
+            test_actionable_path_error_marks_path_not_found_deterministic;
         ] );
     ]

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -93,6 +93,15 @@ let expect_path_access_ok ~label ~keeper_id ~base_path ~path =
   | Ok () -> ()
   | Error msg -> Alcotest.fail (label ^ ", got: " ^ msg)
 
+let expect_path_access_denied_as_unregistered ~label ~keeper_id ~base_path ~path =
+  match Keeper_repo_mapping.validate_path_access ~keeper_id ~base_path ~path with
+  | Ok () -> Alcotest.fail label
+  | Error msg ->
+    Alcotest.(check bool)
+      "mentions not registered"
+      true
+      (contains_substring msg "not registered")
+
 let write_repositories base_path repos =
   let path = Filename.concat base_path ".masc/config/repositories.toml" in
   let repo_block (r : repository) =
@@ -694,7 +703,7 @@ let test_validate_path_access_rejects_empty_url_basename () =
             "mentions identity mismatch" true
             (contains_substring msg "Repository identity mismatch"))
 
-let test_validate_path_access_playground_allows_git_remote_only_clone () =
+let test_validate_path_access_playground_rejects_git_remote_only_identity () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -715,13 +724,13 @@ let test_validate_path_access_playground_allows_git_remote_only_clone () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc.git";
-      expect_path_access_ok
-        ~label:"expected git remote-only sandbox clone to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected git remote-only playground clone to require registration"
         ~keeper_id:"executor"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_allows_exact_remote_url_clone () =
+let test_validate_path_access_playground_rejects_exact_remote_url_identity () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -742,13 +751,13 @@ let test_validate_path_access_playground_allows_exact_remote_url_clone () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc-mcp";
-      expect_path_access_ok
-        ~label:"expected exact-remote sandbox clone to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected exact-remote playground clone to require registration"
         ~keeper_id:"executor"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_allows_secondary_remote_url_clone ()
+let test_validate_path_access_playground_rejects_secondary_remote_url_spoof ()
   =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -773,13 +782,13 @@ let test_validate_path_access_playground_allows_secondary_remote_url_clone ()
           ("origin", Filename.concat base_path "workspace/yousleepwhen/masc-mcp");
           ("github", "https://github.com/jeong-sik/masc.git");
         ];
-      expect_path_access_ok
-        ~label:"expected secondary-remote sandbox clone to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected secondary-remote playground clone to require registration"
         ~keeper_id:"executor"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_allows_gitdir_remote_clone () =
+let test_validate_path_access_playground_rejects_gitdir_remote_identity () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -804,13 +813,13 @@ let test_validate_path_access_playground_allows_gitdir_remote_clone () =
         ~gitdir_ref:"../linked-worktree-gitdir"
         ~gitdir_path
         ~url:"https://github.com/jeong-sik/masc.git";
-      expect_path_access_ok
-        ~label:"expected gitdir sandbox clone to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected gitdir playground clone to require registration"
         ~keeper_id:"executor"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_large_git_config_allowed () =
+let test_validate_path_access_playground_large_git_config_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -834,13 +843,13 @@ let test_validate_path_access_playground_large_git_config_allowed () =
       write_file (Filename.concat repo_root ".git/config")
         (String.make (70 * 1024) 'x'
          ^ "\n[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc.git\n");
-      expect_path_access_ok
-        ~label:"expected oversized-git-config sandbox clone to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected oversized-git-config playground clone to require registration"
         ~keeper_id:"executor"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_unknown_repo_allowed () =
+let test_validate_path_access_playground_unknown_repo_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -862,13 +871,13 @@ let test_validate_path_access_playground_unknown_repo_allowed () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      expect_path_access_ok
-        ~label:"expected unknown sandbox repo to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:"expected unknown playground repo to be denied as unregistered"
         ~keeper_id:"nick0cave"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_unknown_repo_wildcard_allowed () =
+let test_validate_path_access_playground_unknown_repo_wildcard_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -890,13 +899,14 @@ let test_validate_path_access_playground_unknown_repo_wildcard_allowed () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      expect_path_access_ok
-        ~label:"expected unknown sandbox repo under wildcard to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:
+          "expected unknown playground repo under wildcard to be denied as unregistered"
         ~keeper_id:"nick0cave"
         ~base_path
         ~path)
 
-let test_validate_path_access_playground_unknown_repo_no_mapping_allowed () =
+let test_validate_path_access_playground_unknown_repo_no_mapping_denied () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -917,8 +927,9 @@ let test_validate_path_access_playground_unknown_repo_no_mapping_allowed () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      expect_path_access_ok
-        ~label:"expected unknown sandbox repo without mapping to be allowed"
+      expect_path_access_denied_as_unregistered
+        ~label:
+          "expected unknown playground repo without mapping to be denied as unregistered"
         ~keeper_id:"nick0cave"
         ~base_path
         ~path)
@@ -1053,22 +1064,22 @@ let () =
             test_validate_path_access_wildcard_rejects_mismatched_url_basename;
           Alcotest.test_case "empty URL basename is identity mismatch" `Quick
             test_validate_path_access_rejects_empty_url_basename;
-          Alcotest.test_case "playground allows git remote-only clone" `Quick
-            test_validate_path_access_playground_allows_git_remote_only_clone;
-          Alcotest.test_case "playground allows exact remote URL clone" `Quick
-            test_validate_path_access_playground_allows_exact_remote_url_clone;
-          Alcotest.test_case "playground allows secondary remote URL clone" `Quick
-            test_validate_path_access_playground_allows_secondary_remote_url_clone;
-          Alcotest.test_case "playground allows gitdir remote clone" `Quick
-            test_validate_path_access_playground_allows_gitdir_remote_clone;
-          Alcotest.test_case "playground large git config is allowed" `Quick
-            test_validate_path_access_playground_large_git_config_allowed;
-          Alcotest.test_case "playground unknown repo allowed" `Quick
-            test_validate_path_access_playground_unknown_repo_allowed;
-          Alcotest.test_case "playground unknown repo under wildcard allowed" `Quick
-            test_validate_path_access_playground_unknown_repo_wildcard_allowed;
-          Alcotest.test_case "playground unknown repo no mapping allowed" `Quick
-            test_validate_path_access_playground_unknown_repo_no_mapping_allowed;
+          Alcotest.test_case "playground rejects git remote-only identity" `Quick
+            test_validate_path_access_playground_rejects_git_remote_only_identity;
+          Alcotest.test_case "playground rejects exact remote URL identity" `Quick
+            test_validate_path_access_playground_rejects_exact_remote_url_identity;
+          Alcotest.test_case "playground rejects secondary remote URL spoof" `Quick
+            test_validate_path_access_playground_rejects_secondary_remote_url_spoof;
+          Alcotest.test_case "playground rejects gitdir remote identity" `Quick
+            test_validate_path_access_playground_rejects_gitdir_remote_identity;
+          Alcotest.test_case "playground large git config is denied" `Quick
+            test_validate_path_access_playground_large_git_config_denied;
+          Alcotest.test_case "playground unknown repo denied as unregistered" `Quick
+            test_validate_path_access_playground_unknown_repo_denied;
+          Alcotest.test_case "playground unknown repo under wildcard denied as unregistered" `Quick
+            test_validate_path_access_playground_unknown_repo_wildcard_denied;
+          Alcotest.test_case "playground unknown repo no mapping denied" `Quick
+            test_validate_path_access_playground_unknown_repo_no_mapping_denied;
         ] );
       ( "apply_mapping",
         [

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -88,6 +88,11 @@ let write_mapping base_path keeper_id repo_ids =
   | Ok () -> ()
   | Error e -> Alcotest.fail ("write_mapping failed: " ^ e)
 
+let expect_path_access_ok ~label ~keeper_id ~base_path ~path =
+  match Keeper_repo_mapping.validate_path_access ~keeper_id ~base_path ~path with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail (label ^ ", got: " ^ msg)
+
 let write_repositories base_path repos =
   let path = Filename.concat base_path ".masc/config/repositories.toml" in
   let repo_block (r : repository) =
@@ -689,7 +694,7 @@ let test_validate_path_access_rejects_empty_url_basename () =
             "mentions identity mismatch" true
             (contains_substring msg "Repository identity mismatch"))
 
-let test_validate_path_access_playground_rejects_git_remote_only_identity () =
+let test_validate_path_access_playground_allows_git_remote_only_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -710,17 +715,13 @@ let test_validate_path_access_playground_rejects_git_remote_only_identity () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc.git";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected git remote-only identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected git remote-only sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_exact_remote_url_identity () =
+let test_validate_path_access_playground_allows_exact_remote_url_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -741,17 +742,13 @@ let test_validate_path_access_playground_rejects_exact_remote_url_identity () =
       let path = Filename.concat repo_root "docs/proof.md" in
       ensure_dir (Filename.dirname path);
       write_git_origin repo_root "https://github.com/jeong-sik/masc-mcp";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected exact remote URL identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected exact-remote sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_secondary_remote_url_spoof ()
+let test_validate_path_access_playground_allows_secondary_remote_url_clone ()
   =
   with_temp_base_path (fun base_path ->
       let root_repo =
@@ -776,17 +773,13 @@ let test_validate_path_access_playground_rejects_secondary_remote_url_spoof ()
           ("origin", Filename.concat base_path "workspace/yousleepwhen/masc-mcp");
           ("github", "https://github.com/jeong-sik/masc.git");
         ];
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected secondary remote spoof to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected secondary-remote sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_rejects_gitdir_remote_identity () =
+let test_validate_path_access_playground_allows_gitdir_remote_clone () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -811,17 +804,13 @@ let test_validate_path_access_playground_rejects_gitdir_remote_identity () =
         ~gitdir_ref:"../linked-worktree-gitdir"
         ~gitdir_path
         ~url:"https://github.com/jeong-sik/masc.git";
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected gitdir remote identity to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions unregistered repository" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected gitdir sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_large_git_config_denied () =
+let test_validate_path_access_playground_large_git_config_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -845,17 +834,13 @@ let test_validate_path_access_playground_large_git_config_denied () =
       write_file (Filename.concat repo_root ".git/config")
         (String.make (70 * 1024) 'x'
          ^ "\n[remote \"origin\"]\n\turl = https://github.com/jeong-sik/masc.git\n");
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected oversized git config to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected oversized-git-config sandbox clone to be allowed"
+        ~keeper_id:"executor"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_denied () =
+let test_validate_path_access_playground_unknown_repo_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -877,17 +862,13 @@ let test_validate_path_access_playground_unknown_repo_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () -> Alcotest.fail "expected unknown playground repo to be denied"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_wildcard_denied () =
+let test_validate_path_access_playground_unknown_repo_wildcard_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -909,19 +890,13 @@ let test_validate_path_access_playground_unknown_repo_wildcard_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () ->
-          Alcotest.fail
-            "expected unknown playground repo under wildcard to be denied as unregistered"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo under wildcard to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
-let test_validate_path_access_playground_unknown_repo_no_mapping_denied () =
+let test_validate_path_access_playground_unknown_repo_no_mapping_allowed () =
   with_temp_base_path (fun base_path ->
       let root_repo =
         { (sample_repo "me") with name = "me"; local_path = base_path }
@@ -942,17 +917,11 @@ let test_validate_path_access_playground_unknown_repo_no_mapping_denied () =
           ".masc/playground/docker/nick0cave/repos/unknown/lib"
       in
       ensure_dir path;
-      match
-        Keeper_repo_mapping.validate_path_access ~keeper_id:"nick0cave"
-          ~base_path ~path
-      with
-      | Ok () ->
-          Alcotest.fail
-            "expected unknown playground repo without mapping to be denied as unregistered"
-      | Error msg ->
-          Alcotest.(check bool)
-            "mentions not registered" true
-            (contains_substring msg "not registered"))
+      expect_path_access_ok
+        ~label:"expected unknown sandbox repo without mapping to be allowed"
+        ~keeper_id:"nick0cave"
+        ~base_path
+        ~path)
 
 let test_apply_mapping_explicit () =
   with_temp_base_path (fun base_path ->
@@ -1084,22 +1053,22 @@ let () =
             test_validate_path_access_wildcard_rejects_mismatched_url_basename;
           Alcotest.test_case "empty URL basename is identity mismatch" `Quick
             test_validate_path_access_rejects_empty_url_basename;
-          Alcotest.test_case "playground rejects git remote-only identity" `Quick
-            test_validate_path_access_playground_rejects_git_remote_only_identity;
-          Alcotest.test_case "playground rejects exact remote URL identity" `Quick
-            test_validate_path_access_playground_rejects_exact_remote_url_identity;
-          Alcotest.test_case "playground rejects secondary remote URL spoof" `Quick
-            test_validate_path_access_playground_rejects_secondary_remote_url_spoof;
-          Alcotest.test_case "playground rejects gitdir remote identity" `Quick
-            test_validate_path_access_playground_rejects_gitdir_remote_identity;
-          Alcotest.test_case "playground large git config is denied" `Quick
-            test_validate_path_access_playground_large_git_config_denied;
-          Alcotest.test_case "playground unknown repo denied as unregistered" `Quick
-            test_validate_path_access_playground_unknown_repo_denied;
-          Alcotest.test_case "playground unknown repo under wildcard denied as unregistered" `Quick
-            test_validate_path_access_playground_unknown_repo_wildcard_denied;
-          Alcotest.test_case "playground unknown repo no mapping denied" `Quick
-            test_validate_path_access_playground_unknown_repo_no_mapping_denied;
+          Alcotest.test_case "playground allows git remote-only clone" `Quick
+            test_validate_path_access_playground_allows_git_remote_only_clone;
+          Alcotest.test_case "playground allows exact remote URL clone" `Quick
+            test_validate_path_access_playground_allows_exact_remote_url_clone;
+          Alcotest.test_case "playground allows secondary remote URL clone" `Quick
+            test_validate_path_access_playground_allows_secondary_remote_url_clone;
+          Alcotest.test_case "playground allows gitdir remote clone" `Quick
+            test_validate_path_access_playground_allows_gitdir_remote_clone;
+          Alcotest.test_case "playground large git config is allowed" `Quick
+            test_validate_path_access_playground_large_git_config_allowed;
+          Alcotest.test_case "playground unknown repo allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_allowed;
+          Alcotest.test_case "playground unknown repo under wildcard allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_wildcard_allowed;
+          Alcotest.test_case "playground unknown repo no mapping allowed" `Quick
+            test_validate_path_access_playground_unknown_repo_no_mapping_allowed;
         ] );
       ( "apply_mapping",
         [

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -278,6 +278,35 @@ let test_validate_access_allowed () =
       | Ok () -> ()
       | Error e -> Alcotest.fail ("expected Ok, got: " ^ e))
 
+let test_validate_access_accepts_registered_alias () =
+  with_temp_base_path (fun base_path ->
+      let repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc.git";
+          aliases = [ "masc-mcp" ];
+        }
+      in
+      (match Repo_store.save_all ~base_path [ repo ] with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("failed to seed repository alias: " ^ e));
+      write_mapping base_path "keeper-1" [ "masc" ];
+      Alcotest.(check bool)
+        "alias is registered"
+        true
+        (Keeper_repo_mapping.is_allowed
+           ~keeper_id:"keeper-1"
+           ~repository_id:"masc-mcp"
+           ~base_path);
+      match
+        Keeper_repo_mapping.validate_access
+          ~keeper_id:"keeper-1"
+          ~repository_id:"masc-mcp"
+          ~base_path
+      with
+      | Ok () -> ()
+      | Error e -> Alcotest.fail ("expected alias Ok, got: " ^ e))
+
 let test_validate_access_explicit_mapping_does_not_cap_registered_repo () =
   with_temp_base_path (fun base_path ->
       write_repositories base_path [ sample_repo "repo-a"; sample_repo "repo-b" ];
@@ -435,6 +464,38 @@ let test_validate_path_access_playground_repo_uses_registered_name () =
       | Error e ->
           Alcotest.fail
             ("expected playground repo path to resolve by registered name, got: "
+             ^ e))
+
+let test_validate_path_access_playground_repo_uses_registered_alias () =
+  with_temp_base_path (fun base_path ->
+      let root_repo =
+        { (sample_repo "me") with name = "me"; local_path = base_path }
+      in
+      let masc_repo =
+        { (sample_repo "masc") with
+          name = "masc";
+          url = "https://github.com/jeong-sik/masc.git";
+          aliases = [ "masc-mcp" ];
+          local_path = Filename.concat base_path ".masc/repos/masc";
+        }
+      in
+      (match Repo_store.save_all ~base_path [ root_repo; masc_repo ] with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("failed to seed repository alias: " ^ e));
+      write_mapping base_path "executor" [ "masc" ];
+      let path =
+        Filename.concat base_path
+          ".masc/playground/docker/executor/repos/masc-mcp/lib"
+      in
+      ensure_dir path;
+      match
+        Keeper_repo_mapping.validate_path_access ~keeper_id:"executor"
+          ~base_path ~path
+      with
+      | Ok () -> ()
+      | Error e ->
+          Alcotest.fail
+            ("expected playground repo path to resolve by registered alias, got: "
              ^ e))
 
 let test_validate_path_access_playground_repo_uses_url_basename () =
@@ -989,6 +1050,8 @@ let () =
       ( "validate_access",
         [
           Alcotest.test_case "allowed" `Quick test_validate_access_allowed;
+          Alcotest.test_case "registered alias" `Quick
+            test_validate_access_accepts_registered_alias;
           Alcotest.test_case "explicit mapping does not cap registered repo" `Quick
             test_validate_access_explicit_mapping_does_not_cap_registered_repo;
           Alcotest.test_case "no mapping" `Quick test_validate_access_no_mapping;
@@ -1007,6 +1070,8 @@ let () =
             test_validate_path_access_playground_repos_root_ignores_base_repo;
           Alcotest.test_case "playground repo resolves registered name" `Quick
             test_validate_path_access_playground_repo_uses_registered_name;
+          Alcotest.test_case "playground repo resolves registered alias" `Quick
+            test_validate_path_access_playground_repo_uses_registered_alias;
           Alcotest.test_case "playground repo resolves repository URL basename" `Quick
             test_validate_path_access_playground_repo_uses_url_basename;
           Alcotest.test_case "case-only URL basename drift is allowed" `Quick

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -106,48 +106,27 @@ let parse_field raw field =
 let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
-let unregistered_masc_mcp_policy_error =
-  "Repository masc-mcp is not registered; access not allowed"
-
-let assert_repository_registration_policy_response ~raw =
+let assert_sandbox_local_search_response ~raw =
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check (option bool)) "policy response denies access" (Some false)
+  Alcotest.(check (option bool)) "sandbox-local search succeeds" (Some true)
     (Json.member "ok" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "policy error keeps original denial"
-    (Some unregistered_masc_mcp_policy_error)
+  Alcotest.(check (option string)) "no policy error" None
     (Json.member "policy_error" json |> Json.to_string_option);
-  Alcotest.(check bool) "visible error changes from bare denial" true
-    (not
-       (String.equal
-          (Json.member "error" json |> Json.to_string_option |> Option.value ~default:"")
-          unregistered_masc_mcp_policy_error));
-  Alcotest.(check (option bool)) "operator action required" (Some true)
+  Alcotest.(check (option string)) "no visible error" None
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check (option bool)) "no operator action" None
     (Json.member "operator_action_required" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "operator action kind"
-    (Some "repository_registration")
-    (Json.member "operator_action_kind" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "operator action reason"
-    (Some "repository_unregistered")
-    (Json.member "operator_action_reason" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "next action"
-    (Some "wait_for_operator_approval")
-    (Json.member "next_action" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "approval kind"
-    (Some "repository_registration")
-    (Json.member "approval_pending" json |> Json.member "kind"
-   |> Json.to_string_option);
-  Alcotest.(check (option string)) "approval reason"
-    (Some "repository_unregistered")
-    (Json.member "approval_pending" json |> Json.member "reason"
-   |> Json.to_string_option);
-  Alcotest.(check (option bool)) "approval is non-blocking"
-    (Some true)
-    (Json.member "approval_pending" json |> Json.member "non_blocking"
-   |> Json.to_bool_option);
-  Alcotest.(check (option string)) "deterministic retry reason"
-    (Some "policy_blocked")
+  Alcotest.(check (option string)) "no deterministic policy retry" None
     (Json.member "deterministic_retry" json |> Json.member "reason"
-   |> Json.to_string_option)
+     |> Json.to_string_option)
+
+let assert_no_repository_registration_pending ~keeper_name =
+  let pending =
+    AQ.list_pending_entries ()
+    |> List.filter (fun (entry : AQ.pending_approval) ->
+      String.equal entry.keeper_name keeper_name)
+  in
+  Alcotest.(check int) "no repository registration pending" 0 (List.length pending)
 
 let write_executable path content =
   ignore (Fs_compat.save_file_atomic path content);
@@ -641,7 +620,7 @@ let test_readonly_execute_omitted_cwd_does_not_create_write_root () =
       false
       (Sys.file_exists playground)
 
-let test_rg_unregistered_clone_queues_repository_hitl () =
+let test_rg_unknown_playground_clone_is_sandbox_local () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -665,30 +644,8 @@ let test_rg_unregistered_clone_queues_repository_hitl () =
             ; "path", `String "repos/masc-mcp"
             ])
     in
-    assert_repository_registration_policy_response ~raw;
-    match
-      AQ.list_pending_entries ()
-      |> List.filter (fun (entry : AQ.pending_approval) ->
-        String.equal entry.keeper_name meta.name)
-    with
-    | [ pending ] ->
-      Alcotest.(check string)
-        "requested alias action"
-        "add_repository_alias"
-        (Json.member "requested_action" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias target"
-        "masc"
-        (Json.member "target_repository_id" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias"
-        "masc-mcp"
-        (Json.member "alias" pending.input |> Json.to_string)
-    | entries ->
-      Alcotest.failf
-        "expected one pending repository registration approval, got %d; raw=%s"
-        (List.length entries)
-        raw)
+    assert_sandbox_local_search_response ~raw;
+    assert_no_repository_registration_pending ~keeper_name:meta.name)
 
 let test_rg_registered_alias_allows_masc_mcp_path () =
   if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
@@ -734,7 +691,7 @@ let test_rg_registered_alias_allows_masc_mcp_path () =
       true
       (match Json.member "approval_pending" json with `Null -> true | _ -> false)
 
-let test_read_unregistered_clone_surfaces_repository_hitl () =
+let test_read_unknown_playground_clone_is_sandbox_local () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -756,30 +713,15 @@ let test_read_unregistered_clone_surfaces_repository_hitl () =
           (`Assoc
             [ "path", `String "repos/masc-mcp/README.md"; "max_bytes", `Int 4096 ])
     in
-    assert_repository_registration_policy_response ~raw;
-    match
-      AQ.list_pending_entries ()
-      |> List.filter (fun (entry : AQ.pending_approval) ->
-        String.equal entry.keeper_name meta.name)
-    with
-    | [ pending ] ->
-      Alcotest.(check string)
-        "requested alias action"
-        "add_repository_alias"
-        (Json.member "requested_action" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias target"
-        "masc"
-        (Json.member "target_repository_id" pending.input |> Json.to_string);
-      Alcotest.(check string)
-        "alias"
-        "masc-mcp"
-        (Json.member "alias" pending.input |> Json.to_string)
-    | entries ->
-      Alcotest.failf
-        "expected one pending repository registration approval, got %d; raw=%s"
-        (List.length entries)
-        raw)
+    let json = Yojson.Safe.from_string raw in
+    Alcotest.(check (option bool)) "sandbox-local read succeeds" (Some true)
+      (Json.member "ok" json |> Json.to_bool_option);
+    Alcotest.(check (option string)) "read content"
+      (Some "Repository\n")
+      (Json.member "content" json |> Json.to_string_option);
+    Alcotest.(check (option string)) "no policy error" None
+      (Json.member "policy_error" json |> Json.to_string_option);
+    assert_no_repository_registration_pending ~keeper_name:meta.name)
 
 
 let () =
@@ -828,12 +770,12 @@ let () =
             `Quick
             test_rg_registered_alias_allows_masc_mcp_path;
           Alcotest.test_case
-            "rg unregistered clone queues repository HITL"
+            "rg unknown playground clone is sandbox-local"
             `Quick
-            test_rg_unregistered_clone_queues_repository_hitl;
+            test_rg_unknown_playground_clone_is_sandbox_local;
           Alcotest.test_case
-            "Read unregistered clone surfaces repository HITL"
+            "Read unknown playground clone is sandbox-local"
             `Quick
-            test_read_unregistered_clone_surfaces_repository_hitl;
+            test_read_unknown_playground_clone_is_sandbox_local;
         ] );
     ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -690,6 +690,50 @@ let test_rg_unregistered_clone_queues_repository_hitl () =
         (List.length entries)
         raw)
 
+let test_rg_registered_alias_allows_masc_mcp_path () =
+  if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
+  else
+    setup ~keeper_name:"base" ~sandbox:Keeper_types_profile_sandbox.Local
+    @@ fun ~base ~config ~meta ~playground ->
+    let registered =
+      { (sample_repo ~base_path:base "masc") with aliases = [ "masc-mcp" ] }
+    in
+    save_repositories base [ registered ];
+    let repo_root = Filename.concat playground "repos/masc-mcp" in
+    let lib_dir = Filename.concat repo_root "lib" in
+    ensure_dir lib_dir;
+    ignore
+      (Fs_compat.save_file_atomic
+         (Filename.concat lib_dir "foo.ml")
+         "let marker = \"Repository\"\n");
+    let raw =
+      Keeper_tool_command_runtime.handle_tool_search_files
+        ~turn_sandbox_factory:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:
+          (`Assoc
+            [ "op", `String "rg"
+            ; "pattern", `String "Repository"
+            ; "path", `String "repos/masc-mcp/lib"
+            ; "glob", `String "*.ml"
+            ])
+    in
+    let json = Yojson.Safe.from_string raw in
+    Alcotest.(check (option bool))
+      "registered alias search succeeds"
+      (Some true)
+      (Json.member "ok" json |> Json.to_bool_option);
+    Alcotest.(check (option string))
+      "resolved canonical host path"
+      (Some lib_dir)
+      (Json.member "path" json |> Json.to_string_option);
+    Alcotest.(check bool)
+      "no approval pending"
+      true
+      (match Json.member "approval_pending" json with `Null -> true | _ -> false)
+
 let test_read_unregistered_clone_surfaces_repository_hitl () =
   if not (git_available ()) then ()
   else (
@@ -779,6 +823,10 @@ let () =
             "read-only Execute omitted cwd does not create write root"
             `Quick
             test_readonly_execute_omitted_cwd_does_not_create_write_root;
+          Alcotest.test_case
+            "rg registered alias allows masc-mcp path"
+            `Quick
+            test_rg_registered_alias_allows_masc_mcp_path;
           Alcotest.test_case
             "rg unregistered clone queues repository HITL"
             `Quick

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -106,27 +106,49 @@ let parse_field raw field =
 let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
-let assert_sandbox_local_search_response ~raw =
+let unregistered_masc_mcp_policy_error =
+  "Repository masc-mcp is not registered; access not allowed"
+
+let assert_repository_registration_policy_response ~raw =
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check (option bool)) "sandbox-local search succeeds" (Some true)
+  Alcotest.(check (option bool)) "policy response denies access" (Some false)
     (Json.member "ok" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "no policy error" None
+  Alcotest.(check (option string)) "policy error keeps original denial"
+    (Some unregistered_masc_mcp_policy_error)
     (Json.member "policy_error" json |> Json.to_string_option);
-  Alcotest.(check (option string)) "no visible error" None
-    (Json.member "error" json |> Json.to_string_option);
-  Alcotest.(check (option bool)) "no operator action" None
+  Alcotest.(check bool) "visible error changes from bare denial" true
+    (not
+       (String.equal
+          (Json.member "error" json |> Json.to_string_option
+           |> Option.value ~default:"")
+          unregistered_masc_mcp_policy_error));
+  Alcotest.(check (option bool)) "operator action required" (Some true)
     (Json.member "operator_action_required" json |> Json.to_bool_option);
-  Alcotest.(check (option string)) "no deterministic policy retry" None
+  Alcotest.(check (option string)) "operator action kind"
+    (Some "repository_registration")
+    (Json.member "operator_action_kind" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "operator action reason"
+    (Some "repository_unregistered")
+    (Json.member "operator_action_reason" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "next action"
+    (Some "wait_for_operator_approval")
+    (Json.member "next_action" json |> Json.to_string_option);
+  Alcotest.(check (option string)) "approval kind"
+    (Some "repository_registration")
+    (Json.member "approval_pending" json |> Json.member "kind"
+     |> Json.to_string_option);
+  Alcotest.(check (option string)) "approval reason"
+    (Some "repository_unregistered")
+    (Json.member "approval_pending" json |> Json.member "reason"
+     |> Json.to_string_option);
+  Alcotest.(check (option bool)) "approval is non-blocking"
+    (Some true)
+    (Json.member "approval_pending" json |> Json.member "non_blocking"
+     |> Json.to_bool_option);
+  Alcotest.(check (option string)) "deterministic retry reason"
+    (Some "policy_blocked")
     (Json.member "deterministic_retry" json |> Json.member "reason"
      |> Json.to_string_option)
-
-let assert_no_repository_registration_pending ~keeper_name =
-  let pending =
-    AQ.list_pending_entries ()
-    |> List.filter (fun (entry : AQ.pending_approval) ->
-      String.equal entry.keeper_name keeper_name)
-  in
-  Alcotest.(check int) "no repository registration pending" 0 (List.length pending)
 
 let write_executable path content =
   ignore (Fs_compat.save_file_atomic path content);
@@ -620,7 +642,7 @@ let test_readonly_execute_omitted_cwd_does_not_create_write_root () =
       false
       (Sys.file_exists playground)
 
-let test_rg_unknown_playground_clone_is_sandbox_local () =
+let test_rg_unregistered_clone_queues_repository_hitl () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -644,8 +666,30 @@ let test_rg_unknown_playground_clone_is_sandbox_local () =
             ; "path", `String "repos/masc-mcp"
             ])
     in
-    assert_sandbox_local_search_response ~raw;
-    assert_no_repository_registration_pending ~keeper_name:meta.name)
+    assert_repository_registration_policy_response ~raw;
+    match
+      AQ.list_pending_entries ()
+      |> List.filter (fun (entry : AQ.pending_approval) ->
+        String.equal entry.keeper_name meta.name)
+    with
+    | [ pending ] ->
+      Alcotest.(check string)
+        "requested alias action"
+        "add_repository_alias"
+        (Json.member "requested_action" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias target"
+        "masc"
+        (Json.member "target_repository_id" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias"
+        "masc-mcp"
+        (Json.member "alias" pending.input |> Json.to_string)
+    | entries ->
+      Alcotest.failf
+        "expected one pending repository registration approval, got %d; raw=%s"
+        (List.length entries)
+        raw)
 
 let test_rg_registered_alias_allows_masc_mcp_path () =
   if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
@@ -691,7 +735,7 @@ let test_rg_registered_alias_allows_masc_mcp_path () =
       true
       (match Json.member "approval_pending" json with `Null -> true | _ -> false)
 
-let test_read_unknown_playground_clone_is_sandbox_local () =
+let test_read_unregistered_clone_surfaces_repository_hitl () =
   if not (git_available ()) then ()
   else (
     AQ.For_testing.reset_audit_store ();
@@ -713,15 +757,30 @@ let test_read_unknown_playground_clone_is_sandbox_local () =
           (`Assoc
             [ "path", `String "repos/masc-mcp/README.md"; "max_bytes", `Int 4096 ])
     in
-    let json = Yojson.Safe.from_string raw in
-    Alcotest.(check (option bool)) "sandbox-local read succeeds" (Some true)
-      (Json.member "ok" json |> Json.to_bool_option);
-    Alcotest.(check (option string)) "read content"
-      (Some "Repository\n")
-      (Json.member "content" json |> Json.to_string_option);
-    Alcotest.(check (option string)) "no policy error" None
-      (Json.member "policy_error" json |> Json.to_string_option);
-    assert_no_repository_registration_pending ~keeper_name:meta.name)
+    assert_repository_registration_policy_response ~raw;
+    match
+      AQ.list_pending_entries ()
+      |> List.filter (fun (entry : AQ.pending_approval) ->
+        String.equal entry.keeper_name meta.name)
+    with
+    | [ pending ] ->
+      Alcotest.(check string)
+        "requested alias action"
+        "add_repository_alias"
+        (Json.member "requested_action" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias target"
+        "masc"
+        (Json.member "target_repository_id" pending.input |> Json.to_string);
+      Alcotest.(check string)
+        "alias"
+        "masc-mcp"
+        (Json.member "alias" pending.input |> Json.to_string)
+    | entries ->
+      Alcotest.failf
+        "expected one pending repository registration approval, got %d; raw=%s"
+        (List.length entries)
+        raw)
 
 
 let () =
@@ -770,12 +829,12 @@ let () =
             `Quick
             test_rg_registered_alias_allows_masc_mcp_path;
           Alcotest.test_case
-            "rg unknown playground clone is sandbox-local"
+            "rg unregistered clone queues repository HITL"
             `Quick
-            test_rg_unknown_playground_clone_is_sandbox_local;
+            test_rg_unregistered_clone_queues_repository_hitl;
           Alcotest.test_case
-            "Read unknown playground clone is sandbox-local"
+            "Read unregistered clone surfaces repository HITL"
             `Quick
-            test_read_unknown_playground_clone_is_sandbox_local;
+            test_read_unregistered_clone_surfaces_repository_hitl;
         ] );
     ]

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -286,7 +286,7 @@ let test_playground_repos_policy_uses_registered_repository_id () =
   check string "policy repository id" "repo-masc"
     (json_string "policy_repository_id" json)
 
-let test_playground_repos_mark_unknown_clone_sandbox_local_allowed () =
+let test_playground_repos_mark_unknown_clone_unregistered_denied () =
   let base_path = temp_dir "masc-playground-repo-policy" in
   let config = Masc.Workspace.default_config base_path in
   let meta = make_meta "keeper-one" in
@@ -300,15 +300,14 @@ let test_playground_repos_mark_unknown_clone_sandbox_local_allowed () =
   write_mapping base_path meta.name [ "masc" ];
   create_playground_repo_marker ~config ~meta "masc-mcp";
   let json = playground_repo_entry ~config ~meta ~repo_name:"masc-mcp" in
-  check bool "policy allows sandbox-local clone" true
+  check bool "policy denies unregistered clone" false
     (json_bool "policy_allowed" json);
   check string "policy status"
-    (Keeper_sandbox_control.playground_policy_status_to_string Policy_allowed)
+    (Keeper_sandbox_control.playground_policy_status_to_string
+       Policy_unregistered_repository)
     (json_string "policy_status" json);
-  check string "policy scope" "sandbox_local"
-    (json_string "policy_scope" json);
-  check bool "policy repository id is not fabricated" true
-    (Option.is_none (json_string_opt "policy_repository_id" json))
+  check string "policy repository id" "masc-mcp"
+    (json_string "policy_repository_id" json)
 
 let test_playground_repos_mark_repository_identity_mismatch_denied () =
   let base_path = temp_dir "masc-playground-repo-policy" in
@@ -755,9 +754,9 @@ let () =
           `Quick test_playground_repos_mark_wildcard_mapping_allowed;
         test_case "filesystem repo policy uses registered repository id"
           `Quick test_playground_repos_policy_uses_registered_repository_id;
-        test_case "unknown filesystem repo is marked sandbox-local allowed"
+        test_case "unknown filesystem repo is marked unregistered denied"
           `Quick
-          test_playground_repos_mark_unknown_clone_sandbox_local_allowed;
+          test_playground_repos_mark_unknown_clone_unregistered_denied;
         test_case "repository identity mismatch is marked denied" `Quick
           test_playground_repos_mark_repository_identity_mismatch_denied;
         test_case "repository store error is marked denied" `Quick

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -286,6 +286,30 @@ let test_playground_repos_policy_uses_registered_repository_id () =
   check string "policy repository id" "repo-masc"
     (json_string "policy_repository_id" json)
 
+let test_playground_repos_mark_unknown_clone_sandbox_local_allowed () =
+  let base_path = temp_dir "masc-playground-repo-policy" in
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "keeper-one" in
+  save_repositories base_path
+    [ repository_fixture
+        ~id:"masc"
+        ~name:"masc"
+        ~url:"https://github.com/jeong-sik/masc.git"
+        ~local_path:(Filename.concat base_path ".masc/repos/masc")
+    ];
+  write_mapping base_path meta.name [ "masc" ];
+  create_playground_repo_marker ~config ~meta "masc-mcp";
+  let json = playground_repo_entry ~config ~meta ~repo_name:"masc-mcp" in
+  check bool "policy allows sandbox-local clone" true
+    (json_bool "policy_allowed" json);
+  check string "policy status"
+    (Keeper_sandbox_control.playground_policy_status_to_string Policy_allowed)
+    (json_string "policy_status" json);
+  check string "policy scope" "sandbox_local"
+    (json_string "policy_scope" json);
+  check bool "policy repository id is not fabricated" true
+    (Option.is_none (json_string_opt "policy_repository_id" json))
+
 let test_playground_repos_mark_repository_identity_mismatch_denied () =
   let base_path = temp_dir "masc-playground-repo-policy" in
   let config = Masc.Workspace.default_config base_path in
@@ -731,6 +755,9 @@ let () =
           `Quick test_playground_repos_mark_wildcard_mapping_allowed;
         test_case "filesystem repo policy uses registered repository id"
           `Quick test_playground_repos_policy_uses_registered_repository_id;
+        test_case "unknown filesystem repo is marked sandbox-local allowed"
+          `Quick
+          test_playground_repos_mark_unknown_clone_sandbox_local_allowed;
         test_case "repository identity mismatch is marked denied" `Quick
           test_playground_repos_mark_repository_identity_mismatch_denied;
         test_case "repository store error is marked denied" `Quick


### PR DESCRIPTION
## Summary
- Treat registered repository aliases as registered identities in keeper repo access decisions.
- Treat visible unknown playground clones as sandbox-local for read/search access and status projection instead of fabricating a catalog denial.
- Add deterministic retry markers to actionable path errors so same-argument Grep/Read retries are skipped.
- Cover direct alias access, playground `repos/masc-mcp` alias search/read, sandbox-local status projection, and actionable path retry JSON.

## Validation
- `ocamlformat --check lib/repo_manager/keeper_repo_mapping.ml lib/keeper/keeper_tool_shared_runtime.ml lib/keeper/keeper_sandbox_control.ml test/test_keeper_repo_mapping.ml test/test_keeper_tool_search_files_containment.ml test/test_actionable_path_action.ml test/test_playground_repo_readiness.ml`
- `git diff --check`

Note: local dune build intentionally not run; CI is the dune build authority for this change.
