### PR TITLE
refactor(dashboard/connectors): connector-state cluster를 2446줄 표면에서 분리

### DIFF
--- a/dashboard/src/components/connector-state.ts
+++ b/dashboard/src/components/connector-state.ts
@@ -1,0 +1,120 @@
+// Connector state label + its pure visual mappings.
+//
+// Extracted from connector-status.ts (which re-exports the external members for
+// back-compat, matching the ./connector-constants precedent). These are pure
+// functions of a GateConnectorInfo / ConnectorStateLabel — no component state,
+// no signals — so they live apart from the 2000+ line route surface and can be
+// unit-tested (connector-card-border.test.ts) in isolation.
+
+import type { GateConnectorInfo } from '../api/gate'
+
+const CONNECTOR_STATE_LABELS = ['offline', 'stale', 'connected', 'disconnected'] as const
+export type ConnectorStateLabel = (typeof CONNECTOR_STATE_LABELS)[number]
+
+function isConnectorStateLabel(value: string | undefined): value is ConnectorStateLabel {
+  return value === 'offline' || value === 'stale' || value === 'connected' || value === 'disconnected'
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled connector state label: ${String(value)}`)
+}
+
+export function connectorStateLabel(connector: GateConnectorInfo | null): ConnectorStateLabel {
+  const advertised = connector?.status?.trim().toLowerCase()
+  if (isConnectorStateLabel(advertised)) {
+    return advertised
+  }
+  if (!connector?.available) return 'offline'
+  if (connector.stale) return 'stale'
+  if (connector.connected) return 'connected'
+  return 'disconnected'
+}
+
+/** Pure: Portainer-style left border tone for a connector card.
+    A 4px colored left border lets operators scan a vertical stack of
+    cards and spot problem connectors by color alone — no reading the
+    status pill required. Mapping matches Portainer's container state
+    palette: emerald for connected, amber for stale (intermittent),
+    rose for disconnected (broken), muted for offline (not running). */
+export function connectorCardBorderClass(label: ConnectorStateLabel): string {
+  switch (label) {
+    case 'connected':
+      return 'border-l-4 border-l-emerald-500'
+    case 'stale':
+      return 'border-l-4 border-l-[var(--color-warn)]'
+    case 'disconnected':
+      return 'border-l-4 border-l-rose-500'
+    case 'offline':
+      return 'border-l-4 border-l-[var(--color-border-default)]'
+    default:
+      return assertNever(label)
+  }
+}
+
+export function connectorStateTone(connector: GateConnectorInfo | null): string {
+  const label = connectorStateLabel(connector)
+  if (label === 'connected') {
+    return 'border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
+  }
+  if (label === 'disconnected') {
+    return 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]'
+  }
+  return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+}
+
+export function dotClassForLabel(label: ConnectorStateLabel): string {
+  switch (label) {
+    case 'connected':
+      return 'bg-[var(--ok-10)]'
+    case 'stale':
+      return 'bg-[var(--warn-10)]'
+    case 'disconnected':
+      return 'bg-[var(--bad-10)]'
+    case 'offline':
+      return 'bg-[var(--color-fg-disabled)]'
+    default:
+      return assertNever(label)
+  }
+}
+
+export function connectorCardStateClass(label: ConnectorStateLabel): string {
+  switch (label) {
+    case 'connected':
+      return ''
+    case 'stale':
+      return 'stale'
+    case 'offline':
+    case 'disconnected':
+      return 'down'
+    default:
+      return assertNever(label)
+  }
+}
+
+export function connectorStatusPillClass(label: ConnectorStateLabel): string {
+  switch (label) {
+    case 'connected':
+      return 'run'
+    case 'stale':
+      return 'pause'
+    case 'offline':
+    case 'disconnected':
+      return 'off'
+    default:
+      return assertNever(label)
+  }
+}
+
+export function connectorStatusPillLabel(label: ConnectorStateLabel): string {
+  switch (label) {
+    case 'connected':
+      return 'Connected'
+    case 'stale':
+      return 'Stale'
+    case 'offline':
+    case 'disconnected':
+      return 'Down'
+    default:
+      return assertNever(label)
+  }
+}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -45,6 +45,18 @@ export {
   channelIcon,
 } from './connector-constants'
 export type { KnownConnectorId, InProcessConnectorId, SidecarCommands } from './connector-constants'
+import {
+  connectorStateLabel,
+  connectorCardBorderClass,
+  connectorStateTone,
+  dotClassForLabel,
+  connectorCardStateClass,
+  connectorStatusPillClass,
+  connectorStatusPillLabel,
+} from './connector-state'
+// Back-compat re-export: connector state mapping now lives in ./connector-state.
+export { connectorStateLabel, connectorCardBorderClass } from './connector-state'
+export type { ConnectorStateLabel } from './connector-state'
 import { formatTimeAgoEn } from '../lib/format-time'
 import { ErrorState } from './common/feedback-state'
 import { ConnectorOverviewSkeleton } from './connector-overview-skeleton'
@@ -102,17 +114,6 @@ function activeConnectorFilter(): string | null {
 // Connector vocabulary (KNOWN_CONNECTOR_IDS, display names, sidecar commands,
 // accent styles, channel icons) lives in ./connector-constants and is imported
 // at the top of this file; re-exported there for back-compat.
-
-const CONNECTOR_STATE_LABELS = ['offline', 'stale', 'connected', 'disconnected'] as const
-export type ConnectorStateLabel = (typeof CONNECTOR_STATE_LABELS)[number]
-
-function isConnectorStateLabel(value: string | undefined): value is ConnectorStateLabel {
-  return value === 'offline' || value === 'stale' || value === 'connected' || value === 'disconnected'
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled connector state label: ${String(value)}`)
-}
 
 interface ConnectorUiState {
   actionLoading: boolean
@@ -323,21 +324,6 @@ function dotClass(state: LivenessState): string {
   }
 }
 
