### PR TITLE
fix(build): review_completion_notes operator_override required — last main compile break

### DIFF
--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -195,7 +195,7 @@ let owner_transition_action_denylist (ctx : context) =
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_runtime : string option)
-    ?(operator_override : bool = false)
+    ~(operator_override : bool)
     ~(ctx : context)
     ~(task_opt : Masc_domain.task option)
     ~(task_id : string)

--- a/lib/task/tool_task_handlers.mli
+++ b/lib/task/tool_task_handlers.mli
@@ -67,7 +67,7 @@ val owner_transition_action_denylist : context -> string list
 val review_completion_notes :
   completion_contract:string list option ->
   evaluator_runtime:string option ->
-  ?operator_override:bool ->
+  operator_override:bool ->
   ctx:context ->
   task_opt:Masc_domain.task option ->
   task_id:string ->


### PR DESCRIPTION
## 요약 — main 마지막 compile break: `review_completion_notes`의 unerasable optional

#23832의 4번째 수정이었으나, 커밋 push(10:18)가 squash 머지(10:17:35, head 558c9870e0)와 경합해 **머지된 브랜치에 orphan**됐습니다 (masc#5303과 동일 패턴). 새 PR로 재상륙합니다. diff는 orphan 커밋 90017c9483의 cherry-pick 그대로입니다.

## Break

`lib/task/tool_task_handlers.ml:198`의 `?(operator_override : bool = false)` — warning 16 → `-warn-error +a` 에러.

**규칙**: optional 인자의 erasure는 **positional 인자 적용 시에만** 발생합니다. labeled 인자는 erasure를 만들지 않으므로, `?operator_override` 뒤가 전부 labeled인 이 함수는 위치와 무관하게 unerasable입니다. (대비: 같은 churn 계열의 `Anti_rationalization.review`는 뒤에 positional `req`가 있어 통과.)

#23832 머지 전 Lint 로그의 distinct error 집합 = 이 1건뿐이었으므로, 이 PR이 main green의 마지막 조각입니다:

```
File "lib/task/tool_task_handlers.ml", line 198, characters 6-23:
Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
```

## 수정

required `~operator_override:bool`로 환원 (ml + mli). caller census: 유일한 호출처 `lib/task/tool_task.ml:421`이 이미 `~operator_override:force`를 명시 전달 — **caller 변경 0**. 내부에서 `Anti_rationalization.review`의 `?operator_override:bool`로 forwarding하는 것도 그대로 유효합니다.

## 검증

- 2파일 `ocamlc -stop-after parsing` 통과 (전체 빌드는 CI 위임 — repo 규칙)
- orphan 브랜치의 push-run(90017c9483)에서 유일 실패 = branch-protection-watchdog (알려진 enforce_admins drift 노이즈) — 실제 게이트 실패 없음

RFC-WAIVED: main compile-red 수리, 시그니처 정합성 복원만 수행 (동작 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
