### PR TITLE
fix(task): anti_rationalization Gate 0 컴파일 복구 — main red 해소

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -739,10 +739,15 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666 regression) *)
-  if List.is_empty req.evidence_refs then
-    task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)"
-  else
+  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666 regression).
+     WORKAROUND: the enforcing Reject stays disabled; log a warning and fall through
+     to the remaining gates. 근본 해결: wire evidence_refs at the submission call site
+     (PR #23706 task-1882), then restore the terminal Reject.
+     Sequenced (not [else]) so an empty evidence set still runs Gates 1-3 instead of
+     short-circuiting to unit — the [else] form was also a type error
+     (unit vs review_result), which is what broke the build in #23708. *)
+  if List.is_empty req.evidence_refs
+  then task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)";
   (* Gate 1: empty or trivially short notes *)
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length


### PR DESCRIPTION
## 증상
main이 `ac59a15847`(#23708) 이후 **연속 red** — OCaml Build Canary가 컴파일 단계에서 실패. #23638·#23719가 이를 상속했습니다.

```
File "lib/task/anti_rationalization.ml", line 744:
Error: This expression has type unit but an expression was expected of type review_result
```

## 근본 원인
#23708이 Gate 0(empty evidence_refs → Reject)를 비활성화하면서 다음처럼 작성했습니다.

```ocaml
if List.is_empty req.evidence_refs then
  task_warn "..."          (* : unit *)
else
  <나머지 Gate 1-3>        (* : review_result *)
```

`then` 브랜치(`task_warn`=`unit`)와 `else` 브랜치(`review_result`)의 타입이 달라 컴파일이 안 됩니다. 의미상으로도 evidence가 비면 나머지 게이트를 통째로 건너뛰게 되어 이중으로 틀렸습니다.

## 수정
`else`를 sequence(`;`)로 바꿔, evidence_refs가 비어도 경고만 남기고 Gate 1-3를 계속 실행하도록 복원했습니다. Gate 0 enforcement(terminal Reject) 자체는 #23708의 결정대로 여전히 비활성 상태이며, 이 PR은 **컴파일 실패만** 고칩니다.

## 검증
기존 `test_anti_rationalization_empty_reject` (8/8 통과) — `evidence_refs = []` 요청을 넣고 흐름이 Gate 0에서 멈추지 않고 evaluator 게이트까지 도달함을 단언합니다. 이 테스트는 #23708 때문에 **빌드조차 안 돼** 실행 불가였습니다.

- `dune build lib/task/` EXIT=0
- `test_anti_rationalization_empty_reject` 8/8 pass

## 관련
- broke: #23708 (ac59a15847)
- 근본 해결(비활성 게이트 자체): #23706 (task-1882, evidence_refs call-site 배선) — 현재 CONFLICTING

WORKAROUND-WAIVED: 이 PR은 새 워크어라운드를 도입하지 않습니다. #23708이 만든 컴파일 실패를 고쳐 기존 동작(게이트 비활성)을 컴파일 가능하게 복원할 뿐이며, 게이트의 근본 해결은 #23706에 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
