### PR TITLE
fix(build): repair main-red merge-skew (persona risk / board dup / Fs_compat)

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -147,7 +147,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
-  | Surface_post | Person_note_set
+  | Surface_post | Person_note_set | Persona_create | Persona_update
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
   | Board_sub_board_delete -> Critical

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -10,7 +10,7 @@ let personas_dir () =
   | None ->
       let base = match Sys.getenv_opt "MASC_BASE" with
         | Some b -> b
-        | None -> Fs_compat.default_masc_base ()
+        | None -> Config_dir_resolver.base_path_or_cwd ()
       in
       Filename.concat base "personas"
 

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -228,9 +228,6 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
     | "masc_board_sub_board_create" ->
         enforce_caller_identity ~tool:name ~field:"owner" ~agent_name
           arguments
-    | "masc_board_post_update" ->
-        enforce_caller_identity ~tool:name ~field:"author" ~agent_name
-          arguments
     | "masc_board_delete" ->
         enforce_caller_identity ~tool:name ~field:"author" ~agent_name
           arguments


### PR DESCRIPTION
## main-red hotfix (merge-skew)

현재 origin/main이 컴파일 불가 — 최근 머지들이 결합 시 red(각 PR은 단독 green). 로컬 `dune build`가 아래 3개로 83%에서 실패:

1. `lib/governance_pipeline_risk.ml` — `risk_of_keeper` match가 `Persona_create|Persona_update` 누락 (partial-match). Medium arm에 추가 (create/update=Medium, delete만 Critical 패턴).
2. `lib/mcp_tool_runtime_board.ml` — `"masc_board_post_update"` 중복 케이스 (redundant-case; :216에서 `masc_board_post`와 같은 `field:"author"`로 이미 처리). 단독 케이스 삭제.
3. `lib/keeper/keeper_tool_persona_crud.ml` — `Fs_compat.default_masc_base` 제거됨 (unbound). `Config_dir_resolver.base_path_or_cwd ()`로 MASC_BASE-unset fallback 대체.

검증: CI authoritative build (로컬 oas 핀-drift로 full 로컬 링크 불가). 3개 모두 컴파일 에러 해소하는 최소 수정.

RFC-WAIVED: build-break hotfix, no behavior change beyond restoring compilation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
