### PR TITLE
fix(keeper): prevent livelock on chat queue persistence failure

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -286,7 +286,13 @@ let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id =
   try
     let fusion_completion =
-      Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id }
+      Keeper_event_queue.
+        { run_id
+        ; ok
+        ; resolved_answer
+        ; board_post_id
+        ; continuation_channel = Keeper_continuation_channel.unrouted ("fusion:" ^ run_id)
+        }
     in
     let post_id = Keeper_event_queue.fusion_completion_post_id fusion_completion in
     let stimulus : Keeper_event_queue.stimulus =

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -184,11 +184,17 @@ let queue_of_yojson json =
   | Some _, _ -> Error "chat queue snapshot requires items array"
 
 let save_json_atomic path json =
-  Fs_compat.mkdir_p (Filename.dirname path);
-  json
-  |> Safe_ops.sanitize_json_utf8
-  |> Yojson.Safe.pretty_to_string
-  |> Fs_compat.save_file_atomic path
+  match
+    (try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Printexc.to_string exn))
+  with
+  | Error _ as err -> err
+  | Ok () ->
+    json
+    |> Safe_ops.sanitize_json_utf8
+    |> Yojson.Safe.pretty_to_string
+    |> Fs_compat.save_file_atomic path
 
 let load_snapshot ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name with
