### PR TITLE
fix(dashboard): keeper-spawn 패널 이중 간격 제거 + fsm 뷰 테스트 보강

### DIFF
--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -105,6 +105,8 @@ describe('AgentsUnified', () => {
     expect(container.querySelector('[data-testid="fleet-fsm-matrix"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="composite-fsm-flowchart"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="fsm-hub"]')).not.toBeNull()
+    // FSM view is a structural drill-down, not a fleet roster — no keeper-create entry here.
+    expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).toBeNull()
   })
 
   it('marks the FSM hub panel with the v2 monitoring panel class', () => {

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-panel.ts
@@ -8,15 +8,19 @@ import { showSpawnPanel } from './keeper-spawn-state'
 // overrides at creation time are intentionally NOT here — those go through
 // keeper detail (post-create) or masc_keeper_up in the tool executor, keeping
 // this flow to one decision.
+//
+// Spacing below the panel is owned by the parent flex container (gap-4 in
+// AgentsUnified); the root carries no bottom margin so the panel↔roster gap
+// stays a single 16px step instead of stacking margin + gap.
 export function KeeperSpawnPanel() {
   if (!showSpawnPanel.value) {
-    return html`<div class="mb-4 v2-monitoring-surface" data-testid="keeper-spawn-panel">
+    return html`<div class="v2-monitoring-surface" data-testid="keeper-spawn-panel">
       <${ActionButton} variant="primary" size="md" onClick=${() => { showSpawnPanel.value = true }}>+ 키퍼 생성<//>
     </div>`
   }
   return html`
     <div
-      class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 v2-monitoring-panel"
+      class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 v2-monitoring-panel"
       data-testid="keeper-spawn-panel"
     >
       <div class="flex items-center justify-between mb-3 v2-monitoring-toolbar">


### PR DESCRIPTION
## 목적

#23658(Fleet 키퍼 생성) 머지 후 fresh-read 적대적 사후 리뷰에서 발견한 low-severity 2건을 처리합니다. 머지된 브랜치엔 push 불가하므로 follow-up PR로 분리했습니다.

## 배경 (diff만 보면 놓치는 상호작용)

`AgentsUnified`의 부모 컨테이너는 `flex flex-col gap-4`입니다. #23658 전에는 이 브랜치가 `<AgentRoster>` **단일 자식**이라 `gap`이 무효(형제 없음)였습니다. #23658이 `KeeperSpawnPanel`을 형제로 추가하면서 `gap-4`(16px)가 활성화됐는데, 패널 루트에는 기존 `mb-4`(16px)가 그대로 남아 있어 패널↔로스터 간격이 **32px로 이중 적용**됐습니다(fleet 다른 곳은 16px 단일 step).

## 변경 (2 파일, +8/-2)

1. **`keeper-spawn-panel.ts`** — collapsed/expanded 두 루트에서 `mb-4` 제거. 간격은 부모 `gap-4`가 소유하도록 하고, 이유를 주석으로 명시.
2. **`agents-unified.test.ts`** — fsm 뷰에서 `keeper-spawn-panel` 부재를 assert. #23658의 커버리지 갭(fsm 브랜치는 FSM hub를 렌더하고 로스터를 렌더하지 않으므로 keeper-create 진입점이 없어야 함)을 닫음.

## 범위 밖 (의도적 분리)

- **선재 state-leak**: `confirmTarget`/`spawnResult`가 module-level signal이라 패널을 닫고 재오픈해도 이전 confirm/결과가 잔존. `persona-browser.ts`/`keeper-spawn-state.ts` 소관이며 #23658이 두 파일을 안 건드렸으므로 이 PR의 regression 아님 → 별개 PR로 분리 권장.

## 검증

- `vitest run agents-unified.test.ts keeper-spawn/keeper-spawn-panel.test.ts` — 13 tests green (신규 fsm assertion 포함)
- `tsc --noEmit` clean, eslint(source) clean
- 백엔드 무변경, API 무변경. 순수 dashboard FE cosmetic + test.

## RFC / 워크어라운드

- RFC 게이트 대상 아님: `keeper-spawn/`은 credential/repo-mapping component가 아님.
- 워크어라운드 시그니처(telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair) 해당 없음.
