### PR TITLE
fix(keeper): align audit_approval_event .mli label order with .ml

### DIFF
--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -199,14 +199,14 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
   ?rule_match:rule_match ->
   ?source_approval_id:string ->
-  ?actor:string ->
-  ?approval_mode:string ->
-  ?authorizing_band:string ->
   ?auto_approved:bool ->
   ?decision:approval_audit_decision ->
   unit ->


### PR DESCRIPTION
Auto-fleet flipped the audit_approval_event label order between .ml and .mli again (actor before/after audit_disposition). This aligns the .mli to the .ml order so the .ml/.mli match holds. Verified: dune build lib/keeper green. Co-Authored-By: Claude <noreply@anthropic.com>