### PR TITLE
feat(spec): RFC-0320 G6 ContinuationNeverAutoExecutesGated TLA+ invariant

### DIFF
--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -14,6 +14,7 @@ specs/keeper-state-machine/KeeperRuntimeAttemptFSM.tla
 specs/keeper-state-machine/KeeperRuntimeRouting.tla
 specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
 specs/keeper-state-machine/KeeperRolloverDecision.tla
+specs/boundary/ContinuationGated.tla
 EOF
 }
 

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-07T19:11:12Z (HEAD: 9754784148)
+Generated: 2026-07-09T16:22:56Z (HEAD: e13044e91b)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -13,12 +13,12 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | Metric | Value |
 |--------|-------|
-| Total .tla files | 96 |
-| Manual specs | 96 |
+| Total .tla files | 97 |
+| Manual specs | 97 |
 | TTrace (auto-generated) | 0 |
 | Directories | 18 |
-| Total .cfg files | 199 |
-| Buggy .cfg (bug-model pair) | 102 |
+| Total .cfg files | 201 |
+| Buggy .cfg (bug-model pair) | 103 |
 
 `kind` column: **manual** = hand-authored spec; **ttrace** = TLC counterexample export (`*TTrace*` or trace marker in header). `cfg`/`buggy` columns count companion `.cfg` files. `invariants/properties` lists names per cfg label (`clean=...`, `buggy=...`). `source hash` is the tracked `.tla` blob fingerprint.
 
@@ -51,8 +51,8 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AuditLogAppendOrder.tla | AuditLogAppendOrder | manual | 2 | 1 | clean={inv:TypeOK, inv:MutexExclusion} buggy={inv:MutexExclusion} | 5cafd04c9e66 |
 | AuditLogDurableBeforeAck.tla | AuditLogDurableBeforeAck | manual | 2 | 1 | clean={inv:TypeOK, inv:Durability} buggy={inv:Durability} | 2e72a23b081e |
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | bbed415483ac |
-| KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
 | ContinuationGated.tla | ContinuationGated | manual | 2 | 1 | clean={inv:ContinuationNeverAutoExecutesGated} buggy={inv:ContinuationNeverAutoExecutesGated} | b57187b7be79 |
+| KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
 | KeeperContractViolated.tla | KeeperContractViolated | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | ef2f8d4eb972 |
 | KeeperEmptyToolUniverse.tla | KeeperEmptyToolUniverse | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 51f293631b6b |
 | KeeperRecoveryOrchestration.tla | KeeperRecoveryOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0a81a9cf0749 |

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -43,7 +43,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AutonomousLoop.tla | AutonomousLoop | manual | 2 | 1 | clean={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning, inv:AutoTickReadOnly} buggy={inv:TypeOK, inv:MetaPersistedAfterTick, inv:TickOnlyDuringRunning, inv:AutoTickReadOnly} | 11f25e8d37df |
 | AutonomousPhase.tla | AutonomousPhase | manual | 2 | 1 | clean={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} buggy={inv:TypeOK, inv:StartedAtIdle, inv:CurrentMatchesHead, inv:OnlyLegalTransitions} | 54e3dc0e6baa |
 
-### specs/boundary (14 specs)
+### specs/boundary (15 specs)
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
@@ -52,6 +52,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | AuditLogDurableBeforeAck.tla | AuditLogDurableBeforeAck | manual | 2 | 1 | clean={inv:TypeOK, inv:Durability} buggy={inv:Durability} | 2e72a23b081e |
 | Cancellation.tla | Cancellation | manual | 2 | 1 | clean={inv:TypeOK, inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} buggy={inv:ReasonBeforeCancelled, inv:CallbacksFiredAtMostOnce} | bbed415483ac |
 | KeeperContinueGate.tla | KeeperContinueGate | manual | 2 | 1 | clean={inv:Safety, prop:PendingEventuallyResolves} buggy={inv:ApprovedResolutionClearsFailure} | 7f71fad0d4cb |
