### PR TITLE
fix(keeper): route repo-id clone denials to HITL

### DIFF
--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -376,6 +376,49 @@ let registration_candidate_of_path ~repository_id ~expected_repo_root ~path =
         Ok { repository_id; repo_root; expected_repo_root; origin_url; default_branch }))
 ;;
 
+let safe_path_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+;;
+
+type repository_id_clone_probe =
+  | No_clone_candidate
+  | Clone_candidate of registration_candidate
+  | Invalid_clone_candidate of string
+
+let registration_candidate_of_repository_id ~keeper_id ~base_path ~repository_id =
+  let candidate_roots =
+    Keeper_sandbox_repo_path.candidate_repo_roots_no_create
+      ~base_path
+      ~keeper_id
+      ~repository_id
+  in
+  let rec loop invalid = function
+    | [] ->
+      (match invalid with
+       | [] -> No_clone_candidate
+       | errors ->
+         Invalid_clone_candidate
+           (errors
+            |> List.rev
+            |> List.map (fun (path, reason) -> Printf.sprintf "%s: %s" path reason)
+            |> String.concat "; "))
+    | repo_root :: rest ->
+      if not (safe_path_exists repo_root)
+      then loop invalid rest
+      else (
+        match
+          registration_candidate_of_path
+            ~repository_id
+            ~expected_repo_root:(Some repo_root)
+            ~path:repo_root
+        with
+        | Ok candidate -> Clone_candidate candidate
+        | Error reason -> loop ((repo_root, reason) :: invalid) rest)
+  in
+  loop [] candidate_roots
+;;
+
 let pending_operator_action_message detail =
   Printf.sprintf
     "%s; operator approval pending for %s"
@@ -409,7 +452,25 @@ let request_repository_access ~keeper_id ~base_path ~repository_id =
   match Keeper_repo_mapping.access_decision ~keeper_id ~repository_id ~base_path with
   | Keeper_repo_mapping.Access_allowed -> Access_allowed
   | Keeper_repo_mapping.Access_denied denial ->
-    Access_denied (Keeper_repo_mapping.access_denial_to_string denial)
+    let detail = Keeper_repo_mapping.access_denial_to_string denial in
+    (match denial with
+     | Keeper_repo_mapping.Access_denied_unregistered_repository repository_id ->
+       (match
+          registration_candidate_of_repository_id ~keeper_id ~base_path ~repository_id
+        with
+        | Clone_candidate candidate ->
+          let operation = registration_operation ~keeper_id ~base_path candidate in
+          let approval_id = submit_registration_hitl ~keeper_id ~base_path operation in
+          Access_denied_hitl_pending { detail; approval_id }
+        | No_clone_candidate -> Access_denied detail
+        | Invalid_clone_candidate reason ->
+          Access_denied
+            (Printf.sprintf
+               "%s; playground clone candidate could not be verified: %s"
+               detail
+               reason))
+     | Access_denied_load_error _ | Access_denied_repository_store_error _ ->
+       Access_denied detail)
 ;;
 
 let request_path_access ~keeper_id ~base_path ~path =

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -376,9 +376,25 @@ let registration_candidate_of_path ~repository_id ~expected_repo_root ~path =
         Ok { repository_id; repo_root; expected_repo_root; origin_url; default_branch }))
 ;;
 
-let safe_path_exists path =
-  try Sys.file_exists path with
-  | Sys_error _ -> false
+type candidate_path_state =
+  | Candidate_path_absent
+  | Candidate_path_directory
+  | Candidate_path_invalid of string
+
+let candidate_path_state path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Candidate_path_absent
+  | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> Candidate_path_absent
+  | exception Unix.Unix_error (err, fn, arg) ->
+    Candidate_path_invalid
+      (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
+  | _ -> (
+    match Sys.is_directory path with
+    | true -> Candidate_path_directory
+    | false -> Candidate_path_invalid "candidate path exists but is not a directory"
+    | exception Sys_error reason ->
+      Candidate_path_invalid
+        (Printf.sprintf "candidate path could not be inspected as directory: %s" reason))
 ;;
 
 type repository_id_clone_probe =
@@ -404,9 +420,10 @@ let registration_candidate_of_repository_id ~keeper_id ~base_path ~repository_id
             |> List.map (fun (path, reason) -> Printf.sprintf "%s: %s" path reason)
             |> String.concat "; "))
     | repo_root :: rest ->
