### PR TITLE
feat(keeper): expand shell IR approval profile and trust overrides

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -882,6 +882,25 @@ module Shell_ir_approval_gate = struct
       to disable the gate (kill-switch) without recompilation. *)
   let enabled () =
     Feature_flag_registry.get_bool "MASC_SHELL_IR_APPROVAL_GATE_ENABLED"
+
+  (** Optional base profile preset for Shell IR approval.
+      Supported values are parsed as profile presets such as:
+      observe/autonomous, enforced/all_enforced, permissive, suggest, auto_safe. *)
+  let profile () = raw_value_opt "MASC_SHELL_IR_APPROVAL_PROFILE" |> trim_opt
+
+  (** Optional per-risk overrides (override the selected profile).
+      Values are parsed as trust levels such as:
+      observe/obs, suggest/s, auto_safe/auto-safe/autosafe, enforced/ask/strict/deny.
+      Empty / malformed values are ignored. *)
+  let safe_trust () = raw_value_opt "MASC_SHELL_IR_APPROVAL_SAFE_TRUST" |> trim_opt
+
+  (** See {!safe_trust}. *)
+  let audited_trust () =
+    raw_value_opt "MASC_SHELL_IR_APPROVAL_AUDITED_TRUST" |> trim_opt
+
+  (** See {!safe_trust}. *)
+  let privileged_trust () =
+    raw_value_opt "MASC_SHELL_IR_APPROVAL_PRIVILEGED_TRUST" |> trim_opt
 end
 
 (** {1 Internal Safety Configuration} *)

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -343,4 +343,33 @@ module Shell_ir_approval_gate : sig
       gate so safe commands can be auto-allowed while audited/privileged
       operations require explicit approval. Default: [true] (the autonomous
       policy is a strict safety improvement over the no-gate path). *)
+
+  val profile : unit -> string option
+  (** Optional base profile for Shell IR approval from
+      [MASC_SHELL_IR_APPROVAL_PROFILE]. Accepts profile presets such as:
+      observe/autonomous, enforced/all_enforced, permissive, suggest, auto_safe.
+      Empty/unknown values are ignored and fallback is used. *)
+
+  val safe_trust : unit -> string option
+  (** Optional override for safe-band trust from
+      [MASC_SHELL_IR_APPROVAL_SAFE_TRUST]. Empty / malformed values are ignored.
+
+      Accepted values: observe, suggest, auto_safe, enforced.
+   *)
+
+  val audited_trust : unit -> string option
+  (** Optional override for audited-band trust from
+      [MASC_SHELL_IR_APPROVAL_AUDITED_TRUST]. Empty / malformed values are
+      ignored.
+
+      Accepted values: observe, suggest, auto_safe, enforced.
+   *)
+
+  val privileged_trust : unit -> string option
+  (** Optional override for privileged-band trust from
+      [MASC_SHELL_IR_APPROVAL_PRIVILEGED_TRUST]. Empty / malformed values are
+      ignored.
+
+      Accepted values: observe, suggest, auto_safe, enforced.
+   *)
 end

--- a/lib/exec/approval_config.ml
+++ b/lib/exec/approval_config.ml
@@ -6,12 +6,6 @@ type trust_level =
   | Auto_safe    (* Auto-allow for the given risk class *)
   | Enforced     (* Strict ask/deny — fail-closed default *)
 
