### PR TITLE
fix(gate): Slack connector exposed + wired in dashboard (emit connector_id/display_name)

### DIFF
--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -171,13 +171,37 @@ let status_json ?(audit_limit = 10) () =
 
 let connector_json ?gate_status_json ?(audit_limit = 10) () =
   let status = status_json ~audit_limit () in
-  match gate_status_json with
-  | None -> status
-  | Some extra ->
+  let base =
+    match gate_status_json with
+    | None -> status
+    | Some extra ->
+      `Assoc
+        (match (status, extra) with
+         | `Assoc s, `Assoc e -> s @ e
+         | _ -> [ ("status", status); ("gate_status", extra) ])
+  in
+  (* The dashboard connectors endpoint
+     ([Channel_gate_connector.connectors_json]) matches each connector to its
+     tile by [connector_id]; the dashboard's [findConnector(connectors,
+     "slack")] returns null without it, so a connected Slack gateway rendered
+     as an unstarted "설정 필요" placeholder. Mirror Discord/Telegram
+     [connector_json], which carry both identity fields at the top level.
+     Prepend (with a dedupe filter) so the identity is authoritative even if a
+     merged [gate_status_json] also supplied the keys. *)
+  match base with
+  | `Assoc fields ->
+    let without_identity =
+      List.filter
+        (fun (k, _) ->
+          not
+            (String.equal k "connector_id" || String.equal k "display_name"))
+        fields
+    in
     `Assoc
-      (match (status, extra) with
-       | `Assoc s, `Assoc e -> s @ e
-       | _ -> [ ("status", status); ("gate_status", extra) ])
+      (("connector_id", `String connector_id)
+      :: ("display_name", `String display_name)
+      :: without_identity)
+  | other -> other
 
 let rollback_bindings original = save_bindings original
 

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -182,6 +182,31 @@ let test_telegram_connector_json_reads_runtime_status () =
     check int "configured bindings count" 1
       (json |> U.member "configured_bindings" |> U.to_list |> List.length))
 
+let test_slack_connector_json_carries_identity () =
+  with_temp_dir @@ fun dir ->
+  with_sidecar_paths "slack" dir (fun () ->
+    (* Regression: the dashboard connectors endpoint matches a connected
+       gateway to its tile by [connector_id] (findConnector(connectors,
+       "slack")). Slack's connector_json used to omit connector_id/display_name
+       — Discord/Telegram carry them — so a connected Slack gateway rendered as
+       an unstarted "설정 필요" placeholder. Both fields must be present. *)
+    let json = Channel_gate_slack_state.connector_json () in
+    check string "connector id" "slack"
+      (json |> U.member "connector_id" |> U.to_string);
+    check string "display name" "Slack"
+      (json |> U.member "display_name" |> U.to_string);
+    (* The endpoint passes [~gate_status_json]; identity must survive the
+       merge, since it is the tile-matching key. *)
+    let merged =
+      Channel_gate_slack_state.connector_json
+        ~gate_status_json:(`Assoc [ ("channels", `List []) ])
+        ()
+    in
+    check string "connector id survives gate_status merge" "slack"
+      (merged |> U.member "connector_id" |> U.to_string);
+    check string "display name survives gate_status merge" "Slack"
+      (merged |> U.member "display_name" |> U.to_string))
+
 let () =
   run "channel_gate_connector_routes"
     [
@@ -206,5 +231,7 @@ let () =
             test_slack_default_paths_resolve_under_base_path;
           test_case "telegram connector json reads runtime status" `Quick
             test_telegram_connector_json_reads_runtime_status;
+          test_case "slack connector json carries connector_id/display_name" `Quick
+            test_slack_connector_json_carries_identity;
         ] );
     ]


### PR DESCRIPTION
## 요약 — Slack connector가 대시보드에 안 뜨던 근본 원인 수정 (empirically 확인)

라이브 `/api/v1/gate/connectors`를 직접 조회해 근본 원인을 확정했습니다. Slack 게이트웨이가 **실제로 connected**(available=true, gateway_state=connected, app/bot token present)인데도 대시보드 타일은 "설정 필요 / 아직 시작되지 않음" placeholder로 표시됩니다.

## 근본 원인

`Channel_gate_slack_state.connector_json`이 **`connector_id`와 `display_name` 키를 emit하지 않습니다**. Discord(`channel_gate_discord_state.ml:330-331`)와 Telegram은 둘 다 최상위에 명시 포함하는데, Slack은 `status_json`을 그대로(또는 gate_status 병합) 반환할 뿐 identity를 주입하지 않았습니다.

라이브 응답에서 4개 연결자 중 connected인 Slack 엔트리만 `connector_id`/`display_name` 키 부재를 확인:
```
[1] connector_id=None display_name=None available=True status='connected'
    has_cid_key=False has_dn_key=False
```

## 인과 사슬 (백엔드 → FE)

1. 엔드포인트 `Channel_gate_connector.connectors_json`가 각 연결자의 `connector_json`을 그대로 방출.
2. FE 스키마 `gate-connectors.ts`: `GateConnectorInfoRawSchema.connector_id: string()` **required**. `parseGateConnectorInfo`가 파싱 실패 시 `null` 반환(`:346-348`).
3. `parseGateConnectorsData`가 null 엔트리를 **skip**(`:450-453`) → `connectors` 배열에 Slack 부재.
4. `ConnectorOverviewStrip`의 `findConnector(connectors, 'slack')`가 `c.connector_id === 'slack'`로 매칭 → 못 찾음 → placeholder 타일.

per-item 파싱이라 다른 연결자(discord/imessage/telegram)는 정상 표시되고 **Slack만 조용히 탈락**했습니다.

## 수정

`connector_json`이 `connector_id`/`display_name`를 최상위에 주입(Discord/Telegram mirror). None 경로와 gate_status 병합 경로 **둘 다** 커버하고, 병합 payload가 같은 키를 줬더라도 게이트웨이 identity가 authoritative하도록 prepend + dedupe-filter. 모듈 값 `connector_id="slack"`/`display_name="Slack"`(이미 존재) 사용.

## 검증

- **empirical**: 라이브 엔드포인트 조회로 근본 원인 재현·확정.
- **regression test**: `test_slack_connector_json_carries_identity` — `connector_json ()`와 `connector_json ~gate_status_json:... ()`(엔드포인트 실제 경로) 둘 다 `connector_id="slack"`/`display_name="Slack"` assert.
- 2파일 `ocamlc -stop-after parsing` 통과 (빌드/테스트는 CI — repo 규칙).
- **FE 변경 불필요**: 스키마·overview strip은 이미 connector_id 기반 다중 연결자 처리. 백엔드가 키를 emit하면 자동 배선.

RFC 맥락: RFC-0317(in-process Slack gateway, PR1-3 landed) + RFC-0223(typed connector surfaces). 이 수정은 대시보드 노출 표면의 Discord parity 갭을 닫습니다.

RFC-WAIVED: 노출 표면 parity 버그 수정 (Discord/Telegram 기존 패턴의 대칭 적용, 신규 설계 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
