### PR TITLE
docs(rfc): RFC-0334 W3 sizing resolved from census — split W3a/b/c + sanction wake-semantic change

### DIFF
--- a/docs/rfc/RFC-0334-board-mailbox-turn-digest.md
+++ b/docs/rfc/RFC-0334-board-mailbox-turn-digest.md
@@ -24,14 +24,35 @@
 |---|---|---|
 | W1 | enqueue-always + cap-only-the-wake in `wakeup_relevant_keeper_for_board_signal` | a capped keeper's queue contains the stimulus; `BoardSignalWakeupCappedTotal` semantics documented as deferral; zero stimuli discarded on the publish path |
 | W2 | turn-start full drain → one `Board_digest` per turn | a keeper with k>1 queued board signals runs one turn consuming all k; window-parameter reads = 0 |
-| W3 | addressee index for wake-reason inputs | per-event meta-file reads drop from O(N keepers) to O(addressees); index refreshed on meta mutation, not per event |
+| W3a | promote the base-path profile-defaults loader to the fingerprint-revalidating cache | `reload_meta_from_disk` and any hook-driven overlay stop doing uncached TOML I/O per call; no behavior change |
+| W3b | make the meta-store write-sync hook install *effective* (overlay-applied) meta, matching `reload_meta_from_disk` and the heartbeat sync | `entry.meta` provenance is deterministically effective; `effective_meta_overlay_hash` fingerprint stops oscillating raw↔effective; no wake-behavior change (fan-out still reads disk) |
+| W3c | switch `wakeup_relevant_keeper_for_board_signal` from per-event disk `read_meta` to `entry.meta` | per-event meta-file reads drop from O(N keepers) to 0 (registry copy is in-memory); **wake-behavior change**: TOML-profile `mention_targets` now affect board wake (see §W3 design) |
 
 ## Verification
 
 - W1 pins: fanout cap with 3 candidates and limit 2 → 2 woken, 3 queues populated; the deferred keeper's next heartbeat turn observes the signal.
 - W2 pins: 5 board signals spread over >2s while keeper busy → exactly 1 digest observation on next turn; explicit-mention ordering pin; identity-dedup pin unchanged.
