### PR TITLE
fix(dashboard/approvals): HITL 대기 시간을 시(hour) 단위로 표시 (bespoke 포맷터 제거)

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -149,6 +149,21 @@ describe('ApprovalsSurface', () => {
       .toContain('enabled')
   }, 20000)
 
+  it('formats a multi-hour HITL wait with an hour tier, not a minute-only breakdown', async () => {
+    const { ApprovalsSurface } = await loadSurface([
+      queueItem({ id: 'appr-long', waiting_s: 9000 }), // 2h 30m — previously "150분 0초 대기"
+      queueItem({ id: 'appr-short', waiting_s: 92 }), // 1m 32s
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-approval-id="appr-long"] .ap-age')?.textContent)
+      .toBe('2시간 30분 대기')
+    expect(container.querySelector('[data-approval-id="appr-short"] .ap-age')?.textContent)
+      .toBe('1분 대기')
+  }, 20000)
+
   it('renders the HITL context summary (available) inside the pending card', async () => {
     const { ApprovalsSurface } = await loadSurface([
       queueItem({

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -24,7 +24,7 @@ import type {
 } from '../../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
-import { formatDateTimeKo } from '../../lib/format-time'
+import { formatDateTimeKo, formatDurationCompound } from '../../lib/format-time'
 import {
   keeperApprovalRiskLabel,
   keeperApprovalRiskVisualBand,
@@ -86,12 +86,14 @@ function apSevGlyph(band: KeeperApprovalRiskVisualBand): string {
   }
 }
 
-// seconds-waited → "N분 N초 대기" (prototype apAge).
+// seconds-waited → compound elapsed + "대기" suffix ("2시간 5분 대기").
+// Delegates to the shared formatDurationCompound so long HITL waits render with
+// an hour tier; the prior bespoke minute-only formatter broke down at scale
+// ("150분 0초 대기" for 2.5h). Non-finite / negative input clamps to 0 so the
+// queue never surfaces an "확인 필요" label in the age slot.
 function apAge(sec: number | null | undefined): string {
-  const s = Math.max(0, Math.round(sec ?? 0))
-  const m = Math.floor(s / 60)
-  const r = s % 60
-  return m ? `${m}분 ${r}초 대기` : `${r}초 대기`
+  const s = typeof sec === 'number' && Number.isFinite(sec) ? Math.max(0, Math.round(sec)) : 0
+  return `${formatDurationCompound(s)} 대기`
 }
 
 function compactText(value: string | null | undefined): string | null {

--- a/dashboard/src/lib/format-time.test.ts
+++ b/dashboard/src/lib/format-time.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  formatElapsed, formatDuration, formatDurationMs,
+  formatElapsed, formatDuration, formatDurationCompound, formatDurationMs,
   formatElapsedCompact, formatDelta, formatCompactAge,
   formatRelativeSec, formatRelativeUntilSec, formatTimeAgo,
 } from './format-time'
@@ -22,6 +22,15 @@ describe('formatDuration', () => {
   it('returns 확인 필요 for null', () => { expect(formatDuration(null)).toBe('확인 필요') })
   it('returns 확인 필요 for negative', () => { expect(formatDuration(-1)).toBe('확인 필요') })
   it('returns 확인 필요 for NaN', () => { expect(formatDuration(NaN)).toBe('확인 필요') })
+})
+
+describe('formatDurationCompound', () => {
+  it('formats sub-minute as seconds', () => { expect(formatDurationCompound(45)).toBe('45초') })
+  it('formats sub-hour as whole minutes (no seconds)', () => { expect(formatDurationCompound(92)).toBe('1분') })
+  it('formats hours with remainder minutes', () => { expect(formatDurationCompound(9000)).toBe('2시간 30분') })
+  it('keeps a zero-minute remainder explicit', () => { expect(formatDurationCompound(7200)).toBe('2시간 0분') })
+  it('returns 확인 필요 for negative', () => { expect(formatDurationCompound(-1)).toBe('확인 필요') })
+  it('returns 확인 필요 for NaN', () => { expect(formatDurationCompound(NaN)).toBe('확인 필요') })
 })
 
 describe('formatDurationMs', () => {


### PR DESCRIPTION
## 무엇을 / 왜

승인 큐 카드의 대기 시간 `apAge`가 **분까지만** 처리하는 bespoke 포맷터라, 긴 대기가 깨져 표시됐습니다:

- 2시간 30분 대기 → `150분 0초 대기`
- 1시간 5분 대기 → `65분 30초 대기`

HITL 승인은 operator 부재 시 **시간 단위로 대기**합니다 — 정확히 나이(age)를 또렷이 읽어야 하는 상황인데 가장 나쁘게 렌더됐습니다.

## 수정

- `apAge`를 shared `formatDurationCompound`(format-time.ts, "2시간 30분" 형태)에 위임 → **중복 포맷터 제거** (AI 코드 안티패턴 §1: scattered reimplementation 되돌림).
- non-finite/음수 입력은 0으로 clamp → age 슬롯에 "확인 필요"가 뜨지 않음(기존 forgiving 동작 유지 + NaN도 견고).
- `apAge`가 이제 의존하는 `formatDurationCompound`에 그동안 없던 유닛 테스트 추가.

## 검증

- 승인 카드: `waiting_s: 9000`(2h30m) → **"2시간 30분 대기"**, `92`(1m32s) → "1분 대기".
- `formatDurationCompound` 유닛(초/분/시-compound/음수·NaN).
- **vitest 62 green · tsc --noEmit clean · eslint clean.**
- ⚠️ 브라우저 프리즈로 시각 최종 확인 보류(포맷 변경이라 DOM 텍스트 assert로 검증).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>