### PR TITLE
feat(keeper): Retry_no_thinking recovery arm for thinking-only turns (RFC-0271 §4.1)

### DIFF
--- a/docs/rfc/RFC-0271-in-turn-recovery-accept-rejected-and-thinking-budget.md
+++ b/docs/rfc/RFC-0271-in-turn-recovery-accept-rejected-and-thinking-budget.md
@@ -140,3 +140,39 @@ recovery 재시도가 `autonomous_max_turns_per_call` budget을 silent 소비하
 - recovery retry의 budget 회계를 `autonomous_max_turns_per_call`에 포함할지 별도 ceiling으로 격리할지는 PR-1에서 측정 후 결정.
 - `Reroute_tool_reliable`의 "tool-reliable" 판정 기준: capability 선언(`tools-support`)은 신뢰 불가(이 RFC의 동기)이므로, 라이브 tool-call 성공률 메트릭(keeper×runtime별 `thinking_chars` 분포 포함)을 별도 진단 축으로 수집해야 정확한 후보 선택이 가능하다. 초기 구현은 config 선언 순서(media_failover 류)로 시작.
 - RFC number allocation: `.next-number=0272`는 RFC-0270(CI Gate merge guard)와 이 RFC-0271이 모두 배정됐기 때문이다. RFC-0271은 RFC-0270에 runtime/design dependency를 갖지 않는다.
+
+## 9. Implementation status & diagnosis refresh (2026-07-08)
+
+> Verified against `origin/main` @ current HEAD. RFC-0271's original §3 diagnosis
+> ("recovery arm 0", `keeper_turn_driver_try_runtime.ml:196-212`) predates the
+> current tree and is partially stale — the reroute arm has since landed.
+
+### What already exists on current main (not this RFC's work)
+
+- The accept rejection is already typed as `Thinking_only_no_progress` /
+  `Empty_no_progress` / `Read_only_no_progress`
+  (`Keeper_internal_error.accept_no_progress_retry_kind`).
+- The **reroute arm** (§4.1 rule 2 — `Reroute_tool_reliable`) is already
+  implemented: `accept_rejected_result_should_try_next` +
+  `checkpoint_for_accept_rejected_retry` route a no-progress rejection to the next
+  runtime candidate. This is the "failover works" behavior the live diagnosis
+  observed (it just costs a full-turn re-run on a more expensive lane).
+
+### What the first implementation PR does (§4.1 rule 1 — the remaining gap)
+
+- **`Retry_no_thinking`**: a `Thinking_only_no_progress` rejection on a
+  thinking-enabled attempt now gets ONE same-candidate retry with thinking forced
+  off (new `?enable_thinking_override` on `run_try_provider`) BEFORE the existing
+  reroute. Bounded to once per turn (`recovered_no_thinking`); emits a fresh
+  provider-attempt-started so the RFC-0012 watchdog sees progress (§4.3). The
+  decision is a pure `should_retry_no_thinking` gate (unit-tested truth table).
+
+### Deferred / re-scoped
+
+- **§4.2 thinking-budget wiring does NOT fit the observed `deepseek-v4-flash`
+  case.** flash declares `thinking-control-format = "reasoning-effort"`
+  (`config/runtime.toml`) and has no `max_thinking_budget`, so a token-budget
+  ceiling (`with_thinking_budget n`) is the wrong control surface. A flash
+  preventive would need a **reasoning-effort cap**, a separate mechanism outside
+  §4.2's token-budget scope — a follow-up, not this arm. §4.2 remains valid for
+  token-budget runtimes (Anthropic-style).

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -386,8 +386,13 @@ let run_try_provider
       (ctx : try_provider_ctx)
       ?resume_checkpoint
       ?per_provider_timeout_s
+      ?enable_thinking_override
       candidate
   =
+  (* [enable_thinking_override] lets the caller re-issue the SAME candidate with a
+     different thinking policy without mutating [ctx]. RFC-0271 §4.1 uses it for the
+     [Retry_no_thinking] recovery arm: a [Thinking_only_no_progress] rejection is
+     retried once with thinking forced off before rerouting to the next candidate. *)
   let config_result =
     match
       Runtime_candidate.resolve_tool_lane_for_oas_tools
@@ -467,7 +472,10 @@ let run_try_provider
           ; checkpoint_dir = ctx.checkpoint_dir
           ; context_injector = ctx.context_injector
           ; context = ctx.context
