### PR TITLE
chore(verification): RFC-0220 §11 PR-3 — delete neutered timeout sweep fork + knob + force_cancel

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 370 unique knobs across 10 modules.
+**Total**: 369 unique knobs across 10 modules.
 
-**Typed getter classification**: 54/225 tagged (`operator`: 54, `algorithm`: 0, `unclassified`: 171).
+**Typed getter classification**: 54/224 tagged (`operator`: 54, `algorithm`: 0, `unclassified`: 170).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -216,7 +216,7 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 69 |  |
 
-## Env_config_runtime (101 knobs; typed classification 5/81)
+## Env_config_runtime (100 knobs; typed classification 5/80)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -305,7 +305,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 475 | Read-only tool retry limit. Default: 2. |
 | `MASC_USE_H2` | string_literal | n/a | n/a | 273 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
 | `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 302 | Enable AwaitingVerification state and cross-agent approval. Default: true (SSOT: [Feature_flag_registry.all_flags]). |
-| `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 312 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
 | `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 307 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 269 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
 | `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 495 |  |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -306,10 +306,10 @@ module Verification = struct
   let timeout_deadline_seconds () =
     get_float ~default:(24.0 *. 60.0 *. 60.0) "MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC"
 
-  (** Interval for verification timeout check fiber (seconds). Default: 60.
-      Issue #7549. *)
-  let timeout_check_interval_seconds =
-    get_float ~default:60.0 "MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC"
+  (* MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC was deleted by RFC-0220 §11
+     PR-3 together with the [verification_timeout] server fork it paced and
+     the [Verification_protocol.check_timeouts] no-op it invoked. The knob
+     row was removed from docs/runtime-tunables.md in the same change. *)
 end
 
 (** {1 Approval Janitor}

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -150,7 +150,6 @@ end
 module Verification : sig
   val fsm_enabled : unit -> bool
   val timeout_deadline_seconds : unit -> float
-  val timeout_check_interval_seconds : float
 end
 
 (** {1 Approval janitor} *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -779,14 +779,9 @@ let start_keeper_loops
           interaction_judge_ctx));
   fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
-  fork_subsystem "verification_timeout" (fun () ->
-    let interval = Env_config_runtime.Verification.timeout_check_interval_seconds in
-    let rec loop () =
-      Eio.Time.sleep clock interval;
-      Verification_protocol.check_timeouts ~config:(Mcp_server.workspace_config state);
-      loop ()
-    in
-    loop ());
+  (* No verification_timeout fork: RFC-0220 §11 PR-3 deleted the sweep —
+     the wall-clock deadline rescue was removed in §5 and the fork had been
+     spinning on a no-op since PR-1. *)
   (* HITL approval queue death-spiral fix.
      [Keeper_approval_queue.expire_stale] has been a complete
      implementation (queue removal, audit event, promise [Reject]

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -381,14 +381,8 @@ let awaiting_verification_deadline
    With the verification sub-state folded into [task_status] (RFC-0220 §3.1),
    the illegal Todo+Pending drift is unrepresentable, an AwaitingVerification
    obligation stays claimable by a verifier, and a keeper never idles on an
-   empty pool — so the per-obligation wall-clock deadline this enforced (the
-   I2-forbidden heuristic) is unnecessary, and its destructive force-cancel
-   discarded work rather than rescheduling the obligation. Long-waiting
-   obligations are surfaced from the activity-event stream, not a poll-timer.
-   Neutered here in PR-1 (forced by dropping [deadline] from the type); the
-   [verification_timeout] fork and these knobs are deleted in a follow-up
-   (RFC-0220 §11 PR-3). *)
-let check_timeouts ~(config : Workspace.config) =
-  let _ = config in
-  ()
-;;
+   empty pool. Long-waiting obligations are surfaced from the activity-event
+   stream, not a poll-timer. PR-1 neutered [check_timeouts] to a no-op;
+   RFC-0220 §11 PR-3 (this change) deleted the no-op, the
+   [verification_timeout] server fork that spun on it, its interval knob,
+   and the caller-less [Workspace.force_cancel_task_r]. *)

--- a/lib/verification_protocol.mli
+++ b/lib/verification_protocol.mli
@@ -1,15 +1,17 @@
 (** Verification_protocol — task verification FSM transitions
-    (submit -> verdict -> close).
+    (submit -> verdict).
 
-    Three lifecycle phases:
+    Two lifecycle phases:
     + Submit: worker requests verification ({!create_submit_request}
       / {!notify_submit_for_verification} / {!on_submit_for_verification}).
     + Verdict: verifier approves or rejects ({!record_approve_verification}
       / {!notify_approve_verification} for approve;
       {!record_reject_verification} / {!notify_reject_verification} for
       reject).
-    + Close: pending verifications past their TTL transition to
-      reject ({!check_timeouts}).
+
+    There is no timeout close phase: RFC-0220 removed the destructive
+    wall-clock deadline (an AwaitingVerification obligation stays claimable
+    by a verifier; long waits surface from the activity-event stream).
 
     {b record_* vs notify_* split}: \[record_*\] mutates state
     (Verification.ml FSM + journal entries); \[notify_*\] emits SSE
@@ -119,12 +121,3 @@ val notify_reject_verification :
 (** [notify_reject_verification ...] emits the SSE
     [masc/verification/verdict] event with [type=rejected].
     State-free. *)
-
-(** {1 Timeout sweep} *)
-
-val check_timeouts : config:Workspace.config -> unit
-(** [check_timeouts ~config] scans pending verifications and
-    emits operator-visible timeout events for any past their TTL. No-op when
-    [Env_config_runtime.Verification.fsm_enabled ()] is [false]
-    — pinned at the contract seam so disabling the FSM does not
-    silently drop the timeout sweep entirely; it just does nothing. *)

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -237,22 +237,10 @@ let submit_and_approve_task_r
                 (Machine_verify_approve_failed_stranded { approve_error; reject_error }))))
 ;;
 
