### PR TITLE
fix(keeper): main 빌드 복구 — failover 테스트 Accept_rejected에 stop_reason 추가

### DIFF
--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -83,6 +83,7 @@ let accept_empty_no_progress_error scope =
        ; model = Some "runtime"
        ; reason_kind = Some Driver.Accept_no_usable_progress
        ; response_shape = Some Driver.Accept_response_empty
+       ; stop_reason = None
        ; last_tool_effect = None
        ; any_mutating_tool = None
        ; tool_effects_seen = []


### PR DESCRIPTION
## 증상

main(`bfeb2c8af`, #23720 머지 직후)이 red. OCaml 빌드 실패:

```
File "test/test_keeper_turn_driver_failover.ml", lines 82-90:
Error: Some record fields are undefined: stop_reason
```

## 원인

Slice 1(#23720)이 `Keeper_internal_error.Accept_rejected` record에 mandatory `stop_reason` 필드를 추가하고 4개 테스트 생성 지점을 갱신했으나, `test_keeper_turn_driver_failover.ml`의 `accept_empty_no_progress_error` **한 곳을 누락**했습니다.

로컬 dune **증분 캐시**가 이미 컴파일된 해당 테스트 모듈을 재빌드하지 않아 로컬 검증에서 green으로 보였고(false-green), #23720이 그 상태로 머지되어 main이 red가 되었습니다.

## 수정

누락된 생성 지점에 `stop_reason = None` 추가 (1파일 1줄). failover 테스트는 truncation 경로를 다루지 않으므로 `None`이 올바른 값 — **behavior-neutral**.

## 검증

- `dune build --root .` clean (from-scratch) exit 0
- `test_keeper_turn_driver_failover.exe`: 16/16 통과

## 교훈

mandatory record field 추가는 컴파일 타임에 *모든 생성 지점*을 강제하지만, **clean 빌드에서만** 확실하다. 증분 캐시는 재빌드되지 않은 site를 가릴 수 있다. 이런 변경은 from-scratch 빌드로 검증해야 한다.

RFC-0271 §4.5 (#23715). #23720이 유발한 main-red 수정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>