### PR TITLE
fix(keeper): persona_crud .mli — fleet-wide Structure Ratchet red 해소

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -45,6 +45,7 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_memory_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_memory_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_crud.ml` - execution-dispatch
+- `lib/keeper/keeper_tool_persona_crud.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.ml` - execution-dispatch
 - `lib/keeper/keeper_tool_persona_runtime.mli` - execution-dispatch
 - `lib/keeper/keeper_tool_registered_runtime.ml` - execution-dispatch

--- a/lib/keeper/keeper_tool_persona_crud.mli
+++ b/lib/keeper/keeper_tool_persona_crud.mli
@@ -1,14 +1,16 @@
 (** Keeper_tool_persona_crud — masc_persona_create and masc_persona_update handlers. *)
 
-type tool_result = Keeper_types_profile.tool_result
-
 (** Handle a [masc_persona_create] tool call. Validates the create args,
     rejects an existing persona, then writes the new profile. *)
 val handle_persona_create :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
+  _ Keeper_types_profile.context
+  -> Yojson.Safe.t
+  -> Keeper_types_profile.tool_result
 
 (** Handle a [masc_persona_update] tool call. Requires [persona_name],
     rejects an unknown persona, then merges the update args into the
     existing profile. *)
 val handle_persona_update :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
+  _ Keeper_types_profile.context
+  -> Yojson.Safe.t
+  -> Keeper_types_profile.tool_result

--- a/lib/keeper/keeper_tool_persona_crud.mli
+++ b/lib/keeper/keeper_tool_persona_crud.mli
@@ -1,0 +1,14 @@
+(** Keeper_tool_persona_crud — masc_persona_create and masc_persona_update handlers. *)
+
+type tool_result = Keeper_types_profile.tool_result
+
+(** Handle a [masc_persona_create] tool call. Validates the create args,
+    rejects an existing persona, then writes the new profile. *)
+val handle_persona_create :
+  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
+
+(** Handle a [masc_persona_update] tool call. Requires [persona_name],
+    rejects an unknown persona, then merges the update args into the
+    existing profile. *)
+val handle_persona_update :
+  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result


### PR DESCRIPTION
## 목적
main의 **세 번째 fleet-wide red**(OCaml Structure Ratchet)를 해소. `keeper_tool_persona_crud.ml`이 `.mli` 없이 머지되어 `keeper_mli_missing` count 16 > baseline 15 → main red, 모든 오픈 PR 상속.

## 변경
1. `keeper_tool_persona_crud.mli` 신규 — 외부 사용 handler 2개만 노출(`handle_persona_create`/`handle_persona_update`, whole-tree grep으로 표면 확정). 시그니처는 형제 `keeper_persona.mli` 미러링: `_ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result`. count 16→15.
2. `keeper-tool-boundary-matrix.md`에 `.mli` 등재 — audit 정규식(`\.mli?$`)이 .ml/.mli 둘 다 스캔하므로 신규 .mli도 매트릭스 필요(152 files covered).

## 근본 해결
baseline bump(=debt 수용)이 아니라 .mli 추가로 count를 되돌려 debt 감소. ratchet 정책·OCaml 인터페이스 가이드 부합.

## 검증
- `ocaml-structure-ratchet.sh`: OK (16→15).
- `audit-keeper-tool-boundary-matrix.sh`: OK (152 covered).
- .mli 타입 정합은 **CI Build Canary**에서 확인(로컬 pin 함정 회피).

## Test coverage gate
이 변경은 `.mli`(타입 인터페이스, 실행 branch 0) + 매트릭스 `.md`뿐이라 테스트할 runtime 동작이 없어요. handler 동작은 불변이고 타입 시그니처만 선언. 문서화된 escape hatch를 근거와 함께 사용해요(결함 은폐 아님).

# ci:skip-test-coverage

## 반경
#23695(Meta Guards + R6)와 같은 persona_crud 파생 red. 머지 시 main green 완성 → #23638/#23693 등 Structure Ratchet fail이 rebase로 풀려요.
