### PR TITLE
fix: use resolve_claim_goal_scope (backlog-aware) in claim_goal_scope_filter

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -92,15 +92,16 @@ let meta_only_claim_goal_scope ?task_goal_index (meta : keeper_meta) =
    (scope-version tokens) is a separate, unimplemented direction; this is the
    stopgap, reinstated by operator decision, not that design.
 
-   Reads the backlog ([get_tasks_safe], a disk read) to test for a claimable
-   scoped task. Kept on the claim path only — NOT the per-turn observation path
-   ([resolve_observation_claim_goal_scope]), which stays pure-meta to avoid
-   adding a per-keeper, per-cycle backlog read. *)
-let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) () =
+   [resolve_claim_goal_scope] reads the backlog ([get_tasks_safe], a disk read)
+   to test for a claimable scoped task. Call
+   [resolve_claim_goal_scope_for_tasks] when the caller already loaded the
+   backlog. Kept off the pure signal-only observation resolver
+   ([resolve_observation_claim_goal_scope]). *)
+let resolve_claim_goal_scope_for_tasks ~(config : Workspace.config)
+    ~(meta : keeper_meta) ~(tasks : Masc_domain.task list) () =
   match meta.active_goal_ids with
   | [] -> meta_only_claim_goal_scope meta
   | goal_ids ->
-    let tasks = Workspace.get_tasks_safe config in
     let task_goal_index = Workspace_goal_index.build_task_goal_index_for_config config in
     let scoped_claimable_exists =
       List.exists (fun task ->
@@ -120,6 +121,10 @@ let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) 
         effective_goal_ids = goal_ids;
         fallback_reason = Some "no_scoped_claimable_tasks";
       }
+
+let resolve_claim_goal_scope ~(config : Workspace.config) ~(meta : keeper_meta) () =
+  let tasks = Workspace.get_tasks_safe config in
+  resolve_claim_goal_scope_for_tasks ~config ~meta ~tasks ()
 
 let resolve_observation_claim_goal_scope ~(config : Workspace.config)
     ~(meta : keeper_meta) () =

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -26,6 +26,15 @@ val resolve_claim_goal_scope :
   unit ->
   claim_goal_scope
 
+val resolve_claim_goal_scope_for_tasks :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  tasks:Masc_domain.task list ->
+  unit ->
+  claim_goal_scope
+(** Backlog-aware claim scope for callers that already loaded tasks. This
+    avoids re-reading the backlog while preserving the empty-scope fallback. *)
+
 val resolve_observation_claim_goal_scope :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -19,16 +19,13 @@ let backlog_updated_since_last_scheduled_autonomous
     | None -> false)
 ;;
 
-let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta) () =
-  (* Use [resolve_claim_goal_scope] (backlog-aware, widens filter when no
-     scoped claimable tasks exist) rather than the pure-meta observation
-     variant.  [read_backlog_counts] already reads the backlog, so this
-     does not add a disk read.  Without the widening, a keeper whose active
-     goals carry no live claimable task sees [claimable_task_count = 0]
-     and never wakes for backlog work — the "coordination-role tasks are
-     blocked from re-claim by completion" staleness (task-1869). *)
+let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta)
+    ~(tasks : Masc_domain.task list) () =
+  (* [read_backlog_counts] already loaded [tasks]. Reuse them to get the same
+     empty-scope fallback as the claim path without a second backlog read. *)
   let scope =
-    Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
+    Keeper_runtime_contract.resolve_claim_goal_scope_for_tasks ~config ~meta
+      ~tasks ()
   in
   scope.task_filter
 ;;
@@ -63,7 +60,9 @@ let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
         backlog.tasks
     in
     let unclaimed = List.length unclaimed_tasks in
-    let claim_scope_filter = claim_goal_scope_filter ~config ~meta () in
+    let claim_scope_filter =
+      claim_goal_scope_filter ~config ~meta ~tasks:backlog.tasks ()
+    in
     let claimable =
       List.length
         (List.filter

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -20,8 +20,15 @@ let backlog_updated_since_last_scheduled_autonomous
 ;;
 
 let claim_goal_scope_filter ~(config : Workspace.config) ~(meta : keeper_meta) () =
+  (* Use [resolve_claim_goal_scope] (backlog-aware, widens filter when no
+     scoped claimable tasks exist) rather than the pure-meta observation
+     variant.  [read_backlog_counts] already reads the backlog, so this
+     does not add a disk read.  Without the widening, a keeper whose active
+     goals carry no live claimable task sees [claimable_task_count = 0]
+     and never wakes for backlog work — the "coordination-role tasks are
+     blocked from re-claim by completion" staleness (task-1869). *)
   let scope =
-    Keeper_runtime_contract.resolve_observation_claim_goal_scope ~config ~meta ()
+    Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
   in
   scope.task_filter
 ;;

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -111,6 +111,26 @@ let test_no_scoped_match_falls_back_to_all_tasks () =
         failf "expected fallback claim, got error: %s" msg)
 ;;
 
+let test_preloaded_tasks_fall_back_to_all_tasks () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      add_task ~goal_id:"goal-b" config ~title:"goal b task";
+      let meta = make_meta ~active_goal_ids:[ "goal-a" ] () in
+      let tasks = Workspace.get_tasks_raw config in
+      let scope =
+        Keeper_runtime_contract.resolve_claim_goal_scope_for_tasks ~config
+          ~meta ~tasks ()
+      in
+      check string "fallback mode" "empty_goal_scope_fallback_all_tasks"
+        scope.mode;
+      check (option string) "fallback reason recorded"
+        (Some "no_scoped_claimable_tasks") scope.fallback_reason;
+      check (list string) "effective goal ids preserved" [ "goal-a" ]
+        scope.effective_goal_ids)
+;;
+
 let test_scoped_match_present_keeps_isolation () =
   let config = make_config () in
   Fun.protect
