### PR TITLE
fix: fact_is_current no longer eternal for valid_until=None (task-1890)

### DIFF
--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -365,10 +365,24 @@ let fact_effective_valid_until (fact : fact) =
   | None, _ -> None
 ;;
 
+(* Staleness ceiling (seconds) for facts without an explicit valid_until
+   horizon. Tied to [Keeper_memory_os_policy.max_consensus_staleness] so that
+   read-path ([fact_is_current]) and write-path ([not_stale]) agree on when
+   unbounded facts expire. *)
+let fact_staleness_ceiling = 86400.
+
 let fact_is_current ~now (fact : fact) =
   match fact_effective_valid_until fact with
-  | None -> true
   | Some ts -> ts >= now
+  | None ->
+    (* Mirror [not_stale] in consolidator.ml: use last_verified_at when
+       available (shared facts), fall back to first_seen + ceiling. *)
+    let deadline =
+      match fact.last_verified_at with
+      | Some t -> t +. fact_staleness_ceiling
+      | None -> fact.first_seen +. fact_staleness_ceiling
+    in
+    now <= deadline
 ;;
 
 let librarian_unstructured_fallback_claim_prefix =


### PR DESCRIPTION
fact_is_current returned true when valid_until was None, causing promoted shared facts to be treated as eternally current. Read path and write path disagreed: not_stale already used a 24h ceiling for None, but fact_is_current did not.

Fix: fact_is_current now mirrors not_stale fallback - uses last_verified_at + 86400s (shared facts) or first_seen + 86400s ceiling.

Resolves: task-1890

Files: lib/keeper/keeper_memory_os_types.ml (+15 -1)