### PR TITLE
feat(dashboard): expose shell IR approval runtime resolution

### DIFF
--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1204,6 +1204,7 @@ export function SettingsSurface() {
   const runtimeRoutingSaving = runtimeRoutingStatus === 'saving'
   const runtimeResolution = shellRuntimeResolution.value
   const configResolution = shellConfigResolution.value
+  const shellIrApproval = runtimeResolution?.shell_ir_approval
   const hasRuntimePathResolution = runtimeResolution !== null
   const hasConfigPathResolution = configResolution !== null
   const hasShellPathResolution = hasRuntimePathResolution || hasConfigPathResolution
@@ -1569,6 +1570,38 @@ export function SettingsSurface() {
                       <${PathTruthRow} label="Workspace path" item=${runtimeResolution?.workspace_path ?? null} />
                       <${PathTruthRow} label="Data root" item=${runtimeResolution?.data_root ?? null} fallback=${concreteConfigValue(dataDirEntry)} />
                       <${PathTruthRow} label="Prompt markdown dir" item=${runtimeResolution?.prompt_markdown_dir ?? null} />
+                      ${shellIrApproval
+                        ? html`
+                          <div class="set-sub-h">Shell IR approval</div>
+                          <${SetRow} label="gate enabled" hint=${shellIrApproval?.env_key ?? 'shell ir approval'}>
+                            <div class="set-truth-value">
+                              <span class="mono">${shellIrApproval.enabled ? 'enabled' : 'disabled'}</span>
+                              <span class="set-truth-source">${shellIrApproval.source ?? 'runtime projection'}</span>
+                            </div>
+                          <//>
+                          <${SetRow} label="override" hint=${shellIrApproval.env_key}>
+                            <div class="set-truth-value">
+                              <span class="mono">${shellIrApproval.raw_overlay ?? 'default (autonomous)'}</span>
+                            </div>
+                          <//>
+                          <${SetRow} label="trust" hint="safe / audited / privileged">
+                            <div class="set-truth-value">
+                              <span class="mono">${shellIrApproval.trust === null
+                                ? 'unknown'
+                                : `${shellIrApproval.trust.safe}/${shellIrApproval.trust.audited}/${shellIrApproval.trust.privileged}`}</span>
+                            </div>
+                          <//>
+                          ${shellIrApproval.reason
+                            ? html`
+                              <${SetRow} label="reason" hint="projection reason">
+                                <div class="set-truth-value">
+                                  <span class="mono">${shellIrApproval.reason}</span>
+                                </div>
+                              <//>
+                            `
+                            : null}
+                        `
+                        : null}
                     `
                     : null}
                   ${hasConfigPathResolution || runtimeConfigPath

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -239,6 +239,19 @@ function runtimeResolutionPayload() {
     source_mismatch: false,
     server_workspace_mismatch: false,
     diagnostics: [],
+    shell_ir_approval: {
+      schema: 'masc.shell_ir_approval.v1',
+      enabled: true,
+      env_key: 'MASC_SHELL_IR_APPROVAL',
+      raw_overlay: null,
+      trust: {
+        safe: 'safe',
+        audited: 'audited',
+        privileged: 'privileged',
+      },
+      source: 'default_autonomous',
+      reason: 'using fallback overlay: Masc_exec.Approval_config.autonomous',
+    },
     build: {
       release_version: 'dev',
       commit: 'deadbee',
@@ -324,6 +337,19 @@ describe('ConfigResolutionPanel', () => {
               message: 'Received SIGTERM, shutting down server.',
             },
           ],
+          shell_ir_approval: {
+            schema: 'masc.shell_ir_approval.v1',
+            enabled: false,
+            env_key: 'MASC_SHELL_IR_APPROVAL',
+            raw_overlay: null,
+            trust: {
+              safe: 'safe',
+              audited: 'audited',
+              privileged: 'privileged',
+            },
+            source: 'runtime projection',
+            reason: 'using fallback overlay: Masc_exec.Approval_config.autonomous',
+          },
           build: {
             release_version: 'dev',
             commit: 'deadbee',
@@ -362,6 +388,9 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('/tmp/masc')
     expect(container.textContent).toContain('server repo head')
     expect(container.textContent).toContain('feedbee')
+    expect(container.textContent).toContain('Shell IR approval')
+    expect(container.textContent).toContain('disabled')
+    expect(container.textContent).toContain('safe/audited/privileged')
     expect(container.textContent).toContain('source mismatch')
     expect(container.textContent).toContain('server/workspace mismatch')
     expect(container.textContent).toContain('SIGTERM')

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -469,9 +469,20 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
   `
 }
 
+function formatShellIrApproval(
+  approval: DashboardRuntimeResolution['shell_ir_approval'],
+): string {
+  if (!approval) return MISSING_DATA_DASH
+  const trust = approval.trust === null
+    ? 'unknown'
+    : `${approval.trust.safe}/${approval.trust.audited}/${approval.trust.privileged}`
+  return `${approval.enabled ? 'enabled' : 'disabled'} (trust: ${trust})`
+}
+
 function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: DashboardRuntimeResolution }) {
   const fd = runtimeResolution.fd_accountant
   const fleet = runtimeResolution.fleet_safety
+  const shellIr = runtimeResolution.shell_ir_approval
   const fdValue = fd
     ? `${fd.fd_open ?? MISSING_DATA_DASH} / ${fd.fd_limit ?? MISSING_DATA_DASH}`
     : MISSING_DATA_DASH
@@ -489,6 +500,8 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
         <${RuntimeMetaRow} label="effective .masc" value=${runtimeResolution.data_root.path ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="shell IR approval" value=${formatShellIrApproval(shellIr)} />
+        <${RuntimeMetaRow} label="shell IR raw" value=${shellIr?.raw_overlay ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? MISSING_DATA_DASH)} />
         <${RuntimeMetaRow} label="fd pressure" value=${fd?.pressure_active == null ? MISSING_DATA_DASH : fd.pressure_active ? 'active' : 'clear'} />
       </div>

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -606,6 +606,39 @@ function normalizeKeeperRuntimeResolved(raw: unknown): KeeperRuntimeResolved | n
   }
 }
 
