### PR TITLE
task: normalize anti-rationalization optional args

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -713,17 +713,15 @@ let review
       ?(completion_contract : string list option)
       ?(required_evidence = [])
       ?(verify_gate_evidence = [])
-      ?(on_verdict : (review_result -> unit) option)
+      ?(on_verdict : review_result -> unit = fun _ -> ())
       ?(few_shot_block = "")
       ?(operator_override : bool = false)
-      ?(sw : Eio.Switch.t option)
+      ?(sw : Eio.Switch.t option = None)
       (req : review_request)
   : review_result
   =
   let emit result =
-    (match on_verdict with
-     | Some f -> f result
-     | None -> ());
+    on_verdict result;
     result
   in
 

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -239,22 +239,16 @@ let review_completion_notes
       in
       let few_shot_block = (Atomic.get get_few_shot_block_fn) () in
       let ar_result =
-        (match ctx.sw with
-         | None ->
-           Anti_rationalization.review
-             ?evaluator_runtime
-             ?completion_contract
-             ~required_evidence
-             ~verify_gate_evidence
-             ~on_verdict ~few_shot_block ~operator_override ar_req
-         | Some sw ->
-           Anti_rationalization.review
-             ~sw
-             ?evaluator_runtime
-             ?completion_contract
-             ~required_evidence
-             ~verify_gate_evidence
-             ~on_verdict ~few_shot_block ~operator_override ar_req)
+        Anti_rationalization.review
+          ?evaluator_runtime
+          ?completion_contract
+          ~required_evidence
+          ~verify_gate_evidence
+          ~on_verdict
+          ~few_shot_block
+          ~operator_override
+          ~sw:ctx.sw
+          ar_req
       in
       match ar_result.verdict with
       | Anti_rationalization.Reject reason -> Some reason


### PR DESCRIPTION
## Summary
- Normalize `Anti_rationalization.review` signature to match `anti_rationalization.mli`: keep `~sw` as `Eio.Switch.t option` with default `None`, and keep callback as `~on_verdict` (non-optional) with no-op default.
- Remove optionality mismatch for `~operator_override` by keeping it as non-optional in `tool_task_handlers` where mli expects it.
- Keep call sites aligned by passing `~sw:ctx.sw` directly from handler logic.

## Why
This resolves the signature-mismatch errors seen during `dune build` after conflict-rebase:
- optional-argument erasure warnings
- `.mli` / `.ml` interface compatibility errors in `anti_rationalization` and `tool_task_handlers`
- downstream call-site type mismatches using `sw` and operator override labels.
