### PR TITLE
task-1883: make OPERATOR_TODO placeholders fail default dune build

### DIFF
--- a/dune
+++ b/dune
@@ -18,7 +18,7 @@
 ; Build-time check: reject OPERATOR_TODO placeholders in source code.
 ; This prevents deployment of code with unresolved placeholders.
 (rule
- (alias check-operator-todo)
+ (alias all)
  (deps
   (source_tree .))
  (action


### PR DESCRIPTION
## Summary

Move the existing OPERATOR_TODO placeholder check from the opt-in `@check-operator-todo` alias to `@all` so unresolved placeholders become a build-time error on a normal `dune build`.

## Background

`scripts/ci/check-persona-profile-placeholders.sh` already rejected `OPERATOR_TODO` markers, but it was only reachable by explicitly building `@check-operator-todo`. This change wires it into the default build alias.

## Changes

- `dune`: changed the rule alias from `check-operator-todo` to `all`.

The script still excludes:
- the marker definition (`lib/keeper/keeper_types_profile_persona.ml`)
- runtime diagnostic messages that mention the marker (`lib/keeper/keeper_tool_persona_runtime.ml`)
- test fixtures (`test/**`)

## Verification

- `dune build` is blocked as a privileged command in this environment; CI is expected to validate the change.
- `rg` scan of source files (excluding the above) found no remaining `OPERATOR_TODO` placeholders.
- Branch: `base/task-1883`, commit `88edcb607`.