### PR TITLE
fix(slack): fail closed on invalid trigger policy TOML

### DIFF
--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -120,11 +120,13 @@ let status_json ?(audit_limit = 10) () =
   let bot_present = Option.is_some (bot_token_opt ()) in
   let app_present = Option.is_some (app_token_opt ()) in
   (* Socket Mode needs the app token; without it the gateway never starts. *)
-  let available = app_present in
+  let startup_ok = Option.is_none startup_error in
+  let available = app_present && startup_ok in
   let connected =
-    match gateway_state with
-    | Connected -> true
-    | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
+    startup_ok
+    && match gateway_state with
+       | Connected -> true
+       | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
   in
   let stale = false in
   (* NDT-OK: status_json is a dashboard observation boundary; this timestamp
@@ -149,11 +151,7 @@ let status_json ?(audit_limit = 10) () =
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)
     ; ("stale_after_sec", `Int (stale_after_sec ()))
-    ; ( "status"
-      , `String
-          (match startup_error with
-           | Some _ -> "unhealthy"
-           | None -> connector_state_label ~available ~connected ~stale) )
+    ; ("status", `String (connector_state_label ~available ~connected ~stale))
     ; ("error", `String error)
     ; ("status_source", `String "in_process_gateway")
     ; ("gateway_state", `String (gateway_state_label gateway_state))

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -102,6 +102,10 @@ type ready_info = {
 }
 
 let last_ready : ready_info option Atomic.t = Atomic.make None
+let startup_error : string option Atomic.t = Atomic.make None
+
+let record_startup_error message = Atomic.set startup_error (Some message)
+let clear_startup_error () = Atomic.set startup_error None
 
 let record_ready ~bot_user_id =
   Atomic.set last_ready
@@ -112,6 +116,7 @@ let record_ready ~bot_user_id =
 
 let status_json ?(audit_limit = 10) () =
   let gateway_state = Slack_socket_client.connection_state () in
+  let startup_error = Atomic.get startup_error in
   let bot_present = Option.is_some (bot_token_opt ()) in
   let app_present = Option.is_some (app_token_opt ()) in
   (* Socket Mode needs the app token; without it the gateway never starts. *)
@@ -126,11 +131,14 @@ let status_json ?(audit_limit = 10) () =
      reports gateway freshness and is not used for control flow. *)
   let updated_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
   let error =
-    match gateway_state with
-    | Disconnected ->
-      if app_present then "" else "SLACK_APP_TOKEN is unset or empty"
-    | Failed msg -> msg
-    | Awaiting_hello | Connected | Reconnect_pending _ -> ""
+    match startup_error with
+    | Some message -> message
+    | None ->
+      (match gateway_state with
+       | Disconnected ->
+         if app_present then "" else "SLACK_APP_TOKEN is unset or empty"
+       | Failed msg -> msg
+       | Awaiting_hello | Connected | Reconnect_pending _ -> "")
   in
   let configured_bindings = read_bindings () in
   let recent_audit = read_recent_audit ~limit:audit_limit in
@@ -141,7 +149,11 @@ let status_json ?(audit_limit = 10) () =
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)
     ; ("stale_after_sec", `Int (stale_after_sec ()))
-    ; ("status", `String (connector_state_label ~available ~connected ~stale))
+    ; ( "status"
+      , `String
+          (match startup_error with
+           | Some _ -> "unhealthy"
+           | None -> connector_state_label ~available ~connected ~stale) )
     ; ("error", `String error)
     ; ("status_source", `String "in_process_gateway")
     ; ("gateway_state", `String (gateway_state_label gateway_state))

--- a/lib/gate/channel_gate_slack_state.mli
+++ b/lib/gate/channel_gate_slack_state.mli
@@ -37,6 +37,12 @@ val record_ready : bot_user_id:string -> unit
 (** Called by the in-process gateway's hello handler. Stores the bot identity
     that {!status_json} reports as [bot_user_id] / [last_ready_at]. *)
 
