### PR TITLE
fix(keeper): unify wake-hook channel to required labelled (stop ?channel flip-flop)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -852,13 +852,13 @@ let approval_resolution_wake_hook :
   ref
     (fun
       ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
-      ?channel:(_ : Keeper_continuation_channel.t option) -> ())
+      ~channel:(_ : Keeper_continuation_channel.t option) -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
 let wake_keeper_on_approval_resolution
     ~base_path ~keeper_name ~approval_id ~decision
-    ?(channel : Keeper_continuation_channel.t option) =
+    ~(channel : Keeper_continuation_channel.t option) =
   try
     !approval_resolution_wake_hook
       ~base_path ~keeper_name ~approval_id ~decision ~channel

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,7 +241,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       captured :=
         Some
           Keeper_event_queue.
@@ -257,7 +257,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
@@ -339,7 +339,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -349,7 +349,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -396,7 +396,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
@@ -406,7 +406,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->


### PR DESCRIPTION
Main went red again: #23854 fixed the wake-hook channel to required labelled `~channel`, but #23855 re-introduced `?channel` (optional) on the ref body / wake / test callbacks — so the ref signature (`channel:Keeper_continuation_channel.t option`, required) disagrees with the body (`?channel`), producing w16 unerasable + .ml/.mli label mismatch.

This unifies everything to the ref signature's direction (required labelled `~channel`):
- `keeper_approval_queue.ml`: ref body + `wake_keeper_on_approval_resolution`
- `test_keeper_approval_queue.ml`: 10 hook callbacks

Verified: `dune build lib/keeper` green.

Note: this is the same root the auto-fleet keeps flipping (required ↔ optional). The fix pins it to required to match the ref signature and the server_bootstrap caller.

Co-Authored-By: Claude <noreply@anthropic.com>