### PR TITLE
feat(dashboard): surface keeper creation in the fleet (persona → keeper)

### DIFF
--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -27,6 +27,10 @@ vi.mock('./agent-roster', () => ({
   AgentRoster: ({ keeperFilter }: { keeperFilter: string }) => h('div', { 'data-testid': 'agent-roster', 'data-filter': keeperFilter }, 'AgentRoster'),
 }))
 
+vi.mock('./keeper-spawn/keeper-spawn-panel', () => ({
+  KeeperSpawnPanel: () => h('div', { 'data-testid': 'keeper-spawn-panel' }, 'KeeperSpawnPanel'),
+}))
+
 vi.mock('../router', () => ({
   route: mockRoute,
 }))
@@ -69,7 +73,8 @@ describe('AgentsUnified', () => {
     expect(roster).not.toBeNull()
     expect(roster!.getAttribute('data-filter')).toBe('all')
     expect(container.querySelector('[data-testid="filter-chips"]')).toBeNull()
-    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
+    // Keeper creation lives at the top of the fleet roster (all / keepers views).
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="keeper-multi-select"]')).toBeNull()
     expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
   })
@@ -80,12 +85,14 @@ describe('AgentsUnified', () => {
     const roster = container.querySelector('[data-testid="agent-roster"]')
     expect(roster!.getAttribute('data-filter')).toBe('agent-only')
     expect(container.querySelector('[data-testid="filter-chips"]')).toBeNull()
+    // Agents view lists workspace agents, not keepers — no keeper-create entry here.
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
   })
 
   it('renders keepers view as a narrowed roster without multi-select stats', () => {
     mockRoute.value = { tab: 'monitoring', params: { view: 'keepers' }, postId: null }
     render(h(AgentsUnified, null), container)
-    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="keeper-multi-select"]')).toBeNull()
     expect(container.querySelector('[data-testid="keeper-token-stats"]')).toBeNull()
     const roster = container.querySelector('[data-testid="agent-roster"]')

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -8,6 +8,7 @@ import { route } from '../router'
 import { AgentRoster } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
+import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
 import { CompositeFsmFlowchart } from './composite-fsm-flowchart'
@@ -41,11 +42,14 @@ export function AgentsUnified() {
     <div class="v2-monitoring-surface flex flex-col gap-4">
       ${currentView === 'fsm'
         ? html`<${FleetAndFsmHubPanel} />`
-        : html`<${AgentRoster}
-            keeperFilter=${currentView === 'keepers' ? 'keeper-only'
-              : currentView === 'agents' ? 'agent-only'
-              : 'all'}
-          />`}
+        : html`
+            ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
+            <${AgentRoster}
+              keeperFilter=${currentView === 'keepers' ? 'keeper-only'
+                : currentView === 'agents' ? 'agent-only'
+                : 'all'}
+            />
+          `}
     </div>
   `
 }

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.test.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.test.ts
@@ -35,17 +35,14 @@ describe('KeeperSpawnPanel', () => {
     expect(container.textContent).toContain('Browser')
   })
 
-  it('switches to direct tab on click', () => {
+  it('exposes the spawn panel testid in both collapsed and expanded states', () => {
+    const collapsed = document.createElement('div')
+    render(h(KeeperSpawnPanel), collapsed)
+    expect(collapsed.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
     showSpawnPanel.value = true
-    const container = document.createElement('div')
-    render(h(KeeperSpawnPanel), container)
-    const buttons = container.querySelectorAll('button')
-    const directBtn = Array.from(buttons).find((b) => b.textContent?.includes('직접 생성'))
-    expect(directBtn).not.toBeUndefined()
-    directBtn!.click()
-    render(null, container)
-    render(h(KeeperSpawnPanel), container)
-    expect(container.textContent).toContain('masc_keeper_up')
+    const expanded = document.createElement('div')
+    render(h(KeeperSpawnPanel), expanded)
+    expect(expanded.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
   })
 
   it('closes panel on 닫기 click', () => {

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -1,33 +1,32 @@
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
 import { ActionButton } from '../common/button'
 import { PersonaBrowser } from './persona-browser'
 import { showSpawnPanel } from './keeper-spawn-state'
 
-type SpawnMode = 'persona' | 'direct'
-const spawnMode = signal<SpawnMode>('persona')
-
+// Simple keeper creation entry point for the fleet. Pick a persona → confirm →
+// the keeper boots with that persona's default goal/instructions. Fine-grained
+// overrides at creation time are intentionally NOT here — those go through
+// keeper detail (post-create) or masc_keeper_up in the tool executor, keeping
+// this flow to one decision.
 export function KeeperSpawnPanel() {
   if (!showSpawnPanel.value) {
-    return html`<div class="mb-4 v2-monitoring-surface">
+    return html`<div class="mb-4 v2-monitoring-surface" data-testid="keeper-spawn-panel">
       <${ActionButton} variant="primary" size="md" onClick=${() => { showSpawnPanel.value = true }}>+ 키퍼 생성<//>
     </div>`
   }
   return html`
-    <div class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 v2-monitoring-panel">
+    <div
+      class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 v2-monitoring-panel"
+      data-testid="keeper-spawn-panel"
+    >
       <div class="flex items-center justify-between mb-3 v2-monitoring-toolbar">
         <h3 class="text-sm text-[var(--color-fg-secondary)] font-medium">키퍼 생성</h3>
         <${ActionButton} variant="subtle" size="sm" onClick=${() => { showSpawnPanel.value = false }}>닫기<//>
       </div>
-      <div class="flex gap-2 mb-3 v2-monitoring-toolbar">
-        <${ActionButton} variant=${spawnMode.value === 'persona' ? 'primary' : 'ghost'} size="sm"
-          onClick=${() => { spawnMode.value = 'persona' }}>페르소나에서 생성<//>
-        <${ActionButton} variant=${spawnMode.value === 'direct' ? 'primary' : 'ghost'} size="sm"
-          onClick=${() => { spawnMode.value = 'direct' }}>직접 생성<//>
-      </div>
-      ${spawnMode.value === 'persona'
-        ? html`<${PersonaBrowser} />`
-        : html`<p class="text-xs text-[var(--color-fg-muted)]">직접 생성은 도구 실행기에서 <code class="text-[var(--color-accent-fg)]">masc_keeper_up</code>을 사용하세요.</p>`}
+      <p class="text-2xs text-[var(--color-fg-muted)] mb-3">
+        페르소나를 골라 키퍼를 시작합니다. 목표·지시사항은 페르소나 기본값을 쓰고, 세부 조정은 생성 후 keeper 상세에서 합니다.
+      </p>
+      <${PersonaBrowser} />
     </div>
   `
 }


