### PR TITLE
fix(goal): restore legacy status phase migration

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -122,7 +122,7 @@ and goal_of_yojson = function
           in
           let phase =
             match Json_util.assoc_member_opt "phase" json with
-            | None | Some `Null -> Ok (phase_of_goal_status Active)
+            | None | Some `Null -> Result.map phase_of_goal_status legacy_status
             | Some phase_json -> Goal_phase.of_yojson phase_json
           in
           let verifier_policy =


### PR DESCRIPTION
## Summary

- derive a missing persisted `phase` from the already parsed legacy `status`
- preserve completed, paused, and dropped legacy goals during recovery
- reuse the existing closed status-to-phase bridge; no string heuristic added

## 48-hour merge audit finding

Merged conflict-resolution PR #23710 kept parsing the legacy `status` field but ignored its value when `phase` was absent, forcing every old row to `Active`/`Executing`. Completed and failed lifecycle records could therefore re-enter active work after migration or recovery. A Changes Requested review identified the regression before merge, followed by a contradictory same-head approval.

The existing four-state regression test already described the intended compatibility contract and failed on current main. This patch restores that exact bridge with `Result.map phase_of_goal_status legacy_status`.

## Validation

- focused wrapper build for `test/test_goal_store.exe`
- `test_goal_store.exe` — 12/12, including all four legacy status mappings
- `git diff --check`

[근거] #23710 review history, current `goal_of_yojson`, focused executable, 확인일시 2026-07-10 13:04 KST, 신뢰도 High.
