### PR TITLE
hotfix(task-1887): disable Gate 0 (empty evidence_refs -> Reject) until call site is wired

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -739,16 +739,7 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs *)
-  if List.is_empty req.evidence_refs then
-    emit
-      { verdict = Reject "no evidence references supplied"
-      ; evaluator_runtime
-      ; generator_runtime
-      ; gate = Evidence
-      ; fallback_reason = None
-      }
-  else
+  (* Gate 0: disabled — call site not wired yet (PR #23666 regression hotfix) *)
   (* Gate 1: empty or trivially short notes *)
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length


### PR DESCRIPTION
## Problem

PR #23666 added `evidence_refs : string list` to `review_request` and Gate 0 rejects empty `evidence_refs`. But the call site (`tool_task_handlers.ml`) passes `evidence_refs = []` as a placeholder — the call site is not wired yet.

**Result:** Every `keeper_task_done` / `masc_transition` submission is rejected with "no evidence references supplied", blocking all task completion.

## Fix

Remove Gate 0 (the `if List.is_empty req.evidence_refs then Reject` block). The `evidence_refs` field stays in `review_request` for when the call site is wired.

## Related

- PR #23700 (`base/task-1887-disable-gate0`) adds `docs/verification-pipeline-policy.md` but does not touch the code — this PR is the actual code fix.
- PR #23666 introduced the regression.

Closes task-1887.