### PR TITLE
feat(dashboard): surface HITL approvals in keeper chat

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -19,6 +19,8 @@ import type { VNode } from 'preact'
 import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { navigate } from '../../router'
+import { governanceData } from '../governance-signals'
+import { resolveGovernanceApproval } from '../../api/dashboard-governance'
 import type { ChatComposerCommand } from '../chat/primitives'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperThreads } from '../../keeper-state'
@@ -309,6 +311,7 @@ function ChatHeader({
   const tone = keeperStatusTone(keeper)
   const pill = statePillTone(tone)
   const live = phasePulse(keeper.lifecycle_phase)
+  const pendingApprovalCount = keeperPendingApprovals(keeper.name).length
 
   // Single-row header: identity + status + actions only. Runtime / model /
   // throughput / scope live in the context rail (ThroughputSection) — the
@@ -333,6 +336,9 @@ function ChatHeader({
       <div class="kw-chat-id">
         <div class="kw-chat-name-row">
           <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
+          ${pendingApprovalCount > 0
+            ? html`<${Pill} tone="warn" dot="warn" title=${`결재 대기 ${pendingApprovalCount}건`}>${pendingApprovalCount}</${Pill}>`
+            : null}
           <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
             <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
           </span>
@@ -409,26 +415,53 @@ function TurnInspectorDrawer({
 // top of the conversation so an operator who arrives via "대화에서 검토" sees the
 // keeper is awaiting a decision. Read-only display + a link back to the approvals
 // queue (the single act-point); no approve/reject action here by design.
+// Pending approval queue scoped to this keeper. Reads governance
+// approval_queue (the HITL SSOT) directly instead of keeper.trust.
+// approval_state, which is a separate payload field and diverges from the
+// queue — when it is empty while approval_queue has items, the cue stayed
+// blank and the operator saw no HITL signal inside the chat surface.
+function keeperPendingApprovals(keeperName: string) {
+  const queue = governanceData.value?.approval_queue ?? []
+  return queue.filter((a) => a.keeper_name === keeperName)
+}
+
 function PendingApprovalCue({ keeper }: { keeper: Keeper }): VNode | null {
-  const pending = keeper.trust?.approval_state?.pending_first
-  const id = pending?.id?.trim()
-  if (!id) return null
-  const tool = pending?.tool_name?.trim()
+  const pending = keeperPendingApprovals(keeper.name)
+  if (pending.length === 0) return null
+  const first = pending[0]
+  if (!first) return null
+  const rest = pending.length - 1
+  const tool = first.tool_name?.trim() ?? ''
+  const resolve = (decision: 'approve' | 'reject') => {
+    resolveGovernanceApproval(first.id, decision).catch(() => {})
+  }
   return html`
     <div
       class="kw-chat-pending-cue flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-fg-secondary)]"
       role="status"
       data-testid="keeper-pending-approval-cue"
     >
-      <${Pill} tone="warn" dot="warn">승인 대기</${Pill}>
-      <span>이 keeper는 결재 대기 중입니다${tool ? ` · ${tool}` : ''}</span>
+      <${Pill} tone="warn" dot="warn">승인 대기 ${pending.length}</${Pill}>
+      <span>${tool || '결재 요청'}${rest > 0 ? ` 외 ${rest}건` : ''}</span>
       <span class="flex-1"></span>
       <button
         type="button"
         class="kw-act v2-monitoring-action"
+        onClick=${() => resolve('approve')}
+        title="이 요청을 승인합니다"
+      >승인</button>
+      <button
+        type="button"
+        class="kw-act v2-monitoring-action"
+        onClick=${() => resolve('reject')}
+        title="이 요청을 거부합니다"
+      >거부</button>
+      <button
+        type="button"
+        class="kw-act v2-monitoring-action"
         onClick=${() => navigate('approvals')}
-        title="결재 큐에서 이 요청을 승인·거부합니다"
-      >결재 큐에서 처리 →</button>
+        title="결재 큐에서 모든 요청을 봅니다"
+      >결재 큐 →</button>
     </div>
   `
 }


### PR DESCRIPTION
## 배경

keeper 채팅창에 HITL approval이 안 뜬다는 제보. 진단 결과:

- `PendingApprovalCue`(`keeper-workspace-chat.ts`)가 `keeper.trust.approval_state.pending_first`를 읽었다. 이 필드는 `governanceData.approval_queue`(HITL SSOT)와 별개 payload라 **불일치** — approval_queue에 항목이 있어도 keeper.approval_state가 비어 있으면 cue가空白.
- 채팅창에서 **직접 approve/reject 불가** (기존은 "결재 큐로 이동" 버튼만).
- ChatHeader에 keeper별 **pending 배지 없음** (Red dot은 nav-rail에만).

## 변경

- `PendingApprovalCue`를 `governanceData.approval_queue` 기반(keeper_name 필터)으로 전환. 일관성 + 전체 pending 노출.
- approve/reject 버튼 추가 (`resolveGovernanceApproval` 재사용).
- `ChatHeader`에 keeper별 pending 수 `Pill`(warn) 배지.

## 비고

- 진짜 인라인(approval을 채팅 스레드 중간에 통합)은 entry stream 구조 변경이라 별도 PR. 이 PR은 헤더 배지 + cue 강화(입력창 위)로 "채팅창에 approval이 뜬다"를 달성.
- 기존 `keeper.trust.approval_state` source는 제거(불일치 원인). approval_queue SSOT로 단일화.
- typecheck/lint 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
