### PR TITLE
task-1890: fix Memory OS stale-fact regression in consolidator

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -118,7 +118,7 @@ let distinct_keepers contribs =
 
 let consolidate_into_shared ~now ~min_keepers contribs =
   let current_contribs =
-    List.filter (fun c -> fact_is_current ~now c.fact) contribs
+    List.filter (fun c -> not_stale ~now c.fact) contribs
   in
   match representative current_contribs with
   | None -> None

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3815,6 +3815,38 @@ let test_consolidator_stale_peer_does_not_satisfy_min_keepers () =
     (List.length shared)
 ;;
 
+(* A fact with no valid_until but an old last_verified_at is stale and must be
+   excluded from the representative and observed_by set. *)
+let test_consolidator_filters_stale_without_valid_until () =
+  let now = 1_000_000.0 in
+  let claim_id = Some "no-valid-until-stale" in
+  let stale =
+    { (mk_shared_fixture ~now ~category:"lesson" "stale no valid_until") with
+      Types.first_seen = 1.0
+    ; Types.last_verified_at = Some (now -. (Policy.max_consensus_staleness +. 1.0))
+    ; Types.claim_id = claim_id
+    }
+  in
+  let fresh =
+    { (mk_shared_fixture ~now ~category:"lesson" "fresh no valid_until") with
+      Types.first_seen = now -. 1.0
+    ; Types.last_verified_at = Some (now -. 1.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let promoted =
+    promote_one ~now [ "stale", [ stale ]; "fresh", [ fresh ] ]
+  in
+  Alcotest.(check string)
+    "representative excludes stale contributor without valid_until"
+    "fresh no valid_until"
+    promoted.Types.claim;
+  Alcotest.(check (list string))
+    "observed_by excludes stale contributor without valid_until"
+    [ "fresh" ]
+    promoted.Types.observed_by
+;;
+
 (* A claim held by a single keeper is never shared (below min_keepers). *)
 let test_consolidator_solo_not_promoted () =
   let now = 1_000_000.0 in
@@ -6102,6 +6134,10 @@ let () =
             "stale peer does not satisfy min_keepers"
             `Quick
             test_consolidator_stale_peer_does_not_satisfy_min_keepers
+        ; Alcotest.test_case
+            "stale fact without valid_until is filtered"
+            `Quick
+            test_consolidator_filters_stale_without_valid_until
         ; Alcotest.test_case
             "solo claim not promoted"
             `Quick


### PR DESCRIPTION
Fixes the stale-fact regression where `consolidate_into_shared` used `fact_is_current` (only checks `valid_until`) while `eligible` used `not_stale` (also checks `last_verified_at`/`first_seen`). A fact with no `valid_until` but an old `last_verified_at` could be accepted by `fact_is_current` and emitted as the representative shared fact.

Changes:
- `lib/keeper/keeper_memory_os_consolidator.ml`: `consolidate_into_shared` now filters with `not_stale` so it is consistent with `eligible`.
- `test/test_keeper_memory_os.ml`: added `test_consolidator_filters_stale_without_valid_until` covering the regression case.

Note: PR is authored by the shared `anyang-keepers` account, so it requires operator action to merge.