### PR TITLE
feat(dashboard): 키퍼 레인/waiting-inventory 패널 실시간 자동 갱신

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -96,6 +96,35 @@ describe('KeeperLaneStrip', () => {
     expect(el.querySelector('[data-missing="keeper-lane"]')).toBeNull()
   })
 
+  it('shows the auto-refresh cadence beside the snapshot time when polling', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+        autoRefreshMs=${15_000}
+      />
+    `)
+    const text = el.textContent ?? ''
+    expect(text).toContain('기준')
+    expect(text).toContain('Auto-refresh 15s')
+  })
+
+  it('omits the auto-refresh label when the panel is not polling', () => {
+    const el = mount(html`
+      <${KeeperLaneStrip}
+        keeper=${keeperFixture()}
+        inventory=${inventoryFixture()}
+        ready=${true}
+        loading=${false}
+        error=${null}
+      />
+    `)
+    expect(el.textContent ?? '').not.toContain('Auto-refresh')
+  })
+
   it('renders an explicit gap when the keeper is absent from the inventory', () => {
     const el = mount(html`
       <${KeeperLaneStrip}

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -23,9 +23,19 @@ import {
   stateTone,
 } from '../tools/keeper-waiting-inventory-panel'
 import { formatDateTimeKo } from '../../lib/format-time'
+import { setupVisibleAutoRefresh, formatAutoRefreshLabel } from '../../lib/auto-refresh'
 import { CountBadge } from '../v2/primitives-v2'
 
 const LANE_ROW_LIMIT = 3
+
+// The strip mirrors a heavy server-side aggregation (per-keeper event-queue,
+// turn-admission, external-attention, HITL, schedule scans). It is refreshed
+// by polling — not server push — while the keeper detail is open, so a busy
+// fleet does not pay that aggregation on every event. 15s is tighter than the
+// 30s shared panel default because this is the live "what is this keeper
+// waiting on right now" surface; setupVisibleAutoRefresh still pauses when the
+// tab is hidden and refreshes immediately on focus/return.
+const LANE_REFRESH_MS = 15_000
 
 function inventoryEntry(
   inventory: DashboardKeeperWaitingInventory | null | undefined,
@@ -72,6 +82,7 @@ export function KeeperLaneStrip({
   ready,
   loading,
   error,
+  autoRefreshMs,
 }: {
   keeper: Keeper
   inventory: DashboardKeeperWaitingInventory | null | undefined
@@ -80,6 +91,9 @@ export function KeeperLaneStrip({
   ready: boolean
   loading: boolean
   error: string | null
+  /** when set, the container polls at this cadence — shown next to the
+   *  snapshot time so the operator knows the panel refreshes on its own. */
+  autoRefreshMs?: number
 }): VNode {
   const entry = inventoryEntry(inventory, keeper)
   const rows = (entry?.waiting_on ?? []).slice(0, LANE_ROW_LIMIT)
@@ -112,8 +126,10 @@ export function KeeperLaneStrip({
                   `
                 : null}
               ${inventory?.generated_at
-                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">기준 ${formatDateTimeKo(inventory.generated_at)}</div>`
-                : null}
+                ? html`<div class="text-2xs text-[var(--color-fg-muted)]">기준 ${formatDateTimeKo(inventory.generated_at)}${autoRefreshMs ? html` · ${formatAutoRefreshLabel(autoRefreshMs)}` : null}</div>`
+                : autoRefreshMs
+                  ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${formatAutoRefreshLabel(autoRefreshMs)}</div>`
+                  : null}
             </div>
           `
         : inventory
@@ -127,11 +143,17 @@ export function KeeperLaneStrip({
   `
 }
 
-/** Container: reads the shared tools resource (loads it once if absent —
- *  the same pattern schedule-surface uses) and renders the strip. */
+/** Container: reads the shared tools resource, loads it once if absent, and
+ *  keeps it live while mounted by polling on a visibility-aware interval
+ *  (paused when the tab is hidden, refreshed immediately on focus/return).
+ *  The shared resource is stale-while-revalidate, so each refetch swaps the
+ *  inventory in place without flashing a loading gap. */
 export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
   useEffect(() => {
     if (!toolsData.value && !toolsLoading.value) void loadTools()
+    return setupVisibleAutoRefresh(() => {
+      void loadTools()
+    }, LANE_REFRESH_MS)
   }, [])
   return html`
     <${KeeperLaneStrip}
@@ -140,6 +162,7 @@ export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
       ready=${toolsData.value != null}
       loading=${toolsLoading.value}
       error=${toolsError.value}
+      autoRefreshMs=${LANE_REFRESH_MS}
     />
   `
 }

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -3,16 +3,18 @@
 import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
 import { fetchDashboardTools, type DashboardToolsResponse, type DashboardToolInventoryItem } from '../../api'
-import { createAsyncResource, getData } from '../../lib/async-state'
+import { createManagedAsyncResource } from '../../lib/async-state'
 
-const toolsResource = createAsyncResource<DashboardToolsResponse>()
+// Managed (stale-while-revalidate): the previously loaded response stays
+// readable while a refetch is in flight. Panel-level polling — the keeper
+// lane strip re-fetches this shared resource on an interval — therefore
+// keeps showing the last inventory instead of flashing a loading gap every
+// cycle. A plain createAsyncResource would blank the data on each load.
+const toolsResource = createManagedAsyncResource<DashboardToolsResponse>()
 
-export const toolsData = computed(() => getData(toolsResource.state.value) ?? null)
-export const toolsError = computed<string | null>(() => {
-  const s = toolsResource.state.value
-  return s.status === 'error' ? s.message : null
-})
-export const toolsLoading = computed(() => toolsResource.state.value.status === 'loading')
+export const toolsData = computed(() => toolsResource.state.value.data)
+export const toolsError = computed<string | null>(() => toolsResource.state.value.error)
+export const toolsLoading = computed(() => toolsResource.state.value.loading)
 export const searchQuery = signal('')
 export const categoryFilter = signal('all')
 export const directOnly = signal(false)
@@ -38,7 +40,7 @@ export const SURFACE_LABELS: Record<SurfaceFilter, string> = {
 }
 
 export async function loadTools() {
-  await toolsResource.load(() => fetchDashboardTools())
+  await toolsResource.load(signal => fetchDashboardTools({ signal }))
 }
 
 export function hasSurface(item: DashboardToolInventoryItem, surface: string): boolean {


### PR DESCRIPTION
## 문제

키퍼 상세 우측의 **레인 / external-attention 목록**이 실시간이 아니었다. `KeeperLaneSection`이 공유 tools 리소스를 mount 시 **1회만** fetch하고 이후 갱신하지 않아, `기준 <시각>`이 수동 새로고침 전까지 고정. 운영자는 이를 실시간으로 오해(예: `기준 05:40`이 몇 시간째 그대로).

## 접근 (서버 무변경, client-only)

`keeper_waiting_inventory`는 keeper마다 event-queue·turn-admission·external-attention·HITL·schedule을 디스크 스캔하는 **무거운 집계**다. 따라서 매 이벤트 서버 push가 아니라 **패널이 열려 있는 동안 스냅샷 엔드포인트를 폴링**한다.

1. **폴링**: `KeeperLaneSection`이 기존 `setupVisibleAutoRefresh` 헬퍼로 15초 주기 폴링. 탭 숨김 시 자동 중단, focus/복귀 시 즉시 갱신, unmount 시 정리. (15초는 30초 공용 기본보다 타이트 — 이 패널은 "지금 이 키퍼가 뭘 기다리나"의 라이브 운영 뷰라.)
2. **깜빡임 제거**: 공유 tools 리소스를 `createAsyncResource` → `createManagedAsyncResource`로 이관(**stale-while-revalidate**). 재fetch 중 이전 inventory가 그대로 보여, 폴링마다 "레인 상태 로딩…" 플래시가 사라진다. **공개 API(`toolsData`/`toolsLoading`/`toolsError`/`loadTools`)는 불변** → Tools/Schedule surface 코드 변경 0, 그들도 재fetch 시 깜빡임 개선.
3. **가시성**: `기준 <시각>` 옆에 `Auto-refresh 15s` 표시 → 운영자가 패널이 스스로 갱신됨을 인지.

## 왜 서버 push가 아닌가 (트레이드오프)

집계가 무거워 매 keeper 이벤트마다 재계산·broadcast하면 부하(과거 dashboard perf collapse 전례). 폴링은 부하를 "열려 있는 패널당 15초 1회"로 상한. 진짜 event-driven push는 별도 RFC 대상.

## 검증 (로컬 vitest)

- `keeper-lane-strip.test.ts`: **7 pass** (기존 5 + 신규 2 — `autoRefreshMs` 시 `Auto-refresh 15s` 렌더 / 미전달 시 미표시).
- `auto-refresh.test.ts`: pass (폴링 헬퍼 자체 커버).
- `tool-state.test.ts` + `tools-main.test.ts` + `schedule-surface.test.ts`: **45 pass** (공유 리소스 이관 후 소비처 무회귀).
- 변경 파일 3개(+67/-13), 서버·타 surface 무접촉.

> 참고: `pnpm typecheck`는 `keeper-spawn/persona-*`의 기존 main 오류(진행 중 persona CRUD 작업, 본 PR 무관)로 실패하나, 본 PR이 건드린 `tool-state.ts`/`keeper-lane-strip.ts`엔 타입 오류 없음.

RFC-WAIVED: RFC-gated 서브시스템 아님 (대시보드 read-only 패널 갱신).

🤖 Generated with [Claude Code](https://claude.com/claude-code)