### PR TITLE
chore: fix optional continuation-channel and anti-rationalization type drift

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -846,14 +846,12 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
-     ?channel:Keeper_continuation_channel.t ->
+     ?channel:Keeper_continuation_channel.t option ->
      unit)
     ref =
   ref
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
-      ?(channel : Keeper_continuation_channel.t option) ->
-      ignore (channel : Keeper_continuation_channel.t option))
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
@@ -927,7 +925,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ~keeper_name:entry.keeper_name
     ~approval_id:entry.id
     ~decision:(hitl_resolution_decision_of_approval_decision decision)
-    ?channel:entry.channel;
+    ~channel:entry.channel;
   try
     Sse.broadcast
       (`Assoc
@@ -1522,7 +1520,7 @@ let expire_stale ~max_wait_s =
          ~keeper_name:entry.keeper_name
          ~approval_id:id
          ~decision:Keeper_event_queue.Hitl_rejected
-         ?channel:entry.channel;
+         ~channel:entry.channel;
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -328,7 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   ?channel:Keeper_continuation_channel.t ->
+   ?channel:Keeper_continuation_channel.t option ->
    unit) ->
   unit
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -517,7 +517,7 @@ let start_keeper_loops
       ~keeper_name
       ~approval_id
       ~decision
-      ?(channel : Keeper_continuation_channel.t option) ->
+      ?channel ->
        let resolution =
          Keeper_event_queue.
            {


### PR DESCRIPTION
## Summary
- Fix optional continuation-channel types for HITL wake path:
  - `lib/keeper/keeper_approval_queue.ml/.mli`: make `set_approval_resolution_wake_hook`/`wake` channel label `Keeper_continuation_channel.t option`.
  - Default hook now uses explicit no-op with optional channel arg.
- Fix wake invocation sites in approval queue (`resolve_entry`, `expire_stale`) to pass `~channel:entry.channel`.
- Update `lib/server/server_bootstrap_loops.ml` hook injection to accept optional `~channel` in the callback.

## Validation
- Build/test validation in this environment is blocked by missing local dev deps (`opentelemetry.client`/`piaf`); changes were verified by interface/body signature alignment and focused file consistency checks.
