### PR TITLE
fix(test): repair latent-red test pins from masked-red merges (task-1869/G-3/G-8/#23638/#23664)

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -695,7 +695,20 @@ let agent_spans_json config ?(limit = 500) ?since_ms () =
          | None -> ());
         (match span_end_classification e.kind with
          | Some (ek, status) ->
-             let key = (aid, subject_id) in
+             (* RFC-0323 G-3: on approve-produced completion the event actor
+                is the VERIFIER, but the span was opened by the ASSIGNEE, who
+                rides the payload (emitted since G-3). Close the assignee's
+                span; fall back to the actor for pre-G-3 events — mirrors the
+                works_on-edge routing in [Activity_graph_reducer]. *)
+             let closing_aid =
+               match e.kind with
+               | "task.approved" ->
+                   (match Json_util.assoc_member_opt "assignee" e.payload with
+                    | Some (`String name) when String.trim name <> "" -> name
+                    | Some _ | None -> aid)
+               | _ -> aid
+             in
+             let key = (closing_aid, subject_id) in
              (match Hashtbl.find_opt open_spans key with
               | Some (start_ms, sk, label) when String.equal sk ek ->
                   Hashtbl.remove open_spans key;

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -217,6 +217,11 @@ let public_mcp_non_descriptor_names =
   ; "masc_keeper_sandbox_status"
   ; "masc_keeper_create_from_persona"
   ; "masc_persona_list"
+  (* Persona CRUD (#23664) lives with masc_persona_list outside the keeper
+     descriptor spine (operator-plane handlers in mcp_server); #23664 added
+     the surface entries without this allowlist edit while main was red. *)
+  ; "masc_persona_create"
+  ; "masc_persona_update"
   ; "masc_runtime_verify"
   ; "masc_runtime_ollama_probe"
   ]

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -115,10 +115,18 @@ let assert_unregistered_policy_denial_response ~raw =
     "policy response denies access"
     (Some false)
     (Json.member "ok" json |> Json.to_bool_option);
-  Alcotest.(check (option string))
+  (* #23638 appends an environment-dependent diagnostic suffix when a
+     playground clone candidate exists but fails verification ("; playground
+     clone candidate could not be verified: <tmp path>: ..."). The invariant
+     this pin protects is that the ORIGINAL denial survives as the visible
+     error — assert the prefix, not equality. *)
+  Alcotest.(check bool)
     "visible error keeps original denial"
-    (Some unregistered_masc_mcp_policy_error)
-    (Json.member "error" json |> Json.to_string_option);
+    true
+    (match Json.member "error" json |> Json.to_string_option with
+     | Some err ->
+       String.starts_with ~prefix:unregistered_masc_mcp_policy_error err
+     | None -> false);
   Alcotest.(check (option string))
     "no HITL policy error"
     None

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1409,7 +1409,11 @@ let test_task_reclaim_gate_blocks_only_typed_policy () =
 
 
 
-let test_task_claim_next_action_policy_block_is_skip () =
+let test_task_claim_next_action_todo_policy_block_still_claims () =
+  (* task-1869 (#23661): reclaim_policy gates Done -> re-claim only. A Todo
+     task carrying Block_reclaim (e.g. an operator hard-stop release) stays
+     claimable; the block re-arms once the task reaches Done. This pin was
+     inverted before #23661 and sat latent-red while main was compile-red. *)
   let t : Masc_domain.task = {
     id = "task-009";
     title = "Operator stop";
@@ -1427,11 +1431,10 @@ let test_task_claim_next_action_policy_block_is_skip () =
     do_not_reclaim_reason = Some "operator hard stop";
   } in
   match Masc_domain.task_claim_next_action t with
-  | Masc_domain.Skip_claim (Masc_domain.Claim_block_reclaim_policy reason) ->
-    check string "reason" "operator hard stop" reason;
-    check bool "claimable" false (Masc_domain.task_claim_next_action_is_claimable t)
   | Masc_domain.Claim_now ->
-    fail "typed policy block must skip claim"
+    check bool "claimable" true (Masc_domain.task_claim_next_action_is_claimable t)
+  | Masc_domain.Skip_claim (Masc_domain.Claim_block_reclaim_policy _) ->
+    fail "todo task must stay claimable regardless of reclaim_policy (task-1869)"
   | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
     fail "todo task should not be classified as not-todo"
 
@@ -1687,7 +1690,7 @@ let () =
       test_case "to_yojson" `Quick test_task_to_yojson;
       test_case "of_yojson ok" `Quick test_task_of_yojson_ok;
       test_case "of_yojson error" `Quick test_task_of_yojson_error;
-      test_case "claim next action policy block is skip" `Quick
-        test_task_claim_next_action_policy_block_is_skip;
+      test_case "claim next action: todo stays claimable under policy block" `Quick
+        test_task_claim_next_action_todo_policy_block_still_claims;
     ];
   ]

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -590,7 +590,7 @@ let test_claim_next_r_preserved_task_field () =
     | _ -> Alcotest.fail "second claim should succeed")
 ;;
 
