### PR TITLE
fix(orchestrator): use one prompt asset SSOT

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -65,50 +65,41 @@ let should_orchestrate ~min_priority workspace_config =
   end  (* end of else begin for pause check *)
 
 (** The orchestrator prompt - MCP tools are now available via --allowedTools! *)
+let orchestrator_prompt_key = "system.orchestrator"
+let orchestrator_prompt_asset = "prompts/" ^ orchestrator_prompt_key ^ ".md"
+
+type embedded_prompt_error =
+  | Embedded_prompt_missing of string
+  | Embedded_prompt_empty of string
+
+let embedded_orchestrator_prompt () : (string, embedded_prompt_error) result =
+  match Embedded_config.read orchestrator_prompt_asset with
+  | None -> Error (Embedded_prompt_missing orchestrator_prompt_asset)
+  | Some markdown ->
+    let prompt = Prompt_registry.markdown_body markdown in
+    if String.trim prompt = "" then
+      Error (Embedded_prompt_empty orchestrator_prompt_asset)
+    else Ok prompt
+
+let embedded_prompt_error_message = function
+  | Embedded_prompt_missing asset ->
+    Printf.sprintf "orchestrator prompt asset %S is not embedded" asset
+  | Embedded_prompt_empty asset ->
+    Printf.sprintf "orchestrator prompt asset %S has an empty body" asset
+
 let make_orchestrator_prompt ~port:_ =
-  let p = Prompt_registry.get_prompt "system.orchestrator" in
-  if String.trim p <> "" then p
+  let prompt = Prompt_registry.get_prompt orchestrator_prompt_key in
+  if String.trim prompt <> "" then prompt
   else begin
     Log.Orchestrator.warn
-      "system.orchestrator prompt missing or empty, using embedded fallback";
-    {|You are the MASC Orchestrator Agent.
-
-You have access to MASC MCP tools via mcp__masc__* prefix.
-
-## Your Tasks:
-
-1. **Check status**: Call `mcp__masc__masc_status` to see the project state
-
-2. **Find unclaimed tasks**: Look for tasks with "📋" (unclaimed) status
-
-3. **Claim a task**: Call `mcp__masc__masc_transition` with:
-   - agent_name: "orchestrator"
-   - task_id: "task-XXX"
-   - action: "claim"
-
-4. **Work on the task**: Execute the task description
-
-5. **Complete the task**: Call `mcp__masc__masc_transition` with:
-   - agent_name: "orchestrator"
-   - task_id: "task-XXX"
-   - action: "submit_for_verification"
-   - notes: completion summary
-
-   A verifier (a different agent) then approves it to done. Strict-contract
-   tasks reject direct completion; only non-strict tasks may skip verification
-   with action: "done".
-
-6. **Broadcast progress**: Call `mcp__masc__masc_broadcast` to notify others
-
-## Available MCP Tools:
-- mcp__masc__masc_status - Get project status
-- mcp__masc__masc_tasks - List all tasks
-- mcp__masc__masc_transition - Claim/start/done/cancel/release a task
-- mcp__masc__keeper_task_claim - Auto-claim highest priority
-- mcp__masc__masc_broadcast - Send message to all
-- mcp__masc__masc_heartbeat - Update your heartbeat
-
-Start by calling mcp__masc__masc_status to see the current project state.|}
+      "%s prompt missing or empty, using embedded asset %s"
+      orchestrator_prompt_key orchestrator_prompt_asset;
+    match embedded_orchestrator_prompt () with
+    | Ok embedded -> embedded
+    | Error error ->
+      let message = embedded_prompt_error_message error in
+      Log.Orchestrator.error "%s" message;
+      invalid_arg message
   end
 
 (* ── Pulse helpers ─────────────────────────────────────────── *)

--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -118,6 +118,10 @@ let parse_frontmatter content =
       collect_meta [] rest
   | _ -> ([], content)
 
+let markdown_body content =
+  let _metadata, body = parse_frontmatter content in
+  body
+
 (** Parse a bracketed list value like [a, b, c] into string list. *)
 let parse_list_value s =
   let s = String.trim s in
@@ -237,8 +241,7 @@ let prompt_markdown_path key =
 let read_file_if_exists path =
   if Sys.file_exists path && not (Sys.is_directory path) then
     let content = In_channel.with_open_text path In_channel.input_all in
