### PR TITLE
feat(keeper): turn-keyed board digest — retire 2s arrival window (RFC-0334 W2)

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -305,7 +305,7 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
   let batch_len = List.length batch in
   if batch_len > 1 then
     Log.Keeper.info
-      "debounce: coalesced %d board signals (keeper=%s)"
+      "turn digest: coalesced %d board signals into one turn (keeper=%s)"
       batch_len
       meta_after_triage.name;
   List.filter_map
@@ -325,9 +325,11 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
 ;;
 
 let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
-  (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus
-     per turn. Board signals are coalesced by the default debounce
-     window in {!Keeper_event_queue.drain_board_window} (2 s). *)
+  (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus per
+     turn, where the board unit is the turn digest: every queued board
+     signal is consumed as one batch ({!Keeper_event_queue.drain_board_all},
+     RFC-0334 W2 — arrival-window batching is retired), and the non-board
+     fallback below stays a single stimulus. *)
   let board_batch =
     Keeper_registry_event_queue.drain_board
       ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -175,13 +175,13 @@ let dequeue ~base_path name =
     loop ()
 ;;
 
-let drain_board ?window_sec ~base_path name =
+let drain_board ~base_path name =
   match Keeper_registry.get ~base_path name with
   | None -> []
   | Some entry ->
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
-      let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
+      let board, rest = Keeper_event_queue.drain_board_all cur in
       Keeper_event_queue_persistence.record_inflight ~base_path ~keeper_name:name board;
       if Atomic.compare_and_set entry.event_queue cur rest
       then (

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -47,8 +47,9 @@ val drop_by_post_id :
     when durable removal fails so callers do not clear recovery state while a
     replayable stimulus remains on disk. *)
 
