### PR TITLE
fix(workspace): main red — explicit task_status enumeration in verification-id read

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -676,8 +676,10 @@ let handle_keeper_task_tool
                   { approve_error; reject_error }) ->
              Log.Keeper.error ~keeper_name:meta.name
                "deterministic probe stranded %s in awaiting_verification \
-                (approve: %s; compensating reject: %s); resolvable by \
-                another identity via approve/reject"
+                (approve: %s; compensating reject: %s); its pending \
+                verification record keeps it inside the verifier wake signal \
+                and the dashboard panel — any other identity can \
+                approve/reject"
                task_id
                (Masc_domain.masc_error_to_string approve_error)
                (Masc_domain.masc_error_to_string reject_error))

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -3,6 +3,14 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_tool_shared_runtime
 
+(* RFC-0323 G-2: distinct machine identity under which the RFC-0199
+   deterministic probe approves its own submission. The FSM self-approval
+   check compares identity keys (never authority), so the probe cannot
+   approve under the keeper identity it submits with. Single-colon
+   namespacing per [Validation.Agent_id]; follows the [operator:<actor>]
+   precedent of the dashboard verdict route. *)
+let deterministic_probe_verifier = "probe:deterministic"
+
 let keeper_task_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t option)) result =
   match result with
   | Ok msg ->
@@ -595,14 +603,17 @@ let handle_keeper_task_tool
          auto_started_ok := Tool_result.is_success start_result
        end else
          auto_started_ok := true;
-       (* RFC-0199 Phase B: deterministic evidence harness. When the claimed
-          task declares typed [evidence_claims] and all are satisfied by a file
-          probe, complete it immediately — no LLM turn. Uses [force_done_task_r]
-          so a deterministic check does not route through the non-deterministic
-          anti-rationalization gate (force_done is the existing keeper-Done
-          path; Done_action is exempt from the legacy substring gate). Guarded to
-          Claimed/InProgress so it never hits the AwaitingVerification
-          Invalid_transition; idempotent if another agent reached Done first. *)
+       (* RFC-0199 Phase B / RFC-0323 G-2: deterministic evidence harness.
+          When the claimed task declares typed [evidence_claims] and all are
+          satisfied by a file probe, complete it without an LLM turn — through
+          the verification lane: submit as the keeper (assignee), approve
+          under the distinct machine identity [deterministic_probe_verifier].
+          Replaces the former [force_done_task_r] bypass so Done stays
+          reachable only via approve; the typed evidence_claims probe remains
+          the real evidence. Guarded to Claimed/InProgress so it never hits
+          the AwaitingVerification Invalid_transition; idempotent if another
+          agent reached Done first. Failures are logged per branch, never
+          swallowed. *)
        (match
           Workspace.get_tasks_raw config
           |> List.find_opt (fun (t : Masc_domain.task) ->
@@ -626,12 +637,50 @@ let handle_keeper_task_tool
                [%s]"
               (List.length claims) summary
           in
+          let approve_notes =
+            Printf.sprintf
+              "RFC-0199 deterministic probe: %d typed evidence claim(s) \
+               machine-verified"
+              (List.length claims)
+          in
           (match
-             Workspace.force_done_task_r config
-               ~agent_name:(keeper_agent_sender ~meta) ~task_id ~notes ()
+             Workspace.submit_and_approve_task_r config
+               ~agent_name:(keeper_agent_sender ~meta)
+               ~verifier_name:deterministic_probe_verifier ~task_id ~notes
+               ~approve_notes ()
            with
            | Ok _ -> harness_completed := true
-           | Error _ -> ())
+           | Error (Workspace.Machine_verify_invalid_verifier msg) ->
+             Log.Keeper.error ~keeper_name:meta.name
+               "deterministic probe verifier identity rejected for %s: %s"
+               task_id msg
+           | Error (Workspace.Machine_verify_verifier_not_distinct _) ->
+             Log.Keeper.error ~keeper_name:meta.name
+               "deterministic probe verifier collides with keeper identity \
+                for %s; probe completion skipped"
+               task_id
+           | Error (Workspace.Machine_verify_submit_failed e) ->
+             Log.Keeper.warn ~keeper_name:meta.name
+               "deterministic probe submit failed for %s (falling back to \
+                LLM turn): %s"
+               task_id
+               (Masc_domain.masc_error_to_string e)
+           | Error (Workspace.Machine_verify_approve_failed_compensated e) ->
+             Log.Keeper.warn ~keeper_name:meta.name
+               "deterministic probe approve failed for %s; compensating \
+                reject returned it to in_progress: %s"
+               task_id
+               (Masc_domain.masc_error_to_string e)
+           | Error
+               (Workspace.Machine_verify_approve_failed_stranded
+                  { approve_error; reject_error }) ->
+             Log.Keeper.error ~keeper_name:meta.name
+               "deterministic probe stranded %s in awaiting_verification \
+                (approve: %s; compensating reject: %s); resolvable by \
+                another identity via approve/reject"
+               task_id
+               (Masc_domain.masc_error_to_string approve_error)
+               (Masc_domain.masc_error_to_string reject_error))
         | _ -> ())
      | Workspace.Claim_next_no_unclaimed
      | Workspace.Claim_next_no_eligible _

