### PR TITLE
fix(dashboard): consolidate prompt editing — drop Lab duplicate (PR-1/2)

### DIFF
--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -17,6 +17,7 @@ type MockToolsResponse = {
 
 const mocks = vi.hoisted(() => ({
   loadTools: vi.fn(),
+  navigate: vi.fn(),
   toolsData: { value: null as null | MockToolsResponse },
   toolsLoading: { value: false },
   toolsError: { value: null as string | null },
@@ -46,8 +47,8 @@ vi.mock('./tool-full-inventory', () => ({
   FullInventoryView: () => html`<div>FullInventoryView</div>`,
 }))
 
-vi.mock('./prompt-registry-panel', () => ({
-  PromptRegistryPanel: () => html`<div>PromptRegistryPanel</div>`,
+vi.mock('../../router', () => ({
+  navigate: mocks.navigate,
 }))
 
 vi.mock('./config-resolution-panel', () => ({
@@ -126,7 +127,14 @@ describe('Tools', () => {
     expect(container.textContent).toContain('FullInventoryView')
     expect(container.textContent).toContain('도구 사용 현황')
     expect(container.textContent).toContain('ToolMetrics')
-    expect(container.textContent).toContain('PromptRegistryPanel')
+    // Prompt editing was consolidated into Settings › Prompts; Lab now only
+    // shows a read-only pointer, not the editable PromptRegistryPanel.
+    expect(container.textContent).not.toContain('PromptRegistryPanel')
+    expect(container.textContent).toContain('프롬프트 레지스트리')
+    const promptCta = container.querySelector('.v2-lab-prompt-cta') as HTMLElement | null
+    expect(promptCta).not.toBeNull()
+    promptCta!.click()
+    expect(mocks.navigate).toHaveBeenCalledWith('settings', { section: 'prompts' })
   })
 
   it('renders scheduled automation FSM projection', async () => {

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -12,9 +12,9 @@ import {
   loadTools,
 } from './tool-state'
 import { FullInventoryView } from './tool-full-inventory'
-import { PromptRegistryPanel } from './prompt-registry-panel'
 import { ConfigResolutionPanel } from './config-resolution-panel'
 import { ActionButton } from '../common/button'
+import { navigate } from '../../router'
 import { ToolExecutor } from '../tool-executor/tool-executor'
 import { formatElapsedCompact } from '../../lib/format-time'
 import { sourceHealthClass, coverageGapDisplay } from '../common/source-health'
@@ -59,7 +59,16 @@ export function Tools() {
         runtimeResolution=${data?.runtime_resolution}
       />
 
-      <${PromptRegistryPanel} />
+      <${SectionCard} label="프롬프트 레지스트리" class="section v2-lab-panel mb-4">
+        <div class="text-xs text-[var(--color-fg-muted)] mb-3">
+          전역 프롬프트/오버라이드 편집은 <span class="font-mono">설정 › 프롬프트</span>에서 관리됩니다.
+          여기(Lab)에 있던 중복 편집기는 단일 편집 지점으로 통합했습니다.
+        </div>
+        <${ActionButton} variant="ghost" size="md" class="v2-lab-prompt-cta"
+          onClick=${() => { navigate('settings', { section: 'prompts' }) }}>
+          설정 › 프롬프트 열기 →
+        <//>
+      <//>
 
       <${SectionCard} label="예약 자동화 FSM" class="section v2-lab-panel mb-4">
         <${ScheduledAutomationPanel} automation=${data?.scheduled_automation ?? null} onResolved=${loadTools} />


### PR DESCRIPTION
## 목적

사용자 지적: 프롬프트 설정/수정 기능이 여러 UI에 중복. 전역 프롬프트 레지스트리 편집기 `PromptRegistryPanel`(draft + "오버라이드 적용"/"제거", write=`POST /api/v1/prompts`)이 **두 곳에서 편집 가능**:
- Settings › Prompts (`embedded=true`, canonical "종이 스타일" 화면)
- **Lab (`tools-main.ts`, `embedded=false`)** ← 중복

`embedded` prop은 wrapper 클래스만 바꾸고 편집 기능은 동일 — 같은 전역 프롬프트가 두 곳에서 수정 가능(단일 진실 원천 위반).

## 변경 (PR-1: Lab 중복 제거)

- Lab에서 편집 가능한 `PromptRegistryPanel` 제거 → read-only 포인터 카드로 교체("프롬프트 편집은 설정 › 프롬프트에서 관리됩니다" + `navigate('settings', {section:'prompts'})` 버튼).
- Lab 나머지(설정 경로/예약 FSM/waiting 인벤토리/도구 목록/사용현황) 그대로.
- API·canonical 편집기 무변경 — 편집은 이제 Settings › Prompts 단일 지점.
- #23604(keeper 런타임 카드 read-only+deep-link) 패턴과 동일.

## 검증

- `pnpm test` 637파일/8694 green (Lab 테스트: 포인터 렌더 + CTA가 `navigate('settings',{section:'prompts'})` 호출 + 편집기 부재 어서트)
- typecheck / lint clean
- dev 서버: Lab에 편집기 대신 포인터 표시

## 후속 (PR-2)

keeper 상세 prompt 탭의 read-only 전역 블록(world/capabilities)에 Settings › Prompts deep-link 추가 (per-keeper goal/instructions 편집은 유지). 사용자 승인 완료(b1). 별도 작은 PR로 진행.

## 미검증

- 없음 (전체 스위트 green). CI Dashboard job이 최종 판정.