### PR TITLE
fix(keeper): autonomous lane yields on deferred connector/dashboard queue

### DIFF
--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -135,12 +135,22 @@ let rejected_snapshot slot =
 
 let run_if_free ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  (* Yield to a parked chat before touching the lock. [waiting > 0] implies
+  (* Yield to deferred work before touching the lock. [waiting > 0] implies
      the slot is held (a waiter only parks because a turn is in flight), so
      [try_lock] would fail here anyway; the explicit check keeps the
-     autonomous lane from competing for a slot a dashboard/connector message
-     is already queued on and documents the intent at the entry point. *)
+     autonomous lane from competing for a slot a parked chat is already
+     queued on. A non-empty [Keeper_chat_queue] means a busy connector
+     (Slack/Discord) or dashboard message is deferred for this keeper but
+     has not parked on the slot; the autonomous lane must yield for it too,
+     otherwise a long or back-to-back autonomous turn starves that queue
+     indefinitely (the busy-ACK loop). Reading the queue length is a
+     lock-only, non-suspending peek and is the SSOT signal that closes the
+     gap: the autonomous lane cooperates on the same backlog the consumer
+     drains, so the consumer's [in_flight = None] window opens
+     deterministically instead of racing the next autonomous cycle. *)
   if waiting_count slot > 0
