### PR TITLE
task-1882: wire evidence_refs and re-enable Gate 0

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -739,11 +739,12 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs — disabled until call site is wired (PR #23666
-     regression). Log and fall through to Gate 1 rather than returning unit. *)
+  (* Gate 0: empty evidence_refs — required for all code task submissions.
+     Reject completions that lack code-level evidence (file paths, commit hashes,
+     trace/turn/receipt refs). *)
   if List.is_empty req.evidence_refs then
-    task_warn "Gate 0 skipped: empty evidence_refs (call site not yet wired)";
-  (* Gate 1: empty or trivially short notes *)
+    Some (Rejection { reason = "no evidence references supplied"; rule_id = "gate_0_missing_evidence_refs"; hint = "Provide at least one evidence_ref: a file path, a commit hash, or a trace/turn/receipt reference." })
+  else
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length
   then

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -743,7 +743,13 @@ let review
      Reject completions that lack code-level evidence (file paths, commit hashes,
      trace/turn/receipt refs). *)
   if List.is_empty req.evidence_refs then
-    Some (Rejection { reason = "no evidence references supplied"; rule_id = "gate_0_missing_evidence_refs"; hint = "Provide at least one evidence_ref: a file path, a commit hash, or a trace/turn/receipt reference." })
+    emit
+      { verdict = Reject "no evidence references supplied"
+      ; evaluator_runtime
+      ; generator_runtime
+      ; gate = Evidence
+      ; fallback_reason = None
+      }
   else
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -410,8 +410,8 @@ and handle_transition ~tool_name ~start_time ctx args =
   | None ->
   let evidence_refs =
         match handoff_context with
-        | None -> []
-        | Some h -> h.evidence_refs
+        | Ok h -> h.evidence_refs
+        | Error _ -> []
       in
       let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -53,12 +53,19 @@ let missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~
 
 let rec handle_done ~tool_name ~start_time ctx args =
   let notes = get_string args "notes" "" in
+  let evidence_refs = get_string_list args "evidence_refs" in
   handle_transition ~tool_name ~start_time ctx
     (`Assoc
        [
          ("task_id", Json_util.assoc_member_opt "task_id" args |> Option.value ~default:`Null);
          ("action", `String "done");
          ("notes", `String notes);
+         ("handoff_context",
+          `Assoc
+            [
+              ("summary", `String notes);
+              ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+            ]);
        ])
 
 and handle_cancel_task ~tool_name ~start_time ctx args =
@@ -401,7 +408,12 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name ~start_time reason
   | None ->
-  let review_gate_rejection =
+  let evidence_refs =
+        match handoff_context with
+        | None -> []
+        | Some h -> h.evidence_refs
+      in
+      let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then
         None
@@ -416,6 +428,7 @@ and handle_transition ~tool_name ~start_time ctx args =
           ~task_opt
           ~task_id
           ~notes
+          ~evidence_refs
       else
         None
     else

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -408,11 +408,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name ~start_time reason
   | None ->
-  let evidence_refs =
-        match handoff_context with
-        | Ok h -> h.evidence_refs
-        | Error _ -> []
-      in
+  let evidence_refs = handoff_context.evidence_refs in
       let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -408,7 +408,11 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name ~start_time reason
   | None ->
-  let evidence_refs = handoff_context.evidence_refs in
+  let evidence_refs =
+        match handoff_context with
+        | Some h -> h.evidence_refs
+        | None -> []
+      in
       let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -198,7 +198,8 @@ let review_completion_notes
     ~(ctx : context)
     ~(task_opt : Masc_domain.task option)
     ~(task_id : string)
-    ~(notes : string) : string option =
+    ~(notes : string)
+    ~(evidence_refs : string list) : string option =
   match task_opt with
   | None -> None
   | Some task ->
@@ -208,7 +209,7 @@ let review_completion_notes
         completion_notes = notes;
         agent_name = ctx.agent_name;
         task_id = task.id;
-        evidence_refs = [];
+        evidence_refs = evidence_refs;
       } in
       (* task-1664: the persisted contract's evidence obligations must reach
          the LLM prompt too, not only [completion_contract]. Read them from

--- a/lib/task/tool_task_handlers.mli
+++ b/lib/task/tool_task_handlers.mli
@@ -71,6 +71,7 @@ val review_completion_notes :
   task_opt:Masc_domain.task option ->
   task_id:string ->
   notes:string ->
+  evidence_refs:string list ->
   string option
 
 val persisted_contract_rejection :

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -548,7 +548,8 @@ let () = test "handle_done_records_calibration_verdict" (fun () ->
   let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [
       ("task_id", `String "task-001");
-      ("notes", `String "x")
+      ("notes", `String "x");
+      ("evidence_refs", `List [ `String "commit:abc123" ])
     ]) in
   assert (not (Tool_result.is_success result));
   assert (str_contains (Tool_result.message result) "Completion rejected by anti-rationalization gate");
@@ -578,7 +579,8 @@ let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
   let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [
       ("task_id", `String "task-001");
-      ("notes", `String "Task scope satisfied: Approved calibration task. Implemented the calibration coverage path, verified the JSONL verdict store, and completed the task cleanly. commit:abc123")
+      ("notes", `String "Task scope satisfied: Approved calibration task. Implemented the calibration coverage path, verified the JSONL verdict store, and completed the task cleanly. commit:abc123");
+      ("evidence_refs", `List [ `String "commit:abc123" ])
     ]) in
   if not (Tool_result.is_success result) then failwith (Tool_result.message result);
   let store = Eval_calibration.get_store () in
@@ -588,6 +590,22 @@ let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
   let verdict = Yojson.Safe.Util.(first |> member "verdict" |> to_string) in
   assert (verdict = "approve");
   Eval_calibration.reset_store_for_testing ()
+)
+
+let () = test "handle_done_rejects_empty_evidence_refs" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("title", `String "Empty evidence refs task")]) in
+  let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("task_id", `String "task-001")]) in
+  let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [
+      ("task_id", `String "task-001");
+      ("notes", `String "Task scope satisfied: long enough notes to avoid the length gate, but evidence_refs is empty.");
+      ("evidence_refs", `List [])
+    ]) in
+  assert (not (Tool_result.is_success result));
+  assert (str_contains (Tool_result.message result) "Completion rejected by anti-rationalization gate")
 )
 
 let () = test "handle_transition_respects_completion_contract_and_records_custom_evaluator" (fun () ->


### PR DESCRIPTION
## Summary

Closes the regression introduced by PR #23666 by making `evidence_refs` required for all code task submissions and re-enabling Gate 0.

## Changes

- `lib/task/tool_task_handlers.ml`: `review_completion_notes` now accepts an `evidence_refs` parameter and forwards it to `Anti_rationalization.review_request`.
- `lib/task/tool_task_handlers.mli`: Updated interface signature.
- `lib/task/tool_task.ml`: `handle_done` extracts `evidence_refs` from `keeper_task_done` args and forwards it via a synthetic `handoff_context`; `handle_transition` passes the parsed `evidence_refs` to `review_completion_notes`.
- `lib/task/anti_rationalization.ml`: Re-enable Gate 0 so that completions with an empty `evidence_refs` list are rejected instead of only logged.

## Verification

- `dune build` is blocked in this environment as a privileged command; CI is expected to run the build.
- Branch: `base/task-1882` (commit `fac231348`).

## Notes

- Downstream gates (1881-1884) can proceed once this PR is merged.
- I cannot self-approve this PR per policy; a different keeper should review.