### PR TITLE
fix(keeper): complete continuation-channel wake hook compile (w16 + audit arg order + consumer channel)

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -111,73 +111,81 @@ and state_of_yojson = function
 
 and goal_of_yojson = function
   | `Assoc _ as json ->
-match Json_util.assoc_member_opt "id" json, Json_util.assoc_member_opt "title" json with
+      let id_opt = Json_util.assoc_member_opt "id" json in
+      let title_opt = Json_util.assoc_member_opt "title" json in
+      (match id_opt, title_opt with
       | Some (`String id), Some (`String title) ->
+          let legacy_status =
+            match Json_util.assoc_member_opt "status" json with
+            | None | Some `Null -> Ok Active
+            | Some status_json -> goal_status_of_yojson status_json
+          in
           let phase =
             match Json_util.assoc_member_opt "phase" json with
             | None | Some `Null -> Ok (phase_of_goal_status Active)
             | Some phase_json -> Goal_phase.of_yojson phase_json
           in
-            let verifier_policy =
-              match Json_util.assoc_member_opt "verifier_policy" json with
-              | None | Some `Null -> Ok None
-              | Some policy_json ->
-                  Result.map
-                    Option.some
-                    (Goal_verification.goal_verifier_policy_of_yojson policy_json)
-            in
-            let created_at =
-              match Json_util.assoc_member_opt "created_at" json with
-              | Some (`String value) -> Ok value
-              | _ -> Error "goal_of_yojson: created_at missing"
-            in
-            let updated_at =
-              match Json_util.assoc_member_opt "updated_at" json with
-              | Some (`String value) -> Ok value
-              | _ -> Error "goal_of_yojson: updated_at missing"
-            in
-            begin
-              match legacy_status, phase, verifier_policy, created_at, updated_at with
-              | Ok _legacy_status, Ok phase, Ok verifier_policy, Ok created_at, Ok updated_at ->
-                  Ok
-                    (normalize_goal
-                       {
-                         id;
-                         title;
-                         metric = Json_util.get_string json "metric" ;
-                         target_value = Json_util.get_string json "target_value" ;
-                         due_date = Json_util.get_string json "due_date" ;
-                         priority =
-                           (match Json_util.assoc_member_opt "priority" json with
-                           | Some (`Int value) -> clamp_priority value
-                           | _ -> 3);
-                         status = goal_status_of_phase phase;
-                         phase;
-                         verifier_policy;
-                         require_completion_approval =
-                           (match Json_util.assoc_member_opt "require_completion_approval" json with
-                           | Some (`Bool value) -> value
-                           | _ -> false);
-                         active_verification_request_id =
-                           Json_util.get_string json "active_verification_request_id" ;
-                         parent_goal_id = Json_util.get_string json "parent_goal_id" ;
-                         last_review_note = Json_util.get_string json "last_review_note" ;
-                         last_review_at = Json_util.get_string json "last_review_at" ;
-                         created_at;
-                         updated_at;
-                       })
-              | Error msg, _, _, _, _
-              | _, Error msg, _, _, _
-              | _, _, Error msg, _, _
-              | _, _, _, Error msg, _
-              | _, _, _, _, Error msg ->
-                  Error msg
-            end
-        | _ ->
-            Error "goal_of_yojson: invalid goal"
-      end
-  | json ->
-      Error ("goal_of_yojson: " ^ Yojson.Safe.to_string json)
+          let verifier_policy =
+            match Json_util.assoc_member_opt "verifier_policy" json with
+            | None | Some `Null -> Ok None
+            | Some policy_json ->
+                Result.map
+                  Option.some
+                  (Goal_verification.goal_verifier_policy_of_yojson policy_json)
+          in
+          let created_at =
+            match Json_util.assoc_member_opt "created_at" json with
+            | Some (`String value) -> Ok value
+            | _ -> Error "goal_of_yojson: created_at missing"
+          in
+          let updated_at =
+            match Json_util.assoc_member_opt "updated_at" json with
+            | Some (`String value) -> Ok value
+            | _ -> Error "goal_of_yojson: updated_at missing"
+          in
+          (match
+             legacy_status, phase, verifier_policy, created_at, updated_at
+           with
+           | ( Ok _legacy_status
+             , Ok phase
+             , Ok verifier_policy
+             , Ok created_at
+             , Ok updated_at ) ->
+             Ok
+               (normalize_goal
+                  {
+                    id;
+                    title;
+                    metric = Json_util.get_string json "metric";
+                    target_value = Json_util.get_string json "target_value";
+                    due_date = Json_util.get_string json "due_date";
+                    priority =
+                      (match Json_util.assoc_member_opt "priority" json with
+                      | Some (`Int value) -> clamp_priority value
+                      | _ -> 3);
+                    status = goal_status_of_phase phase;
+                    phase;
+                    verifier_policy;
+                    require_completion_approval =
+                      (match Json_util.assoc_member_opt "require_completion_approval" json with
+                      | Some (`Bool value) -> value
+                      | _ -> false);
+                    active_verification_request_id =
+                      Json_util.get_string json "active_verification_request_id";
+                    parent_goal_id = Json_util.get_string json "parent_goal_id";
+                    last_review_note = Json_util.get_string json "last_review_note";
+                    last_review_at = Json_util.get_string json "last_review_at";
+                    created_at;
+                    updated_at;
+                  })
+           | Error msg, _, _, _, _ -> Error msg
+           | _, Error msg, _, _, _ -> Error msg
+           | _, _, Error msg, _, _ -> Error msg
+           | _, _, _, Error msg, _ -> Error msg
+           | _, _, _, _, Error msg -> Error msg)
+      | _ -> Error "goal_of_yojson: invalid goal")
+  | other_json ->
+      Error ("goal_of_yojson: " ^ Yojson.Safe.to_string other_json)
 
 and normalize_goal (goal : goal) =
   {

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -846,15 +846,15 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
-     ?channel:Keeper_continuation_channel.t ->
+     channel:Keeper_continuation_channel.t option ->
      unit)
     ref =
-  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
+  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
-let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision ?channel =
-  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ?channel with
+let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision ~channel =
+  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ~channel with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.warn
@@ -921,7 +921,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ~keeper_name:entry.keeper_name
     ~approval_id:entry.id
     ~decision:(hitl_resolution_decision_of_approval_decision decision)
-    ?channel:entry.channel;
+    ~channel:entry.channel;
   try
     Sse.broadcast
       (`Assoc
@@ -1516,7 +1516,7 @@ let expire_stale ~max_wait_s =
          ~keeper_name:entry.keeper_name
          ~approval_id:id
          ~decision:Keeper_event_queue.Hitl_rejected
-         ?channel:entry.channel;
+         ~channel:entry.channel;
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -489,6 +489,8 @@ let create_entry
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?(continuation_channel =
+         Keeper_continuation_channel.unrouted "legacy: continuation channel not provided")
       ~audit_base_path
       ~resolver
       ~on_resolution
@@ -525,12 +527,13 @@ let create_entry
   ; disposition
   ; disposition_reason
   ; phase = Awaiting_operator
+  ; continuation_channel
   ; audit_base_path
   ; resolver
   ; on_resolution
   ; context_summary = None
   ; summary_status = Summary_not_requested
-  ; channel = None
+  ; channel = Some continuation_channel
   }
 ;;
 
@@ -843,7 +846,7 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
-     ?channel:string option ->
+     ?channel:Keeper_continuation_channel.t ->
      unit)
     ref =
   ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
