### PR TITLE
fix(dashboard): sch-bg raw px → --fs-* 토큰 (CI Gate font lint 해소)

### DIFF
--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -252,8 +252,8 @@
 /* ── Keeper 자율 백그라운드 (폴링 · 비동기 도구) — per-keeper recurring group view ── */
 .sch-bg { margin-top: 26px; border-top: 1px solid var(--border-soft); padding-top: 18px; }
 .sch-bg-h { margin-bottom: 14px; }
-.sch-bg-h h3 { font-family: var(--font-display); font-size: 13px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-bright); margin: 0 0 4px; }
-.sch-bg-sub { font-size: 11px; color: var(--text-dim); display: flex; flex-wrap: wrap; gap: 10px; }
+.sch-bg-h h3 { font-family: var(--font-display); font-size: var(--fs-13); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-bright); margin: 0 0 4px; }
+.sch-bg-sub { font-size: var(--fs-11); color: var(--text-dim); display: flex; flex-wrap: wrap; gap: 10px; }
 .sch-bg-grps { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
 .sch-bg-grp { min-width: 0; }
 .sch-bg-grp-h { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 9px; }
@@ -267,12 +267,12 @@
 .sch-bg-row.st-warn { --tone: var(--status-warn); }
 .sch-bg-row.st-dim { --tone: var(--border-highlight); }
 .sch-bg-row:hover { border-color: var(--border-highlight); border-left-color: var(--tone); background: var(--bg-card-hover); }
-.sch-bg-when { flex: none; width: 62px; font-size: 11px; color: var(--text-mid); padding-top: 1px; }
+.sch-bg-when { flex: none; width: 62px; font-size: var(--fs-11); color: var(--text-mid); padding-top: 1px; }
 .sch-bg-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.sch-bg-title { font-size: 12px; line-height: 1.4; color: var(--text-primary); text-wrap: pretty; }
+.sch-bg-title { font-size: var(--fs-12); line-height: 1.4; color: var(--text-primary); text-wrap: pretty; }
 .sch-bg-meta { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
-.sch-bg-by { font-size: 11px; color: var(--text-mid); }
-.sch-bg-since { font-size: 10px; color: var(--text-dim); }
+.sch-bg-by { font-size: var(--fs-11); color: var(--text-mid); }
+.sch-bg-since { font-size: var(--fs-10); color: var(--text-dim); }
 .sch-bg-row [data-status-chip] { flex: none; align-self: flex-start; }
 .sch-bg-grp-h [data-status-chip] { flex: none; }
 


### PR DESCRIPTION
## 증상
`scripts/lint/no-raw-font-size-px.sh`("Raw font-size px" 잡)가 실패하며, 이 잡이 **CI Gate를 fail**시켜 모든 PR에 red를 남깁니다. `dd209e7513`(#23712) 이후 지속.

```
Raw font-size literal found where a --fs-* token exists.
  dashboard/src/styles/keeper-v2/schedule.css:255 font-size: 13px;
  :256 11px  :270 11px  :272 12px  :274 11px  :275 10px
```

## 원인
#23712가 `.sch-bg-*` 그룹 뷰를 추가하며 `--fs-*` 토큰이 이미 존재하는 크기(13/12/11/10px)를 raw literal로 작성했습니다. 같은 파일의 `.sch-bg-grp-ctx`/`.sch-bg-empty`는 이미 `var(--fs-10)`/`var(--fs-11)`을 쓰고 있어 일관성도 깨진 상태였습니다.

## 수정
플래그된 6개 literal을 토큰으로 치환:
- 255 `13px`→`var(--fs-13)`, 256 `11px`→`var(--fs-11)`, 270 `11px`→`var(--fs-11)`, 272 `12px`→`var(--fs-12)`, 274 `11px`→`var(--fs-11)`, 275 `10px`→`var(--fs-10)`
- `.sch-bg-grp-n`의 `12.5px`는 fractional/unmapped(토큰 없음)이라 lint 규칙상 **면제 유지**.

값 변화 없음(토큰이 동일 px로 정의됨) — 순수 lint 정합.

## 검증
- `bash scripts/lint/no-raw-font-size-px.sh` → `no-raw-font-size-px: clean`
- diff: schedule.css 6줄(6 insertions/6 deletions)

## 관련
- broke: #23712 (dd209e7513)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