-      if not (safe_path_exists repo_root)
-      then loop invalid rest
-      else (
+      (match candidate_path_state repo_root with
+       | Candidate_path_absent -> loop invalid rest
+       | Candidate_path_invalid reason -> loop ((repo_root, reason) :: invalid) rest
+       | Candidate_path_directory -> (
         match
           registration_candidate_of_path
             ~repository_id
@@ -414,7 +431,7 @@ let registration_candidate_of_repository_id ~keeper_id ~base_path ~repository_id
             ~path:repo_root
         with
         | Ok candidate -> Clone_candidate candidate
-        | Error reason -> loop ((repo_root, reason) :: invalid) rest)
+        | Error reason -> loop ((repo_root, reason) :: invalid) rest))
   in
   loop [] candidate_roots
 ;;

--- a/lib/keeper/keeper_repo_claim_hitl.mli
+++ b/lib/keeper/keeper_repo_claim_hitl.mli
@@ -20,7 +20,10 @@ val request_repository_access :
   access_result
 (** Request access to a registered repository. Registered repositories are
     allowed even when outside the keeper's advisory/default mapping scope. Hard
-    fail-closed cases return [Access_denied]. *)
+    fail-closed cases return [Access_denied]. When [repository_id] is not
+    registered but the keeper already has a verifiable sandbox clone with the
+    same repository component, this queues a non-blocking operator repository
+    registration request instead of silently collapsing to a terminal denial. *)
 
 val request_path_access :
   keeper_id:string -> base_path:string -> path:string -> access_result

--- a/lib/keeper/keeper_sandbox_repo_path.ml
+++ b/lib/keeper/keeper_sandbox_repo_path.ml
@@ -8,6 +8,13 @@ let normalize_path path =
 let playground_root_no_create ~(config : Workspace.config) ~(meta : keeper_meta) =
   Keeper_sandbox.host_root_abs_of_meta ~config meta
 
+let repos_root_of_playground_root playground_root =
+  Filename.concat playground_root "repos" |> normalize_path
+
+let repo_root_of_playground_root ~playground_root ~repo_name =
+  Filename.concat (repos_root_of_playground_root playground_root) repo_name
+  |> normalize_path
+
 let safe_repo_component s =
   s <> ""
   && s <> "."
@@ -25,6 +32,20 @@ let safe_repo_component s =
           || c = '.')
        s
 
+let candidate_repo_roots_no_create ~base_path ~keeper_id ~repository_id =
+  if not (safe_repo_component repository_id)
+  then []
+  else
+    [ Keeper_types_profile_sandbox.Local; Keeper_types_profile_sandbox.Docker ]
+    |> List.map (fun sandbox_profile ->
+      let playground_root =
+        Filename.concat
+          base_path
+          (Keeper_sandbox.host_root_rel_of_profile sandbox_profile keeper_id)
+      in
+      repo_root_of_playground_root ~playground_root ~repo_name:repository_id)
+    |> List.sort_uniq String.compare
+
 type path_context =
   { path_repo_name : string
   ; path_repo_root : string
@@ -37,7 +58,7 @@ let classify_path ~(config : Workspace.config) ~(meta : keeper_meta) ~path =
     playground_root_no_create ~config ~meta
     |> normalize_path
   in
-  let repos_root = Filename.concat playground "repos" |> normalize_path in
+  let repos_root = repos_root_of_playground_root playground in
   let path = normalize_path path in
   if String.equal path repos_root then None
   else
@@ -49,7 +70,7 @@ let classify_path ~(config : Workspace.config) ~(meta : keeper_meta) ~path =
       in
       match String.split_on_char '/' suffix with
       | repo_name :: _ when safe_repo_component repo_name ->
-        let repo_root = Filename.concat repos_root repo_name |> normalize_path in
+        let repo_root = repo_root_of_playground_root ~playground_root:playground ~repo_name in
         Some
           { path_repo_name = repo_name
           ; path_repo_root = repo_root

--- a/lib/keeper/keeper_sandbox_repo_path.mli
+++ b/lib/keeper/keeper_sandbox_repo_path.mli
@@ -9,6 +9,16 @@ val normalize_path : string -> string
 val playground_root_no_create :
   config:Workspace.config -> meta:Keeper_meta_contract.keeper_meta -> string
 
+val candidate_repo_roots_no_create :
+  base_path:string ->
+  keeper_id:string ->
+  repository_id:string ->
+  string list
+(** Candidate host-side sandbox repo roots for [repository_id] under
+    [keeper_id]'s known sandbox backends. Returns [[]] when [repository_id] is
+    not a safe single path component. This performs no filesystem mutation and
+    does not require the keeper registry. *)
+
 type path_context =
   { path_repo_name : string
   ; path_repo_root : string

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -179,7 +179,13 @@ let test_registered_repo_outside_advisory_mapping_is_allowed () =
   Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
 ;;
 
-let test_unregistered_repository_does_not_request_hitl () =
+let playground_repo_root ~base_path ~keeper_id ~repository_id =
+  Filename.concat
+    base_path
+    (Filename.concat (Playground_paths.repos_path keeper_id) repository_id)
+;;
+
+let test_unregistered_repository_without_clone_does_not_request_hitl () =
   AQ.For_testing.reset_audit_store ();
   Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
   with_temp_base_path @@ fun base_path ->
@@ -202,7 +208,7 @@ let test_unregistered_repository_does_not_request_hitl () =
        (contains_substring detail "not-registered")
    | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
    | Claim.Access_denied_hitl_pending _ ->
-     Alcotest.fail "direct repository id request must not create HITL");
+     Alcotest.fail "repository id without clone must not create HITL");
   Alcotest.(check int) "pending count unchanged" pending_before (AQ.pending_count ())
 ;;
 
@@ -228,6 +234,47 @@ let string_field key json =
       "expected string field %s, got %s"
       key
       (Yojson.Safe.to_string other)
+;;
+
+let test_unregistered_repository_id_with_clone_requests_hitl () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-direct-register" in
+    write_repositories base_path [];
+    let repo_root =
+      playground_repo_root ~base_path ~keeper_id ~repository_id:"not-registered"
+    in
+    init_git_repo repo_root "https://github.com/test/not-registered.git";
+    let pending_before = AQ.pending_count () in
+    let result =
+      Claim.request_repository_access
+        ~keeper_id
+        ~base_path
+        ~repository_id:"not-registered"
+    in
+    (match result with
+     | Claim.Access_denied_hitl_pending { detail; approval_id } ->
+       Alcotest.(check bool)
+         "denial mentions unregistered repository"
+         true
+         (contains_substring detail "not-registered");
+       Alcotest.(check bool) "approval id nonempty" true (String.trim approval_id <> "")
+     | Claim.Access_allowed -> Alcotest.fail "expected unregistered denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected HITL pending denial, got: " ^ detail));
+    Alcotest.(check int) "pending count increments" (pending_before + 1) (AQ.pending_count ());
+    let pending = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "requested action"
+      "register_repository"
+      (string_field "requested_action" pending.input);
+    Alcotest.(check string)
+      "repo root"
+      (canonical_path repo_root)
+      (string_field "repo_root" pending.input))
 ;;
 
 let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
