### PR TITLE
fix(keeper): scope internal-state path guard to .masc components

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -259,22 +259,11 @@ let raw_looks_like_playground_subdir (raw : string) : bool =
     that also dropped the internal-state defence. The fix is to keep the arm
     and narrow the match so only workspace-level state is blocked. *)
 let is_masc_internal_state_path (raw : string) : bool =
-  (* Match ".masc/", "./.masc/", ".masc" at end, "*/backlog.json" *)
-  let masc_state =
-    (String.starts_with ~prefix:".masc/" raw)
-    || (String.starts_with ~prefix:"./.masc/" raw)
-    || (String.equal raw ".masc")
-    || (String.equal raw "./.masc")
-    || (let len = String.length raw in
-        len >= 12
-        && String.sub raw (len - 12) 12 = "backlog.json"
-        && (len = 12 || raw.[len - 13] = '/'))
-  in
-  let under_playground =
-    String.starts_with ~prefix:".masc/playground" raw
-    || String.starts_with ~prefix:"./.masc/playground" raw
-  in
-  masc_state && not under_playground
+  match split_relative_components raw with
+  | masc_dir :: "playground" :: _ when String.equal masc_dir Common.masc_dirname ->
+    false
+  | masc_dir :: _ when String.equal masc_dir Common.masc_dirname -> true
+  | [] | _ -> false
 ;;
 
 let is_masc_internal_state_norm ~(root_norm : string) ~(target_norm : string) : bool =

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -263,7 +263,7 @@ let is_masc_internal_state_path (raw : string) : bool =
   | masc_dir :: "playground" :: _ when String.equal masc_dir Common.masc_dirname ->
     false
   | masc_dir :: _ when String.equal masc_dir Common.masc_dirname -> true
-  | [] | _ -> false
+  | _ -> false
 ;;
 
 let is_masc_internal_state_norm ~(root_norm : string) ~(target_norm : string) : bool =

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -86,9 +86,9 @@ val playground_root_of_allowed : string list -> string option
 
 val raw_looks_like_playground_subdir : string -> bool
 
