### PR TITLE
feat(keeper): RFC-0320 W3c deterministic HITL continuation delivery

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -219,6 +219,7 @@ let run_turn
       ?event_bus
       ?trace_link
       ?continuation_channel
+      ?hitl_delivery_channel
       ?yield_to_chat_waiting
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
@@ -897,6 +898,7 @@ let run_turn
                           ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
                           ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
                           ~raw_response_text:response_text
+                          ?hitl_delivery_channel
                           ~capture_replay_response:
                             (fun ~response_text ->
                               (* Phase O observability: capture the exact

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -156,6 +156,7 @@ val run_turn
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?trace_link:string * string
   -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
   -> ?yield_to_chat_waiting:(unit -> bool)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
           (the same guard point as [max_idle_turns], before the next model

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -316,6 +316,7 @@ let finalize
     ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
     ~capture_replay_response
+    ?hitl_delivery_channel
     () =
   let budget_exhausted =
     Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted
@@ -421,6 +422,29 @@ let finalize
        assistant_msg;
      capture_replay_response ~response_text
    | _ -> ());
+  (* RFC-0320 W3c: deterministic HITL continuation delivery. When this turn was
+     opened by a Hitl_resolved wake carrying a routable originating channel, and
+     the keeper did not itself post a reply this turn (the W3b prompt steer is
+     best-effort), deliver the visible response to that channel so the
+     conversation is always answered. Routing is deterministic (the captured
+     channel); [Keeper_continuation_delivery] fails closed on [Unrouted]. *)
+  (match hitl_delivery_channel, replay_response_text with
+   | Some channel, Some content ->
+     let already_replied =
+       List.exists
+         (fun name ->
+           String.equal name "keeper_surface_post"
+           || String.equal name "masc_keeper_msg")
+         actual_keeper_tool_names
+     in
+     let outcome =
+       Keeper_continuation_delivery.maybe_deliver ~config
+         ~keeper_name:meta.name ~channel ~already_replied ~content
+     in
+     Log.Keeper.info ~keeper_name:meta.name
+       "RFC-0320 W3c continuation delivery: %s"
+       (Keeper_continuation_delivery.describe_outcome outcome)
+   | (None, _) | (_, None) -> ());
   let saved_checkpoint_result =
     match result.checkpoint with
     | Some checkpoint ->

--- a/lib/keeper/keeper_continuation_delivery.ml
+++ b/lib/keeper/keeper_continuation_delivery.ml
@@ -24,15 +24,23 @@ let slack_token_opt () =
       let trimmed = String.trim raw in
       if String.equal trimmed "" then None else Some trimmed
 
-let deliver_dashboard ~config ~keeper_name ~content =
+(* The originating surface identity captured by W2b (thread/session/parent
+   coordinates) is preserved end-to-end so the reply lands in — and is audited
+   against — the same conversation thread, not a fresh top-level post. *)
+
+let deliver_dashboard ~config ~keeper_name ~thread_id ~content =
   Keeper_chat_store.append_assistant_message
     ~base_dir:config.Workspace.base_path ~keeper_name ~content
-    ~surface:(Surface_ref.Dashboard { session_id = None }) ();
+    ~surface:(Surface_ref.Dashboard { session_id = Some thread_id }) ();
   Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"dashboard" ~content ();
   Delivered { kind = "dashboard" }
 
-let deliver_discord ~config ~keeper_name ~channel_id ~content =
-  match Channel_gate_discord_state.send_message ~channel_id ~content () with
+let deliver_discord ~config ~keeper_name ~guild_id ~channel_id
+    ~parent_channel_id ~thread_id ~content =
+  (* Discord threads are channels: post to the thread id when the conversation
+     was in a thread, else the channel id. *)
+  let send_channel_id = Option.value thread_id ~default:channel_id in
+  match Channel_gate_discord_state.send_message ~channel_id:send_channel_id ~content () with
   | Error send_error ->
       Failed
         {
@@ -46,18 +54,13 @@ let deliver_discord ~config ~keeper_name ~channel_id ~content =
         ~base_dir:config.Workspace.base_path ~keeper_name ~content
         ~surface:
           (Surface_ref.Discord
-             {
-               guild_id = None;
-               channel_id;
-               parent_channel_id = None;
-               thread_id = None;
-             })
+             { guild_id; channel_id; parent_channel_id; thread_id })
         ();
       Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"discord"
         ~content ();
       Delivered { kind = "discord" }
 
-let deliver_slack ~config ~keeper_name ~channel_id ~content =
+let deliver_slack ~config ~keeper_name ~team_id ~channel_id ~thread_ts ~content =
   match slack_token_opt () with
   | None ->
       Failed { kind = "slack"; error = "MASC_SLACK_BOT_TOKEN is unset or empty" }
@@ -76,9 +79,7 @@ let deliver_slack ~config ~keeper_name ~channel_id ~content =
       | Ok () ->
           Keeper_chat_store.append_assistant_message
             ~base_dir:config.Workspace.base_path ~keeper_name ~content
-            ~surface:
-              (Surface_ref.Slack
-                 { team_id = None; channel_id; thread_ts = None })
+            ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
             ();
           Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"slack"
             ~content ();
@@ -104,12 +105,16 @@ let maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content =
   | Skip outcome -> outcome
   | Deliver -> (
       match (channel : Keeper_continuation_channel.t) with
-      | Keeper_continuation_channel.Dashboard { thread_id = _ } ->
-          deliver_dashboard ~config ~keeper_name ~content
-      | Keeper_continuation_channel.Discord { channel_id; _ } ->
-          deliver_discord ~config ~keeper_name ~channel_id ~content
-      | Keeper_continuation_channel.Slack { channel_id; _ } ->
-          deliver_slack ~config ~keeper_name ~channel_id ~content
+      | Keeper_continuation_channel.Dashboard { thread_id } ->
+          deliver_dashboard ~config ~keeper_name ~thread_id ~content
+      | Keeper_continuation_channel.Discord
+          { guild_id; channel_id; parent_channel_id; thread_id; user_id = _ } ->
+          deliver_discord ~config ~keeper_name ~guild_id ~channel_id
+            ~parent_channel_id ~thread_id ~content
+      | Keeper_continuation_channel.Slack
+          { team_id; channel_id; thread_ts; user_id = _ } ->
+          deliver_slack ~config ~keeper_name ~team_id ~channel_id ~thread_ts
+            ~content
       (* [gate_decision] returns [Skip] for [Unrouted]; this arm keeps the
          match exhaustive and is unreachable via [Deliver]. *)
       | Keeper_continuation_channel.Unrouted _ -> Skipped_unrouted)

--- a/lib/keeper/keeper_continuation_delivery.ml
+++ b/lib/keeper/keeper_continuation_delivery.ml
@@ -1,0 +1,98 @@
+(* RFC-0320 W3c — deterministic delivery of a wake-turn response to the
+   originating channel captured on a Hitl_resolved wake. The send calls mirror
+   Keeper_tool_in_process_runtime.handle_surface_post (the keeper_surface_post
+   tool) so a wake-turn reply lands exactly like a tool-authored reply. *)
+
+type outcome =
+  | Delivered of { kind : string }
+  | Skipped_unrouted
+  | Skipped_already_replied
+  | Skipped_empty
+  | Failed of { kind : string; error : string }
+
+let describe_outcome = function
+  | Delivered { kind } -> Printf.sprintf "delivered:%s" kind
+  | Skipped_unrouted -> "skipped:unrouted"
+  | Skipped_already_replied -> "skipped:already_replied"
+  | Skipped_empty -> "skipped:empty"
+  | Failed { kind; error } -> Printf.sprintf "failed:%s:%s" kind error
+
+let slack_token_opt () =
+  match Sys.getenv_opt "MASC_SLACK_BOT_TOKEN" with
+  | None -> None
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if String.equal trimmed "" then None else Some trimmed
+
+let deliver_dashboard ~config ~keeper_name ~content =
+  Keeper_chat_store.append_assistant_message
+    ~base_dir:config.Workspace.base_path ~keeper_name ~content
+    ~surface:(Surface_ref.Dashboard { session_id = None }) ();
+  Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"dashboard" ~content ();
+  Delivered { kind = "dashboard" }
+
+let deliver_discord ~config ~keeper_name ~channel_id ~content =
+  match Channel_gate_discord_state.send_message ~channel_id ~content () with
+  | Error send_error ->
+      Failed
+        {
+          kind = "discord";
+          error =
+            Format.asprintf "%a" Channel_gate_discord_state.pp_send_error
+              send_error;
+        }
+  | Ok _message_id ->
+      Keeper_chat_store.append_assistant_message
+        ~base_dir:config.Workspace.base_path ~keeper_name ~content
+        ~surface:
+          (Surface_ref.Discord
+             {
+               guild_id = None;
+               channel_id;
+               parent_channel_id = None;
+               thread_id = None;
+             })
+        ();
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"discord"
+        ~content ();
+      Delivered { kind = "discord" }
+
+let deliver_slack ~config ~keeper_name ~channel_id ~content =
+  match slack_token_opt () with
+  | None ->
+      Failed { kind = "slack"; error = "MASC_SLACK_BOT_TOKEN is unset or empty" }
+  | Some token -> (
+      let blocks = Keeper_chat_slack.content_blocks_of_text content in
+      match
+        Keeper_chat_slack.send_message_with_blocks ~token ~channel:channel_id
+          ~content ~blocks
+      with
+      | Error err ->
+          Failed
+            {
+              kind = "slack";
+              error = Format.asprintf "%a" Keeper_chat_slack.pp_error err;
+            }
+      | Ok () ->
+          Keeper_chat_store.append_assistant_message
+            ~base_dir:config.Workspace.base_path ~keeper_name ~content
+            ~surface:
+              (Surface_ref.Slack
+                 { team_id = None; channel_id; thread_ts = None })
+            ();
+          Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"slack"
+            ~content ();
+          Delivered { kind = "slack" })
+
+let maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content =
+  if String.trim content = "" then Skipped_empty
+  else if already_replied then Skipped_already_replied
+  else
+    match (channel : Keeper_continuation_channel.t) with
+    | Keeper_continuation_channel.Unrouted _ -> Skipped_unrouted
+    | Keeper_continuation_channel.Dashboard { thread_id = _ } ->
+        deliver_dashboard ~config ~keeper_name ~content
+    | Keeper_continuation_channel.Discord { channel_id; _ } ->
+        deliver_discord ~config ~keeper_name ~channel_id ~content
+    | Keeper_continuation_channel.Slack { channel_id; _ } ->
+        deliver_slack ~config ~keeper_name ~channel_id ~content

--- a/lib/keeper/keeper_continuation_delivery.ml
+++ b/lib/keeper/keeper_continuation_delivery.ml
@@ -17,13 +17,6 @@ let describe_outcome = function
   | Skipped_empty -> "skipped:empty"
   | Failed { kind; error } -> Printf.sprintf "failed:%s:%s" kind error
 
-let slack_token_opt () =
-  match Sys.getenv_opt "MASC_SLACK_BOT_TOKEN" with
-  | None -> None
-  | Some raw ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
-
 (* The originating surface identity captured by W2b (thread/session/parent
    coordinates) is preserved end-to-end so the reply lands in — and is audited
    against — the same conversation thread, not a fresh top-level post. *)
@@ -61,29 +54,31 @@ let deliver_discord ~config ~keeper_name ~guild_id ~channel_id
       Delivered { kind = "discord" }
 
 let deliver_slack ~config ~keeper_name ~team_id ~channel_id ~thread_ts ~content =
-  match slack_token_opt () with
-  | None ->
-      Failed { kind = "slack"; error = "MASC_SLACK_BOT_TOKEN is unset or empty" }
-  | Some token -> (
-      let blocks = Keeper_chat_slack.content_blocks_of_text content in
-      match
-        Keeper_chat_slack.send_message_with_blocks ~token ~channel:channel_id
-          ~content ~blocks
-      with
-      | Error err ->
-          Failed
-            {
-              kind = "slack";
-              error = Format.asprintf "%a" Keeper_chat_slack.pp_error err;
-            }
-      | Ok () ->
-          Keeper_chat_store.append_assistant_message
-            ~base_dir:config.Workspace.base_path ~keeper_name ~content
-            ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
-            ();
-          Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"slack"
-            ~content ();
-          Delivered { kind = "slack" })
+  (* [Channel_gate_slack_state.send_message] threads the reply via
+     [reply_to_message_id] (a Slack [ts]) and resolves the bot token internally,
+     so a continuation lands in the originating thread rather than a fresh
+     top-level message. Plain content (no Block Kit) is the accepted trade-off
+     for thread continuity. *)
+  match
+    Channel_gate_slack_state.send_message ~channel_id ~content
+      ?reply_to_message_id:thread_ts ()
+  with
+  | Error send_error ->
+      Failed
+        {
+          kind = "slack";
+          error =
+            Format.asprintf "%a" Channel_gate_slack_state.pp_send_error
+              send_error;
+        }
+  | Ok _ts ->
+      Keeper_chat_store.append_assistant_message
+        ~base_dir:config.Workspace.base_path ~keeper_name ~content
+        ~surface:(Surface_ref.Slack { team_id; channel_id; thread_ts })
+        ();
+      Keeper_chat_broadcast.chat_appended ~keeper_name ~source:"slack"
+        ~content ();
+      Delivered { kind = "slack" }
 
 type gate =
   | Deliver

--- a/lib/keeper/keeper_continuation_delivery.ml
+++ b/lib/keeper/keeper_continuation_delivery.ml
@@ -84,15 +84,32 @@ let deliver_slack ~config ~keeper_name ~channel_id ~content =
             ~content ();
           Delivered { kind = "slack" })
 
-let maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content =
-  if String.trim content = "" then Skipped_empty
-  else if already_replied then Skipped_already_replied
+type gate =
+  | Deliver
+  | Skip of outcome
+
+let gate_decision ~channel ~already_replied ~content : gate =
+  if String.trim content = "" then Skip Skipped_empty
+  else if already_replied then Skip Skipped_already_replied
   else
     match (channel : Keeper_continuation_channel.t) with
-    | Keeper_continuation_channel.Unrouted _ -> Skipped_unrouted
-    | Keeper_continuation_channel.Dashboard { thread_id = _ } ->
-        deliver_dashboard ~config ~keeper_name ~content
-    | Keeper_continuation_channel.Discord { channel_id; _ } ->
-        deliver_discord ~config ~keeper_name ~channel_id ~content
-    | Keeper_continuation_channel.Slack { channel_id; _ } ->
-        deliver_slack ~config ~keeper_name ~channel_id ~content
+    | Keeper_continuation_channel.Unrouted _ -> Skip Skipped_unrouted
+    | Keeper_continuation_channel.Dashboard _
+    | Keeper_continuation_channel.Discord _
+    | Keeper_continuation_channel.Slack _ ->
+        Deliver
+
+let maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content =
+  match gate_decision ~channel ~already_replied ~content with
+  | Skip outcome -> outcome
+  | Deliver -> (
+      match (channel : Keeper_continuation_channel.t) with
+      | Keeper_continuation_channel.Dashboard { thread_id = _ } ->
+          deliver_dashboard ~config ~keeper_name ~content
+      | Keeper_continuation_channel.Discord { channel_id; _ } ->
+          deliver_discord ~config ~keeper_name ~channel_id ~content
+      | Keeper_continuation_channel.Slack { channel_id; _ } ->
+          deliver_slack ~config ~keeper_name ~channel_id ~content
+      (* [gate_decision] returns [Skip] for [Unrouted]; this arm keeps the
+         match exhaustive and is unreachable via [Deliver]. *)
+      | Keeper_continuation_channel.Unrouted _ -> Skipped_unrouted)

--- a/lib/keeper/keeper_continuation_delivery.mli
+++ b/lib/keeper/keeper_continuation_delivery.mli
@@ -19,6 +19,22 @@ type outcome =
 (** [describe_outcome o] is a stable one-line tag for logs/observability. *)
 val describe_outcome : outcome -> string
 
+(** The pure delivery decision, separated from the I/O so it can be tested
+    without a live connector. *)
+type gate =
+  | Deliver  (** the channel is routable and no dedup/empty skip applies *)
+  | Skip of outcome  (** delivery is skipped; carries the reason *)
+
+(** [gate_decision ~channel ~already_replied ~content] is the fail-closed gate:
+    empty content, an already-replied turn, or an [Unrouted] channel each yield
+    [Skip] with the matching outcome; a routable channel yields [Deliver]. Pure
+    (no I/O), so tests can assert the gate without a connector. *)
+val gate_decision :
+  channel:Keeper_continuation_channel.t ->
+  already_replied:bool ->
+  content:string ->
+  gate
+
 (** [maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content]
     delivers [content] to [channel] via the existing send infrastructure, gated:
 

--- a/lib/keeper/keeper_continuation_delivery.mli
+++ b/lib/keeper/keeper_continuation_delivery.mli
@@ -1,0 +1,39 @@
+(** Keeper_continuation_delivery — RFC-0320 W3c.
+
+    Deterministic delivery of a wake-turn's response to the originating chat
+    channel captured on a [Hitl_resolved] wake (see {!Keeper_continuation_channel}).
+
+    This is the deterministic floor that complements the W3b prompt steer: when a
+    keeper resumes on a [Hitl_resolved] wake and does not itself post a reply
+    (the steer is best-effort), the response is delivered to the captured channel
+    here so the conversation is always answered. Routing is deterministic (the
+    captured channel); only the reply text is model-authored. *)
+
+type outcome =
+  | Delivered of { kind : string }  (** posted to the channel; [kind] is the connector tag *)
+  | Skipped_unrouted  (** channel is [Unrouted]; fail-closed, no fabricated target *)
+  | Skipped_already_replied  (** the keeper already posted on a surface this turn (dedup with W3b) *)
+  | Skipped_empty  (** no visible response text to deliver *)
+  | Failed of { kind : string; error : string }  (** the connector send returned an error *)
+
+(** [describe_outcome o] is a stable one-line tag for logs/observability. *)
+val describe_outcome : outcome -> string
+
+(** [maybe_deliver ~config ~keeper_name ~channel ~already_replied ~content]
+    delivers [content] to [channel] via the existing send infrastructure, gated:
+
+    - empty [content] -> [Skipped_empty];
+    - [already_replied] (keeper called a surface-post tool this turn) ->
+      [Skipped_already_replied] (avoids a double reply with the W3b steer);
+    - [Unrouted] channel -> [Skipped_unrouted] (fail-closed);
+    - otherwise dispatches to Dashboard / Discord / Slack and returns
+      [Delivered] or [Failed].
+
+    The gate branches ([Skipped_*]) perform no I/O. *)
+val maybe_deliver :
+  config:Workspace.config ->
+  keeper_name:string ->
+  channel:Keeper_continuation_channel.t ->
+  already_replied:bool ->
+  content:string ->
+  outcome

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -495,9 +495,24 @@ let run_keepalive_unified_turn
             ~keeper_name:meta_after_triage.name
             !consumed_stimuli;
           let event_bus = Keeper_event_bus.get () in
+          (* RFC-0320 W3c: if this cycle was opened by a Hitl_resolved wake,
+             carry that wake's captured originating channel into the turn so the
+             reply is deterministically delivered back to the conversation the
+             approval was requested from. First routable resolution wins; other
+             lanes leave this [None] (fail-closed: no delivery). *)
+          let hitl_delivery_channel =
+            List.find_map
+              (fun (stim : Keeper_event_queue.stimulus) ->
+                match stim.Keeper_event_queue.payload with
+                | Keeper_event_queue.Hitl_resolved resolution ->
+                  Some resolution.Keeper_event_queue.channel
+                | _ -> None)
+              !consumed_stimuli
+          in
           let meta_after_cycle =
             run_keeper_cycle
               ?event_bus
+              ?hitl_delivery_channel
               ~ctx
               ~meta_after_triage
               ~stop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -45,6 +45,7 @@ module Observations = Keeper_heartbeat_loop_observations
    must not interleave with this lane's meta writes (RFC-0225 §1). *)
 let run_keeper_cycle_admitted
       ?event_bus
+      ?hitl_delivery_channel
       ~ctx
       ~meta_after_triage
       ~stop
@@ -61,6 +62,7 @@ let run_keeper_cycle_admitted
         ~observation:obs
         ~generation:meta_after_triage.runtime.generation
         ~channel:turn_decision.channel
+        ?hitl_delivery_channel
         (* RFC-0315: pass the whole decision, not just its channel — the
            prompt renders the verdict reasons so the turn knows why it woke. *)
         ~turn_decision
@@ -132,6 +134,7 @@ let run_keeper_cycle_admitted
 
 let run_keeper_cycle
       ?event_bus
+      ?hitl_delivery_channel
       ~ctx
       ~meta_after_triage
       ~stop
@@ -151,7 +154,8 @@ let run_keeper_cycle
          ~obs
          ~turn_decision
          ~shared_context
-         ?event_bus)
+         ?event_bus
+         ?hitl_delivery_channel)
   with
   | `Ran updated -> updated
   | `Busy in_flight ->

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -2,6 +2,7 @@
 
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t
+  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
   -> ctx:_ Keeper_types_profile.context
   -> meta_after_triage:Keeper_meta_contract.keeper_meta
   -> stop:bool Atomic.t

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -29,6 +29,7 @@ let run_keeper_cycle
       ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
       ?shared_context
       ?event_bus