+val record_startup_error : string -> unit
+val clear_startup_error : unit -> unit
+(** Record/clear a fail-closed gateway bootstrap error. [status_json] exposes a
+    recorded error as [status = "unhealthy"] instead of presenting an invalid
+    configuration as an ordinary disconnected connector. *)
+
 val set_trigger_policy : Slack_gateway_state.trigger_policy -> unit
 val get_trigger_policy : unit -> Slack_gateway_state.trigger_policy option
 

--- a/lib/repo_manager/field_resolution.ml
+++ b/lib/repo_manager/field_resolution.ml
@@ -16,11 +16,10 @@ let path_to_string path = String.concat "." path
    - the key is present and the accessor raises [Otoml.Type_error] →
      [Type_mismatch].
 
-   Otoml's [find_opt] returns [None] only for key-absence; type
-   errors come from the accessor itself. Using [Fun.id] as the
-   accessor in [find_opt] guarantees the [Otoml.Type_error] is
-   raised at the call to [accessor], not inside [find_opt], so the
-   two outcomes stay separable. *)
+   Otoml's [find_opt] also returns [None] when an intermediate path
+   component is not a table. Traverse the path explicitly so that
+   only a genuinely absent key becomes [Missing]; a scalar parent is
+   a schema [Type_mismatch]. *)
 let resolve_with
   (accessor : Otoml.t -> 'a)
   (expected : string)
@@ -28,11 +27,25 @@ let resolve_with
   (path : string list)
   : 'a t
   =
-  match Otoml.find_opt toml Fun.id path with
-  | None -> Missing
-  | Some raw ->
-    (try Present (accessor raw)
-     with Otoml.Type_error message -> Type_mismatch { path; expected; message })
+  let rec descend traversed value remaining =
+    match remaining with
+    | [] ->
+      (try Present (accessor value)
+       with Otoml.Type_error message -> Type_mismatch { path; expected; message })
+    | key :: rest ->
+      (match Otoml.get_table value with
+       | exception Otoml.Type_error message ->
+         Type_mismatch
+           { path = List.rev traversed
+           ; expected = "table"
+           ; message
+           }
+       | fields ->
+         (match List.assoc_opt key fields with
+          | None -> Missing
+          | Some child -> descend (key :: traversed) child rest))
+  in
+  descend [] toml path
 ;;
 
 let resolve_string toml path =

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -52,26 +52,76 @@ let parse_trigger_policy raw : Gw.trigger_policy =
         (Gw.trigger_policy_to_string default_trigger_policy);
       default_trigger_policy
 
+type trigger_policy_toml_load =
+  | Runtime_toml_missing
+  | Trigger_policy_missing
+  | Trigger_policy_loaded of Gw.trigger_policy
+
+type trigger_policy_load_error =
+  | Runtime_toml_unreadable of { path : string; detail : string }
+  | Runtime_toml_invalid of { path : string; detail : string }
+  | Trigger_policy_invalid of { path : string; detail : string }
+
+let trigger_policy_load_error_to_string = function
+  | Runtime_toml_unreadable { path; detail } ->
+    Printf.sprintf "cannot read %s: %s" path detail
+  | Runtime_toml_invalid { path; detail } ->
+    Printf.sprintf "invalid TOML in %s: %s" path detail
+  | Trigger_policy_invalid { path; detail } ->
+    Printf.sprintf "invalid slack.trigger_policy in %s: %s" path detail
+;;
+
+let load_trigger_policy_from_toml ~path =
+  match Unix.stat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Runtime_toml_missing
+  | exception Unix.Unix_error (code, _, _) ->
+    Error
+      (Runtime_toml_unreadable
+         { path; detail = Unix.error_message code })
+  | _ ->
+    (match Safe_ops.read_file_safe path with
+     | Error detail -> Error (Runtime_toml_unreadable { path; detail })
+     | Ok content ->
+       (match Otoml.Parser.from_string_result content with
+        | Error detail -> Error (Runtime_toml_invalid { path; detail })
+        | Ok toml ->
+          (match
+             Field_resolution.resolve_string toml [ "slack"; "trigger_policy" ]
+           with
+           | Field_resolution.Missing -> Ok Trigger_policy_missing
+           | Field_resolution.Type_mismatch { expected; message; _ } ->
+             Error
+               (Trigger_policy_invalid
+                  { path
+                  ; detail =
+                      Printf.sprintf "expected %s: %s" expected message
+                  })
+           | Field_resolution.Present raw ->
+             let raw = String.trim raw in
+             if String.equal raw ""
+             then Ok Trigger_policy_missing
+             else
+               (match Gw.parse_trigger_policy raw with
+                | Ok policy -> Ok (Trigger_policy_loaded policy)
+                | Error detail ->
+                  Error (Trigger_policy_invalid { path; detail })))))
+;;
+
 let resolved_trigger_policy () =
-  let from_toml () =
-    try
-      let resolution = Config_dir_resolver.resolve () in
-      let toml_path =
-        Filename.concat resolution.Config_dir_resolver.config_root.path
-          Config_dir_resolver.runtime_toml_filename
-      in
-      if Sys.file_exists toml_path then
-        let tbl = Otoml.Parser.from_file toml_path in
-        Otoml.find_opt tbl Otoml.get_string [ "slack"; "trigger_policy" ]
-      else None
-    with _ -> None
+  let resolution = Config_dir_resolver.resolve () in
+  let toml_path =
+    Filename.concat resolution.Config_dir_resolver.config_root.path
+      Config_dir_resolver.runtime_toml_filename
   in
-  match from_toml () with
-  | Some raw -> parse_trigger_policy raw
-  | None ->
-    (match Env_config_slack.trigger_policy_opt () with
-     | None -> default_trigger_policy
-     | Some raw -> parse_trigger_policy raw)
+  match load_trigger_policy_from_toml ~path:toml_path with
+  | Error _ as error -> error
+  | Ok (Trigger_policy_loaded policy) -> Ok policy
+  | Ok (Runtime_toml_missing | Trigger_policy_missing) ->
+    Ok
+      (match Env_config_slack.trigger_policy_opt () with
+       | None -> default_trigger_policy
+       | Some raw -> parse_trigger_policy raw)
+;;
 
 (* ---------------------------------------------------------------- *)
 (* Metadata helpers (mirror the Discord gateway)                    *)
@@ -376,60 +426,73 @@ let on_event ~dispatch ~clock (ev : Gw.slack_event) =
 let start ~sw ~env ~state =
   match Env_config_slack.app_token_opt () with
   | None ->
+    State.clear_startup_error ();
     Log.Server.warn
       "RFC-0317: SLACK_APP_TOKEN is unset; in-process Slack gateway not \
        started"
   | Some app_token ->
-    (* One clock for the whole gateway: bounds [auth.test] at start and every
-       outbound reply send/edit, and feeds the dispatch adapter. *)
-    let clock = Eio.Stdenv.clock env in
-    (* Resolve the bot's own identity for mention detection. Non-fatal: without
-       it, [app_mention] events still trigger (a mention by construction); only
-       plain-message mention detection on the [message] event degrades. *)
-    let bot_user_id =
-      match Env_config_slack.bot_token_opt () with
-      | None ->
-        Log.Server.warn
-          "RFC-0317: SLACK_BOT_TOKEN unset; Slack plain-message mention \
-           detection disabled (app_mention still triggers)";
-        None
-      | Some bot_token -> (
-        match Slack_rest_client.auth_test ~clock ~token:bot_token () with
-        | Ok { user_id; team_id = _ } ->
-          State.record_ready ~bot_user_id:user_id;
-          Log.Server.info "RFC-0317: Slack auth.test ok (bot_user_id=%s)"
-            user_id;
-          Some user_id
-        | Error e ->
-          Log.Server.warn
-            "RFC-0317: Slack auth.test failed (%s); proceeding without \
-             bot_user_id"
-            (Format.asprintf "%a" Slack_rest_client.pp_error e);
-          None)
-    in
-    let policy = resolved_trigger_policy () in
-    State.set_trigger_policy policy;
-    let dispatch =
-      (* Tag this dispatch as the Slack connector so a message arriving while
-         the keeper is in flight enqueues onto [Keeper_chat_queue] (drained by
-         the serial consumer, delivered via [Keeper_chat_slack.adapter_loop])
-         rather than the outbound-less async poll store. *)
-      Gate_keeper_backend.dispatch_with_text_snapshot
-        ~connector_kind:Gate_keeper_backend.Slack ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ~net:state.Mcp_server.net
-        ~config:(Mcp_server.workspace_config state)
-    in
-    let policy_label = Gw.trigger_policy_to_string policy in
-    Log.Server.info
-      "RFC-0317: starting in-process Slack gateway (policy=%s)" policy_label;
-    Eio.Fiber.fork ~sw (fun () ->
-      try
-        Slack_socket_client.run ~sw ~env ~bot_user_id ~app_token
-          ~trigger_policy:policy
-          ~on_event:(fun ev -> on_event ~dispatch ~clock ev)
-          ()
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Log.Server.error "RFC-0317: in-process Slack gateway crashed: %s"
-          (Printexc.to_string exn))
+    (match resolved_trigger_policy () with
+     | Error error ->
+       let detail = trigger_policy_load_error_to_string error in
+       State.record_startup_error detail;
+       Log.Server.error
+         "RFC-0317: Slack trigger-policy configuration rejected; gateway not \
+          started (%s)"
+         detail
+     | Ok policy ->
+       State.clear_startup_error ();
+       (* One clock for the whole gateway: bounds [auth.test] at start and every
+          outbound reply send/edit, and feeds the dispatch adapter. *)
+       let clock = Eio.Stdenv.clock env in
+       (* Resolve the bot's own identity for mention detection. Non-fatal:
+          without it, [app_mention] events still trigger (a mention by
+          construction); only plain-message mention detection on the [message]
+          event degrades. *)
+       let bot_user_id =
+         match Env_config_slack.bot_token_opt () with
+         | None ->
+           Log.Server.warn
+             "RFC-0317: SLACK_BOT_TOKEN unset; Slack plain-message mention \
+              detection disabled (app_mention still triggers)";
+           None
+         | Some bot_token -> (
+           match Slack_rest_client.auth_test ~clock ~token:bot_token () with
+           | Ok { user_id; team_id = _ } ->
+             State.record_ready ~bot_user_id:user_id;
+             Log.Server.info "RFC-0317: Slack auth.test ok (bot_user_id=%s)"
+               user_id;
+             Some user_id
+           | Error e ->
+             Log.Server.warn
+               "RFC-0317: Slack auth.test failed (%s); proceeding without \
+                bot_user_id"
+               (Format.asprintf "%a" Slack_rest_client.pp_error e);
+             None)
+       in
+       State.set_trigger_policy policy;
+       let dispatch =
+         (* Tag this dispatch as the Slack connector so a message arriving while
+            the keeper is in flight enqueues onto [Keeper_chat_queue] (drained
+            by the serial consumer, delivered via
+            [Keeper_chat_slack.adapter_loop]) rather than the outbound-less
+            async poll store. *)
+         Gate_keeper_backend.dispatch_with_text_snapshot
+           ~connector_kind:Gate_keeper_backend.Slack ~sw ~clock
+           ~proc_mgr:state.Mcp_server.proc_mgr ~net:state.Mcp_server.net
+           ~config:(Mcp_server.workspace_config state)
+       in
+       let policy_label = Gw.trigger_policy_to_string policy in
+       Log.Server.info
+         "RFC-0317: starting in-process Slack gateway (policy=%s)"
+         policy_label;
+       Eio.Fiber.fork ~sw (fun () ->
+         try
+           Slack_socket_client.run ~sw ~env ~bot_user_id ~app_token
+             ~trigger_policy:policy
+             ~on_event:(fun ev -> on_event ~dispatch ~clock ev)
+             ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Server.error "RFC-0317: in-process Slack gateway crashed: %s"
+             (Printexc.to_string exn)))

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -72,7 +72,7 @@ let trigger_policy_load_error_to_string = function
 ;;
 
 let load_trigger_policy_from_toml ~path =
-  match Unix.stat path with
+  match Unix.lstat path with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Runtime_toml_missing
   | exception Unix.Unix_error (code, _, _) ->
     Error

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -35,6 +35,27 @@ val parse_trigger_policy : string -> Slack_gateway_state.trigger_policy
     default rather than being silently coerced. Exposed for unit testing the
     config boundary. *)
 
