### PR TITLE
feat(keeper): RFC-0323 G-5 gate 3 cross-store join audit

### DIFF
--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -48,6 +48,34 @@ let task_has_actionable_verification actionable_request_ids
   | Masc_domain.Cancelled _ -> false
 ;;
 
+(** RFC-0323 G-5 readiness gate 3 audit: AwaitingVerification tasks whose
+    [verification_id] has no actionable verification-store record. Such a task
+    will never wake — the wake join ([actionable_verification_request_ids])
+    requires the record, so an orphan starves silently (no wake signal, no
+    timer backstop per RFC-0220). This is the inverse of
+    [task_has_actionable_verification]: it lists the violations rather than
+    counting healthy ones, so a default-on flip (G-5) can detect store-record
+    loss before it becomes invisible starvation. *)
+let audit_tasks_without_actionable_verification_ids
+    (actionable_request_ids : string list) (tasks : Masc_domain.task list)
+    : (string * string) list =
+  List.filter_map
+    (fun (task : Masc_domain.task) ->
+      match task.task_status with
+      | Masc_domain.AwaitingVerification { verification_id; _ } ->
+        if List.exists (String.equal verification_id) actionable_request_ids
+        then None
+        else Some (task.id, verification_id)
+      | _ -> None)
+    tasks
+;;
+
+let audit_tasks_without_actionable_verification ~config
+    (tasks : Masc_domain.task list) : (string * string) list =
+  audit_tasks_without_actionable_verification_ids
+    (actionable_verification_request_ids ~config) tasks
+;;
+
 (** Read workspace backlog counts. *)
 let read_backlog_counts ~(config : Workspace.config) ~(meta : keeper_meta)
   : int * int * int * int * bool

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -14,6 +14,24 @@ val read_backlog_counts
   -> meta:keeper_meta
   -> int * int * int * int * bool
 
+val audit_tasks_without_actionable_verification_ids
+  :  string list
+  -> Masc_domain.task list
+  -> (string * string) list
+(** RFC-0323 G-5 readiness gate 3 (pure core): list AwaitingVerification tasks
+    whose [verification_id] is absent from the given actionable request-id list.
+    Each entry is (task_id, verification_id). An orphan never wakes — the wake
+    join requires the record — so it is a silent starvation source under the
+    default-on flip. Pure so tests can drive it without a verification store. *)
+
+val audit_tasks_without_actionable_verification
+  :  config:Workspace.config
+  -> Masc_domain.task list
+  -> (string * string) list
+(** [audit_tasks_without_actionable_verification_ids] backed by the live
+    verification store ([actionable_verification_request_ids]). For runtime
+    diagnostics. *)
+
 val read_current_task
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_verification_audit
   test_keeper_connector_attention_wake
   test_keeper_no_signal_silence
   test_keeper_failed_task_not_proactive_driver
@@ -397,6 +398,7 @@
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate
+  test_keeper_verification_audit
   test_keeper_connector_attention_wake
   test_keeper_no_signal_silence
   test_keeper_failed_task_not_proactive_driver

--- a/test/test_keeper_verification_audit.ml
+++ b/test/test_keeper_verification_audit.ml
@@ -1,0 +1,67 @@
+(** RFC-0323 G-5 readiness gate 3 audit — unit tests for the pure core.
+
+    [audit_tasks_without_actionable_verification_ids] is the inverse of the
+    wake join: it lists AwaitingVerification tasks whose verification_id has no
+    actionable verification-store record. Such orphans never wake (the join
+    requires the record) and starve silently under the G-5 default-on flip. *)
+
+open Alcotest
+
+module Inputs = Masc.Keeper_world_observation_inputs
+module D = Masc_domain
+
+let mk_awaiting ~id ~vid : D.task =
+  { D.id
+  ; title = "t"
+  ; description = ""
+  ; task_status =
+      D.AwaitingVerification
+        { assignee = "alice"
+        ; submitted_at = "2026-07-09T00:00:00Z"
+        ; verification_id = vid
+        ; phase = D.Awaiting_verifier
+        }
+  ; priority = 1
+  ; files = []
+  ; created_at = "2026-07-09T00:00:00Z"
+  ; created_by = None
+  ; predecessor_task_id = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+;;
+
+let test_audit_lists_only_orphans () =
+  let with_record = mk_awaiting ~id:"t1" ~vid:"v1" in
+  let orphan = mk_awaiting ~id:"t2" ~vid:"v2" in
+  let todo = { with_record with D.id = "t3"; D.task_status = D.Todo } in
+  let orphans =
+    Inputs.audit_tasks_without_actionable_verification_ids
+      [ "v1" ]
+      [ with_record; orphan; todo ]
+  in
+  check (list (pair string string)) "orphans only" [ "t2", "v2" ] orphans
+;;
+
+let test_audit_empty_when_all_have_records () =
+  let t1 = mk_awaiting ~id:"t1" ~vid:"v1" in
+  let t2 = mk_awaiting ~id:"t2" ~vid:"v2" in
+  let orphans =
+    Inputs.audit_tasks_without_actionable_verification_ids [ "v1"; "v2" ] [ t1; t2 ]
+  in
+  check (list (pair string string)) "no orphans" [] orphans
+;;
+
+let () =
+  run "keeper verification audit (RFC-0323 G-5 gate 3)"
+    [ "audit"
+      , [ "lists awaiting tasks without an actionable store record", `Quick
+          , test_audit_lists_only_orphans
+        ; "empty when every awaiting task has a record", `Quick
+          , test_audit_empty_when_all_have_records
+        ]
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0323 G-5 readiness **gate 3** cross-store join audit. G-5 Phase B (#23839) flipped verification to default-on behind `MASC_VERIFICATION_DEFAULT_ON`; gate 3 ("zero AwaitingVerification tasks without an actionable verification-store record") is the structural starvation backstop, but it currently reads "0 awaiting = vacuously true" and has **no observable violation detector**.

This adds the detector:
- `audit_tasks_without_actionable_verification_ids` (pure core) — list AwaitingVerification tasks whose `verification_id` is absent from the given actionable request-id list. An orphan never wakes (the wake join requires the record) and starves silently.
- `audit_tasks_without_actionable_verification` (config wrapper) — reads the live store for runtime diagnostics.

## Why

gate 2 (≥2 approve-capable identities per room) is an operational precondition; gate 3 is code-enforceable. Without this audit, a lost verification-store record under the default-on flip produces invisible starvation (no wake signal, no timer backstop per RFC-0220). Making the violation observable is the first step to closing gate 3.

## Changes

- `lib/keeper/keeper_world_observation_inputs.{ml,mli}`: two new audit fns — the inverse of the existing `task_has_actionable_verification` wake join.
- `test/test_keeper_verification_audit.ml` + `test/dune`: 2 unit tests (orphan-only, all-have-records). The pure core is driven directly, so no store fixture is needed.

## Verification

- `dune build lib/keeper/` green
- `test_keeper_verification_audit`: 2 tests pass (0.000s)

## Out of scope (follow-ups)

- Wiring the config wrapper into a runtime diagnostic/telemetry sink (keeper boot or dashboard) — follow-up once a sink is chosen.
- gate 2 is operational (room provisioning), not addressed here.

Co-Authored-By: Claude <noreply@anthropic.com>