### PR TITLE
refactor(dashboard/work): task priority 기본값 4를 named constant로 (산포 6→1)

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -8,6 +8,9 @@ import {
   phaseFilterLabel,
   matchesGoalPhaseFilter,
   sortByPriority,
+  effectiveTaskPriority,
+  DEFAULT_TASK_PRIORITY,
+  HIGH_TASK_PRIORITY_MAX,
   sortByTimeDesc,
   filterTasksByQuery,
   resetTaskSearch,
@@ -154,6 +157,26 @@ describe('sortByPriority', () => {
     const a = makeTask(2)
     const b = makeTask(2)
     expect(sortByPriority(a, b)).toBe(0)
+  })
+})
+
+// ================================================================
+// effectiveTaskPriority
+// ================================================================
+
+describe('effectiveTaskPriority', () => {
+  it('returns the task priority when set', () => {
+    expect(effectiveTaskPriority({ priority: 2 })).toBe(2)
+  })
+
+  it('falls back to DEFAULT_TASK_PRIORITY when unset or null', () => {
+    expect(effectiveTaskPriority({})).toBe(DEFAULT_TASK_PRIORITY)
+    expect(effectiveTaskPriority({ priority: null })).toBe(DEFAULT_TASK_PRIORITY)
+  })
+
+  it('pins the shared priority literals (default 4, high-priority cutoff 2)', () => {
+    expect(DEFAULT_TASK_PRIORITY).toBe(4)
+    expect(HIGH_TASK_PRIORITY_MAX).toBe(2)
   })
 })
 

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -192,8 +192,21 @@ export function phaseFilterLabel(value: GoalPhaseFilter): string {
   }
 }
 
+// Priority is 1 (highest) .. N; a task with no priority set sorts as the
+// lowest urgency. Kept as one constant so every sort/filter/badge agrees on the
+// fallback (previously the literal 4 was copied across 5 task sites).
+export const DEFAULT_TASK_PRIORITY = 4
+// Priority at or below this is surfaced as "high priority" (the red planning KPI).
+export const HIGH_TASK_PRIORITY_MAX = 2
+
+/** Effective priority for sorting/filtering: the task's own priority, or the
+ * default when unset. */
+export function effectiveTaskPriority(task: { priority?: number | null }): number {
+  return task.priority ?? DEFAULT_TASK_PRIORITY
+}
+
 export function sortByPriority(a: Task, b: Task): number {
-  return (a.priority ?? 4) - (b.priority ?? 4)
+  return effectiveTaskPriority(a) - effectiveTaskPriority(b)
 }
 
 export function sortByTimeDesc(a: Task, b: Task): number {

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -19,6 +19,7 @@ import type { Task } from '../../types'
 import {
   expandedTasks,
   toggleTaskExpand,
+  effectiveTaskPriority,
   priorityLabel,
   sortByPriority,
   sortByTimeDesc,
@@ -161,7 +162,7 @@ function taskLink(task: Task): { href: string; label: string } {
 }
 
 function KanbanCard({ task }: { task: Task }) {
-  const p = task.priority ?? 4
+  const p = effectiveTaskPriority(task)
   const isExpanded = expandedTasks.value.has(task.id)
   const hasDescription = Boolean(task.description)
   const isDeleting = deletingTaskId.value === task.id

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -15,7 +15,9 @@ import {
 } from '../../store'
 import { navigate } from '../../router'
 import {
+  effectiveTaskPriority,
   goalProgressFor,
+  HIGH_TASK_PRIORITY_MAX,
   TaskProgressBar,
   goalPhaseLabel,
 } from './goal-helpers'
@@ -200,7 +202,7 @@ function KeeperToolActivity() {
 export function Planning() {
   const { todo, inProgress, done } = tasksByStatus.value
   const totalTasks = todo.length + inProgress.length + done.length
-  const highPriority = [...todo, ...inProgress].filter(t => (t.priority ?? 4) <= 2).length
+  const highPriority = [...todo, ...inProgress].filter(t => effectiveTaskPriority(t) <= HIGH_TASK_PRIORITY_MAX).length
 
   const hasGoals = goals.value.length > 0
   const onlyBacklogActive = totalTasks > 0 && !hasGoals

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -35,7 +35,7 @@ import {
   type TaskDetailTab,
 } from './task-detail-state'
 import { TaskActivityList } from './task-activity-list'
-import { goalById, priorityLabel } from './goal-helpers'
+import { effectiveTaskPriority, goalById, priorityLabel } from './goal-helpers'
 import type { Task, TaskGateEvaluation } from '../../types'
 
 const CARD_BOX = 'v2-workspace-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-3'
@@ -479,7 +479,7 @@ export function TaskDetailOverlay() {
 
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const titleId = `task-detail-title-${task.id}`
-  const p = task.priority ?? 4
+  const p = effectiveTaskPriority(task)
   const keeper = findKeeper(task.assignee)
   const goalIds = assigneeGoalIds(task)
   const assigneeKind = task.assignee_kind ?? (keeper ? 'keeper' : null)

--- a/dashboard/src/components/goals/task-wall.ts
+++ b/dashboard/src/components/goals/task-wall.ts
@@ -15,6 +15,7 @@ import { computed } from '@preact/signals'
 import { tasks } from '../../store'
 import { navigate } from '../../router'
 import type { Task } from '../../types'
+import { sortByPriority } from './goal-helpers'
 
 interface KeeperColumn {
   keeper: string
@@ -50,7 +51,7 @@ const wallColumns = computed<KeeperColumn[]>(() => {
     bucket.push(t)
   }
   for (const list of grouped.values()) {
-    list.sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4))
+    list.sort(sortByPriority)
   }
   const cols: KeeperColumn[] = []
   for (const [keeper, list] of grouped.entries()) {


### PR DESCRIPTION
## 무엇을 / 왜

Work(Planning) 표면에서 **task priority 기본값 리터럴 `4`가 5개 task 사이트에 복붙**돼 있었습니다:

- `goal-helpers.sortByPriority`, `kanban` 카드, `task-wall` 그룹 정렬, `planning` 높은우선순위 KPI, `task-detail-overlay`

게다가 `task-wall`은 이미 존재하는 `sortByPriority`를 **인라인 재구현**(`(a.priority ?? 4) - (b.priority ?? 4)`)했습니다 — 매직넘버 + DRY 이중 위반.

CLAUDE.md "Magic Number 금지 — 같은 리터럴이 2곳 이상 등장하면 반드시 named constant" 규칙의 명시적 위반입니다.

## 수정 (동작 불변)

- `goal-helpers.ts`: `DEFAULT_TASK_PRIORITY = 4` + `HIGH_TASK_PRIORITY_MAX = 2` + `effectiveTaskPriority(task)` 헬퍼 신설. `sortByPriority`가 이를 사용.
- 5개 task 사이트를 헬퍼/상수로 교체. `task-wall`은 인라인 sort → **SSOT `sortByPriority` 재사용**.
- `planning`의 **goal 정렬(304)은 스코프 밖**으로 유지 — goal 기본값은 3(별도 개념, `GOAL_PRIORITY_DEFAULT`).

## 검증

- 기존 `sortByPriority` "defaults missing priority to 4" 테스트가 그대로 통과 → **동작 불변 증명**.
- `effectiveTaskPriority` 유닛 테스트 추가(값/기본값/상수 pin).
- **goals dir vitest 116 green · tsc --noEmit clean · eslint clean.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>