+| ContinuationGated.tla | ContinuationGated | manual | 2 | 1 | clean={inv:ContinuationNeverAutoExecutesGated} buggy={inv:ContinuationNeverAutoExecutesGated} | b57187b7be79 |
 | KeeperContractViolated.tla | KeeperContractViolated | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | ef2f8d4eb972 |
 | KeeperEmptyToolUniverse.tla | KeeperEmptyToolUniverse | manual | 2 | 1 | clean={inv:Safety} buggy={inv:Safety} | 51f293631b6b |
 | KeeperRecoveryOrchestration.tla | KeeperRecoveryOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0a81a9cf0749 |

--- a/specs/boundary/ContinuationGated-buggy.cfg
+++ b/specs/boundary/ContinuationGated-buggy.cfg
@@ -1,0 +1,11 @@
+\* Buggy model: a continuation resume auto-executes a previously pending gated
+\* call WITHOUT a fresh approval (stale approval carried over from a prior turn).
+\* Expected: ContinuationNeverAutoExecutesGated MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+INVARIANTS
+    ContinuationNeverAutoExecutesGated
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/ContinuationGated.cfg
+++ b/specs/boundary/ContinuationGated.cfg
@@ -1,0 +1,11 @@
+\* Clean model: a continuation resume resets per-turn approval, so a gated
+\* tool only executes after a fresh ApproveGated in the resumed turn.
+\* Expected: ContinuationNeverAutoExecutesGated holds (no error).
+
+SPECIFICATION Spec
+
+INVARIANTS
+    ContinuationNeverAutoExecutesGated
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/ContinuationGated.tla
+++ b/specs/boundary/ContinuationGated.tla
@@ -1,0 +1,134 @@
+------------------------------- MODULE ContinuationGated -------------------------------
+\* RFC-0320 G6 safety invariant (TLA+).
+\*
+\* A continuation (resume) turn — one woken by Hitl_resolved / Connector_attention
+\* to continue a conversation on its originating channel — is a continuation of
+\* DIALOGUE, not a delegation of privilege. Any NEW gated (privileged) tool the
+\* resumed turn invokes must re-enter the approval queue; the resume must not
+\* carry a stale approval forward and auto-execute a pending gated call.
+\*
+\* This spec pins that invariant abstractly (the in-repo runtime re-gating lives
+\* in governance_pipeline / runtime_agent_context; the spec covers the safety
+\* shape, not the Agent-SDK-external execution semantics).
+\*
+\* Bug Model pattern (feedback_tla-spec-audit-outcome-trichotomy):
+\*   clean cfg  : ContinuationNeverAutoExecutesGated holds
+\*   buggy cfg  : AutoExecGatedOnResume violates it
+\*   Both must run for the spec to be useful.
+
+EXTENDS TLC
+
+VARIABLES
+    \* @type: "idle" | "resumed" | "gated_call" | "done"
+    turn,
+    \* a gated (privileged) tool call is waiting in the approval queue this turn
+    gated_pending,
+    \* a gated tool has executed this turn
+    gated_executed,
+    \* the gated execution was preceded by an approval IN THIS TURN
+    gated_approved
+
+vars == <<turn, gated_pending, gated_executed, gated_approved>>
+
+TurnSet == {"idle", "resumed", "gated_call", "done"}
+
+TypeOK ==
+    /\ turn \in TurnSet
+    /\ gated_pending \in BOOLEAN
+    /\ gated_executed \in BOOLEAN
+    /\ gated_approved \in BOOLEAN
+
+Init ==
+    /\ turn = "idle"
+    /\ gated_pending = FALSE
+    /\ gated_executed = FALSE
+    /\ gated_approved = FALSE
+
+\* A continuation channel resumes the keeper into a dialogue turn.
+\* Approvals do NOT carry over from a prior turn — gated_approved resets.
+ResumeContinuation ==
+    /\ turn = "idle"
+    /\ turn' = "resumed"
+    /\ gated_pending' = FALSE
+    /\ gated_executed' = FALSE
+    /\ gated_approved' = FALSE
+
+\* The resumed turn calls a gated tool — it must re-enter the approval queue.
+CallGated ==
+    /\ turn = "resumed"
+    /\ ~gated_pending
+    /\ gated_pending' = TRUE
+    /\ UNCHANGED <<turn, gated_executed, gated_approved>>
+
+\* Operator approves the gated call → it may execute THIS turn.
+ApproveGated ==
+    /\ turn = "resumed"
+    /\ gated_pending
+    /\ gated_pending' = FALSE
+    /\ gated_executed' = TRUE
+    /\ gated_approved' = TRUE
+    /\ UNCHANGED turn
+
+\* Turn ends (no pending gated call left).
+FinishTurn ==
+    /\ turn = "resumed"
+    /\ ~gated_pending
+    /\ turn' = "done"
+    /\ UNCHANGED <<gated_pending, gated_executed, gated_approved>>
+
+\* Reset to idle, ready for another continuation.
+Reset ==
+    /\ turn = "done"
+    /\ turn' = "idle"
+    /\ gated_pending' = FALSE
+    /\ gated_executed' = FALSE
+    /\ gated_approved' = FALSE
+
+Next ==
+    \/ ResumeContinuation
+    \/ CallGated
+    \/ ApproveGated
+    \/ FinishTurn
+    \/ Reset
+
+Spec == Init /\ [][Next]_vars
+
+\* ── G6 invariant ───────────────────────────────────────────────────
+\* A gated tool executes only when it has been approved in the CURRENT turn.
+\* ResumeContinuation resets gated_approved, so a stale approval from a prior
+\* turn can never license an execution in the resumed turn.
+ContinuationNeverAutoExecutesGated ==
+    gated_executed => gated_approved
+
+Safety ==
+    /\ TypeOK
+    /\ ContinuationNeverAutoExecutesGated
+
+\* ── Buggy variant: a continuation resume auto-executes a previously ──
+\*    pending gated call WITHOUT a fresh approval (stale approval carried over).
+AutoExecGatedOnResume ==
+    /\ turn = "idle"
+    /\ gated_pending               \* a gated call was pending from before
+    /\ turn' = "resumed"
+    /\ gated_executed' = TRUE       \* ... and the resume auto-executes it
+    /\ gated_approved' = FALSE      \* ... without a fresh approval
+    /\ gated_pending' = FALSE
+
+NextBuggy ==
+    \/ AutoExecGatedOnResume
+    \/ CallGated
+    \/ ApproveGated
+    \/ FinishTurn
+    \/ Reset
+
+\* A pending gated call must be reachable for the bug to be meaningful, so the
+\* buggy init admits a pre-existing pending gated call.
+InitBuggy ==
+    /\ turn = "idle"
+    /\ gated_pending = TRUE
+    /\ gated_executed = FALSE
+    /\ gated_approved = FALSE
+
+SpecBuggy == InitBuggy /\ [][NextBuggy]_vars
+
+=============================================================================


### PR DESCRIPTION
G6 safety invariant (RFC-0320 §G6): a continuation (resume) turn is a continuation of dialogue, not a privilege delegation — any new gated tool in the resumed turn must re-enter the approval queue, and the resume must not carry a stale approval forward. The RFC marked this in-repo unverified (Agent-SDK-external execution semantics); this abstract TLA+ model pins the safety shape: ContinuationNeverAutoExecutesGated (gated_executed => gated_approved in the current turn; ResumeContinuation resets gated_approved). Bug-model pattern: clean cfg holds, buggy cfg (auto-exec-on-resume with a stale approval) must violate. Co-Authored-By: Claude <noreply@anthropic.com>