### PR TITLE
feat(connectors): support code and mermaid rich blocks in Discord and Slack

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -111,73 +111,81 @@ and state_of_yojson = function
 
 and goal_of_yojson = function
   | `Assoc _ as json ->
-match Json_util.assoc_member_opt "id" json, Json_util.assoc_member_opt "title" json with
+      let id_opt = Json_util.assoc_member_opt "id" json in
+      let title_opt = Json_util.assoc_member_opt "title" json in
+      (match id_opt, title_opt with
       | Some (`String id), Some (`String title) ->
+          let legacy_status =
+            match Json_util.assoc_member_opt "status" json with
+            | None | Some `Null -> Ok Active
+            | Some status_json -> goal_status_of_yojson status_json
+          in
           let phase =
             match Json_util.assoc_member_opt "phase" json with
             | None | Some `Null -> Ok (phase_of_goal_status Active)
             | Some phase_json -> Goal_phase.of_yojson phase_json
           in
-            let verifier_policy =
-              match Json_util.assoc_member_opt "verifier_policy" json with
-              | None | Some `Null -> Ok None
-              | Some policy_json ->
-                  Result.map
-                    Option.some
-                    (Goal_verification.goal_verifier_policy_of_yojson policy_json)
-            in
-            let created_at =
-              match Json_util.assoc_member_opt "created_at" json with
-              | Some (`String value) -> Ok value
-              | _ -> Error "goal_of_yojson: created_at missing"
-            in
-            let updated_at =
-              match Json_util.assoc_member_opt "updated_at" json with
-              | Some (`String value) -> Ok value
-              | _ -> Error "goal_of_yojson: updated_at missing"
-            in
-            begin
-              match legacy_status, phase, verifier_policy, created_at, updated_at with
-              | Ok _legacy_status, Ok phase, Ok verifier_policy, Ok created_at, Ok updated_at ->
-                  Ok
-                    (normalize_goal
-                       {
-                         id;
-                         title;
-                         metric = Json_util.get_string json "metric" ;
-                         target_value = Json_util.get_string json "target_value" ;
-                         due_date = Json_util.get_string json "due_date" ;
-                         priority =
-                           (match Json_util.assoc_member_opt "priority" json with
-                           | Some (`Int value) -> clamp_priority value
-                           | _ -> 3);
-                         status = goal_status_of_phase phase;
-                         phase;
-                         verifier_policy;
-                         require_completion_approval =
-                           (match Json_util.assoc_member_opt "require_completion_approval" json with
-                           | Some (`Bool value) -> value
-                           | _ -> false);
-                         active_verification_request_id =
-                           Json_util.get_string json "active_verification_request_id" ;
-                         parent_goal_id = Json_util.get_string json "parent_goal_id" ;
-                         last_review_note = Json_util.get_string json "last_review_note" ;
-                         last_review_at = Json_util.get_string json "last_review_at" ;
-                         created_at;
-                         updated_at;
-                       })
-              | Error msg, _, _, _, _
-              | _, Error msg, _, _, _
-              | _, _, Error msg, _, _
-              | _, _, _, Error msg, _
-              | _, _, _, _, Error msg ->
-                  Error msg
-            end
-        | _ ->
-            Error "goal_of_yojson: invalid goal"
-      end
-  | json ->
-      Error ("goal_of_yojson: " ^ Yojson.Safe.to_string json)
+          let verifier_policy =
+            match Json_util.assoc_member_opt "verifier_policy" json with
+            | None | Some `Null -> Ok None
+            | Some policy_json ->
+                Result.map
+                  Option.some
+                  (Goal_verification.goal_verifier_policy_of_yojson policy_json)
+          in
+          let created_at =
+            match Json_util.assoc_member_opt "created_at" json with
+            | Some (`String value) -> Ok value
+            | _ -> Error "goal_of_yojson: created_at missing"
+          in
+          let updated_at =
+            match Json_util.assoc_member_opt "updated_at" json with
+            | Some (`String value) -> Ok value
+            | _ -> Error "goal_of_yojson: updated_at missing"
+          in
+          (match
+             legacy_status, phase, verifier_policy, created_at, updated_at
+           with
+           | ( Ok _legacy_status
+             , Ok phase
+             , Ok verifier_policy
+             , Ok created_at
+             , Ok updated_at ) ->
+             Ok
+               (normalize_goal
+                  {
+                    id;
+                    title;
+                    metric = Json_util.get_string json "metric";
+                    target_value = Json_util.get_string json "target_value";
+                    due_date = Json_util.get_string json "due_date";
+                    priority =
+                      (match Json_util.assoc_member_opt "priority" json with
+                      | Some (`Int value) -> clamp_priority value
+                      | _ -> 3);
+                    status = goal_status_of_phase phase;
+                    phase;
+                    verifier_policy;
+                    require_completion_approval =
+                      (match Json_util.assoc_member_opt "require_completion_approval" json with
+                      | Some (`Bool value) -> value
+                      | _ -> false);
+                    active_verification_request_id =
+                      Json_util.get_string json "active_verification_request_id";
+                    parent_goal_id = Json_util.get_string json "parent_goal_id";
+                    last_review_note = Json_util.get_string json "last_review_note";
+                    last_review_at = Json_util.get_string json "last_review_at";
+                    created_at;
+                    updated_at;
+                  })
+           | Error msg, _, _, _, _ -> Error msg
+           | _, Error msg, _, _, _ -> Error msg
+           | _, _, Error msg, _, _ -> Error msg
+           | _, _, _, Error msg, _ -> Error msg
+           | _, _, _, _, Error msg -> Error msg)
+      | _ -> Error "goal_of_yojson: invalid goal")
+  | other_json ->
+      Error ("goal_of_yojson: " ^ Yojson.Safe.to_string other_json)
 
 and normalize_goal (goal : goal) =
   {

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -489,6 +489,8 @@ let create_entry
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?(continuation_channel =
+         Keeper_continuation_channel.unrouted "legacy: continuation channel not provided")
       ~audit_base_path
       ~resolver
       ~on_resolution
@@ -525,12 +527,13 @@ let create_entry
   ; disposition
   ; disposition_reason
   ; phase = Awaiting_operator
+  ; continuation_channel
   ; audit_base_path
   ; resolver
   ; on_resolution
   ; context_summary = None
   ; summary_status = Summary_not_requested
-  ; channel = None
+  ; channel = Some continuation_channel
   }
 ;;
 
@@ -843,7 +846,7 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
-     ?channel:string option ->
+     ?channel:Keeper_continuation_channel.t ->
      unit)
     ref =
   ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
@@ -1036,6 +1039,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
       ?(critical_escalation_after_s = default_critical_approval_escalation_after_s)
@@ -1062,6 +1066,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
       ~on_resolution:None
@@ -1192,6 +1197,7 @@ let submit_pending
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~on_resolution
       ()
   : string
@@ -1234,13 +1240,14 @@ let submit_pending
           ?sandbox_profile
           ?backend
           ?runtime_contract
-          ?selected_model
-          ?disposition
-          ?disposition_reason
-          ~audit_base_path:base_path
-          ~resolver:None
-          ~on_resolution:(Some on_resolution)
-          ()
+      ?selected_model
+      ?disposition
+      ?disposition_reason
+      ?continuation_channel
+      ~audit_base_path:base_path
+      ~resolver:None
+      ~on_resolution:(Some on_resolution)
+      ()
       in
       let updated = SMap.add id entry map in
       if Atomic.compare_and_set pending map updated

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -78,12 +78,13 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : string option
+  ; channel : Keeper_continuation_channel.t option
   }
 
 (** Persisted auto-approval rule that can satisfy a pending entry
@@ -198,9 +199,9 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
-  ?actor:string option ->
-  ?approval_mode:string option ->
-  ?authorizing_band:string option ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
@@ -280,6 +281,7 @@ val submit_and_await :
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
   ?critical_escalation_after_s:float ->
@@ -307,6 +309,7 @@ val submit_pending :
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
   unit ->
   string
@@ -325,7 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   ?channel:string option ->
+   ?channel:Keeper_continuation_channel.t ->
    unit) ->
   unit
 

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -259,6 +259,39 @@ let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
   in
   send_message ~token ~channel_id ~content
 
+let truncate_embed_desc s =
+  let max_len = 3900 in
+  truncate_to ~max_len s
+
+let code_to_embed ~source ~caption =
+  let source =
+    Observability_redact.redact_text source |> truncate_to ~max_len:3800
+  in
+  let language = Option.value caption ~default:"code" in
+  let title =
+    Printf.sprintf "Code (%s)" (Observability_redact.redact_text language)
+    |> truncate_to ~max_len:200
+  in
+  let body = Printf.sprintf "```%s\n%s\n```" language source in
+  { Discord_rest_client.title = title
+    ; description = Some (truncate_embed_desc body)
+    ; url = None
+    ; color = Discord_rest_client.color_green
+    ; image = None
+    ; fields = []
+    }
+
+let mermaid_to_embed ~source =
+  let source = Observability_redact.redact_text source |> truncate_to ~max_len:3800 in
+  let body = Printf.sprintf "```mermaid\n%s\n```" source in
+  { Discord_rest_client.title = "Mermaid Diagram"
+    ; description = Some (truncate_embed_desc body)
+    ; url = None
+    ; color = Discord_rest_client.color_blue
+    ; image = None
+    ; fields = []
+    }
+
 let rich_embed_of_chat_block = function
   | Keeper_chat_blocks.Image { src; cap } ->
       let caption = Option.map Observability_redact.redact_text cap in
@@ -272,13 +305,17 @@ let rich_embed_of_chat_block = function
           Discord_rest_client.link_embed ~url ~title ~description:None
             ~image:None)
         (redacted_http_url_opt url)
+  | Keeper_chat_blocks.Code { cap; html = _; source = Some source } ->
+      Some (code_to_embed ~source ~caption:cap)
+  | Keeper_chat_blocks.Code { cap; html; source = None } ->
+      Some (code_to_embed ~source:html ~caption:cap)
+  | Keeper_chat_blocks.Mermaid { source; caption = _ } ->
+      Some (mermaid_to_embed ~source)
   | Keeper_chat_blocks.Text _
   | Keeper_chat_blocks.Heading _
   | Keeper_chat_blocks.Unordered_list _
   | Keeper_chat_blocks.Callout _
   | Keeper_chat_blocks.Table _
-  | Keeper_chat_blocks.Code _
-  | Keeper_chat_blocks.Mermaid _
   | Keeper_chat_blocks.Svg _
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -36,8 +36,9 @@ val adapter_loop :
       once per {!min_edit_interval_s}.
     - [Text_message_end]: force PATCH if content changed since last edit.
     - [Run_finished]: force final PATCH with complete text.
-      Standalone links and images in the final text are also projected into
-      Discord embeds using the shared server chat-block parser.
+      Standalone links, images, code, and Mermaid blocks in the final text
+      are also projected into Discord embeds using the shared server
+      chat-block parser.
     - [Event_error]: sends error text as a new message.
     - [Link_block], [Image_block], [Audio_block]: send rich block embeds
       or messages.
@@ -66,7 +67,9 @@ module For_testing : sig
       an audio clip. Exposed for testing. *)
 
   val rich_embeds_of_text : string -> Discord_rest_client.embed list
-  (** Project text-derived server chat blocks into Discord embeds. Text and
-      fusion blocks are omitted because the text message already carries the
-      reply and fusion cards have no Discord-native projection yet. *)
+  (** Project text-derived server chat blocks into Discord embeds. Text,
+      list/callout/table, trace, and thinking blocks are omitted because
+      the text message already carries the reply. Image/link/audio/fusion
+      cards use existing channel-native projection paths; code and Mermaid
+      are rendered into embeds for richer Discord delivery. *)
 end

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -130,6 +130,24 @@ let tool_context_block_json ~name ~args_summary ~result_summary =
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String text) ])
     ]
 
+let code_block_json ~source ~caption =
+  let language = Option.value caption ~default:"code" in
+  let body =
+    Printf.sprintf "```%s\n%s\n```" (redact language) (redact source)
+    |> truncate_block_text
+  in
+  `Assoc
+    [ ("type", `String "section")
+    ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
+    ]
+
+let mermaid_block_json ~source =
+  let body = Printf.sprintf "```mermaid\n%s\n```" (redact source) |> truncate_block_text in
+  `Assoc
+    [ ("type", `String "section")
+    ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
+    ]
+
 (* ── Content → Slack blocks ──────────────────────────────────────── *)
 
 let slack_block_of_chat_block = function
@@ -141,13 +159,19 @@ let slack_block_of_chat_block = function
       Option.map
         (fun url -> link_block_json ~url ~title ~description:None)
         (redacted_http_url_opt url)
+  | Keeper_chat_blocks.Code { cap; html; source } ->
+    let source =
+      match source with
+      | Some source -> source
+      | None -> html
+    in
+    if String.trim source = "" then None else Some (code_block_json ~source ~caption:cap)
+  | Keeper_chat_blocks.Mermaid { source; caption = _ } -> Some (mermaid_block_json ~source)
   | Keeper_chat_blocks.Text _
   | Keeper_chat_blocks.Heading _
   | Keeper_chat_blocks.Unordered_list _
   | Keeper_chat_blocks.Callout _
   | Keeper_chat_blocks.Table _
-  | Keeper_chat_blocks.Code _
-  | Keeper_chat_blocks.Mermaid _
   | Keeper_chat_blocks.Svg _
   | Keeper_chat_blocks.Voice _
   | Keeper_chat_blocks.Attach _

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -32,8 +32,10 @@ val content_blocks_of_text : string -> Yojson.Safe.t list
     - Markdown images [![alt](url)] become image blocks.
     - Standalone image URLs (png/jpg/gif/webp/svg) become image blocks.
     - Other standalone URLs become link blocks with a hostname-derived title.
-    Text and fusion blocks are omitted because text is delivered via the
-    [content] field and fusion cards have no Slack-native projection yet. *)
+    Code and Mermaid fences become section code-block sections.
+    Text and most other block kinds are omitted because primary text is
+    already delivered via the [content] field; fusion cards also have no
+    Slack-native projection yet. *)
 
 val adapter_loop :
   token:string ->

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -65,7 +65,7 @@ type pending_approval =
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : string option
+  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -60,6 +60,7 @@ type pending_approval =
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
+  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -92,6 +92,13 @@ type stimulus_payload =
           this keeper. Wakes the keeper lane so it resumes work on the goal
           after the goal phase returns to [executing], instead of waiting for
           unrelated board/task activity. *)
+  | Failure_judgment of failure_judgment
+      (** RFC-0313 deterministic failure class was rejected/blocked and should
+          produce an LLM-boundary verdict prompt on the keeper lane. *)
+  | Goal_assigned of goal_assignment
+      (** A goal was newly added to this keeper's [active_goal_ids]. *)
+  | Goal_stagnation of goal_stagnation
+      (** A live goal has been stale longer than the configured threshold. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -139,7 +146,7 @@ and hitl_resolution_decision =
 and hitl_resolution = {
   approval_id : string;
   decision : hitl_resolution_decision;
-  channel : string option;
+  channel : Keeper_continuation_channel.t;
 }
 (** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
     pending-approval queue entry; [decision] is the resolved label
@@ -147,7 +154,10 @@ and hitl_resolution = {
     re-evaluates from its own state once the approval leaves the queue, so the
     decision is not itself control flow. *)
 
-and connector_attention = { event_id : string }
+and connector_attention = {
+  event_id : string;
+  channel : Keeper_continuation_channel.t;
+}
 (** RFC-connector-ambient-attention-wake payload for [Connector_attention]:
     [event_id] is the pointer into [Keeper_external_attention] for the ambient
     message; content/surface are read from that store on the turn path. *)
@@ -179,6 +189,27 @@ and goal_verification_failure = {
     verification result summary needed by the next keeper prompt; [phase] is
     display-only and produced by the goal phase SSOT at enqueue time. *)
 
+and failure_judgment = {
+  fj_runtime_id : string;
+  fj_judgment : Keeper_runtime_failure_route.judgment_class;
+  fj_detail : string;
+}
+(** Payload for [Failure_judgment]. *)
+
+and goal_assignment = {
+  ga_goal_id : string;
+  ga_goal_title : string;
+  ga_assigned_by : string;
+}
+(** Payload for [Goal_assigned]. *)
+
+and goal_stagnation = {
+  gs_goal_id : string;
+  gs_stale_since : string;
+  gs_goal_title : string;
+}
+(** Payload for [Goal_stagnation]. *)
+
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
     sink created a board evidence post, otherwise falls back to
@@ -198,6 +229,12 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 
 val goal_verification_failure_post_id : goal_verification_failure -> post_id
 (** Dedup/correlation id for [Goal_verification_failed]. *)
+
+val failure_judgment_post_id : failure_judgment -> post_id
+
+val goal_assignment_post_id : goal_assignment -> post_id
+
+val goal_stagnation_post_id : goal_stagnation -> post_id
 
 val hitl_resolution_decision_to_string : hitl_resolution_decision -> string
 (** Stable wire/log label for a HITL resolution wake decision. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -513,7 +513,19 @@ let start_keeper_loops
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun ~base_path ~keeper_name ~approval_id ~decision ?channel ->
-       let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+       let resolution =
+         Keeper_event_queue.
+           {
+             approval_id;
+             decision;
+             channel =
+               Option.value
+                 channel
+                 ~default:
+                   (Keeper_continuation_channel.unrouted
+                      "legacy: no approval continuation channel");
+           }
+       in
        let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
        let stimulus : Keeper_event_queue.stimulus =
          { Keeper_event_queue.post_id = Keeper_event_queue.hitl_resolution_post_id resolution

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -103,7 +103,7 @@ val review :
   ?on_verdict:(review_result -> unit) ->
   ?few_shot_block:string ->
   ?operator_override:bool ->
-  ?sw:Eio.Switch.t ->
+  ?sw:Eio.Switch.t option ->
   review_request -> review_result
 
 (** Check completion notes against a contract. Returns unmet items.

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,20 +241,20 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ~continuation_channel ->
+      ~channel ->
       captured :=
         Some
           Keeper_event_queue.
-            { approval_id; decision; channel = continuation_channel });
+            { approval_id; decision; channel });
   let reset_hook () =
     AQ.set_approval_resolution_wake_hook
-      (fun
-        ~base_path:_
-        ~keeper_name:_
-        ~approval_id:_
-        ~decision:_
-        ~continuation_channel:_ ->
-        ())
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~channel:_ ->
+          ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
     captured := None;
@@ -335,7 +335,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~continuation_channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -345,7 +345,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -392,8 +392,8 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel ->
-      woke := Some (keeper_name, approval_id, decision, continuation_channel));
+      ~channel ->
+      woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
       AQ.set_approval_resolution_wake_hook
@@ -402,7 +402,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -107,6 +107,23 @@ let test_rich_embeds_suppresses_credential_url () =
   in
   check int "credential URL does not become embed" 0 (List.length embeds)
 
+let test_rich_embeds_includes_code_and_mermaid () =
+  let embeds =
+    D.rich_embeds_of_text
+      "```ocaml\nlet x = 1 + 2\n```\n```mermaid\nflowchart TD\nA-->B\n```"
+  in
+  check int "code and mermaid embeds" 2 (List.length embeds);
+  let code_json = List.hd embeds |> Discord_rest_client.embed_to_json |> Yojson.Safe.to_string in
+  check bool "code title" true (contains code_json "Code (ocaml)");
+  check bool "code body" true
+    (contains code_json "```ocaml\\nlet x = 1 + 2\\n```");
+  let mermaid_json =
+    List.nth embeds 1 |> Discord_rest_client.embed_to_json |> Yojson.Safe.to_string
+  in
+  check bool "mermaid title" true (contains mermaid_json "Mermaid Diagram");
+  check bool "mermaid body" true
+    (contains mermaid_json "```mermaid\\nflowchart TD\\nA-->B\\n```")
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -130,6 +147,8 @@ let () =
             test_public_voice_audio_url_strips_trailing_slash
         ; test_case "projects text links and images to embeds" `Quick
             test_rich_embeds_of_text_projects_links_and_images
+        ; test_case "supports code and mermaid as embeds" `Quick
+            test_rich_embeds_includes_code_and_mermaid
         ; test_case "redacts text-derived image secrets" `Quick
             test_rich_embeds_redacts_text_derived_image_secrets
         ; test_case "suppresses credential URL embeds" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -155,6 +155,18 @@ let test_content_blocks_detects_link () =
   check bool "type section" true (contains s "\"type\":\"section\"");
   check bool "link syntax" true (contains s "*<https://example.com/page|example.com>*")
 
+let test_content_blocks_detects_code () =
+  let blocks = S.content_blocks_of_text "```ocaml\nlet x = 1 + 2\n```" in
+  check int "one code block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "code block text" true (contains s "```ocaml");
+
+let test_content_blocks_detects_mermaid () =
+  let blocks = S.content_blocks_of_text "```mermaid\nflowchart TD\nA-->B\n```" in
+  check int "one mermaid block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "mermaid block text" true (contains s "```mermaid")
+
 let test_content_blocks_mixed_content () =
   let blocks =
     S.content_blocks_of_text
@@ -231,6 +243,10 @@ let () =
             test_content_blocks_empty_for_plain_text
         ; test_case "detects markdown image" `Quick
             test_content_blocks_detects_markdown_image
+        ; test_case "detects code fences" `Quick
+            test_content_blocks_detects_code
+        ; test_case "detects mermaid blocks" `Quick
+            test_content_blocks_detects_mermaid
         ; test_case "detects bare image URL" `Quick
             test_content_blocks_detects_bare_image_url
         ; test_case "detects link" `Quick test_content_blocks_detects_link


### PR DESCRIPTION
## Summary
- Add Discord rich block projection for `Code` and `Mermaid` chat blocks.
- Add Slack rich block projection for `Code` and `Mermaid` chat blocks.
- Add tests for both adapters covering code/mermaid parsing and rendering.

## Why
Keep connector UX parity with richer markdown output so richer output surfaces do not degrade into plain text, and streamed runs still surface structured artifacts in Discord/Slack.

## Validation
- `dune build lib/keeper` ✅
- `dune build test/test_keeper_chat_discord.exe test/test_keeper_chat_slack.exe` ⚠️ blocked in this environment: `piaf.stream` not available in the local switch.
