### PR TITLE
chore(task): retire Task_dispatch.update_status FSM side door (RFC-0323 G-7)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -304,7 +304,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Minimum polling interval (seconds) - for urgent tempo |
 | `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 475 | Read-only tool retry limit. Default: 2. |
 | `MASC_USE_H2` | string_literal | n/a | n/a | 273 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 302 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
+| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 302 | Enable AwaitingVerification state and cross-agent approval. Default: true (SSOT: [Feature_flag_registry.all_flags]). |
 | `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 312 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
 | `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 307 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 269 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -297,7 +297,7 @@ module Transport = struct
 end
 
 module Verification = struct
-  (** Enable AwaitingVerification state and cross-agent approval. Default: false. *)
+  (** Enable AwaitingVerification state and cross-agent approval. Default: true (SSOT: [Feature_flag_registry.all_flags]). *)
   let fsm_enabled () =
     Feature_flag_registry.get_bool "MASC_VERIFICATION_FSM_ENABLED"
 

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -87,19 +87,6 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
       ) backlog.tasks in
       Ok tasks
 
-(** Validate that a state transition is allowed.
-    Terminal states (Done, Cancelled) cannot transition to each other. *)
-let validate_transition ~(current : task_status) ~(next : task_status) ~task_id =
-  match current, next with
-  | Done _, Done _ | Done _, Cancelled _ | Cancelled _, Done _ | Cancelled _, Cancelled _ ->
-      Error (Task (Task_error.InvalidState
-               (Printf.sprintf
-                  "task %s: cannot transition from %s to %s"
-                  task_id
-                  (task_status_to_string current)
-                  (task_status_to_string next))))
-  | _ -> Ok ()
-
 let backlog_lock_path config =
   Filename.concat (Workspace.tasks_dir config) ".backlog"
 
@@ -112,44 +99,11 @@ let with_locked_backlog
     | Error msg -> Error (System (System_error.IoError msg))
     | Ok backlog -> f backlog)
 
-(** Update task status (claim, start, complete, cancel) *)
-let update_status config ~task_id ~status =
-  match backend () with
-  | Jsonl ->
-      with_locked_backlog config (fun backlog ->
-        let task_opt =
-          List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks
-        in
-        match task_opt with
-        | None -> Error (Task (Task_error.NotFound task_id))
-        | Some t -> (
-            match validate_transition ~current:t.task_status ~next:status ~task_id with
-            | Error e -> Error e
-            | Ok () ->
-                let updated_tasks =
-                  List.map
-                    (fun (t : task) ->
-                      if t.id = task_id then { t with task_status = status } else t)
-                    backlog.tasks
-                in
-                let new_backlog =
-                  {
-                    tasks = updated_tasks;
-                    last_updated = now_iso ();
-                    version = backlog.version + 1;
-                  }
-                in
-                let clear_stale () =
-                  if Task_cache_invariant.is_terminal status
-                  then
-                    Task_cache_invariant.clear_stale_agent_task_for_task
-                      config
-                      ~task_id
-                      ~status
-                      ~module_name:"task_dispatch.update_status"
-                in
-                Workspace.write_backlog ~after_commit:clear_stale config new_backlog;
-                Ok ()))
+(* update_status / validate_transition were retired by RFC-0323 G-7: the
+   direct status writer bypassed the workspace FSM (Workspace.transition_task_r)
+   — its private terminal-pair check enforced none of the FSM's ownership,
+   RFC-0308 done-guard, or #23719 evidence rules — and had zero production
+   callers. Status changes go through the FSM; there is no side door. *)
 
 (** Delete a task.  Also clears any agent [current_task] cache that still
     points to the deleted task id, so the backlog write and cache

--- a/lib/task/task_dispatch.mli
+++ b/lib/task/task_dispatch.mli
@@ -90,36 +90,11 @@ val list_tasks :
     Active states ([Todo] / [Claimed] / [InProgress] /
     [AwaitingVerification]) always pass through. *)
 
-val validate_transition :
-  current:Masc_domain.task_status ->
-  next:Masc_domain.task_status ->
-  task_id:string ->
-  (unit, Masc_error.t) result
-(** [validate_transition ~current ~next ~task_id] enforces the
-    terminal-state rule: neither [Done _] nor [Cancelled _] may
-    transition to either terminal state.  The error message
-    embeds [task_id] + the rendered current/next status so
-    operator logs surface the full context.  Pure — no side
-    effects, suitable for use in client-side preflight checks. *)
-
-val update_status :
-  Workspace.config ->
-  task_id:string ->
-  status:Masc_domain.task_status ->
-  (unit, Masc_error.t) result
-(** [update_status config ~task_id ~status] takes the Workspace [.backlog]
-    file lock, reads the backlog,
-    runs {!validate_transition}, and on success rewrites the task
-    list with the new status, bumping [version] and refreshing
-    [last_updated] (ISO 8601 of the current monotonic time).
-    If [status] is terminal, the commit also clears any agent
-    [current_task] cache still pointing to [task_id] so the backlog
-    write and cache invalidation happen atomically in the same
-    transaction.
-    Errors:
-    - [TaskNotFound task_id] when the task is absent.
-    - [TaskInvalidState <message>] from {!validate_transition}.
-    - [System IoError <message>] when the backlog cannot be read. *)
+(* [validate_transition] / [update_status] were retired by RFC-0323 G-7:
+   a direct status writer with its own 2-state terminal check bypassed the
+   workspace FSM ([Workspace.transition_task_r]) — including the RFC-0308
+   done guard and the #23719 evidence gate — and had zero production
+   callers. Status changes go through the FSM; there is no side door. *)
 
 val delete_task :
   Workspace.config ->

--- a/test/test_task_dispatch.ml
+++ b/test/test_task_dispatch.ml
@@ -39,7 +39,9 @@ let test_add_task_in_jsonl_mode () =
           Alcotest.(check bool) "returns success message" true
             (String.length message > 0))
 
-let test_update_status_and_delete_use_locked_jsonl_path () =
+(* update_status coverage was retired with the function (RFC-0323 G-7);
+   delete_task keeps its locked-path pin. *)
+let test_delete_uses_locked_jsonl_path () =
   with_temp_config (fun config ->
       ignore (Workspace.init config ~agent_name:(Some "tester"));
       Task.Dispatch.reset_for_test ();
@@ -58,31 +60,11 @@ let test_update_status_and_delete_use_locked_jsonl_path () =
                  Alcotest.failf "expected exactly one task, got %d"
                    (List.length tasks))
       in
-      let status =
-        Masc_domain.Claimed
-          { assignee = "tester"; claimed_at = Masc_domain.now_iso () }
-      in
-      (match Task.Dispatch.update_status config ~task_id ~status with
-       | Ok () -> ()
-       | Error e -> Alcotest.fail (Masc_domain.show_masc_error e));
-      let updated = Workspace.read_backlog config in
-      Alcotest.(check int) "version bumped by update" 3 updated.version;
-      (match updated.tasks with
-       | [ task ] ->
-           Alcotest.(check bool)
-             "task claimed"
-             true
-             (match task.Masc_domain.task_status with
-              | Masc_domain.Claimed { assignee; _ } -> String.equal assignee "tester"
-              | _ -> false)
-       | tasks ->
-           Alcotest.failf "expected exactly one task after update, got %d"
-             (List.length tasks));
       (match Task.Dispatch.delete_task config ~task_id with
        | Ok () -> ()
        | Error e -> Alcotest.fail (Masc_domain.show_masc_error e));
       let deleted = Workspace.read_backlog config in
-      Alcotest.(check int) "version bumped by delete" 4 deleted.version;
+      Alcotest.(check int) "version bumped by delete" 3 deleted.version;
       Alcotest.(check int) "task deleted" 0 (List.length deleted.tasks))
 
 let write_string path content =
@@ -91,7 +73,7 @@ let write_string path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let test_update_status_and_delete_return_error_when_backlog_unreadable () =
+let test_delete_returns_error_when_backlog_unreadable () =
   with_temp_config (fun config ->
       ignore (Workspace.init config ~agent_name:(Some "tester"));
       Task.Dispatch.reset_for_test ();
@@ -99,10 +81,6 @@ let test_update_status_and_delete_return_error_when_backlog_unreadable () =
       let backlog_path = Filename.concat (Workspace.tasks_dir config) "backlog.json" in
       write_string backlog_path "{not-json";
       write_string (backlog_path ^ ".last-good") "{not-json";
-      let status =
-        Masc_domain.Claimed
-          { assignee = "tester"; claimed_at = Masc_domain.now_iso () }
-      in
       let expect_io_error label = function
         | Error (Masc_domain.System (Masc_domain.System_error.IoError _)) -> ()
         | Ok () -> Alcotest.failf "%s unexpectedly succeeded" label
@@ -110,8 +88,6 @@ let test_update_status_and_delete_return_error_when_backlog_unreadable () =
             Alcotest.failf "%s returned unexpected error: %s" label
               (Masc_domain.show_masc_error e)
       in
-      expect_io_error "update_status"
-        (Task.Dispatch.update_status config ~task_id:"missing" ~status);
       expect_io_error "delete_task"
         (Task.Dispatch.delete_task config ~task_id:"missing");
       let ic = open_in backlog_path in
@@ -177,10 +153,10 @@ let () =
       ( "jsonl",
         [
           Alcotest.test_case "add task" `Quick test_add_task_in_jsonl_mode;
