### PR TITLE
fix(dashboard/approvals): aside overflow 시 숨은 Always 규칙 명시 (no silent caps)

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -481,6 +481,42 @@ describe('ApprovalsSurface', () => {
     expect(history?.textContent).not.toContain('appr-approved')
   }, 20000)
 
+  it('makes hidden Always rules explicit when the aside list overflows its cap', async () => {
+    const rules = Array.from({ length: 8 }, (_, i) => ({
+      id: `rule-${i}`,
+      keeper_name: 'keeper-a',
+      tool_name: 'fs_write',
+      max_risk: 'medium',
+      match_count: 1,
+    })) as KeeperApprovalRule[]
+    const { ApprovalsSurface } = await loadSurface([], [], rules)
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    // Only the first 6 rows render, and the remaining 2 are surfaced explicitly
+    // rather than silently dropped (Always rules have no other view).
+    expect(container.querySelectorAll('[data-testid="approval-rule-row"]').length).toBe(6)
+    expect(container.querySelector('[data-testid="approvals-rules-overflow"]')?.textContent)
+      .toContain('외 2건')
+  }, 20000)
+
+  it('omits the rules overflow note when the list fits the cap', async () => {
+    const rules = Array.from({ length: 6 }, (_, i) => ({
+      id: `rule-${i}`,
+      keeper_name: 'k',
+      tool_name: 't',
+      max_risk: 'low',
+      match_count: 1,
+    })) as KeeperApprovalRule[]
+    const { ApprovalsSurface } = await loadSurface([], [], rules)
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="approvals-rules-overflow"]')).toBeNull()
+  }, 20000)
+
   it('shows the empty state when no approvals are pending', async () => {
     const { ApprovalsSurface } = await loadSurface([])
 

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -65,6 +65,14 @@ const APPROVAL_HISTORY_FILTERS: ReadonlyArray<{
 ]
 const DEFAULT_APPROVAL_HISTORY_FILTER = APPROVAL_HISTORY_FILTERS[0]!
 
+// Aside preview caps. The recent list is a preview of recent_resolved — the full
+// set lives in the 이력 (history) tab, so its overflow is expected. The Always
+// Rules list has NO other view, so when it overflows we make the hidden count
+// explicit (auto-approve rules bypass HITL; the operator must know the full set
+// exists even if it is not all shown here).
+const ASIDE_RECENT_LIMIT = 5
+const ASIDE_RULES_LIMIT = 6
+
 function apSev(riskLevel: string | null | undefined): KeeperApprovalRiskVisualBand {
   return keeperApprovalRiskVisualBand(riskLevel)
 }
@@ -470,7 +478,7 @@ function ApAside({
   const enabled = hitl?.enabled ?? null
   const recent = [...resolvedItems]
     .sort((a, b) => resolvedAtMs(b) - resolvedAtMs(a))
-    .slice(0, 5)
+    .slice(0, ASIDE_RECENT_LIMIT)
   // RFC-0319 operator approval mode. Bound to the real backend posture
   // (hitl.approval_mode), NOT to rules.length. The separation-of-duties floor
   // — critical/high/medium never auto-approve — is enforced backend-side; this
@@ -483,6 +491,7 @@ function ApAside({
   // must not race a decision already in flight.
   const toggleDisabled = acting !== null || hitlDisabledByEnv
   const eligibleBands = approvalMode?.auto_eligible_bands ?? []
+  const hiddenRules = Math.max(0, rules.length - ASIDE_RULES_LIMIT)
   return html`
     <aside class="ap-aside" data-testid="approvals-aside">
       <section class="wka-card ap-auto-card">
@@ -535,7 +544,12 @@ function ApAside({
           <span class="mono">${rules.length}</span>
         </div>
         ${rules.length > 0
-          ? html`<ul class="ap-rule-list">${rules.slice(0, 6).map(rule => html`<${ApprovalRuleRow} key=${rule.id} rule=${rule} />`)}</ul>`
+          ? html`
+              <ul class="ap-rule-list">${rules.slice(0, ASIDE_RULES_LIMIT).map(rule => html`<${ApprovalRuleRow} key=${rule.id} rule=${rule} />`)}</ul>
+              ${hiddenRules > 0
+                ? html`<div class="ap-side-empty mono" data-testid="approvals-rules-overflow">외 ${hiddenRules.toLocaleString()}건 더</div>`
+                : null}
+            `
           : html`<div class="ap-side-empty">저장된 Always 규칙 없음</div>`}
       </section>
 


### PR DESCRIPTION
## 무엇을 / 왜

승인 큐 aside의 **Always Rules 리스트는 `slice(0, 6)`가 유일한 뷰**입니다. recent(처리 완료)는 "이력" 탭으로 전체를 볼 수 있지만, Always 규칙은 6개 초과 시 **7번째부터 어디서도 안 보이고 조용히 잘립니다**.

Always 규칙은 HITL을 **우회(자동 승인)**하므로, operator가 전체 규칙 집합의 존재를 모르면 거버넌스 사각지대가 됩니다.

## 수정

- cap 리터럴(6·5)을 named constant로: `ASIDE_RULES_LIMIT` / `ASIDE_RECENT_LIMIT` (매직넘버 규칙).
- rules 리스트가 넘치면 **"외 N건 더"** 표시 추가 → 잘림을 명시("no silent caps").
- recent 리스트는 표시 없이 cap 유지 — 전체는 이력 탭에 있음(설계상 preview). 주석으로 구분 명시.

## 검증

- rules 8개 → 6행 렌더 + "외 2건 더" 표시. rules 6개 → 표시 없음.
- **vitest 23 green · tsc --noEmit clean · eslint clean.**

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>