### PR TITLE
fix(workspace): main red — explicit task_status enumeration in verification-id read

### DIFF
--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -149,12 +149,16 @@ let submit_and_approve_task_r
                  (fun (t : Masc_domain.task) -> String.equal t.id task_id)
                  backlog.tasks
              with
-             | Some
-                 { task_status =
-                     Masc_domain.AwaitingVerification { verification_id; _ }
-                 ; _
-                 } -> Some verification_id
-             | Some _ | None -> None)
+             | None -> None
+             | Some t ->
+               (match t.task_status with
+                | Masc_domain.AwaitingVerification { verification_id; _ } ->
+                  Some verification_id
+                | Masc_domain.Todo
+                | Masc_domain.Claimed _
+                | Masc_domain.InProgress _
+                | Masc_domain.Done _
+                | Masc_domain.Cancelled _ -> None))
         in
         let record_verdict decision =
           match verification_id with


### PR DESCRIPTION
**main is red**: #23665 merged (`6414ff758`) with its last commit `5772e78398` carrying a fragile-match compile error — `lib/workspace` builds with `-w +4 -warn-error`, and the `Some _ | None` catch-all after an `AwaitingVerification`-specific arm trips warning 4. Canary/Build/Health/Lint red on main and on every PR merge-build until this lands. One-hunk fix: enumerate all `task_status` constructors (repo FSM no-catch-all rule). RFC-0323 G-2 follow-up. Supersedes #23672 (stale merge-base). Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>