### PR TITLE
fix(anti_rationalization): disable Gate 0 evidence check until call site is wired (task-1887)

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -740,10 +740,11 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs — required for all code task submissions.
-     Reject completions that lack code-level evidence (file paths, commit hashes,
-     trace/turn/receipt refs). *)
-  if List.is_empty req.evidence_refs then
+  (* Gate 0: DISABLED (task-1887 hotfix) — re-enable when call site is wired
+     to pass actual evidence_refs from handoff_context via review_request.
+     PR #23666 merged this gate with evidence_refs = [] hardcoded in
+     tool_task_handlers.ml, causing all submissions to be rejected. *)
+  if false && List.is_empty req.evidence_refs then
     emit
       { verdict = Reject "no evidence references supplied"
       ; evaluator_runtime


### PR DESCRIPTION
## Summary

Disables Gate 0 (empty evidence_refs → immediate Reject) in the anti-rationalization pipeline until the call site is wired to pass actual evidence_refs.

## Problem

PR #23666 merged Gate 0 with `evidence_refs = []` hardcoded in `tool_task_handlers.ml`. This means **every** `keeper_task_done` submission is rejected by Gate 0, regardless of whether evidence was actually provided. The call site doesn't wire `handoff_context.evidence_refs` through to `review_request.evidence_refs`.

## Fix

Changed the Gate 0 condition from:
```ocaml
if List.is_empty req.evidence_refs then
```
to:
```ocaml
if false && List.is_empty req.evidence_refs then
```

The gate code stays visible and documented for re-enabling once task-1889 wires the call site.

## Follow-up

- **task-1889**: Wire `handoff_context.evidence_refs` through to `review_request.evidence_refs` in `tool_task_handlers.ml`, then re-enable Gate 0.

## Refs

- task-1887
- PR #23666 (original Gate 0 merge)