### PR TITLE
fix(keeper): Grep rg hardening — Rust-regex dialect doc + -e separator + host preflight (audit #7)

### DIFF
--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -118,6 +118,18 @@ let try_handle
   in
   let run_readonly_in_sandbox ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
       ~max_bytes ~timeout_sec () =
+    (* Pre-flight parity with [Keeper_sandbox_read_backend.read_file]: verify
+       the host target exists before spawning a container, so a wrong
+       repos/<segment> guess fails with a precise host-path error instead of
+       burning a docker run that ends in "No such file or directory". *)
+    if not (Sys.file_exists target) then
+      Error
+        (sandbox_read_error ~target
+           (Printf.sprintf
+              "path_not_found: %s (host path does not exist; list repos/ to \
+               see your actual checkouts before searching)"
+              target))
+    else
     let max_eintr_retries = 8 in
     let rec loop attempts_left =
       match
@@ -168,7 +180,11 @@ let try_handle
                (match
                   run_readonly_in_sandbox ~target
                     ~command_argv:(fun cpath ->
-                      base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
+                      (* [-e] marks the pattern as a pattern even when it
+                         starts with a dash — without it a model-authored
+                         leading-dash pattern parses as an rg flag (latent
+                         argv-injection-shaped failure; 24h audit #7). *)
+                      base_argv @ type_argv @ glob_argv @ [ "-e"; pattern; cpath ])
                     ~ok_exit_codes:[ 0; 1 ]
                     ~max_bytes:1_000_000
                     ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec ~bucket:Read ())
@@ -199,7 +215,8 @@ let try_handle
                  @ (if glob <> "" then
                       [ "--glob"; glob ]
                     else [])
-                 @ [ pattern; target ]
+                 (* [-e]: same leading-dash guard as the sandbox lane. *)
+                 @ [ "-e"; pattern; target ]
                in
                let ir = Keeper_tool_execute_shell_ir.simple Masc_exec.Exec_program.Rg argv in
                run_host_shell_ir

--- a/lib/tool_surface/tool_shard_types_schemas_search_files.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_search_files.ml
@@ -20,7 +20,7 @@ let tool_search_files_schema : Masc_domain.tool_schema =
                 [ ( "pattern"
                   , `Assoc
                       [ "type", `String "string"
-                      ; "description", `String "Regular expression to search file contents for. Must be a syntactically valid regex."
+                      ; "description", `String "Regular expression in Rust regex syntax (ripgrep). No lookaround (?!...) (?<=...) and no backreferences; alternation is a plain | (never \\|); a literal double quote needs no backslash. PCRE/BRE-dialect patterns are rejected with a regex parse error."
                       ] )
                 ; ( "path"
                   , `Assoc


### PR DESCRIPTION
## 배경 (24h 도구 에러 감사 #7 재조사 — 당시 미확정)

2-agent 재조사가 두 시그니처의 근본을 확정했습니다 (로그 96MB + origin/main 코드 추적):

- **rg escaping 가설 반증**: pattern은 argv 원소로 shell 없이 rg까지 도달 (`exec_gate.ml:32-34`가 raw_source 미사용 증명)
- **29/52** = 모델이 잘못된 regex dialect로 작성 (PCRE lookaround `(?!...)`, 불필요한 `\\\"`, BRE `\\|`) → Rust-regex가 거부
- **23/52 + cwd_not_directory 64건 전부** = catalog-vs-clone 세그먼트 추측 (RFC-0324 leak path 1 — 수리는 #23791이 담당; 디스크 대조로 실패 세그먼트 전원이 '다른 keeper lane에는 존재하는 이름'임을 확인)

## 변경 3종 (기계적 하드닝)

1. **스키마 dialect 명시**: pattern 필드가 Rust regex 문법 규칙을 서술 (lookaround/backreference 불가, `|`는 평문, `\"` 불필요)
2. **`-e` separator** (양 lane): leading-dash pattern이 rg 플래그로 파싱되는 잠재 갭 폐쇄 — `validate_rg_inputs`는 pattern을 검사하지 않고, 이번 창에서 0건이지만 argv-injection 형태의 구조적 구멍
3. **sandbox lane host preflight**: read_file에 이미 있는 존재 검사(`keeper_sandbox_read_backend.ml:230-247`)의 패리티 — 틀린 세그먼트가 docker spawn을 태우기 전에 정확한 path_not_found로 실패

## 워크어라운드 자기점검

- 스키마 문구는 counter/분류기가 아니라 도구 계약 서술
- `-e`는 typed-boundary 강화 (파서 레벨), string 분류 아님
- preflight는 기존 read_file 선례의 대칭 — 신규 패턴 아님

## 검증

- 2파일 parse-check 통과 (빌드는 CI). Grep argv를 pin하는 기존 테스트 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
