### PR TITLE
fix(gate): resolve Slack paths under base path

### DIFF
--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -26,10 +26,15 @@ let default_binding_audit_path = ".gate/runtime/slack/binding_audit.jsonl"
 
 (* Slack has no Discord-style guilds; the bot token authorizes per-workspace.
    Path resolvers read an env override, else fall back to the default. *)
+let resolve_path raw_path =
+  if Filename.is_relative raw_path then
+    Filename.concat (Env_config_core.base_path ()) raw_path
+  else raw_path
+
 let slack_path ~env_var ~default () =
   match Env_config_core.raw_value_opt env_var |> Env_config_core.trim_opt with
-  | Some path -> path
-  | None -> default
+  | Some path -> resolve_path path
+  | None -> resolve_path default
 
 let status_path () =
   slack_path ~env_var:"MASC_SLACK_STATUS_PATH" ~default:default_status_path ()

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -114,6 +114,41 @@ let test_slack_binding_store_error_is_typed () =
     | Ok _ -> fail "expected invalid Slack binding store to return Error"
     | Error err -> check bool "reports read error" true (String.length err > 0))
 
+
+let test_slack_default_paths_resolve_under_base_path () =
+  with_temp_dir @@ fun base_dir ->
+  with_temp_dir @@ fun cwd_dir ->
+  with_env "MASC_BASE_PATH" (Some base_dir) (fun () ->
+    with_env "MASC_BASE_PATH_INPUT" None (fun () ->
+      with_envs
+        [ "SLACK_STATUS_PATH"; "MASC_SLACK_STATUS_PATH"; "SLACK_BINDING_STORE_PATH"
+        ; "MASC_SLACK_BINDING_STORE_PATH"; "SLACK_BINDING_AUDIT_PATH"
+        ; "MASC_SLACK_BINDING_AUDIT_PATH" ]
+        None
+        (fun () ->
+          let original_cwd = Sys.getcwd () in
+          Fun.protect
+            ~finally:(fun () -> Sys.chdir original_cwd)
+            (fun () ->
+              Sys.chdir cwd_dir;
+              match
+                Channel_gate_slack_state.bind ~channel_id:"C123"
+                  ~keeper_name:"luna" ~actor_name:"dashboard"
+              with
+              | Error err -> fail err
+              | Ok json ->
+                let expected_binding_path =
+                  Filename.concat base_dir ".gate/runtime/slack/bindings.json"
+                in
+                check string "binding store path under base" expected_binding_path
+                  (json |> U.member "binding_store_path" |> U.to_string);
+                check bool "binding written under base" true
+                  (Sys.file_exists expected_binding_path);
+                check bool "binding not written under cwd" false
+                  (Sys.file_exists
+                     (Filename.concat cwd_dir
+                        ".gate/runtime/slack/bindings.json")))))))
+
 let test_telegram_connector_json_reads_runtime_status () =
   with_temp_dir @@ fun dir ->
   with_sidecar_paths "telegram" dir (fun () ->
@@ -166,6 +201,8 @@ let () =
             test_slack_bind_persists_binding_and_audit;
           test_case "slack binding read errors are typed" `Quick
             test_slack_binding_store_error_is_typed;
+          test_case "slack default paths resolve under base path" `Quick
+            test_slack_default_paths_resolve_under_base_path;
           test_case "telegram connector json reads runtime status" `Quick
             test_telegram_connector_json_reads_runtime_status;
         ] );


### PR DESCRIPTION
### Motivation
- The Slack connector rewrite stopped resolving relative runtime/binding/audit paths under `MASC_BASE_PATH`, while the Python Slack sidecar still resolves relative paths against `MASC_BASE_PATH`, causing a cwd/base-path split that can leave bindings written to the wrong location and break authorization changes. 
- The intent is to ensure the server and sidecar agree on where relative connector state is stored so bind/unbind operations affect the file the active sidecar reads.

### Description
- Add `resolve_path` to `lib/gate/channel_gate_slack_state.ml` and make `slack_path` resolve both env overrides and defaults via `Env_config_core.base_path ()` when the path is relative, leaving absolute paths unchanged. 
- Keep the `Channel_gate_binding_store` wiring but ensure `binding_store_path`, `binding_store_read_path`, and `binding_audit_path` now return base-path-resolved values. 
- Add a regression test `test_slack_default_paths_resolve_under_base_path` in `test/test_channel_gate_connector_routes.ml` that sets `MASC_BASE_PATH`, switches the process cwd, performs a Slack `bind`, and asserts the binding file is written under the base path (and not under cwd), and register the test in the existing suite.

### Testing
- Ran `git diff --check` locally which reported no whitespace/patch errors. 
- Attempted to run `dune runtest test/test_channel_gate_connector_routes.ml` but the `dune` binary is not available in the container so the unit test run could not be executed locally; the added regression test should be exercised by CI where `dune` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd85be7008333b56a949a193a15fa)