-(** Detect paths that reference .masc/ internal state files
-    (backlog.json, tasks/, etc). These should be accessed via
-    keeper_tasks_list / keeper_context_status, not direct file access. *)
+(** Detect relative paths rooted at the workspace [.masc/] internal-state
+    directory.  The keeper playground is exempt.  Ordinary repository files
+    named [backlog.json] are not internal state. *)
 val is_masc_internal_state_path : string -> bool
 
 (** Detect normalized targets that resolve under the workspace-level

--- a/test/test_keeper_alerting_path_norms.ml
+++ b/test/test_keeper_alerting_path_norms.ml
@@ -122,6 +122,42 @@ let test_raw_looks_repos_typo_rejected () =
     false
     (KAP.raw_looks_like_playground_subdir "repository/foo")
 
+(* ── is_masc_internal_state_path ────────────────────────────── *)
+
+let test_raw_masc_state_paths_blocked () =
+  List.iter
+    (fun path ->
+       check_bool
+         (Printf.sprintf "%s → internal" path)
+         true
+         (KAP.is_masc_internal_state_path path))
+    [ ".masc"; "./.masc/tasks/backlog.json"; ".masc/config/keepers/a.toml" ]
+;;
+
+let test_raw_masc_playground_allowed () =
+  check_bool
+    ".masc playground → keeper-owned"
+    false
+    (KAP.is_masc_internal_state_path ".masc/playground/keeper/repos/masc")
+;;
+
+let test_raw_masc_playground_sibling_blocked () =
+  check_bool
+    ".masc playground sibling → internal"
+    true
+    (KAP.is_masc_internal_state_path ".masc/playground-archive/backlog.json")
+;;
+
+let test_repository_backlog_files_allowed () =
+  List.iter
+    (fun path ->
+       check_bool
+         (Printf.sprintf "%s → ordinary repository file" path)
+         false
+         (KAP.is_masc_internal_state_path path))
+    [ "backlog.json"; "docs/backlog.json"; "fixtures/team/backlog.json" ]
+;;
+
 (* ── normalize_path_for_check_stripped ──────────────────────── *)
 
 let test_normalize_path_for_check_stripped_removes_trailing_slash () =
@@ -206,6 +242,17 @@ let () =
         [
           Alcotest.test_case "removes trailing slash" `Quick
             test_normalize_path_for_check_stripped_removes_trailing_slash;
+        ] );
+      ( "is_masc_internal_state_path",
+        [
+          Alcotest.test_case "blocks .masc state paths" `Quick
+            test_raw_masc_state_paths_blocked;
+          Alcotest.test_case "allows keeper playground" `Quick
+            test_raw_masc_playground_allowed;
+          Alcotest.test_case "blocks playground sibling" `Quick
+            test_raw_masc_playground_sibling_blocked;
+          Alcotest.test_case "allows repository backlog files" `Quick
+            test_repository_backlog_files_allowed;
         ] );
       ( "is_masc_internal_state_norm",
         [

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -150,18 +150,20 @@ let test_playground_internal_path_now_allowed () =
      reachable. #23843 unblocked the whole arm; this keeps the playground half
      unblocked after re-narrowing the helper to exempt .masc/playground. *)
   setup
-  @@ fun ~config ~meta ~playground:_ ->
+  @@ fun ~config ~meta ~playground ->
   let private_raw =
     Masc.Keeper_sandbox.allowed_root_rel_of_meta ~meta ^ "mind/README.md"
   in
+  let target = Filename.concat playground "mind/README.md" in
+  write_file target "private storage fixture\n";
   (match
      Keeper_tool_shared_runtime.resolve_keeper_read_path
        ~config
        ~meta
        ~raw_path:private_raw
    with
-   | Ok _ ->
-     () (* playground-internal path resolves — keeper may reach its own area *)
+   | Ok path ->
+     Alcotest.(check string) "resolved private path" target path
    | Error e -> Alcotest.fail ("playground-internal path should resolve: " ^ e))
 ;;
 
@@ -209,6 +211,30 @@ let test_read_with_visible_repo_cwd_and_relative_file_path () =
   Alcotest.(check (option string))
     "content"
     (Some "repo readme\n")
+    (parse_string "content" raw)
+;;
+
+let test_repository_backlog_file_is_readable () =
+  setup
+  @@ fun ~config ~meta ~playground ->
+  allow_repo ~config ~meta "masc";
+  let target = Filename.concat playground "repos/masc/docs/backlog.json" in
+  write_file target {|{"scope":"repository fixture"}|};
+  let raw =
+    Keeper_tool_filesystem_runtime.handle_read_file
+      ~turn_sandbox_factory:None
+      ~config
+      ~keeper_name:meta.name
+      ~args:
+        (`Assoc
+            [ "path", `String "repos/masc/docs/backlog.json"
+            ; "max_bytes", `Int 4096
+            ])
+  in
+  if not (parse_ok raw) then Alcotest.failf "expected Read ok, got: %s" raw;
+  Alcotest.(check (option string))
+    "repository backlog content"
+    (Some {|{"scope":"repository fixture"}|})
     (parse_string "content" raw)
 ;;
 
@@ -298,6 +324,10 @@ let () =
             "Write visible mind path"
             `Quick
             test_write_visible_mind_path
+        ; Alcotest.test_case
+            "repository backlog.json remains readable"
+            `Quick
+            test_repository_backlog_file_is_readable
         ; Alcotest.test_case
             "repo-prefixed missing read surfaces playground hint"
             `Quick


### PR DESCRIPTION
## 문제

48시간 병합 감사에서 #23846의 raw-path guard가 경로가 `backlog.json`으로 끝나기만 하면 MASC 내부 상태로 분류함을 확인했소. 그 결과 `repos/masc/docs/backlog.json` 같은 정상 저장소 파일도 normalization 전에 차단됐소.

## 변경

- filename suffix 휴리스틱을 제거했소.
- `Common.masc_dirname`을 첫 경로 component로 갖는 경우만 내부 상태로 판정하오.
- `.masc/playground/...`는 기존 계약대로 허용하고 `.masc/playground-*` sibling은 차단하오.
- raw helper와 실제 file-read 경로 모두에 회귀 테스트를 추가했소.
- 기존 playground fixture가 파일을 만들지 않아 자체 실패하던 부분도 실제 경로를 생성하고 정확한 resolved path를 검증하게 고쳤소.

## 검증

- `opam exec --switch=5.4.1 -- ocamlformat --check ...`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_alerting_path_norms.exe`
- `test_keeper_alerting_path_norms.exe`: 24/24 pass
- `scripts/dune-local.sh build test/test_keeper_visible_path_projection.exe`
- `test_keeper_visible_path_projection.exe`: 7/7 pass

## 감사 추적

- 원인 병합: #23846 (`deaa1d9fb2f4`)
- 감사 창: `2026-07-08T01:03:16Z..2026-07-10T01:03:16Z`

[근거] current `main=f242ea1d46`, originating merge diff, full resolver data-flow와 focused tests를 2026-07-10 KST에 확인했소. 신뢰도 High.