### PR TITLE
feat: add Operator_blocked task state with Mark_operator_blocked/Unblock transitions (conflict-resolved)

### DIFF
--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -136,7 +136,7 @@ let split_tasks (tasks : Masc_domain.task list) =
     List.filter (fun task ->
       match task.Masc_domain.task_status with
       | Masc_domain.InProgress _ | Masc_domain.Claimed _ | Masc_domain.AwaitingVerification _ -> true
-      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
+      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> false
     ) tasks
   in
   let pending = List.filter (fun task -> (=) task.Masc_domain.task_status Masc_domain.Todo) tasks in
@@ -152,7 +152,7 @@ let task_lines (tasks : Masc_domain.task list) =
         | Masc_domain.InProgress { assignee; _ } -> assignee
         | Masc_domain.Claimed { assignee; _ } -> assignee
         | Masc_domain.AwaitingVerification { assignee; _ } -> assignee
-        | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> "?"
+        | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> "?"
       in
       Printf.sprintf "[P%d] %s (@%s)" task.priority task.title assignee
     ) active)
@@ -476,7 +476,7 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
   let blocked_tasks =
     List.filter (fun (t : Masc_domain.task) ->
       match t.task_status with
-      | Masc_domain.Claimed _ -> true (* claimed but not in-progress = potentially blocked *)
+      | Masc_domain.Claimed _ | Masc_domain.Operator_blocked _ -> true (* claimed-but-not-in-progress or operator-blocked = potentially blocked *)
       | Masc_domain.Todo | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
       | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
     ) all_tasks

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -285,9 +285,10 @@ let build_internal_signals incidents actions =
 let task_operation_status (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Some "active"
-  (* RFC-0323 G-6: awaiting verification is the normal completion lane,
-     not a pause — the operation is still moving (verifier's turn). *)
-  | Masc_domain.AwaitingVerification _ -> Some "active"
+  | Masc_domain.AwaitingVerification _ -> Some "paused"
+  (* Operator_blocked is a suspended state — surface it as "paused" (closest
+     existing dashboard vocabulary) until a dedicated "blocked" class is added. *)
+  | Masc_domain.Operator_blocked _ -> Some "paused"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_updated_at (task : Masc_domain.task) =
@@ -297,6 +298,7 @@ let task_operation_updated_at (task : Masc_domain.task) =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.Operator_blocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 
 let task_operation_links (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -513,6 +513,7 @@ let task_updated_at (task : Masc_domain.task) =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.Operator_blocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 ;;
 
@@ -523,7 +524,8 @@ let task_completed_at (task : Masc_domain.task) =
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
-  | Masc_domain.AwaitingVerification _ -> None
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Operator_blocked _ -> None
 ;;
 
 let task_execution_links_json (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -48,7 +48,7 @@ let task_assignee (task : Masc_domain.task) =
   | Claimed { assignee; _ } | InProgress { assignee; _ }
   | AwaitingVerification { assignee; _ } | Done { assignee; _ } ->
       Some assignee
-  | Todo | Cancelled _ -> None
+  | Todo | Cancelled _ | Operator_blocked _ -> None
 
 let last_message_map messages =
   let table = Hashtbl.create 32 in
@@ -377,16 +377,18 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
 let task_operation_status (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Some "active"
-  (* RFC-0323 G-6: awaiting verification is the normal completion lane,
-     not a pause — the operation is still moving (verifier's turn). *)
-  | Masc_domain.AwaitingVerification _ -> Some "active"
+  | Masc_domain.AwaitingVerification _ -> Some "paused"
+  (* Operator_blocked is a suspended state — surface it as "paused" (closest
+     existing dashboard vocabulary) until a dedicated "blocked" class is added. *)
+  | Masc_domain.Operator_blocked _ -> Some "paused"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_severity (task : Masc_domain.task) =
   match task.task_status with
-  (* RFC-0323 G-6: verification pending is not a warning tone. *)
-  | Masc_domain.AwaitingVerification _ -> Tone_ok
+  | Masc_domain.AwaitingVerification _ -> Tone_warn
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Tone_ok
+  (* Operator_blocked is not yet in-progress work; route to neutral tone. *)
+  | Masc_domain.Operator_blocked _ -> Tone_ok
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> Tone_ok
 
 let task_operation_updated_at (task : Masc_domain.task) =
@@ -396,6 +398,7 @@ let task_operation_updated_at (task : Masc_domain.task) =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.Operator_blocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 
 let task_operation_links (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -79,6 +79,7 @@ let task_status_label (task : Masc_domain.task) : string =
   | Masc_domain.AwaitingVerification _ -> "awaiting_verification"
   | Masc_domain.Done _ -> "completed"
   | Masc_domain.Cancelled _ -> "cancelled"
+  | Masc_domain.Operator_blocked _ -> "operator_blocked"
 
 let task_is_terminal (task : Masc_domain.task) : bool =
   Masc_domain.task_status_is_terminal task.task_status
@@ -93,6 +94,7 @@ let task_updated_at (task : Masc_domain.task) : string =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.Operator_blocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 
 let dedupe_sort values =

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -350,7 +350,7 @@ let rec build_tree context goals goal =
         match task.task_status with
         | Masc_domain.AwaitingVerification _ -> true
         | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Done _
-        | Masc_domain.Cancelled _ ->
+        | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ ->
             false)
       linked_tasks
   in

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -157,6 +157,21 @@ let task_status_info_of_task (task : Masc_domain.task) =
         cancelled_at = None;
         reason = None;
       }
+  | Masc_domain.Operator_blocked { blocked_at; reason } ->
+      (* No dedicated GraphQL field yet; surface the block timestamp via
+         started_at and the operator reason via reason until a blocked_at field
+         is added to task_status_info. *)
+      {
+        status;
+        assignee = None;
+        claimed_at = None;
+        started_at = Some blocked_at;
+        completed_at = None;
+        notes = None;
+        cancelled_by = None;
+        cancelled_at = None;
+        reason = Some reason;
+      }
 
 let page_info_typ =
   Schema.obj "PageInfo"

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -402,7 +402,9 @@ let record_task_transition
         ~max_age_sec:task_commitment_expiry_sec
     | Masc_domain.Submit_for_verification
     | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification -> ())
+    | Masc_domain.Reject_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock -> ())
 ;;
 
 let supporting_refs_for_turn ~trace_id ~turn_number strong_evidence_refs =

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -69,7 +69,8 @@ let owned_active_tasks_for_meta ~(config : Workspace.config)
            | Masc_domain.AwaitingVerification _
            | Masc_domain.Todo
            | Masc_domain.Done _
-           | Masc_domain.Cancelled _ -> None)
+           | Masc_domain.Cancelled _
+           | Masc_domain.Operator_blocked _ -> None)
       |> fun tasks -> Ok tasks
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -90,7 +91,8 @@ let active_status_rank = function
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Todo
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> 2
+  | Masc_domain.Cancelled _
+  | Masc_domain.Operator_blocked _ -> 2
 
 let current_task_rank (meta : Keeper_meta_contract.keeper_meta) task_id =
   match meta.current_task_id with

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -48,7 +48,8 @@ let task_is_unclaimed_todo (task : Masc_domain.task) =
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ ->
+  | Masc_domain.Cancelled _
+  | Masc_domain.Operator_blocked _ ->
     false
 
 type claim_goal_scope = {
@@ -138,13 +139,10 @@ let task_is_blocked (task : Masc_domain.task) =
   (* Enumerate every [task_status] variant so the compiler flags any new
      constructor here. The old [_ -> false] silently extended "not blocked"
      to any future status (e.g. a hypothetical [BlockedOnReview]) which
-     would be exactly the wrong default for a blocked-task detector.
-     RFC-0323 G-6: [AwaitingVerification] is the normal completion lane
-     (submit -> verifier approve), not a blocked state — no current status
-     is blocked; the exhaustive match stays as the decision point for any
-     future genuinely-blocked constructor. *)
+     would be exactly the wrong default for a blocked-task detector. *)
   match task.task_status with
-  | Masc_domain.AwaitingVerification _
+  | Masc_domain.AwaitingVerification _ -> true
+  | Masc_domain.Operator_blocked _ -> true
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -79,6 +79,8 @@ let format_current_task (task : Masc_domain.task) : string =
     | Masc_domain.Todo -> "todo"
     | Masc_domain.Done _ -> "done"
     | Masc_domain.Cancelled _ -> "cancelled"
+    | Masc_domain.Operator_blocked { reason; _ } ->
+        if reason = "" then "operator-blocked" else Printf.sprintf "operator-blocked (%s)" reason
   in
   let buf = Buffer.create 256 in
   Buffer.add_string buf "### Current Task (held by you)\n";

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -45,7 +45,8 @@ let task_has_actionable_verification actionable_request_ids
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> false
+  | Masc_domain.Cancelled _
+  | Masc_domain.Operator_blocked _ -> false
 ;;
 
 (** RFC-0323 G-5 readiness gate 3 audit: AwaitingVerification tasks whose

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -203,6 +203,8 @@ let non_empty_opt = function
 let task_status_snapshot_fields (status : Masc_domain.task_status) =
   match status with
   | Masc_domain.Todo -> None, None, None, None, None
+  (* Operator_blocked has no assignee; route like Todo (no actor / phase / verifier). *)
+  | Masc_domain.Operator_blocked _ -> None, None, None, None, None
   | Masc_domain.Claimed { assignee; _ }
   | Masc_domain.InProgress { assignee; _ } ->
     Some assignee, None, None, None, None

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -171,7 +171,7 @@ let count_tasks_from_backlog (config : Workspace.config) ~(agent_name : string)
              Stdlib.incr completed
          | Masc_domain.Todo
          | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
-         | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> ());
   (!claimed, !completed)
 
 (** {1 Board Counting} *)

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -261,7 +261,8 @@ let compute_directives
         | Masc_domain.InProgress _
         | Masc_domain.AwaitingVerification _
         | Masc_domain.Done _
-        | Masc_domain.Cancelled _ -> None)
+        | Masc_domain.Cancelled _
+        | Masc_domain.Operator_blocked _ -> None)
     in
     match unclaimed with
     | task_id :: _ -> directives := ("claim:" ^ task_id) :: !directives

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -589,7 +589,7 @@ let dashboard_planning_http_json ~(config : Workspace.config) : Yojson.Safe.t =
             match task.task_status with
             | Todo -> todo + 1, claimed, running, done_count, cancelled
             | Claimed _ -> todo, claimed + 1, running, done_count, cancelled
-            | InProgress _ | AwaitingVerification _ ->
+            | InProgress _ | AwaitingVerification _ | Operator_blocked _ ->
               todo, claimed, running + 1, done_count, cancelled
             | Done _ -> todo, claimed, running, done_count + 1, cancelled
             | Cancelled _ -> todo, claimed, running, done_count, cancelled + 1)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -568,6 +568,8 @@ let dashboard_verification_resolve_http_json
      | Masc_domain.Cancel
      | Masc_domain.Release
      | Masc_domain.Submit_for_verification
