### PR TITLE
fix(keeper): main red 수습 — playground unregistered fail-closed 복원 (#23609 regression)

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -326,9 +326,8 @@ let playground_policy_reason = function
   | Policy_allowed -> None
   | Policy_unregistered_repository ->
       Some
-        "repository is visible in the keeper playground but is not registered \
-         in the repository catalog; read access is governed by sandbox \
-         containment"
+        "repository is not registered in the repository catalog; access is \
+         denied fail-closed"
   | Policy_mapping_load_error ->
       Some
         "keeper repository mapping could not be loaded; advisory mapping is \
@@ -341,9 +340,9 @@ let playground_policy_reason = function
       Some
         "repository catalog could not be loaded; access is denied fail-closed"
 
-(* Which config file actually decided this status. The repository catalog
-   (repositories.toml) owns metadata/alias identity, while the sandbox
-   containment layer owns read authorization for visible playground clones. Per
+(* Which config file actually decided this status. The binding allow/deny gate
+   is the repository catalog (repositories.toml): a repo is usable iff it is
+   registered there, and [access_decision] never denies on the mapping — per
    RFC-0312 the keeper_repo_mappings.toml scope is advisory. So every
    catalog-sourced verdict (allowed / unregistered / identity mismatch / store
    load error) is labelled with the catalog basename; only the
@@ -444,7 +443,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
          field Policy_repository_store_error false ~repository_id ~error:msg ()
        | Ok true ->
          field Policy_allowed true ~repository_id ?mapping_error ~default_scope ()
-       | Ok false -> field Policy_unregistered_repository true ~repository_id ())
+       | Ok false -> field Policy_unregistered_repository false ~repository_id ())
   in
   match policy with
   | Keeper_repo_mapping.Mapping_load_error msg ->
@@ -466,7 +465,7 @@ let playground_repo_policy_fields ~base_path ~repo_catalog ~keeper_id:_ policy
          (match repository_id_in_catalog repository_id with
           | Error (`Store_error msg) ->
             field Policy_repository_store_error false ~repository_id ~error:msg ()
-          | Ok false -> field Policy_unregistered_repository true ~repository_id ()
+          | Ok false -> field Policy_unregistered_repository false ~repository_id ()
           | Ok true ->
             let default_scope =
               Keeper_repo_mapping.mapping_allows_repository mapping ~repository_id

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -61,12 +61,12 @@ val playground_policy_status_to_string : playground_policy_status -> string
 
 val policy_source_basename_of_status : playground_policy_status -> string
 (** Basename of the config file that actually decided a status: the repository
-    catalog ([repositories.toml]) for metadata/alias identity verdicts, and the
-    advisory mapping ([keeper_repo_mappings.toml]) only for its own load failure
-    (RFC-0312). Playground read authorization is owned by sandbox containment,
-    so an unregistered visible repo can be observable without being a read
-    denial. Exposed so the [policy_source] field's source-of-truth is asserted
-    against the same mapping the JSON uses, rather than a hardcoded basename. *)
+    catalog ([repositories.toml]) for every allow/deny verdict, since that is
+    the binding gate, and the advisory mapping ([keeper_repo_mappings.toml])
+    only for its own load failure (RFC-0312). Exposed so the [policy_source]
+    field's source-of-truth is asserted against the same mapping the JSON uses,
+    rather than a hardcoded basename that misreported catalog denials as
+    mapping denials. *)
 
 val playground_repos_json :
   config:Workspace.config ->


### PR DESCRIPTION
## 긴급: main red 수습

#23609(35f7a06bd0)가 머지되면서 **main Build가 빨강**이에용. 원인은 자기모순:
- 코드: `keeper_sandbox_control.ml:447,469` `Policy_unregistered_repository` → `policy_allowed=true`(fail-open)
- 같은 PR이 넣은 가디언 테스트 `test_playground_repos_mark_unregistered_visible_repo_denied`(`test_playground_repo_readiness.ml:291`)는 `policy_allowed=false` 단정

→ 코드 `true` vs 테스트 `false`라 Build FAIL.

## 변경

flip 2사이트 + reason/mli 문구를 **fail-closed**로 되돌려용. projection이 실제 게이트(`access_decision`: registered=allow, unregistered=deny)와 다시 일치해용. #23609의 **alias 해석 기능은 그대로**예용(authz 중립).

## P0/P1/P2

- **P0(main red)**: 해소 — 가디언 테스트가 `false` 단정하니 revert 후 통과.
- **하드코딩/휴리스틱 없음**: 리터럴 복원(추가 아님), 새 분기 없음.
- **연계**: keeper가 미등록 repo에서 멈추는 "깽판"의 진짜 fix는 self-registration(`register_discovered`를 keeper encounter 경로에 배선)이며 별도 트랙이에용. 이 PR은 그것과 독립적으로 projection 정직성 + main green을 회복해용.

## 검증

로컬 대신 CI로 확인. 가디언 테스트 통과 예상.