--- a/lib/keeper/keeper_tool_task_runtime.mli
+++ b/lib/keeper/keeper_tool_task_runtime.mli
@@ -7,6 +7,12 @@
     #1) yet still counted by the per-(tool,args) breaker (Gate #2). *)
 val validation_error_json : string -> string
 
+(** RFC-0323 G-2: machine identity under which the RFC-0199 deterministic
+    probe approves its own submission ([Workspace.submit_and_approve_task_r]).
+    Distinct from every keeper identity key, so the FSM self-approval check
+    holds. Exposed so tests can pin its [Validation.Agent_id] validity. *)
+val deterministic_probe_verifier : string
+
 val handle_keeper_task_tool :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -149,12 +149,16 @@ let submit_and_approve_task_r
                  (fun (t : Masc_domain.task) -> String.equal t.id task_id)
                  backlog.tasks
              with
-             | Some
-                 { task_status =
-                     Masc_domain.AwaitingVerification { verification_id; _ }
-                 ; _
-                 } -> Some verification_id
-             | Some _ | None -> None)
+             | None -> None
+             | Some t ->
+               (match t.task_status with
+                | Masc_domain.AwaitingVerification { verification_id; _ } ->
+                  Some verification_id
+                | Masc_domain.Todo
+                | Masc_domain.Claimed _
+                | Masc_domain.InProgress _
+                | Masc_domain.Done _
+                | Masc_domain.Cancelled _ -> None))
         in
         let record_verdict decision =
           match verification_id with

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -50,6 +50,87 @@ let force_done_task_r config ~agent_name ~task_id ~notes ()
     ()
 ;;
 
