### PR TITLE
Fix lifecycle decide signature and slack path test syntax

### DIFF
--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,7 +108,7 @@ let decide
       ~authority
       ~notes
       ~reason
-      ?(system_gate_exempt = false)
+      ~system_gate_exempt
   =
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -58,7 +58,7 @@ val decide
   -> authority:Masc_domain.completion_authority
   -> notes:string
   -> reason:string
-  -> ?system_gate_exempt:bool
+  -> system_gate_exempt:bool
   -> (decision, invalid) result
 
 (** Enumerate the [task_action]s that [decide] would accept for the given

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -168,6 +168,7 @@ let transition_task_outcome_r
               ~action
               ~now
               ~authority
+              ~system_gate_exempt:false
               ~notes
               ~reason
           with

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -148,7 +148,7 @@ let test_slack_default_paths_resolve_under_base_path () =
                       (Sys.file_exists expected_binding_path);
                     check bool "binding not written under cwd" false
                       (Sys.file_exists
-                         (Filename.concat cwd_dir ".gate/runtime/slack/bindings.json")))))))
+                         (Filename.concat cwd_dir ".gate/runtime/slack/bindings.json"))))))))
 
 let test_telegram_connector_json_reads_runtime_status () =
   with_temp_dir @@ fun dir ->


### PR DESCRIPTION
## Summary
- Make `Workspace_task_lifecycle.decide`'s `system_gate_exempt` argument required in both signature and implementation (`~system_gate_exempt`).
- Pass `~system_gate_exempt:false` at call site in `workspace_task_transitions`.
- Fix unmatched parenthesis in `test_slack_default_paths_resolve_under_base_path` so parser accepts the test module.

## Notes
- This addresses remaining compile blockers reported on `main` after PR `#23814` merge.
