### PR TITLE
fix(exec): preserve gh api graphql opacity through api flags

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -664,15 +664,22 @@ let disposition_of_simple (simple : Shell_ir.simple) : disposition option =
        subcommand past leading value-taking global flags, so [gh --repo O/R pr
        view] is read as [Pr/view] (Allowed) rather than [Gh_verb.Other] (Ask).
        Falls back to the word-list [Gh_verb.classify] only for the [Generic]
-       escape hatch (non-literal argv), preserving prior behavior there. The
-       typed parser preserves the [Api]/[gh api graphql] identity, so the graphql
-       opacity fail-closed below still fires (RFC-0208). *)
+       escape hatch (non-literal argv), preserving prior behavior there.
+
+       The RFC-0208 graphql opacity check also consults the word-list
+       classifier.  That deliberately preserves fail-closed behavior for valid
+       gh api boolean flags that the typed parser does not model (for example
+       [gh api --paginate graphql --input body.json]): such flags must not hide
+       the [graphql] endpoint from the approval gate. *)
+    let words_verb = Gh_verb.classify words in
     let verb =
       match Shell_ir_risk.gh_verb_of_simple simple with
       | Some v -> v
-      | None -> Gh_verb.classify words
+      | None -> words_verb
     in
-    if is_graphql_api verb && graphql_query_body_is_opaque simple.Shell_ir.args
+    if
+      (is_graphql_api verb || is_graphql_api words_verb)
+      && graphql_query_body_is_opaque simple.Shell_ir.args
     then Some Requires_approval
     else Some (disposition_of_words words verb))
   | Some _ | None -> None

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -246,6 +246,12 @@ let test_graphql_opaque_query_simple () =
     ; ( "attached query"
       , [ lit "api"; lit "graphql"; concat [ lit "--raw-field=query="; var "MUTATION" ] ]
       )
+    ; ( "--paginate before graphql with --input file"
+      , [ lit "api"; lit "--paginate"; lit "graphql"; lit "--input"; lit "body.json" ]
+      )
+    ; ( "--paginate before graphql with external query field"
+      , [ lit "api"; lit "--paginate"; lit "graphql"; lit "-F"; lit "query=@mutation.graphql" ]
+      )
     ]
   in
   List.iter


### PR DESCRIPTION
### Motivation
- The typed `gh` parser can consume a following non-flag token as a boolean flag value (e.g. `gh api --paginate graphql ...`), causing the typed verb to lose the `graphql` action and skip the opaque-GraphQL approval guard, enabling an approval bypass for external GraphQL bodies.

### Description
- Consult the word-list classifier (`Gh_verb.classify words`) alongside the typed lowering and keep the typed verb for capability disposition while using the word-list result when checking the RFC-0208 opaque GraphQL gate.
- Treat the command as GraphQL for approval if either the typed verb or the word-list verb identifies `api` with action `graphql` by changing the predicate to `(is_graphql_api verb || is_graphql_api words_verb)`.
- Add regression coverage in `lib/exec/test/test_gh_capability_policy.ml` for `gh api --paginate graphql --input body.json` and `gh api --paginate graphql -F query=@mutation.graphql` to ensure external/opaque GraphQL bodies still require approval.

### Testing
- Ran `git diff --check` which succeeded.
- Attempted `dune runtest lib/exec/test/test_gh_capability_policy.ml` but it could not be executed in this environment because `dune` is not installed (test run failed to start).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d3557da00833387562abc21e2b14f)