### PR TITLE
fix(keeper): finish channel-required migration + audit label order (main compile-red)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -174,14 +174,14 @@ let audit_approval_event
       ?sandbox_target
       ?runtime_contract
       ?selected_model
-      ?actor
-      ?approval_mode
-      ?authorizing_band
       ?audit_disposition
       ?disposition
       ?disposition_reason
       ?rule_match
       ?source_approval_id
+      ?actor
+      ?approval_mode
+      ?authorizing_band
       ?auto_approved
       ?decision
       ()
@@ -852,13 +852,13 @@ let approval_resolution_wake_hook :
   ref
     (fun
       ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
-      ?channel:(_ : Keeper_continuation_channel.t option) -> ())
+      ~channel:(_ : Keeper_continuation_channel.t option) -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
 let wake_keeper_on_approval_resolution
     ~base_path ~keeper_name ~approval_id ~decision
-    ?(channel : Keeper_continuation_channel.t option) =
+    ~(channel : Keeper_continuation_channel.t option) =
   try
     !approval_resolution_wake_hook
       ~base_path ~keeper_name ~approval_id ~decision ~channel

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,7 +241,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       captured :=
         Some
           Keeper_event_queue.
@@ -257,7 +257,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
@@ -339,7 +339,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -349,7 +349,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -396,7 +396,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
@@ -406,7 +406,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->


### PR DESCRIPTION
## fix: keeper approval queue channel-required 마무리 + audit label 순서

main(5eff6be298)에서 HITL approval wake hook이 required `channel:t option`로 **절반만 마이그레이션**된 상태(#23854/#23855가 hook ref 타입·mli는 옮겼으나 2곳은 optional 잔류):

- `keeper_approval_queue.ml:855` hook default: `?channel:(_ : t option)` → `~channel` (w16 unerasable optional; ref 타입은 이미 required)
- `keeper_approval_queue.ml:861` `wake_keeper_on_approval_resolution`: `?(channel : t option)` → `~(channel : t option)` (같은 w16; caller 전부 `~channel:entry.channel` 명시)
- `test/test_keeper_approval_queue.ml`: 8개 `?channel` hook lambda → `~channel` (required 시그니처 정합)

같은 파일의 **별도 mli/ml 불일치**도 fix (빌드 블로커): `audit_approval_event` optional-label **순서**가 .ml과 .mli가 엇갈림(`?actor`/`?approval_mode`/`?authorizing_band`가 .ml에선 `?audit_disposition` 앞, .mli에선 뒤). OCaml은 optional-label 순서를 타입의 일부로 보아 hard error. .ml을 공개 .mli 순서로 정렬.

### 검증
`dune build --root .` exit 0 (이전: 이 파일에서 w16×2 + mli mismatch + test 타입 에러 8건).

### 메모
- 활성 #23854/#23855가 같은 영역을 다루는 중일 수 있어 중복/경합 시 close 가능.
- 이 fix 없이는 main이 compile-red (`?channel` w16 + audit mli/ml mismatch).

Co-Authored-By: Claude <noreply@anthropic.com>