+  then `Busy (peek_info slot)
+  else if Keeper_chat_queue.length ~keeper_name > 0
   then `Busy (peek_info slot)
   else if Eio.Mutex.try_lock slot.turn_mu
   then run_locked slot ~lane:Autonomous f

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -73,11 +73,18 @@ val run_if_free
     (including [Eio.Cancel.Cancelled]) release the slot and re-raise.
 
     Also returns [`Busy] without attempting the lock when a chat request is
-    already parked on this slot ([chat_waiting] is true). Eio.Mutex hands a
-    released slot directly to the next parked waiter, so a new autonomous
-    cycle would not overtake a queued chat regardless; this pre-check makes
-    the yield explicit and keeps a heartbeat-scheduled cycle from competing
-    for a slot a dashboard/connector message is already waiting on. *)
+    already parked on this slot ([chat_waiting] is true), or when a busy
+    connector/dashboard message is deferred in [Keeper_chat_queue] for this
+    keeper ([Keeper_chat_queue.length] > 0). Eio.Mutex hands a released slot
+    directly to the next parked waiter, so a new autonomous cycle would not
+    overtake a queued chat regardless; these pre-checks make the yield
+    explicit and keep a heartbeat-scheduled cycle from competing for a slot
+    a dashboard/connector message is already waiting on or queued behind.
+    The [Keeper_chat_queue] half closes the starvation gap where a long or
+    back-to-back autonomous turn could otherwise busy-ACK a connector
+    forever: the autonomous lane yields on the same backlog the consumer
+    drains, so the consumer's [in_flight = None] window opens
+    deterministically. *)
 
 val chat_waiting : base_path:string -> keeper_name:string -> bool
 (** [true] when at least one chat request is parked on this keeper's slot

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -201,12 +201,17 @@ let run (ctx : ctx)
                       lane runs [run_keeper_msg_turn_admitted] on a separate
                       path. So passing the yield hook here is inherently
                       lane-gated: an idle-filler turn stops at the next boundary
-                      when a dashboard/connector chat is parked, but a chat turn
-                      never yields to a later-queued chat. *)
+                      when a dashboard/connector chat is parked on the slot or
+                      already deferred in [Keeper_chat_queue], but a chat turn
+                      never yields to a later-queued chat. The queue-length
+                      half is what keeps a long autonomous turn from starving a
+                      busy Slack/Discord/Dashboard message that has not parked
+                      on the slot. *)
                  ~yield_to_chat_waiting:(fun () ->
                    Keeper_turn_admission.chat_waiting
                      ~base_path:config.base_path
-                     ~keeper_name:meta.name)
+                     ~keeper_name:meta.name
+                   || Keeper_chat_queue.length ~keeper_name:meta.name > 0)
                  ()))
     in
     result, turn_state

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -393,6 +393,44 @@ let test_idle_loop_yields_to_parked_chat () =
   check "parked chat admitted after the autonomous turn yielded" !chat_ran
 ;;
 
+let test_autonomous_yields_to_queued_connector_message () =
+  reset ();
+  Keeper_chat_queue.clear ~keeper_name;
+  Printf.printf
+    "Test 10: autonomous lane yields while a connector/dashboard message is queued\n%!";
+  (* Sanity: an empty queue lets the autonomous lane run. *)
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> 7) with
+   | `Ran 7 -> check "run_if_free admits when the chat queue is empty" true
+   | `Ran _ | `Busy _ -> check "run_if_free admits when the chat queue is empty" false);
+  (* A busy connector (Slack/Discord) message is deferred on the chat queue
+     without parking on the admission slot, so [chat_waiting] stays false. The
+     autonomous lane must still yield, or a long/back-to-back autonomous turn
+     busy-ACKs the connector forever (the starvation this pins). *)
+  Keeper_chat_queue.enqueue ~keeper_name
+    { Keeper_chat_queue.content = "deferred slack mention"
+    ; user_blocks = []
+    ; attachments = []
+    ; timestamp = 1.0
+    ; source = Keeper_chat_queue.Slack { channel = "C-test"; user_id = "U-test" }
+    };
+  check "queue depth is 1 after enqueue" (Keeper_chat_queue.length ~keeper_name = 1);
+  check
+    "a queued connector message is not a parked chat"
+    (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy _ ->
+     check "run_if_free yields (Busy) while a connector message is queued" true
+   | `Ran () ->
+     check "run_if_free must not admit while a connector message is queued" false);
+  (* Draining the queue (what the consumer does in the yielded window) lets the
+     autonomous lane run again. *)
+  ignore (Keeper_chat_queue.dequeue_batch ~keeper_name);
+  check "queue empty after drain" (Keeper_chat_queue.length ~keeper_name = 0);
+  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "ok") with
+  | `Ran "ok" -> check "run_if_free admits again once the queue is drained" true
+  | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -405,6 +443,7 @@ let () =
   test_cancelled_waiter_leaves_queue ();
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
+  test_autonomous_yields_to_queued_connector_message ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## Summary
Fix the Slack/connector busy-starvation where a busy keeper answers every connector mention with the "is busy; your message is queued" notice and the deferred reply never comes.

Root cause: when a connector/dashboard message arrives during a keeper turn, it is deferred onto `Keeper_chat_queue`, but the autonomous lane's yield points only consulted `chat_waiting` (parked chats). A long or back-to-back autonomous turn therefore never noticed the deferred queue, the consumer's `in_flight = None` drain window never opened, and the connector was busy-ACKed indefinitely.

This change makes both autonomous yield points also observe `Keeper_chat_queue.length` for the keeper:

- `Keeper_turn_admission.run_if_free` yields (Busy) while the queue is non-empty, so a heartbeat cycle no longer grabs the slot while deferred work waits. The consumer's drain window now opens deterministically instead of racing the next autonomous cycle.
- `Keeper_unified_turn_execution` `yield_to_chat_waiting` now stops a running idle-filler turn at its next boundary when deferred work is queued, bounding connector reply latency.

The consumer polling drain is unchanged; it is now race-free because the autonomous lane stays off the slot while the queue is non-empty. Coalescing, per-source reply routing, and durability (messages stay in the queue until drained) are preserved.

## Test
`test_keeper_turn_admission` Test 10 pins that `run_if_free` yields while a connector message is queued (`chat_waiting` stays false, i.e. queued not parked) and admits again once the queue is drained.

## Scope / non-goals
4 files, keeper lib only. No HITL/Scheduler/Fusion/Memory, no connector auth/token/UI, no change to the single-flight slot invariant.

A follow-up RFC will make the deferred message a first-class admission waiter (park via `run_serialized`) once `process_single_turn`'s admission and execution are split. This PR is the minimal, low-risk serialization fix (option A).

## Verification status (honest)
`scripts/dune-local.sh build test/test_keeper_turn_admission.exe` under the repo `ocaml>=5.5` switch currently fails on pre-existing main-HEAD errors in untouched files, not on this change:

- `lib/keeper/keeper_approval_queue.{ml,mli}`: optional-label order mismatch (`?audit_disposition`, `?actor`).
- `lib/server/server_bootstrap_loops.ml:1139-1142`: the consumer `handle_turn` calls `process_single_turn` without the now-required `~continuation_channel` (partial application).

The diff is limited to `keeper_turn_admission.{ml,mli}`, `keeper_unified_turn_execution.ml`, and `test_keeper_turn_admission.ml`. It adds a boolean `|| Keeper_chat_queue.length ~keeper_name > 0` to two yield predicates and one unit test, and introduces no new optional-arg/label or partial-application surface (verified by reading the relevant call sites). CI is the authoritative builder.

Note: `server_bootstrap_loops.ml:1139` sits in the same consumer drain path; it is a separate compile bug on main and is intentionally left out of this PR's scope.
