### PR TITLE
fix(ide): require token-bound authorization for keeper_lane reads

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -163,6 +163,29 @@ let keeper_filter_for_scope ~scope ~requested_keeper_id =
   | Scope_canonical_url _ | Scope_repo_id _ -> Ok requested_keeper_id
 ;;
 
+let with_keeper_lane_read_auth ~state ~request ~reqd ~scope continue =
+  match scope with
+  | Scope_canonical_url _ | Scope_repo_id _ -> continue ()
+  | Scope_keeper_lane { keeper_id = lane } ->
+    let base_path = base_path_of_state state in
+    (match
+       authorize_token_bound_permission_request
+         ~base_path
+         ~permission:Masc_domain.CanReadState
+         request
+     with
+     | Error err -> respond_auth_error request reqd err
+     | Ok agent_name when String.equal agent_name lane -> continue ()
+     | Ok _ ->
+       respond_ide_error
+         ~status:`Forbidden
+         ~request
+         (ide_error
+            "keeper_lane_forbidden"
+            "keeper_lane reads require a bearer token for the requested keeper")
+         reqd)
+;;
+
 type annotation_scope_error =
   | File_path_repo_id_mismatch
   | File_path_canonical_url_mismatch
@@ -588,6 +611,7 @@ let add_routes router =
            (match keeper_filter_for_scope ~scope ~requested_keeper_id:keeper_id with
             | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
             | Ok keeper_id ->
+              with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
               let partition = partition_of_ide_scope scope in
               let filter =
                 { Ide_annotation_types.file_path; keeper_id; goal_id; task_id }
@@ -606,7 +630,7 @@ let add_routes router =
                 ~compress:true
                 ~request
                 (json_ok json)
-                reqd))
+                reqd)))
       request
       reqd)
   |> Http.Router.post "/api/v1/ide/annotations" (fun request reqd ->
@@ -844,6 +868,7 @@ let add_routes router =
          match resolve_ide_scope_for_query ~state ~uri with
          | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
          | Ok scope ->
+           with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
            let partition = partition_of_ide_scope scope in
            let regions =
              Ide_region_tracker.read_regions
@@ -870,6 +895,7 @@ let add_routes router =
              ~request
              (json_ok json)
              reqd)
+      )
       request
       reqd)
   |> Http.Router.get "/api/v1/ide/events" (fun request reqd ->
@@ -904,6 +930,7 @@ let add_routes router =
                   | Error err ->
                     respond_ide_error ~status:`Bad_request ~request err reqd
                   | Ok keeper_id ->
+                    with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
                     let partition = partition_of_ide_scope scope in
                     let events =
                       Ide_bridge.list_events
@@ -933,7 +960,7 @@ let add_routes router =
                       ~compress:true
                       ~request
                       (json_ok result)
-                      reqd))))
+                      reqd)))))
       request
       reqd)
   (* [build_presence_snapshot] extracted in main — conflict resolved by taking
@@ -971,6 +998,7 @@ let add_routes router =
                with
                | Error err -> respond_ide_error ~status:`Bad_request ~request err reqd
                | Ok keeper_id ->
+                 with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
                  let partition = partition_of_ide_scope scope in
                  let snapshot =
                    build_cursor_snapshot state uri ~partition ~keeper_id ~limit ~offset
@@ -979,7 +1007,7 @@ let add_routes router =
                    ~compress:true
                    ~request
                    (json_ok snapshot)
-                   reqd)))
+                   reqd))))
       request
       reqd)
   |> Http.Router.post "/api/v1/ide/cursors" (fun request reqd ->
@@ -1152,6 +1180,7 @@ let add_routes router =
                | Error err ->
                  respond_ide_error ~status:`Bad_request ~request err inner_reqd
                | Ok keeper_id ->
+              with_keeper_lane_read_auth ~state ~request ~reqd:inner_reqd ~scope (fun () ->
               let partition = partition_of_ide_scope scope in
               let origin = get_origin request in
               let headers =
@@ -1197,7 +1226,7 @@ let add_routes router =
                        "IDE cursor SSE loop exited: %s"
                        (Printexc.to_string exn);
                      Httpun.Body.Writer.close writer)
-               | _ -> Httpun.Body.Writer.close writer))))
+               | _ -> Httpun.Body.Writer.close writer)))))
       request
       reqd)
   |> Http.Router.get "/api/v1/ide/memory" (fun request reqd ->
@@ -1228,6 +1257,7 @@ let add_routes router =
                | Error err ->
                  respond_ide_error ~status:`Bad_request ~request err inner_reqd
                | Ok keeper_id ->
+              with_keeper_lane_read_auth ~state ~request ~reqd:inner_reqd ~scope (fun () ->
               let partition = partition_of_ide_scope scope in
               let filter : Ide_annotation_types.annotation_filter =
                 { file_path = None; keeper_id; goal_id = None; task_id = None }
@@ -1270,7 +1300,7 @@ let add_routes router =
               in
               let body = Yojson.Safe.to_string result in
               let response = Httpun.Response.create ~headers `OK in
-              Httpun.Reqd.respond_with_string inner_reqd response body)))
+              Httpun.Reqd.respond_with_string inner_reqd response body))))
       request
       reqd)
 ;;

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -752,12 +752,17 @@ let seed_lane_turn_event ~base_path ~keeper_id ~turn_id ~timestamp_ms =
 
 let test_events_keeper_lane_returns_only_lane_events () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "alice" in
     seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
       ~timestamp_ms:1700000000000L;
     seed_lane_turn_event ~base_path ~keeper_id:"bob" ~turn_id:"turn-bob-1"
       ~timestamp_ms:1700000001000L;
     let request =
