### PR TITLE
task-1889 follow-up: wire handoff_context.evidence_refs in completion_trust_eval

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -337,6 +337,14 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
     |> Option.value ~default:""
   in
   let notes = str_field "notes" in
+  let evidence_refs =
+    Yojson.Safe.Util.(
+      args |> member "handoff_context" |> member "evidence_refs" |> to_list_option
+    )
+    |> Option.value ~default:[]
+    |> List.filter_map (fun j ->
+        try Some (Yojson.Safe.Util.to_string j) with _ -> None)
+  in
   let task_id = match str_field "task_id" with "" -> scenario.EH.id | s -> s in
   let req : AR.review_request =
     {
@@ -345,7 +353,7 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
       completion_notes = notes;
       agent_name = eval_agent_name;
       task_id;
-      evidence_refs = [];
+      evidence_refs = evidence_refs;
     }
   in
   let on_verdict (result : AR.review_result) =


### PR DESCRIPTION
Wires `handoff_context.evidence_refs` from tool args into the `review_request` constructed in `bin/masc_completion_trust_eval.ml`. Previously the eval hardcoded `evidence_refs = []`; now it extracts the list from `args.handoff_context.evidence_refs` so the anti-rationalization gate sees real evidence refs during eval runs. Complements #23753.