### PR TITLE
fix(dashboard): 스케줄 뷰를 keeper-lane 진단 위로 (스케줄이 주인공)

### DIFF
--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -239,6 +239,11 @@ describe('ScheduleSurface', () => {
     container.querySelector<HTMLButtonElement>('[data-testid="schedule-view-list"]')?.click()
     await flush()
     expect(container.textContent).toContain('wake signal 피드 · schedule_runner.tick')
+    // The keeper-lane / background diagnostics are collapsed AND lazy-mounted by
+    // default; open them before asserting their content.
+    expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')).toBeNull()
+    container.querySelector<HTMLButtonElement>('[data-testid="schedule-diagnostics-toggle"]')?.click()
+    await flush()
     expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)
       .toContain('Keeper Lanes · wake evidence')
     expect(container.querySelector('[data-testid="schedule-keeper-lanes"]')?.textContent)

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -237,19 +237,24 @@ export function ScheduleSurface() {
                 onSelectSchedule=${setSelectedScheduleId}
               />`}
 
-        ${'' /* Secondary diagnostics live BELOW the schedule: the actual schedule
-              (calendar/list) is the primary, above-the-fold content. The keeper-lane
-              wake evidence + background panels are large operator diagnostics that
-              previously buried the schedule at the bottom of the page. */}
-        <section class="ov-card mt-4" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
-          <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
-          <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
-        </section>
+        ${'' /* Secondary diagnostics live BELOW the schedule AND collapsed by
+              default: the actual schedule (calendar/list) is the primary,
+              above-the-fold content. The keeper-lane wake evidence + background
+              panels are large operator diagnostics (a card per keeper, up to 64
+              lane rows) that previously buried the schedule. They stay one click
+              away via <details>; content remains in the DOM when collapsed. */}
+        <details class="ov-card mt-4 sch-diag" data-testid="schedule-diagnostics">
+          <summary class="sch-diag-summary">Keeper 진단 · wake evidence · background</summary>
+          <section class="mt-3" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
+            <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
+            <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
+          </section>
 
-        <section class="ov-card mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
-          <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
-          <${KeeperBackgroundPanel} background=${keeperBackground} />
-        </section>
+          <section class="mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
+            <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
+            <${KeeperBackgroundPanel} background=${keeperBackground} />
+          </section>
+        </details>
       </div>
       ${automation
         ? html`<${ScheduleAside}

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -220,16 +220,6 @@ export function ScheduleSurface() {
           <${CadenceSummary} counts=${cadCounts} active=${cadenceFilter} onFilter=${setCadenceFilter} />
         </div>
 
-        <section class="ov-card mt-4" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
-          <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
-          <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
-        </section>
-
-        <section class="ov-card mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
-          <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
-          <${KeeperBackgroundPanel} background=${keeperBackground} />
-        </section>
-
         ${loading && !automation
           ? html`<${LoadingState}>예약 자동화 projection 불러오는 중...<//>`
           : view === 'calendar'
@@ -246,6 +236,20 @@ export function ScheduleSurface() {
                 selectedScheduleId=${selectedScheduleId}
                 onSelectSchedule=${setSelectedScheduleId}
               />`}
+
+        ${'' /* Secondary diagnostics live BELOW the schedule: the actual schedule
+              (calendar/list) is the primary, above-the-fold content. The keeper-lane
+              wake evidence + background panels are large operator diagnostics that
+              previously buried the schedule at the bottom of the page. */}
+        <section class="ov-card mt-4" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
+          <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
+          <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
+        </section>
+
+        <section class="ov-card mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
+          <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
+          <${KeeperBackgroundPanel} background=${keeperBackground} />
+        </section>
       </div>
       ${automation
         ? html`<${ScheduleAside}

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -97,6 +97,11 @@ export function ScheduleSurface() {
   // Detail-overlay selection is lifted here so the calendar view, the list
   // panel, and the operations aside all drive the same overlay.
   const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
+  // Keeper-lane wake evidence + background are large operator diagnostics
+  // (a card per keeper, dozens of lane rows). Collapsed AND unmounted by default
+  // so the schedule stays the light, primary content; the panels only mount when
+  // the operator opens them.
+  const [diagOpen, setDiagOpen] = useState(false)
 
   useEffect(() => {
     if (!toolsData.value && !toolsLoading.value) {
@@ -237,24 +242,34 @@ export function ScheduleSurface() {
                 onSelectSchedule=${setSelectedScheduleId}
               />`}
 
-        ${'' /* Secondary diagnostics live BELOW the schedule AND collapsed by
-              default: the actual schedule (calendar/list) is the primary,
+        ${'' /* Secondary diagnostics live BELOW the schedule and are unmounted
+              until opened: the actual schedule (calendar/list) is the primary,
               above-the-fold content. The keeper-lane wake evidence + background
-              panels are large operator diagnostics (a card per keeper, up to 64
-              lane rows) that previously buried the schedule. They stay one click
-              away via <details>; content remains in the DOM when collapsed. */}
-        <details class="ov-card mt-4 sch-diag" data-testid="schedule-diagnostics">
-          <summary class="sch-diag-summary">Keeper 진단 · wake evidence · background</summary>
-          <section class="mt-3" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
-            <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
-            <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
-          </section>
+              panels are large operator diagnostics (a card per keeper, dozens of
+              lane rows) that previously buried the schedule and rendered on every
+              tick. Lazy-mounting them keeps the default surface light. */}
+        <section class="ov-card mt-4 sch-diag" data-testid="schedule-diagnostics">
+          <button
+            type="button"
+            class="sch-diag-summary"
+            aria-expanded=${diagOpen ? 'true' : 'false'}
+            data-testid="schedule-diagnostics-toggle"
+            onClick=${() => setDiagOpen(open => !open)}
+          >Keeper 진단 · wake evidence · background ${diagOpen ? '▴' : '▾'}</button>
+          ${diagOpen
+            ? html`
+                <section class="mt-3" aria-label="Keeper lane inventory" data-testid="schedule-keeper-lanes">
+                  <div class="ov-card-h"><h3>Keeper Lanes · wake evidence</h3></div>
+                  <${KeeperLaneInventoryPanel} inventory=${waitingInventory} />
+                </section>
 
-          <section class="mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
-            <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
-            <${KeeperBackgroundPanel} background=${keeperBackground} />
-          </section>
-        </details>
+                <section class="mt-4" aria-label="Keeper background" data-testid="schedule-keeper-background">
+                  <div class="ov-card-h"><h3>Keeper Background · recurring tasks</h3></div>
+                  <${KeeperBackgroundPanel} background=${keeperBackground} />
+                </section>
+              `
+            : null}
+        </section>
       </div>
       ${automation
         ? html`<${ScheduleAside}

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -281,9 +281,16 @@
 }
 
 /* Collapsible operator-diagnostics group: the schedule stays primary, the large
-   keeper-lane wake-evidence + background panels are one click away (collapsed by
-   default). Summary reads as a section header (mono caps, dim). */
+   keeper-lane wake-evidence + background panels are one click away and lazy-
+   mounted (collapsed by default). The toggle is a bare <button> styled as a
+   section header (mono caps, dim). */
 .sch-diag > .sch-diag-summary {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: none;
+  padding: 0;
   cursor: pointer;
   user-select: none;
   font-family: var(--font-mono);
@@ -293,4 +300,4 @@
   color: var(--text-dim);
 }
 .sch-diag > .sch-diag-summary:hover { color: var(--text-mid); }
-.sch-diag[open] > .sch-diag-summary { margin-bottom: 10px; color: var(--text-mid); }
+.sch-diag > .sch-diag-summary[aria-expanded="true"] { margin-bottom: 10px; color: var(--text-mid); }

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -279,3 +279,18 @@
 @media (max-width: 900px) {
   .sch-bg-grps { grid-template-columns: 1fr; }
 }
+
+/* Collapsible operator-diagnostics group: the schedule stays primary, the large
+   keeper-lane wake-evidence + background panels are one click away (collapsed by
+   default). Summary reads as a section header (mono caps, dim). */
+.sch-diag > .sch-diag-summary {
+  cursor: pointer;
+  user-select: none;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.sch-diag > .sch-diag-summary:hover { color: var(--text-mid); }
+.sch-diag[open] > .sch-diag-summary { margin-bottom: 10px; color: var(--text-mid); }


### PR DESCRIPTION
## 목적 (사용자 지목)

"예약·자동화 스케줄 보기가 너무 힘들다 / 실제 구현이 시안과 너무 다르다."

## 근본 원인

Schedule surface(`예약 · 자동화 큐`) 콘텐츠 순서가:
1. `Keeper Lanes · wake evidence` — keeper당 카드 + **최대 64 lane rows** (거대 operator 진단)
2. `Keeper Background · recurring tasks` — 또 하나의 진단
3. **실제 스케줄 뷰(캘린더/목록)** ← 맨 아래

14 keeper 기준 wake-evidence 벽이 화면을 도배해, 실제 예약(예: 오늘 `정기 검증 체크 21:00`)이 **한참 스크롤해야** 보였습니다. 예약 surface의 주인공이 예약이 아니라 keeper 내부 진단이 된 **정보 우선순위 역전**.

## 변경 (schedule-surface.ts, 단일 파일)

캘린더/목록 뷰를 탭 바로 아래 **1순위(above the fold)**로, wake-evidence·background 진단 2섹션을 그 **아래**로 이동. 기능 제거 없음(진단은 아래에 그대로).

## 검증 (브라우저)

- `#schedule`에서 탭 바로 아래에 **오늘/내일 agenda가 즉시 렌더**됨(오늘 `정기 검증 체크 21:00 · scheduled`). keeper-lane/background는 아래로.
- schedule 테스트 **26 green**(존재 검사, 순서 무관), tsc/eslint clean.

## 범위 밖 (후속 논의 가능)
진단 섹션을 접이식(collapsed)으로 만들거나, 더 풍부한 캘린더 그리드 뷰는 별도 — 사용자 "아직 먼 거 같다" 취지의 큰 방향은 추가 논의.