### PR TITLE
fix(keeper): continuation-channel typed wake hook (root fix on current main, supersedes #23849)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -846,15 +846,15 @@ let approval_resolution_wake_hook :
      keeper_name:string ->
      approval_id:string ->
      decision:Keeper_event_queue.hitl_resolution_decision ->
-     ?channel:Keeper_continuation_channel.t ->
+     channel:Keeper_continuation_channel.t option ->
      unit)
     ref =
-  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
+  ref (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
-let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision ?channel =
-  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ?channel with
+let wake_keeper_on_approval_resolution ~base_path ~keeper_name ~approval_id ~decision ~channel =
+  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ~channel with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.warn
@@ -921,7 +921,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     ~keeper_name:entry.keeper_name
     ~approval_id:entry.id
     ~decision:(hitl_resolution_decision_of_approval_decision decision)
-    ?channel:entry.channel;
+    ~channel:entry.channel;
   try
     Sse.broadcast
       (`Assoc
@@ -1516,7 +1516,7 @@ let expire_stale ~max_wait_s =
          ~keeper_name:entry.keeper_name
          ~approval_id:id
          ~decision:Keeper_event_queue.Hitl_rejected
-         ?channel:entry.channel;
+         ~channel:entry.channel;
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -199,14 +199,14 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
-  ?actor:string ->
-  ?approval_mode:string ->
-  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
   ?rule_match:rule_match ->
   ?source_approval_id:string ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?auto_approved:bool ->
   ?decision:approval_audit_decision ->
   unit ->
@@ -328,7 +328,7 @@ val set_approval_resolution_wake_hook :
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   ?channel:Keeper_continuation_channel.t ->
+   channel:Keeper_continuation_channel.t option ->
    unit) ->
   unit
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -512,7 +512,7 @@ let start_keeper_loops
      Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
      the Fusion_completed/Bg_completed async-completion wakes. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
-    (fun ~base_path ~keeper_name ~approval_id ~decision ?channel ->
+    (fun ~base_path ~keeper_name ~approval_id ~decision ~channel ->
        let resolution =
          Keeper_event_queue.
            {
@@ -1136,10 +1136,20 @@ let start_keeper_loops
                | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
                | Keeper_chat_queue.Dashboard -> false
              in
+             (* Derive the typed reply-continuation channel from the queued
+                message source so [process_single_turn] can route the
+                assistant reply to the originating connector (Discord/Slack)
+                or dashboard thread. [dashboard_thread_id] is the same
+                [thread_id] the turn itself uses. *)
+             let continuation_channel =
+               Keeper_chat_queue.continuation_channel_of_message_source
+                 ~dashboard_thread_id:thread_id
+                 queued_message.source
+             in
              process_single_turn ~connector_user_line_recorded_upstream
                ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~closed ~client_disconnects:None ~payload ~run_id ~message_id
-               ~agent_name ~events)
+               ~thread_id ~continuation_channel ~closed ~client_disconnects:None
+               ~payload ~run_id ~message_id ~agent_name ~events)
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -245,7 +245,11 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       captured :=
         Some
           Keeper_event_queue.
-            { approval_id; decision; channel });
+            { approval_id;
+              decision;
+              channel =
+                Option.value channel
+                  ~default:(Keeper_continuation_channel.unrouted "test: no channel") });
   let reset_hook () =
     AQ.set_approval_resolution_wake_hook
         (fun
@@ -441,7 +445,9 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
             true
             (Keeper_continuation_channel.same_route
                continuation_channel
-               wake_channel)
+               (Option.value wake_channel
+                  ~default:
+                    (Keeper_continuation_channel.unrouted "test: no wake channel")))
         | None -> Alcotest.fail "submit_pending stale expiry must fire wake hook")
        )
 ;;


### PR DESCRIPTION
Supersedes #23849 (CONFLICTING/DIRTY, 8-file). Same root fix — typed `Keeper_continuation_channel.t` wake hook — re-applied cleanly on current main by resolving the conflicts in favour of the typed-channel direction and fixing the audit_approval_event .ml/.mli label order to match.

Closes the w16 unerasable-optional, the ~channel/?channel mismatch, and the audit_event label mismatch that kept main red in keeper_approval_queue / server_bootstrap_loops.

Out of scope (separate reds): sw drift in `masc_completion_trust_eval` and `test_keeper_chat_slack` syntax — these are not the continuation-channel fix and should be tracked separately.

Verified: `dune build lib/keeper lib/keeper_contract lib/keeper_runtime lib/server` green.

Co-Authored-By: Claude <noreply@anthropic.com>