-      http_request ~meth:`GET ~path:"/api/v1/ide/events?keeper_lane=alice" ()
+      http_request
+        ~meth:`GET
+        ~path:"/api/v1/ide/events?keeper_lane=alice"
+        ~token:(Some token)
+        ()
     in
     let response = dispatch router request in
     check_status "GET keeper-lane events succeeds" 200 response;
@@ -800,8 +805,30 @@ let test_events_keeper_lane_rejects_mismatched_keeper_filter () =
       (error_code_of_response response))
 ;;
 
+let test_events_keeper_lane_rejects_other_keeper_token () =
+  with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "bob" in
+    seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
+      ~timestamp_ms:1700000000000L;
+    let request =
+      http_request
+        ~meth:`GET
+        ~path:"/api/v1/ide/events?keeper_lane=alice"
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "other keeper token returns 403" 403 response;
+    check
+      string
+      "keeper lane forbidden code"
+      "keeper_lane_forbidden"
+      (error_code_of_response response))
+;;
+
 let test_cursors_keeper_lane_filters_to_lane_keeper () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
+    let token = create_worker_token base_path "alice" in
     (let seed keeper_id line =
        match
          Ide_bridge.ingest_cursor_event
@@ -819,7 +846,11 @@ let test_cursors_keeper_lane_filters_to_lane_keeper () =
      seed "alice" 1;
      seed "bob" 2);
     let request =
-      http_request ~meth:`GET ~path:"/api/v1/ide/cursors?keeper_lane=alice" ()
+      http_request
+        ~meth:`GET
+        ~path:"/api/v1/ide/cursors?keeper_lane=alice"
+        ~token:(Some token)
+        ()
     in
     let response = dispatch router request in
     check_status "GET keeper-lane cursors succeeds" 200 response;
@@ -934,6 +965,8 @@ let () =
             test_events_keeper_lane_conflicts_with_repo_scope
         ; test_case "keeper_lane rejects mismatched keeper filter" `Quick
             test_events_keeper_lane_rejects_mismatched_keeper_filter
+        ; test_case "keeper_lane rejects other keeper token" `Quick
+            test_events_keeper_lane_rejects_other_keeper_token
         ; test_case "GET cursors keeper_lane filters to lane keeper" `Quick
             test_cursors_keeper_lane_filters_to_lane_keeper
         ; test_case "POST cursor rejects keeper_lane scope" `Quick


### PR DESCRIPTION
### Motivation
- Prevent cross-keeper disclosure: `keeper_lane` scope previously mapped to the shared orphan partition and allowed any caller to request another keeper's lane without verifying the caller's token-bound identity. 
- Limit exposure of potentially sensitive tool-output and annotation data stored in the orphan (`Legacy_default`) partition.

### Description
- Add a token-bound guard `with_keeper_lane_read_auth` that enforces `CanReadState` bearer-token authorization and requires the token's agent name to match the requested keeper lane when `Scope_keeper_lane` is used. (`lib/server/server_ide_http.ml`) 
- Apply the guard to IDE read surfaces that could address the orphan partition: annotations, regions, events, cursors, cursor SSE stream, and memory endpoints. (`lib/server/server_ide_http.ml`) 
- Preserve existing behavior for `Scope_canonical_url` and `Scope_repo_id` (no change to their public/read semantics). (`lib/server/server_ide_http.ml`) 
- Update tests to use a matching keeper token for successful keeper-lane reads and add a regression test asserting that a token for a different keeper is rejected with `keeper_lane_forbidden`. (`test/test_server_ide_http.ml`)

### Testing
- Ran static checks: `git diff --check` reported no whitespace/format issues. (succeeded)
- Attempted to run unit tests via the repository test harness (`make test` / `dune test`) but the environment lacks `dune`/OCaml toolchain so the test invocation failed with `/workspace/masc/scripts/dune-local.sh: line 720: exec: dune: not found` (blocked by environment). (failed / not run)
- Added/updated unit tests in `test/test_server_ide_http.ml` to cover the authorization behavior; these tests exercise the keeper-lane success path and the rejected-other-keeper-token path (can be validated in CI where the OCaml toolchain is available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c945408ac833399afc177002234ec)