### PR TITLE
Fix compile signature parity and slack path parser close

### DIFF
--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,7 +108,7 @@ let decide
       ~authority
       ~notes
       ~reason
-      ~(system_gate_exempt : bool)
+      ?(system_gate_exempt = false)
   =
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -116,37 +116,39 @@ let test_slack_binding_store_error_is_typed () =
 
 
 let test_slack_default_paths_resolve_under_base_path () =
-  with_temp_dir @@ fun base_dir ->
-  with_temp_dir @@ fun cwd_dir ->
-  with_env "MASC_BASE_PATH" (Some base_dir) (fun () ->
-    with_env "MASC_BASE_PATH_INPUT" None (fun () ->
-      with_envs
-        [ "SLACK_STATUS_PATH"; "MASC_SLACK_STATUS_PATH"; "SLACK_BINDING_STORE_PATH"
-        ; "MASC_SLACK_BINDING_STORE_PATH"; "SLACK_BINDING_AUDIT_PATH"
-        ; "MASC_SLACK_BINDING_AUDIT_PATH" ]
-        None
-        (fun () ->
-          let original_cwd = Sys.getcwd () in
-          Fun.protect
-            ~finally:(fun () -> Sys.chdir original_cwd)
+  with_temp_dir (fun base_dir ->
+    with_temp_dir (fun cwd_dir ->
+      with_env "MASC_BASE_PATH" (Some base_dir) (fun () ->
+        with_env "MASC_BASE_PATH_INPUT" None (fun () ->
+          with_envs
+            [
+              "SLACK_STATUS_PATH"; "MASC_SLACK_STATUS_PATH"; "SLACK_BINDING_STORE_PATH"
+            ; "MASC_SLACK_BINDING_STORE_PATH"; "SLACK_BINDING_AUDIT_PATH"
+            ; "MASC_SLACK_BINDING_AUDIT_PATH"
+            ]
+            None
             (fun () ->
-              Sys.chdir cwd_dir;
-              match
-                Channel_gate_slack_state.bind ~channel_id:"C123"
-                  ~keeper_name:"luna" ~actor_name:"dashboard"
-              with
-              | Error err -> fail err
-              | Ok json ->
-                let expected_binding_path =
-                  Filename.concat base_dir ".gate/runtime/slack/bindings.json"
-                in
-                check string "binding store path under base" expected_binding_path
-                  (json |> U.member "binding_store_path" |> U.to_string);
-                check bool "binding written under base" true
-                  (Sys.file_exists expected_binding_path);
-                check bool "binding not written under cwd" false
-                (Sys.file_exists
-                   (Filename.concat cwd_dir ".gate/runtime/slack/bindings.json")))))
+              let original_cwd = Sys.getcwd () in
+              Fun.protect
+                ~finally:(fun () -> Sys.chdir original_cwd)
+                (fun () ->
+                  Sys.chdir cwd_dir;
+                  match
+                    Channel_gate_slack_state.bind ~channel_id:"C123"
+                      ~keeper_name:"luna" ~actor_name:"dashboard"
+                  with
+                  | Error err -> fail err
+                  | Ok json ->
+                    let expected_binding_path =
+                      Filename.concat base_dir ".gate/runtime/slack/bindings.json"
+                    in
+                    check string "binding store path under base" expected_binding_path
+                      (json |> U.member "binding_store_path" |> U.to_string);
+                    check bool "binding written under base" true
+                      (Sys.file_exists expected_binding_path);
+                    check bool "binding not written under cwd" false
+                      (Sys.file_exists
+                         (Filename.concat cwd_dir ".gate/runtime/slack/bindings.json")))))))
 
 let test_telegram_connector_json_reads_runtime_status () =
   with_temp_dir @@ fun dir ->


### PR DESCRIPTION
## Summary\n- Restore  as optional in  implementation to match interface.\n- Fix malformed parentheses in  after prior refactor.\n\n## Notes\n- Worktree:  (from  + this commit).\n- Environment currently lacks some external libs (, ) for full  execution in this workspace.\n