### PR TITLE
feat(keeper): board wake budget defers to mailboxes — no delivery drops (RFC-0334 W1)

### DIFF
--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -414,15 +414,30 @@ let take = List.take
 
 (* RFC-0020: select which keepers wake for a board signal from typed
    [Board_wake.wake_reason] candidates. Explicit mentions short-circuit and
-   wake unconditionally; thread-reply/reaction followups compete for [total_limit] slots
-   in candidate order. [None] reasons are dropped (the structural reactive
-   pipeline found no deterministic address for that keeper). Semantic
-   relatedness is intentionally not a wake reason here: it must enter through an
-   LLM/Judge attention boundary, not goal-keyword matching in the board publish
-   hook. *)
+   wake unconditionally; thread-reply/reaction followups compete for
+   [total_limit] immediate-wake slots in candidate order. [None] reasons are
+   dropped (the structural reactive pipeline found no deterministic address
+   for that keeper). Semantic relatedness is intentionally not a wake reason
+   here: it must enter through an LLM/Judge attention boundary, not
+   goal-keyword matching in the board publish hook.
+
+   RFC-0334 W1: the cap bounds WAKES, not delivery. Addressed candidates
+   beyond the wake budget — cap overflow, or followups shadowed by an
+   explicit-mention short-circuit — return as [deferred]: the caller appends
+   the stimulus to their mailboxes and they observe it on their next turn.
+   Only [None]-reason candidates receive nothing. *)
 let select_board_wakeup_candidates
     ?(total_limit = board_reactive_wakeup_max)
     candidates =
+  let followups =
+    candidates
+    |> List.filter_map (fun (item, reason) ->
+      match reason with
+      | Some
+          (( Board_wake.Thread_reply_after_self_comment
+           | Board_wake.Reaction_after_self_activity ) as r) -> Some (item, r)
+      | Some Board_wake.Explicit_mention | None -> None)
+  in
   let explicit =
     candidates
     |> List.filter_map (fun (item, reason) ->
@@ -434,17 +449,11 @@ let select_board_wakeup_candidates
       | None -> None)
   in
   match explicit with
-  | _ :: _ -> explicit, 0
+  | _ :: _ -> explicit, followups
   | [] ->
-    let non_explicit =
-      List.filter_map
-        (fun (item, reason) ->
-          match reason with None -> None | Some r -> Some (item, r))
-        candidates
-    in
-    let selected = take total_limit non_explicit in
-    let dropped = List.length non_explicit - List.length selected in
-    selected, dropped
+    let selected = take total_limit followups in
+    let deferred = List.drop total_limit followups in
+    selected, deferred
 ;;
 
 (* RFC-0020: enqueue the board signal as a typed [stimulus_payload] (PR-1).
@@ -685,25 +694,42 @@ let wakeup_relevant_keeper_for_board_signal
           signal.post_id
           err)
   in
-  let selected, dropped = select_board_wakeup_candidates candidates in
+  let selected, deferred = select_board_wakeup_candidates candidates in
   let yield_meter = Eio_guard.create_yield_meter ~interval:1 () in
   selected
   |> List.iter (fun (meta, reason) ->
          wake_meta meta reason;
          Eio_guard.yield_step yield_meter);
-  if dropped > 0 then begin
-    (* Counter tracks wakeups dropped by the cap, not capped events; under
-       high fanout [dropped] can be >1 per signal, so add the actual amount
-       (not a fixed 1) to keep BOARD-CAPPED accurate on the compact dashboard. *)
+  (* RFC-0334 W1: the wake budget defers, it does not drop. Every addressed
+     candidate beyond the budget still receives the stimulus in its mailbox
+     ([Keeper_registry_event_queue.enqueue]: identity-dedup + durable
+     persist, no wakeup-flag flip) and observes it on its next turn —
+     whatever triggers that turn. The wake debounce
+     ([board_reactive_wakeup_allowed]) guards wakes, not delivery; queue
+     identity dedup already collapses repeats on this path. *)
+  deferred
+  |> List.iter (fun (meta, reason) ->
+         let stimulus = board_signal_stimulus ~reason signal in
+         Keeper_registry_event_queue.enqueue
+           ~base_path:config.base_path
+           meta.name
+           stimulus;
+         Eio_guard.yield_step yield_meter);
+  let deferred_count = List.length deferred in
+  if deferred_count > 0 then begin
+    (* Counter semantics per RFC-0334 W1: wakes deferred to the mailbox by
+       the wake budget — no longer a loss count. Under high fanout it can
+       be >1 per signal, so add the actual amount (not a fixed 1) to keep
+       the compact dashboard accurate. *)
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string BoardSignalWakeupCappedTotal)
       ~labels:[("kind", signal_kind_label)]
