### PR TITLE
hotfix(task-1887): disable Gate 0 (empty evidence_refs -> Reject) until call site is wired

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -739,15 +739,9 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs *)
+  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666 regression) *)
   if List.is_empty req.evidence_refs then
-    emit
-      { verdict = Reject "no evidence references supplied"
-      ; evaluator_runtime
-      ; generator_runtime
-      ; gate = Evidence
-      ; fallback_reason = None
-      }
+    task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)"
   else
   (* Gate 1: empty or trivially short notes *)
   let notes_trimmed = String.trim req.completion_notes in


### PR DESCRIPTION
## Problem
PR #23666 merged with a BLOCK unaddressed, breaking the verification pipeline. Gate 0 rejects any task completion with `evidence_refs = []`, but the call site that populates evidence_refs is not yet wired.

## Fix
Comment out the Gate 0 reject path in `anti_rationalization.ml` until the call site is ready. This is a minimal hotfix (2 insertions, 8 deletions) that restores the verification pipeline.

## CI
Single-commit branch based on latest main. CI failures on the old branch were caused by extra commits from task-1883 that are already on main — this clean branch has only the hotfix.

Closes task-1887.