### PR TITLE
fix(keeper): finish required ~channel in approval wake hook + audit arg order

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -852,13 +852,13 @@ let approval_resolution_wake_hook :
   ref
     (fun
       ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
-      ?channel:(_ : Keeper_continuation_channel.t option) -> ())
+      ~channel:_ -> ())
 
 let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
 
 let wake_keeper_on_approval_resolution
     ~base_path ~keeper_name ~approval_id ~decision
-    ?(channel : Keeper_continuation_channel.t option) =
+    ~(channel : Keeper_continuation_channel.t option) =
   try
     !approval_resolution_wake_hook
       ~base_path ~keeper_name ~approval_id ~decision ~channel

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -199,14 +199,14 @@ val audit_approval_event :
   ?sandbox_target:string ->
   ?runtime_contract:Yojson.Safe.t ->
   ?selected_model:string ->
+  ?actor:string ->
+  ?approval_mode:string ->
+  ?authorizing_band:string ->
   ?audit_disposition:approval_audit_disposition ->
   ?disposition:string ->
   ?disposition_reason:string ->
   ?rule_match:rule_match ->
   ?source_approval_id:string ->
-  ?actor:string ->
-  ?approval_mode:string ->
-  ?authorizing_band:string ->
   ?auto_approved:bool ->
   ?decision:approval_audit_decision ->
   unit ->

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -129,7 +129,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -141,7 +141,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -187,7 +187,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel:_ ->
+      ~channel:_ ->
       woke := Some (keeper_name, approval_id, decision));
   Fun.protect
     ~finally:(fun () ->
@@ -197,7 +197,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ());
       cleanup_dir base_path)
     (fun () ->
@@ -241,7 +241,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~keeper_name:_
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       captured :=
         Some
           Keeper_event_queue.
@@ -257,7 +257,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
   in
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
@@ -339,7 +339,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   let woke = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ?channel:_ ->
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
       woke := true);
   Fun.protect
     ~finally:(fun () ->
@@ -349,7 +349,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->
@@ -396,7 +396,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~keeper_name
       ~approval_id
       ~decision
-      ?channel ->
+      ~channel ->
       woke := Some (keeper_name, approval_id, decision, channel));
   Fun.protect
     ~finally:(fun () ->
@@ -406,7 +406,7 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
           ~keeper_name:_
           ~approval_id:_
           ~decision:_
-          ?channel:_ ->
+          ~channel:_ ->
           ())
       ; cleanup_dir base_path)
     (fun () ->


### PR DESCRIPTION
## 목표

`main`가 #23852–#23855 연속 머지 후에도 **compile-red**로 남은 것을 마저 고칩니다. typed wake-hook 리팩터가 대부분의 사이트를 required `~channel`로 바꿨지만, **hook ref default lambda(855)와 `wake_keeper_on_approval_resolution` param(861)이 trailing optional `?channel`로 남아** w16 + 타입 불일치, 그리고 `audit_approval_event` mli optional 순서가 ml과 어긋난 것이 원인입니다.

## 변경 (커밋 `69591576e7`, base `main` 5eff6be298)

- `lib/keeper/keeper_approval_queue.ml`
  - `approval_resolution_wake_hook` ref default lambda: `?channel:(_ : t option)` → `~channel:_`
  - `wake_keeper_on_approval_resolution` param: `?(channel : t option)` → `~(channel : t option)` (hook type·`entry.channel : t option` call site과 일치)
- `lib/keeper/keeper_approval_queue.mli`
  - `audit_approval_event`: optional 인자 순서를 ml에 정렬 (`?actor`/`?approval_mode`/`?authorizing_band`를 `?audit_disposition` 앞으로)
- `test/test_keeper_approval_queue.ml`
  - wake-hook callback 전부 `?channel` → `~channel` (required hook arg에 일치)

3 files, +15/-15. wake-hook 파일에 `?channel` 잔존 0.

## 검증

로컬 빌드는 사용자 터미널과 dune lock 경합이 잦아 **CI에 맡깁니다**. 이 PR의 CI가 main red(855 w16 · 861 · audit mli 순서 · test callback)를 잡는지 확인해 주세요.

## 참고

- 같은 수정이 이전 PR #23849(base가 2732b2c046로 낡음)에도 있었으나, main가 #23852–55로 크게 이동해 이 PR이 현재 main 기준입니다. #23849는 stale로 닫습니다.
- optional 접근은 trailing `?channel`이 구조적으로 w16을 피할 수 없어 required 환원만이 근본 해법입니다.

Co-Authored-By: Claude <noreply@anthropic.com>
