### PR TITLE
feat(workspace): state-keyed completion side effects (RFC-0323 G-3)

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -642,6 +642,8 @@ let span_start_kind = function
     compile time (Parse, don't validate). *)
 let span_end_classification = function
   | "task.done"                 -> Some ("task",      Span_completed)
+  (* RFC-0323 G-3: approve-produced Done completes the task span too. *)
+  | "task.approved"             -> Some ("task",      Span_completed)
   | "task.released"             -> Some ("task",      Span_released)
   | "task.cancelled"            -> Some ("task",      Span_cancelled)
   | "agent.left"                -> Some ("presence",  Span_left)

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -41,7 +41,7 @@ let is_generic_status = function
 (* Semantic weight multiplier by event kind.
    Completion events score high; routine lifecycle events score low. *)
 let semantic_multiplier = function
-  | "task.done" | "decision.resolved" | "operation.finalized" -> 5.0
+  | "task.done" | "task.approved" | "decision.resolved" | "operation.finalized" -> 5.0
   | "task.created" | "task.claimed" | "decision.opened" -> 3.0
   | "agent.handoff" | "agent.spawned" -> 3.0
   | "board.posted" | "board.voted" -> 2.0
@@ -212,6 +212,28 @@ let reduce_event ~nodes ~edges (value : event) =
   | "task.done" ->
       set_subject_status Done;
       (match (actor_id, subject_id) with
+      | Some source, Some target ->
+          ensure_edge edges ~source ~target ~kind:"works_on" ~active:false
+            ~ts_iso:value.ts_iso ~meta:value.payload
+      | (None, _) | (_, None) -> ())
+  | "task.approved" ->
+      (* RFC-0323 G-3: approve-produced Done completes the task like
+         task.done. The event actor is the VERIFIER; the assignee rides the
+         payload (emitted since G-3), and its works_on edge is the one to
+         close. Events from before G-3 lack the field — fall back to the
+         actor so the subject status still flips for historical replays. *)
+      set_subject_status Done;
+      let completer_id =
+        match payload_string "assignee" value.payload with
+        | Some name ->
+            Some
+              (ensure_entity_node nodes
+                 { kind = "agent"; id = name }
+                 ~fallback_status:Active ~ts_iso:value.ts_iso
+                 ~meta:value.payload ~sw_delta:sw)
+        | None -> actor_id
+      in
+      (match (completer_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -607,12 +607,26 @@ let transition_task_outcome_r
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Submit_for_verification)
                ~payload
            | Masc_domain.Approve_verification ->
+             (* RFC-0323 G-3: the event actor is the verifier; carry the
+                assignee so graph reducers can close the assignee's
+                works_on edge. *)
+             let payload =
+               match new_status with
+               | Masc_domain.Done { assignee; _ } ->
+                 `Assoc
+                   [ "task_id", `String task_id; "assignee", `String assignee ]
+               | Masc_domain.Todo
+               | Masc_domain.Claimed _
+               | Masc_domain.InProgress _
+               | Masc_domain.AwaitingVerification _
+               | Masc_domain.Cancelled _ -> `Assoc [ "task_id", `String task_id ]
+             in
              emit_task_activity
                config
                ~agent_name
                ~task_id
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Approved)
-               ~payload:(`Assoc [ "task_id", `String task_id ])
+               ~payload
            | Masc_domain.Reject_verification ->
              emit_task_activity
                config
@@ -620,15 +634,32 @@ let transition_task_outcome_r
                ~task_id
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Rejected)
                ~payload:(`Assoc [ "task_id", `String task_id ]));
-          let duration_ms = match action with
-            | Masc_domain.Done_action | Masc_domain.Cancel ->
-              Some (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))
-            | Masc_domain.Claim
-            | Masc_domain.Start
-            | Masc_domain.Release
-            | Masc_domain.Submit_for_verification
-            | Masc_domain.Approve_verification
-            | Masc_domain.Reject_verification -> None
+          (* RFC-0323 G-3: completion side effects key off the RESULT (Done),
+             not the action — otherwise Approve_verification completions
+             record no duration. The value measures the last status phase
+             (started_at for in_progress, submitted_at for
+             awaiting_verification). *)
+          let completes_task =
+            Masc_domain.task_status_is_done new_status
+            && not (Masc_domain.task_status_is_done task.task_status)
+          in
+          let phase_duration_ms () =
+            Some
+              (max 0 (int_of_float ((now_ts -. task_started_at_unix task.task_status) *. 1000.0)))
+          in
+          let duration_ms =
+            if completes_task
+            then phase_duration_ms ()
+            else (
+              match action with
+              | Masc_domain.Cancel -> phase_duration_ms ()
+              | Masc_domain.Done_action
+              | Masc_domain.Claim
+              | Masc_domain.Start
+              | Masc_domain.Release
+              | Masc_domain.Submit_for_verification
+              | Masc_domain.Approve_verification
+              | Masc_domain.Reject_verification -> None)
           in
           observe_task_transition
             config
@@ -644,12 +675,28 @@ let transition_task_outcome_r
                  ?duration_ms
                  ~forced:forced
                  ());
+          (* RFC-0323 G-3: done hooks (economy earn, relation/hebbian) fire for
+             every transition that PRODUCES Done — Done via
+             Approve_verification included. The completer is the Done record's
+             assignee: on approve the acting [agent_name] is the verifier. *)
+          (match new_status with
+           | Masc_domain.Done { assignee; _ } ->
+             if completes_task
+             then
+               Workspace_task_cleanup.run_done_hooks
+                 config
+                 ~agent_name:assignee
+                 ~task_id
+           | Masc_domain.Todo
+           | Masc_domain.Claimed _
+           | Masc_domain.InProgress _
+           | Masc_domain.AwaitingVerification _
+           | Masc_domain.Cancelled _ -> ());
           (match action with
-           | Masc_domain.Done_action ->
-             Workspace_task_cleanup.run_done_hooks config ~agent_name ~task_id
            | Masc_domain.Cancel ->
              Workspace_task_cleanup.run_cancel_hooks config ~agent_name
-           | Masc_domain.Release -> ()
+           | Masc_domain.Done_action
+           | Masc_domain.Release
            | Masc_domain.Claim
            | Masc_domain.Start
            | Masc_domain.Submit_for_verification

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -554,6 +554,79 @@ let test_agent_spans_json_honors_since_ms () =
       check string "recent span label kept" "task-new"
         (List.hd spans |> member "label" |> to_string))
 
+(* RFC-0323 G-3: approve-produced Done must complete the task in the graph
+   projection exactly like task.done — node status, the ASSIGNEE's works_on
+   edge (the event actor is the verifier), and the task span. *)
+let test_task_approved_completes_graph_and_span () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_config (fun config ->
+      ignore
+        (Activity_graph.emit config ~kind:"task.claimed"
+           ~actor:(Activity_graph.entity ~kind:"agent" "worker-a")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-901")
+           ~tags:[ "task"; "claim" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-901") ])
+           ());
+      ignore
+        (Activity_graph.emit config ~kind:"task.started"
+           ~actor:(Activity_graph.entity ~kind:"agent" "worker-a")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-901")
+           ~tags:[ "task"; "start" ]
+           ~payload:(`Assoc [ ("task_id", `String "task-901") ])
+           ());
+      ignore
+        (Activity_graph.emit config ~kind:"task.approved"
+           ~actor:(Activity_graph.entity ~kind:"agent" "verifier-b")
+           ~subject:(Activity_graph.entity ~kind:"task" "task-901")
+           ~tags:[ "task"; "approve" ]
+           ~payload:
+             (`Assoc
+               [ ("task_id", `String "task-901");
+                 ("assignee", `String "worker-a");
+               ])
+           ());
+      let json =
+        Activity_graph.graph_json config ~limit:20 ~timeline_limit:10 ()
+      in
+      let open Yojson.Safe.Util in
+      let nodes = json |> member "nodes" |> to_list in
+      (match
+         List.find_opt
+           (fun n -> String.equal (n |> member "id" |> to_string) "task:task-901")
+           nodes
+       with
+      | Some n ->
+          check string "task node completed" "done"
+            (n |> member "status" |> to_string)
+      | None -> Alcotest.fail "task node missing");
+      let edges = json |> member "edges" |> to_list in
+      (match
+         List.find_opt
+           (fun e ->
+             String.equal (e |> member "source" |> to_string) "agent:worker-a"
+             && String.equal (e |> member "target" |> to_string) "task:task-901"
+             && String.equal (e |> member "kind" |> to_string) "works_on")
+           edges
+       with
+      | Some e ->
+          check bool "assignee works_on deactivated" false
+            (e |> member "active" |> to_bool)
+      | None -> Alcotest.fail "assignee works_on edge missing");
+      let spans_json =
+        Activity_graph.agent_spans_json config ~since_ms:0 ~limit:20 ()
+      in
+      let spans = spans_json |> member "spans" |> to_list in
+      match
+        List.find_opt
+          (fun s -> String.equal (s |> member "label" |> to_string) "task-901")
+          spans
+      with
+      | Some s ->
+          check string "task span completed" "completed"
+            (s |> member "status" |> to_string)
+      | None -> Alcotest.fail "task span missing")
+
 let test_parse_since_ms_supports_minutes () =
   check (option int) "5m parses" (Some (5 * 60 * 1000))
     (Server_activity_http.parse_since_ms "5m");
@@ -605,6 +678,8 @@ let () =
             `Quick test_graph_json_reports_kind_counts_and_heatmap_totals;
           test_case "agent spans honor since filter" `Quick
             test_agent_spans_json_honors_since_ms;
+          test_case "task.approved completes graph and span" `Quick
+            test_task_approved_completes_graph_and_span;
           test_case "parse_since_ms supports minutes" `Quick
             test_parse_since_ms_supports_minutes;
           test_case "span_status_opt None for unknown" `Quick

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1453,6 +1453,62 @@ let test_submit_and_approve_non_assignee_submit_fails () =
        | Some { task_status = Masc_domain.Claimed _; _ } -> true
        | Some _ | None -> false))
 
+(* === RFC-0323 G-3: completion side effects are state-keyed === *)
+
+(* Records economy-earn calls while [f] runs, restoring the previous hook. *)
+let with_economy_recorder f =
+  let recorded = ref [] in
+  let prev =
+    Atomic.exchange Workspace_hooks.agent_economy_earn_fn
+      (fun ~base_path:_ ~agent_name ~reason:_ ->
+        recorded := agent_name :: !recorded)
+  in
+  Fun.protect
+    ~finally:(fun () -> Atomic.set Workspace_hooks.agent_economy_earn_fn prev)
+    (fun () -> f recorded)
+
+let test_approve_completion_credits_assignee () =
+  with_test_env (fun config ->
+    with_economy_recorder (fun recorded ->
+      let _ = Workspace.add_task config ~title:"Parity Task" ~priority:1 ~description:"" in
+      let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+      let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+      let submitted =
+        Workspace.transition_task_r config ~agent_name:test_agent_a ~task_id:"task-001"
+          ~action:Masc_domain.Submit_for_verification ~notes:"evidence attached" ()
+      in
+      Alcotest.(check bool) "submit ok" true
+        (match submitted with Ok _ -> true | Error _ -> false);
+      Alcotest.(check (list string)) "no earn before approve" [] !recorded;
+      let approved =
+        Workspace.transition_task_r config ~agent_name:admin_keeper_agent
+          ~task_id:"task-001" ~action:Masc_domain.Approve_verification ()
+      in
+      Alcotest.(check bool) "approve ok" true
+        (match approved with Ok _ -> true | Error _ -> false);
+      (* The acting agent is the verifier; the earn must credit the assignee. *)
+      Alcotest.(check (list string))
+        "approve completion credits assignee" [ test_agent_a ] !recorded))
+
+let test_force_done_still_credits_forcing_actor () =
+  with_test_env (fun config ->
+    with_economy_recorder (fun recorded ->
+      let _ = Workspace.add_task config ~title:"Parity Force" ~priority:1 ~description:"" in
+      let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+      let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+      let forced =
+        Workspace.force_done_task_r config ~agent_name:admin_keeper_agent
+          ~task_id:"task-001" ~notes:"forced by admin" ()
+      in
+      Alcotest.(check bool) "force done ok" true
+        (match forced with Ok _ -> true | Error _ -> false);
+      (* Regression pin: G-3 keys the earn off the resulting Done record's
+         assignee. [done_status] sets that to the acting agent, so a forced
+         done still credits the forcing actor — unchanged behavior. *)
+      Alcotest.(check (list string))
+        "force done still credits the forcing actor" [ admin_keeper_agent ]
+        !recorded))
+
 let test_audit_orphan_tasks () =
   with_test_env (fun config ->
     let _ = Workspace.add_task config ~title:"Orphan Candidate" ~priority:1 ~description:"" in
@@ -2178,6 +2234,14 @@ let () =
         test_submit_and_approve_rejects_invalid_verifier;
       Alcotest.test_case "non-assignee submit fails typed" `Quick
         test_submit_and_approve_non_assignee_submit_fails;
+    ];
+
+    (* === RFC-0323 G-3: state-keyed completion side effects === *)
+    "done_side_effects", [
+      Alcotest.test_case "approve completion credits assignee" `Quick
+        test_approve_completion_credits_assignee;
+      Alcotest.test_case "force done still credits forcing actor" `Quick
+        test_force_done_still_credits_forcing_actor;
     ];
 
     (* === Board Admin Tests === *)


### PR DESCRIPTION
## RFC-0323 G-3 — 완료 부작용 state-키 전환

RFC: `docs/rfc/RFC-0323-done-via-verification-linked-rerun.md` (main 착지), Goal Matrix **G-3**.
census 발견(NC 클러스터): 완료 부작용이 전부 `Done_action` **action**에 게이팅 — 검증 레인(Approve→Done) 완료는 economy earn·relation/hebbian 훅·`duration_ms`·activity graph 완료(reducer arm 부재, span 미종료, weight 미등재)를 **전부 조용히 소실**. RFC-0323이 approve를 유일한 완료 레인으로 만들면 fleet 전체 완료가 어두워진다.

### 변경

- **transitions** — `completes_task` = 결과 status가 Done을 *생산*했는가. `duration_ms`·`run_done_hooks`가 이 술어로 발화. **함정 처리**: approve 시 `agent_name`은 verifier — completer는 Done 레코드의 `assignee`에서 추출. Cancel의 cancel 훅은 action-키 유지. `task.approved` 이벤트 payload에 `assignee` 추가(그래프가 올바른 works_on edge를 닫도록).
- **activity graph** — `task.approved` reducer arm(subject→Done, payload assignee의 works_on edge 비활성화, pre-G-3 이벤트는 actor fallback으로 status만 flip), 완료 weight class(5.0) 등재, `span_end_classification`에 `task.approved → Span_completed`.
- **force_done 무변화**: `done_status`가 Done.assignee = acting agent로 세팅하므로 forced done은 여전히 forcing actor 크레딧 — 테스트로 pin.

### 검증

- `test_workspace.ml` `done_side_effects` 그룹: ① approve 완료가 **assignee**에게 economy earn (recorder = `Atomic.exchange` + `Fun.protect` 복원 — finally는 raise 없음) ② force done은 forcing actor 크레딧 유지(회귀 pin).
- `test_activity_graph.ml`: claim→start→approve(verifier actor + payload assignee) → task node "done" + `agent:worker-a`→`task:task-901` works_on inactive + task span "completed".
- 로컬 parse-only 통과; 빌드/테스트는 CI.
- 미검증: duration_ms 값 자체의 런타임 assert는 생략(관측 지점이 event log) — 술어 전환의 단순성으로 리뷰 커버. AwaitingVerification phase의 duration은 submitted_at 기준(마지막 phase 구간)임을 코드 주석에 명시.

### 경계 (매트릭스 선언)

- FSM arm 불변. `event_kind.ml` closed enum 불변 — kind 신설 대신 reducer를 가르침(이벤트 스트림 소비자에 이중 완료 이벤트 없음).
- `masc_task_completion_path_total` 등 완료 카운트 메트릭은 기존에 이미 양 레인 커버(`track_task_completed`) — 무수정.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
