### PR TITLE
fix(tool_task): Gate 0 — require evidence_refs for all code task submissions

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -413,7 +413,24 @@ let evidence_refs =
         | Some h -> h.evidence_refs
         | None -> []
       in
-      let review_gate_rejection =
+      (* Gate 0: evidence_refs required for all code task submissions.
+         Reject completions that lack code-level evidence (file paths,
+         commit hashes, trace/turn/receipt refs). *)
+      let gate0_rejection =
+        if evidence_refs = [] then
+          Some
+            "evidence_refs is required. Include at least one locally \
+             validated base-path artifact, local git commit, or \
+             .masc trace/turn/receipt reference."
+        else
+          None
+      in
+      (match gate0_rejection with
+       | Some reason ->
+         Tool_result.error
+           ~failure_class:(Some Tool_result.Workflow_rejection)
+           ~tool_name ~start_time reason
+       | None -> let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then
         None

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1593,6 +1593,61 @@ let () = test "handle_transition_verifier_blocks_non_verdict_actions" (fun () ->
   assert_task_todo ctx;
   assert (Planning_eio.get_current_task ctx.config = None))
 
+(* Gate 0: submit_for_verification rejects empty evidence_refs *)
+let () = test "gate0_submit_rejects_empty_evidence_refs" (fun () ->
+  let ctx = make_test_ctx () in
+  let task_id = "task-gate0-" ^ string_of_int (Random.int 100000) in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Gate 0 test task") ])
+  in
+  (* Submit without handoff_context → evidence_refs will be [] *)
+  let result =
+    Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String task_id);
+          ("action", `String "submit_for_verification");
+          ("notes", `String "Gate 0 test — should fail");
+        ])
+  in
+  assert (not (Tool_result.is_success result));
+  assert
+    ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
+  assert (str_contains (Tool_result.message result) "evidence_refs is required"))
+
+(* Gate 0: submit_for_verification accepts non-empty evidence_refs *)
+let () = test "gate0_submit_accepts_evidence_refs" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Gate 0 test task with evidence") ])
+  in
+  let result =
+    Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "submit_for_verification");
+          ("notes", `String "with evidence");
+          ( "handoff_context",
+            `Assoc
+              [
+                ("summary", `String "has evidence");
+                ( "evidence_refs",
+                  `List [ `String "test/fixtures/sample.txt" ] );
+              ] );
+        ])
+  in
+  (* Should NOT be rejected by Gate 0 — it has evidence_refs.
+     May still fail downstream for other reasons. *)
+  let msg = Tool_result.message result in
+  if Tool_result.is_success result
+  then ()
+  else
+    (* If it fails, it should NOT be because of empty evidence_refs *)
+    assert (not (str_contains msg "evidence_refs is required")))
+
 let () = test "handle_transition_verifier_noops_terminal_verdicts" (fun () ->
   let ctx = make_test_ctx_with_agent "worker" in
   register_test_keeper ctx ~keeper_name:"verifier" ~agent_name:"verifier"


### PR DESCRIPTION
## Summary

Add explicit evidence_refs non-empty check in the `submit_for_verification` path.

## Problem

Previously, only `keeper_task_done` enforced evidence_refs at the API level:
- `keeper_tool_task_runtime.ml:348` — parses and requires evidence_refs in JSON args
- `anti_rationalization.ml:743` — Gate 0 rejects empty evidence_refs

The `submit_for_verification` path in `tool_task.ml` silently accepted empty `evidence_refs`, relying solely on the downstream `task_completion_gate.ml` which has a known bug (`has_git_marker` walks UP only from workspace root, missing `repos/` child directories).

## Fix

Add a deterministic, fail-closed check at the earliest possible point in the submission pipeline — before any gate evaluation or state transition:

```ocaml
let gate0_rejection =
  if evidence_refs = [] then
    Some "evidence_refs is required."
  else None
in
(match gate0_rejection with
 | Some reason -> Tool_result.error ~failure_class:(Some Tool_result.Workflow_rejection) ...
 | None -> (* existing review_gate_rejection logic *)
```

## Impact

- All `submit_for_verification` calls without evidence_refs will now be rejected immediately with a clear error message
- This is consistent with `keeper_task_done` behavior
- Prevents silent pass-through to broken downstream gates

## Refs

- task-1882
- Board post p-21e43936cf329206831ad0b90cc06f9d (evidence gate root cause analysis)