### PR TITLE
Separate Keeper prompt, HITL, and terminal workflow boundaries

### DIFF
--- a/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
+++ b/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
@@ -40,7 +40,7 @@
 <body>
 <main>
   <h1>MASC live System/Keeper log adversarial audit</h1>
-  <p class="sub">Capture: 2026-07-10 10:24:43 KST / 2026-07-10T01:24:43Z · Runtime root: <code>/Users/dancer/me/.masc</code> · Source window: 2026-07-07 through capture time</p>
+  <p class="sub">Capture: 2026-07-10 10:24:43 KST / 2026-07-10T01:24:43Z · Runtime root: <code>&lt;base_path&gt;/.masc</code> · Source window: 2026-07-07 through capture time</p>
 
   <div class="summary">
     <div class="stat"><strong>degraded</strong><span>health overall status</span></div>
@@ -58,7 +58,7 @@
   <table>
     <tr><th>항목</th><th>관찰값</th><th>판정</th></tr>
     <tr><td>Health</td><td><code>status=ok</code>, version <code>0.20.0</code>, <code>overall_status=degraded</code></td><td>프로세스 응답은 정상. degraded 사유는 reaction ledger pending stimulus와 stale durable queue.</td></tr>
-    <tr><td>Config</td><td>effective base <code>/Users/dancer/me</code>, runtime root <code>/Users/dancer/me/.masc</code>, parse error 0, unknown key 0</td><td class="oktext">현재 설정 파싱 오류는 아님</td></tr>
+    <tr><td>Config</td><td>effective base <code>&lt;base_path&gt;</code>, runtime root <code>&lt;base_path&gt;/.masc</code>, parse error 0, unknown key 0</td><td class="oktext">현재 설정 파싱 오류는 아님</td></tr>
     <tr><td>Scheduler</td><td>tick/failure counters는 정상이고 crash 0</td><td class="oktext">스케줄러 자체의 정지 증거 없음</td></tr>
     <tr><td><code>verifier</code> queue</td><td><code>schedule_due</code> pending 1, 약 3,864초; durable meta는 <code>operator_paused</code></td><td>운영 상태와 autoboot 설정의 충돌. pause 중 queue가 남는 것은 현재 pause semantics의 결과이지 queue 손실 증거는 아님.</td></tr>
     <tr><td><code>nick0cave</code> queue</td><td><code>board_signal</code> inflight 1, 약 195초</td><td>처리 중인 lane의 receipt/ack를 재확인해야 함. queue 파일을 직접 삭제하면 안 됨.</td></tr>
@@ -72,11 +72,11 @@
   <h3>10:59 KST live recheck — source 수정 미배포</h3>
   <table>
     <tr><th>항목</th><th>현재 관찰값</th><th>판정</th></tr>
-    <tr><td>실행 파일</td><td>commit <code>61a643565b</code>, <code>/Users/dancer/me/workspace/yousleepwhen/masc/_build/default/bin/main_eio.exe</code></td><td>worktree branch의 HITL/prompt 수정 미포함</td></tr>
+    <tr><td>실행 파일</td><td>commit <code>61a643565b</code>, <code>&lt;masc-repo&gt;/_build/default/bin/main_eio.exe</code></td><td>worktree branch의 HITL/prompt 수정 미포함</td></tr>
     <tr><td>Health</td><td><code>status=ok</code>, <code>overall_status=degraded</code></td><td>operator reasons는 reaction-ledger pending stimulus와 stale durable queue</td></tr>
     <tr><td>Durable queue</td><td><code>verifier</code>의 <code>schedule_due</code> pending 1개, inflight 0개, oldest age 약 6,075초, ack 0</td><td><code>operator_paused</code> 상태와 일치하는 미처리 항목. 직접 삭제/ack하지 않음</td></tr>
     <tr><td>Keeper fleet</td><td>running/healthy 10개, paused 4개</td><td>전체 fleet 정지는 아니지만 paused/autoboot 정책 충돌은 남음</td></tr>
-    <tr><td>BasePath/config</td><td>cwd/base <code>/Users/dancer/me</code>, mascot root <code>/Users/dancer/me/.masc</code>, roots diverge false, startup warnings 없음</td><td class="oktext">현재 path/config bootstrap 오류 증거 없음</td></tr>
+    <tr><td>BasePath/config</td><td>cwd/base <code>&lt;base_path&gt;</code>, runtime root <code>&lt;base_path&gt;/.masc</code>, roots diverge false, startup warnings 없음</td><td class="oktext">현재 path/config bootstrap 오류 증거 없음</td></tr>
   </table>
   <p>따라서 이번 recheck는 라이브 개선을 입증하지 않는다. 현재 바이너리는 이전 동작을 계속 실행하고 있고, 같은 날 로그에도 pending HITL 9건, 기존 blocking warning 150건, no-progress failure 8건, stale-turn 5건이 남아 있다.</p>
   <p><strong>11:14 KST delta recheck:</strong> health는 여전히 <code>degraded</code>이고, keeper fibers는 9개, durable queue는 pending 1개·inflight 1개·event-queue ack 0·stale 2개였다. 이 변동성 때문에 초기 queue 수치를 현재 SSOT로 해석하지 않으며, 라이브 queue를 직접 조작하지 않았다.</p>
@@ -102,7 +102,7 @@
     <tr><td>Keeper fleet</td><td>running/healthy/executable 10개, target 10개, failing/recovering 0개</td><td class="oktext">이전 reaction-capacity shortfall은 현재 snapshot에서 회복됨</td></tr>
     <tr><td>Turn admission</td><td>autonomous in-flight 6개, chat waiting/rejected 0개</td><td><code>mad-improver</code> lane은 약 39분째 in-flight이므로 F-05 장기 turn 관찰은 계속 필요</td></tr>
     <tr><td>Durable queue</td><td><code>verifier</code> <code>schedule_due</code> pending 1개, inflight 0개, age 약 20,095초</td><td><code>verifier</code>는 <code>operator_paused</code>; 직접 ack·삭제·resume하지 않음</td></tr>
-    <tr><td>Config/paths</td><td>parse error 0, unknown key 0, schema <code>ok</code>, startup degradation false; root <code>/Users/dancer/me/.masc</code></td><td class="oktext">현재 config/bootstrap 오류 증거 없음</td></tr>
+    <tr><td>Config/paths</td><td>parse error 0, unknown key 0, schema <code>ok</code>, startup degradation false; root <code>&lt;base_path&gt;/.masc</code></td><td class="oktext">현재 config/bootstrap 오류 증거 없음</td></tr>
   </table>
   <p><code>overall_status=degraded</code>의 현재 원인은 reaction ledger의 pending stimulus와 stale durable queue다. fleet recovery는 확인했지만, paused Keeper의 durable event가 5시간 이상 남은 상태와 source 수정 미배포 사실은 별개다.</p>
 
@@ -205,8 +205,8 @@
 
   <h2>검증 근거</h2>
   <pre>curl -fsS 'http://127.0.0.1:8935/health?full=1'
-rg 'keeper cycle FAILED.*no_usable_progress' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
-rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl</pre>
+rg 'keeper cycle FAILED.*no_usable_progress' &lt;base_path&gt;/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
+rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' &lt;base_path&gt;/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl</pre>
   <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue 파일은 read-only evidence로만 확인했으며 삭제·ack·resume 조작은 하지 않았다. 12:35, 13:11, 14:52 KST recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
 
   <footer>이 보고서와 MASC 수정은 <a href="https://github.com/jeong-sik/masc/pull/23923">MASC draft PR #23923</a>, OAS provider-catalog 수정은 <a href="https://github.com/jeong-sik/oas/pull/2506">OAS draft PR #2506</a>에서 추적한다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>

--- a/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
+++ b/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
@@ -95,6 +95,17 @@
   <h3>13:11 KST latest recheck — recovery remains partial</h3>
   <p>현재 live executable과 commit은 여전히 <code>61a643565b</code>다. running/healthy Keeper는 9개, <code>base</code>는 recovering, <code>garnet</code>은 <code>phase=dead</code>와 <code>restart_count=5</code>를 유지한다. effective reaction capacity는 9, executable capacity는 10, target은 11이며, durable event queue는 pending 1(<code>verifier</code>, operator-paused)·inflight 5(<code>analyst</code> 3, <code>issue_king</code> 2)·ack 0·stale 6이다. chat waiting은 0이므로 현재 queue 지연을 dashboard chat starvation으로 단정하지 않는다. 이전 snapshot과 수치가 달라졌지만 source worktree 수정이 live에 반영된 것은 아니다.</p>
 
+  <h3>14:52 KST latest recheck — fleet recovered, one paused-lane stimulus remains</h3>
+  <table>
+    <tr><th>항목</th><th>현재 관찰값</th><th>판정</th></tr>
+    <tr><td>실행 파일</td><td>commit <code>61a643565b</code>, uptime 53,419초</td><td>아래 worktree/PR 수정은 여전히 live에 미반영</td></tr>
+    <tr><td>Keeper fleet</td><td>running/healthy/executable 10개, target 10개, failing/recovering 0개</td><td class="oktext">이전 reaction-capacity shortfall은 현재 snapshot에서 회복됨</td></tr>
+    <tr><td>Turn admission</td><td>autonomous in-flight 6개, chat waiting/rejected 0개</td><td><code>mad-improver</code> lane은 약 39분째 in-flight이므로 F-05 장기 turn 관찰은 계속 필요</td></tr>
+    <tr><td>Durable queue</td><td><code>verifier</code> <code>schedule_due</code> pending 1개, inflight 0개, age 약 20,095초</td><td><code>verifier</code>는 <code>operator_paused</code>; 직접 ack·삭제·resume하지 않음</td></tr>
+    <tr><td>Config/paths</td><td>parse error 0, unknown key 0, schema <code>ok</code>, startup degradation false; root <code>/Users/dancer/me/.masc</code></td><td class="oktext">현재 config/bootstrap 오류 증거 없음</td></tr>
+  </table>
+  <p><code>overall_status=degraded</code>의 현재 원인은 reaction ledger의 pending stimulus와 stale durable queue다. fleet recovery는 확인했지만, paused Keeper의 durable event가 5시간 이상 남은 상태와 source 수정 미배포 사실은 별개다.</p>
+
   <h2>확인된 버그 및 장애</h2>
 
   <section class="finding p0">
@@ -123,16 +134,17 @@
   </section>
 
   <section class="finding">
-    <h3>F-03 · P1 · OAS unknown stop reasons become fatal pipeline errors</h3>
+    <h3>F-03 · P1 · Documented MiMo terminal reason falls through to Unknown/fatal</h3>
     <div class="meta">Confidence: High · Owner boundary: OAS provider result semantics, consumed by MASC</div>
     <p>System Log에 <code>Unrecognized stop_reason from API: repetition_truncation</code>이 포함된 레코드가 100개 확인되었다(중복 전파 레코드 포함). 반복적으로 <code>rondo</code>, <code>ramarama</code>, <code>base</code>, <code>mad-improver</code> 등의 cycle이 수백 초 후 실패한다.</p>
     <ul>
-      <li>OAS의 <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/llm_provider/types.ml">stop_reason</a> 타입은 <code>Unknown of string</code>을 보존한다.</li>
-      <li>기존 OAS pipeline은 unknown을 <code>UnrecognizedStopReason</code> fatal error로 승격했다.</li>
-      <li>Provider/model이 바뀌는 시스템에서 raw string을 fatal로 취급하면 fallback catalog가 있어도 cycle이 종료된다.</li>
+      <li>Xiaomi MiMo 공식 <a href="https://mimo.mi.com/docs/en-US/api/chat/openai-api">OpenAI-compatible API</a>와 <a href="https://mimo.mi.com/docs/en-US/api/chat/anthropic-api">Anthropic-compatible API</a> 문서는 모두 <code>content_filter</code>와 <code>repetition_truncation</code>을 terminal reason으로 명시한다.</li>
+      <li>OAS의 기존 <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/llm_provider/types.ml">stop_reason</a> 타입과 OpenAI wire catalog에는 이 두 값이 없어서 <code>Unknown of string</code>으로 강등됐다.</li>
+      <li>임의의 미래 값에 대한 pipeline fail-closed 정책 자체는 맞지만, 공식 catalog 값까지 <code>Unknown</code>으로 분류한 것이 실제 결함이다.</li>
     </ul>
-    <p><strong>수정 경계:</strong> OAS에서 “provider가 보고한 terminal reason”과 “프로토콜이 깨진 malformed response”를 타입으로 분리한다. MASC는 <code>repetition_truncation</code> 같은 신규 terminal reason을 문자열 match하지 말고 OAS의 typed outcome을 받아 retry/fallback/terminal receipt를 결정해야 한다. OAS는 MASC를 몰라야 한다.</p>
-    <p><strong>현재 worktree 수정:</strong> OAS pipeline은 임의의 <code>Unknown _</code> provider terminal reason을 <code>on_stop</code>으로 보존해 <code>Complete</code> 결과를 반환하고, OAS의 <code>UnmatchedToolCalls</code> typed outcome이 tool block 없는 malformed tool-stop만 fail-closed로 거부한다. OAS worktree에서 pipeline 49개, stop-reason SSOT 4개, backend tool-call harness 11개, streaming coverage 42개 테스트가 성공했다. 이 수정은 MASC live binary에 아직 반영되지 않았다.</p>
+    <p><strong>[근거]</strong> Xiaomi MiMo 공식 API 문서 2개, 2026-07-10 14:52 KST 확인, 신뢰도 High. OpenAI 문서는 <code>choices.finish_reason</code>에, Anthropic 문서는 <code>stop_reason</code>에 두 값을 열거한다. <a href="https://ocaml.org/manual/5.4/typedecl.html">OCaml 5.4 variant type definitions</a>와 <a href="https://ocaml.org/manual/5.4/patterns.html">variant patterns</a>를 기준으로 public constructor와 모든 exhaustive match를 함께 갱신했다(2026-07-10 확인, 신뢰도 High).</p>
+    <p><strong>수정 경계:</strong> OAS에서 <code>ContentFilter</code>와 <code>RepetitionTruncation</code>을 first-class constructor로 추가하고 OpenAI/Anthropic wire를 하나의 stop-reason SSOT로 수렴한다. 임의의 <code>Unknown _</code>과 tool block 없는 <code>UnmatchedToolCalls</code>은 계속 fail-closed다. MASC는 raw string을 match하지 않고 OAS의 typed terminal outcome만 소비하며, OAS는 MASC를 모른다.</p>
+    <p><strong>현재 worktree 수정:</strong> OAS type/wire/pipeline 경계에 위 두 constructor를 추가했고, Responses incomplete parser는 자신의 wire enum에서 <code>content_filter</code>만 typed 처리한다. <code>repetition_truncation</code>은 <code>on_stop</code>을 거친 <code>Complete</code>로 보존하지만 임의 <code>Unknown</code>은 <code>UnrecognizedStopReason</code>으로 남는다. focused build와 Types 61개, stop-reason SSOT 4개, OpenAI streaming 40개, pipeline 50개 테스트가 성공했다. full suite/OCaml 5.4·5.5 proof는 PR CI authority로 남고, MASC live binary에는 아직 반영되지 않았다.</p>
   </section>
 
   <section class="finding">
@@ -140,6 +152,7 @@
     <div class="meta">Confidence: High for symptom; Medium for root cause · Owner boundary: MASC acceptance/fallback + provider outcome</div>
     <p><code>keeper cycle FAILED ... no_usable_progress</code>가 193건이다. 최대 발생 Keeper는 <code>mad-improver</code> 106건, <code>idealist</code> 51건, <code>issue_king</code> 18건이다. 예시에는 empty response + <code>max_tokens</code>, thinking-only + <code>end_turn</code>, 208~732초 지연이 포함된다.</p>
     <p>현재 accept guard와 degraded retry log는 존재하지만, 생산적인 tool/text 결과가 없다는 사실을 수백 초를 소비한 뒤에야 cycle 실패로 표면화한다. 이는 단순히 retry 횟수를 늘릴 문제가 아니다. OAS typed result, runtime slot phase, MASC lane receipt가 “진행 없음”을 독립적으로 관측하고, 장기 대기 lane을 다른 reactive 활동과 분리해야 한다.</p>
+    <p><strong>14:40 KST 추가 증거:</strong> <code>idealist</code>는 empty response + <code>max_tokens</code> 한 attempt에 255,051ms, cycle에 267,481ms를 썼다. <code>analyst</code>는 62,601자의 thinking-only + <code>end_turn</code> response에 1,593,268ms를 쓴 뒤 cycle이 1,601,119ms(약 26.7분)에 <code>no_usable_progress</code>로 실패했다. 임의 retry 수치가 아니라 phase receipt와 비동기 continuation이 필요한 증거다.</p>
   </section>
 
   <section class="finding">
@@ -149,6 +162,7 @@
     <p>12:27 KST 재확인에서도 <code>garnet</code>이 <code>idle_turn(11003s)</code> stale timeout 뒤 <code>restart_count=5</code>로 dead가 되었고, <code>idealist</code>는 recovering 상태였다. 8개 Keeper는 healthy였으므로 전체 fleet stop은 아니지만, target 10 대비 effective reaction capacity 8로 낮아진 live 후속 상태다.</p>
     <p>watchdog가 결국 lane을 회수하는 것은 안전장치이지 정상 동작이 아니다. 어떤 provider call, tool call, approval wait, stream read가 시간을 소비했는지 typed phase별로 보이고, 독립 lane이 한 stalled call 때문에 사용자 응답·connector ack를 잃지 않도록 cancellation과 continuation을 분리해야 한다.</p>
     <p><strong>소스 경계 추적:</strong> MASC의 전체 provider/tool 시도에는 누적 wall-clock watchdog을 걸지 않고, OAS의 <code>stream_idle_timeout_s</code>는 stream line 간 정적만 감지한다. OAS Agent-level execution-idle timeout은 지원되지만 MASC Keeper 경로는 active tool 실행과 idle accounting을 분리했다는 증거가 없어 전달하지 않는다. Supervisor의 <code>Idle_turn</code>은 turn observation이 없는 no-turn 정지, <code>Mid_turn_no_progress</code>는 opt-in이며 deliverable progress가 없는 in-turn 상태이고 active tool count는 제외한다. 따라서 현재 증거는 하나의 잘못된 timeout 숫자보다 provider/thinking·tool·approval·continuation phase의 관측/분리 공백을 가리킨다. arbitrary turn/timeout cutoff은 추가하지 않는다.</p>
