### PR TITLE
Fix keeper approval wake hook channel optionality

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -851,14 +851,18 @@ let approval_resolution_wake_hook :
     ref =
   ref
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ -> ())
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
+      ?channel:(_ : Keeper_continuation_channel.t option) -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
 let wake_keeper_on_approval_resolution
     ~base_path ~keeper_name ~approval_id ~decision
     ?(channel : Keeper_continuation_channel.t option) =
-  try !approval_resolution_wake_hook ~base_path ~keeper_name ~approval_id ~decision ?channel with
+  try
+    !approval_resolution_wake_hook
+      ~base_path ~keeper_name ~approval_id ~decision ~channel
+  with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Log.Keeper.warn


### PR DESCRIPTION
## Summary
- Fix type mismatch in keeper approval wake hook optional channel handling.
- Make the default hook callback signature explicitly accept `?channel:Keeper_continuation_channel.t option`.
- Invoke hook with `~channel` instead of `?channel` to avoid producing `option option`.

## Validation
- `dune build lib/keeper/keeper_approval_queue.ml`
- `dune build lib/keeper/keeper_approval_queue.mli`

This addresses the last blocking type errors in the keeper approval wake path after #23826-style conflict repairs.
