### PR TITLE
fix(test): keeper chat HITL cue 테스트를 governance 큐 기반으로 (main red)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -4,12 +4,42 @@ import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { act, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Keeper } from '../../types'
+import type { DashboardGovernanceResponse, Keeper, KeeperApprovalQueueItem } from '../../types'
 
 const mockKeeper: Keeper = {
   name: 'sangsu',
   koreanName: '상수',
   status: 'running',
+}
+
+// The pending-approval cue reads the governance approval_queue (the HITL SSOT)
+// via governanceData — NOT keeper.trust.approval_state (#23678). Tests drive the
+// cue by setting this signal, which loadChat() injects in place of the real
+// computed. Reset in beforeEach so it never leaks across cases.
+const mockGovernanceData = signal<DashboardGovernanceResponse | undefined>(undefined)
+
+function approvalItem(id: string, keeperName: string, toolName: string): KeeperApprovalQueueItem {
+  return {
+    id,
+    keeper_name: keeperName,
+    tool_name: toolName,
+    risk_level: 'critical',
+    waiting_s: 10,
+    input_preview: 'x',
+    task_id: 'T-1',
+  } as KeeperApprovalQueueItem
+}
+
+function governanceResponse(queue: KeeperApprovalQueueItem[]): DashboardGovernanceResponse {
+  return {
+    generated_at: '2026-07-08T00:00:00Z',
+    summary: { judge_online: false },
+    items: [],
+    activity: [],
+    judgments: [],
+    pending_actions: [],
+    approval_queue: queue,
+  } as DashboardGovernanceResponse
 }
 
 async function loadChat() {
@@ -87,10 +117,20 @@ async function loadChat() {
     keeperMobilePane: signal<'roster' | 'chat'>('chat'),
   }))
   // Preserve the real router but capture navigate() so the pending-approval cue's
-  // "결재 큐에서 처리" link can be asserted.
+  // "결재 큐 →" link can be asserted.
   vi.doMock('../../router', async (importOriginal) => ({
     ...(await importOriginal<typeof import('../../router')>()),
     navigate: vi.fn(),
+  }))
+  // The cue reads governanceData.approval_queue; inject a controllable signal in
+  // place of the real computed so a test can populate the queue directly.
+  vi.doMock('../governance-signals', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../governance-signals')>()),
+    governanceData: mockGovernanceData,
+  }))
+  vi.doMock('../../api/dashboard-governance', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../api/dashboard-governance')>()),
+    resolveGovernanceApproval: vi.fn().mockResolvedValue({ ok: true }),
   }))
   return import('./keeper-workspace-chat')
 }
@@ -101,11 +141,13 @@ describe('KeeperWorkspaceChat', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    mockGovernanceData.value = undefined
   })
 
   afterEach(() => {
     render(null, container)
     container.remove()
+    mockGovernanceData.value = undefined
     vi.clearAllMocks()
     vi.restoreAllMocks()
     vi.resetModules()
@@ -118,29 +160,32 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../keeper-action-panel')
     vi.doUnmock('../keeper-detail-state')
     vi.doUnmock('../../router')
+    vi.doUnmock('../governance-signals')
+    vi.doUnmock('../../api/dashboard-governance')
   })
 
   it('shows a pending-approval cue linking to the approvals queue when the keeper awaits a decision', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
     const { navigate } = await import('../../router')
-    const pendingKeeper: Keeper = {
-      ...mockKeeper,
-      trust: { approval_state: { pending_first: { id: 'appr-1', tool_name: 'fs_write' } } },
-    }
+    // The cue derives from the governance approval_queue (HITL SSOT), not
+    // keeper.trust.approval_state (#23678).
+    mockGovernanceData.value = governanceResponse([approvalItem('appr-1', 'sangsu', 'fs_write')])
 
     await act(async () => {
-      render(html`<${KeeperWorkspaceChat} keeper=${pendingKeeper} />`, container)
+      render(html`<${KeeperWorkspaceChat} keeper=${mockKeeper} />`, container)
     })
 
     const cue = container.querySelector('[data-testid="keeper-pending-approval-cue"]')
     expect(cue).not.toBeNull()
-    expect(cue?.textContent).toContain('결재 대기')
+    expect(cue?.textContent).toContain('승인 대기')
     expect(cue?.textContent).toContain('fs_write')
 
-    const link = cue?.querySelector('button')
-    expect(link?.textContent).toContain('결재 큐에서 처리')
+    // Three actions render (승인 / 거부 / 결재 큐 →); the queue link navigates.
+    const queueLink = Array.from(cue?.querySelectorAll('button') ?? [])
+      .find(button => button.textContent?.includes('결재 큐'))
+    expect(queueLink).not.toBeUndefined()
     await act(async () => {
-      link?.click()
+      queueLink?.click()
     })
     expect(navigate).toHaveBeenCalledWith('approvals')
   })


### PR DESCRIPTION
## 무엇을 / 왜

`keeper-workspace-chat.test.ts`의 "shows a pending-approval cue..." 테스트가 **flaky main-red**의 원인입니다.

`#23678`이 `PendingApprovalCue`를 **governance `approval_queue`(HITL SSOT)** 기반으로 리팩터했는데(주석에 명시), **이 테스트는 옛 소스(`keeper.trust.approval_state`)와 옛 문구('결재 대기' / '결재 큐에서 처리')를 그대로 assert**하고 `governanceData`를 채우지 않았습니다.

- **격리 실행**: cue가 null → `expected null not to be null` **결정론적 실패**.
- **full 스위트**: 앞선 다른 테스트 파일이 전역 `governanceData` 시그널에 매칭 keeper를 남겼을 때만 우연히 통과 → **flaky**(main CI success/failure 혼재의 원인).

## 수정 (test-only)

- `loadChat()`에서 `../governance-signals`의 `governanceData`(computed)를 **제어 가능한 signal로 주입**, `../../api/dashboard-governance`의 `resolveGovernanceApproval` mock.
- `beforeEach`/`afterEach`에서 `mockGovernanceData` 리셋 → 크로스-파일 전역 상태 의존 제거(결정론화).
- 테스트가 `approval_queue`를 직접 채우고 현재 문구('승인 대기' / '결재 큐 →') + `navigate('approvals')` 검증.
- **컴포넌트 동작 변경 없음.**

## 검증

- origin/main 격리 재현: keeper-workspace-chat.test.ts **1 failed**.
- 수정 후: **8 passed · tsc --noEmit clean · eslint clean.**

관련: `#23727`(schedule 큐-드레인) 등 dashboard PR들이 이 선재 main-red 때문에 Dashboard CI가 red였음 — 이 PR로 unblock.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>