### PR TITLE
task-1869: fix claimable filter staleness — Todo tasks always claimable regardless of reclaim_policy

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -637,11 +637,11 @@ let task_claim_readiness (_task : task) = Claim_ready
 let task_claim_decision (task : task) =
   match task.task_status with
   | Todo ->
-    (match task_reclaim_gate task with
-     | Reclaim_gate_open ->
-       Claim_available (task_claim_readiness task)
-     | Reclaim_gate_blocked_by_policy reason ->
-       Claim_unavailable (Claim_block_reclaim_policy reason))
+    (* Todo tasks are always claimable regardless of reclaim_policy.
+       reclaim_policy only gates Done -> re-claim, not Todo -> first claim.
+       task-1869: 6 TaskError fingerprints show coordination-role tasks
+       with Block_reclaim policy were blocked from claiming. *)
+    Claim_available (task_claim_readiness task)
   | AwaitingVerification { verification_id; _ } ->
     (* Verification tasks with a valid verification_id can be claimed by
        other agents for cross-agent verification dispatch. The actual


### PR DESCRIPTION
## Summary

Fixes the claimable filter staleness bug where coordination-role tasks with `Block_reclaim` policy were blocked from claiming Todo tasks.

## Change

`lib/types/types_core.ml`: Todo tasks are always claimable regardless of `reclaim_policy`. The reclaim policy only gates Done → re-claim, not Todo → first claim.

## Related

- Closes task-1869
- Complements PR #23640 (nick0cave's runtime contract refactor) which addresses the backlog-reading side of the same issue

## Evidence

6 TaskError fingerprints showed coordination-role tasks blocked from re-claim by completion. The root cause: `task_claim_decision` was checking `reclaim_policy` even for Todo tasks, when reclaim_policy should only gate Done → re-claim.