### PR TITLE
task-1876: W3c — deliver HITL continuation response

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1380,6 +1380,24 @@ let run_keeper_msg_turn_admitted
                     Ids.Turn_ref.to_yojson turn_ref );
                 ]
               in
+              (* W3c: deterministic HITL continuation delivery — fire-and-forget
+                 the response back to the originating channel when a
+                 continuation_channel was captured.  Errors are logged but do
+                 not block or fail the turn. *)
+              (match continuation_channel with
+               | Some channel ->
+                 (try
+                    Keeper_continuation_delivery.deliver_continuation
+                      ~config:ctx.config
+                      ~agent_name:meta.name
+                      ~continuation_channel:channel
+                      ~text:result.response_text
+                      ()
+                  with exn ->
+                    Log.Keeper.warn
+                      "continuation delivery failed after keeper_msg turn: %s"
+                      (Printexc.to_string exn))
+               | None -> ());
               tool_result_ok (Yojson.Safe.to_string reply_json)
 
 ))))))))

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -734,6 +734,60 @@ let test_pending_phase_conversions () =
 (* RFC-0320 W3c: the delivery gate is fail-closed and dedups with the W3b
    prompt steer. [gate_decision] is pure, so we assert the decision matrix
    without a live connector. *)
+let test_w3c_deliver_continuation_unrouted_returns_skip () =
+  let module D = Masc.Keeper_continuation_delivery in
+  let config = Masc.Workspace_utils.default_config (Filename.get_temp_dir_name ()) in
+  let result =
+    D.deliver_continuation
+      ~config
+      ~agent_name:"test-agent"
+      ~continuation_channel:(Masc.Keeper_continuation_channel.Unrouted { reason = "test" })
+      ~text:"hello from test"
+      ()
+  in
+  Alcotest.(check bool)
+    "deliver_continuation with Unrouted channel returns Skipped_unrouted"
+    true
+    (result = D.Skipped_unrouted)
+;;
+
+let test_w3c_deliver_continuation_empty_text_returns_skip () =
+  let module D = Masc.Keeper_continuation_delivery in
+  let config = Masc.Workspace_utils.default_config (Filename.get_temp_dir_name ()) in
+  let result =
+    D.deliver_continuation
+      ~config
+      ~agent_name:"test-agent"
+      ~continuation_channel:(Masc.Keeper_continuation_channel.Dashboard)
+      ~text:""
+      ()
+  in
+  Alcotest.(check bool)
+    "deliver_continuation with empty text returns Skipped_empty"
+    true
+    (result = D.Skipped_empty)
+;;
+
+let test_w3c_describe_outcome () =
+  let module D = Masc.Keeper_continuation_delivery in
+  Alcotest.(check string)
+    "describe Delivered"
+    "delivered"
+    (D.describe_outcome D.Delivered);
+  Alcotest.(check string)
+    "describe Skipped_unrouted"
+    "skipped: unrouted"
+    (D.describe_outcome D.Skipped_unrouted);
+  Alcotest.(check string)
+    "describe Skipped_empty"
+    "skipped: empty content"
+    (D.describe_outcome D.Skipped_empty);
+  Alcotest.(check string)
+    "describe Skipped_already_replied"
+    "skipped: already replied"
+    (D.describe_outcome D.Skipped_already_replied)
+;;
+
 let test_w3c_continuation_delivery_gate () =
   let module D = Masc.Keeper_continuation_delivery in
   let dashboard =
@@ -800,6 +854,18 @@ let () =
             "W3c continuation delivery gate is fail-closed"
             `Quick
             test_w3c_continuation_delivery_gate
+        ; Alcotest.test_case
+            "W3c deliver_continuation with Unrouted returns skip"
+            `Quick
+            test_w3c_deliver_continuation_unrouted_returns_skip
+        ; Alcotest.test_case
+            "W3c deliver_continuation with empty text returns skip"
+            `Quick
+            test_w3c_deliver_continuation_empty_text_returns_skip
+        ; Alcotest.test_case
+            "W3c describe_outcome covers all variants"
+            `Quick
+            test_w3c_describe_outcome
         ] )
     ; ( "summary"
       , [ Alcotest.test_case


### PR DESCRIPTION
Wire deliver_continuation into keeper_msg turn response path. When continuation_channel is captured (PR #23797), response text is fire-and-forget delivered back to originating channel. Errors logged, not propagated. Closes task-1876.