@@ -337,7 +343,7 @@ let dequeue_batch ~keeper_name =
   | None -> []
   | Some entry ->
       with_entry_lock entry (fun () ->
-          let before = queue_to_list entry.q in
+          let _before = queue_to_list entry.q in
           match Queue.take_opt entry.q with
           | None -> []
           | Some first ->
@@ -349,7 +355,9 @@ let dequeue_batch ~keeper_name =
                 | Some _ | None -> List.rev acc
               in
               let batch = first :: drain [] in
-              persist_or_rollback ~keeper_name entry.q ~before;
+              (try persist_if_configured ~keeper_name entry.q with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn -> Log.Keeper.warn "keeper_chat_queue: dequeue_batch persistence failed for keeper=%s: %s" keeper_name (Printexc.to_string exn));
               batch)
 
 let merge_batch batch =

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -108,6 +108,7 @@ and fusion_completion = {
   (* judge resolved answer; a failure label when [ok = false]. *)
   board_post_id : string;
   (* correlates to the sink's board evidence post; "" if none was created. *)
+  continuation_channel : Keeper_continuation_channel.t;
 }
 
 and bg_job_completion = {
@@ -538,6 +539,7 @@ let payload_to_yojson = function
       ; "ok", `Bool fusion.ok
       ; "resolved_answer", `String fusion.resolved_answer
       ; "board_post_id", `String fusion.board_post_id
+      ; "channel", Keeper_continuation_channel.to_yojson fusion.continuation_channel
       ]
   | Bg_completed c ->
     let ok, payload =
@@ -649,7 +651,15 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
-    Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id })
+    let* continuation_channel = continuation_channel_field fields in
+    Ok
+      (Fusion_completed
+         { run_id
+         ; ok
+         ; resolved_answer
+         ; board_post_id
+         ; continuation_channel
+         })
   | "bg_completed" ->
     let* run_id = string_field ~context "run_id" fields in
     let* job_kind_s = string_field ~context "job_kind" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -112,6 +112,7 @@ and fusion_completion = {
   ok : bool;
   resolved_answer : string;
   board_post_id : string;
+  continuation_channel : Keeper_continuation_channel.t;
 }
 (** RFC-0266 payload for [Fusion_completed]: [ok] distinguishes a synthesized
     judge result from denied/sink_failed/aborted; [resolved_answer] carries the

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -144,7 +144,12 @@ let fusion_payload
       ()
   : Keeper_event_queue.fusion_completion
   =
-  { run_id; ok; resolved_answer; board_post_id }
+  { run_id
+  ; ok
+  ; resolved_answer
+  ; board_post_id
+  ; continuation_channel = Keeper_continuation_channel.unrouted "test legacy"
+  }
 ;;
 
 let fusion_stimulus ?run_id ?ok ?resolved_answer ?board_post_id () : Keeper_event_queue.stimulus =

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -155,19 +155,34 @@ let () =
   (* RFC-0266: Fusion_completed is a non-board stimulus with its own label. *)
   let fusion_payload () =
     Fusion_completed
-      { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" }
+      { run_id = "fus-1"
+      ; ok = true
+      ; resolved_answer = "ok"
+      ; board_post_id = "post-1"
+      ; continuation_channel = Keeper_continuation_channel.unrouted "test legacy"
+      }
   in
   assert (not (is_board_signal (fusion_payload ())));
   assert (String.equal (payload_kind_label (fusion_payload ())) "fusion_completed");
   assert (
     String.equal
       (fusion_completion_post_id
-         { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" })
+         { run_id = "fus-1"
+         ; ok = true
+         ; resolved_answer = "ok"
+         ; board_post_id = "post-1"
+         ; continuation_channel = Keeper_continuation_channel.unrouted "test legacy"
+         })
       "post-1");
   assert (
     String.equal
       (fusion_completion_post_id
-         { run_id = "fus-2"; ok = false; resolved_answer = "sink_failed"; board_post_id = "" })
+         { run_id = "fus-2"
+         ; ok = false
+         ; resolved_answer = "sink_failed"
+         ; board_post_id = ""
+         ; continuation_channel = Keeper_continuation_channel.unrouted "test legacy"
+         })
       "fusion-run:fus-2");
 
   (* RFC-0290: Bg_completed is a non-board stimulus with its own label; its
@@ -543,18 +558,20 @@ let () =
     in
     enqueue
       q
-         { post_id = "fp1"
-         ; urgency = Low
-         ; arrived_at = 2.5
-         ; payload =
-             Fusion_completed
-               { run_id = "fus-3"
-               ; ok = false
-               ; resolved_answer = "denied"
-               ; board_post_id = ""
-               }
-         }
-  in
+            { post_id = "fp1"
+              ; urgency = Low
+              ; arrived_at = 2.5
+              ; payload =
+                  Fusion_completed
+                    { run_id = "fus-3"
+                    ; ok = false
+                    ; resolved_answer = "denied"
+                    ; board_post_id = ""
+                    ; continuation_channel =
+                        Keeper_continuation_channel.unrouted "test legacy"
+                    }
+                 }
+      in
   let queue_for_snapshot =
     enqueue
       queue_for_snapshot
@@ -600,7 +617,8 @@ let () =
   assert (String.equal fourth.post_id "fp1");
   assert (
     match fourth.payload with
-    | Fusion_completed { run_id; ok; resolved_answer; board_post_id } ->
+    | Fusion_completed
+        { run_id; ok; resolved_answer; board_post_id; continuation_channel = _ } ->
       String.equal run_id "fus-3"
       && (not ok)
       && String.equal resolved_answer "denied"

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -50,7 +50,12 @@ let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
   ; arrived_at = 1234.5
   ; payload =
       Keeper_event_queue.Fusion_completed
-        { run_id; ok = true; resolved_answer = "use approach B"; board_post_id = "post-fus" }
+        { run_id
+        ; ok = true
+        ; resolved_answer = "use approach B"
+        ; board_post_id = "post-fus"
+        ; continuation_channel = Keeper_continuation_channel.unrouted "test legacy"
+        }
   }
 ;;
 


### PR DESCRIPTION
## Description
Fixes a system livelock caused by continuous chat queue dispatch retries when disk I/O fails.

- `keeper_chat_queue.ml`: Make `save_json_atomic` return a safe `Result` rather than throwing uncaught `Eio` or `Sys_error` exceptions on `mkdir_p` failure.
- `dequeue_batch` now operates on a best-effort basis for disk updates (logs warning and continues) instead of rolling back the queue upon `Persistence_failed`. This allows the queue to be drained and unblocks the autonomous turn scheduler from infinite `Busy None` status.
- Included the `continuation_channel` fix to the `Fusion_completed` event that was also pending in the same workspace.