### PR TITLE
fix(keeper): idle-termination UX — 텍스트 리플라이 유도(B) + reasoning surface(C)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -45,7 +45,17 @@ let normalize_response_text_for_finalization
       ~tool_names
       ()
   =
-  match Keeper_tool_response.normalize_response_text ~text ~tool_names () with
+  (* Surface the model's reasoning when the turn produced no final answer text,
+     so an empty-answer turn shows why (e.g. a keeper waiting on approval)
+     instead of a bare tool list. *)
+  let reasoning =
+    run_result.response.Agent_sdk.Types.content
+    |> List.filter_map (function
+         | Agent_sdk.Types.Thinking { content; _ } -> Some content
+         | _ -> None)
+    |> String.concat "\n"
+  in
+  match Keeper_tool_response.normalize_response_text ~text ~tool_names ~reasoning () with
   | Ok response_text -> Ok response_text
   | Error _ ->
     (* Finalization intentionally exposes the higher-level accept-rejected

--- a/lib/keeper/keeper_hooks_oas_idle.ml
+++ b/lib/keeper/keeper_hooks_oas_idle.ml
@@ -160,8 +160,12 @@ let on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     Agent_sdk.Hooks.Nudge
       (append_hint
          (Printf.sprintf
-            "FINAL WARNING: you repeated %s %d times. Next idle = turn ends. \
-             Use one of these instead: %s."
+            "FINAL WARNING: you repeated %s %d times; the next idle ends the \
+             turn. If you are waiting on an external decision (approval, \
+             another agent, a scheduled event), stop calling tools and reply \
+             with a short text status describing what you are waiting for — \
+             that ends the turn cleanly and is visible to the operator. \
+             Otherwise use a different tool: %s."
             tools_str consecutive_idle_turns alt_str))
   else
     Agent_sdk.Hooks.Nudge

--- a/lib/keeper_tooling/keeper_tool_response.ml
+++ b/lib/keeper_tooling/keeper_tool_response.ml
@@ -1,20 +1,44 @@
 (** Keeper_tool_response - provider response acceptance and keeper reply text
     normalization. *)
 
-let normalize_response_text ~(text : string) ~(tool_names : string list) ()
+(* When a turn ends with no final answer text, surface a bounded tail of the
+   model's reasoning so an operator sees WHY (e.g. "waiting on approval")
+   instead of only a tool list. The tail is used because a reasoning block's
+   conclusion sits at its end. This is the keeper's user-facing fallback reply
+   only; the accept-rejection diagnostic still never carries thinking. *)
+let empty_reply_reasoning_tail_chars = 1200
+
+let reasoning_tail ~max_chars reasoning =
+  let len = String.length reasoning in
+  if len <= max_chars then reasoning else "…" ^ String.sub reasoning (len - max_chars) max_chars
+;;
+
+let normalize_response_text
+      ~(text : string)
+      ~(tool_names : string list)
+      ?(reasoning = "")
+      ()
   : (string, string) result
   =
   let trimmed = String.trim text in
   if trimmed <> ""
   then Ok text
   else (
-    match tool_names with
-    | [] -> Error "keeper turn completed with no textual reply"
-    | _ ->
+    let tools_note =
+      match tool_names with
+      | [] -> ""
+      | names -> Printf.sprintf " Tools used: %s." (String.concat ", " names)
+    in
+    match String.trim reasoning, tool_names with
+    | "", [] -> Error "keeper turn completed with no textual reply"
+    | "", _ ->
+      Ok (Printf.sprintf "Completed without a textual reply.%s" tools_note)
+    | reasoning_trimmed, _ ->
       Ok
         (Printf.sprintf
-           "Completed without a textual reply. Tools used: %s."
-           (String.concat ", " tool_names)))
+           "No final reply text was produced. Reasoning: %s%s"
+           (reasoning_tail ~max_chars:empty_reply_reasoning_tail_chars reasoning_trimmed)
+           tools_note))
 ;;
 
 type accept_rejection_kind =

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -1,12 +1,18 @@
 (** Keeper_tool_response - provider response acceptance and keeper reply text
     normalization. *)
 
