### PR TITLE
fix(schedule): keeper_wake는 reminder_only — self-wake 승인 데드락 해소

### DIFF
--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -86,6 +86,15 @@ let classify_kind = function
   | _ -> None
 ;;
 
+(* The intrinsic risk of a payload kind, when the kind itself determines it
+   rather than the caller. [Keeper_wake] is always [Reminder_only] (an internal
+   self-wake, never a human-grant action); [Board_post] is caller-specified
+   (it may write to the board and require approval), so it returns [None]. *)
+let intrinsic_risk_class_of_kind = function
+  | Keeper_wake -> Some Schedule_domain.Reminder_only
+  | Board_post -> None
+;;
+
 let assoc_string key fields =
   match List.assoc_opt key fields with
   | Some (`String value) -> trim_nonempty value
@@ -150,6 +159,16 @@ let payload_view (request : Schedule_domain.schedule_request) =
 let kind_of_json_result payload =
   let* view = payload_view_of_json payload in
   Ok view.raw_kind
+;;
+
+(* Resolve the intrinsic risk_class a payload's kind mandates, if any, so the
+   creation boundary can clamp a caller-supplied risk_class that would otherwise
+   deadlock (e.g. a keeper_wake escalated to a human-grant it cannot satisfy).
+   Returns [None] when the kind is unknown or caller-specified. *)
+let intrinsic_risk_class_of_payload payload =
+  match kind_of_json_result payload with
+  | Ok raw -> Option.bind (classify_kind raw) intrinsic_risk_class_of_kind
+  | Error _ -> None
 ;;
 
 let board_schema_version_error ~creation schema_version =
@@ -223,21 +242,34 @@ let validate_keeper_wake_body body =
        |> Result.map (fun _ -> ()))
 ;;
 
+(* A keeper_wake enqueues an internal keeper wake signal; it has no
+   external/destructive effect, so it must NOT be side-effecting. A
+   side-effecting risk_class would force [Pending_approval] and require a
+   separate human grant that a self-waking keeper cannot supply — the keeper
+   then polls [masc_schedule_get] on a status that never changes until the
+   idle guard kills the turn. Requiring a non-side-effecting risk_class keeps
+   a wake in [Scheduled] so it fires automatically. board_post is the opposite
+   (it writes to the shared board and legitimately requires approval). *)
 let validate_keeper_wake_for_creation ~risk_class view =
   let* () = keeper_wake_schema_version_error ~creation:true view.schema_version in
-  if not (Schedule_domain.is_side_effecting risk_class)
+  if Schedule_domain.is_side_effecting risk_class
   then
     Error
       (keeper_wake_kind
-       ^ " requires a side-effecting risk_class such as workspace_write")
+       ^ " requires a non-side-effecting risk_class such as reminder_only")
   else validate_keeper_wake_body view.body
 ;;
 
-let validate_keeper_wake_for_dispatch (request : Schedule_domain.schedule_request) view =
+(* Dispatch validates only payload well-formedness. risk_class gating is a
+   creation-time concern (it decides Pending_approval vs Scheduled); a schedule
+   that reaches dispatch already cleared that gate. Re-checking risk here is
+   redundant, and re-checking a *direction* would reject legacy keeper_wake rows
+   persisted under the old (side-effecting) rule. Enqueuing a keeper wake is
+   harmless regardless of the stored risk label. *)
+let validate_keeper_wake_for_dispatch
+    (_request : Schedule_domain.schedule_request) view =
   let* () = keeper_wake_schema_version_error ~creation:false view.schema_version in
-  if not (Schedule_domain.is_side_effecting request.Schedule_domain.risk_class)
-  then Error (keeper_wake_kind ^ " requires a side-effecting risk_class")
-  else validate_keeper_wake_body view.body
+  validate_keeper_wake_body view.body
 ;;
 
 let validate_request_payload_for_creation_detailed ~payload ~risk_class =

--- a/lib/schedule_payload_projection.mli
+++ b/lib/schedule_payload_projection.mli
@@ -49,6 +49,15 @@ val support_summary_yojson : support_summary -> Yojson.Safe.t
 val support_summary_to_yojson : Schedule_domain.schedule_request list -> Yojson.Safe.t
 val kind_of_json_result : Yojson.Safe.t -> (string, string) result
 
+(** [intrinsic_risk_class_of_payload payload] is the risk_class the payload's
+    kind mandates, when the kind (not the caller) determines it. [masc.keeper_wake]
+    is always [Reminder_only]; other/unknown kinds return [None] (caller-specified).
+    Used at the creation boundary to clamp a caller-supplied risk_class that would
+    otherwise force a self-wake into a human-grant deadlock. *)
+val intrinsic_risk_class_of_payload
+  :  Yojson.Safe.t
+  -> Schedule_domain.risk_class option
+
 val validate_request_payload_for_creation_detailed
   :  payload:Yojson.Safe.t
   -> risk_class:Schedule_domain.risk_class

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -383,7 +383,17 @@ let request_result ~tool_name ~start_time = function
 let handle_create ~tool_name ~start_time ctx args =
   let result =
     let* payload = payload_from_args args in
-    let* risk_class = risk_class_of_arg args in
+    let* requested_risk_class = risk_class_of_arg args in
+    (* Clamp the caller-supplied risk_class to the payload kind's intrinsic risk
+       when the kind mandates one. A keeper_wake is intrinsically reminder_only;
+       without this a keeper can request a side-effecting risk_class, forcing its
+       own wake into Pending_approval and then deadlocking as it polls a status
+       no self-waking keeper can advance. *)
+    let risk_class =
+      match Schedule_payload_projection.intrinsic_risk_class_of_payload payload with
+      | Some intrinsic -> intrinsic
+      | None -> requested_risk_class
+    in
     let* () = validate_known_payload_request ~payload ~risk_class in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -132,7 +132,14 @@ let create_schema =
     ; string_prop ~description:"Optional board thread id." "board_thread_id"
     ; integer_prop ~description:"Optional board post TTL in hours." "board_ttl_hours"
     ; object_prop ~description:"Optional board post metadata object." "board_meta"
-    ; string_prop ~enum:risk_classes "risk_class"
+    ; string_prop
+        ~description:
+          "Risk class of the scheduled action. masc.keeper_wake is always \
+           reminder_only (an internal self-wake; it auto-schedules and needs no \
+           approval — any higher value is clamped down). masc.board_post writes \
+           to the board and requires workspace_write. Side-effecting classes \
+           start pending_approval and need a separate human grant."
+        ~enum:risk_classes "risk_class"
     ; bool_prop
         ~description:
           "Force a separate human grant even for reminder_only or read_only requests."

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -690,12 +690,18 @@ let test_dispatch_create_keeper_wake_payload () =
        (data |> member "payload_target" |> to_string);
      check string "result payload summary" "Scheduled lane wake"
        (data |> member "payload_summary" |> to_string);
-     check bool "result separate grant" true
+     (* keeper_wake is intrinsically reminder_only: the handler clamps the
+        caller-supplied workspace_write down, so a self-wake never needs a
+        human grant (this is what previously deadlocked — the keeper polled a
+        pending_approval it could not self-approve). *)
+     check bool "result separate grant" false
        (data |> member "requires_separate_human_grant" |> to_bool));
   (match Schedule_store.get_schedule config ~schedule_id:"sched-keeper-wake" with
    | None -> fail "schedule missing"
    | Some request ->
-     check string "status" "pending_approval"
+     check string "clamped risk_class" "reminder_only"
+       (Schedule_domain.risk_class_to_string request.risk_class);
+     check string "status" "scheduled"
        (Schedule_domain.schedule_status_to_string request.status);
      let payload = Schedule_domain.payload_to_yojson request.payload in
      let open Yojson.Safe.Util in
@@ -723,6 +729,32 @@ let test_dispatch_create_keeper_wake_payload () =
     (row |> member "payload_target" |> to_string);
   check string "dashboard payload summary" "Scheduled lane wake"
     (row |> member "payload_summary" |> to_string)
+;;
+
+let test_keeper_wake_creation_requires_reminder_only () =
+  (* Projection invariant guarding the tool-handler clamp: a keeper_wake with a
+     side-effecting risk_class is rejected at creation; reminder_only is
+     accepted. This keeps a self-wake out of the human-grant deadlock even for a
+     direct caller that bypasses the handler clamp. *)
+  let payload =
+    `Assoc
+      [ "kind", `String "masc.keeper_wake"
+      ; "schema_version", `Int 1
+      ; ( "body"
+        , `Assoc
+            [ "keeper_name", `String "schedule-keeper"
+            ; "message", `String "wake"
+            ] )
+      ]
+  in
+  check bool "side-effecting keeper_wake rejected" true
+    (Result.is_error
+       (Schedule_payload_projection.validate_request_payload_for_creation
+          ~payload ~risk_class:Schedule_domain.Workspace_write));
+  check bool "reminder_only keeper_wake accepted" true
+    (Result.is_ok
+       (Schedule_payload_projection.validate_request_payload_for_creation
+          ~payload ~risk_class:Schedule_domain.Reminder_only))
 ;;
 
 let test_dispatch_create_rejects_keeper_wake_invalid_urgency () =
@@ -1700,6 +1732,8 @@ let () =
             test_dispatch_create_board_post_convenience_payload
         ; test_case "dispatch create accepts keeper wake payload" `Quick
             test_dispatch_create_keeper_wake_payload
+        ; test_case "keeper wake creation requires reminder_only" `Quick
+            test_keeper_wake_creation_requires_reminder_only
         ; test_case "dispatch create rejects invalid keeper wake urgency" `Quick
             test_dispatch_create_rejects_keeper_wake_invalid_urgency
         ; test_case "dispatch create rejects invalid keeper wake target name" `Quick


### PR DESCRIPTION
## 문제 (live 재현: garnet, albini)
키퍼가 `masc_schedule_create`로 자기 wake 타이머를 만들면 `Pending_approval`이 되고, **키퍼 스스로 승인 못 함**(Human_operator grant 필요) → `masc_schedule_get` 폴링 → 상태 안 바뀜 → idle 가드가 턴 종료 → "Completed without a textual reply" placeholder.

## 근본 원인
`masc.keeper_wake`는 내부 wake 신호를 enqueue할 뿐 external/destructive 효과가 없는데, payload projection이 **side-effecting risk_class를 요구**했어요 (board_post 복붙, 방향 안 뒤집힘). `risk_class`는 키퍼가 넘기는 인자라, self-wake가 승인 게이트에 걸림.

## 수정 (데드락을 표현 불가능하게)
- `schedule_payload_projection`: keeper_wake **생성은 non-side-effecting(reminder_only) 요구**. dispatch는 payload 형식만 검증(risk는 creation-time 게이트; 레거시 side-effecting 행도 무해하게 dispatch).
- `intrinsic_risk_class_of_payload` 추가 (SSOT: keeper_wake→Reminder_only).
- `tool_schedule.handle_create`가 payload 고유 risk로 **clamp** → 키퍼가 자기 wake를 승인지옥으로 못 올림. reminder_only→Scheduled→자동 발동.
- 스키마 설명에 keeper_wake=reminder_only 명시.

## 검증 (빌드 아닌 **실행**으로)
- keeper_wake+workspace_write → reminder_only로 clamp, Scheduled 저장, separate_grant=false.
- projection 불변식: side-effecting reject, reminder_only accept.
- 기존 consumer-dispatch 스위트 10/10 green (회귀 없음).
- dune 빌드는 CI에서 확인.

## 반경 / 남은 것
사용자 요청 3개 중 **A(구조적 근본)**. B(키퍼가 pending 만들면 폴링 말고 텍스트로 승인요청)·C(idle 종료 placeholder가 thinking·부분결과 버림)는 후속.

Related: RFC-0199(evidence-driven auto-approval). "과잉 게이팅 금지" 정렬 — 자기 wake는 operator 승인 불필요.

이 PR의 "clamp"는 runaway counter의 cap이 아니라 **payload kind→intrinsic risk 파생**(Parse, don't validate)이라 워크어라운드가 아님.
