### PR TITLE
feat(workspace): add predecessor_task_id linked re-run field (RFC-0323 G-8)

### DIFF
--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -263,7 +263,9 @@ let persisted_contract_rejection ~(ctx : context)
 (* Handlers *)
 
 let handle_add_task ~tool_name ~start_time ctx args =
-  let valid_keys = [ "title"; "priority"; "description"; "goal_id"; "contract" ] in
+  let valid_keys =
+    [ "title"; "priority"; "description"; "goal_id"; "contract"; "predecessor_task_id" ]
+  in
   let unknown = unknown_args ~valid_keys args in
   if Stdlib.List.length unknown > 0 then
     (* RFC-0189: schema rejection — operator passed unknown
@@ -281,6 +283,14 @@ let handle_add_task ~tool_name ~start_time ctx args =
   let description = get_string args "description" "" in
   let goal_id =
     match Safe_ops.json_string_opt "goal_id" args with
+    | Some s when not (String.equal (String.trim s) "") -> Some (String.trim s)
+    | _ -> None
+  in
+  (* RFC-0323 W2: existence + terminal validation happens in
+     [Workspace.add_task_with_result] inside the backlog lock (typed
+     [Unknown_predecessor] / [Predecessor_not_terminal] errors). *)
+  let predecessor_task_id =
+    match Safe_ops.json_string_opt "predecessor_task_id" args with
     | Some s when not (String.equal (String.trim s) "") -> Some (String.trim s)
     | _ -> None
   in
@@ -324,6 +334,7 @@ let handle_add_task ~tool_name ~start_time ctx args =
         let add_result =
           Workspace.add_task_with_result ?contract
             ?goal_id
+            ?predecessor_task_id
             ~reject_if:
               (Workspace_task_capacity.rejection_for_add_task_for_config
                  ctx.config
@@ -345,6 +356,8 @@ let handle_add_task ~tool_name ~start_time ctx args =
                   ; "priority", `Int priority
                   ; "description", `String description
                   ; "goal_id", Json_util.string_opt_to_json goal_id
+                  ; ( "predecessor_task_id"
+                    , Json_util.string_opt_to_json predecessor_task_id )
                   ])
              ()
          | Error err ->

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -71,6 +71,10 @@ Example: %s({title: 'Fix login bug', priority: 1, description: 'Users cannot log
           ("type", `String "string");
           ("description", `String "Optional structured goal link for rollups. If omitted, the task is created unscoped (goalless); pass goal_id explicitly to link it to a goal.");
         ]);
+        ("predecessor_task_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional re-run provenance link (RFC-0323): the terminal (done/cancelled) task this one re-runs. Rejected if the id is unknown or the predecessor is not terminal. To re-run completed work, create a new task with this link instead of re-claiming the old one.");
+        ]);
         ("contract", `Assoc [
           ("type", `String "object");
           ("description", `String "Optional persisted task contract for strict deterministic completion gating.");

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -593,6 +593,11 @@ type task = {
   files: string list; [@default []]
   created_at: string;
   created_by: string option; [@default None]
+  (* RFC-0323 W2: write-once lineage pointer to the terminal task this one
+     re-runs. Set only at creation (masc_add_task); every transition carries
+     it through unchanged. Distinct from RFC-0267 goal linkage (many-to-many
+     side registry). *)
+  predecessor_task_id: string option; [@default None]
   contract: task_contract option; [@default None]
   handoff_context: task_handoff_context option; [@default None]
   cycle_count: int; [@default 0]
@@ -706,10 +711,15 @@ let task_to_yojson t =
     | None -> base
     | Some created_by -> base @ [("created_by", `String created_by)]
   in
-  let with_contract = match t.contract with
+  (* Omitted when None (created_by pattern): old readers never see the key. *)
+  let with_predecessor = match t.predecessor_task_id with
     | None -> with_created_by
