### PR TITLE
fix(build): keeper_tool_surface -> Keeper_tool_persona_crud (last main-red error)

### DIFF
--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -696,8 +696,8 @@ let dispatch ?continuation_channel ctx ~name ~args : tool_result option =
   let ctx = resolve_ctx ctx ~name args in
   match name with
   | "masc_persona_list" -> Some (tool_result_with_tool_name ~tool_name:name (Persona.handle_persona_list ctx args))
-  | "masc_persona_create" -> Some (tool_result_with_tool_name ~tool_name:name (Persona_crud.handle_persona_create ctx args))
-  | "masc_persona_update" -> Some (tool_result_with_tool_name ~tool_name:name (Persona_crud.handle_persona_update ctx args))
+  | "masc_persona_create" -> Some (tool_result_with_tool_name ~tool_name:name (Keeper_tool_persona_crud.handle_persona_create ctx args))
+  | "masc_persona_update" -> Some (tool_result_with_tool_name ~tool_name:name (Keeper_tool_persona_crud.handle_persona_update ctx args))
   | "masc_keeper_create_from_persona" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_create_from_persona ctx args))
   | "masc_keeper_up" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_up ctx args))
   | "masc_keeper_status" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_status ctx args))


### PR DESCRIPTION
main-red: keeper_tool_surface.ml:699-700 referenced nonexistent module `Persona_crud`; handlers live in `Keeper_tool_persona_crud`. Use the real module name. Last error after #23683 (persona_crud internals). CI authoritative build. RFC-WAIVED: build-break hotfix, no behavior change.