### PR TITLE
feat(dashboard): wire RFC-0319 operator approval-mode toggle

### DIFF
--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -25,6 +25,8 @@ import type {
   KeeperResolvedApprovalItem,
   GovernanceCaseBundle,
   PendingConfirmation,
+  ApprovalMode,
+  HitlApprovalModeStatus,
 } from '../types'
 import type { AbortableRequestOptions } from './core'
 
@@ -57,6 +59,23 @@ function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
   }
 }
 
+// RFC-0319: normalize the operator approval mode. Any wire value other than the
+// two known modes collapses to 'manual' — fail-closed, so a corrupt/unknown mode
+// never renders as auto-approving. The band floor is enforced backend-side; this
+// only governs how the toggle displays.
+function normalizeApprovalMode(raw: unknown): HitlApprovalModeStatus | undefined {
+  if (!isRecord(raw)) return undefined
+  const mode: ApprovalMode = raw.mode === 'auto_low_risk' ? 'auto_low_risk' : 'manual'
+  return {
+    mode,
+    auto_eligible_bands: Array.isArray(raw.auto_eligible_bands)
+      ? raw.auto_eligible_bands.filter((value): value is string => typeof value === 'string')
+      : [],
+    fail_closed: asBoolean(raw.fail_closed) ?? false,
+    read_error: asNullableString(raw.read_error) ?? undefined,
+  }
+}
+
 function normalizeHitlStatus(raw: unknown): DashboardGovernanceResponse['hitl'] | undefined {
   if (!isRecord(raw)) return undefined
   return {
@@ -64,6 +83,7 @@ function normalizeHitlStatus(raw: unknown): DashboardGovernanceResponse['hitl'] 
     disabled_by_env: asBoolean(raw.disabled_by_env) ?? false,
     env_name: asString(raw.env_name, 'MASC_DISABLE_HITL'),
     default_enabled: asBoolean(raw.default_enabled) ?? true,
+    approval_mode: normalizeApprovalMode(raw.approval_mode),
   }
 }
 
@@ -203,6 +223,21 @@ export function deleteGovernanceApprovalRule(
   id: string,
 ): Promise<{ ok: boolean; id: string }> {
   return post('/api/v1/dashboard/governance/approvals/rules/delete', { id })
+}
+
+export interface SetApprovalModeResponse {
+  ok: boolean
+  mode: ApprovalMode
+  previous_mode: ApprovalMode
+  actor: string
+  changed_at: string
+}
+
+// RFC-0319: set the operator approval mode. The backend rejects any value
+// outside the closed union and enforces the separation-of-duties floor
+// (critical/high never auto-approved) regardless of the mode set here.
+export function setApprovalMode(mode: ApprovalMode): Promise<SetApprovalModeResponse> {
+  return post('/api/v1/dashboard/governance/approval-mode', { mode })
 }
 
 export type DashboardScheduleDecision = 'approve' | 'reject'

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -108,11 +108,16 @@ export {
   fetchDashboardMemory,
 } from './dashboard-execution'
 
-export type { DashboardScheduleDecision, DashboardScheduleResolveResponse } from './dashboard-governance'
+export type {
+  DashboardScheduleDecision,
+  DashboardScheduleResolveResponse,
+  SetApprovalModeResponse,
+} from './dashboard-governance'
 export {
   fetchDashboardGovernance,
   resolveGovernanceApproval,
   deleteGovernanceApprovalRule,
+  setApprovalMode,
   resolveScheduleApproval,
   pruneSchedules,
   fetchGovernanceCaseStatus,

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -30,6 +30,12 @@ function responseWithQueue(
   approval_queue: KeeperApprovalQueueItem[],
   recent_resolved: KeeperResolvedApprovalItem[] = [],
   approval_rules: KeeperApprovalRule[] = [],
+  hitl: DashboardGovernanceResponse['hitl'] = {
+    enabled: true,
+    disabled_by_env: false,
+    env_name: 'MASC_DISABLE_HITL',
+    default_enabled: true,
+  },
 ): DashboardGovernanceResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
@@ -41,7 +47,7 @@ function responseWithQueue(
     approval_queue,
     recent_resolved,
     approval_rules,
-    hitl: { enabled: true, disabled_by_env: false, env_name: 'MASC_DISABLE_HITL', default_enabled: true },
+    hitl,
   } as DashboardGovernanceResponse
 }
 
