### PR TITLE
fix: remove keeper task-state path-block circuit breaker

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -279,11 +279,6 @@ let resolve_keeper_target_path
   let raw = String.trim raw_path in
   if raw = ""
   then Error Path_required
-  else if is_masc_internal_state_path raw
-  then (
-    let rej = Task_state_file_path_blocked { raw } in
-    rejection_to_telemetry rej;
-    Error rej)
   else (
     let root = project_root_of_config config in
     let candidate = if Filename.is_relative raw then Filename.concat root raw else raw in
@@ -300,11 +295,6 @@ let resolve_keeper_target_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
-    else if is_masc_internal_state_norm ~root_norm ~target_norm
-    then (
-      let rej = Task_state_file_path_blocked { raw } in
-      rejection_to_telemetry rej;
-      Error rej)
     else if allowed_paths = []
     then Ok candidate
     else (
@@ -413,14 +403,6 @@ let resolve_keeper_read_path
     let rej = Absolute_path_rejected { raw } in
     rejection_to_telemetry rej;
     Error rej)
-  else if is_masc_internal_state_path raw
-  then (
-    (* Block direct access to .masc/ internal state files.
-       Keepers should use keeper_tasks_list / keeper_context_status
-       instead of probing .masc/backlog.json, .masc/tasks/, etc. *)
-    let rej = Task_state_file_path_blocked { raw } in
-    rejection_to_telemetry rej;
-    Error rej)
   else (
     let root = project_root_of_config config in
     let candidate = Filename.concat root raw in
@@ -437,11 +419,6 @@ let resolve_keeper_read_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
-    else if is_masc_internal_state_norm ~root_norm ~target_norm
-    then (
-      let rej = Task_state_file_path_blocked { raw } in
-      rejection_to_telemetry rej;
-      Error rej)
     else (
       let allowed_norms =
         if allowed_paths = []

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -734,10 +734,6 @@ let resolve_projected_allowed_path
   in
   if not within_root
   then user_message_error (Keeper_alerting_path.Outside_project_root { raw = raw_for_error })
-  else if Keeper_alerting_path.is_masc_internal_state_norm ~root_norm ~target_norm
-  then
-    user_message_error
-      (Keeper_alerting_path.Task_state_file_path_blocked { raw = raw_for_error })
   else (
     let allowed_norms =
       if allowed_paths = []

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -144,24 +144,26 @@ let test_visible_mind_read_resolves_to_private_storage () =
   | Error e -> Alcotest.fail ("visible mind path should resolve: " ^ e)
 ;;
 
-let test_direct_private_storage_read_stays_blocked () =
+let test_direct_private_storage_read_now_allowed () =
   setup
   @@ fun ~config ~meta ~playground:_ ->
   let private_raw =
     Masc.Keeper_sandbox.allowed_root_rel_of_meta ~meta ^ "mind/README.md"
   in
+  let private_target = Filename.concat config.Workspace.base_path private_raw in
+  write_file private_target "private readme\n";
   match
     Keeper_tool_shared_runtime.resolve_keeper_read_path
       ~config
       ~meta
       ~raw_path:private_raw
   with
-  | Ok path -> Alcotest.fail ("direct private storage path should be blocked: " ^ path)
-  | Error e ->
-    Alcotest.(check bool)
-      "task state/private path blocked"
-      true
-      (String.starts_with ~prefix:"task_state_file_path_blocked:" e)
+  | Ok path ->
+    Alcotest.(check string)
+      "direct private storage path should resolve"
+      private_target
+      path
+  | Error e -> Alcotest.fail ("direct private storage path should resolve: " ^ e)
 ;;
 
 let test_read_with_visible_repo_cwd_and_relative_file_path () =
@@ -258,9 +260,9 @@ let () =
             `Quick
             test_visible_mind_read_resolves_to_private_storage
         ; Alcotest.test_case
-            "direct private storage read stays blocked"
+            "direct private storage read resolves"
             `Quick
-            test_direct_private_storage_read_stays_blocked
+            test_direct_private_storage_read_now_allowed
         ] )
     ; ( "file_tools"
       , [ Alcotest.test_case


### PR DESCRIPTION
Removes task-state path blocking checks from keeper path resolvers and updates the visible-path projection regression test that expected private-read blocking.