### PR TITLE
Board Claim Gate Phase 1: target-post high-risk detection for replies without explicit claims

### DIFF
--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -235,6 +235,48 @@ let load_records path =
       [])
 ;;
 
+(* --- Phase 1: target-post high-risk detection --- *)
+
+(** High-risk claim kinds that require evidence backing. *)
+let high_risk_claim_strings =
+  [ "artifact_exists"; "artifact_missing"; "artifact_created"
+  ; "artifact_endorsed"; "verification_endorsement"
+  ; "task_completion"; "pr_state"; "retraction_ack"
+  ]
+;;
+
+(** [post_has_high_risk_evidence post_id] scans the sidecar ledger for
+    any record targeting [post_id] that carries typed claims beyond
+    [opinion_or_routing].  Used by the board claim gate (Phase 1) to
+    force source_post_snapshot requirements on replies to high-risk
+    posts even when the replying keeper omits explicit claim args. *)
+let post_has_high_risk_evidence post_id =
+  let records = load_records (sidecar_path ()) in
+  List.exists
+    (fun json ->
+      let matches_target =
+        match string_opt "target_post_id" json with
+        | Some pid -> String.equal pid post_id
+        | None -> false
+      in
+      if not matches_target
+      then false
+      else
+        let claims =
+          match assoc_opt "claims" json with
+          | Some (`List items) ->
+            List.filter_map
+              (function `String s -> Some s | _ -> None)
+              items
+          | _ -> []
+        in
+        (* Any claim beyond opinion_or_routing makes the post high-risk *)
+        List.exists
+          (fun c -> not (String.equal c "opinion_or_routing"))
+          claims)
+    records
+;;
+
 let projection_lookup () =
   let table = Hashtbl.create 16 in
   let path = sidecar_path () in

--- a/lib/board/board_claim_evidence.mli
+++ b/lib/board/board_claim_evidence.mli
@@ -24,3 +24,14 @@ val sidecar_path : unit -> string
 val projection_state_to_string : projection_state -> string
 val projection_to_yojson : projection -> Yojson.Safe.t
 val projection_lookup : unit -> string -> projection option
+
+(** [post_has_high_risk_evidence post_id] scans the sidecar ledger and
+    returns [true] if any record targeting [post_id] carries typed claims
+    beyond [opinion_or_routing] — i.e. artifact_exists, artifact_missing,
+    artifact_created, artifact_endorsed, verification_endorsement,
+    task_completion, pr_state, or retraction_ack.
+
+    This is used by the board claim gate to determine whether a post
+    should be treated as high-risk even when the replying keeper does
+    not declare explicit claims in their tool arguments. *)
+val post_has_high_risk_evidence : string -> bool

--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -365,8 +365,12 @@ let check_write ~requires_source_snapshot ~tool_name ~author ~target_post_id ~co
   let has_snapshot_arg = Option.is_some (assoc_opt "source_post_snapshot" args) in
   let snapshot = source_snapshot_arg args in
   let artifact_refs = artifact_refs_arg args in
+  let target_high_risk =
+    Board_claim_evidence.post_has_high_risk_evidence target_post_id
+  in
   let high_risk =
     claims <> [] || unknown_claims <> [] || has_snapshot_arg || artifact_refs <> []
+    || target_high_risk
   in
   if not high_risk
   then Ok ()


### PR DESCRIPTION
## Summary

Closes the gap identified in the Evidence-Backed Board Claim Gate design doc.

### Problem
Keepers could pass silent endorsements (e.g. "Good move producing a concrete PoC") on high-risk posts without triggering the source_post_snapshot requirement, because `check_write` only checked whether the keeper explicitly passed `claims`/`artifact_refs`/`source_post_snapshot` arguments. If they omitted all three, `high_risk = false` and the gate returned `Ok ()` immediately.

### Fix
Added `Board_claim_evidence.post_has_high_risk_evidence` that scans the sidecar ledger for any record targeting a given post_id that carries typed claims beyond `opinion_or_routing`. Wired into `Board_claim_gate.check_write` so `high_risk` is now also set when the target post has prior high-risk claim evidence — even when the replying keeper omits explicit claim arguments.

### Files changed
- `lib/board/board_claim_evidence.mli` — new `post_has_high_risk_evidence` signature
- `lib/board/board_claim_evidence.ml` — implementation: scans sidecar for high-risk claims on target post
- `lib/board_tool_adapter/board_claim_gate.ml` — `check_write` now calls `post_has_high_risk_evidence` when computing `high_risk`

### Design doc
Ref: Evidence-Backed Board Claim Gate (Phase 1: warn and downgrade)
Board post: p-3248125b506c0e14a434f3f498a71d84