+type machine_verify_failure =
+  | Machine_verify_invalid_verifier of string
+  | Machine_verify_verifier_not_distinct of
+      { agent_name : string
+      ; verifier_name : string
+      }
+  | Machine_verify_submit_failed of Masc_domain.masc_error
+  | Machine_verify_approve_failed_compensated of Masc_domain.masc_error
+  | Machine_verify_approve_failed_stranded of
+      { approve_error : Masc_domain.masc_error
+      ; reject_error : Masc_domain.masc_error
+      }
+
+(** RFC-0323 G-2: machine-verified completion through the verification lane.
+
+    Submits as [agent_name] (must be the assignee; the FSM submit arm enforces
+    it), then approves as [verifier_name] — a distinct machine identity, since
+    the FSM self-approval check compares identity keys and never authority.
+    Both preconditions (verifier name shape, verifier distinct from submitter)
+    are checked before any state mutation.
+
+    No verification-store record is created: the store hooks are tool-layer
+    callbacks, so the [AwaitingVerification] window here is bounded by the
+    immediate approve. If the approve fails after a successful submit, one
+    compensating reject (as [verifier_name]) returns the task to
+    [InProgress { assignee }]; if that also fails, the task remains
+    [AwaitingVerification] and the error carries both failures — resolvable by
+    any other identity via approve/reject or the dashboard verdict route. *)
+let submit_and_approve_task_r
+      config
+      ~agent_name
+      ~verifier_name
+      ~task_id
+      ~notes
+      ~approve_notes
+      ()
+  : (string, machine_verify_failure) result
+  =
+  match Validation.Agent_id.validate verifier_name with
+  | Error msg -> Error (Machine_verify_invalid_verifier msg)
+  | Ok _ ->
+    if Workspace_task_classify.same_task_actor config verifier_name agent_name
+    then Error (Machine_verify_verifier_not_distinct { agent_name; verifier_name })
+    else (
+      match
+        transition_task_r
+          config
+          ~agent_name
+          ~task_id
+          ~action:Masc_domain.Submit_for_verification
+          ~notes
+          ()
+      with
+      | Error e -> Error (Machine_verify_submit_failed e)
+      | Ok _submitted ->
+        (match
+           transition_task_r
+             config
+             ~agent_name:verifier_name
+             ~task_id
+             ~action:Masc_domain.Approve_verification
+             ~notes:approve_notes
+             ()
+         with
+         | Ok message -> Ok message
+         | Error approve_error ->
+           (match
+              transition_task_r
+                config
+                ~agent_name:verifier_name
+                ~task_id
+                ~action:Masc_domain.Reject_verification
+                ~reason:"machine verification approve failed; compensating reject"
+                ()
+            with
+            | Ok _ -> Error (Machine_verify_approve_failed_compensated approve_error)
+            | Error reject_error ->
+              Error
+                (Machine_verify_approve_failed_stranded { approve_error; reject_error }))))
+;;
+
 (** Force-cancel a task regardless of assignee. System privilege.
     Used by [Verification_protocol.check_timeouts] to expire
     [AwaitingVerification] tasks whose verifier deadline has passed,

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -63,6 +63,10 @@ type machine_verify_failure =
       ; reject_error : Masc_domain.masc_error
       }
 
+let machine_verify_compensation_reason =
+  "machine verification approve failed; compensating reject"
+;;
+
 (** RFC-0323 G-2: machine-verified completion through the verification lane.
 
     Submits as [agent_name] (must be the assignee; the FSM submit arm enforces
@@ -71,13 +75,20 @@ type machine_verify_failure =
     Both preconditions (verifier name shape, verifier distinct from submitter)
     are checked before any state mutation.
 
-    No verification-store record is created: the store hooks are tool-layer
-    callbacks, so the [AwaitingVerification] window here is bounded by the
-    immediate approve. If the approve fails after a successful submit, one
-    compensating reject (as [verifier_name]) returns the task to
-    [InProgress { assignee }]; if that also fails, the task remains
-    [AwaitingVerification] and the error carries both failures — resolvable by
-    any other identity via approve/reject or the dashboard verdict route. *)
+    Verification-store lifecycle mirrors the tool layer (RFC-0221): the
+    request record is created before the submit commit and deleted if that
+    commit fails; a successful approve (or compensating reject) records the
+    machine verdict, resolving the record. Board/SSE notify hooks are
+    deliberately not invoked — machine completions do not announce; the store
+    record is the audit trail. Hook defaults are no-ops, so contexts without
+    the verification store stay store-free.
+
+    If the approve fails after a successful submit, one compensating reject
+    (as [verifier_name]) returns the task to [InProgress { assignee }]. If
+    that also fails, the task stays [AwaitingVerification] and the Pending
+    store record is deliberately left in place: the task remains inside the
+    pending-verification wake signal and the dashboard verification panel, so
+    any other identity can approve/reject it through the normal lane. *)
 let submit_and_approve_task_r
       config
       ~agent_name
