### PR TITLE
feat(keeper): steer HITL approval continuation back to conversation (RFC-0320 W3b)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1556,24 +1556,28 @@ let expire_stale ~max_wait_s =
          ~decision:(Approval_expired reason)
          ~continuation_channel:entry.continuation_channel
          ();
-       (* Expiry clears the [Approval_pending] skip just like a resolution, so
-          the keeper needs the same wake or it stays stalled until an unrelated
-          stimulus. The keeper's suspended tool call (if any) receives
-          [Reject reason]. *)
-       wake_keeper_on_approval_resolution
-         ~base_path:entry.audit_base_path
-         ~keeper_name:entry.keeper_name
-         ~approval_id:id
-         ~decision:Keeper_event_queue.Hitl_rejected
-         ~continuation_channel:entry.continuation_channel;
-       (match entry.resolver with
-        | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
-        | None -> ());
-       match entry.on_resolution with
-       | Some f ->
+      (* Expiry clears the [Approval_pending] skip just like a resolution, so
+         the keeper needs the same wake or it stays stalled until an unrelated
+         stimulus. The keeper's suspended tool call (if any) receives
+         [Reject reason]. *)
+      (match entry.resolver with
+       | Some resolver ->
+         (* Blocking entries already resume through the live resolver; keep this
+            path single-rail and skip synthetic wake. *)
+         Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
+       | None ->
+         wake_keeper_on_approval_resolution
+           ~base_path:entry.audit_base_path
+           ~keeper_name:entry.keeper_name
+           ~approval_id:id
+           ~decision:Keeper_event_queue.Hitl_rejected
+           ~continuation_channel:entry.continuation_channel);
+      (match entry.resolver, entry.on_resolution with
+       | None, Some f ->
          Cancel_safe.observe
            ~on_exn:(fun exn ->
-             Otel_metric_store.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string LifecycleCallbackFailures)
                ~labels:[ ("keeper", entry.keeper_name); ("callback", "on_approval_expire") ]
                ();
              Otel_metric_store.inc_counter
@@ -1585,6 +1589,7 @@ let expire_stale ~max_wait_s =
                id
                (Printexc.to_string exn))
            (fun () -> f (Agent_sdk.Hooks.Reject reason))
-       | None -> ())
-    stale
+       | Some _, _ | None, None -> ());
+  )
+  stale
 ;;

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -826,15 +826,15 @@ let spawn_hitl_summary_worker_on_root_switch ~(entry : pending_approval) =
        record_summary_failure ~id:entry.id ~reason ~retryable:false)
 ;;
 
-(* Wake the keeper that was waiting on this approval. A keeper that enqueued an
-   approval and is now skipping cycles via [has_pending_for_keeper -> Skip
-   Approval_pending] (keeper_world_observation) has no in-process fiber blocked
-   on the resolver promise, so resolving the promise does not resume it. The
-   composition root registers a hook that enqueues a [Hitl_resolved] wake
-   stimulus — the same async-completion-wake mechanism [Fusion_completed]
-   (RFC-0266) and [Bg_completed] (RFC-0290) use — so the keeper re-evaluates
-   immediately instead of stalling until an unrelated stimulus, no-progress
-   recovery, or the 30-minute approval janitor.
+(* Wake the keeper for non-blocking approvals. A [submit_and_await] entry has an
+   in-process resolver promise; resolving that promise resumes the suspended
+   tool call directly, so an additional [Hitl_resolved] stimulus would open a
+   second turn with only a soft prompt guard against duplicate replies.
+
+   A [submit_pending] entry has no resolver promise. Its [on_resolution]
+   callback handles side effects, and the keeper still needs a durable
+   [Hitl_resolved] wake so its lane re-evaluates instead of stalling until an
+   unrelated stimulus, no-progress recovery, or the 30-minute approval janitor.
 
    Injected as a hook rather than a direct call to break a dependency cycle:
    this module sits below [Keeper_keepalive_signal], which depends on
@@ -916,11 +916,14 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
            (Printexc.to_string exn))
        (fun () -> f decision)
    | None -> ());
