### PR TITLE
fix(build): anti_rationalization.mli review_request evidence_refs (main red)

### DIFF
--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -23,6 +23,7 @@ type review_request = {
   completion_notes : string;
   agent_name : string;
   task_id : string;
+  evidence_refs : string list;
 }
 
 (** Gate verdict. *)


### PR DESCRIPTION
main-red: anti_rationalization.ml + tool_task_handlers.ml carry review_request.evidence_refs but the .mli lacked it (interface != implementation, from evidence-gate #23666). Add the field to the .mli. CI authoritative. RFC-WAIVED: build-break hotfix. NOTE: a SEPARATE main-red remains in the persona CRUD feature (#23664) — see PR comment / recommend revert.