### PR TITLE
fix(docs): fleet-wide 언블록 — persona_crud 매트릭스 등재 + RFC-0324 R6 준수

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -44,6 +44,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_in_process_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_memory_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_memory_runtime.mli` - execution-dispatch
+- `lib/keeper/keeper_tool_persona_crud.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_registered_runtime.ml` - execution-dispatch

--- a/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
+++ b/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
@@ -77,7 +77,7 @@ dune runtest test_exec_policy
 
 ## Migration
 
-- 백업 보관: `~/.masc/config/keepers/` tar(`masc-config-keepers-backup-2026-07-08.tar.gz`).
+- 백업 보관: `<base-path>/.masc/config/keepers/` tar(`masc-config-keepers-backup-2026-07-08.tar.gz`).
 - keeper runtime json 갱신: keeper reload/restart로 toml SSOT 반영.
 
 ## Risks


### PR DESCRIPTION
## 목적
main에 겹쳐 있던 **fleet-wide red 2건**을 해소해 모든 오픈 PR을 언블록.

## 커밋
- `b1827894f1` — **Meta Guards red**: `keeper_tool_persona_crud.ml`이 `keeper-tool-boundary-matrix.md`에 미등재라 `audit-keeper-tool-boundary-matrix.sh`가 모든 PR에서 fail. 1줄 등재(`execution-dispatch`).
- `2a51fcaf00` — **Lint R6 red**: RFC-0324가 `~/.masc/config/keepers/`(4번째 occurrence)를 baseline(3) bump 없이 올려 main Lint red. ratchet 자체 remediation대로 `<base-path>/.masc`로 재작성. baseline 상향(=bypass 수용) 대신 규칙 준수.

## 검증
- `scripts/check-ssot.sh` 로컬: R6 `3 (baseline 3)`, R1 `0` — clean (grep 기반, 결정론적).
- Meta Guards: pass 확인.
- dune 빌드는 CI에서 확인.

## 반경
두 red 모두 내용상 서로 무관하나 **동일하게 fleet 전체를 red로 만드는 docs-only 결함**이라 한 PR로 묶음. 머지 시 main green 복구 → 나머지 오픈 PR rebase만으로 통과.
