### PR TITLE
fix(keeper): preserve fallback after failed surface reply

### DIFF
--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -143,12 +143,11 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Board_post_get | Board_list | Board_post | Board_search | Board_stats
   | Board_sub_board_get | Board_sub_board_list | Board_vote | Broadcast
   | Context_status | Handoff | Library_read | Library_search | Memory_search
-  | Memory_write | Search_files | Surface_read | Tasks_audit | Tasks_list | Time_now
-  | Tool_search | Tools_list | Voice_agent | Voice_listen
+  | Memory_write | Keeper_msg | Search_files | Surface_read | Tasks_audit | Tasks_list
+  | Time_now | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
-  | Surface_post | Keeper_msg | Person_note_set | Persona_create | Persona_update
-    -> Medium
+  | Surface_post | Person_note_set | Persona_create | Persona_update -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
   | Board_sub_board_delete -> Critical
 ;;

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -147,7 +147,7 @@ let risk_of_keeper (k : Keeper_tool_name.t) : risk_level =
   | Tool_search | Tools_list | Voice_agent | Voice_listen
   | Voice_session_end | Voice_session_start | Voice_sessions | Voice_speak -> Low
   | Board_sub_board_create | Board_sub_board_update | Task_claim | Task_create | Task_done
-  | Surface_post | Person_note_set | Persona_create | Persona_update
+  | Surface_post | Keeper_msg | Person_note_set | Persona_create | Persona_update
     -> Medium
   | Fs_edit | Fs_write | Fs_read | Ide_annotate -> High
   | Board_sub_board_delete -> Critical

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -9,7 +9,8 @@ type tool_call_detail =
   ; outcome : string
       (** Progress-classification label retained for receipt compatibility. *)
   ; execution_outcome : Tool_result.tool_call_outcome