-(** Keep [text] when non-blank; otherwise synthesize a
-    "Completed without a textual reply. Tools used: ..." line if [tool_names]
-    is non-empty, else error. *)
+(** Keep [text] when non-blank. Otherwise, for an empty-answer turn:
+    - with [reasoning] (the model's thinking): surface a bounded tail of it so
+      an operator sees why no final reply was produced (e.g. "waiting on
+      approval");
+    - else with [tool_names]: synthesize a "Completed without a textual reply.
+      Tools used: ..." line;
+    - else error.
+    [reasoning] defaults to empty (preserves the prior tool-list fallback). *)
 val normalize_response_text
   :  text:string
   -> tool_names:string list
+  -> ?reasoning:string
   -> unit
   -> (string, string) result
 

--- a/test/test_keeper_unified_inline_skip.ml
+++ b/test/test_keeper_unified_inline_skip.ml
@@ -71,6 +71,39 @@ let test_normalize_override_passthrough () =
   | Error e -> fail ("unexpected error: " ^ e)
 ;;
 
+let contains_substring haystack needle =
+  let hl = String.length haystack and nl = String.length needle in
+  let rec loop i = i + nl <= hl && (String.sub haystack i nl = needle || loop (i + 1)) in
+  nl = 0 || loop 0
+;;
+
+let test_normalize_surfaces_reasoning_on_empty () =
+  (* Empty answer + reasoning: surface the model's reasoning, not just a tool
+     list, so an operator sees why no final reply was produced. *)
+  (match
+     KTR.normalize_response_text
+       ~text:""
+       ~tool_names:[ "masc_schedule_get" ]
+       ~reasoning:"The schedule is pending_approval; the user must approve it."
+       ()
+   with
+   | Ok text ->
+     check bool "surfaces reasoning" true
+       (contains_substring text "the user must approve it");
+     check bool "keeps tool note" true (contains_substring text "masc_schedule_get")
+   | Error e -> fail ("unexpected error: " ^ e));
+  (* Empty answer, no reasoning, tools: prior tool-list fallback is retained. *)
+  (match KTR.normalize_response_text ~text:"" ~tool_names:[ "tool_execute" ] () with
+   | Ok text ->
+     check bool "fallback placeholder retained" true
+       (contains_substring text "Completed without a textual reply")
+   | Error e -> fail ("unexpected error: " ^ e));
+  (* Empty answer, no reasoning, no tools: still an error. *)
+  match KTR.normalize_response_text ~text:"" ~tool_names:[] () with
+  | Ok _ -> fail "expected error for empty turn with no tools or reasoning"
+  | Error _ -> ()
+;;
+
 let () =
   run
     "keeper unified inline skip"
@@ -95,6 +128,10 @@ let () =
             "normalize override passthrough"
             `Quick
             test_normalize_override_passthrough
+        ; test_case
+            "normalize surfaces reasoning on empty answer"
+            `Quick
+            test_normalize_surfaces_reasoning_on_empty
         ] )
     ]
 ;;

--- a/test/test_keeper_unified_metacognition.ml
+++ b/test/test_keeper_unified_metacognition.ml
@@ -339,11 +339,40 @@ let test_recent_tool_streak_count_ignores_stale_entries () =
     (HK.recent_tool_streak_count ~within_sec:60.0 ~tool_name:"masc_status" entries)
 ;;
 
+let test_on_idle_final_warning_guides_text_reply_when_waiting () =
+  (* At the final-warning threshold (skip_at - 1) a keeper polling a status it
+     cannot self-advance (e.g. a pending approval) should be steered to reply
+     with text and end the turn, not to try another tool. *)
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:4
+      ~consecutive_idle_turns:3
+      ~allowed_tools:[ "masc_schedule_get"; "keeper_broadcast" ]
+      ~tool_names:[ "masc_schedule_get" ]
+  in
+  match decision with
+  | Agent_sdk.Hooks.Nudge msg ->
+    check bool "final warning announces turn end" true
+      (contains_substring msg "the next idle ends the turn");
+    check bool "final warning steers to a text status reply when waiting" true
+      (contains_substring msg "reply with a short text status")
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected Nudge, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
+
 let () =
   run
     "keeper unified metacognition"
     [ ( "metacognition"
       , [ test_case "on_idle nudge at first idle" `Quick test_on_idle_nudge_at_first_idle
+        ; test_case
+            "on_idle final warning guides text reply when waiting"
+            `Quick
+            test_on_idle_final_warning_guides_text_reply_when_waiting
         ; test_case
             "on_idle board_get nudge names post_id discovery"
             `Quick


### PR DESCRIPTION
## 배경
#23716(A, self-wake 데드락)의 후속. 키퍼가 진행 못 하는 동작을 반복하면(승인 대기 폴링·재읽기) idle 가드가 턴을 종료하고, reply는 **tool 이름 목록**만 남았어요 — 오퍼레이터는 쓸모없는 목록을 보고, 키퍼의 reasoning("승인 필요")은 사라졌어요.

## B — idle FINAL WARNING이 텍스트 리플라이로 유도
`keeper_hooks_oas_idle`: `skip_at-1`에서 FINAL WARNING이 **"외부 결정(승인/다른 에이전트/스케줄) 대기 중이면 툴 그만 부르고 짧은 텍스트 상태로 답하라(그게 턴을 깔끔히 끝내고 오퍼레이터에게 보임)"**를 우선 유도. 기존엔 "다른 툴 써"만.

## C — 빈 답변 턴이 모델 reasoning을 surface
`normalize_response_text`에 optional `~reasoning` 추가. 최종 텍스트가 없으면 reasoning 꼬리(≤1200자)를 `"No final reply text was produced. Reasoning: …"`로 노출. `keeper_agent_run`이 `run_result.response`의 Thinking 블록을 추출해 전달. **accept-rejection 진단은 여전히 thinking 미포함**(설계 스탠스 존중) — 이건 키퍼 user-facing fallback reply 한정. reasoning 없으면 기존 tool-list, 둘 다 없으면 error — 하위호환 유지.

## 검증 (실행)
- `dune exec` metacognition **12/12**(신규 final-warning 테스트), inline_skip **6/6**(신규 reasoning 테스트).
- 변경 모듈 로컬 컴파일 EXIT=0, ocamlformat clean.
- placeholder 문자열 소비자 없음(grep 확인) → 출력 변경 안전.

## 반경
A(#23716 merged)로 self-wake 데드락 자체는 해소됨. B·C는 **모든 HITL 대기/반복 루프**의 일반 케이스 UX. 사용자 요청 3개(A/B/C) 완결.
