### PR TITLE
feat(dashboard): predecessor lineage link in task detail (RFC-0323 G-9)

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.class.test.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.class.test.ts
@@ -10,4 +10,14 @@ describe('TaskDetailOverlay source class hygiene', () => {
     expect(src).toContain('rounded-t-[var(--r-1)]')
     expect(src).not.toContain('rounded-[var(--r-1)]-t-2xl')
   })
+
+  it('renders the predecessor lineage section in the overview (RFC-0323 G-9)', () => {
+    const src = readFileSync(SOURCE, 'utf-8')
+    expect(src).toContain('function PredecessorSection')
+    expect(src).toContain('task.predecessor_task_id')
+    // Wired into the overview body, not just defined.
+    expect(src).toMatch(/PredecessorSection}\s+task=/)
+    // Opens the predecessor's own detail when it is in the loaded list.
+    expect(src).toContain('openTaskDetail(predecessor)')
+  })
 })

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -13,8 +13,10 @@ import { TextInput } from '../common/input'
 import { TimeAgo } from '../common/time-ago'
 import { findKeeper } from '../../lib/keeper-utils'
 import { selectedTask } from './task-detail-selection'
+import { tasks } from '../../store'
 import {
   closeTaskDetail,
+  openTaskDetail,
   taskEvents,
   taskEventsLoading,
   taskEventsError,
@@ -300,6 +302,36 @@ function GateSection({
   `
 }
 
+// RFC-0323 G-9: linked re-run lineage. A task created as a re-run carries
+// the write-once predecessor_task_id (G-8); surface it as a link so the
+// operator can walk back to the original. Clicking opens the predecessor's
+// detail when it is in the loaded task list; otherwise the id renders as
+// plain text (the store may window out old terminal tasks).
+function PredecessorSection({ task }: { task: Task }) {
+  const predecessorId = task.predecessor_task_id
+  if (!predecessorId) return null
+  const predecessor = tasks.value.find(t => t.id === predecessorId) ?? null
+  return html`
+    <div>
+      <${SectionTitle}>이전 실행 (재실행 계보)</${SectionTitle}>
+      <div class="${CARD_BOX} flex items-center gap-2 text-sm">
+        <span class="text-2xs uppercase tracking-3 text-text-muted">predecessor</span>
+        ${predecessor ? html`
+          <button
+            type="button"
+            class="font-mono text-accent-fg underline-offset-2 hover:underline"
+            onClick=${() => openTaskDetail(predecessor)}
+          >${predecessorId}</button>
+          <span class="truncate text-text-dim">${predecessor.title}</span>
+        ` : html`
+          <span class="font-mono text-text-body">${predecessorId}</span>
+          <span class="text-2xs text-text-dim">(현재 목록에 없음)</span>
+        `}
+      </div>
+    </div>
+  `
+}
+
 function ContractSection({ task }: { task: Task }) {
   const contract = task.contract
   const gate = task.gate
@@ -543,6 +575,7 @@ export function TaskDetailOverlay() {
           ` : null}
 
           <${TaskLineageSection} task=${task} />
+          <${PredecessorSection} task=${task} />
           <${ContractSection} task=${task} />
           <${VerdictLineageSection} />
           <${ExecutionLinksSection} task=${task} />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -62,6 +62,7 @@ export interface Task {
   created_at?: string
   updated_at?: string
   completed_at?: string
+  predecessor_task_id?: string | null
   contract?: TaskContract | null
   handoff_context?: TaskHandoffContext | null
   gate?: TaskGateSnapshot | null

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -35,6 +35,9 @@ let dashboard_task_json config (task : Masc_domain.task) =
     ; "priority", `Int task.priority
     ; "assignee", Json_util.string_opt_to_json (dashboard_task_assignee task)
     ; "created_at", `String task.created_at
+    (* RFC-0323 G-9: surface the linked re-run lineage (G-8 write-once
+       field) so the task detail can link back to the predecessor. *)
+    ; "predecessor_task_id", Json_util.string_opt_to_json task.predecessor_task_id
     ]
   in
   let projection_fields =


### PR DESCRIPTION
## RFC-0323 G-9 — predecessor 재실행 계보 표시 (display-only)

G-8이 심은 write-once `predecessor_task_id`가 rich task_json(codec 자동상속)에는 있지만 **대시보드 수제 task subset에는 없어** task detail이 렌더할 데이터가 없었습니다.

## 변경

- `server_dashboard_http_core_entities.ml` `dashboard_task_json`: `predecessor_task_id` 필드 추가 (None→null, 기존 option 필드 관례)
- FE `Task` 타입: `predecessor_task_id?: string | null`
- task-detail overview에 `PredecessorSection`: predecessor가 로드된 목록에 있으면 **클릭 시 해당 태스크 상세로 이동**, 없으면 id 텍스트+'(현재 목록에 없음)' (store가 오래된 terminal 태스크를 window out할 수 있음)

## Goal Matrix 정합

- 게이트 G-8: MERGED (#23668)
- 면제 준수: rich task_json(`dashboard_execution.ml`)은 codec 자동상속이라 무수정
- Exit criterion: "task detail에 predecessor 링크 표시" ✓

## 검증

- vitest 2/2 (신규 source pin: 섹션 정의+overview 배선+클릭 네비게이션)
- `tsc --noEmit` 에러 집합이 변경 전후 동일 (기존 persona-lane 8건, 내 파일 0건 — stash 대조로 확인)
- OCaml parse-check 통과 (빌드는 CI)

RFC: RFC-0323 G-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