+    <p><strong>14:52 KST 추가 증거:</strong> <code>sangsu</code>에는 <code>idle_turn(5488s)</code> stale timeout이 기록됐고, 현재 fleet은 10/10으로 회복했지만 <code>mad-improver</code> autonomous lane은 약 39분째 in-flight다. 한 Keeper의 장기 turn과 fleet 전체 liveness를 분리해 관측해야 한다.</p>
   </section>
 
   <section class="finding p2">
@@ -157,6 +171,7 @@
     <p><code>Transition 'release' from status 'cancelled' is not allowed</code>가 320건이다. task FSM은 <a href="../../lib/workspace/workspace_task_classify.ml">workspace_task_classify.ml</a>에서 <code>Cancelled</code>를 terminal로 정의하고 valid actions를 빈 목록으로 돌려준다. 따라서 이 오류는 task FSM 자체가 cancelled를 release로 바꾼다는 증거가 아니라, 호출자가 terminal rejection을 받은 뒤 같은 행동을 반복한다는 증거다.</p>
     <p>tool 결과를 일반 workflow rejection 문자열로만 반환하지 말고 terminal task state와 valid-next-actions를 typed result로 명시하여, Keeper가 다른 일을 하거나 operator에게 명확히 보고하도록 해야 한다. 문자열 기반 “몇 번 실패하면 중단” 휴리스틱은 추가하지 않는다.</p>
     <p><strong>현재 worktree 수정:</strong> task FSM의 <code>recoverable=false</code>를 OAS tool boundary까지 보존하도록 nested workflow payload를 typed merge하고, terminal rejection에는 <code>self_correction_required=false</code>와 <code>workflow_rejection_terminal=true</code>를 반환한다. next-tool 정보가 있으면 그 다음 valid action을 안내하고, 같은 <code>masc_transition</code> 재시도 문구는 만들지 않는다. <code>test_tool_result</code> 25개와 <code>test_keeper_tool_dispatch_runtime</code> 36개가 통과했다. 이 수정은 live binary에 아직 반영되지 않았으므로 live 320건 감소를 주장하지 않는다.</p>
+    <p><strong>14:43 KST live 재현:</strong> old binary의 <code>analyst</code>가 cancelled <code>task-1891</code>에 다시 <code>masc_transition release</code>를 호출했고, 응답 JSON에는 <code>self_correction_required=true</code> 키가 중복으로 들어간 채 retry 지시가 남았다. worktree 수정이 아직 live가 아니라는 직접 증거다.</p>
   </section>
 
   <h2>버그로 확정하지 않은 항목</h2>
@@ -183,8 +198,8 @@
   <div class="note">
     <p><strong>F-01 1차 수정 완료 (worktree only):</strong> unified prompt 경로가 structured world-state user message를 더 이상 token scanner/registry strip에 넣지 않고, system/continuity instruction surfaces만 검사하도록 분리했다. <a href="../../lib/keeper/keeper_unified_prompt.ml">keeper_unified_prompt.ml</a>와 <a href="../../test/test_keeper_unified_verification_surface.ml">verification-surface regression test</a>에 변경이 있다.</p>
     <p><strong>F-02 1차 수정 완료 (worktree only):</strong> <a href="../../lib/keeper/keeper_approval_queue.ml">keeper_approval_queue.ml</a>에 typed blocking/nonblocking queue boundary를 추가하고, <a href="../../lib/governance_pipeline.ml">governance_pipeline.ml</a>과 <a href="../../lib/keeper/keeper_agent_run.ml">keeper_agent_run.ml</a>의 일반 Keeper tool approval을 nonblocking 경로로 연결했다. 명시적 critical continuation gate의 blocking policy는 유지한다.</p>
-    <p><strong>F-03 1차 수정 완료 (OAS worktree only):</strong> <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/pipeline/pipeline.ml">OAS pipeline</a>이 provider가 새 terminal reason을 보고해도 fatal로 승격하지 않고 typed terminal result로 보존한다. tool block 없는 malformed tool-stop은 <code>UnmatchedToolCalls</code> constructor로 fail-closed 한다. <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/test/test_pipeline.ml">OAS pipeline regression tests</a>를 포함해 49/4/11/42 테스트가 성공했다.</p>
-    <p>검증: approval queue 12개, HITL approval 51개, supervisor 87개, unified verification surface 18개, prompt token integrity 15개, F-06 tool-result 25개, Keeper tool-dispatch runtime 36개 테스트가 성공했다. 이 로컬 narrow build의 compiler는 <code>ocamlc 5.5.0</code>였고, OCaml 5.4 공식 manual을 설계 기준으로 삼았으므로 5.4 CI proof는 별도다. Dune full build/CI는 아직 실행하지 않았다. 테스트 실행 시 packaged model catalog 경고가 있었지만 worktree-only test fixture의 catalog discovery 경고이며, 라이브 health의 startup config warning과는 별개다.</p>
+    <p><strong>F-03 1차 수정 구현:</strong> <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/llm_provider/types.ml">OAS stop-reason SSOT</a>에 공식 <code>ContentFilter</code>/<code>RepetitionTruncation</code> constructor를 추가하고 <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/pipeline/pipeline.ml">pipeline</a>은 두 값만 typed terminal result로 보존한다. 임의 <code>Unknown</code>과 tool block 없는 <code>UnmatchedToolCalls</code>은 fail-closed를 유지한다. commit <code>7529dfbfd</code>를 <a href="https://github.com/jeong-sik/oas/pull/2506">OAS draft PR #2506</a>에 게시했다. focused build와 61/4/40/50 테스트가 성공했고 current-head full proof는 PR CI에서 확인한다.</p>
+    <p>검증: MASC approval queue 12개, HITL approval 51개, supervisor 87개, unified verification surface 18개, prompt token integrity 15개, F-06 tool-result 25개, Keeper tool-dispatch runtime 36개 테스트가 성공했다. OAS Types 61개, stop-reason SSOT 4개, OpenAI streaming 40개, pipeline 50개 테스트도 성공했다. 로컬 narrow build의 compiler는 <code>ocamlc 5.5.0</code>였고, OCaml 5.4 공식 manual을 설계 기준으로 삼았으므로 5.4 CI proof는 별도다. Dune full build/CI는 PR에서 수행한다. 테스트 실행 시 packaged model catalog 경고가 있었지만 worktree-only test fixture의 catalog discovery 경고이며, 라이브 health의 startup config warning과는 별개다.</p>
     <p>현재 live executable은 이 worktree 변경을 포함하지 않으므로 live warning 감소나 runtime 개선으로 해석하면 안 된다. 배포/재시작 및 CI green 전에는 remediation을 완료 상태로 주장하지 않는다.</p>
   </div>
 
@@ -192,9 +207,9 @@
   <pre>curl -fsS 'http://127.0.0.1:8935/health?full=1'
 rg 'keeper cycle FAILED.*no_usable_progress' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
 rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl</pre>
-  <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue 파일은 read-only evidence로만 확인했으며 삭제·ack 조작은 하지 않았다. 12:35 및 13:11 KST current recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
+  <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue 파일은 read-only evidence로만 확인했으며 삭제·ack·resume 조작은 하지 않았다. 12:35, 13:11, 14:52 KST recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
 
-  <footer>이 보고서는 MASC worktree <code>codex/live-log-audit-20260710</code>에서 작성되었다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>
+  <footer>이 보고서와 MASC 수정은 <a href="https://github.com/jeong-sik/masc/pull/23923">MASC draft PR #23923</a>, OAS provider-catalog 수정은 <a href="https://github.com/jeong-sik/oas/pull/2506">OAS draft PR #2506</a>에서 추적한다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>
 </main>
 </body>
 </html>