+      ?hitl_delivery_channel
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
   =
@@ -510,6 +511,7 @@ let run_keeper_cycle
                            ; base_dir
                            ; build_turn_prompt
                            ; channel
+                           ; hitl_delivery_channel
                            ; cleanup
                            ; committed_mutating_tools_snapshot
                            ; config

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -205,6 +205,7 @@ val run_keeper_cycle
   -> ?turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
+  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -36,6 +36,10 @@ type ctx =
       base_system_prompt:string -> messages:Agent_sdk.Types.message list ->
       Keeper_agent_run.turn_prompt
   ; channel : Keeper_world_observation.keeper_cycle_channel
+  ; hitl_delivery_channel : Keeper_continuation_channel.t option
+      (* RFC-0320 W3c: the originating channel to deterministically deliver this
+         turn's reply to when the turn was opened by a Hitl_resolved wake; [None]
+         on every other lane (fail-closed: no delivery). *)
   ; cleanup : unit -> unit
   ; committed_mutating_tools_snapshot : unit -> string list
   ; config : Workspace.config
@@ -78,6 +82,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
+      ; hitl_delivery_channel
       ; shared_context
       ; base_dir
       ; build_turn_prompt
@@ -154,6 +159,7 @@ let run (ctx : ctx)
                Keeper_agent_run.run_turn
                  ~config
                  ~meta:run_meta