@@ -360,6 +407,45 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
 	        (List.exists (String.equal "masc-mcp") repo.aliases))
 	;;
 
+let test_unregistered_repository_id_clone_matching_existing_remote_requests_alias () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    AQ.For_testing.reset_audit_store ();
+    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "keeper-repo-direct-alias" in
+    let registered = sample_repo ~base_path "masc" in
+    let registered =
+      { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
+    in
+    write_repositories base_path [ registered ];
+    let repo_root =
+      playground_repo_root ~base_path ~keeper_id ~repository_id:"masc-mcp"
+    in
+    init_git_repo repo_root registered.url;
+    let result =
+      Claim.request_repository_access
+        ~keeper_id
+        ~base_path
+        ~repository_id:"masc-mcp"
+    in
+    (match result with
+     | Claim.Access_denied_hitl_pending _ -> ()
+     | Claim.Access_allowed -> Alcotest.fail "expected alias HITL denial"
+     | Claim.Access_denied detail ->
+       Alcotest.fail ("expected alias HITL pending denial, got: " ^ detail));
+    let pending = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "requested action"
+      "add_repository_alias"
+      (string_field "requested_action" pending.input);
+    Alcotest.(check string)
+      "target repository"
+      "masc"
+      (string_field "target_repository_id" pending.input);
+    Alcotest.(check string) "alias" "masc-mcp" (string_field "alias" pending.input))
+;;
+
 let test_nested_git_root_queues_manual_review_without_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
@@ -459,9 +545,13 @@ let () =
             `Quick
             test_registered_repo_outside_advisory_mapping_is_allowed
         ; Alcotest.test_case
-            "unregistered repository remains fail-closed"
+            "unregistered repository without clone remains fail-closed"
             `Quick
-            test_unregistered_repository_does_not_request_hitl
+            test_unregistered_repository_without_clone_does_not_request_hitl
+        ; Alcotest.test_case
+            "unregistered repository id with clone queues repository HITL"
+            `Quick
+            test_unregistered_repository_id_with_clone_requests_hitl
         ; Alcotest.test_case
             "unregistered sandbox clone queues registration HITL"
             `Quick