--- a/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
+++ b/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MASC live System/Keeper log adversarial audit — 2026-07-10</title>
+  <style>
+    :root { color-scheme: light; --ink:#17202a; --muted:#5f6b76; --line:#d8dee4; --bg:#f6f8fa; --card:#fff; --p0:#8b1e1e; --p1:#a33a00; --p2:#735c00; --ok:#12633c; }
+    * { box-sizing:border-box; }
+    body { margin:0; color:var(--ink); background:var(--bg); font:15px/1.58 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+    main { max-width:1180px; margin:0 auto; padding:32px 22px 64px; }
+    h1 { margin:0 0 8px; font-size:30px; line-height:1.2; }
+    h2 { margin:34px 0 12px; padding-bottom:6px; border-bottom:2px solid var(--line); font-size:21px; }
+    h3 { margin:0 0 8px; font-size:18px; }
+    p { margin:8px 0; }
+    a { color:#075ca8; }
+    code, pre { font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+    code { padding:1px 4px; border-radius:3px; background:#eef1f4; }
+    pre { overflow:auto; padding:12px 14px; border:1px solid var(--line); border-radius:6px; background:#111820; color:#e8edf1; }
+    .sub { color:var(--muted); }
+    .summary { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; margin:22px 0; }
+    .stat, .finding, .note { border:1px solid var(--line); border-radius:8px; background:var(--card); padding:15px; }
+    .stat strong { display:block; font-size:25px; }
+    .stat span { color:var(--muted); }
+    .finding { margin:14px 0; border-left:5px solid var(--p1); }
+    .finding.p0 { border-left-color:var(--p0); }
+    .finding.p2 { border-left-color:var(--p2); }
+    .finding .meta { color:var(--muted); font-size:13px; }
+    .finding ul, .note ul { margin:7px 0 0 21px; padding:0; }
+    table { width:100%; border-collapse:collapse; background:var(--card); }
+    th, td { padding:9px 10px; border:1px solid var(--line); text-align:left; vertical-align:top; }
+    th { background:#edf1f4; }
+    .p0text { color:var(--p0); font-weight:700; }
+    .p1text { color:var(--p1); font-weight:700; }
+    .oktext { color:var(--ok); font-weight:700; }
+    .small { font-size:13px; }
+    footer { margin-top:36px; color:var(--muted); font-size:13px; }
+  </style>
+</head>
+<body>
+<main>
+  <h1>MASC live System/Keeper log adversarial audit</h1>
+  <p class="sub">Capture: 2026-07-10 10:24:43 KST / 2026-07-10T01:24:43Z · Runtime root: <code>/Users/dancer/me/.masc</code> · Source window: 2026-07-07 through capture time</p>
+
+  <div class="summary">
+    <div class="stat"><strong>degraded</strong><span>health overall status</span></div>
+    <div class="stat"><strong>2</strong><span>initial durable queue entries: 1 pending, 1 inflight</span></div>
+    <div class="stat"><strong>4,700+</strong><span>pending-HITL warning records</span></div>
+    <div class="stat"><strong>193</strong><span>keeper-cycle failures with no usable progress</span></div>
+    <div class="stat"><strong>320</strong><span>release from cancelled transition failures</span></div>
+  </div>
+
+  <h2>결론</h2>
+  <p>현재 런타임은 프로세스 자체가 죽은 상태는 아니지만, 독립 Keeper lane의 진행 보장과 관측 데이터 보존을 만족하지 못하는 결함이 확인된다. 가장 명확한 소스 결함은 <strong>구조화된 world observation을 tool-token 문자열로 재해석하고 삭제하는 프롬프트 경계</strong>다. 그 다음은 <strong>pending HITL 하나가 Keeper 전체 cycle admission을 막는 전역 차단</strong>이다. 이 두 MASC 수정은 현재 worktree에서 구현·검증했지만 라이브 실행 파일에는 아직 반영하지 않았다.</p>
+  <p>OAS stop reason 문제와 provider의 empty/thinking-only 응답은 MASC가 문자열 예외를 임의로 해석해서 고칠 영역이 아니다. OAS가 provider terminal outcome을 타입으로 보존하고, MASC는 그 타입을 받아 fallback 또는 cycle 결과를 결정해야 한다. 아래에서 MASC/OAS 경계를 분리했다.</p>
+
+  <h2>라이브 상태 — initial snapshot</h2>
+  <table>
+    <tr><th>항목</th><th>관찰값</th><th>판정</th></tr>
+    <tr><td>Health</td><td><code>status=ok</code>, version <code>0.20.0</code>, <code>overall_status=degraded</code></td><td>프로세스 응답은 정상. degraded 사유는 reaction ledger pending stimulus와 stale durable queue.</td></tr>
+    <tr><td>Config</td><td>effective base <code>/Users/dancer/me</code>, runtime root <code>/Users/dancer/me/.masc</code>, parse error 0, unknown key 0</td><td class="oktext">현재 설정 파싱 오류는 아님</td></tr>
+    <tr><td>Scheduler</td><td>tick/failure counters는 정상이고 crash 0</td><td class="oktext">스케줄러 자체의 정지 증거 없음</td></tr>
+    <tr><td><code>verifier</code> queue</td><td><code>schedule_due</code> pending 1, 약 3,864초; durable meta는 <code>operator_paused</code></td><td>운영 상태와 autoboot 설정의 충돌. pause 중 queue가 남는 것은 현재 pause semantics의 결과이지 queue 손실 증거는 아님.</td></tr>
+    <tr><td><code>nick0cave</code> queue</td><td><code>board_signal</code> inflight 1, 약 195초</td><td>처리 중인 lane의 receipt/ack를 재확인해야 함. queue 파일을 직접 삭제하면 안 됨.</td></tr>
+  </table>
+
+  <h3>10:34 KST 재확인</h3>
+  <p>재확인 시 durable queue는 pending 5 + inflight 6 = 11개로 변했다. <code>verifier</code>의 오래된 schedule은 여전히 operator-paused 상태이고, <code>issue_king</code> pending 3개와 <code>nick0cave</code> inflight 4개는 모두 같은 thread root post id를 공유하지만 payload content가 서로 다른 board comments였다. 따라서 이것을 동일 이벤트 중복으로 단정하지 않는다.</p>
+  <p>반면 <code>nick0cave</code>의 로그에는 <code>turn digest: coalesced 4 board signals into one turn</code>가 있고, 그 직후 4개를 한 lane turn에서 소비했다. 이것은 Lane Per Keeper batching 의도와 맞는다. 당시 <code>event_queue_ack_count=0</code>였으므로, turn 완료 후 durable ack가 발생하는지 별도 recheck가 필요하다. 10:34 시점의 수치만으로 queue 파일을 삭제하거나 수동 ack하면 안 된다.</p>
+  <p>10:38 KST 재확인에서는 <code>keeper_turn_admission.in_flight_keeper_count=6</code>이고 <code>idealist</code>, <code>issue_king</code>, <code>nick0cave</code>가 autonomous in-flight였다. 이 중 <code>nick0cave</code>의 lane은 약 13분, <code>idealist</code>는 약 8분 동안 점유된 상태로 mailbox/ack가 지연되고 있었다. 모든 Keeper가 멈춘 것은 아니지만, 독립 lane이 장시간 점유되어 reactive 입력이 쌓이는 것은 F-05의 현재 재현 증거다.</p>
+
+  <h3>10:59 KST live recheck — source 수정 미배포</h3>
+  <table>
+    <tr><th>항목</th><th>현재 관찰값</th><th>판정</th></tr>
+    <tr><td>실행 파일</td><td>commit <code>61a643565b</code>, <code>/Users/dancer/me/workspace/yousleepwhen/masc/_build/default/bin/main_eio.exe</code></td><td>worktree branch의 HITL/prompt 수정 미포함</td></tr>
+    <tr><td>Health</td><td><code>status=ok</code>, <code>overall_status=degraded</code></td><td>operator reasons는 reaction-ledger pending stimulus와 stale durable queue</td></tr>
+    <tr><td>Durable queue</td><td><code>verifier</code>의 <code>schedule_due</code> pending 1개, inflight 0개, oldest age 약 6,075초, ack 0</td><td><code>operator_paused</code> 상태와 일치하는 미처리 항목. 직접 삭제/ack하지 않음</td></tr>
+    <tr><td>Keeper fleet</td><td>running/healthy 10개, paused 4개</td><td>전체 fleet 정지는 아니지만 paused/autoboot 정책 충돌은 남음</td></tr>
+    <tr><td>BasePath/config</td><td>cwd/base <code>/Users/dancer/me</code>, mascot root <code>/Users/dancer/me/.masc</code>, roots diverge false, startup warnings 없음</td><td class="oktext">현재 path/config bootstrap 오류 증거 없음</td></tr>
+  </table>
+  <p>따라서 이번 recheck는 라이브 개선을 입증하지 않는다. 현재 바이너리는 이전 동작을 계속 실행하고 있고, 같은 날 로그에도 pending HITL 9건, 기존 blocking warning 150건, no-progress failure 8건, stale-turn 5건이 남아 있다.</p>
+  <p><strong>11:14 KST delta recheck:</strong> health는 여전히 <code>degraded</code>이고, keeper fibers는 9개, durable queue는 pending 1개·inflight 1개·event-queue ack 0·stale 2개였다. 이 변동성 때문에 초기 queue 수치를 현재 SSOT로 해석하지 않으며, 라이브 queue를 직접 조작하지 않았다.</p>
+  <h3>12:27 KST live recheck — restart budget exhaustion and reaction-capacity shortfall</h3>
+  <table>
+    <tr><th>항목</th><th>현재 관찰값</th><th>판정</th></tr>
+    <tr><td>Keeper fleet</td><td>running/healthy 8개, paused 4개, failing 1개, recovering 1개(<code>idealist</code>), bootable/autoboot target 10개</td><td><code>overall_status=degraded</code>; 전체 fleet 정지는 아니지만 reaction capacity는 target보다 낮다.</td></tr>
+    <tr><td><code>garnet</code></td><td><code>phase=dead</code>, <code>stale_turn_timeout(idle_turn(11003s))</code>, <code>restart_count=5</code>, latest crash <code>idle_turn(9163s)</code></td><td>장기 stall 뒤 restart budget을 소진한 live operator action 상태다. queue나 registry를 직접 변경하지 않았다.</td></tr>
+    <tr><td>Reaction capacity</td><td>effective 8, executable 9, target 10, blocked name <code>garnet</code></td><td>health가 <code>keeper_fleet_safety:reaction_capacity_below_target</code>를 명시적으로 보고한다.</td></tr>
+    <tr><td>Durable reaction ledger</td><td>pending 1(<code>verifier</code> schedule_due, 약 11,405초), inflight 4(<code>analyst</code>, <code>idealist</code>, <code>issue_king</code>), ack 0, stale 5</td><td>이전 snapshot과 다른 현재 관찰값이며, pending/inflight를 수동 ack·삭제하지 않았다.</td></tr>
+  </table>
+  <p>이 상태는 <a href="../../lib/keeper/keeper_status_runtime.ml">Keeper status runtime</a>의 <code>Fiber_dead -&gt; manual_restart</code> 정책 및 supervisor의 max-restart exhaustion 테스트와 일치한다. 그러므로 자동 재시작 정책의 결함으로 확정하지 않고, F-05 장기 stall의 live 후속 증거와 운영 blocker로 분류한다. 소스 수정이 live executable에 배포된 상태도 아니다.</p>
+  <p>같은 시점의 raw system-log pattern count는 HITL pending 11, blocking warning 201, no-progress 51, unknown stop reason 5, stale-turn 9, cancelled-release 32였다. 이 수치는 structured propagation 중복을 제거하지 않은 관측값이다.</p>
+  <h3>12:35 KST latest recheck — partial recovery, shortfall remains</h3>
+  <p>12:27 snapshot 이후 <code>idealist</code>는 recovering을 벗어났고 현재 running/healthy Keeper는 9개다. <code>garnet</code>은 여전히 dead이며 effective/executable capacity는 각각 9/9, target은 10이다. durable event queue는 pending 3·inflight 2·ack 0·stale 5이고, 현재 pending은 <code>analyst</code> 2개와 operator-paused <code>verifier</code> 1개다. 즉 한 lane의 회복이 다른 lane을 중단시키지는 않았지만, reaction-capacity shortfall과 operator action required는 해소되지 않았다.</p>
+  <h3>13:11 KST latest recheck — recovery remains partial</h3>
+  <p>현재 live executable과 commit은 여전히 <code>61a643565b</code>다. running/healthy Keeper는 9개, <code>base</code>는 recovering, <code>garnet</code>은 <code>phase=dead</code>와 <code>restart_count=5</code>를 유지한다. effective reaction capacity는 9, executable capacity는 10, target은 11이며, durable event queue는 pending 1(<code>verifier</code>, operator-paused)·inflight 5(<code>analyst</code> 3, <code>issue_king</code> 2)·ack 0·stale 6이다. chat waiting은 0이므로 현재 queue 지연을 dashboard chat starvation으로 단정하지 않는다. 이전 snapshot과 수치가 달라졌지만 source worktree 수정이 live에 반영된 것은 아니다.</p>
+
+  <h2>확인된 버그 및 장애</h2>
+
+  <section class="finding p0">
+    <h3>F-01 · P1 · Prompt data corruption: observation token false positive</h3>
+    <div class="meta">Confidence: High · Owner boundary: MASC prompt assembly</div>
+    <p>2026-07-07~07-10 System Log에서 <code>keeper_turn_id</code>가 user message 안의 unknown keeper token으로 기록된 레코드가 11,672건, 같은 토큰이 prompt에서 stripped된 레코드가 13,954건이다. <code>masc_oas_error</code>와 <code>keeper_repo_mappings</code> 등 진단 필드도 같은 패턴으로 오탐된다.</p>
+    <ul>
+      <li><a href="../../lib/keeper/keeper_unified_prompt.ml">keeper_unified_prompt.ml</a>는 structured <code>user_message</code> 전체를 <code>scan_rendered_prompt</code>에 넣고, 이어서 registry strip을 적용한다.</li>
+      <li><a href="../../lib/keeper/keeper_prompt_token_integrity.ml">keeper_prompt_token_integrity.ml</a>는 문자열에서 <code>keeper_</code>/<code>masc_</code> 접두사를 추출한다. 이는 typed prompt segment가 아니라 heuristic scanner다.</li>
+      <li>결과적으로 board/task/connector/diagnostic observation의 원문이 삭제되거나 <code>&lt;stale_tool_token&gt;</code>으로 바뀐다. 관측 사실을 보존해야 하는 world-state 경계와 충돌한다.</li>
+    </ul>
+    <p><strong>정당한 수정 방향:</strong> tool instruction segment와 observation segment를 타입으로 분리하고, registry 검사는 instruction segment에만 적용한다. observation은 문자열 allowlist나 이름 예외 목록이 아니라 불변 데이터로 보존한다. 기존 scanner 단위 테스트가 “all surfaces”를 요구하므로 해당 계약도 segment 경계에 맞춰 재작성해야 한다.</p>
+  </section>
+
+  <section class="finding">
+    <h3>F-02 · P1 · Pending HITL approval blocks the whole Keeper lane</h3>
+    <div class="meta">Confidence: High · Owner boundary: MASC Keeper admission / HITL continuation</div>
+    <p>같은 로그 기간에 <code>keeper:&lt;name&gt; blocked on ... pending HITL approval(s)</code> 경고가 4,700건 이상 발생했다(초기 grep 기준 4,721 records, event dedup 아님). 이는 라이브 바이너리의 기존 동작에 대한 관찰이다. 소스 흐름은 다음과 같다.</p>
+    <ul>
+      <li><a href="../../lib/keeper/keeper_world_observation.ml">keeper_world_observation.ml</a>의 cycle decision은 pending approval이 하나라도 있으면 새 cycle을 <code>Approval_pending</code>으로 막는다.</li>
+      <li><a href="../../lib/keeper/keeper_supervisor.ml">keeper_supervisor.ml</a>는 이를 “silent chat stall”로 설명하고 있지만, 로그만 남기는 것으로는 외부 사용자에게 반응할 수 없다.</li>
+      <li><a href="../../lib/keeper/keeper_approval_queue.mli">keeper_approval_queue.mli</a>의 <code>submit_and_await</code>는 호출 fiber를 실제로 기다리게 한다. 별도의 <code>submit_pending</code> callback 경로가 있어도 admission precheck가 전체 lane을 다시 막는다.</li>
+    </ul>
+    <p><strong>스펙 위반:</strong> HITL은 약한 결합이어야 하며, Keeper는 승인 대기 중에도 busy 응답·무관한 reactive wake·다른 작업을 처리해야 한다. 승인에 종속된 continuation만 durable queue에 남기고, lane 전체를 pause하지 않는 typed continuation 구조가 필요하다.</p>
+    <p><strong>현재 worktree 수정:</strong> queue entry에 <code>lane_policy = Blocking | Nonblocking</code>을 명시했다. 일반 Keeper tool approval은 <code>Nonblocking</code>으로 등록한 뒤 typed rejection을 반환하고, 명시적 <code>submit_and_await</code> 및 persisted lifecycle gate만 <code>Blocking</code>으로 분류한다. resolution wake는 independent-cycle entry에만 발행하고, blocking continuation에는 중복 turn을 만들지 않는다. <code>keeper_world_observation</code>, heartbeat board admission, supervisor recovery가 모두 typed blocking policy만 참조한다.</p>
+  </section>
+
+  <section class="finding">
+    <h3>F-03 · P1 · OAS unknown stop reasons become fatal pipeline errors</h3>
+    <div class="meta">Confidence: High · Owner boundary: OAS provider result semantics, consumed by MASC</div>
+    <p>System Log에 <code>Unrecognized stop_reason from API: repetition_truncation</code>이 포함된 레코드가 100개 확인되었다(중복 전파 레코드 포함). 반복적으로 <code>rondo</code>, <code>ramarama</code>, <code>base</code>, <code>mad-improver</code> 등의 cycle이 수백 초 후 실패한다.</p>
+    <ul>
+      <li>OAS의 <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/llm_provider/types.ml">stop_reason</a> 타입은 <code>Unknown of string</code>을 보존한다.</li>
+      <li>기존 OAS pipeline은 unknown을 <code>UnrecognizedStopReason</code> fatal error로 승격했다.</li>
+      <li>Provider/model이 바뀌는 시스템에서 raw string을 fatal로 취급하면 fallback catalog가 있어도 cycle이 종료된다.</li>
+    </ul>
+    <p><strong>수정 경계:</strong> OAS에서 “provider가 보고한 terminal reason”과 “프로토콜이 깨진 malformed response”를 타입으로 분리한다. MASC는 <code>repetition_truncation</code> 같은 신규 terminal reason을 문자열 match하지 말고 OAS의 typed outcome을 받아 retry/fallback/terminal receipt를 결정해야 한다. OAS는 MASC를 몰라야 한다.</p>
+    <p><strong>현재 worktree 수정:</strong> OAS pipeline은 임의의 <code>Unknown _</code> provider terminal reason을 <code>on_stop</code>으로 보존해 <code>Complete</code> 결과를 반환하고, OAS의 <code>UnmatchedToolCalls</code> typed outcome이 tool block 없는 malformed tool-stop만 fail-closed로 거부한다. OAS worktree에서 pipeline 49개, stop-reason SSOT 4개, backend tool-call harness 11개, streaming coverage 42개 테스트가 성공했다. 이 수정은 MASC live binary에 아직 반영되지 않았다.</p>
+  </section>
+
+  <section class="finding">
+    <h3>F-04 · P1 · Empty/thinking-only responses consume a long turn and fail as no progress</h3>
+    <div class="meta">Confidence: High for symptom; Medium for root cause · Owner boundary: MASC acceptance/fallback + provider outcome</div>
+    <p><code>keeper cycle FAILED ... no_usable_progress</code>가 193건이다. 최대 발생 Keeper는 <code>mad-improver</code> 106건, <code>idealist</code> 51건, <code>issue_king</code> 18건이다. 예시에는 empty response + <code>max_tokens</code>, thinking-only + <code>end_turn</code>, 208~732초 지연이 포함된다.</p>
+    <p>현재 accept guard와 degraded retry log는 존재하지만, 생산적인 tool/text 결과가 없다는 사실을 수백 초를 소비한 뒤에야 cycle 실패로 표면화한다. 이는 단순히 retry 횟수를 늘릴 문제가 아니다. OAS typed result, runtime slot phase, MASC lane receipt가 “진행 없음”을 독립적으로 관측하고, 장기 대기 lane을 다른 reactive 활동과 분리해야 한다.</p>
+  </section>
+
+  <section class="finding">
+    <h3>F-05 · P1 · Long-turn watchdog fires only after very long stalls</h3>
+    <div class="meta">Confidence: High for liveness incident · Root cause class: phase-boundary/continuation gap; exact remediation design pending</div>
+    <p>로그에 <code>stale_turn_timeout</code> 153개, <code>[long-turn]</code> 236개가 있다. 대표적으로 <code>garnet</code>은 <code>idle_turn(1808s)</code> 후 supervisor recovery를 받았고, <code>nick0cave</code>는 약 1,843,621ms, <code>base</code>는 약 636,105ms의 turn을 기록했다.</p>
+    <p>12:27 KST 재확인에서도 <code>garnet</code>이 <code>idle_turn(11003s)</code> stale timeout 뒤 <code>restart_count=5</code>로 dead가 되었고, <code>idealist</code>는 recovering 상태였다. 8개 Keeper는 healthy였으므로 전체 fleet stop은 아니지만, target 10 대비 effective reaction capacity 8로 낮아진 live 후속 상태다.</p>
+    <p>watchdog가 결국 lane을 회수하는 것은 안전장치이지 정상 동작이 아니다. 어떤 provider call, tool call, approval wait, stream read가 시간을 소비했는지 typed phase별로 보이고, 독립 lane이 한 stalled call 때문에 사용자 응답·connector ack를 잃지 않도록 cancellation과 continuation을 분리해야 한다.</p>
+    <p><strong>소스 경계 추적:</strong> MASC의 전체 provider/tool 시도에는 누적 wall-clock watchdog을 걸지 않고, OAS의 <code>stream_idle_timeout_s</code>는 stream line 간 정적만 감지한다. OAS Agent-level execution-idle timeout은 지원되지만 MASC Keeper 경로는 active tool 실행과 idle accounting을 분리했다는 증거가 없어 전달하지 않는다. Supervisor의 <code>Idle_turn</code>은 turn observation이 없는 no-turn 정지, <code>Mid_turn_no_progress</code>는 opt-in이며 deliverable progress가 없는 in-turn 상태이고 active tool count는 제외한다. 따라서 현재 증거는 하나의 잘못된 timeout 숫자보다 provider/thinking·tool·approval·continuation phase의 관측/분리 공백을 가리킨다. arbitrary turn/timeout cutoff은 추가하지 않는다.</p>
+  </section>
+
+  <section class="finding p2">
+    <h3>F-06 · P2 · Terminal task state keeps receiving impossible release requests</h3>
+    <div class="meta">Confidence: High for repeated workflow loop · Owner boundary: MASC task-tool feedback / Keeper behavior</div>
+    <p><code>Transition 'release' from status 'cancelled' is not allowed</code>가 320건이다. task FSM은 <a href="../../lib/workspace/workspace_task_classify.ml">workspace_task_classify.ml</a>에서 <code>Cancelled</code>를 terminal로 정의하고 valid actions를 빈 목록으로 돌려준다. 따라서 이 오류는 task FSM 자체가 cancelled를 release로 바꾼다는 증거가 아니라, 호출자가 terminal rejection을 받은 뒤 같은 행동을 반복한다는 증거다.</p>
+    <p>tool 결과를 일반 workflow rejection 문자열로만 반환하지 말고 terminal task state와 valid-next-actions를 typed result로 명시하여, Keeper가 다른 일을 하거나 operator에게 명확히 보고하도록 해야 한다. 문자열 기반 “몇 번 실패하면 중단” 휴리스틱은 추가하지 않는다.</p>
+    <p><strong>현재 worktree 수정:</strong> task FSM의 <code>recoverable=false</code>를 OAS tool boundary까지 보존하도록 nested workflow payload를 typed merge하고, terminal rejection에는 <code>self_correction_required=false</code>와 <code>workflow_rejection_terminal=true</code>를 반환한다. next-tool 정보가 있으면 그 다음 valid action을 안내하고, 같은 <code>masc_transition</code> 재시도 문구는 만들지 않는다. <code>test_tool_result</code> 25개와 <code>test_keeper_tool_dispatch_runtime</code> 36개가 통과했다. 이 수정은 live binary에 아직 반영되지 않았으므로 live 320건 감소를 주장하지 않는다.</p>
+  </section>
+
+  <h2>버그로 확정하지 않은 항목</h2>
+  <div class="note">
+    <ul>
+      <li><strong>verifier pending schedule:</strong> 현재 durable meta가 명시적으로 <code>operator_paused</code>이므로 queue replay 손실로 판정하지 않았다. 다만 autoboot enabled와 장시간 operator pause가 충돌하고, 사용자 스펙상 pause는 정말 망가진 경우에만 허용되어야 하므로 운영 정책을 정리해야 한다.</li>
+      <li><strong>deterministic retry/identical-tool guard:</strong> <code>idle_turns=3</code>, 동일 tool 반복 억제, 3회 실패 경고는 현재 무한루프를 제한하는 관측 가능한 안전장치다. 그 자체를 결함으로 세지 않았다.</li>
+      <li><strong>legacy sandbox_profile parse reports:</strong> Keeper chat의 과거 기록에는 오류가 있으나 현재 config parse error는 0이다. 현재 장애로 재분류하지 않았다.</li>
+      <li><strong>provider capacity/backpressure:</strong> 외부 capacity 오류는 관측되지만, 이를 MASC 내부 로직 결함으로 단정하지 않았다. 다만 해당 call이 다른 lane을 막지 않는지는 F-04/F-05와 함께 검증해야 한다.</li>
+    </ul>
+  </div>
+
+  <h2>개선 우선순위</h2>
+  <table>
+    <tr><th>순서</th><th>작업</th><th>완료 조건</th></tr>
+    <tr><td>1</td><td>MASC prompt segment type boundary</td><td>observation의 <code>keeper_turn_id</code>/<code>masc_oas_error</code> 원문 보존, instruction의 stale tool 검사는 유지, false-positive warning/strip 0, 회귀 테스트 통과</td></tr>
+    <tr><td>2</td><td>MASC HITL continuation redesign</td><td>승인 대기 continuation만 block; 같은 Keeper lane에서 busy ack와 무관한 reactive work가 진행; Keeper 전체 pause 없음</td></tr>
+    <tr><td>3</td><td>OAS typed stop outcome</td><td>새 provider terminal reason을 fatal string match 없이 보존; malformed protocol과 분리; MASC fallback receipt가 원인과 함께 관측됨</td></tr>
+    <tr><td>4</td><td>Long-turn phase receipts</td><td>provider/tool/approval/stream별 elapsed와 cancellation이 기록되고, 한 lane의 stall이 전체 fleet을 막지 않음</td></tr>
+    <tr><td>5</td><td>Terminal task rejection contract</td><td>cancelled task에 대한 release 재호출이 typed terminal result로 끝나고 Keeper가 다른 활동으로 이동</td></tr>
+  </table>
+
+  <h2>현재 remediation 상태</h2>
+  <div class="note">
+    <p><strong>F-01 1차 수정 완료 (worktree only):</strong> unified prompt 경로가 structured world-state user message를 더 이상 token scanner/registry strip에 넣지 않고, system/continuity instruction surfaces만 검사하도록 분리했다. <a href="../../lib/keeper/keeper_unified_prompt.ml">keeper_unified_prompt.ml</a>와 <a href="../../test/test_keeper_unified_verification_surface.ml">verification-surface regression test</a>에 변경이 있다.</p>
+    <p><strong>F-02 1차 수정 완료 (worktree only):</strong> <a href="../../lib/keeper/keeper_approval_queue.ml">keeper_approval_queue.ml</a>에 typed blocking/nonblocking queue boundary를 추가하고, <a href="../../lib/governance_pipeline.ml">governance_pipeline.ml</a>과 <a href="../../lib/keeper/keeper_agent_run.ml">keeper_agent_run.ml</a>의 일반 Keeper tool approval을 nonblocking 경로로 연결했다. 명시적 critical continuation gate의 blocking policy는 유지한다.</p>
+    <p><strong>F-03 1차 수정 완료 (OAS worktree only):</strong> <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/pipeline/pipeline.ml">OAS pipeline</a>이 provider가 새 terminal reason을 보고해도 fatal로 승격하지 않고 typed terminal result로 보존한다. tool block 없는 malformed tool-stop은 <code>UnmatchedToolCalls</code> constructor로 fail-closed 한다. <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/test/test_pipeline.ml">OAS pipeline regression tests</a>를 포함해 49/4/11/42 테스트가 성공했다.</p>
+    <p>검증: approval queue 12개, HITL approval 51개, supervisor 87개, unified verification surface 18개, prompt token integrity 15개, F-06 tool-result 25개, Keeper tool-dispatch runtime 36개 테스트가 성공했다. 이 로컬 narrow build의 compiler는 <code>ocamlc 5.5.0</code>였고, OCaml 5.4 공식 manual을 설계 기준으로 삼았으므로 5.4 CI proof는 별도다. Dune full build/CI는 아직 실행하지 않았다. 테스트 실행 시 packaged model catalog 경고가 있었지만 worktree-only test fixture의 catalog discovery 경고이며, 라이브 health의 startup config warning과는 별개다.</p>
+    <p>현재 live executable은 이 worktree 변경을 포함하지 않으므로 live warning 감소나 runtime 개선으로 해석하면 안 된다. 배포/재시작 및 CI green 전에는 remediation을 완료 상태로 주장하지 않는다.</p>
+  </div>
+
+  <h2>검증 근거</h2>
+  <pre>curl -fsS 'http://127.0.0.1:8935/health?full=1'
+rg 'keeper cycle FAILED.*no_usable_progress' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
+rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' /Users/dancer/me/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl</pre>
+  <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue 파일은 read-only evidence로만 확인했으며 삭제·ack 조작은 하지 않았다. 12:35 및 13:11 KST current recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
+
+  <footer>이 보고서는 MASC worktree <code>codex/live-log-audit-20260710</code>에서 작성되었다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>
+</main>
+</body>
+</html>

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -329,7 +329,7 @@ end
     on_resolution callback) and a unit test, but was never invoked
     anywhere in production code.  Result: any HITL approval enqueued
     by a keeper turn would block [keeper_cycle_decision] forever via
-    [has_pending_for_keeper → Skip Approval_pending].  Once the 300s
+    [has_blocking_pending_for_keeper → Skip Approval_pending].  Once the 300s
     stale watchdog fired, the supervisor would respawn the fiber, the
     same approval would still be in the queue, and the cycle would
     repeat indefinitely.  This fork makes the existing timeout policy

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -324,6 +324,34 @@ let forbidden_reject_reason ~risk ~runtime_blocked =
       "forbidden_reject_reason: expected Critical risk or runtime auto-approval blocker"
 ;;
 
+type hitl_approval_grant =
+  { approval_id : string
+  ; approved_action : Keeper_event_queue.hitl_approved_action
+  ; consumed : bool Atomic.t
+  }
+
+let hitl_approval_grant_of_resolution
+      (resolution : Keeper_event_queue.hitl_resolution)
+  =
+  match resolution.decision with
+  | Keeper_event_queue.Hitl_approved approved_action ->
+    Some
+      { approval_id = resolution.approval_id
+      ; approved_action
+      ; consumed = Atomic.make false
+      }
+  | Keeper_event_queue.Hitl_rejected | Keeper_event_queue.Hitl_edited -> None
+;;
+
+let consume_hitl_approval_grant grant ~keeper_name ~tool_name ~input =
+  Keeper_approval_queue.approved_action_matches_request
+    grant.approved_action
+    ~keeper_name
+    ~tool_name
+    ~input
+  && Atomic.compare_and_set grant.consumed false true
+;;
+
 (* Reject a hard-forbidden request outright, auditing the decision as a
    terminal event. Called before any HITL queue path so the request can
    never be approved by an operator or a remembered rule. *)
@@ -383,7 +411,8 @@ let to_oas_approval_callback
       ?meta
       ?clock
       ?continuation_channel
-      ?(nonblocking = false)
+      ?(lane_policy = Keeper_approval_queue.Blocking)
+      ?hitl_approval_grant
       ()
   : Agent_sdk.Hooks.approval_callback
   =
@@ -488,20 +517,41 @@ let to_oas_approval_callback
              | None -> false)
           | None -> false
         in
-        let rule_match =
-          Keeper_approval_queue.find_matching_rule
+        let consumed_approval_id =
+          match hitl_approval_grant with
+          | Some grant ->
+            if consume_hitl_approval_grant grant ~keeper_name ~tool_name ~input
+            then Some grant.approval_id
+            else None
+          | None -> None
+        in
+        match consumed_approval_id with
+        | Some approval_id ->
+          Keeper_approval_queue.audit_approval_event
             ~base_path
+            ~event_type:"approved_continuation_consumed"
+            ~id:approval_id
             ~keeper_name
             ~tool_name
-            ~input
             ~risk_level
-            ?sandbox_profile
-            ?backend
+            ?turn_id
+            ?task_id
+            ?goal_id
+            ~goal_ids
+            ?sandbox_target
             ?runtime_contract
-            ()
-        in
-        if (not auto_approval_forbidden) && always_approve
-        then (
+            ?selected_model
+            ~disposition:"Pass"
+            ~disposition_reason:"operator_approved_one_shot"
+            ~auto_approved:false
+            ();
+          Log.Governance.info
+            "one-shot HITL approval consumed keeper=%s tool=%s approval=%s"
+            keeper_name
+            tool_name
+            approval_id;
+          Agent_sdk.Hooks.Approve
+        | None when (not auto_approval_forbidden) && always_approve ->
           Keeper_approval_queue.audit_approval_event
             ~base_path
             ~event_type:"auto_approved_always"
@@ -520,9 +570,20 @@ let to_oas_approval_callback
             ~disposition_reason:"always_approve_enabled"
             ~auto_approved:true
             ();
-          Agent_sdk.Hooks.Approve)
-        else
-          match rule_match with
+          Agent_sdk.Hooks.Approve
+        | None ->
+          match
+            Keeper_approval_queue.find_matching_rule
+              ~base_path
+              ~keeper_name
+              ~tool_name
+              ~input
+              ~risk_level
+              ?sandbox_profile
+              ?backend
+              ?runtime_contract
+              ()
+          with
           | Some matched ->
             Keeper_approval_queue.audit_approval_event
               ~base_path
@@ -551,8 +612,8 @@ let to_oas_approval_callback
               let disposition_reason =
                 Operator_approval.approval_mode_queue_reason_to_string reason
               in
-              if nonblocking
-              then
+              match lane_policy with
+              | Keeper_approval_queue.Nonblocking ->
                 let approval_id =
                   Keeper_approval_queue.submit_pending
                     ~keeper_name
@@ -571,6 +632,7 @@ let to_oas_approval_callback
                     ~disposition:"Blocked"
                     ~disposition_reason
                     ?continuation_channel
+                    ~lane_policy
                     ~risk_level
                     ~on_resolution:(fun decision ->
                       Log.Governance.info
@@ -584,7 +646,7 @@ let to_oas_approval_callback
                   (Printf.sprintf
                      "HITL approval pending: id=%s; the Keeper will be woken after the operator decision; do not retry this tool call until then"
                      approval_id)
-              else
+              | Keeper_approval_queue.Blocking ->
                 Keeper_approval_queue.submit_and_await
                   ~keeper_name
                   ~tool_name

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -383,6 +383,7 @@ let to_oas_approval_callback
       ?meta
       ?clock
       ?continuation_channel
+      ?(nonblocking = false)
       ()
   : Agent_sdk.Hooks.approval_callback
   =
@@ -547,27 +548,63 @@ let to_oas_approval_callback
             let mode = Operator_approval.read_approval_mode_or_manual ~base_path in
             let band = approval_band_of_risk risk in
             let submit_for_operator reason =
-              Keeper_approval_queue.submit_and_await
-                ~keeper_name
-                ~tool_name
-                ~input
-                ~base_path
-                ?turn_id
-                ?task_id
-                ?goal_id
-                ~goal_ids
-                ?sandbox_target
-                ?sandbox_profile
-                ?backend
-                ?runtime_contract
-                ?selected_model
-                ~disposition:"Blocked"
-                ~disposition_reason:
-                  (Operator_approval.approval_mode_queue_reason_to_string reason)
-                ~risk_level
-                ?clock
-                ?continuation_channel
-                ()
+              let disposition_reason =
+                Operator_approval.approval_mode_queue_reason_to_string reason
+              in
+              if nonblocking
+              then
+                let approval_id =
+                  Keeper_approval_queue.submit_pending
+                    ~keeper_name
+                    ~tool_name
+                    ~input
+                    ~base_path
+                    ?turn_id
+                    ?task_id
+                    ?goal_id
+                    ~goal_ids
+                    ?sandbox_target
+                    ?sandbox_profile
+                    ?backend
+                    ?runtime_contract
+                    ?selected_model
+                    ~disposition:"Blocked"
+                    ~disposition_reason
+                    ?continuation_channel
+                    ~risk_level
+                    ~on_resolution:(fun decision ->
+                      Log.Governance.info
+                        "nonblocking HITL approval resolved keeper=%s tool=%s decision=%s"
+                        keeper_name
+                        tool_name
+                        (Keeper_approval_queue.approval_decision_to_string decision))
+                    ()
+                in
+                Agent_sdk.Hooks.Reject
+                  (Printf.sprintf
+                     "HITL approval pending: id=%s; the Keeper will be woken after the operator decision; do not retry this tool call until then"
+                     approval_id)
+              else
+                Keeper_approval_queue.submit_and_await
+                  ~keeper_name
+                  ~tool_name
+                  ~input
+                  ~base_path
+                  ?turn_id
+                  ?task_id
+                  ?goal_id
+                  ~goal_ids
+                  ?sandbox_target
+                  ?sandbox_profile
+                  ?backend
+                  ?runtime_contract
+                  ?selected_model
+                  ~disposition:"Blocked"
+                  ~disposition_reason
+                  ~risk_level
+                  ?clock
+                  ?continuation_channel
+                  ()
             in
             (match Operator_approval.decide_approval_mode ~mode ~band with
              | Operator_approval.Auto_approved { mode; band } ->

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -137,6 +137,16 @@ val combinatorial_risk_escalation :
 (** If trifecta is active and the tool is a state_modification tool,
     escalate risk to at least High. Otherwise return base_risk unchanged. *)
 
+type hitl_approval_grant
+(** Cycle-scoped, one-shot authorization derived from a durable
+    [Hitl_resolved] wake. The type is abstract so callers cannot reset or forge
+    its consumed state. *)
+
+val hitl_approval_grant_of_resolution :
+  Keeper_event_queue.hitl_resolution -> hitl_approval_grant option
+(** Return a fresh one-shot grant for an approved resolution. Rejected and
+    edited resolutions do not authorize a tool call. *)
+
 val to_oas_approval_callback :
   config:Workspace.config ->
   governance_level:string ->
@@ -144,7 +154,8 @@ val to_oas_approval_callback :
   ?meta:Keeper_meta_contract.keeper_meta ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
-  ?nonblocking:bool ->
+  ?lane_policy:Keeper_approval_queue.lane_policy ->
+  ?hitl_approval_grant:hitl_approval_grant ->
   unit ->
   Agent_sdk.Hooks.approval_callback
 (** Build an OAS approval callback with HITL approval handling.
@@ -152,13 +163,18 @@ val to_oas_approval_callback :
     Pre-computes trifecta status from the keeper's active shard tool set.
     When trifecta is active, state-modifying tools get risk escalation.
 
-    When [nonblocking] is [false] (the compatibility default), a tool that
+    With [lane_policy = Blocking] (the compatibility default), a tool that
     exceeds the governance threshold suspends via
-    [Keeper_approval_queue.submit_and_await]. When [nonblocking] is [true],
-    the approval is registered with [submit_pending], the callback returns a
+    [Keeper_approval_queue.submit_and_await]. With [Nonblocking], the approval
+    is registered with [submit_pending], the callback returns a
     typed-in-protocol rejection, and the resolution wake starts a later
-    independent Keeper cycle. Production Keeper runs use [true] so ordinary
-    tool approval cannot monopolize the Keeper lane.
+    independent Keeper cycle. Production Keeper runs use [Nonblocking] so
+    ordinary tool approval cannot monopolize the Keeper lane.
+
+    [hitl_approval_grant] authorizes only the exact keeper/tool/full-input
+    fingerprint approved by the operator, and is atomically consumed once.
+    It is scoped by the caller to the independent cycle opened by that wake;
+    there is no persisted blanket rule or time-based grant.
 
     Tools below the threshold are auto-approved unless auto-approval is
     explicitly forbidden. Critical risk and runtime safety blockers still enter

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -144,17 +144,21 @@ val to_oas_approval_callback :
   ?meta:Keeper_meta_contract.keeper_meta ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?nonblocking:bool ->
   unit ->
   Agent_sdk.Hooks.approval_callback
-(** Build an OAS approval callback with genuine HITL fiber suspension.
+(** Build an OAS approval callback with HITL approval handling.
 
     Pre-computes trifecta status from the keeper's active shard tool set.
     When trifecta is active, state-modifying tools get risk escalation.
 
-    When a tool exceeds the governance threshold, the agent fiber
-    suspends via [Keeper_approval_queue.submit_and_await]. An operator
-    resolves the approval via the dashboard approval HTTP handler
-    ([server_dashboard_http.ml]), resuming the fiber.
+    When [nonblocking] is [false] (the compatibility default), a tool that
+    exceeds the governance threshold suspends via
+    [Keeper_approval_queue.submit_and_await]. When [nonblocking] is [true],
+    the approval is registered with [submit_pending], the callback returns a
+    typed-in-protocol rejection, and the resolution wake starts a later
+    independent Keeper cycle. Production Keeper runs use [true] so ordinary
+    tool approval cannot monopolize the Keeper lane.
 
     Tools below the threshold are auto-approved unless auto-approval is
     explicitly forbidden. Critical risk and runtime safety blockers still enter

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -785,6 +785,7 @@ let run_turn
                          ~meta
                          ?clock:(Eio_context.get_clock_opt ())
                          ?continuation_channel
+                         ~nonblocking:true
                          ())
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
                       (* Mutation-boundary is native to OAS now; [exit_condition]

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -230,6 +230,7 @@ let run_turn
       ?trace_link
       ?continuation_channel
       ?hitl_delivery_channel
+      ?hitl_approval_grant
       ?yield_to_chat_waiting
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
@@ -785,7 +786,8 @@ let run_turn
                          ~meta
                          ?clock:(Eio_context.get_clock_opt ())
                          ?continuation_channel
-                         ~nonblocking:true
+                         ~lane_policy:Keeper_approval_queue.Nonblocking
+                         ?hitl_approval_grant
                          ())
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
                       (* Mutation-boundary is native to OAS now; [exit_condition]

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -157,6 +157,7 @@ val run_turn
   -> ?trace_link:string * string
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?hitl_delivery_channel:Keeper_continuation_channel.t
+  -> ?hitl_approval_grant:Governance_pipeline.hitl_approval_grant
   -> ?yield_to_chat_waiting:(unit -> bool)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
           (the same guard point as [max_idle_turns], before the next model

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -495,6 +495,7 @@ let create_entry
             closed" (#23716). #23845 reworded it in passing (main red #23901,
             family B). *)
          Keeper_continuation_channel.unrouted "no originating connector")
+      ~lane_policy
       ~audit_base_path
       ~resolver
       ~on_resolution
@@ -531,6 +532,7 @@ let create_entry
   ; disposition
   ; disposition_reason
   ; phase = Awaiting_operator
+  ; lane_policy
   ; continuation_channel
   ; audit_base_path
   ; resolver
@@ -577,6 +579,7 @@ let pending_entry_json_fields
   ; "sandbox_target", `String entry.sandbox_target
   ; "risk_level", `String (risk_level_to_string entry.risk_level)
   ; "phase", `String (pending_phase_to_string entry.phase)
+  ; "lane_policy", `String (lane_policy_to_string entry.lane_policy)
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -652,11 +655,12 @@ let broadcast_pending entry =
 
 let record_pending (entry : pending_approval) =
   Log.Keeper.info
-    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s risk=%s"
+    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s risk=%s lane_policy=%s"
     entry.id
     entry.keeper_name
     entry.tool_name
-    (risk_level_to_string entry.risk_level);
+    (risk_level_to_string entry.risk_level)
+    (lane_policy_to_string entry.lane_policy);
   audit_approval_event
     ~base_path:entry.audit_base_path
     ~event_type:approval_audit_pending_event
@@ -829,20 +833,19 @@ let spawn_hitl_summary_worker_on_root_switch ~(entry : pending_approval) =
        record_summary_failure ~id:entry.id ~reason ~retryable:false)
 ;;
 
-(* Wake the keeper that was waiting on this approval. A keeper that enqueued an
-   approval and is now skipping cycles via [has_pending_for_keeper -> Skip
-   Approval_pending] (keeper_world_observation) has no in-process fiber blocked
-   on the resolver promise, so resolving the promise does not resume it. The
-   composition root registers a hook that enqueues a [Hitl_resolved] wake
+(* Wake an independent-cycle Keeper after its approval resolves. A
+   [Nonblocking] approval does not own a suspended fiber or a lifecycle pause,
+   so the composition root registers a hook that enqueues a [Hitl_resolved]
    stimulus — the same async-completion-wake mechanism [Fusion_completed]
    (RFC-0266) and [Bg_completed] (RFC-0290) use — so the keeper re-evaluates
-   immediately instead of stalling until an unrelated stimulus, no-progress
-   recovery, or the 30-minute approval janitor.
+   immediately instead of waiting for an unrelated stimulus, no-progress
+   recovery, or the 30-minute approval janitor. [Blocking] entries resume their
+   own resolver or lifecycle callback and do not call this hook.
 
    Injected as a hook rather than a direct call to break a dependency cycle:
    this module sits below [Keeper_keepalive_signal], which depends on
    [Keeper_world_observation], which depends back on this module for
-   [has_pending_for_keeper]. The default is a no-op so unit tests and
+   [has_blocking_pending_for_keeper]. The default is a no-op so unit tests and
    pre-bootstrap contexts stay wake-free; [Server_bootstrap] installs the real
    [Keeper_keepalive_signal]-backed wake. *)
 let approval_resolution_wake_hook :
@@ -928,14 +931,12 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
            (Printexc.to_string exn))
        (fun () -> f decision)
    | None -> ());
-  (* Blocking approvals (live resolver) resume through the promise above;
-     firing the wake too would double-stimulate the keeper. Only non-blocking
-     approvals (no suspended fiber) need the [Hitl_resolved] wake. #23681
-     collaterally dropped this guard while rewiring channel provenance
-     (main red #23901, family B). *)
-  (match entry.resolver with
-   | Some _ -> ()
-   | None ->
+  (* [Blocking] entries own their continuation: [submit_and_await] resumes its
+     resolver, while lifecycle callbacks resume their paused keeper explicitly.
+     Only [Nonblocking] entries need the durable resolution stimulus. *)
+  (match entry.lane_policy with
+   | Blocking -> ()
+   | Nonblocking ->
      wake_keeper_on_approval_resolution
        ~base_path
        ~keeper_name:entry.keeper_name
@@ -978,12 +979,14 @@ let pending_entry_matches
       ~task_id
       ~goal_id
       ~sandbox_target
+      ~lane_policy
   =
   String.equal entry.keeper_name keeper_name
   && String.equal entry.tool_name tool_name
   && String.equal entry.action_key action_key
   && String.equal entry.input_hash input_hash
   && String.equal entry.sandbox_target sandbox_target
+  && entry.lane_policy = lane_policy
   && entry.task_id = task_id
   && entry.goal_id = goal_id
 ;;
@@ -997,6 +1000,7 @@ let find_pending_id_in_map
       ~task_id
       ~goal_id
       ~sandbox_target
+      ~lane_policy
   =
   SMap.fold
     (fun id (entry : pending_approval) acc ->
@@ -1013,6 +1017,7 @@ let find_pending_id_in_map
              ~task_id
              ~goal_id
              ~sandbox_target
+             ~lane_policy
          then Some id
          else None)
     map
@@ -1087,6 +1092,7 @@ let submit_and_await
       ?disposition
       ?disposition_reason
       ?continuation_channel
+      ~lane_policy:Blocking
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
       ~on_resolution:None
@@ -1218,6 +1224,7 @@ let submit_pending
       ?disposition
       ?disposition_reason
       ?continuation_channel
+      ?(lane_policy = Nonblocking)
       ~on_resolution
       ()
   : string
@@ -1241,6 +1248,7 @@ let submit_pending
         ~task_id
         ~goal_id
         ~sandbox_target
+        ~lane_policy
     with
     | Some id -> id
     | None ->
@@ -1260,14 +1268,15 @@ let submit_pending
           ?sandbox_profile
           ?backend
           ?runtime_contract
-      ?selected_model
-      ?disposition
-      ?disposition_reason
-      ?continuation_channel
-      ~audit_base_path:base_path
-      ~resolver:None
-      ~on_resolution:(Some on_resolution)
-      ()
+          ?selected_model
+          ?disposition
+          ?disposition_reason
+          ?continuation_channel
+          ~lane_policy
+          ~audit_base_path:base_path
+          ~resolver:None
+          ~on_resolution:(Some on_resolution)
+          ()
       in
       let updated = SMap.add id entry map in
       if Atomic.compare_and_set pending map updated
@@ -1446,6 +1455,25 @@ let pending_count_for_keeper ~keeper_name : int =
     0
 ;;
 
+(* [lane_policy] is explicit because a non-suspending callback can still own a
+   lifecycle continuation (for example, a persisted partial-commit gate).
+   Keep that distinction typed at the queue boundary instead of inferring lane
+   ownership from a resolver or from tool names. *)
+let blocking_pending_count_for_keeper ~keeper_name : int =
+  SMap.fold
+    (fun _ (entry : pending_approval) count ->
+       if String.equal entry.keeper_name keeper_name
+          && entry.lane_policy = Blocking
+       then count + 1
+       else count)
+    (Atomic.get pending)
+    0
+;;
+
+let has_blocking_pending_for_keeper ~keeper_name : bool =
+  blocking_pending_count_for_keeper ~keeper_name > 0
+;;
+
 let has_pending_for_keeper ~keeper_name : bool =
   SMap.fold
     (fun _ (entry : pending_approval) acc ->
@@ -1527,14 +1555,13 @@ let expire_stale ~max_wait_s =
          ?disposition_reason:entry.disposition_reason
          ~decision:(Approval_expired reason)
          ();
-       (* Expiry clears the [Approval_pending] skip just like a resolution.
-          Blocking entries resume via the resolver promise below; only
-          non-blocking entries (no suspended fiber) need the wake, or the
-          keeper stays stalled until an unrelated stimulus. #23681 dropped
-          this resolver guard (main red #23901, family B). *)
-       (match entry.resolver with
-        | Some _ -> ()
-        | None ->
+       (* Expiry clears the [Approval_pending] skip for [Nonblocking] entries,
+          so those keepers need the same wake or they stay stalled until an
+          unrelated stimulus. A [Blocking] resolver/callback receives
+          [Reject reason] through its own continuation. *)
+       (match entry.lane_policy with
+        | Blocking -> ()
+        | Nonblocking ->
           wake_keeper_on_approval_resolution
             ~base_path:entry.audit_base_path
             ~keeper_name:entry.keeper_name

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -413,8 +413,30 @@ let list_recent_resolved_json ~base_path ?(n = recent_resolved_history_limit) ()
 
 let generate_id () = make_generated_id "appr"
 
+let rec canonical_exact_input = function
+  | `Assoc fields ->
+    fields
+    |> List.map (fun (key, value) -> key, canonical_exact_input value)
+    |> List.stable_sort (fun (left, _) (right, _) -> String.compare left right)
+    |> fun normalized -> `Assoc normalized
+  | `List items -> `List (List.map canonical_exact_input items)
+  | other -> other
+;;
+
 let normalized_input_hash (input : Yojson.Safe.t) =
-  Digestif.SHA256.(digest_string (Yojson.Safe.to_string input) |> to_hex)
+  let canonical = canonical_exact_input input |> Yojson.Safe.to_string in
+  Digestif.SHA256.(digest_string canonical |> to_hex)
+;;
+
+let approved_action_matches_request
+      (approved : Keeper_event_queue.hitl_approved_action)
+      ~keeper_name
+      ~tool_name
+      ~input
+  =
+  String.equal approved.keeper_name keeper_name
+  && String.equal approved.tool_name tool_name
+  && String.equal approved.input_hash (normalized_input_hash input)
 ;;
 
 let first_cmd_token (cmd : string) =
@@ -879,8 +901,15 @@ let wake_keeper_on_approval_resolution
       (Printexc.to_string exn)
 ;;
 
-let hitl_resolution_decision_of_approval_decision = function
-  | Agent_sdk.Hooks.Approve -> Keeper_event_queue.Hitl_approved
+let hitl_resolution_decision_of_approval_decision
+      (entry : pending_approval)
+  = function
+  | Agent_sdk.Hooks.Approve ->
+    Keeper_event_queue.Hitl_approved
+      { keeper_name = entry.keeper_name
+      ; tool_name = entry.tool_name
+      ; input_hash = entry.input_hash
+      }
   | Agent_sdk.Hooks.Reject _ -> Keeper_event_queue.Hitl_rejected
   | Agent_sdk.Hooks.Edit _ -> Keeper_event_queue.Hitl_edited
 ;;
@@ -941,7 +970,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
        ~base_path
        ~keeper_name:entry.keeper_name
        ~approval_id:entry.id
-       ~decision:(hitl_resolution_decision_of_approval_decision decision)
+       ~decision:(hitl_resolution_decision_of_approval_decision entry decision)
        ~channel:entry.channel);
   try
     Sse.broadcast

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -140,6 +140,17 @@ val approval_audit_decision_to_string : approval_audit_decision -> string
 val hitl_context_summary_to_yojson : hitl_context_summary -> Yojson.Safe.t
 val summary_status_to_yojson : summary_status -> Yojson.Safe.t
 
+val approved_action_matches_request :
+  Keeper_event_queue.hitl_approved_action ->
+  keeper_name:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  bool
+(** Exact structural match for a one-cycle operator approval. Object field
+    order is canonicalized, but no request field is removed or interpreted.
+    This intentionally differs from remembered-rule matching, which has a
+    broader persisted-policy contract. *)
+
 (** {1 Rule store (persisted)} *)
 
 (** List every persisted rule for the given [base_path]. *)

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -44,6 +44,10 @@ type pending_phase =
   | Awaiting_operator
   | Escalated
 
+type lane_policy =
+  | Nonblocking
+  | Blocking
+
 (** [Agent_sdk.Hooks.approval_decision] alias used as the resolver type. *)
 type decision = Agent_sdk.Hooks.approval_decision
 
@@ -54,8 +58,8 @@ type approval_audit_decision =
 type approval_audit_disposition =
   | Approval_escalated of string
 
-(** Pending approval entry — the suspended-fiber side of the
-    Eio.Promise rendez-vous. *)
+(** Pending approval entry. [lane_policy] records whether this approval owns
+    the Keeper lane independently of whether it has an Eio promise resolver. *)
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -78,6 +82,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; lane_policy : lane_policy
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
@@ -129,6 +134,7 @@ val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
 val pending_phase_to_string : pending_phase -> string
 val pending_phase_of_string : string -> pending_phase option
+val lane_policy_to_string : lane_policy -> string
 val approval_decision_to_string : decision -> string
 val approval_audit_decision_to_string : approval_audit_decision -> string
 val hitl_context_summary_to_yojson : hitl_context_summary -> Yojson.Safe.t
@@ -290,8 +296,10 @@ val submit_and_await :
 
 (** Submit a tool call for approval without suspending the caller —
     the supplied [on_resolution] callback is invoked when the
-    operator resolves. Returns the new pending entry's id, or the
-    existing id when an equivalent entry is already pending. *)
+    operator resolves. [lane_policy] defaults to [Nonblocking]; lifecycle
+    gates that deliberately pause a keeper must pass [Blocking] and resume
+    that pause from their callback. Returns the new pending entry's id, or
+    the existing id when an equivalent entry with the same policy is pending. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->
@@ -310,6 +318,7 @@ val submit_pending :
   ?disposition:string ->
   ?disposition_reason:string ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?lane_policy:lane_policy ->
   on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
   unit ->
   string
@@ -321,8 +330,9 @@ val submit_pending :
     [Keeper_keepalive_signal] call) to break a dependency cycle: this module
     sits below [Keeper_keepalive_signal], which depends on
     [Keeper_world_observation], which depends back here for
-    [has_pending_for_keeper]. The default is a no-op; [Server_bootstrap]
-    installs the [Hitl_resolved]-stimulus wake. *)
+    [has_blocking_pending_for_keeper]. The default is a no-op;
+    [Server_bootstrap] installs the [Hitl_resolved]-stimulus wake for
+    nonblocking entries. *)
 val set_approval_resolution_wake_hook :
   (base_path:string ->
    keeper_name:string ->
@@ -370,6 +380,12 @@ val update_pending_entry : id:string -> (pending_approval -> pending_approval) -
 
 val pending_count : unit -> int
 val pending_count_for_keeper : keeper_name:string -> int
+val blocking_pending_count_for_keeper : keeper_name:string -> int
+(** Number of pending approvals with [Blocking] lane policy. *)
+
+val has_blocking_pending_for_keeper : keeper_name:string -> bool
+(** Whether a [Blocking] approval currently owns a live Keeper lane. *)
+
 val has_pending_for_keeper : keeper_name:string -> bool
 
 (** {1 Timeout cleanup} *)

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -23,8 +23,11 @@
 
     Action mapping (TLA+ -> OCaml):
       Submit                 [submit_and_await] / [submit_pending]
-                             record a new pending entry and suspend
-                             the fiber on [Eio.Promise.await].
+                             record a new pending entry. [submit_and_await]
+                             suspends the caller on [Eio.Promise.await];
+                             [submit_pending] invokes its callback later and
+                             defaults to an independent Keeper cycle unless
+                             an explicit lifecycle [Blocking] policy is used.
       Resolve                operator approves/rejects via the HTTP
                              handler in [server_dashboard_http.ml],
                              which calls [resolve] on the queue and

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1003,7 +1003,8 @@ let run_heartbeat_loop
           | Keeper_pressure_admission.Blocked _ -> false
         in
         let approval_pending =
-          Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta_current.name
+          Keeper_approval_queue.has_blocking_pending_for_keeper
+            ~keeper_name:meta_current.name
         in
         let keeper_health_blocker =
           if Health.is_healthy ~agent_name:meta_current.name then None else Some "unhealthy"

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -495,24 +495,23 @@ let run_keepalive_unified_turn
             ~keeper_name:meta_after_triage.name
             !consumed_stimuli;
           let event_bus = Keeper_event_bus.get () in
-          (* RFC-0320 W3c: if this cycle was opened by a Hitl_resolved wake,
-             carry that wake's captured originating channel into the turn so the
-             reply is deterministically delivered back to the conversation the
-             approval was requested from. First routable resolution wins; other
-             lanes leave this [None] (fail-closed: no delivery). *)
-          let hitl_delivery_channel =
+          (* A [Hitl_resolved] wake is the SSOT for both continuation delivery
+             and an optional exact-action grant. The unified turn derives those
+             two cycle-scoped views from this single typed resolution. First
+             consumed resolution wins; other lanes leave this [None]. *)
+          let hitl_resolution =
             List.find_map
               (fun (stim : Keeper_event_queue.stimulus) ->
                 match stim.Keeper_event_queue.payload with
                 | Keeper_event_queue.Hitl_resolved resolution ->
-                  Some resolution.Keeper_event_queue.channel
+                  Some resolution
                 | _ -> None)
               !consumed_stimuli
           in
           let meta_after_cycle =
             run_keeper_cycle
               ?event_bus
-              ?hitl_delivery_channel
+              ?hitl_resolution
               ~ctx
               ~meta_after_triage
               ~stop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -45,7 +45,7 @@ module Observations = Keeper_heartbeat_loop_observations
    must not interleave with this lane's meta writes (RFC-0225 §1). *)
 let run_keeper_cycle_admitted
       ?event_bus
-      ?hitl_delivery_channel
+      ?hitl_resolution
       ~ctx
       ~meta_after_triage
       ~stop
@@ -62,7 +62,7 @@ let run_keeper_cycle_admitted
         ~observation:obs
         ~generation:meta_after_triage.runtime.generation
         ~channel:turn_decision.channel
-        ?hitl_delivery_channel
+        ?hitl_resolution
         (* RFC-0315: pass the whole decision, not just its channel — the
            prompt renders the verdict reasons so the turn knows why it woke. *)
         ~turn_decision
@@ -134,7 +134,7 @@ let run_keeper_cycle_admitted
 
 let run_keeper_cycle
       ?event_bus
-      ?hitl_delivery_channel
+      ?hitl_resolution
       ~ctx
       ~meta_after_triage
       ~stop
@@ -155,7 +155,7 @@ let run_keeper_cycle
          ~turn_decision
          ~shared_context
          ?event_bus
-         ?hitl_delivery_channel)
+         ?hitl_resolution)
   with
   | `Ran updated -> updated
   | `Busy in_flight ->

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -2,7 +2,7 @@
 
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t
-  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
+  -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> ctx:_ Keeper_types_profile.context
   -> meta_after_triage:Keeper_meta_contract.keeper_meta
   -> stop:bool Atomic.t

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -287,12 +287,10 @@ let consume_single_heartbeat_stimulus
       meta_after_triage.name;
     pending_events
   | Keeper_event_queue.Hitl_resolved r ->
-    (* The HITL approval this keeper was skipping on ([Skip Approval_pending])
-       was resolved. The wake is the whole point: the approval has left the
-       queue, so this cycle no longer skips and the keeper resumes on its own
-       state. There is no observation to inject — the decision reached the
-       keeper's suspended tool call (or the reject/expire teardown) through the
-       resolver, not turn input; injecting a pending event would fabricate one. *)
+    (* The approval has left the queue, so this cycle no longer skips. There is
+       no observation to fabricate: the typed resolution itself is threaded as
+       cycle context. An approved exact-action grant is consumed at governance;
+       reject/edit wakes carry no grant. *)
     Log.Keeper.info
       "turn entry: hitl resolution delivered approval=%s decision=%s (keeper=%s)"
       r.approval_id

--- a/lib/keeper/keeper_prompt_token_integrity.ml
+++ b/lib/keeper/keeper_prompt_token_integrity.ml
@@ -166,6 +166,18 @@ let scan_rendered_prompt
   in
   system_unknowns @ user_unknowns @ continuity_unknowns |> dedup_strings
 
+let scan_instruction_surfaces
+      ~keeper_name
+      ~system_prompt
+      ~continuity_summary =
+  let system_unknowns =
+    scan_text ~keeper_name ~source:System_prompt system_prompt
+  in
+  let continuity_unknowns =
+    scan_text ~keeper_name ~source:Continuity continuity_summary
+  in
+  system_unknowns @ continuity_unknowns |> dedup_strings
+
 (* ── Registry-driven sanitization ─────────────────────────────────── *)
 
 let stale_tool_token_placeholder = "<stale_tool_token>"

--- a/lib/keeper/keeper_prompt_token_integrity.ml
+++ b/lib/keeper/keeper_prompt_token_integrity.ml
@@ -10,7 +10,6 @@
 
 type source =
   | System_prompt
-  | User_message
   | Continuity
 
 type token_kind =
@@ -19,7 +18,6 @@ type token_kind =
 
 let source_to_string = function
   | System_prompt -> "system_prompt"
-  | User_message -> "user_message"
   | Continuity -> "continuity"
 
 let kind_to_string = function
@@ -153,18 +151,6 @@ let scan_text ~keeper_name ~source text : string list =
   |> dedup_tokens
   |> List.filter_map (verify_token ~keeper_name ~source)
   |> dedup_strings
-
-let scan_rendered_prompt
-      ~keeper_name
-      ~system_prompt
-      ~user_message
-      ~continuity_summary =
-  let system_unknowns = scan_text ~keeper_name ~source:System_prompt system_prompt in
-  let user_unknowns = scan_text ~keeper_name ~source:User_message user_message in
-  let continuity_unknowns =
-    scan_text ~keeper_name ~source:Continuity continuity_summary
-  in
-  system_unknowns @ user_unknowns @ continuity_unknowns |> dedup_strings
 
 let scan_instruction_surfaces
       ~keeper_name

--- a/lib/keeper/keeper_prompt_token_integrity.mli
+++ b/lib/keeper/keeper_prompt_token_integrity.mli
@@ -29,6 +29,22 @@ val scan_rendered_prompt :
   user_message:string ->
   continuity_summary:string ->
   string list
+(** [scan_rendered_prompt] is the generic all-text scanner used for explicit
+    caller-supplied text. It must not be used for a structured world-state
+    observation, because observation values are data rather than tool
+    instructions. Use {!scan_instruction_surfaces} from the unified prompt
+    builder. *)
+
+(** Scan only prompt surfaces that are owned by the instruction/memory
+    producer. The unified prompt's structured world-state user message is
+    intentionally absent: board/task/connector observations must remain
+    immutable even when a field happens to contain a [keeper_*] or [masc_*]
+    diagnostic name. *)
+val scan_instruction_surfaces :
+  keeper_name:string ->
+  system_prompt:string ->
+  continuity_summary:string ->
+  string list
 
 (** Sanitize keeper_*/masc_* tokens that do not resolve to a live tool via
     [Keeper_tool_resolution]. Registry-driven presentation-layer band-aid for

--- a/lib/keeper/keeper_prompt_token_integrity.mli
+++ b/lib/keeper/keeper_prompt_token_integrity.mli
@@ -1,6 +1,6 @@
-(** Keeper_prompt_token_integrity — scan rendered prompts and continuity
-    summaries for keeper_*/masc_* tokens and verify each one resolves through
-    the policy tool-name chain.
+(** Keeper_prompt_token_integrity — scan instruction-owned system prompts and
+    continuity summaries for keeper_*/masc_* tokens and verify each one
+    resolves through the policy tool-name chain.
 
     P0-3: Rendered Prompt Token Scanner. Emits the
     [masc_keeper_prompt_unknown_tool_tokens_total] CI metric for every token
@@ -9,7 +9,6 @@
 (** Which prompt/continuity surface a token came from. *)
 type source =
   | System_prompt
-  | User_message
   | Continuity
 
 val source_to_string : source -> string
@@ -19,21 +18,6 @@ val source_to_string : source -> string
     is logged. Returns the deduplicated list of unknown token names in the
     order they were first seen. *)
 val scan_text : keeper_name:string -> source:source -> string -> string list
-
-(** Scan the rendered system prompt, user message, and raw continuity summary.
-    Returns the deduplicated list of unknown token names across all three
-    surfaces. *)
-val scan_rendered_prompt :
-  keeper_name:string ->
-  system_prompt:string ->
-  user_message:string ->
-  continuity_summary:string ->
-  string list
-(** [scan_rendered_prompt] is the generic all-text scanner used for explicit
-    caller-supplied text. It must not be used for a structured world-state
-    observation, because observation values are data rather than tool
-    instructions. Use {!scan_instruction_surfaces} from the unified prompt
-    builder. *)
 
 (** Scan only prompt surfaces that are owned by the instruction/memory
     producer. The unified prompt's structured world-state user message is

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -219,10 +219,28 @@ let release_dead_keeper_owned_tasks (ctx : _ context) (entry : Keeper_registry.r
           err)
 ;;
 
-let pending_hitl_approval_keeper_names config =
+let pending_hitl_approval_counts config =
+  let pending_entries = Keeper_approval_queue.list_pending_entries () in
   keeper_names config
-  |> List.filter (fun name ->
-       Keeper_approval_queue.has_pending_for_keeper ~keeper_name:name)
+  |> List.filter_map (fun name ->
+       let blocking_count, nonblocking_count =
+         List.fold_left
+           (fun (blocking_count, nonblocking_count) (entry : Keeper_approval_queue.pending_approval) ->
+              if String.equal entry.keeper_name name
+              then
+                (match entry.lane_policy with
+                 | Keeper_approval_queue.Blocking -> blocking_count + 1, nonblocking_count
+                 | Keeper_approval_queue.Nonblocking -> blocking_count, nonblocking_count + 1)
+              else blocking_count, nonblocking_count)
+           (0, 0)
+           pending_entries
+       in
+       if blocking_count = 0 && nonblocking_count = 0
+       then None
+       else Some (name, blocking_count, nonblocking_count))
+
+let pending_hitl_approval_keeper_names config =
+  pending_hitl_approval_counts config |> List.map (fun (name, _, _) -> name)
 ;;
 
 let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _ context)
@@ -233,23 +251,25 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
   in
   let dead_ttl_sec = Runtime_params.get Governance_registry.keeper_dead_ttl_sec in
   let base_path = ctx.config.base_path in
-  (* HITL visibility: a keeper blocked on a pending approval surfaces to the
-     operator only as a silent chat stall — [keeper_cycle_decision] returns
-     [blocked Approval_pending] and the keeper emits no further
-     chat/observation until the operator resolves the approval (or
-     [approval_janitor] expires it at the 30m mark). Name the keeper and
-     pending approval count on every sweep so the terminal log and downstream
-     consumers can see *why* the chat is awaiting a response. *)
-  pending_hitl_approval_keeper_names ctx.config
-  |> List.iter (fun name ->
-       let pending_count =
-         Keeper_approval_queue.pending_count_for_keeper ~keeper_name:name
-       in
-       Log.Keeper.warn
-         "keeper:%s blocked on %d pending HITL approval(s); chat awaits operator \
-          decision"
-         name
-         pending_count);
+  (* HITL visibility: distinguish a typed blocking continuation from an
+     independent-cycle callback. Only the former prevents a Keeper cycle; the
+     latter must remain observable without falsely reporting a chat stall. *)
+  pending_hitl_approval_counts ctx.config
+  |> List.iter (fun (name, blocking_count, nonblocking_count) ->
+       if blocking_count > 0
+       then
+         Log.Keeper.warn
+           "keeper:%s blocked on %d blocking HITL approval(s); %d nonblocking \
+            approval(s) also pending; chat awaits operator decision"
+           name
+           blocking_count
+           nonblocking_count
+       else
+         Log.Keeper.info
+           "keeper:%s has %d nonblocking HITL approval(s); chat lane remains \
+            available"
+           name
+           nonblocking_count);
   (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
      This prevents reconcile from re-launching keepers that sweep is about
      to process (defense-in-depth alongside is_registered check). *)
@@ -827,7 +847,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
     (match read_meta ctx.config name with
      | Ok (Some meta)
        when paused_meta_requires_reconcile_recovery meta
-            && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
+            && not
+                 (Keeper_approval_queue.has_blocking_pending_for_keeper
+                    ~keeper_name:meta.name)
        -> restore_reconcile_continue_gate ctx meta
      | Ok (Some _)
      | Ok None
@@ -845,7 +867,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
       | Ok (Some meta)
         when is_stale_paused_meta ~now ~paused_ttl_sec meta
              && (not (paused_meta_requires_reconcile_recovery meta))
-             && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
+             && not
+                  (Keeper_approval_queue.has_blocking_pending_for_keeper
+                     ~keeper_name:meta.name)
         ->
         let path = Keeper_types_profile.keeper_meta_path ctx.config name in
         (try
@@ -910,7 +934,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
       match read_meta ctx.config name with
       | Ok (Some meta)
         when Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta
-             && not (Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name)
+             && not
+                  (Keeper_approval_queue.has_blocking_pending_for_keeper
+                     ~keeper_name:meta.name)
         ->
         (match
            ( Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta

--- a/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
@@ -57,6 +57,7 @@ let restore_reconcile_continue_gate
       ~input
       ~risk_level:Keeper_approval_queue.Critical
       ~base_path:ctx.config.base_path
+      ~lane_policy:Keeper_approval_queue.Blocking
       ~on_resolution:(fun decision ->
         match decision with
         | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -211,8 +211,19 @@ let normalize_tool_result
   let ensure_workflow_self_correction fields =
     match List.assoc_opt "failure_class" fields with
     | Some (`String "workflow_rejection")
-      when not (List.mem_assoc "self_correction_required" fields) ->
-      fields @ [ "self_correction_required", `Bool true ]
+      when not (List.mem_assoc "self_correction_required" fields)
+           && not
+                (List.mem_assoc
+                   "self_correction_required"
+                   workflow_rejection_recovery_fields) ->
+      let self_correction_required =
+        match List.assoc_opt "recoverable" fields with
+        | Some (`Bool false) -> false
+        | Some (`Bool true)
+        | None
+        | Some _ -> true
+      in
+      fields @ [ "self_correction_required", `Bool self_correction_required ]
     | _ -> fields
   in
   try

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -170,18 +170,51 @@ let workflow_rejection_payload_of_json json =
   | None ->
     None
   in
+  let nested_payload_of_json json =
+    match json_assoc_string_opt "error" json with
+    | Some raw ->
+      (try
+         match Yojson.Safe.from_string raw with
+         | `Assoc _ as nested -> payload_from_json nested
+         | _ -> None
+       with
+       | Yojson.Json_error _ -> None)
+    | None -> None
+  in
+  let first_some left right =
+    match left with
+    | Some _ -> left
+    | None -> right
+  in
+  let merge_info outer nested =
+    { task_id = first_some nested.task_id outer.task_id
+    ; rule_id = first_some nested.rule_id outer.rule_id
+    ; tool_suggestion = first_some nested.tool_suggestion outer.tool_suggestion
+    ; alternatives = if nested.alternatives = [] then outer.alternatives else nested.alternatives
+    ; hint = first_some nested.hint outer.hint
+    ; scope_policy =
+        (match outer.scope_policy with
+         | Block_scope -> Block_scope
+         | Observe_scope -> nested.scope_policy)
+    }
+  in
+  let merge_payload outer nested =
+    { info = merge_info outer.info nested.info
+    ; error_class = first_some nested.error_class outer.error_class
+    ; recoverability = first_some nested.recoverability outer.recoverability
+    }
+  in
   match payload_from_json json with
-  | Some _ as payload -> payload
-  | None ->
-    (match json_assoc_string_opt "error" json with
-     | Some raw ->
-       (try
-          match Yojson.Safe.from_string raw with
-          | `Assoc _ as nested -> payload_from_json nested
-          | _ -> None
-        with
-        | Yojson.Json_error _ -> None)
-     | None -> None)
+  | Some payload ->
+    (* Tool dispatch may wrap a typed workflow payload in the outer [error]
+       string while retaining only [failure_class] at the outer level. The
+       nested payload owns the recoverability bit; losing it turns a terminal
+       rejection into a retry instruction. Merge both typed envelopes instead
+       of scraping the human-readable error text. *)
+    (match nested_payload_of_json json with
+     | Some nested -> Some (merge_payload payload nested)
+     | None -> Some payload)
+  | None -> nested_payload_of_json json
 ;;
 
 let workflow_rejection_retry_policy payload =
@@ -330,9 +363,17 @@ let workflow_rejection_recovery_instruction ~tool_name ~count (info : workflow_r
 ;;
 
 let workflow_rejection_recovery_fields ~tool_name ~count raw =
-  match workflow_rejection_info_of_raw raw with
+  let payload_opt =
+    try
+      workflow_rejection_payload_of_json (Yojson.Safe.from_string raw)
+    with
+    | Yojson.Json_error _ -> None
+  in
+  match payload_opt with
   | None -> []
-  | Some info ->
+  | Some payload ->
+    let info = payload.info in
+    let terminal = workflow_rejection_should_skip_retry payload in
     let optional_string key = function
       | Some value -> [ key, `String value ]
       | None -> []
@@ -355,9 +396,18 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
          | Some next_tool -> [ "suggested_next_tool", `String next_tool ]
          | None -> [])
     in
+    let instruction =
+      if terminal && Option.is_none info.tool_suggestion && info.alternatives = []
+      then
+        Printf.sprintf
+          "Do not retry this %s call: the workflow rejection is terminal for the \
+           current task state. Inspect task history and choose an allowed next action."
+          tool_name
+      else workflow_rejection_recovery_instruction ~tool_name ~count info
+    in
     let recovery =
       [ "count", `Int count
-      ; "instruction", `String (workflow_rejection_recovery_instruction ~tool_name ~count info)
+      ; "instruction", `String instruction
       ]
       @ optional_string "rule_id" info.rule_id
       @ optional_string "tool_suggestion" info.tool_suggestion
@@ -367,7 +417,8 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
           , `String (workflow_rejection_scope_policy_to_string info.scope_policy) )
         ]
     in
-    [ "self_correction_required", `Bool true
+    [ "self_correction_required", `Bool (not terminal)
+    ; "workflow_rejection_terminal", `Bool terminal
     ; "workflow_rejection_recovery", `Assoc recovery
     ]
     @ next_tool_fields

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -1060,6 +1060,7 @@ let enqueue_partial_commit_continue_gate
     ~input
     ~risk_level:Keeper_approval_queue.Critical
     ~base_path:config.base_path
+    ~lane_policy:Keeper_approval_queue.Blocking
     ~on_resolution:(fun decision ->
       let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
       match decision with

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -38,7 +38,7 @@ let blocker_requires_continue_gate (old : keeper_meta) =
   | None -> false
 
 let paused_state_requires_approval (old : keeper_meta) =
-  Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
+  Keeper_approval_queue.has_blocking_pending_for_keeper ~keeper_name:old.name
   || blocker_requires_continue_gate old
 
 let update_keeper ?(preserve_prompt_defaults = false)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -1097,15 +1097,11 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
   let user_message =
     "## Current World State\n\n" ^ Keeper_context_layers.assemble ~content_of
   in
-  (* Single registry-driven sanitization pass: tool tokens that no longer
-     resolve via Keeper_tool_resolution are replaced with the
-     [<stale_tool_token>] placeholder so the surrounding sentence stays
-     intact; env-var-shaped tokens (uppercase) are preserved. The legacy
-     hardcoded [sanitize_retired_tool_names] pass is deleted (38-bug
-     campaign #6): it removed standalone words like "Grep"/"Bash" and
-     retired keeper_*-prefixed tokens outright, mangling legitimate prompt
-     prose. Hallucinated calls to non-existent tools are rejected at the
-     tool-dispatch boundary with a typed error, which is the correct seam. *)
+  (* The registry is the sole tool-token SSOT for instruction-owned prompt
+     surfaces. The deleted hardcoded sanitizer removed valid prose such as
+     "Grep"/"Bash". The structured world-state user message is different: its
+     board/task/connector values are observations, not tool instructions, so a
+     [keeper_*]/[masc_*] substring there must remain byte-for-byte intact. *)
   (* P0-3: rendered prompt token integrity ratchet. Scan the prompt surfaces
      *before* the registry-driven strip so stale tokens that are about to be
      replaced still increment [PromptUnknownToolTokens] and are logged. The
@@ -1113,10 +1109,9 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
      running the ratchet first preserves the producer-side alarm signal that
      would otherwise be silently dropped after removal. *)
   let (_ : string list) =
-    Keeper_prompt_token_integrity.scan_rendered_prompt
+    Keeper_prompt_token_integrity.scan_instruction_surfaces
       ~keeper_name:meta.name
       ~system_prompt
-      ~user_message
       ~continuity_summary:continuity_for_prompt
   in
   let sanitized_system =
@@ -1124,11 +1119,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
          ~keeper_name:meta.name
   in
-  let sanitized_user =
-    user_message
-    |> Keeper_prompt_token_integrity.strip_unresolved_tool_tokens
-         ~keeper_name:meta.name
-  in
+  let sanitized_user = user_message in
   (* set_gauge only: a stray inc_counter here used to create this
      (name, labels) cell as Counter first, so the system_prompt series
      kept Counter kind, carried a non-monotonic byte length, and exported

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -29,7 +29,7 @@ let run_keeper_cycle
       ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
       ?shared_context
       ?event_bus
-      ?hitl_delivery_channel
+      ?hitl_resolution
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
   =
@@ -47,6 +47,16 @@ let run_keeper_cycle
      so dashboards/tests can inspect the same routing contract for blocked
      phases like Overflowed. *)
   let registry_base_path = config.base_path in
+  let hitl_delivery_channel =
+    Option.map
+      (fun (resolution : Keeper_event_queue.hitl_resolution) -> resolution.channel)
+      hitl_resolution
+  in
+  let hitl_approval_grant =
+    Option.bind
+      hitl_resolution
+      Governance_pipeline.hitl_approval_grant_of_resolution
+  in
   (* Decide turn_id at function entry so phase-gate / runtime-routing /
      livelock skip paths can include it in the receipt and observability
      stream.  Previously this was [let turn_id = ...] only after several
@@ -512,6 +522,7 @@ let run_keeper_cycle
                            ; build_turn_prompt
                            ; channel
                            ; hitl_delivery_channel
+                           ; hitl_approval_grant
                            ; cleanup
                            ; committed_mutating_tools_snapshot
                            ; config

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -205,7 +205,7 @@ val run_keeper_cycle
   -> ?turn_decision:Keeper_world_observation.keeper_cycle_decision
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
-  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
+  -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -40,6 +40,9 @@ type ctx =
       (* RFC-0320 W3c: the originating channel to deterministically deliver this
          turn's reply to when the turn was opened by a Hitl_resolved wake; [None]
          on every other lane (fail-closed: no delivery). *)
+  ; hitl_approval_grant : Governance_pipeline.hitl_approval_grant option
+      (* Exact operator authorization scoped to this cycle and shared across
+         all runtime retry attempts so a retry cannot recreate the grant. *)
   ; cleanup : unit -> unit
   ; committed_mutating_tools_snapshot : unit -> string list
   ; config : Workspace.config
@@ -83,6 +86,7 @@ let run (ctx : ctx)
       ; turn_id
       ; channel
       ; hitl_delivery_channel
+      ; hitl_approval_grant
       ; shared_context
       ; base_dir
       ; build_turn_prompt
@@ -160,6 +164,7 @@ let run (ctx : ctx)
                  ~config
                  ~meta:run_meta
                  ?hitl_delivery_channel
+                 ?hitl_approval_grant
                  ~turn_ctx_cell
                  ~base_dir
                  ~max_context:execution.max_context

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1411,7 +1411,8 @@ let keeper_cycle_decision
   in
   if meta.paused
   then blocked Keeper_paused
-  else if Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name
+  else if
+    Keeper_approval_queue.has_blocking_pending_for_keeper ~keeper_name:meta.name
   then blocked Approval_pending
   else (
     let scheduled_autonomous_decision () =

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -38,6 +38,10 @@ type pending_phase =
   | Awaiting_operator
   | Escalated
 
+type lane_policy =
+  | Nonblocking
+  | Blocking
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -59,6 +63,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; lane_policy : lane_policy
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
@@ -131,6 +136,11 @@ let risk_level_of_string = function
 let pending_phase_to_string = function
   | Awaiting_operator -> "awaiting_operator"
   | Escalated -> "escalated"
+;;
+
+let lane_policy_to_string = function
+  | Nonblocking -> "nonblocking"
+  | Blocking -> "blocking"
 ;;
 
 let pending_phase_of_string = function

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -33,6 +33,10 @@ type pending_phase =
   | Awaiting_operator
   | Escalated
 
+type lane_policy =
+  | Nonblocking
+  | Blocking
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -54,6 +58,7 @@ type pending_approval =
   ; disposition : string option
   ; disposition_reason : string option
   ; phase : pending_phase
+  ; lane_policy : lane_policy
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
@@ -102,6 +107,7 @@ val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
 val pending_phase_to_string : pending_phase -> string
 val pending_phase_of_string : string -> pending_phase option
+val lane_policy_to_string : lane_policy -> string
 val approval_decision_to_string : decision -> string
 
 val approval_audit_decision_to_string : approval_audit_decision -> string

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -60,13 +60,13 @@ type stimulus_payload =
          content). Dormant — no producer emits it yet (handle_ambient enqueuer
          lands in P3), same staging as [Bg_completed] above. *)
   | Hitl_resolved of hitl_resolution
-      (* A HITL approval this keeper enqueued — and then skipped cycles on via
-         [has_pending_for_keeper -> Skip Approval_pending] — was resolved. Wakes
-         the keeper so it re-evaluates and proceeds on its next cycle instead of
-         stalling until an unrelated stimulus, no-progress recovery, or the
-         30-minute approval janitor. Mirrors [Fusion_completed]/[Bg_completed]:
-         a HITL decision is an async completion the waiting keeper must be
-         notified of. *)
+      (* A nonblocking HITL approval this keeper enqueued was resolved. Wakes
+         the keeper so it re-evaluates and proceeds on its next independent
+         cycle instead of waiting for unrelated stimulus, no-progress recovery,
+         or the 30-minute approval janitor. Blocking approvals resume their
+         resolver directly and do not emit this duplicate wake. Mirrors
+         [Fusion_completed]/[Bg_completed]: a HITL decision is an async
+         completion the waiting keeper must be notified of. *)
   | Goal_verification_failed of goal_verification_failure
       (* A goal completion verification was rejected for a goal assigned to this
          keeper. Wakes the keeper lane so it resumes the goal after the phase

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -122,8 +122,14 @@ and bg_job_kind = Subprocess
       (* RFC-0290: closed sum of background job kinds (v1 = [Subprocess]); a new
          kind forces every match to add an arm rather than defaulting. *)
 
+and hitl_approved_action = {
+  keeper_name : string;
+  tool_name : string;
+  input_hash : string;
+}
+
 and hitl_resolution_decision =
-  | Hitl_approved
+  | Hitl_approved of hitl_approved_action
   | Hitl_rejected
   | Hitl_edited
 
@@ -236,12 +242,11 @@ let goal_stagnation_post_id (gs : goal_stagnation) =
   "goal-stagnation:" ^ gs.gs_goal_id ^ ":" ^ gs.gs_stale_since
 
 let hitl_resolution_decision_to_string = function
-  | Hitl_approved -> "approve"
+  | Hitl_approved _ -> "approve"
   | Hitl_rejected -> "reject"
   | Hitl_edited -> "edit"
 
-let hitl_resolution_decision_of_string = function
-  | "approve" -> Ok Hitl_approved
+let hitl_nonapproved_resolution_decision_of_string = function
   | "reject" -> Ok Hitl_rejected
   | "edit" -> Ok Hitl_edited
   | other -> Error (Printf.sprintf "unknown hitl_resolution decision: %s" other)
@@ -567,10 +572,21 @@ let payload_to_yojson = function
       ; "channel", Keeper_continuation_channel.to_yojson ca.channel
       ]
   | Hitl_resolved r ->
+    let approved_action =
+      match r.decision with
+      | Hitl_approved action ->
+        `Assoc
+          [ "keeper_name", `String action.keeper_name
+          ; "tool_name", `String action.tool_name
+          ; "input_hash", `String action.input_hash
+          ]
+      | Hitl_rejected | Hitl_edited -> `Null
+    in
     `Assoc
       [ "kind", `String "hitl_resolved"
       ; "approval_id", `String r.approval_id
       ; "decision", `String (hitl_resolution_decision_to_string r.decision)
+      ; "approved_action", approved_action
       ; "channel", Keeper_continuation_channel.to_yojson r.channel
       ]
   | Goal_verification_failed failure ->
@@ -675,7 +691,23 @@ let payload_of_yojson json =
   | "hitl_resolved" ->
     let* approval_id = string_field ~context "approval_id" fields in
     let* decision_s = string_field ~context "decision" fields in
-    let* decision = hitl_resolution_decision_of_string decision_s in
+    let* decision =
+      match decision_s with
+      | "approve" ->
+        let* action_json = required_field ~context "approved_action" fields in
+        let* action_fields = assoc_fields ~context:(context ^ ".approved_action") action_json in
+        let* keeper_name =
+          string_field ~context:(context ^ ".approved_action") "keeper_name" action_fields
+        in
+        let* tool_name =
+          string_field ~context:(context ^ ".approved_action") "tool_name" action_fields
+        in
+        let* input_hash =
+          string_field ~context:(context ^ ".approved_action") "input_hash" action_fields
+        in
+        Ok (Hitl_approved { keeper_name; tool_name; input_hash })
+      | other -> hitl_nonapproved_resolution_decision_of_string other
+    in
     let* channel = continuation_channel_field fields in
     Ok (Hitl_resolved { approval_id; decision; channel })
   | "goal_verification_failed" ->

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -138,8 +138,17 @@ and bg_job_outcome =
   | Bg_ok of string  (** result payload *)
   | Bg_failed of string  (** failure label *)
 
+and hitl_approved_action = {
+  keeper_name : string;
+  tool_name : string;
+  input_hash : string;
+}
+(** Exact action identity authorized by an operator. [input_hash] is the
+    canonical full-input fingerprint produced by [Keeper_approval_queue]; it
+    is not an action-name heuristic or a persistent approval rule. *)
+
 and hitl_resolution_decision =
-  | Hitl_approved
+  | Hitl_approved of hitl_approved_action
   | Hitl_rejected
   | Hitl_edited
 
@@ -149,10 +158,10 @@ and hitl_resolution = {
   channel : Keeper_continuation_channel.t;
 }
 (** Payload for [Hitl_resolved]: [approval_id] correlates to the resolved
-    pending-approval queue entry; [decision] is the resolved label
-    ("approve" | "reject" | ...), carried for observability. The keeper
-    re-evaluates from its own state once the approval leaves the queue, so the
-    decision is not itself control flow. *)
+    pending-approval queue entry. An approved decision carries the exact action
+    identity authorized by the operator; rejected and edited decisions carry no
+    grant. The action is consumed at most once in the independent Keeper cycle
+    opened by this durable wake. *)
 
 and connector_attention = {
   event_id : string;

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -82,11 +82,11 @@ type stimulus_payload =
           Edge-triggered: dequeued once, re-armed only by a new ambient
           message. Dormant until [handle_ambient] enqueues it (P3). *)
   | Hitl_resolved of hitl_resolution
-      (** A HITL approval this keeper enqueued — and skipped cycles on via
-          [has_pending_for_keeper -> Skip Approval_pending] — was resolved.
-          Wakes the keeper so it re-evaluates immediately instead of stalling
-          until an unrelated stimulus, no-progress recovery, or the 30-minute
-          approval janitor. Mirrors [Fusion_completed]/[Bg_completed]. *)
+      (** A nonblocking HITL approval this keeper enqueued was resolved. Wakes
+          the keeper so it re-evaluates immediately instead of waiting for an
+          unrelated stimulus, no-progress recovery, or the 30-minute approval
+          janitor. Blocking approvals resume their resolver directly and do not
+          emit this duplicate wake. Mirrors [Fusion_completed]/[Bg_completed]. *)
   | Goal_verification_failed of goal_verification_failure
       (** A goal completion verification was rejected for a goal assigned to
           this keeper. Wakes the keeper lane so it resumes work on the goal

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -835,9 +835,9 @@ let start_keeper_loops
      implementation (queue removal, audit event, promise [Reject]
      resolution, on_resolution callback) with a unit test since
      introduction, but was never invoked by any production caller.
-     Result: a HITL approval enqueued by a keeper turn would block
+     Result: a blocking HITL approval enqueued by a keeper turn would block
      [keeper_cycle_decision] forever via the
-     [has_pending_for_keeper → Skip Approval_pending] branch in
+     [has_blocking_pending_for_keeper → Skip Approval_pending] branch in
      [keeper_world_observation.ml:928].  At the 300s stale-watchdog
      threshold the supervisor would respawn the fiber, the same
      approval entry would still be in the queue, and the cycle

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1668,6 +1668,67 @@ let test_callback_auto_mode_high_queues_for_operator () =
       | Some (Agent_sdk.Hooks.Edit _) -> Alcotest.fail "expected operator approval, got edit"
       | None -> Alcotest.fail "approval callback did not return")
 
+(* Production Keeper runs use the nonblocking callback mode: an approval is a
+   durable continuation and the current OAS turn receives a terminal tool
+   rejection, so the lane can return to its heartbeat and handle unrelated
+   board/chat work. Resolution wakes a later Keeper cycle. *)
+let test_callback_nonblocking_high_returns_without_suspending () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let keeper_name = "nonblocking-high-floor-keeper" in
+  let tool_name = "masc_create_task" in
+  let input = `Assoc [ "title", `String "nonblocking high-risk task" ] in
+  let base_path = temp_dir () in
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let config = Mcp_server.workspace_config state in
+      set_approval_mode_or_fail config OA.Auto_low_risk;
+      let initial_pending = AQ.pending_count () in
+      let callback =
+        GP.to_oas_approval_callback
+          ~config
+          ~governance_level:"enterprise"
+          ~keeper_name
+          ~nonblocking:true
+          ()
+      in
+      let decision = callback ~tool_name ~input in
+      (match decision with
+       | Agent_sdk.Hooks.Reject reason ->
+         Alcotest.(check bool)
+           "rejection identifies pending HITL continuation"
+           true
+           (contains_substring reason "HITL approval pending")
+       | Agent_sdk.Hooks.Approve ->
+         Alcotest.fail "nonblocking high-risk approval unexpectedly approved"
+       | Agent_sdk.Hooks.Edit _ ->
+         Alcotest.fail "nonblocking high-risk approval unexpectedly edited");
+      Alcotest.(check int)
+        "nonblocking callback returns while approval remains queued"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      Alcotest.(check bool)
+        "nonblocking approval does not own the Keeper lane"
+        false
+        (AQ.has_blocking_pending_for_keeper ~keeper_name);
+      let id =
+        match pending_id_for_keeper ~keeper_name with
+        | Some id -> id
+        | None -> Alcotest.fail "nonblocking approval was not queued"
+      in
+      resolve_pending_or_fail ~id ~decision:Agent_sdk.Hooks.Approve;
+      Alcotest.(check int)
+        "resolution clears the continuation entry"
+        initial_pending
+        (AQ.pending_count ()))
+
 let test_callback_manual_mode_preserves_remembered_medium_policy () =
   with_eio_base_path @@ fun base_path ->
   Eio.Switch.run @@ fun sw ->
@@ -2318,6 +2379,9 @@ let () =
           test_callback_production_claimed_worktree_write_auto_approved;
         Alcotest.test_case "Auto_low_risk high band queues for operator" `Quick
           test_callback_auto_mode_high_queues_for_operator;
+        Alcotest.test_case
+          "nonblocking high approval returns without suspending"
+          `Quick test_callback_nonblocking_high_returns_without_suspending;
         Alcotest.test_case "Manual preserves remembered medium policy" `Quick
           test_callback_manual_mode_preserves_remembered_medium_policy;
         Alcotest.test_case "Manual preserves remembered soft rule" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1679,11 +1679,51 @@ let test_callback_nonblocking_high_returns_without_suspending () =
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
   let keeper_name = "nonblocking-high-floor-keeper" in
   let tool_name = "masc_create_task" in
-  let input = `Assoc [ "title", `String "nonblocking high-risk task" ] in
+  let input =
+    `Assoc
+      [ "title", `String "nonblocking high-risk task"
+      ; "description", `String "exact approval continuation"
+      ]
+  in
+  let reordered_input =
+    `Assoc
+      [ "description", `String "exact approval continuation"
+      ; "title", `String "nonblocking high-risk task"
+      ]
+  in
+  let different_input =
+    `Assoc
+      [ "description", `String "exact approval continuation"
+      ; "title", `String "different high-risk task"
+      ]
+  in
   let base_path = temp_dir () in
+  let captured_resolution = ref None in
+  AQ.set_approval_resolution_wake_hook
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id ~decision ~channel ->
+       captured_resolution :=
+         Some
+           Keeper_event_queue.
+             { approval_id
+             ; decision
+             ; channel =
+                 Option.value
+                   channel
+                   ~default:
+                     (Keeper_continuation_channel.unrouted
+                        "test: no approval continuation channel")
+             });
   AQ.For_testing.reset_audit_store ();
   Fun.protect
     ~finally:(fun () ->
+      AQ.set_approval_resolution_wake_hook
+        (fun
+          ~base_path:_
+          ~keeper_name:_
+          ~approval_id:_
+          ~decision:_
+          ~channel:_ ->
+          ());
       AQ.For_testing.reset_audit_store ();
       cleanup_dir base_path)
     (fun () ->
@@ -1696,7 +1736,7 @@ let test_callback_nonblocking_high_returns_without_suspending () =
           ~config
           ~governance_level:"enterprise"
           ~keeper_name
-          ~nonblocking:true
+          ~lane_policy:AQ.Nonblocking
           ()
       in
       let decision = callback ~tool_name ~input in
@@ -1727,7 +1767,88 @@ let test_callback_nonblocking_high_returns_without_suspending () =
       Alcotest.(check int)
         "resolution clears the continuation entry"
         initial_pending
-        (AQ.pending_count ()))
+        (AQ.pending_count ());
+      let grant =
+        match !captured_resolution with
+        | Some resolution ->
+          (match GP.hitl_approval_grant_of_resolution resolution with
+           | Some grant -> grant
+           | None -> Alcotest.fail "approved resolution did not create a grant")
+        | None -> Alcotest.fail "approved resolution did not emit a durable wake"
+      in
+      let resumed_callback =
+        GP.to_oas_approval_callback
+          ~config
+          ~governance_level:"enterprise"
+          ~keeper_name
+          ~lane_policy:AQ.Nonblocking
+          ~hitl_approval_grant:grant
+          ()
+      in
+      (match resumed_callback ~tool_name ~input:different_input with
+       | Agent_sdk.Hooks.Reject reason ->
+         Alcotest.(check bool)
+           "different action stays on the approval path"
+           true
+           (contains_substring reason "HITL approval pending")
+       | Agent_sdk.Hooks.Approve ->
+         Alcotest.fail "grant authorized a different action"
+       | Agent_sdk.Hooks.Edit _ ->
+         Alcotest.fail "different action unexpectedly returned Edit");
+      let different_id =
+        match pending_id_for_keeper ~keeper_name with
+        | Some pending_id -> pending_id
+        | None -> Alcotest.fail "different action was not queued"
+      in
+      resolve_pending_or_fail
+        ~id:different_id
+        ~decision:(Agent_sdk.Hooks.Reject "different action test cleanup");
+      Alcotest.(check int)
+        "different action cleanup restores pending count"
+        initial_pending
+        (AQ.pending_count ());
+      (match resumed_callback ~tool_name ~input:reordered_input with
+       | Agent_sdk.Hooks.Approve -> ()
+       | Agent_sdk.Hooks.Reject reason ->
+         Alcotest.fail ("exact approved action was rejected: " ^ reason)
+       | Agent_sdk.Hooks.Edit _ ->
+         Alcotest.fail "exact approved action unexpectedly returned Edit");
+      Alcotest.(check int)
+        "exact approved action executes without creating a new approval"
+        initial_pending
+        (AQ.pending_count ());
+      (match resumed_callback ~tool_name ~input with
+       | Agent_sdk.Hooks.Reject reason ->
+         Alcotest.(check bool)
+           "consumed grant returns to the nonblocking approval path"
+           true
+           (contains_substring reason "HITL approval pending")
+       | Agent_sdk.Hooks.Approve ->
+         Alcotest.fail "one-shot approval grant authorized the action twice"
+       | Agent_sdk.Hooks.Edit _ ->
+         Alcotest.fail "second exact action unexpectedly returned Edit");
+      Alcotest.(check int)
+        "second exact action creates a fresh approval"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      let second_id =
+        match pending_id_for_keeper ~keeper_name with
+        | Some pending_id -> pending_id
+        | None -> Alcotest.fail "second exact action was not queued"
+      in
+      resolve_pending_or_fail
+        ~id:second_id
+        ~decision:(Agent_sdk.Hooks.Reject "test cleanup");
+      Alcotest.(check int)
+        "test cleanup restores pending count"
+        initial_pending
+        (AQ.pending_count ());
+      Alcotest.(check bool)
+        "one-shot grant consumption is audited"
+        true
+        (List.exists
+           (String.equal "approved_continuation_consumed")
+           (audit_event_names ~base_path ~keeper_name)))
 
 let test_callback_manual_mode_preserves_remembered_medium_policy () =
   with_eio_base_path @@ fun base_path ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -84,6 +84,7 @@ let dummy_pending_approval
   ; disposition = None
   ; disposition_reason = None
   ; phase = Q.Awaiting_operator
+  ; lane_policy = Q.Nonblocking
   ; continuation_channel = Keeper_continuation_channel.unrouted "test fixture"
   ; audit_base_path
   ; resolver = None

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -207,11 +207,12 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
     (fun () ->
        let keeper_name = "pending-resolve-wake-test" in
        let callback_decision = ref None in
+       let input = `Assoc [ "kind", `String "critical_gate" ] in
        let id =
          AQ.submit_pending
            ~keeper_name
            ~tool_name:"keeper_continue_after_reconcile"
-           ~input:(`Assoc [ "kind", `String "critical_gate" ])
+           ~input
            ~risk_level:AQ.Critical
            ~base_path
            ~on_resolution:(fun decision -> callback_decision := Some decision)
@@ -229,10 +230,18 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
         | Some (kn, aid, decision) ->
           Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
           Alcotest.(check string) "wake carries the resolved approval id" id aid;
-          Alcotest.(check bool)
-            "wake carries the typed decision label"
-            true
-            (decision = Keeper_event_queue.Hitl_approved)
+          (match decision with
+           | Keeper_event_queue.Hitl_approved action ->
+             Alcotest.(check bool)
+               "wake carries the exact approved action"
+               true
+               (AQ.approved_action_matches_request
+                  action
+                  ~keeper_name
+                  ~tool_name:"keeper_continue_after_reconcile"
+                  ~input)
+           | Keeper_event_queue.Hitl_rejected | Keeper_event_queue.Hitl_edited ->
+             Alcotest.fail "approved queue entry emitted a non-approved wake")
         | None -> Alcotest.fail "non-blocking resolve did not fire the keeper wake hook"))
 ;;
 

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -88,6 +88,10 @@ let test_fresh_critical_entry_phase_is_awaiting_operator () =
          | None -> Alcotest.fail "in-memory entry not found"
        in
        Alcotest.(check bool)
+         "submit_and_await entry owns a blocking lane"
+         true
+         (AQ.has_blocking_pending_for_keeper ~keeper_name);
+       Alcotest.(check bool)
          "fresh Critical entry is Awaiting_operator in-memory"
          true
          (entry.phase = AQ.Awaiting_operator);
@@ -230,6 +234,60 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
             true
             (decision = Keeper_event_queue.Hitl_approved)
         | None -> Alcotest.fail "non-blocking resolve did not fire the keeper wake hook"))
+;;
+
+let test_blocking_callback_policy_owns_lane_without_resolver () =
+  let base_path = temp_dir () in
+  let woke = ref false in
+  let callback_decision = ref None in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      woke := true);
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.set_approval_resolution_wake_hook
+        (fun
+          ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+          ());
+      cleanup_dir base_path)
+    (fun () ->
+       let keeper_name = "blocking-callback-policy-test" in
+       let id =
+         AQ.submit_pending
+           ~keeper_name
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "lifecycle_gate" ])
+           ~risk_level:AQ.Critical
+           ~base_path
+           ~lane_policy:AQ.Blocking
+           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ()
+       in
+       Alcotest.(check bool)
+         "explicit blocking callback owns the lane"
+         true
+         (AQ.has_blocking_pending_for_keeper ~keeper_name);
+       (match AQ.get_pending_entry ~id with
+        | Some entry ->
+          Alcotest.(check bool) "lane policy is typed as Blocking" true
+            (entry.lane_policy = AQ.Blocking)
+        | None -> Alcotest.fail "blocking callback entry not found");
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.(check bool) "blocking callback does not emit duplicate wake" false !woke;
+       Alcotest.(check bool)
+         "resolved blocking callback releases the lane"
+         false
+         (AQ.has_blocking_pending_for_keeper ~keeper_name);
+       match !callback_decision with
+       | Some Agent_sdk.Hooks.Approve -> ()
+       | Some decision ->
+         Alcotest.fail
+           ("unexpected callback decision: "
+            ^ AQ.approval_decision_to_string decision)
+       | None -> Alcotest.fail "blocking callback did not run")
 ;;
 
 let test_resolution_wake_carries_originating_continuation_channel () =
@@ -859,6 +917,10 @@ let () =
             "submit_pending resolve fires the keeper wake hook"
             `Quick
             test_submit_pending_resolve_fires_keeper_wake_hook
+        ; Alcotest.test_case
+            "explicit blocking callback owns a lane without resolver"
+            `Quick
+            test_blocking_callback_policy_owns_lane_without_resolver
         ; Alcotest.test_case
             "expire_stale does not fire wake for blocking submit_and_await"
             `Quick

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1,6 +1,12 @@
 let temp_dir prefix =
   Filename.temp_dir prefix ""
 
+let approved_action : Keeper_event_queue.hitl_approved_action =
+  { keeper_name = "keeper-hitl-test"
+  ; tool_name = "keeper_continue_after_reconcile"
+  ; input_hash = String.make 64 'a'
+  }
+
 let rec rm_rf path =
   if Sys.file_exists path
   then
@@ -271,17 +277,27 @@ let () =
        (stimulus_to_yojson
           { post_id =
               hitl_resolution_post_id
-                { approval_id = "appr-9"; decision = Hitl_approved; channel = Keeper_continuation_channel.unrouted "test" }
+                { approval_id = "appr-9"
+                ; decision = Hitl_approved approved_action
+                ; channel = Keeper_continuation_channel.unrouted "test"
+                }
           ; urgency = Immediate
           ; arrived_at = 4.0
-          ; payload = Hitl_resolved { approval_id = "appr-9"; decision = Hitl_approved; channel = Keeper_continuation_channel.unrouted "test" }
+          ; payload =
+              Hitl_resolved
+                { approval_id = "appr-9"
+                ; decision = Hitl_approved approved_action
+                ; channel = Keeper_continuation_channel.unrouted "test"
+                }
           })
    with
    | Ok s ->
      (match s.payload with
-      | Hitl_resolved { approval_id; decision } ->
+      | Hitl_resolved { approval_id; decision = Hitl_approved action } ->
         assert (String.equal approval_id "appr-9");
-        assert (decision = Hitl_approved);
+        assert (String.equal action.keeper_name approved_action.keeper_name);
+        assert (String.equal action.tool_name approved_action.tool_name);
+        assert (String.equal action.input_hash approved_action.input_hash);
         assert (String.equal s.post_id "hitl-approval:appr-9")
       | _ -> Alcotest.fail "Hitl_resolved codec round-trip changed payload shape")
   | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));
@@ -1094,7 +1110,7 @@ let () =
      ; payload =
          Hitl_resolved
            { approval_id = "a"
-           ; decision = Hitl_approved
+           ; decision = Hitl_approved approved_action
            ; channel = Keeper_continuation_channel.unrouted "seed"
            }
      }

--- a/test/test_keeper_prompt_token_integrity.ml
+++ b/test/test_keeper_prompt_token_integrity.ml
@@ -35,7 +35,7 @@ let test_unknown_token_reported () =
   let prompt = "Call keeper_p0_3_fictional_tool to proceed." in
   let before = total_unknown () in
   let unknowns =
-    Scanner.scan_text ~keeper_name:keeper ~source:User_message prompt
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
   in
   Alcotest.(check (list string))
     "unknown keeper token is reported"
@@ -111,31 +111,12 @@ let test_token_boundaries () =
     "mykeeper_foo xkeeper_baz foo-keeper_bar keeper_qux"
   in
   let unknowns =
-    Scanner.scan_text ~keeper_name:keeper ~source:User_message prompt
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
   in
   Alcotest.(check (list string))
     "only standalone keeper_qux is matched"
     [ "keeper_qux" ]
     unknowns
-
-let test_rendered_prompt_scans_all_surfaces () =
-  let system_prompt = "Known keeper_board_post is fine." in
-  let user_message = "Unknown masc_p0_3_prompt_probe here." in
-  let continuity_summary = "Unknown keeper_p0_3_continuity_probe here." in
-  let before = total_unknown () in
-  let unknowns =
-    Scanner.scan_rendered_prompt
-      ~keeper_name:keeper
-      ~system_prompt
-      ~user_message
-      ~continuity_summary
-  in
-  Alcotest.(check (list string))
-    "returns both distinct unknown tokens"
-    [ "keeper_p0_3_continuity_probe"; "masc_p0_3_prompt_probe" ]
-    unknowns;
-  Alcotest.(check (float 0.0001))
-    "metric +2 across surfaces" (before +. 2.0) (total_unknown ())
 
 let test_case_insensitive_resolution () =
   (* Mixed-case token text should normalize to lowercase before resolution. *)
@@ -230,8 +211,6 @@ let () =
           Alcotest.test_case "deduplicates within surface" `Quick
             test_deduplicates_within_surface;
           Alcotest.test_case "token boundaries" `Quick test_token_boundaries;
-          Alcotest.test_case "rendered prompt scans all surfaces" `Quick
-            test_rendered_prompt_scans_all_surfaces;
           Alcotest.test_case "case insensitive resolution" `Quick
             test_case_insensitive_resolution;
           Alcotest.test_case "unified system prompt has no unresolved tokens"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1438,7 +1438,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check bool "keeper registered after approval" true
         (Reg.is_registered ~base_path:config.base_path meta.name))
 
-let test_sweep_warns_for_pending_hitl_approval () =
+let test_sweep_reports_pending_hitl_approval () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -1482,21 +1482,21 @@ let test_sweep_warns_for_pending_hitl_approval () =
       sweep_and_recover_no_materialize ctx;
       let expected =
         Printf.sprintf
-          "keeper:%s blocked on 1 pending HITL approval(s); chat awaits operator \
-           decision"
+          "keeper:%s has 1 nonblocking HITL approval(s); chat lane remains \
+           available"
           name
       in
-      let warning_seen =
+      let visibility_seen =
         Log.Ring.recent
           ~limit:50
           ~module_filter:"Keeper"
-          ~min_level:(Log.level_to_int Log.Warn)
+          ~min_level:(Log.level_to_int Log.Info)
           ~since_seq:baseline
           ()
         |> List.exists (fun (entry : Log.Ring.entry) ->
              String.equal entry.message expected)
       in
-      check bool "pending HITL approval warning emitted" true warning_seen;
+      check bool "pending HITL approval visibility emitted" true visibility_seen;
       check bool "approval remains pending after visibility sweep" true
         (AQ.has_pending_for_keeper ~keeper_name:name);
       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
@@ -3745,7 +3745,7 @@ let () =
       test_case "sweep restores reconcile gate for paused keeper" `Quick
         test_sweep_restores_reconcile_gate_for_paused_keeper;
       test_case "sweep warns for pending HITL approval" `Quick
-        test_sweep_warns_for_pending_hitl_approval;
+        test_sweep_reports_pending_hitl_approval;
     ];
     "restart_metrics", [
       test_case "restart path emits attempt and started outcome metrics" `Quick

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -248,6 +248,31 @@ let test_board_reaction_event_renders_reaction_context () =
     (contains_sub "emoji=\"👏\"" user_msg)
 ;;
 
+(* Structured world-state values are observations, not tool instructions. A
+   diagnostic token must survive prompt assembly verbatim; the instruction
+   token scanner is intentionally not allowed to rewrite this surface. *)
+let test_observation_tool_names_are_preserved () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  let event =
+    {
+      sample_board_event with
+      post_id = "diagnostic-observation-1";
+      preview = "keeper_turn_id=turn-1 masc_oas_error=provider-timeout";
+    }
+  in
+  let obs = { base_observation with pending_board_events = [ event ] } in
+  let _, user_msg =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs ()
+  in
+  check bool "keeper diagnostic token remains in observation" true
+    (contains_sub "keeper_turn_id=turn-1" user_msg);
+  check bool "OAS diagnostic token remains in observation" true
+    (contains_sub "masc_oas_error=provider-timeout" user_msg);
+  check bool "observation does not receive stale-token placeholder" false
+    (contains_sub "<stale_tool_token>" user_msg)
+;;
+
 let test_task_claim_requires_matched_backlog () =
   let obs =
     { base_observation with unclaimed_task_count = 3; claimable_task_count = 0 }
@@ -389,6 +414,9 @@ let () =
           test_case
             "prompt: board reaction event renders reaction context"
             `Quick test_board_reaction_event_renders_reaction_context;
+          test_case
+            "prompt: observation tool names remain immutable"
+            `Quick test_observation_tool_names_are_preserved;
           test_case "affordance: task claim requires matched backlog" `Quick
             test_task_claim_requires_matched_backlog;
           test_case "affordance: task claim present for claimable backlog" `Quick

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -4,6 +4,7 @@ module Tool_result = Tool_result
 module Tool_dispatch = Tool_dispatch
 module Time_compat = Time_compat
 module Keeper_tools_oas_workflow = Masc.Keeper_tools_oas_workflow
+module Keeper_tools_oas = Masc.Keeper_tools_oas
 
 let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
@@ -444,6 +445,98 @@ let test_workflow_recovery_fields_require_next_tool () =
     "instruction avoids same-tool retry"
     false
     (str_contains instruction "retry this keeper_task_done call")
+  ;
+  Alcotest.(check bool)
+    "unrecoverable transition does not require same-turn self correction"
+    false
+    (match List.assoc_opt "self_correction_required" fields with
+     | Some (`Bool value) -> value
+     | _ -> true)
+  ;
+  Alcotest.(check bool)
+    "unrecoverable transition is terminal"
+    true
+    (match List.assoc_opt "workflow_rejection_terminal" fields with
+     | Some (`Bool value) -> value
+     | _ -> false)
+;;
+
+let test_workflow_recovery_terminal_without_next_tool_does_not_retry () =
+  let raw =
+    {|{"ok":false,"error":"Invalid task state: cancelled is terminal","failure_class":"workflow_rejection","error_class":"deterministic","recoverable":false,"diagnosis":{"rule_id":"task_transition_invalid_state","scope_policy":"observe"}}|}
+  in
+  let fields =
+    Keeper_tools_oas_workflow.workflow_rejection_recovery_fields
+      ~tool_name:"masc_transition"
+      ~count:1
+      raw
+  in
+  let instruction =
+    match List.assoc_opt "workflow_rejection_recovery" fields with
+    | Some (`Assoc recovery) ->
+      (match List.assoc_opt "instruction" recovery with
+       | Some (`String value) -> value
+       | _ -> Alcotest.fail "missing terminal recovery instruction")
+    | _ -> Alcotest.fail "missing terminal workflow rejection recovery"
+  in
+  Alcotest.(check bool)
+    "terminal instruction forbids same-tool retry"
+    true
+    (str_contains instruction "Do not retry this masc_transition call");
+  Alcotest.(check bool)
+    "terminal rejection does not require self correction"
+    false
+    (match List.assoc_opt "self_correction_required" fields with
+     | Some (`Bool value) -> value
+     | _ -> true)
+;;
+
+let test_nested_workflow_payload_preserves_unrecoverable_boundary () =
+  let nested =
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String "cancelled is terminal"
+      ; "failure_class", `String "workflow_rejection"
+      ; "error_class", `String "deterministic"
+      ; "recoverable", `Bool false
+      ; "diagnosis", `Assoc [ "rule_id", `String "task_transition_invalid_state" ]
+      ]
+  in
+  let outer =
+    `Assoc
+      [ "ok", `Bool false
+      ; "error", `String (Yojson.Safe.to_string nested)
+      ; "failure_class", `String "workflow_rejection"
+      ; "error_class", `String "transient"
+      ; "recoverable", `Bool true
+      ]
+  in
+  let payload =
+    match Keeper_tools_oas_workflow.workflow_rejection_payload_of_json outer with
+    | Some payload -> payload
+    | None -> Alcotest.fail "nested workflow payload was not classified"
+  in
+  Alcotest.(check bool)
+    "nested recoverability remains terminal"
+    true
+    (Keeper_tools_oas_workflow.workflow_rejection_should_skip_retry payload);
+  let recovery_fields =
+    Keeper_tools_oas_workflow.workflow_rejection_recovery_fields
+      ~tool_name:"masc_transition"
+      ~count:1
+      (Yojson.Safe.to_string outer)
+  in
+  let normalized =
+    Keeper_tools_oas.normalize_tool_result
+      ~workflow_rejection_recovery_fields:recovery_fields
+      ~success:false
+      (Yojson.Safe.to_string outer)
+    |> Yojson.Safe.from_string
+  in
+  Alcotest.(check bool)
+    "normalizer does not request self correction for terminal rejection"
+    false
+    Yojson.Safe.Util.(member "self_correction_required" normalized |> to_bool)
 ;;
 
 let test_workflow_recovery_uses_alternatives_without_tool_suggestion () =
@@ -562,6 +655,14 @@ let () =
             "recovery fields use alternatives"
             `Quick
             test_workflow_recovery_uses_alternatives_without_tool_suggestion
+        ; Alcotest.test_case
+            "terminal recovery does not retry same tool"
+            `Quick
+            test_workflow_recovery_terminal_without_next_tool_does_not_retry
+        ; Alcotest.test_case
+            "nested terminal recovery stays typed"
+            `Quick
+            test_nested_workflow_payload_preserves_unrecoverable_boundary
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Preserve structured world-state observations by scanning only instruction-owned prompt surfaces; the obsolete all-text scanner API is removed.
- Make HITL lane ownership typed (`Blocking | Nonblocking`) and let ordinary Keeper approvals return the lane immediately.
- Carry an approved action through the durable `Hitl_resolved` wake and consume its exact keeper/tool/full-input fingerprint once in the resumed cycle.
- Preserve terminal workflow rejection semantics through the MASC/OAS tool boundary.
- Include the read-only live-system audit report with machine-local paths redacted.

## Base integration

#23917 has merged into `main` as `f71c3540da`. This branch is rebased on that main head, so the final prompt composition is now:

1. the hardcoded retired-tool sanitizer is absent;
2. registry scanning/stripping is limited to instruction-owned system/continuity surfaces;
3. structured world-state remains byte-for-byte unchanged.

## Root cause

- Prompt token integrity treated observation data as tool instructions and stripped diagnostic values.
- Pending approval state was conflated with Keeper lane ownership.
- The first nonblocking implementation woke the Keeper after approval but carried no execution authorization, so a plain approval could create the same approval again.
- Terminal task rejections carried `recoverable=false`, but the outer tool wrapper could lose that field and emit a same-tool retry instruction.

## One-shot approval contract

- Durable wake payload: typed approved action identity (`keeper_name`, `tool_name`, canonical full-input SHA-256).
- Scope: the independent Keeper cycle opened by that wake, shared across provider retry attempts.
- Consumption: atomic and at most once; a different action does not consume it, and a second identical action returns to normal governance.
- No TTL, blanket rule, heuristic action matching, or persistent auto-approval.

## Validation

Before the final main rebase, all focused executables passed on the composed #23917 + #23923 source:

- Prompt token integrity: 15 tests
- Keeper event queue: pass
- Keeper approval queue: 13 tests
- HITL approval: 51 tests
- HITL summary worker: 16 tests
- Supervisor: 87 tests
- Unified verification surface: 18 tests
- Tool result: 25 tests

On the current rebased head, all changed OCaml files pass parser-only validation and `ocamlformat --check`; HTML parse and `git diff --check` also pass. The repository wrapper stopped current-head focused build before Dune because the shared local switch has `agent_sdk 0.208.22` while current main requires `>= 0.209.0`. The guard was not bypassed and shared opam state was not mutated. Full Dune remains current-head CI authority.

The live executable and runtime state were not rebuilt, restarted, resumed, acknowledged, or deleted by this PR.
