### PR TITLE
fix(auth): avoid worker login bootstrap admin

### DIFF
--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -61,13 +61,19 @@ let persist_raw_token ~base_path ~agent_name raw_token =
   Auth.save_private_text_file path raw_token;
   path
 
-let ensure_required_bearer_auth ~base_path ~agent_name =
+let ensure_required_bearer_auth ~base_path ~agent_name ~role =
   let cfg = Auth.load_auth_config base_path in
   if cfg.enabled && cfg.require_token then
     Ok Auth_already_required
   else if not cfg.enabled then
     let _workspace_secret, _bootstrap_token =
-      Auth.enable_auth base_path ~require_token:true ~agent_name
+      let bootstrap_agent_name =
+        match role with
+        | Admin -> agent_name
+        | Worker -> ""
+      in
+      Auth.enable_auth base_path ~require_token:true
+        ~agent_name:bootstrap_agent_name
     in
     Ok Auth_enabled
   else (
@@ -82,7 +88,7 @@ let mint ~base_path ~host ~port ~agent_name ~role ~token_env_var
     ~token_lifetime () =
   ensure_rng_initialized ();
   let base_path = normalize_base_path base_path in
-  match ensure_required_bearer_auth ~base_path ~agent_name with
+  match ensure_required_bearer_auth ~base_path ~agent_name ~role with
   | Error err -> Error err
   | Ok auth_change -> (
       let create_token = create_token_for_lifetime token_lifetime in

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -66,6 +66,27 @@ let test_login_with_expiry_uses_caller_env_var () =
        | Error err ->
            failf "minted token did not verify: %s"
              (Masc_domain.masc_error_to_string err));
+      (match
+         Auth.check_permission base_path ~agent_name:"test-agent"
+           ~token:(Some report.bearer_token)
+           ~permission:Masc_domain.CanInit
+       with
+       | Ok () -> fail "worker login token must not have admin permission"
+       | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+       | Error err ->
+           failf "expected forbidden for worker admin action: %s"
+             (Masc_domain.masc_error_to_string err));
+      (match
+         Auth.resolve_role base_path ~agent_name:"test-agent"
+           ~token:(Some report.bearer_token)
+       with
+       | Ok Masc_domain.Worker -> ()
+       | Ok role ->
+           failf "expected worker effective role, got %s"
+             (Masc_domain.agent_role_to_string role)
+       | Error err ->
+           failf "expected worker effective role: %s"
+             (Masc_domain.masc_error_to_string err));
       let shell = Auth_login.render_shell report in
       check bool "shell exports caller-named env var" true
         (contains_substring ~needle:"export MASC_TOKEN="


### PR DESCRIPTION
### Motivation
- Prevent a privilege-escalation where `login --role worker` on a fresh workspace recorded the worker agent as the bootstrap `initial_admin`, granting Admin privileges before token-role checks.

### Description
- Change `Auth_login.ensure_required_bearer_auth` to accept the requested `role` and only write the bootstrap `initial_admin` when `role = Admin`, leaving it empty for `Worker` logins (file: `lib/auth_login.ml`).
- Wire the requested `role` through the login flow so the bootstrap decision happens before token creation (file: `lib/auth_login.ml`).
- Add regression assertions that a freshly minted worker token is denied admin permission via `Auth.check_permission` and resolves to `Worker` via `Auth.resolve_role` (file: `test/test_auth_login.ml`).

### Testing
- Ran `git diff --check` which passed successfully.
- Attempted `dune test test/test_auth_login.exe` but the environment is missing `dune`, so the unit test run could not be executed (error: `dune: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8bd1014083338589729b7106d963)