-let trust_level_to_string = function
-  | Observe -> "observe"
-  | Suggest -> "suggest"
-  | Auto_safe -> "auto_safe"
-  | Enforced -> "enforced"
-
 type agent_overlay = {
   safe_trust : trust_level;
   audited_trust : trust_level;
@@ -22,6 +16,83 @@ type t = {
   defaults : agent_overlay;
   per_agent : (Agent_id.t * agent_overlay) list;
 }
+
+let trust_level_to_string = function
+  | Observe -> "observe"
+  | Suggest -> "suggest"
+  | Auto_safe -> "auto_safe"
+  | Enforced -> "enforced"
+
+let normalize_level_token (raw : string) : string =
+  String.lowercase_ascii (String.trim raw)
+
+let trust_level_of_string (raw : string) : trust_level option =
+  match normalize_level_token raw with
+  | "observe"
+  | "obs" ->
+    Some Observe
+  | "suggest"
+  | "s" ->
+    Some Suggest
+  | "auto_safe"
+  | "auto-safe"
+  | "autosafe"
+  | "allow" ->
+    Some Auto_safe
+  | "enforced"
+  | "ask"
+  | "strict"
+  | "deny" ->
+    Some Enforced
+  | _ -> None
+
+let agent_overlay_of_profile (raw : string) : agent_overlay option =
+  match normalize_level_token raw with
+  | "autonomous"
+  | "observe" ->
+    Some
+      {
+        safe_trust = Observe;
+        audited_trust = Observe;
+        privileged_trust = Observe;
+      }
+  | "enforced"
+  | "enforced_all"
+  | "strict"
+  | "deny_all"
+  | "all_enforced" ->
+    Some
+      {
+        safe_trust = Enforced;
+        audited_trust = Enforced;
+        privileged_trust = Enforced;
+      }
+  | "permissive"
+  | "permissive_default"
+  | "perm" ->
+    Some
+      {
+        safe_trust = Auto_safe;
+        audited_trust = Enforced;
+        privileged_trust = Enforced;
+      }
+  | "suggest" ->
+    Some
+      {
+        safe_trust = Suggest;
+        audited_trust = Suggest;
+        privileged_trust = Suggest;
+      }
+  | "auto_safe"
+  | "auto-safe"
+  | "autosafe" ->
+    Some
+      {
+        safe_trust = Auto_safe;
+        audited_trust = Auto_safe;
+        privileged_trust = Auto_safe;
+      }
+  | _ -> None
 
 let enforced_all : agent_overlay =
   {

--- a/lib/exec/approval_config.mli
+++ b/lib/exec/approval_config.mli
@@ -19,6 +19,14 @@ type trust_level =
 
 val trust_level_to_string : trust_level -> string
 
+val trust_level_of_string : string -> trust_level option
+(** Parse a loose trust-level token.
+    Accepted values (case-insensitive):
+    - observe, obs
+    - suggest, s
+    - auto_safe, auto-safe, autosafe, allow
+    - enforced, ask, strict, deny. *)
+
 type agent_overlay = {
   safe_trust : trust_level;
   (** Trust level for [Safe] bins ([ls], [cat], [rg]). *)
@@ -42,6 +50,17 @@ type t = {
     a hashtable so the whole config can be compared structurally in
     tests.  Lookup is linear but the list is tiny (one entry per
     keeper / worker). *)
+
+val agent_overlay_of_profile : string -> agent_overlay option
+(** Parse a loose profile token to a complete overlay.
+    Accepted values (case-insensitive):
+    - autonomous, observe
+    - enforced, enforced_all, strict, deny_all, all_enforced
+    - permissive, permissive_default, perm
+    - suggest
+    - auto_safe, auto-safe, autosafe.
+
+    Returns [None] for unknown values. *)
 
 val enforced_all : agent_overlay
 (** All risk classes at [Enforced].  The safest default. *)

--- a/lib/exec/test/test_approval_config.ml
+++ b/lib/exec/test/test_approval_config.ml
@@ -20,6 +20,28 @@ let test_empty_uses_enforced_defaults () =
   let o = Approval_config.lookup cfg ~actor:`Other_agent in
   assert (o = Approval_config.enforced_all)
 
+let test_parse_trust_level () =
+  assert (Approval_config.trust_level_of_string "OBSERVE" = Some Observe);
+  assert (Approval_config.trust_level_of_string "  suggest " = Some Suggest);
+  assert (Approval_config.trust_level_of_string "auto-safe" = Some Auto_safe);
+  assert (Approval_config.trust_level_of_string "deny" = Some Enforced);
+  assert (Approval_config.trust_level_of_string "garbage" = None)
+
+let test_parse_profile () =
+  (match Approval_config.agent_overlay_of_profile " AUTONOMOUS " with
+   | Some overlay ->
+     assert (overlay.safe_trust = Observe);
+     assert (overlay.audited_trust = Observe);
+     assert (overlay.privileged_trust = Observe)
+   | None -> assert false);
+  (match Approval_config.agent_overlay_of_profile "permissive" with
+   | Some overlay ->
+     assert (overlay.safe_trust = Auto_safe);
+     assert (overlay.audited_trust = Enforced);
+     assert (overlay.privileged_trust = Enforced)
+   | None -> assert false);
+  assert (Approval_config.agent_overlay_of_profile "bad-profile" = None)
+
 let test_lookup_matches_registered_agent () =
   let cfg : Approval_config.t =
     {
@@ -39,4 +61,6 @@ let () =
   test_permissive_default_auto_safe ();
   test_empty_uses_enforced_defaults ();
   test_lookup_matches_registered_agent ();
+  test_parse_trust_level ();
+  test_parse_profile ();
   print_endline "[test_approval_config] all tests passed"

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -1061,24 +1061,72 @@ let handle_tool_execute_typed
           Retired_env_warnings.report_shell_ir_path_jail_if_set
             ~source:"execute"
             ();
+          let shell_ir_approval_config_for_agent _agent_id =
+            let open Masc_exec.Approval_config in
+            let parse_trust_override raw ~band =
+              match raw with
+              | None -> None
+              | Some raw ->
+                (match trust_level_of_string raw with
+                 | Some value -> Some value
+                 | None ->
+                   (Log.Keeper.warn
+                      "invalid shell IR %s trust override %s=%S (allowed: observe, suggest, auto_safe, enforced); fallback to profile value"
+                      band
+                      (String.concat "" [ "MASC_SHELL_IR_APPROVAL_"; String.uppercase_ascii band; "_TRUST" ])
+                      raw);
+                   None))
+            in
+            let profile_overlay =
+              match Env_config_runtime.Shell_ir_approval_gate.profile () with
+              | None -> autonomous
+              | Some raw ->
+                (match agent_overlay_of_profile raw with
+                 | Some overlay -> overlay
+                 | None ->
+                   (Log.Keeper.warn
+                      "invalid %s=%S for shell IR approval profile, fallback=autonomous"
+                      "MASC_SHELL_IR_APPROVAL_PROFILE"
+                      raw);
+                   autonomous)
+            in
+            let safe_override =
+              parse_trust_override
+                ~band:"safe"
+                (Env_config_runtime.Shell_ir_approval_gate.safe_trust ())
+            in
+            let audited_override =
+              parse_trust_override
+                ~band:"audited"
+                (Env_config_runtime.Shell_ir_approval_gate.audited_trust ())
+            in
+            let privileged_override =
+              parse_trust_override
+                ~band:"privileged"
+                (Env_config_runtime.Shell_ir_approval_gate.privileged_trust ())
+            in
+            {
+              defaults =
+                {
+                  safe_trust = Option.value safe_override ~default:profile_overlay.safe_trust;
+                  audited_trust = Option.value audited_override ~default:profile_overlay.audited_trust;
+                  privileged_trust = Option.value privileged_override ~default:profile_overlay.privileged_trust;
+                };
+              per_agent = [];
+            }
+          in
           let dispatch_result =
             if Env_config_runtime.Shell_ir_approval_gate.enabled ()
             then (
               let agent_id = Masc_exec.Agent_id.of_string meta.name in
-              (* RFC-0254 §5.2/§5.5: the keeper lane is autonomous — no human or
-                 resolver can answer an [Ask], so the overlay is [autonomous]
-                 (all [Observe] => non-catastrophic [Allow] + telemetry).  This
-                 unblocks the toolchain (defect §2.2.2) while the
-                 trust-independent catastrophic floor in [Approval_policy.decide]
-                 (destructive git, redirect write-escape, [mkfs]) still denies.
-                 The floor is applied identically on Host and inside Docker
-                 (RFC §13 Q2: defense-in-depth — a destructive git push reaches
-                 the real remote even from a container), so no sandbox-conditional
-                 branch is needed: both profiles use the same overlay. *)
+              (* RFC-0254 §5.2/§5.5: base approval profile and per-band
+                 overrides are now env-configurable via
+                 MASC_SHELL_IR_APPROVAL_PROFILE,
+                 MASC_SHELL_IR_APPROVAL_{SAFE,AUDITED,PRIVILEGED}_TRUST.
+                 Keepers remain non-interactive in autonomous execution, so the
+                 catastrophic floor stays trust-independent and non-overridable. *)
               let approval_config =
-                { Masc_exec.Approval_config.defaults = Masc_exec.Approval_config.autonomous
-                ; per_agent = []
-                }
+                shell_ir_approval_config_for_agent agent_id
               in
               Keeper_tool_execute_shell_ir.dispatch_classified_with_approval
                 ~agent_id


### PR DESCRIPTION
## Summary
- Expand shell IR approval configuration by introducing env-configurable base profile + per-band trust overrides.
- Added trust/profile parsers in `lib/exec/approval_config` and exposed them in mli.
- Added env readers for:
  - `MASC_SHELL_IR_APPROVAL_PROFILE`
  - `MASC_SHELL_IR_APPROVAL_SAFE_TRUST`
  - `MASC_SHELL_IR_APPROVAL_AUDITED_TRUST`
  - `MASC_SHELL_IR_APPROVAL_PRIVILEGED_TRUST`
- Rewired keeper runtime approval config composition in `lib/keeper/keeper_tool_execute_runtime.ml`.
- Added parser tests in `lib/exec/test/test_approval_config.ml`.

## Why
- Make the approval behavior more flexible across bands while keeping the default behavior unchanged.

## Testing
- Not run (per request: PR preparation only).

## Notes
- Invalid env values log warnings and fall back to profile defaults.