### PR TITLE
fix(build): evidence_refs at all 5 review_request sites (main red)

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -345,6 +345,7 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
       completion_notes = notes;
       agent_name = eval_agent_name;
       task_id;
+      evidence_refs = [];
     }
   in
   let on_verdict (result : AR.review_result) =

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -17,6 +17,7 @@ let make_request () : AR.review_request =
     task_description = "Implement and verify a concrete task.";
     completion_notes = "Implemented the change and verified the focused test.";
     task_id = "test-task-empty-reject";
+    evidence_refs = [];
   }
 
 let with_reviewer reviewer f =

--- a/test/test_anti_rationalization_gate2_advisory_10113.ml
+++ b/test/test_anti_rationalization_gate2_advisory_10113.ml
@@ -55,6 +55,7 @@ let make_request ~notes : AR.review_request =
     task_description = "test description";
     completion_notes = notes;
     task_id = "test-task-10113";
+    evidence_refs = [];
   }
 
 (* The advisory text must contain the flagged phrase verbatim and

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -34,7 +34,8 @@ let make_req ?(title = "Fix auth bug") ?(desc = "Fix the login issue")
     ?(notes = "Implemented JWT refresh token rotation") ?(agent = "alice") ()
   : AR.review_request =
   { task_title = title; task_description = desc;
-    completion_notes = notes; agent_name = agent; task_id = "test-task-eval" }
+    completion_notes = notes; agent_name = agent; task_id = "test-task-eval";
+    evidence_refs = [] }
 
 let make_result ?(verdict = AR.Approve) ?(runtime = "verifier")
     ?gen_runtime ?(gate = AR.Structured_tool) ?fallback_reason () : AR.review_result =

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2642,7 +2642,7 @@ let make_review_request () : Task.Anti_rationalization.review_request =
     task_description = "desc";
     completion_notes = "notes";
     agent_name = "alice";
-    task_id = "test-task-1" }
+    task_id = "test-task-1"; evidence_refs = [] }
 
 let make_review_result
     ?(verdict = Task.Anti_rationalization.Approve)


### PR DESCRIPTION
review_request gained evidence_refs (#23666) but 5 construction sites (1 bin + 4 test) did not set it. Add evidence_refs = [] at each (mirrors tool_task_handlers.ml:211). Grep-verified no other site missing. CI authoritative. RFC-WAIVED: build-break hotfix.