### PR TITLE
Fix operator_override arity for review_completion_notes

### DIFF
--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -195,7 +195,7 @@ let owner_transition_action_denylist (ctx : context) =
 let review_completion_notes
     ~(completion_contract : string list option)
     ~(evaluator_runtime : string option)
-    ?(operator_override : bool = false)
+    ~(operator_override : bool)
     ~(ctx : context)
     ~(task_opt : Masc_domain.task option)
     ~(task_id : string)

--- a/lib/task/tool_task_handlers.mli
+++ b/lib/task/tool_task_handlers.mli
@@ -67,7 +67,7 @@ val owner_transition_action_denylist : context -> string list
 val review_completion_notes :
   completion_contract:string list option ->
   evaluator_runtime:string option ->
-  ?operator_override:bool ->
+  operator_override:bool ->
   ctx:context ->
   task_opt:Masc_domain.task option ->
   task_id:string ->


### PR DESCRIPTION
## Summary
- Make Tool_task_handlers.review_completion_notes' `operator_override` a required boolean.
- Align `.mli` and `.ml` signatures so there is no optional-arg mismatch.

## Verification
- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build lib/task/tool_task_handlers.ml` passes.

## Notes
- Full `dune build .` currently fails in this environment due missing optional external deps (`opentelemetry.client`, `piaf`), unrelated to this change.