@@ -146,6 +166,8 @@ let () =
             test_scoped_match_present_keeps_isolation
         ; test_case "falls back to all_tasks when no scoped match" `Quick
             test_no_scoped_match_falls_back_to_all_tasks
+        ; test_case "preloaded tasks fall back to all_tasks" `Quick
+            test_preloaded_tasks_fall_back_to_all_tasks
         ] )
     ]
 ;;

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1519,6 +1519,21 @@ let keeper_meta_for_self_filter agent_name =
   | Ok meta -> { meta with active_goal_ids = [] }
   | Error err -> Alcotest.fail ("keeper_meta_for_self_filter failed: " ^ err)
 
+let keeper_meta_for_goal_filter agent_name active_goal_ids =
+  let json =
+    `Assoc
+      [ ("name", `String "goal-filter-keeper")
+      ; ("agent_name", `String agent_name)
+      ; ("trace_id", `String "trace-goal-filter")
+      ; ("goal", `String "goal filter regression")
+      ; ( "active_goal_ids"
+        , `List (List.map (fun goal_id -> `String goal_id) active_goal_ids) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("keeper_meta_for_goal_filter failed: " ^ err)
+
 (* Keepers can claim without a materialized [.masc/agents/] record. The keeper
    backlog failed-task count must exclude the keeper's own claimed task so it
    does not re-trigger a self-wake loop. *)
@@ -1534,6 +1549,23 @@ let test_read_backlog_counts_excludes_self_owned_orphan () =
       Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
     in
     Alcotest.(check int) "keeper's own orphan excluded from failed count" 0 failed
+  )
+
+let test_read_backlog_counts_falls_back_to_unscoped_claimable_task () =
+  with_test_env (fun config ->
+    let keeper = "keeper-goal-filter-agent" in
+    let _ =
+      Workspace.add_task config ~goal_id:"goal-b" ~title:"Goal B work"
+        ~priority:1 ~description:""
+    in
+    let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
+    let _, claimable, _, _, _ =
+      Keeper_world_observation_inputs.read_backlog_counts ~config ~meta
+    in
+    Alcotest.(check int)
+      "claimable count falls back to unscoped todo"
+      1
+      claimable
   )
 
 let test_keeper_tasks_audit_excludes_self_owned_orphan () =
@@ -2051,6 +2083,9 @@ let () =
         test_audit_orphan_spares_keeper_owned_meta_within_grace;
       Alcotest.test_case "read backlog counts excludes self-owned orphan" `Quick
         test_read_backlog_counts_excludes_self_owned_orphan;
+      Alcotest.test_case "read backlog counts falls back to unscoped claimable"
+        `Quick
+        test_read_backlog_counts_falls_back_to_unscoped_claimable_task;
       Alcotest.test_case "keeper tasks audit excludes self-owned orphan" `Quick
         test_keeper_tasks_audit_excludes_self_owned_orphan;
       Alcotest.test_case "cleanup zombies runtime" `Quick test_cleanup_zombies_releases_tasks;


### PR DESCRIPTION
## Summary

Fixes the per-keeper 'claimable' filter staleness (task-1869): coordination-role tasks blocked from re-claim by completion.

## Root cause

`claim_goal_scope_filter` in `keeper_world_observation_inputs.ml:22` was using `resolve_observation_claim_goal_scope` (pure-meta, no backlog read), but the actual claim path uses `resolve_claim_goal_scope` (reads backlog, widens filter when no scoped claimable tasks exist).

Since `read_backlog_counts` already reads the backlog, switching to `resolve_claim_goal_scope` doesn't add a disk read.

## Effect

Without the widening, a keeper whose active goals carry no live claimable task sees `claimable_task_count = 0` and never wakes for backlog work — the 'coordination-role tasks are blocked from re-claim by completion' staleness.

## Changes

- `lib/keeper/keeper_world_observation_inputs.ml`: Changed `claim_goal_scope_filter` to use `resolve_claim_goal_scope` instead of `resolve_observation_claim_goal_scope`

Fixes: task-1869