### PR TITLE
Require admin auth for dashboard approval resolution

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1056,22 +1056,25 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/resolve" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
-         Http.Request.read_body_async reqd (fun body_str ->
-           try
-             let args = Yojson.Safe.from_string body_str in
-             let base_path = (Mcp_server.workspace_config state).base_path in
-             match dashboard_governance_approval_resolve_http_json ~base_path ~args with
-             | Ok json ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state _operator_name _req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             try
+               let args = Yojson.Safe.from_string body_str in
+               let base_path = (Mcp_server.workspace_config state).base_path in
+               match dashboard_governance_approval_resolve_http_json ~base_path ~args with
+               | Ok json ->
                  respond_json_value_with_cors request reqd json
-             | Error (Gone _ as err) ->
+               | Error (Gone _ as err) ->
                  respond_json_value_with_cors ~status:`Not_found request reqd (operator_error_json (approval_resolve_http_error_to_string err))
-             | Error (Bad_request _ as err) ->
+               | Error (Bad_request _ as err) ->
                  respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (approval_resolve_http_error_to_string err))
-           with Yojson.Json_error msg ->
-             respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
+             with Yojson.Json_error msg ->
+               respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
+           )
          )
-       ) request reqd)
+         request
+         reqd)
   |> Http.Router.post "/api/v1/dashboard/schedule/resolve" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state operator_name _req reqd ->


### PR DESCRIPTION
### Motivation
- Prevent lower-privileged Worker tokens from resolving HITL repository-claim approvals and thereby mutating keeper repository mappings by enforcing an Admin-only guard on the approval resolution endpoint.

### Description
- Replace the dashboard approvals resolve route's use of `with_tool_auth ~tool_name:"masc_operator_confirm"` with token-bound admin authorization `with_token_permission_auth ~permission:Masc_domain.CanAdmin` in `lib/server/server_routes_http_routes_dashboard.ml` so only callers with `CanAdmin` may resolve approvals.

### Testing
- Ran `git diff --check` and a static Python check that verifies the `/api/v1/dashboard/governance/approvals/resolve` route is now guarded by `with_token_permission_auth ~permission:Masc_domain.CanAdmin`, which passed. 
- Attempted to run `dune build @all` but could not because `dune` is not available in the environment, so full build/test execution was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b2a01e0708333b914eef4ccc9d51b)