### PR TITLE
feat(exec-policy): playground exec gate = filesystem truth (RFC-0324 B-2')

### DIFF
--- a/lib/exec_policy/exec_policy_paths.ml
+++ b/lib/exec_policy/exec_policy_paths.ml
@@ -99,7 +99,23 @@ let keeper_registered_repo_path_allowed ?keeper_id ?base_path path =
       | Keeper_repo_mapping.Repository_identity_mismatch _
       | Keeper_repo_mapping.Repository_store_error _ ->
           false
-      | Keeper_repo_mapping.Repository { repository_id; _ } -> (
+      | Keeper_repo_mapping.Repository
+          { repository_id = _; repo_root = Some repo_root } ->
+          (* RFC-0324 B-2': inside a keeper playground [repos/<segment>] lane
+             the filesystem is the repo truth — the Execute gate asks whether
+             the clone actually exists, not whether its segment is in the
+             repositories.toml catalog (catalog ids and clone directory names
+             have no invariant linking them, so catalog membership blocked
+             real clones; 379 path errors/24h in the 2026-07-08 audit). The
+             playground boundary is unchanged: [repo_root] is a prefix of the
+             already symlink-resolved candidate path, so paths outside the
+             playground never reach this arm. Fail-closed: a missing or
+             unstatable directory rejects. *)
+          (try Sys.is_directory repo_root with Sys_error _ -> false)
+      | Keeper_repo_mapping.Repository { repository_id; repo_root = None } -> (
+          (* Non-playground path that resolved via a catalog repo's
+             local_path prefix — the catalog stays the authority there
+             (RFC-0324 keeps catalog authz for non-playground consumers). *)
           match
             Keeper_repo_mapping.validate_access ~keeper_id ~repository_id
               ~base_path

--- a/lib/exec_policy/exec_policy_paths.mli
+++ b/lib/exec_policy/exec_policy_paths.mli
@@ -6,6 +6,13 @@ val is_within_dir : dir:string -> string -> bool
 
 val keeper_registered_repo_path_allowed :
   ?keeper_id:string -> ?base_path:string -> string -> bool
+(** RFC-0324 B-2': for paths inside a keeper playground [repos/<segment>]
+    lane the decision is filesystem truth — the clone directory must exist
+    (fail-closed on missing/unstatable). Catalog membership no longer gates
+    playground exec paths; it still gates non-playground paths that resolve
+    via a catalog repo's [local_path]. Paths outside any repo resolution
+    return [false] (the playground boundary is enforced upstream by the
+    resolution itself). *)
 
 val validate_path :
   ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool

--- a/test/test_keeper_tool_policy_paths.ml
+++ b/test/test_keeper_tool_policy_paths.ml
@@ -217,6 +217,55 @@ let test_exec_policy_validate_path_survives_deleted_cwd () =
        Unix.rmdir doomed;
        ignore (Exec_policy.Paths.validate_path "/not-under-tmp-or-workspace"))
 
+(* ── RFC-0324 B-2': playground exec gate = filesystem truth ──────────
+   [keeper_registered_repo_path_allowed] is pinned directly (not through
+   [validate_path]) because CI temp dirs live under [/tmp], where
+   [validate_path]'s /tmp arm would allow everything and mask the repo
+   arm under test. The missing repositories.toml falls back to the
+   single "default" catalog entry, so the "ghost-clone" segment below is
+   deterministically NOT catalog-registered — pre-B-2' the gate rejected
+   it; the filesystem-truth gate admits the existing clone and still
+   rejects a nonexistent one (fail-closed). *)
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path) then begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let playground_repo_path base segments =
+  List.fold_left Filename.concat base ([ ".masc"; "playground" ] @ segments)
+
+let test_b2_playground_clone_allowed_without_catalog_entry () =
+  with_temp_dir "exec-b2-clone-" @@ fun base ->
+  let repo_root = playground_repo_path base [ "kp"; "repos"; "ghost-clone" ] in
+  mkdir_p repo_root;
+  assert (
+    Exec_policy.Paths.keeper_registered_repo_path_allowed ~keeper_id:"kp"
+      ~base_path:base
+      (Filename.concat repo_root "src/main.ml"))
+
+let test_b2_playground_missing_clone_rejected () =
+  with_temp_dir "exec-b2-ghost-" @@ fun base ->
+  mkdir_p (playground_repo_path base [ "kp"; "repos" ]);
+  assert (
+    not
+      (Exec_policy.Paths.keeper_registered_repo_path_allowed ~keeper_id:"kp"
+         ~base_path:base
+         (Filename.concat
+            (playground_repo_path base [ "kp"; "repos"; "nonexistent" ])
+            "x.txt")))
+
+let test_b2_outside_playground_still_rejected () =
+  (* RFC-0324 line 86: the playground/sandbox boundary is the invariant the
+     filesystem flip must not loosen — a path resolving to no repository
+     stays rejected by this arm regardless of what exists on disk. *)
+  with_temp_dir "exec-b2-outside-" @@ fun base ->
+  assert (
+    not
+      (Exec_policy.Paths.keeper_registered_repo_path_allowed ~keeper_id:"kp"
+         ~base_path:base "/definitely/not/a/repo/path"))
+
 (* ── runner ──────────────────────────────────────────────────────── *)
 
 let () =
@@ -241,4 +290,7 @@ let () =
   test_playground_sibling_rejected ();
   test_worktrees_sibling_rejected ();
   test_exec_policy_validate_path_survives_deleted_cwd ();
+  test_b2_playground_clone_allowed_without_catalog_entry ();
+  test_b2_playground_missing_clone_rejected ();
+  test_b2_outside_playground_still_rejected ();
   print_endline "test_keeper_tool_policy_paths: all assertions passed"


### PR DESCRIPTION
## 배경 (RFC-0324 B-2' · 도구 에러 감사 P1의 두 번째 누수 경로)

Execute gate가 keeper playground의 **실제 클론** 경로도 repos/<segment>가 repositories.toml에 없으면 거절했습니다. 카탈로그 id와 클론 디렉토리명 사이에 불변식이 없어 keeper가 자기 체크아웃에서 막혔습니다 (RFC-0324 Context: garnet/nick0cave 사고, 379 path 에러/24h).

## 변경 (3-agent 정찰 후, 정찰 판정: clean-slice / no-conflict)

`keeper_registered_repo_path_allowed`의 Repository arm을 `repo_root` 유무로 분리:

- **`repo_root = Some _` (playground repos lane)**: `Sys.is_directory repo_root` — 파일시스템 실존이 진실. missing/unstatable → fail-closed 거절
- **`repo_root = None` (비-playground, catalog local_path 경유)**: `validate_access` 유지 — RFC가 카탈로그 권한을 유지하는 소비자

핵심 레버: resolution 타입이 이미 playground lane에서만 `repo_root`를 운반 → **신규 dune 의존 0** (keeper 헬퍼 사용 시 exec_policy←keeper 경계 역전이라 회피 — 정찰이 잡은 함정).

## 보존된 불변식 (RFC line 52, 86)

- **Playground 경계 불변**: repo_root는 이미 symlink-해소된 후보 경로의 prefix — playground 밖 경로는 이 arm에 도달 불가. 회귀 테스트로 pin
- `validate_access` 자체, `validate_path_access`, repo-claim/HITL(`keeper_repo_claim_hitl`), sandbox-control, dashboard CRUD — 전부 무변경 (RFC 명시 scope)

## 테스트 (신규 3 pin — 기존 pin flip 0)

arm을 **직접** pin (CI temp가 /tmp 아래라 validate_path의 /tmp arm이 가려버리는 함정 회피):
1. 카탈로그 미등재+실존 클론 → 허용 (pre-B-2'와의 차등 pin)
2. 미실존 클론 → 거절 (fail-closed)
3. 비해소 경로 → 거절 (경계 회귀 가드, RFC line 86)

정찰 census: exec-gate catalog 분기를 pin하는 기존 테스트 0 (search_files containment pin은 별개의 HITL 경로).

## 명시된 확대 (RFC 승인 범위)

미등재-but-클론된 playground repo가 exec-visible해짐. lane 소유권은 기존 validate_access도 검사하지 않았음(mappings=advisory) — cross-keeper 방어는 RFC-0322 lane(#23662) 소관이며 이 PR은 그 전제(resolution 의미론)를 건드리지 않음.

RFC: RFC-0324 (docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md) B-2'. B-1은 #23791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
