### PR TITLE
fix(task): empty evaluator output attributes to evaluator via typed Evaluator_empty gate (audit P0-b)

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -98,6 +98,7 @@ type gate =
   | Structured_tool
   | Llm_text_fallback
   | Format_reject
+  | Evaluator_empty
   | Fallback
 
 let gate_to_string = function
@@ -108,6 +109,7 @@ let gate_to_string = function
   | Structured_tool -> "structured_tool"
   | Llm_text_fallback -> "llm_text_fallback"
   | Format_reject -> "format_reject"
+  | Evaluator_empty -> "evaluator_empty"
   | Fallback -> "fallback"
 ;;
 
@@ -891,17 +893,33 @@ let review
                 task_info "[anti-rationalization] verdict via native JSON response";
                 (match parse_review_verdict_from_response_text text with
                  | Ok v -> v, Llm_text_fallback, None
-                 | Error parse_error ->
+                 | Error Empty_review_output ->
+                   (* Misattribution fix (24h tool-error audit, 2026-07-08): an
+                      empty completion is an evaluator-side failure — the
+                      keeper's notes were never reviewed, so a reason phrased
+                      as "review format unrecognized" sent keepers into a
+                      revise-notes retry loop (305 hits/24h). Still a
+                      deterministic Reject: #22573's ratchet (empty must not
+                      approve by liveness, independent of the fail_mode knob)
+                      holds. Only the attribution and the gate change. *)
+                   task_warn
+                     "[anti-rationalization] evaluator returned empty completion \
+                      (rejecting fail-closed; evaluator-side failure — keeper \
+                      notes were not reviewed)";
+                   ( Reject
+                       "evaluator returned an empty response; the completion \
+                        notes were not reviewed (evaluator-side failure). \
+                        Revising notes will not help — retry later, and if \
+                        this repeats the evaluator runtime needs operator \
+                        attention (structured-output capability or token \
+                        budget)."
+                   , Evaluator_empty
+                   , Some (verdict_parse_error_to_string Empty_review_output) )
+                 | Error (Unrecognized_review_format _ as parse_error) ->
                    let parse_err = verdict_parse_error_to_string parse_error in
-                   (match parse_error with
-                    | Empty_review_output ->
-                      task_warn
-                        "[anti-rationalization] evaluator returned empty text \
-                         (rejecting)"
-                    | Unrecognized_review_format _ ->
-                      task_warn
-                        "[anti-rationalization] verdict parse failed: %s (rejecting)"
-                        parse_err);
+                   task_warn
+                     "[anti-rationalization] verdict parse failed: %s (rejecting)"
+                     parse_err;
                    ( Reject (sprintf "review format unrecognized: %s" parse_err)
                    , Format_reject
                    , Some parse_err ))

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -64,6 +64,12 @@ type gate =
   | Structured_tool
   | Llm_text_fallback
   | Format_reject
