### PR TITLE
fix: #23761 컴파일 에러 2종 복구 — keeper_guards unbound keeper_name + tool_task operator_override extra-arg (main 빌드 red)

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -914,7 +914,7 @@ let destructive_guard
    required, authorized keepers bypass the approval gate to unblock code work.
    PM accepted policy risk (albini, p-6e2a0927be). Replace with a proper
    Env_config_core mechanism once one exists. *)
-let per_keeper_code_exemption _keeper_name =
+let per_keeper_code_exemption keeper_name =
   (* task-1807: operator-controlled exemption via MASC_CODE_EXEMPT_KEEPERS env var
      as specified in RFC-0329 §4 (config-driven code exemption).
      Replaces hardcoded per-keeper allowlist. *)


### PR DESCRIPTION
## 배경 — #23761이 main에 도입한 컴파일 에러 2종 (main OCaml 빌드 red)
#23761(task-1884, c159c1a1)이 코드를 반쯤 넣으며 컴파일 에러 2건을 main에 도입해, main 위 모든 OCaml PR이 빌드 실패 중입니다.

## 변경 (커밋 2개)
1. `keeper_guards.ml:917` — `let per_keeper_code_exemption _keeper_name =`의 밑줄 제거(`keeper_name`). 921행 `code_exempt_keeper ~keeper_name`이 밑줄 없는 이름을 참조해 Unbound 에러. 매개변수가 실제 쓰이므로 unused 표시가 잘못.
2. `tool_task.ml:427` — `review_completion_notes` 호출에서 `~operator_override:force` 제거. 이 함수 시그니처에 `operator_override`가 없어 extra-arg 에러. 동시에 같은 파일 455-456행 설계 원칙("force는 비즈니스 가드만 우회, 안전 게이트는 우회 안 함")과 일치 — anti-rationalization 리뷰는 안전 게이트(#22573). `force` 자체는 다른 비즈니스 가드(222/289/389/634)와 admin-gating(201)에 그대로 사용됨.

## 영향
main OCaml 빌드 복구 → 대다수 inherited-red PR이 update-branch 시 빌드 축 green으로 풀립니다.