-      ~delta:(float_of_int dropped)
+      ~delta:(float_of_int deferred_count)
       ();
     Log.Keeper.info
-      "board signal wakeup capped by configured fanout: dropped=%d post=%s \
-       total_limit=%d"
-      dropped
+      "board signal wake budget reached: deferred=%d to mailboxes post=%s \
+       total_limit=%d (delivered, not dropped — RFC-0334 W1)"
+      deferred_count
       signal.post_id
       board_reactive_wakeup_max
   end

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -175,17 +175,22 @@ val board_reactive_wakeup_allowed :
     resumed implicitly by board posts or comments. *)
 val paused_meta_allows_board_auto_resume : keeper_meta -> bool
 
-(** Select which keepers wake for a board signal (RFC-0020). Explicit mentions
-    short-circuit and wake unconditionally (returned with [dropped = 0]);
-    thread-reply followups compete for [?total_limit] slots in candidate order.
-    [None] reasons are dropped. Semantic relatedness is not a deterministic
-    board wake reason; it belongs behind an LLM/Judge attention boundary.
-    Returns the selected [(item, reason)] pairs and the number of non-explicit
-    candidates dropped by the cap. *)
+(** Select which keepers wake for a board signal (RFC-0020). Explicit
+    mentions short-circuit and wake unconditionally; thread-reply/reaction
+    followups compete for [?total_limit] immediate-wake slots in candidate
+    order. [None] reasons receive nothing (no deterministic address).
+    Semantic relatedness is not a deterministic board wake reason; it belongs
+    behind an LLM/Judge attention boundary.
+
+    RFC-0334 W1: returns [(selected, deferred)] — the wake budget bounds
+    wakes, not delivery. [deferred] carries every addressed followup beyond
+    the budget (cap overflow, or all followups when an explicit mention
+    short-circuits); the caller appends the stimulus to their mailboxes. *)
 val select_board_wakeup_candidates :
   ?total_limit:int ->
   ('a * Keeper_world_observation_board_signal.wake_reason option) list ->
-  ('a * Keeper_world_observation_board_signal.wake_reason) list * int
+  ('a * Keeper_world_observation_board_signal.wake_reason) list
+  * ('a * Keeper_world_observation_board_signal.wake_reason) list
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.board_signal -> unit

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -410,7 +410,7 @@ let test_board_auto_resume_allows_auto_paused_keeper () =
     (KKS.paused_meta_allows_board_auto_resume meta)
 
 let test_board_wakeup_selection_keeps_explicit_mentions () =
-  let selected, dropped =
+  let selected, deferred =
     KKS.select_board_wakeup_candidates
       [
         "a", Some KWOBS.Thread_reply_after_self_comment;
@@ -418,15 +418,17 @@ let test_board_wakeup_selection_keeps_explicit_mentions () =
         "c", Some KWOBS.Explicit_mention;
       ]
   in
-  (* Explicit mentions short-circuit: they wake unconditionally, the
-     non-explicit candidate is excluded, and there are no cap drops. *)
+  (* Explicit mentions short-circuit the WAKE; the shadowed followup is
+     deferred to its mailbox, not discarded (RFC-0334 W1). *)
   check (list (pair string string)) "selected explicit wakeups"
     [ "b", "explicit_mention"; "c", "explicit_mention" ]
     (labeled selected);
-  check int "no drops when explicit present" 0 dropped
+  check (list (pair string string)) "shadowed followup deferred, not dropped"
+    [ "a", "thread_reply_after_self_comment" ]
+    (labeled deferred)
 
 let test_board_wakeup_selection_drops_none_reasons () =
-  let selected, dropped =
+  let selected, deferred =
     KKS.select_board_wakeup_candidates
       [
         "a", Some KWOBS.Thread_reply_after_self_comment;
@@ -434,15 +436,17 @@ let test_board_wakeup_selection_drops_none_reasons () =
         "c", None;
       ]
   in
-  (* [None] reasons (no deterministic address) are dropped; structural
-     followup reasons survive in candidate order. *)
+  (* [None] reasons (no deterministic address) receive nothing — neither a
+     wake nor a mailbox delivery; structural followup reasons survive in
+     candidate order. *)
   check (list (pair string string)) "None dropped, real reasons kept"
     [ "a", "thread_reply_after_self_comment" ]
     (labeled selected);
-  check int "no cap drops under total limit" 0 dropped
+  check (list (pair string string)) "nothing deferred under the limit" []
+    (labeled deferred)
 
 let test_board_wakeup_selection_caps_thread_followups () =
-  let selected, dropped =
+  let selected, deferred =
     KKS.select_board_wakeup_candidates
       ~total_limit:2
       [
@@ -452,12 +456,15 @@ let test_board_wakeup_selection_caps_thread_followups () =
         "d", Some KWOBS.Thread_reply_after_self_comment;
       ]
   in
-  (* Thread followups compete for [total_limit] slots in candidate order; the
-     overflow is dropped. *)
+  (* Thread followups compete for [total_limit] immediate-wake slots in
+     candidate order; the overflow is deferred to mailboxes with its reasons
+     intact (RFC-0334 W1: the cap bounds wakes, not delivery). *)
   check (list (pair string string)) "first two non-explicit kept in order"
     [ "a", "thread_reply_after_self_comment"; "b", "thread_reply_after_self_comment" ]
     (labeled selected);
-  check int "overflow dropped" 2 dropped
+  check (list (pair string string)) "overflow deferred in order with reasons"
+    [ "c", "thread_reply_after_self_comment"; "d", "thread_reply_after_self_comment" ]
+    (labeled deferred)
 
 let test_board_goal_keyword_overlap_is_not_wake_reason () =
   let meta = make_board_resume_meta "keyword-overlap" in


### PR DESCRIPTION
## RFC-0334 W1 — enqueue-always, cap-only-the-wake

RFC-0334(#23766, MERGED)의 W1 슬라이스. fanout cap이 **delivery까지 drop**하던 것을 wake 예산으로 재정의합니다.

## 변경

- `select_board_wakeup_candidates`: `(selected, dropped:int)` → **`(selected, deferred:list)`** — cap 초과분과 explicit-mention short-circuit에 가려진 followup들이 사유(reason)와 함께 반환
- 콜사이트: deferred 각각에 typed `Board_signal` stimulus를 `Keeper_registry_event_queue.enqueue`로 mailbox 적재 (identity-dedup+durable persist 내장, wakeup flag는 안 건드림) → 다음 턴(무엇이 트리거하든)에 관측
- `BoardSignalWakeupCappedTotal`: 손실 카운터 → **deferral 카운터** (메트릭 이름 유지 — wire 라벨 호환), 로그도 "delivered, not dropped"로
- publish 경로에서 버려지는 stimulus **0** (W1 exit criterion)

## 불변 경계 (RFC Boundaries)

- RFC-0020 결정론적 addressing: None-reason(주소 없음)은 여전히 아무것도 받지 않음 — semantic wake 금지 경계 유지
- wake debounce(`board_reactive_wakeup_allowed`)는 wake만 가드 — delivery는 큐 identity dedup이 담당
- `Keeper_event_queue` dedup/persist 의미론 재사용, 재설계 없음

## 테스트

- select 계약 pin 3종 재작성: explicit short-circuit이 가린 followup은 **deferred**(폐기 아님) / cap overflow는 reason 보존한 채 deferred / None-reason은 deferred에도 없음
- 큐 적재/dedup/persist는 기존 test_keeper_event_queue pin이 커버 (glue는 pinned 프리미티브 2개의 조합)

## 검증

- 3파일 parse-check 통과 (빌드는 CI)
- select 소비자 전수: lib/test에서 이 두 파일+테스트뿐

RFC: RFC-0334 (docs/rfc/RFC-0334-board-mailbox-turn-digest.md) W1. W2(턴 시작 전체 드레인→Board_digest)·W3(addressee index)는 후속 슬라이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
