### PR TITLE
fix(antirat): gate-0 disabled falls through to gate-1 (main red)

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -739,10 +739,10 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666 regression) *)
+  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666
+     regression). Log and fall through to Gate 1 rather than returning unit. *)
   if List.is_empty req.evidence_refs then
-    task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)"
-  else
+    task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)";
   (* Gate 1: empty or trivially short notes *)
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length


### PR DESCRIPTION
## 근본
main red (`anti_rationalization.ml:744`). #23666 evidence gate가 Gate 0을 "disabled until call site wired"로 뒀으나, `task_warn`(unit 반환)을 `if ... else Gate-1` 의 결과 자리에 둬 **unit vs review_result 타입 불일치**. #23719가 gate-0 rejection을 다른 각도에서 fix했으나 이 744 red는 잔존.

## fix (커밋 `f07ebe748a`, 1파일)
- Gate 0 disabled 분기를 `if ... then task_warn ...;` 로 만들어 unit side-effect로 처리하고, Gate 1로 폴스루. 빈 evidence_refs여도 Gate 1+ 진행 (기존 disabled 의도 유지).
- `dune build --root .` green.

## 메모
#23719와 병렬. Gate 0 call site wiring은 #23666 후속.