### PR TITLE
fix(test): split playground/internal-state into two test_cases (main red from #23846)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -279,6 +279,11 @@ let resolve_keeper_target_path
   let raw = String.trim raw_path in
   if raw = ""
   then Error Path_required
+  else if is_masc_internal_state_path raw
+  then (
+    let rej = Task_state_file_path_blocked { raw } in
+    rejection_to_telemetry rej;
+    Error rej)
   else (
     let root = project_root_of_config config in
     let candidate = if Filename.is_relative raw then Filename.concat root raw else raw in
@@ -295,6 +300,11 @@ let resolve_keeper_target_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
+    else if is_masc_internal_state_norm ~root_norm ~target_norm
+    then (
+      let rej = Task_state_file_path_blocked { raw } in
+      rejection_to_telemetry rej;
+      Error rej)
     else if allowed_paths = []
     then Ok candidate
     else (
@@ -403,6 +413,14 @@ let resolve_keeper_read_path
     let rej = Absolute_path_rejected { raw } in
     rejection_to_telemetry rej;
     Error rej)
+  else if is_masc_internal_state_path raw
+  then (
+    (* Block direct access to .masc/ internal state files.
+       Keepers should use keeper_tasks_list / keeper_context_status
+       instead of probing .masc/backlog.json, .masc/tasks/, etc. *)
+    let rej = Task_state_file_path_blocked { raw } in
+    rejection_to_telemetry rej;
+    Error rej)
   else (
     let root = project_root_of_config config in
     let candidate = Filename.concat root raw in
@@ -419,6 +437,11 @@ let resolve_keeper_read_path
          input. The "outside_project_root" label is enough for the
          caller to course-correct without enumerating the host. *)
       Error (Outside_project_root { raw })
+    else if is_masc_internal_state_norm ~root_norm ~target_norm
+    then (
+      let rej = Task_state_file_path_blocked { raw } in
+      rejection_to_telemetry rej;
+      Error rej)
     else (
       let allowed_norms =
         if allowed_paths = []

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -247,27 +247,52 @@ let raw_looks_like_playground_subdir (raw : string) : bool =
   || raw = "mind"
 ;;
 
-(** Detect paths that reference .masc/ internal state files.
-    These are workspace-level directories that should not be accessed
-    directly from a keeper's cwd (which is inside repos/<name>/).
-    Keepers should use keeper_tasks_list / keeper_context_status instead. *)
+(** Detect paths that reference .masc/ internal state files (workspace-level
+    state a keeper must reach via [keeper_tasks_list] / [keeper_context_status],
+    not by probing the files: backlog.json, tasks/, etc.). This preserves the
+    #23807 traversal/symlink write-bypass defence.
+
+    The keeper's own working area — [Playground_paths] [.masc/playground/<keeper>/{mind,repos}]
+    — is EXEMPT: it is where keepers clone repos and write drafts, so blocking
+    it (as the pre-#23843 raw match did, catching every [.masc/] prefix) breaks
+    keeper work. [#23843] removed the whole arm to unblock the playground, but
+    that also dropped the internal-state defence. The fix is to keep the arm
+    and narrow the match so only workspace-level state is blocked. *)
 let is_masc_internal_state_path (raw : string) : bool =
   (* Match ".masc/", "./.masc/", ".masc" at end, "*/backlog.json" *)
-  (String.starts_with ~prefix:".masc/" raw)
-  || (String.starts_with ~prefix:"./.masc/" raw)
-  || (String.equal raw ".masc")
-  || (String.equal raw "./.masc")
-  || (let len = String.length raw in
-      len >= 12
-      && String.sub raw (len - 12) 12 = "backlog.json"
-      && (len = 12 || raw.[len - 13] = '/'))
+  let masc_state =
+    (String.starts_with ~prefix:".masc/" raw)
+    || (String.starts_with ~prefix:"./.masc/" raw)
+    || (String.equal raw ".masc")
+    || (String.equal raw "./.masc")
+    || (let len = String.length raw in
+        len >= 12
+        && String.sub raw (len - 12) 12 = "backlog.json"
+        && (len = 12 || raw.[len - 13] = '/'))
+  in
+  let under_playground =
+    String.starts_with ~prefix:".masc/playground" raw
+    || String.starts_with ~prefix:"./.masc/playground" raw
+  in
+  masc_state && not under_playground
 ;;
 
 let is_masc_internal_state_norm ~(root_norm : string) ~(target_norm : string) : bool =
   let root_norm = strip_trailing_slashes root_norm in
   let target_norm = strip_trailing_slashes target_norm in
   let masc_root = Filename.concat root_norm Common.masc_dirname in
-  target_norm = masc_root || String.starts_with ~prefix:(masc_root ^ "/") target_norm
+  let playground_root = Filename.concat masc_root "playground" in
+  let under_masc =
+    target_norm = masc_root
+    || String.starts_with ~prefix:(masc_root ^ "/") target_norm
+  in
+  let under_playground =
+    target_norm = playground_root
+    || String.starts_with ~prefix:(playground_root ^ "/") target_norm
+  in
+  (* Exempt the keeper playground (Playground_paths SSOT); keep the internal-
+     state traversal/symlink defence for everything else under .masc/. *)
+  under_masc && not under_playground
 ;;
 
 let resolve_keeper_target_path

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -734,6 +734,10 @@ let resolve_projected_allowed_path
   in
   if not within_root
   then user_message_error (Keeper_alerting_path.Outside_project_root { raw = raw_for_error })
+  else if Keeper_alerting_path.is_masc_internal_state_norm ~root_norm ~target_norm
+  then
+    user_message_error
+      (Keeper_alerting_path.Task_state_file_path_blocked { raw = raw_for_error })
   else (
     let allowed_norms =
       if allowed_paths = []

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -144,26 +144,24 @@ let test_visible_mind_read_resolves_to_private_storage () =
   | Error e -> Alcotest.fail ("visible mind path should resolve: " ^ e)
 ;;
 
-let test_direct_private_storage_read_now_allowed () =
+let test_direct_private_storage_read_stays_blocked () =
   setup
   @@ fun ~config ~meta ~playground:_ ->
   let private_raw =
     Masc.Keeper_sandbox.allowed_root_rel_of_meta ~meta ^ "mind/README.md"
   in
-  let private_target = Filename.concat config.Workspace.base_path private_raw in
-  write_file private_target "private readme\n";
   match
     Keeper_tool_shared_runtime.resolve_keeper_read_path
       ~config
       ~meta
       ~raw_path:private_raw
   with
-  | Ok path ->
-    Alcotest.(check string)
-      "direct private storage path should resolve"
-      private_target
-      path
-  | Error e -> Alcotest.fail ("direct private storage path should resolve: " ^ e)
+  | Ok path -> Alcotest.fail ("direct private storage path should be blocked: " ^ path)
+  | Error e ->
+    Alcotest.(check bool)
+      "task state/private path blocked"
+      true
+      (String.starts_with ~prefix:"task_state_file_path_blocked:" e)
 ;;
 
 let test_read_with_visible_repo_cwd_and_relative_file_path () =
@@ -260,9 +258,9 @@ let () =
             `Quick
             test_visible_mind_read_resolves_to_private_storage
         ; Alcotest.test_case
-            "direct private storage read resolves"
+            "direct private storage read stays blocked"
             `Quick
-            test_direct_private_storage_read_now_allowed
+            test_direct_private_storage_read_stays_blocked
         ] )
     ; ( "file_tools"
       , [ Alcotest.test_case

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -144,24 +144,47 @@ let test_visible_mind_read_resolves_to_private_storage () =
   | Error e -> Alcotest.fail ("visible mind path should resolve: " ^ e)
 ;;
 
-let test_direct_private_storage_read_stays_blocked () =
+let test_playground_internal_path_now_allowed () =
+  (* RFC-0006: the keeper playground (.masc/playground/<keeper>/...) is the
+     keeper's own working area — its internal paths (mind/, drafts) are
+     reachable. #23843 unblocked the whole arm; this keeps the playground half
+     unblocked after re-narrowing the helper to exempt .masc/playground. *)
   setup
   @@ fun ~config ~meta ~playground:_ ->
   let private_raw =
     Masc.Keeper_sandbox.allowed_root_rel_of_meta ~meta ^ "mind/README.md"
   in
-  match
-    Keeper_tool_shared_runtime.resolve_keeper_read_path
-      ~config
-      ~meta
-      ~raw_path:private_raw
-  with
-  | Ok path -> Alcotest.fail ("direct private storage path should be blocked: " ^ path)
-  | Error e ->
-    Alcotest.(check bool)
-      "task state/private path blocked"
-      true
-      (String.starts_with ~prefix:"task_state_file_path_blocked:" e)
+  (match
+     Keeper_tool_shared_runtime.resolve_keeper_read_path
+       ~config
+       ~meta
+       ~raw_path:private_raw
+   with
+   | Ok _ ->
+     () (* playground-internal path resolves — keeper may reach its own area *)
+   | Error e -> Alcotest.fail ("playground-internal path should resolve: " ^ e))
+;;
+
+let test_masc_internal_state_read_stays_blocked () =
+  (* The narrowing is load-bearing: workspace-level internal state
+     (.masc/backlog.json, .masc/tasks/) must stay blocked — keepers reach it
+     via keeper_tasks_list / keeper_context_status, not by probing the files.
+     This is the #23807 traversal/symlink write-bypass defence that #23843
+     dropped. *)
+  setup
+  @@ fun ~config ~meta ~playground:_ ->
+  (match
+     Keeper_tool_shared_runtime.resolve_keeper_read_path
+       ~config
+       ~meta
+       ~raw_path:".masc/backlog.json"
+   with
+   | Ok path -> Alcotest.fail (".masc internal state should be blocked: " ^ path)
+   | Error e ->
+     Alcotest.(check bool)
+       "masc internal state blocked"
+       true
+       (String.starts_with ~prefix:"task_state_file_path_blocked:" e))
 ;;
 
 let test_read_with_visible_repo_cwd_and_relative_file_path () =
@@ -260,7 +283,8 @@ let () =
         ; Alcotest.test_case
             "direct private storage read stays blocked"
             `Quick
-            test_direct_private_storage_read_stays_blocked
+            test_playground_internal_path_now_allowed
+            test_masc_internal_state_read_stays_blocked
         ] )
     ; ( "file_tools"
       , [ Alcotest.test_case

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -281,9 +281,12 @@ let () =
             `Quick
             test_visible_mind_read_resolves_to_private_storage
         ; Alcotest.test_case
-            "direct private storage read stays blocked"
+            "playground internal path now allowed"
             `Quick
             test_playground_internal_path_now_allowed
+        ; Alcotest.test_case
+            "masc internal state read stays blocked"
+            `Quick
             test_masc_internal_state_read_stays_blocked
         ] )
     ; ( "file_tools"


### PR DESCRIPTION
## What

#23846 merged with a runner arity bug: both new tests were registered under a single `Alcotest.test_case`, so the second test function became an extra argument → main compile red at `test/test_keeper_visible_path_projection.ml:283-287`.

## Fix

Split them into two `test_case` entries:
- `"playground internal path now allowed"` → `test_playground_internal_path_now_allowed`
- `"masc internal state read stays blocked"` → `test_masc_internal_state_read_stays_blocked`

No behaviour change to the guard itself (the narrowed helper from #23846 stays) — this is purely the test registration fix that should have been in #23846.

Co-Authored-By: Claude <noreply@anthropic.com>