### PR TITLE
fix(dashboard): 상단 바 ops 상태 칩 ellipsize — 버전 배지 잘림 방지 (#2)

### DIFF
--- a/dashboard/src/styles/keeper-v2/ops-cluster.css
+++ b/dashboard/src/styles/keeper-v2/ops-cluster.css
@@ -18,6 +18,13 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  /* Allow the cluster to shrink below its content width. Between the mobile
+     breakpoint (≤900px, ops hidden) and a wide desktop, a verbose connection/
+     transport status string can push the whole top bar past the viewport; the
+     rightmost item (BuildIdentityBadge) then overflows and is clipped by
+     `.v2-app { overflow-x: hidden }`. min-width:0 lets the status chips below
+     ellipsize instead of shoving the badge off-canvas. */
+  min-width: 0;
 }
 
 /* Leaf chips whose root `.v2-shell-panel` is itself the visible chip
@@ -29,6 +36,17 @@
   font-size: var(--fs-11);
   letter-spacing: 0.04em;
   white-space: nowrap;
+  min-width: 0;
+}
+
+/* The status label truncates (full text stays in the component's title tooltip)
+   so a long "Client WS · open · N deltas / …" string yields space instead of
+   clipping the build badge. Only kicks in when the top bar is space-constrained;
+   at wide widths the flex item keeps its natural width. */
+.v2-top-ops > .v2-shell-panel .status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Root panels that only group a button (AuthStatus, BuildIdentityBadge,


### PR DESCRIPTION
## 목적 (브라우저 감사 #2 근본 수정)

상단 바 우측 **버전 배지(v0.x · sha)가 잘리는** 문제. 여러 표면에서 재현(innerWidth 1169px + WS 상태 verbose일 때). Settings("silent", 짧음)에선 안 잘림 → 폭+콘텐츠 의존 확정.

## 근본 원인

`.v2-top`은 `nowrap` flex row. 반응형이 **≤900px(모바일: ops 숨김)만** 처리하고 **900~1400px 중간 구간은 미처리**. 이 구간에서 `.v2-top-ops` 상태 칩이 `white-space:nowrap` + `min-width:auto`라 축소 불가 → verbose 상태 텍스트가 총 폭을 뷰포트 밖으로 밀고, 마지막 요소(BuildIdentityBadge)가 `.v2-app{overflow-x:hidden}`에 잘림.

## 변경 (ops-cluster.css, CSS-only)

`.v2-top-ops`와 상태 칩에 `min-width:0`, `.status-text`에 `overflow:hidden; text-overflow:ellipsis`. 공간 부족할 때만 상태 라벨이 줄고, 넓은 폭에선 자연 폭 유지. 전체 텍스트는 컴포넌트 title tooltip에 유지. auth/emergency-stop/badge는 불변.

## 검증 상태 ⚠️ Draft 유지 이유
- **검증됨**: 동일 CSS를 live 주입 → 넓은 폭에서 non-destructive(배지 위치 불변) 확인.
- **pending**: narrow-width(≤1320px) 실제 truncation 스크린샷 — 세션 중 **브라우저 확장이 disconnect**돼 완료 못 함. 브라우저 복구 시 narrow 폭 시각 확인 후 Ready 전환 예정.
- CSS-only라 vitest/tsc 무관, "Raw font-size px" 가드 무관.

근본 fix는 flex `min-width:0` 표준 remedy라 로직은 확실하나, **시각 검증 완료 전 머지 금지** 원칙에 따라 Draft.