### PR TITLE
fix(main-red): register persona_crud in boundary matrix + reword bare tilde .masc

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -46,6 +46,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_memory_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.mli` - execution-dispatch
+- `lib/keeper/keeper_tool_persona_crud.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_registered_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_registered_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_shared_runtime.ml` - execution-dispatch

--- a/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
+++ b/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
@@ -77,7 +77,7 @@ dune runtest test_exec_policy
 
 ## Migration
 
-- 백업 보관: `~/.masc/config/keepers/` tar(`masc-config-keepers-backup-2026-07-08.tar.gz`).
+- 백업 보관: `<base-path>/.masc/config/keepers/` tar(`masc-config-keepers-backup-2026-07-08.tar.gz`). bare tilde-home 형식은 shell에서 operator home으로 해석되므로 resolved base path를 쓴다.
 - keeper runtime json 갱신: keeper reload/restart로 toml SSOT 반영.
 
 ## Risks


### PR DESCRIPTION
## 목적

origin/main에 잠복해 있던 **main-red 2건**을 수정합니다. RFC-0326 Draft PR(#23696)의 docs 변경이 Lint·Meta Guards 스코프를 트리거하면서 드러났으나, **두 실패 모두 #23696과 무관**하며 origin/main에서도 실패합니다.

## 원인과 수정

### 1. Meta Guards / doc-truth — boundary matrix 미등재
`lib/keeper/keeper_tool_persona_crud.ml`(#23679/#23683/#23692로 추가)이 `audit-keeper-tool-boundary-matrix.sh`의 scope regex(`keeper_tool*`)에 걸리는 in-scope 파일인데 matrix 문서에 등재되지 않아 `FAIL - missing source paths`.

- **수정**: matrix에 `keeper_tool_persona_crud.ml - execution-dispatch` 등재.
- **owner 근거**: 이 파일은 `masc_persona_create`/`masc_persona_update` 핸들러(persona 실행 dispatch). matrix owner-category 정의(L26)가 execution-dispatch = "...persona... execution dispatch"로 명시하고, sibling `keeper_tool_persona_runtime.ml`도 execution-dispatch. audit/surface(tool-surface-policy)와는 구분됨.

### 2. Lint / SSOT bypass ratchet R6-home-masc-root (#8462)
`docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md:80`이 bare `~/.masc` 백업 경로를 써서 count 4 > baseline 3.

- **수정**: ratchet가 지정한 대체 형식 `<base-path>/.masc`로 변경. 설명 문구는 리터럴 형식을 피함 — R6 정규식은 그 형식을 *경고하는* 산문(백틱 내부 포함)에서도 매칭하므로, baseline 3인 나머지 3개 경고 문서처럼 리터럴을 재도입하지 않도록 서술로 대체.

## 검증 (로컬)

```
R6-home-masc-root: 3 occurrences (baseline 3) — OK
[keeper-tool-boundary-matrix] OK - 151 scoped keeper files covered
```

## 성격

main-red 복구(문서 2줄). 코드 변경 없음, RFC-0326 설계와 독립. 병합 후 #23696을 rebase하면 해당 브랜치의 required check도 green이 됩니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