+  | Evaluator_empty
+      (** Evaluator responded with an empty completion — an evaluator-side
+          failure, distinct from [Format_reject] (a parseable-but-wrong
+          response). Deterministic Reject either way; empty output never
+          approves (#22573 ratchet). Typed apart so evaluator health is
+          observable and the keeper is not told to revise its notes. *)
   | Fallback
 
 val gate_to_string : gate -> string

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -1,12 +1,19 @@
-(** Ratchet: [Task.Anti_rationalization.review] treats an empty evaluator
-    response as an invalid verdict and rejects via [Format_reject].
+(** Ratchet: [Task.Anti_rationalization.review] never approves an empty
+    evaluator response.
 
     The runtime log on 2026-06-28 showed repeated
     "evaluator returned empty text (approving by liveness)" entries. That
-    path silently accepted task completion without a reviewer verdict. The
-    parser still preserves the public string error for callers, but
-    production routing uses the typed parse error so the reject branch does
-    not depend on matching an error string. *)
+    path silently accepted task completion without a reviewer verdict
+    (#22573 closed it). The parser still preserves the public string error
+    for callers, but production routing uses the typed parse error so the
+    reject branch does not depend on matching an error string.
+
+    2026-07-09 (24h tool-error audit): the reject stays deterministic, but
+    empty output is now [Evaluator_empty] instead of [Format_reject] and the
+    reason names the evaluator-side failure — the old
+    "review format unrecognized" wording sent keepers into a revise-notes
+    retry loop for a failure their notes did not cause. The must-not-approve
+    invariant is unchanged and re-pinned below. *)
 
 module AR = Masc.Task.Anti_rationalization
 
@@ -79,17 +86,19 @@ let test_review_rejects_empty_evaluator_output () =
         AR.review ~evaluator_runtime:"test-empty-evaluator" (make_request ())
       in
       Alcotest.(check string)
-        "gate" "format_reject" (AR.gate_to_string result.AR.gate);
+        "gate" "evaluator_empty" (AR.gate_to_string result.AR.gate);
       Alcotest.(check (option string))
         "fallback reason"
         (Some "empty review output")
         result.AR.fallback_reason;
       match result.AR.verdict with
       | AR.Reject reason ->
-        Alcotest.(check string)
-          "reject reason"
-          "review format unrecognized: empty review output"
-          reason
+        Alcotest.(check bool)
+          "reject reason attributes the failure to the evaluator, not the notes"
+          true
+          (contains_substring reason "evaluator-side failure"
+           && contains_substring reason "not reviewed"
+           && not (contains_substring reason "review format unrecognized"))
       | AR.Approve ->
         Alcotest.fail
           "empty evaluator output must not approve by liveness")


### PR DESCRIPTION
## 배경 (도구 실행 에러 감사 24h · P0-b, 305건/24h)

evaluator LLM이 빈 응답을 내면 게이트가 `review format unrecognized: empty review output`(gate=`format_reject`)으로 거부합니다. 키퍼는 이를 **자기 노트 문제**로 읽고 revise-notes 재시도 루프에 빠집니다(base 키퍼 집중). 오귀속이 실증상입니다.

## 감사 처방을 기각한 이유 (3-agent 정찰)

감사는 "Empty를 #9794 unavailability 핸들러(gate=Fallback)로 라우팅"을 처방했지만, 이력 정찰이 반증했습니다:

- **#22573 (2026-06-29)**이 empty→approve-by-liveness를 silent-failure로 규정하고 의도적으로 뒤집음 (2026-06-28 사고, #22567 item 8)
- ratchet 테스트(`test_anti_rationalization_empty_reject.ml`)가 "empty evaluator output must not approve by liveness"를 명시 pin
- unavailability 핸들러의 fail_mode 기본값은 **Open(승인)** — 감사 처방대로면 empty→Approve 회귀 재도입
- 감사 콘솔(07-08)이 #22573(06-29)보다 늦게 작성됐는데 ratchet을 놓침

## 수정 (두 불변식 모두 보존)

1. **Reject 유지** — empty는 결정론적 거부, fail_mode와 무관 (#22573 불변)
2. **귀속 정정** — reason이 evaluator-side 실패를 명시 + "노트 수정은 도움 안 됨" 안내 → 재시도 루프 차단
3. **typed 분리** — 새 gate `Evaluator_empty`: `Format_reject`(파싱 가능하나 틀린 응답)와 구분, Fallback 카운터(`metric_anti_rationalization_fallback`, eval_calibration `fallback_count`) 미오염. census 결과 production 코드는 gate를 branch하지 않음(serialize/display 전용)이라 안전
4. ratchet 테스트 re-pin: must-not-approve 불변 유지, gate/reason만 갱신

## Ops 후속 (코드 밖)

- `evaluator_empty`가 반복되면 evaluator runtime의 구조화 출력 능력·토큰 예산 점검 (hook의 max_tokens=200 — thinking 모델이면 RFC-0271 truncation 계열로 구조적 empty 가능)
- 감사의 병행 처방 "cross_verifier가 구조화 JSON 가능 모델인지 config 점검"과 일치

## 충돌 주의

- #23747/54/56/58/60 (operator_override 스택)이 같은 Gate 3 블록을 begin/end로 감쌈 — 병렬 세션 리뷰 판정은 close/RFC 방향. 먼저 머지되면 이 PR이 rebase

## 검증

- 3파일 parse-check 통과 (빌드는 CI)
- Evaluator_empty 배선 5사이트 확인 (variant/to_string/mli/arm/test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
