### PR TITLE
fix(config): expose Verification.default_on in mli (G-5 #23839 main-red regression)

### DIFF
--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -149,6 +149,10 @@ end
 
 module Verification : sig
   val fsm_enabled : unit -> bool
+  (** RFC-0323 G-5 Phase B default-on flip. Default: false. When true, the
+      done guard treats every task as verification-required. Flip only when
+      readiness gate S5 holds (identity>=2 anti-starvation). *)
+  val default_on : unit -> bool
   val timeout_deadline_seconds : unit -> float
 end
 


### PR DESCRIPTION
## fix: G-5 flip main-red 회귀 — Verification.default_on mli 노출

#23839 (RFC-0323 G-5 Phase-B flip)이 main red 회귀 도입:
`workspace_task_transitions.ml:169` — **Unbound value `Env_config_runtime.Verification.default_on`**.

### 원인
.ml에 `default_on`을 추가했으나 .mli에 노출 안 함 → OCaml이 hidden → 외부에서 unbound.

### fix
`env_config_runtime.mli`의 Verification 모듈에 `val default_on : unit -> bool` 노출. .ml 정의와 decide-caller flip은 불변, 순수 mli export 1줄(+주석).

### 자기 비판
G-5 flip을 main compile-red 상태에서 작성하고 compile 검증 없이 머지해 mli 노출 누락을 놓침 (메모리 "로컬 빌드 false-green"). flip의 blast radius는 검증했으나 mli 일치는 확인 안 한 대가. 이 fix로 회귀 복원.

### 메모
- 이 PR은 G-5 flip 회귀(default_on)만 fix. main의 나머지 red(`tool_task_handlers.ml:198` warning 16, exec-policy 연쇄)는 별개.
- CI는 main red를 상속하지만 이 PR의 hunk(default_on mli)는 해당 에러를 resolve.

Co-Authored-By: Claude <noreply@anthropic.com>