@@ -470,17 +560,21 @@ let () =
             "registration approval rechecks clone origin"
             `Quick
             test_registration_approval_rechecks_clone_origin
-	        ; Alcotest.test_case
-	            "clone name mismatch queues alias HITL"
-	            `Quick
-	            test_unregistered_clone_matching_existing_remote_requests_alias
+        ; Alcotest.test_case
+            "clone name mismatch queues alias HITL"
+            `Quick
+            test_unregistered_clone_matching_existing_remote_requests_alias
+        ; Alcotest.test_case
+            "repository id clone name mismatch queues alias HITL"
+            `Quick
+            test_unregistered_repository_id_clone_matching_existing_remote_requests_alias
         ; Alcotest.test_case
             "nested git root queues manual review without alias"
             `Quick
             test_nested_git_root_queues_manual_review_without_alias
-	        ; Alcotest.test_case
-	            "alias approval rechecks clone origin"
-	            `Quick
+        ; Alcotest.test_case
+            "alias approval rechecks clone origin"
+            `Quick
             test_alias_approval_rechecks_clone_origin
         ] )
     ]

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -446,6 +446,27 @@ let test_unregistered_repository_id_clone_matching_existing_remote_requests_alia
     Alcotest.(check string) "alias" "masc-mcp" (string_field "alias" pending.input))
 ;;
 
+let test_unregistered_repository_id_empty_clone_reports_verification_failure () =
+  with_temp_base_path @@ fun base_path ->
+  let keeper_id = "keeper-repo-direct-empty-clone" in
+  let repository_id = "masc-empty" in
+  let repo_root = playground_repo_root ~base_path ~keeper_id ~repository_id in
+  ensure_dir repo_root;
+  match Claim.request_repository_access ~keeper_id ~base_path ~repository_id with
+  | Claim.Access_allowed -> Alcotest.fail "expected explicit verification denial"
+  | Claim.Access_denied_hitl_pending _ ->
+    Alcotest.fail "empty clone directory must not queue HITL"
+  | Claim.Access_denied detail ->
+    Alcotest.(check bool)
+      "denial names clone verification"
+      true
+      (contains_substring detail "playground clone candidate could not be verified");
+    Alcotest.(check bool)
+      "denial keeps git probe reason"
+      true
+      (contains_substring detail repo_root)
+;;
+
 let test_nested_git_root_queues_manual_review_without_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
@@ -568,6 +589,10 @@ let () =
             "repository id clone name mismatch queues alias HITL"
             `Quick
             test_unregistered_repository_id_clone_matching_existing_remote_requests_alias
+        ; Alcotest.test_case
+            "repository id empty clone reports verification failure"
+            `Quick
+            test_unregistered_repository_id_empty_clone_reports_verification_failure
         ; Alcotest.test_case
             "nested git root queues manual review without alias"
             `Quick


### PR DESCRIPTION
Follow-up to #23592.

P0
- Fixes the path-based access flow so that a Read/Grep resolving to an *unregistered* repository that has a physically present, verifiable sandbox clone no longer collapses to `Repository <id> is not registered; access not allowed`. The path flow (`request_path_access`) now derives a repo-id-based clone-registration HITL candidate (via `request_repository_access`) before its existing path-based candidate fallback.
- Live callers exercised: `keeper_tool_filesystem_runtime.ml` and `keeper_workspace_read_ops.ml` → `request_path_access` → (internal) `request_repository_access`.

Scope note (claim downgraded after self-review, ref caller-graph)
- `request_repository_access` is also exposed in the `.mli` as a *direct* repository-id entry point, but it currently has **no live direct caller** — only `request_path_access` (internal) and regression tests reach it. So the value delivered by this PR is the **path-flow improvement above**, not a live "direct repository-id access request" fix. The direct repo-id-clone entry wiring is deferred to the repo-id-clone follow-up (playground repo-access cluster #23590/#23609, to be adjudicated under RFC-0322).

P1
- Keeps fail-closed behavior when there is no clone or the clone cannot be verified.
- Existing registered repository access remains allowed; per-keeper repo mappings stay advisory/default-scope metadata, not authorization caps.

P2
- Centralizes candidate sandbox repo root calculation in `Keeper_sandbox_repo_path.candidate_repo_roots_no_create`, using safe single-component repository ids and known Local/Docker sandbox roots.
- Adds repository-id regressions (test-only coverage of the direct entry point) for both new registration and the `masc` catalog / `masc-mcp` clone-name alias case.

P3
- This is a draft follow-up because #23592 is already merged.

Validation
- `ocamlformat --check lib/keeper/keeper_sandbox_repo_path.ml lib/keeper/keeper_sandbox_repo_path.mli lib/keeper/keeper_repo_claim_hitl.ml lib/keeper/keeper_repo_claim_hitl.mli test/test_keeper_repo_claim_hitl.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_SKIP_OCAML_VERSION_CHECK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_repo_claim_hitl.exe test/test_keeper_tool_search_files_containment.exe`
- `./_build/default/test/test_keeper_repo_claim_hitl.exe` pass: 9 tests
- `./_build/default/test/test_keeper_tool_search_files_containment.exe` pass: 18 tests