-      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary. *)
+      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary.
+          Turn-local only; durable audit is written by [Keeper_tool_call_log]. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -7,6 +7,9 @@ type tool_call_detail =
   { tool_name : string
   ; provider : string
   ; outcome : string
+      (** Progress-classification label retained for receipt compatibility. *)
+  ; execution_outcome : Tool_result.tool_call_outcome
+      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -4,6 +4,9 @@ type tool_call_detail =
   { tool_name : string
   ; provider : string
   ; outcome : string
+      (** Progress-classification label retained for receipt compatibility. *)
+  ; execution_outcome : Tool_result.tool_call_outcome
+      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -6,7 +6,10 @@ type tool_call_detail =
   ; outcome : string
       (** Progress-classification label retained for receipt compatibility. *)
   ; execution_outcome : Tool_result.tool_call_outcome
-      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary. *)
+      (** Typed [Tool_result.Ok]/[Error] truth captured at the OAS hook boundary.
+          This turn-local delivery signal is intentionally not part of
+          [tool_call_detail_to_json]; durable tool-call audit uses
+          [Keeper_tool_call_log]. *)
   ; typed_outcome : Keeper_tool_outcome.t option
   ; latency_ms : float
   ; task_id : string option

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -90,9 +90,7 @@ let replay_response_text_for_capture ~suppress_visible_response ~response_text =
   else Some response_text
 ;;
 
-type reply_delivery_tool =
-  | Surface_post
-  | Keeper_message
+type reply_delivery_tool = Surface_post
 
 type reply_delivery_effect =
   | Reply_delivered
@@ -101,14 +99,9 @@ type reply_delivery_effect =
 let reply_delivery_tool_of_name tool_name =
   (* Parse exact wire names once into a closed delivery-effect vocabulary. *)
   let canonical_name = Keeper_tool_resolution.canonical_tool_name tool_name in
-  if
-    String.equal
-      canonical_name
-      (Keeper_tool_name.to_string Keeper_tool_name.Surface_post)
-  then Some Surface_post
-  else if String.equal canonical_name "masc_keeper_msg"
-  then Some Keeper_message
-  else None
+  match Keeper_tool_name.of_string canonical_name with
+  | Some Keeper_tool_name.Surface_post -> Some Surface_post
+  | Some _ | None -> None
 ;;
 
 let reply_delivery_effect_of_tool_call

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -90,6 +90,61 @@ let replay_response_text_for_capture ~suppress_visible_response ~response_text =
   else Some response_text
 ;;
 
+type reply_delivery_tool =
+  | Surface_post
+  | Keeper_message
+
+type reply_delivery_effect =
+  | Reply_delivered
+  | No_reply_delivery
+
+let reply_delivery_tool_of_name tool_name =
+  (* Parse exact wire names once into a closed delivery-effect vocabulary. *)
+  let canonical_name = Keeper_tool_resolution.canonical_tool_name tool_name in
+  if
+    String.equal
+      canonical_name
+      (Keeper_tool_name.to_string Keeper_tool_name.Surface_post)
+  then Some Surface_post
+  else if String.equal canonical_name "masc_keeper_msg"
+  then Some Keeper_message
+  else None
+;;
+
+let reply_delivery_effect_of_tool_call
+      (detail : Keeper_agent_result.tool_call_detail)
+  =
+  match
+    reply_delivery_tool_of_name detail.tool_name,
+    detail.execution_outcome,
+    detail.typed_outcome
+  with
+  | Some _, Tool_result.Ok, (None | Some Keeper_tool_outcome.Progress) ->
+    Reply_delivered
+  | ( Some _
+    , Tool_result.Ok
+    , Some (Keeper_tool_outcome.No_progress _ | Keeper_tool_outcome.Error _) )
+  | Some _, (Tool_result.Error | Tool_result.Unknown), _
+  | None, _, _ ->
+    No_reply_delivery
+;;
+
+let has_reply_delivery_effect tool_calls =
+  List.exists
+    (fun detail ->
+       match reply_delivery_effect_of_tool_call detail with
+       | Reply_delivered -> true
+       | No_reply_delivery -> false)
+    tool_calls
+;;
+
+let continuation_delivery_gate ~channel ~tool_calls ~content =
+  Keeper_continuation_delivery.gate_decision
+    ~channel
+    ~already_replied:(has_reply_delivery_effect tool_calls)
+    ~content
+;;
+
 type wire_capture_response_suppression_reason =
   | Budget_exhausted
   | Completion_contract
@@ -286,6 +341,10 @@ module For_testing = struct
 
   let emit_wire_capture_response_suppressed_metrics =
     emit_wire_capture_response_suppressed_metrics
+
+  let reply_delivery_effect_of_tool_call = reply_delivery_effect_of_tool_call
+  let has_reply_delivery_effect = has_reply_delivery_effect
+  let continuation_delivery_gate = continuation_delivery_gate
 end
 
 let finalize
@@ -430,13 +489,7 @@ let finalize
      channel); [Keeper_continuation_delivery] fails closed on [Unrouted]. *)
   (match hitl_delivery_channel, replay_response_text with
    | Some channel, Some content ->
-     let already_replied =
-       List.exists
-         (fun name ->
-           String.equal name "keeper_surface_post"
-           || String.equal name "masc_keeper_msg")
-         actual_keeper_tool_names
-     in
+     let already_replied = has_reply_delivery_effect acc.tool_calls in
      let outcome =
        Keeper_continuation_delivery.maybe_deliver ~config
          ~keeper_name:meta.name ~channel ~already_replied ~content

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -227,6 +227,8 @@ let assemble_hooks
           <- { tool_name
              ; provider
              ; outcome
+             ; execution_outcome =
+                 (if success then Tool_result.Ok else Tool_result.Error)
              ; typed_outcome
              ; latency_ms = duration_ms
              ; task_id

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -35,6 +35,7 @@ type t =
   | Library_search
   | Memory_search
   | Memory_write
+  | Keeper_msg
   | Search_files
   | Surface_read
   | Surface_post
@@ -84,6 +85,7 @@ let all : t list =
   ; Library_search
   ; Memory_search
   ; Memory_write
+  ; Keeper_msg
   ; Search_files
   ; Surface_read
   ; Surface_post
@@ -135,6 +137,7 @@ let to_string = function
   | Library_search -> "keeper_library_search"
   | Memory_search -> "keeper_memory_search"
   | Memory_write -> "keeper_memory_write"
+  | Keeper_msg -> "masc_keeper_msg"
   | Search_files -> "tool_search_files"
   | Surface_read -> "keeper_surface_read"
   | Surface_post -> "keeper_surface_post"
@@ -185,6 +188,7 @@ let of_string = function
   | "keeper_library_search" -> Some Library_search
   | "keeper_memory_search" -> Some Memory_search
   | "keeper_memory_write" -> Some Memory_write
+  | "masc_keeper_msg" -> Some Keeper_msg
   | "tool_search_files" -> Some Search_files
   | "keeper_surface_read" -> Some Surface_read
   | "keeper_surface_post" -> Some Surface_post
@@ -197,6 +201,8 @@ let of_string = function
   | "keeper_time_now" -> Some Time_now
   | "keeper_tool_search" -> Some Tool_search
   | "keeper_tools_list" -> Some Tools_list
+  | "masc_persona_create" -> Some Persona_create
+  | "masc_persona_update" -> Some Persona_update
   | "keeper_voice_agent" -> Some Voice_agent
   | "keeper_voice_listen" -> Some Voice_listen
   | "keeper_voice_session_end" -> Some Voice_session_end
@@ -255,6 +261,7 @@ let is_keeper_board_tool = function
   | Library_search
   | Memory_search
   | Memory_write
+  | Keeper_msg
   | Search_files
   | Surface_read
   | Surface_post
@@ -305,6 +312,7 @@ let masc_board_name_of_keeper_tool = function
   | Library_search
   | Memory_search
   | Memory_write
+  | Keeper_msg
   | Search_files
   | Surface_read
   | Surface_post

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -201,8 +201,6 @@ let of_string = function
   | "keeper_time_now" -> Some Time_now
   | "keeper_tool_search" -> Some Tool_search
   | "keeper_tools_list" -> Some Tools_list
-  | "masc_persona_create" -> Some Persona_create
-  | "masc_persona_update" -> Some Persona_update
   | "keeper_voice_agent" -> Some Voice_agent
   | "keeper_voice_listen" -> Some Voice_listen
   | "keeper_voice_session_end" -> Some Voice_session_end

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -33,6 +33,7 @@ type t =
   | Library_search
   | Memory_search
   | Memory_write
+  | Keeper_msg
   | Search_files
   | Surface_read
   | Surface_post

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -742,6 +742,7 @@ let receipt_detail_of_provider_call
   { tool_name = call.name
   ; provider
   ; outcome = "ok"
+  ; execution_outcome = Tool_result.Ok
   ; typed_outcome = Some Keeper_tool_outcome.Progress
   ; latency_ms = 1.0
   ; task_id = None

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -801,11 +801,30 @@ let test_w3c_reply_delivery_effect_requires_success () =
           ~typed_outcome:(Keeper_tool_outcome.Error { reason = "send failed" })
           ~execution_outcome:Tool_result.Ok
           "keeper_surface_post"));
-  Alcotest.(check bool) "successful keeper message has delivery effect" true
+  Alcotest.(check bool) "keeper message is not a surface reply" false
     (is_delivered
        (reply_tool_call
           ~execution_outcome:Tool_result.Ok
           "masc_keeper_msg"));
+  Alcotest.(check bool) "MCP-prefixed keeper message is not a surface reply" false
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Ok
+          "mcp__masc__masc_keeper_msg"));
+  let keeper_message =
+    reply_tool_call ~execution_outcome:Tool_result.Ok "masc_keeper_msg"
+  in
+  let channel = Keeper_continuation_channel.Dashboard { thread_id = "thread-1" } in
+  let module D = Masc.Keeper_continuation_delivery in
+  Alcotest.(check bool) "keeper message leaves continuation fallback enabled" true
+    (match
+       F.For_testing.continuation_delivery_gate
+         ~channel
+         ~tool_calls:[ keeper_message ]
+         ~content:"fallback"
+     with
+     | D.Deliver -> true
+     | D.Skip _ -> false);
   Alcotest.(check bool) "failed keeper message has no delivery effect" false
     (is_delivered
        (reply_tool_call

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -762,6 +762,62 @@ let test_w3c_continuation_delivery_gate () =
        (D.gate_decision ~channel:dashboard ~already_replied:false ~content:"hi"))
 ;;
 
+let reply_tool_call ?typed_outcome ~execution_outcome tool_name
+  : Masc.Keeper_agent_result.tool_call_detail
+  =
+  { tool_name
+  ; provider = "test"
+  ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
+  ; execution_outcome
+  ; typed_outcome
+  ; latency_ms = 1.0
+  ; task_id = None
+  ; route_evidence = None
+  ; input_fingerprint = None
+  ; output_fingerprint = None
+  }
+;;
+
+let test_w3c_reply_delivery_effect_requires_success () =
+  let module F = Masc.Keeper_agent_run_finalize_response in
+  let is_delivered detail =
+    match F.For_testing.reply_delivery_effect_of_tool_call detail with
+    | F.Reply_delivered -> true
+    | F.No_reply_delivery -> false
+  in
+  Alcotest.(check bool) "failed surface post has no delivery effect" false
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Error
+          "keeper_surface_post"));
+  Alcotest.(check bool) "successful surface post has delivery effect" true
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Ok
+          "keeper_surface_post"));
+  Alcotest.(check bool) "typed semantic error cannot claim delivery" false
+    (is_delivered
+       (reply_tool_call
+          ~typed_outcome:(Keeper_tool_outcome.Error { reason = "send failed" })
+          ~execution_outcome:Tool_result.Ok
+          "keeper_surface_post"));
+  Alcotest.(check bool) "successful keeper message has delivery effect" true
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Ok
+          "masc_keeper_msg"));
+  Alcotest.(check bool) "failed keeper message has no delivery effect" false
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Error
+          "masc_keeper_msg"));
+  Alcotest.(check bool) "unrelated successful tool has no delivery effect" false
+    (is_delivered
+       (reply_tool_call
+          ~execution_outcome:Tool_result.Ok
+          "keeper_tasks_list"))
+;;
+
 let () =
   Alcotest.run
     "Keeper_approval_queue"
