### PR TITLE
docs: sync ROADMAP/OPERATING-PLAN/SPEC-INDEX package version to 0.20.0 (unblock doc-truth)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # masc Roadmap
 
-> Current package version: v0.19.56
-> Latest changelog entry: v0.19.56 (2026-07-06)
+> Current package version: v0.20.0
+> Latest changelog entry: v0.20.0 (2026-07-08)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
 > Updated: 2026-07-03
 

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,8 +9,8 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.56
-> Latest changelog entry: v0.19.56 (2026-07-06)
+> Current package version: v0.20.0
+> Latest changelog entry: v0.20.0 (2026-07-08)
 > Latest published GitHub release: v0.19.51 (2026-06-28)
 > Updated: 2026-07-03
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -11,7 +11,7 @@ code_refs:
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-07-03
-> Snapshot baseline: `dune-project` version `0.19.56`
+> Snapshot baseline: `dune-project` version `0.20.0`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 Keeper/MCP client가 동일 workspace에서 작업할 때 필요한 조율과 관찰성을 제공한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper turn, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 


### PR DESCRIPTION
## Meta Guards "Check doc truth" fleet-wide red 수리

#23730이 dune-project/CHANGELOG만 0.20.0으로 올리고 doc-truth가 검증하는 3개 문서 표면(ROADMAP.md :3-4, docs/PRODUCT-OPERATING-PLAN.md :12-13, docs/spec/SPEC-INDEX.md :14)을 안 올려서, **docs/를 건드리는 모든 PR**이 Meta Guards에서 fail합니다 (#23741/#23742/#23743에서 실측).

- 로컬 검증: `check-version-truth.sh` PASS(package=0.20.0 changelog=0.20.0), `check-doc-truth.sh` PASS.
- release bump 시 이 3개 표면 동기화가 bump PR의 체크리스트여야 함 — release-please 류 자동화 검토는 별도.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
