### PR TITLE
feat(dashboard/schedule): 캘린더 뷰에 큐-드레인 상태 노출 + KPI

### DIFF
--- a/dashboard/src/components/schedule/queue-drain-status.test.ts
+++ b/dashboard/src/components/schedule/queue-drain-status.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  DashboardScheduledAutomationKeeperQueueEvidence,
+  DashboardScheduledAutomationKeeperReactionEvidence,
+  DashboardScheduledAutomationRequest,
+} from '../../api'
+import {
+  countQueueDrainMisses,
+  isCalendarVisible,
+  queueDrainStatusOf,
+} from './queue-drain-status'
+
+type QueueStatus = DashboardScheduledAutomationKeeperQueueEvidence['projection_status']
+type ReactionStatus = DashboardScheduledAutomationKeeperReactionEvidence['projection_status']
+
+function req(
+  queue: QueueStatus | null,
+  reaction?: ReactionStatus,
+): DashboardScheduledAutomationRequest {
+  return {
+    schedule_id: 'sched-1',
+    status: 'scheduled',
+    risk_class: 'read_only',
+    approval_required: false,
+    source: 'automated_request',
+    recurrence: { kind: 'one_shot' },
+    keeper_queue_evidence: queue === null ? null : { projection_status: queue },
+    keeper_reaction_evidence: reaction === undefined ? null : { projection_status: reaction },
+  }
+}
+
+describe('queueDrainStatusOf', () => {
+  it('returns null when the request carries no keeper-wake queue evidence', () => {
+    expect(queueDrainStatusOf(req(null))).toBeNull()
+  })
+
+  it('maps a pending queue match to 큐 대기 (info)', () => {
+    const status = queueDrainStatusOf(req('matched_pending'))
+    expect(status?.state).toBe('pending')
+    expect(status?.label).toBe('큐 대기')
+    expect(status?.tone).toBe('info')
+  })
+
+  it('maps an inflight queue match to 드레인 중 (info)', () => {
+    const status = queueDrainStatusOf(req('matched_inflight'))
+    expect(status?.state).toBe('inflight')
+    expect(status?.label).toBe('드레인 중')
+  })
+
+  it('treats not_found + a recorded keeper reaction as a healthy 완료 (drained), never a miss', () => {
+    for (const reaction of ['matched_consumed_ack', 'matched_turn_started', 'matched_stimulus'] as const) {
+      const status = queueDrainStatusOf(req('not_found', reaction))
+      expect(status?.state, `reaction=${reaction}`).toBe('drained')
+      expect(status?.label).toBe('완료')
+    }
+  })
+
+  it('flags a genuine miss only when the wake is in no queue AND the keeper never reacted', () => {
+    const status = queueDrainStatusOf(req('not_found', 'not_found'))
+    expect(status?.state).toBe('missed')
+    expect(status?.label).toBe('누락 ⚠')
+    expect(status?.tone).toBe('warn')
+  })
+
+  it('does not conclude a miss when the reaction cannot be correlated (missing_stimulus_id / absent)', () => {
+    expect(queueDrainStatusOf(req('not_found', 'missing_stimulus_id'))?.state).toBe('indeterminate')
+    expect(queueDrainStatusOf(req('not_found'))?.state).toBe('indeterminate')
+  })
+
+  it('surfaces a queue read error as 읽기 오류 (warn), not a miss', () => {
+    const status = queueDrainStatusOf(req('read_error'))
+    expect(status?.state).toBe('read_error')
+    expect(status?.tone).toBe('warn')
+  })
+
+  it('surfaces an unrecognized receipt as 확인 불가 (indeterminate)', () => {
+    expect(queueDrainStatusOf(req('unrecognized_receipt'))?.state).toBe('indeterminate')
+  })
+})
+
+describe('isCalendarVisible', () => {
+  it('renders the actionable/in-flight states and hides healthy-completion + legacy noise', () => {
+    const visible = (queue: QueueStatus, reaction?: ReactionStatus): boolean => {
+      const status = queueDrainStatusOf(req(queue, reaction))
+      return status !== null && isCalendarVisible(status)
+    }
+    expect(visible('matched_pending')).toBe(true)
+    expect(visible('matched_inflight')).toBe(true)
+    expect(visible('not_found', 'not_found')).toBe(true) // missed
+    expect(visible('read_error')).toBe(true)
+    expect(visible('not_found', 'matched_consumed_ack')).toBe(false) // drained
+    expect(visible('unrecognized_receipt')).toBe(false) // indeterminate
+  })
+})
+
+describe('countQueueDrainMisses', () => {
+  it('counts only genuine misses (queue=not_found AND reaction=not_found)', () => {
+    const requests: DashboardScheduledAutomationRequest[] = [
+      req('matched_pending'),
+      req('not_found', 'not_found'), // miss
+      req('not_found', 'matched_turn_started'), // drained — not a miss
+      req('not_found', 'not_found'), // miss
+      req('read_error'), // read error — not counted as a miss
+      req(null), // no evidence
+    ]
+    expect(countQueueDrainMisses(requests)).toBe(2)
+  })
+
+  it('returns 0 for an empty list', () => {
+    expect(countQueueDrainMisses([])).toBe(0)
+  })
+})

