### PR TITLE
test(config): pin Cleanup_rm 10s default

### DIFF
--- a/test/test_env_config_sandbox.ml
+++ b/test/test_env_config_sandbox.ml
@@ -147,7 +147,7 @@ let test_defaults_pinned () =
   pin S.Shell_timeout.Git_meta 5.0;
   pin S.Shell_timeout.Gh_min 15.0;
   pin S.Shell_timeout.User_max 180.0;
-  pin S.Shell_timeout.Cleanup_rm 5.0
+  pin S.Shell_timeout.Cleanup_rm 10.0
 
 (* ---------------------------------------------------------------- *)
 (* 2. Env-override                                                  *)


### PR DESCRIPTION
## 문제

#23722가 production `Cleanup_rm` timeout default를 5초에서 10초로 올렸지만 `test_env_config_sandbox`의 explicit default pin은 5초에 남았습니다. failed required gate 상태로 병합된 뒤 current main push run `29068462314` quick suite에서 expected 5 / received 10으로 재현됐습니다.

## 변경

- `Shell_timeout.Cleanup_rm`의 intentional regression pin을 production SSOT와 같은 10초로 갱신
- production code, env override semantics, 다른 bucket은 변경하지 않음

이 test의 목적이 default drift를 잡는 것이므로 production 값을 test에서 파생해 vacuous하게 만들지 않고, 의도된 10초 contract를 명시적으로 고정합니다.

## 검증

- `scripts/dune-local.sh build test/test_env_config_sandbox.exe`
- `test_env_config_sandbox.exe`: 10/10 pass
- `ocamlformat --check test/test_env_config_sandbox.ml`
- `git diff --check`

current main에는 이 건 외에도 Docker cleanup fixture와 Gate0/L1 fixture red가 남아 있어, 이 surgical PR 단독 full CI는 inherited failures를 가질 수 있습니다. 세 독립 수리를 atomic recovery branch로 모아 required-green을 만든 뒤 main landing을 판정합니다.

[근거] #23722 diff/body, main push run 29068462314 job 86285372514, focused executable, 확인일시 2026-07-10 14:31 KST, 신뢰도 High.