### PR TITLE
feat(dashboard): AwaitingVerification reads as normal completion lane (RFC-0323 G-6)

### DIFF
--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -285,7 +285,9 @@ let build_internal_signals incidents actions =
 let task_operation_status (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Some "active"
-  | Masc_domain.AwaitingVerification _ -> Some "paused"
+  (* RFC-0323 G-6: awaiting verification is the normal completion lane,
+     not a pause — the operation is still moving (verifier's turn). *)
+  | Masc_domain.AwaitingVerification _ -> Some "active"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_updated_at (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -377,12 +377,15 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
 let task_operation_status (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Some "active"
-  | Masc_domain.AwaitingVerification _ -> Some "paused"
+  (* RFC-0323 G-6: awaiting verification is the normal completion lane,
+     not a pause — the operation is still moving (verifier's turn). *)
+  | Masc_domain.AwaitingVerification _ -> Some "active"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_severity (task : Masc_domain.task) =
   match task.task_status with
-  | Masc_domain.AwaitingVerification _ -> Tone_warn
+  (* RFC-0323 G-6: verification pending is not a warning tone. *)
+  | Masc_domain.AwaitingVerification _ -> Tone_ok
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Tone_ok
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> Tone_ok
 

--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -163,7 +163,7 @@ val goal_health_reason :
   pending_approvals:int ->
   sandbox_risk:bool ->
   runtime_risk:bool ->
-  fsm_risk:bool ->
+  verification_pending:bool ->
   stalled:bool ->
   stagnation_seconds:int ->
   child_at_risk:bool ->
@@ -183,7 +183,7 @@ val tree_badges :
   pending_approvals:int ->
   sandbox_risk:bool ->
   runtime_risk:bool ->
-  fsm_risk:bool ->
+  verification_pending:bool ->
   stalled:bool ->
   activity_unobserved:bool ->
   string list

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -341,7 +341,10 @@ let rec build_tree context goals goal =
                   | None -> trust_disposition_reason trust)
              | _ -> None)
   in
-  let direct_fsm_risk =
+  (* RFC-0323 G-6: AwaitingVerification is the NORMAL completion lane
+     (submit -> verifier approve), so it is surfaced as a pending badge and
+     never feeds [at_risk] or a blocking source. *)
+  let direct_verification_pending =
     List.exists
       (fun ((task, _) : Masc_domain.task * string) ->
         match task.task_status with
@@ -407,7 +410,7 @@ let rec build_tree context goals goal =
   let direct_badges =
     tree_badges ~pending_approvals:(List.length direct_pending_approvals)
       ~sandbox_risk:direct_sandbox_risk ~runtime_risk:direct_runtime_risk
-      ~fsm_risk:direct_fsm_risk ~stalled
+      ~verification_pending:direct_verification_pending ~stalled
       ~activity_unobserved:(String.equal stagnation_status "unobserved")
   in
   let direct_badges =
@@ -473,7 +476,6 @@ let rec build_tree context goals goal =
     pending_approval_count > 0
     || infra_risk_count > 0
     || Option.is_some direct_runtime_blocking_reason
-    || direct_fsm_risk
     || Option.is_some linkage_warning_reason
     || stalled
     || child_at_risk
@@ -486,7 +488,7 @@ let rec build_tree context goals goal =
     goal_health_reason ~goal_phase:goal.Goal_store.phase ~blocked_by_receipt
       ~child_blocked ~pending_approvals:pending_approval_count
       ~sandbox_risk:direct_sandbox_risk ~runtime_risk:direct_runtime_risk
-      ~fsm_risk:direct_fsm_risk ~stalled
+      ~verification_pending:direct_verification_pending ~stalled
       ~stagnation_seconds ~child_at_risk ~linkage_warning_reason
       ~activity_observation ~stagnation_status
   in
@@ -503,8 +505,6 @@ let rec build_tree context goals goal =
         else if Option.is_some direct_runtime_blocking_reason then
           ( "keeper_runtime",
             Option.value direct_runtime_blocking_reason ~default:status_reason )
-        else if direct_fsm_risk then
-          ("task_fsm", status_reason)
         else if Option.is_some linkage_warning_reason then
           ("goal_linkage", status_reason)
         else if stalled then

--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -21,7 +21,7 @@ let goal_phase_to_health = function
       None
 
 let goal_health_reason ~goal_phase ~blocked_by_receipt ~child_blocked
-    ~pending_approvals ~sandbox_risk ~runtime_risk ~fsm_risk ~stalled
+    ~pending_approvals ~sandbox_risk ~runtime_risk ~verification_pending ~stalled
     ~stagnation_seconds ~child_at_risk ~linkage_warning_reason
     ~activity_observation ~stagnation_status =
   match goal_phase_to_health goal_phase with
@@ -44,8 +44,8 @@ let goal_health_reason ~goal_phase ~blocked_by_receipt ~child_blocked
         "Linked keeper is constrained by the current sandbox or scope."
       else if runtime_risk then
         "Latest keeper run fell back within the configured runtime."
-      else if fsm_risk then
-        "Linked task is waiting on FSM verification or remediation."
+      else if verification_pending then
+        "Linked task is awaiting verification (normal completion lane)."
       else if Option.is_some linkage_warning_reason then
         (match linkage_warning_reason with
          | Some "no_linked_tasks" ->
@@ -76,13 +76,13 @@ let tree_health ~goal_phase ~blocked_by_receipt ~child_blocked ~at_risk =
       else if at_risk then "at_risk"
       else "on_track"
 
-let tree_badges ~pending_approvals ~sandbox_risk ~runtime_risk ~fsm_risk ~stalled
+let tree_badges ~pending_approvals ~sandbox_risk ~runtime_risk ~verification_pending ~stalled
     ~activity_unobserved =
   let badges = ref [] in
   if pending_approvals > 0 then badges := "awaiting_approval" :: !badges;
   if sandbox_risk then badges := "sandbox" :: !badges;
   if runtime_risk then badges := "runtime" :: !badges;
-  if fsm_risk then badges := "task_verification_pending" :: !badges;
+  if verification_pending then badges := "task_verification_pending" :: !badges;
   if stalled then badges := "stalled" :: !badges;
   if activity_unobserved then badges := "activity_unobserved" :: !badges;
   List.rev !badges

--- a/lib/dashboard/dashboard_goals_types_health.mli
+++ b/lib/dashboard/dashboard_goals_types_health.mli
@@ -11,7 +11,7 @@ val goal_health_reason :
   pending_approvals:int ->
   sandbox_risk:bool ->
   runtime_risk:bool ->
-  fsm_risk:bool ->
+  verification_pending:bool ->
   stalled:bool ->
   stagnation_seconds:int ->
   child_at_risk:bool ->
@@ -31,7 +31,7 @@ val tree_badges :
   pending_approvals:int ->
   sandbox_risk:bool ->
   runtime_risk:bool ->
-  fsm_risk:bool ->
+  verification_pending:bool ->
   stalled:bool ->
   activity_unobserved:bool ->
   string list

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -138,9 +138,13 @@ let task_is_blocked (task : Masc_domain.task) =
   (* Enumerate every [task_status] variant so the compiler flags any new
      constructor here. The old [_ -> false] silently extended "not blocked"
      to any future status (e.g. a hypothetical [BlockedOnReview]) which
-     would be exactly the wrong default for a blocked-task detector. *)
+     would be exactly the wrong default for a blocked-task detector.
+     RFC-0323 G-6: [AwaitingVerification] is the normal completion lane
+     (submit -> verifier approve), not a blocked state — no current status
+     is blocked; the exhaustive match stays as the decision point for any
+     future genuinely-blocked constructor. *)
   match task.task_status with
-  | Masc_domain.AwaitingVerification _ -> true
+  | Masc_domain.AwaitingVerification _
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _

--- a/test/dune
+++ b/test/dune
@@ -1145,6 +1145,7 @@
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
   test_goal_metric_unevaluated
+  test_goal_awaiting_read_model
   test_goal_verification
   test_string_util
   test_prompt_asset_sync
@@ -1341,6 +1342,7 @@
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
   test_goal_metric_unevaluated
+  test_goal_awaiting_read_model
   test_goal_verification
   test_string_util
   test_prompt_asset_sync

--- a/test/test_goal_awaiting_read_model.ml
+++ b/test/test_goal_awaiting_read_model.ml
@@ -1,0 +1,140 @@
+(** RFC-0323 G-6 — AwaitingVerification is the normal completion lane in
+    every goal read model.
+
+    Pre-G-6 the read models treated a linked [AwaitingVerification] task as
+    a problem: the goals tree fed it into [at_risk] (health degraded to
+    "at_risk", blocking_source "task_fsm") and the briefing/execution
+    operation projections rendered it as "paused" with a warn tone. Under
+    RFC-0323 approve-only completion, every completing task passes through
+    AwaitingVerification — flagging it as risk would mark all healthy
+    completion traffic at-risk.
+
+    Pinned here:
+    - differential build_tree: swapping a linked task's status from
+      InProgress to AwaitingVerification must not change health or
+      blocking_source (awaiting is never worse than in-progress), and must
+      surface the "task_verification_pending" badge (visibility is kept,
+      reclassified from risk to pending).
+    - unit pins on the renamed [verification_pending] axis in
+      [Dashboard_goals_types_health]. *)
+
+open Alcotest
+open Masc
+
+let iso_now () = Masc_domain.now_iso ()
+
+let make_goal id title =
+  {
+    Goal_store.id;
+    title;
+    metric = None;
+    target_value = None;
+    due_date = None;
+    priority = 3;
+    status = Active;
+    phase = Goal_phase.Executing;
+    verifier_policy = None;
+    require_completion_approval = false;
+    active_verification_request_id = None;
+    parent_goal_id = None;
+    last_review_note = None;
+    last_review_at = None;
+    created_at = iso_now ();
+    updated_at = iso_now ();
+  }
+
+let make_task ~status id : Masc_domain.task =
+  {
+    id;
+    title = "linked task";
+    description = "";
+    task_status = status;
+    priority = 3;
+    files = [];
+    created_at = iso_now ();
+    created_by = None;
+    predecessor_task_id = None;
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = None;
+    do_not_reclaim_reason = None;
+  }
+
+let build_single_goal_tree ~task =
+  let goal = make_goal "goal-g6" "G-6 read model" in
+  let goal_task_index : (string, string list) Hashtbl.t = Hashtbl.create 4 in
+  Hashtbl.replace goal_task_index task.Masc_domain.id [ goal.Goal_store.id ];
+  let context =
+    {
+      Dashboard_goals_types.now_ts = Time_compat.now ();
+      all_tasks = [ task ];
+      pending_approvals = [];
+      keeper_metas = [];
+      latest_receipts = [];
+      latest_runtime_trusts = [];
+      goal_task_index;
+    }
+  in
+  Dashboard_goals_types.build_tree context [ goal ] goal
+
+let awaiting_status : Masc_domain.task_status =
+  Masc_domain.AwaitingVerification
+    {
+      assignee = "worker-a";
+      submitted_at = iso_now ();
+      verification_id = "vrf-g6-read-model";
+      phase = Masc_domain.Awaiting_verifier;
+    }
+
+let in_progress_status : Masc_domain.task_status =
+  Masc_domain.InProgress { assignee = "worker-a"; started_at = iso_now () }
+
+let test_awaiting_task_never_worse_than_in_progress () =
+  let in_progress =
+    build_single_goal_tree ~task:(make_task ~status:in_progress_status "task-ip")
+  in
+  let awaiting =
+    build_single_goal_tree ~task:(make_task ~status:awaiting_status "task-av")
+  in
+  check string "health identical to the in-progress baseline"
+    in_progress.Dashboard_goals_types.health awaiting.Dashboard_goals_types.health;
+  check string "blocking_source identical to the in-progress baseline"
+    in_progress.Dashboard_goals_types.blocking_source
+    awaiting.Dashboard_goals_types.blocking_source;
+  check bool "blocking_source is never task_fsm" false
+    (String.equal awaiting.Dashboard_goals_types.blocking_source "task_fsm");
+  check bool "verification-pending badge surfaces" true
+    (List.mem "task_verification_pending" awaiting.Dashboard_goals_types.badges);
+  check bool "no pending badge on the in-progress baseline" false
+    (List.mem "task_verification_pending" in_progress.Dashboard_goals_types.badges)
+
+let test_health_axis_verification_pending_is_not_risk () =
+  let badges =
+    Dashboard_goals_types.tree_badges ~pending_approvals:0 ~sandbox_risk:false
+      ~runtime_risk:false ~verification_pending:true ~stalled:false
+      ~activity_unobserved:false
+  in
+  check (list string) "pending badge only" [ "task_verification_pending" ] badges;
+  let reason =
+    Dashboard_goals_types.goal_health_reason ~goal_phase:Goal_phase.Executing
+      ~blocked_by_receipt:false ~child_blocked:false ~pending_approvals:0
+      ~sandbox_risk:false ~runtime_risk:false ~verification_pending:true
+      ~stalled:false ~stagnation_seconds:0 ~child_at_risk:false
+      ~linkage_warning_reason:None ~activity_observation:"task"
+      ~stagnation_status:"recent"
+  in
+  check string "reason names the normal lane, not remediation"
+    "Linked task is awaiting verification (normal completion lane)." reason
+
+let () =
+  run "Goal awaiting read model (RFC-0323 G-6)"
+    [
+      ( "g6",
+        [
+          test_case "awaiting never worse than in-progress" `Quick
+            test_awaiting_task_never_worse_than_in_progress;
+          test_case "verification_pending axis is badge-only" `Quick
+            test_health_axis_verification_pending_is_not_risk;
+        ] );
+    ]

--- a/test/test_goal_awaiting_read_model.ml
+++ b/test/test_goal_awaiting_read_model.ml
@@ -20,6 +20,8 @@
 
 open Alcotest
 open Masc
+module Acc = Dashboard_goals_types_accessor
+module B = Dashboard_goals_types_builder
 
 let iso_now () = Masc_domain.now_iso ()
 
@@ -61,13 +63,13 @@ let make_task ~status id : Masc_domain.task =
     do_not_reclaim_reason = None;
   }
 
-let build_single_goal_tree ~task =
+let build_single_goal_tree ~(task : Masc_domain.task) =
   let goal = make_goal "goal-g6" "G-6 read model" in
   let goal_task_index : (string, string list) Hashtbl.t = Hashtbl.create 4 in
-  Hashtbl.replace goal_task_index task.Masc_domain.id [ goal.Goal_store.id ];
+  Hashtbl.replace goal_task_index task.id [ goal.Goal_store.id ];
   let context =
     {
-      Dashboard_goals_types.now_ts = Time_compat.now ();
+      B.now_ts = Time_compat.now ();
       all_tasks = [ task ];
       pending_approvals = [];
       keeper_metas = [];
@@ -76,7 +78,7 @@ let build_single_goal_tree ~task =
       goal_task_index;
     }
   in
-  Dashboard_goals_types.build_tree context [ goal ] goal
+  B.build_tree context [ goal ] goal
 
 let awaiting_status : Masc_domain.task_status =
   Masc_domain.AwaitingVerification
@@ -98,26 +100,26 @@ let test_awaiting_task_never_worse_than_in_progress () =
     build_single_goal_tree ~task:(make_task ~status:awaiting_status "task-av")
   in
   check string "health identical to the in-progress baseline"
-    in_progress.Dashboard_goals_types.health awaiting.Dashboard_goals_types.health;
+    in_progress.Acc.health awaiting.Acc.health;
   check string "blocking_source identical to the in-progress baseline"
-    in_progress.Dashboard_goals_types.blocking_source
-    awaiting.Dashboard_goals_types.blocking_source;
+    in_progress.Acc.blocking_source
+    awaiting.Acc.blocking_source;
   check bool "blocking_source is never task_fsm" false
-    (String.equal awaiting.Dashboard_goals_types.blocking_source "task_fsm");
+    (String.equal awaiting.Acc.blocking_source "task_fsm");
   check bool "verification-pending badge surfaces" true
-    (List.mem "task_verification_pending" awaiting.Dashboard_goals_types.badges);
+    (List.mem "task_verification_pending" awaiting.Acc.badges);
   check bool "no pending badge on the in-progress baseline" false
-    (List.mem "task_verification_pending" in_progress.Dashboard_goals_types.badges)
+    (List.mem "task_verification_pending" in_progress.Acc.badges)
 
 let test_health_axis_verification_pending_is_not_risk () =
   let badges =
-    Dashboard_goals_types.tree_badges ~pending_approvals:0 ~sandbox_risk:false
+    Dashboard_goals_types_health.tree_badges ~pending_approvals:0 ~sandbox_risk:false
       ~runtime_risk:false ~verification_pending:true ~stalled:false
       ~activity_unobserved:false
   in
   check (list string) "pending badge only" [ "task_verification_pending" ] badges;
   let reason =
-    Dashboard_goals_types.goal_health_reason ~goal_phase:Goal_phase.Executing
+    Dashboard_goals_types_health.goal_health_reason ~goal_phase:Goal_phase.Executing
       ~blocked_by_receipt:false ~child_blocked:false ~pending_approvals:0
       ~sandbox_risk:false ~runtime_risk:false ~verification_pending:true
       ~stalled:false ~stagnation_seconds:0 ~child_at_risk:false


### PR DESCRIPTION
## RFC-0323 G-6 — AwaitingVerification = 정상 경로 read-model 전환

approve-only 완료(G-1~G-4) 하에서는 **모든 완료 태스크가 AwaitingVerification을 통과**합니다. 이를 문제로 읽는 read model은 건강한 완료 트래픽 전부를 at-risk로 칠하게 됩니다. Goal Matrix G-6가 지정한 4개 사이트를 반전:

| 사이트 | 이전 | 이후 |
|---|---|---|
| `dashboard_goals_types_builder.ml` | `direct_fsm_risk`→at_risk + blocking_source=`task_fsm` | 축을 `verification_pending`으로 개명, at_risk/blocking에서 제거. `task_verification_pending` 배지로 가시성 유지 |
| `dashboard_briefing_assembly.ml` + `dashboard_execution_builders.ml` (중복 2벌) | awaiting→"paused" + `Tone_warn` | "active" + `Tone_ok` |
| `keeper_runtime_contract.ml` `task_is_blocked` | awaiting→blocked_task_count 계상 | 미계상 (exhaustive match는 미래의 진짜 blocked 상태를 위한 결정 지점으로 유지) |
| `server_dashboard_http.ml` rollup | — | 이미 running으로 정합 (변경 불필요, 확인만) |

## 테스트

- **차등 pin**: 같은 goal에서 linked task를 InProgress↔AwaitingVerification로 바꿔도 health/blocking_source 동일 + awaiting에서만 배지 노출 (`test_goal_awaiting_read_model.ml`) — 직교 리스크 축(unstaffed 등)에 면역인 형태
- `verification_pending` 축 단위 pin (badge-only, 사유 문구)

## 경계

- FE: `blocking_source='task_fsm'`은 더 이상 생산 안 됨 — FE switch arm은 string fallback으로 무해한 dead code. 정리는 G-9(FE surfacing) lane에서
- G-5(Phase-B flip)는 이 PR로 readiness gate 하나를 더 충족

RFC: RFC-0323 (docs/rfc/RFC-0323-done-via-verification-linked-rerun.md) G-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
