### PR TITLE
fix(test): failover Accept_rejected fixture missing stop_reason (main red)

### DIFF
--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -83,6 +83,11 @@ let accept_empty_no_progress_error scope =
        ; model = Some "runtime"
        ; reason_kind = Some Driver.Accept_no_usable_progress
        ; response_shape = Some Driver.Accept_response_empty
+       (* RFC-0271 §4.5 slice 1 threaded stop_reason into Accept_rejected; this
+          synthetic failover fixture does not exercise stop_reason classification
+          (slices 2-3), so [None] faithfully models "provider stop_reason not
+          specified" for this empty-response case. *)
+       ; stop_reason = None
        ; last_tool_effect = None
        ; any_mutating_tool = None
        ; tool_effects_seen = []


### PR DESCRIPTION
## 증상
`main`(bfeb2c8af6)에서 `dune build .` 실패:
```
File "test/test_keeper_turn_driver_failover.ml", lines 82-90:
Error: Some record fields are undefined: stop_reason
```

## 근본 원인
RFC-0271 §4.5 slice 1 (#23720)이 `Keeper_turn_driver.Accept_rejected`에 typed `stop_reason : Agent_sdk.Types.stop_reason option` 필드를 추가했으나, `test/test_keeper_turn_driver_failover.ml`의 `accept_empty_no_progress_error` 리터럴이 갱신되지 않아 main이 red가 됨. 다른 모든 `Accept_rejected` full-construction 리터럴(lib/ producer 3곳, test 5곳)은 `stop_reason`을 세팅함을 전수 확인 — 이 fixture 하나만 누락.

## 수정
`stop_reason = None` 한 줄 추가 (타입 필드 순서상 `response_shape` 다음).

`None`인 이유: 이 fixture는 failover 라우팅을 검증하는 generic empty-response 에러이며 stop_reason 분류를 assert하지 않음. §4.5 slice 1은 "threaded and serialized, not yet consumed by classification (slices 2-3)"이므로, `None`이 "provider stop_reason 미지정"을 `option` 타입에 정직하게 모델링. 임의 truncation 값(`Some MaxTokens`)을 넣으면 slice 2-3 도입 시 오도.

## 검증
- 로컬: 다른 `Accept_rejected` construction이 모두 stop_reason 세팅함을 grep 전수 확인. 이 파일이 유일한 누락.
- dune 컴파일은 CI에서 검증.

## RFC
테스트 fixture 수정 — RFC-게이트 subsystem(credential/repo/operator/hooks) 해당 없음.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)