### PR TITLE
fix(exec): scan pipeline capabilities for gh approvals

### DIFF
--- a/lib/exec/approval_policy.ml
+++ b/lib/exec/approval_policy.ml
@@ -347,16 +347,35 @@ let ask_of policy ~caps ~bin : Verdict.t =
    floored or Ask-graded; [Allowed] verbs fall through to the overlay), so this
    layer only ADDS an approval requirement, never removes one. Non-gh commands
    are unaffected. *)
-let gh_verb_of_simple (simple : Shell_ir.simple) : Gh_verb.t option =
-  match Exec_program.known simple.Shell_ir.bin with
+let gh_verb_of_program bin args : Gh_verb.t option =
+  match Exec_program.known bin with
   | Some Exec_program.Gh ->
     let words =
-      Exec_program.to_string simple.Shell_ir.bin
-      :: List.map repo_hosting_arg_word simple.Shell_ir.args
+      Exec_program.to_string bin
+      :: List.map repo_hosting_arg_word args
     in
     Some (Gh_verb.classify words)
   | Some _ | None -> None
 [@@warning "-4"]
+
+let cap_requires_gh_approval cap =
+  let requires_approval v =
+    Gh_capability_policy.disposition_of v
+    = Gh_capability_policy.Requires_approval
+  in
+  let rec scan = function
+    | Capability.Exec_program (bin, args) ->
+      (match gh_verb_of_program bin args with
+       | Some v -> requires_approval v
+       | None -> false)
+    | Capability.Pipeline_fold caps -> List.exists scan caps
+    | Capability.Read_path _ | Capability.Write_path _ | Capability.Git _
+    | Capability.Env_set _ ->
+      false
+  in
+  scan cap
+
+let caps_require_gh_approval caps = List.exists cap_requires_gh_approval caps
 
 let trust_dispatch ~trust_level ~caps ~policy ~bin ~simple : Verdict.t =
   match trust_level with
@@ -377,15 +396,11 @@ let decide (policy : t)
   | Some reason ->
     (* Trust-independent: denied regardless of [overlay] (RFC-0254 §5.3). *)
     Verdict.Deny { caps; reason }
-  | None when
-      (match gh_verb_of_simple simple with
-       | Some v ->
-         Gh_capability_policy.disposition_of v
-         = Gh_capability_policy.Requires_approval
-       | None -> false) ->
+  | None when caps_require_gh_approval caps ->
     (* RFC-0309 W3: a gh verb the capability axis marks [Requires_approval] is
-       escalated to [Ask] regardless of overlay. Additive only — reached solely
-       for gh, and only to REQUIRE approval the risk grading would not. *)
+       escalated to [Ask] regardless of overlay. Scan the full capability tree
+       rather than only the representative command so non-final pipeline stages
+       cannot bypass this additive approval requirement. *)
     ask_of policy ~caps ~bin:simple.bin
   | None ->
     (* Non-catastrophic: graded by the per-actor trust overlay.  Under the

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -489,6 +489,24 @@ let test_gh_durable_remote_asks_under_autonomous () =
     ; "gh frobnicate (unknown -> Requires_approval)", [ "frobnicate"; "now" ]
     ]
 
+let test_gh_durable_remote_pipeline_stage_asks_under_autonomous () =
+  let gh =
+    simple (bin_ok "gh") ~args:[ lit "repo"; lit "edit"; lit "--description"; lit "d" ]
+  in
+  let cat = simple (bin_ok "cat") in
+  let caps =
+    Capability_check.of_ir
+      (Shell_ir.Pipeline [ Shell_ir.Simple gh; Shell_ir.Simple cat ])
+  in
+  match
+    Approval_policy.decide default_policy ~overlay:Approval_config.autonomous
+      ~caps ~simple:cat
+  with
+  | Verdict.Ask _ -> ()
+  | _ ->
+    Alcotest.fail
+      "durable-remote gh op in a non-final pipeline stage must Ask under autonomous"
+
 (* #23362 keeps discussion mutations and repo create/fork at R2, so the
    capability disposition is [Denied] and they take the floor Deny path, NOT
    the W3 Ask path. Pinned here so W4/G-9 (R2 -> R1) produces a visible delta:
@@ -652,6 +670,7 @@ let () =
   test_gh_leading_dynamic_flag_destructive_floored_under_autonomous ();
   test_gh_leading_flag_read_not_floored_under_autonomous ();
   test_gh_durable_remote_asks_under_autonomous ();
+  test_gh_durable_remote_pipeline_stage_asks_under_autonomous ();
   test_gh_r2_durable_remote_denies_pending_w4 ();
   test_gh_reads_and_local_still_allowed_under_autonomous ();
   test_non_gh_unaffected_by_capability_layer ();


### PR DESCRIPTION
### Motivation
- Close an approval bypass where `gh` verbs requiring human approval could be executed without approval when they appeared in non-final pipeline stages because only the last `simple` stage was inspected.

### Description
- Replace the single-stage classification with a capability-tree scan by adding `cap_requires_gh_approval` and `caps_require_gh_approval` to `lib/exec/approval_policy.ml` and using them in `Approval_policy.decide` so any `Requires_approval` `gh` capability anywhere in the IR yields `Ask`.
- Factor `gh` classification into `gh_verb_of_program` to reuse classification for capabilities that carry `(bin,args)` pairs.
- Add a regression test `test_gh_durable_remote_pipeline_stage_asks_under_autonomous` in `lib/exec/test/test_approval_policy.ml` that constructs a pipeline `gh repo edit | cat` and asserts the pipeline still produces an `Ask` under the `autonomous` overlay.

### Testing
- Added a unit test exercising `gh` in a non-final pipeline stage (`test_gh_durable_remote_pipeline_stage_asks_under_autonomous`) which is included in the approval policy test runner.;
- Attempted to run `dune runtest lib/exec/test/test_approval_policy.exe --no-buffer` but the `dune` tool is not available in this environment so the test binary could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c4ca078608333ad111d77845bb9ce)