### PR TITLE
Fix task lifecycle/rationalization optional label drift

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -716,7 +716,7 @@ let review
       ?(on_verdict : (review_result -> unit) option)
       ?(few_shot_block = "")
       ?(operator_override : bool = false)
-      ?(sw : Eio.Switch.t option)
+      ?(sw : Eio.Switch.t option = None)
       (req : review_request)
   : review_result
   =

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -240,19 +240,19 @@ let review_completion_notes
       let few_shot_block = (Atomic.get get_few_shot_block_fn) () in
       let ar_result =
         (match ctx.sw with
-         | None ->
-           Anti_rationalization.review
-             ?evaluator_runtime
-             ?completion_contract
-             ~required_evidence
-             ~verify_gate_evidence
-             ~on_verdict ~few_shot_block ~operator_override ar_req
-         | Some sw ->
-           Anti_rationalization.review
-             ~sw
-             ?evaluator_runtime
-             ?completion_contract
-             ~required_evidence
+	         | None ->
+	           Anti_rationalization.review
+	             ?evaluator_runtime
+	             ?completion_contract
+	             ~required_evidence
+	             ~verify_gate_evidence
+	             ~on_verdict ~few_shot_block ~operator_override ar_req
+	         | Some sw ->
+	           Anti_rationalization.review
+	             ~sw:(Some sw)
+	             ?evaluator_runtime
+	             ?completion_contract
+	             ~required_evidence
              ~verify_gate_evidence
              ~on_verdict ~few_shot_block ~operator_override ar_req)
       in

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -108,9 +108,8 @@ let decide
       ~authority
       ~notes
       ~reason
-      ?system_gate_exempt
+      ?(system_gate_exempt = false)
   =
-  let system_gate_exempt = Option.value system_gate_exempt ~default:false in
   (* RFC-0323 W1 / RFC-0308: a verification-required task cannot reach Done
      through Done_action — submit -> approve is the completion lane. Gated on
      [verification_enabled] so a disabled verification FSM cannot deadlock


### PR DESCRIPTION
This addresses remaining compile mismatches for optional labels after cleanup.

- Make `anti_rationalization.review` expose `?sw:Eio.Switch.t option` with explicit default.
- Pass `~sw:(Some sw)` from task handler when switch exists.
- Align workspace `decide` `system_gate_exempt` API with optional label and remove redundant Option fallback.