-  wake_keeper_on_approval_resolution
-    ~base_path
-    ~keeper_name:entry.keeper_name
-    ~approval_id:entry.id
-    ~decision:(hitl_resolution_decision_of_approval_decision decision);
+  (match entry.resolver with
+   | Some _ -> ()
+   | None ->
+     wake_keeper_on_approval_resolution
+       ~base_path
+       ~keeper_name:entry.keeper_name
+       ~approval_id:entry.id
+       ~decision:(hitl_resolution_decision_of_approval_decision decision));
   try
     Sse.broadcast
       (`Assoc

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -312,8 +312,10 @@ val submit_pending :
 
 (** {1 Resolve (operator action)} *)
 
-(** Install the hook that wakes a keeper when one of its pending approvals is
-    resolved or expires. Injected (rather than a direct
+(** Install the hook that wakes a keeper when a non-blocking pending approval
+    is resolved or expires. Blocking [submit_and_await] entries resume through
+    their resolver promise and must not also enqueue a [Hitl_resolved] wake.
+    Injected (rather than a direct
     [Keeper_keepalive_signal] call) to break a dependency cycle: this module
     sits below [Keeper_keepalive_signal], which depends on
     [Keeper_world_observation], which depends back here for

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -317,8 +317,10 @@ val submit_pending :
 (** {1 Resolve (operator action)} *)
 
 (** Install the hook that wakes a keeper when a non-blocking pending approval
-    is resolved or expires. Blocking [submit_and_await] entries resume through
-    their resolver promise and must not also enqueue a [Hitl_resolved] wake.
+    is resolved or expired. Blocking [submit_and_await] entries resolve through
+    their resolver promise and must not also enqueue a [Hitl_resolved] wake. This
+    includes the stale-expiry path: expiry must preserve resolver-first behavior for
+    blocking entries and only wake non-blocking entries.
     Injected (rather than a direct
     [Keeper_keepalive_signal] call) to break a dependency cycle: this module
     sits below [Keeper_keepalive_signal], which depends on

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -101,18 +101,23 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
     Some Keeper_world_observation.Scheduled_automation_stimulus
   | Keeper_event_queue.Connector_attention _ ->
     Some Keeper_world_observation.Connector_attention_stimulus
+  | Keeper_event_queue.Hitl_resolved _ ->
+    (* RFC-0320 W3b: give the HITL-resolution wake a dedicated turn_reason so
+       the prompt can steer the keeper back to the originating conversation
+       instead of silently proceeding on its own state. The [Approval_pending]
+       skip is already gone (the approval left the queue); this changes only
+       how the resumed turn is described, not whether it runs. *)
+    Some Keeper_world_observation.Hitl_resolved_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Fusion_completed _
   | Keeper_event_queue.Bg_completed _
-  | Keeper_event_queue.Hitl_resolved _
   | Keeper_event_queue.Goal_verification_failed _
   | Keeper_event_queue.Failure_judgment _
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_stagnation _ ->
     (* No dedicated turn_reason: like the other async-completion wakes, the
-       stimulus itself forces the keeper to re-run its cycle. Once the resolved
-       approval has left the queue the keeper no longer skips on
-       [Approval_pending] and proceeds on its own state. *)
+       stimulus itself forces the keeper to re-run its cycle and proceed on its
+       own state. *)
     None
 ;;
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -744,13 +744,38 @@ let autonomous_trigger_lines
          still render in their own layers; event-queue stimuli (bootstrap,
          no-progress recovery, schedule-due, connector attention) surface
          ONLY here — before this arm the model had no trace of why it woke. *)
-      "- Scheduler: reactive turn (external stimulus)."
-      :: (match
-            Keeper_world_observation.verdict_reasons_to_strings decision.verdict
-          with
-          | [] -> []
-          | reasons ->
-              [ Printf.sprintf "- Reasons: %s" (String.concat ", " reasons) ])
+      let hitl_continuation_steer =
+        (* RFC-0320 W3b: when this reactive turn was opened by a resolved HITL
+           approval, steer the keeper back to the conversation it asked from.
+           The routing (which surface) stays the keeper's own recent context;
+           this only tells it to answer there rather than proceed silently. A
+           keeper whose original turn already resumed (fast approval) can
+           ignore this soft line, so it does not force a duplicate reply. *)
+        let has_hitl_resolution =
+          match decision.verdict with
+          | Keeper_world_observation.Run { reasons = first, rest } ->
+              List.exists
+                (function
+                  | Keeper_world_observation.Hitl_resolved_pending -> true
+                  | _ -> false)
+                (first :: rest)
+          | Keeper_world_observation.Skip _ -> false
+        in
+        if has_hitl_resolution then
+          [ "- Continuation: an approval you were waiting on was just resolved. \
+             If you requested it inside a conversation (dashboard / Discord / \
+             Slack), reply back into that conversation with keeper_surface_post \
+             instead of only proceeding on your own state." ]
+        else []
+      in
+      ("- Scheduler: reactive turn (external stimulus)."
+       :: (match
+             Keeper_world_observation.verdict_reasons_to_strings decision.verdict
+           with
+           | [] -> []
+           | reasons ->
+               [ Printf.sprintf "- Reasons: %s" (String.concat ", " reasons) ]))
+      @ hitl_continuation_steer
   | _ -> []
 
 let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -129,6 +129,7 @@ type event_queue_trigger =
   | No_progress_recovery_stimulus
   | Scheduled_automation_stimulus
   | Connector_attention_stimulus
+  | Hitl_resolved_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -137,6 +138,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
   | Connector_attention_pending
+  | Hitl_resolved_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -186,6 +186,7 @@ type event_queue_trigger =
   | No_progress_recovery_stimulus
   | Scheduled_automation_stimulus
   | Connector_attention_stimulus
+  | Hitl_resolved_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -196,6 +197,7 @@ type turn_reason =
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
   | Connector_attention_pending
+  | Hitl_resolved_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of { idle_sec : int; cooldown : int }

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -35,6 +35,12 @@ type event_queue_trigger =
           recorded as Keeper_external_attention. Edge-triggered (dequeued once),
           carries an event_id pointer (not content). Dormant until a producer
           enqueues it (P3). *)
+  | Hitl_resolved_stimulus
+      (** RFC-0320 W3b: an operator resolved a gated-tool approval this keeper
+          was waiting on. When the original turn already ended (the approval
+          outlived it), the wake arrives with no live tool call to resume, so
+          the keeper must be steered back to the originating conversation
+          instead of proceeding on its own state. *)
 
 type turn_reason =
   | Mention_pending
@@ -43,6 +49,7 @@ type turn_reason =
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
   | Connector_attention_pending
+  | Hitl_resolved_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of
@@ -82,6 +89,7 @@ let turn_reason_to_string = function
   | Bootstrap_stimulus_pending -> "bootstrap_stimulus_pending"
   | No_progress_recovery_stimulus_pending -> "no_progress_recovery_stimulus_pending"
   | Connector_attention_pending -> "connector_attention_pending"
+  | Hitl_resolved_pending -> "hitl_resolved_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
@@ -97,6 +105,7 @@ let turn_reason_of_event_queue_trigger = function
   | No_progress_recovery_stimulus -> No_progress_recovery_stimulus_pending
   | Scheduled_automation_stimulus -> Scheduled_automation_due
   | Connector_attention_stimulus -> Connector_attention_pending
+  | Hitl_resolved_stimulus -> Hitl_resolved_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -12,6 +12,11 @@ type event_queue_trigger =
       (** RFC-connector-ambient-attention-wake P1: ambient connector message
           recorded as external attention; edge-triggered, carries an event_id
           pointer. Dormant until a producer enqueues it (P3). *)
+  | Hitl_resolved_stimulus
+      (** RFC-0320 W3b: an operator resolved a gated-tool approval this keeper
+          waited on; when the original turn already ended, the wake has no live
+          tool call to resume and must steer the keeper back to the originating
+          conversation. *)
 
 type turn_reason =
   | Mention_pending
@@ -20,6 +25,7 @@ type turn_reason =
   | Bootstrap_stimulus_pending
   | No_progress_recovery_stimulus_pending
   | Connector_attention_pending
+  | Hitl_resolved_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -112,11 +112,12 @@ let test_fresh_critical_entry_phase_is_awaiting_operator () =
        | None -> Alcotest.fail "Critical approval did not resume after resolve")
 ;;
 
-(* A keeper skipping cycles on [Approval_pending] is not blocked in-process, so
-   resolving must fire the wake hook that enqueues a [Hitl_resolved] stimulus.
-   Without it the keeper only resumes on an unrelated stimulus / no-progress
-   recovery / the 30-minute janitor (the reported "HITL 됐는데 핑을 못 받음"). *)
-let test_resolve_fires_keeper_wake_hook () =
+(* Blocking approvals resume through their live resolver. Non-blocking
+   approvals have no suspended fiber, so resolving them must fire the wake hook
+   that enqueues a [Hitl_resolved] stimulus. Without that wake the keeper only
+   resumes on an unrelated stimulus / no-progress recovery / the 30-minute
+   janitor (the reported "HITL 됐는데 핑을 못 받음"). *)
+let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
   Eio_main.run
   @@ fun _env ->
   let base_path = temp_dir () in
@@ -156,7 +157,45 @@ let test_resolve_fires_keeper_wake_hook () =
         | Ok () -> ()
         | Error err ->
           Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
-       (* resolve_entry fires the hook synchronously before returning. *)
+       (match !woke with
+        | Some _ -> Alcotest.fail "live resolver must resume directly without wake hook"
+        | None -> ());
+       yield_until (fun () -> Option.is_some !result))
+;;
+
+let test_submit_pending_resolve_fires_keeper_wake_hook () =
+  Eio_main.run
+  @@ fun _env ->
+  let base_path = temp_dir () in
+  let woke = ref None in
+  AQ.set_approval_resolution_wake_hook (fun ~base_path:_ ~keeper_name ~approval_id ~decision ->
+    woke := Some (keeper_name, approval_id, decision));
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.set_approval_resolution_wake_hook
+        (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ -> ());
+      cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "pending-resolve-wake-test" in
+       let callback_decision = ref None in
+       let id =
+         AQ.submit_pending
+           ~keeper_name
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "critical_gate" ])
+           ~risk_level:AQ.Critical
+           ~base_path
+           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ()
+       in
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       Alcotest.(check bool)
+         "on_resolution callback ran"
+         true
+         (Option.is_some !callback_decision);
        (match !woke with
         | Some (kn, aid, decision) ->
           Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
@@ -165,8 +204,7 @@ let test_resolve_fires_keeper_wake_hook () =
             "wake carries the typed decision label"
             true
             (decision = Keeper_event_queue.Hitl_approved)
-        | None -> Alcotest.fail "resolve did not fire the keeper wake hook");
-       yield_until (fun () -> Option.is_some !result))
+        | None -> Alcotest.fail "non-blocking resolve did not fire the keeper wake hook"))
 ;;
 
 let test_critical_entry_phase_becomes_escalated_after_timer () =
@@ -463,9 +501,13 @@ let () =
         ] )
     ; ( "wake"
       , [ Alcotest.test_case
-            "resolve fires the keeper wake hook"
+            "submit_and_await resolve resumes directly without wake hook"
             `Quick
-            test_resolve_fires_keeper_wake_hook
+            test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook
+        ; Alcotest.test_case
+            "submit_pending resolve fires the keeper wake hook"
+            `Quick
+            test_submit_pending_resolve_fires_keeper_wake_hook
         ] )
     ; ( "summary"
       , [ Alcotest.test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -329,6 +329,123 @@ let test_resolution_wake_carries_originating_continuation_channel () =
         Alcotest.fail "missing connector must not synthesize a routable channel")
 ;;
 
+let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
+  Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  let woke = ref false in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~continuation_channel:_ ->
+      woke := true);
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.set_approval_resolution_wake_hook
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~continuation_channel:_ ->
+          ())
+      ; cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "expire-stale-await-no-wake-test" in
+       let result = ref None in
+       Eio.Switch.run
+       @@ fun sw ->
+       Eio.Fiber.fork ~sw (fun () ->
+         let decision =
+           AQ.submit_and_await
+             ~keeper_name
+             ~tool_name:"keeper_continue_after_reconcile"
+             ~input:(`Assoc [ "kind", `String "medium_gate" ])
+             ~risk_level:AQ.Medium
+             ~base_path
+             ()
+         in
+         result := Some decision);
+       yield_until (fun () -> Option.is_some (pending_id_for_keeper ~keeper_name));
+       AQ.expire_stale ~max_wait_s:0.0;
+       yield_until (fun () -> Option.is_some !result);
+       Alcotest.(check bool) "expire path resolves blocking entry via resolver" true
+         (Option.is_some !result);
+       (match !result with
+        | Some (Agent_sdk.Hooks.Reject _reason) -> ()
+        | Some _ -> Alcotest.fail "expire path should reject in stale blocking entry"
+        | None -> Alcotest.fail "blocking stale entry should resolve");
+       Alcotest.(check bool) "blocking stale resolution does not fire keeper wake hook" true
+         (not !woke))
+;;
+
+let test_expire_stale_submit_pending_fires_wake_hook () =
+  let base_path = temp_dir () in
+  let woke = ref None in
+  let resolved = ref None in
+  let continuation_channel =
+    Chat_queue.continuation_channel_of_message_source
+      ~dashboard_thread_id:"dashboard-thread-1"
+      Chat_queue.Dashboard
+  in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_
+      ~keeper_name
+      ~approval_id
+      ~decision
+      ~continuation_channel ->
+      woke := Some (keeper_name, approval_id, decision, continuation_channel));
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.set_approval_resolution_wake_hook
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~continuation_channel:_ ->
+          ())
+      ; cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "expire-stale-pending-wake-test" in
+       let id =
+         AQ.submit_pending
+           ~keeper_name
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~continuation_channel
+           ~on_resolution:(fun decision -> resolved := Some decision)
+           ()
+       in
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool) "on_resolution callback runs on stale expiry" true
+         (Option.is_some !resolved);
+       (match !woke with
+        | Some
+            (keeper, wake_id, decision, wake_channel) ->
+          Alcotest.(check string)
+            "wake carries waiting keeper"
+            keeper_name
+            keeper;
+          Alcotest.(check string)
+            "wake carries matching approval id"
+            id
+            wake_id;
+          Alcotest.(check bool)
+            "wake carries reject decision"
+            true
+            (decision = Keeper_event_queue.Hitl_rejected);
+          Alcotest.(check bool)
+            "wake channel is preserved on stale expiry"
+            true
+            (Keeper_continuation_channel.same_route
+               continuation_channel
+               wake_channel)
+        | None -> Alcotest.fail "submit_pending stale expiry must fire wake hook")
+       )
+;;
+
 let test_critical_entry_phase_becomes_escalated_after_timer () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -621,7 +738,7 @@ let () =
             `Quick
             test_critical_entry_phase_becomes_escalated_after_timer
         ] )