+type trigger_policy_toml_load =
+  | Runtime_toml_missing
+  | Trigger_policy_missing
+  | Trigger_policy_loaded of Slack_gateway_state.trigger_policy
+(** Typed result of reading the optional Slack trigger policy from
+    [runtime.toml]. Missing file/key are deliberate no-config outcomes; a
+    present value has already passed the canonical policy parser. *)
+
+type trigger_policy_load_error =
+  | Runtime_toml_unreadable of { path : string; detail : string }
+  | Runtime_toml_invalid of { path : string; detail : string }
+  | Trigger_policy_invalid of { path : string; detail : string }
+(** Fail-closed configuration errors. They are never converted to the env or
+    default policy. *)
+
+val load_trigger_policy_from_toml :
+  path:string -> (trigger_policy_toml_load, trigger_policy_load_error) result
+(** Read and validate the Slack trigger policy at [path]. *)
+
+val trigger_policy_load_error_to_string : trigger_policy_load_error -> string
+
 val start :
   sw:Eio.Switch.t ->
   env:Eio_unix.Stdenv.base ->

--- a/test/test_field_resolution.ml
+++ b/test/test_field_resolution.ml
@@ -97,6 +97,13 @@ name = "bar"|} in
      | Missing -> true
      | _ -> false)
 
