### PR TITLE
feat(workspace): RFC-0323 G-5 Phase-B default-on verification flip

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -301,6 +301,16 @@ module Verification = struct
   let fsm_enabled () =
     Feature_flag_registry.get_bool "MASC_VERIFICATION_FSM_ENABLED"
 
+  (** RFC-0323 G-5 Phase B default-on flip. Default: false (SSOT:
+      [Feature_flag_registry.all_flags]). When true, the done guard treats
+      every task as verification-required (completion routes through
+      submit→approve). The evidence gate is unaffected — it reads
+      [Masc_domain.task_requires_verification] (= contract.strict) directly,
+      so only the done guard flips. Flip only when readiness gate §5 holds:
+      solo-room flip-on starves (no timer backstop, RFC-0220 §5/§11). *)
+  let default_on () =
+    Feature_flag_registry.get_bool "MASC_VERIFICATION_DEFAULT_ON"
+
   (** Maximum time a task may remain AwaitingVerification before surfacing an
       operator-visible timeout. Default: 24h. *)
   let timeout_deadline_seconds () =

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -223,6 +223,17 @@ let all_flags : flag list = [
     default = true; category = "runtime";
     lifecycle = Active; since = "0.9.3" };
 
+  (* RFC-0323 G-5 Phase B: route all task completion through submit→approve
+     (verification-required) regardless of contract.strict. Default off —
+     flip only when the readiness gate §5 holds (≥2 distinct verifier
+     identities per submitting room, else solo-room starvation with no timer
+     backstop, RFC-0220 §5/§11). Only the done guard flips; the evidence
+     gate stays on contract.strict (Phase A scope). *)
+  { env_name = "MASC_VERIFICATION_DEFAULT_ON";
+    description = "RFC-0323 G-5 Phase B: verification-required by default (submit→approve)";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "0.20.0" };
+
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -157,7 +157,16 @@ let transition_task_outcome_r
           match
             Workspace_task_lifecycle.decide
               ~verification_enabled:(Env_config_runtime.Verification.fsm_enabled ())
-              ~requires_verification:(Masc_domain.task_requires_verification task)
+              (* RFC-0323 G-5 Phase B: when [Verification.default_on] is set,
+                 treat every task as verification-required so completion
+                 routes through submit→approve. The evidence gate above
+                 reads [task_requires_verification] (= contract.strict)
+                 directly and is intentionally NOT flipped here — keeping
+                 it on Phase-A scope avoids the #23719 G-2 regression
+                 (unannounced Phase B). Default off (readiness gate §5). *)
+              ~requires_verification:
+                (Masc_domain.task_requires_verification task
+                 || Env_config_runtime.Verification.default_on ())
               ~verification_timeout_seconds:
                 (Env_config_runtime.Verification.timeout_deadline_seconds ())
               ~new_verification_id:(fun () -> Random_id.prefixed ~prefix:"vrf-" ~bytes:16)


### PR DESCRIPTION
## RFC-0323 G-5 — Phase-B default-on verification flip (매트릭스 종착지)

매트릭스 11개 goal 중 마지막. G-0..G-4, G-6..G-10 이미 main에 land. 이 PR이 flip core.

### 결정 (RFC-0323 §0)
> "승인-반려 스텝을 안 거친 것은 Done이 되면 안 된다."

Phase-A는 `contract.strict` opt-in만 verification-required. Phase-B flip은 **default-on**: 모든 태스크의 완료가 submit→approve lane을 거친다.

### Flip core (3 파일, +31/-1)
1. `feature_flag_registry.ml`: `MASC_VERIFICATION_DEFAULT_ON` (default **false**, runtime).
2. `env_config_runtime.ml`: `Verification.default_on ()` reader.
3. `workspace_task_transitions.ml` (decide caller): `requires_verification:(task_requires_verification task || Verification.default_on ())`.

### Blast radius 검증 (회귀 없음 — adversarial workflow wf_8a81e2fd-8fe, 5 agent/463k tokens)
- **evidence gate(`transitions.ml:103/117`)는 자동 분리**: decide 파라미터가 아니라 직접 `task_requires_verification`(= contract.strict)을 호출 → flip 영향 없음. 이게 #23719 G-2 회귀(unannounced Phase B)를 구조적으로 차단.
- **`valid_next_actions` production caller 0** → flip 영향 없음.
- **decide caller가 유일 flip site**.

### Readiness gate §5 (flip 전제조건)
default **off**. flip on은 운영자가 gate 충족 시:
- gate1: `MASC_VERIFICATION_FSM_ENABLED` default=true (충족).
- gate2: room마다 approve 가능 별도 identity ≥2 (구조적 anti-starvation). **solo-room flip-on = 영구 starvation + wake-livelock** (timer backstop은 RFC-0220 §5/§11로 제거됨).
- gate3: cross-store join 무결성 (actionable verification record).

starvation 완화는 timer가 아니라 gate2 구조적 보장에 맡김 (RFC-0323 §5 gate6).

### 상태
- **테스트**: `default_on env → non-strict task done routes to submit_for_verification` 통합 테스트는 main이 compile green 수렴 후 추가 예정 (현재 main이 active exec-policy push로 compile-red 상태 — G-4/G-6과 동일하게 CI는 main red를 상속).
- decide 레벨 증명(`requires_verification=true → Verification_required_use_submit`)은 G-1 `test_strict_task_done_routes_to_submit`이 이미 커버.

### 메모
main green 수렴 후 통합 테스트 + Ready 전환 예정.

Co-Authored-By: Claude <noreply@anthropic.com>