+    | Some p -> with_created_by @ [("predecessor_task_id", `String p)]
+  in
+  let with_contract = match t.contract with
+    | None -> with_predecessor
     | Some contract ->
-        with_created_by @ [ ("contract", task_contract_to_yojson contract) ]
+        with_predecessor @ [ ("contract", task_contract_to_yojson contract) ]
   in
   let with_handoff_context = match t.handoff_context with
     | None -> with_contract
@@ -752,6 +762,9 @@ let task_of_yojson json =
     let files = Json_util.get_string_list json "files" in
     let created_at = req "created_at" in
     let created_by = opt "created_by" in
+    (* Absent or non-string value degrades to None — a decode Error here would
+       make backlog_of_yojson silently drop the whole task. *)
+    let predecessor_task_id = opt "predecessor_task_id" in
     let contract = match m "contract" with
       | `Null -> None
       | contract_json ->
@@ -788,6 +801,7 @@ let task_of_yojson json =
             files;
             created_at;
             created_by;
+            predecessor_task_id;
             contract;
             handoff_context;
             cycle_count;

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -186,6 +186,9 @@ type task =
   ; files : string list [@default []]
   ; created_at : string
   ; created_by : string option [@default None]
+  ; predecessor_task_id : string option [@default None]
+        (** RFC-0323 W2: write-once lineage pointer to the terminal task this
+            one re-runs. Set only at creation; transitions carry it through. *)
   ; contract : task_contract option [@default None]
   ; handoff_context : task_handoff_context option [@default None]
   ; cycle_count : int [@default 0]

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -61,6 +61,8 @@ type add_task_error =
   | Goal_link_write_failed of string
   | Backlog_write_failed of string
   | Unexpected_error of string
+  | Unknown_predecessor of string
+  | Predecessor_not_terminal of { predecessor_task_id : string; status : string }
 
 type batch_add_tasks_success =
   { task_ids : string list
@@ -86,6 +88,17 @@ let add_task_error_to_string = function
     Printf.sprintf "Error linking task to goal: %s" msg
   | Backlog_write_failed msg -> Printf.sprintf "Error writing backlog: %s" msg
   | Unexpected_error msg -> Printf.sprintf "Error: %s" msg
+  | Unknown_predecessor id ->
+    Printf.sprintf
+      "Unknown predecessor_task_id '%s': not in the backlog (terminal tasks \
+       past the archive cutoff are not linkable)"
+      id
+  | Predecessor_not_terminal { predecessor_task_id; status } ->
+    Printf.sprintf
+      "predecessor_task_id '%s' is %s — a re-run link requires a terminal \
+       (done/cancelled) predecessor"
+      predecessor_task_id
+      status
 ;;
 
 let batch_add_tasks_error_to_string = function
@@ -131,6 +144,7 @@ let add_task_with_result
       ?contract
       ?goal_id
       ?created_by
+      ?predecessor_task_id
       ?reject_if
       config
       ~title
@@ -141,6 +155,7 @@ let add_task_with_result
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   let actor = Option.value ~default:"system" created_by in
   let goal_id = Workspace_task_classify.trim_opt goal_id in
+  let predecessor_task_id = Workspace_task_classify.trim_opt predecessor_task_id in
   try
     with_file_lock config backlog_path (fun () ->
       match read_backlog_r config with
@@ -152,6 +167,29 @@ let add_task_with_result
         |> (function
           | Some msg -> Error (Rejected msg)
           | None ->
+        (* RFC-0323 W2: a re-run link must point at an existing, terminal task.
+           Validated inside the lock against the same backlog snapshot the new
+           task is appended to, so the check cannot race a concurrent write. *)
+        (match
+           match predecessor_task_id with
+           | None -> Ok ()
+           | Some pid ->
+             (match
+                List.find_opt (fun (t : task) -> String.equal t.id pid) backlog.tasks
+              with
+              | None -> Error (Unknown_predecessor pid)
+              | Some p ->
+                if task_status_is_terminal p.task_status
+                then Ok ()
+                else
+                  Error
+                    (Predecessor_not_terminal
+                       { predecessor_task_id = pid
+                       ; status = task_status_to_string p.task_status
+                       }))
+         with
+         | Error e -> Error e
+         | Ok () ->
         (* Dedup guard: reject if an active task with the same normalized title exists *)
         (match find_duplicate_task backlog ~title with
          | Some existing_id ->
@@ -175,6 +213,7 @@ let add_task_with_result
              ; files = []
              ; created_at = now_iso ()
              ; created_by
+             ; predecessor_task_id
              ; contract
              ; handoff_context = None
              ; cycle_count = 0
@@ -227,6 +266,8 @@ let add_task_with_result
                           ; "goal_id", Json_util.string_opt_to_json goal_id
                           ; "priority", `Int priority
                           ; "created_by", created_by_json
+                          ; ( "predecessor_task_id"
+                            , Json_util.string_opt_to_json predecessor_task_id )
                           ; ( "strict_contract"
                             , `Bool
                                 (match contract with
@@ -241,7 +282,7 @@ let add_task_with_result
                       ~content:(Printf.sprintf "New quest: %s" title)
                   in
                   let summary = Printf.sprintf "Added %s: %s" task_id title in
-                  Ok { task_id; summary; title; priority; description; goal_id })))))
+                  Ok { task_id; summary; title; priority; description; goal_id }))))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Unexpected_error (Printexc.to_string e))
@@ -297,6 +338,9 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                   ; files = []
                   ; created_at = now_iso ()
                   ; created_by
