### PR TITLE
gate0: require evidence_refs for masc_transition done action

### DIFF
--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -168,4 +168,5 @@ let transition_known_args =
     "completion_contract";
     "evaluator_runtime";
     "handoff_context";
+    "evidence_refs";
   ]

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -712,4 +712,5 @@ let transition_known_args =
     "completion_contract";
     "evaluator_runtime";
     "handoff_context";
+    "evidence_refs";
   ]


### PR DESCRIPTION
handle_done now extracts and validates evidence_refs before forwarding to handle_transition. Added evidence_refs to transition_known_args in tool_task_args.ml and tool_task_handlers.ml.

Resolves: task-1882