### PR TITLE
fix(dashboard): Fusion 문구 정리 (언어 일관성 + 중복 제거 + API 배관 숨김)

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -670,7 +670,7 @@ describe('FusionSurface', () => {
     render(html`<${FusionSurface} />`, container)
 
     expect(container.querySelector('[data-testid="fusion-empty"]')).not.toBeNull()
-    expect(container.textContent).toContain('No board-sink fusion posts yet')
+    expect(container.textContent).toContain('아직 기록된 보드 심의가 없습니다')
     expect(container.textContent).toContain('/api/v1/dashboard/fusion-runs')
   })
 
@@ -687,9 +687,9 @@ describe('FusionSurface', () => {
     expect(error?.textContent).toContain('Board sink load failed')
     expect(error?.textContent).toContain('HTTP 502 board sink unavailable')
     const empty = container.querySelector('[data-testid="fusion-empty"]')
-    expect(empty?.textContent).toContain('Board-sink fusion posts are unverified')
+    expect(empty?.textContent).toContain('보드 심의 기록을 확인하지 못했습니다')
     expect(empty?.textContent).toContain('/api/v1/dashboard/board?sort_by=recent&limit=500')
-    expect(empty?.textContent).not.toContain('No board-sink fusion posts yet')
+    expect(empty?.textContent).not.toContain('아직 기록된 보드 심의가 없습니다')
   })
 
   it('keeps cached board-sink detail visible while showing a refresh failure', () => {
@@ -739,8 +739,8 @@ describe('FusionSurface', () => {
     // registry run is selected by default and shows its own detail.
     expect(container.querySelector('[data-testid="fusion-empty"]')).toBeNull()
     expect(container.querySelector('[data-testid="fusion-registry-detail"]')?.textContent).toContain('fus-running')
-    expect(container.textContent).toContain('board runs')
-    expect(container.textContent).toContain('registry')
+    expect(container.textContent).toContain('보드 런')
+    expect(container.textContent).toContain('레지스트리')
     // The running count now surfaces as the sidebar live badge, not the removed panel.
     expect(container.textContent).toContain('1 진행')
   })

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -964,7 +964,7 @@ function FusionRegistryRow({ record, active }: { record: FusionRunRecord; active
           ? html`<span class="fus-dec-badge run">심의 중</span>`
           : record.status === 'failed'
             ? html`<span class="fus-dec-badge bad">실패</span>`
-            : html`<span class="fus-dec-badge">registry</span>`}
+            : html`<span class="fus-dec-badge">레지스트리</span>`}
       </span>
     </button>
   `
@@ -1288,9 +1288,8 @@ function FusionRegistryDetail({ record }: { record: FusionRunRecord }) {
       </div>
 
       <div class="fus-block">
-        <div class="fus-block-lbl">
+        <div class="fus-block-lbl" title="GET /api/v1/dashboard/fusion-runs">
           레지스트리 관측
-          <span class="fus-sub-note">GET /api/v1/dashboard/fusion-runs</span>
         </div>
         <div class="fus-judge-wait">
           ${record.status === 'running'
@@ -1355,21 +1354,20 @@ export function FusionSurface() {
         : null}
 
       <section class="fus-kpis" aria-label="Fusion overview">
-        <${FusionMetric} label="board runs" value=${runs.length} tone=${runs.length ? 'ok' : undefined} />
+        <${FusionMetric} label="보드 런" value=${runs.length} tone=${runs.length ? 'ok' : undefined} />
         <${FusionMetric}
-          label="registry"
+          label="레지스트리"
           value=${registryRuns.length}
           tone=${registryRunning ? 'warn' : registryRuns.length ? 'ok' : undefined}
         />
-        <${FusionMetric} label="running" value=${registryRunning} tone=${registryRunning ? 'warn' : undefined} />
-        <${FusionMetric} label="failed" value=${registryFailed} tone=${registryFailed ? 'bad' : undefined} />
+        <${FusionMetric} label="실행 중" value=${registryRunning} tone=${registryRunning ? 'warn' : undefined} />
+        <${FusionMetric} label="실패" value=${registryFailed} tone=${registryFailed ? 'bad' : undefined} />
       </section>
 
       <div class="fus-body">
         <aside class="fus-list" aria-label="Fusion runs">
           <div class="fus-list-h">
             <h4>심의 런</h4>
-            <span class="fus-list-sub">RFC-0252 · 패널+심판</span>
             ${registryRunning > 0
               ? html`<span class="fus-list-live"><span class="fus-rdot run"></span>${registryRunning} 진행</span>`
               : null}
@@ -1399,7 +1397,7 @@ export function FusionSurface() {
                 <div class="fus-block">
                   <div class="fus-block-lbl">${boardError ? '보드 sink 확인 실패' : '보드 sink 대기'}</div>
                   <div class="fus-judge-wait">
-                    ${boardError ? 'Board-sink fusion posts are unverified.' : 'No board-sink fusion posts yet.'}
+                    ${boardError ? '보드 심의 기록을 확인하지 못했습니다.' : '아직 기록된 보드 심의가 없습니다.'}
                   </div>
                   <p class="fus-rec-rationale">
                     ${boardError


### PR DESCRIPTION
## 목적

사용자 지적: "Fusion 문구/워딩 정리 필요". 브라우저로 전수 검토 후 **A+B+C**(사용자 승인 범위) 적용. 도메인 jargon(sink/JoJ/reconcile/fail-closed/masc_fusion)은 **operator 대시보드 어휘라 의도적으로 유지**.

## 변경 (fusion-surface.ts + 테스트)

**A. 언어 일관성** — 한국어 UI에 섞인 영어 라벨 → 한국어
- KPI: `board runs/registry/running/failed` → `보드 런/레지스트리/실행 중/실패`
- registry-only 행 배지: `registry` → `레지스트리`
- empty-state 문장: `No board-sink fusion posts yet.` / `Board-sink fusion posts are unverified.` → 한국어

**B. 중복 제거** — 사이드바 헤더가 상단 eyebrow의 `RFC-0252 · 패널+심판`을 중복(띄어쓰기도 불일치) → 사이드바 부제 제거(eyebrow가 유지).

**C. API 배관 숨김** — registry 상세가 raw `GET /api/v1/dashboard/fusion-runs`를 본문 텍스트로 노출 → `title` tooltip으로 이동(화면엔 "레지스트리 관측"만). empty-state 진단 엔드포인트는 로드 실패 설명이라 유지.

## 검증
- `vitest` fusion-surface + fusion-runs-panel: **41 tests green** (문구 assertion 갱신)
- `tsc --noEmit` clean, eslint clean
- **브라우저 검증**: KPI(보드 런/레지스트리/실행 중/실패)·사이드바(심의 런)·empty-state(아직 기록된 보드 심의가 없습니다) 모두 새 한국어로 렌더 확인.

## 범위 밖 (D, 미적용)
jargon 순화(JoJ→판정관, sink→기록 등)는 사용자가 "도메인 정확성 유지"로 A+B+C만 선택. 추후 별도 논의.