### PR TITLE
fix: repair main latent red — 25 tests across 9 families (#23901)

### DIFF
--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -146,11 +146,26 @@ let invalid_vote_direction ~tool_name ~start_time raw : Tool_result.result =
     (Printf.sprintf "invalid vote direction %S; expected up or down" raw)
 ;;
 
+(* Rejection tombstone for the retired [vote] parameter. Deleting it (#23710)
+   made a legacy {vote:"down"} call silently default direction to "up" —
+   an inverted vote instead of a typed rejection (main red #23901, voting). *)
+let legacy_vote_parameter_removed ~tool_name ~start_time raw : Tool_result.result =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Policy_rejection
+    ~start_time
+    (Printf.sprintf
+       "legacy vote parameter %S is no longer accepted; use direction"
+       raw)
+;;
+
 let handle_vote ~tool_name ~start_time args =
   let post_id = get_string args "post_id" "" in
   let voter = get_string args "voter" "anonymous" in
-  match Safe_ops.json_string_opt "direction" args with
-  | direction_arg ->
+  match Safe_ops.json_string_opt "direction" args, get_string_opt args "vote" with
+  | None, Some raw ->
+    legacy_vote_parameter_removed ~tool_name ~start_time raw
+  | direction_arg, _ ->
     let direction_str =
       match direction_arg with
       | Some raw -> raw

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -121,8 +121,14 @@ and goal_of_yojson = function
             | Some status_json -> goal_status_of_yojson status_json
           in
           let phase =
+            (* Legacy rows (written before the phase field existed) carry only
+               [status]; the read path must map it the same way the update
+               path does (see the status→phase mapping near [set_status]).
+               #23710 dropped this mapping to an unconditional Active default
+               and #23845 sealed the compile without restoring it — a paused
+               legacy goal then decoded as Executing (main red #23901). *)
             match Json_util.assoc_member_opt "phase" json with
-            | None | Some `Null -> Ok (phase_of_goal_status Active)
+            | None | Some `Null -> Result.map phase_of_goal_status legacy_status
             | Some phase_json -> Goal_phase.of_yojson phase_json
           in
           let verifier_policy =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -490,7 +490,11 @@ let create_entry
       ?disposition
       ?disposition_reason
       ?(continuation_channel =
-         Keeper_continuation_channel.unrouted "legacy: continuation channel not provided")
+         (* Missing connector fails closed as [Unrouted]; the reason string is
+            pinned by test_keeper_approval_queue "missing connector fails
+            closed" (#23716). #23845 reworded it in passing (main red #23901,
+            family B). *)
+         Keeper_continuation_channel.unrouted "no originating connector")
       ~audit_base_path
       ~resolver
       ~on_resolution
@@ -924,12 +928,20 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
            (Printexc.to_string exn))
        (fun () -> f decision)
    | None -> ());
-  wake_keeper_on_approval_resolution
-    ~base_path
-    ~keeper_name:entry.keeper_name
-    ~approval_id:entry.id
-    ~decision:(hitl_resolution_decision_of_approval_decision decision)
-    ~channel:entry.channel;
+  (* Blocking approvals (live resolver) resume through the promise above;
+     firing the wake too would double-stimulate the keeper. Only non-blocking
+     approvals (no suspended fiber) need the [Hitl_resolved] wake. #23681
+     collaterally dropped this guard while rewiring channel provenance
+     (main red #23901, family B). *)
+  (match entry.resolver with
+   | Some _ -> ()
+   | None ->
+     wake_keeper_on_approval_resolution
+       ~base_path
+       ~keeper_name:entry.keeper_name
+       ~approval_id:entry.id
+       ~decision:(hitl_resolution_decision_of_approval_decision decision)
+       ~channel:entry.channel);
   try
     Sse.broadcast
       (`Assoc
@@ -1515,16 +1527,20 @@ let expire_stale ~max_wait_s =
          ?disposition_reason:entry.disposition_reason
          ~decision:(Approval_expired reason)
          ();
-       (* Expiry clears the [Approval_pending] skip just like a resolution, so
-          the keeper needs the same wake or it stays stalled until an unrelated
-          stimulus. The keeper's suspended tool call (if any) receives
-          [Reject reason]. *)
-       wake_keeper_on_approval_resolution
-         ~base_path:entry.audit_base_path
-         ~keeper_name:entry.keeper_name
-         ~approval_id:id
-         ~decision:Keeper_event_queue.Hitl_rejected
-         ~channel:entry.channel;
+       (* Expiry clears the [Approval_pending] skip just like a resolution.
+          Blocking entries resume via the resolver promise below; only
+          non-blocking entries (no suspended fiber) need the wake, or the
+          keeper stays stalled until an unrelated stimulus. #23681 dropped
+          this resolver guard (main red #23901, family B). *)
+       (match entry.resolver with
+        | Some _ -> ()
+        | None ->
+          wake_keeper_on_approval_resolution
+            ~base_path:entry.audit_base_path
+            ~keeper_name:entry.keeper_name
+            ~approval_id:id
+            ~decision:Keeper_event_queue.Hitl_rejected
+            ~channel:entry.channel);
        (match entry.resolver with
         | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
         | None -> ());

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -288,7 +288,7 @@ let send_text_bigstring session payload =
       if is_session_closed session then false
       else begin
         try
-          Ws_wsd.send_text session.wsd (Bigstringaf.to_string payload);
+          Ws_wsd.send_text_bigstring session.wsd payload;
           Transport_metrics.inc_ws_bytes_sent ~bytes:len;
           Transport_metrics.observe_ws_message_bytes_sent len;
           true

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -90,8 +90,11 @@ let verdict_constructor_name = function
 
 let valid_verdict_strings = [ "APPROVE"; "REJECT" ]
 
+(* No [Evidence] gate here: empty-evidence rejection is owned by L1
+   [Task_completion_gate.decide] (RFC-0337 decision 2 / migration 2). The
+   short-lived Anti Gate 0 (#23738) duplicated L1 ahead of every evaluator
+   gate and mis-attributed evaluator outcomes (main red #23901, family A). *)
 type gate =
-  | Evidence
   | Length
   | Excuse
   | Contract
@@ -102,7 +105,6 @@ type gate =
   | Fallback
 
 let gate_to_string = function
-  | Evidence -> "evidence"
   | Length -> "length"
   | Excuse -> "excuse"
   | Contract -> "contract"
@@ -740,18 +742,9 @@ let review
       (fun message -> Log.Task.error "task_id=%s %s" req.task_id message)
       fmt
   in
-  (* Gate 0: empty evidence_refs — required for all code task submissions.
-     Reject completions that lack code-level evidence (file paths, commit hashes,
-     trace/turn/receipt refs). *)
-  if List.is_empty req.evidence_refs then
-    emit
-      { verdict = Reject "no evidence references supplied"
-      ; evaluator_runtime
-      ; generator_runtime
-      ; gate = Evidence
-      ; fallback_reason = None
-      }
-  else
+  (* Empty evidence_refs is NOT rejected here (RFC-0337 migration 2): L1
+     [Task_completion_gate.decide] owns that decision for every completion.
+     [req.evidence_refs] still feeds the L2 evaluator prompt below. *)
   let notes_trimmed = String.trim req.completion_notes in
   if String.length notes_trimmed < min_notes_length
   then

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -55,9 +55,10 @@ val valid_verdict_strings : string list
     compilation in [verdict_constructor_name]. *)
 
 (** Which gate produced the verdict. Variant type prevents typos that
-    would silently compile with a stringly-typed field. *)
+    would silently compile with a stringly-typed field. There is no
+    [Evidence] constructor: empty-evidence rejection belongs to L1
+    [Task_completion_gate.decide] (RFC-0337 decision 2 / migration 2). *)
 type gate =
-  | Evidence
   | Length
   | Excuse
   | Contract

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3816,7 +3816,13 @@ let test_consolidator_stale_peer_does_not_satisfy_min_keepers () =
 ;;
 
 (* A fact with no valid_until but an old last_verified_at is stale and must be
-   excluded from the representative and observed_by set. *)
+   excluded from the representative and observed_by set. Two fresh
+   contributors are required so the claim still meets min_keepers (=2) after
+   the stale one is filtered — with a single fresh peer nothing would be
+   promoted at all (that quorum behavior is pinned separately by
+   [test_consolidator_stale_peer_does_not_satisfy_min_keepers]). The original
+   #23748 version used one fresh peer and could never pass (main red #23901,
+   family consolidator). *)
 let test_consolidator_filters_stale_without_valid_until () =
   let now = 1_000_000.0 in
   let claim_id = Some "no-valid-until-stale" in
@@ -3827,7 +3833,14 @@ let test_consolidator_filters_stale_without_valid_until () =
     ; Types.claim_id = claim_id
     }
   in
-  let fresh =
+  let fresh_old =
+    { (mk_shared_fixture ~now ~category:"lesson" "fresh older no valid_until") with
+      Types.first_seen = 100.0
+    ; Types.last_verified_at = Some (now -. 100.0)
+    ; Types.claim_id = claim_id
+    }
+  in
+  let fresh_new =
     { (mk_shared_fixture ~now ~category:"lesson" "fresh no valid_until") with
       Types.first_seen = now -. 1.0
     ; Types.last_verified_at = Some (now -. 1.0)
@@ -3835,7 +3848,9 @@ let test_consolidator_filters_stale_without_valid_until () =
     }
   in
   let promoted =
-    promote_one ~now [ "stale", [ stale ]; "fresh", [ fresh ] ]
+    promote_one
+      ~now
+      [ "stale", [ stale ]; "fresh-a", [ fresh_old ]; "fresh-b", [ fresh_new ] ]
   in
   Alcotest.(check string)
     "representative excludes stale contributor without valid_until"
@@ -3843,7 +3858,7 @@ let test_consolidator_filters_stale_without_valid_until () =
     promoted.Types.claim;
   Alcotest.(check (list string))
     "observed_by excludes stale contributor without valid_until"
-    [ "fresh" ]
+    [ "fresh-a"; "fresh-b" ]
     promoted.Types.observed_by
 ;;
 

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -37,14 +37,31 @@ let make_ctx base_path =
   ignore (Workspace.init config ~agent_name:(Some agent_name));
   { Task.Tool.config; agent_name; sw = None }
 
-let run_transition ctx ~task_id ~action ?(notes = "") () =
+(* [evidence_refs]: completions require evidence since #23738 (Gate 0 /
+   Task_completion_gate); this test covers the telemetry lifecycle, not the
+   evidence gate, so the done transition carries a real ref. *)
+let run_transition ctx ~task_id ~action ?(notes = "") ?(evidence_refs = []) () =
+  let base_args =
+    [
+      ("task_id", `String task_id);
+      ("action", `String action);
+      ("notes", `String notes);
+    ]
+  in
   let args =
-    `Assoc
-      [
-        ("task_id", `String task_id);
-        ("action", `String action);
-        ("notes", `String notes);
-      ]
+    match evidence_refs with
+    | [] -> `Assoc base_args
+    | refs ->
+      `Assoc
+        (base_args
+         @ [
+             ( "handoff_context",
+               `Assoc
+                 [
+                   ("summary", `String notes);
+                   ("evidence_refs", `List (List.map (fun r -> `String r) refs));
+                 ] );
+           ])
   in
   match Task.Tool.dispatch ctx ~name:"masc_transition" ~args with
   | Some result ->
