### PR TITLE
feat(execute): self-correction hint when argv[0] duplicates the executable

### DIFF
--- a/lib/exec/shell_ir_diagnostics.ml
+++ b/lib/exec/shell_ir_diagnostics.ml
@@ -45,7 +45,12 @@ let directory_and_pattern_of_glob_token token =
     , String.sub token (idx + 1) (String.length token - idx - 1) )
 ;;
 
-let should_emit_glob_failure ~status ~stderr =
+(* A nonzero exit whose stderr carries an OS-level "not found" signature.
+   Shared by the glob-literal and duplicate-argv0 diagnostics: both explain a
+   suspect argv SHAPE that only becomes a problem when the command could not
+   find its target.  This is an OS error signature, not a domain classifier —
+   it narrows advisory hints to the failure mode they describe. *)
+let is_path_not_found_failure ~status ~stderr =
   match status with
   | Unix.WEXITED 0 -> false
   | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
@@ -65,7 +70,7 @@ let matching_glob_stage ir =
 
 let glob_literal_failure_fields ~ir ~status ~stderr =
   let stderr = String.trim stderr in
-  if not (should_emit_glob_failure ~status ~stderr)
+  if not (is_path_not_found_failure ~status ~stderr)
   then []
   else
     match matching_glob_stage ir with
@@ -94,5 +99,58 @@ let glob_literal_failure_fields ~ir ~status ~stderr =
       ; "typed_glob_not_expanded", `Bool true
       ; "literal_glob_token", `String token
       ; "alternatives", `List [ `String find_alt; `String rg_alt ]
+      ]
+;;
+
+(* Typed Execute accepts a leading argv token equal to the executable because it
+   CAN be an intentional literal argument (e.g. searching for the string "grep"),
+   so the gate does not reject it — see the [duplicate_executable_argv0] case in
+   test_keeper_tool_execute_typed_input.  But when such a command fails with a
+   path-not-found error it is almost always the execve-style mistake of repeating
+   the program name: [{executable="wc"; argv=["wc"]}] runs as [wc wc], and wc
+   then tries to open a file literally named "wc".  This diagnoses that failure
+   with a self-correction hint WITHOUT rejecting — the intentional-payload design
+   is preserved; only the not-found failure signature is narrowed and explained.
+
+   Detection is structural: the first stage whose argv[0] equals its executable.
+   The path-not-found gate (shared with the glob diagnostic) avoids hinting on
+   intentional same-name commands that simply produced no match. *)
+let duplicate_argv0_stage ir =
+  Shell_ir_command_shape.effective_stages ir
+  |> List.find_map (fun { Shell_ir_command_shape.bin; args } ->
+    match args with
+    | first :: rest
+      when String.trim first = String.trim bin && String.trim bin <> "" ->
+      Some (String.trim bin, rest)
+    | _ -> None)
+;;
+
+let duplicate_argv0_failure_fields ~ir ~status ~stderr =
+  let stderr = String.trim stderr in
+  if not (is_path_not_found_failure ~status ~stderr)
+  then []
+  else
+    match duplicate_argv0_stage ir with
+    | None -> []
+    | Some (executable, remainder) ->
+      let hint =
+        Printf.sprintf
+          "argv[0]=%S is identical to the executable, so it ran as a literal \
+           argument (typed Execute passes argv verbatim, execve-style; the \
+           program name is NOT prepended). If the duplicate was unintended, \
+           retry with argv[0] removed."
+          executable
+      in
+      let rewrite =
+        Printf.sprintf
+          "Rewrite: executable=%S argv=[%s]."
+          executable
+          (String.concat "; " (List.map (Printf.sprintf "%S") remainder))
+      in
+      [ "execution_hint", `String hint
+      ; "shell_ir_hint", `String hint
+      ; "argv0_duplicates_executable", `Bool true
+      ; "duplicated_executable", `String executable
+      ; "rewrite_suggestion", `String rewrite
       ]
 ;;

--- a/lib/exec/shell_ir_diagnostics.mli
+++ b/lib/exec/shell_ir_diagnostics.mli
@@ -6,3 +6,13 @@ val glob_literal_failure_fields :
   stderr:string ->
   (string * Yojson.Safe.t) list
 (** JSON fields explaining likely literal glob argv failures. *)
+
+val duplicate_argv0_failure_fields :
+  ir:Shell_ir.t ->
+  status:Unix.process_status ->
+  stderr:string ->
+  (string * Yojson.Safe.t) list
+(** JSON fields for a path-not-found failure whose argv[0] duplicates the
+    executable (the execve-style "repeated program name" mistake). Advisory
+    only — the typed gate still accepts such argv because it may be an
+    intentional literal argument. *)

--- a/lib/exec/test/test_shell_ir_diagnostics.ml
+++ b/lib/exec/test/test_shell_ir_diagnostics.ml
@@ -38,6 +38,48 @@ let test_success_has_no_glob_hint () =
   in
   Alcotest.(check int) "no fields" 0 (List.length fields)
 