-let test_release_hard_stop_blocks_future_claim_next () =
+let test_release_hard_stop_todo_stays_claimable () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
     let _ = Workspace.add_task config ~title:"Phantom task" ~priority:1 ~description:"" in
@@ -639,13 +639,20 @@ let test_release_hard_stop_blocks_future_claim_next () =
       "typed hard-stop persisted"
       (Some "block_reclaim")
       (Option.map Masc_domain.task_reclaim_policy_to_string task_001.reclaim_policy);
+    (* task-1869 (#23661): reclaim_policy gates Done -> re-claim only, so the
+       released Todo task stays claimable and claim_next picks it back up by
+       priority. The pre-#23661 pin expected task-002 here and sat latent-red
+       while main was compile-red. The persisted policy/reason above re-arm
+       once the task reaches Done. *)
     match Workspace.claim_next_r config ~agent_name:claude () with
     | Workspace.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "claim_next skips blocked todo" "task-002" task_id
-    | _ -> Alcotest.fail "expected claim_next_r to skip blocked task-001")
+      Alcotest.(check string)
+        "claim_next re-claims released todo despite block policy"
+        "task-001" task_id
+    | _ -> Alcotest.fail "expected claim_next_r to claim the released task-001")
 ;;
 
-let test_release_hard_stop_blocks_direct_reclaim () =
+let test_release_hard_stop_allows_direct_todo_reclaim () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
     let _ = Workspace.add_task config ~title:"Phantom task" ~priority:1 ~description:"" in
@@ -671,16 +678,26 @@ let test_release_hard_stop_blocks_direct_reclaim () =
      with
      | Ok _ -> ()
      | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
