### PR TITLE
fix(workspace): scope #23719 evidence gate to strict contracts + thread probe evidence (RFC-0323 G-2 repair)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -647,7 +647,9 @@ let handle_keeper_task_tool
              Workspace.submit_and_approve_task_r config
                ~agent_name:(keeper_agent_sender ~meta)
                ~verifier_name:deterministic_probe_verifier ~task_id ~notes
-               ~approve_notes ()
+               ~approve_notes
+               ~evidence_refs:(List.map Evidence_claim.to_human_string claims)
+               ()
            with
            | Ok _ -> harness_completed := true
            | Error (Workspace.Machine_verify_invalid_verifier msg) ->

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -96,6 +96,7 @@ let submit_and_approve_task_r
       ~task_id
       ~notes
       ~approve_notes
+      ~evidence_refs
       ()
   : (string, machine_verify_failure) result
   =
@@ -105,6 +106,22 @@ let submit_and_approve_task_r
     if Workspace_task_classify.same_task_actor config verifier_name agent_name
     then Error (Machine_verify_verifier_not_distinct { agent_name; verifier_name })
     else (
+      (* The machine-verified evidence rides the same typed handoff channel as
+         operator submissions: the submit persists it onto the task (so the
+         strict-contract approve gate reads it) and the approve re-supplies it
+         (the executor persists the incoming argument on every action, so an
+         approve without it would wipe the Done record's evidence). *)
+      let machine_handoff : Masc_domain.task_handoff_context =
+        { summary = notes
+        ; reason = None
+        ; next_step = None
+        ; failure_mode = None
+        ; reclaim_policy = None
+        ; evidence_refs
+        ; updated_at = None
+        ; updated_by = None
+        }
+      in
       let prepare_verification_request ~task ~assignee ~verification_id ~evidence_refs =
         (Atomic.get Workspace_hooks.verification_submit_request_fn)
           config
@@ -134,6 +151,7 @@ let submit_and_approve_task_r
           ~task_id
           ~action:Masc_domain.Submit_for_verification
           ~notes
+          ~handoff_context:machine_handoff
           ~prepare_verification_request
           ~compensate_verification_request
           ()
@@ -191,6 +209,7 @@ let submit_and_approve_task_r
              ~task_id
              ~action:Masc_domain.Approve_verification
              ~notes:approve_notes
+             ~handoff_context:machine_handoff
              ()
          with
          | Ok message ->
@@ -204,6 +223,7 @@ let submit_and_approve_task_r
                 ~task_id
                 ~action:Masc_domain.Reject_verification
                 ~reason:machine_verify_compensation_reason
+                ~handoff_context:machine_handoff
                 ()
             with
             | Ok _ ->

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -120,10 +120,17 @@ type machine_verify_failure =
     Verification-store lifecycle mirrors the tool layer (RFC-0221 hooks):
     record created with the submit, machine verdict recorded on approve or on
     the compensating reject; board/SSE notify hooks are not invoked (machine
-    completions do not announce). Hook defaults are no-ops. *)
+    completions do not announce). Hook defaults are no-ops.
+
+    [evidence_refs] is carried as the submit's [handoff_context.evidence_refs]
+    (summary = [notes]) and persisted through approve onto the Done record, so
+    the #23719 strict-contract evidence gate and audit consumers see the
+    machine-verified evidence. Pass the satisfied claim descriptions (probe:
+    [Evidence_claim.to_human_string]); [[]] is only valid for tasks without a
+    strict contract. *)
 val submit_and_approve_task_r :
   config -> agent_name:string -> verifier_name:string -> task_id:string ->
-  notes:string -> approve_notes:string -> unit ->
+  notes:string -> approve_notes:string -> evidence_refs:string list -> unit ->
   (string, machine_verify_failure) result
 
 (** {1 Task cancellation} *)

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -94,32 +94,44 @@ let transition_task_outcome_r
           | Masc_domain.Release -> Ok ()
           | Masc_domain.Done_action
           | Masc_domain.Submit_for_verification ->
