### PR TITLE
fix(masc): route no-progress turn failures to Contract_violation instead of rotate

### DIFF
--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -89,12 +89,7 @@ let route_of_masc_internal ~err (internal : Keeper_internal_error.masc_internal_
      | Keeper_internal_error.Max_turns_exceeded
      | Keeper_internal_error.Other_detail _ ->
        rotate Runtime_exhausted)
-  | Keeper_internal_error.Accept_rejected _ ->
-    (match Keeper_internal_error.accept_no_progress_retry_kind internal with
-     | Some `Empty_no_progress -> rotate No_progress_empty
-     | Some `Read_only_no_progress -> rotate No_progress_read_only
-     | Some `Thinking_only_no_progress -> rotate No_progress_thinking_only
-     | None -> judge ~err Contract_violation)
+  | Keeper_internal_error.Accept_rejected _ -> judge ~err Contract_violation
   | Keeper_internal_error.Max_tokens_ceiling_violation _ -> judge ~err Contract_violation
   | Keeper_internal_error.Internal_contract_rejected _ -> judge ~err Contract_violation
   | Keeper_internal_error.Ambiguous_post_commit _ -> judge ~err Mutating_ambiguity


### PR DESCRIPTION
RFC-0313 W3: an idle loop (repeated no-usable-progress turns) was a manual-resume pause class on the legacy ladder; under existence invariance it escalates as a behavioral contract judgment, not as an opaque internal error.

This fixes an issue where the agent falls into an infinite thinking loop (Thinking_only_no_progress) because the rotate failure route is a no-op at the turn level.