-- W3 pins: meta read counter per event = addressee count; index invalidation on mention_targets change.
-- Workaround-gate self-check: this *removes* a cap-as-loss signature by re-typing it as deferral; W2 removes a time-window heuristic in favor of a structural unit (the turn). Any future PR re-introducing a drop on the delivery path is a cap/cooldown reject.
+- W3c pin: register a keeper, delete its on-disk meta file, emit a board signal whose text mentions it → the keeper still matches via the in-memory `entry.meta` (disk-read independence). No per-event meta-read counter is added (a counter whose only consumer is a test is a counter-as-pin reject); the structural disk-deletion pin proves the same property.
+- Workaround-gate self-check: this *removes* a cap-as-loss signature by re-typing it as deferral; W2 removes a time-window heuristic in favor of a structural unit (the turn); W3c *removes* a per-event disk scan, and W3b removes a raw↔effective oscillation rather than adding a cache layer over it. Any future PR re-introducing a drop on the delivery path is a cap/cooldown reject.
+
+## W3 design (census-resolved 2026-07-10, issue #23837)
+
+The RFC deferred W3 sizing to a census; here is its resolution. The original "addressee index" framing (an inverted needle→keeper map) is the *eventual* O(addressees) target, but the census found the dominant per-event cost is not the match loop — it is `N` **uncached disk `read_meta` calls** (`keeper_keepalive_signal.ml:636`), one per running keeper per board event. Eliminating that disk scan is the bulk of the win and is separable from building an inverted index, so W3 is split.
+
+**Provenance is the gate.** `Keeper_registry` `entry.meta` today has *mixed* provenance: the write-sync hook (`sync_meta_if_registered`) installs RAW persisted meta, while `reload_meta_from_disk` and the heartbeat loop install EFFECTIVE (TOML/persona-overlay-applied) meta. The fan-out reads RAW today (via disk `read_meta`). Switching it to `entry.meta` naively would read whichever provenance last won — nondeterministic. So provenance must be unified first (W3b).
+
+**Direction: unify to effective, not raw.** The overlaid-field set (`effective_meta_of_profile_defaults`, `keeper_meta_contract.ml:705-783`) is: `persona`, `proactive.*`, `tool_denylist`, `goal`, `instructions`, `autoboot_enabled`, `mention_targets` (when TOML defaults non-empty), `active_goal_ids`, `tool_access`, `sandbox_profile`, `sandbox_image`, `network_mode`, `multimodal_policy`, `allowed_paths`, `telemetry_feedback_*`, `always_approve`, `oas_env`. Of these the board fan-out consumes exactly one — `mention_targets` (`keeper_world_observation_board_signal.ml:103`); every other field it reads (`name`, `agent_name`, `paused`, `auto_resume_after_sec`, `runtime.last_blocker`) is raw-safe. Meanwhile `keeper_status_detail.ml:209` is literally named `effective_meta_overlay_hash` and fingerprints the *effective* overlay to invalidate its status cache — it *requires* effective. Unifying to raw would break that by design; unifying to effective is what the majority consumer already wants and what the heartbeat loop already installs most of the time.
+
+**Consequence to sanction (W3c exit behavior).** Once the fan-out reads effective `entry.meta`, a keeper whose `mention_targets` come from its TOML profile (not the `masc_keeper_up`/`update` MCP path) will begin matching `@alias` board mentions. Today it does not, because the fan-out reads raw disk meta which lacks the overlay. This aligns board wake with operator configuration intent — a latent-bug fix — but it is a **wake-semantic change** and is the explicit, RFC-sanctioned exit behavior of W3c, not an incidental side effect.
+
+**Ordering and gates.**
+1. **W3a (prerequisite, perf, no behavior change):** `load_keeper_profile_defaults_result_for_base_path` (`keeper_types_profile.ml:232`) is uncached; only the scope-keyed variant (`:481`) uses `profile_defaults_cache` with fingerprint revalidation. W3b would put overlay computation in the hot write-sync hook, so the base-path loader must first be promoted to the cache (base-path-keyed, same fingerprint revalidation) or W3b will regress every durable meta write into an uncached TOML read.
+2. **W3b (behavior-preserving):** hook installs effective. Removes the raw↔effective oscillation (which currently churns `effective_meta_overlay_hash` and the status cache). Fan-out still reads disk, so no wake change yet.
+3. **W3c (sanctioned wake-semantic change):** fan-out reads `entry.meta`; disk scan eliminated. The paused-wake path's meta-version lag (`keeper_keepalive_signal.ml:579`) becomes a real registry-CAS clobber risk only here, so it is fixed as part of W3c, not before.
+
+Prerequisite already landed: the supervisor prune ghost-entry fix (#23861, census freshness caveat 1) removes the "pruned keeper resurrected via `entry.meta` write" hazard that W3c would otherwise expose.
+
+An inverted needle→keeper index (the original framing, O(addressees) instead of O(N) match loop) remains a possible W3d, but the census showed the match loop is cheap relative to the disk scan; W3d is deferred until profiling shows the in-memory scan is a bottleneck.
 
 ## Boundaries (untouched)
 
@@ -43,5 +64,5 @@
 ## Evidence record
 
 - Evidence: `lib/keeper/keeper_keepalive_signal.ml:423-448,606-710`, `lib/keeper_runtime/keeper_event_queue.ml` (`enqueue_if_missing`, `drain_board_window`), `lib/keeper/keeper_registry_event_queue.ml`, census artifact e1d4ba86 (axis A5, WEAKENED→surviving core), fresh-read verified 2026-07-09 at `ae027bed8f`.
-- Confidence: High for the three seams (all cited lines re-read at HEAD); Medium for W3 sizing (index invalidation surface needs a dedicated census before implementation).
+- Confidence: High for the three seams (all cited lines re-read at HEAD). W3 sizing was resolved by the 2026-07-10 consumer census (issue #23837, §W3 design above): the disk scan — not the match loop — is the cost, provenance unification is the gate, and the fan-out wake-semantic change is now RFC-sanctioned. W3a/W3b remain unimplemented; W3c is gated on them plus the §W3 wake-semantic sanction.
 - Delta: reframes the fanout cap from loss to deferral using infrastructure that already exists; the census's "no mailbox" claim is corrected to "mailbox exists, delivery and consumption still event-keyed".


### PR DESCRIPTION
## 요약 — RFC-0334 §W3 sizing을 census 결과로 확정 (문서 전용)

RFC-0334는 W3 sizing을 "Medium confidence, dedicated census 선행"으로 미뤄뒀습니다. 그 census(이슈 #23837, 3-lane + adversarial verify + 인라인 보강)를 완료해 §W3를 확정합니다. **코드 변경 없음** — 설계 문서만.

## 확정한 것

1. **비용의 실체**: 이벤트당 지배적 비용은 매치 루프가 아니라 **N × uncached 디스크 `read_meta`**(keeper당 1회, keeper_keepalive_signal.ml:636). 원래 "addressee index" 프레이밍(inverted needle→keeper)은 *eventual* 타깃이나, 디스크 스캔 제거가 win의 대부분이고 인덱스와 분리 가능 → W3를 W3a/b/c로 분할.

2. **provenance가 게이트**: `entry.meta`는 현재 raw(hook)↔effective(reload/heartbeat) 혼재. fan-out은 오늘 raw를 읽으므로 순진한 `entry.meta` 전환은 비결정적 → 먼저 provenance 통일.

3. **방향 = unify-to-EFFECTIVE**: fan-out이 소비하는 overlay 필드는 `mention_targets` 하나(나머지는 raw-safe)인데, `keeper_status_detail.ml:209`는 이름 그대로 `effective_meta_overlay_hash`로 effective를 *요구*. raw 통일은 이를 깸.

4. **W3c의 sanctioned wake-semantic 변경**: fan-out이 effective를 읽으면 TOML-profile `mention_targets`가 board wake에 반영되기 시작(현재 raw만 읽어 무반영). operator config 의도와 정렬되는 latent-bug fix이나 **wake 시맨틱 변경**이므로 RFC에 명시적으로 sanction.

## 분할 + 게이트

- **W3a** (선행, perf, 무변화): base-path profile-defaults 로더를 fingerprint-revalidating 캐시로 승격 (현재 keeper_types_profile.ml:232 uncached). W3b가 hot write-hook에 overlay를 넣으므로 선행 필수.
- **W3b** (behavior-preserving): write-sync hook이 effective 설치 → provenance 결정화, `effective_meta_overlay_hash` 진동/status 캐시 thrash 해소. fan-out은 계속 디스크 read → wake 무변화.
- **W3c** (sanctioned): fan-out을 `entry.meta`로 전환, 디스크 스캔 소멸. :579 CAS lag는 여기서만 실위험 → 함께 수정.

선행 착지: prune 유령 엔트리 fix (#23861, census freshness caveat 1) — W3c가 노출할 "pruned keeper 부활" 하자드 제거.

W3d(inverted index)는 profiling이 in-memory 스캔을 병목으로 보일 때까지 defer.

## Pin (W3c)

keeper 등록 → 디스크 meta 파일 삭제 → mention 포함 board 신호 → 여전히 `entry.meta`로 매칭(디스크 독립성 증명). per-event meta-read 카운터는 추가 안 함(counter-as-pin reject) — 구조적 삭제 pin으로 동일 성질 증명.

RFC-WAIVED: 설계 문서 전용 (구현 코드 0, 본 문서가 RFC 자신). 근거: #23837 census, RFC-0334가 명시적으로 요청한 sizing 확정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
