### PR TITLE
fix(dashboard): keeper-detail global prompt blocks → Settings deep-link (PR-2/2)

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1148,6 +1148,11 @@ describe('KeeperConfigPanel', () => {
     // prompt tab: editable prompt controls.
     selectKcfTab(container, '프롬프트')
     await flush()
+    // The global system-prompt blocks (world/capabilities) are read-only here;
+    // a deep-link routes their editing to the canonical Settings › Prompts.
+    const globalEditLink = container.querySelector('[data-testid="kcf-prompt-global-edit-link"]')
+    expect(globalEditLink).not.toBeNull()
+    expect(globalEditLink?.textContent).toContain('설정 › 프롬프트')
     const editButton = Array.from(container.querySelectorAll('button')).find(button =>
       button.textContent?.includes('편집'),
     )

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -39,6 +39,7 @@ import {
   runtimeCatalogSnapshotFacts,
 } from '../lib/runtime-provider-summary'
 import { refreshKeeperRuntimeStatus } from '../store'
+import { navigate } from '../router'
 import { SetupGuideCard } from './setup-guide-card'
 import { SectionHeader } from './common/section-header'
 import { StatusDot } from './common/status-dot'
@@ -1952,7 +1953,18 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       <${SectionHeader} size="xs" class="mt-2 mb-0.5">지시사항</${SectionHeader}>
       <${LongText} text=${c.prompt.instructions} />
     ` : null}
-    <${SectionHeader} size="xs" class="mt-3 mb-0.5">시스템 프롬프트</${SectionHeader}>
+    <${SectionHeader} size="xs" class="mt-3 mb-0.5" right=${html`
+      <button
+        type="button"
+        class="text-2xs text-accent-fg hover:underline v2-monitoring-action"
+        data-testid="kcf-prompt-global-edit-link"
+        title="세계관·능력 등 전역 프롬프트 블록은 설정 › 프롬프트에서 관리합니다"
+        onClick=${() => { navigate('settings', { section: 'prompts' }) }}
+      >설정 › 프롬프트 열기 →</button>
+    `}>시스템 프롬프트</${SectionHeader}>
+    <div class="text-3xs text-text-dim mb-2">
+      헌법·세계관·능력 블록은 <span class="font-mono">전역 프롬프트</span>입니다 (read-only) — 편집은 설정 › 프롬프트. 아래 목표·지시사항만 이 keeper 고유값입니다.
+    </div>
     <div class="flex gap-2 mb-2 v2-monitoring-toolbar">
       <button
         type="button"


### PR DESCRIPTION
## 목적

프롬프트 편집 통합의 후속(PR-1 #23645에 이어). keeper 상세(config 모달)의 prompt 탭은 전역 system-prompt 블록(헌법/세계관/능력)을 read-only로 보여주면서 편집 경로가 없어, 사용자가 그 블록을 어디서 편집하는지 알 수 없었다.

## 변경 (사용자 승인 b1: per-keeper 편집 유지 + 전역 블록 deep-link)

`keeper-config-panel.ts` prompt 탭:
- "시스템 프롬프트" 헤더 우측에 **"설정 › 프롬프트 열기 →" deep-link** 추가 → `navigate('settings', {section:'prompts'})`.
- 한 줄 안내: 헌법·세계관·능력은 전역 read-only 블록, 아래 목표·지시사항만 이 keeper 고유 편집값.
- per-keeper goal/instructions 편집기는 **무변경**.

이로써 통합 완료: 전역 프롬프트 편집은 Settings › Prompts 한 곳, 다른 표면(Lab·keeper 상세)은 모두 그리로 안내.

## 검증

- `pnpm test` 637파일/8694 green, typecheck/lint clean
- prompt 탭 테스트: deep-link(`data-testid=kcf-prompt-global-edit-link`) 렌더 + "설정 › 프롬프트" 텍스트 어서트. edit-mode 버튼 finder는 여전히 "편집하기" 매칭(내 링크는 "열기"라 충돌 없음).
- 참고: 전체 스위트 첫 실행에서 무관 테스트 1건 flaky fail → 재실행·단독 실행 모두 green(내 변경은 keeper-config만).

## 미검증

- 라이브 keeper config 모달 prompt 탭 시각 캡처는 playwright 모달-오픈 흐름이 까다로워 미확보. deterministic 컴포넌트 테스트(실제 promptSection 렌더 + 탭 선택 + 링크 어서트)로 대체.

## 관련

PR-1 #23645 (Lab 중복 제거). 두 PR로 프롬프트 편집 단일화 완료.
