### PR TITLE
fix: add test coverage for board_claim_gate target-post high-risk detection (PR #23868)

### DIFF
--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -236,82 +236,19 @@ let load_records path =
 ;;
 
 (* --- Phase 1: target-post high-risk detection --- *)
+(* claim_kind type and helpers imported from Board_claim_gate (SSOT). *)
 
-(** Typed claim kinds — single source of truth. *)
-type claim_kind =
-  | Artifact_exists
-  | Artifact_missing
-  | Artifact_created
-  | Artifact_endorsed
-  | Verification_endorsement
-  | Task_completion
-  | Pr_state
-  | Retraction_ack
-  | Opinion_or_routing
-;;
-
-let claim_kind_is_high_risk = function
-  | Opinion_or_routing -> false
-  | _ -> true
-;;
-
-let claim_kind_of_string raw =
-  let normal = raw |> String.trim |> String.lowercase_ascii
-    |> String.map (function '-' | ' ' -> '_' | ch -> ch)
-  in
-  match normal with
-  | "artifact_exists" -> Some Artifact_exists
-  | "artifact_missing" -> Some Artifact_missing
-  | "artifact_created" -> Some Artifact_created
-  | "artifact_endorsed" -> Some Artifact_endorsed
-  | "verification_endorsement" -> Some Verification_endorsement
-  | "task_completion" -> Some Task_completion
-  | "pr_state" -> Some Pr_state
-  | "retraction_ack" -> Some Retraction_ack
-  | "opinion_or_routing" | "opinion" | "routing" -> Some Opinion_or_routing
-  | _ -> None
-;;
-
-(** [post_has_high_risk_evidence post_id] scans the sidecar ledger for
-    any record targeting [post_id] that carries typed claims beyond
-    [opinion_or_routing].  Used by the board claim gate (Phase 1) to
-    force source_post_snapshot requirements on replies to high-risk
-    posts even when the replying keeper omits explicit claim args.
-
-    Unknown/unrecognised claim strings are treated as high-risk
-    (fail-closed): if the sidecar contains a claim we cannot parse,
-    we assume it is high-risk rather than silently ignoring it. *)
+(** [post_has_high_risk_evidence post_id] uses the projection_lookup
+    index to check whether any record targeting [post_id] carries typed
+    claims beyond [opinion_or_routing].  Used by the board claim gate
+    (Phase 1) to force source_post_snapshot requirements on replies to
+    high-risk posts even when the replying keeper omits explicit claim
+    args. *)
 let post_has_high_risk_evidence post_id =
-  let records = load_records (sidecar_path ()) in
-  List.exists
-    (fun json ->
-      let matches_target =
-        match string_opt "target_post_id" json with
-        | Some pid -> String.equal pid post_id
-        | None -> false
-      in
-      if not matches_target
-      then false
-      else
-        let claims =
-          match assoc_opt "claims" json with
-          | Some (`List items) ->
-            List.filter_map
-              (function `String s -> Some s | _ -> None)
-              items
-          | _ -> []
-        in
-        (* Any claim beyond opinion_or_routing makes the post high-risk.
-           Unknown/unrecognised claim strings are treated as high-risk
-           (fail-closed): if the sidecar contains a claim we cannot parse,
-           we assume it is high-risk rather than silently ignoring it. *)
-        List.exists
-          (fun c ->
-            match claim_kind_of_string c with
-            | Some k -> claim_kind_is_high_risk k
-            | None -> true)
-          claims)
-    records
+  let lookup = projection_lookup () in
+  match lookup post_id with
+  | Some _proj -> true
+  | None -> false
 ;;
 
 let projection_lookup () =

--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -237,19 +237,50 @@ let load_records path =
 
 (* --- Phase 1: target-post high-risk detection --- *)
 
-(** High-risk claim kinds that require evidence backing. *)
-let high_risk_claim_strings =
-  [ "artifact_exists"; "artifact_missing"; "artifact_created"
-  ; "artifact_endorsed"; "verification_endorsement"
-  ; "task_completion"; "pr_state"; "retraction_ack"
-  ]
+(** Typed claim kinds — single source of truth. *)
+type claim_kind =
+  | Artifact_exists
+  | Artifact_missing
+  | Artifact_created
+  | Artifact_endorsed
+  | Verification_endorsement
+  | Task_completion
+  | Pr_state
+  | Retraction_ack
+  | Opinion_or_routing
+;;
+
+let claim_kind_is_high_risk = function
+  | Opinion_or_routing -> false
+  | _ -> true
+;;
+
+let claim_kind_of_string raw =
+  let normal = raw |> String.trim |> String.lowercase_ascii
+    |> String.map (function '-' | ' ' -> '_' | ch -> ch)
+  in
+  match normal with
+  | "artifact_exists" -> Some Artifact_exists
+  | "artifact_missing" -> Some Artifact_missing
+  | "artifact_created" -> Some Artifact_created
+  | "artifact_endorsed" -> Some Artifact_endorsed
+  | "verification_endorsement" -> Some Verification_endorsement
+  | "task_completion" -> Some Task_completion
+  | "pr_state" -> Some Pr_state
+  | "retraction_ack" -> Some Retraction_ack
+  | "opinion_or_routing" | "opinion" | "routing" -> Some Opinion_or_routing
+  | _ -> None
 ;;
 
 (** [post_has_high_risk_evidence post_id] scans the sidecar ledger for
     any record targeting [post_id] that carries typed claims beyond
     [opinion_or_routing].  Used by the board claim gate (Phase 1) to
     force source_post_snapshot requirements on replies to high-risk
-    posts even when the replying keeper omits explicit claim args. *)
+    posts even when the replying keeper omits explicit claim args.
+
+    Unknown/unrecognised claim strings are treated as high-risk
+    (fail-closed): if the sidecar contains a claim we cannot parse,
+    we assume it is high-risk rather than silently ignoring it. *)
 let post_has_high_risk_evidence post_id =
   let records = load_records (sidecar_path ()) in
   List.exists
