### PR TITLE
fix(slack): observe deferred-reply delivery and surface token-missing skip

### DIFF
--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -249,7 +249,8 @@ let send_message ~token ~channel ~content =
 
 let add_block acc block = block :: acc
 
-let adapter_loop ~token ~channel ~events ?base_url () =
+let adapter_loop ~token ~channel ~events ?base_url
+    ?(on_send_result = fun _ -> ()) () =
   let rec loop ~acc_text ~acc_blocks ~run_id_opt =
     match Keeper_chat_events.subscribe events with
     | Text_delta text ->
@@ -262,14 +263,12 @@ let adapter_loop ~token ~channel ~events ?base_url () =
             ~event_blocks:(List.rev acc_blocks)
         in
         if String.length acc_text > 0 || List.length blocks > 0 then
-          ignore
-            (send_message_with_blocks ~token ~channel ~content:acc_text ~blocks
-              : (unit, error) result);
+          on_send_result
+            (send_message_with_blocks ~token ~channel ~content:acc_text ~blocks);
         ()
     | Event_error { message } ->
-        ignore
-          (send_message ~token ~channel ~content:("Keeper error: " ^ message)
-            : (unit, error) result);
+        on_send_result
+          (send_message ~token ~channel ~content:("Keeper error: " ^ message));
         ()
     | Run_started { run_id; thread_id = _ } ->
         loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:(Some run_id)
@@ -290,12 +289,11 @@ let adapter_loop ~token ~channel ~events ?base_url () =
     | Oas_media_delta _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Oas_stream_protocol_error error ->
-        ignore
+        on_send_result
           (send_message ~token ~channel
              ~content:
                ("Keeper stream protocol: "
-                ^ Keeper_chat_events.stream_protocol_error_summary error)
-            : (unit, error) result);
+                ^ Keeper_chat_events.stream_protocol_error_summary error));
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Tool_call_start _ | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -40,11 +40,12 @@ val adapter_loop :
   channel:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   ?base_url:string ->
+  ?on_send_result:((unit, error) result -> unit) ->
   unit ->
   unit
-(** [adapter_loop ~token ~channel ~events ?base_url ()] blocks on the event
-    stream until [Run_finished] or [Error], then sends the accumulated
-    text (or error message) to the given Slack channel.
+(** [adapter_loop ~token ~channel ~events ?base_url ?on_send_result ()]
+    blocks on the event stream until [Run_finished] or [Error], then sends
+    the accumulated text (or error message) to the given Slack channel.
 
     Rich events ([Link_block], [Image_block], [Audio_block],
     [Tool_context_block]) are rendered as Slack Block Kit sections and
@@ -54,6 +55,11 @@ val adapter_loop :
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.
+
+    [on_send_result] is invoked once per outbound attempt with the send
+    outcome, so callers (e.g. the connector gateway) can record delivery
+    observability without this adapter depending on any metric sink. It
+    defaults to a no-op to preserve existing behavior.
 
     The loop exits after one turn. *)
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1107,12 +1107,20 @@ let start_keeper_loops
                              keeper_name (Printexc.to_string exn))
                          (fun () ->
                            Keeper_chat_slack.adapter_loop ~token
-                             ~channel ~events ())
+                             ~channel ~events
+                             ~on_send_result:(fun result ->
+                               Slack_observability.record_reply
+                                 (match result with
+                                  | Ok () -> Slack_observability.Reply_send_ok
+                                  | Error _ ->
+                                      Slack_observability.Reply_send_failed))
+                             ())
                    | None ->
-                       Log.Keeper.warn
+                       Log.Keeper.error
                          "keeper_chat_consumer: \
-                          SLACK_BOT_TOKEN not set, \
-                          skipping Slack delivery for keeper=%s"
+                          SLACK_BOT_TOKEN not set; \
+                          Slack delivery skipped for keeper=%s \
+                          (queued reply will not be delivered)"
                          keeper_name));
              (* RFC-connector-deferred-reply-via-chat-queue §3.4: connector sources (Discord/Slack) had their user
                 line recorded at the gate inbound boundary before the message was


### PR DESCRIPTION
## Summary
- The deferred/queued Slack delivery path (`Keeper_chat_consumer` → `Keeper_chat_slack.adapter_loop`) discarded send outcomes with `ignore`, so failures were only logged at `warn` and never counted in `masc_slack_outbound_replies_total`. The streaming path already records both ok/failed.
- A missing `SLACK_BOT_TOKEN` at drain time was only a quiet `warn`, although the queued reply cannot be delivered without a token.

## Changes
- `Keeper_chat_slack.adapter_loop` gains optional `?on_send_result` (default no-op); the three send sites hand the `(unit, error) result` to it instead of `ignore`.
- `Keeper_chat_consumer` injects `Slack_observability.record_reply`, mapping `Ok () → Reply_send_ok` and `Error _ → Reply_send_failed`, so the deferred path is metered like the streaming path without `keeper` depending on any metric sink (weak coupling preserved).
- Token-missing skip at drain is now `Log.Keeper.error` with an explicit "will not be delivered" message.

## Out of scope
- Discord has the same `ignore` / token-missing-skip patterns; left untouched (separate follow-up).
- `slack_observability.ml/.mli` not modified (another in-progress branch is editing them).

Refs RFC-0317.