### PR TITLE
task-1881: add operator_override path to anti-rationalization gate

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -713,6 +713,7 @@ let review
       ?(verify_gate_evidence = [])
       ?(on_verdict : (review_result -> unit) option)
       ?(few_shot_block = "")
+      ?(operator_override : bool = false)
       ?sw
       (req : review_request)
   : review_result
@@ -845,7 +846,15 @@ let review
            ; fallback_reason = None
            }
        | None ->
-         (* Gate 3: LLM review via evaluator runtime (structured tool output, ADR D3) *)
+         if operator_override then emit
+           { verdict = Approve
+           ; evaluator_runtime
+           ; generator_runtime
+           ; gate = Fallback
+           ; fallback_reason = Some "operator override: shared-account self-approval deadlock"
+           }
+         else begin
+           (* Gate 3: LLM review via evaluator runtime (structured tool output, ADR D3) *)
          let prompt =
            build_prompt
              ~few_shot_block
@@ -1062,5 +1071,5 @@ let review
                   ; generator_runtime
                   ; gate = Fallback
                   ; fallback_reason = Some msg
-                  }))))
+                  })))) end
 ;;

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -846,14 +846,15 @@ let review
            ; fallback_reason = None
            }
        | None ->
-         if operator_override then emit
-           { verdict = Approve
-           ; evaluator_runtime
-           ; generator_runtime
-           ; gate = Fallback
-           ; fallback_reason = Some "operator override: shared-account self-approval deadlock"
-           }
-         else begin
+         if operator_override then begin
+           emit
+             { verdict = Approve
+             ; evaluator_runtime
+             ; generator_runtime
+             ; gate = Fallback
+             ; fallback_reason = Some "operator override: shared-account self-approval deadlock"
+             }
+         end else begin
            (* Gate 3: LLM review via evaluator runtime (structured tool output, ADR D3) *)
          let prompt =
            build_prompt

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -402,7 +402,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~tool_name ~start_time reason
   | None ->
   let review_gate_rejection =
-    if (=) action Masc_domain.Done_action && not force then
+    if (=) action Masc_domain.Done_action then
       if not completion_owned_by_caller then
         None
       else if can_review_completion ~task_opt ~agent_name:ctx.agent_name then
@@ -412,6 +412,7 @@ and handle_transition ~tool_name ~start_time ctx args =
              | Some persisted -> Some persisted
              | None -> completion_contract)
           ~evaluator_runtime
+          ~operator_override:force
           ~ctx
           ~task_opt
           ~task_id

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -195,6 +195,7 @@ let owner_transition_action_denylist (ctx : context) =
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_runtime : string option)
+    ~(operator_override : bool = false)
     ~(ctx : context)
     ~(task_opt : Masc_domain.task option)
     ~(task_id : string)
@@ -242,7 +243,7 @@ let review_completion_notes
          ?completion_contract
          ~required_evidence
          ~verify_gate_evidence
-         ~on_verdict ~few_shot_block ar_req).verdict with
+         ~on_verdict ~few_shot_block ~operator_override ar_req).verdict with
       | Anti_rationalization.Reject reason -> Some reason
       | Anti_rationalization.Approve -> None
 

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -144,6 +144,21 @@ let test_review_rejects_non_object_json_evaluator_response () =
     ~text:{|[{"verdict":"APPROVE"}]|}
     ~reason_substring:"review verdict"
 
+let test_operator_override_skips_llm_and_approves () =
+  let result = AR.review ~operator_override:true (make_request ()) in
+  Alcotest.(check string)
+    "gate"
+    "fallback"
+    (AR.gate_to_string result.AR.gate);
+  Alcotest.(check (option string))
+    "fallback reason"
+    (Some "operator override: shared-account self-approval deadlock")
+    result.AR.fallback_reason;
+  match result.AR.verdict with
+  | AR.Approve -> ()
+  | AR.Reject reason ->
+    Alcotest.failf "operator_override should approve, got reject: %s" reason
+
 let () =
   Alcotest.run
     "anti_rationalization_empty_reject"
@@ -185,5 +200,12 @@ let () =
             "non-object JSON evaluator response rejects"
             `Quick
             test_review_rejects_non_object_json_evaluator_response;
+        ] );
+      ( "operator override policy",
+        [
+          Alcotest.test_case
+            "operator override skips LLM and approves"
+            `Quick
+            test_operator_override_skips_llm_and_approves;
         ] );
     ]


### PR DESCRIPTION
Adds an `operator_override` path to the anti-rationalization gate so that forceful task completions (`force=true`, operator authority) can bypass the LLM review while still emitting an auditable `review_result` with `gate = Fallback` and a fallback reason.

This resolves the completion gate topology deadlock against the shared-account no-self-merge constraint: when every keeper shares the `anyang-keepers` GitHub account, no PR can receive GitHub approval, so task completion would otherwise be blocked by the anti-rationalization gate.

Files changed:
- `lib/task/anti_rationalization.ml`
- `lib/task/tool_task.ml`
- `lib/task/tool_task_handlers.ml`

Note: Because the PR author is the shared `anyang-keepers` account, this PR cannot receive a GitHub PR-level review approval from another keeper. It will require operator action (force-merge or a distinct GitHub actor) to land.