### PR TITLE
fix(schedule): wire terminal-row GC into 24h maintenance prune (audit P0-c)

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -639,7 +639,24 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                Log.Server.info
                  "periodic JSONL prune: pruned %d day-files (retention=%dd)"
                  total
-                 days
+                 days;
+             (* Schedule terminal-row GC on the same 24h cadence: terminal
+                rows (Succeeded/Failed/Rejected/Cancelled/Expired) otherwise
+                accumulate unbounded — the only pruner was the manual
+                dashboard action (Server_dashboard_http_schedule_actions).
+                Same operation as that button, so operator semantics are
+                unchanged; the cadence bounds how long terminal history
+                lingers, mirroring the dated-JSONL retention above. *)
+             (match Schedule_service.prune (Mcp_server.workspace_config state) with
+              | Ok (_, pruned) when pruned > 0 ->
+                Log.Server.info
+                  "periodic schedule prune: removed %d terminal rows"
+                  pruned
+              | Ok (_, _) -> ()
+              | Error err ->
+                Log.Server.warn
+                  "periodic schedule prune failed: %s"
+                  (Schedule_service.service_error_to_string err))
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->


### PR DESCRIPTION
## 배경 (도구 실행 에러 감사 24h · P0-c)

스케줄 terminal row(Succeeded/Failed/Rejected/Cancelled/Expired)가 무한 누적됩니다. `Schedule_store.prune_completed`는 존재하지만 production caller가 **수동 대시보드 prune 버튼 하나**뿐이라, 오퍼레이터가 누르지 않으면 store가 계속 자랍니다. (직접 증상이던 로그 노이즈 9,232건은 #23573이 이미 수리 — 이 PR은 잔여 근본인 자동 GC 부재만 다룹니다.)

## 변경

- cleanup 루프의 기존 24h JSONL prune 블록에 `Schedule_service.prune` 배선 (1 사이트, +18줄)
- 버튼과 동일 연산이므로 오퍼레이터 의미 불변, cadence가 terminal history 성장을 상한
- 실패는 warn 로그 (기존 recall_injections prune 실패 처리와 대칭)

## 감사 주장 정정 (fresh-read)

감사는 "RFC-0234가 설계한 청소, prune_completed는 정의만 있음"이라 했으나 — RFC-0234에는 prune 섹션이 없고, 수동 HTTP caller(`server_dashboard_http_schedule_actions.ml:133`)가 존재합니다. 진짜 갭은 **주기 배선 부재**뿐이며 이 PR이 그것만 추가합니다.

## 워크어라운드 자기점검

- log-dedup/demote 아님, cooldown 아님, counter-only 아님 — 상태머신 만료 개념의 결정론적 자원 회수(감사 처방 그대로)
- legacy row 4건 취소는 코드가 아니라 라이브 인스턴스 데이터 조작이라 이 PR 범위 밖 (오퍼레이터 액션)

## 검증

- parse-check 통과 (빌드는 CI). prune 자체는 기존 store 테스트가 커버, 이 PR은 배선만

🤖 Generated with [Claude Code](https://claude.com/claude-code)
