### PR TITLE
Fix keeper approval event interface signature

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -173,15 +173,15 @@ let audit_approval_event
       ?(goal_ids = [])
       ?sandbox_target
       ?runtime_contract
-      ?selected_model
-      ?actor
-      ?approval_mode
-      ?authorizing_band
+      ?selected_model:(selected_model : string option)
       ?audit_disposition
       ?disposition
       ?disposition_reason
       ?rule_match
       ?source_approval_id
+      ?actor
+      ?approval_mode
+      ?authorizing_band
       ?auto_approved
       ?decision
       ()


### PR DESCRIPTION
## Summary
- Fix remaining keeper approval event API mismatch between implementation and interface.
- Align `audit_approval_event` optional labels/order with `keeper_approval_queue.mli`.
- Pin `selected_model` optional type to `string option` instead of polymorphic `'a option`.
- Keep changes minimal and behavior-compatible; only interface/type-level mismatch repair.

## Validation
- `dune build lib/keeper/keeper_approval_queue.ml`
- `dune build lib/keeper/keeper_approval_queue.mli`
