### PR TITLE
Fix OCaml compile regressions in task lifecycle and anti-rationalization

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -716,7 +716,7 @@ let review
       ?(on_verdict : (review_result -> unit) option)
       ?(few_shot_block = "")
       ?(operator_override : bool = false)
-      ?sw
+      ?(sw : Eio.Switch.t)
       (req : review_request)
   : review_result
   =

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -102,6 +102,7 @@ val review :
   ?verify_gate_evidence:string list ->
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
+  ?operator_override:bool ->
   ?sw:Eio.Switch.t ->
   review_request -> review_result
 

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,7 +108,7 @@ let decide
       ~authority
       ~notes
       ~reason
-      ?(system_gate_exempt = false)
+      ~(system_gate_exempt : bool)
   =
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -58,6 +58,7 @@ val decide
   -> authority:Masc_domain.completion_authority
   -> notes:string
   -> reason:string
+  -> ?system_gate_exempt:bool
   -> (decision, invalid) result
 
 (** Enumerate the [task_action]s that [decide] would accept for the given

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -145,9 +145,8 @@ let test_slack_default_paths_resolve_under_base_path () =
                 check bool "binding written under base" true
                   (Sys.file_exists expected_binding_path);
                 check bool "binding not written under cwd" false
-                  (Sys.file_exists
-                     (Filename.concat cwd_dir
-                        ".gate/runtime/slack/bindings.json")))))))
+                (Sys.file_exists
+                   (Filename.concat cwd_dir ".gate/runtime/slack/bindings.json")))))
 
 let test_telegram_connector_json_reads_runtime_status () =
   with_temp_dir @@ fun dir ->


### PR DESCRIPTION
## Summary\n- Fix Optional-arg signature mismatch for task lifecycle decide (add ?system_gate_exempt to .mli).\n- Fix anti-rationalization review interface/signature ordering so ?operator_override is visible to callers.\n- Fix malformed parenthesis in test/test_channel_gate_connector_routes.ml that caused parser syntax error.\n\n## Validation\n- Not run here (per request).\n\n## Notes\n- Existing unrelated tracked/untracked files outside scope were intentionally left untouched.\n