### PR TITLE
feat(runtime): wire max-thinking-budget to bound over-thinking (RFC-0271 §4.2)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -121,6 +121,13 @@ max-context = 1048576
 tools-support = true
 thinking-support = true
 streaming = true
+# RFC-0271 §4.2: bound the fleet-default's reasoning effort. Without a budget the
+# SDK sends Medium effort, under which live turns emit 43k-86k chars of reasoning
+# and sometimes terminate thinking-only. 2048 maps to Low via
+# Reasoning_effort.of_budget (<=2048). The corrective Retry_no_thinking arm
+# backstops any under-thinking. Tune against the live over-thinking rate; the
+# effort effect on this provider is not yet measured.
+max-thinking-budget = 2048
 
 [models.deepseek-v4-flash.capabilities]
 max-output-tokens = 384000

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1145,6 +1145,17 @@ let thinking_support_of_runtime_id (id : string) : bool option =
   | None -> None
 ;;
 
+(* Per-model thinking ceiling from runtime.toml ([max-thinking-budget]). RFC-0271
+   §4.2 wires it as the reasoning seed budget so the SDK derives a bounded
+   reasoning effort ([Reasoning_effort.of_budget]) instead of the unbounded
+   provider default. [None] (the current state for every runtime) preserves the
+   prior wire exactly. *)
+let max_thinking_budget_of_runtime_id (id : string) : int option =
+  match get_runtime_by_id id with
+  | Some rt -> rt.model.max_thinking_budget
+  | None -> None
+;;
+
 (* The per-model [temperature] override declared in runtime.toml
    ([models.<id>.temperature]), or [None] when the runtime is unknown or the
    model leaves it unset. Projects the runtime.toml [model] record (per-binding

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -296,6 +296,12 @@ val max_output_tokens_of_runtime_id : string -> int option
     reasoning turn from the model's own output ceiling rather than the flat
     fallback. *)
 
+val max_thinking_budget_of_runtime_id : string -> int option
+(** Per-model [max-thinking-budget] ceiling from runtime.toml, or [None] when the
+    id is not configured or the model declares no ceiling. RFC-0271 §4.2 wires it
+    through {!Runtime_inference.for_runtime} so the SDK derives a bounded reasoning
+    effort ([Reasoning_effort.of_budget]). *)
+
 val thinking_support_of_runtime_id : string -> bool option
 (** [thinking-support] capability of the model bound to runtime [id], or [None]
     when the id is not configured (e.g. before {!init_default}).  Consumed by

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -81,18 +81,27 @@ type seed = {
     id, or before [Runtime.init_default]): no per-model signal, leave the
     caller policy unchanged.
 
-    [thinking_budget] stays [None] here: the per-model [max_thinking_budget] is
-    a ceiling, not an active budget, so wiring it as the active budget would be
-    a category error — the keeper's adaptive budget owns the active value. *)
-let seed_of_thinking_support ?(preserve_thinking = None) (thinking_support : bool option)
+    [thinking_budget] carries the per-model [max-thinking-budget] ceiling
+    (RFC-0271 §4.2). It is not a bypass of the keeper's adaptive budget: the
+    adaptive step ([Keeper_agent_prompt_metrics.adaptive_thinking_budget]) seeds
+    from this value and may lower it (e.g. to 1500 on a tool-error retry), so the
+    ceiling is the adaptive UPPER bound. The SDK converts the resulting budget to
+    a bounded reasoning effort ([Reasoning_effort.of_budget]) for
+    reasoning-effort/thinking-object models. [None] — every runtime today, since
+    no [max-thinking-budget] is configured — preserves the prior wire exactly. *)
+let seed_of_thinking_support
+      ?(preserve_thinking = None)
+      ?(thinking_budget = None)
+      (thinking_support : bool option)
   : seed
   =
-  { thinking_budget = None; thinking_enabled = thinking_support; preserve_thinking }
+  { thinking_budget; thinking_enabled = thinking_support; preserve_thinking }
 ;;
 
 let for_runtime ~name =
   seed_of_thinking_support
     ~preserve_thinking:(Runtime.preserve_thinking_of_runtime_id name)
+    ~thinking_budget:(Runtime.max_thinking_budget_of_runtime_id name)
     (Runtime.thinking_support_of_runtime_id name)
 ;;
 

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -15,11 +15,14 @@ type seed = {
 
 val seed_of_thinking_support
   :  ?preserve_thinking:bool option
+  -> ?thinking_budget:int option
   -> bool option
   -> seed
 (** Pure: map a model's [thinking-support] capability to the keeper thinking
     seed.  [Some false] is a force-thinking-off signal;
-    [Some true] actively enables thinking for that model binding. *)
+    [Some true] actively enables thinking for that model binding.
+    [thinking_budget] carries the per-model [max-thinking-budget] ceiling
+    (RFC-0271 §4.2); [None] preserves the prior wire. *)
 
 val for_runtime : name:string -> seed
 (** Per-model thinking seed for runtime [name], resolved from the runtime.toml

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -999,6 +999,7 @@ max-context = 128000
 tools-support = true
 thinking-support = true
 preserve-thinking = true
+max-thinking-budget = 4096
 streaming = true
 
 [models.nothink]
@@ -1185,6 +1186,26 @@ let test_thinking_support_false_forces_off () =
       "non-thinking model emits Some false (capability gate forces thinking off)"
       (Some false)
       seed.Runtime_inference.thinking_enabled)
+;;
+
+(* RFC-0271 §4.2: [max-thinking-budget] flows through [for_runtime] into the
+   reasoning seed budget, from which the SDK derives a bounded reasoning effort
+   ([Reasoning_effort.of_budget]). A runtime without the config key preserves
+   [None] (byte-identical prior wire). *)
+let test_max_thinking_budget_wired_into_seed () =
+  with_runtime_thinking (fun () ->
+    let seed = Runtime_inference.for_runtime ~name:"ollama_cloud.think" in
+    Alcotest.(check (option int))
+      "max-thinking-budget flows into the reasoning seed"
+      (Some 4096)
+      seed.Runtime_inference.thinking_budget;
+    let seed_default =
+      Runtime_inference.for_runtime ~name:"ollama_cloud.thinkdefault"
+    in
+    Alcotest.(check (option int))
+      "runtime with no max-thinking-budget preserves None"
+      None
+      seed_default.Runtime_inference.thinking_budget)
 ;;
 
 let test_runtime_inventory_surfaces_parameter_policy () =
@@ -1945,6 +1966,10 @@ let () =
             "thinking-support=false forces thinking off (Some false)"
             `Quick
             test_thinking_support_false_forces_off
+        ; Alcotest.test_case
+            "max-thinking-budget wires into reasoning seed (RFC-0271 §4.2)"
+            `Quick
+            test_max_thinking_budget_wired_into_seed
         ; Alcotest.test_case
             "runtime inventory surfaces OAS parameter policy"
             `Quick


### PR DESCRIPTION
## 목표

RFC-0271 §4.2 **thinking-budget wiring** — reasoning-effort 모델(flash 등)의 over-thinking을 원천에서 바운드하는 preventive. corrective(#23648 Retry_no_thinking)와 상보.

## 진단 (세션 중 정정 포함)

- SDK는 request마다 `enable_thinking + thinking_budget`에서 reasoning effort를 **자동 파생**(`backend_openai_request` → `Provider_config.reasoning_effort_request_value_typed` → `effort_of_thinking_config_value`): budget `Some n` → `Reasoning_effort.of_budget n`, budget `None` → **Medium** 기본.
- `of_budget`: `<=2048→Low`, `<=8192→Medium`, `<=32768→High`, else `XHigh`.
- flash(fleet default)는 현재 `thinking_budget=None` → **Medium** effort로 live 턴이 43K~86K자 사고, 일부 thinking_only 종료.
- **dead wiring**: `runtime_inference.ml`이 `seed.thinking_budget=None`을 하드코딩("category error" 주석)해, 파싱된 per-runtime `max-thinking-budget`이 of_budget에 **도달하지 못함**. (정정: 앞선 세션 판단 "§4.2 token budget이 flash엔 부적합"은 틀렸음 — of_budget이 budget→effort를 변환하므로 §4.2가 바로 flash의 effort 레버.)

## 변경

- `runtime.ml/.mli`: `max_thinking_budget_of_runtime_id` accessor 추가(`rt.model.max_thinking_budget`).
- `runtime_inference.ml/.mli`: `seed_of_thinking_support`에 `?thinking_budget`, `for_runtime`가 accessor 전달. 주석 정정(ceiling은 adaptive **상한**이지 bypass 아님 — adaptive가 seed로 받아 retry 시 1500으로 낮춤). **blast radius 0**: 현재 `max-thinking-budget` 설정된 런타임 **0개**라 기존 wire 불변.
- `config/runtime.toml`: flash `max-thinking-budget = 2048` → of_budget → **Low** effort. Medium(43K자) 대비 cap.

## 정직 (미검증)

flash를 Low로 낮추면 사고가 줄어드는지는 **provider(deepseek)가 effort hint를 준수하는지에 달렸고 미측정**입니다. 이 PR은 (a) dead wiring을 살리는 **mechanism**(safe, blast 0)과 (b) flash 값 **제안**(Draft, 리뷰/튜닝 대상)입니다. Low가 과하면 corrective #23648이 thinking_only를 backstop하고, config 한 줄로 Medium(8192)으로 튜닝 가능. fleet default라 리뷰 후 머지 권장.

## 검증

- 신규 테스트 `max_thinking_budget_wired_into_seed`: budget 설정 런타임 → `seed.thinking_budget=Some 4096`, 미설정 → `None` 보존.
- `test_runtime_per_keeper_routing` 회귀 green. 전체 build + config 파싱 확인.

RFC: RFC-0271 §4.2. Related #23648(§4.1 corrective), RFC-0136(ceiling semantics), RFC-0082(§3.5 producer-consumer same PR).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