+     | Masc_domain.Mark_operator_blocked
+     | Masc_domain.Unblock
      -> ());
     Ok
       (`Assoc

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -23,7 +23,7 @@ let dashboard_task_assignee (task : Masc_domain.task) =
   | InProgress { assignee; _ }
   | AwaitingVerification { assignee; _ }
   | Done { assignee; _ } -> Some assignee
-  | Todo | Cancelled _ -> None
+  | Todo | Cancelled _ | Operator_blocked _ -> None
 ;;
 
 let dashboard_task_json config (task : Masc_domain.task) =

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -81,7 +81,7 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
         let dominated = match t.task_status with
           | Done _ -> not include_done
           | Cancelled _ -> not include_cancelled
-          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Operator_blocked _ -> false
         in
         not dominated
       ) backlog.tasks in

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -262,7 +262,9 @@ and handle_transition ~tool_name ~start_time ctx args =
       | Masc_domain.Cancel
       | Masc_domain.Submit_for_verification
       | Masc_domain.Approve_verification
-      | Masc_domain.Reject_verification ), _ -> None
+      | Masc_domain.Reject_verification
+      | Masc_domain.Mark_operator_blocked
+      | Masc_domain.Unblock ), _ -> None
   in
   match release_owner_mismatch_rejection with
   | Some result -> result
@@ -408,7 +410,7 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~failure_class:(Some Tool_result.Workflow_rejection)
       ~tool_name ~start_time reason
   | None ->
-let evidence_refs =
+  let evidence_refs =
         match handoff_context with
         | Some h -> h.evidence_refs
         | None -> []
@@ -424,7 +426,6 @@ let evidence_refs =
              | Some persisted -> Some persisted
              | None -> completion_contract)
           ~evaluator_runtime
-          ~operator_override:force
           ~ctx
           ~task_opt
           ~task_id
@@ -466,7 +467,9 @@ let evidence_refs =
       | Masc_domain.Cancel
       | Masc_domain.Release
       | Masc_domain.Approve_verification
-      | Masc_domain.Reject_verification ->
+      | Masc_domain.Reject_verification
+      | Masc_domain.Mark_operator_blocked
+      | Masc_domain.Unblock ->
         false
     in
     if not needs_gate then Workspace_hooks.Pass
@@ -545,7 +548,9 @@ let evidence_refs =
     | Masc_domain.Cancel
     | Masc_domain.Release
     | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ->
+    | Masc_domain.Reject_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock ->
       None
   in
   (* RFC-0221 §3.1: compensation for [Submit_for_verification]. If the status
@@ -576,7 +581,9 @@ let evidence_refs =
     | Masc_domain.Cancel
     | Masc_domain.Release
     | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ->
+    | Masc_domain.Reject_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock ->
       None
   in
   let prepare_verification_verdict =
@@ -605,7 +612,9 @@ let evidence_refs =
     | Masc_domain.Done_action
     | Masc_domain.Cancel
     | Masc_domain.Release
-    | Masc_domain.Submit_for_verification ->
+    | Masc_domain.Submit_for_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock ->
       None
   in
   let verifier_approve_gate_rejection =
@@ -688,23 +697,26 @@ let evidence_refs =
                 (Atomic.get Workspace_hooks.verification_notify_submit_fn)
                   ctx.config ~task ~assignee ~verification_id ~evidence_refs
               | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-              | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ())
+              | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> ())
            | None -> ())
         | Masc_domain.Approve_verification ->
+          (* Previously this arm used [Option.value ~default:""
+             verification_id_before], which silently turned a missing
+             verification_id into the empty string and let
+             [notify_approve_verification] proceed against an invalid
+             id.  An Approve_verification action without a preceding
+             AwaitingVerification record is a logical invariant
+             violation — log it so dashboards surface the drift
+             instead of acting on empty strings. *)
           (match verification_id_before with
            | None ->
              task_log_warn ~task_id
                "approve_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
-             if String.equal (String.trim notes) "" then
-               task_log_warn ~task_id
-                 "approve_verification for task %s rejected: empty justification (rubber-stamp guard)"
-                 task_id
-             else
-               (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
-                 ~task_id ~verifier:ctx.agent_name ~verification_id
-                 ~decision:(`Approve notes))
+             (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
+               ~task_id ~verifier:ctx.agent_name ~verification_id
+               ~decision:(`Approve notes))
         | Masc_domain.Reject_verification ->
           let reason = if not (String.equal notes "") then notes else reason in
           (match verification_id_before with
@@ -713,15 +725,11 @@ let evidence_refs =
                "reject_verification action for task %s without verification_id_before (skipping notify)"
                task_id
            | Some verification_id ->
-             if String.equal (String.trim reason) "" then
-               task_log_warn ~task_id
-                 "reject_verification for task %s rejected: empty justification (unsubstantiated guard)"
-                 task_id
-             else
-               (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
-                 ~task_id ~verifier:ctx.agent_name ~verification_id
-                 ~decision:(`Reject reason))
-        | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release -> ())
+             (Atomic.get Workspace_hooks.verification_notify_verdict_fn)
+               ~task_id ~verifier:ctx.agent_name ~verification_id
+               ~decision:(`Reject reason))
+        | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release
+        | Masc_domain.Mark_operator_blocked | Masc_domain.Unblock -> ())
    | Error err ->
        log_task_transition_failed ~agent_name:ctx.agent_name err);
   (* Record metrics *)
@@ -761,7 +769,8 @@ let evidence_refs =
           ~reason:(Some "task_cancelled");
         ()
    | Ok _, (Masc_domain.Claim | Masc_domain.Start | Masc_domain.Submit_for_verification
-            | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
+            | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release
+            | Masc_domain.Mark_operator_blocked | Masc_domain.Unblock)
    | Error _, _ -> ());
   result_to_response ~tool_name ~start_time result
 

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -426,6 +426,7 @@ and handle_transition ~tool_name ~start_time ctx args =
              | Some persisted -> Some persisted
              | None -> completion_contract)
           ~evaluator_runtime
+          ~operator_override:false
           ~ctx
           ~task_opt
           ~task_id

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -93,7 +93,7 @@ let transition_action_requires_summary : Masc_domain.task_action -> bool =
   | Masc_domain.Approve_verification
   | Masc_domain.Reject_verification ->
     true
-  | Masc_domain.Claim | Masc_domain.Start ->
+  | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Mark_operator_blocked | Masc_domain.Unblock ->
     false
 
 let parse_handoff_context ~(agent_name : string)

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -17,7 +17,8 @@ let can_review_completion ~(task_opt : Masc_domain.task option) ~(agent_name : s
        | Masc_domain.Todo
        | Masc_domain.AwaitingVerification _
        | Masc_domain.Done _
-       | Masc_domain.Cancelled _ -> false)
+       | Masc_domain.Cancelled _
+       | Masc_domain.Operator_blocked _ -> false)
   | None -> false
 
 let persisted_completion_contract ~(task_opt : Masc_domain.task option) =

--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -66,6 +66,11 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
            (Printf.sprintf
               "task %s is awaiting verification by %s; approve or reject before marking done"
               task_id assignee)))
+    | Masc_domain.Operator_blocked _ ->
+      Some
+        (Masc_domain.Task (Masc_domain.Task_error.InvalidState
+           (Printf.sprintf
+              "task %s is operator-blocked; unblock before marking done" task_id)))
 
 (* Verification is owned solely by [Task_completion_gate], applied upstream in
    [Tool_task.handle_transition]. This per-action layer formerly ran a second

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -170,7 +170,8 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
              | Masc_domain.Todo
              | Masc_domain.AwaitingVerification _
              | Masc_domain.Done _
-             | Masc_domain.Cancelled _ -> None)
+             | Masc_domain.Cancelled _
+             | Masc_domain.Operator_blocked _ -> None)
     in
     match owned_task with
     | Some task_id ->

--- a/lib/task/tool_task_payloads.ml
+++ b/lib/task/tool_task_payloads.ml
@@ -45,7 +45,9 @@ let is_verdict_transition_action = function
   | Masc_domain.Done_action
   | Masc_domain.Cancel
   | Masc_domain.Release
-  | Masc_domain.Submit_for_verification ->
+  | Masc_domain.Submit_for_verification
+  | Masc_domain.Mark_operator_blocked
+  | Masc_domain.Unblock ->
     false
 
 let transition_action_policy_rejection ~agent_name ~action ~allowed_actions =

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -230,7 +230,8 @@ let todo_task_has_completed_deliverable_conflict (ctx : context) (task : Masc_do
   | Masc_domain.InProgress _
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> false
+  | Masc_domain.Cancelled _
+  | Masc_domain.Operator_blocked _ -> false
 ;;
 
 let todo_completed_deliverable_conflicts (ctx : context) tasks =
@@ -427,7 +428,11 @@ let status_summary_string (ctx : context) =
            , done_cnt
            , cancelled_cnt )
          | Masc_domain.Cancelled _ ->
-           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1)
+           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1
+         (* Operator_blocked is suspended, not active work; it is not counted in
+            any bucket (no dedicated blocked bucket yet). *)
+         | Masc_domain.Operator_blocked _ ->
+           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt)
       ([], 0, 0, 0, 0, 0)
       backlog.tasks
   in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -682,7 +682,8 @@ let task_claim_decision (task : task) =
      claiming wipes it). *)
   | Claimed _
   | InProgress _
-  | Cancelled _ ->
+  | Cancelled _
+  | Operator_blocked _ ->
     Claim_unavailable (Claim_block_not_todo task.task_status)
 ;;
 

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -233,6 +233,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Mark_operator_blocked
+  | Unblock
 [@@deriving show]
 
 (** RFC-0262: who authorizes a transition that would otherwise require the
@@ -269,6 +271,8 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
+  | "mark_operator_blocked" -> Ok Mark_operator_blocked
+  | "unblock" -> Ok Unblock
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,11 +284,14 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
+  | Mark_operator_blocked -> "mark_operator_blocked"
+  | Unblock -> "unblock"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification ]
+    Submit_for_verification; Approve_verification; Reject_verification;
+    Mark_operator_blocked; Unblock ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (* RFC-0220: the verification sub-state (previously a separate request_status
@@ -313,6 +320,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | Operator_blocked of { blocked_at: string; reason: string }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -336,6 +344,7 @@ let task_status_to_string = function
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+  | Operator_blocked _ -> "operator_blocked"
 
 let string_of_task_status = task_status_to_string
 
@@ -347,6 +356,7 @@ let task_status_icon = function
   | AwaitingVerification _ -> "🔍"
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"
+  | Operator_blocked _ -> "🔒"
 
 (** Display assignee for task status.
     Cancelled surfaces [cancelled_by]; Todo yields "unclaimed".
@@ -355,6 +365,7 @@ let task_display_assignee = function
   | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
   | AwaitingVerification { assignee; _ } -> assignee
   | Cancelled { cancelled_by; _ } -> cancelled_by
+  | Operator_blocked _ -> "operator"
   | Todo -> "unclaimed"
 
 (** Extract assignee as [Some string], or [None] for Todo/Cancelled.
@@ -363,20 +374,20 @@ let task_assignee_of_status = function
   | Claimed { assignee; _ } -> Some assignee
   | InProgress { assignee; _ } -> Some assignee
   | AwaitingVerification { assignee; _ } -> Some assignee
-  | Todo | Done _ | Cancelled _ -> None
+  | Todo | Done _ | Cancelled _ | Operator_blocked _ -> None
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.
     Exhaustive match — adding a constructor forces an update here. *)
 let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Operator_blocked _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
     also includes [Cancelled]. Use this when only successful completion
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ | Operator_blocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],
@@ -401,7 +412,7 @@ let task_status_is_done = function
       renames cannot desync.
 
     The remaining hand-coded axis is the witness list's length —
-    [test_types.ml] pins it at 6, so adding a constructor without
+    [test_types.ml] pins it at 7, so adding a constructor without
     adding a witness here breaks that test.
 
     Order matches the FSM lifecycle (Todo -> Claimed -> InProgress ->
@@ -420,6 +431,7 @@ let task_status_schema_witnesses : task_status list =
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
       { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
+  ; Operator_blocked { blocked_at = placeholder; reason = placeholder }
   ]
 
 let all_task_status_names : string list =
@@ -470,6 +482,12 @@ let task_status_to_yojson = function
         ("cancelled_at", `String cancelled_at);
         ("reason", Json_util.string_opt_to_json reason);
       ]