-          ; enable_thinking = ctx.enable_thinking
+          ; enable_thinking =
+              (match enable_thinking_override with
+               | Some v -> Some v
+               | None -> ctx.enable_thinking)
           ; preserve_thinking = ctx.preserve_thinking
           ; event_bus = ctx.event_bus
           ; approval = ctx.approval

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -71,6 +71,7 @@ val run_try_provider :
   try_provider_ctx ->
   ?resume_checkpoint:Agent_sdk.Checkpoint.t ->
   ?per_provider_timeout_s:float ->
+  ?enable_thinking_override:bool ->
   Runtime_candidate.t ->
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
   * Agent_sdk.Checkpoint.t option

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -84,6 +84,24 @@ let accept_no_progress_retry_kind err =
   | Some err -> Keeper_internal_error.accept_no_progress_retry_kind err
   | None -> None
 
+(* RFC-0271 §4.1 [Retry_no_thinking] gate: a [Thinking_only_no_progress]
+   rejection is retried once on the SAME candidate with thinking forced off,
+   provided the rejected attempt had thinking enabled and this turn has not
+   already spent its single re-shape. [Empty]/[Read_only] rejections and
+   thinking-already-off attempts are not re-shaped (nothing to change). *)
+let should_retry_no_thinking ~recovered ~enable_thinking ~retry_kind =
+  let thinking_was_enabled =
+    match enable_thinking with
+    | Some false -> false
+    | Some true | None -> true
+  in
+  let is_thinking_only =
+    match retry_kind with
+    | Some `Thinking_only_no_progress -> true
+    | Some (`Empty_no_progress | `Read_only_no_progress) | None -> false
+  in
+  (not recovered) && is_thinking_only && thinking_was_enabled
+
 let accept_rejected_result_should_try_next ~is_last err =
   (not is_last) && accept_no_progress_should_try_next err
 
@@ -270,10 +288,19 @@ let run
     , ctx.wait_timeout_sec
     , ctx.turn_deadline )
   in
-  let rec loop resume_checkpoint last_err = function
+  let rec loop resume_checkpoint last_err recovered_no_thinking = function
     | [] -> Error (sdk_error_of_exhausted ~runtime_id:ctx.error_runtime_id last_err)
     | candidate :: rest ->
       let is_last = rest = [] in
+      let record_attempt_success ~latency_ms run_result =
+        Keeper_turn_driver_provider_attempt.record_candidate_health_success
+          ~keeper_name:ctx.keeper_name
+          candidate
+          ~latency_ms;
+        ctx.record_provider_health_result candidate ~success:true ~http_status:None;
+        on_success ~provider_key:(Runtime_candidate.health_key candidate);
+        Ok run_result
+      in
       maybe_mark_provider_attempt_started ctx;
       emit_attempt_started ctx candidate ~is_last ~per_provider_timeout_s;
       let started_at = Mtime_clock.now () in
@@ -289,13 +316,7 @@ let run
       in
       (match result with
        | Ok run_result when ctx.accept run_result.Runtime_agent.response ->
-         Keeper_turn_driver_provider_attempt.record_candidate_health_success
-           ~keeper_name:ctx.keeper_name
-           candidate
-           ~latency_ms;
-         ctx.record_provider_health_result candidate ~success:true ~http_status:None;
-         on_success ~provider_key:(Runtime_candidate.health_key candidate);
-         Ok run_result
+         record_attempt_success ~latency_ms run_result
        | Ok run_result ->
          let last_tool_context =
            Keeper_turn_driver_try_provider.accept_rejection_context_of_run_result
@@ -317,21 +338,68 @@ let run
            ~keeper_name:ctx.keeper_name
            candidate
            ~reason;
-         if accept_rejected_result_should_try_next ~is_last err
-         then
-           let checkpoint_for_retry =
+         let try_next_or_error err ~recovered =
+           if accept_rejected_result_should_try_next ~is_last err
+           then
+             let checkpoint_for_retry =
+               checkpoint_for_accept_rejected_retry
+                 ~resume_checkpoint
+                 ~checkpoint_after
+                 err
+             in
+             let next_last_err =
+               match sdk_error_to_http_error err with
+               | Some http_err -> Some http_err
+               | None -> last_err
+             in
+             loop checkpoint_for_retry next_last_err recovered rest
+           else Error err
+         in
+         (* RFC-0271 §4.1 [Retry_no_thinking]: a [Thinking_only_no_progress]
+            rejection on a thinking-enabled attempt gets ONE same-candidate retry
+            with thinking forced off, before the (existing) reroute to the next
+            candidate. This is the cheap deterministic re-shape that avoids a full
+            reroute to a more expensive lane when the model merely over-thought.
+            Bounded to once per turn via [recovered_no_thinking]. *)
+         if
+           should_retry_no_thinking
+             ~recovered:recovered_no_thinking
+             ~enable_thinking:ctx.try_provider_ctx.enable_thinking
+             ~retry_kind:(accept_no_progress_retry_kind err)
+         then begin
+           (* Mark progress so the RFC-0012 mid-turn watchdog does not kill the
+              recovery attempt as no-progress (RFC-0271 §4.3). *)
+           maybe_mark_provider_attempt_started ctx;
+           emit_attempt_started ctx candidate ~is_last ~per_provider_timeout_s;
+           let retry_started_at = Mtime_clock.now () in
+           let retry_resume =
              checkpoint_for_accept_rejected_retry
                ~resume_checkpoint
                ~checkpoint_after
                err
            in
-           let next_last_err =
-             match sdk_error_to_http_error err with
-             | Some http_err -> Some http_err
-             | None -> last_err
+           let retry_result, retry_checkpoint_after, _retry_sample =
+             Keeper_turn_driver_try_provider.run_try_provider
+               ctx.try_provider_ctx
+               ~enable_thinking_override:false
+               ?resume_checkpoint:retry_resume
+               ?per_provider_timeout_s
+               candidate
            in
-           loop checkpoint_for_retry next_last_err rest
-         else Error err
+           let retry_latency =
+             emit_attempt_finished
+               ctx
+               candidate
+               ~started_at:retry_started_at
+               retry_result
+               retry_checkpoint_after
+           in
+           (match retry_result with
+            | Ok retry_run when ctx.accept retry_run.Runtime_agent.response ->
+              record_attempt_success ~latency_ms:retry_latency retry_run
+            | Ok _ | Error _ -> try_next_or_error err ~recovered:true)
+         end
+         else try_next_or_error err ~recovered:recovered_no_thinking
        | Error err ->
          Keeper_turn_driver_provider_attempt.record_candidate_health_error
            ~keeper_name:ctx.keeper_name
@@ -349,7 +417,7 @@ let run
                 && (Runtime_attempt_fsm.should_try_next http_err
                     || accept_no_progress_should_try_next original_error)
            ->
-           loop checkpoint_after (Some http_err) rest
+           loop checkpoint_after (Some http_err) recovered_no_thinking rest
          | Some http_err ->
            Error
              (sdk_error_of_nonretryable_attempt_error
@@ -357,12 +425,15 @@ let run
                 ~original_error
                 http_err)
          | None ->
-           if is_last then Error err else loop checkpoint_after last_err rest)
+           if is_last
+           then Error err
+           else loop checkpoint_after last_err recovered_no_thinking rest)
   in
-  loop resume_checkpoint last_err candidates
+  loop resume_checkpoint last_err false candidates
 
 module For_testing = struct
   let accept_no_progress_should_try_next = accept_no_progress_should_try_next
+  let should_retry_no_thinking = should_retry_no_thinking
 
   let accept_no_progress_read_only_should_try_next =
     accept_no_progress_read_only_should_try_next

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1658,6 +1658,33 @@ let test_thinking_only_non_end_turn_response_is_rejected () =
     true
     (contains ~needle:"stop_reason=stop_sequence" reason)
 
+(* RFC-0271 §4.1 [Retry_no_thinking] gate truth table: only a thinking-only
+   rejection on a thinking-enabled attempt, once per turn, triggers the cheap
+   thinking-off re-shape before reroute. *)
+let test_should_retry_no_thinking_gate () =
+  let gate = Masc.Keeper_turn_driver_try_runtime.For_testing.should_retry_no_thinking in
+  let check label expected actual = Alcotest.(check bool) label expected actual in
+  check "thinking_only + thinking on + fresh turn -> retry" true
+    (gate ~recovered:false ~enable_thinking:(Some true)
+       ~retry_kind:(Some `Thinking_only_no_progress));
+  check "thinking_only + thinking default(None=on) -> retry" true
+    (gate ~recovered:false ~enable_thinking:None
+       ~retry_kind:(Some `Thinking_only_no_progress));
+  check "thinking_only + already recovered -> no second retry (bounded)" false
+    (gate ~recovered:true ~enable_thinking:(Some true)
+       ~retry_kind:(Some `Thinking_only_no_progress));
+  check "thinking_only + thinking already off -> nothing to re-shape" false
+    (gate ~recovered:false ~enable_thinking:(Some false)
+       ~retry_kind:(Some `Thinking_only_no_progress));
+  check "empty_no_progress -> no retry" false
+    (gate ~recovered:false ~enable_thinking:(Some true)
+       ~retry_kind:(Some `Empty_no_progress));
+  check "read_only_no_progress -> no retry" false
+    (gate ~recovered:false ~enable_thinking:(Some true)
+       ~retry_kind:(Some `Read_only_no_progress));
+  check "no retry kind -> no retry" false
+    (gate ~recovered:false ~enable_thinking:(Some true) ~retry_kind:None)
+
 let test_thinking_only_no_tool_can_try_next_candidate () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -2340,6 +2367,10 @@ let () =
             "thinking-only no-tool response rotates typed no-progress"
             `Quick
             test_thinking_only_no_tool_can_try_next_candidate;
+          Alcotest.test_case
+            "Retry_no_thinking gate is bounded and thinking-only-scoped (RFC-0271)"
+            `Quick
+            test_should_retry_no_thinking_gate;
           Alcotest.test_case "empty non-end-turn response is rejected" `Quick
             test_empty_non_end_turn_response_is_rejected;
           Alcotest.test_case


### PR DESCRIPTION
## 목표

keeper `thinking_only` 무진전 오류의 근본 해결 — RFC-0271 §4.1 **`Retry_no_thinking`** recovery arm 구현.

관측된 오류: `runtime=ollama_cloud.deepseek-v4-flash ... reason_kind=no_usable_progress response_shape=thinking_only stop_reason=end_turn`. 모델이 사고 블록만 내고 자발 종료 → accept 계약이 정당하게 거부하지만, 그에 대한 값싼 교정이 없어 비싼 reroute(pro/GLM full-turn 재실행) 또는 누적 시 PAUSE로 빠짐.

## 진단 (현재 main 실측 — RFC-0271 §3 진단은 부분 stale)

- **Phase-0 증거**: 실제 trajectory reasoning(43K자)을 읽으니 완성된 답이 아니라 meandering 자기심의였음. reasoning 채널에 숨은 답 없음 → "thinking을 답으로 projection"은 불가/무의미(RFC-0271 §4.2가 이미 배제).
- **reroute arm(§4.1 rule 2)은 이미 main에 존재**: `accept_no_progress_retry_kind`가 rejection을 `Thinking_only_no_progress`로 typed 분류하고 `accept_rejected_result_should_try_next`가 다음 candidate로 reroute. RFC-0271이 "recovery arm 0"이라 한 진단은 그 사이 main이 진화해 stale.
- **진짜 MISSING = `Retry_no_thinking`(§4.1 rule 1)**: 같은 runtime을 thinking OFF로 1회 재시도해 비싼 reroute 전에 값싸게 회복.

## 변경

- `keeper_turn_driver_try_provider.{ml,mli}`: `run_try_provider`에 `?enable_thinking_override:bool` 추가 — ctx 변형 없이 같은 candidate를 다른 thinking 정책으로 재발행.
- `keeper_turn_driver_try_runtime.ml`: accept-rejected 분기에 Retry_no_thinking 삽입. `Thinking_only_no_progress` + thinking-enabled 거부면 thinking OFF로 1회 재시도 → 성공 시 Ok, 실패 시 기존 reroute. **once/turn bounded**(`recovered_no_thinking`), 재시도 시 provider-attempt-started emit으로 RFC-0012 watchdog progress 신호(§4.3). 결정은 순수 `should_retry_no_thinking` gate로 추출.
- `docs/rfc/RFC-0271...md` §9: 현재 main 진단 갱신(reroute 기존재/Retry_no_thinking 본 PR/flash 재-scope).

## 범위 밖 (후속)

- **§4.2 token budget wiring은 flash에 부적합**: flash는 `thinking-control-format = "reasoning-effort"`(config/runtime.toml)에 `max_thinking_budget` 미설정 → `with_thinking_budget n`(토큰)이 아니라 **reasoning-effort cap**이 필요. §4.2는 token-budget 런타임(Anthropic류)엔 유효하나 flash preventive는 별도 mechanism → 후속.

## 검증

- 신규 진리표 테스트 `should_retry_no_thinking_gate` 7-case (thinking_only+on→retry / default(None)=on→retry / already-recovered→no(bounded) / thinking-off→no / empty·read_only·None→no).
- 회귀: `test_keeper_turn_driver_accept` 40/40, `test_keeper_turn_driver_failover` 16/16 (루프 리팩터가 기존 reroute/분류 불변 증명).
- 전체 `dune build --root .` green. ocamlformat --check 4파일 clean.

## 성격

typed recovery arm(RFC-0271 §4.1). 워크어라운드 아님 — dead-end를 **fix**(턴이 회복)하지 symptom 억제(telemetry/string분류기/cap/cooldown) 아님. reroute는 기존 그대로 유지하고 그 앞에 값싼 re-shape 1회를 추가.

RFC: RFC-0271 (keeper runtime recovery). Related RFC-0012, RFC-0082, RFC-0222/0262, RFC-0265.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