@@ -800,6 +856,10 @@ let () =
             "W3c continuation delivery gate is fail-closed"
             `Quick
             test_w3c_continuation_delivery_gate
+        ; Alcotest.test_case
+            "W3c reply delivery effect requires success"
+            `Quick
+            test_w3c_reply_delivery_effect_requires_success
         ] )
     ; ( "summary"
       , [ Alcotest.test_case

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -122,6 +122,7 @@ let tool_call
   { tool_name
   ; provider = "test"
   ; outcome = "ok"
+  ; execution_outcome = Tool_result.Ok
   ; typed_outcome
   ; latency_ms = 0.0
   ; task_id = None

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -136,6 +136,28 @@ let outcome_label = function
   | `Success -> "success"
   | `Failure -> "failure"
 
+let tool_call_detail_of_execution tool_name
+      (result : KET.executed_tool_result)
+  : Masc.Keeper_agent_result.tool_call_detail
+  =
+  let execution_outcome =
+    match result.outcome with
+    | `Success -> Tool_result.Ok
+    | `Failure -> Tool_result.Error
+  in
+  { tool_name
+  ; provider = "test"
+  ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
+  ; execution_outcome
+  ; typed_outcome = None
+  ; latency_ms = 1.0
+  ; task_id = None
+  ; route_evidence = None
+  ; input_fingerprint = None
+  ; output_fingerprint = None
+  }
+;;
+
 let non_empty_lines text =
   String.split_on_char '\n' text
   |> List.map String.trim
@@ -221,6 +243,52 @@ let test_malformed_json_like_payload_detected () =
     fail
       (Printf.sprintf "expected malformed_structured, got %s"
          (payload_kind other))
+
+let test_surface_post_execution_controls_continuation_fallback () =
+  with_exec_fixture
+    ~tool_access:[ "keeper_surface_post" ]
+    "keeper_surface_post_continuation_fallback"
+    (fun ~config ~meta ~ctx_work ->
+      let execute input =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"keeper_surface_post"
+          ~input
+          ()
+      in
+      let failed = execute (`Assoc [ ("content", `String "reply") ]) in
+      let succeeded =
+        execute
+          (`Assoc
+            [ "surface", `String "dashboard"
+            ; "content", `String "reply"
+            ])
+      in
+      check string "missing surface is execution failure" "failure"
+        (outcome_label failed.outcome);
+      check string "dashboard post is execution success" "success"
+        (outcome_label succeeded.outcome);
+      let channel =
+        Keeper_continuation_channel.Dashboard { thread_id = "thread-1" }
+      in
+      let gate result =
+        Masc.Keeper_agent_run_finalize_response.For_testing.continuation_delivery_gate
+          ~channel
+          ~tool_calls:
+            [ tool_call_detail_of_execution "keeper_surface_post" result ]
+          ~content:"deterministic fallback"
+      in
+      let module D = Masc.Keeper_continuation_delivery in
+      check bool "failed post leaves fallback enabled" true
+        (match gate failed with D.Deliver -> true | D.Skip _ -> false);
+      check bool "successful post suppresses duplicate fallback" true
+        (match gate succeeded with
+         | D.Skip D.Skipped_already_replied -> true
+         | D.Deliver | D.Skip _ -> false))
+;;
 
 let test_registered_descriptor_bypasses_tool_access_allowlist () =
   with_exec_fixture
@@ -1606,6 +1674,8 @@ let () =
         test_malformed_json_like_payload_detected;
     ]);
     ("execute_keeper_tool_call_with_outcome", [
+      test_case "surface post execution controls continuation fallback" `Quick
+        test_surface_post_execution_controls_continuation_fallback;
       test_case "registered descriptor bypasses tool_access allowlist" `Quick
         test_registered_descriptor_bypasses_tool_access_allowlist;
       test_case "public Read rejects unsupported range fields" `Quick

--- a/test/test_keeper_tool_name.ml
+++ b/test/test_keeper_tool_name.ml
@@ -1,5 +1,13 @@
 open Alcotest
 
+let test_all_names_round_trip () =
+  List.iter
+    (fun tool ->
+       let name = Keeper_tool_name.to_string tool in
+       check bool name true (Keeper_tool_name.of_string name = Some tool))
+    Keeper_tool_name.all
+;;
+
 let test_board_write_surface_names () =
   List.iter
     (fun name ->
@@ -36,7 +44,9 @@ let test_non_write_board_surface_names () =
 let () =
   run
     "Keeper_tool_name"
-    [ ( "board-write"
+    [ ( "vocabulary"
+      , [ test_case "all names round-trip" `Quick test_all_names_round_trip ] )
+    ; ( "board-write"
       , [ test_case "recognizes write surfaces" `Quick test_board_write_surface_names
         ; test_case
             "rejects non-write and unknown surfaces"

--- a/test/test_keeper_tool_name.ml
+++ b/test/test_keeper_tool_name.ml
@@ -1,11 +1,13 @@
 open Alcotest
 
-let test_all_names_round_trip () =
-  List.iter
-    (fun tool ->
-       let name = Keeper_tool_name.to_string tool in
-       check bool name true (Keeper_tool_name.of_string name = Some tool))
-    Keeper_tool_name.all
+let test_keeper_msg_round_trip () =
+  let name = Keeper_tool_name.to_string Keeper_tool_name.Keeper_msg in
+  check string "wire name" "masc_keeper_msg" name;
+  check
+    bool
+    "typed parse"
+    true
+    (Keeper_tool_name.of_string name = Some Keeper_tool_name.Keeper_msg)
 ;;
 
 let test_board_write_surface_names () =
@@ -45,7 +47,7 @@ let () =
   run
     "Keeper_tool_name"
     [ ( "vocabulary"
-      , [ test_case "all names round-trip" `Quick test_all_names_round_trip ] )
+      , [ test_case "keeper_msg round-trip" `Quick test_keeper_msg_round_trip ] )
     ; ( "board-write"
       , [ test_case "recognizes write surfaces" `Quick test_board_write_surface_names
         ; test_case

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -211,6 +211,7 @@ let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
   ; outcome
+  ; execution_outcome = Tool_result.Ok
   ; typed_outcome = None
   ; latency_ms = 1.0
   ; task_id = None


### PR DESCRIPTION
## Audit finding

Merged PR #23663 treated reply-like tool names as proof that a response had already reached the originating conversation. A failed keeper_surface_post could therefore suppress deterministic continuation fallback and leave the user without a reply. masc_keeper_msg was also treated as a user-facing reply even though it is peer messaging, not delivery to the HITL channel.

## Change

- carry the typed OAS PostToolUse execution result into the turn-local tool-call detail
- count only a successful keeper_surface_post with a non-error semantic outcome as reply delivery
- keep fallback enabled for failed/unknown surface posts, semantic failure, keeper messages, and unrelated tools
- parse delivery names through Keeper_tool_name instead of business string matching
- preserve the existing Low governance risk for masc_keeper_msg

The typed execution field stays out of the HTTP tool_call_evidence JSON; durable per-call audit remains Keeper_tool_call_log. The legacy `outcome` field is a separate progress-classification label (`ok`/`ok_no_progress`/`error`), so it is not derived from the execution result.

## Verification

- focused changed-module/executable build: pass
- W3c delivery regression: 1/1
- keeper tool dispatch runtime: 37/37
- Keeper_tool_name: 3/3
- keeper_msg governance contract: 1/1
- claim-progress: 13/13
- ocamlformat and git diff --check: pass

The full approval-queue executable still has three pre-existing wake-fixture failures in untouched cases; the new W3c delivery case passes independently.

## Compatibility and follow-up

The turn-local tool_call_detail record gains a required typed field and Keeper_tool_name gains Keeper_msg. No other workspace consumers were found, but external exhaustive matches or record constructors may require an update.

Route-aware delivery remains separate work: #23911 records that a successful post to a different surface must not suppress the originating Discord/Slack/Dashboard continuation. This PR does not infer routes from tool-name or argument strings.

Other out-of-scope issue discovered during review: #23898.

Audit source: #23663

RFC-WAIVED: narrow correction to the existing W3c continuation-delivery contract; no new protocol or workflow.