--- a/dashboard/src/components/schedule/queue-drain-status.ts
+++ b/dashboard/src/components/schedule/queue-drain-status.ts
@@ -1,0 +1,144 @@
+// Queue-drain status for a scheduled keeper wake.
+//
+// The schedule surface's calendar (default) view and KPI strip need to answer
+// one operator question the list view already answers per row: did a scheduled
+// keeper wake actually flow through the keeper_event_queue drain?
+//
+// Two backend evidence axes must be combined — neither is sufficient alone
+// (see the derivation in server_dashboard_http_runtime_info.ml):
+//
+//   · keeper_queue_evidence  — is the last execution's wake in the durable
+//     event-queue snapshot right now? matched_pending / matched_inflight mean
+//     "yes, awaiting / mid drain". not_found means "in neither queue" — but that
+//     is ALSO the normal post-completion state (a drained wake leaves the
+//     queue), so not_found alone cannot mean "lost".
+//   · keeper_reaction_evidence — did the keeper actually react to the stimulus
+//     (consumed_ack / turn_started / stimulus recorded)? This disambiguates a
+//     drained-and-handled wake from a genuinely lost one.
+//
+// A genuine miss is ONLY queue=not_found AND reaction=not_found: dispatched, not
+// in the queue, and never recorded as reacted. Every other not_found is a
+// healthy completion. Labeling not_found alone as "missed" would false-alarm on
+// every successful wake.
+
+import type { DashboardScheduledAutomationRequest } from '../../api'
+import type { StatusChipTone } from '../common/status-chip'
+
+export type QueueDrainState =
+  | 'pending' // in the pending queue — awaiting drain
+  | 'inflight' // in the inflight queue — draining now
+  | 'drained' // left the queue AND the keeper reacted — healthy completion
+  | 'missed' // left the queue with no keeper reaction — dispatched then lost
+  | 'read_error' // queue snapshot unreadable — drain state indeterminate (I/O)
+  | 'indeterminate' // receipt / stimulus cannot be correlated (legacy record)
+
+export interface QueueDrainStatus {
+  readonly state: QueueDrainState
+  readonly label: string
+  readonly tone: StatusChipTone
+  /** Tooltip explaining the two-axis derivation behind this state. */
+  readonly title: string
+}
+
+// keeper_reaction_evidence statuses that prove the keeper handled the stimulus.
+const REACTED: ReadonlySet<string> = new Set([
+  'matched_consumed_ack',
+  'matched_turn_started',
+  'matched_stimulus',
+])
+
+const PRESENTATION: Readonly<Record<QueueDrainState, Omit<QueueDrainStatus, 'state'>>> = {
+  pending: {
+    label: '큐 대기',
+    tone: 'info',
+    title: 'wake가 keeper_event_queue pending에 있음 — 드레인 대기 중',
+  },
+  inflight: {
+    label: '드레인 중',
+    tone: 'info',
+    title: 'wake가 inflight — keeper가 지금 드레인 중',
+  },
+  drained: {
+    label: '완료',
+    tone: 'neutral',
+    title: '큐에서 빠졌고 keeper 반응이 기록됨 (consumed_ack / turn_started / stimulus)',
+  },
+  missed: {
+    label: '누락 ⚠',
+    tone: 'warn',
+    title: 'dispatch됐으나 큐에 없고 keeper 반응 기록도 없음 — 실행 누락',
+  },
+  read_error: {
+    label: '읽기 오류',
+    tone: 'warn',
+    title: '큐 스냅샷 읽기 실패 — 드레인 상태 확인 불가',
+  },
+  indeterminate: {
+    label: '확인 불가',
+    tone: 'neutral',
+    title: '영수증 / stimulus_id 부재로 큐-반응 상관 불가 (레거시 기록)',
+  },
+}
+
+function stateOf(request: DashboardScheduledAutomationRequest): QueueDrainState | null {
+  const queue = request.keeper_queue_evidence
+  // No keeper-wake dispatch/execution yet (or a board post) — nothing to show.
+  if (queue == null) return null
+  switch (queue.projection_status) {
+    case 'matched_pending':
+      return 'pending'
+    case 'matched_inflight':
+      return 'inflight'
+    case 'read_error':
+      return 'read_error'
+    case 'unrecognized_receipt':
+      return 'indeterminate'
+    case 'not_found': {
+      const reaction = request.keeper_reaction_evidence?.projection_status
+      if (reaction != null && REACTED.has(reaction)) return 'drained'
+      if (reaction === 'not_found') return 'missed'
+      // missing_stimulus_id / unrecognized / absent — cannot conclude "lost".
+      return 'indeterminate'
+    }
+    default:
+      // Unknown future queue status: surface as indeterminate rather than
+      // collapsing it into a permissive OK or an alarmist miss.
+      return 'indeterminate'
+  }
+}
+
+/** Combined queue-drain status for a request's last execution, or null when the
+ * request has no keeper-wake queue evidence (board posts, or nothing dispatched
+ * yet). */
+export function queueDrainStatusOf(
+  request: DashboardScheduledAutomationRequest,
+): QueueDrainStatus | null {
+  const state = stateOf(request)
+  return state === null ? null : { state, ...PRESENTATION[state] }
+}
+
+// States surfaced as a chip on the calendar rows. 'drained' and 'indeterminate'
+// are intentionally omitted: a healthy completion and a legacy-correlation gap
+// are not actionable, and a chip on every recurring row would be noise.
+const CALENDAR_VISIBLE: ReadonlySet<QueueDrainState> = new Set<QueueDrainState>([
+  'pending',
+  'inflight',
+  'missed',
+  'read_error',
+])
+
+export function isCalendarVisible(status: QueueDrainStatus): boolean {
+  return CALENDAR_VISIBLE.has(status.state)
+}
+
+/** Count of requests whose last keeper-wake execution is a genuine miss
+ * (queue=not_found AND reaction=not_found). Feeds the KPI strip. */
+export function countQueueDrainMisses(
+  requests: readonly DashboardScheduledAutomationRequest[],
+): number {
+  let misses = 0
+  for (const request of requests) {
+    if (stateOf(request) === 'missed') misses += 1
+  }
+  return misses
+}