+  | Operator_blocked { blocked_at; reason } ->
+      `Assoc [
+        ("status", `String "operator_blocked");
+        ("blocked_at", `String blocked_at);
+        ("reason", `String reason);
+      ]
 
 let task_status_of_yojson json =
   let req key = Json_util.get_string_with_default json ~key ~default:"" in
@@ -504,6 +522,11 @@ let task_status_of_yojson json =
               { cancelled_by = req "cancelled_by"
               ; cancelled_at = req "cancelled_at"
               ; reason = opt "reason"
+              })
+    | "operator_blocked" ->
+        Ok (Operator_blocked
+              { blocked_at = req "blocked_at"
+              ; reason = req "reason"
               })
     | s -> Error ("Unknown task status: " ^ s)
   with e -> Error (Printexc.to_string e)

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -64,6 +64,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Mark_operator_blocked
+  | Unblock
 [@@deriving show]
 
 val task_action_of_string : string -> (task_action, string) result
@@ -103,6 +105,7 @@ type task_status =
       }
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
+  | Operator_blocked of { blocked_at : string; reason : string }
 [@@deriving show]
 
 (** RFC-0220 §3.5: [task_status] of an [AwaitingVerification] obligation once

--- a/lib/workspace/event_kind.ml
+++ b/lib/workspace/event_kind.ml
@@ -10,6 +10,8 @@ module Task = struct
     | Approved
     | Rejected
     | Linked
+    | Operator_blocked
+    | Unblocked
 
   let to_string = function
     | Created -> "task.created"
@@ -22,6 +24,8 @@ module Task = struct
     | Approved -> "task.approved"
     | Rejected -> "task.rejected"
     | Linked -> "task.linked"
+    | Operator_blocked -> "task.operator_blocked"
+    | Unblocked -> "task.unblocked"
 
   let of_string = function
     | "task.created" -> Some Created
@@ -34,11 +38,14 @@ module Task = struct
     | "task.approved" -> Some Approved
     | "task.rejected" -> Some Rejected
     | "task.linked" -> Some Linked
+    | "task.operator_blocked" -> Some Operator_blocked
+    | "task.unblocked" -> Some Unblocked
     | _ -> None
 
   let all =
     [ Created; Claimed; Started; Released; Done; Cancelled;
-      Submit_for_verification; Approved; Rejected; Linked ]
+      Submit_for_verification; Approved; Rejected; Linked;
+      Operator_blocked; Unblocked ]
 end
 
 module Message = struct