-    match Workspace.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
-    | Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState message)) ->
-      Alcotest.(check bool)
-        "direct claim blocked by typed reclaim_policy"
-        true
-        (str_contains message "blocked from re-claim")
-    | Error e ->
-      Alcotest.fail
-        ("expected TaskInvalidState, got " ^ Masc_domain.masc_error_to_string e)
-    | Ok _ -> Alcotest.fail "direct claim should be blocked after hard-stop release")
+    (* task-1869 (#23661): a Todo task is always claimable — Block_reclaim
+       re-arms only at Done -> re-claim. Direct re-claim of the released
+       task therefore succeeds; the typed policy stays persisted on the task. *)
+    (match Workspace.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e ->
+       Alcotest.fail
+         ("direct todo re-claim should succeed under task-1869: "
+          ^ Masc_domain.masc_error_to_string e));
+    match
+      List.find_opt
+        (fun (t : Masc_domain.task) -> String.equal t.id "task-001")
+        (Workspace.get_tasks_raw config)
+    with
+    | Some task ->
+      Alcotest.(check (option string))
+        "typed hard-stop policy survives the re-claim"
+        (Some "block_reclaim")
+        (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
+    | None -> Alcotest.fail "task-001 not found after re-claim")
 ;;
 
 let write_tasks config tasks =
@@ -2446,13 +2463,29 @@ let test_predecessor_non_terminal_rejected () =
 
 let test_predecessor_terminal_accepted_and_persisted () =
   with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
     let _ =
       Workspace.add_task config ~title:"Original" ~priority:2 ~description:""
     in
+    (* Todo -> Done is not a legal transition even under System authority;
+       walk the task to InProgress first (this test was added by #23668
+       during a compile-red main, so the invalid setup never ran). *)
+    let _ = Workspace.claim_task config ~agent_name:claude ~task_id:"task-001" in
+    (match
+       Workspace.transition_task_r
+         config
+         ~agent_name:claude
+         ~task_id:"task-001"
+         ~action:Masc_domain.Start
+         ()
+     with
+     | Ok _ -> ()
+     | Error e ->
+       Alcotest.fail ("start failed: " ^ Masc_domain.masc_error_to_string e));
     let forced =
       Workspace.force_done_task_r
         config
-        ~agent_name:"claude"
+        ~agent_name:claude
         ~task_id:"task-001"
         ~notes:"done"
         ()
@@ -2595,13 +2628,13 @@ let () =
             `Quick
             test_claim_next_r_preserved_task_field
         ; Alcotest.test_case
-            "release hard-stop blocks future claim_next"
+            "release hard-stop persists policy, todo stays claimable"
             `Quick
-            test_release_hard_stop_blocks_future_claim_next
+            test_release_hard_stop_todo_stays_claimable
         ; Alcotest.test_case
-            "release hard-stop blocks direct reclaim"
+            "release hard-stop allows direct todo re-claim (task-1869)"
             `Quick
-            test_release_hard_stop_blocks_direct_reclaim
+            test_release_hard_stop_allows_direct_todo_reclaim
         ; Alcotest.test_case
             "completed allow-reclaim task is scheduled"
             `Quick


### PR DESCRIPTION
## 문제

main의 Build and Test가 #23719 evidence-gate 낙진(#23740이 수리 중) 외에 **3개의 masked-red 계열**을 더 안고 있습니다. 전부 main이 compile-red인 동안 머지된 PR들이 남긴 잠복 실패로, 어떤 PR도 base보다 green일 수 없어 fleet 전체 Build red의 공통 원인입니다.

## 수리 내역 (테스트 실패 7건 + lib 근본수정 1건)

| 계열 | 원인 PR | 실패 | 수리 |
|---|---|---|---|
| task-1869 stale pins | #23661 | claim_next skips blocked todo / direct claim blocked / typed policy block must skip claim | Todo는 reclaim_policy와 무관하게 claimable(현행 의미)로 re-pin. Block_reclaim이 re-claim에서 보존됨을 추가 단언 |
| G-3 span closer 미완 | #23680 | task span completed | **lib 수정**: task.approved의 span-close 키를 payload assignee로 라우팅(actor=verifier), works_on edge reducer와 동일 패턴. 테스트는 옳았고 구현이 미완 |
| G-8 born-broken setup | #23668 | predecessor completed | Todo→force_done은 원래 불법 전이. claim→start 후 force_done |
| #23638 enriched denial | #23638 | visible error keeps original denial | 환경 의존 진단 서픽스가 붙음. '원본 거부가 보존된다'는 불변식을 prefix로 pin |
| persona surface | #23664 | public_mcp_surface_tools 2 entries | masc_persona_create/update를 RFC-0190 allowlist에 masc_persona_list 선례와 함께 등재 |

## 검증

- 5개 파일 parse-check 통과 (전체 빌드는 CI)
- 실패 귀속: PR #23740 run(28952602124)과 main run(28951181699)의 --log-failed diff로 계열 분리
- 'Test 6/10: failed ...'는 실패가 아니라 테스트명이 'failed ...'로 시작하는 통과 테스트임을 확인

## 경계

- evidence-gate 낙진(41건 중 대부분)은 이 PR이 아니라 #23740 소관
- dashboard chat 테스트는 #23732가 이미 main에서 수리

RFC-WAIVED: 테스트 pin 갱신 + 기존 G-3 reducer 패턴의 span closer 완성(신규 설계 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