-    ; ( "wake"
+      ; ( "wake"
       , [ Alcotest.test_case
             "submit_and_await resolve resumes directly without wake hook"
             `Quick
@@ -630,6 +747,14 @@ let () =
             "submit_pending resolve fires the keeper wake hook"
             `Quick
             test_submit_pending_resolve_fires_keeper_wake_hook
+        ; Alcotest.test_case
+            "expire_stale does not fire wake for blocking submit_and_await"
+            `Quick
+            test_expire_stale_submit_and_await_does_not_fire_wake_hook
+        ; Alcotest.test_case
+            "expire_stale fires wake for non-blocking submit_pending"
+            `Quick
+            test_expire_stale_submit_pending_fires_wake_hook
         ; Alcotest.test_case
             "resolution wake carries originating continuation channel"
             `Quick

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -235,6 +235,22 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
   check bool "bootstrap reason listed" true
     (contains ~needle:"bootstrap" threaded)
 
+let test_hitl_resolution_steers_continuation () =
+  (* RFC-0320 W3b: a Hitl_resolved event-queue stimulus opens a reactive turn
+     whose prompt steers the keeper back to the originating conversation via
+     keeper_surface_post instead of only proceeding on its own state. *)
+  let decision =
+    WO.keeper_cycle_decision
+      ~event_queue_triggers:[ WO.Hitl_resolved_stimulus ]
+      ~meta base_observation
+  in
+  check bool "fixture: hitl decision runs" true decision.WO.should_run;
+  let threaded = user_message ~turn_decision:decision base_observation in
+  check bool "continuation steers a keeper_surface_post reply" true
+    (contains ~needle:"keeper_surface_post" threaded);
+  check bool "continuation names the resolved approval" true
+    (contains ~needle:"approval you were waiting on was just resolved" threaded)
+
 let test_legacy_recompute_renders_no_reason_on_empty_world () =
   (* Same empty world without the threaded decision: the recompute sees no
      trigger, so no wake-reason section renders — the pre-RFC-0315 blindness
@@ -353,6 +369,8 @@ let () =
         [
           test_case "stimulus decision renders wake reason" `Quick
             test_threaded_stimulus_decision_renders_wake_reason;
+          test_case "hitl resolution steers continuation reply" `Quick
+            test_hitl_resolution_steers_continuation;
           test_case "legacy recompute stays blind on empty world" `Quick
             test_legacy_recompute_renders_no_reason_on_empty_world;
         ] );


### PR DESCRIPTION
## 목적

RFC-0320 W3b — HITL(operator 승인) continuation. keeper가 gated tool 승인을 기다리다 원 turn이 종료된 뒤 승인이 도착하면, 원 대화로 돌아가 답하도록 유도합니다. W1·W2(#23623 main 착지) + W3a(#23628 mention)에 이어집니다.

## 근본원인 (실측 확정)

`submit_and_await`는 원 turn을 `Eio.Promise.await`로 블로킹 대기시키므로, **timeout(600s) 이내 승인하면 원 turn이 resume돼 채널로 답합니다(이미 작동)**. 문제는 원 turn이 종료된 뒤 승인이 오는 경우입니다:

- `system_log_2026-07-08` 실측: `hitl resolution wake decision=approve` → **2분 17초 뒤** `delivered`, 게다가 **중복 delivery**. 블로킹 resume이면 즉시 연속이어야 하므로, 이는 원 turn이 없어 `Hitl_resolved` wake만 남고 keeper가 자기상태로 진행(원 대화 복귀 안 함)하는 (ii) 경로입니다.
- 기존 intake는 `Hitl_resolved`에 대해 `[]`(no observation)을 반환하고 `event_queue_trigger_of_stimulus`가 `None`이라, wake가 keeper prompt에 **표현조차 되지 않았습니다**.

## 이 PR (W3b)

`Hitl_resolved` wake에 typed turn_reason을 부여해 prompt가 keeper를 원 대화로 유도합니다.

- `turn_types` + `keeper_world_observation` (ml/mli): `Hitl_resolved_stimulus` / `Hitl_resolved_pending` typed variant (catch-all 없음 — 새 wake reason이 모든 match에 arm을 강제).
- `keeper_heartbeat_stimulus_intake`: `Hitl_resolved` → `Some Hitl_resolved_stimulus`. **typed turn_reason이지 fabricated pending observation이 아닙니다** — intake 주석이 경고한 안티패턴("injecting a pending event")을 피합니다.
- `keeper_unified_prompt`: wake reason에 게이팅된 **soft continuation steer** — "an approval you were waiting on was just resolved — reply into that conversation with keeper_surface_post instead of only proceeding on your own state." 블로킹-resume으로 이미 답한 turn은 이 soft 라인을 무시할 수 있어 중복 답을 강제하지 않습니다.

라우팅(어느 대화)은 keeper의 최근 컨텍스트로 결정론적, 무엇을 말할지는 LLM 판단(RFC-0320 §2 경계). 기존 blocking-resume 경로는 변경 없음.

## 검증

- `test_keeper_wake_turn_context`: `Hitl_resolved_stimulus` decision이 should_run=true + continuation steer(`keeper_surface_post` + "approval you were waiting on") 렌더. **10 tests run, green.**
- 전체 빌드 green, `ocamlformat --check` clean.

## 범위 밖

- **chat queue edge case**: 이미 구현된 경로(consumer + broadcast + FE hydrate)라 재현 정보 필요, 별개.
- **W3b 결정론적 auto-deliver**: 이 PR은 prompt steer(LLM이 도구 호출). finalize seam에서 강제 delivery는 RFC-0320 청사진의 후속.

RFC: `docs/rfc/RFC-0320-keeper-connector-aware-continuation.md` (#23623 main 착지)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
