### PR TITLE
fix(dashboard): shell-IR trust reconstruction (#23795에서 main 누락분, line 636 TS2322)

### DIFF
--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -626,7 +626,7 @@ function normalizeDashboardShellIrApproval(
   const normalizedTrust =
     trust === null || trust.safe === undefined || trust.audited === undefined || trust.privileged === undefined
       ? null
-      : trust
+      : { safe: trust.safe, audited: trust.audited, privileged: trust.privileged }
   if (schema === undefined || enabled === undefined || envKey === undefined) return null
   return {
     schema,


### PR DESCRIPTION
## 배경
#23795가 dashboard typecheck main-red 복구를 목표로 했으나, **trust reconstruction 한 줄이 main에 누락**됐습니다. mergeCommit `be9e6392` 확인 결과 여전히 `: trust`(reconstruction 전). 결과적으로 `store-normalizers.ts:636` TS2322가 main에 잔존해 dashboard typecheck가 red이고, #23790/#23785 등 dashboard PR들이 상속 실패 중입니다.

## 변경 (커밋 `3938d4f96e`)
성공 분기 객체 리터럴 재구성: `: trust` → `: { safe: trust.safe, audited: trust.audited, privileged: trust.privileged }`. TS는 속성별 `=== undefined` 검사로 객체 전체 타입을 좁히지 않으므로, 리터럴 재구성으로 `{safe:string;audited:string;privileged:string}` 추론. 의미 불변.

## 검증
CI dashboard typecheck가 green으로 전환되는 것으로 확인합니다. 본 PR land 후 #23790/#23785가 update-branch 시 green 예상.
