### PR TITLE
fix(build): main compile red — sw mli label type + unerasable optional + redundant arm

### DIFF
--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -103,7 +103,7 @@ val review :
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
   ?operator_override:bool ->
-  ?sw:Eio.Switch.t option ->
+  ?sw:Eio.Switch.t ->
   review_request -> review_result
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,9 +108,8 @@ let decide
       ~authority
       ~notes
       ~reason
-      ?system_gate_exempt
+      ~system_gate_exempt
   =
-  let system_gate_exempt = Option.value system_gate_exempt ~default:false in
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on
      [verification_enabled] so a disabled verification FSM cannot deadlock

--- a/lib/workspace/workspace_task_lifecycle.mli
+++ b/lib/workspace/workspace_task_lifecycle.mli
@@ -58,7 +58,7 @@ val decide
   -> authority:Masc_domain.completion_authority
   -> notes:string
   -> reason:string
-  -> ?system_gate_exempt:bool
+  -> system_gate_exempt:bool
   -> (decision, invalid) result
 
 (** Enumerate the [task_action]s that [decide] would accept for the given

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -1436,7 +1436,6 @@ let test_task_claim_next_action_todo_policy_block_still_claims () =
     check bool "claimable" true (Masc_domain.task_claim_next_action_is_claimable t)
   | Masc_domain.Skip_claim (Masc_domain.Claim_block_not_todo _) ->
     fail "todo task should not be classified as not-todo"
-  | _ -> fail "todo task should not be unclaimable"
 
 (* ============================================================
    Test Runners


### PR DESCRIPTION
## 요약 (main compile red 수리 — 공유 문제 선점 선언)

main(cd83bac156)은 #23817 → #23819 → #23824 → #23826 → #23831 다섯 번의 수리 후에도 컴파일 red입니다. main CI run들이 큐에 적체된 상태(add8948fa0 이후 전부 queued/in_progress)에서 수정 PR들이 CI 판정 없이 연속 머지되며 남은 break 3건입니다. masc 서버 broadcast 불가(빈 응답)라 본 PR 본문으로 선점을 선언합니다.

## Break 1 — `anti_rationalization.mli` ml/mli 라벨 타입 불일치

OCaml에서 두 표기는 다른 의미입니다:
- `.ml`의 `?(sw : Eio.Switch.t option)` — 주석은 내부 패턴(option-wrapped)에 붙으므로 라벨 타입은 `?sw:Eio.Switch.t`
- `.mli`의 `?sw:Eio.Switch.t option` — 라벨 타입 자체가 `Switch.t option` (내부는 `option option`)

#23831이 ml/mli를 "둘 다 option"으로 맞췄지만 표기 의미가 달라 implementation-vs-interface 불일치가 남았습니다. 수정: mli를 `?sw:Eio.Switch.t ->`로. 유일한 spelled-out 참조는 이 mli 한 줄이며(`git grep 'sw:Eio.Switch.t option'`), caller(tool_task_handlers.ml:244/251의 `match ctx.sw` 분기)는 라벨 타입 `Switch.t` 기준이라 변경 없음.

## Break 2 — `decide`의 trailing optional → warning 16

`decide`는 positional 인자가 0개라 마지막 `?system_gate_exempt`는 erasure 불가 → warning 16 → `-warn-error +a`에서 에러. 격리 재현:

```
let decide ~a ~b ?c = ... 
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
```

caller census: 전 호출처 5곳(workspace_task_transitions.ml:171, workspace_task_lifecycle.ml:303, test_workspace_task_lifecycle.ml ×3)이 이미 `~system_gate_exempt:false`를 명시적으로 전달합니다. optional이 아무에게도 쓰이지 않으므로 required로 환원 — caller 변경 0, `Option.value` 기본값 라인 제거.

## Break 3 — `test_types_coverage.ml` redundant `| _` arm → warning 11

`task_claim_next_action` = `Claim_now | Skip_claim of task_claim_block`이고 `task_claim_block`은 G-10(#23731) 이후 `Claim_block_not_todo` 단일 생성자입니다. 선행 두 arm으로 exhaustive하므로 #23824가 추가한 `| _ ->` arm은 unused → warning 11 → 에러. 격리 재현:

```
let f = function X -> 1 | Y (B _) -> 2 | _ -> 3
Error (warning 11 [redundant-case]): this match case is unused.
```

arm 제거. 새 skip 사유 variant가 추가되면 exhaustive match가 컴파일 타임에 이 pin의 갱신을 강제합니다(catch-all 금지 원칙과 일치).

## 검증

- 4파일 `ocamlc -stop-after parsing` 통과 (전체 빌드는 CI 위임 — repo 규칙)
- warning 11/16 및 `?(x : t)` 패턴 의미는 각각 격리 미니 파일로 ocamlc 5.4.1 실증
- caller census는 `git grep` 전수 (위 인용)

RFC-WAIVED: main compile-red 수리, 시그니처 정합성 복원만 수행 (동작 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