+let test_nested_path_scalar_parent_is_type_mismatch () =
+  let toml = toml_of_string {|repository = "not-a-table"|} in
+  Alcotest.(check bool) "scalar parent is not Missing" true
+    (match F.resolve_string toml [ "repository"; "name" ] with
+     | Type_mismatch { path = [ "repository" ]; expected = "table"; _ } -> true
+     | Present _ | Missing | Type_mismatch _ -> false)
+
 (* ── or_default / require ───────────────────────────────────── *)
 
 let test_or_default_present () =
@@ -166,6 +173,8 @@ let () =
           Alcotest.test_case "present" `Quick test_nested_path_present;
           Alcotest.test_case "missing different table" `Quick
             test_nested_path_missing;
+          Alcotest.test_case "scalar parent is type_mismatch" `Quick
+            test_nested_path_scalar_parent_is_type_mismatch;
         ] );
       ( "or_default"
       , [

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -10,9 +10,49 @@
 
 open Alcotest
 module G = Server_slack_in_process_gateway
+module State = Channel_gate_slack_state
 
 let ps p = Slack_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
+
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    (fun () ->
+      Unix.putenv key value;
+      f ())
+;;
+
+let with_temp_base f =
+  let base_path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-slack-trigger-policy-status-%d-%d"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  with_env Env_config_core.base_path_env_key base_path (fun () ->
+    with_env Env_config_core.base_path_input_env_key base_path f)
+;;
+
+let with_temp_toml content f =
+  let path = Filename.temp_file "masc-slack-trigger-policy-" ".toml" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+       let out = open_out_bin path in
+       Fun.protect
+         ~finally:(fun () -> close_out_noerr out)
+         (fun () -> output_string out content);
+       f path)
+;;
+
+let load_error_to_string error = G.trigger_policy_load_error_to_string error
 
 let test_empty_is_default () =
   check string "empty => default" default_str (ps (G.parse_trigger_policy ""))
@@ -47,6 +87,81 @@ let test_user_only_empty_id_falls_back () =
   check string "user_only: empty id => default" default_str
     (ps (G.parse_trigger_policy "user_only:"))
 
+let test_missing_runtime_toml_is_typed_missing () =
+  let path = Filename.temp_file "masc-slack-trigger-policy-missing-" ".toml" in
+  Sys.remove path;
+  match G.load_trigger_policy_from_toml ~path with
+  | Ok G.Runtime_toml_missing -> ()
+  | Ok G.Trigger_policy_missing ->
+    fail "expected missing runtime.toml, got missing key"
+  | Ok (G.Trigger_policy_loaded policy) ->
+    failf "expected missing runtime.toml, got policy %s" (ps policy)
+  | Error error ->
+    failf "expected typed missing, got %s" (load_error_to_string error)
+;;
+
+let test_missing_key_is_deliberate_no_config () =
+  with_temp_toml "[server]\nport = 8935\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Ok G.Trigger_policy_missing -> ()
+    | Ok G.Runtime_toml_missing -> fail "runtime.toml should exist"
+    | Ok (G.Trigger_policy_loaded policy) ->
+      failf "expected missing Slack key, got policy %s" (ps policy)
+    | Error error ->
+      failf "expected missing Slack key, got %s" (load_error_to_string error))
+;;
+
+let test_malformed_runtime_toml_is_error () =
+  with_temp_toml "[slack\ntrigger_policy = \"all\"\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Error (G.Runtime_toml_invalid _) -> ()
+    | Error error ->
+      failf "expected invalid TOML, got %s" (load_error_to_string error)
+    | Ok _ -> fail "malformed runtime.toml must fail closed")
+;;
+
+let test_valid_runtime_toml_loads_policy () =
+  with_temp_toml "[slack]\ntrigger_policy = \"all\"\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Ok (G.Trigger_policy_loaded policy) ->
+      check string "policy" "all" (ps policy)
+    | Ok G.Runtime_toml_missing -> fail "runtime.toml should exist"
+    | Ok G.Trigger_policy_missing -> fail "trigger policy should be present"
+    | Error error ->
+      failf "expected valid policy, got %s" (load_error_to_string error))
+;;
+
+let test_wrong_type_runtime_toml_is_error () =
+  with_temp_toml "[slack]\ntrigger_policy = 42\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Error (G.Trigger_policy_invalid _) -> ()
+    | Error error ->
+      failf "expected invalid policy type, got %s" (load_error_to_string error)
+    | Ok _ -> fail "wrong trigger-policy type must fail closed")
+;;
+
+let test_invalid_runtime_toml_policy_is_error () =
+  with_temp_toml "[slack]\ntrigger_policy = \"mention_ony\"\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Error (G.Trigger_policy_invalid _) -> ()
+    | Error error ->
+      failf "expected invalid policy value, got %s" (load_error_to_string error)
+    | Ok _ -> fail "invalid trigger-policy value must fail closed")
+;;
+
+let test_startup_error_is_operator_visible () =
+  with_temp_base (fun () ->
+    State.record_startup_error "invalid Slack trigger policy";
+    Fun.protect
+      ~finally:State.clear_startup_error
+      (fun () ->
+         let status = State.status_json () in
+         check string "status" "unhealthy"
+           Yojson.Safe.Util.(status |> member "status" |> to_string);
+         check string "error" "invalid Slack trigger policy"
+           Yojson.Safe.Util.(status |> member "error" |> to_string)))
+;;
+
 let () =
   run "server_slack_trigger_policy"
     [ ( "parse_trigger_policy"
@@ -58,5 +173,21 @@ let () =
             test_unknown_falls_back_to_default
         ; test_case "user_only empty id => default" `Quick
             test_user_only_empty_id_falls_back