--- a/lib/workspace/event_kind.mli
+++ b/lib/workspace/event_kind.mli
@@ -27,6 +27,8 @@ module Task : sig
     | Approved
     | Rejected
     | Linked
+    | Operator_blocked
+    | Unblocked
 
   val to_string : t -> string
   (** Canonical dotted-form wire name ([task.claimed] etc.). *)

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -181,7 +181,7 @@ let cleanup_zombies
                    ("ts", `String (now_iso ()));
                  ]))
         | Masc_domain.Claimed _ | Masc_domain.InProgress _
-        | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ()
+        | Todo | AwaitingVerification _ | Done _ | Cancelled _ | Operator_blocked _ -> ()
       ) backlog.tasks;
 
       (* Phase 4: Delete files — skip agents with release failures *)

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -225,7 +225,7 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
       | Masc_domain.AwaitingVerification { assignee; _ } ->
           if is_active_agent assignee then None
           else Some (task, assignee)
-      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> None
     ) backlog.tasks
 
 (* RFC-0294 PR-4: the single typed source of truth for "is this status
@@ -243,7 +243,7 @@ let orphan_status_class_of_status : Masc_domain.task_status -> string option = f
   | Masc_domain.Claimed _ -> Some "claimed"
   | Masc_domain.InProgress _ -> Some "in_progress"
   | Masc_domain.AwaitingVerification _ -> Some "awaiting_verification"
-  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> None
 
 (* The fixed class set the gauge reports (0 when a class is empty, so a cleared
    class resets rather than going stale). Exactly the Some-range of
@@ -429,7 +429,7 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
           let is_cancelled = match status with
             | Masc_domain.Cancelled _ -> true
             | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-            | Masc_domain.AwaitingVerification _ | Masc_domain.Done _ -> false
+            | Masc_domain.AwaitingVerification _ | Masc_domain.Done _ | Masc_domain.Operator_blocked _ -> false
           in
           (include_done || not is_done) &&
           (include_cancelled || not is_cancelled)

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -176,7 +176,8 @@ let submit_and_approve_task_r
                 | Masc_domain.Claimed _
                 | Masc_domain.InProgress _
                 | Masc_domain.Done _
-                | Masc_domain.Cancelled _ -> None))
+                | Masc_domain.Cancelled _
+                | Masc_domain.Operator_blocked _ -> None))
         in
         let record_verdict decision =
           match verification_id with
@@ -265,7 +266,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                | Masc_domain.Claimed { assignee; _ }
                | Masc_domain.InProgress { assignee; _ }
                | Masc_domain.AwaitingVerification { assignee; _ } -> assignee = agent_name
-               | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
+               | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> false
              in
              if not can_cancel
              then

--- a/lib/workspace/workspace_task_claim.ml
+++ b/lib/workspace/workspace_task_claim.ml
@@ -33,7 +33,8 @@ let active_owned_task_ids_for_agent config ~agent_name (backlog : Masc_domain.ba
          | InProgress _
          | AwaitingVerification _
          | Done _
-         | Cancelled _ -> None)
+         | Cancelled _
+         | Operator_blocked _ -> None)
   |> List.sort_uniq String.compare
 ;;
 
@@ -117,7 +118,8 @@ let claim_task_r config ~agent_name ~task_id ()
            | InProgress _
            | AwaitingVerification _
            | Done _
-           | Cancelled _ -> Ok ()
+           | Cancelled _
+           | Operator_blocked _ -> Ok ()
          in
          (* fold_left to find+transform in a single pass without mutable refs.
          Uses polymorphic variants for inline state tracking. *)

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -55,7 +55,8 @@ let classify_completion_path
   | Masc_domain.Approve_verification -> "via_verification"
   | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action
   | Masc_domain.Cancel | Masc_domain.Release
-  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification ->
+  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification
+  | Masc_domain.Mark_operator_blocked | Masc_domain.Unblock ->
     if force then "forced_done"
     else (match drift with
           | Some Workspace_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
@@ -85,7 +86,7 @@ let working_agents config =
       (fun (t : task) ->
          match t.task_status with
          | Claimed { assignee; _ } | InProgress { assignee; _ } -> Some assignee
-         | Todo | Done _ | Cancelled _ | AwaitingVerification _ -> None)
+         | Todo | Done _ | Cancelled _ | AwaitingVerification _ | Operator_blocked _ -> None)
       backlog.tasks
     |> List.sort_uniq String.compare
 ;;
@@ -370,6 +371,8 @@ let valid_next_actions_for_status
   | Masc_domain.AwaitingVerification _ ->
     [ Masc_domain.Approve_verification; Masc_domain.Reject_verification ]
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> [] (* terminal *)
+  | Masc_domain.Operator_blocked _ ->
+    [ Masc_domain.Mark_operator_blocked; Masc_domain.Unblock ]
 ;;
 
 let next_actions_hint status =
@@ -391,7 +394,8 @@ let task_started_at_unix status =
   | Masc_domain.Todo
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> default_time
+  | Masc_domain.Cancelled _
+  | Masc_domain.Operator_blocked _ -> default_time
 ;;
 
 let task_transition_details

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -79,6 +79,7 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
        [predecessor_task_id]. *)
     Held_terminal task.task_status
   | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+  | Masc_domain.Operator_blocked { reason; _ } -> Held_by_other reason
 ;;
 
 (* RFC-0262: a transition that overrides the assignee guard is permitted when
@@ -192,6 +193,17 @@ let decide
      | Operator | System -> ok (cancelled_status ~agent_name ~now ~reason)
      | Assignee -> Error Invalid_transition)
   | Masc_domain.Cancel, Masc_domain.Done _ -> Error Invalid_transition
+  (* ── Mark operator blocked ──────────────────── *)
+  | Masc_domain.Mark_operator_blocked, Masc_domain.Operator_blocked _ -> ok task_status
+  | ( Masc_domain.Mark_operator_blocked
+    , (Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Todo
+      | Masc_domain.AwaitingVerification _) ) ->
+    ok (Masc_domain.Operator_blocked { blocked_at = now; reason })
+  | Masc_domain.Mark_operator_blocked, (Masc_domain.Done _ | Masc_domain.Cancelled _) ->
+    Error Invalid_transition
+  (* ── Unblock ──────────────────────────────────── *)
+  | Masc_domain.Unblock, Masc_domain.Operator_blocked _ -> ok Masc_domain.Todo
+  | Masc_domain.Unblock, _ -> Error Invalid_transition
   (* ── Release ──────────────────────────────────── *)
   | ( Masc_domain.Release
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ) ->

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -278,6 +278,10 @@ let decide
       | Masc_domain.Done _
       | Masc_domain.Cancelled _ ) ) ->
     if verification_enabled then Error Invalid_transition else Error Verification_disabled
+  (* Operator_blocked is a terminal-like suspension: only Mark_operator_blocked
+     (idempotent) and Unblock (to Todo) are valid. All other actions are
+     invalid until the operator removes the block. *)
+  | _, Masc_domain.Operator_blocked _ -> Error Invalid_transition
 ;;
 
 (* Enumerate the actions that [decide] would accept for the given status under

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -22,6 +22,7 @@ let task_status_label (status : Masc_domain.task_status) : string =
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+  | Operator_blocked _ -> "operator_blocked"
 ;;
 
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
@@ -60,7 +61,7 @@ let active_task_assignees_by_task_id backlog =
        match task.task_status with
        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
          Hashtbl.replace table task.id assignee
-       | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
+       | Todo | AwaitingVerification _ | Done _ | Cancelled _ | Operator_blocked _ -> ())
     backlog.tasks;
   table
 ;;
@@ -624,7 +625,8 @@ let release_stale_claims config ~ttl_seconds =
       | Masc_domain.Todo
       | Masc_domain.AwaitingVerification _
       | Masc_domain.Done _
-      | Masc_domain.Cancelled _ -> None
+      | Masc_domain.Cancelled _
+      | Masc_domain.Operator_blocked _ -> None
     in
     let older_than_ttl task =
       match status_timestamp task.task_status with

--- a/lib/workspace/workspace_task_transition_executor.ml
+++ b/lib/workspace/workspace_task_transition_executor.ml
@@ -21,7 +21,9 @@ let action_persists_handoff_context = function
   | Masc_domain.Start
   | Masc_domain.Cancel
   | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
+  | Masc_domain.Reject_verification
+  | Masc_domain.Mark_operator_blocked
+  | Masc_domain.Unblock ->
     true
 ;;
 
@@ -35,7 +37,9 @@ let normalize_task_before_status ~action task =
   | Masc_domain.Cancel
   | Masc_domain.Submit_for_verification
   | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
+  | Masc_domain.Reject_verification
+  | Masc_domain.Mark_operator_blocked
+  | Masc_domain.Unblock ->
     task
 ;;
 
@@ -57,7 +61,9 @@ let release_counters ~action task handoff_context =
   | Masc_domain.Done_action
   | Masc_domain.Submit_for_verification
   | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
+  | Masc_domain.Reject_verification
+  | Masc_domain.Mark_operator_blocked
+  | Masc_domain.Unblock ->
     task.cycle_count, task.reclaim_policy, task.do_not_reclaim_reason
 ;;
 

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -147,7 +147,9 @@ let transition_task_outcome_r
             | Masc_domain.Release
             | Masc_domain.Submit_for_verification
             | Masc_domain.Approve_verification
-            | Masc_domain.Reject_verification ), _ -> Ok ())
+            | Masc_domain.Reject_verification
+            | Masc_domain.Mark_operator_blocked
+            | Masc_domain.Unblock ), _ -> Ok ())
           [@warning "-4"]
         in
         let now = now_iso () in

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -87,7 +87,9 @@ let transition_task_outcome_r
           | Masc_domain.Claim
           | Masc_domain.Start
           | Masc_domain.Cancel
-          | Masc_domain.Release -> Ok ()
+          | Masc_domain.Release
+          | Masc_domain.Mark_operator_blocked
+          | Masc_domain.Unblock -> Ok ()
           | Masc_domain.Done_action
           | Masc_domain.Submit_for_verification ->
             (* #23719 evidence gate, scoped to the RFC-0323 Phase A predicate
@@ -300,7 +302,9 @@ let transition_task_outcome_r
           | Masc_domain.Release
           | Masc_domain.Submit_for_verification
           | Masc_domain.Approve_verification
-          | Masc_domain.Reject_verification -> Ok ()
+          | Masc_domain.Reject_verification
+          | Masc_domain.Mark_operator_blocked
+          | Masc_domain.Unblock -> Ok ()
         in
         (* WORKAROUND: action (9) × task_status (6) × new_status (6) × option (2) = 648 combos. *)
         let* () =
@@ -350,7 +354,9 @@ let transition_task_outcome_r
               | Masc_domain.Cancel
               | Masc_domain.Release
               | Masc_domain.Approve_verification
-              | Masc_domain.Reject_verification )
+              | Masc_domain.Reject_verification
+              | Masc_domain.Mark_operator_blocked
+              | Masc_domain.Unblock )
             , _
             , _
             , Some _ ) -> Ok ()
@@ -361,7 +367,9 @@ let transition_task_outcome_r
               | Masc_domain.Release
               | Masc_domain.Approve_verification
               | Masc_domain.Reject_verification
-              | Masc_domain.Submit_for_verification )
+              | Masc_domain.Submit_for_verification
+              | Masc_domain.Mark_operator_blocked
+              | Masc_domain.Unblock )
             , _
             , _
             , None ) -> Ok ()) [@warning "-4"]
@@ -399,7 +407,8 @@ let transition_task_outcome_r
          | Masc_domain.Claimed _
          | Masc_domain.InProgress _
          | Masc_domain.AwaitingVerification _
-         | Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Cancelled _
+         | Masc_domain.Operator_blocked _ -> ());
         (match action, task.task_status with
          | Masc_domain.Release, Masc_domain.Todo ->
 (* Idempotent: already in backlog, nothing to release. *)
@@ -410,12 +419,15 @@ let transition_task_outcome_r
         | Masc_domain.Cancel, _
         | Masc_domain.Submit_for_verification, _
         | Masc_domain.Approve_verification, _
-         | Masc_domain.Reject_verification, _
-         | Masc_domain.Release, Masc_domain.Claimed _
-         | Masc_domain.Release, Masc_domain.InProgress _
-         | Masc_domain.Release, Masc_domain.AwaitingVerification _
-         | Masc_domain.Release, Masc_domain.Done _
-         | Masc_domain.Release, Masc_domain.Cancelled _ -> ());
+        | Masc_domain.Reject_verification, _
+        | Masc_domain.Mark_operator_blocked, _
+        | Masc_domain.Unblock, _
+        | Masc_domain.Release, Masc_domain.Claimed _
+        | Masc_domain.Release, Masc_domain.InProgress _
+        | Masc_domain.Release, Masc_domain.AwaitingVerification _
+        | Masc_domain.Release, Masc_domain.Done _
+        | Masc_domain.Release, Masc_domain.Cancelled _
+        | Masc_domain.Release, Masc_domain.Operator_blocked _ -> ());
 (* #10719: surface tasks that have crossed oscillation thresholds so dashboards/triage can pick them up before they reach 20+ cycles with zero progress. *)
         (match action with
          | Masc_domain.Release ->
@@ -448,7 +460,9 @@ let transition_task_outcome_r
          | Masc_domain.Cancel
          | Masc_domain.Submit_for_verification
          | Masc_domain.Approve_verification
-         | Masc_domain.Reject_verification -> ());
+         | Masc_domain.Reject_verification
+         | Masc_domain.Mark_operator_blocked
+         | Masc_domain.Unblock -> ());
         if new_status = task.task_status && set_current = None
         then
 (* Idempotent no-op: status unchanged, skip write/events. Match None explicitly so set_current=Some is never silently dropped. *)
@@ -494,14 +508,17 @@ let transition_task_outcome_r
                     | Masc_domain.Claimed _
                     | Masc_domain.InProgress _
                     | Masc_domain.Done _
-                    | Masc_domain.Cancelled _ -> ())
+                    | Masc_domain.Cancelled _
+                    | Masc_domain.Operator_blocked _ -> ())
                  | Masc_domain.Claim
                  | Masc_domain.Start
                  | Masc_domain.Done_action
                  | Masc_domain.Cancel
                  | Masc_domain.Release
                  | Masc_domain.Approve_verification
-                 | Masc_domain.Reject_verification -> ()));
+                 | Masc_domain.Reject_verification
+                 | Masc_domain.Mark_operator_blocked
+                 | Masc_domain.Unblock -> ()));
              raise exn);
           (* RFC-0221 §3.3: clear stale agent task-cache entries AFTER the
              commit so agents that cache the task don't emit stale broadcasts
@@ -544,7 +561,8 @@ let transition_task_outcome_r
                  | Masc_domain.Claimed _
                  | Masc_domain.InProgress _
                  | Masc_domain.Done _
-                 | Masc_domain.Cancelled _ -> ())
+                 | Masc_domain.Cancelled _
+                 | Masc_domain.Operator_blocked _ -> ())
               | Masc_domain.Reject_verification ->
                 (match task.task_status with
                  | Masc_domain.AwaitingVerification { verification_id; _ } ->
@@ -566,13 +584,16 @@ let transition_task_outcome_r
                  | Masc_domain.Claimed _
                  | Masc_domain.InProgress _
                  | Masc_domain.Done _
-                 | Masc_domain.Cancelled _ -> ())
+                 | Masc_domain.Cancelled _
+                 | Masc_domain.Operator_blocked _ -> ())
               | Masc_domain.Claim
               | Masc_domain.Start
               | Masc_domain.Done_action
               | Masc_domain.Cancel
               | Masc_domain.Release
-              | Masc_domain.Submit_for_verification -> ()));
+              | Masc_domain.Submit_for_verification
+              | Masc_domain.Mark_operator_blocked
+              | Masc_domain.Unblock -> ()));
           update_local_agent_state config ~agent_name (fun agent ->
             match set_current with
             | Some _ -> { agent with status = Busy; current_task = Some task_id }
@@ -667,7 +688,8 @@ let transition_task_outcome_r
                | Masc_domain.Claimed _
                | Masc_domain.InProgress _
                | Masc_domain.AwaitingVerification _
-               | Masc_domain.Cancelled _ -> `Assoc [ "task_id", `String task_id ]
+               | Masc_domain.Cancelled _
+               | Masc_domain.Operator_blocked _ -> `Assoc [ "task_id", `String task_id ]
              in
              emit_task_activity
                config
@@ -681,6 +703,24 @@ let transition_task_outcome_r
                ~agent_name
                ~task_id
                ~kind:(Event_kind.Task.to_string Event_kind.Task.Rejected)
+               ~payload:(`Assoc [ "task_id", `String task_id ])
+           | Masc_domain.Mark_operator_blocked ->
+             emit_task_activity
+               config
+               ~agent_name
+               ~task_id
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Operator_blocked)
+               ~payload:
+                 (`Assoc
+                     [ "task_id", `String task_id
+                     ; ("reason", if reason = "" then `Null else `String reason)
+                     ])
+           | Masc_domain.Unblock ->
+             emit_task_activity
+               config
+               ~agent_name
+               ~task_id
+               ~kind:(Event_kind.Task.to_string Event_kind.Task.Unblocked)
                ~payload:(`Assoc [ "task_id", `String task_id ]));
           (* RFC-0323 G-3: completion side effects key off the RESULT (Done),
              not the action — otherwise Approve_verification completions
@@ -707,7 +747,9 @@ let transition_task_outcome_r
               | Masc_domain.Release
               | Masc_domain.Submit_for_verification
               | Masc_domain.Approve_verification
-              | Masc_domain.Reject_verification -> None)
+              | Masc_domain.Reject_verification
+              | Masc_domain.Mark_operator_blocked
+              | Masc_domain.Unblock -> None)
           in
           observe_task_transition
             config
@@ -739,7 +781,8 @@ let transition_task_outcome_r
            | Masc_domain.Claimed _
            | Masc_domain.InProgress _
            | Masc_domain.AwaitingVerification _
-           | Masc_domain.Cancelled _ -> ());
+           | Masc_domain.Cancelled _
+           | Masc_domain.Operator_blocked _ -> ());
           (match action with
            | Masc_domain.Cancel ->
              Workspace_task_cleanup.run_cancel_hooks config ~agent_name
@@ -749,7 +792,9 @@ let transition_task_outcome_r
            | Masc_domain.Start
            | Masc_domain.Submit_for_verification
            | Masc_domain.Approve_verification
-           | Masc_domain.Reject_verification -> ());
+           | Masc_domain.Reject_verification
+           | Masc_domain.Mark_operator_blocked
+           | Masc_domain.Unblock -> ());
           Ok
             { message =
                 Printf.sprintf

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -34,7 +34,9 @@ let task_action_of_transition : Masc_domain.task_action -> Audit_log.action = fu
   | Masc_domain.Release -> Audit_log.ReleaseTask
   | ( Masc_domain.Submit_for_verification
     | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification ) as action ->
+    | Masc_domain.Reject_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock ) as action ->
     Audit_log.Custom ("task_" ^ Masc_domain.task_action_to_string action)
 ;;
 
@@ -136,7 +138,9 @@ let observe_task_transition_event
     | Masc_domain.Release
     | Masc_domain.Submit_for_verification
     | Masc_domain.Approve_verification
-    | Masc_domain.Reject_verification -> Log.Info
+    | Masc_domain.Reject_verification
+    | Masc_domain.Mark_operator_blocked
+    | Masc_domain.Unblock -> Log.Info
   in
   let message = Printf.sprintf "task %s %s by %s" task_id transition_s agent_name in
   Log.Task.emit level ~details message;
@@ -163,7 +167,9 @@ let observe_task_transition_event
          Otel_metric_store.record_task_failed ()
        | Masc_domain.Release
        | Masc_domain.Submit_for_verification
-       | Masc_domain.Reject_verification -> ())
+       | Masc_domain.Reject_verification
+       | Masc_domain.Mark_operator_blocked
+       | Masc_domain.Unblock -> ())
    with
    | Stdlib.Effect.Unhandled _ as exn ->
      warn_telemetry_drop ~event:(Task_transition transition) exn);

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -46,6 +46,7 @@ let task_status_badge = function
   | Masc_domain.AwaitingVerification _ -> ("🔍", "awaiting_verification")
   | Masc_domain.Done _ -> ("✅", "done")
   | Masc_domain.Cancelled _ -> ("🚫", "cancelled")
+  | Masc_domain.Operator_blocked _ -> ("🔒", "operator_blocked")
 
 let task_assignee = function
   | Masc_domain.Claimed { assignee; _ }
@@ -53,6 +54,7 @@ let task_assignee = function
   | Masc_domain.AwaitingVerification { assignee; _ }
   | Masc_domain.Done { assignee; _ } -> assignee
   | Masc_domain.Cancelled { cancelled_by; _ } -> cancelled_by
+  | Masc_domain.Operator_blocked _ -> "operator"
   | Masc_domain.Todo -> "unclaimed"
 
 let active_task_assignee = function
@@ -60,7 +62,7 @@ let active_task_assignee = function
   | Masc_domain.InProgress { assignee; _ }
   | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some assignee
-  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.Operator_blocked _ -> None
 
 let assigned_task_ids ~matches_you tasks =
   List.filter_map

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -78,7 +78,9 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
         Telemetry_eio.track_task_completed config ~task_id ~duration_ms:0 ~success:false
       | Masc_domain.Release
       | Masc_domain.Submit_for_verification
-      | Masc_domain.Reject_verification -> ());
+      | Masc_domain.Reject_verification
+      | Masc_domain.Mark_operator_blocked
+      | Masc_domain.Unblock -> ());
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Workspace_hooks.get_default_runtime_id_fn previous_default_runtime;

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -59,6 +59,8 @@ let action_to_string = function
   | D.Submit_for_verification -> "submit_for_verification"
   | D.Approve_verification -> "approve"
   | D.Reject_verification -> "reject"
+  | D.Mark_operator_blocked -> "mark_operator_blocked"
+  | D.Unblock -> "unblock"
 ;;
 
 let sort_actions xs =


### PR DESCRIPTION
This PR replaces #23866 (nick0cave/task-1900) which has a merge conflict.

Cherry-picked the 3 commits from nick0cave/task-1900 onto latest origin/main and resolved conflicts:
- 9c7678d1c feat: add Operator_blocked task state
- 4e96c8e54 fix: add Mark_operator_blocked/Unblock to pre-check match
- 5f1ad55bf fix: exhaust pattern matches for Operator_blocked

Conflicts resolved by keeping HEAD (RFC-0323 G-6) changes and cherry-pick's Operator_blocked additions.

Closes #23866