### PR TITLE
docs(rfc): resolve RFC-0323 number collision (0324 for filesystem-truth RFC)

### DIFF
--- a/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
+++ b/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
@@ -1,4 +1,4 @@
-# RFC-0323: keeper repo 경로를 filesystem 진실로 (catalog 거짓 주입 제거)
+# RFC-0324: keeper repo 경로를 filesystem 진실로 (catalog 거짓 주입 제거)
 
 ## Status
 Draft


### PR DESCRIPTION
## 요약
- `main`에 RFC-0323을 주장하는 파일이 두 개 병존합니다: `#23659`(Done via verification, merged `126963f`)와 `#23667`(keeper filesystem truth, merged).
- CI의 `Check RFC number collisions across open PRs`가 머지 전 경고했지만 두 브랜치 모두 갱신 없이 랜딩됐습니다.

## 변경
- `docs/rfc/RFC-0323-keeper-filesystem-repo-truth.md` → `docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md` (파일명 + 본문 타이틀만 변경, 내용 무변경)
- Done-reclaim RFC는 RFC-0323 번호를 유지합니다. 이미 머지된 `workspace_task_lifecycle.ml:74-92`의 interim guard 주석이 `removal target: RFC-0323 merge`를 가리키고 있어서, 그쪽을 바꾸면 shipped 코드 주석도 같이 고쳐야 하기 때문입니다.

## 검증
단일 파일 rename + 문자열 치환뿐이라 dune 빌드 대상 아님. `rg`로 다른 파일에서 옛 파일명/타이틀 참조 없음 확인.