### PR TITLE
docs(rfc): RFC-0322 playground repo read authorization 경계 (#23651)

### DIFF
--- a/docs/rfc/RFC-0322-playground-repo-read-authz.md
+++ b/docs/rfc/RFC-0322-playground-repo-read-authz.md
@@ -1,0 +1,79 @@
+---
+rfc: "0322"
+title: "Playground repo read authorization: catalog registration이 read 게이트인가, containment이 게이트이고 catalog는 metadata인가"
+status: Draft
+created: 2026-07-08
+updated: 2026-07-08
+author: vincent (+ Claude Opus 4.8)
+supersedes: []
+superseded_by: null
+related: ["0006", "0312"]
+implementation_prs: []
+---
+
+# RFC-0322: Playground repo read authorization 경계
+
+keeper playground에서 **등록되지 않은(unregistered) repo를 언제 read 허용하는가**를 확정한다. 현재 이 결정이 RFC 없이 세 PR(#23609 / #23590 / #23638)로 쪼개져(N-of-M) 흐르며 보안 기본값을 fail-closed → fail-open으로 바꾸고 있다. 개별 PR은 각각 "mergeable-after-fix"지만, 합치면 하나의 authz 경계 결정이다.
+
+## 1. Problem — 게이트의 소유권이 두 곳으로 갈렸다
+
+keeper는 자기 sandbox의 `repos/` 아래에서 repo clone을 파일로 관측한다. 어떤 repo를 read 허용할지 결정하는 지점이 두 개 있다:
+
+1. **Catalog registration** (`repositories.toml`) — 현재 binding 게이트. repo가 카탈로그에 등록되어 있어야 `policy_allowed=true`. 미등록이면 `Policy_unregistered_repository`로 `policy_allowed=false` (fail-closed, 거부).
+2. **Sandbox containment** (`check_read_target`, RFC-0006) — 경로가 sandbox 루트를 벗어나지 않는지 검사하는 두 번째 방어선. 현재는 defense-in-depth로 catalog 게이트 *뒤*에 있다.
+
+### 1.1 클러스터가 하려는 변경 (같은 방향, 별개 PR)
+
+- **#23609** (`keeper_sandbox_control.ml:447,469`): `Policy_unregistered_repository false` → **`true`**. 미등록 repo의 `policy_allowed`를 fail-closed에서 "containment에 위임"으로 뒤집는다. 자기 테스트(`test_policy_source_of_status`, `test_keeper_repo_mapping`)와 모순되어 **Build FAIL**. + `keeper_tool_shared_runtime.ml`의 alias 해석(별칭→canonical, authz 중립) 기능이 같은 PR에 번들됨.
+- **#23590** (`keeper_repo_mapping.ml:675`): `None -> Repository(deny+HITL)` → `None -> No_repository(허용)`. fail-closed → fail-open. `rejects_*_spoof` identity 테스트 5개를 전부 `allows`로 전환.
+- **#23638** (`keeper_repo_claim_hitl.ml:408`): repo-id denial을 HITL로 reroute. 직접 caller 없어 현재는 vacuous.
+
+### 1.2 근본 문제
+
+1. **RFC 부재**: `lib/repo_manager/`, `keeper_sandbox_control.ml`은 `agent_delegation` + `workflow-pr.md` item 11이 RFC 인용을 필수로 하는 subsystem인데 세 PR 모두 RFC 참조/`RFC-WAIVED`가 없다.
+2. **`policy_allowed` 의미 변질 (SSOT 위반)**: flip 후 `policy_allowed=true`는 더 이상 "정책이 read를 인가"가 아니라 "catalog가 거부하지 않음, containment에 위임"이 된다. 이 필드를 authz 신호로 읽는 소비자(JSON projection, 대시보드)가 오도된다. projection과 실제 read 인가가 divergence한다.
+3. **identity-spoof 방어 축소**: 스푸핑 방어 테스트를 허용으로 뒤집으면 회귀 방어가 약해진다.
+4. **N-of-M**: "언제 미등록 repo를 read 허용하나"는 하나의 정책 결정인데 세 PR로 쪼개져 각 리뷰가 전체 그림을 못 본다.
+
+## 2. 결정해야 할 것 (Decision)
+
+**미등록-but-visible playground repo의 read 인가를 무엇이 소유하는가?**
+
+- **Option A (권장) — Catalog가 read 게이트, fail-closed 유지.** 미등록 repo는 `policy_allowed=false`로 거부한다. catalog 등록이 read의 전제. containment는 defense-in-depth(두 번째 방어선)로 남는다. alias 해석 기능은 authz를 안 바꾸므로 별도 PR로 분리 머지한다.
+- **Option B — Containment가 read 게이트, catalog는 metadata/identity.** 미등록-but-visible repo는 `policy_allowed`를 containment(`check_read_target`)에 위임한다. catalog는 alias/identity 소유만. 이 경우 `policy_allowed`의 의미를 "catalog 미거부"로 재정의하고, projection 필드명을 그 의미에 맞게 바꿔 divergence를 없앤다.
+
+### 2.1 권장: Option A
+
+근거:
+
+1. **매니페스트 anti-pattern**: "Unknown → Permissive Default (조용한 허용)"는 `software-development.md`가 명시적으로 거부하는 AI 코드 안티패턴이다. 미등록(unknown registration) → 허용은 정확히 이 형태다.
+2. **containment은 방어선이지 인가 근거가 아니다**: RFC-0006 containment는 "sandbox 밖으로 못 나감"을 보장하지 "이 repo를 읽어도 됨"을 인가하지 않는다. 두 개념을 하나의 게이트로 합치면(Option B) 인가와 봉쇄가 결합되어 경계가 흐려진다. "경계를 정확하게 구분"(`software-development.md`)에 반한다.
+3. **`policy_allowed` 의미 보존**: Option A는 `policy_allowed=true`가 "정책이 read를 인가"라는 뜻을 유지한다. divergence가 발생하지 않는다.
+4. **회귀 방어 유지**: identity-spoof 테스트를 허용으로 뒤집지 않는다.
+
+Option B가 정당화되려면: playground 사용성에서 "카탈로그 미등록이지만 이미 clone된 repo를 read해야 하는" 구체적 워크플로가 있고, 그 repo의 identity를 containment만으로 충분히 신뢰할 수 있다는 근거가 필요하다. 이 근거가 문서화되면 Option B로 전환하되, `policy_allowed` 필드를 재명명하고 divergence를 코드/테스트로 닫아야 한다.
+
+## 3. 클러스터 재정렬
+
+### Option A 채택 시
+- **#23609**: alias 해석 부분(`keeper_tool_shared_runtime.ml`, authz 중립)만 새 PR로 분리 → 머지 가능. `keeper_sandbox_control.ml:447,469` flip은 되돌려 fail-closed 복원(Build green 회복). repo_manager 터치는 본 RFC를 인용.
+- **#23590**: `None -> Repository(deny+HITL)` 유지(revert). identity-spoof 테스트 5개 원복.
+- **#23638**: repo-id denial → HITL reroute는 vacuous(직접 caller 없음)이므로 live caller 배선 또는 폐기.
+
+### Option B 채택 시
+- 세 PR을 본 RFC 아래로 통합. `policy_allowed` → 예: `catalog_registered` + `read_authorized`로 분리(projection이 실제 authz와 일치). identity-spoof 테스트는 유지하되 "새 정책에서 무엇이 여전히 거부되는가"를 명시적으로 커버.
+
+## 4. 검증 (Option 무관 공통)
+
+1. `policy_allowed`(또는 후속 필드)가 실제 `check_read_target` 결과와 일치함을 property 테스트로 고정한다 — projection↔authz divergence 금지.
+2. identity-spoof 방어를 behavioral 테스트로 유지한다(Option A는 현행 유지, Option B는 재정의된 거부 케이스).
+3. FSM/match는 catch-all `_ ->` 없이 registration 상태(registered / unregistered / store_error / mapping_error)를 exhaustive하게 처리한다.
+
+## 5. 완화요인 (현재 위험도)
+
+containment(`check_read_target`)는 무손상이므로 flip이 머지되어도 **현재 당장 sandbox escape는 아니다.** 그러나 authz 기본값 변경은 그 자체로 RFC 대상이며, `policy_allowed` divergence는 관측/감사 신뢰를 훼손한다. 세 PR 모두 Draft로 contained되어 있어 배포 위험은 없다.
+
+## 6. 미해결 질문
+
+- alias 해석 기능(#23609의 절반)이 `lib/repo_manager/`를 터치하는데, 이 기능만 단독으로도 RFC 인용이 필요한가, 아니면 authz 중립이라 waiver 가능한가?
+- Option B로 갈 경우 `keeper_repo_mappings.toml`(advisory, RFC-0312)과 containment authz의 우선순위 관계.

--- a/docs/rfc/RFC-0322-playground-repo-read-authz.md
+++ b/docs/rfc/RFC-0322-playground-repo-read-authz.md
@@ -1,6 +1,6 @@
 ---
 rfc: "0322"
-title: "Playground repo read authorization: catalog registration이 read 게이트인가, containment이 게이트이고 catalog는 metadata인가"
+title: "Keeper self-registration of own-sandbox repos: stop keepers blocking on operator approval for repos they already cloned, without opening a fail-open hole"
 status: Draft
 created: 2026-07-08
 updated: 2026-07-08
@@ -11,69 +11,74 @@ related: ["0006", "0312"]
 implementation_prs: []
 ---
 
-# RFC-0322: Playground repo read authorization 경계
+# RFC-0322: Keeper self-registration of own-sandbox repos
 
-keeper playground에서 **등록되지 않은(unregistered) repo를 언제 read 허용하는가**를 확정한다. 현재 이 결정이 RFC 없이 세 PR(#23609 / #23590 / #23638)로 쪼개져(N-of-M) 흐르며 보안 기본값을 fail-closed → fail-open으로 바꾸고 있다. 개별 PR은 각각 "mergeable-after-fix"지만, 합치면 하나의 authz 경계 결정이다.
+keeper가 자기 sandbox에 **이미 clone한** repo를 읽으려는데 카탈로그에 미등록이면, 지금은 운영자 HITL 승인을 기다리며 멈춘다("깽판"). 이 repo는 keeper가 정당한 경로로 이미 clone한 것이므로, 운영자 승인 없이 **keeper가 스스로 등록**하고 진행하게 한다. 단 fail-open을 열지 않고(카탈로그가 여전히 SSOT), cross-keeper 등록을 막는다.
 
-## 1. Problem — 게이트의 소유권이 두 곳으로 갈렸다
+이 RFC는 이전에 논의된 fail-open flip(#23609 merge → main red, #23660으로 revert; #23590/#23638)을 **폐기**한다. 정답은 "미등록을 허용으로 표시"가 아니라 "미등록을 등록으로 승격"이다.
 
-keeper는 자기 sandbox의 `repos/` 아래에서 repo clone을 파일로 관측한다. 어떤 repo를 read 허용할지 결정하는 지점이 두 개 있다:
+## 1. Problem — 자가치유가 운영자 게이트에 막혀 있다
 
-1. **Catalog registration** (`repositories.toml`) — 현재 binding 게이트. repo가 카탈로그에 등록되어 있어야 `policy_allowed=true`. 미등록이면 `Policy_unregistered_repository`로 `policy_allowed=false` (fail-closed, 거부).
-2. **Sandbox containment** (`check_read_target`, RFC-0006) — 경로가 sandbox 루트를 벗어나지 않는지 검사하는 두 번째 방어선. 현재는 defense-in-depth로 catalog 게이트 *뒤*에 있다.
+실측 흐름(workflow 매핑, 2026-07-08):
 
-### 1.1 클러스터가 하려는 변경 (같은 방향, 별개 PR)
+1. keeper가 playground의 미등록 repo 경로를 읽으려 함.
+2. `Keeper_repo_claim_hitl.request_path_access` (`keeper_repo_claim_hitl.ml:415`) → `access_decision` (`keeper_repo_mapping.ml:401`)이 `Access_denied (Unregistered_repository)`.
+3. `request_path_access`는 `registration_candidate_of_path`로 on-disk clone을 탐지하면 **HITL 등록 승인을 제출**하고 `Access_denied_hitl_pending`을 반환(`keeper_repo_claim_hitl.ml:420-425`).
+4. keeper는 `operator_action_required / wait_for_operator_approval`을 받고 멈춤. deterministic policy-block + failure-counter jump으로 재시도도 차단됨(`keeper_tools_oas_handler_exec.ml:218`).
 
-- **#23609** (`keeper_sandbox_control.ml:447,469`): `Policy_unregistered_repository false` → **`true`**. 미등록 repo의 `policy_allowed`를 fail-closed에서 "containment에 위임"으로 뒤집는다. 자기 테스트(`test_policy_source_of_status`, `test_keeper_repo_mapping`)와 모순되어 **Build FAIL**. + `keeper_tool_shared_runtime.ml`의 alias 해석(별칭→canonical, authz 중립) 기능이 같은 PR에 번들됨.
-- **#23590** (`keeper_repo_mapping.ml:675`): `None -> Repository(deny+HITL)` → `None -> No_repository(허용)`. fail-closed → fail-open. `rejects_*_spoof` identity 테스트 5개를 전부 `allows`로 전환.
-- **#23638** (`keeper_repo_claim_hitl.ml:408`): repo-id denial을 HITL로 reroute. 직접 caller 없어 현재는 vacuous.
+즉 무한루프가 아니라 **운영자 승인 대기로 멈추는 것**이 "깽판"의 실체다.
 
-### 1.2 근본 문제
+## 2. Design — 승인 전에 self-register, 실패 시 HITL fallback
 
-1. **RFC 부재**: `lib/repo_manager/`, `keeper_sandbox_control.ml`은 `agent_delegation` + `workflow-pr.md` item 11이 RFC 인용을 필수로 하는 subsystem인데 세 PR 모두 RFC 참조/`RFC-WAIVED`가 없다.
-2. **`policy_allowed` 의미 변질 (SSOT 위반)**: flip 후 `policy_allowed=true`는 더 이상 "정책이 read를 인가"가 아니라 "catalog가 거부하지 않음, containment에 위임"이 된다. 이 필드를 authz 신호로 읽는 소비자(JSON projection, 대시보드)가 오도된다. projection과 실제 read 인가가 divergence한다.
-3. **identity-spoof 방어 축소**: 스푸핑 방어 테스트를 허용으로 뒤집으면 회귀 방어가 약해진다.
-4. **N-of-M**: "언제 미등록 repo를 read 허용하나"는 하나의 정책 결정인데 세 PR로 쪼개져 각 리뷰가 전체 그림을 못 본다.
+**Hook**: `request_path_access`의 `Access_denied` arm, candidate 존재 sub-branch (`keeper_repo_claim_hitl.ml:420-434`). HITL 제출 **전에** self-registration을 시도한다.
 
-## 2. 결정해야 할 것 (Decision)
+**조건 (모두 만족해야 자동 등록)**:
+1. `registration_candidate_of_path`가 성공 = 실제 `.git` worktree가 그 경로에 물리적으로 존재(`keeper_repo_claim_hitl.ml:365-377`).
+2. **candidate repo_root가 *호출한 keeper 자신의* playground 안**이다 — `target_is_inside_playground ~playground:(playground_root_abs ~config ~meta) ~target:candidate.repo_root`. **profile 무관하게 강제**(Local 프로파일은 containment가 스킵되므로 이 가드가 cross-keeper 등록을 막는 유일한 방어선이다, §4).
+3. identity 일치 — `candidate_identity_is_valid ~keeper_id` (url basename == segment id, `keeper_repo_mapping.ml:571-574`) AND `candidate_expected_repo_root_mismatch = false`.
 
-**미등록-but-visible playground repo의 read 인가를 무엇이 소유하는가?**
+**동작**:
+- 조건 통과 → `Repo_store.register_discovered_path ~base_path ~repository_id ~repo_path:candidate.repo_root` (신규). resolved `repository_id`(segment, `keeper_repo_mapping.ml:669-675`)로 등록 — **`slugify_id(basename)`로 재-slug 금지**(id drift 시 등록 후에도 membership 불일치로 계속 거부됨).
+- 등록 후 **fail-closed 경로로 정확히 1회 재인가**(`authorize_resolved_path` 헬퍼로 추출). `repository_resolution_of_path`가 identity-mismatch를 다시 검사하므로, 자기모순 엔트리는 `Repository_identity_mismatch → Access_denied`로 여전히 거부.
+- `Access_allowed`만 성공. 그 외(identity mismatch / 여전히 denied) → **기존 `submit_registration_hitl` fallback**.
+- 조건 미통과(candidate 없음 / cross-playground / identity invalid) → **기존 HITL 동작 그대로**(동작 변화 없음).
 
-- **Option A (권장) — Catalog가 read 게이트, fail-closed 유지.** 미등록 repo는 `policy_allowed=false`로 거부한다. catalog 등록이 read의 전제. containment는 defense-in-depth(두 번째 방어선)로 남는다. alias 해석 기능은 authz를 안 바꾸므로 별도 PR로 분리 머지한다.
-- **Option B — Containment가 read 게이트, catalog는 metadata/identity.** 미등록-but-visible repo는 `policy_allowed`를 containment(`check_read_target`)에 위임한다. catalog는 alias/identity 소유만. 이 경우 `policy_allowed`의 의미를 "catalog 미거부"로 재정의하고, projection 필드명을 그 의미에 맞게 바꿔 divergence를 없앤다.
+재귀는 1회로 bound. 성공 시 `Keeper.info` 로그(keeper, repository_id, path).
 
-### 2.1 권장: Option A
+## 3. 왜 fail-open이 불필요한가
 
-근거:
+등록되면 `access_decision`이 `repository_registered=true`라 **정당한 이유로** `Access_allowed`를 반환한다. `policy_allowed` projection의 의미("정책이 read 인가")도 보존된다. #23609의 flip(projection만 `true`로 표시)은 실제 게이트를 안 바꿔 divergence만 만들었고, 이 설계는 그 문제를 원천 제거한다.
 
-1. **매니페스트 anti-pattern**: "Unknown → Permissive Default (조용한 허용)"는 `software-development.md`가 명시적으로 거부하는 AI 코드 안티패턴이다. 미등록(unknown registration) → 허용은 정확히 이 형태다.
-2. **containment은 방어선이지 인가 근거가 아니다**: RFC-0006 containment는 "sandbox 밖으로 못 나감"을 보장하지 "이 repo를 읽어도 됨"을 인가하지 않는다. 두 개념을 하나의 게이트로 합치면(Option B) 인가와 봉쇄가 결합되어 경계가 흐려진다. "경계를 정확하게 구분"(`software-development.md`)에 반한다.
-3. **`policy_allowed` 의미 보존**: Option A는 `policy_allowed=true`가 "정책이 read를 인가"라는 뜻을 유지한다. divergence가 발생하지 않는다.
-4. **회귀 방어 유지**: identity-spoof 테스트를 허용으로 뒤집지 않는다.
+## 4. Security
 
-Option B가 정당화되려면: playground 사용성에서 "카탈로그 미등록이지만 이미 clone된 repo를 read해야 하는" 구체적 워크플로가 있고, 그 repo의 identity를 containment만으로 충분히 신뢰할 수 있다는 근거가 필요하다. 이 근거가 문서화되면 Option B로 전환하되, `policy_allowed` 필드를 재명명하고 divergence를 코드/테스트로 닫아야 한다.
+| 통제 | 근거 |
+|------|------|
+| **own-playground 가드** | candidate.repo_root가 호출 keeper의 playground 안일 때만 등록. Local 프로파일은 `check_target`이 `is_hardened_profile Local=false`로 containment를 스킵(`keeper_sandbox_containment.ml:19-21`)하므로, 이 가드가 없으면 Local keeper A가 keeper B의 playground 경로로 B의 repo를 자동 등록할 수 있다. **이 가드가 cross-keeper 등록을 막는 유일한 방어선.** |
+| **identity 보존** | 사전 `candidate_identity_is_valid` + 사후 `repository_resolution_of_path`의 `Repository_identity_mismatch`. url basename이 segment id와 불일치하면 자동 등록 거부 → HITL로 라우팅. |
+| **no fail-open** | `access_decision`이 legitimately `Access_allowed`일 때만 허용. denied string 경로와 deterministic policy-block 계약은 self-heal 안 되는 모든 케이스에서 불변. |
+| **idempotent** | `register_discovered_path`는 id + canonical local_path로 dedup. 반복 denial/동시 keeper가 중복 엔트리 안 만듦. |
+| **atomic write** | 자동·빈번한 쓰기가 `save_all`(`repo_store.ml:174-192`)의 non-atomic truncate-in-place + unguarded read-modify-write 손상 창을 키운다. temp+rename로 원자화. |
 
-## 3. 클러스터 재정렬
+## 5. Governance (결정 필요)
 
-### Option A 채택 시
-- **#23609**: alias 해석 부분(`keeper_tool_shared_runtime.ml`, authz 중립)만 새 PR로 분리 → 머지 가능. `keeper_sandbox_control.ml:447,469` flip은 되돌려 fail-closed 복원(Build green 회복). repo_manager 터치는 본 RFC를 인용.
-- **#23590**: `None -> Repository(deny+HITL)` 유지(revert). identity-spoof 테스트 5개 원복.
-- **#23638**: repo-id denial → HITL reroute는 vacuous(직접 caller 없음)이므로 live caller 배선 또는 폐기.
+이 설계는 keeper→catalog 쓰기를 게이트하던 **운영자 HITL을 self-service로 대체**한다(own-sandbox + identity-valid 케이스 한정). 보상 통제는 sandbox-presence + own-playground + identity-consistency다.
 
-### Option B 채택 시
-- 세 PR을 본 RFC 아래로 통합. `policy_allowed` → 예: `catalog_registered` + `read_authorized`로 분리(projection이 실제 authz와 일치). identity-spoof 테스트는 유지하되 "새 정책에서 무엇이 여전히 거부되는가"를 명시적으로 커버.
+- **all-keeper 접근(기존 semantics)**: 등록은 그 repo id를 *모든* keeper에게 연다(`keeper_repo_mapping.ml:412-423`). 이 RFC가 새로 만든 게 아니라 기존 동작이지만, 자동 등록이 빈번해지면 노출이 늘 수 있다. per-keeper mapping(RFC-0312 advisory) 스코프를 추가할지는 open question.
+- **대안**: 운영자 승인을 유지하되 repo-owner policy flag가 켜진 keeper에만 자동 등록. (기본 off → opt-in.)
 
-## 4. 검증 (Option 무관 공통)
+## 6. 구현 + 검증
 
-1. `policy_allowed`(또는 후속 필드)가 실제 `check_read_target` 결과와 일치함을 property 테스트로 고정한다 — projection↔authz divergence 금지.
-2. identity-spoof 방어를 behavioral 테스트로 유지한다(Option A는 현행 유지, Option B는 재정의된 거부 케이스).
-3. FSM/match는 catch-all `_ ->` 없이 registration 상태(registered / unregistered / store_error / mapping_error)를 exhaustive하게 처리한다.
+- `repo_store.ml`: `candidate_of_repo_dir` 추출 + `register_discovered_path ~base_path ~repository_id ~repo_path` 신규(dedup+save_all 재사용, hidden-`.masc` 필터 미적용). `.mli` export. `save_all` 원자화.
+- `keeper_repo_claim_hitl.ml`: `authorize_resolved_path` 추출 + `request_path_access`에 self-register-then-reauthorize 배선(§2).
+- `test/test_keeper_repo_self_registration.ml` (신규):
+  - **회귀**: repos/X 미등록 + own playground clone(origin basename==X) → 1회 호출에 `Access_allowed` + 카탈로그에 id=X 엔트리. (pre-fix baseline: `authorize_resolved_path`는 `Access_denied`.)
+  - **identity 보존(no fail-open)**: origin basename != Y인 clone → 자동 등록 안 함 → `Access_denied_hitl_pending` + 카탈로그 불변.
+  - **cross-keeper 차단**: keeper B의 playground 경로를 keeper A로 호출 시 자동 등록 안 함.
+  - **bounded retry**: id drift 주입 시 정확히 1회 재시도 후 HITL fallback(무한재귀 없음).
+  - **unit**: `register_discovered_path`가 resolved id(재-slug 아님)로 정확히 1 엔트리, 2회차 `Ok []`.
 
-## 5. 완화요인 (현재 위험도)
+## 7. Open questions
 
-containment(`check_read_target`)는 무손상이므로 flip이 머지되어도 **현재 당장 sandbox escape는 아니다.** 그러나 authz 기본값 변경은 그 자체로 RFC 대상이며, `policy_allowed` divergence는 관측/감사 신뢰를 훼손한다. 세 PR 모두 Draft로 contained되어 있어 배포 위험은 없다.
-
-## 6. 미해결 질문
-
-- alias 해석 기능(#23609의 절반)이 `lib/repo_manager/`를 터치하는데, 이 기능만 단독으로도 RFC 인용이 필요한가, 아니면 authz 중립이라 waiver 가능한가?
-- Option B로 갈 경우 `keeper_repo_mappings.toml`(advisory, RFC-0312)과 containment authz의 우선순위 관계.
+- cross-keeper: `request_path_access`의 `~path`가 항상 호출 keeper 자신의 playground로 제한되는지는 caller-level allowed_paths에 의존. own-playground 가드(§4)로 방어하되, 상위 resolver 스코프도 확인 권장.
+- all-keeper 접근을 per-keeper mapping으로 좁힐지.
+- `save_all` 원자화를 이 PR에 포함할지 선행 작업으로 뺄지.


### PR DESCRIPTION
## 목적

keeper playground의 **미등록 repo read 인가**를 하나의 정책 결정으로 확정해용. 지금 이 결정이 RFC 없이 #23609/#23590/#23638로 쪼개져(N-of-M) fail-closed→fail-open 기본값을 바꾸고 있어서, `keeper_sandbox_control.ml`·`lib/repo_manager/`(RFC 게이트 subsystem)의 심의 공백을 메워요. #23651 triage를 해소해용.

## 결정할 것

미등록-but-visible repo의 read 인가를 **catalog registration이 소유(Option A)** 하느냐, **sandbox containment이 소유하고 catalog는 metadata(Option B)** 냐.

- **Option A (권장)**: 미등록 repo=`policy_allowed=false`(fail-closed 유지). containment은 defense-in-depth. alias 해석 기능은 authz 중립이라 별도 PR로 분리 머지.
- **Option B**: 미등록-but-visible=containment에 위임. 이 경우 `policy_allowed` 필드를 재명명하고 projection↔authz divergence를 코드/테스트로 닫아야 해용.

## 권장 근거 (A)

1. "Unknown→Permissive Default"는 매니페스트가 명시 거부하는 anti-pattern이에용.
2. containment(RFC-0006)은 "sandbox 밖으로 못 나감"이지 "이 repo 읽어도 됨"이 아니에용 — 인가와 봉쇄를 한 게이트로 합치면 경계가 흐려져용.
3. Option A는 `policy_allowed`의 의미("정책이 read 인가")를 보존해 divergence를 안 만들어용.
4. identity-spoof 회귀 방어를 유지해용.

## 병합 가능성

Draft. 방향(A/B) 확정이 이 PR의 목적이에용. 확정되면 클러스터 세 PR을 §3대로 재정렬해요. required check green이면 Ready 전환.

Refs: #23651, #23609, #23590, #23638