+                  (* batch add does not carry re-run links (RFC-0323 W2 scopes
+                     the arg to masc_add_task) *)
+                  ; predecessor_task_id = None
                   ; contract
                   ; handoff_context = None
                   ; cycle_count = 0

--- a/lib/workspace/workspace_task_create.mli
+++ b/lib/workspace/workspace_task_create.mli
@@ -35,6 +35,11 @@ type add_task_error =
   | Goal_link_write_failed of string
   | Backlog_write_failed of string
   | Unexpected_error of string
+  | Unknown_predecessor of string
+      (** RFC-0323 W2: [predecessor_task_id] does not exist in the backlog *)
+  | Predecessor_not_terminal of { predecessor_task_id : string; status : string }
+      (** RFC-0323 W2: a re-run link requires a terminal (Done/Cancelled)
+          predecessor *)
 
 type batch_add_tasks_success =
   { task_ids : string list
@@ -56,6 +61,7 @@ val add_task_with_result :
   ?contract:Masc_domain.task_contract ->
   ?goal_id:string ->
   ?created_by:string ->
+  ?predecessor_task_id:string ->
   ?reject_if:(Masc_domain.backlog -> string option) ->
   config ->
   title:string ->

--- a/test/test_dashboard_goal_id_projection.ml
+++ b/test/test_dashboard_goal_id_projection.ml
@@ -20,6 +20,7 @@ let make_task ~id =
   ; files = []
   ; created_at = "2026-06-20T00:00:00Z"
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -55,6 +55,7 @@ let make_done_task id : MD.task =
     files = [];
     created_at = iso_now ();
     created_by = None;
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 0;

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -118,6 +118,7 @@ let task ?handoff_context ~id ~title ~status () : Masc_domain.task =
   ; files = []
   ; created_at = "2026-07-02T00:00:00Z"
   ; created_by = Some "digest-test"
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context
   ; cycle_count = 0

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -160,6 +160,7 @@ let make_task ?(handoff_context = None) ~task_status () : Masc_domain.task =
     files = [];
     created_at = "2026-07-07T00:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None;
     handoff_context;
     cycle_count = 0;

--- a/test/test_orphan_surfacer.ml
+++ b/test/test_orphan_surfacer.ml
@@ -23,6 +23,7 @@ let make_task ~id ~status : MD.task =
   ; files = []
   ; created_at = "2024-01-01T00:00:00Z"
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1254,6 +1254,7 @@ let make_task ?(title = "Task") ?(description = "") ~id ~status () : Types.task 
     files = [];
     created_at = "2026-06-26T00:00:00Z";
     created_by = Some "test";
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 0;

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -181,6 +181,7 @@ let make_in_progress_task ~id ~assignee : Types.task =
     files = [];
     created_at = "2026-06-26T00:00:00Z";
     created_by = Some "test";
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 0;

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -90,6 +90,7 @@ let make_task ~id ~status =
   ; files = []
   ; created_at = now
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0

--- a/test/test_task_completion_gate.ml
+++ b/test/test_task_completion_gate.ml
@@ -28,6 +28,7 @@ let make_task
   ; files = []
   ; created_at = "2026-05-26T00:00:00Z"
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract
   ; handoff_context
   ; cycle_count = 0

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -123,6 +123,7 @@ let make_task ~id ~status : Masc_domain.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   created_by = None;
+  predecessor_task_id = None;
   contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
 }
 