-            (match handoff_context with
-             | None ->
-               Error
-                 (Masc_domain.Task
-                    (Masc_domain.Task_error.InvalidState
-                       "Code task submission requires handoff_context with evidence_refs"))
-             | Some ctx when ctx.evidence_refs = [] ->
-               Error
-                 (Masc_domain.Task
-                    (Masc_domain.Task_error.InvalidState
-                       "Code task submission requires at least one evidence_ref in handoff_context"))
-             | Some _ -> Ok ())
+            (* #23719 evidence gate, scoped to the RFC-0323 Phase A predicate
+               (contract.strict, same as the G-1 done guard). Unconditional
+               enforcement regressed the G-2 deterministic probe and broke the
+               invariant documented below (empty evidence is valid for
+               analysis-only / advisory-contract tasks) — an unannounced
+               Phase B, exactly what the G-1 predicate decision avoided. *)
+            if not (Masc_domain.task_requires_verification task)
+            then Ok ()
+            else
+              (match handoff_context with
+               | None ->
+                 Error
+                   (Masc_domain.Task
+                      (Masc_domain.Task_error.InvalidState
+                         "Strict-contract task completion requires handoff_context with evidence_refs (submit_for_verification carries the evidence a verifier approves)"))
+               | Some ctx when ctx.evidence_refs = [] ->
+                 Error
+                   (Masc_domain.Task
+                      (Masc_domain.Task_error.InvalidState
+                         "Strict-contract task completion requires at least one evidence_ref in handoff_context"))
+               | Some _ -> Ok ())
           | Masc_domain.Approve_verification
           | Masc_domain.Reject_verification ->
-            (match task.handoff_context with
-             | None ->
-               Error
-                 (Masc_domain.Task
-                    (Masc_domain.Task_error.InvalidState
-                       "Approve/reject requires task to carry handoff_context with evidence_refs"))
-             | Some ctx when ctx.evidence_refs = [] ->
-               Error
-                 (Masc_domain.Task
-                    (Masc_domain.Task_error.InvalidState
-                       "Approve/reject requires task to carry at least one evidence_ref"))
-             | Some _ -> Ok ())
+            if not (Masc_domain.task_requires_verification task)
+            then Ok ()
+            else
+              (match task.handoff_context with
+               | None ->
+                 Error
+                   (Masc_domain.Task
+                      (Masc_domain.Task_error.InvalidState
+                         "Approve/reject on a strict-contract task requires it to carry handoff_context with evidence_refs"))
+               | Some ctx when ctx.evidence_refs = [] ->
+                 Error
+                   (Masc_domain.Task
+                      (Masc_domain.Task_error.InvalidState
+                         "Approve/reject on a strict-contract task requires at least one evidence_ref"))
+               | Some _ -> Ok ())
         in
         let* () =
           (match action, task.task_status with

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -99,39 +99,37 @@ let transition_task_outcome_r
                enforcement regressed the G-2 deterministic probe and broke the
                invariant documented below (empty evidence is valid for
                analysis-only / advisory-contract tasks) — an unannounced
-               Phase B, exactly what the G-1 predicate decision avoided. *)
+               Phase B, exactly what the G-1 predicate decision avoided.
+               "Declared evidence" mirrors the verifier-request projection
+               (contract refs + typed handoff refs, prose excluded): a
+               contract that names its evidence up front satisfies the
+               gate without re-supplying refs at submit time. *)
             if not (Masc_domain.task_requires_verification task)
             then Ok ()
