### PR TITLE
fix(dashboard): Fleet 로스터 액션 버튼이 컨텍스트값과 겹치는 문제 (열 폭 부족)

### DIFF
--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -17,8 +17,11 @@
     var(--bg-deep);
   color: var(--text-primary);
   font-family: var(--font-ui);
-  /* shared roster column track — header + rows + group dividers align to this */
-  --fl-cols: minmax(196px, 1.3fr) 184px 140px minmax(108px, 1fr) 128px;
+  /* shared roster column track — header + rows + group dividers align to this.
+     Last track = action cell (멈춤/깨움/종료): the 3 text buttons render ~156px,
+     so the track must be wide enough or the button group overflows left into the
+     context value (fl-ctx-val) on a selected/hovered row. */
+  --fl-cols: minmax(196px, 1.3fr) 184px 140px minmax(108px, 1fr) 160px;
   --fl-gap: 14px;
 }
 
@@ -253,7 +256,7 @@
 /* ── responsive: progressively shed columns instead of letting strings collide ── */
 /* mid width — aside still present, but main is tight: drop 최근 도구 first */
 @media (max-width: 1320px) and (min-width: 1101px) {
-  .fl-shell { --fl-cols: minmax(168px, 1.3fr) 168px 132px 120px; }
+  .fl-shell { --fl-cols: minmax(168px, 1.3fr) 168px 132px 160px; }
   .fl-rhead span:nth-child(4), .fl-row .fl-tool { display: none; }
 }
 


### PR DESCRIPTION
## 목적

브라우저 시각 감사에서 발견: **Keeper Fleet 로스터에서 선택/hover된 행의 액션 버튼(멈춤/깨움/종료)이 컨텍스트값(N%)과 겹쳐** "2팸춤"처럼 깨져 보임.

## 근본 원인

`.fl-row`은 `--fl-cols` 그리드. 3개 텍스트 버튼 그룹은 ~156px로 렌더되는데, 액션 트랙은 **128px(base) / 120px(1101–1320px)** 만 예약. `justify-content:flex-end`라 버튼 그룹이 **왼쪽으로 넘쳐** 컨텍스트 열(`.fl-ctx-val`)을 침범.

- 측정(1169px): `.fl-ctx-val` right=967 > 액션 버튼 left=945 → **22px 겹침**.

## 변경

`--fl-cols`의 마지막(액션) 트랙을 base·mid 양쪽 모두 **160px**로 확대 (156px 버튼 그룹 수용).

## 검증 (브라우저)

- DOM 주입 후 재측정: ctx-val right 967→927, 버튼 left 945 → **overlap false, gap 18px**.
- 스크린샷: before "2팸춤"(겹침) → after "22%  멈춤 깨움 종료"(깔끔히 분리).
- CSS-only. tsc/eslint 무관, "Raw font-size px" 가드 무관(grid 트랙 폭 변경).

## RFC / 워크어라운드

- RFC 게이트/워크어라운드 시그니처 해당 없음. 반응형 그리드 트랙 폭 조정.