### PR TITLE
test: repair 3 residual main-red tests (#23901 round 2)

### DIFF
--- a/test/test_env_config_sandbox.ml
+++ b/test/test_env_config_sandbox.ml
@@ -147,7 +147,9 @@ let test_defaults_pinned () =
   pin S.Shell_timeout.Git_meta 5.0;
   pin S.Shell_timeout.Gh_min 15.0;
   pin S.Shell_timeout.User_max 180.0;
-  pin S.Shell_timeout.Cleanup_rm 5.0
+  (* 10.0 since #23722 (rm -v can outlive 5s on loaded runners); that PR
+     changed the lib default without this pin (main red #23901 residual). *)
+  pin S.Shell_timeout.Cleanup_rm 10.0
 
 (* ---------------------------------------------------------------- *)
 (* 2. Env-override                                                  *)

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -885,7 +885,7 @@ case \"$1\" in\n\
     exit 2\n\
     ;;\n\
   rm)\n\
-    if [ \"$2\" = \"-f\" ] && [ \"$3\" = \"old-container\" ]; then\n\
+    if [ \"$2\" = \"-f\" ] && [ \"$3\" = \"-v\" ] && [ \"$4\" = \"old-container\" ]; then\n\
       printf 'old-container\\n'\n\
       exit 0\n\
     fi\n\
@@ -1215,9 +1215,9 @@ let test_cleanup_stale_containers_removes_only_stale_masc_scope () =
   Alcotest.(check (list string)) "no cleanup errors" [] result.errors;
   let log = read_file log_path in
   Alcotest.(check bool) "removes old container" true
-    (contains_substring log "rm -f old-container");
+    (contains_substring log "rm -f -v old-container");
   Alcotest.(check bool) "keeps fresh container" false
-    (contains_substring log "rm -f fresh-container")
+    (contains_substring log "rm -f -v fresh-container")
 
 let test_maybe_cleanup_stale_containers_runs_once_per_interval () =
   with_fake_docker fake_docker_cleanup_script @@ fun () ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -605,10 +605,15 @@ let () = test "handle_done_rejects_empty_evidence_refs" (fun () ->
   let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("task_id", `String "task-001")]) in
   with_task_completion_gate_decide real_task_completion_gate (fun () ->
+    (* Notes repeat the auto-injected default contract item verbatim
+       ("Task scope satisfied: <title>") so the legacy substring contract
+       gate (Gate 2.5, FSM disabled here) passes and the flow actually
+       reaches L1 — otherwise the contract gate rejects first and this
+       test pins the wrong gate (#23901 residual). *)
     let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [
         ("task_id", `String "task-001");
-        ("notes", `String "Task scope satisfied: long enough notes to avoid the length gate, but evidence_refs is empty.");
+        ("notes", `String "Task scope satisfied: Empty evidence refs task — notes long enough to clear the length gate, but evidence_refs is empty.");
         ("evidence_refs", `List [])
       ]) in
     assert (not (Tool_result.is_success result));

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -599,21 +599,25 @@ let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
    [Workspace_metric_hooks.install] — and pins that an empty evidence_refs
    completion is rejected with L1's canonical wording. *)
 let () = test "handle_done_rejects_empty_evidence_refs" (fun () ->
+  let task_title = "Empty evidence refs task" in
+  let completion_contract =
+    Workspace_task_classify.default_completion_contract_text
+      ~title:task_title
+      ~description:""
+  in
   let ctx = make_test_ctx () in
   let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-    (`Assoc [("title", `String "Empty evidence refs task")]) in
+    (`Assoc [("title", `String task_title)]) in
   let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("task_id", `String "task-001")]) in
   with_task_completion_gate_decide real_task_completion_gate (fun () ->
-    (* Notes repeat the auto-injected default contract item verbatim
-       ("Task scope satisfied: <title>") so the legacy substring contract
-       gate (Gate 2.5, FSM disabled here) passes and the flow actually
-       reaches L1 — otherwise the contract gate rejects first and this
-       test pins the wrong gate (#23901 residual). *)
     let result = Task.Tool.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [
         ("task_id", `String "task-001");
-        ("notes", `String "Task scope satisfied: Empty evidence refs task — notes long enough to clear the length gate, but evidence_refs is empty.");
+        ( "notes"
+        , `String
+            (completion_contract
+             ^ ". The notes satisfy the advisory contract so the test reaches the L1 evidence gate.") );
         ("evidence_refs", `List [])
       ]) in
     assert (not (Tool_result.is_success result));


### PR DESCRIPTION
## 목적

main 잠재 red 후속 라운드 (#23901): #23902가 post-repair main push run `29068462314`에서 잔여 quick-suite 3건을 남겼습니다. 셋 다 결정론적 fixture drift이며, required CI Gate 실패 상태로 병합된 #23722/#23902의 후속입니다.

## 잔여 3건과 수리

| 테스트 | 원인 | 수리 |
|---|---|---|
| `env-config-sandbox defaults 0` | #23722가 `Cleanup_rm` 기본값 5.0→10.0으로 바꾸며 pin test 미갱신 | pin을 10.0으로 갱신 + 근거 주석 |
| `docker_cleanup 1` | #23722가 `rm -f -v <id>`로 인자를 바꿨는데 fake Docker rm arm은 기존 argv만 허용 → exit 2 → removed=0 | fake arm과 positive/fresh-negative log pin을 `rm -f -v`로 갱신 |
| `coverage 14` | #23902 test가 auto-injected advisory contract의 legacy Contract gate에 먼저 걸려 L1 도달 전 거부 | `Workspace_task_classify.default_completion_contract_text` SSOT로 notes를 생성해 Contract gate를 통과하고 실제 L1 rejection source를 pin |

## RFC와 경계

- RFC-0337 migration 2: empty-evidence rejection의 단일 소유자는 L1 `Task_completion_gate.decide`입니다.
- Gate fixture는 계약 문구를 복제하지 않고 production contract generator를 공유합니다.
- #23722 계열 두 건은 production behavior를 되돌리지 않고 stale test만 현행 typed/default contract에 정렬합니다.
- 세 failure는 같은 current-main CI incident의 전체 set이므로 atomic recovery PR 하나로 required-green을 복원합니다. 각 fixture는 독립 focused evidence를 남겼습니다.

## 검증

- `test_env_config_sandbox.exe`: 10/10 pass
- `test_keeper_sandbox_read_backend.exe test docker_cleanup`: 4/4 pass
- `test_tool_task_coverage.exe test coverage 14 --show-errors`: 1/1 pass
- coverage log: canonical L1 `rule=cdal_evidence_incomplete`, `handoff_refs=0`
- touched files `ocamlformat --check`, parse checks, `git diff --check`: pass
- full current-head Build and Test / required CI Gate: 새 head `8243d1390f`에서 재실행 중

## 연계

- duplicate #23930은 이 PR로 superseded되어 닫았습니다.
- #23900/#23907/#23909/#23910/#23914/#23915/#23916의 current-head red는 main과 동일한 이 세 failure뿐입니다. 본 PR이 green/land한 뒤 최신 base로 재실행합니다.

[근거] main push run 29068462314/job 86285372514, focused wrapper/executables, current source, 확인일시 2026-07-10 14:43 KST, 신뢰도 High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>