### PR TITLE
Fix anti-rationalization and task lifecycle signature mismatches

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -716,7 +716,7 @@ let review
       ?(on_verdict : (review_result -> unit) option)
       ?(few_shot_block = "")
       ?(operator_override : bool = false)
-      ?(sw : Eio.Switch.t option)
+      ?(sw : Eio.Switch.t)
       (req : review_request)
   : review_result
   =

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -103,7 +103,7 @@ val review :
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
   ?operator_override:bool ->
-  ?sw:Eio.Switch.t option ->
+  ?sw:Eio.Switch.t ->
   review_request -> review_result
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -238,13 +238,25 @@ let review_completion_notes
               (Stdlib.Printexc.to_string exn))
       in
       let few_shot_block = (Atomic.get get_few_shot_block_fn) () in
-      match (Anti_rationalization.review
-         ?sw:ctx.sw
-         ?evaluator_runtime
-         ?completion_contract
-         ~required_evidence
-         ~verify_gate_evidence
-         ~on_verdict ~few_shot_block ~operator_override ar_req).verdict with
+      let ar_result =
+        (match ctx.sw with
+         | None ->
+           Anti_rationalization.review
+             ?evaluator_runtime
+             ?completion_contract
+             ~required_evidence
+             ~verify_gate_evidence
+             ~on_verdict ~few_shot_block ~operator_override ar_req
+         | Some sw ->
+           Anti_rationalization.review
+             ~sw
+             ?evaluator_runtime
+             ?completion_contract
+             ~required_evidence
+             ~verify_gate_evidence
+             ~on_verdict ~few_shot_block ~operator_override ar_req)
+      in
+      match ar_result.verdict with
       | Anti_rationalization.Reject reason -> Some reason
       | Anti_rationalization.Approve -> None
 

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,7 +108,7 @@ let decide
       ~authority
       ~notes
       ~reason
-      ~system_gate_exempt
+      ?(system_gate_exempt = false)
   =
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -58,7 +58,7 @@ val decide
   -> authority:Masc_domain.completion_authority
   -> notes:string
   -> reason:string
-  -> system_gate_exempt:bool
+  -> ?system_gate_exempt:bool
   -> (decision, invalid) result
 
 (** Enumerate the [task_action]s that [decide] would accept for the given

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1433,10 +1433,9 @@ let test_task_claim_next_action_todo_policy_block_still_claims () =
   match Masc_domain.task_claim_next_action t with
   | Masc_domain.Claim_now ->
     check bool "claimable" true (Masc_domain.task_claim_next_action_is_claimable t)
-  | Masc_domain.Skip_claim (Masc_domain.Claim_block_reclaim_policy _) ->
-    fail "todo task must stay claimable regardless of reclaim_policy (task-1869)"
   | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
     fail "todo task should not be classified as not-todo"
+  | _ -> fail "todo task should not be unclaimable"
 
 (* ============================================================
    Test Runners

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -105,6 +105,7 @@ let decide_claim ~same_agent ~agent_name ~task_id ~task_status =
     ~authority:D.Assignee
     ~notes:""
     ~reason:""
+    ~system_gate_exempt:false
 ;;
 
 (* Cross-check: [valid_next_actions] returns exactly the [task_action]s for
@@ -134,6 +135,7 @@ let assert_consistent_with_decide
         ~authority
         ~notes:""
         ~reason:""
+        ~system_gate_exempt:false
     with
     | Ok _ -> true
     | Error _ -> false
@@ -492,6 +494,7 @@ let decide_done ~requires_verification ~verification_enabled ~task_status ~autho
     ~authority
     ~notes:"done notes"
     ~reason:""
+    ~system_gate_exempt:false
 ;;
 
 let test_verification_required_blocks_done () =


### PR DESCRIPTION
## Summary
- Fix optional argument signature drift causing compile failures: make Workspace_task_lifecycle.decide expose ?system_gate_exempt and thread it through callers.
- Align anti-rationalization review API to use non-optional Eio.Switch in impl/mli and adjust callers safely.
- Fix stale claim_reclaim constructor match in tests for Claim_block_not_todo variant.
- Restore compile compatibility for workspace transitions and anti-rationalization callsites.

## Testing
- Not run here due local environment dependency on runtime/dependency setup in current session.