@@ -94,6 +105,28 @@ let submit_and_approve_task_r
     if Workspace_task_classify.same_task_actor config verifier_name agent_name
     then Error (Machine_verify_verifier_not_distinct { agent_name; verifier_name })
     else (
+      let prepare_verification_request ~task ~assignee ~verification_id ~evidence_refs =
+        (Atomic.get Workspace_hooks.verification_submit_request_fn)
+          config
+          ~task
+          ~assignee
+          ~verification_id
+          ~evidence_refs
+      in
+      let compensate_verification_request ~verification_id =
+        match
+          (Atomic.get Workspace_hooks.verification_delete_request_fn)
+            config
+            ~verification_id
+        with
+        | Ok () -> ()
+        | Error e ->
+          Log.Workspace.warn
+            "machine-verify submit compensation failed (task=%s vrf=%s): %s"
+            task_id
+            verification_id
+            e
+      in
       match
         transition_task_r
           config
@@ -101,10 +134,52 @@ let submit_and_approve_task_r
           ~task_id
           ~action:Masc_domain.Submit_for_verification
           ~notes
+          ~prepare_verification_request
+          ~compensate_verification_request
           ()
       with
       | Error e -> Error (Machine_verify_submit_failed e)
       | Ok _submitted ->
+        let verification_id =
+          match read_backlog_r config with
+          | Error _ -> None
+          | Ok backlog ->
+            (match
+               List.find_opt
+                 (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+                 backlog.tasks
+             with
+             | Some
+                 { task_status =
+                     Masc_domain.AwaitingVerification { verification_id; _ }
+                 ; _
+                 } -> Some verification_id
+             | Some _ | None -> None)
+        in
+        let record_verdict decision =
+          match verification_id with
+          | None ->
+            Log.Workspace.warn
+              "machine-verify: verification id unreadable after submit \
+               (task=%s); a store record may remain pending"
+              task_id
+          | Some verification_id ->
+            (match
+               (Atomic.get Workspace_hooks.verification_record_verdict_fn)
+                 config
+                 ~task_id
+                 ~verifier:verifier_name
+                 ~verification_id
+                 ~decision
+             with
+             | Ok () -> ()
+             | Error e ->
+               Log.Workspace.warn
+                 "machine-verify verdict record failed (task=%s vrf=%s): %s"
+                 task_id
+                 verification_id
+                 e)
+        in
         (match
            transition_task_r
              config
@@ -114,7 +189,9 @@ let submit_and_approve_task_r
              ~notes:approve_notes
              ()
          with
-         | Ok message -> Ok message
+         | Ok message ->
+           record_verdict (`Approve approve_notes);
+           Ok message
          | Error approve_error ->
            (match
               transition_task_r
@@ -122,11 +199,16 @@ let submit_and_approve_task_r
                 ~agent_name:verifier_name
                 ~task_id
                 ~action:Masc_domain.Reject_verification
-                ~reason:"machine verification approve failed; compensating reject"
+                ~reason:machine_verify_compensation_reason
                 ()
             with
-            | Ok _ -> Error (Machine_verify_approve_failed_compensated approve_error)
+            | Ok _ ->
+              record_verdict (`Reject machine_verify_compensation_reason);
+              Error (Machine_verify_approve_failed_compensated approve_error)
             | Error reject_error ->
+              (* Deliberately no record cleanup: the Pending record keeps the
+                 stranded task actionable for the pending-verification wake
+                 signal and the dashboard verification panel. *)
               Error
                 (Machine_verify_approve_failed_stranded { approve_error; reject_error }))))
 ;;

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -85,6 +85,39 @@ val force_done_task_r :
   config -> agent_name:string -> task_id:string ->
   notes:string -> unit -> string Masc_domain.masc_result
 
+(** Typed failure surface of {!submit_and_approve_task_r}. Every branch is
+    reported; none is swallowed. *)
+type machine_verify_failure =
+  | Machine_verify_invalid_verifier of string
+      (** [verifier_name] failed [Validation.Agent_id] — rejected before any
+          state mutation *)
+  | Machine_verify_verifier_not_distinct of
+      { agent_name : string
+      ; verifier_name : string
+      }
+      (** verifier and submitter share one identity key — rejected before any
+          state mutation (self-approval would be unrecoverable post-submit) *)
+  | Machine_verify_submit_failed of Masc_domain.masc_error
+      (** submit rejected by the FSM; task state unchanged *)
+  | Machine_verify_approve_failed_compensated of Masc_domain.masc_error
+      (** approve failed; the compensating reject succeeded — task is back to
+          [InProgress { assignee }] *)
+  | Machine_verify_approve_failed_stranded of
+      { approve_error : Masc_domain.masc_error
+      ; reject_error : Masc_domain.masc_error
+      }
+      (** approve and the compensating reject both failed — task remains
+          [AwaitingVerification]; another identity can approve/reject it *)
+
+(** RFC-0323 G-2: complete a task through the verification lane — submit as
+    [agent_name] (the assignee), approve as the distinct machine identity
+    [verifier_name]. Replaces direct [force_done_task_r] completion for
+    deterministic harnesses (RFC-0199 probe). *)
+val submit_and_approve_task_r :
+  config -> agent_name:string -> verifier_name:string -> task_id:string ->
+  notes:string -> approve_notes:string -> unit ->
+  (string, machine_verify_failure) result
+
 (** {1 Task cancellation} *)
 
 val cancel_task_r :

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -106,13 +106,21 @@ type machine_verify_failure =
       { approve_error : Masc_domain.masc_error
       ; reject_error : Masc_domain.masc_error
       }