@@ -1036,6 +1039,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
       ?(critical_escalation_after_s = default_critical_approval_escalation_after_s)
@@ -1062,6 +1066,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
       ~on_resolution:None
@@ -1192,6 +1197,7 @@ let submit_pending
       ?selected_model
       ?disposition
       ?disposition_reason
+      ?continuation_channel
       ~on_resolution
       ()
   : string
@@ -1234,13 +1240,14 @@ let submit_pending
           ?sandbox_profile
           ?backend
           ?runtime_contract
-          ?selected_model
-          ?disposition
-          ?disposition_reason
-          ~audit_base_path:base_path
-          ~resolver:None
-          ~on_resolution:(Some on_resolution)
-          ()
+      ?selected_model
+      ?disposition
+      ?disposition_reason
+      ?continuation_channel
+      ~audit_base_path:base_path
+      ~resolver:None
+      ~on_resolution:(Some on_resolution)
+      ()
       in
       let updated = SMap.add id entry map in
       if Atomic.compare_and_set pending map updated

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -199,14 +199,14 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
-  ?actor:string ->
-  ?approval_mode:string ->
-  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
   ?rule_match:rule_match ->
   ?source_approval_id:string ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?auto_approved:bool ->
   ?decision:approval_audit_decision ->
   unit ->
@@ -328,7 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   ?channel:Keeper_continuation_channel.t ->
+   channel:Keeper_continuation_channel.t option ->
    unit) ->
   unit
 

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -78,12 +78,13 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : string option
+  ; channel : Keeper_continuation_channel.t option
   }
 
 (** Persisted auto-approval rule that can satisfy a pending entry
@@ -198,9 +199,9 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
-  ?actor:string option ->
-  ?approval_mode:string option ->
-  ?authorizing_band:string option ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
@@ -280,6 +281,7 @@ val submit_and_await :
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
   ?critical_escalation_after_s:float ->
@@ -307,6 +309,7 @@ val submit_pending :
   ?selected_model:string ->
   ?disposition:string ->
   ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
   on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
   unit ->
   string
@@ -325,7 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   ?channel:string option ->
+   ?channel:Keeper_continuation_channel.t ->
    unit) ->
   unit
 

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -65,7 +65,7 @@ type pending_approval =
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : string option
+  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -60,6 +60,7 @@ type pending_approval =
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
+  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -92,6 +92,13 @@ type stimulus_payload =
           this keeper. Wakes the keeper lane so it resumes work on the goal
           after the goal phase returns to [executing], instead of waiting for
           unrelated board/task activity. *)