-            else
-              (match handoff_context with
-               | None ->
-                 Error
-                   (Masc_domain.Task
-                      (Masc_domain.Task_error.InvalidState
-                         "Strict-contract task completion requires handoff_context with evidence_refs (submit_for_verification carries the evidence a verifier approves)"))
-               | Some ctx when ctx.evidence_refs = [] ->
-                 Error
-                   (Masc_domain.Task
-                      (Masc_domain.Task_error.InvalidState
-                         "Strict-contract task completion requires at least one evidence_ref in handoff_context"))
-               | Some _ -> Ok ())
+            else if
+              Workspace_task_verification.declared_verification_evidence_refs
+                task handoff_context
+              = []
+            then
+              Error
+                (Masc_domain.Task
+                   (Masc_domain.Task_error.InvalidState
+                      "Strict-contract task completion requires declared evidence: contract required_evidence/verify_gate_evidence or handoff_context.evidence_refs (a verifier needs something to approve)"))
+            else Ok ()
           | Masc_domain.Approve_verification
           | Masc_domain.Reject_verification ->
             if not (Masc_domain.task_requires_verification task)
             then Ok ()
-            else
-              (match task.handoff_context with
-               | None ->
-                 Error
-                   (Masc_domain.Task
-                      (Masc_domain.Task_error.InvalidState
-                         "Approve/reject on a strict-contract task requires it to carry handoff_context with evidence_refs"))
-               | Some ctx when ctx.evidence_refs = [] ->
-                 Error
-                   (Masc_domain.Task
-                      (Masc_domain.Task_error.InvalidState
-                         "Approve/reject on a strict-contract task requires at least one evidence_ref"))
-               | Some _ -> Ok ())
+            else if
+              Workspace_task_verification.declared_verification_evidence_refs
+                task None
+              = []
+            then
+              Error
+                (Masc_domain.Task
+                   (Masc_domain.Task_error.InvalidState
+                      "Approve/reject on a strict-contract task requires declared evidence: contract required_evidence/verify_gate_evidence or persisted handoff_context.evidence_refs"))
+            else Ok ()
         in
         let* () =
           (match action, task.task_status with

--- a/lib/workspace/workspace_task_verification.ml
+++ b/lib/workspace/workspace_task_verification.ml
@@ -26,6 +26,27 @@ let is_placeholder_verification_evidence value =
   in
   List.mem value placeholders
 
+(* Declared refs only — contract metadata plus the typed handoff channel.
+   Free-text summary/notes are excluded on purpose: they are observability,
+   and an evidence gate that counted arbitrary prose would be vacuous. *)
+let declared_verification_evidence_refs (task : Masc_domain.task) handoff_context =
+  let contract_refs =
+    match task.contract with
+    | Some c -> c.verify_gate_evidence @ c.required_evidence
+    | None -> []
+  in
+  let handoff_refs =
+    match
+      (match handoff_context with
+       | Some _ -> handoff_context
+       | None -> task.handoff_context)
+    with
+    | Some (hc : Masc_domain.task_handoff_context) -> hc.evidence_refs
+    | None -> []
+  in
+  Workspace_state.normalized_string_list (contract_refs @ handoff_refs)
+  |> List.filter (fun s -> not (is_placeholder_verification_evidence s))
+
 let verification_submission_evidence_refs task ~notes handoff_context =
   let contract_refs =
     match task.contract with

--- a/lib/workspace/workspace_task_verification.mli
+++ b/lib/workspace/workspace_task_verification.mli
@@ -13,6 +13,19 @@ val is_placeholder_verification_evidence : string -> bool
 (** True for trimmed lowercase placeholders like ["draft"], ["tbd"],
     [""]. Used to keep the typed concat free of trash entries. *)
 
+val declared_verification_evidence_refs :
+  Masc_domain.task ->
+  Masc_domain.task_handoff_context option ->
+  string list
+(** Declared evidence refs only: contract metadata
+    ([verify_gate_evidence] @ [required_evidence]) plus [evidence_refs]
+    from the handoff argument (falling back to the task's persisted
+    handoff), normalized and placeholder-filtered. Excludes free-text
+    summary/notes — same sources as
+    [verification_submission_evidence_refs] minus prose. A pure
+    projection; the transition-layer evidence gate (#23719, scoped by
+    RFC-0323 Phase A) consumes it. *)
+
 val verification_submission_evidence_refs :
   Masc_domain.task ->
   notes:string ->

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -167,6 +167,19 @@ let status_string config task_id =
 
 let submit_notes = "verification evidence captured for FSM transition test"
 
+(* Strict-contract submits carry evidence through the typed handoff channel
+   (#23719 evidence gate, scoped to contract.strict by RFC-0323 Phase A). *)
+let submit_handoff : Masc_domain.task_handoff_context =
+  { summary = submit_notes
+  ; reason = None
+  ; next_step = None
+  ; failure_mode = None
+  ; reclaim_policy = None
+  ; evidence_refs = [ "output.json" ]
+  ; updated_at = None
+  ; updated_by = None
+  }
+
 let verification_id_of_task config task_id =
   match get_task config task_id with
   | None -> Alcotest.fail "task not found"
@@ -224,7 +237,7 @@ let test_submit_for_verification_moves_to_awaiting () =
     claim_and_start config "worker" task_id;
     match Workspace.transition_task_r config ~agent_name:"worker"
             ~task_id ~action:Masc_domain.Submit_for_verification
-            ~notes:submit_notes () with
+            ~notes:submit_notes ~handoff_context:submit_handoff () with
     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
     | Ok _ ->
       Alcotest.(check string) "status" "awaiting_verification"
@@ -238,7 +251,7 @@ let test_submit_for_verification_from_claimed_moves_to_awaiting () =
          ~task_id ~action:Masc_domain.Claim ());
     match Workspace.transition_task_r config ~agent_name:"worker"
             ~task_id ~action:Masc_domain.Submit_for_verification
-            ~notes:submit_notes () with
+            ~notes:submit_notes ~handoff_context:submit_handoff () with
     | Error e -> Alcotest.fail ("submit from claimed failed: " ^ Masc_domain.show_masc_error e)
     | Ok _ ->
       Alcotest.(check string) "status" "awaiting_verification"
@@ -253,6 +266,7 @@ let test_submit_prepare_failure_keeps_task_in_progress () =
       Workspace.transition_task_r config ~agent_name:"worker"
         ~task_id ~action:Masc_domain.Submit_for_verification
         ~notes:submit_notes
+        ~handoff_context:submit_handoff
         ~prepare_verification_request:
           (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ ->
              prepare_called := true;
@@ -294,6 +308,7 @@ let test_submit_phase_e_no_substring_reject_at_transition () =
       Workspace.transition_task_r config ~agent_name:"worker"
         ~task_id ~action:Masc_domain.Submit_for_verification
         ~notes:"implementation complete"
+        ~handoff_context:submit_handoff
         ~prepare_verification_request:
           (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs ->
              prepare_called := true;
@@ -342,6 +357,7 @@ let test_submit_retry_records_request_created_backlog_orphan_policy () =
          ~task_id
          ~action:Masc_domain.Submit_for_verification
          ~notes:submit_notes
+         ~handoff_context:submit_handoff
          ~prepare_verification_request:
            (fun ~task:_ ~assignee ~verification_id ~evidence_refs ->
              retry_request_id := Some verification_id;
@@ -538,6 +554,7 @@ let test_submit_uses_required_evidence_when_verify_refs_empty () =
         ~task_id
         ~action:Masc_domain.Submit_for_verification
         ~notes:"implementation complete"
+        ~handoff_context:submit_handoff
         ~prepare_verification_request:
           (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs ->
              captured_refs := Some evidence_refs;
@@ -608,7 +625,7 @@ let test_approve_by_other_agent_moves_to_done () =
     claim_and_start config "worker" task_id;
     let _ = Workspace.transition_task_r config ~agent_name:"worker"
       ~task_id ~action:Masc_domain.Submit_for_verification
-      ~notes:submit_notes () in
+      ~notes:submit_notes ~handoff_context:submit_handoff () in
     match Workspace.transition_task_r config ~agent_name:"verifier"
             ~task_id ~action:Masc_domain.Approve_verification () with
     | Error e -> Alcotest.fail ("approve failed: " ^ Masc_domain.show_masc_error e)
@@ -622,7 +639,7 @@ let test_reject_by_other_agent_moves_to_in_progress () =
     claim_and_start config "worker" task_id;
     let _ = Workspace.transition_task_r config ~agent_name:"worker"
       ~task_id ~action:Masc_domain.Submit_for_verification
-      ~notes:submit_notes () in
+      ~notes:submit_notes ~handoff_context:submit_handoff () in
     match Workspace.transition_task_r config ~agent_name:"verifier"
             ~task_id ~action:Masc_domain.Reject_verification ~reason:"test reject" () with
     | Error e -> Alcotest.fail ("reject failed: " ^ Masc_domain.show_masc_error e)
@@ -648,6 +665,7 @@ let test_approve_verdict_failure_still_completes () =
          ~task_id
          ~action:Masc_domain.Submit_for_verification
          ~notes:submit_notes
+         ~handoff_context:submit_handoff
          ()
      with
      | Ok _ -> ()
@@ -705,6 +723,7 @@ let test_reject_verdict_failure_still_transitions () =
          ~task_id
          ~action:Masc_domain.Submit_for_verification
          ~notes:submit_notes
+         ~handoff_context:submit_handoff
          ()
      with
      | Ok _ -> ()
@@ -758,6 +777,7 @@ let test_approve_retry_recovers_completed_verdict_orphan () =
          ~task_id
          ~action:Masc_domain.Submit_for_verification
          ~notes:submit_notes
+         ~handoff_context:submit_handoff
          ()
      with
      | Ok _ -> ()
@@ -829,6 +849,7 @@ let test_reject_retry_recovers_completed_verdict_orphan () =
          ~task_id
          ~action:Masc_domain.Submit_for_verification
          ~notes:submit_notes
+         ~handoff_context:submit_handoff
          ()
      with
      | Ok _ -> ()
@@ -897,7 +918,7 @@ let test_claim_next_preserves_rejected_verification_owner_task () =
     claim_and_start config "worker" task_1;
     (match Workspace.transition_task_r config ~agent_name:"worker"
              ~task_id:task_1 ~action:Masc_domain.Submit_for_verification
-             ~notes:submit_notes () with
+             ~notes:submit_notes ~handoff_context:submit_handoff () with
      | Ok _ -> ()
      | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e));
     let req =
@@ -925,7 +946,7 @@ let test_self_approval_blocked () =
     claim_and_start config "worker" task_id;
     let _ = Workspace.transition_task_r config ~agent_name:"worker"
       ~task_id ~action:Masc_domain.Submit_for_verification
-      ~notes:submit_notes () in
+      ~notes:submit_notes ~handoff_context:submit_handoff () in
     match Workspace.transition_task_r config ~agent_name:"worker"
             ~task_id ~action:Masc_domain.Approve_verification () with
     | Ok _ -> Alcotest.fail "self-approval should be blocked"
@@ -940,7 +961,7 @@ let test_self_rejection_blocked () =
     claim_and_start config "worker" task_id;
     let _ = Workspace.transition_task_r config ~agent_name:"worker"
       ~task_id ~action:Masc_domain.Submit_for_verification
-      ~notes:submit_notes () in
+      ~notes:submit_notes ~handoff_context:submit_handoff () in
     match Workspace.transition_task_r config ~agent_name:"worker"
             ~task_id ~action:Masc_domain.Reject_verification () with
     | Ok _ -> Alcotest.fail "self-rejection should be blocked"
@@ -1009,7 +1030,8 @@ let test_fsm_disabled_submit_fails () =
     let task_id = add_strict_task config in
     claim_and_start config "worker" task_id;
     match Workspace.transition_task_r config ~agent_name:"worker"
-            ~task_id ~action:Masc_domain.Submit_for_verification () with
+            ~task_id ~action:Masc_domain.Submit_for_verification
+            ~handoff_context:submit_handoff () with
     | Ok _ -> Alcotest.fail "submit should fail when FSM disabled"
     | Error e ->
       let msg = Masc_domain.show_masc_error e in

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -554,7 +554,11 @@ let test_submit_uses_required_evidence_when_verify_refs_empty () =
         ~task_id
         ~action:Masc_domain.Submit_for_verification
         ~notes:"implementation complete"
-        ~handoff_context:submit_handoff
+        (* Deliberately no handoff: this test pins the fallback where the
+           contract's required_evidence alone reaches the verifier refs.
+           The strict gate accepts it because the contract declares the
+           evidence (declared_verification_evidence_refs includes
+           contract refs). *)
         ~prepare_verification_request:
           (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs ->
              captured_refs := Some evidence_refs;

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1366,12 +1366,15 @@ let test_submit_and_approve_completes_via_verification () =
     let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
     (* Uses the exported probe identity so this test also pins that the
        constant passes Agent_id validation and is distinct from a plain
-       agent identity, end-to-end through the real FSM. *)
+       agent identity, end-to-end through the real FSM. evidence_refs=[]
+       pins the RFC-0323 Phase A boundary: a task without a strict contract
+       machine-verifies with no evidence (the #23719 gate is strict-scoped). *)
     let result =
       Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
         ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
         ~task_id:"task-001"
-        ~notes:"deterministic evidence satisfied" ~approve_notes:"machine-verified" ()
+        ~notes:"deterministic evidence satisfied" ~approve_notes:"machine-verified"
+        ~evidence_refs:[] ()
     in
     Alcotest.(check bool) "submit+approve ok" true
       (match result with Ok _ -> true | Error _ -> false);
@@ -1403,7 +1406,7 @@ let test_submit_and_approve_rejects_same_identity () =
     let result =
       Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
         ~verifier_name:test_agent_a ~task_id:"task-001"
-        ~notes:"n" ~approve_notes:"a" ()
+        ~notes:"n" ~approve_notes:"a" ~evidence_refs:[] ()
     in
     Alcotest.(check bool) "rejected as not distinct" true
       (match result with
@@ -1423,7 +1426,7 @@ let test_submit_and_approve_rejects_invalid_verifier () =
     let result =
       Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
         ~verifier_name:"probe:bad:double" ~task_id:"task-001"
-        ~notes:"n" ~approve_notes:"a" ()
+        ~notes:"n" ~approve_notes:"a" ~evidence_refs:[] ()
     in
     Alcotest.(check bool) "rejected as invalid verifier" true
       (match result with
@@ -1442,13 +1445,78 @@ let test_submit_and_approve_non_assignee_submit_fails () =
     let result =
       Workspace.submit_and_approve_task_r config ~agent_name:admin_keeper_agent
         ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
-        ~task_id:"task-001" ~notes:"n" ~approve_notes:"a" ()
+        ~task_id:"task-001" ~notes:"n" ~approve_notes:"a" ~evidence_refs:[] ()
     in
     Alcotest.(check bool) "submit failed typed" true
       (match result with
        | Error (Workspace.Machine_verify_submit_failed _) -> true
        | Ok _ | Error _ -> false);
     Alcotest.(check bool) "task still claimed" true
+      (match find_task config "task-001" with
+       | Some { task_status = Masc_domain.Claimed _; _ } -> true
+       | Some _ | None -> false))
+
+(* The #23719 evidence gate, scoped to strict contracts: a strict task
+   machine-verifies when the probe supplies evidence_refs, and fail-closes
+   before any mutation when it does not. *)
+
+let g2_strict_contract : Masc_domain.task_contract =
+  { strict = true
+  ; completion_contract = [ "machine-verifiable deliverable" ]
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; evidence_claims = []
+  ; stale_claim_timeout_sec = 0
+  ; links = { operation_id = None; session_id = None }
+  }
+
+let test_submit_and_approve_strict_with_evidence_completes () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~contract:g2_strict_contract
+        ~title:"Strict Probe Task" ~priority:1 ~description:""
+    in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
+        ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
+        ~task_id:"task-001" ~notes:"claims satisfied" ~approve_notes:"machine-verified"
+        ~evidence_refs:[ "file exists: proof.json" ] ()
+    in
+    Alcotest.(check bool) "strict submit+approve ok" true
+      (match result with Ok _ -> true | Error _ -> false);
+    match find_task config "task-001" with
+    | Some { task_status = Masc_domain.Done _; handoff_context; _ } ->
+      (* The approve re-supplies the machine handoff, so the Done record
+         keeps the evidence for audit consumers instead of wiping it. *)
+      Alcotest.(check bool) "Done record carries the machine evidence" true
+        (match handoff_context with
+         | Some ctx -> ctx.evidence_refs = [ "file exists: proof.json" ]
+         | None -> false)
+    | Some _ -> Alcotest.fail "strict task not Done after submit+approve"
+    | None -> Alcotest.fail "task-001 missing")
+
+let test_submit_and_approve_strict_without_evidence_fail_closed () =
+  with_test_env (fun config ->
+    let _ =
+      Workspace.add_task config ~contract:g2_strict_contract
+        ~title:"Strict Probe Task" ~priority:1 ~description:""
+    in
+    let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
+    let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
+    let result =
+      Workspace.submit_and_approve_task_r config ~agent_name:test_agent_a
+        ~verifier_name:Keeper_tool_task_runtime.deterministic_probe_verifier
+        ~task_id:"task-001" ~notes:"no evidence" ~approve_notes:"a"
+        ~evidence_refs:[] ()
+    in
+    Alcotest.(check bool) "strict submit without evidence fail-closed" true
+      (match result with
+       | Error (Workspace.Machine_verify_submit_failed _) -> true
+       | Ok _ | Error _ -> false);
+    Alcotest.(check bool) "task unchanged (still claimed)" true
       (match find_task config "task-001" with
        | Some { task_status = Masc_domain.Claimed _; _ } -> true
        | Some _ | None -> false))
@@ -1530,7 +1598,9 @@ let test_strict_task_done_routes_to_submit () =
     in
     let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
     let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
-    (* Direct done is blocked with the RFC-0308 remediation, even for the owner. *)
+    (* Direct done is blocked and the error names the submit lane — whether
+       the strict evidence gate (no handoff supplied here) or the RFC-0308
+       lifecycle guard fires first, both route to submit_for_verification. *)
     let direct =
       Workspace.transition_task_r config ~agent_name:test_agent_a ~task_id:"task-001"
         ~action:Masc_domain.Done_action ~notes:"done" ()
@@ -1540,10 +1610,22 @@ let test_strict_task_done_routes_to_submit () =
        Alcotest.(check bool) "error routes to submit_for_verification" true
          (str_contains (Masc_domain.masc_error_to_string e) "submit_for_verification")
      | Ok _ -> Alcotest.fail "strict task completed via direct done");
-    (* The verification lane still completes it. *)
+    (* The verification lane completes it — a strict submit carries evidence
+       (the #23719 gate, strict-scoped). *)
     let submitted =
       Workspace.transition_task_r config ~agent_name:test_agent_a ~task_id:"task-001"
-        ~action:Masc_domain.Submit_for_verification ~notes:"evidence attached" ()
+        ~action:Masc_domain.Submit_for_verification ~notes:"evidence attached"
+        ~handoff_context:
+          { Masc_domain.summary = "evidence attached"
+          ; reason = None
+          ; next_step = None
+          ; failure_mode = None
+          ; reclaim_policy = None
+          ; evidence_refs = [ "tests green: dune runtest" ]
+          ; updated_at = None
+          ; updated_by = None
+          }
+        ()
     in
     Alcotest.(check bool) "submit ok" true
       (match submitted with Ok _ -> true | Error _ -> false);
@@ -2297,6 +2379,10 @@ let () =
         test_submit_and_approve_rejects_invalid_verifier;
       Alcotest.test_case "non-assignee submit fails typed" `Quick
         test_submit_and_approve_non_assignee_submit_fails;
+      Alcotest.test_case "strict + evidence completes, Done keeps evidence" `Quick
+        test_submit_and_approve_strict_with_evidence_completes;
+      Alcotest.test_case "strict without evidence fail-closed pre-mutation" `Quick
+        test_submit_and_approve_strict_without_evidence_fail_closed;
     ];
 
     (* === RFC-0323 G-3: state-keyed completion side effects === *)


### PR DESCRIPTION
## P0 — #23719 evidence gate가 RFC-0323 G-2 probe를 붕괴 (완성도 감사 최우선 finding)

근거: 완성도 감사 콘솔(2026-07-08, masc@33e937bcb7 기준) P0 CONFIRMED — "#23719 evidence gate breaks G-2 deterministic probe: `submit_and_approve_task_r` never threads handoff_context, so submit always fails the new unconditional evidence gate." 본 세션에서 fresh-read 재검증 완료(submit :130-139, approve :205-212 모두 `~handoff_context` 부재, 게이트는 무조건).

### 무엇이 깨졌나

#23719(lib 2파일, **테스트 0**)가 evidence 게이트를 모든 Submit/Done에 무조건 적용:

1. **G-2 probe 회귀**: `submit_and_approve_task_r`가 handoff를 안 꿰므로 machine verification이 항상 게이트에서 Error → probe가 매번 LLM turn으로 fallback (RFC-0199/G-2 무력화).
2. **문서화된 invariant 위반**: 같은 파일이 "Empty list is valid for analysis-only / no-contract tasks"라고 명시하는데 게이트는 무조건 거부 — 감사 P2 boundary-violation.
3. **테스트 잠복 red**: `test_workspace.ml` G-2 4종 + `test_verification_fsm.ml` 16 submit 사이트가 main red 뒤에서 깨짐 (#23661과 동일한 lib-only-merge 패턴 2호).
4. **무예고 Phase B**: fleet 전체 evidence 강제는 G-1이 predicate 결정(contract.strict)으로 명시적으로 회피한 시나리오.

### 수정

| 지점 | 변경 |
|---|---|
| `workspace_task_transitions.ml` | 게이트를 `task_requires_verification`(=contract.strict, **G-1과 동일 Phase A 술어**)로 조건화. submit/done arm + approve/reject arm. 메시지가 "Code task submission" 오기술 대신 strict 스코프+submit 레인을 명명 |
| `workspace_task.ml{,i}` | `submit_and_approve_task_r`에 `~evidence_refs` 추가 — submit의 typed handoff(summary=notes)로 운반. **approve/보상 reject도 같은 handoff 재공급** (executor가 모든 액션에서 인자를 persist하므로, 없으면 Done 레코드의 evidence가 None으로 소거 — 감사 "악마의 디테일" 1번) |
| `keeper_tool_task_runtime.ml` | probe가 satisfied claims(`Evidence_claim.to_human_string`)를 evidence_refs로 전달 — strict 태스크도 machine-verify 가능 |

### 검증

- 신규 pin 2종: strict+evidence → Ok + **Done 레코드가 evidence 보존**; strict+무증거 → `Machine_verify_submit_failed` fail-closed(무변이).
- 기존 G-2 4종에 `~evidence_refs:[]` — contract-less 케이스가 Phase A 경계 자체를 pin.
- G-1 flow 테스트: strict submit이 evidence 운반(직접 done 거부 assertion 불변 — 게이트/가드 둘 다 submit_for_verification을 명명).
- `test_verification_fsm.ml` 16 사이트에 공용 `submit_handoff` 배선 (#23719 이후 main에서 잠복 red였음).
- 비-strict 도구/coverage 경로는 무수정 치유 (게이트가 더는 적용 안 됨).
- 로컬 parse-only 통과; 빌드/테스트는 CI.

### 경계

- verification timeout no-op sweep(감사 P1), anti_rationalization Gate-0(#23738이 진행 중), executor persist 의미론 자체는 **불변** — 본 PR은 게이트 스코프+evidence 관통만.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
