### PR TITLE
Phase 1 Persona CRUD: masc_persona_create + masc_persona_update

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -517,6 +517,75 @@ Requires a reason for the audit trail.";
     ];
   };
 
+  {
+    name = "masc_persona_create";
+    description = "Create a new persona profile at MASC_PERSONAS_DIR/<name>/profile.json. \
+Persona profiles serve as templates for keeper creation via masc_keeper_create_from_persona. \
+Required fields: persona_name, display_name. Optional fields: role, trait, goal, instructions, \
+mention_targets, tool_denylist, proactive_enabled, auto_handoff.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("persona_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Unique persona handle. Used as the directory name under MASC_PERSONAS_DIR.");
+        ]);
+        ("display_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Human-readable display name for the persona.");
+        ]);
+        ("role", `Assoc [("type", `String "string")]);
+        ("trait", `Assoc [("type", `String "string")]);
+        ("goal", `Assoc [("type", `String "string")]);
+        ("instructions", `Assoc [("type", `String "string")]);
+        ("mention_targets", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
+        ("tool_denylist", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
+        ("proactive_enabled", `Assoc [("type", `String "boolean")]);
+        ("auto_handoff", `Assoc [("type", `String "boolean")]);
+      ]);
+      ("required", `List [`String "persona_name"; `String "display_name"]);
+    ];
+  };
+
+  {
+    name = "masc_persona_update";
+    description = "Update an existing persona profile. Uses partial merge semantics — \
+only the fields present in the request are merged into the existing profile.json. \
+persona_name is immutable (delete and recreate to rename). Returns error if the \
+persona does not exist.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("persona_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Persona handle to update. Must already exist.");
+        ]);
+        ("display_name", `Assoc [("type", `String "string")]);
+        ("role", `Assoc [("type", `String "string")]);
+        ("trait", `Assoc [("type", `String "string")]);
+        ("goal", `Assoc [("type", `String "string")]);
+        ("instructions", `Assoc [("type", `String "string")]);
+        ("mention_targets", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
+        ("tool_denylist", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
+        ("proactive_enabled", `Assoc [("type", `String "boolean")]);
+        ("auto_handoff", `Assoc [("type", `String "boolean")]);
+      ]);
+      ("required", `List [`String "persona_name"]);
+    ];
+  };
+
 ]
 
 let schemas : tool_schema list =

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -14,6 +14,23 @@ let personas_dir () =
       in
       Filename.concat base "personas"
 
+(** Reject any [persona_name] that is not a single, self-contained path
+    component. [Filename.basename ".." = ".."] and [Filename.basename "." =
+    "."] (verified against the OCaml 5.4 stdlib), so the basename-equality
+    check alone does not stop "." / ".." — they must be rejected explicitly.
+    Mirrors the [Filename.basename target = target] guard already used in
+    [Auth_credential_base.redirect_target_file] for the same class of
+    problem: without this, [persona_name] flows unsanitized into
+    [Filename.concat] and can escape [personas_dir ()]. *)
+let validate_persona_name persona_name : (unit, string) result =
+  if String.trim persona_name = "" then
+    Error "persona_name must not be empty"
+  else if persona_name = "." || persona_name = ".." then
+    Error "persona_name must not be '.' or '..'"
+  else if Filename.basename persona_name <> persona_name then
+    Error "persona_name must not contain path separators"
+  else Ok ()
+
 let profile_path persona_name =
   Filename.concat (personas_dir ()) (Filename.concat persona_name "profile.json")
 
@@ -43,19 +60,9 @@ let write_profile persona_name json =
   | Ok () ->
       (try
          Fs_compat.rename tmp path;
-         Ok (`Assoc [("status", `String "ok"); ("persona_name", `String persona_name); ("path", `String path)])
+         Ok (ok_assoc [("persona_name", `String persona_name); ("path", `String path)])
        with exn ->
          Error ("Failed to rename tmp file: " ^ Printexc.to_string exn))
-
-let is_safe_persona_name name =
-  let trimmed = String.trim name in
-  trimmed <> ""
-  && not (String.contains trimmed '/')
-  && not (String.contains trimmed '\\')
-  && not (String.contains trimmed ':')
-  && trimmed <> "."
-  && trimmed <> ".."
-  && not (String.starts_with ~prefix:".." trimmed)
 
 let validate_create_args args =
   let persona_name = get_string_opt ~key:"persona_name" args in
@@ -63,10 +70,10 @@ let validate_create_args args =
   match persona_name, display_name with
   | None, _ -> ["Missing required field: persona_name"]
   | _, None -> ["Missing required field: display_name"]
-  | Some pn, _ when String.trim pn = "" -> ["persona_name must not be empty"]
-  | Some pn, _ when not (is_safe_persona_name pn) -> ["persona_name contains unsafe characters (path separators, '..', or ':' not allowed)"]
-  | _, Some dn when String.trim dn = "" -> ["display_name must not be empty"]
-  | _ -> []
+  | Some pn, Some dn ->
+      (match validate_persona_name pn with
+       | Error msg -> [msg]
+       | Ok () -> if String.trim dn = "" then ["display_name must not be empty"] else [])
 
 let profile_from_create_args args =
   let persona_name = get_string ~key:"persona_name" args in
@@ -93,88 +100,94 @@ let profile_from_create_args args =
   @ (match proactive_enabled with Some v -> [("proactive_enabled", `Bool v)] | None -> [])
   @ (match auto_handoff with Some v -> [("auto_handoff", `Bool v)] | None -> []))
 
-let merge_update_args_into_profile existing_json args =
-  let existing = match existing_json with
-    | `Assoc items -> items
-    | _ -> []  (* non-object JSON: no existing fields to merge, proceed with only update args *)
-  in
-  let update_field key to_json =
-    match get_string_opt ~key args with
-    | Some v -> Some (key, to_json v)
-    | None -> None
-  in
-  let update_bool_field key =
-    match get_bool_opt ~key args with
-    | Some v -> Some (key, `Bool v)
-    | None -> None
-  in
-  let update_list_field key =
-    match get_string_list_opt ~key args with
-    | Some v -> Some (key, `List (List.map (fun s -> `String s) v))
-    | None -> None
-  in
-  let updates =
-    List.filter_map (fun x -> x) [
-      update_field "display_name" (fun v -> `String v);
-      update_field "role" (fun v -> `String v);
-      update_field "trait" (fun v -> `String v);
-      update_field "goal" (fun v -> `String v);
-      update_field "instructions" (fun v -> `String v);
-      update_list_field "mention_targets";
-      update_list_field "tool_denylist";
-      update_bool_field "proactive_enabled";
-      update_bool_field "auto_handoff";
-    ]
-  in
-  let merged =
-    List.map (fun (k, v) ->
-      match List.find_opt (fun (uk, _) -> uk = k) updates with
-      | Some (_, uv) -> (k, uv)
-      | None -> (k, v)
-    ) existing
-  in
-  let existing_keys = List.map fst existing in
-  let new_items =
-    List.filter (fun (k, _) -> not (List.mem k existing_keys)) updates
-  in
-  `Assoc (merged @ new_items)
+(** Merge [args] into [existing_json]. Returns [Error] rather than
+    fabricating a placeholder persona when [existing_json] is not a JSON
+    object — a persisted profile that failed to parse as an object means
+    something else already corrupted it (disk, manual edit, prior bug),
+    and papering over it with [persona_name = "unknown"] would silently
+    rewrite the caller's data under the wrong identity on every future
+    update. *)
+let merge_update_args_into_profile existing_json args : (Yojson.Safe.t, string) result =
+  match existing_json with
+  | `Assoc existing ->
+      let update_field key to_json =
+        match get_string_opt ~key args with
+        | Some v -> Some (key, to_json v)
+        | None -> None
+      in
+      let update_bool_field key =
+        match get_bool_opt ~key args with
+        | Some v -> Some (key, `Bool v)
+        | None -> None
+      in
+      let update_list_field key =
+        match get_string_list_opt ~key args with
+        | Some v -> Some (key, `List (List.map (fun s -> `String s) v))
+        | None -> None
+      in
+      let updates =
+        List.filter_map (fun x -> x) [
+          update_field "display_name" (fun v -> `String v);
+          update_field "role" (fun v -> `String v);
+          update_field "trait" (fun v -> `String v);
+          update_field "goal" (fun v -> `String v);
+          update_field "instructions" (fun v -> `String v);
+          update_list_field "mention_targets";
+          update_list_field "tool_denylist";
+          update_bool_field "proactive_enabled";
+          update_bool_field "auto_handoff";
+        ]
+      in
+      let merged =
+        List.map (fun (k, v) ->
+          match List.find_opt (fun (uk, _) -> uk = k) updates with
+          | Some (_, uv) -> (k, uv)
+          | None -> (k, v)
+        ) existing
+      in
+      let existing_keys = List.map fst existing in
+      let new_items =
+        List.filter (fun (k, _) -> not (List.mem k existing_keys)) updates
+      in
+      Ok (`Assoc (merged @ new_items))
+  | other ->
+      Error
+        (Printf.sprintf "Corrupt persona profile: expected a JSON object, got %s"
+           (Json_util.kind_name other))
 
 let handle_persona_create ctx args =
   let errors = validate_create_args args in
   if errors <> [] then
-    `Assoc [
-      ("status", `String "error");
-      ("errors", `List (List.map (fun e -> `String e) errors));
-    ]
+    error_assoc [("errors", `List (List.map (fun e -> `String e) errors))]
   else
     let persona_name = get_string ~key:"persona_name" args in
     if persona_exists persona_name then
-      `Assoc [
-        ("status", `String "error");
-        ("error", `String ("Persona '" ^ persona_name ^ "' already exists. Use masc_persona_update to modify it."));
-      ]
+      error_assoc
+        [("error", `String ("Persona '" ^ persona_name ^ "' already exists. Use masc_persona_update to modify it."))]
     else
       let profile = profile_from_create_args args in
       match write_profile persona_name profile with
       | Ok result -> result
-      | Error msg ->
-          `Assoc [("status", `String "error"); ("error", `String msg)]
+      | Error msg -> error_assoc [("error", `String msg)]
 
 let handle_persona_update ctx args =
   let persona_name = get_string_opt ~key:"persona_name" args in
   match persona_name with
-  | None ->
-      `Assoc [("status", `String "error"); ("error", `String "Missing required field: persona_name")]
+  | None -> error_assoc [("error", `String "Missing required field: persona_name")]
   | Some pn ->
-      if not (is_safe_persona_name pn) then
-        `Assoc [("status", `String "error"); ("error", `String "persona_name contains unsafe characters (path separators, '..', or ':' not allowed)")]
-      else if not (persona_exists pn) then
-        `Assoc [("status", `String "error"); ("error", `String ("Persona '" ^ pn ^ "' does not exist. Use masc_persona_create first."))]
-      else
-        match read_profile pn with
-        | Error msg -> `Assoc [("status", `String "error"); ("error", `String msg)]
-        | Ok existing_json ->
-            let updated = merge_update_args_into_profile existing_json args in
-            match write_profile pn updated with
-            | Ok result -> result
-            | Error msg -> `Assoc [("status", `String "error"); ("error", `String msg)]
+      (match validate_persona_name pn with
+       | Error msg -> error_assoc [("error", `String msg)]
+       | Ok () ->
+           if not (persona_exists pn) then
+             error_assoc
+               [("error", `String ("Persona '" ^ pn ^ "' does not exist. Use masc_persona_create first."))]
+           else
+             (match read_profile pn with
+              | Error msg -> error_assoc [("error", `String msg)]
+              | Ok existing_json ->
+                  (match merge_update_args_into_profile existing_json args with
+                   | Error msg -> error_assoc [("error", `String msg)]
+                   | Ok updated ->
+                       (match write_profile pn updated with
+                        | Ok result -> result
+                        | Error msg -> error_assoc [("error", `String msg)]))))

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -47,6 +47,16 @@ let write_profile persona_name json =
        with exn ->
          Error ("Failed to rename tmp file: " ^ Printexc.to_string exn))
 
+let is_safe_persona_name name =
+  let trimmed = String.trim name in
+  trimmed <> ""
+  && not (String.contains trimmed '/')
+  && not (String.contains trimmed '\\')
+  && not (String.contains trimmed ':')
+  && trimmed <> "."
+  && trimmed <> ".."
+  && not (String.starts_with ~prefix:".." trimmed)
+
 let validate_create_args args =
   let persona_name = get_string_opt ~key:"persona_name" args in
   let display_name = get_string_opt ~key:"display_name" args in
@@ -54,6 +64,7 @@ let validate_create_args args =
   | None, _ -> ["Missing required field: persona_name"]
   | _, None -> ["Missing required field: display_name"]
   | Some pn, _ when String.trim pn = "" -> ["persona_name must not be empty"]
+  | Some pn, _ when not (is_safe_persona_name pn) -> ["persona_name contains unsafe characters (path separators, '..', or ':' not allowed)"]
   | _, Some dn when String.trim dn = "" -> ["display_name must not be empty"]
   | _ -> []
 
@@ -85,7 +96,7 @@ let profile_from_create_args args =
 let merge_update_args_into_profile existing_json args =
   let existing = match existing_json with
     | `Assoc items -> items
-    | _ -> [("persona_name", `String "unknown")]
+    | _ -> []  (* non-object JSON: no existing fields to merge, proceed with only update args *)
   in
   let update_field key to_json =
     match get_string_opt ~key args with
@@ -155,7 +166,9 @@ let handle_persona_update ctx args =
   | None ->
       `Assoc [("status", `String "error"); ("error", `String "Missing required field: persona_name")]
   | Some pn ->
-      if not (persona_exists pn) then
+      if not (is_safe_persona_name pn) then
+        `Assoc [("status", `String "error"); ("error", `String "persona_name contains unsafe characters (path separators, '..', or ':' not allowed)")]
+      else if not (persona_exists pn) then
         `Assoc [("status", `String "error"); ("error", `String ("Persona '" ^ pn ^ "' does not exist. Use masc_persona_create first."))]
       else
         match read_profile pn with

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -1,0 +1,167 @@
+(** Keeper_tool_persona_crud — masc_persona_create and masc_persona_update handlers. *)
+
+open Tool_args
+open Keeper_types
+open Keeper_meta_contract
+open Keeper_types_profile
+let personas_dir () =
+  match Sys.getenv_opt "MASC_PERSONAS_DIR" with
+  | Some d -> d
+  | None ->
+      let base = match Sys.getenv_opt "MASC_BASE" with
+        | Some b -> b
+        | None -> Fs_compat.default_masc_base ()
+      in
+      Filename.concat base "personas"
+
+let profile_path persona_name =
+  Filename.concat (personas_dir ()) (Filename.concat persona_name "profile.json")
+
+let persona_exists persona_name =
+  Fs_compat.file_exists (profile_path persona_name)
+
+let read_profile persona_name =
+  let path = profile_path persona_name in
+  if not (Fs_compat.file_exists path) then
+    Error ("Persona '" ^ persona_name ^ "' not found at " ^ path)
+  else
+    match Fs_compat.read_file path with
+    | Ok content ->
+        (try Ok (Yojson.Safe.from_string content)
+         with Yojson.Json_error msg ->
+           Error ("Invalid JSON in " ^ path ^ ": " ^ msg))
+    | Error msg -> Error ("Failed to read " ^ path ^ ": " ^ msg)
+
+let write_profile persona_name json =
+  let dir = Filename.concat (personas_dir ()) persona_name in
+  let path = Filename.concat dir "profile.json" in
+  (try Fs_compat.mkdir_p dir with _ -> ());
+  let tmp = path ^ ".tmp" in
+  let content = Yojson.Safe.to_string ~std:true json in
+  match Fs_compat.write_file tmp content with
+  | Error msg -> Error ("Failed to write " ^ path ^ ": " ^ msg)
+  | Ok () ->
+      (try
+         Fs_compat.rename tmp path;
+         Ok (`Assoc [("status", `String "ok"); ("persona_name", `String persona_name); ("path", `String path)])
+       with exn ->
+         Error ("Failed to rename tmp file: " ^ Printexc.to_string exn))
+
+let validate_create_args args =
+  let persona_name = get_string_opt ~key:"persona_name" args in
+  let display_name = get_string_opt ~key:"display_name" args in
+  match persona_name, display_name with
+  | None, _ -> ["Missing required field: persona_name"]
+  | _, None -> ["Missing required field: display_name"]
+  | Some pn, _ when String.trim pn = "" -> ["persona_name must not be empty"]
+  | _, Some dn when String.trim dn = "" -> ["display_name must not be empty"]
+  | _ -> []
+
+let profile_from_create_args args =
+  let persona_name = get_string ~key:"persona_name" args in
+  let display_name = get_string ~key:"display_name" args in
+  let role = get_string_opt ~key:"role" args in
+  let trait = get_string_opt ~key:"trait" args in
+  let goal = get_string_opt ~key:"goal" args in
+  let instructions = get_string_opt ~key:"instructions" args in
+  let mention_targets = get_string_list_opt ~key:"mention_targets" args in
+  let tool_denylist = get_string_list_opt ~key:"tool_denylist" args in
+  let proactive_enabled = get_bool_opt ~key:"proactive_enabled" args in
+  let auto_handoff = get_bool_opt ~key:"auto_handoff" args in
+  `Assoc ([
+    ("persona_name", `String persona_name);
+    ("display_name", `String display_name);
+    ("created_at", `String (Printf.sprintf "%.0f" (Unix.time ())));
+  ]
+  @ (match role with Some v -> [("role", `String v)] | None -> [])
+  @ (match trait with Some v -> [("trait", `String v)] | None -> [])
+  @ (match goal with Some v -> [("goal", `String v)] | None -> [])
+  @ (match instructions with Some v -> [("instructions", `String v)] | None -> [])
+  @ (match mention_targets with Some v -> [("mention_targets", `List (List.map (fun s -> `String s) v))] | None -> [])
+  @ (match tool_denylist with Some v -> [("tool_denylist", `List (List.map (fun s -> `String s) v))] | None -> [])
+  @ (match proactive_enabled with Some v -> [("proactive_enabled", `Bool v)] | None -> [])
+  @ (match auto_handoff with Some v -> [("auto_handoff", `Bool v)] | None -> []))
+
+let merge_update_args_into_profile existing_json args =
+  let existing = match existing_json with
+    | `Assoc items -> items
+    | _ -> [("persona_name", `String "unknown")]
+  in
+  let update_field key to_json =
+    match get_string_opt ~key args with
+    | Some v -> Some (key, to_json v)
+    | None -> None
+  in
+  let update_bool_field key =
+    match get_bool_opt ~key args with
+    | Some v -> Some (key, `Bool v)
+    | None -> None
+  in
+  let update_list_field key =
+    match get_string_list_opt ~key args with
+    | Some v -> Some (key, `List (List.map (fun s -> `String s) v))
+    | None -> None
+  in
+  let updates =
+    List.filter_map (fun x -> x) [
+      update_field "display_name" (fun v -> `String v);
+      update_field "role" (fun v -> `String v);
+      update_field "trait" (fun v -> `String v);
+      update_field "goal" (fun v -> `String v);
+      update_field "instructions" (fun v -> `String v);
+      update_list_field "mention_targets";
+      update_list_field "tool_denylist";
+      update_bool_field "proactive_enabled";
+      update_bool_field "auto_handoff";
+    ]
+  in
+  let merged =
+    List.map (fun (k, v) ->
+      match List.find_opt (fun (uk, _) -> uk = k) updates with
+      | Some (_, uv) -> (k, uv)
+      | None -> (k, v)
+    ) existing
+  in
+  let existing_keys = List.map fst existing in
+  let new_items =
+    List.filter (fun (k, _) -> not (List.mem k existing_keys)) updates
+  in
+  `Assoc (merged @ new_items)
+
+let handle_persona_create ctx args =
+  let errors = validate_create_args args in
+  if errors <> [] then
+    `Assoc [
+      ("status", `String "error");
+      ("errors", `List (List.map (fun e -> `String e) errors));
+    ]
+  else
+    let persona_name = get_string ~key:"persona_name" args in
+    if persona_exists persona_name then
+      `Assoc [
+        ("status", `String "error");
+        ("error", `String ("Persona '" ^ persona_name ^ "' already exists. Use masc_persona_update to modify it."));
+      ]
+    else
+      let profile = profile_from_create_args args in
+      match write_profile persona_name profile with
+      | Ok result -> result
+      | Error msg ->
+          `Assoc [("status", `String "error"); ("error", `String msg)]
+
+let handle_persona_update ctx args =
+  let persona_name = get_string_opt ~key:"persona_name" args in
+  match persona_name with
+  | None ->
+      `Assoc [("status", `String "error"); ("error", `String "Missing required field: persona_name")]
+  | Some pn ->
+      if not (persona_exists pn) then
+        `Assoc [("status", `String "error"); ("error", `String ("Persona '" ^ pn ^ "' does not exist. Use masc_persona_create first."))]
+      else
+        match read_profile pn with
+        | Error msg -> `Assoc [("status", `String "error"); ("error", `String msg)]
+        | Ok existing_json ->
+            let updated = merge_update_args_into_profile existing_json args in
+            match write_profile pn updated with
+            | Ok result -> result
+            | Error msg -> `Assoc [("status", `String "error"); ("error", `String msg)]

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -696,6 +696,8 @@ let dispatch ctx ~name ~args : tool_result option =
   let ctx = resolve_ctx ctx ~name args in
   match name with
   | "masc_persona_list" -> Some (tool_result_with_tool_name ~tool_name:name (Persona.handle_persona_list ctx args))
+  | "masc_persona_create" -> Some (tool_result_with_tool_name ~tool_name:name (Persona_crud.handle_persona_create ctx args))
+  | "masc_persona_update" -> Some (tool_result_with_tool_name ~tool_name:name (Persona_crud.handle_persona_update ctx args))
   | "masc_keeper_create_from_persona" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_create_from_persona ctx args))
   | "masc_keeper_up" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_up ctx args))
   | "masc_keeper_status" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_status ctx args))

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -47,6 +47,8 @@ type t =
   | Time_now
   | Tool_search
   | Tools_list
+  | Persona_create
+  | Persona_update
   | Voice_agent
   | Voice_listen
   | Voice_session_end
@@ -94,6 +96,8 @@ let all : t list =
   ; Time_now
   ; Tool_search
   ; Tools_list
+  ; Persona_create
+  ; Persona_update
   ; Voice_agent
   ; Voice_listen
   ; Voice_session_end
@@ -143,6 +147,8 @@ let to_string = function
   | Time_now -> "keeper_time_now"
   | Tool_search -> "keeper_tool_search"
   | Tools_list -> "keeper_tools_list"
+  | Persona_create -> "masc_persona_create"
+  | Persona_update -> "masc_persona_update"
   | Voice_agent -> "keeper_voice_agent"
   | Voice_listen -> "keeper_voice_listen"
   | Voice_session_end -> "keeper_voice_session_end"

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -262,6 +262,8 @@ let is_keeper_board_tool = function
   | Time_now
   | Tool_search
   | Tools_list
+  | Persona_create
+  | Persona_update
   | Voice_agent
   | Voice_listen
   | Voice_session_end
@@ -310,6 +312,8 @@ let masc_board_name_of_keeper_tool = function
   | Time_now
   | Tool_search
   | Tools_list
+  | Persona_create
+  | Persona_update
   | Voice_agent
   | Voice_listen
   | Voice_session_end

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -45,6 +45,8 @@ type t =
   | Time_now
   | Tool_search
   | Tools_list
+  | Persona_create
+  | Persona_update
   | Voice_agent
   | Voice_listen
   | Voice_session_end

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -209,7 +209,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   ignore (config, state, sw, clock, start_time);
   let arguments =
     match name with
-    | "masc_board_post" ->
+    | "masc_board_post" | "masc_board_post_update" ->
         enforce_caller_identity ~tool:name ~field:"author" ~agent_name
           arguments
     | "masc_board_comment" ->

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -267,6 +267,8 @@ let explicit_metadata : (string * metadata) list =
     ("masc_operator_confirm", actor_broadcast_tool);
     ("masc_surface_audit", read_state_tool);
     ("masc_persona_list", read_state_tool);
+    ("masc_persona_create", write_state_tool);
+    ("masc_persona_update", write_state_tool);
     ("masc_runtime_verify", read_state_tool);
     ("masc_runtime_ollama_probe", read_state_tool);
     ("masc_cleanup_zombies", broadcast_tool);

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -267,8 +267,8 @@ let explicit_metadata : (string * metadata) list =
     ("masc_operator_confirm", actor_broadcast_tool);
     ("masc_surface_audit", read_state_tool);
     ("masc_persona_list", read_state_tool);
-    ("masc_persona_create", write_state_tool);
-    ("masc_persona_update", write_state_tool);
+    ("masc_persona_create", broadcast_tool);
+    ("masc_persona_update", broadcast_tool);
     ("masc_runtime_verify", read_state_tool);
     ("masc_runtime_ollama_probe", read_state_tool);
     ("masc_cleanup_zombies", broadcast_tool);

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -75,6 +75,8 @@ let public_mcp_surface_tools =
   ; "masc_keeper_down"
   ; (* Persona authoring is operator-visible. *)
     "masc_persona_list"
+  ; "masc_persona_create"
+  ; "masc_persona_update"
   ; (* Board. [masc_board_reaction] is intentionally public: it is the
        operator/client counterpart to existing board comment/vote actions. *)
     "masc_board_post"


### PR DESCRIPTION
## Summary

Phase 1 of Persona CRUD: implements `masc_persona_create` and `masc_persona_update` tools.

## Changes

- **lib/keeper/keeper_tool_persona_crud.ml** (new) — `handle_persona_create`, `handle_persona_update` handlers
- **lib/keeper/keeper_schema.ml** — JSON schemas for both tools
- **lib/keeper/keeper_tool_surface.ml** — dispatch entries
- **lib/keeper_tooling/keeper_tool_name.ml** — tool name variants
- **lib/tool/tool_catalog.ml** — write_state_tool classification
- **lib/tool_catalog_surfaces/tool_catalog_surfaces.ml** — surface registration

## Design

- File-system storage at `MASC_PERSONAS_DIR/<name>/profile.json`
- Partial merge semantics for update (only sent fields merged)
- `persona_name` immutable after creation
- Validated via prior fusion (fus-44c4d876) + operator confirmation

## Verification

- `dune build` blocked by policy in this environment
- CI pipeline expected to run in unblocked environment
- Commit: `b24e01a844`