+  | Failure_judgment of failure_judgment
+      (** RFC-0313 deterministic failure class was rejected/blocked and should
+          produce an LLM-boundary verdict prompt on the keeper lane. *)
+  | Goal_assigned of goal_assignment
+      (** A goal was newly added to this keeper's [active_goal_ids]. *)
+  | Goal_stagnation of goal_stagnation
+      (** A live goal has been stale longer than the configured threshold. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -139,7 +146,7 @@ and hitl_resolution_decision =
 and hitl_resolution = {
   approval_id : string;
   decision : hitl_resolution_decision;
-  channel : string option;
+  channel : Keeper_continuation_channel.t;
 }
 (** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
     pending-approval queue entry; [decision] is the resolved label
@@ -147,7 +154,10 @@ and hitl_resolution = {
     re-evaluates from its own state once the approval leaves the queue, so the
     decision is not itself control flow. *)
 
-and connector_attention = { event_id : string }
+and connector_attention = {
+  event_id : string;
+  channel : Keeper_continuation_channel.t;
+}
 (** RFC-connector-ambient-attention-wake payload for [Connector_attention]:
     [event_id] is the pointer into [Keeper_external_attention] for the ambient
     message; content/surface are read from that store on the turn path. *)
@@ -179,6 +189,27 @@ and goal_verification_failure = {
     verification result summary needed by the next keeper prompt; [phase] is
     display-only and produced by the goal phase SSOT at enqueue time. *)
 
+and failure_judgment = {
+  fj_runtime_id : string;
+  fj_judgment : Keeper_runtime_failure_route.judgment_class;
+  fj_detail : string;
+}
+(** Payload for [Failure_judgment]. *)
+
+and goal_assignment = {
+  ga_goal_id : string;
+  ga_goal_title : string;
+  ga_assigned_by : string;
+}
+(** Payload for [Goal_assigned]. *)
+
+and goal_stagnation = {
+  gs_goal_id : string;
+  gs_stale_since : string;
+  gs_goal_title : string;
+}
+(** Payload for [Goal_stagnation]. *)
+
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
     sink created a board evidence post, otherwise falls back to
@@ -198,6 +229,12 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 
 val goal_verification_failure_post_id : goal_verification_failure -> post_id
 (** Dedup/correlation id for [Goal_verification_failed]. *)
+
+val failure_judgment_post_id : failure_judgment -> post_id
+
+val goal_assignment_post_id : goal_assignment -> post_id
+
+val goal_stagnation_post_id : goal_stagnation -> post_id
 
 val hitl_resolution_decision_to_string : hitl_resolution_decision -> string
 (** Stable wire/log label for a HITL resolution wake decision. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -513,7 +513,19 @@ let start_keeper_loops
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun ~base_path ~keeper_name ~approval_id ~decision ?channel ->
-       let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+       let resolution =
+         Keeper_event_queue.
+           {
+             approval_id;
+             decision;
+             channel =
+               Option.value
+                 channel
+                 ~default:
+                   (Keeper_continuation_channel.unrouted
+                      "legacy: no approval continuation channel");
+           }
+       in
        let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
        let stimulus : Keeper_event_queue.stimulus =
          { Keeper_event_queue.post_id = Keeper_event_queue.hitl_resolution_post_id resolution

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -512,7 +512,7 @@ let start_keeper_loops
      Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
-    (fun ~base_path ~keeper_name ~approval_id ~decision ?channel ->
+    (fun ~base_path ~keeper_name ~approval_id ~decision ~channel ->
        let resolution =
          Keeper_event_queue.
            {
@@ -1136,10 +1136,20 @@ let start_keeper_loops
                | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
                | Keeper_chat_queue.Dashboard -> false
              in
+             (* Derive the typed reply-continuation channel from the queued
+                message source so [process_single_turn] can route the
+                assistant reply to the originating connector (Discord/Slack)
+                or dashboard thread. [dashboard_thread_id] is the same
+                [thread_id] the turn itself uses. *)
+             let continuation_channel =
+               Keeper_chat_queue.continuation_channel_of_message_source
+                 ~dashboard_thread_id:thread_id
+                 queued_message.source
+             in
              process_single_turn ~connector_user_line_recorded_upstream
                ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~closed ~client_disconnects:None ~payload ~run_id ~message_id
-               ~agent_name ~events)
+               ~thread_id ~continuation_channel ~closed ~client_disconnects:None
+               ~payload ~run_id ~message_id ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -245,7 +245,11 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       captured :=
         Some
           Keeper_event_queue.
-            { approval_id; decision; channel });
+            { approval_id;
+              decision;
+              channel =
+                Option.value channel
+                  ~default:(Keeper_continuation_channel.unrouted "test: no channel") });
   let reset_hook () =
     AQ.set_approval_resolution_wake_hook
         (fun
@@ -441,7 +445,9 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
             true
             (Keeper_continuation_channel.same_route
                continuation_channel
-               wake_channel)
+               (Option.value wake_channel
+                  ~default:
+                    (Keeper_continuation_channel.unrouted "test: no wake channel")))
         | None -> Alcotest.fail "submit_pending stale expiry must fire wake hook")
        )
 ;;

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,20 +241,20 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ~continuation_channel ->
+      ~channel ->
       captured :=
         Some
           Keeper_event_queue.
-            { approval_id; decision; channel = continuation_channel });
+            { approval_id; decision; channel });
   let reset_hook () =
     AQ.set_approval_resolution_wake_hook
-      (fun
-        ~base_path:_
-        ~keeper_name:_
-        ~approval_id:_
-        ~decision:_
-        ~continuation_channel:_ ->
-        ())
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~channel:_ ->
+          ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
     captured := None;
@@ -335,7 +335,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~continuation_channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -345,7 +345,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -392,8 +392,8 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~continuation_channel ->
-      woke := Some (keeper_name, approval_id, decision, continuation_channel));
+      ~channel ->
+      woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
       AQ.set_approval_resolution_wake_hook