+        ] )
+    ; ( "runtime.toml loading"
+      , [ test_case "missing file => typed missing" `Quick
+            test_missing_runtime_toml_is_typed_missing
+        ; test_case "missing key => deliberate no-config" `Quick
+            test_missing_key_is_deliberate_no_config
+        ; test_case "malformed file => error" `Quick
+            test_malformed_runtime_toml_is_error
+        ; test_case "valid file => configured policy" `Quick
+            test_valid_runtime_toml_loads_policy
+        ; test_case "wrong field type => error" `Quick
+            test_wrong_type_runtime_toml_is_error
+        ; test_case "invalid policy value => error" `Quick
+            test_invalid_runtime_toml_policy_is_error
+        ; test_case "startup error => unhealthy status" `Quick
+            test_startup_error_is_operator_visible
         ] )
     ]

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -12,6 +12,8 @@ open Alcotest
 module G = Server_slack_in_process_gateway
 module State = Channel_gate_slack_state
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 let ps p = Slack_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
 
@@ -21,7 +23,7 @@ let with_env key value f =
     ~finally:(fun () ->
       match previous with
       | Some previous -> Unix.putenv key previous
-      | None -> Unix.putenv key "")
+      | None -> unsetenv key)
     (fun () ->
       Unix.putenv key value;
       f ())
@@ -53,6 +55,14 @@ let with_temp_toml content f =
 ;;
 
 let load_error_to_string error = G.trigger_policy_load_error_to_string error
+
+let test_with_env_restores_unset () =
+  let key = "MASC_SLACK_TRIGGER_POLICY_TEST_UNSET" in
+  unsetenv key;
+  with_env key "all" (fun () ->
+    check (option string) "set inside scope" (Some "all") (Sys.getenv_opt key));
+  check (option string) "restored unset" None (Sys.getenv_opt key)
+;;
 
 let test_empty_is_default () =
   check string "empty => default" default_str (ps (G.parse_trigger_policy ""))
@@ -194,7 +204,8 @@ let test_startup_error_is_operator_visible () =
 let () =
   run "server_slack_trigger_policy"
     [ ( "parse_trigger_policy"
-      , [ test_case "empty => default" `Quick test_empty_is_default
+      , [ test_case "with_env restores unset" `Quick test_with_env_restores_unset
+        ; test_case "empty => default" `Quick test_empty_is_default
         ; test_case "whitespace => default" `Quick test_whitespace_is_default
         ; test_case "valid values parse through strict grammar" `Quick
             test_valid_values_parse_through

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -100,6 +100,21 @@ let test_missing_runtime_toml_is_typed_missing () =
     failf "expected typed missing, got %s" (load_error_to_string error)
 ;;
 
+let test_dangling_runtime_toml_symlink_is_unreadable () =
+  let link_path = Filename.temp_file "masc-slack-trigger-policy-link-" ".toml" in
+  Sys.remove link_path;
+  let missing_target = link_path ^ ".missing" in
+  Unix.symlink missing_target link_path;
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove link_path with Sys_error _ -> ())
+    (fun () ->
+       match G.load_trigger_policy_from_toml ~path:link_path with
+       | Error (G.Runtime_toml_unreadable _) -> ()
+       | Error error ->
+         failf "expected unreadable dangling symlink, got %s" (load_error_to_string error)
+       | Ok _ -> fail "dangling runtime.toml symlink must not enable fallback")
+;;
+
 let test_missing_key_is_deliberate_no_config () =
   with_temp_toml "[server]\nport = 8935\n" (fun path ->
     match G.load_trigger_policy_from_toml ~path with
@@ -140,6 +155,15 @@ let test_wrong_type_runtime_toml_is_error () =
     | Ok _ -> fail "wrong trigger-policy type must fail closed")
 ;;
 
+let test_wrong_type_slack_parent_is_error () =
+  with_temp_toml "slack = \"not-a-table\"\n" (fun path ->
+    match G.load_trigger_policy_from_toml ~path with
+    | Error (G.Trigger_policy_invalid _) -> ()
+    | Error error ->
+      failf "expected invalid Slack table, got %s" (load_error_to_string error)
+    | Ok _ -> fail "wrong Slack parent type must fail closed")
+;;
+
 let test_invalid_runtime_toml_policy_is_error () =
   with_temp_toml "[slack]\ntrigger_policy = \"mention_ony\"\n" (fun path ->
     match G.load_trigger_policy_from_toml ~path with
@@ -150,16 +174,21 @@ let test_invalid_runtime_toml_policy_is_error () =
 ;;
 
 let test_startup_error_is_operator_visible () =
-  with_temp_base (fun () ->
-    State.record_startup_error "invalid Slack trigger policy";
-    Fun.protect
-      ~finally:State.clear_startup_error
-      (fun () ->
-         let status = State.status_json () in
-         check string "status" "unhealthy"
-           Yojson.Safe.Util.(status |> member "status" |> to_string);
-         check string "error" "invalid Slack trigger policy"
-           Yojson.Safe.Util.(status |> member "error" |> to_string)))
+  with_env "SLACK_APP_TOKEN" "xapp-test" (fun () ->
+    with_temp_base (fun () ->
+      State.record_startup_error "invalid Slack trigger policy";
+      Fun.protect
+        ~finally:State.clear_startup_error
+        (fun () ->
+           let status = State.status_json () in
+           check bool "not available despite app token" false
+             Yojson.Safe.Util.(status |> member "available" |> to_bool);
+           check bool "not connected" false
+             Yojson.Safe.Util.(status |> member "connected" |> to_bool);
+           check string "status uses connector vocabulary" "offline"
+             Yojson.Safe.Util.(status |> member "status" |> to_string);
+           check string "error" "invalid Slack trigger policy"
+             Yojson.Safe.Util.(status |> member "error" |> to_string))))
 ;;
 
 let () =
@@ -177,6 +206,8 @@ let () =
     ; ( "runtime.toml loading"
       , [ test_case "missing file => typed missing" `Quick
             test_missing_runtime_toml_is_typed_missing
+        ; test_case "dangling symlink => unreadable" `Quick
+            test_dangling_runtime_toml_symlink_is_unreadable
         ; test_case "missing key => deliberate no-config" `Quick
             test_missing_key_is_deliberate_no_config
         ; test_case "malformed file => error" `Quick
@@ -185,9 +216,11 @@ let () =
             test_valid_runtime_toml_loads_policy
         ; test_case "wrong field type => error" `Quick
             test_wrong_type_runtime_toml_is_error
+        ; test_case "wrong Slack table type => error" `Quick
+            test_wrong_type_slack_parent_is_error
         ; test_case "invalid policy value => error" `Quick
             test_invalid_runtime_toml_policy_is_error
-        ; test_case "startup error => unhealthy status" `Quick
+        ; test_case "startup error => offline with error" `Quick
             test_startup_error_is_operator_visible
         ] )
     ]


### PR DESCRIPTION
## 문제

48시간 병합 감사에서 #23714가 Slack trigger policy를 읽을 때 모든 TOML read/parse 예외를 `None`으로 접고 env/default로 진행하는 것을 확인했소. 없는 설정과 손상된 설정이 같은 결과가 되어, operator가 쓴 잘못된 정책 대신 다른 정책으로 gateway가 조용히 시작될 수 있었소.

## 변경

- runtime.toml 결과를 `Runtime_toml_missing | Trigger_policy_missing | Trigger_policy_loaded`로 분리했소.
- unreadable, malformed TOML, 잘못된 leaf/parent type, invalid policy를 typed error로 보존했소.
- missing file/key에서만 env/default를 허용하고, invalid config는 startup error를 기록한 뒤 Slack fiber를 시작하지 않소.
- startup-rejected connector는 app token이 있어도 `available=false`, `connected=false`, 기존 connector vocabulary의 `offline`과 명시적 error를 보고하오.
- dangling runtime.toml symlink도 missing fallback이 아니라 unreadable error로 처리하오.
- 공용 `Field_resolution`이 scalar intermediate parent를 Missing으로 오분류하던 SSOT 결함도 고쳤소.

## 검증

- touched OCamlFormat 0.29.0 check: pass
- `git diff --check`: pass
- focused wrapper build: `test_field_resolution.exe`, `test_server_slack_trigger_policy.exe`
- Field_resolution: 18/18 pass
- Slack trigger policy: 14/14 pass
- Repo_store regression: 37/37 pass (독립 리뷰 실행)
- 독립 구조 리뷰 P1 두 건과 P2 세 건 반영: scalar parent, token-present availability, dashboard label, dangling symlink

## 남은 검증 경계

- socket/auth를 실제로 여는 `start` network integration test는 이 draft에 추가하지 않았소. Invalid-result match가 auth/dispatch/fork 이전에 종료되는 구조는 확인했지만, merge 전 CI와 review에서 이 경계를 다시 확인해야 하오.

## 감사 추적

- 원인 병합: #23714
- 감사 창: `2026-07-08T01:03:16Z..2026-07-10T01:03:16Z`

[근거] current `origin/main=9d38fa68d9`, #23714 merge diff, focused build/tests와 독립 adversarial review를 2026-07-10 KST에 확인했소. 신뢰도 High.