### PR TITLE
fix(dashboard/test): Shell IR approval 라벨 대소문자 정합 (#23793 낙진, dashboard tests main-red)

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -388,7 +388,7 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('/tmp/masc')
     expect(container.textContent).toContain('server repo head')
     expect(container.textContent).toContain('feedbee')
-    expect(container.textContent).toContain('Shell IR approval')
+    expect(container.textContent).toContain('shell IR approval')
     expect(container.textContent).toContain('disabled')
     expect(container.textContent).toContain('safe/audited/privileged')
     expect(container.textContent).toContain('source mismatch')


### PR DESCRIPTION
## 배경
`config-resolution-panel.test.ts:391`이 `toContain('Shell IR approval')`(대문자 S)를 검사하지만, 컴포넌트(`config-resolution-panel.ts:503`)는 `label="shell IR approval"`(소문자 s)을 렌더링합니다. 패널 전체 라벨이 소문자 규약("executable commit", "base path", "shell IR raw" 등). 이 대소문자 불일치로 테스트가 매번 실패 — #23793 merged-red 낙진으로 main 위 모든 dashboard PR이 1건씩 상속 실패(#23790/#23785 등).

## 변경 (1줄)
`toContain('Shell IR approval')` → `toContain('shell IR approval')`. 컴포넌트 실제 라벨에 정합. 테스트 자체는 #23793 Shell IR approval 섹션 렌더링 검증이라 의미를 유지합니다(제거 아님).

## 영향
dashboard tests 축 main-red 해소 → #23790/#23785 등 dashboard PR이 update-branch 시 green으로 풀립니다.