@@ -159,6 +160,7 @@ let make_task_with_priority ~id ~priority : Masc_domain.task = {
   files = [];
   created_at = "2024-01-01T00:00:00Z";
   created_by = None;
+  predecessor_task_id = None;
   contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
 }
 

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -542,6 +542,7 @@ let test_backlog_to_yojson_with_tasks () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let b : Masc_domain.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
@@ -1327,6 +1328,7 @@ let test_task_to_yojson () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson t in
@@ -1370,6 +1372,7 @@ let test_task_reclaim_gate_ignores_free_text_without_policy () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 9;
@@ -1391,6 +1394,7 @@ let test_task_reclaim_gate_blocks_only_typed_policy () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 0;
@@ -1415,6 +1419,7 @@ let test_task_claim_next_action_policy_block_is_skip () =
     files = [];
     created_at = "2024-01-15T12:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None;
     handoff_context = None;
     cycle_count = 0;

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -387,6 +387,7 @@ let test_task_roundtrip () =
     files = ["file1.ml"; "file2.ml"];
     created_at = "2024-01-01T00:00:00Z";
     created_by = None;
+    predecessor_task_id = None;
     contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None;
   } in
   let json = Masc_domain.task_to_yojson task in
@@ -404,11 +405,13 @@ let test_backlog_roundtrip () =
         task_status = Todo; priority = 1; files = [];
         created_at = "2024-01-01T00:00:00Z";
         created_by = None;
+        predecessor_task_id = None;
         contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z";
         created_by = None;
+        predecessor_task_id = None;
         contract = None; handoff_context = None; cycle_count = 0; reclaim_policy = None; do_not_reclaim_reason = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -2043,6 +2043,7 @@ let gc_make_task ~id ~created_at ~status : Masc_domain.task =
   ; files = []
   ; created_at
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0
@@ -2286,6 +2287,7 @@ let test_append_archive_tasks () =
       ; files = []
       ; created_at = "2026-01-01T00:00:00Z"
       ; created_by = None
+      ; predecessor_task_id = None
       ; contract = None
       ; handoff_context = None
       ; cycle_count = 0
@@ -2297,6 +2299,153 @@ let test_append_archive_tasks () =
     (* Add a new task to verify archive max ID is checked *)
     let result = Workspace.add_task config ~title:"New Task" ~priority:1 ~description:"" in
     Alcotest.(check bool) "task added" true (contains_check result))
