### PR TITLE
fix(dashboard): restore read-only HITL chat cue

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -128,10 +128,6 @@ async function loadChat() {
     ...(await importOriginal<typeof import('../governance-signals')>()),
     governanceData: mockGovernanceData,
   }))
-  vi.doMock('../../api/dashboard-governance', async (importOriginal) => ({
-    ...(await importOriginal<typeof import('../../api/dashboard-governance')>()),
-    resolveGovernanceApproval: vi.fn().mockResolvedValue({ ok: true }),
-  }))
   return import('./keeper-workspace-chat')
 }
 
@@ -161,7 +157,6 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../keeper-detail-state')
     vi.doUnmock('../../router')
     vi.doUnmock('../governance-signals')
-    vi.doUnmock('../../api/dashboard-governance')
   })
 
   it('shows a pending-approval cue linking to the approvals queue when the keeper awaits a decision', async () => {
@@ -180,10 +175,13 @@ describe('KeeperWorkspaceChat', () => {
     expect(cue?.textContent).toContain('승인 대기')
     expect(cue?.textContent).toContain('fs_write')
 
-    // Three actions render (승인 / 거부 / 결재 큐 →); the queue link navigates.
-    const queueLink = Array.from(cue?.querySelectorAll('button') ?? [])
-      .find(button => button.textContent?.includes('결재 큐'))
-    expect(queueLink).not.toBeUndefined()
+    // Chat remains read-only: the approvals surface is the single act-point
+    // that includes risk and input evidence before approve/reject.
+    const actions = Array.from(cue?.querySelectorAll('button') ?? [])
+    expect(actions).toHaveLength(1)
+    expect(cue?.textContent).not.toContain('거부')
+    const queueLink = actions[0]
+    expect(queueLink?.textContent).toContain('결재 큐')
     await act(async () => {
       queueLink?.click()
     })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -20,7 +20,6 @@ import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { navigate } from '../../router'
 import { governanceData } from '../governance-signals'
-import { resolveGovernanceApproval } from '../../api/dashboard-governance'
 import type { ChatComposerCommand } from '../chat/primitives'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperThreads } from '../../keeper-state'
@@ -432,9 +431,6 @@ function PendingApprovalCue({ keeper }: { keeper: Keeper }): VNode | null {
   if (!first) return null
   const rest = pending.length - 1
   const tool = first.tool_name?.trim() ?? ''
-  const resolve = (decision: 'approve' | 'reject') => {
-    resolveGovernanceApproval(first.id, decision).catch(() => {})
-  }
   return html`
     <div
       class="kw-chat-pending-cue flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-fg-secondary)]"
@@ -444,18 +440,6 @@ function PendingApprovalCue({ keeper }: { keeper: Keeper }): VNode | null {
       <${Pill} tone="warn" dot="warn">승인 대기 ${pending.length}</${Pill}>
       <span>${tool || '결재 요청'}${rest > 0 ? ` 외 ${rest}건` : ''}</span>
       <span class="flex-1"></span>
-      <button
-        type="button"
-        class="kw-act v2-monitoring-action"
-        onClick=${() => resolve('approve')}
-        title="이 요청을 승인합니다"
-      >승인</button>
-      <button
-        type="button"
-        class="kw-act v2-monitoring-action"
-        onClick=${() => resolve('reject')}
-        title="이 요청을 거부합니다"
-      >거부</button>
       <button
         type="button"
         class="kw-act v2-monitoring-action"


### PR DESCRIPTION
## Audit finding

Merged PR #23678 intentionally added direct approve/reject buttons to the keeper-chat cue, reversing the existing `keeper-conversation-hitl-flow` contract without citing or updating it. RFC §4.1-A defines the chat cue as read-only navigation, and §5 keeps the evidence-bearing approvals surface as the single act-point. The new chat actions also omitted the risk/input evidence shown there and swallowed every request failure with an empty catch.

## Change

- remove direct approve/reject actions from the chat cue
- keep the governance approval_queue as the pending-count SSOT
- keep one navigation action to the approvals surface
- pin the read-only/single-act-point contract in the component test

This is an explicit restoration of the RFC contract after #23678's contrary product decision. It does not build a second approval surface with duplicate risk, error, and in-flight state policy.

## Verification

- focused keeper-workspace-chat test: 8/8
- focused ESLint: pass
- dashboard tsc --noEmit: pass
- git diff --check: pass

Audit source: #23678

RFC-WAIVED: follow-up restores the existing keeper-conversation-hitl-flow §4.1-A/§5 contract; no new protocol or workflow.
