### PR TITLE
docs(rfc): RFC-0333 — deterministic cost↔success frontier join for the eval harness

### DIFF
--- a/docs/rfc/RFC-0333-eval-cost-success-frontier.md
+++ b/docs/rfc/RFC-0333-eval-cost-success-frontier.md
@@ -1,0 +1,49 @@
+# RFC-0333 — Deterministic cost↔success frontier join for the eval harness
+
+- Status: Draft
+- Decision driver: Ilya-30-papers adversarial transfer census (2026-07-08), axis A2's surviving core after the scaling-law refutation: "`total_cost_usd` ↔ `pass_at_k` paired frontier join — 오늘 없는 join, stochasticity 추가 0." The Kaplan curve-fit proposal was refuted on power grounds (6-value quantized Bernoulli at n=5, SE≈0.22, <1 OOM of resource range — curve shape unidentifiable); what survives is a deterministic join over data the harness already records.
+- Area: `lib/eval_harness.ml:105,113-124` (`eval_run.total_cost_usd`, `eval_result` carrying both `pass_at_k` and `total_cost_usd` per scenario, `:321-337` aggregation), `:629-633` (summary print — pass/score/consistency only), `lib/fusion_policy.ml:86` (`max_panel = 8` — an OpenRouter API cap, not a measured optimum).
+- Refinement over the census (fresh-read 2026-07-09): the census said "success↔cost가 join 안 됨"; in fact both metrics already coexist **per scenario** in `eval_result`. The missing join is **across configurations** — nothing pairs the same scenario under different resource configs (model, panel size, retry budget) and computes dominance, and the human-facing summary does not surface cost at all.
+
+## Problem (audited)
+
+Resource choices (which model, what panel width, how many retries) are made without a cost-per-success comparison, even though every input is already recorded:
+
+- Per run: `total_cost_usd : float option` (`eval_harness.ml:105`), missing costs propagate as `None` (`sum_costs`, `:309-311`) — the honest-unknown path already exists.
+- Per scenario: `pass_at_k` (`:334`) and summed `total_cost_usd` (`:337`) sit in the same record; the PASS/FAIL summary (`:629-633`) prints pass\@k, mean score, and consistency but not cost.
+- `fusion_policy.ml:86` pins `max_panel = 8` with a comment that it is the OpenRouter API cap — panel width has never been chosen by measurement.
+
+The refuted alternative (fit `success = f(N, R, B)` curves) would have burned ~900 real API calls to produce "no recommendation" at the harness's statistical power. The frontier join asks a weaker, answerable question: **among the configs we actually ran, which are dominated** (worse-or-equal success at higher-or-equal cost)?
+
+## Decision
+
+1. **A deterministic pairing**: group `eval_result`s by scenario across configs (config identity = the scenario's resource parameters, carried explicitly rather than parsed from names). Emit per scenario a frontier table: `(config, pass_at_k, total_cost_usd, cost_per_success)` where `cost_per_success = total_cost_usd / max pass_at_k ε` is defined only when cost is known (`None` cost ⇒ excluded from ranking, shown as unknown — never coerced to 0/free; the unknown-model→$0 anti-pattern is the exact failure class this respects).
+2. **Dominance verdict, not a recommendation engine**: a config is `Dominated` iff some other config has ≥ pass_at_k and ≤ cost with at least one strict inequality; otherwise `On_frontier`. A closed sum, no scores, no fitting, no thresholds to tune.
+3. **Statistical honesty is structural**: results with `min_runs_met = false` (`:123`) are excluded from dominance and rendered as `Insufficient_runs` — the harness's own n≥5 gate, reused. No confidence claims beyond what `ci95_low/high` already carry.
+4. **Zero new stochasticity**: the join is a pure function over persisted `eval_suite_result`s. No new API calls; the sufficient-power A/B (n≈200) stays DEFER as the census recorded.
+
+## Waves
+
+| Wave | Scope | Exit criterion |
+|---|---|---|
+| W1 | `frontier_row` / `dominance = On_frontier \| Dominated \| Insufficient_runs \| Unknown_cost` types + pure join fn + unit pins | dominance is a total function over any two results; None cost never ranks |
+| W2 | Summary surface: frontier table in the suite report (`:629` region) and JSON output | cost visible where pass/fail already prints |
+| W3 | Panel-width sweep harness config (2/4/8) so `max_panel` gets its first measured data point — still no auto-tuning; the number stays in code and a human moves it | one recorded comparison exists; `fusion_policy.ml:86` comment gains a data citation or stays honest about the cap |
+
+## Verification
+
+- Property pins: dominance is irreflexive/antisymmetric on strict pairs; `None` cost ⇒ `Unknown_cost` regardless of pass_at_k; `min_runs_met=false` ⇒ `Insufficient_runs` even if it would dominate.
+- Golden test: a fixed 3-config fixture with a known frontier.
+- Workaround-gate self-check: no curve fitting, no learned scorer, no threshold knobs — a dominated/on-frontier partition is the whole output.
+
+## Boundaries (untouched)
+
+- `compute_pass_at_k` and CI math — unchanged.
+- `max_panel = 8` — not auto-tuned; W3 only produces the first measured comparison for a human decision.
+- No new eval executions are triggered by the join itself; it consumes existing results.
+
+## Evidence record
+
+- Evidence: `lib/eval_harness.ml:105,113-124,309-337,629-633`, `lib/fusion_policy.ml:86`, census artifact e1d4ba86 (axis A2, WEAKENED→surviving core), fresh-read re-verified 2026-07-09 at `63b5a69975` including the per-scenario-join refinement.
+- Confidence: High (all cited lines re-read; the census claim was tightened, not weakened, by the re-read).
+- Delta: replaces the refuted Kaplan-style curve fit with a dominance partition over already-persisted data; the expensive A/B remains deferred.


### PR DESCRIPTION
## RFC-0333 — eval cost↔success frontier (Ilya 전이 백로그 3위, READY RFC → 정식화)

fresh-read 정밀화: census의 'join 안 됨'과 달리 `eval_result`는 per-scenario로 두 지표를 이미 보유(:116,:119,:321-337). 진짜 갭 = **config 간 dominance 비교 부재** + 요약 출력에 cost 부재(:629-633) + `max_panel=8`이 측정 아닌 API cap(fusion_policy.ml:86).

- 결정: 저장된 결과 위의 순수 dominance partition (`On_frontier | Dominated | Insufficient_runs | Unknown_cost`) — 신규 API 호출 0, curve-fit 0(검정력 부족으로 기각된 Kaplan 제안 부활 금지).
- 정직성 구조화: `None` cost는 $0으로 강등 금지(미등록모델-$0 안티패턴 회피), `min_runs_met=false`는 dominance에서 제외.
- W3는 panel 2/4/8 첫 실측 비교만 — auto-tuning 없음, 숫자는 사람이 움직임.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