-      (** approve and the compensating reject both failed — task remains
-          [AwaitingVerification]; another identity can approve/reject it *)
+      (** approve and the compensating reject both failed — the task remains
+          [AwaitingVerification] and its Pending verification-store record is
+          deliberately left actionable, so the stranded task surfaces through
+          the pending-verification wake signal and the dashboard verification
+          panel; any other identity can approve/reject it *)
 
 (** RFC-0323 G-2: complete a task through the verification lane — submit as
     [agent_name] (the assignee), approve as the distinct machine identity
     [verifier_name]. Replaces direct [force_done_task_r] completion for
-    deterministic harnesses (RFC-0199 probe). *)
+    deterministic harnesses (RFC-0199 probe).
+
+    Verification-store lifecycle mirrors the tool layer (RFC-0221 hooks):
+    record created with the submit, machine verdict recorded on approve or on
+    the compensating reject; board/SSE notify hooks are not invoked (machine
+    completions do not announce). Hook defaults are no-ops. *)
 val submit_and_approve_task_r :
   config -> agent_name:string -> verifier_name:string -> task_id:string ->
   notes:string -> approve_notes:string -> unit ->

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1349,6 +1349,97 @@ let test_force_done_bypasses_assignee () =
     Alcotest.(check bool) "task is done" true (str_contains tasks "Done" || str_contains tasks "done")
   )
 
+(* === RFC-0323 G-2: submit_and_approve_task_r (machine-verified completion) === *)
+
+let find_task config task_id =
+  Workspace.get_tasks_raw config
+  |> List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+
+let test_submit_and_approve_completes_via_verification () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Probe Task" ~priority:1 ~description:"" in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    (* Uses the exported probe identity so this test also pins that the
+       constant passes Agent_id validation and is distinct from a plain
+       agent identity, end-to-end through the real FSM. *)
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
+        ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
+        ~task_id:"task-001"
+        ~notes:"deterministic evidence satisfied" ~approve_notes:"machine-verified" ()
+    in
+    Alcotest.(check bool) "submit+approve ok" true
+      (match result with Ok _ -> true | Error _ -> false);
+    match find_task config "task-001" with
+    | Some { task_status = Masc_domain.Done { assignee; notes; _ }; _ } ->
+      Alcotest.(check string) "assignee preserved" test_agent_a assignee;
+      Alcotest.(check bool) "approved-by verifier recorded" true
+        (match notes with
+         | Some n ->
+           str_contains n Keeper_tool_task_runtime.deterministic_probe_verifier
+         | None -> false)
+    | Some _ -> Alcotest.fail "task not Done after submit+approve"
+    | None -> Alcotest.fail "task-001 missing")
+
+let test_submit_and_approve_rejects_same_identity () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Probe Task" ~priority:1 ~description:"" in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
+        ~verifier_name:test_agent_a ~task_id:"task-001"
+        ~notes:"n" ~approve_notes:"a" ()
+    in
+    Alcotest.(check bool) "rejected as not distinct" true
+      (match result with
+       | Error (Workspace.Machine_verify_verifier_not_distinct _) -> true
+       | Ok _ | Error _ -> false);
+    (* Rejected before any mutation: task must still be Claimed. *)
+    Alcotest.(check bool) "task still claimed" true
+      (match find_task config "task-001" with
+       | Some { task_status = Masc_domain.Claimed _; _ } -> true
+       | Some _ | None -> false))
+
+let test_submit_and_approve_rejects_invalid_verifier () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Probe Task" ~priority:1 ~description:"" in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
+        ~verifier_name:"probe:bad:double" ~task_id:"task-001"
+        ~notes:"n" ~approve_notes:"a" ()
+    in
+    Alcotest.(check bool) "rejected as invalid verifier" true
+      (match result with
+       | Error (Workspace.Machine_verify_invalid_verifier _) -> true
+       | Ok _ | Error _ -> false);
+    Alcotest.(check bool) "task still claimed" true
+      (match find_task config "task-001" with
+       | Some { task_status = Masc_domain.Claimed _; _ } -> true
+       | Some _ | None -> false))
+
+let test_submit_and_approve_non_assignee_submit_fails () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Probe Task" ~priority:1 ~description:"" in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:admin_keeper_agent
+        ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
+        ~task_id:"task-001" ~notes:"n" ~approve_notes:"a" ()
+    in
+    Alcotest.(check bool) "submit failed typed" true
+      (match result with
+       | Error (Workspace.Machine_verify_submit_failed _) -> true
+       | Ok _ | Error _ -> false);
+    Alcotest.(check bool) "task still claimed" true
+      (match find_task config "task-001" with
+       | Some { task_status = Masc_domain.Claimed _; _ } -> true
+       | Some _ | None -> false))
+
 let test_audit_orphan_tasks () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Orphan Candidate" ~priority:1 ~description:"" in
