### PR TITLE
fix(dashboard): generic SurfaceHeader 타이틀 42px 폭발 수정 (전역 h1 override)

### DIFF
--- a/dashboard/src/components/common/surface-header.ts
+++ b/dashboard/src/components/common/surface-header.ts
@@ -83,6 +83,11 @@ export function SurfaceHeader(): VNode | null {
   const trail = currentSection !== null
     ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
     : []
+  // The <h1> is intentionally class-less: it is styled by the T1 surface-title
+  // group in keeper-v2/surfaces.css (`.v2-surface-header h1`). Tailwind text
+  // utilities do not work here — the unlayered global `h1` (colors_and_type.css:
+  // 42px display + glow) beats layered utilities and blew the title up to 42px
+  // uppercase across every generic-header surface (monitoring/command/lab).
   return html`
     <header class="v2-surface-header mb-3 flex flex-col gap-1.5" data-testid="surface-header">
       ${trail.length > 0
@@ -94,9 +99,7 @@ export function SurfaceHeader(): VNode | null {
           />`
         : null}
       <div class="flex items-center gap-2">
-        <h1 class="text-lg font-semibold leading-tight tracking-normal normal-case text-[var(--color-fg-secondary)]" style="text-shadow: none;">
-          ${title}
-        </h1>
+        <h1>${title}</h1>
         <${SurfaceHeaderActions} label=${title} />
       </div>
       ${description

--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -753,9 +753,10 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
    here changes every title of that level at once.
    ══════════════════════════════════════════════════════════════ */
 
-/* T1 — surface / subject title (개요 · 커넥터 · Command Map · keeper 이름) */
+/* T1 — surface / subject title (개요 · 커넥터 · Command Map · keeper 이름 · generic SurfaceHeader) */
 .ov-head h1,
 .surf-head h1,
+.v2-surface-header h1,
 .chat-id h2 {
   font-family: var(--font-display);
   font-weight: var(--fw-t1);


### PR DESCRIPTION
## 목적

사용자 관찰: "Fleet 페이지 상단 타이틀이 겁나 큼". 조사 결과 Fleet 전용이 아니라 **generic `SurfaceHeader` 공통 버그**였습니다.

## 근본 원인

`keeper-v2/colors_and_type.css`의 **전역 bare `h1` 셀렉터**:
```css
h1 { font-size: 42px; letter-spacing: 0.2em; text-shadow: 0 0 40px var(--accent-glow); }
```
`SurfaceHeader`(monitoring→Keeper Fleet, command→Actions, lab→Tools가 공용)의 h1은 tailwind `text-lg`(18px)로 크기를 지정했지만, **tailwind 유틸리티는 `@layer`에 있고 전역 `h1`은 unlayered라 CSS Cascade Layers 규칙상 unlayered가 layered를 이깁니다**(특이도 무관). 결과: 타이틀이 42px·UPPERCASE·0.2em 자간·glow로 폭발.

다른 표면들(`.ov-head h1`, `.surf-head h1`)은 T1 타이틀 그룹(`var(--fs-t1)`=22px, sentence-case)으로 **명시 override**해서 전역 h1을 이기고 있었습니다. `SurfaceHeader`만 tailwind에 의존하다 layer 규칙에 진 것 — 즉 그 tailwind 클래스들은 **한 번도 적용된 적 없는 dead 클래스**였습니다.

## 변경 (2 파일, +8/-4)

- **`surfaces.css`**: `.v2-surface-header h1`을 기존 T1 surface-title 그룹(`.ov-head h1, .surf-head h1, ...`)에 편입 → 앱의 다른 모든 표면 타이틀과 **동일한 규칙**(22px·600·sentence-case·`--fs-t1` 토큰) 적용. 42px→22px, UPPERCASE→sentence, glow 축소.
- **`surface-header.ts`**: h1에서 dead tailwind 클래스(`text-lg` 등)와 inline `text-shadow` 제거, 스타일 출처를 JS 주석으로 명시.

영향 범위: monitoring/command/lab 등 generic `SurfaceHeader`를 쓰는 모든 표면의 타이틀이 정상 크기로 교정됩니다.

## 검증

- `vitest run surface-header.test.ts` — 6 tests green (타이틀 텍스트·actions·breadcrumb·widget-solo)
- `tsc --noEmit` clean, eslint(source) clean
- 전체 dashboard 스위트 green (아래 CI)
- 스크린샷: Chrome 확장 미연결로 미첨부. CSS 변경은 기존 T1 토큰 재사용이며, 크기는 `--fs-t1`(22px, 다른 표면과 동일)로 결정론적.

## RFC / 워크어라운드

- RFC 게이트 대상 아님(공용 헤더 CSS·컴포넌트, credential/operator/hooks 아님).
- 워크어라운드 시그니처 해당 없음. N-of-M 아님: 단일 selector 그룹 편입으로 generic 헤더 **전 표면**을 한 번에 고침(사이트별 패치 아님).

## 후속(범위 밖, 근본)

- 진짜 근본은 "unlayered 전역 element 스타일이 layered tailwind 유틸리티를 이김" — 전역 `h1/h2/..` 스타일을 `@layer base`로 내려 tailwind가 이기게 하면 표면별 override가 불필요. 다만 전역 CSS 아키텍처 변경이라 리스크 큼 → 별도 RFC/PR 후보.