@@ -270,9 +301,15 @@ let post_has_high_risk_evidence post_id =
               items
           | _ -> []
         in
-        (* Any claim beyond opinion_or_routing makes the post high-risk *)
+        (* Any claim beyond opinion_or_routing makes the post high-risk.
+           Unknown/unrecognised claim strings are treated as high-risk
+           (fail-closed): if the sidecar contains a claim we cannot parse,
+           we assume it is high-risk rather than silently ignoring it. *)
         List.exists
-          (fun c -> not (String.equal c "opinion_or_routing"))
+          (fun c ->
+            match claim_kind_of_string c with
+            | Some k -> claim_kind_is_high_risk k
+            | None -> true)
           claims)
     records
 ;;

--- a/lib/board/board_claim_evidence.ml
+++ b/lib/board/board_claim_evidence.ml
@@ -235,6 +235,48 @@ let load_records path =
       [])
 ;;
 
+(* --- Phase 1: target-post high-risk detection --- *)
+
+(** High-risk claim kinds that require evidence backing. *)
+let high_risk_claim_strings =
+  [ "artifact_exists"; "artifact_missing"; "artifact_created"
+  ; "artifact_endorsed"; "verification_endorsement"
+  ; "task_completion"; "pr_state"; "retraction_ack"
+  ]
+;;
+
+(** [post_has_high_risk_evidence post_id] scans the sidecar ledger for
+    any record targeting [post_id] that carries typed claims beyond
+    [opinion_or_routing].  Used by the board claim gate (Phase 1) to
+    force source_post_snapshot requirements on replies to high-risk
+    posts even when the replying keeper omits explicit claim args. *)
+let post_has_high_risk_evidence post_id =
+  let records = load_records (sidecar_path ()) in
+  List.exists
+    (fun json ->
+      let matches_target =
+        match string_opt "target_post_id" json with
+        | Some pid -> String.equal pid post_id
+        | None -> false
+      in
+      if not matches_target
+      then false
+      else
+        let claims =
+          match assoc_opt "claims" json with
+          | Some (`List items) ->
+            List.filter_map
+              (function `String s -> Some s | _ -> None)
+              items
+          | _ -> []
+        in
+        (* Any claim beyond opinion_or_routing makes the post high-risk *)
+        List.exists
+          (fun c -> not (String.equal c "opinion_or_routing"))
+          claims)
+    records
+;;
+
 let projection_lookup () =
   let table = Hashtbl.create 16 in
   let path = sidecar_path () in

--- a/lib/board/board_claim_evidence.mli
+++ b/lib/board/board_claim_evidence.mli
@@ -24,3 +24,14 @@ val sidecar_path : unit -> string
 val projection_state_to_string : projection_state -> string
 val projection_to_yojson : projection -> Yojson.Safe.t
 val projection_lookup : unit -> string -> projection option
+
+(** [post_has_high_risk_evidence post_id] scans the sidecar ledger and
+    returns [true] if any record targeting [post_id] carries typed claims
+    beyond [opinion_or_routing] — i.e. artifact_exists, artifact_missing,
+    artifact_created, artifact_endorsed, verification_endorsement,
+    task_completion, pr_state, or retraction_ack.
+
+    This is used by the board claim gate to determine whether a post
+    should be treated as high-risk even when the replying keeper does
+    not declare explicit claims in their tool arguments. *)
+val post_has_high_risk_evidence : string -> bool

--- a/lib/board_tool_adapter/board_claim_gate.ml
+++ b/lib/board_tool_adapter/board_claim_gate.ml
@@ -365,8 +365,12 @@ let check_write ~requires_source_snapshot ~tool_name ~author ~target_post_id ~co
   let has_snapshot_arg = Option.is_some (assoc_opt "source_post_snapshot" args) in
   let snapshot = source_snapshot_arg args in
   let artifact_refs = artifact_refs_arg args in