@@ -102,7 +119,8 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
     run_transition ctx ~task_id:"task-001" ~action:"claim" ();
     run_transition ctx ~task_id:"task-001" ~action:"start" ();
     run_transition ctx ~task_id:"task-001" ~action:"done"
-      ~notes:"Telemetry lifecycle regression proof completed." ();
+      ~notes:"Telemetry lifecycle regression proof completed."
+      ~evidence_refs:[ "test/test_telemetry_task_transition_10358.ml" ] ();
     let started =
       event_exists
         (function

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -592,21 +592,30 @@ let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
   Eval_calibration.reset_store_for_testing ()
 )
 
+(* RFC-0337 decision 2 / migration 2: empty-evidence rejection is owned by L1
+   [Task_completion_gate.decide], not by an anti-rationalization pre-gate
+   (the short-lived Anti Gate 0, #23738, is deleted). This test installs the
+   REAL L1 gate — the production adapter shape from
+   [Workspace_metric_hooks.install] — and pins that an empty evidence_refs
+   completion is rejected with L1's canonical wording. *)
 let () = test "handle_done_rejects_empty_evidence_refs" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("title", `String "Empty evidence refs task")]) in
   let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("task_id", `String "task-001")]) in
-  let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
-    (`Assoc [
-      ("task_id", `String "task-001");
-      ("notes", `String "Task scope satisfied: long enough notes to avoid the length gate, but evidence_refs is empty.");
-      ("evidence_refs", `List [])
-    ]) in
-  assert (not (Tool_result.is_success result));
-  assert (str_contains (Tool_result.message result) "Completion rejected by anti-rationalization gate")
-)
+  with_task_completion_gate_decide real_task_completion_gate (fun () ->
+    let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [
+        ("task_id", `String "task-001");
+        ("notes", `String "Task scope satisfied: long enough notes to avoid the length gate, but evidence_refs is empty.");
+        ("evidence_refs", `List [])
+      ]) in
+    assert (not (Tool_result.is_success result));
+    assert (str_contains (Tool_result.message result)
+      "Task-completion evidence is insufficient");
+    assert (str_contains (Tool_result.message result)
+      "handoff_context.evidence_refs")))
 
 let () = test "handle_transition_respects_completion_contract_and_records_custom_evaluator" (fun () ->
   (* Legacy substring gate (Gate 2.5). When
@@ -731,6 +740,13 @@ let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (f
     tasks
 )
 
+(* Non-strict on purpose: RFC-0323 G-1 structurally blocks direct done on a
+   strict task while the verification FSM is enabled
+   (Verification_required_use_submit, workspace_task_lifecycle.ml) — the
+   strict lane is covered by the submit/approve tests. This test's subject is
+   the direct-done path: LLM review runs and there is no keeper-verifier
+   redirect. Previously strict=true only "worked" because CI was infra-blind
+   (main red #23901, family A). *)
 let () = test "handle_done_uses_llm_review_without_keeper_verifier_redirect" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
@@ -740,11 +756,11 @@ let () = test "handle_done_uses_llm_review_without_keeper_verifier_redirect" (fu
           Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
             (`Assoc
               [
-                ("title", `String "Strict verifier task");
+                ("title", `String "Direct-done LLM review task");
                 ( "contract",
                   `Assoc
                     [
-                      ("strict", `Bool true);
+                      ("strict", `Bool false);
                       ( "completion_contract",
                         `List [ `String "deliverable-ready" ] );
                       ("required_evidence", `List [ `String "run_deliverable" ]);
@@ -1546,12 +1562,31 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
           ])
     in
     let _ = Workspace.claim_task ctx.config ~agent_name:"test-agent" ~task_id:"task-001" in
-    let _ =
+    (* A strict submit must carry evidence (#23719/#23740 strict precheck) or
+       the task never reaches AwaitingVerification and this test would assert
+       against the precheck error instead (main red #23901, family A). *)
+    let submitted =
       Workspace.transition_task_r ctx.config ~agent_name:"test-agent"
         ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification
         ~notes:"strict contract verification setup notes"
+        ~handoff_context:
+          { Masc_domain.summary = "strict contract verification setup notes"
+          ; reason = None
+          ; next_step = None
+          ; failure_mode = None
+          ; reclaim_policy = None
+          ; evidence_refs = [ "tests green: dune runtest" ]
+          ; updated_at = None
+          ; updated_by = None
+          }
         ()
     in
+    (match submitted with
+     | Ok _ -> ()
+     | Error e ->
+       failwith
+         ("setup submit should reach AwaitingVerification: "
+          ^ Masc_domain.masc_error_to_string e));
     let result =
       Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1598,7 +1598,14 @@ let test_submit_and_approve_rejects_empty_justification () =
 let strict_contract : Masc_domain.task_contract =
   { strict = true
   ; completion_contract = [ "deliverable verified by a second agent" ]
-  ; required_evidence = []
+  ; (* Declared up front so the #23719/#23740 strict evidence precheck is
+       satisfied by the contract itself and direct done reaches the RFC-0308
+       G-1 guard, whose error names the submit lane. With an empty
+       required_evidence the precheck fires first and its message does not
+       mention submit_for_verification (main red #23901, family A); the
+       precheck fail-closed path is pinned separately by
+       [test_submit_and_approve_strict_without_evidence_fail_closed]. *)
+    required_evidence = [ "artifact:deliverable" ]
   ; inspect_gate_evidence = []
   ; verify_gate_evidence = []
   ; evidence_claims = []
@@ -1614,9 +1621,8 @@ let test_strict_task_done_routes_to_submit () =
     in
     let _ = Workspace.bind_session config ~agent_name:test_agent_a ~capabilities:[] () in
     let _ = Workspace.claim_task config ~agent_name:test_agent_a ~task_id:"task-001" in
-    (* Direct done is blocked and the error names the submit lane — whether
-       the strict evidence gate (no handoff supplied here) or the RFC-0308
-       lifecycle guard fires first, both route to submit_for_verification. *)
+    (* Direct done is blocked by the RFC-0308 lifecycle guard (G-1), whose
+       error routes to submit_for_verification. *)
     let direct =
       Workspace.transition_task_r config ~agent_name:test_agent_a ~task_id:"task-001"
         ~action:Masc_domain.Done_action ~notes:"done" ()

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -746,7 +746,11 @@ let done_status assignee =
     { assignee; completed_at = Masc_domain.now_iso (); notes = Some "completed" }
 ;;
 
-let test_claim_next_reclaims_done_allow_reclaim () =
+(* RFC-0323 G-10 (#23731): a Done task is terminal for every actor regardless
+   of reclaim_policy — re-running completed work creates a NEW task linked via
+   predecessor_task_id (types_core.ml Claim_block_not_todo arm). This test
+   previously pinned the retired #23632 Done-reclaim mechanism. *)
+let test_claim_next_done_allow_reclaim_is_terminal () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
     let _ =
@@ -758,22 +762,24 @@ let test_claim_next_reclaims_done_allow_reclaim () =
       ; reclaim_policy = Some Masc_domain.Allow_reclaim
       });
     match Workspace.claim_next_r config ~agent_name:claude () with
-    | Workspace.Claim_next_claimed { task_id; _ } ->
-      Alcotest.(check string) "completed task claimed" "task-001" task_id;
-      assert_claimed_by config "task-001" claude;
-      let task = task_by_id config "task-001" in
-      Alcotest.(check (option string))
-        "allow_reclaim policy cleared"
-        None
-        (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
-    | Workspace.Claim_next_no_eligible _ ->
-      Alcotest.fail "completed Allow_reclaim task should be eligible"
     | Workspace.Claim_next_no_unclaimed ->
-      Alcotest.fail "completed Allow_reclaim task should not be treated as absent"
+      let task = task_by_id config "task-001" in
+      Alcotest.(check string)
+        "completed task stays done"
+        "done"
+        (Masc_domain.task_status_to_string task.task_status)
+    | Workspace.Claim_next_claimed { task_id; _ } ->
+      Alcotest.failf "Done task must be terminal (RFC-0323 G-10), got claim of %s" task_id
+    | Workspace.Claim_next_no_eligible _ ->
+      Alcotest.fail "Done task must not be counted as blocked — reclaim gate is retired"
     | Workspace.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
-let test_claim_next_blocks_done_block_reclaim () =
+(* RFC-0323 G-10: Block_reclaim on a Done task is equally moot — Done is
+   terminal, and the blocked-by-reclaim scan is a literal empty list
+   (workspace_task_schedule.ml [blocked_reclaim]), so the task is simply
+   invisible to claim_next rather than "blocked". *)
+let test_claim_next_done_block_reclaim_is_terminal () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
     let _ =
@@ -786,17 +792,17 @@ let test_claim_next_blocks_done_block_reclaim () =
       ; do_not_reclaim_reason = Some "completed upstream scope"
       });
     match Workspace.claim_next_r config ~agent_name:claude () with
-    | Workspace.Claim_next_no_eligible { blocked_count; _ } ->
-      Alcotest.(check int) "blocked completed task counted" 1 blocked_count;
+    | Workspace.Claim_next_no_unclaimed ->
       let task = task_by_id config "task-001" in
       Alcotest.(check string)
-        "blocked completed task preserved"
+        "completed task preserved"
         "done"
         (Masc_domain.task_status_to_string task.task_status)
     | Workspace.Claim_next_claimed { task_id; _ } ->
       Alcotest.failf "Block_reclaim completed task must not be claimed, got %s" task_id
-    | Workspace.Claim_next_no_unclaimed ->
-      Alcotest.fail "Block_reclaim completed task should be reported as blocked"
+    | Workspace.Claim_next_no_eligible _ ->
+      Alcotest.fail
+        "Done task must not be counted as blocked — the reclaim claim gate is retired (RFC-0323 G-10)"
     | Workspace.Claim_next_error msg -> Alcotest.fail msg)
 ;;
 
@@ -2049,7 +2055,10 @@ let test_claim_task_r_blocks_done_default_policy () =
     | Ok _ -> Alcotest.fail "completed default-policy task must not be claimable")
 ;;
 
-let test_claim_task_r_reclaims_done_allow_reclaim () =
+(* RFC-0323 G-10 (#23731): even Allow_reclaim does not make Done claimable —
+   completed work is terminal for every actor and the caller is pointed at the
+   predecessor_task_id re-run path (workspace_task_claim.ml `Terminal arm). *)
+let test_claim_task_r_done_allow_reclaim_is_terminal () =
   with_test_env (fun config ->
     let _ =
       Workspace.add_task config ~title:"Completed allow-reclaim task" ~priority:1 ~description:""
@@ -2060,21 +2069,22 @@ let test_claim_task_r_reclaims_done_allow_reclaim () =
       ; reclaim_policy = Some Masc_domain.Allow_reclaim
       });
     match Workspace.claim_task_r config ~agent_name:"claude" ~task_id:"task-001" () with
-    | Ok outcome ->
+    | Error (Masc_domain.Task (Masc_domain.Task_error.InvalidState msg)) ->
       Alcotest.(check bool)
-        "direct completed-task reclaim succeeds"
+        "terminal rejection points at the linked re-run path"
         true
-        (str_contains outcome.message "claimed");
-      assert_claimed_by config "task-001" "claude";
+        (str_contains msg "predecessor_task_id");
       let task = task_by_id config "task-001" in
-      Alcotest.(check (option string))
-        "allow_reclaim policy cleared"
-        None
-        (Option.map Masc_domain.task_reclaim_policy_to_string task.reclaim_policy)
+      Alcotest.(check string)
+        "completed task stays done"
+        "done"
+        (Masc_domain.task_status_to_string task.task_status)
     | Error e ->
       Alcotest.fail
-        ("completed allow-reclaim task should be claimable: "
-         ^ Masc_domain.masc_error_to_string e))
+        ("expected InvalidState terminal rejection, got: "
+         ^ Masc_domain.masc_error_to_string e)
+    | Ok _ ->
+      Alcotest.fail "Done task must not be claimable (RFC-0323 G-10)")
 ;;
 
 let test_claim_task_r_already_claimed () =
@@ -2636,13 +2646,13 @@ let () =
             `Quick
             test_release_hard_stop_allows_direct_todo_reclaim
         ; Alcotest.test_case
-            "completed allow-reclaim task is scheduled"
+            "completed allow-reclaim task is terminal (RFC-0323 G-10)"
             `Quick
-            test_claim_next_reclaims_done_allow_reclaim
+            test_claim_next_done_allow_reclaim_is_terminal
         ; Alcotest.test_case
-            "completed block-reclaim task is skipped"
+            "completed block-reclaim task is terminal (RFC-0323 G-10)"
             `Quick
-            test_claim_next_blocks_done_block_reclaim
+            test_claim_next_done_block_reclaim_is_terminal
         ; Alcotest.test_case
             "legacy auto-cycle text is ignored"
             `Quick
@@ -2784,9 +2794,9 @@ let () =
             `Quick
             test_claim_task_r_blocks_done_default_policy
         ; Alcotest.test_case
-            "claim_task_r reclaims allow-reclaim completed task"
+            "claim_task_r treats allow-reclaim completed task as terminal"
             `Quick
-            test_claim_task_r_reclaims_done_allow_reclaim
+            test_claim_task_r_done_allow_reclaim_is_terminal
         ; Alcotest.test_case
             "claim_task_r already claimed"
             `Quick


### PR DESCRIPTION
## 목적

main 잠재 red 25건(#23901)의 근본 수리. opam-504 인프라 블라인드 창(07-07~09)에 red 상태로 admin-merge된 PR들이 남긴 실패를 가족 단위로 해소한다. 진단은 #23901의 가족별 root-cause 분석(7개 병렬 진단, 전 항목 file:line 재검증) 기반.

## RFC

- **RFC-0337** (`docs/rfc/RFC-0337-evidence-gate-semantics.md`, #23888 머지됨): decision 2 / migration 2 — Anti Gate 0 삭제, L1 `Task_completion_gate.decide`가 empty-evidence 거부의 단일 소유자.
- **RFC-0323 G-1/G-10**: strict done 가드, Done terminal 시맨틱 (테스트 재핀의 근거).

## 가족별 변경

| 가족 | 종류 | 변경 | 원인 커밋 |
|---|---|---|---|
| A. Gate 0 evidence 선발화 (10 tests) | code+test | Anti Gate 0 삭제 + `Evidence` 생성자 제거 (RFC-0337 mig.2); coverage 14→실 L1 핀, 38→setup submit에 evidence 선언, 19→비-strict(G-1 구조 차단), workspace strict contract→required_evidence 선언 | #23738 (재활성), #23789 (red-merge) |
| B. wake 채널 (3 tests) | code | resolver-guard 복원(resolve_entry/expire_stale) + Unrouted reason "no originating connector" 복원 — #23716 시맨틱 | #23681 (collateral revert), #23845 (reason 개서) |
| C. goal-store (1 test) | code | 레거시 status→phase 읽기 매핑 복원 (paused 레거시 goal이 Executing으로 디코드되던 버그) | #23710, #23845 |
| voting (1 test) | code | legacy `vote` 파라미터 거부 tombstone 복원 (삭제 시 down vote가 조용히 up으로 반전) | #23710 |
| bytes_cache (1 test) | code | WS fanout `send_text_bigstring` zero-copy 복원 | #23812 |
| D. reclaim (3 tests) | test | RFC-0323 G-10 terminal-done 시맨틱 재핀 (프로덕션이 정답) | #23731 (의도적 변경) |
| consolidator (1 test) | test | 쿼럼 불충족으로 통과 불가능했던 테스트 교정 (fresh 기여자 2명) | #23748 (born-red test) |
| shared_projection (1 test) | test | 드롭된 파일 시딩 복원 | #23846 |
| telemetry (1 test) | test | done 전이에 evidence_refs 탑재 (#23738 래칫 정합) | #23738 |

## 검증

- 전 편집 파일 `ocamlc -stop-after parsing` 통과 (구문 레벨).
- 빌드/테스트 최종 판정은 CI (main red 상태라 로컬 diff-green 비교 불가; 본 PR이 기준선 복원).
- 각 가족의 "코드가 정답인가 테스트가 정답인가" 판정 근거는 #23901 코멘트의 진단 verdict 참조.

## 연계

- Closes #23901 의 수리 항목 (이슈는 재발 방지 논의를 위해 열어둠).
- #23775 (L1 provenance 핀): 본 PR 머지 후 rebase 필요 — coverage 14가 실 L1 핀으로 전환되어 #23775의 신규 테스트와 부분 중복, 머지 순서에 따라 정리.
- 후속 이슈 (별도 등록): `handle_done`이 중첩 `handoff_context` 인자를 폐기하고 top-level `evidence_refs`만 전달하는 결함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
