### PR TITLE
chore: fix optional arg and continuation wake types

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -368,7 +368,13 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
   ()
 ;;
 
-let run_one (scenario : EH.scenario) ~runtime_id ~base_path ~run_index ~sw ~record_verdicts
+let run_one
+  (scenario : EH.scenario)
+  ~runtime_id
+  ~base_path
+  ~run_index
+  ~(sw : Eio.Switch.t option)
+  ~record_verdicts
     ~(evaluator_runtime : string option) : EH.eval_run =
   let calls = ref [] in
   let dispatch ~name ~args =
@@ -402,7 +408,13 @@ let run_one (scenario : EH.scenario) ~runtime_id ~base_path ~run_index ~sw ~reco
   build_eval_run scenario ~run_index ~res ~calls ~duration_ms
 ;;
 
-let run_scenario (scenario : EH.scenario) ~runtime_id ~base_path ~k ~sw ~record_verdicts
+let run_scenario
+  (scenario : EH.scenario)
+  ~runtime_id
+  ~base_path
+  ~k
+  ~(sw : Eio.Switch.t option)
+  ~record_verdicts
     ~(evaluator_runtime : string option) : EH.eval_result =
   Printf.eprintf "running scenario %s (k=%d)...\n%!" scenario.EH.id k;
   let runs =
@@ -602,7 +614,7 @@ let () =
     let results =
       List.map
         (fun s ->
-          run_scenario s ~runtime_id:cfg.runtime_id ~base_path ~k:cfg.k ~sw
+          run_scenario s ~runtime_id:cfg.runtime_id ~base_path ~k:cfg.k ~sw:(Some sw)
             ~record_verdicts:cfg.record_verdicts
             ~evaluator_runtime)
         scenarios

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -174,14 +174,14 @@ let audit_approval_event
       ?sandbox_target
       ?runtime_contract
       ?selected_model
+      ?actor
+      ?approval_mode
+      ?authorizing_band
       ?audit_disposition
       ?disposition
       ?disposition_reason
       ?rule_match
       ?source_approval_id
-      ?actor
-      ?approval_mode
-      ?authorizing_band
       ?auto_approved
       ?decision
       ()
@@ -849,11 +849,17 @@ let approval_resolution_wake_hook :
      ?channel:Keeper_continuation_channel.t ->
      unit)
     ref =
-  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
+  ref
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
+      ?(channel : Keeper_continuation_channel.t option) ->
+      ignore (channel : Keeper_continuation_channel.t option))
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
-let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision ?channel =
+let wake_keeper_on_approval_resolution
+    ~base_path ~keeper_name ~approval_id ~decision
+    ?(channel : Keeper_continuation_channel.t option) =
   try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ?channel with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -512,7 +512,12 @@ let start_keeper_loops
      Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
-    (fun ~base_path ~keeper_name ~approval_id ~decision ?channel ->
+    (fun
+      ~base_path
+      ~keeper_name
+      ~approval_id
+      ~decision
+      ?(channel : Keeper_continuation_channel.t option) ->
        let resolution =
          Keeper_event_queue.
            {
@@ -1136,10 +1141,15 @@ let start_keeper_loops
                | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
                | Keeper_chat_queue.Dashboard -> false
              in
-             process_single_turn ~connector_user_line_recorded_upstream
-               ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~closed ~client_disconnects:None ~payload ~run_id ~message_id
-               ~agent_name ~events)
+               process_single_turn ~connector_user_line_recorded_upstream
+                 ~state ~clock ~sw ~auth_token:None
+                 ~thread_id
+                 ~continuation_channel:
+                   (Keeper_chat_queue.continuation_channel_of_message_source
+                      ~dashboard_thread_id:thread_id
+                      queued_message.source)
+                 ~closed ~client_disconnects:None ~payload ~run_id ~message_id
+                 ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~channel:_ ->
+      ?channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~channel:_ ->
+          ?channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~channel:_ ->
+      ?channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~channel:_ ->
+          ?channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,7 +241,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ~channel ->
+      ?channel ->
       captured :=
         Some
           Keeper_event_queue.
@@ -253,7 +253,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~channel:_ ->
+          ?channel:_ ->
           ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
@@ -335,7 +335,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -345,7 +345,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~channel:_ ->
+          ?channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -392,7 +392,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ~channel ->
+      ?channel ->
       woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
@@ -402,7 +402,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ~channel:_ ->
+          ?channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -159,7 +159,7 @@ let test_content_blocks_detects_code () =
   let blocks = S.content_blocks_of_text "```ocaml\nlet x = 1 + 2\n```" in
   check int "one code block" 1 (List.length blocks);
   let s = json_string (List.hd blocks) in
-  check bool "code block text" true (contains s "```ocaml");
+  check bool "code block text" true (contains s "```ocaml")
 
 let test_content_blocks_detects_mermaid () =
   let blocks = S.content_blocks_of_text "```mermaid\nflowchart TD\nA-->B\n```" in

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -281,9 +281,12 @@ let () =
             `Quick
             test_visible_mind_read_resolves_to_private_storage
         ; Alcotest.test_case
-            "direct private storage read stays blocked"
+            "direct private storage read is allowed"
             `Quick
             test_playground_internal_path_now_allowed
+        ; Alcotest.test_case
+            "internal masc state read stays blocked"
+            `Quick
             test_masc_internal_state_read_stays_blocked
         ] )
     ; ( "file_tools"


### PR DESCRIPTION
## Summary

- Fix optional argument label mismatches introduced by optional-argument refactor.
- Align keeper approval queue contract with its interface:
  - reorder optional labels in `audit_approval_event` to match .mli
  - make approval wake callback/channel plumbing optional consistently
  - preserve wake hook semantics while avoiding optional-argument erasure warnings
- Pass continuation channel from queued message source into `process_single_turn`.
- Thread `Eio.Switch.t option` through completion trust eval call path.
- Fix test callback signatures and minor syntax breakages in keeper slack/visible-path tests.

## Validation

- Attempted targeted local build:
  - `bin/masc_completion_trust_eval.exe`
  - `test/test_keeper_approval_queue.exe`
  - `test/test_keeper_chat_slack.exe`
  - `test/test_keeper_visible_path_projection.exe`
- Environment lacks some transitive deps in this machine:
  - `piaf.stream`
  - `opentelemetry.client`
  - so compile couldn't complete end-to-end here.

## Notes

- Scope is limited to signature/typing fixes and related call-sites/tests only.
