### PR TITLE
fix(keeper-sandbox): cleanup removes volumes (-v) + Cleanup_rm timeout 5s to 10s

### DIFF
--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -172,7 +172,7 @@ module Shell_timeout = struct
     | Git_meta -> Some 5.0
     | Gh_min -> Some (timeout_floor_default_sec Tool_dispatch_floor)
     | User_max -> Some 180.0
-    | Cleanup_rm -> Some 5.0
+    | Cleanup_rm -> Some 10.0
     | Unknown _ -> None
 
   let upper_case s =

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -235,10 +235,15 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
 ;;
 
 let remove_cleanup_container ~container_id ~timeout_sec =
-  let argv = docker_command_argv () @ [ "rm"; "-f"; container_id ] in
+  (* -v also removes the container's anonymous volumes. Without it the
+     per-turn sandbox volumes accumulate in the docker daemon's metadata
+     index (9563 volumes observed in production), starving even simple
+     commands like `docker ps` until they time out. Keeper sandbox volumes
+     are per-turn/ephemeral, so -v is safe here. *)
+  let argv = docker_command_argv () @ [ "rm"; "-f"; "-v"; container_id ] in
   let st, out =
     run_docker_argv_with_status
-      ~summary:"keeper sandbox docker rm cleanup"
+      ~summary:"keeper sandbox docker rm -v cleanup"
       ~timeout_sec
       argv
   in
@@ -247,7 +252,7 @@ let remove_cleanup_container ~container_id ~timeout_sec =
   else
     Error
       (Printf.sprintf
-         "docker rm -f failed for cleanup container %s: %s"
+         "docker rm -fv failed for cleanup container %s: %s"
          container_id
          (Exec_policy.truncate_for_log out))
 ;;


### PR DESCRIPTION
## 근본
`docker ps` 간헐 5s 타임아웃의 원인 = sandbox cleanup이 `docker rm -f`로 컨테이너만 지우고 volume을 안 지워, **9563개 volume이 daemon 메타데이터로 누적**. 용량은 작아도 daemon이 순회할 객체 수가 늘어 단순 `docker ps`도 타임아웃.

## 변경 (커밋 `3b9e866683`, 2파일)
- `keeper_sandbox_runtime.ml:remove_cleanup_container`: `docker rm -f` → `docker rm -f -v` (container + anonymous volume 제거). keeper sandbox volume은 per-turn/ephemeral이라 `-v` 안전.
- `env_config_sandbox.ml`: `Cleanup_rm` timeout 5.0 → 10.0 (daemon 일시 지연 흡수).

## 인프라 조치 (즉시)
`docker system prune -f` + `docker volume prune -f`로 **Local Volumes 9563 → 6** 회복. 본 PR은 재누적 방지(근본).

## 메모
- 본 PR 파일(keeper_sandbox_runtime, env_config_sandbox)은 clean이나, main이 `anti_rationalization.ml:744`(23666 evidence gate, task_warn unit→review_result)로 red라 CI 전체 검증이 막힘. 해당 main red는 별개.