### PR TITLE
task-1870: thread ?continuation_channel through keeper_msg_body direct dispatch

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -644,6 +644,7 @@ let keeper_msg_body
       ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
       ?proc_mgr
       ?net
+      ?continuation_channel
       args : tool_result =
   let keeper_ctx : _ Keeper_types_profile.context =
     { config; agent_name; sw; clock; proc_mgr; net }
@@ -664,7 +665,7 @@ let keeper_msg_body
         ~base_path:config.base_path
         ~keeper_name:name
         ~f:(fun ?event_bus () ->
-          let result = Turn.handle_keeper_msg ?event_bus keeper_ctx resolved_args in
+          let result = Turn.handle_keeper_msg ?event_bus ?continuation_channel keeper_ctx resolved_args in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply


### PR DESCRIPTION
## task-1870: HITL approval provenance capture

### What
Thread `?continuation_channel` through the `keeper_msg_body` direct dispatch path in `keeper_tool_surface_ops.ml`, matching what the `handle_keeper_msg` wrapper already does.

### Why
`create_entry` in `keeper_approval_queue.ml` defaults `continuation_channel` to `Unrouted "no originating connector"`. When the direct MCP dispatch path calls `Turn.handle_keeper_msg` without the channel, all HITL approvals from that path lose their provenance, and `Hitl_resolved` wakes go to `Unrouted` instead of the originating chat connector.

### What this PR does
- Adds `?continuation_channel` parameter to `keeper_msg_body` function signature
- Passes `?continuation_channel` through to `Turn.handle_keeper_msg` call
- Non-breaking: optional param defaults to `None` (same behavior as before)

### What remains
- Thread channel from the caller in `keeper_tool_surface.ml` dispatch (line 875) — requires the dispatch lambda to receive channel info from the Eio context
- Remove `Unrouted` default in `keeper_approval_queue.ml` (make required or fail loudly)

### Testing
- Non-breaking change, existing behavior preserved when `continuation_channel` is not provided
- No dune build available in sandbox (policy-blocked); needs CI verification