+let test_duplicate_argv0_failure_fields () =
+  let fields =
+    Shell_ir_diagnostics.duplicate_argv0_failure_fields
+      ~ir:(parse "wc wc")
+      ~status:(Unix.WEXITED 1)
+      ~stderr:"wc: wc: No such file or directory"
+  in
+  Alcotest.(check (option bool))
+    "argv0 duplicate flag"
+    (Some true)
+    (match field "argv0_duplicates_executable" fields with
+     | Some (`Bool value) -> Some value
+     | Some _ | None -> None);
+  Alcotest.(check (option string))
+    "duplicated executable"
+    (Some "wc")
+    (match field "duplicated_executable" fields with
+     | Some (`String value) -> Some value
+     | Some _ | None -> None)
+
+let test_duplicate_argv0_no_hint_on_success () =
+  (* argv[0] == executable that SUCCEEDS is treated as intentional payload;
+     the intentional-payload design must not be nagged. *)
+  let fields =
+    Shell_ir_diagnostics.duplicate_argv0_failure_fields
+      ~ir:(parse "wc wc")
+      ~status:(Unix.WEXITED 0)
+      ~stderr:""
+  in
+  Alcotest.(check int) "no fields on success" 0 (List.length fields)
+
+let test_duplicate_argv0_no_hint_when_distinct () =
+  (* A normal command whose argv[0] differs from the executable never triggers
+     the duplicate hint, even on a path-not-found failure. *)
+  let fields =
+    Shell_ir_diagnostics.duplicate_argv0_failure_fields
+      ~ir:(parse "cat README.md")
+      ~status:(Unix.WEXITED 1)
+      ~stderr:"cat: README.md: No such file or directory"
+  in
+  Alcotest.(check int) "no fields when argv0 != executable" 0 (List.length fields)
+
 let () =
   Alcotest.run
     "Shell_ir_diagnostics"
@@ -50,5 +92,19 @@ let () =
             "does not emit hint on success"
             `Quick
             test_success_has_no_glob_hint
+        ] )
+    ; ( "duplicate_argv0"
+      , [ Alcotest.test_case
+            "emits rewrite hint on path failure with duplicated argv[0]"
+            `Quick
+            test_duplicate_argv0_failure_fields
+        ; Alcotest.test_case
+            "does not emit hint on success (intentional payload preserved)"
+            `Quick
+            test_duplicate_argv0_no_hint_on_success
+        ; Alcotest.test_case
+            "does not emit hint when argv[0] differs from executable"
+            `Quick
+            test_duplicate_argv0_no_hint_when_distinct
         ] )
     ]

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -1301,6 +1301,18 @@ let handle_tool_execute_typed
                 ~status:result.status
                 ~stderr
             in
+            (* Mutually exclusive with the glob hint: both share the
+               execution_hint/shell_ir_hint keys, and a command carrying a glob
+               token gets the more specific glob guidance first. *)
+            let duplicate_argv0_failure_fields =
+              if glob_literal_failure_fields <> []
+              then []
+              else
+                Masc_exec.Shell_ir_diagnostics.duplicate_argv0_failure_fields
+                  ~ir
+                  ~status:result.status
+                  ~stderr
+            in
             let classification = Exec_core.classify_command_of_ir ir in
             (* Only include command_descriptor on success — errors already carry
                sufficient diagnostic info (exit code, stderr, classification). *)
@@ -1320,6 +1332,7 @@ let handle_tool_execute_typed
                  ~extra:
                    (failure_error_fields
                     @ glob_literal_failure_fields
+                    @ duplicate_argv0_failure_fields
                     @ sandbox_extra_fields
                     @ [ "typed", `Bool true
                       ; "execution_time_ms", `Int elapsed_ms


### PR DESCRIPTION
## 배경 (24h 도구 실행 에러 감사)
지난 24시간 `~/me/.masc/logs` 감사에서 `<cmd>: cannot access '<cmd>'` / `<cmd>: <cmd>: No such file or directory` 형태의 Execute 실패가 **122건/24h** 관측됨. 원인: 키퍼/LLM이 execve-style argv에서 프로그램 이름을 argv[0]에 중복 삽입(`{executable="wc"; argv=["wc"]}` → `wc wc` 실행). 상당수가 3-strike 재시도 브레이커까지 도달.

## 왜 reject가 아닌 hint인가 (설계 보존)
`test_keeper_tool_execute_typed_input`의 `duplicate_executable_argv0` 케이스는 `expect_typed=true`로 **argv[0]==executable을 accept하도록 명시 pin** — "a leading token equal to executable **may be intentional payload**"(예: 문자열 "grep" 검색 `grep grep file`). 즉 typed gate가 이를 거부하지 않는 것은 **의도된 설계**다. reject 가드 복원은 이 설계를 역전한다.

대신 기존 `glob_literal_failure_fields`와 **같은 run-then-diagnose 패턴**으로, 실패 시 자기교정 힌트만 첨부:
- **탐지는 구조적**: 첫 stage의 `argv[0] == executable`(문자열 equality). stderr 분류 없음.
- **path-not-found 게이트**(glob 진단과 공유하는 OS-레벨 not-found 시그니처)로 좁혀, 의도적 same-name 명령이 단순 no-match한 경우는 힌트 안 함.
- **성공 시 무힌트** → intentional payload 설계 보존.
- glob 힌트와 **상호 배타**(execution_hint 키 충돌 회피).

## 변경
- `lib/exec/shell_ir_diagnostics.ml/.mli`: `duplicate_argv0_failure_fields` 추가. 내부 `should_emit_glob_failure` → `is_path_not_found_failure`로 rename(두 진단 공유).
- `lib/keeper/keeper_tool_execute_runtime.ml`: 실패 결과 extra 필드에 배선(glob과 상호 배타).
- `lib/exec/test/test_shell_ir_diagnostics.ml`: 3 케이스(실패→힌트 / 성공→무힌트 / 비중복→무힌트). **로컬 5/5 green.**

## 검증
`dune exec lib/exec/test/test_shell_ir_diagnostics.exe` → Test Successful, 5 tests. 나머지는 CI.

## RFC
Execute 영역이나 **governance(무엇을 허용/차단/실행)를 바꾸지 않음** — 실패한 명령에 advisory 진단 필드만 첨부. RFC-0327(payload-aware Execute governance)의 authz/classification과 무관한 diagnostic-only 변경.
RFC-WAIVED: diagnostic-only advisory, no governance/authz/execution behavior change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
