### PR TITLE
fix(activity-graph): task.approved span은 assignee 기준으로 닫기 (main-red 클러스터 B)

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -695,12 +695,26 @@ let agent_spans_json config ?(limit = 500) ?since_ms () =
          | None -> ());
         (match span_end_classification e.kind with
          | Some (ek, status) ->
-             let key = (aid, subject_id) in
+             (* RFC-0323 G-3: an approve-produced completion closes the span
+                opened by the assignee, but the [task.approved] actor is the
+                verifier. The assignee rides the payload (emitted since G-3),
+                mirroring Activity_graph_reducer's completer_id resolution, so
+                close the span under it. Pre-G-3 events lack the field — fall
+                back to the actor so historical replays still close. *)
+             let owner =
+               match e.kind with
+               | "task.approved" -> (
+                   match Json_util.assoc_string_opt "assignee" e.payload with
+                   | Some assignee -> assignee
+                   | None -> aid)
+               | _ -> aid
+             in
+             let key = (owner, subject_id) in
              (match Hashtbl.find_opt open_spans key with
               | Some (start_ms, sk, label) when String.equal sk ek ->
                   Hashtbl.remove open_spans key;
                   closed_spans := {
-                    agent = aid;
+                    agent = owner;
                     start_ms;
                     end_ms = e.ts_ms;
                     span_kind = sk;


### PR DESCRIPTION
## 목표

main-red 클러스터 B(evidence-gate와 **독립**) 중 하나를 conflict 없이 닫는다: `test_activity_graph` "task.approved completes graph and span" 실패.

## 근본 원인

`agent_spans_json`(lib/activity_graph/activity_graph.ml)은 span 닫기를 이벤트 **actor(aid)** 기준으로 키잉한다. `task.approved`의 actor는 **verifier**인데, span은 **assignee**가 `task.claimed`/`task.started`로 열었으므로 닫기 key `(verifier, task)`가 열린 key `(assignee, task)`와 불일치 → span이 안 닫히고 `Span_open`("open")으로 방출된다. 테스트는 "completed"를 기대.

#23680(RFC-0323 G-3)이 reducer의 node/edge 경로는 payload `assignee`로 고쳤으나(`activity_graph_reducer.ml:219-240`, `completer_id`) **span 경로는 누락** — incomplete N-of-M.

## 수정

`agent_spans_json`의 span-close에서 `task.approved`일 때 owner를 payload `assignee`로 해석(reducer 선례 미러링). pre-G-3 이벤트는 필드가 없으므로 actor로 fallback. 닫힌 span의 `agent` 필드도 owner로 정정(비-approved 이벤트는 owner=actor라 무변화).

- 파일 1개, +16/-2.
- evidence-gate / persona CRUD / workspace-verification 무접촉 (fleet 작업과 비겹침).

## 검증

- 로컬 빌드 `dune build test/test_activity_graph.exe` EXIT=0.
- `test_activity_graph.exe`: `[OK] core 13 task.approved completes graph and span`, **16/16 green** (기존엔 core#13 red).
- ocamlformat 0.29.0 `--check` 통과.

## 배경

main-red 교차진단(별도)에서 이 실패가 evidence-gate 클러스터와 독립임을 확인. 클러스터 A(evidence-gate)는 #23740로 수렴 중. 본 PR은 클러스터 B 독립 슬라이스로, fleet 파일과 겹치지 않는다.

RFC-WAIVED: RFC-gated 서브시스템 무접촉(activity-graph span 렌더링). RFC-0323 G-3에서 reducer에 이미 착지한 assignee-resolution을 span 경로로 완결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