### PR DESCRIPTION
## 목적

사용자 관찰: "Fleet에 Persona/Keeper 추가 기능이 있어야 할 것 같다." 조사 결과 — keeper 생성 UI(`KeeperSpawnPanel` + `PersonaBrowser`)와 백엔드(`masc_keeper_create_from_persona`)는 **완성돼 있으나 어디에도 마운트 안 된 orphan**이었습니다. v2 reskin 때 fleet 로스터에서 빠졌고(`agents-unified.test.ts`가 부재를 못박음) 재배선 안 됨 → UI에서 keeper를 추가할 방법이 없었습니다.

## 변경 (심플한 제작 방식 — 사용자 요청)

- **Keeper Fleet 로스터(`AgentsUnified`) 상단에 `KeeperSpawnPanel` 재배선**. keeper 관련 뷰(all / keepers)에만 노출, agents 뷰(workspace agent ≠ keeper)·fsm 뷰에선 숨김.
- **패널 단순화 — 결정 하나로**: persona/direct 모드 토글 제거("직접 생성"은 도구 실행기 포인터일 뿐이었음). 흐름 = **페르소나 선택 → 확인 → 페르소나 기본 goal/instructions로 keeper 부팅**. 세부 조정은 생성 후 keeper 상세에서(#23650과 일관: 전역/per-keeper 편집 분리).
- worker 접근 게이팅 유지(PersonaBrowser가 차단 사유 표시). collapsed/expanded 양쪽에 `data-testid`.
- **백엔드 무변경** — 기존 `masc_keeper_create_from_persona` 도구를 fleet 진입점에 배선만.

## 검증

- `pnpm test` 638파일/8699 green, typecheck/lint clean
- dev 서버: fleet에 "+ 키퍼 생성" 표시 → 확장 시 페르소나 그리드(11개), worker 게이트가 사유("AuthError] Unauthorized...")까지 정확히 보고

## 설계 노트 (사용자와 논의한 구조)

Persona → Keeper → Runtime 층위에서, 생성은 "템플릿(persona)에서 인스턴스화"가 옳은 모델이라 그대로 사용. 복잡함의 본질(persona↔keeper 필드 이중화)은 이 PR 범위 밖의 별개 문제로 남김.

## 미검증

- 라이브 실제 keeper 생성(실행)은 dev에 auth 토큰이 없어 미실행(게이트가 정상 차단). 프로덕션 worker 권한에서 활성화.
