### PR TITLE
feat(dashboard): keeper background panel on schedule surface (G3)

### DIFF
--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -1,7 +1,11 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { DashboardKeeperWaitingInventory, DashboardScheduledAutomation } from '../../api'
+import type {
+  DashboardKeeperBackground,
+  DashboardKeeperWaitingInventory,
+  DashboardScheduledAutomation,
+} from '../../api'
 
 type MockToolsResponse = {
   generated_at?: string
@@ -9,6 +13,7 @@ type MockToolsResponse = {
   tool_usage: Record<string, unknown>
   scheduled_automation?: DashboardScheduledAutomation
   keeper_waiting_inventory?: DashboardKeeperWaitingInventory
+  keeper_background?: DashboardKeeperBackground
 }
 
 const mocks = vi.hoisted(() => ({
@@ -129,6 +134,37 @@ function sampleWaitingInventory(): DashboardKeeperWaitingInventory {
   }
 }
 
+function sampleKeeperBackground(): DashboardKeeperBackground {
+  return {
+    schema: 'masc.dashboard.keeper_background.v1',
+    source: 'server_keeper_background',
+    keeper_count: 1,
+    recurring_keeper_count: 1,
+    recurring_count: 1,
+    keepers: [
+      {
+        keeper_name: 'sangsu',
+        loop: { phase: 'running', restart_count: 0, started_at_iso: '2026-07-08T00:00:00Z' },
+        recurring_count: 1,
+        recurring: [
+          {
+            id: 'loop-1-1',
+            label: 'heartbeat-check',
+            action_kind: 'broadcast',
+            interval_sec: 30,
+            enabled: true,
+            run_count: 3,
+            failure_count: 0,
+            max_failures: 3,
+            last_run_at_iso: '2026-07-08T00:01:00Z',
+            next_run_at_iso: '2026-07-08T00:01:30Z',
+          },
+        ],
+      },
+    ],
+  }
+}
+
 async function flush(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()
@@ -178,6 +214,7 @@ describe('ScheduleSurface', () => {
       tool_usage: {},
       scheduled_automation: sampleAutomation(),
       keeper_waiting_inventory: sampleWaitingInventory(),
+      keeper_background: sampleKeeperBackground(),
     }
 
     render(html`<${ScheduleSurface} />`, container)
@@ -208,6 +245,12 @@ describe('ScheduleSurface', () => {
       .toContain('sangsu')
     expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)
       .toContain('masc.board_post')
+    // Keeper background panel renders as a sibling card on the same surface,
+    // reading data.keeper_background (recurring tasks + loop liveness).
+    expect(container.querySelector('[data-testid="schedule-keeper-background"]')?.textContent)
+      .toContain('Keeper Background · recurring tasks')
+    expect(container.querySelector('[data-testid="schedule-keeper-background"]')?.textContent)
+      .toContain('heartbeat-check')
     // REMOVED: '출처 <signal_source>' feed attribution line is not rendered on
     // the v2 surface (it is diagnostics-only); no equivalent element exists to
     // retarget, so this coverage is dropped rather than weakened.

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -19,6 +19,7 @@ import { ActionButton } from '../common/button'
 import { StatusChip } from '../common/status-chip'
 import { showToast } from '../common/toast'
 import { KeeperLaneInventoryPanel } from '../tools/keeper-waiting-inventory-panel'
+import { KeeperBackgroundPanel } from '../tools/keeper-background-panel'
 import {
   ScheduleAside,
   ScheduledAutomationPanel,
@@ -73,6 +74,7 @@ export function ScheduleSurface() {
   const data = toolsData.value
   const automation = data?.scheduled_automation ?? null
   const waitingInventory = data?.keeper_waiting_inventory ?? null
+  const keeperBackground = data?.keeper_background ?? null
   const loading = toolsLoading.value
   const error = toolsError.value
   const dueEffective = automation?.derived_counts?.due_effective ?? 0
@@ -210,6 +212,11 @@ export function ScheduleSurface() {
         <section class="ov-card mt-4" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
           <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
           <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
+        </section>
+
+        <section class="ov-card mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
+          <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
+          <${KeeperBackgroundPanel} background=${keeperBackground} />
         </section>
 
         ${loading && !automation

--- a/dashboard/src/components/tools/keeper-background-panel.test.ts
+++ b/dashboard/src/components/tools/keeper-background-panel.test.ts
@@ -1,0 +1,172 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { DashboardKeeperBackground } from '../../api'
+import { KeeperBackgroundPanel } from './keeper-background-panel'
+
+function backgroundFixture(): DashboardKeeperBackground {
+  return {
+    schema: 'masc.dashboard.keeper_background.v1',
+    source: 'server_keeper_background',
+    generated_at: '2026-07-08T00:00:00Z',
+    keeper_count: 2,
+    recurring_keeper_count: 2,
+    recurring_count: 3,
+    keepers: [
+      {
+        keeper_name: 'sangsu',
+        loop: {
+          phase: 'running',
+          started_at_iso: '2026-07-08T00:00:00Z',
+          restart_count: 1,
+          last_restart_at_iso: '2026-07-08T00:05:00Z',
+          dead_since_iso: null,
+        },
+        recurring_count: 2,
+        recurring: [
+          {
+            id: 'loop-1-1',
+            label: 'heartbeat-check',
+            action_kind: 'broadcast',
+            interval_sec: 30,
+            enabled: true,
+            run_count: 12,
+            failure_count: 0,
+            max_failures: 3,
+            last_run_at_iso: '2026-07-08T00:10:00Z',
+            next_run_at_iso: '2026-07-08T00:10:30Z',
+          },
+          {
+            id: 'loop-1-2',
+            label: 'stale-sweep',
+            action_kind: 'broadcast',
+            interval_sec: 600,
+            enabled: false,
+            run_count: 4,
+            failure_count: 2,
+            max_failures: 2,
+            last_run_at_iso: '2026-07-08T00:02:00Z',
+            next_run_at_iso: null,
+          },
+        ],
+      },
+      {
+        keeper_name: 'recovery-bot',
+        loop: {
+          phase: 'dead',
+          started_at_iso: '2026-07-07T23:00:00Z',
+          restart_count: 3,
+          dead_since_iso: '2026-07-08T00:08:00Z',
+        },
+        recurring_count: 1,
+        recurring: [
+          {
+            id: 'loop-2-1',
+            label: 'audit-scan',
+            action_kind: 'broadcast',
+            interval_sec: 300,
+            enabled: true,
+            run_count: 0,
+            failure_count: 0,
+            max_failures: 5,
+            last_run_at_iso: null,
+            next_run_at_iso: null,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('KeeperBackgroundPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders one card per keeper with recurring tasks and loop context', () => {
+    render(html`<${KeeperBackgroundPanel} background=${backgroundFixture()} />`, container)
+
+    const cards = container.querySelectorAll('[data-testid="keeper-background-card"]')
+    expect(cards).toHaveLength(2)
+
+    // Header count pills
+    expect(container.textContent).toContain('keepers')
+    expect(container.textContent).toContain('recurring keepers')
+    expect(container.textContent).toContain('recurring tasks')
+
+    // Keeper names + loop phase chips
+    expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('running')
+    expect(container.textContent).toContain('recovery-bot')
+    expect(container.textContent).toContain('dead')
+
+    // Recurring task rows (labels, interval, run/fail counts, enabled state)
+    expect(container.textContent).toContain('heartbeat-check')
+    expect(container.textContent).toContain('stale-sweep')
+    expect(container.textContent).toContain('every 30s')
+    expect(container.textContent).toContain('runs 12')
+    expect(container.textContent).toContain('fail 2/2')
+    expect(container.textContent).toContain('enabled')
+    expect(container.textContent).toContain('disabled')
+    // action_kind and loop restart context are rendered verbatim from the projection.
+    expect(container.textContent).toContain('broadcast')
+    expect(container.querySelector('[data-keeper-background="sangsu"]')?.textContent).toContain('restarts 1')
+  })
+
+  it('surfaces a dead loop and never fabricates a next-run time', () => {
+    render(html`<${KeeperBackgroundPanel} background=${backgroundFixture()} />`, container)
+
+    const dead = container.querySelector('[data-keeper-background="recovery-bot"]')
+    expect(dead?.textContent).toContain('dead since')
+    expect(dead?.textContent).toContain('restarts 3')
+    // A never-run task reports next/last as '-' (projection null), not a guess.
+    expect(dead?.textContent).toContain('next -')
+    expect(dead?.textContent).toContain('last -')
+  })
+
+  it('renders unavailable state without inventing cards', () => {
+    render(html`<${KeeperBackgroundPanel} background=${null} />`, container)
+
+    expect(container.textContent).toContain('keeper background unavailable')
+    expect(container.querySelector('[data-testid="keeper-background-card"]')).toBeNull()
+  })
+
+  it('renders empty projection without inventing keepers', () => {
+    const empty: DashboardKeeperBackground = {
+      keeper_count: 0,
+      recurring_keeper_count: 0,
+      recurring_count: 0,
+      keepers: [],
+    }
+    render(html`<${KeeperBackgroundPanel} background=${empty} />`, container)
+
+    expect(container.textContent).toContain('no keeper background loops in projection')
+    expect(container.querySelector('[data-testid="keeper-background-card"]')).toBeNull()
+  })
+
+  it('renders a keeper with zero recurring tasks as an explicit empty sub-state', () => {
+    const fixture = backgroundFixture()
+    fixture.keepers = [
+      {
+        keeper_name: 'quiet-one',
+        loop: { phase: 'running', restart_count: 0 },
+        recurring_count: 0,
+        recurring: [],
+      },
+    ]
+    render(html`<${KeeperBackgroundPanel} background=${fixture} />`, container)
+
+    expect(container.querySelector('[data-keeper-background="quiet-one"]')?.textContent).toContain(
+      'no recurring tasks',
+    )
+  })
+})

--- a/dashboard/src/components/tools/keeper-background-panel.ts
+++ b/dashboard/src/components/tools/keeper-background-panel.ts
@@ -1,0 +1,134 @@
+// Keeper autonomous background panel (server_keeper_background.dashboard_json).
+//
+// Renders per-keeper recurring tasks with the owning keeper's heartbeat-loop
+// liveness as context. The backend projection only includes keepers that have
+// at least one recurring task, so a keeper appearing here is, by construction,
+// running autonomous recurring work — the loop row is the "is it alive" context
+// for that work, not a standalone liveness board (fleet already carries that).
+//
+// Honesty contract (matches the projection's own rule): every field shown comes
+// straight from the projection. `next`/`last` run times are `-` when the
+// projection reports null (paused or never-run) — no ETA is fabricated, no
+// bg-task is relabelled as a tool call.
+import { html } from 'htm/preact'
+import type {
+  DashboardKeeperBackground,
+  DashboardKeeperBackgroundKeeper,
+  DashboardKeeperBackgroundLoop,
+  DashboardKeeperRecurringTask,
+} from '../../api'
+import { formatDateTimeKo } from '../../lib/format-time'
+import { StatusChip, keeperStateTone } from '../common/status-chip'
+import { enumLabel } from './keeper-waiting-inventory-panel'
+
+function timeLabel(iso: string | null | undefined): string {
+  if (!iso) return '-'
+  return formatDateTimeKo(iso)
+}
+
+function CountPill({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string | null | undefined
+}) {
+  const displayValue =
+    typeof value === 'number' ? value.toLocaleString() : value ?? 'unknown'
+  return html`
+    <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-2 py-1 text-2xs text-[var(--color-fg-secondary)]">
+      <span>${label}</span>
+      <span class="font-mono text-[var(--color-fg-primary)]">${displayValue}</span>
+    </span>
+  `
+}
+
+function LoopContext({ loop }: { loop: DashboardKeeperBackgroundLoop }) {
+  return html`
+    <div class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-2xs text-[var(--color-fg-muted)]">
+      <span class="font-mono">restarts ${loop.restart_count.toLocaleString()}</span>
+      <span aria-hidden="true">·</span>
+      <span class="font-mono">since ${timeLabel(loop.started_at_iso)}</span>
+      ${loop.dead_since_iso
+        ? html`
+            <span aria-hidden="true">·</span>
+            <span class="font-mono text-[var(--color-status-warn)]">dead since ${timeLabel(loop.dead_since_iso)}</span>
+          `
+        : null}
+    </div>
+  `
+}
+
+function RecurringRow({ task }: { task: DashboardKeeperRecurringTask }) {
+  const failed = task.failure_count > 0
+  return html`
+    <div class="grid gap-1 border-t border-[var(--color-border-subtle)] py-2 first:border-t-0">
+      <div class="flex min-w-0 flex-wrap items-center gap-2">
+        <${StatusChip} tone=${task.enabled ? 'ok' : 'paused'} uppercase=${false}>${task.enabled ? 'enabled' : 'disabled'}<//>
+        <span class="min-w-0 truncate font-mono text-xs text-[var(--color-fg-primary)]">${task.label}</span>
+        <span class="text-2xs text-[var(--color-fg-muted)]">${enumLabel(task.action_kind)}</span>
+      </div>
+      <div class="grid gap-1 text-2xs text-[var(--color-fg-muted)] sm:grid-cols-5">
+        <span class="font-mono">every ${task.interval_sec.toLocaleString()}s</span>
+        <span class="font-mono">runs ${task.run_count.toLocaleString()}</span>
+        <span class=${failed ? 'font-mono text-[var(--color-status-warn)]' : 'font-mono'}
+          >fail ${task.failure_count.toLocaleString()}/${task.max_failures.toLocaleString()}</span
+        >
+        <span>next ${timeLabel(task.next_run_at_iso)}</span>
+        <span>last ${timeLabel(task.last_run_at_iso)}</span>
+      </div>
+    </div>
+  `
+}
+
+function KeeperBackgroundCard({ keeper }: { keeper: DashboardKeeperBackgroundKeeper }) {
+  const tasks = keeper.recurring ?? []
+  return html`
+    <article
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      data-testid="keeper-background-card"
+      data-keeper-background=${keeper.keeper_name}
+    >
+      <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
+        <div class="min-w-0">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <span class="min-w-0 truncate font-mono text-sm font-semibold text-[var(--color-fg-primary)]">${keeper.keeper_name}</span>
+            <${StatusChip} tone=${keeperStateTone(keeper.loop.phase)} uppercase=${false}>${enumLabel(keeper.loop.phase)}<//>
+          </div>
+          <${LoopContext} loop=${keeper.loop} />
+        </div>
+        <span class="text-2xs text-[var(--color-fg-muted)]">
+          <span class="font-mono text-[var(--color-fg-primary)]">${keeper.recurring_count.toLocaleString()}</span> recurring
+        </span>
+      </div>
+      <div class="mt-2">
+        ${tasks.length > 0
+          ? tasks.map(task => html`<${RecurringRow} key=${task.id} task=${task} />`)
+          : html`<div class="border-t border-[var(--color-border-subtle)] pt-2 text-xs text-[var(--color-fg-muted)]">no recurring tasks</div>`}
+      </div>
+    </article>
+  `
+}
+
+export function KeeperBackgroundPanel({
+  background,
+}: {
+  background: DashboardKeeperBackground | null | undefined
+}) {
+  if (!background) {
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">keeper background unavailable</div>`
+  }
+  const keepers = background.keepers ?? []
+  return html`
+    <div class="grid gap-3" data-testid="keeper-background-inventory">
+      <div class="flex flex-wrap gap-1.5">
+        <${CountPill} label="keepers" value=${background.keeper_count} />
+        <${CountPill} label="recurring keepers" value=${background.recurring_keeper_count} />
+        <${CountPill} label="recurring tasks" value=${background.recurring_count} />
+      </div>
+      ${keepers.length > 0
+        ? html`<div class="grid gap-2 lg:grid-cols-2">${keepers.map(keeper => html`<${KeeperBackgroundCard} key=${keeper.keeper_name} keeper=${keeper} />`)}</div>`
+        : html`<div class="text-xs text-[var(--color-fg-muted)]">no keeper background loops in projection</div>`}
+    </div>
+  `
+}

--- a/dashboard/src/components/tools/keeper-background-panel.ts
+++ b/dashboard/src/components/tools/keeper-background-panel.ts
@@ -60,7 +60,8 @@ function LoopContext({ loop }: { loop: DashboardKeeperBackgroundLoop }) {
 }
 
 function RecurringRow({ task }: { task: DashboardKeeperRecurringTask }) {
-  const failed = task.failure_count > 0
+  const failClass =
+    task.failure_count > 0 ? 'font-mono text-[var(--color-status-warn)]' : 'font-mono'
   return html`
     <div class="grid gap-1 border-t border-[var(--color-border-subtle)] py-2 first:border-t-0">
       <div class="flex min-w-0 flex-wrap items-center gap-2">
@@ -71,9 +72,7 @@ function RecurringRow({ task }: { task: DashboardKeeperRecurringTask }) {
       <div class="grid gap-1 text-2xs text-[var(--color-fg-muted)] sm:grid-cols-5">
         <span class="font-mono">every ${task.interval_sec.toLocaleString()}s</span>
         <span class="font-mono">runs ${task.run_count.toLocaleString()}</span>
-        <span class=${failed ? 'font-mono text-[var(--color-status-warn)]' : 'font-mono'}
-          >fail ${task.failure_count.toLocaleString()}/${task.max_failures.toLocaleString()}</span
-        >
+        <span class=${failClass}>fail ${task.failure_count.toLocaleString()}/${task.max_failures.toLocaleString()}</span>
         <span>next ${timeLabel(task.next_run_at_iso)}</span>
         <span>last ${timeLabel(task.last_run_at_iso)}</span>
       </div>


### PR DESCRIPTION
## What

Adds `KeeperBackgroundPanel` to the keeper-v2 schedule surface — a card that renders the `server_keeper_background` projection (`masc.dashboard.keeper_background.v1`): each keeper that owns recurring tasks, its recurring-task rows (label, interval, run/failure counts, next/last run), and its heartbeat-loop liveness (phase, restart count, dead-since) as context.

This completes **G3** of the keeper-autonomous-background observability matrix (`docs/design/keeper-autonomous-background-goal-matrix.html`). G1 (backend projection) and G2 (HTTP wiring + TS types) already landed on main; this is the frontend consumer of an existing `DashboardToolsResponse.keeper_background` field.

## Why now

G3 was held until the projection could carry real data. Its producer — RFC-0314 `masc_recurring_add` (#23626) — is approved and CI-green (the actor-binding findings from adversarial review were resolved and re-verified). The panel therefore reflects actual recurring-task registration state, not an empty-by-construction surface.

## Observe-only contract

Every field is read straight from the projection. Never-run / paused tasks render `next -` / `last -` (the projection reports null), rather than a computed ETA. Three explicit empty states: `keeper background unavailable` (null projection), `no keeper background loops in projection` (zero keepers), `no recurring tasks` (per keeper). No background task is relabelled as a tool call. This matches the matrix's own observe-only rule for Phase 1.

## Scope

- New: `dashboard/src/components/tools/keeper-background-panel.ts` — pure Preact (htm/preact) prop consumer, mirrors `KeeperLaneInventoryPanel` (no hooks, no store reads; parent passes the projection slice).
- Mount: `dashboard/src/components/schedule/schedule-surface.ts` — a sibling `.ov-card` after Keeper Lanes; reads `data?.keeper_background ?? null`; no view/selection state changes, so the calendar/list toggle, aside, and detail overlay are untouched.
- Tests: `keeper-background-panel.test.ts` (5 cases: data render, dead-loop + never-run honesty, null / empty / zero-recurring states) + a `schedule-surface.test.ts` integration assertion for the mounted section.

## Verification

Frontend is vite/vitest (not dune), so this was verified locally:
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` (changed files) — clean
- `pnpm exec vitest run` — 14/14 (5 panel + 9 surface)

Adversarially self-reviewed for correctness (nullability/crash-safety vs the projection types), observe-only honesty, and test non-vacuity. No OCaml/backend files touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