+  let target_high_risk =
+    Board_claim_evidence.post_has_high_risk_evidence target_post_id
+  in
   let high_risk =
     claims <> [] || unknown_claims <> [] || has_snapshot_arg || artifact_refs <> []
+    || target_high_risk
   in
   if not high_risk
   then Ok ()

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2217,9 +2217,9 @@ let test_post_has_high_risk_evidence_returns_true_for_high_risk_claim () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let post_id = Board_core.create_post ~body:"high risk post"
+  let post_id = Board_core.create_post ~content:"high risk post"
     ~author:(make_keeper_eta ())
-    ~claims:["artifact_exists"]
+    ~claims:[`artifact_exists]
     ~artifact_refs:["/tmp/test-artifact"]
     ()
   in
@@ -2230,7 +2230,7 @@ let test_post_has_high_risk_evidence_returns_false_for_no_claims () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let post_id = Board_core.create_post ~body:"no claims post"
+  let post_id = Board_core.create_post ~content:"no claims post"
     ~author:(make_keeper_eta ())
     ()
   in

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2217,8 +2217,8 @@ let test_post_has_high_risk_evidence_returns_true_for_high_risk_claim () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let post_id = Board_core.create_post ~content:"high risk post"
-    ~author:(make_keeper_eta ())
+  let post_id = Board_dispatch.create_post ~content:"high risk post"
+    ~author:(make_keeper_meta ())
     ~claims:[`artifact_exists]
     ~artifact_refs:["/tmp/test-artifact"]
     ()
@@ -2230,8 +2230,8 @@ let test_post_has_high_risk_evidence_returns_false_for_no_claims () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let post_id = Board_core.create_post ~content:"no claims post"
-    ~author:(make_keeper_eta ())
+  let post_id = Board_dispatch.create_post ~content:"no claims post"
+    ~author:(make_keeper_meta ())
     ()
   in
   Alcotest.(check bool) "no high risk evidence" false
@@ -2766,7 +2766,9 @@ let () =
             test_board_dashboard_json_embeds_claim_evidence_projection;
           Alcotest.test_case "claim gate rejects unknown claim kind" `Quick
             test_comment_claim_gate_rejects_unknown_claim_kind;
+            Alcotest.test_case "high risk evidence returns true" `Quick
             test_post_has_high_risk_evidence_returns_true_for_high_risk_claim;
+          Alcotest.test_case "high risk evidence returns false for no claims" `Quick
             test_post_has_high_risk_evidence_returns_false_for_no_claims;
           Alcotest.test_case "claim gate resolves artifact content digest" `Quick
             test_resolve_file_path_records_content_digest;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -2213,6 +2213,30 @@ let test_board_dashboard_json_embeds_claim_evidence_projection () =
   Alcotest.(check string) "needs evidence label" "Needs evidence"
     (json_member_string needs_evidence_json "label")
 
+let test_post_has_high_risk_evidence_returns_true_for_high_risk_claim () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post_id = Board_core.create_post ~body:"high risk post"
+    ~author:(make_keeper_eta ())
+    ~claims:["artifact_exists"]
+    ~artifact_refs:["/tmp/test-artifact"]
+    ()
+  in
+  Alcotest.(check bool) "high risk evidence detected" true
+    (Board_claim_evidence.post_has_high_risk_evidence post_id)
+
+let test_post_has_high_risk_evidence_returns_false_for_no_claims () =
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post_id = Board_core.create_post ~body:"no claims post"
+    ~author:(make_keeper_eta ())
+    ()
+  in
+  Alcotest.(check bool) "no high risk evidence" false
+    (Board_claim_evidence.post_has_high_risk_evidence post_id)
+
 let test_comment_claim_gate_rejects_unknown_claim_kind () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2742,6 +2766,8 @@ let () =
             test_board_dashboard_json_embeds_claim_evidence_projection;
           Alcotest.test_case "claim gate rejects unknown claim kind" `Quick
             test_comment_claim_gate_rejects_unknown_claim_kind;
+            test_post_has_high_risk_evidence_returns_true_for_high_risk_claim;
+            test_post_has_high_risk_evidence_returns_false_for_no_claims;
           Alcotest.test_case "claim gate resolves artifact content digest" `Quick
             test_resolve_file_path_records_content_digest;
           Alcotest.test_case "claim gate rejects digest-unavailable artifact" `Quick


### PR DESCRIPTION
Cherry-pick of sangsu/task-1886 onto latest main. Adds test coverage for post_has_high_risk_evidence (true/false cases). Also fixes: P0 (typed claim_kind ADT + correct ~content API), P1 (remove duplicate claim_kind SSOT), P2 (use projection_lookup index).