### PR TITLE
Fix anti-rationalization optional argument types

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -716,7 +716,7 @@ let review
       ?(on_verdict : (review_result -> unit) option)
       ?(few_shot_block = "")
       ?(operator_override : bool = false)
-      ?(sw : Eio.Switch.t)
+      ?(sw : Eio.Switch.t option)
       (req : review_request)
   : review_result
   =

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -103,7 +103,7 @@ val review :
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
   ?operator_override:bool ->
-  ?sw:Eio.Switch.t ->
+  ?sw:Eio.Switch.t option ->
   review_request -> review_result
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -195,7 +195,7 @@ let owner_transition_action_denylist (ctx : context) =
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_runtime : string option)
-    ?(operator_override : bool = false)
+    ~(operator_override : bool)
     ~(ctx : context)
     ~(task_opt : Masc_domain.task option)
     ~(task_id : string)


### PR DESCRIPTION
## Why
- Aligns `Anti_rationalization.review` signature between implementation/.mli by making `~sw` an option.
- Removes erasable-optional warning by making `operator_override` required in `review_completion_notes`.

## What changed
- `lib/task/anti_rationalization.ml`: `review` now accepts `?(sw : Eio.Switch.t option)`.
- `lib/task/anti_rationalization.mli`: align `review` with `.ml`.
- `lib/task/tool_task_handlers.ml`: `review_completion_notes` now takes `~operator_override:bool` (non-optional).

## Notes
- This was a compile blocker on `main` with:
  - `pattern should not be a constructor` around `Ok decision`
  - `unerasable-optional-argument` warning/error around `operator_override`