-          Alcotest.test_case "update/delete use locked path" `Quick
-            test_update_status_and_delete_use_locked_jsonl_path;
-          Alcotest.test_case "update/delete fail on unreadable backlog" `Quick
-            test_update_status_and_delete_return_error_when_backlog_unreadable;
+          Alcotest.test_case "delete uses locked path" `Quick
+            test_delete_uses_locked_jsonl_path;
+          Alcotest.test_case "delete fails on unreadable backlog" `Quick
+            test_delete_returns_error_when_backlog_unreadable;
           Alcotest.test_case "source pins backlog lock" `Quick
             test_task_dispatch_source_pins_backlog_lock;
         ] );


### PR DESCRIPTION
## RFC-0323 G-7 — 휴면 FSM 우회로 삭제

`Task_dispatch.update_status`는 backlog 락 아래에서 task_status를 **직접** 재작성하는 함수로, 자체 terminal-pair 검사(2쌍)만 있고 workspace FSM(`transition_task_r`)의 ownership/RFC-0308 done guard/#23719 evidence gate를 전부 우회합니다.

- Production 소비자: **0** (rg 전수 — 자기 테스트만)
- RFC-0323이 approve를 유일한 완료 lane으로 만드는 시점에서, 휴면 상태의 FSM 우회로는 G-7이 닫기로 한 바로 그 구멍
- `validate_transition`(유일 소비자 = update_status)도 함께 삭제
- `delete_task`의 locked-path/unreadable-backlog 커버리지는 단일 목적 테스트명으로 보존

## 검증

- 3파일 parse-check 통과 (빌드는 CI)
- 잔여 참조 0 (`Repo_store.update_status`는 무관한 동명 함수)
- net -95줄

RFC: RFC-0323 (docs/rfc/RFC-0323-done-via-verification-linked-rerun.md) G-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