+                 ?hitl_delivery_channel
                  ~turn_ctx_cell
                  ~base_dir
                  ~max_context:execution.max_context

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -725,6 +725,37 @@ let test_pending_phase_conversions () =
     (Option.is_none (AQ.pending_phase_of_string "unknown"))
 ;;
 
+(* RFC-0320 W3c: the delivery gate is fail-closed and dedups with the W3b
+   prompt steer. [gate_decision] is pure, so we assert the decision matrix
+   without a live connector. *)
+let test_w3c_continuation_delivery_gate () =
+  let module D = Masc.Keeper_continuation_delivery in
+  let dashboard =
+    Keeper_continuation_channel.Dashboard { thread_id = "thread-1" }
+  in
+  let unrouted = Keeper_continuation_channel.unrouted "no originating connector" in
+  let is_skip_empty = function D.Skip D.Skipped_empty -> true | _ -> false in
+  let is_skip_replied =
+    function D.Skip D.Skipped_already_replied -> true | _ -> false
+  in
+  let is_skip_unrouted =
+    function D.Skip D.Skipped_unrouted -> true | _ -> false
+  in
+  let is_deliver = function D.Deliver -> true | _ -> false in
+  Alcotest.(check bool) "empty content is skipped" true
+    (is_skip_empty
+       (D.gate_decision ~channel:dashboard ~already_replied:false ~content:"   "));
+  Alcotest.(check bool) "already-replied turn is skipped (dedup with W3b)" true
+    (is_skip_replied
+       (D.gate_decision ~channel:dashboard ~already_replied:true ~content:"hi"));
+  Alcotest.(check bool) "unrouted channel is skipped (fail-closed)" true
+    (is_skip_unrouted
+       (D.gate_decision ~channel:unrouted ~already_replied:false ~content:"hi"));
+  Alcotest.(check bool) "routable + fresh + non-empty delivers" true
+    (is_deliver
+       (D.gate_decision ~channel:dashboard ~already_replied:false ~content:"hi"))
+;;
+
 let () =
   Alcotest.run
     "Keeper_approval_queue"