@@ -51,29 +57,30 @@ async function loadSurface(
   approval_queue: KeeperApprovalQueueItem[],
   recent_resolved: KeeperResolvedApprovalItem[] = [],
   approval_rules: KeeperApprovalRule[] = [],
+  hitl?: DashboardGovernanceResponse['hitl'],
 ) {
   vi.resetModules()
   const resolveGovernanceApproval = vi
     .fn()
     .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
-  vi.doMock('../../api', () => ({
+  const setApprovalMode = vi
+    .fn()
+    .mockResolvedValue({ ok: true, mode: 'auto_low_risk', previous_mode: 'manual', actor: 'op', changed_at: '2026-06-19T00:00:00Z' })
+  const response = hitl
+    ? responseWithQueue(approval_queue, recent_resolved, approval_rules, hitl)
+    : responseWithQueue(approval_queue, recent_resolved, approval_rules)
+  const apiMock = () => ({
     decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved, approval_rules)),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(response),
     fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
     resolveGovernanceApproval,
     deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
+    setApprovalMode,
     submitGovernanceCaseBrief: vi.fn().mockResolvedValue(null),
     submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'x' } }),
-  }))
-  vi.doMock('../../api/dashboard-governance', () => ({
-    decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved, approval_rules)),
-    fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
-    resolveGovernanceApproval,
-    deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
-    submitGovernanceCaseBrief: vi.fn().mockResolvedValue(null),
-    submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'x' } }),
-  }))
+  })
+  vi.doMock('../../api', apiMock)
+  vi.doMock('../../api/dashboard-governance', apiMock)
   vi.doMock('../../sse-store', () => ({ registerGovernanceRefresh: vi.fn() }))
   // Preserve the real router (route signal etc.) but capture navigate() so the
   // "open keeper conversation" wiring can be asserted without a real route change.
@@ -83,7 +90,7 @@ async function loadSurface(
     navigate,
   }))
   const mod = await import('./approvals-surface')
