### PR TITLE
fix(dashboard): dashboard typecheck main-red 복구 — persona export(#23703) + normalizer 가드(#23793)

### DIFF
--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -93,3 +93,79 @@ export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRu
     spawning.value = false
   }
 }
+
+// ---------------------------------------------------------------------------
+// Persona create/edit state.
+//
+// Completes the persona create/edit UI surface introduced in #23703
+// (persona-form.ts, persona-browser.ts import these). The exports were
+// omitted from that change, leaving the dashboard TypeScript typecheck
+// broken on every branch that runs the Dashboard job. The job does not run
+// on pushes to main, so main itself stays latently green and every PR
+// sitting on top inherits the failure.
+//
+// masc_persona_create / masc_persona_update accept (see keeper_schema.ml):
+// persona_name, display_name, role, trait, goal, instructions,
+// mention_targets, tool_denylist, proactive_enabled, auto_handoff.
+// persona-form.ts additionally collects `mode` and `description`, which are
+// NOT part of the persona schema; they are accepted here only for type
+// compatibility with the form and are deliberately not forwarded. Aligning
+// the form to the real persona field model is tracked separately.
+// ---------------------------------------------------------------------------
+
+export const showCreateForm = signal(false)
+export const editingPersona = signal<PersonaSummary | null>(null)
+
+export async function createPersona(fields: {
+  persona_name: string
+  display_name?: string
+  role?: string
+  mode?: string
+  description?: string
+}): Promise<boolean> {
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  if (!access.allowed) {
+    showToast(access.reason ?? '페르소나 생성 권한이 없습니다.', 'error')
+    return false
+  }
+  const args: Record<string, unknown> = { persona_name: fields.persona_name }
+  if (fields.display_name !== undefined) args.display_name = fields.display_name
+  if (fields.role !== undefined) args.role = fields.role
+  try {
+    await callMcpTool('masc_persona_create', args)
+    showToast(`${fields.persona_name} 페르소나 생성 완료`, 'success')
+    void loadPersonas()
+    return true
+  } catch (err) {
+    showToast(`페르소나 생성 실패: ${errorToString(err)}`, 'error')
+    return false
+  }
+}
+
+export async function updatePersona(
+  name: string,
+  patch: {
+    display_name?: string
+    role?: string
+    mode?: string
+    description?: string
+  },
+): Promise<boolean> {
+  const access = dashboardAuthAccess(shellAuthSummary.value, 'worker')
+  if (!access.allowed) {
+    showToast(access.reason ?? '페르소나 수정 권한이 없습니다.', 'error')
+    return false
+  }
+  const args: Record<string, unknown> = { persona_name: name }
+  if (patch.display_name !== undefined) args.display_name = patch.display_name
+  if (patch.role !== undefined) args.role = patch.role
+  try {
+    await callMcpTool('masc_persona_update', args)
+    showToast(`${name} 페르소나 수정 완료`, 'success')
+    void loadPersonas()
+    return true
+  } catch (err) {
+    showToast(`페르소나 수정 실패: ${errorToString(err)}`, 'error')
+    return false
+  }
+}

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -624,10 +624,10 @@ function normalizeDashboardShellIrApproval(
     }
     : null
   const normalizedTrust =
-    trust === null || trust.safe === null || trust.audited === null || trust.privileged === null
+    trust === null || trust.safe === undefined || trust.audited === undefined || trust.privileged === undefined
       ? null
       : trust
-  if (schema === null || enabled === undefined || envKey === null) return null
+  if (schema === undefined || enabled === undefined || envKey === undefined) return null
   return {
     schema,
     enabled,


### PR DESCRIPTION
## 배경 — main dashboard typecheck가 다축 red
main의 dashboard TypeScript typecheck가 두 독립 회귀로 깨져 있고, 이 job이 main push엔 돌지 않아 main은 latent green, 위에 올라간 PR들이 실패를 상속합니다.

1. **#23703**(persona create/edit UI)이 `keeper-spawn-state`의 4 export(`showCreateForm`, `editingPersona`, `createPersona`, `updatePersona`)를 누락.
2. **#23793**(shell-IR approval)이 `normalizeDashboardShellIrApproval`의 가드를 `=== null`로 작성했으나 `asString`/`asBoolean`은 `| undefined`를 반환해 좁혀지지 않음 → TS2322 3건(632/634/636).

## 변경 (커밋 2개)
- `1716a2723e` — persona 4 export 실구현: `masc_persona_create`/`masc_persona_update`를 `callMcpTool`로 호출, worker auth 게이트, try/catch fail-closed(`callMcpTool`는 `isError` 시 throw), 성공 시 목록 refresh. stub/하드코딩/문자열 매치 없이 기존 패턴 SSOT 재사용.
- `ca8bbc1ac9` — shell-IR normalizer 가드 `=== null` → `=== undefined` 정정. 의미 불변(빈 optional → null).

## 영향 — unblock
Dashboard typecheck가 green으로 전환되어, 같은 에러로 막혀 있던 `#23790`, `#23785` (외 dashboard PR)이 rebase 시 green으로 풀립니다.

## 남은 점 (별도 이슈 #23796)
`persona-form.ts`가 `mode`/`description`을 수집하나 이는 `masc_persona_*` 스키마에 없는 필드(#23703 설계 갭). type 호환용으로만 받고 forward하지 않습니다.

## 검증
dune 빌드는 로컬이 아닌 CI. dashboard TypeScript typecheck가 본 PR에서 green으로 전환되는 것으로 두 수정을 확인합니다.