-(** Force-cancel a task regardless of assignee. System privilege.
-    Used by [Verification_protocol.check_timeouts] to expire
-    [AwaitingVerification] tasks whose verifier deadline has passed,
-    so the FSM does not stall and re-emit Timeout posts forever. *)
-let force_cancel_task_r config ~agent_name ~task_id ~reason ()
-  : string Masc_domain.masc_result
-  =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Cancel
-    ~reason
-    ~authority:Masc_domain.System
-    ()
-;;
+(* force_cancel_task_r was deleted by RFC-0220 §11 PR-3: its only advertised
+   consumer was the retired [Verification_protocol.check_timeouts] deadline
+   sweep, and a caller-less System-privilege cancel invites misuse. System
+   cancels go through [transition_task_r ~authority:System] explicitly. *)
 
 let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_result =
   if not (is_initialized config)

--- a/lib/workspace/workspace_task.mli
+++ b/lib/workspace/workspace_task.mli
@@ -139,13 +139,6 @@ val cancel_task_r :
   config -> agent_name:string -> task_id:string ->
   reason:string -> string Masc_domain.masc_result
 
-(** Force-cancel a task regardless of assignee. System privilege.
-    Used by {!Verification_protocol.check_timeouts} to expire
-    [AwaitingVerification] tasks whose verifier deadline has passed. *)
-val force_cancel_task_r :
-  config -> agent_name:string -> task_id:string ->
-  reason:string -> unit -> string Masc_domain.masc_result
-
 val link_task_execution_artifacts_r :
   config -> task_id:string ->
   ?session_id:string -> ?operation_id:string ->


### PR DESCRIPTION
## 배경

감사 콘솔 P1: `check_timeouts`가 60초마다 깨어나 아무것도 안 하는 no-op인데 server fork로 "동작하는 스위퍼"처럼 광고되고 있었습니다.

**감사의 처방(force-cancel 스위퍼 구현)은 채택하지 않았습니다** — 그 메커니즘이 정확히 RFC-0220 §5가 '파괴적'이라며 제거한 것입니다(AwaitingVerification은 verifier가 claim 가능한 상태로 유지, 장기 대기는 activity-event stream에서 표면화). 옳은 수리는 §11 PR-3에 약속된 **삭제의 집행**입니다.

## 삭제 목록

- `server_bootstrap_loops.ml`: verification_timeout fork (sleep→no-op 스핀)
- `verification_protocol.ml/.mli`: `check_timeouts` + timeout-close phase 문서
- `workspace_task.ml/.mli`: `force_cancel_task_r` — 소비자 0 (rg 전수: lib/test/dashboard 0건), 유일한 광고 소비자가 은퇴한 스위퍼. caller-less System 권한 cancel은 오용 유인
- `env_config_runtime.ml/.mli`: `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` (read 0)
- `docs/runtime-tunables.md`: 행 + 카운트 갱신 (env_config_runtime.ml 편집을 라인-중립으로 유지해 다른 행의 라인 참조 보존)

## 검증

- 7파일 parse-check 통과 (빌드는 CI)
- 삭제 심볼 참조 전수 0 (톰스톤 주석 제외)
- `timeout_deadline_seconds`는 transitions의 AwaitingVerification deadline 필드가 소비하므로 유지

RFC: RFC-0220 §5, §11 PR-3 (이 PR이 그 집행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# ci:skip-test-coverage
(deletion-only PR: +25줄은 전부 톰스톤 주석/문서 재서술이며 새 기능 경로 없음. 삭제 검증은 참조 0 스윕 + parse-check + 기존 스위트가 담당)