-(** Drain stimuli intended for board reactivity. [window_sec] caps the
-    age of stimuli returned to the caller. *)
+(** Drain every queued board-signal stimulus for the keeper (RFC-0334 W2:
+    turn-keyed digest — one turn consumes everything queued since the
+    keeper's last turn, however it arrived). *)
 val drain_board :
-  ?window_sec:float -> base_path:string -> string
+  base_path:string -> string
   -> Keeper_event_queue.stimulus list

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -391,12 +391,10 @@ let is_board_signal = function
   | Goal_stagnation _ ->
     false
 
-let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
-  let now = Unix.gettimeofday () in
-  let is_board_in_window s =
-    is_board_signal s.payload && Float.abs (now -. s.arrived_at) <= window_sec
+let drain_board_all (queue : t) : stimulus list * t =
+  let board, rest =
+    List.partition (fun s -> is_board_signal s.payload) (to_list queue)
   in
-  let board, rest = List.partition is_board_in_window (to_list queue) in
   (to_list (sort_by_urgency (of_list board)), of_list rest)
 
 let summary (queue : t) : string =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -9,9 +9,9 @@
     This module is data only. The enqueue side is wired:
     [keeper_keepalive_signal.ml] calls [Keeper_registry_event_queue.enqueue]
     before the wakeup flag flips (RFC-0020 Rule 1). On the dequeue side,
-    [keeper_heartbeat_loop.ml] drains the board-signal batch within the
-    debounce window via [Keeper_registry_event_queue.drain_board] (a CAS loop
-    over [drain_board_window]) and falls back to a single non-board
+    [keeper_heartbeat_loop.ml] drains every queued board signal at turn
+    start via [Keeper_registry_event_queue.drain_board] (a CAS loop
+    over [drain_board_all], RFC-0334 W2) and falls back to a single non-board
     [dequeue_event] when that batch is empty — either path pins the
     [Conservation] invariant. [run_smart_heartbeat_gate] then snapshots
     the queue and forces [Emit] when it is non-empty (pinning
@@ -362,12 +362,14 @@ val urgency_of_string : string -> (urgency, string) result
 val is_board_signal : stimulus_payload -> bool
 (** [true] iff the payload is a [Board_signal]. *)
 
-val drain_board_window : ?window_sec:float -> t -> stimulus list * t
-(** [drain_board_window q] separates board-signal stimuli that arrived
-    within [window_sec] seconds (default [2.0]) of now from the rest of
-    the queue.  Board signals are urgency-sorted; non-board stimuli and
-    board signals outside the window remain in the returned queue in
-    their original order. *)
+val drain_board_all : t -> stimulus list * t
+(** [drain_board_all q] separates every board-signal stimulus from the
+    rest of the queue, regardless of arrival time (RFC-0334 W2: the turn
+    is the batching unit, not an arrival window — identity dedup at
+    enqueue already bounds the batch).  Board signals are urgency-sorted
+    (explicit mentions enqueue as [Immediate], so they surface first);
+    non-board stimuli remain in the returned queue in their original
+    order. *)
 
 val stimulus_to_yojson : stimulus -> Yojson.Safe.t
 (** Stable JSON representation used by MASC-owned durable queue snapshots. *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -488,7 +488,11 @@ let () =
   assert (String.equal stim.post_id "p1");
   assert (length q = 1);
 
-  (* --- drain_board_window: coalesces board signals within window --- *)
+  (* --- drain_board_all: turn-keyed digest drains every board signal
+     regardless of arrival time (RFC-0334 W2). [old_board] arrived far
+     outside the retired 2 s window — under the old arrival-keyed drain
+     it starved in the queue and cost one extra wake→turn cycle; the
+     turn digest consumes it with the rest. *)
   let now = Unix.gettimeofday () in
   let recent_board_1 =
     { post_id = "rb1"; urgency = Normal; arrived_at = now; payload = board_payload () }
@@ -507,15 +511,20 @@ let () =
   let q_drain = enqueue q_drain old_board in
   let q_drain = enqueue q_drain bootstrap_in_queue in
   let q_drain = enqueue q_drain recent_board_2 in
-  let board_in_window, rest_queue = drain_board_window ~window_sec:5.0 q_drain in
-  assert (List.length board_in_window = 2);
-  (match board_in_window with
-   | first :: _ -> assert (String.equal first.post_id "rb2") (* urgency-sorted: Immediate first *)
-   | [] -> Alcotest.fail "expected at least one board signal in window");
-  assert (length rest_queue = 2);
+  let board_digest, rest_queue = drain_board_all q_drain in
+  assert (List.length board_digest = 3);
+  (match board_digest with
+   | first :: _ ->
+     (* Explicit mentions enqueue as [Immediate], so they lead the digest. *)
+     assert (String.equal first.post_id "rb2")
+   | [] -> Alcotest.fail "expected board signals in digest");
+  assert (
+    List.exists (fun s -> String.equal s.post_id "ob1") board_digest);
+  (* Non-board stimuli are not part of the board digest. *)
+  assert (length rest_queue = 1);
 
-  (* --- drain_board_window: empty queue --- *)
-  let empty_board, empty_rest = drain_board_window empty in
+  (* --- drain_board_all: empty queue --- *)
+  let empty_board, empty_rest = drain_board_all empty in
   assert (List.length empty_board = 0);
   assert (is_empty empty_rest);
 
@@ -917,6 +926,52 @@ let () =
       assert (String.equal replayed.post_id "p1");
       Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name [ replayed ];
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- registry drain_board: turn digest consumes every queued board
+     signal in one call, however spread their arrival times (RFC-0334 W2
+     pin: 5 signals spread over >2 s while the keeper was busy → one
+     drain, mention-urgency first; the non-board stimulus stays queued
+     for the single-dequeue lane). --- *)
+  let base_path = temp_dir "keeper-event-queue-turn-digest" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-turn-digest-test" in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-turn-digest-test" in
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      let digest_now = Unix.gettimeofday () in
+      let board_at ~post_id ~urgency arrived_at =
+        { post_id; urgency; arrived_at; payload = board_payload () }
+      in
+      List.iter
+        (Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name)
+        [ board_at ~post_id:"dg1" ~urgency:Normal 0.0
+        ; board_at ~post_id:"dg2" ~urgency:Normal (digest_now -. 600.0)
+        ; board_at ~post_id:"dg3" ~urgency:Immediate (digest_now -. 90.0)
+        ; board_at ~post_id:"dg4" ~urgency:Normal (digest_now -. 3.0)
+        ; board_at ~post_id:"dg5" ~urgency:Normal digest_now
+        ; { post_id = "dg-bootstrap"
+          ; urgency = Normal
+          ; arrived_at = digest_now
+          ; payload = Bootstrap
+          }
+        ];
+      let digest = Masc.Keeper_registry_event_queue.drain_board ~base_path keeper_name in
+      assert (List.length digest = 5);
+      (match digest with
+       | first :: _ -> assert (String.equal first.post_id "dg3")
+       | [] -> Alcotest.fail "turn digest should not be empty");
+      (* Second drain finds no board signals; the bootstrap stimulus is
+         still queued for the non-board single-dequeue lane. *)
+      assert (
+        List.length (Masc.Keeper_registry_event_queue.drain_board ~base_path keeper_name)
+        = 0);
+      (match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+       | Some stim -> assert (String.equal stim.post_id "dg-bootstrap")
+       | None -> Alcotest.fail "bootstrap stimulus should remain after board drain"));
 
   (* --- registry unavailable window: enqueue persists before register --- *)
   let base_path = temp_dir "keeper-event-queue-unregistered" in


### PR DESCRIPTION
## 요약 — RFC-0334 W2: 턴 단위 board digest (arrival-window 폐기)

W1(#23825, merged)이 publish 경로의 유실을 없앴다면, W2는 **소비 경로의 단위를 시간 창에서 턴으로** 바꿉니다.

## 문제 (RFC-0334 §문제 2)

`drain_board_window`는 `|now - arrived_at| <= 2s`인 board 신호만 드레인합니다. 90초 턴 동안 신호 5개가 쌓인 keeper가 턴에 복귀하면:
- 5개 전부 2초 창 밖 → board batch = `[]`
- batch-empty 경로의 단일 `dequeue`(턴당 1개)로만 소진 → **신호 5개 = wake→turn 사이클 5회**

기존 테스트 pin이 이 굶주림을 그대로 문서화하고 있었습니다(`old_board`(arrived_at=0.0)가 `rest_queue`에 잔류하는 것을 assert).

## 변경

- `Keeper_event_queue.drain_board_window ?window_sec` → **`drain_board_all`** — payload 종류로만 분할, 시간 조건 제거. window 파라미터는 타입에서 소멸(컴파일러가 "window-parameter reads = 0" exit criterion을 강제).
- `Keeper_registry_event_queue.drain_board`에서 `?window_sec` 제거 (CAS 루프는 그대로).
- intake(`heartbeat_event_intake`)는 코드 변경 없음 — 이미 batch 전체를 한 턴의 `pending_board_events`로 소비. RFC-0020 §3 Rule 4 주석을 "board 단위 = 턴 digest"로 갱신.
- "explicit mentions surfaced first"는 신규 코드 0줄: enqueue 시 `Explicit_mention → Immediate`(keeper_keepalive_signal.ml)이고 `drain_board_all`이 stable urgency-sort를 유지하므로 구조적으로 이미 성립 — pin으로 고정만 했습니다.

## 테스트 (RFC W2 pins)

- 큐 레벨: arrival 0.0/과거/현재가 섞인 board 3개 + Bootstrap 1개 → digest 3개 전부(Immediate 선두), rest에는 non-board만.
- registry 레벨(신규): **5개 board 신호를 >2s 간격으로 spread + Bootstrap 1개 → `drain_board` 1회가 5개 전부 반환**(Immediate 선두), 2회차 drain = 0개, Bootstrap은 single-dequeue lane에 잔존. identity-dedup pin은 변경 없음(post_id 구분).

## 검증

- 6파일 `ocamlc -stop-after parsing` 통과 (전체 빌드/테스트는 CI 위임 — repo 규칙)
- `drain_board` 소비처 전수: `keeper_heartbeat_stimulus_intake.ml` 단일 (rg census)
- workaround-gate self-check: 시간 창 휴리스틱을 구조적 단위(턴)로 대체하는 방향 — RFC-0334 §W2가 명시한 제거 대상이며, cap/cooldown 추가가 아니라 제거입니다.

## 참고

- base가 main compile-red 상태일 수 있습니다 — 수리는 #23832 (sw mli 표기 + warning 16 + warning 11). 머지 후 branch update 예정.
- W3(addressee index)는 후속 슬라이스.

RFC: docs/rfc/RFC-0334-board-mailbox-turn-digest.md §W2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