@@ -759,6 +790,10 @@ let () =
             "resolution wake carries originating continuation channel"
             `Quick
             test_resolution_wake_carries_originating_continuation_channel
+        ; Alcotest.test_case
+            "W3c continuation delivery gate is fail-closed"
+            `Quick
+            test_w3c_continuation_delivery_gate
         ] )
     ; ( "summary"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 목적

RFC-0320 **W3c** — HITL 승인 후 keeper가 원 발화 채널로 **결정론적으로** 복귀해 답하도록 delivery를 완성합니다. W2b(#23633)가 `Hitl_resolved` wake에 originating `continuation_channel`을 캡처했고, W3b(#23639)가 prompt로 keeper를 유도(best-effort)했지만, 캡처된 채널을 **소비하는 결정론적 delivery**가 없었습니다(RFC §2 "라우팅=결정론적" 미충족). 이 PR이 그 소비자입니다.

## 동작

`keeper_agent_run_finalize_response.finalize`에 delivery gate 추가 — 아래 **AND** 조건일 때만 turn 응답을 캡처된 채널로 전송:
- turn이 `Hitl_resolved` wake로 열림 (wake lane), AND
- `Keeper_continuation_channel.is_routable` (Unrouted면 skip, fail-closed), AND
- keeper가 이번 턴에 `keeper_surface_post`/`masc_keeper_msg`를 **호출하지 않음** (W3b steer와 dedup → 이중 전송 방지), AND
- 응답 텍스트 비어있지 않음.

라우팅은 결정론적(캡처된 채널), 무엇을 말할지는 LLM. blocking-resume 빠른 경로(timeout 내 승인→원 turn resume)는 불변.

## 변경

- **신규 `Keeper_continuation_delivery`** (`lib/keeper/keeper_continuation_delivery.{ml,mli}`): `continuation_channel → send` mapper. Dashboard(append+broadcast)/Discord(`Channel_gate_discord_state.send_message`)/Slack(`Keeper_chat_slack.send_message_with_blocks`)로 기존 send 인프라(=`keeper_surface_post` 하부) 재사용. exhaustive match, catch-all 없음, Unrouted→`Skipped_unrouted`.
- **관통** (all optional, fail-closed None): `keeper_heartbeat_loop`이 consumed stimuli에서 첫 routable `Hitl_resolved` 채널 추출 → `run_keeper_cycle`(wrapper+admitted) → `Keeper_unified_turn.run_keeper_cycle` → execution `ctx` → `Keeper_agent_run.run_turn` → `finalize`. wake/HITL 아닌 lane은 None → 미전송.

## 검증

- 로컬 `dune build --profile release lib/keeper/` green. dev(warn-error) 프로파일도 green(로컬 oas 핀 drift로 무관 `keeper_hooks_oas.ml`만 임시 우회 후 확인; CI는 올바른 핀이라 무영향, main green이 증거).
- CI가 authoritative build/test (올바른 oas 핀).
- 테스트: mapper gate(Unrouted/already-replied/empty → Skipped_*) 후속 커밋.

## 범위

W3c delivery만. 다중 대기/커넥터 만료 등 RFC §10 open questions는 후속.

RFC: `docs/rfc/RFC-0320-keeper-connector-aware-continuation.md` §9 W3(b).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