-  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGovernanceApproval, navigate }
+  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGovernanceApproval, setApprovalMode, navigate }
 }
 
 describe('ApprovalsSurface', () => {
@@ -613,6 +620,89 @@ describe('ApprovalsSurface', () => {
 
     expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-a', 'approve', true)
   })
+
+  it('binds the RFC-0319 approval-mode toggle to hitl.approval_mode (auto_low_risk → on)', async () => {
+    const { ApprovalsSurface } = await loadSurface([], [], [], {
+      enabled: true,
+      disabled_by_env: false,
+      env_name: 'MASC_DISABLE_HITL',
+      default_enabled: true,
+      approval_mode: { mode: 'auto_low_risk', auto_eligible_bands: ['low'], fail_closed: false },
+    })
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="approval-mode-toggle"]')
+    expect(toggle).not.toBeNull()
+    // A real toggle switch, not the former display-only aria-hidden span.
+    expect(toggle?.getAttribute('role')).toBe('switch')
+    expect(toggle?.getAttribute('aria-checked')).toBe('true')
+    expect(toggle?.className).toContain('on')
+    const aside = container.querySelector('[data-testid="approvals-aside"]')
+    expect(aside?.textContent).toContain('자동 승인 (low-risk)')
+    // the enforced separation-of-duties floor is stated, not decorative
+    expect(aside?.textContent).toContain('비가역·파괴적·high-risk 요청은 항상 수동 결재')
+    expect(aside?.textContent).toContain('자동 승인 대상: low')
+  }, 20000)
+
+  it('defaults the approval-mode toggle to off when hitl.approval_mode is manual', async () => {
+    const { ApprovalsSurface } = await loadSurface([], [], [], {
+      enabled: true,
+      disabled_by_env: false,
+      env_name: 'MASC_DISABLE_HITL',
+      default_enabled: true,
+      approval_mode: { mode: 'manual', auto_eligible_bands: ['low'], fail_closed: false },
+    })
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="approval-mode-toggle"]')
+    expect(toggle?.getAttribute('aria-checked')).toBe('false')
+    expect(toggle?.className).not.toContain('on')
+    expect(container.querySelector('[data-testid="approvals-aside"]')?.textContent).toContain('수동 결재')
+  }, 20000)
+
+  it('routes the approval-mode toggle through setApprovalMode (manual → auto_low_risk)', async () => {
+    const { ApprovalsSurface, setApprovalMode } = await loadSurface([], [], [], {
+      enabled: true,
+      disabled_by_env: false,
+      env_name: 'MASC_DISABLE_HITL',
+      default_enabled: true,
+      approval_mode: { mode: 'manual', auto_eligible_bands: ['low'], fail_closed: false },
+    })
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="approval-mode-toggle"]')
+    expect(toggle?.disabled).toBe(false)
+    toggle?.click()
+    await flushUi()
+
+    expect(setApprovalMode).toHaveBeenCalledWith('auto_low_risk')
+  }, 20000)
+
+  it('disables the approval-mode toggle when HITL is disabled by env (nothing gates)', async () => {
+    const { ApprovalsSurface, setApprovalMode } = await loadSurface([], [], [], {
+      enabled: false,
+      disabled_by_env: true,
+      env_name: 'MASC_DISABLE_HITL',
+      default_enabled: true,
+      approval_mode: { mode: 'manual', auto_eligible_bands: ['low'], fail_closed: false },
+    })
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const toggle = container.querySelector<HTMLButtonElement>('[data-testid="approval-mode-toggle"]')
+    expect(toggle?.disabled).toBe(true)
+    toggle?.click()
+    await flushUi()
+
+    expect(setApprovalMode).not.toHaveBeenCalled()
+  }, 20000)
 
   it('surfaces a visible error and re-enables the actions when a decision fails (no silent failure)', async () => {
     const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -45,6 +45,7 @@ import {
   governanceApprovalActing,
   refreshGovernance,
   respondToKeeperApproval,
+  setKeeperApprovalMode,
 } from '../governance-store'
 
 type ApprovalsView = 'queue' | 'history'
@@ -468,6 +469,18 @@ function ApAside({
   const recent = [...resolvedItems]
     .sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a))
     .slice(0, 5)
+  // RFC-0319 operator approval mode. Bound to the real backend posture
+  // (hitl.approval_mode), NOT to rules.length. The separation-of-duties floor
+  // — critical/high/medium never auto-approve — is enforced backend-side; this
+  // toggle only flips manual ↔ auto_low_risk.
+  const approvalMode = hitl?.approval_mode
+  const autoOn = approvalMode?.mode === 'auto_low_risk'
+  const hitlDisabledByEnv = hitl?.disabled_by_env ?? false
+  const acting = governanceApprovalActing.value
+  // The toggle is meaningless while HITL is env-disabled (nothing gates), and
+  // must not race a decision already in flight.
+  const toggleDisabled = acting !== null || hitlDisabledByEnv
+  const eligibleBands = approvalMode?.auto_eligible_bands ?? []
   return html`
     <aside class="ap-aside" data-testid="approvals-aside">
       <section class="wka-card ap-auto-card">
@@ -480,17 +493,36 @@ function ApAside({
         <div class="wka-auto">
           <div class="wka-auto-top">
             <span class="wka-auto-lbl">
-              자동 승인
-              <b>${rules.length > 0 ? 'Always 규칙 기반' : '수동 결재 중'}</b>
+              자동 승인 모드
+              <b>${autoOn ? '자동 승인 (low-risk)' : '수동 결재'}</b>
             </span>
-            <span class=${`wka-switch ${rules.length > 0 ? 'on' : ''}`} aria-hidden="true"></span>
+            <button
+              type="button"
+              class=${`wka-switch ${autoOn ? 'on' : ''}`}
+              role="switch"
+              aria-checked=${autoOn ? 'true' : 'false'}
+              aria-label="자동 승인 모드 전환"
+              data-testid="approval-mode-toggle"
+              title=${hitlDisabledByEnv
+                ? 'HITL이 비활성화되어 있어 자동 승인 모드를 변경할 수 없습니다'
+                : autoOn
+                  ? '수동 결재로 전환합니다'
+                  : 'low-risk 요청만 자동 승인하도록 전환합니다'}
+              onClick=${() => void setKeeperApprovalMode(autoOn ? 'manual' : 'auto_low_risk')}
+              disabled=${toggleDisabled}
+            ></button>
           </div>
           <div class="wka-auto-stat">${rules.length.toLocaleString()}개 Always 규칙 · 열린 승인 ${openCount.toLocaleString()}건</div>
           <div class="wka-auto-note">
-            <b>비가역·파괴적 요청은 수동 결재</b> · 규칙 생성은 카드의 “항상 승인” 액션으로만 수행됩니다.
+            <b>비가역·파괴적·high-risk 요청은 항상 수동 결재</b>${eligibleBands.length > 0
+              ? ` · 자동 승인 대상: ${eligibleBands.join(', ')}`
+              : ''} · 직무분리 원칙(RFC-0319)
           </div>
-          ${hitl?.disabled_by_env
-            ? html`<div class="ap-env-warn mono">${hitl.env_name} disables HITL</div>`
+          ${approvalMode?.fail_closed
+            ? html`<div class="ap-env-warn mono">approval-mode 상태를 읽지 못해 수동 결재로 처리 중</div>`
+            : null}
+          ${hitlDisabledByEnv
+            ? html`<div class="ap-env-warn mono">${hitl?.env_name ?? 'MASC_DISABLE_HITL'} disables HITL</div>`
             : null}
         </div>
       </section>

--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -3,9 +3,11 @@ import {
   deleteGovernanceApprovalRule,
   decideGovernanceExecutionOrder,
   resolveGovernanceApproval,
+  setApprovalMode,
   submitGovernanceCaseBrief,
   submitGovernancePetition,
 } from '../api/dashboard-governance'
+import type { ApprovalMode } from '../types'
 import { getSelectedDecision } from './governance-utils'
 import { refreshGovernance, selectDecision } from './governance-refresh'
 import {
@@ -113,6 +115,30 @@ export async function deleteKeeperApprovalRule(id: string) {
     await refreshGovernance({ force: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Always 규칙을 삭제하지 못했습니다'
+    governanceError.value = message
+    showToast(message, 'error')
+  } finally {
+    governanceApprovalActing.value = null
+  }
+}
+
+// Busy-state key for the RFC-0319 approval-mode toggle. Distinct from the
+// per-approval and per-rule keys so the toggle disables independently.
+export const APPROVAL_MODE_ACTING_KEY = 'approval-mode'
+
+export async function setKeeperApprovalMode(mode: ApprovalMode) {
+  governanceApprovalActing.value = APPROVAL_MODE_ACTING_KEY
+  try {
+    await setApprovalMode(mode)
+    showToast(
+      mode === 'auto_low_risk'
+        ? '자동 승인 모드(low-risk)를 켰습니다'
+        : '수동 결재 모드로 전환했습니다',
+      'success',
+    )
+    await refreshGovernance({ force: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '자동 승인 모드를 변경하지 못했습니다'
     governanceError.value = message
     showToast(message, 'error')
   } finally {

--- a/dashboard/src/components/governance-store.ts
+++ b/dashboard/src/components/governance-store.ts
@@ -23,4 +23,5 @@ export {
   respondToExecutionOrder,
   respondToKeeperApproval,
   deleteKeeperApprovalRule,
+  setKeeperApprovalMode,
 } from './governance-actions'

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -184,6 +184,12 @@
 .wka-switch::after { content: ""; position: absolute; top: 3px; left: 3px; width: 10px; height: 10px; border-radius: 50%; background: var(--text-dim); transition: transform 120ms ease, background 120ms ease; }
 .wka-switch.on { border-color: var(--volt-dim); background: var(--volt-wash); }
 .wka-switch.on::after { transform: translateX(15px); background: var(--volt-strong); }
+/* RFC-0319: the switch is an interactive <button role="switch"> — reset the
+   default button chrome so it renders identically to the former display span,
+   and expose keyboard focus + a disabled affordance. */
+button.wka-switch { padding: 0; margin: 0; cursor: pointer; -webkit-appearance: none; appearance: none; }
+button.wka-switch:disabled { cursor: not-allowed; opacity: 0.5; }
+button.wka-switch:focus-visible { outline: 2px solid var(--volt-strong); outline-offset: 2px; }
 .wka-auto-stat { color: var(--text-primary); font-size: var(--fs-12); }
 .wka-auto-note { color: var(--text-dim); font-size: var(--fs-11); line-height: 1.45; }
 .wka-auto-note b { color: var(--text-bright); }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -649,6 +649,23 @@ export interface DashboardMemoryResponse {
   sort_by?: string
 }
 
+// RFC-0319 operator approval mode. Closed union mirrors the backend
+// `approval_mode_to_string` (manual | auto_low_risk); any other wire value is
+// normalized to 'manual' (fail-closed) at the api-normalize boundary.
+export type ApprovalMode = 'manual' | 'auto_low_risk'
+
+export interface HitlApprovalModeStatus {
+  mode: ApprovalMode
+  // Bands the backend will auto-approve in auto_low_risk mode (SSOT: ['low']).
+  // critical/high/medium are structurally excluded by the separation-of-duties
+  // floor in Operator_approval.decide_approval_mode, not by this list.
+  auto_eligible_bands: string[]
+  // True when the backend could not read the persisted mode and fell back to
+  // manual — surfaced so the operator knows the toggle reflects a fallback.
+  fail_closed: boolean
+  read_error?: string
+}
+
 export interface DashboardGovernanceResponse {
   generated_at?: string
   note?: string
@@ -678,6 +695,7 @@ export interface DashboardGovernanceResponse {
     disabled_by_env: boolean
     env_name: string
     default_enabled: boolean
+    approval_mode?: HitlApprovalModeStatus
   }
 }
 


### PR DESCRIPTION
## 목표

대시보드 승인 화면(`#approvals`)의 "자동 승인" 토글을 실제로 동작하게 만듭니다. RFC-0319 §6의 마지막 프론트엔드 배선 조각입니다.

## 배경 (문제)

`approvals-surface.ts`의 "자동 승인" 스위치는 `aria-hidden="true"`인 display-only `<span>`으로, 상태를 `rules.length > 0`에서만 파생하고 **클릭 핸들러가 없었습니다.** 즉 조작 불가능한 장식이었습니다.

반면 백엔드는 RFC-0319가 이미 end-to-end로 구현돼 있습니다:
- 타입드 모드 `approval_mode = Manual | Auto_low_risk` + 5-band exhaustive `decide_approval_mode` (`operator_approval.ml`)
- governance 결정 통합 (`governance_pipeline.ml` `to_oas_approval_callback`)
- HTTP `GET/POST /api/v1/dashboard/governance/approval-mode` (CanAdmin, SSE broadcast)
- governance payload에 `hitl.approval_mode` 노출 (`dashboard_governance.ml`)

빠진 것은 프론트엔드 배선 하나뿐이었습니다 (`rg approval_mode dashboard/src/` → 0건). 이 PR이 그 한 조각을 채웁니다.

## 변경 파일

- `types/dashboard-execution.ts` — `ApprovalMode` + `HitlApprovalModeStatus`를 governance `hitl` payload에 추가
- `api/dashboard-governance.ts` — `hitl.approval_mode` 정규화(unknown 값은 **fail-closed로 manual**), `setApprovalMode()` POST 헬퍼 추가
- `api/dashboard.ts` — `setApprovalMode` / `SetApprovalModeResponse` re-export
- `components/governance-actions.ts` — `setKeeperApprovalMode` 액션 래퍼(toast + force refresh)
- `components/governance-store.ts` — 배럴 re-export
- `components/approvals/approvals-surface.ts` — 토글을 `hitl.approval_mode`에 바인딩. 실제 `<button role="switch" aria-checked>`, 정직한 라벨/직무분리 note, HITL env-disabled 또는 결정 진행 중이면 비활성화
- `styles/approvals-v2.css` — `<button>` 기본 chrome 리셋 + focus-visible/disabled affordance
- `components/approvals/approvals-surface.test.ts` — 토글 테스트 4종

## 안전성

- **직무분리 floor는 백엔드에서 강제됩니다** (`decide_approval_mode`: `critical`/`high`/`medium`/`unclassified`는 어떤 모드에서도 자동 승인 불가, `auto_eligible_bands = [Band_low]`). 이 PR은 **안전 로직을 작성하지 않고**, 이미 강제되는 `manual ↔ auto_low_risk` posture를 UI에 노출할 뿐입니다.
- 지속 기본값은 **Manual** 유지. 운영자가 UI에서 명시적으로 켭니다.
- unknown/미분류 mode 값은 프론트에서 manual로 fail-closed 렌더.

RFC: **RFC-0319 (Operator Approval Mode)** — 이 PR이 §6 Dashboard 항목을 구현. 워크어라운드 시그니처(telemetry-as-fix / string classifier / N-of-M / cap-cooldown) 없음.

## 로컬 검증

- `npx tsc --noEmit` — pass
- `eslint src` — clean
- `vitest`(governance + api 관련): **503 tests pass (34 files)**, 신규 토글 테스트 4종 포함

## 남은 미검증 / 후속 (별도 이슈)

이 PR 범위 밖, 조사 중 발견:
1. **HITL 요약 파싱 실패** (화면의 "structured response parse failed"): 근본원인 확정 — `runtime.toml`에 `hitl_summary` lane 미설정 → reasoning 모델(minimax-m3-native-structured) + `hitl_summary.max_tokens=512`를 thinking이 소진 → answer 텍스트 empty → parse 실패. 자문(advisory)용이라 승인 안전엔 영향 없음(deterministic fallback으로 degrade). fix는 백엔드 LLM 라우팅 변경 + 라이브 프로바이더 검증 필요 → #23771.
2. **SoD floor gap**: per-keeper `always_approve` 플래그가 mode 분기 이전에 평가돼 band floor 제약을 받지 않음 → High-risk 자동 승인 가능(RFC-0319 "never auto-approve high"와 모순). 사전 존재 백엔드 이슈, 이 토글과 무관 → #23772.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