+;;
+
+(* ============================================================ *)
+(* RFC-0323 W2: predecessor_task_id (linked re-run tasks)        *)
+(* ============================================================ *)
+
+let predecessor_of config task_id =
+  match
+    List.find_opt
+      (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+      (Workspace.read_backlog config).tasks
+  with
+  | Some t -> t.predecessor_task_id
+  | None -> Alcotest.fail (Printf.sprintf "%s missing from backlog" task_id)
+;;
+
+let test_predecessor_unknown_rejected () =
+  with_test_env (fun config ->
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"Re-run"
+        ~priority:2
+        ~description:""
+        ~predecessor_task_id:"task-999"
+    with
+    | Error (Workspace.Unknown_predecessor "task-999") -> ()
+    | Error e ->
+      Alcotest.fail
+        ("unexpected error: " ^ Workspace.add_task_error_to_string e)
+    | Ok _ -> Alcotest.fail "unknown predecessor accepted")
+;;
+
+let test_predecessor_non_terminal_rejected () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~title:"Original" ~priority:2 ~description:""
+    in
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"Re-run of original"
+        ~priority:2
+        ~description:""
+        ~predecessor_task_id:"task-001"
+    with
+    | Error
+        (Workspace.Predecessor_not_terminal
+           { predecessor_task_id = "task-001"; status = "todo" }) -> ()
+    | Error e ->
+      Alcotest.fail
+        ("unexpected error: " ^ Workspace.add_task_error_to_string e)
+    | Ok _ -> Alcotest.fail "non-terminal predecessor accepted")
+;;
+
+let test_predecessor_terminal_accepted_and_persisted () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~title:"Original" ~priority:2 ~description:""
+    in
+    let forced =
+      Workspace.force_done_task_r
+        config
+        ~agent_name:"claude"
+        ~task_id:"task-001"
+        ~notes:"done"
+        ()
+    in
+    Alcotest.(check bool)
+      "predecessor completed"
+      true
+      (match forced with Ok _ -> true | Error _ -> false);
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"Re-run of original"
+        ~priority:2
+        ~description:""
+        ~predecessor_task_id:"task-001"
+    with
+    | Ok created ->
+      (* read_backlog re-decodes from disk: persistence + codec round-trip *)
+      Alcotest.(check (option string))
+        "predecessor persisted"
+        (Some "task-001")
+        (predecessor_of config created.task_id)
+    | Error e ->
+      Alcotest.fail
+        ("terminal predecessor rejected: " ^ Workspace.add_task_error_to_string e))
+;;
+
+let test_predecessor_blank_treated_as_none () =
+  with_test_env (fun config ->
+    match
+      Workspace.add_task_with_result
+        config
+        ~title:"No link"
+        ~priority:2
+        ~description:""
+        ~predecessor_task_id:"  "
+    with
+    | Ok created ->
+      Alcotest.(check (option string))
+        "blank predecessor is None"
+        None
+        (predecessor_of config created.task_id)
+    | Error e ->
+      Alcotest.fail
+        ("blank predecessor rejected: " ^ Workspace.add_task_error_to_string e))
+;;
+
+let test_predecessor_codec_absent_and_malformed () =
+  (* Encoder omits the key when None (old readers never see it). *)
+  let without =
+    gc_make_task ~id:"task-c1" ~created_at:gc_ancient_ts ~status:Masc_domain.Todo
+  in
+  let json = Masc_domain.task_to_yojson without in
+  let keys = match json with `Assoc kvs -> List.map fst kvs | _ -> [] in
+  Alcotest.(check bool)
+    "key omitted when None"
+    false
+    (List.mem "predecessor_task_id" keys);
+  (* Absent key decodes to None (pre-W2 backlogs parse unchanged). *)
+  (match Masc_domain.task_of_yojson json with
+   | Ok t ->
+     Alcotest.(check (option string)) "absent -> None" None t.predecessor_task_id
+   | Error e -> Alcotest.fail ("decode without key failed: " ^ e));
+  (* Present string value round-trips. *)
+  let with_link = { without with predecessor_task_id = Some "task-000" } in
+  (match Masc_domain.task_of_yojson (Masc_domain.task_to_yojson with_link) with
+   | Ok t ->
+     Alcotest.(check (option string))
+       "round-trip"
+       (Some "task-000")
+       t.predecessor_task_id
+   | Error e -> Alcotest.fail ("round-trip decode failed: " ^ e));
+  (* Malformed value degrades to None instead of erroring — a decode Error
+     would make backlog_of_yojson silently drop the whole task. *)
+  let malformed =
+    match json with
+    | `Assoc kvs -> `Assoc (kvs @ [ "predecessor_task_id", `Int 7 ])
+    | other -> other
+  in
+  match Masc_domain.task_of_yojson malformed with
+  | Ok t ->
+    Alcotest.(check (option string)) "malformed -> None" None t.predecessor_task_id
+  | Error e -> Alcotest.fail ("malformed value dropped the task: " ^ e)
 ;;
 
 (* ============================================================ *)
@@ -2547,5 +2696,25 @@ let () =
         ] )
     ; (* === Archive === *)
       "archive", [ Alcotest.test_case "append tasks" `Quick test_append_archive_tasks ]
+    ; (* === RFC-0323 W2: predecessor_task_id === *)
+      ( "predecessor"
+      , [ Alcotest.test_case "unknown rejected" `Quick test_predecessor_unknown_rejected
+        ; Alcotest.test_case
+            "non-terminal rejected"
+            `Quick
+            test_predecessor_non_terminal_rejected
+        ; Alcotest.test_case
+            "terminal accepted and persisted"
+            `Quick
+            test_predecessor_terminal_accepted_and_persisted
+        ; Alcotest.test_case
+            "blank treated as none"
+            `Quick
+            test_predecessor_blank_treated_as_none
+        ; Alcotest.test_case
+            "codec absent and malformed"
+            `Quick
+            test_predecessor_codec_absent_and_malformed
+        ] )
     ]
 ;;

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -37,6 +37,7 @@ let make_task ~id ~status =
   ; files = []
   ; created_at = "2026-06-03T00:00:00Z"
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -41,6 +41,7 @@ let mk_task ?reclaim_policy status =
   ; files = []
   ; created_at = now
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract = None
   ; handoff_context = None
   ; cycle_count = 0