@@ -402,7 +402,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~continuation_channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->


### PR DESCRIPTION
## 목표

`main`(1efb028e86)가 continuation-channel 리팩터 도입 후 **compile-red**입니다. codex 로컬 커밋 `2732b2c046`("Align keeper approval wake contracts and continuation types")이 이를 부분 수리하지만 잔존 compile 에러로 여전히 red. 이 PR은 컴파일을 완료해 main를 green으로 만듭니다.

## 변경 파일 (커밋 `e1ce01259c`)

- `lib/keeper/keeper_approval_queue.{ml,mli}` — wake hook의 trailing optional `?channel` → required `~channel:Keeper_continuation_channel.t option` (w16 unerasable-optional 회피; 모든 caller가 `entry.channel` 명시 전달). `audit_approval_event` mli optional 인자 순서를 ml 선언에 정렬 (optional erasure는 순서 의존).
- `lib/server/server_bootstrap_loops.ml` — `keeper_chat_consumer`의 `process_single_turn` 호출에 누락된 `~continuation_channel` 전달. `queued_message.source` → 기존 `Keeper_chat_queue.continuation_channel_of_message_source` 헬퍼로 생성 (dashboard-stream route와 동일 패턴, ad-hoc 중복 회피).
- `test/test_keeper_approval_queue.ml` — typed `channel : t option`을 `hitl_resolution.channel`/`same_route`(non-option)에 맞게 unwrap.

Base: `main`(1efb028e86). 커밋 1(`2732b2c046`, codex) + 커밋 2(`e1ce01259c`, Claude) 구성.

## 검증

- `dune build --root .` → **green** (lib/server/test/masc_http_client 전부).
- `ocamlformat` — repo가 `.ocamlformat` `disable = true` (RFC-0010)이라 비활성. 해당 없음.

## 미검증 / 남은 런타임 실패 (이 PR이 도입/수정한 것 아님)

`test_keeper_approval_queue.exe` 런타임 3개 실패 — compile-fix(서명 변경 + 무관 경로 채널 추가)와 무관하며, 코드가 compile되지 않아 지금까지 관측 안 된 잠재/기능 결함:

1. `live resolver must resume directly without wake hook` (wake.000)
2. `blocking stale resolution does not fire keeper wake hook` (wake.002)
   - `resolve`(`keeper_approval_queue.ml:919`)가 `wake_keeper_on_approval_resolution`을 무조건 호출 (`entry.resolver` 가드 없음). 2732b2c046이 이 영역 미변경 -> main 잠재 기존 결함.
3. `missing connector fails closed` (wake.004)
   - `create_entry` 기본 continuation_channel reason `"legacy: continuation channel not provided"` vs 테스트 기대 `"no originating connector"`. 2732b2c046이 추가한 기본값 -> 진행 중 기능 디테일.

별도 작업 권장. Draft 상태로 올립니다.

Co-Authored-By: Claude <noreply@anthropic.com>
