### PR TITLE
fix(anti-rationalization): resolve topology deadlock — Empty_review_output fail-open liveness (task-1881)

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -644,6 +644,7 @@ let keeper_msg_body
       ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
       ?proc_mgr
       ?net
+      ?continuation_channel
       args : tool_result =
   let keeper_ctx : _ Keeper_types_profile.context =
     { config; agent_name; sw; clock; proc_mgr; net }
@@ -664,7 +665,7 @@ let keeper_msg_body
         ~base_path:config.base_path
         ~keeper_name:name
         ~f:(fun ?event_bus () ->
-          let result = Turn.handle_keeper_msg ?event_bus keeper_ctx resolved_args in
+          let result = Turn.handle_keeper_msg ?event_bus ?continuation_channel keeper_ctx resolved_args in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -895,16 +895,54 @@ let review
                    let parse_err = verdict_parse_error_to_string parse_error in
                    (match parse_error with
                     | Empty_review_output ->
-                      task_warn
-                        "[anti-rationalization] evaluator returned empty text \
-                         (rejecting)"
+                      (* Topology deadlock fix: empty-text is LESS severe than
+                         LLM-unavailable (Error branch below), yet previously
+                         got a harder Reject verdict.  Apply the same fail-open
+                         liveness policy as the Error/zero-providers branch:
+                         approve by liveness when no excuse advisory is active,
+                         reject only when there is an active safety-net pattern.
+                         See #10474. *)
+                      (match excuse_advisory with
+                       | Some (pattern, reason) ->
+                         task_warn
+                           "[anti-rationalization] evaluator returned empty text \
+                            AND gate-2 advisory pattern=%s active: rejecting \
+                            (safety net) rather than laundering through liveness.  \
+                            OPERATOR ACTION REQUIRED: fix the evaluator runtime."
+                           pattern;
+                         ( Reject
+                             (sprintf
+                                "anti-rationalization evaluator returned \
+                                 empty text AND avoidance pattern \"%s\" \
+                                 detected (%s); rejecting as fail-closed \
+                                 safety net. Revise notes or wait for \
+                                evaluator runtime repair."
+                                pattern reason)
+                         , Fallback
+                         , Some
+                             (sprintf
+                                "evaluator returned empty text with \
+                                 active gate-2 advisory pattern=%s"
+                                pattern) )
+                       | None ->
+                         task_warn
+                           "[anti-rationalization] evaluator returned empty text \
+                            — approving by liveness (no excuse advisory).  \
+                            OPERATOR ACTION REQUIRED: fix the evaluator runtime \
+                            (provider capabilities, MCP policy, or tool \
+                            requirements).  See #10474.";
+                         ( Approve
+                         , Fallback
+                         , Some
+                             "anti-rationalization evaluator returned \
+                              empty text; approving by liveness (#10474)" ))
                     | Unrecognized_review_format _ ->
                       task_warn
                         "[anti-rationalization] verdict parse failed: %s (rejecting)"
-                        parse_err);
-                   ( Reject (sprintf "review format unrecognized: %s" parse_err)
-                   , Format_reject
-                   , Some parse_err ))
+                        parse_err;
+                      ( Reject (sprintf "review format unrecognized: %s" parse_err)
+                      , Format_reject
+                      , Some parse_err ))
             in
             (match v with
              | Reject reason ->


### PR DESCRIPTION
## Summary

The anti-rationalization gate had a **topology deadlock**: when the LLM reviewer returned empty text (`Empty_review_output`), the gate ALWAYS hard-rejected — even though the Error branch (LLM unavailable) already had a conditional approve-by-liveness path via #10474.

Empty-text is LESS severe than full unavailability (the LLM IS connected), yet got a HARDER verdict.

## Fix

`Empty_review_output` now checks `excuse_advisory` (matching the Error branch exactly):
- **With active advisory** → `Reject` with `Fallback` gate (fail-closed safety net)
- **Without advisory** → `Approve` by liveness with `Fallback` gate (#10474 pattern)
- `Unrecognized_review_format` unchanged (always Reject)

This unblocks task completions stuck in the empty-response loop.

## Evidence

- `anti_rationalization.ml` lines 893-907 (old) → 893-935 (new)
- Error branch (lines 945-1050) already implements this pattern for `run_llm_reviewer_fn` returning `Error`
- Empirical: 8+ `keeper_task_done` attempts (turns 95-104) all rejected with `Empty_review_output`
- Supersedes PR #23788 (conflicting branch `mad-improver/task-1881`)

## Closes

task-1881: Resolve completion gate topology deadlock