--- a/test/test_workspace_task_verification_phase_e.ml
+++ b/test/test_workspace_task_verification_phase_e.ml
@@ -21,6 +21,7 @@ let dummy_task ?contract ?handoff_context () : Masc_domain.task =
   ; task_status = Masc_domain.Todo
   ; priority = 5
   ; created_by = None
+  ; predecessor_task_id = None
   ; contract
   ; handoff_context
   ; cycle_count = 0


### PR DESCRIPTION
## RFC-0323 G-8 — `predecessor_task_id` 연관 re-run 필드

RFC: `docs/rfc/RFC-0323-done-via-verification-linked-rerun.md` (#23659), Goal Matrix **G-8**.
Operator 결정: "다시 하려면 태스크를 만들고 연관으로 걸어라" — 완료 태스크 재실행은 in-place reclaim이 아니라 **terminal predecessor에 링크된 새 태스크**. 하드 순서상 **G-10(Done-reclaim 은퇴)의 선행 조건** — G-10의 claim-on-Done 에러가 이 successor 경로를 안내하게 된다.

### 변경

- **`types_core`**: task record에 `predecessor_task_id : string option` (write-once — 생성 시에만 설정, 모든 전이는 `{ t with }`로 통과). 인코더는 None이면 키 생략(`created_by` 패턴), 디코더는 부재/비문자열 값을 None으로 degrade — decode `Error`였다면 `backlog_of_yojson`이 **태스크를 통째로 silent drop**하는 함정을 회피. 구 backlog 무마이그레이션 호환.
- **`workspace_task_create`**: `?predecessor_task_id` 인자. 존재+terminal 검증을 **backlog 파일 락 안에서, 태스크가 append되는 동일 스냅샷에 대해** 수행(TOCTOU 없음). typed error `Unknown_predecessor` / `Predecessor_not_terminal{id; status}`. 공백 입력은 trim→None. `task.created` activity payload에 링크 포함.
- **`masc_add_task`**: `predecessor_task_id` 인자(valid_keys 미등록 시 Workflow_rejection이므로 필수) + 성공 payload 포함. 스키마 설명은 재실행-대신-재claim 금지 방향을 명시.

### 경계 (매트릭스 선언)

- batch add(positional 5-tuple)·`keeper_task_create`는 링크 미보유(None) — 스코프 밖.
- RFC-0267 goal registry 불가침 — 다대다 가변 그룹핑 ≠ task→task write-once lineage.
- 표시 표면(G-9: dashboard 7-field subset, FE lineage)은 후속 — rich `task_json`은 codec 자동 상속이라 이 PR만으로도 노출됨.
- 아카이브된 terminal predecessor는 링크 불가(에러 메시지에 명시) — RFC 기록된 스코프 컷.

### 검증

- `test_workspace_coverage.ml` `predecessor` 그룹 5케이스: unknown 거부 / non-terminal 거부(typed record 패턴 매치) / terminal 수용+디스크 round-trip 영속 / blank→None / codec(None시 키 생략·absent→None·string round-trip·malformed→None로 태스크 미탈락).
- full task literal 24곳(17 테스트 파일) 컴파일 강제 갱신.
- 로컬 parse-only 검사 통과; 빌드/테스트는 CI (repo 정책: 로컬 dune build 금지).

### 충돌 주의

#23661(`albini/task-1869-clean`, `types_core.ml` 단독)과 파일 겹침 — 해당 PR에 RFC-0323 redirect 코멘트 게시됨. 이 PR이 매트릭스 경로의 canonical 구현.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