--- a/dashboard/src/components/schedule/schedule-agenda.test.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.test.ts
@@ -238,4 +238,43 @@ describe('schedule calendar components', () => {
     render(html`<${Agenda} requests=${[]} nowMs=${NOW_MS} onOpen=${() => {}} />`, container)
     expect(container.querySelector('[data-testid="sch-agenda-empty"]')).not.toBeNull()
   })
+
+  it('surfaces a queue-drain miss on the agenda row (queue not_found + reaction not_found)', () => {
+    render(
+      html`<${Agenda}
+        requests=${[
+          req({
+            schedule_id: 'miss-1',
+            due_at_iso: '2026-07-07T18:00:00Z',
+            keeper_queue_evidence: { projection_status: 'not_found' },
+            keeper_reaction_evidence: { projection_status: 'not_found' },
+          }),
+        ]}
+        nowMs=${NOW_MS}
+        onOpen=${() => {}}
+      />`,
+      container,
+    )
+    const chip = container.querySelector('[data-schedule-id="miss-1"] [data-testid="sch-drain-chip"]')
+    expect(chip?.textContent).toContain('누락')
+  })
+
+  it('does not chip a healthy completion (queue not_found + keeper reaction recorded)', () => {
+    render(
+      html`<${Agenda}
+        requests=${[
+          req({
+            schedule_id: 'done-1',
+            due_at_iso: '2026-07-07T18:00:00Z',
+            keeper_queue_evidence: { projection_status: 'not_found' },
+            keeper_reaction_evidence: { projection_status: 'matched_consumed_ack' },
+          }),
+        ]}
+        nowMs=${NOW_MS}
+        onOpen=${() => {}}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-schedule-id="done-1"] [data-testid="sch-drain-chip"]')).toBeNull()
+  })
 })

--- a/dashboard/src/components/schedule/schedule-agenda.ts
+++ b/dashboard/src/components/schedule/schedule-agenda.ts
@@ -19,6 +19,7 @@ import {
   automationTone,
   recurrenceLabel,
 } from '../tools/scheduled-automation-panel'
+import { isCalendarVisible, queueDrainStatusOf } from './queue-drain-status'
 import {
   SCHED_CADENCE,
   SCHED_CADENCE_ORDER,
@@ -281,6 +282,9 @@ function PollingCard({
   onOpen: (scheduleId: string) => void
 }) {
   const tone = automationTone(request.effective_status ?? request.status)
+  // Interval loops drain through the same queue; surface the last execution's
+  // drain status so a silently-failing poll is visible without opening the row.
+  const drain = queueDrainStatusOf(request)
   return html`
     <button
       class=${`sch-poll-card st-${tone}`}
@@ -296,6 +300,14 @@ function PollingCard({
       <div class="sch-poll-foot">
         <span class="mono sch-poll-by">${scheduledBy(request)}</span>
         <${RiskTag} risk=${request.risk_class} />
+        ${drain && isCalendarVisible(drain)
+          ? html`<${StatusChip}
+              tone=${drain.tone}
+              uppercase=${false}
+              title=${drain.title}
+              testId="sch-drain-chip"
+            >${drain.label}<//>`
+          : null}
         <span class="sch-poll-next mono" title="다음 tick (next_due_at)">
           ${nextTickMs === null ? '다음 tick 미상' : `다음 ~${formatClock(nextTickMs)}`}
         </span>
@@ -348,6 +360,9 @@ function AgendaEventRow({
   const request = event.request
   const tone = automationTone(request.effective_status ?? request.status)
   const pending = isPending(request)
+  // Queue-drain status of the last keeper-wake execution (calendar parity with
+  // the list view). Only the actionable states render — see isCalendarVisible.
+  const drain = queueDrainStatusOf(request)
   return html`
     <button
       class=${`sch-ev st-${tone} ${pending ? 'pending' : ''}`}
@@ -365,6 +380,14 @@ function AgendaEventRow({
           <span class="mono sch-ev-by">${scheduledBy(request)}</span>
           <${RiskTag} risk=${request.risk_class} />
           ${pending ? html`<span class="sch-ev-need mono">⊙ 승인 필요</span>` : null}
+          ${drain && isCalendarVisible(drain)
+            ? html`<${StatusChip}
+                tone=${drain.tone}
+                uppercase=${false}
+                title=${drain.title}
+                testId="sch-drain-chip"
+              >${drain.label}<//>`
+            : null}
         </span>
       </span>
       <${StatusChip} tone=${tone} uppercase=${false}>${request.effective_status ?? request.status}<//>

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -315,6 +315,40 @@ describe('ScheduleSurface', () => {
     expect(pendingKpi?.textContent).toContain('2')
   })
 
+  it('counts genuine queue-drain misses in the KPI (not_found queue AND not_found reaction)', async () => {
+    const automation = sampleAutomation()
+    automation.requests = [
+      // Healthy completion: not in queue but the keeper reacted → not a miss.
+      {
+        ...automation.requests[0]!,
+        schedule_id: 'sched-drained',
+        keeper_queue_evidence: { projection_status: 'not_found' },
+        keeper_reaction_evidence: { projection_status: 'matched_turn_started' },
+      },
+      // Genuine miss: dispatched, in no queue, no keeper reaction recorded.
+      {
+        ...automation.requests[0]!,
+        schedule_id: 'sched-miss',
+        keeper_queue_evidence: { projection_status: 'not_found' },
+        keeper_reaction_evidence: { projection_status: 'not_found' },
+      },
+    ]
+    mocks.toolsData.value = {
+      generated_at: '2026-06-21T00:00:00Z',
+      tool_inventory: { tools: [] },
+      tool_usage: {},
+      scheduled_automation: automation,
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    const missKpi = container.querySelector('[data-testid="schedule-kpi-queue-miss"]')
+    expect(missKpi?.textContent).toContain('큐 누락')
+    expect(missKpi?.textContent).toContain('1')
+    expect(missKpi?.querySelector('.ov-kpi-v')?.className).toContain('warn')
+  })
+
   it('surfaces projection load errors without hiding stale schedule data', async () => {
     mocks.toolsError.value = 'dashboard tools unavailable'
     mocks.toolsData.value = {

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -29,6 +29,7 @@ import {
 } from '../tools/scheduled-automation-panel'
 import type { Cadence } from '../v2/schedule-constants'
 import { CadenceSummary, ScheduleCalendar, cadenceCounts, cadenceOfRequest } from './schedule-agenda'
+import { countQueueDrainMisses } from './queue-drain-status'
 import {
   loadTools,
   toolsData,
@@ -86,6 +87,9 @@ export function ScheduleSurface() {
   const requests = automation?.requests ?? []
   const totalCount = requests.length
   const cadCounts = cadenceCounts(requests)
+  // Scheduled keeper wakes that were dispatched but are in neither queue AND
+  // never recorded as reacted — the drain-miss the calendar surfaces per row.
+  const queueMisses = countQueueDrainMisses(requests)
 
   const [view, setView] = useState<ScheduleView>('calendar')
   const [cadenceFilter, setCadenceFilter] = useState<Cadence | null>(null)
@@ -168,7 +172,7 @@ export function ScheduleSurface() {
 
         ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
 
-        <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }} aria-label="예약 요약">
+        <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }} aria-label="예약 요약">
           <div class="ov-kpi">
             <div class="ov-kpi-k">승인 대기</div>
             <div class=${`ov-kpi-v ${pendingCount > 0 ? 'warn' : 'ok'}`}>${countLabel(pendingCount)}</div>
@@ -184,6 +188,13 @@ export function ScheduleSurface() {
           <div class="ov-kpi">
             <div class="ov-kpi-k">총 예약</div>
             <div class="ov-kpi-v volt">${countLabel(totalCount)}</div>
+          </div>
+          <div class="ov-kpi" data-testid="schedule-kpi-queue-miss">
+            <div class="ov-kpi-k">큐 누락</div>
+            <div
+              class=${`ov-kpi-v ${queueMisses > 0 ? 'warn' : 'ok'}`}
+              title="dispatch됐으나 큐(pending·inflight)에도 없고 keeper 반응 기록도 없는 예약 실행 수 — 실행 누락"
+            >${countLabel(queueMisses)}</div>
           </div>
         </section>
 


### PR DESCRIPTION
## 무엇을 / 왜

스케줄 표면의 **기본 캘린더 뷰**와 KPI 스트립에서는 예약된 keeper wake가 실제로 `keeper_event_queue` 드레인을 통과했는지 알 수 없었습니다. request별 `keeper_queue_evidence`는 이미 **목록(list) 뷰에서만** 렌더되고, 캘린더는 이를 전혀 보여주지 않았습니다. operator가 "예약이 떴는데 keeper가 안 움직였다"를 진단하려면 탭을 목록으로 전환해야 했습니다.

이 PR은 그 큐-드레인 상태를 기본 캘린더 뷰와 KPI로 끌어올려 **목록 뷰와의 관측 동등성(observability parity)** 을 맞춥니다.

## 정직한 상태 판정 (두 축 조합)

`not_found` 하나로 "실행 안 됨"이라 낙인하면 **정상 완료된 모든 wake를 오탐 처리**합니다 — 드레인 완료된 wake는 큐에서 빠지므로 `not_found`가 정상 상태이기도 합니다. 그래서 두 축을 조합합니다:

- `keeper_queue_evidence`: 지금 wake가 pending/inflight 큐에 있나?
- `keeper_reaction_evidence`: keeper가 실제로 stimulus에 반응했나?

| 조합 | 상태 | 캘린더 표시 |
|---|---|---|
| `matched_pending` | 큐 대기 | 칩 (info) |
| `matched_inflight` | 드레인 중 | 칩 (info) |
| `not_found` + reaction matched | **완료** (정상) | 칩 없음 |
| `not_found` + reaction `not_found` | **누락 ⚠** | 칩 (warn) |
| `read_error` | 읽기 오류 | 칩 (warn) |
| 기타/미상 | 확인 불가 | 칩 없음 |

진짜 누락은 `queue=not_found AND reaction=not_found`일 때만입니다. 미래에 추가될 알 수 없는 큐 status는 permissive OK로 뭉개지 않고 `indeterminate`로 표면화합니다 (parse, don't validate).

## 변경

- **신규** `queue-drain-status.ts` — SSOT 헬퍼(두 축 조합 → 라벨/tone, `countQueueDrainMisses`). 캘린더·KPI 양쪽이 이 하나를 씀.
- `schedule-agenda.ts` — agenda 이벤트 행 + 폴링 카드에 드레인 칩(pending/inflight/missed/read_error만; 정상완료·레거시는 무칩으로 노이즈 억제).
- `schedule-surface.ts` — KPI 스트립에 "큐 누락" 셀 추가(4→5열), 진짜 누락 수. >0이면 warn.

## 경계 (workaround 아님)

이 PR은 **기존 백엔드 evidence를 표면화**할 뿐, 드레인 자체를 수리하지 않습니다. 백엔드 컴비네이션(`schedule_runner.tick` → `Keeper_wake_enqueued` → `Keeper_event_queue` drain)은 이미 `test_schedule_consumer_dispatch.ml`에서 end-to-end 테스트됩니다. "큐 누락"이 지속적으로 0이 아니면 그건 별도 백엔드 조사 대상이며 이 PR이 고쳤다고 주장하지 않습니다. telemetry-as-fix가 아니라 목록 뷰와의 관측 동등성입니다.

## 검증

- `queue-drain-status.test.ts` — 조합 매트릭스 전수(완료/누락/읽기오류/미상 구분, `countQueueDrainMisses`).
- `schedule-agenda.test.ts` — 누락 칩 렌더 + 정상완료 무칩.
- `schedule-surface.test.ts` — KPI 큐 누락 카운트 + warn.
- **vitest 40 green · `tsc --noEmit` clean · eslint clean.**
- ⚠️ 브라우저 렌더러 프리즈로 시각 최종 확인은 보류(재연결 시 확인).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
