### PR TITLE
fix(keeper): block normalized .masc paths

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -263,6 +263,13 @@ let is_masc_internal_state_path (raw : string) : bool =
       && (len = 12 || raw.[len - 13] = '/'))
 ;;
 
+let is_masc_internal_state_norm ~(root_norm : string) ~(target_norm : string) : bool =
+  let root_norm = strip_trailing_slashes root_norm in
+  let target_norm = strip_trailing_slashes target_norm in
+  let masc_root = Filename.concat root_norm Common.masc_dirname in
+  target_norm = masc_root || String.starts_with ~prefix:(masc_root ^ "/") target_norm
+;;
+
 let resolve_keeper_target_path
       ~(config : Workspace.config)
       ~(allowed_paths : string list)
@@ -293,6 +300,11 @@ let resolve_keeper_target_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
+    else if is_masc_internal_state_norm ~root_norm ~target_norm
+    then (
+      let rej = Task_state_file_path_blocked { raw } in
+      rejection_to_telemetry rej;
+      Error rej)
     else if allowed_paths = []
     then Ok candidate
     else (
@@ -425,6 +437,11 @@ let resolve_keeper_read_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
+    else if is_masc_internal_state_norm ~root_norm ~target_norm
+    then (
+      let rej = Task_state_file_path_blocked { raw } in
+      rejection_to_telemetry rej;
+      Error rej)
     else (
       let allowed_norms =
         if allowed_paths = []

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -91,6 +91,12 @@ val raw_looks_like_playground_subdir : string -> bool
     keeper_tasks_list / keeper_context_status, not direct file access. *)
 val is_masc_internal_state_path : string -> bool
 
+(** Detect normalized targets that resolve under the workspace-level
+    MASC internal state directory.  Call this after resolving traversal
+    and symlinks, so raw paths such as [lib/../.masc/config/keepers/x.toml]
+    cannot bypass the internal-state guard. *)
+val is_masc_internal_state_norm : root_norm:string -> target_norm:string -> bool
+
 (** Resolve a write target path under [allowed_paths] within the
     project root. *)
 val resolve_keeper_target_path :

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -541,6 +541,10 @@ let resolve_projected_allowed_path
   in
   if not within_root
   then user_message_error (Keeper_alerting_path.Outside_project_root { raw = raw_for_error })
+  else if Keeper_alerting_path.is_masc_internal_state_norm ~root_norm ~target_norm
+  then
+    user_message_error
+      (Keeper_alerting_path.Task_state_file_path_blocked { raw = raw_for_error })
   else (
     let allowed_norms =
       if allowed_paths = []

--- a/test/test_keeper_alerting_path_norms.ml
+++ b/test/test_keeper_alerting_path_norms.ml
@@ -132,6 +132,32 @@ let test_normalize_path_for_check_stripped_removes_trailing_slash () =
     (KAP.normalize_path_for_check cwd)
     (KAP.normalize_path_for_check_stripped raw)
 
+(* ── is_masc_internal_state_norm ────────────────────────────── *)
+
+let test_normalized_masc_root_blocked () =
+  check_bool "normalized .masc root → internal" true
+    (KAP.is_masc_internal_state_norm
+       ~root_norm:"/workspace/project"
+       ~target_norm:"/workspace/project/.masc")
+
+let test_normalized_masc_config_keeper_blocked () =
+  check_bool "normalized .masc/config/keepers target → internal" true
+    (KAP.is_masc_internal_state_norm
+       ~root_norm:"/workspace/project"
+       ~target_norm:"/workspace/project/.masc/config/keepers/evil.toml")
+
+let test_normalized_masc_sibling_allowed () =
+  check_bool "sibling .masc-tools directory → not internal" false
+    (KAP.is_masc_internal_state_norm
+       ~root_norm:"/workspace/project"
+       ~target_norm:"/workspace/project/.masc-tools/notes.md")
+
+let test_normalized_project_file_allowed () =
+  check_bool "ordinary project file → not internal" false
+    (KAP.is_masc_internal_state_norm
+       ~root_norm:"/workspace/project"
+       ~target_norm:"/workspace/project/lib/file.ml")
+
 (* ── runner ──────────────────────────────────────────────────── *)
 
 let () =
@@ -180,5 +206,16 @@ let () =
         [
           Alcotest.test_case "removes trailing slash" `Quick
             test_normalize_path_for_check_stripped_removes_trailing_slash;
+        ] );
+      ( "is_masc_internal_state_norm",
+        [
+          Alcotest.test_case "blocks .masc root" `Quick
+            test_normalized_masc_root_blocked;
+          Alcotest.test_case "blocks .masc keeper config" `Quick
+            test_normalized_masc_config_keeper_blocked;
+          Alcotest.test_case "allows .masc sibling" `Quick
+            test_normalized_masc_sibling_allowed;
+          Alcotest.test_case "allows project file" `Quick
+            test_normalized_project_file_allowed;
         ] );
     ]


### PR DESCRIPTION
### Motivation
- Prevent a traversal/symlink normalization bypass that allowed writes resolving under the workspace `.masc` directory to slip past the raw-path `.masc` check, which could let attacker-planted keeper TOMLs be hot-materialized and started.
- Ensure normalized targets are rejected when they resolve into MASC internal state so materialization and keepalive startup remain limited to trusted bootstrap paths.

### Description
- Add `is_masc_internal_state_norm : root_norm:string -> target_norm:string -> bool` to detect normalized targets that resolve under the workspace `.masc` directory and strip trailing slashes before comparison.
- Reject normalized `.masc` targets in `resolve_keeper_target_path` and the read resolver so post-normalization traversal cannot bypass the internal-state guard by resolving into `.masc`.
- Apply the same normalized `.masc` rejection to projected tool paths in `keeper_tool_shared_runtime.ml` so projected writes cannot resolve into `.masc/config/keepers`.
- Export the new API in the `.mli` and add unit tests exercising `is_masc_internal_state_norm` in `test/test_keeper_alerting_path_norms.ml` covering `.masc` root, `.masc/config/keepers/*`, sibling-prefix non-regressions, and ordinary project files.

### Testing
- New `Alcotest` unit cases were added in `test/test_keeper_alerting_path_norms.ml` to validate `is_masc_internal_state_norm`, but the test suite could not be executed in this environment because `dune` is not installed (`dune build @test` failed with `dune: command not found`).
- Local lint/check (`git diff --check`) reported no diff-style problems in the patch files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e38aadc0c8333862e11ac801c0053)