### PR TITLE
[G02] board composer voice 직렬화 거부 (text body)

### DIFF
--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -154,10 +154,6 @@ export function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function formatClock(seconds: number): string {
-  const whole = Math.max(0, Math.round(seconds))
-  return `${Math.floor(whole / 60)}:${String(whole % 60).padStart(2, '0')}`
-}
 
 export function appendVoiceTranscriptDraft(current: string, transcript: string): string {
   const text = transcript.trim()
@@ -174,16 +170,15 @@ export function serializeComposerBody(input: {
   if (input.attachments.length > 0) {
     throw new Error('Composer attachments require block transport and must not be serialized into text body')
   }
-  const blocks: string[] = []
   if (input.voice) {
-    blocks.push([
-      `Voice memo ${formatClock(input.voice.secs)} (${input.voice.size})`,
-      input.voice.transcript,
-    ].join('\n'))
+    // G02 (multimodal parity) — voice must travel as a block, not be folded into
+    // the text body. Chat and board share the ComposerBlocks transport; the text
+    // path must refuse voice rather than silently serializing its transcript and
+    // dropping the audio metadata. All current callers pass voice: null, so this
+    // removes the dead serialization branch.
+    throw new Error('Composer voice requires block transport and must not be serialized into text body')
   }
-  const text = input.text.trim()
-  if (text) blocks.push(text)
-  return blocks.join('\n\n')
+  return input.text.trim()
 }
 
 interface ComposerV2Props {


### PR DESCRIPTION
## 배경

v2 Reference Gap Matrix G02: board composer가 voice/attachment를 text body로 직렬화 → multimodal parity 위반. 조사 결과 main은 대부분 닫혀 있었으나, `serializeComposerBody`는 attachment는 throw(정직 차단)하면서 **voice는 여전히 transcript를 text로 접어 넣음** (오디오 메타 손실).

## 변경 (Step A — honest refusal)

`serializeComposerBody`(`board/composer-v2.ts`)에서 voice도 attachment와 대칭으로 **throw**: "voice requires block transport, must not be serialized into text body".

- 모든 현재 호출처(`composer-v2.ts:360`, `board-surface.ts:1005`)가 이미 `voice: null`로 호출 → dead 직렬화 branch 제거 + 이제 unused `formatClock` 제거.
- `pnpm exec tsc --noEmit` 통과.

## 범위 밖 (follow-up)

- **G02 본 해결**: chat/board가 공유하는 `ComposerBlocks` block transport 도입. voice/attachment가 block으로 전송. 별도 큰 PR.
- `appendVoiceTranscriptDraft`(voice transcript를 body text에 append)가 진짜 voice→text 경로(`composer-v2.ts:222`, `board-surface.ts:836`). 테스트:203 'transcribes voice input into the current text transport'이 이를 명시 기대. 본 해결 시 이 경로를 block transport로 옮기고 테스트 갱신.

## 검증 상태

- tsc 통과(worktree).
- **vitest 미실행** (worktree에 node_modules 없음). 이 PR은 Draft — CI가 테스트 검증. serializeComposerBody 직접 단위 테스트는 없고, 통합 테스트(composer-v2.test.ts:203)는 voice: null 경로(appendVoiceTranscriptDraft)라 이 PR 변경에 영향 없음 예상.

## self-review

- 대상: `dashboard/src/components/board/composer-v2.ts` (1파일, +7/-12)
- 미검증: vitest (CI 대기)

G02 (v2 Reference Gap Matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)