@@ -2030,6 +2121,18 @@ let () =
       Alcotest.test_case "xss in message" `Quick test_xss_in_message;
       Alcotest.test_case "xss in agent name" `Quick test_xss_in_agent_name;
       Alcotest.test_case "xss in message type" `Quick test_xss_in_message_type;
+    ];
+
+    (* === RFC-0323 G-2: machine-verified completion === *)
+    "machine_verify", [
+      Alcotest.test_case "submit+approve completes via verification" `Quick
+        test_submit_and_approve_completes_via_verification;
+      Alcotest.test_case "same identity rejected before mutation" `Quick
+        test_submit_and_approve_rejects_same_identity;
+      Alcotest.test_case "invalid verifier rejected before mutation" `Quick
+        test_submit_and_approve_rejects_invalid_verifier;
+      Alcotest.test_case "non-assignee submit fails typed" `Quick
+        test_submit_and_approve_non_assignee_submit_fails;
     ];
 
     (* === Board Admin Tests === *)

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -6,6 +6,10 @@ open Masc
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
+(* RFC-0323 G-2: wires the verification-store hooks (among others) so the
+   machine_verify tests can assert the store record lifecycle. *)
+let () = Workspace_metric_hooks.install ()
+
 (* UTF-8 emoji helpers: ✅ is E2 9C 85, ⚠ is E2 9A A0, 🔒 is F0 9F 94 92, 🔓 is F0 9F 94 93 *)
 
 (* Helper for substring check - define early *)
@@ -1371,6 +1375,15 @@ let test_submit_and_approve_completes_via_verification () =
     in
     Alcotest.(check bool) "submit+approve ok" true
       (match result with Ok _ -> true | Error _ -> false);
+    (* Verification-store lifecycle (hooks installed above): the submit
+       created a record and the machine verdict resolved it — nothing
+       actionable remains to wake verifiers or linger in the dashboard
+       panel. *)
+    let requests = Verification.list_requests config.Workspace.base_path in
+    Alcotest.(check bool) "store record created" true
+      (List.length requests >= 1);
+    Alcotest.(check int) "no actionable record remains" 0
+      (List.length (List.filter Verification.request_is_actionable requests));
     match find_task config "task-001" with
     | Some { task_status = Masc_domain.Done { assignee; notes; _ }; _ } ->
       Alcotest.(check string) "assignee preserved" test_agent_a assignee;


### PR DESCRIPTION
**main is red**: #23665 merged (`6414ff758`) while its last commit `5772e78398` had a fragile-match compile error — `lib/workspace` builds with `-w +4 -warn-error`, and the `Some _ | None` catch-all after an `AwaitingVerification`-specific arm trips warning 4 (Canary/Build/Health/Lint all red on that run).

One-hunk fix: enumerate all `task_status` constructors explicitly (repo FSM no-catch-all rule).

Branch note: this is the recreated `rfc-0323/g2-probe-verification-lane` branch — its content diff vs main is exactly this fix (everything else landed in the squash merge).

RFC-0323 G-2 follow-up.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
