### PR TITLE
feat(dashboard): Fusion 상단 registry 목록을 master 목록으로 통합 (시안 2-pane)

### DIFF
--- a/dashboard/src/components/fusion/fusion-runs-panel.test.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.test.ts
@@ -1,14 +1,6 @@
-import { html } from 'htm/preact'
-import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { parseFusionRunsResponse } from '../../api/dashboard'
-import { fusionRuns, fusionRunsError, fusionRunsLoading } from '../../store'
-import {
-  FusionRunsPanel,
-  fusionRunPipelineSegments,
-  fusionRunStatusText,
-  fusionRunStatusTone,
-} from './fusion-runs-panel'
+import { fusionRunStatusText, fusionRunStatusTone } from './fusion-runs-panel'
 
 describe('parseFusionRunsResponse', () => {
   it('maps snake_case rows to FusionRunRecord and falls back count to length', () => {
@@ -76,6 +68,8 @@ describe('parseFusionRunsResponse', () => {
   })
 })
 
+// The FusionRunsPanel component was merged into the FusionSurface master list, so
+// only the pure status helpers remain here. Their SSOT mapping stays tested.
 describe('fusion run status helpers', () => {
   it('maps status to the reused chip tone', () => {
     expect(fusionRunStatusTone('running')).toBe('warn')
@@ -87,160 +81,5 @@ describe('fusion run status helpers', () => {
     expect(fusionRunStatusText('running')).toBe('running')
     expect(fusionRunStatusText('completed')).toBe('completed')
     expect(fusionRunStatusText('failed')).toBe('failed')
-  })
-
-  it('maps registry status to a conservative backed pipeline', () => {
-    expect(fusionRunPipelineSegments('running').map(segment => [segment.key, segment.state])).toEqual([
-      ['keeper', 'done'],
-      ['registry', 'done'],
-      ['deliberation', 'active'],
-      ['sink', 'pending'],
-    ])
-    expect(fusionRunPipelineSegments('completed').map(segment => segment.state)).toEqual([
-      'done',
-      'done',
-      'done',
-      'done',
-    ])
-    expect(fusionRunPipelineSegments('failed').map(segment => [segment.key, segment.state])).toEqual([
-      ['keeper', 'done'],
-      ['registry', 'done'],
-      ['deliberation', 'failed'],
-      ['sink', 'failed'],
-    ])
-  })
-})
-
-describe('FusionRunsPanel', () => {
-  let container: HTMLDivElement
-
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-    fusionRuns.value = []
-    fusionRunsError.value = null
-    fusionRunsLoading.value = false
-  })
-
-  afterEach(() => {
-    render(null, container)
-    container.remove()
-    fusionRuns.value = []
-    fusionRunsError.value = null
-    fusionRunsLoading.value = false
-  })
-
-  it('shows the empty state when there are no runs', () => {
-    render(html`<${FusionRunsPanel} />`, container)
-    expect(container.querySelector('[data-testid="fusion-runs-empty"]')).not.toBeNull()
-    expect(container.textContent).toContain('No active or recent fusion runs')
-  })
-
-  it('shows a loading hint while empty and loading', () => {
-    fusionRunsLoading.value = true
-    render(html`<${FusionRunsPanel} />`, container)
-    expect(container.textContent).toContain('Loading fusion runs')
-  })
-
-  it('renders a registry load error instead of the empty state', () => {
-    fusionRunsError.value = 'HTTP 503 registry unavailable'
-
-    render(html`<${FusionRunsPanel} />`, container)
-
-    const error = container.querySelector('[data-testid="fusion-runs-error"]')
-    expect(error).not.toBeNull()
-    expect(error?.getAttribute('data-registry-source')).toBe('/api/v1/dashboard/fusion-runs')
-    expect(error?.textContent).toContain('Registry load failed')
-    expect(error?.textContent).toContain('HTTP 503 registry unavailable')
-    expect(container.querySelector('[data-testid="fusion-runs-empty"]')).toBeNull()
-    expect(container.textContent).not.toContain('No active or recent fusion runs')
-  })
-
-  it('keeps cached registry rows visible while surfacing the refresh error', () => {
-    fusionRuns.value = [
-      {
-        runId: 'cached-failed',
-        keeper: 'analyst',
-        preset: 'trio',
-        startedAt: 1_783_106_656,
-        status: 'failed',
-        error: 'fusion aborted: 0 of 3 panels answered',
-        failureCode: 'panels_unavailable',
-      },
-    ]
-    fusionRunsError.value = 'network offline'
-
-    render(html`<${FusionRunsPanel} />`, container)
-
-    expect(container.querySelector('[data-testid="fusion-runs-error"]')?.textContent).toContain('network offline')
-    const cards = container.querySelectorAll('[data-testid="fusion-run-status-card"]')
-    expect(cards).toHaveLength(1)
-    expect(cards[0]?.getAttribute('data-run-id')).toBe('cached-failed')
-    expect(cards[0]?.textContent).toContain('panels_unavailable')
-    expect(container.textContent).not.toContain('No active or recent fusion runs')
-  })
-
-  it('renders one card per run with its status and a running indicator', () => {
-    fusionRuns.value = [
-      { runId: 'r-run', keeper: 'k1', preset: 'balanced', startedAt: 300, status: 'running' },
-      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
-      { runId: 'r-fail', keeper: 'k3', preset: 'deep', startedAt: 200, status: 'failed' },
-    ]
-    render(html`<${FusionRunsPanel} />`, container)
-
-    const cards = container.querySelectorAll('[data-testid="fusion-run-status-card"]')
-    expect(cards).toHaveLength(3)
-
-    const byRun = (id: string) =>
-      Array.from(cards).find(card => card.getAttribute('data-run-id') === id)
-    expect(byRun('r-run')?.getAttribute('data-status')).toBe('running')
-    expect(byRun('r-done')?.getAttribute('data-status')).toBe('completed')
-    expect(byRun('r-fail')?.getAttribute('data-status')).toBe('failed')
-
-    const runningPipeline = byRun('r-run')?.querySelector('[data-testid="fusion-run-pipeline"]')
-    expect(runningPipeline?.querySelector('[data-stage="deliberation"]')?.getAttribute('data-state')).toBe('active')
-    expect(runningPipeline?.querySelector('[data-stage="sink"]')?.getAttribute('data-state')).toBe('pending')
-    expect(byRun('r-done')?.querySelector('[data-stage="sink"]')?.getAttribute('data-state')).toBe('done')
-    expect(byRun('r-fail')?.querySelector('[data-stage="sink"]')?.getAttribute('data-state')).toBe('failed')
-
-    // the running indicator counts only in-progress runs
-    expect(container.textContent).toContain('1 running')
-    expect(container.textContent).toContain('r-run')
-    expect(container.textContent).toContain('k1')
-  })
-
-  it('omits the running indicator when nothing is in progress', () => {
-    fusionRuns.value = [
-      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
-    ]
-    render(html`<${FusionRunsPanel} />`, container)
-    expect(container.querySelector('.fus-runs-live')).toBeNull()
-  })
-
-  it('surfaces the failure code and error on a failed run card', () => {
-    fusionRuns.value = [
-      {
-        runId: 'r-fail',
-        keeper: 'k3',
-        preset: 'deep',
-        startedAt: 200,
-        status: 'failed',
-        error: 'judge timed out after 30s',
-        failureCode: 'timeout',
-      },
-    ]
-    render(html`<${FusionRunsPanel} />`, container)
-    const reason = container.querySelector('[data-testid="fusion-run-reason"]')
-    expect(reason).not.toBeNull()
-    expect(reason?.querySelector('.fus-runs-code')?.textContent).toBe('timeout')
-    expect(reason?.textContent).toContain('judge timed out after 30s')
-  })
-
-  it('omits the reason line for a completed run', () => {
-    fusionRuns.value = [
-      { runId: 'r-done', keeper: 'k2', preset: 'deep', startedAt: 100, status: 'completed' },
-    ]
-    render(html`<${FusionRunsPanel} />`, container)
-    expect(container.querySelector('[data-testid="fusion-run-reason"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/fusion/fusion-runs-panel.ts
+++ b/dashboard/src/components/fusion/fusion-runs-panel.ts
@@ -1,29 +1,17 @@
-// RFC-0266 §7 Phase 4 — fusion run status panel.
+// RFC-0266 §7 — fusion run status helpers.
 //
-// Renders the in-memory fusion run registry (GET /api/v1/dashboard/fusion-runs)
-// as a live status strip: in-progress (`running`) deliberations plus recently
-// finished (`completed` / `failed`) ones. This is the half the board-meta detail
-// view (FusionSurface) cannot show — a deliberation has no board post while it is
-// still running, so only the registry surfaces it. The `fusion_run_status` SSE
-// event re-fetches the signal, so a `running` card flips to completed/failed
-// without the operator polling.
+// The registry status panel these helpers once backed was merged into the
+// FusionSurface master list (one list for board-sink + registry-only runs), so
+// only the pure status→tone/text mappers remain here. They are the single source
+// of truth for the closed registry status enum, reused by the sidebar
+// registry row and the registry-only detail placeholder in fusion-surface.ts.
 
-import { html } from 'htm/preact'
-import type { FusionRunRecord, FusionRunStatusLabel } from '../../api/dashboard'
-import { fusionRuns, fusionRunsError, fusionRunsLoading } from '../../store'
-import { TimeAgo } from '../common/time-ago'
+import type { FusionRunStatusLabel } from '../../api/dashboard'
 
 type StatusTone = 'ok' | 'warn' | 'bad'
-type PipelineState = 'done' | 'active' | 'pending' | 'failed'
 
-interface FusionRunPipelineSegment {
-  key: 'keeper' | 'registry' | 'deliberation' | 'sink'
-  label: string
-  state: PipelineState
-}
-
-// Reuses the existing `.fus-status.tone-*` chip styling. `running` is `warn`
-// (drawing the eye to active work), `completed` `ok`, `failed` `bad`.
+// Reuses the existing `.fus-status.tone-*` chip. `running` is `warn` (drawing the
+// eye to active work), `completed` `ok`, `failed` `bad`.
 export function fusionRunStatusTone(status: FusionRunStatusLabel): StatusTone {
   switch (status) {
     case 'running':
@@ -44,114 +32,4 @@ export function fusionRunStatusText(status: FusionRunStatusLabel): string {
     case 'failed':
       return 'failed'
   }
-}
-
-export function fusionRunPipelineSegments(status: FusionRunStatusLabel): FusionRunPipelineSegment[] {
-  const deliberationState: PipelineState =
-    status === 'running' ? 'active' : status === 'failed' ? 'failed' : 'done'
-  const sinkState: PipelineState =
-    status === 'running' ? 'pending' : status === 'failed' ? 'failed' : 'done'
-  return [
-    { key: 'keeper', label: 'keeper turn', state: 'done' },
-    { key: 'registry', label: 'registry', state: 'done' },
-    { key: 'deliberation', label: 'panel/judge', state: deliberationState },
-    { key: 'sink', label: 'sink', state: sinkState },
-  ]
-}
-
-function FusionRunPipeline({ status }: { status: FusionRunStatusLabel }) {
-  const segments = fusionRunPipelineSegments(status)
-  return html`
-    <ol
-      class="fus-runs-pipe"
-      data-testid="fusion-run-pipeline"
-      aria-label=${`Fusion registry pipeline: ${fusionRunStatusText(status)}`}
-    >
-      ${segments.map(segment => html`
-        <li
-          key=${segment.key}
-          class="fus-runs-pipe-node"
-          data-stage=${segment.key}
-          data-state=${segment.state}
-        >
-          <span class="fus-runs-pipe-dot" aria-hidden="true"></span>
-          <span class="fus-runs-pipe-label">${segment.label}</span>
-        </li>
-      `)}
-    </ol>
-  `
-}
-
-function FusionRunStatusCard({ run }: { run: FusionRunRecord }) {
-  const tone = fusionRunStatusTone(run.status)
-  return html`
-    <li
-      class="fus-runs-card"
-      data-testid="fusion-run-status-card"
-      data-run-id=${run.runId}
-      data-status=${run.status}
-    >
-      <div class="fus-runs-card-main">
-        <span class=${`fus-status tone-${tone}`}>${fusionRunStatusText(run.status)}</span>
-        <span class="fus-runs-id">${run.runId}</span>
-        <span class="fus-runs-meta">
-          <span class="fus-runs-keeper">${run.keeper || 'system'}</span>
-          ${run.preset ? html`<span class="fus-runs-preset">${run.preset}</span>` : null}
-          <${TimeAgo} timestamp=${run.startedAt} />
-        </span>
-      </div>
-      ${run.status === 'failed' && (run.failureCode || run.error)
-        ? html`<div class="fus-runs-reason" data-testid="fusion-run-reason">
-            ${run.failureCode
-              ? html`<span class="fus-runs-code mono" title=${run.error ?? run.failureCode}>${run.failureCode}</span>`
-              : null}
-            ${run.error ? html`<span class="fus-runs-reason-text" title=${run.error}>${run.error}</span>` : null}
-          </div>`
-        : null}
-      <${FusionRunPipeline} status=${run.status} />
-    </li>
-  `
-}
-
-export function FusionRunsPanel() {
-  const runs = fusionRuns.value
-  const loading = fusionRunsLoading.value
-  const error = fusionRunsError.value
-  const runningCount = runs.filter(run => run.status === 'running').length
-
-  return html`
-    <section class="fus-runs-panel" data-testid="fusion-runs-panel" aria-label="Fusion run status">
-      <header class="fus-runs-head">
-        <h2>Run status</h2>
-        <div class="fus-runs-head-meta">
-          ${runningCount > 0
-            ? html`<span class="fus-runs-live" title="Deliberations in progress">
-                <span class="fus-runs-live-dot"></span>${runningCount} running
-              </span>`
-            : null}
-          <span class="fus-runs-count">${runs.length}</span>
-        </div>
-      </header>
-      ${error
-        ? html`<div
-            class="fus-runs-error"
-            data-testid="fusion-runs-error"
-            data-registry-source="/api/v1/dashboard/fusion-runs"
-            role="alert"
-          >
-            <span class="fus-runs-error-k">Registry load failed</span>
-            <span class="fus-runs-error-v">${error}</span>
-          </div>`
-        : null}
-      ${runs.length > 0
-        ? html`<ul class="fus-runs-list" aria-live="polite">
-            ${runs.map(run => html`<${FusionRunStatusCard} key=${run.runId} run=${run} />`)}
-          </ul>`
-        : error
-          ? null
-          : html`<p class="fus-runs-empty" data-testid="fusion-runs-empty">
-              ${loading ? 'Loading fusion runs...' : 'No active or recent fusion runs.'}
-            </p>`}
-    </section>
-  `
 }

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -717,7 +717,7 @@ describe('FusionSurface', () => {
     expect(container.querySelector('[data-testid="fusion-empty"]')).toBeNull()
   })
 
-  it('keeps registry-only running rows visible without claiming no fusion runs exist', () => {
+  it('merges a registry-only running run into the master list instead of a separate top panel', () => {
     fusionRuns.value = [
       {
         runId: 'fus-running',
@@ -730,12 +730,19 @@ describe('FusionSurface', () => {
 
     render(html`<${FusionSurface} />`, container)
 
-    expect(container.querySelector('[data-testid="fusion-run-status-card"]')?.textContent).toContain('fus-running')
-    expect(container.querySelector('[data-testid="fusion-empty"]')?.textContent).toContain('No board-sink fusion posts yet')
+    // Registry-only run now lives in the sidebar master list (2-pane layout),
+    // not the removed top "Run status" panel.
+    expect(container.querySelector('[data-testid="fusion-run-status-card"]')).toBeNull()
+    const row = container.querySelector('[data-testid="fusion-registry-row"]')
+    expect(row?.textContent).toContain('fus-running')
+    // A real run exists, so there is no board-sink empty placeholder — the
+    // registry run is selected by default and shows its own detail.
+    expect(container.querySelector('[data-testid="fusion-empty"]')).toBeNull()
+    expect(container.querySelector('[data-testid="fusion-registry-detail"]')?.textContent).toContain('fus-running')
     expect(container.textContent).toContain('board runs')
     expect(container.textContent).toContain('registry')
-    expect(container.textContent).toContain('1 running')
-    expect(container.textContent).not.toContain('No fusion runs found')
+    // The running count now surfaces as the sidebar live badge, not the removed panel.
+    expect(container.textContent).toContain('1 진행')
   })
 
   it('renders preset from registry when board meta does not carry it', () => {

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
 import type { BoardPost } from '../../types'
+import type { FusionRunRecord, FusionRunStatusLabel } from '../../api/dashboard'
 import { navigate, replaceRoute, route } from '../../router'
 import { ConnectionStatus } from '../dashboard-shell'
 import {
@@ -16,7 +17,7 @@ import { TimeAgo } from '../common/time-ago'
 import { ringFocusClasses } from '../common/ring'
 import { RichContent } from '../common/rich-content'
 import { AgentAvatar } from '../overview/agent-avatar'
-import { FusionRunsPanel } from './fusion-runs-panel'
+import { fusionRunStatusText, fusionRunStatusTone } from './fusion-runs-panel'
 import { asRecord, asString, asStringArray } from '../common/normalize'
 import { StatusChip } from '../common/status-chip'
 import { fusionDecisionSpec, type FusionDecisionSpec } from '../v2/fusion-constants'
@@ -392,6 +393,54 @@ function buildFusionRuns(posts: readonly BoardPost[]): FusionRunView[] {
       return run ? [run] : []
     })
     .sort((a, b) => timeValue(b.updatedAt) - timeValue(a.updatedAt))
+}
+
+// Registry status ('completed') aligned to the board run status enum ('complete')
+// so the shared status glyph / row styling apply to registry-only rows unchanged.
+function registryToRunStatus(status: FusionRunStatusLabel): FusionRunStatus {
+  return status === 'completed' ? 'complete' : status
+}
+
+// A sidebar run is either a board-sink run (full panel/judge detail) or a
+// registry-only run — an in-progress or just-finished deliberation the registry
+// tracks before a board post exists. They are merged into ONE master list so the
+// surface matches the prototype's 2-pane master/detail instead of stacking a
+// separate registry panel above it.
+type MergedRun =
+  | { kind: 'board'; runId: string; sortTime: number; running: boolean; view: FusionRunView }
+  | { kind: 'registry'; runId: string; sortTime: number; running: boolean; record: FusionRunRecord }
+
+// Dedup key is runId: once a deliberation lands a board post the board entry wins
+// (it carries the detail), so the registry duplicate is dropped. Running rows pin
+// to the top (the live work), then recency — registry startedAt is unix seconds,
+// board updatedAt is an ISO string, so both are normalized to ms before sorting.
+function buildMergedRuns(
+  boardRuns: readonly FusionRunView[],
+  registryRuns: readonly FusionRunRecord[],
+): MergedRun[] {
+  const boardIds = new Set(boardRuns.map(run => run.runId))
+  const merged: MergedRun[] = [
+    ...boardRuns.map((view): MergedRun => ({
+      kind: 'board',
+      runId: view.runId,
+      sortTime: timeValue(view.updatedAt),
+      running: view.status === 'running',
+      view,
+    })),
+    ...registryRuns
+      .filter(record => !boardIds.has(record.runId))
+      .map((record): MergedRun => ({
+        kind: 'registry',
+        runId: record.runId,
+        sortTime: record.startedAt * 1000,
+        running: record.status === 'running',
+        record,
+      })),
+  ]
+  return merged.sort((a, b) => {
+    if (a.running !== b.running) return a.running ? -1 : 1
+    return b.sortTime - a.sortTime
+  })
 }
 
 function formatCost(value: number | null): string {
@@ -886,6 +935,41 @@ function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) 
   `
 }
 
+// Sidebar row for a registry-only run (no board post yet). Reuses the board
+// row's `.fus-row` shell but carries no prompt/decision — the registry record
+// only knows runId, keeper, preset, status, startedAt.
+function FusionRegistryRow({ record, active }: { record: FusionRunRecord; active: boolean }) {
+  const status = registryToRunStatus(record.status)
+  const keeper = record.keeper || 'system'
+  return html`
+    <button
+      type="button"
+      class=${`fus-run-row fus-row registry-only ${active ? 'active sel' : ''} st-${status} ${ringFocusClasses()}`}
+      aria-current=${active ? 'true' : undefined}
+      data-testid="fusion-registry-row"
+      onClick=${() => replaceRoute('fusion', { run_id: record.runId })}
+    >
+      <span class="fus-row-h">
+        <${FusionStatusGlyph} status=${status} />
+        <span class="fus-run-id mono">${record.runId}</span>
+        <span class="fus-row-ts"><${TimeAgo} timestamp=${record.startedAt} /></span>
+      </span>
+      <span class="fus-row-f">
+        <span class="fus-who static" title=${keeper}>
+          <${AgentAvatar} name=${keeper} size="sm" />
+          <span class="nm">${keeper}</span>
+        </span>
+        <span class="spacer"></span>
+        ${record.status === 'running'
+          ? html`<span class="fus-dec-badge run">심의 중</span>`
+          : record.status === 'failed'
+            ? html`<span class="fus-dec-badge bad">실패</span>`
+            : html`<span class="fus-dec-badge">registry</span>`}
+      </span>
+    </button>
+  `
+}
+
 function findPreset(runId: string): string | null {
   return fusionRuns.value.find(run => run.runId === runId)?.preset ?? null
 }
@@ -1179,13 +1263,55 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
   `
 }
 
+// Detail placeholder for a registry-only run: the deliberation is tracked by the
+// registry but has not landed a board post, so there is no panel/judge evidence
+// to render yet. Shows identity + live/failed status instead of fabricating detail.
+function FusionRegistryDetail({ record }: { record: FusionRunRecord }) {
+  const status = registryToRunStatus(record.status)
+  const tone = fusionRunStatusTone(record.status)
+  const keeper = record.keeper || 'system'
+  return html`
+    <div class="fus-run-scroll" data-testid="fusion-registry-detail">
+      <div class="fus-run-head">
+        <div class="fus-run-id-row">
+          <${FusionStatusGlyph} status=${status} />
+          <h1 class="mono">${record.runId}</h1>
+          ${record.preset
+            ? html`<span class="fus-preset" title="runtime.toml [fusion.presets.*]">preset · ${record.preset}</span>`
+            : null}
+          <span class=${`fus-status tone-${tone}`}>${fusionRunStatusText(record.status)}</span>
+        </div>
+        <div class="fus-run-by">
+          <${FusionKeeperLink} keeper=${keeper} size="md" />
+          <span class="fus-run-meta"><${TimeAgo} timestamp=${record.startedAt} mode="both" /></span>
+        </div>
+      </div>
+
+      <div class="fus-block">
+        <div class="fus-block-lbl">
+          레지스트리 관측
+          <span class="fus-sub-note">GET /api/v1/dashboard/fusion-runs</span>
+        </div>
+        <div class="fus-judge-wait">
+          ${record.status === 'running'
+            ? html`<span class="fus-rdot run"></span>심의 진행 중 — 패널·심판 상세는 fusion sink가 <code>meta.source = "fusion"</code> 보드 포스트를 기록한 뒤 이 자리에 나타납니다.`
+            : record.status === 'failed'
+              ? html`실패로 종료됨.${record.failureCode ? html` <span class="mono">${record.failureCode}</span>` : null}${record.error ? html` · ${record.error}` : null}`
+              : '완료됨 — 보드 sink 기록을 기다리는 중입니다.'}
+        </div>
+      </div>
+    </div>
+  `
+}
+
 export function FusionSurface() {
   const posts = fusionBoardPosts.value
   const runs = useMemo(() => buildFusionRuns(posts), [posts])
-  const boardError = fusionBoardError.value
   const registryRuns = fusionRuns.value
+  const merged = useMemo(() => buildMergedRuns(runs, registryRuns), [runs, registryRuns])
+  const boardError = fusionBoardError.value
   const selectedRunId = route.value.params.run_id ?? route.value.params.run
-  const selected = runs.find(run => run.runId === selectedRunId) ?? runs[0] ?? null
+  const selected = merged.find(run => run.runId === selectedRunId) ?? merged[0] ?? null
   const registryRunning = registryRuns.filter(run => run.status === 'running').length
   const registryFailed = registryRuns.filter(run => run.status === 'failed').length
 
@@ -1213,8 +1339,6 @@ export function FusionSurface() {
           >${fusionBoardLoading.value || fusionRunsLoading.value ? 'Refreshing...' : 'Refresh'}</button>
         </div>
       </header>
-
-      <${FusionRunsPanel} />
 
       ${boardError
         ? html`<div
@@ -1250,22 +1374,26 @@ export function FusionSurface() {
               ? html`<span class="fus-list-live"><span class="fus-rdot run"></span>${registryRunning} 진행</span>`
               : null}
           </div>
-          ${runs.length === 0
-            ? html`<div class="fus-list-scroll"><div class="ov-empty">보드 sink 심의 런이 없습니다</div></div>`
+          ${merged.length === 0
+            ? html`<div class="fus-list-scroll"><div class="ov-empty">심의 런이 없습니다</div></div>`
             : html`
                 <div class="fus-list-scroll">
-                  ${runs.map(run => html`
-                    <${FusionRunRow}
-                      key=${run.runId}
-                      run=${run}
-                      active=${selected?.runId === run.runId}
-                    />
-                  `)}
+                  ${merged.map(run => run.kind === 'board'
+                    ? html`<${FusionRunRow}
+                        key=${run.runId}
+                        run=${run.view}
+                        active=${selected?.runId === run.runId}
+                      />`
+                    : html`<${FusionRegistryRow}
+                        key=${run.runId}
+                        record=${run.record}
+                        active=${selected?.runId === run.runId}
+                      />`)}
                 </div>
               `}
         </aside>
 
-        ${runs.length === 0
+        ${merged.length === 0
           ? html`
               <div class="fus-run-scroll" data-testid="fusion-empty">
                 <div class="fus-block">
@@ -1275,15 +1403,17 @@ export function FusionSurface() {
                   </div>
                   <p class="fus-rec-rationale">
                     ${boardError
-                      ? html`보드 sink read path(<code>${'/api/v1/dashboard/board?sort_by=recent&limit=500'}</code>)가 실패했습니다. 위 레지스트리 패널은 독립 소스이며, 캐시된 보드 sink 행만 상세 리뷰에 표시됩니다.`
-                      : html`레지스트리 상태는 위 패널(<code>/api/v1/dashboard/fusion-runs</code>)에 표시됩니다.
+                      ? html`보드 sink read path(<code>${'/api/v1/dashboard/board?sort_by=recent&limit=500'}</code>)가 실패했습니다. registry 관측(<code>/api/v1/dashboard/fusion-runs</code>)은 독립 소스이며, 캐시된 보드 sink 행만 상세 리뷰에 표시됩니다.`
+                      : html`레지스트리 관측(<code>/api/v1/dashboard/fusion-runs</code>)은 상단 KPI에 집계되고, 진행 중 런은 왼쪽 목록에 표시됩니다.
                         상세한 패널·심판 리뷰는 fusion sink가 <code>meta.source = "fusion"</code> 보드 포스트를 기록한 뒤 나타납니다.`}
                   </p>
                 </div>
               </div>
             `
           : selected
-            ? html`<${FusionRunDetail} run=${selected} />`
+            ? (selected.kind === 'board'
+                ? html`<${FusionRunDetail} run=${selected.view} />`
+                : html`<${FusionRegistryDetail} record=${selected.record} />`)
             : null}
       </div>
     </main>


### PR DESCRIPTION
## 목적

사용자 관찰: "Fusion이 시안하고 너무 다르다 — 상단에 목록이 주욱 내려온다." 조사 결과 근본 원인 2겹:

1. **스타일 미포팅(orphaned CSS)**: `FusionRunsPanel`(RFC-0266 registry "Run status" 목록)의 `.fus-runs-*` 스타일(39규칙)이 **import되지 않는** `src/styles/fusion-v2.css`에만 존재하고, 활성 스킨 `src/styles/keeper-v2/fusion.css`엔 0개. 즉 상단 패널이 **완전 unstyled raw `<ul>`**로 세로로 늘어남.
2. **시안과의 구조적 발산**: 프로토타입(`design-system/prototype-v2/styles/fusion.css`)은 **순수 2-pane**(master 목록 + 상세)인데, 앱은 그 위에 registry 패널을 별도로 쌓음. RFC-0266 registry는 시안 이후 추가된 기능이라 시안엔 없음.

사용자 선택(AskUserQuestion): **"사이드바로 통합 (시안 최정합)"**.

## 변경 (dashboard FE, 백엔드 0)

- **상단 `FusionRunsPanel` 제거**. registry-only running/finished 런을 좌측 master 목록(`.fus-list`)에 **병합** → 시안의 순수 2-pane.
- **`buildMergedRuns(board, registry)`** 순수 함수 추가: runId로 중복제거(board post 있으면 board 우선, 상세 보유), running-first + 시간 desc 정렬. registry `startedAt`(unix 초) ↔ board `updatedAt`(ISO)을 ms로 정규화.
- **`FusionRegistryRow`**: registry-only 런의 사이드바 행(기존 `.fus-row` 재사용, prompt/decision 없이 status·keeper·시간). **`FusionRegistryDetail`**: board post 없는 런 선택 시 "레지스트리 관측 / board sink 대기" 플레이스홀더(패널·심판 상세를 날조하지 않음).
- **`fusion-runs-panel.ts`**: 컴포넌트(`FusionRunsPanel`/`FusionRunStatusCard`/`FusionRunPipeline`) + `fusionRunPipelineSegments` 제거, 재사용되는 순수 helper(`fusionRunStatusText`/`fusionRunStatusTone`)만 존치. (파일명은 import 안정성 위해 유지, 헤더에 "패널은 master 목록으로 통합됨" 명시 — 원하면 `fusion-run-status.ts` 리네임 후속 가능.)
- overview KPIs(board/registry/running/failed), board-error, reality-notice, board 런의 상세(`FusionRunDetail`)·preset 해석(`findPreset`, registry augment)은 **불변**. empty-state 문구에서 "위 패널" 참조 제거(패널 삭제 반영).

## 검증

- `vitest run fusion-surface.test.ts fusion-runs-panel.test.ts` — 41 tests green
  - 신규: registry-only 런이 사이드바에 병합(별도 top 패널 부재), registry detail 렌더, empty 부재
  - 불변 확인: board preset-from-registry, board 선택/네비, empty/board-error 경로
- `tsc --noEmit` clean, eslint(source) clean
- 전체 dashboard 스위트 green (아래 CI)
- 브라우저 스크린샷: Chrome 확장 미연결로 미첨부. DOM 구조는 happy-dom 테스트로 검증. CSS 2-pane 레이아웃은 기존 `.fus-body`/`.fus-list-scroll`/`.fus-run-scroll`(board 상세에서 이미 정상 동작)을 그대로 사용하며, 상단 패널 제거로 `flex:1` 본문이 공간을 되찾음.

## RFC / 워크어라운드

- RFC 게이트 대상 아님(`components/fusion/`은 credential/repo-mapping/operator/hooks 아님).
- 워크어라운드 시그니처(telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair) 해당 없음. registry→board 상태 정규화는 두 소스의 closed enum 매핑(단일 함수)이며 fallback 억제가 아님.

## 후속(범위 밖)

- orphaned `src/styles/fusion-v2.css`(미import) 정리 — 이번 변경으로 `.fus-runs-*`가 doubly-dead가 됨. 별도 정리 PR 후보.
- `fusion-runs-panel.ts` → `fusion-run-status.ts` 리네임.
