### PR TITLE
fix(keeper): HITL summary dedicated non-reasoning lane + /v1 JSON recovery

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -24,6 +24,14 @@ librarian = "ollama_cloud_native.minimax-m3-native-structured"
 # dashboard operator/governance judges fail at config load on typo/unsupported
 # routing instead of discovering the mismatch in the daemon loop.
 structured_judge = "ollama_cloud_native.minimax-m3-native-structured"
+# HITL approval context summary (advisory operator display). Unset previously,
+# so it inherited [runtime].structured_judge = minimax-m3, a *reasoning* model:
+# extended thinking consumed the whole keeper.hitl_summary.max_tokens=512 budget,
+# leaving an empty answer that failed structured parse and always fell back to the
+# deterministic summary. Pin a *non-reasoning* structured runtime so the full token
+# budget produces the answer. devstral-2-123b (thinking-support=false,
+# supports-structured-output=true) is the same runtime the Fusion judge uses.
+hitl_summary = "ollama_cloud.ollama-cloud-devstral-2-123b"
 # Anti-rationalization/cross-verifier work asks for JSON and higher judgment.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
 # this explicit smart lane.

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -536,7 +536,16 @@ let summary_of_response ~generated_at ~mode (response : Agent_sdk.Types.api_resp
      with
      | Ok json -> parse_json json
      | Error detail ->
-       Error (Printf.sprintf "HITL summary structured response parse failed: %s" detail))
+       (* Dual-path recovery before failing: some native-schema runtimes served
+          over the OpenAI-compatible /v1 transport return the JSON as visible
+          text (optionally fenced) instead of an enforced structured payload.
+          Reuse the [Plain_json_text] extractor on the visible text so those
+          responses parse instead of degrading to the deterministic fallback.
+          Only genuinely empty/non-JSON output falls through to [Error]. *)
+       (match extract_json_object (Agent_sdk_response.text_of_response response) with
+        | Ok json -> parse_json json
+        | Error _ ->
+          Error (Printf.sprintf "HITL summary structured response parse failed: %s" detail)))
   | Plain_json_text ->
     (match extract_json_object (Agent_sdk_response.text_of_response response) with
      | Ok json -> parse_json json

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -420,6 +420,62 @@ let test_summary_of_response_plain_json_text_parses_prose_wrapped () =
   | Error e -> failf "expected plain-path parse to succeed, got %s" e
 ;;
 
+let test_summary_of_response_native_recovers_prose_wrapped_json () =
+  (* Native path over the OpenAI-compatible /v1 transport: a native-schema runtime
+     may return the JSON as visible (fenced) prose instead of an enforced structured
+     payload. [summary_of_response ~mode:Native_structured] must recover via the
+     plain-text extractor rather than degrading to the deterministic fallback. Only
+     genuinely empty/non-JSON output should fail. *)
+  let text =
+    "Here is the structured judgment:\n```json\n"
+    ^ Yojson.Safe.to_string valid_summary_json
+    ^ "\n```\nDone."
+  in
+  let response : Agent_sdk.Types.api_response =
+    { id = "run-native-recover"
+    ; model = "test-model"
+    ; stop_reason = Agent_sdk.Types.EndTurn
+    ; content = [ Agent_sdk.Types.Text text ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match
+    H.For_testing.summary_of_response
+      ~generated_at:1234567890.0
+      ~mode:H.For_testing.Native_structured
+      response
+  with
+  | Ok summary ->
+    check string "context_summary parsed" "A tool request is pending." summary.context_summary;
+    check int "suggested_options length" 1 (List.length summary.suggested_options)
+  | Error e -> failf "expected native-path recovery to succeed, got %s" e
+;;
+
+let test_summary_of_response_native_empty_text_still_fails () =
+  (* The recovery must not paper over a genuinely empty answer (the reasoning-model
+     thinking-budget exhaustion case): with no JSON anywhere, both the structured
+     extractor and the plain-text fallback fail, and the worker degrades to the
+     deterministic fallback rather than fabricating a summary. *)
+  let response : Agent_sdk.Types.api_response =
+    { id = "run-native-empty"
+    ; model = "test-model"
+    ; stop_reason = Agent_sdk.Types.EndTurn
+    ; content = [ Agent_sdk.Types.Text "" ]
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  match
+    H.For_testing.summary_of_response
+      ~generated_at:1234567890.0
+      ~mode:H.For_testing.Native_structured
+      response
+  with
+  | Ok _ -> fail "expected empty native response to fail, not fabricate a summary"
+  | Error reason -> check bool "error reason non-empty" true (String.length reason > 0)
+;;
+
 let test_plain_mode_error_outcomes_record_degradation () =
   let provider_error = Agent_sdk.Error.Internal "synthetic provider failure" in
   let timeout_error =
@@ -510,6 +566,10 @@ let () =
             test_extract_json_object_variants
         ; test_case "summary_of_response plain path parses prose-wrapped JSON" `Quick
             test_summary_of_response_plain_json_text_parses_prose_wrapped
+        ; test_case "summary_of_response native path recovers prose-wrapped JSON" `Quick
+            test_summary_of_response_native_recovers_prose_wrapped_json
+        ; test_case "summary_of_response native path still fails on empty text" `Quick
+            test_summary_of_response_native_empty_text_still_fails
         ; test_case "plain-mode errors keep degradation observable" `Quick
             test_plain_mode_error_outcomes_record_degradation
         ; test_case "fallback summary is redacted and uncertain" `Quick


### PR DESCRIPTION
## 목표

승인 카드의 HITL context 요약이 **항상 parse 실패**로 deterministic fallback에 빠지던 문제를 고칩니다. Fixes #23771.

화면 증상: `HITL summary structured response parse failed: JSON parse error: structured output response did not contain text JSON. Deterministic fallback.`

## 근본원인 (코드 확인됨)

1. `config/runtime.toml`에 `[runtime].hitl_summary` lane 미설정 → `provider_config_for_summary`가 `[runtime].structured_judge = minimax-m3`(reasoning 모델)를 상속.
2. `keeper.hitl_summary.max_tokens = 512`를 **extended thinking이 소진** → answer 텍스트 empty.
3. `structured_json_of_response`가 빈 텍스트에서 "did not contain text JSON" 반환 → parse 실패 → 매번 deterministic fallback.

## 변경 (root + hardening)

- **root** — `config/runtime.toml`: `[runtime].hitl_summary`를 **비-reasoning** structured 런타임(`ollama_cloud.ollama-cloud-devstral-2-123b`, `thinking-support=false` + `supports-structured-output=true`, Fusion judge와 동일)으로 지정. thinking이 예산을 먹지 않아 512토큰 전부가 answer로 감.
- **hardening** — `lib/keeper/hitl_summary_worker.ml`: `summary_of_response ~mode:Native_structured`가 structured 추출 실패 시 **기존 `Plain_json_text` 추출기(`extract_json_object`)로 폴백**. native-schema 런타임이 /v1 전송에서 JSON을 (fenced) prose로 반환하는 경우를 복구. 완전히 빈 답변은 여전히 실패(요약 날조 안 함)하고 deterministic fallback으로 degrade.

## 검증

- `dune build --root . ./test/test_hitl_summary_worker.exe` — pass
- `test/test_hitl_summary_worker.ml`: **16 tests pass**
  - 신규 `native path recovers prose-wrapped JSON` — **load-bearing 증명**: `.ml` 변경을 stash하면 이 테스트가 FAIL(`JSON parse error: Line 1, bytes 0-34`), 복원하면 PASS. 즉 schema_extractor는 엄격하고 dual-path가 실제로 복구를 수행함.
  - 신규 `native path still fails on empty text` — 빈 답변은 정직하게 실패(날조 방지) 확인.
- `hitl_summary` lane은 `validate_hitl_summary_runtime`의 존재 검증을 통과(런타임 바인딩 `[ollama_cloud.ollama-cloud-devstral-2-123b]` 존재).

## 남은 미검증 (정직 고지)

- **라이브 프로바이더 행동**: devstral-2-123b가 실제 ollama.com /v1 호출에서 512토큰·요약 스키마로 parseable JSON을 반환하는지는 **라이브 검증 미완**. 근거(비-reasoning + Fusion judge 실사용 + dual-path 안전망)는 강하나 empirical 미확인.
- **seed vs live**: `config/runtime.toml`은 **seed**(신규 워크스페이스에만 복사). 기존 실행 인스턴스는 `<base>/.masc/config/runtime.toml`을 별도 편집 + 서버 재시작해야 반영됨.

## 안전성

요약은 **advisory-only**이며 `auto_approved` 결정에 관여하지 않음. 이 변경은 승인 안전 동작을 바꾸지 않음.

이 변경은 워크어라운드 시그니처(telemetry-as-fix / string classifier / N-of-M / cap-cooldown) 없음. dual-path는 새 sanitizer가 아니라 코드베이스가 이미 문서화한 `Plain_json_text` 경로를 재사용하며, root fix(비-reasoning lane)와 함께 제공됨.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