-    let _meta, body = parse_frontmatter content in
-    Some body
+    Some (markdown_body content)
   else None
 
 (** {1 Registration and Lookup} *)

--- a/lib/prompt_registry/prompt_registry.mli
+++ b/lib/prompt_registry/prompt_registry.mli
@@ -110,6 +110,13 @@ type persisted_mutation_error =
   | Validation_error of string
   | Persistence_error of string
 
+(** {1 Markdown parsing} *)
+
+val markdown_body : string -> string
+(** Return the body of a markdown asset after removing one leading YAML-style
+    frontmatter block. Content without frontmatter is returned unchanged. *)
+
+
 (** {1 Markdown directory} *)
 
 val set_markdown_dir : string -> unit

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -109,6 +109,36 @@ let test_make_orchestrator_prompt_mentions_broadcast () =
       let _ = Str.search_forward (Str.regexp "masc_broadcast") prompt 0 in true
     with Not_found -> false)
 
+let test_runtime_and_embedded_fallback_share_asset () =
+  let asset_path =
+    Masc_test_deps.source_path "config/prompts/system.orchestrator.md"
+  in
+  let canonical_body =
+    Masc_test_deps.read_file asset_path |> Prompt_registry.markdown_body
+  in
+  let runtime_prompts_dir = Filename.dirname asset_path in
+  let missing_prompts_dir = Filename.temp_file "masc-orchestrator-prompts-" "" in
+  Sys.remove missing_prompts_dir;
+  Fun.protect
+    ~finally:Prompt_registry.clear
+    (fun () ->
+      Prompt_registry.clear ();
+      Prompt_registry.set_markdown_dir runtime_prompts_dir;
+      let runtime_prompt = Orchestrator.make_orchestrator_prompt ~port:8935 in
+      check string "runtime prompt resolves from markdown" "file"
+        (Prompt_registry.prompt_source "system.orchestrator");
+      check string "runtime prompt is the canonical asset body" canonical_body
+        runtime_prompt;
+      Prompt_registry.clear ();
+      Prompt_registry.set_markdown_dir missing_prompts_dir;
+      let embedded_fallback = Orchestrator.make_orchestrator_prompt ~port:8935 in
+      check string "missing runtime file uses embedded asset" "missing"
+        (Prompt_registry.prompt_source "system.orchestrator");
+      check string "embedded fallback is the canonical asset body" canonical_body
+        embedded_fallback;
+      check string "runtime and embedded prompt bodies are identical" runtime_prompt
+        embedded_fallback)
+
 (* ============================================================
    Config Field Bounds Tests
    ============================================================ *)
@@ -236,6 +266,8 @@ let () =
         test_make_orchestrator_prompt_contains_transition_claim_path;
       test_case "contains done" `Quick test_make_orchestrator_prompt_contains_done;
       test_case "mentions broadcast" `Quick test_make_orchestrator_prompt_mentions_broadcast;
+      test_case "runtime and embedded fallback share asset" `Quick
+        test_runtime_and_embedded_fallback_share_asset;
     ];
     "config_bounds", [
       test_case "reasonable interval" `Quick test_config_reasonable_interval;


### PR DESCRIPTION
## Summary

- remove the manually synchronized orchestrator prompt literal
- use the embedded `config/prompts/system.orchestrator.md` asset as fallback
- share one frontmatter-body parser between runtime files and embedded assets
- fail closed when the required embedded asset is missing or empty

## 48-hour merge audit finding

Merged PR #23735 changed both `config/prompts/system.orchestrator.md` and a second embedded literal in `lib/orchestrator.ml`. The paired edit was direct evidence that completion teaching had two owners and would drift again.

The release binary already embeds the config tree. This patch keeps runtime override/file precedence, then derives fallback from that same built asset. No prompt text is copied into OCaml.

## Validation

- focused wrapper build for two executables
- `test_orchestrator_coverage` — 28/28
- `test_prompt_registry_defaults` — 17/17
- runtime file body, canonical source body, and embedded fallback are asserted identical
- touched OCaml parse 4/4; `git diff --check`

Repo-wide `@fmt` remains red on two unrelated Dune-format drifts and local ocamlformat is absent; changed-file formatting remains a PR-CI check.

[근거] #23735 review/data flow and focused executables, 확인일시 2026-07-10 13:06 KST, 신뢰도 High.