-function dotClassForLabel(label: ConnectorStateLabel): string {
-  switch (label) {
-    case 'connected':
-      return 'bg-[var(--ok-10)]'
-    case 'stale':
-      return 'bg-[var(--warn-10)]'
-    case 'disconnected':
-      return 'bg-[var(--bad-10)]'
-    case 'offline':
-      return 'bg-[var(--color-fg-disabled)]'
-    default:
-      return assertNever(label)
-  }
-}
-
 function uniqueStrings(values: string[]): string[] {
   const seen = new Set<string>()
   const ordered: string[] = []
@@ -354,49 +340,6 @@ function runtimeLabelForKeeper(keeper: GateKeeperInfo | null | undefined): strin
   const runtime = keeper?.agent_name?.trim()
   if (!runtime || runtime === keeper?.name) return ''
   return runtime
-}
-
-export function connectorStateLabel(connector: GateConnectorInfo | null): ConnectorStateLabel {
-  const advertised = connector?.status?.trim().toLowerCase()
-  if (isConnectorStateLabel(advertised)) {
-    return advertised
-  }
-  if (!connector?.available) return 'offline'
-  if (connector.stale) return 'stale'
-  if (connector.connected) return 'connected'
-  return 'disconnected'
-}
-
-/** Pure: Portainer-style left border tone for a connector card.
-    A 4px colored left border lets operators scan a vertical stack of
-    cards and spot problem connectors by color alone — no reading the
-    status pill required. Mapping matches Portainer's container state
-    palette: emerald for connected, amber for stale (intermittent),
-    rose for disconnected (broken), muted for offline (not running). */
-export function connectorCardBorderClass(label: ConnectorStateLabel): string {
-  switch (label) {
-    case 'connected':
-      return 'border-l-4 border-l-emerald-500'
-    case 'stale':
-      return 'border-l-4 border-l-[var(--color-warn)]'
-    case 'disconnected':
-      return 'border-l-4 border-l-rose-500'
-    case 'offline':
-      return 'border-l-4 border-l-[var(--color-border-default)]'
-    default:
-      return assertNever(label)
-  }
-}
-
-function connectorStateTone(connector: GateConnectorInfo | null): string {
-  const label = connectorStateLabel(connector)
-  if (label === 'connected') {
-    return 'border-[var(--ok-border)] bg-[var(--ok-10)] text-[var(--color-status-ok)]'
-  }
-  if (label === 'disconnected') {
-    return 'border-[var(--err-border)] bg-[var(--bad-10)] text-[var(--bad-light)]'
-  }
-  return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
 }
 
 function findKnownConnector(connectors: GateConnectorInfo[], connectorId: KnownConnectorId): GateConnectorInfo | null {
@@ -1782,48 +1725,6 @@ function GateStatusStrip({
       <span style=${{ marginLeft: 'auto' }} class="mono">generated_at ${generatedAt}</span>
     </div>
   `
-}
-
-function connectorCardStateClass(label: ConnectorStateLabel): string {
-  switch (label) {
-    case 'connected':
-      return ''
-    case 'stale':
-      return 'stale'
-    case 'offline':
-    case 'disconnected':
-      return 'down'
-    default:
-      return assertNever(label)
-  }
-}
-
-function connectorStatusPillClass(label: ConnectorStateLabel): string {
-  switch (label) {
-    case 'connected':
-      return 'run'
-    case 'stale':
-      return 'pause'
-    case 'offline':
-    case 'disconnected':
-      return 'off'
-    default:
-      return assertNever(label)
-  }
-}
-
-function connectorStatusPillLabel(label: ConnectorStateLabel): string {
-  switch (label) {
-    case 'connected':
-      return 'Connected'
-    case 'stale':
-      return 'Stale'
-    case 'offline':
-    case 'disconnected':
-      return 'Down'
-    default:
-      return assertNever(label)
-  }
 }
 
 function connectorDisplayValue(value: string | number | null | undefined): string {


### PR DESCRIPTION
## 무엇을 / 왜

`connector-status.ts`는 **2446줄 route 표면**(god-file)이었습니다. 순수 `ConnectorStateLabel` 클러스터 — 라벨 타입/guard + 시각 매핑 7종(`connectorStateLabel`, `connectorCardBorderClass`, `connectorStateTone`, `dotClassForLabel`, `connectorCardStateClass`, `connectorStatusPillClass/Label`) — 을 `connector-state.ts`로 추출했습니다. 컴포넌트/signal 상태 없는 순수 함수라 표면과 분리 가능.

## 방식 (non-breaking)

- `connector-status.ts`가 외부 import되는 멤버(`connectorStateLabel`, `connectorCardBorderClass`, `ConnectorStateLabel`)를 **re-export** → importer 무변경. 기존 `./connector-constants` re-export 관습과 동일.
- 표면 **2446 → 2348줄**(−98). 추출 클러스터(120줄)는 기존 `connector-card-border.test`로 격리 유닛 테스트.

## 검증

- connector card-border / status / overview-strip 테스트 **120 green (무수정)** → 동작 보존 증명.
- 두 파일 tsc clean · eslint clean.

## ⚠️ CI 주의 — 선재 main-red (내 변경 무관)

현재 origin/main이 **tsc-red**입니다: `keeper-spawn/persona-form.ts`(#23703)가 `keeper-spawn-state`에 없는 export(`editingPersona`/`createPersona`/`updatePersona`)를 import. 제 PR은 이를 상속하므로 Dashboard CI가 red로 뜹니다 — **connector 변경과 무관**(`git diff origin/main -- keeper-spawn/` = 비어있음). main이 고쳐지면 rebase → green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>