+function normalizeDashboardShellIrApproval(
+  raw: unknown,
+): DashboardRuntimeResolution['shell_ir_approval'] {
+  if (!isRecord(raw)) return null
+  const schema = asString(raw.schema)
+  const enabled = asBoolean(raw.enabled)
+  const envKey = asString(raw.env_key)
+  const rawOverlay = asString(raw.raw_overlay)
+  const reason = asString(raw.reason)
+  const source = asString(raw.source)
+  const trust = isRecord(raw.trust)
+    ? {
+      safe: asString(raw.trust.safe),
+      audited: asString(raw.trust.audited),
+      privileged: asString(raw.trust.privileged),
+    }
+    : null
+  const normalizedTrust =
+    trust === null || trust.safe === null || trust.audited === null || trust.privileged === null
+      ? null
+      : trust
+  if (schema === null || enabled === undefined || envKey === null) return null
+  return {
+    schema,
+    enabled,
+    env_key: envKey,
+    raw_overlay: rawOverlay ?? null,
+    trust: normalizedTrust,
+    source: source ?? null,
+    reason: reason ?? null,
+  }
+}
+
 export function normalizeDashboardRuntimeResolution(
   raw: unknown,
   generatedAt?: string,
@@ -640,6 +673,7 @@ export function normalizeDashboardRuntimeResolution(
       .map(normalizeDashboardRuntimeDiagnostic)
       .filter((item): item is DashboardRuntimeDiagnostic => item !== null),
     build,
+    shell_ir_approval: normalizeDashboardShellIrApproval(raw.shell_ir_approval),
     keeper_runtime: normalizeKeeperRuntimeResolved(raw.keeper_runtime),
     fleet_safety: normalizeDashboardFleetSafetyHealth(raw),
     fd_accountant: normalizeDashboardFdAccountant(raw.fd_accountant),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -94,6 +94,22 @@ export interface DashboardRuntimeDiagnostic {
   message: string
 }
 
+export interface DashboardShellIrTrust {
+  safe: string
+  audited: string
+  privileged: string
+}
+
+export interface DashboardShellIrApproval {
+  schema: string
+  enabled: boolean
+  env_key: string
+  raw_overlay: string | null
+  trust: DashboardShellIrTrust | null
+  source: string | null
+  reason: string | null
+}
+
 export type KeeperRuntimeSource = 'env' | 'toml' | 'default' | 'derived'
 
 export interface KeeperRuntimeField<T> {
@@ -129,6 +145,7 @@ export interface DashboardRuntimeResolution {
   server_workspace_mismatch: boolean
   diagnostics: DashboardRuntimeDiagnostic[]
   build: ServerBuildIdentity
+  shell_ir_approval?: DashboardShellIrApproval | null
   keeper_runtime: KeeperRuntimeResolved | null
   fleet_safety: DashboardFleetSafetyHealth | null
   fd_accountant: DashboardFdAccountant | null

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -884,4 +884,19 @@ module Shell_ir_approval_gate = struct
     Feature_flag_registry.get_bool "MASC_SHELL_IR_APPROVAL_GATE_ENABLED"
 end
 
+(** {1 Shell IR approval policy config (RFC-0254)} *)
+
+module Shell_ir_approval = struct
+  (** Single env spec that controls the approval overlay for keeper lanes.
+      Examples:
+
+      - [autonomous]
+      - [permissive]
+      - [safe=observe,audited=enforced,privileged=auto_safe]
+      - [profile=autonomous,safe=observe]
+
+      The parser is implemented in {!Masc_exec.Approval_config}. *)
+  let raw_overlay () = Sys.getenv_opt "MASC_SHELL_IR_APPROVAL" |> trim_opt
+end
+
 (** {1 Internal Safety Configuration} *)

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -344,3 +344,13 @@ module Shell_ir_approval_gate : sig
       operations require explicit approval. Default: [true] (the autonomous
       policy is a strict safety improvement over the no-gate path). *)
 end
+
+(** {1 Shell IR approval policy config (RFC-0254)} *)
+
+module Shell_ir_approval : sig
+  val raw_overlay : unit -> string option
+  (** Single env spec for Shell IR approval trust overlay.
+      See {!Masc_exec.Approval_config.shell_ir_approval_overlay_of_string} for
+      supported values and validation semantics.
+      Returns [None] when unset/blank. *)
+end

--- a/lib/exec/approval_config.ml
+++ b/lib/exec/approval_config.ml
@@ -23,6 +23,177 @@ type t = {
   per_agent : (Agent_id.t * agent_overlay) list;
 }
 
+let normalize_level_token (raw : string) : string =
+  String.lowercase_ascii (String.trim raw)
+
+let trust_level_of_string (raw : string) : trust_level option =
+  match normalize_level_token raw with
+  | "observe"
+  | "obs" ->
+    Some Observe
+  | "suggest"
+  | "s" ->
+    Some Suggest
+  | "auto_safe"
+  | "auto-safe"
+  | "autosafe"
+  | "allow" ->
+    Some Auto_safe
+  | "enforced"
+  | "ask"
+  | "strict"
+  | "deny" ->
+    Some Enforced
+  | _ -> None
+
+let agent_overlay_of_profile (raw : string) : agent_overlay option =
+  match normalize_level_token raw with
+  | "autonomous"
+  | "observe" ->
+    Some
+      {
+        safe_trust = Observe;
+        audited_trust = Observe;
+        privileged_trust = Observe;
+      }
+  | "enforced"
+  | "enforced_all"
+  | "strict"
+  | "deny_all"
+  | "all_enforced" ->
+    Some
+      {
+        safe_trust = Enforced;
+        audited_trust = Enforced;
+        privileged_trust = Enforced;
+      }
+  | "permissive"
+  | "permissive_default"
+  | "perm" ->
+    Some
+      {
+        safe_trust = Auto_safe;
+        audited_trust = Enforced;
+        privileged_trust = Enforced;
+      }
+  | "suggest" ->
+    Some
+      {
+        safe_trust = Suggest;
+        audited_trust = Suggest;
+        privileged_trust = Suggest;
+      }
+  | "auto_safe"
+  | "auto-safe"
+  | "autosafe" ->
+    Some
+      {
+        safe_trust = Auto_safe;
+        audited_trust = Auto_safe;
+        privileged_trust = Auto_safe;
+      }
+  | _ -> None
+
+let shell_ir_approval_overlay_of_string (raw : string) : agent_overlay option =
+  let raw = normalize_level_token raw in
+  if raw = "" then
+    None
+  else
+    let parse_entry entry =
+      let entry = String.trim entry in
+      if entry = "" then
+        None
+      else
+        match String.index_opt entry '=' with
+        | None -> Some (`Profile entry)
+        | Some eq_pos ->
+          if eq_pos = 0 || eq_pos = String.length entry - 1 then
+            None
+          else
+            let key = String.sub entry 0 eq_pos |> normalize_level_token in
+            let value =
+              String.sub entry (eq_pos + 1) (String.length entry - eq_pos - 1)
+              |> normalize_level_token
+            in
+            Some (`Pair (key, value))
+    in
+    let rec parse_entries entries ~profile ~safe ~audited ~privileged =
+      match entries with
+      | [] ->
+        Option.map
+          (fun base ->
+            {
+              safe_trust = Option.value safe ~default:base.safe_trust
+            ; audited_trust = Option.value audited ~default:base.audited_trust
+            ; privileged_trust =
+                Option.value privileged ~default:base.privileged_trust
+            })
+          profile
+      | entry :: rest ->
+        (match parse_entry entry with
+         | None -> None
+         | Some (`Profile profile_token) ->
+           (match profile with
+            | Some _ -> None
+            | None ->
+              (match agent_overlay_of_profile profile_token with
+               | Some overlay ->
+                 parse_entries
+                   rest
+                   ~profile:(Some overlay)
+                   ~safe
+                   ~audited
+                   ~privileged
+               | None -> None))
+         | Some (`Pair ("profile", value)) ->
+           (match agent_overlay_of_profile value with
+            | Some overlay ->
+              parse_entries
+                rest
+                ~profile:(Some overlay)
+                ~safe
+                ~audited
+                ~privileged
+            | None -> None)
+         | Some (`Pair ("safe", value)) ->
+           (match trust_level_of_string value with
+            | Some level ->
+              parse_entries
+                rest
+                ~profile
+                ~safe:(Some level)
+                ~audited
+                ~privileged
+            | None -> None)
+         | Some (`Pair ("audited", value)) ->
+           (match trust_level_of_string value with
+            | Some level ->
+              parse_entries
+                rest
+                ~profile
+                ~safe
+                ~audited:(Some level)
+                ~privileged
+            | None -> None)
+         | Some (`Pair ("privileged", value)) ->
+           (match trust_level_of_string value with
+            | Some level ->
+              parse_entries
+                rest
+                ~profile
+                ~safe
+                ~audited
+                ~privileged:(Some level)
+            | None -> None)
+         | Some (`Pair _) -> None)
+    in
+    parse_entries
+      (String.split_on_char ',' raw)
+      ~profile:None
+      ~safe:None
+      ~audited:None
+      ~privileged:None
+
 let enforced_all : agent_overlay =
   {
     safe_trust = Enforced;

--- a/lib/exec/approval_config.mli
+++ b/lib/exec/approval_config.mli
@@ -19,6 +19,14 @@ type trust_level =
 
 val trust_level_to_string : trust_level -> string
 
+val trust_level_of_string : string -> trust_level option
+(** Parse a loose trust-level token.
+    Accepted values (case-insensitive):
+    - observe, obs
+    - suggest, s
+    - auto_safe, auto-safe, autosafe, allow
+    - enforced, ask, strict, deny. *)
+
 type agent_overlay = {
   safe_trust : trust_level;
   (** Trust level for [Safe] bins ([ls], [cat], [rg]). *)
@@ -49,6 +57,28 @@ val enforced_all : agent_overlay
 val permissive_default : agent_overlay
 (** [safe_trust = Auto_safe], audited/privileged at [Enforced].
     For well-trusted keeper agents in a dev worktree. *)
+
+val agent_overlay_of_profile : string -> agent_overlay option
+(** Parse a loose profile token to a complete overlay.
+    Accepted values (case-insensitive):
+    - autonomous, observe
+    - enforced, enforced_all, strict, deny_all, all_enforced
+    - permissive, permissive_default, perm
+    - suggest
+    - auto_safe, auto-safe, autosafe.
+
+    Returns [None] for unknown values. *)
+
+val shell_ir_approval_overlay_of_string : string -> agent_overlay option
+(** Parse a single env string to Shell IR overlay.
+    Accepted forms:
+    - preset profile token (e.g. [autonomous], [permissive])
+    - key/value overrides (comma-separated), e.g.
+      [safe=observe,audited=enforced,privileged=auto_safe]
+    - [profile=permissive,safe=enforced] (profile + overrides).
+    A profile must be present either as a bare token or via [profile=].
+
+    Unknown keys or values return [None]. *)
 
 val autonomous : agent_overlay
 (** All risk classes at [Observe] (allow + telemetry).  The overlay for an

--- a/lib/exec/test/test_approval_config.ml
+++ b/lib/exec/test/test_approval_config.ml
@@ -34,9 +34,34 @@ let test_lookup_matches_registered_agent () =
   let other = Approval_config.lookup cfg ~actor:`Other_agent in
   assert (other = Approval_config.enforced_all)
 
+let test_shell_ir_approval_overlay_parses_profile () =
+  let o = Option.get (Approval_config.shell_ir_approval_overlay_of_string "permissive") in
+  assert (o.safe_trust = Auto_safe);
+  assert (o.audited_trust = Enforced);
+  assert (o.privileged_trust = Enforced)
+
+let test_shell_ir_approval_overlay_parses_profile_with_overrides () =
+  let raw = "profile=permissive, safe=observe,audited=auto_safe,privileged=auto_safe" in
+  match Approval_config.shell_ir_approval_overlay_of_string raw with
+  | None -> assert false
+  | Some o ->
+    assert (o.safe_trust = Observe);
+    assert (o.audited_trust = Auto_safe);
+    assert (o.privileged_trust = Auto_safe)
+
+let test_shell_ir_approval_overlay_rejects_unknown_profile () =
+  assert (Approval_config.shell_ir_approval_overlay_of_string "nonsense" = None)
+
+let test_shell_ir_approval_overlay_rejects_invalid_key_value () =
+  assert (Approval_config.shell_ir_approval_overlay_of_string "permissive,foo=bar" = None)
+
 let () =
   test_enforced_all_is_fail_closed ();
   test_permissive_default_auto_safe ();
   test_empty_uses_enforced_defaults ();
   test_lookup_matches_registered_agent ();
+  test_shell_ir_approval_overlay_parses_profile ();
+  test_shell_ir_approval_overlay_parses_profile_with_overrides ();
+  test_shell_ir_approval_overlay_rejects_unknown_profile ();
+  test_shell_ir_approval_overlay_rejects_invalid_key_value ();
   print_endline "[test_approval_config] all tests passed"

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -305,6 +305,19 @@ let dispatch_error_deterministic_retry_fields error =
   | Some reason -> Keeper_tool_deterministic_error.deterministic_retry_fields reason
   | None -> []
 
+let shell_ir_approval_overlay =
+  let default_overlay = Masc_exec.Approval_config.autonomous in
+  match Env_config_runtime.Shell_ir_approval.raw_overlay () with
+  | None -> default_overlay
+  | Some raw ->
+    (match Masc_exec.Approval_config.shell_ir_approval_overlay_of_string raw with
+     | Some overlay -> overlay
+     | None ->
+       Log.Dashboard.warn
+         "invalid MASC_SHELL_IR_APPROVAL value %S; using autonomous overlay"
+         raw;
+       default_overlay)
+
 let pr_action_status_label = function
   | Unix.WEXITED 0 -> "success"
   | Unix.WEXITED _ -> "exit_nonzero"
@@ -1076,7 +1089,7 @@ let handle_tool_execute_typed
                  the real remote even from a container), so no sandbox-conditional
                  branch is needed: both profiles use the same overlay. *)
               let approval_config =
-                { Masc_exec.Approval_config.defaults = Masc_exec.Approval_config.autonomous
+                { Masc_exec.Approval_config.defaults = shell_ir_approval_overlay
                 ; per_agent = []
                 }
               in

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1970,6 +1970,51 @@ let governance_hitl_json () =
     ]
 ;;
 
+let shell_ir_approval_json () =
+  let gate_enabled = Env_config_runtime.Shell_ir_approval_gate.enabled () in
+  let raw_overlay = Env_config_runtime.Shell_ir_approval.raw_overlay () in
+  let parsed_overlay =
+    match raw_overlay with
+    | Some raw -> Masc_exec.Approval_config.shell_ir_approval_overlay_of_string raw
+    | None -> None
+  in
+  let effective_overlay =
+    Option.value parsed_overlay ~default:Masc_exec.Approval_config.autonomous
+  in
+  let source =
+    match raw_overlay with
+    | None -> `String "default_autonomous"
+    | Some _ when Option.is_some parsed_overlay -> `String "raw_overlay"
+    | Some _ -> `String "invalid_overlay_fallback_autonomous"
+  in
+  let reason =
+    match gate_enabled, raw_overlay, parsed_overlay with
+    | false, _, _ ->
+      `String "shell-ir approval gate disabled via MASC_SHELL_IR_APPROVAL_GATE_ENABLED"
+    | true, None, _ ->
+      `String "using fallback overlay: Masc_exec.Approval_config.autonomous"
+    | true, Some raw, Some _ ->
+      `String ("using parsed MASC_SHELL_IR_APPROVAL value: " ^ raw)
+    | true, Some raw, None ->
+      `String
+        ("invalid MASC_SHELL_IR_APPROVAL value; fallback to autonomous: " ^ raw)
+  in
+  `Assoc
+    [ "schema", `String "masc.shell_ir_approval.v1"
+    ; "enabled", `Bool gate_enabled
+    ; "env_key", `String "MASC_SHELL_IR_APPROVAL"
+    ; "raw_overlay", Json_util.string_opt_to_json raw_overlay
+    ; ( "trust"
+      , `Assoc
+          [ "safe", `String (Masc_exec.Approval_config.trust_level_to_string effective_overlay.safe_trust)
+          ; "audited", `String (Masc_exec.Approval_config.trust_level_to_string effective_overlay.audited_trust)
+          ; "privileged", `String (Masc_exec.Approval_config.trust_level_to_string effective_overlay.privileged_trust)
+          ] )
+    ; "source", source
+    ; "reason", reason
+    ]
+;;
+
 let runtime_inventory_json () =
   let runtimes = Runtime.get_runtimes () in
   let default_id = runtime_default_runtime_id () in
@@ -2255,6 +2300,7 @@ let runtime_resolution_json (config : Workspace.config) =
         , deployment_state_json ~build ~server_repo_commit ~workspace_commit
             ~resolved_base_commit ~upstream_status ~source_mismatch )
       ; "governance_hitl", governance_hitl_json ()
+      ; "shell_ir_approval", shell_ir_approval_json ()
       ]
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;
@@ -2334,6 +2380,7 @@ let light_runtime_resolution_json (config : Workspace.config) =
       ; "diagnostics", `List []
       ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
       ; "build", Build_identity.to_yojson build
+      ; "shell_ir_approval", shell_ir_approval_json ()
       ]
       @ fleet_fields )
 ;;


### PR DESCRIPTION
## Summary\n- Add runtime projection for shell IR approval in server dashboard JSON (full and light).\n- Add dashboard runtime types + normalizers for shell IR approval block.\n- Expose shell IR approval state in Settings path truth and Runtime Truth panels.\n- Add regression coverage updates for config-resolution panel fixture shape.\n\n## Validation\n- Not run in this step (per request).