### PR TITLE
fix(board): wire authenticated reaction transport

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -304,84 +304,12 @@ let dispatch_route ~router ~request ~path ~upgrade reqd =
           ]
       in
       Http.Response.json (Yojson.Safe.to_string json) reqd
-  | `POST, "/api/v1/board/reactions" ->
-      Http.Request.read_body_async reqd (fun body ->
-        try
-          let args = Yojson.Safe.from_string body in
-          let target_type_raw =
-            Option.value ~default:""
-              (Safe_ops.json_string_opt "target_type" args)
-          in
-          let target_id =
-            Option.value ~default:"" (Safe_ops.json_string_opt "target_id" args)
-          in
-          let user_id =
-            Option.value ~default:"" (Safe_ops.json_string_opt "user_id" args)
-          in
-          let emoji =
-            Option.value ~default:"" (Safe_ops.json_string_opt "emoji" args)
-          in
-          match Board.reaction_target_type_of_string_opt target_type_raw with
-          | None ->
-              Http.Response.json ~status:`Bad_request
-                {|{"error":"target_type must be post or comment"}|} reqd
-          | Some target_type ->
-              (match
-                 Board_dispatch.toggle_reaction ~target_type ~target_id
-                   ~user_id ~emoji
-               with
-               | Ok result ->
-                   Http.Response.json
-                     (Yojson.Safe.to_string
-                        (Board.reaction_toggle_result_to_yojson result))
-                     reqd
-               | Error e ->
-                   Http.Response.json ~status:`Bad_request
-                     (Yojson.Safe.to_string
-                        (`Assoc
-                           [
-                             ("error", `String (Tool_board.board_error_to_string e));
-                           ]))
-                     reqd)
-        with
-        | Yojson.Json_error msg ->
-            Http.Response.json ~status:`Bad_request
-              (Yojson.Safe.to_string
-                 (`Assoc [ ("error", `String ("invalid JSON: " ^ msg)) ]))
-              reqd)
-  | `GET, "/api/v1/board/reactions" ->
-      let target_type_raw =
-        Option.value ~default:"" (query_param request "target_type")
-      in
-      let target_id =
-        Option.value ~default:"" (query_param request "target_id")
-      in
-      let user_id = query_param request "user_id" in
-      (match Board.reaction_target_type_of_string_opt target_type_raw with
-       | None ->
-           Http.Response.json ~status:`Bad_request
-             {|{"error":"target_type must be post or comment"}|} reqd
-       | Some target_type ->
-           (match
-              Board_dispatch.list_reactions ~target_type ~target_id ?user_id ()
-            with
-            | Ok summary ->
-                let json =
-                  `Assoc
-                    [
-                      ( "reactions",
-                        `List (List.map Board.reaction_summary_to_yojson summary) );
-                    ]
-                in
-                Http.Response.json (Yojson.Safe.to_string json) reqd
-            | Error e ->
-                Http.Response.json ~status:`Bad_request
-                  (Yojson.Safe.to_string
-                     (`Assoc
-                        [
-                          ("error", `String (Tool_board.board_error_to_string e));
-                        ]))
-                  reqd))
+  (* Board reactions are owned by the typed route table. Keep this delegation
+     before the legacy board-detail prefix below, which would otherwise treat
+     [reactions] as a post id and bypass bearer-bound actor resolution. *)
+  | (`GET | `POST), "/api/v1/board/reactions"
+  | `GET, "/api/v1/board/reactions/catalog" ->
+      Http.Router.dispatch router ~upgrade request reqd
   | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -304,24 +304,9 @@ let dispatch_route ~router ~request ~path ~upgrade reqd =
           ]
       in
       Http.Response.json (Yojson.Safe.to_string json) reqd
-  (* Board reactions are owned by the typed route table. Keep this delegation
-     before the legacy board-detail prefix below, which would otherwise treat
-     [reactions] as a post id and bypass bearer-bound actor resolution. *)
-  | (`GET | `POST), "/api/v1/board/reactions"
-  | `GET, "/api/v1/board/reactions/catalog" ->
-      Http.Router.dispatch router ~upgrade request reqd
-  | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
-      let post_id = String.sub p 14 (String.length p - 14) in
-      let format = Option.value ~default:"nested" (query_param request "format") in
-      let voter = board_voter_query request in
-      let config =
-        Option.map (fun state -> (Mcp_server.workspace_config state)) !server_state
-      in
-      let (status, body) =
-        board_post_detail_json ~include_moderation:false ~blind_votes:false
-          ~config ~voter ~response_format:format ~post_id
-      in
-      Http.Response.json ~status body reqd
+  (* Board reads/reactions are owned by the typed route table: exact routes
+     ([/api/v1/board/reactions], [/catalog]) win over the board prefix route,
+     and the prefix route resolves the bearer-bound reaction actor itself. *)
   | _ -> Http.Router.dispatch router ~upgrade request reqd
 
 let log_late_response_failure ~context msg =

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1241,7 +1241,7 @@ describe('board reactions', () => {
           has_reacted: true,
           recent_user_ids: ['agent-b', 'agent-a'],
         }],
-        supported_emojis: ['👍', '🚀'],
+        supported_reaction_emojis: ['👍', '🚀'],
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1331,7 +1331,7 @@ describe('board reactions', () => {
     ))
 
     await expect(fetchBoardReactionState('post', 'post-1')).rejects.toThrow(
-      'supported_emojis is required',
+      'supported_reaction_emojis is required',
     )
   })
 })

--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -9,7 +9,7 @@ import {
   fetchBoardHearths,
   fetchBoardKarmaLedger,
   fetchBoardPost,
-  fetchBoardReactions,
+  fetchBoardReactionState,
   normalizeBoardContextInferenceSubmission,
   normalizeBoardKarmaLedger,
   requestBoardContextInference,
@@ -556,6 +556,7 @@ describe('fetchBoard', () => {
               recent_user_ids: ['analyst', 'reviewer'],
             },
           ],
+          supported_reaction_emojis: ['🔥', '👍'],
           claim_evidence: {
             source: 'board_claim_evidence.jsonl',
             target_post_id: 'post-1',
@@ -626,6 +627,7 @@ describe('fetchBoard', () => {
           recent_user_ids: ['analyst', 'reviewer'],
         },
       ],
+      supported_reaction_emojis: ['🔥', '👍'],
     })
     expect(result.posts[0]?.author_identity).toMatchObject({
       kind: 'keeper',
@@ -934,6 +936,7 @@ describe('fetchBoardPost', () => {
             recent_user_ids: ['reader-a'],
           },
         ],
+        supported_reaction_emojis: ['👍', '🚀'],
       },
       comments: [
         {
@@ -957,6 +960,7 @@ describe('fetchBoardPost', () => {
               recent_user_ids: ['reviewer'],
             },
           ],
+          supported_reaction_emojis: ['👍', '🚀'],
         },
       ],
     }
@@ -989,6 +993,7 @@ describe('fetchBoardPost', () => {
           recent_user_ids: ['reviewer'],
         },
       ],
+      supported_reaction_emojis: ['👍', '🚀'],
     })
     expect(result.current_vote).toBe('down')
     expect(result.reactions).toEqual([
@@ -1000,6 +1005,7 @@ describe('fetchBoardPost', () => {
         recent_user_ids: ['reader-a'],
       },
     ])
+    expect(result.supported_reaction_emojis).toEqual(['👍', '🚀'])
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('format=flat')
     expect(url).toContain('voter=')
@@ -1222,7 +1228,7 @@ describe('voteComment', () => {
 })
 
 describe('board reactions', () => {
-  it('fetches reaction summaries with the dashboard voter', async () => {
+  it('fetches reaction state without sending a forgeable user id', async () => {
     window.history.replaceState({}, '', '/?agent=dashboard-reviewer')
     vi.spyOn(performance, 'now')
       .mockReturnValueOnce(0)
@@ -1235,6 +1241,7 @@ describe('board reactions', () => {
           has_reacted: true,
           recent_user_ids: ['agent-b', 'agent-a'],
         }],
+        supported_emojis: ['👍', '🚀'],
       }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -1242,20 +1249,23 @@ describe('board reactions', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await fetchBoardReactions('post', 'post-1')
+    const result = await fetchBoardReactionState('post', 'post-1')
 
-    expect(result).toEqual([{
-      emoji: '👍',
-      count: 2,
-      reacted: true,
-      has_reacted: true,
-      recent_user_ids: ['agent-b', 'agent-a'],
-    }])
+    expect(result).toEqual({
+      summaries: [{
+        emoji: '👍',
+        count: 2,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['agent-b', 'agent-a'],
+      }],
+      supportedEmojis: ['👍', '🚀'],
+    })
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('/api/v1/board/reactions?')
     expect(url).toContain('target_type=post')
     expect(url).toContain('target_id=post-1')
-    expect(url).toContain('user_id=dashboard-reviewer')
+    expect(url).not.toContain('user_id=')
     expect(boardLatencyMetrics.value.reaction_summary).toMatchObject({
       last_latency_ms: 18,
       last_ok: true,
@@ -1302,14 +1312,27 @@ describe('board reactions', () => {
     expect(JSON.parse(String(init.body))).toMatchObject({
       target_type: 'comment',
       target_id: 'comment-1',
-      user_id: 'dashboard-reviewer',
       emoji: '🚀',
     })
+    expect(JSON.parse(String(init.body))).not.toHaveProperty('user_id')
     expect(boardLatencyMetrics.value.reaction_toggle).toMatchObject({
       last_latency_ms: 21,
       last_ok: true,
       sample_count: 1,
     })
+  })
+
+  it('rejects a reaction state without the server-owned emoji catalog', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ reactions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    await expect(fetchBoardReactionState('post', 'post-1')).rejects.toThrow(
+      'supported_emojis is required',
+    )
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -5,7 +5,7 @@ import { normalizePendingConfirmation } from '../pending-confirm'
 import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardPostOrigin, BoardComment, BoardReactionSummary,
-  BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
+  BoardReactionState, BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
   BoardVoteDirection, BoardModerationStatus, BoardContributorQuality,
   BoardClaimEvidenceProjection, BoardClaimEvidenceState,
   BoardCurationSnapshot, BoardKarmaLedger, BoardKarmaLedgerEvent, BoardKarmaTotal,
@@ -580,6 +580,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
         .map(normalizeBoardReactionSummary)
         .filter((row): row is BoardReactionSummary => row !== null)
     : undefined
+  const supportedReactionEmojis = normalizeSupportedReactionEmojis(raw.supported_reaction_emojis)
 
   return {
     id,
@@ -622,6 +623,9 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     contributor_quality: normalizeBoardContributorQuality(raw.contributor_quality),
     claim_evidence: normalizeBoardClaimEvidence(raw.claim_evidence),
     ...(reactions !== undefined ? { reactions } : {}),
+    ...(supportedReactionEmojis !== undefined
+      ? { supported_reaction_emojis: supportedReactionEmojis }
+      : {}),
     origin: normalizeBoardPostOrigin(raw.origin),
   }
 }
@@ -680,6 +684,7 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
         .map(normalizeBoardReactionSummary)
         .filter((row): row is BoardReactionSummary => row !== null)
     : undefined
+  const supportedReactionEmojis = normalizeSupportedReactionEmojis(raw.supported_reaction_emojis)
   return {
     id,
     post_id: postId,
@@ -699,6 +704,9 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     report_count: Math.max(0, Math.trunc(asNumber(raw.report_count, 0))),
     moderation_status: normalizeBoardModerationStatus(raw.moderation_status),
     ...(reactions !== undefined ? { reactions } : {}),
+    ...(supportedReactionEmojis !== undefined
+      ? { supported_reaction_emojis: supportedReactionEmojis }
+      : {}),
   }
 }
 
@@ -872,6 +880,20 @@ function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | nul
   }
 }
 
+function normalizeSupportedReactionEmojis(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const values: string[] = []
+  const seen = new Set<string>()
+  for (const item of raw) {
+    if (typeof item !== 'string') return undefined
+    const emoji = item.trim()
+    if (!emoji || seen.has(emoji)) return undefined
+    seen.add(emoji)
+    values.push(emoji)
+  }
+  return values.length > 0 ? values : undefined
+}
+
 function normalizeBoardReactionToggleResult(raw: unknown): BoardReactionToggleResult | null {
   if (!isRecord(raw)) return null
   const targetType = asString(raw.target_type, '').trim()
@@ -986,20 +1008,31 @@ export async function fetchBoardKarmaLedger(options: { agent?: string; limit?: n
   })
 }
 
-export async function fetchBoardReactions(
+export async function fetchBoardReactionState(
   targetType: BoardReactionTargetType,
   targetId: string,
-): Promise<BoardReactionSummary[]> {
-  return timeBoardRequest('reaction_summary', () => withRetries('fetchBoardReactions', async () => {
+): Promise<BoardReactionState> {
+  return timeBoardRequest('reaction_summary', () => withRetries('fetchBoardReactionState', async () => {
     const params = new URLSearchParams({
       target_type: targetType,
       target_id: targetId,
-      user_id: defaultBoardVoter(),
     })
-    const raw = await get<{ reactions?: unknown[] }>(`/api/v1/board/reactions?${params}`)
-    return Array.isArray(raw.reactions)
-      ? raw.reactions.map(normalizeBoardReactionSummary).filter((row): row is BoardReactionSummary => row !== null)
-      : []
+    const raw = await get<unknown>(`/api/v1/board/reactions?${params}`)
+    if (!isRecord(raw) || !Array.isArray(raw.reactions)) {
+      throw new Error('Malformed board reaction state: reactions must be an array')
+    }
+    const summaries = raw.reactions.map(normalizeBoardReactionSummary)
+    if (summaries.some(row => row === null)) {
+      throw new Error('Malformed board reaction state: invalid reaction summary')
+    }
+    const supportedEmojis = normalizeSupportedReactionEmojis(raw.supported_emojis)
+    if (!supportedEmojis || supportedEmojis.length === 0) {
+      throw new Error('Malformed board reaction state: supported_emojis is required')
+    }
+    return {
+      summaries: summaries as BoardReactionSummary[],
+      supportedEmojis,
+    }
   }))
 }
 
@@ -1065,7 +1098,6 @@ export async function toggleReaction(
     const raw = await post<unknown>('/api/v1/board/reactions', {
       target_type: targetType,
       target_id: targetId,
-      user_id: defaultBoardVoter(),
       emoji,
     })
     const normalized = normalizeBoardReactionToggleResult(raw)

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1025,9 +1025,9 @@ export async function fetchBoardReactionState(
     if (summaries.some(row => row === null)) {
       throw new Error('Malformed board reaction state: invalid reaction summary')
     }
-    const supportedEmojis = normalizeSupportedReactionEmojis(raw.supported_emojis)
+    const supportedEmojis = normalizeSupportedReactionEmojis(raw.supported_reaction_emojis)
     if (!supportedEmojis || supportedEmojis.length === 0) {
-      throw new Error('Malformed board reaction state: supported_emojis is required')
+      throw new Error('Malformed board reaction state: supported_reaction_emojis is required')
     }
     return {
       summaries: summaries as BoardReactionSummary[],

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -60,6 +60,11 @@ vi.mock('../../api/actions', () => ({
 
 vi.mock('../../api/board', () => ({
   requestBoardContextInference: vi.fn(),
+  fetchBoardReactionState: vi.fn().mockResolvedValue({
+    summaries: [],
+    supportedEmojis: ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'],
+  }),
+  toggleReaction: vi.fn(),
 }))
 
 vi.mock('../../operator-store', async (importOriginal) => {
@@ -113,6 +118,7 @@ function makePost(overrides: Partial<BoardPost> & { id: string; title: string; a
     visibility: 'internal',
     expires_at: null,
     hearth_count: 0,
+    supported_reaction_emojis: ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'],
     ...overrides,
   } as BoardPost
 }

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -484,6 +484,7 @@ function PostCard({ post }: { post: BoardPost }) {
             targetId=${post.id}
             compact
             initialSummaries=${post.reactions ?? []}
+            supportedEmojis=${post.supported_reaction_emojis}
           />
         </div>
         <span class="karma" aria-label=${voteScoreAria} title=${voteScoreLabel}>karma <b>${voteScoreLabel}</b></span>

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -39,7 +39,10 @@ vi.mock('../common/feedback-state', () => ({
 }))
 
 vi.mock('../../api/board', () => ({
-  fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  fetchBoardReactionState: vi.fn().mockResolvedValue({
+    summaries: [],
+    supportedEmojis: ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'],
+  }),
   votePost: vi.fn().mockResolvedValue(undefined),
   voteComment: vi.fn().mockResolvedValue(undefined),
   requestBoardContextInference: vi.fn().mockResolvedValue({

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -322,7 +322,13 @@ function CommentItem({
           >${expanded ? '접기' : '더 보기...'}<//>
         ` : null}
         <div class="mt-2">
-          <${ReactionBar} targetType="comment" targetId=${comment.id} compact initialSummaries=${comment.reactions} />
+          <${ReactionBar}
+            targetType="comment"
+            targetId=${comment.id}
+            compact
+            initialSummaries=${comment.reactions}
+            supportedEmojis=${comment.supported_reaction_emojis}
+          />
         </div>
         ${isReplying ? html`
           <div class="mt-2">
@@ -690,7 +696,12 @@ export function PostDetail({ post }: { post: BoardPost }) {
             >▼ 비추천<//>
           </div>
 
-          <${ReactionBar} targetType="post" targetId=${post.id} initialSummaries=${post.reactions} />
+          <${ReactionBar}
+            targetType="post"
+            targetId=${post.id}
+            initialSummaries=${post.reactions}
+            supportedEmojis=${post.supported_reaction_emojis}
+          />
         </div>
       <//>
 

--- a/dashboard/src/components/board/reaction-bar.a11y.test.ts
+++ b/dashboard/src/components/board/reaction-bar.a11y.test.ts
@@ -6,7 +6,10 @@ import { axe } from 'jest-axe'
 import '@testing-library/jest-dom'
 
 vi.mock('../../api/board', () => ({
-  fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  fetchBoardReactionState: vi.fn().mockResolvedValue({
+    summaries: [],
+    supportedEmojis: ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'],
+  }),
   toggleReaction: vi.fn(),
 }))
 
@@ -34,6 +37,7 @@ describe('ReactionBar a11y', () => {
         has_reacted: true,
         recent_user_ids: ['agent-a'],
       }],
+      supportedEmojis: ['🔥'],
     }))
 
     expect(await axe(container)).toHaveNoViolations()
@@ -46,6 +50,7 @@ describe('ReactionBar a11y', () => {
       targetType: 'post',
       targetId: 'post-1',
       initialSummaries: [],
+      supportedEmojis: ['👍'],
     }))
 
     fireEvent.click(screen.getByRole('button', { name: '👍 리액션 0개' }))

--- a/dashboard/src/components/board/reaction-bar.test.ts
+++ b/dashboard/src/components/board/reaction-bar.test.ts
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
 vi.mock('../../api/board', () => ({
-  fetchBoardReactions: vi.fn().mockResolvedValue([]),
+  fetchBoardReactionState: vi.fn().mockResolvedValue({
+    summaries: [],
+    supportedEmojis: ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'],
+  }),
   toggleReaction: vi.fn(),
 }))
 
@@ -12,7 +15,7 @@ vi.mock('../common/toast', () => ({
   showToast: vi.fn(),
 }))
 
-import { fetchBoardReactions, toggleReaction } from '../../api/board'
+import { fetchBoardReactionState, toggleReaction } from '../../api/board'
 import { lastEvent } from '../../sse'
 import { showToast } from '../common/toast'
 import { ReactionBar } from './reaction-bar'
@@ -24,13 +27,15 @@ afterEach(() => {
 })
 
 describe('ReactionBar', () => {
-  it('renders the eight standard board reactions', () => {
+  it('renders the reaction catalog returned by the server', async () => {
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
-    for (const emoji of ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥']) {
-      expect(screen.getByRole('button', { name: `${emoji} 리액션 0개` })).toBeInTheDocument()
-    }
-    expect(screen.getByRole('status')).toHaveTextContent('')
+    await waitFor(() => {
+      for (const emoji of ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥']) {
+        expect(screen.getByRole('button', { name: `${emoji} 리액션 0개` })).toBeInTheDocument()
+      }
+      expect(screen.getByRole('status')).toHaveTextContent('')
+    })
   })
 
   it('uses embedded initial summaries without an initial fetch', async () => {
@@ -44,28 +49,32 @@ describe('ReactionBar', () => {
         has_reacted: true,
         recent_user_ids: ['agent-a'],
       }],
+      supportedEmojis: ['👏'],
     }))
 
     expect(screen.getByRole('button', { name: '👏 리액션 5개' })).toHaveAttribute('aria-pressed', 'true')
     await Promise.resolve()
-    expect(fetchBoardReactions).not.toHaveBeenCalled()
+    expect(fetchBoardReactionState).not.toHaveBeenCalled()
   })
 
   it('refreshes summaries only when a matching reaction_changed event arrives', async () => {
-    vi.mocked(fetchBoardReactions)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{
-        emoji: '🔥',
-        count: 3,
-        reacted: false,
-        has_reacted: false,
-        recent_user_ids: ['agent-a', 'agent-b'],
-      }])
+    vi.mocked(fetchBoardReactionState)
+      .mockResolvedValueOnce({ summaries: [], supportedEmojis: ['🔥'] })
+      .mockResolvedValueOnce({
+        summaries: [{
+          emoji: '🔥',
+          count: 3,
+          reacted: false,
+          has_reacted: false,
+          recent_user_ids: ['agent-a', 'agent-b'],
+        }],
+        supportedEmojis: ['🔥'],
+      })
 
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
     await waitFor(() => {
-      expect(fetchBoardReactions).toHaveBeenCalledTimes(1)
+      expect(fetchBoardReactionState).toHaveBeenCalledTimes(1)
     })
 
     lastEvent.value = {
@@ -77,7 +86,7 @@ describe('ReactionBar', () => {
       reacted: true,
     }
     await Promise.resolve()
-    expect(fetchBoardReactions).toHaveBeenCalledTimes(1)
+    expect(fetchBoardReactionState).toHaveBeenCalledTimes(1)
 
     lastEvent.value = {
       type: 'reaction_changed',
@@ -89,13 +98,13 @@ describe('ReactionBar', () => {
     }
 
     await waitFor(() => {
-      expect(fetchBoardReactions).toHaveBeenCalledTimes(2)
+      expect(fetchBoardReactionState).toHaveBeenCalledTimes(2)
       expect(screen.getByRole('button', { name: '🔥 리액션 3개' })).toBeInTheDocument()
     })
   })
 
   it('clears the live status before retrying reaction summary refreshes', async () => {
-    vi.mocked(fetchBoardReactions).mockRejectedValueOnce(new Error('offline'))
+    vi.mocked(fetchBoardReactionState).mockRejectedValueOnce(new Error('offline'))
 
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
@@ -103,8 +112,8 @@ describe('ReactionBar', () => {
       expect(screen.getByRole('status')).toHaveTextContent('리액션 요약을 불러오지 못했습니다')
     })
 
-    let resolveRefresh: (value: []) => void = () => {}
-    vi.mocked(fetchBoardReactions).mockImplementationOnce(() => new Promise(resolve => {
+    let resolveRefresh: (value: { summaries: []; supportedEmojis: string[] }) => void = () => {}
+    vi.mocked(fetchBoardReactionState).mockImplementationOnce(() => new Promise(resolve => {
       resolveRefresh = resolve
     }))
 
@@ -118,10 +127,43 @@ describe('ReactionBar', () => {
     }
 
     await waitFor(() => {
-      expect(fetchBoardReactions).toHaveBeenCalledTimes(2)
-      expect(screen.getByRole('status')).toHaveTextContent('')
+      expect(fetchBoardReactionState).toHaveBeenCalledTimes(2)
+      expect(screen.getByRole('status')).toHaveTextContent('리액션 종류를 불러오는 중입니다')
     })
-    resolveRefresh([])
+    resolveRefresh({ summaries: [], supportedEmojis: ['🔥'] })
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/^$/)
+    })
+  })
+
+  it('applies a successful click result to the visible reaction state', async () => {
+    vi.mocked(toggleReaction).mockResolvedValueOnce({
+      target_type: 'post',
+      target_id: 'post-1',
+      user_id: 'dashboard-reviewer',
+      emoji: '👍',
+      reacted: true,
+      summary: [{
+        emoji: '👍',
+        count: 1,
+        reacted: true,
+        has_reacted: true,
+        recent_user_ids: ['dashboard-reviewer'],
+      }],
+    })
+
+    render(h(ReactionBar, {
+      targetType: 'post',
+      targetId: 'post-1',
+      initialSummaries: [],
+      supportedEmojis: ['👍'],
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '👍 리액션 0개' }))
+
+    const reacted = await screen.findByRole('button', { name: '👍 리액션 1개' })
+    expect(reacted).toHaveAttribute('aria-pressed', 'true')
+    expect(toggleReaction).toHaveBeenCalledWith('post', 'post-1', '👍')
   })
 
   it('announces and toasts failed reaction toggles', async () => {
@@ -129,7 +171,7 @@ describe('ReactionBar', () => {
 
     render(h(ReactionBar, { targetType: 'post', targetId: 'post-1' }))
 
-    const reaction = screen.getByRole('button', { name: '👍 리액션 0개' })
+    const reaction = await screen.findByRole('button', { name: '👍 리액션 0개' })
     fireEvent.click(reaction)
 
     await waitFor(() => {

--- a/dashboard/src/components/board/reaction-bar.ts
+++ b/dashboard/src/components/board/reaction-bar.ts
@@ -1,41 +1,49 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { fetchBoardReactions, toggleReaction } from '../../api/board'
+import { fetchBoardReactionState, toggleReaction } from '../../api/board'
 import { lastEvent } from '../../sse'
 import { showToast } from '../common/toast'
 import type { BoardReactionSummary, BoardReactionTargetType } from '../../types'
-
-const BOARD_REACTION_EMOJIS = ['👍', '❤️', '🎉', '🚀', '👀', '😕', '👏', '🔥'] as const
 
 export function ReactionBar({
   targetType,
   targetId,
   compact = false,
   initialSummaries,
+  supportedEmojis,
 }: {
   targetType: BoardReactionTargetType
   targetId: string
   compact?: boolean
   initialSummaries?: BoardReactionSummary[]
+  supportedEmojis?: readonly string[]
 }) {
-  const hasInitialSummaries = initialSummaries !== undefined
+  const hasInitialState =
+    initialSummaries !== undefined && supportedEmojis !== undefined && supportedEmojis.length > 0
   const [summaries, setSummaries] = useState<BoardReactionSummary[]>(() => initialSummaries ?? [])
+  const [supportedEmojiCatalog, setSupportedEmojiCatalog] = useState<string[] | null>(
+    () => supportedEmojis && supportedEmojis.length > 0 ? [...supportedEmojis] : null,
+  )
   const [busyEmoji, setBusyEmoji] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState('')
 
   useEffect(() => {
     setSummaries(initialSummaries ?? [])
+    setSupportedEmojiCatalog(
+      supportedEmojis && supportedEmojis.length > 0 ? [...supportedEmojis] : null,
+    )
     setStatusMessage('')
-  }, [targetType, targetId, initialSummaries])
+  }, [targetType, targetId, initialSummaries, supportedEmojis])
 
   useEffect(() => {
     let cancelled = false
     const refresh = () => {
       setStatusMessage('')
-      void fetchBoardReactions(targetType, targetId)
+      void fetchBoardReactionState(targetType, targetId)
         .then(next => {
           if (!cancelled) {
-            setSummaries(next)
+            setSummaries(next.summaries)
+            setSupportedEmojiCatalog(next.supportedEmojis)
             setStatusMessage('')
           }
         })
@@ -46,7 +54,7 @@ export function ReactionBar({
           }
         })
     }
-    if (!hasInitialSummaries) refresh()
+    if (!hasInitialState) refresh()
     const unsubscribe = lastEvent.subscribe(event => {
       if (event?.type !== 'reaction_changed') return
       if (event.target_type === targetType && event.target_id === targetId) {
@@ -57,7 +65,7 @@ export function ReactionBar({
       cancelled = true
       unsubscribe()
     }
-  }, [targetType, targetId, hasInitialSummaries])
+  }, [targetType, targetId, hasInitialState])
 
   const summaryByEmoji = useMemo(() => {
     const map = new Map<string, BoardReactionSummary>()
@@ -84,7 +92,7 @@ export function ReactionBar({
 
   return html`
     <div class="flex items-center gap-1 flex-wrap" role="group" aria-label="리액션">
-      ${BOARD_REACTION_EMOJIS.map(emoji => {
+      ${(supportedEmojiCatalog ?? []).map(emoji => {
         const summary = summaryByEmoji.get(emoji)
         const count = summary?.count ?? 0
         const reacted = summary?.reacted ?? false
@@ -107,7 +115,9 @@ export function ReactionBar({
           </button>
         `
       })}
-      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true">${statusMessage}</span>
+      <span class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        ${statusMessage || (supportedEmojiCatalog === null ? '리액션 종류를 불러오는 중입니다' : '')}
+      </span>
     </div>
   `
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -227,6 +227,7 @@ export interface BoardPost {
   contributor_quality?: BoardContributorQuality | null
   claim_evidence?: BoardClaimEvidenceProjection | null
   reactions?: BoardReactionSummary[]
+  supported_reaction_emojis?: string[]
   origin?: BoardPostOrigin | null
 }
 
@@ -249,6 +250,7 @@ export interface BoardComment {
   report_count?: number
   moderation_status?: BoardModerationStatus
   reactions?: BoardReactionSummary[]
+  supported_reaction_emojis?: string[]
 }
 
 export type BoardReactionTargetType = 'post' | 'comment'
@@ -268,6 +270,11 @@ export interface BoardReactionToggleResult {
   emoji: string
   reacted: boolean
   summary: BoardReactionSummary[]
+}
+
+export interface BoardReactionState {
+  summaries: BoardReactionSummary[]
+  supportedEmojis: string[]
 }
 
 export interface BoardCurationSnapshot {

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -917,6 +917,16 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
                   ; action = Masc_domain.show_permission permission
                   }))
 
+let authorize_optional_token_bound_permission_request
+    ~base_path
+    ~permission
+    request =
+  match Httpun.Headers.get request.Httpun.Request.headers "authorization" with
+  | None -> Ok None
+  | Some _ ->
+    authorize_token_bound_permission_request ~base_path ~permission request
+    |> Result.map Option.some
+
 let is_dashboard_bootstrap_path path =
   String.starts_with ~prefix:"/api/v1/dashboard/" path
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -68,16 +68,27 @@ let bearer_token_from_header value =
   then Some (String.sub value prefix_len (String.length value - prefix_len))
   else None
 
+let authorization_header_name = "authorization"
+let internal_token_header_name = "x-masc-internal-token"
+
 let auth_token_from_request request =
   match
     Option.bind
-      (Httpun.Headers.get request.Httpun.Request.headers "authorization")
+      (Httpun.Headers.get request.Httpun.Request.headers authorization_header_name)
       bearer_token_from_header
   with
   | Some _ as token -> token
   | None ->
       trim_opt
-        (Httpun.Headers.get request.Httpun.Request.headers "x-masc-internal-token")
+        (Httpun.Headers.get request.Httpun.Request.headers internal_token_header_name)
+
+let request_carries_auth_credential request =
+  match
+    ( Httpun.Headers.get request.Httpun.Request.headers authorization_header_name
+    , Httpun.Headers.get request.Httpun.Request.headers internal_token_header_name )
+  with
+  | None, None -> false
+  | None, Some _ | Some _, None | Some _, Some _ -> true
 
 let observer_sse_query_token_from_request request =
   let path = Http_server_eio.Request.path request in
@@ -921,11 +932,11 @@ let authorize_optional_token_bound_permission_request
     ~base_path
     ~permission
     request =
-  match auth_token_from_request request with
-  | None -> Ok None
-  | Some _ ->
+  if request_carries_auth_credential request
+  then
     authorize_token_bound_permission_request ~base_path ~permission request
     |> Result.map Option.some
+  else Ok None
 
 let is_dashboard_bootstrap_path path =
   String.starts_with ~prefix:"/api/v1/dashboard/" path

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -921,7 +921,7 @@ let authorize_optional_token_bound_permission_request
     ~base_path
     ~permission
     request =
-  match Httpun.Headers.get request.Httpun.Request.headers "authorization" with
+  match auth_token_from_request request with
   | None -> Ok None
   | Some _ ->
     authorize_token_bound_permission_request ~base_path ~permission request

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -321,8 +321,8 @@ val authorize_optional_token_bound_permission_request :
   base_path:string ->
   permission:Masc_domain.permission ->
   Httpun.Request.t -> (string option, Masc_domain.masc_error) result
-(** Return [Ok None] when the request has no Authorization header. If one is
-    present, validate its bearer credential and permission and return its
+(** Return [Ok None] when the request carries no supported bearer header. If a
+    bearer is present, validate its credential and permission and return its
     canonical agent name. Malformed, invalid, or underprivileged credentials
     are errors rather than anonymous fallbacks. *)
 

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -65,6 +65,12 @@ val bearer_token_from_header : string -> string option
 val auth_token_from_request : Httpun.Request.t -> string option
 (** Token from [Authorization: Bearer …] on the request. *)
 
+val request_carries_auth_credential : Httpun.Request.t -> bool
+(** Whether the request presents either supported credential header, including
+    an empty or malformed value. This presence check lets optional-auth routes
+    distinguish a genuinely anonymous request from a credential that must fail
+    closed during parsing or validation. *)
+
 val observer_sse_query_token_from_request : Httpun.Request.t -> string option
 (** Observer/presence/cursor SSE allows the token via query string for browser
     EventSource. *)
@@ -321,10 +327,10 @@ val authorize_optional_token_bound_permission_request :
   base_path:string ->
   permission:Masc_domain.permission ->
   Httpun.Request.t -> (string option, Masc_domain.masc_error) result
-(** Return [Ok None] when the request carries no supported bearer header. If a
-    bearer is present, validate its credential and permission and return its
-    canonical agent name. Malformed, invalid, or underprivileged credentials
-    are errors rather than anonymous fallbacks. *)
+(** Return [Ok None] only when the request carries no supported credential
+    header. If a header is present, validate its credential and permission and
+    return its canonical agent name. Malformed, empty, invalid, or
+    underprivileged credentials are errors rather than anonymous fallbacks. *)
 
 val is_dashboard_bootstrap_path : string -> bool
 (** [true] when the path is part of the dashboard bootstrap surface

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -314,8 +314,17 @@ val authorize_token_bound_permission_request :
   base_path:string ->
   permission:Masc_domain.permission ->
   Httpun.Request.t -> (string, Masc_domain.masc_error) result
-(** Like [authorize_permission_request] but returns the token id used
-    for auditing the call. *)
+(** Like [authorize_permission_request] but returns the credential's canonical
+    agent name for actor-bound operations. *)
+
+val authorize_optional_token_bound_permission_request :
+  base_path:string ->
+  permission:Masc_domain.permission ->
+  Httpun.Request.t -> (string option, Masc_domain.masc_error) result
+(** Return [Ok None] when the request has no Authorization header. If one is
+    present, validate its bearer credential and permission and return its
+    canonical agent name. Malformed, invalid, or underprivileged credentials
+    are errors rather than anonymous fallbacks. *)
 
 val is_dashboard_bootstrap_path : string -> bool
 (** [true] when the path is part of the dashboard bootstrap surface

--- a/lib/server/server_board_post_response_format.ml
+++ b/lib/server/server_board_post_response_format.ml
@@ -1,0 +1,43 @@
+type t =
+  | Nested
+  | Flat
+
+type error = Unsupported of string
+
+let default = Nested
+
+let to_wire = function
+  | Nested -> "nested"
+  | Flat -> "flat"
+;;
+
+let supported = [ Nested; Flat ]
+
+let of_query = function
+  | None -> Ok default
+  | Some supplied ->
+    let normalized = String.lowercase_ascii (String.trim supplied) in
+    (match
+       List.find_opt
+         (fun response_format ->
+            String.equal normalized (to_wire response_format))
+         supported
+     with
+     | Some response_format -> Ok response_format
+     | None -> Error (Unsupported supplied))
+;;
+
+let error_json (Unsupported supplied) =
+  let supported_formats = List.map to_wire supported in
+  `Assoc
+    [ ( "error"
+      , `String
+          (Printf.sprintf
+             "format must be one of: %s"
+             (String.concat ", " supported_formats)) )
+    ; "code", `String "unsupported_board_post_response_format"
+    ; "supplied", `String supplied
+    ; ( "supported_formats"
+      , `List (List.map (fun value -> `String value) supported_formats) )
+    ]
+;;

--- a/lib/server/server_board_post_response_format.mli
+++ b/lib/server/server_board_post_response_format.mli
@@ -1,0 +1,12 @@
+(** Typed codec for the Board post-detail [format] query parameter. *)
+
+type t =
+  | Nested
+  | Flat
+
+type error = Unsupported of string
+
+val default : t
+val to_wire : t -> string
+val of_query : string option -> (t, error) result
+val error_json : error -> Yojson.Safe.t

--- a/lib/server/server_board_reaction_http.ml
+++ b/lib/server/server_board_reaction_http.ml
@@ -1,0 +1,207 @@
+open Result.Syntax
+
+type target =
+  { target_type : Board.reaction_target_type
+  ; target_id : string
+  }
+
+type toggle_request =
+  { target : target
+  ; emoji : string
+  }
+
+type error_code =
+  | Invalid_json
+  | Missing_field
+  | Invalid_target_type
+  | Invalid_id
+  | Post_not_found
+  | Comment_not_found
+  | Rate_limited
+  | Capacity_exceeded
+  | Io_error
+  | Validation_error
+  | Already_voted
+  | Already_exists
+  | Unauthorized
+
+type http_status =
+  [ `Bad_request
+  | `Conflict
+  | `Forbidden
+  | `Internal_server_error
+  | `Not_found
+  | `Too_many_requests
+  ]
+
+type error =
+  { code : error_code
+  ; message : string
+  ; status : http_status
+  ; details : (string * Yojson.Safe.t) list
+  }
+
+let error_code_to_string = function
+  | Invalid_json -> "invalid_json"
+  | Missing_field -> "missing_field"
+  | Invalid_target_type -> "invalid_target_type"
+  | Invalid_id -> "invalid_id"
+  | Post_not_found -> "post_not_found"
+  | Comment_not_found -> "comment_not_found"
+  | Rate_limited -> "rate_limited"
+  | Capacity_exceeded -> "capacity_exceeded"
+  | Io_error -> "io_error"
+  | Validation_error -> "validation_error"
+  | Already_voted -> "already_voted"
+  | Already_exists -> "already_exists"
+  | Unauthorized -> "unauthorized"
+;;
+
+let make_error ?(details = []) ~code ~status message =
+  { code; message; status; details }
+;;
+
+let malformed_json message =
+  make_error
+    ~code:Invalid_json
+    ~status:`Bad_request
+    ("Board reaction request is not valid JSON: " ^ message)
+;;
+
+let required_nonempty field value =
+  match Option.map String.trim value with
+  | Some value when not (String.equal value "") -> Ok value
+  | Some _ | None ->
+    Error
+      (make_error
+         ~code:Missing_field
+         ~status:`Bad_request
+         (field ^ " is required"))
+;;
+
+let target_of_strings ~target_type ~target_id =
+  let* target_type = required_nonempty "target_type" target_type in
+  let* target_id = required_nonempty "target_id" target_id in
+  match Board.reaction_target_type_of_string_opt target_type with
+  | Some target_type -> Ok { target_type; target_id }
+  | None ->
+    Error
+      (make_error
+         ~code:Invalid_target_type
+         ~status:`Bad_request
+         (Printf.sprintf
+            "target_type must be one of: %s"
+            (String.concat ", " Board.valid_reaction_target_type_strings)))
+;;
+
+let toggle_request_of_json = function
+  | `Assoc _ as json ->
+    let* target =
+      target_of_strings
+        ~target_type:(Json_util.get_string json "target_type")
+        ~target_id:(Json_util.get_string json "target_id")
+    in
+    let+ emoji = required_nonempty "emoji" (Json_util.get_string json "emoji") in
+    { target; emoji }
+  | `Null
+  | `Bool _
+  | `Int _
+  | `Intlit _
+  | `Float _
+  | `String _
+  | `List _
+  | `Tuple _
+  | `Variant _ ->
+    Error
+      (make_error
+         ~code:Invalid_json
+         ~status:`Bad_request
+         "Board reaction request must be a JSON object")
+;;
+
+let status_of_board_error = function
+  | Board.Invalid_id _
+  | Board.Validation_error _ -> `Bad_request
+  | Board.Already_voted _ | Board.Already_exists _ -> `Conflict
+  | Board.Post_not_found _ | Board.Comment_not_found _ -> `Not_found
+  | Board.Rate_limited _ | Board.Capacity_exceeded _ -> `Too_many_requests
+  | Board.Unauthorized _ -> `Forbidden
+  | Board.Io_error _ -> `Internal_server_error
+;;
+
+let code_and_details_of_board_error = function
+  | Board.Invalid_id _ -> Invalid_id, []
+  | Board.Post_not_found _ -> Post_not_found, []
+  | Board.Comment_not_found _ -> Comment_not_found, []
+  | Board.Rate_limited { retry_after } ->
+    Rate_limited, [ "retry_after_seconds", `Float retry_after ]
+  | Board.Capacity_exceeded { current; max } ->
+    Capacity_exceeded, [ "current", `Int current; "max", `Int max ]
+  | Board.Io_error _ -> Io_error, []
+  | Board.Validation_error _ -> Validation_error, []
+  | Board.Already_voted _ -> Already_voted, []
+  | Board.Already_exists _ -> Already_exists, []
+  | Board.Unauthorized _ -> Unauthorized, []
+;;
+
+let of_board_error board_error =
+  let code, details = code_and_details_of_board_error board_error in
+  let message =
+    match board_error with
+    | Board.Io_error detail ->
+      Log.Server.error "Board reaction storage operation failed: %s" detail;
+      "Board reaction storage operation failed"
+    | _ -> Board_tool.board_error_to_string board_error
+  in
+  make_error
+    ~code
+    ~details
+    ~status:(status_of_board_error board_error)
+    message
+;;
+
+let catalog_json () =
+  `Assoc
+    [ ( "supported_emojis"
+      , `List (List.map (fun emoji -> `String emoji) Board.board_reaction_emojis) )
+    ]
+;;
+
+let reaction_state_json summaries =
+  `Assoc
+    [ ( "reactions"
+      , `List (List.map Board.reaction_summary_to_yojson summaries) )
+    ; ( "supported_emojis"
+      , `List (List.map (fun emoji -> `String emoji) Board.board_reaction_emojis) )
+    ]
+;;
+
+let list_json ~actor target =
+  Board_dispatch.list_reactions
+    ~target_type:target.target_type
+    ~target_id:target.target_id
+    ~user_id:actor
+    ()
+  |> Result.map reaction_state_json
+  |> Result.map_error of_board_error
+;;
+
+let toggle_json ~actor request =
+  Board_dispatch.toggle_reaction
+    ~target_type:request.target.target_type
+    ~target_id:request.target.target_id
+    ~user_id:actor
+    ~emoji:request.emoji
+  |> Result.map Board.reaction_toggle_result_to_yojson
+  |> Result.map_error of_board_error
+;;
+
+let error_status error = error.status
+
+let error_json error =
+  Tool_args.error_assoc
+    ([ "error_code", `String (error_code_to_string error.code)
+     ; "message", `String error.message
+     ]
+     @ error.details)
+;;

--- a/lib/server/server_board_reaction_http.ml
+++ b/lib/server/server_board_reaction_http.ml
@@ -160,19 +160,19 @@ let of_board_error board_error =
     message
 ;;
 
+let supported_reaction_emojis_json () =
+  `List (List.map (fun emoji -> `String emoji) Board.board_reaction_emojis)
+;;
+
 let catalog_json () =
-  `Assoc
-    [ ( "supported_emojis"
-      , `List (List.map (fun emoji -> `String emoji) Board.board_reaction_emojis) )
-    ]
+  `Assoc [ "supported_reaction_emojis", supported_reaction_emojis_json () ]
 ;;
 
 let reaction_state_json summaries =
   `Assoc
     [ ( "reactions"
       , `List (List.map Board.reaction_summary_to_yojson summaries) )
-    ; ( "supported_emojis"
-      , `List (List.map (fun emoji -> `String emoji) Board.board_reaction_emojis) )
+    ; "supported_reaction_emojis", supported_reaction_emojis_json ()
     ]
 ;;
 

--- a/lib/server/server_board_reaction_http.mli
+++ b/lib/server/server_board_reaction_http.mli
@@ -1,0 +1,38 @@
+(** Typed HTTP projection for Board reactions.
+
+    The Board domain owns reaction validation, persistence, and the supported
+    emoji catalog.  HTTP/1.1 and HTTP/2 adapters only authenticate the actor,
+    parse their transport payload, and render this shared result. *)
+
+type target
+type toggle_request
+type error
+
+type http_status =
+  [ `Bad_request
+  | `Conflict
+  | `Forbidden
+  | `Internal_server_error
+  | `Not_found
+  | `Too_many_requests
+  ]
+
+val target_of_strings :
+  target_type:string option ->
+  target_id:string option ->
+  (target, error) result
+
+val toggle_request_of_json : Yojson.Safe.t -> (toggle_request, error) result
+
+val malformed_json : string -> error
+
+val catalog_json : unit -> Yojson.Safe.t
+
+val list_json :
+  actor:string -> target -> (Yojson.Safe.t, error) result
+
+val toggle_json :
+  actor:string -> toggle_request -> (Yojson.Safe.t, error) result
+
+val error_status : error -> http_status
+val error_json : error -> Yojson.Safe.t

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -896,6 +896,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_reqd
             ~permission:Masc_domain.CanReadState
             (fun _state actor ->
+               let actor = board_actor_author_for_write actor in
                let result =
                  Result.bind
                    (Server_board_reaction_http.target_of_strings
@@ -910,6 +911,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_reqd
             ~permission:Masc_domain.CanVote
             (fun _state actor ->
+               let actor = board_actor_author_for_write actor in
                h2_read_body h2_reqd (fun body ->
                  let parsed =
                    match Yojson.Safe.from_string body with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -146,7 +146,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
         h2_respond_json_value
           h2_reqd
           (Server_board_reaction_http.error_json error)
-          ~status:(Server_board_reaction_http.error_status error)
+          ~status:(Server_board_reaction_http.error_status error :> H2.Status.t)
           ~extra_headers:cors
     in
     let session_id_opt = get_session_id_any httpun_request in
@@ -896,12 +896,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_reqd
             ~permission:Masc_domain.CanReadState
             (fun _state actor ->
-               let actor = board_actor_author_for_write actor in
+               let actor = Server_utils.board_actor_author_for_write actor in
                let result =
                  Result.bind
                    (Server_board_reaction_http.target_of_strings
-                      ~target_type:(query_param httpun_request "target_type")
-                      ~target_id:(query_param httpun_request "target_id"))
+                      ~target_type:
+                        (Server_utils.query_param httpun_request "target_type")
+                      ~target_id:
+                        (Server_utils.query_param httpun_request "target_id"))
                    (Server_board_reaction_http.list_json ~actor)
                in
                h2_respond_board_reaction_result h2_reqd result)
@@ -911,7 +913,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_reqd
             ~permission:Masc_domain.CanVote
             (fun _state actor ->
-               let actor = board_actor_author_for_write actor in
+               let actor = Server_utils.board_actor_author_for_write actor in
                h2_read_body h2_reqd (fun body ->
                  let parsed =
                    match Yojson.Safe.from_string body with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -140,6 +140,15 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
              | Error () -> ())
         | Error err -> h2_respond_auth_error h2_reqd err)
     in
+    let h2_respond_board_reaction_result h2_reqd = function
+      | Ok json -> h2_respond_json_value h2_reqd json ~extra_headers:cors
+      | Error error ->
+        h2_respond_json_value
+          h2_reqd
+          (Server_board_reaction_http.error_json error)
+          ~status:(Server_board_reaction_http.error_status error)
+          ~extra_headers:cors
+    in
     let session_id_opt = get_session_id_any httpun_request in
     let h2_respond_dashboard_index () =
       let index_path = dashboard_index_path () in
@@ -874,6 +883,46 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `POST, p when String.starts_with ~prefix:"/api/v1/command-plane" p ->
           h2_respond_removed_surface h2_reqd ~surface:"command_plane" ~extra_headers:cors
+
+      | `GET, "/api/v1/board/reactions/catalog" ->
+          with_h2_public_read h2_reqd (fun _state ->
+            h2_respond_json_value
+              h2_reqd
+              (Server_board_reaction_http.catalog_json ())
+              ~extra_headers:cors)
+
+      | `GET, "/api/v1/board/reactions" ->
+          with_h2_token_permission_auth
+            h2_reqd
+            ~permission:Masc_domain.CanReadState
+            (fun _state actor ->
+               let result =
+                 Result.bind
+                   (Server_board_reaction_http.target_of_strings
+                      ~target_type:(query_param httpun_request "target_type")
+                      ~target_id:(query_param httpun_request "target_id"))
+                   (Server_board_reaction_http.list_json ~actor)
+               in
+               h2_respond_board_reaction_result h2_reqd result)
+
+      | `POST, "/api/v1/board/reactions" ->
+          with_h2_token_permission_auth
+            h2_reqd
+            ~permission:Masc_domain.CanVote
+            (fun _state actor ->
+               h2_read_body h2_reqd (fun body ->
+                 let parsed =
+                   match Yojson.Safe.from_string body with
+                   | json -> Server_board_reaction_http.toggle_request_of_json json
+                   | exception Yojson.Json_error message ->
+                     Error (Server_board_reaction_http.malformed_json message)
+                 in
+                 let result =
+                   Result.bind
+                     parsed
+                     (Server_board_reaction_http.toggle_json ~actor)
+                 in
+                 h2_respond_board_reaction_result h2_reqd result))
 
       (* ═══════════════════════════════════════════════════════════════════════
          Delegated route groups

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -9,6 +9,41 @@ open Server_h2_gateway_helpers
 let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
     (httpun_meth : [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
                     | `CONNECT | `TRACE | `Other of string ]) =
+  let h2_respond_auth_error error =
+    h2_respond_json
+      h2_reqd
+      (Server_auth.auth_error_json error)
+      ~status:(Server_auth.http_status_of_auth_error error :> H2.Status.t)
+      ~extra_headers:cors
+  in
+  let with_optional_board_reaction_actor f =
+    match config with
+    | None ->
+      (match
+         Httpun.Headers.get
+           httpun_request.Httpun.Request.headers
+           "authorization"
+       with
+       | None -> f None
+       | Some _ ->
+         h2_respond_json
+           h2_reqd
+           (Server_auth.not_initialized_response path)
+           ~status:`Internal_server_error
+           ~extra_headers:cors;
+         true)
+    | Some config ->
+      (match
+         Server_auth.authorize_optional_token_bound_permission_request
+           ~base_path:config.base_path
+           ~permission:Masc_domain.CanReadState
+           httpun_request
+       with
+       | Ok actor -> f (Option.map board_actor_author_for_write actor)
+       | Error error ->
+         h2_respond_auth_error error;
+         true)
+  in
   match httpun_meth, path with
   | `GET, "/api/v1/voice/config" ->
       let status, json = voice_config_payload () in
@@ -19,6 +54,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       true
 
   | `GET, "/api/v1/board" ->
+      with_optional_board_reaction_actor (fun reaction_actor ->
       let hearth = query_param httpun_request "hearth" in
       let sort_by = board_sort_order_of_request httpun_request in
       let exclude_system = bool_query_param httpun_request "exclude_system" ~default:false in
@@ -52,7 +88,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
                (fun (p : Board.post) ->
                   (Board.Reaction_post, Board.Post_id.to_string p.id))
                paged)
-          ~voter
+          ~voter:reaction_actor
       in
       let reactions_for = board_reactions_lookup reaction_rows in
       let contributor_quality_for = board_contributor_quality_lookup ?config () in
@@ -75,7 +111,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
         ("sort_by", `String (board_sort_label sort_by));
       ] in
       h2_respond_json_value h2_reqd json ~extra_headers:cors;
-      true
+      true)
 
   | `GET, "/api/v1/board/curation" ->
       let json =
@@ -151,6 +187,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
   | `GET, p
     when String.starts_with ~prefix:"/api/v1/board/" p
          && String.length p > 14 ->
+      with_optional_board_reaction_actor (fun reaction_actor ->
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param httpun_request "format") in
       let voter = board_voter_query httpun_request in
@@ -159,11 +196,11 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes ~voter
-          ~config
+          ~reaction_actor ~config
           ~response_format:format ~post_id
       in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;
-      true
+      true)
 
   | `GET, "/api/v1/karma" ->
       let karma_list = Board_dispatch.get_all_karma () in

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -19,19 +19,15 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
   let with_optional_board_reaction_actor f =
     match config with
     | None ->
-      (match
-         Httpun.Headers.get
-           httpun_request.Httpun.Request.headers
-           "authorization"
-       with
-       | None -> f None
-       | Some _ ->
+      if Server_auth.request_carries_auth_credential httpun_request
+      then (
          h2_respond_json
            h2_reqd
            (Server_auth.not_initialized_response path)
            ~status:`Internal_server_error
            ~extra_headers:cors;
          true)
+      else f None
     | Some (config : Workspace.config) ->
       (match
          Server_auth.authorize_optional_token_bound_permission_request
@@ -189,18 +185,28 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
          && String.length p > 14 ->
       with_optional_board_reaction_actor (fun reaction_actor ->
       let post_id = String.sub p 14 (String.length p - 14) in
-      let format = Option.value ~default:"nested" (query_param httpun_request "format") in
-      let voter = board_voter_query httpun_request in
-      let blind_votes =
-        bool_query_param httpun_request "blind_votes" ~default:false
-      in
-      let (status, body) =
-        board_post_detail_json ~include_moderation:false ~blind_votes ~voter
-          ~reaction_actor ~config
-          ~response_format:format ~post_id
-      in
-      h2_respond_json h2_reqd body ~status ~extra_headers:cors;
-      true)
+      match
+        Server_board_post_response_format.of_query
+          (query_param httpun_request "format")
+      with
+      | Error error ->
+        h2_respond_json_value
+          h2_reqd
+          (Server_board_post_response_format.error_json error)
+          ~status:`Bad_request
+          ~extra_headers:cors;
+        true
+      | Ok response_format ->
+        let voter = board_voter_query httpun_request in
+        let blind_votes =
+          bool_query_param httpun_request "blind_votes" ~default:false
+        in
+        let status, body =
+          board_post_detail_json ~include_moderation:false ~blind_votes ~voter
+            ~reaction_actor ~config ~response_format ~post_id
+        in
+        h2_respond_json h2_reqd body ~status ~extra_headers:cors;
+        true)
 
   | `GET, "/api/v1/karma" ->
       let karma_list = Board_dispatch.get_all_karma () in

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -32,7 +32,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
            ~status:`Internal_server_error
            ~extra_headers:cors;
          true)
-    | Some config ->
+    | Some (config : Workspace.config) ->
       (match
          Server_auth.authorize_optional_token_bound_permission_request
            ~base_path:config.base_path

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -35,7 +35,8 @@ val dispatch :
     - [GET /api/v1/board/curation] — latest AI curation snapshot
       ([{snapshot: null}] when no snapshot has been submitted yet).
     - [GET /api/v1/board/<post_id>] — single post with
-      configurable [format] query param (defaults to [nested]).
+      configurable [format] query param (defaults to [nested]); unsupported
+      values return [400 Bad Request].
     - [GET /api/v1/board/sub-boards] — sub-board list.
     - [POST /api/v1/board/sub-boards] — create sub-board (auth required).
       Body: [{ slug, name, description, access? }].

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -899,27 +899,35 @@ let add_routes ~sw ~clock router =
                 req
                 reqd
                 (fun reaction_actor ->
-                   let format =
-                     query_param req "format" |> Option.value ~default:"nested"
-                   in
-                   let voter = board_voter_query req in
-                   let blind_votes =
-                     bool_query_param req "blind_votes" ~default:false
-                   in
-                   let include_moderation =
-                     include_moderation_projection ~base_path:config.base_path req
-                   in
-                   let status, body =
-                     board_post_detail_json
-                       ~include_moderation
-                       ~blind_votes
-                       ~voter
-                       ~reaction_actor
-                       ~config:(Some config)
-                       ~response_format:format
-                       ~post_id
-                   in
-                   respond_json_with_cors ~status request reqd body))
+                   match
+                     Server_board_post_response_format.of_query
+                       (query_param req "format")
+                   with
+                   | Error error ->
+                     respond_json_value_with_cors
+                       ~status:`Bad_request
+                       request
+                       reqd
+                       (Server_board_post_response_format.error_json error)
+                   | Ok response_format ->
+                     let voter = board_voter_query req in
+                     let blind_votes =
+                       bool_query_param req "blind_votes" ~default:false
+                     in
+                     let include_moderation =
+                       include_moderation_projection ~base_path:config.base_path req
+                     in
+                     let status, body =
+                       board_post_detail_json
+                         ~include_moderation
+                         ~blind_votes
+                         ~voter
+                         ~reaction_actor
+                         ~config:(Some config)
+                         ~response_format
+                         ~post_id
+                     in
+                     respond_json_with_cors ~status request reqd body))
        ) request reqd)
 
   (* Board write APIs — used by dashboard + Bevy Viewer.

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -40,6 +40,16 @@ let include_moderation_projection ~base_path request =
       | Ok _ -> true
       | Error _ -> false)
 
+let with_optional_board_reaction_actor ~base_path request reqd f =
+  match
+    authorize_optional_token_bound_permission_request
+      ~base_path
+      ~permission:Masc_domain.CanReadState
+      request
+  with
+  | Ok actor -> f (Option.map board_actor_author_for_write actor)
+  | Error err -> respond_auth_error request reqd err
+
 let activity_http_deps ~sw ~clock : Server_activity_http.deps =
   {
     query_param;
@@ -550,6 +560,11 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let config = Mcp_server.workspace_config state in
+         with_optional_board_reaction_actor
+           ~base_path:config.base_path
+           req
+           reqd
+           (fun reaction_actor ->
          let hearth = query_param req "hearth" in
          let sort_by = board_sort_order_of_request req in
          let exclude_system = bool_query_param req "exclude_system" ~default:false in
@@ -579,13 +594,14 @@ let add_routes ~sw ~clock router =
              | Some value -> value
              | None -> ""
            in
-           Printf.sprintf "board:list:%s:%s:%s:%b:%b:%s:%d:%d:%s:%b:%b"
+           Printf.sprintf "board:list:%s:%s:%s:%b:%b:%s:%d:%d:%s:%s:%b:%b"
              config.base_path
              (cache_part hearth)
              (board_sort_label sort_by)
              exclude_system exclude_automation
              (cache_part author_query)
-             limit offset (cache_part voter) blind_votes include_moderation
+             limit offset (cache_part voter) (cache_part reaction_actor)
+             blind_votes include_moderation
          in
          let json =
            Dashboard_cache.get_or_compute cache_key
@@ -610,7 +626,7 @@ let add_routes ~sw ~clock router =
                            (fun (p : Board.post) ->
                               (Board.Reaction_post, Board.Post_id.to_string p.id))
                            paged)
-                      ~voter
+                      ~voter:reaction_actor
                   in
                   let reactions_for = board_reactions_lookup reaction_rows in
                   let contributor_quality_for =
@@ -640,7 +656,7 @@ let add_routes ~sw ~clock router =
                     ("sort_by", `String (board_sort_label sort_by));
                   ]))
          in
-         Http.Response.json_value json reqd
+         Http.Response.json_value json reqd)
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board/reactions/catalog" (fun request reqd ->
@@ -656,6 +672,7 @@ let add_routes ~sw ~clock router =
        with_token_permission_auth
          ~permission:Masc_domain.CanReadState
          (fun _state actor req reqd ->
+            let actor = board_actor_author_for_write actor in
             let result =
               Result.bind
                 (Server_board_reaction_http.target_of_strings
@@ -671,6 +688,7 @@ let add_routes ~sw ~clock router =
        with_token_permission_auth
          ~permission:Masc_domain.CanVote
          (fun _state actor _req reqd ->
+            let actor = board_actor_author_for_write actor in
             Http.Request.read_body_async reqd (fun body ->
               let parsed =
                 match Yojson.Safe.from_string body with
@@ -875,24 +893,33 @@ let add_routes ~sw ~clock router =
           | Some "karma/ledger" ->
               respond_board_json reqd (board_karma_ledger_json req)
           | Some post_id ->
-              let format =
-                query_param req "format" |> Option.value ~default:"nested"
-              in
-              let voter = board_voter_query req in
-              let blind_votes =
-                bool_query_param req "blind_votes" ~default:false
-              in
-              let include_moderation =
-                include_moderation_projection
-                  ~base_path:(Mcp_server.workspace_config state).base_path
-                  req
-              in
-              let (status, body) =
-                board_post_detail_json ~include_moderation ~blind_votes ~voter
-                  ~config:(Some (Mcp_server.workspace_config state))
-                  ~response_format:format ~post_id
-              in
-              respond_json_with_cors ~status request reqd body)
+              let config = Mcp_server.workspace_config state in
+              with_optional_board_reaction_actor
+                ~base_path:config.base_path
+                req
+                reqd
+                (fun reaction_actor ->
+                   let format =
+                     query_param req "format" |> Option.value ~default:"nested"
+                   in
+                   let voter = board_voter_query req in
+                   let blind_votes =
+                     bool_query_param req "blind_votes" ~default:false
+                   in
+                   let include_moderation =
+                     include_moderation_projection ~base_path:config.base_path req
+                   in
+                   let status, body =
+                     board_post_detail_json
+                       ~include_moderation
+                       ~blind_votes
+                       ~voter
+                       ~reaction_actor
+                       ~config:(Some config)
+                       ~response_format:format
+                       ~post_id
+                   in
+                   respond_json_with_cors ~status request reqd body))
        ) request reqd)
 
   (* Board write APIs — used by dashboard + Bevy Viewer.

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -17,6 +17,16 @@ let activity_result_json ~ok ~message =
   `Assoc [ ("ok", `Bool ok); ("message", `String message) ]
 ;;
 
+let respond_board_reaction_result request reqd = function
+  | Ok json -> respond_json_value_with_cors request reqd json
+  | Error error ->
+    respond_json_value_with_cors
+      ~status:(Server_board_reaction_http.error_status error)
+      request
+      reqd
+      (Server_board_reaction_http.error_json error)
+;;
+
 let include_moderation_projection ~base_path request =
   match auth_token_from_request request with
   | None -> false
@@ -632,6 +642,50 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value json reqd
        ) request reqd)
+
+  |> Http.Router.get "/api/v1/board/reactions/catalog" (fun request reqd ->
+       with_public_read
+         (fun _state _request reqd ->
+            Http.Response.json_value
+              (Server_board_reaction_http.catalog_json ())
+              reqd)
+         request
+         reqd)
+
+  |> Http.Router.get "/api/v1/board/reactions" (fun request reqd ->
+       with_token_permission_auth
+         ~permission:Masc_domain.CanReadState
+         (fun _state actor req reqd ->
+            let result =
+              Result.bind
+                (Server_board_reaction_http.target_of_strings
+                   ~target_type:(query_param req "target_type")
+                   ~target_id:(query_param req "target_id"))
+                (Server_board_reaction_http.list_json ~actor)
+            in
+            respond_board_reaction_result request reqd result)
+         request
+         reqd)
+
+  |> Http.Router.post "/api/v1/board/reactions" (fun request reqd ->
+       with_token_permission_auth
+         ~permission:Masc_domain.CanVote
+         (fun _state actor _req reqd ->
+            Http.Request.read_body_async reqd (fun body ->
+              let parsed =
+                match Yojson.Safe.from_string body with
+                | json -> Server_board_reaction_http.toggle_request_of_json json
+                | exception Yojson.Json_error message ->
+                  Error (Server_board_reaction_http.malformed_json message)
+              in
+              let result =
+                Result.bind
+                  parsed
+                  (Server_board_reaction_http.toggle_json ~actor)
+              in
+              respond_board_reaction_result request reqd result))
+         request
+         reqd)
 
   |> Http.Router.get "/api/v1/board/hearths" (fun request reqd ->
        with_public_read (fun state _req reqd ->

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -21,7 +21,7 @@ let respond_board_reaction_result request reqd = function
   | Ok json -> respond_json_value_with_cors request reqd json
   | Error error ->
     respond_json_value_with_cors
-      ~status:(Server_board_reaction_http.error_status error)
+      ~status:(Server_board_reaction_http.error_status error :> Httpun.Status.t)
       request
       reqd
       (Server_board_reaction_http.error_json error)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1334,7 +1334,7 @@ let readiness_handler _request reqd =
       reqd
 
 let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
-    ~response_format ~post_id =
+    ~reaction_actor ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
       (* Render a human-readable message (e.g. "Post not found: <id>") via the
@@ -1364,7 +1364,9 @@ let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
                 (Board.Reaction_comment, Board.Comment_id.to_string comment.id))
              comments
       in
-      let reaction_rows = board_reactions_batch ~targets:reaction_targets ~voter in
+      let reaction_rows =
+        board_reactions_batch ~targets:reaction_targets ~voter:reaction_actor
+      in
       let reactions_for = board_reactions_lookup reaction_rows in
       let reactions = reactions_for (Board.Reaction_post, post_id) in
       let contributor_quality =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1387,11 +1387,12 @@ let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
         ) comments)
       in
       let json =
-        if String.equal (String.lowercase_ascii (String.trim response_format)) "flat" then
-          match post_json with
-          | `Assoc fields -> `Assoc (fields @ [ ("comments", comments_json) ])
-          | _ -> `Assoc [ ("post", post_json); ("comments", comments_json) ]
-        else
+        match response_format with
+        | Server_board_post_response_format.Flat ->
+          (match post_json with
+           | `Assoc fields -> `Assoc (fields @ [ ("comments", comments_json) ])
+           | _ -> `Assoc [ ("post", post_json); ("comments", comments_json) ])
+        | Server_board_post_response_format.Nested ->
           `Assoc [ ("post", post_json); ("comments", comments_json) ]
       in
       (`OK, Yojson.Safe.to_string json)

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -301,16 +301,17 @@ val board_post_detail_json :
   blind_votes:bool ->
   config:Workspace.config option ->
   voter:string option ->
+  reaction_actor:string option ->
   response_format:string ->
   post_id:string ->
   [> `OK | `Not_found ] * string
-(** [board_post_detail_json ~voter ~response_format ~post_id] returns
+(** [board_post_detail_json ~voter ~reaction_actor ~response_format ~post_id] returns
     [(status, json_string)] for [GET /api/v1/board/<post_id>].
     When [voter] is supplied, post/comment rows include vote state for
-    that voter.  When [include_moderation] is [true], rows also include
-    operator-only moderation projection fields.  When [blind_votes] is
-    [true], rows hide score fields until that voter has voted.
-    operator-only moderation projection fields.  When [config] is
+    that voter. [reaction_actor] independently selects the actor-aware
+    reaction state and must come from authenticated credential identity,
+    never a query parameter. When [include_moderation] is [true], rows also
+    include operator-only moderation projection fields. When [config] is
     supplied, post rows include contributor-quality projection fields.
     When [blind_votes] is [true], rows hide score fields until that
     voter has voted.

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -302,7 +302,7 @@ val board_post_detail_json :
   config:Workspace.config option ->
   voter:string option ->
   reaction_actor:string option ->
-  response_format:string ->
+  response_format:Server_board_post_response_format.t ->
   post_id:string ->
   [> `OK | `Not_found ] * string
 (** [board_post_detail_json ~voter ~reaction_actor ~response_format ~post_id] returns
@@ -316,12 +316,14 @@ val board_post_detail_json :
     When [blind_votes] is [true], rows hide score fields until that
     voter has voted.
 
-    {2 response_format values (case-insensitive, trimmed)}
+    [response_format] is decoded once at the HTTP boundary by
+    {!Server_board_post_response_format.of_query}; unsupported wire values are
+    rejected rather than silently projected as [nested].
 
     | Format | Shape |
     |---|---|
-    | [["flat"]] | post fields + [comments] sibling |
-    | otherwise (default [["nested"]]) | [{"post": ..., "comments": [...]}] |
+    | {!Server_board_post_response_format.Flat} | post fields + [comments] sibling |
+    | {!Server_board_post_response_format.Nested} | [{"post": ..., "comments": [...]}] |
 
     {2 Status / body}
 

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -214,7 +214,13 @@ let board_reactions_lookup rows =
 let board_reaction_fields = function
   | None -> []
   | Some summaries ->
-      [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries)) ]
+      [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries))
+      ; ( "supported_reaction_emojis"
+        , `List
+            (List.map
+               (fun emoji -> `String emoji)
+               Board.board_reaction_emojis) )
+      ]
 
 let board_moderation_fields ~include_moderation ~target_kind ~target_id =
   if not include_moderation then []

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1200,7 +1200,7 @@ let test_dashboard_detail_uses_authenticated_reaction_actor () =
       ~config:None
       ~voter:(Some "forgeable-query-voter")
       ~reaction_actor:(Some "credential-owner")
-      ~response_format:"flat"
+      ~response_format:Server_board_post_response_format.Flat
       ~post_id
   in
   Alcotest.(check bool) "detail status" true (status = `OK);
@@ -1216,8 +1216,36 @@ let test_dashboard_detail_uses_authenticated_reaction_actor () =
   | Some summary ->
     Alcotest.(check bool)
       "reacted is bound to authenticated credential, not query voter"
-      true
-      (summary |> member "reacted" |> to_bool)
+       true
+       (summary |> member "reacted" |> to_bool)
+
+let test_board_post_response_format_query_contract () =
+  let check_format label expected query =
+    match Server_board_post_response_format.of_query query with
+    | Error _ -> Alcotest.fail (label ^ ": expected a supported format")
+    | Ok actual ->
+      Alcotest.(check string)
+        label
+        (Server_board_post_response_format.to_wire expected)
+        (Server_board_post_response_format.to_wire actual)
+  in
+  check_format
+    "missing format defaults to nested"
+    Server_board_post_response_format.Nested
+    None;
+  check_format
+    "flat format is normalized at the boundary"
+    Server_board_post_response_format.Flat
+    (Some " FLAT ");
+  match Server_board_post_response_format.of_query (Some "yaml") with
+  | Ok _ -> Alcotest.fail "unsupported format must be rejected"
+  | Error error ->
+    let open Yojson.Safe.Util in
+    let json = Server_board_post_response_format.error_json error in
+    Alcotest.(check string)
+      "typed error code"
+      "unsupported_board_post_response_format"
+      (json |> member "code" |> to_string)
 
 let test_board_sse_reaction_changed () =
   let post_id =
@@ -1867,9 +1895,11 @@ let () =
         (with_eio test_reaction_summary_recent_user_ids);
       Alcotest.test_case "summary batch" `Quick
         (with_eio test_reaction_summary_batch);
-      Alcotest.test_case "dashboard detail binds reaction actor" `Quick
-        (with_eio test_dashboard_detail_uses_authenticated_reaction_actor);
-      Alcotest.test_case "SSE reaction_changed" `Quick
+       Alcotest.test_case "dashboard detail binds reaction actor" `Quick
+         (with_eio test_dashboard_detail_uses_authenticated_reaction_actor);
+       Alcotest.test_case "post detail response format boundary" `Quick
+         test_board_post_response_format_query_contract;
+       Alcotest.test_case "SSE reaction_changed" `Quick
         (with_eio test_board_sse_reaction_changed);
       Alcotest.test_case "board signal reaction_changed resolves comment parent" `Quick
         (with_eio test_board_signal_reaction_changed_resolves_comment_parent);

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1171,6 +1171,54 @@ let test_reaction_summary_batch () =
            Alcotest.(check bool) "comment reacted" true summary.reacted
        | [] -> Alcotest.fail "expected comment reaction summary")
 
+let test_dashboard_detail_uses_authenticated_reaction_actor () =
+  let post =
+    match
+      Board_dispatch.create_post
+        ~author:"reaction-author"
+        ~content:"credential-bound reaction state"
+        ~post_kind:Board.Human_post
+        ()
+    with
+    | Ok post -> post
+    | Error error -> Alcotest.fail (Board.show_board_error error)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.toggle_reaction
+       ~target_type:Board.Reaction_post
+       ~target_id:post_id
+       ~user_id:"credential-owner"
+       ~emoji:"👍"
+   with
+   | Ok _ -> ()
+   | Error error -> Alcotest.fail (Board.show_board_error error));
+  let status, body =
+    Server_routes_http_runtime.board_post_detail_json
+      ~include_moderation:false
+      ~blind_votes:false
+      ~config:None
+      ~voter:(Some "forgeable-query-voter")
+      ~reaction_actor:(Some "credential-owner")
+      ~response_format:"flat"
+      ~post_id
+  in
+  Alcotest.(check bool) "detail status" true (status = `OK);
+  let open Yojson.Safe.Util in
+  let summary =
+    Yojson.Safe.from_string body
+    |> member "reactions"
+    |> to_list
+    |> List.find_opt (fun json -> String.equal (json |> member "emoji" |> to_string) "👍")
+  in
+  match summary with
+  | None -> Alcotest.fail "expected thumbs-up reaction summary"
+  | Some summary ->
+    Alcotest.(check bool)
+      "reacted is bound to authenticated credential, not query voter"
+      true
+      (summary |> member "reacted" |> to_bool)
+
 let test_board_sse_reaction_changed () =
   let post_id =
     match
@@ -1819,6 +1867,8 @@ let () =
         (with_eio test_reaction_summary_recent_user_ids);
       Alcotest.test_case "summary batch" `Quick
         (with_eio test_reaction_summary_batch);
+      Alcotest.test_case "dashboard detail binds reaction actor" `Quick
+        (with_eio test_dashboard_detail_uses_authenticated_reaction_actor);
       Alcotest.test_case "SSE reaction_changed" `Quick
         (with_eio test_board_sse_reaction_changed);
       Alcotest.test_case "board signal reaction_changed resolves comment parent" `Quick

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -45,6 +45,12 @@ let reaction_internal_auth_request token =
     `GET
     "/api/v1/board/reactions"
 
+let reaction_raw_auth_request header value =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list [ header, value ])
+    `GET
+    "/api/v1/board/reactions"
+
 (* /api/v1/tools/* endpoints called by dashboard/src/api/board.ts.
    Kept in sync with that file — see module doc. *)
 let dashboard_board_tool_routes =
@@ -133,10 +139,10 @@ let test_board_reaction_catalog_uses_board_ssot () =
   match Server_board_reaction_http.catalog_json () with
   | `Assoc fields ->
     let actual =
-      match List.assoc_opt "supported_emojis" fields with
+      match List.assoc_opt "supported_reaction_emojis" fields with
       | Some (`List values) ->
         List.filter_map (function `String value -> Some value | _ -> None) values
-      | Some _ | None -> fail "supported_emojis must be a JSON array"
+      | Some _ | None -> fail "supported_reaction_emojis must be a JSON array"
     in
     check (list string) "catalog" Masc.Board.board_reaction_emojis actual
   | _ -> fail "reaction catalog must be a JSON object"
@@ -181,6 +187,33 @@ let test_board_reaction_optional_auth_rejects_invalid_internal_header () =
         (Server_auth.http_status_of_auth_error error = `Unauthorized)
     | Ok None -> fail "invalid internal bearer fell back to anonymous"
     | Ok (Some actor) -> failf "invalid internal bearer resolved actor %s" actor)
+
+let test_board_reaction_optional_auth_rejects_malformed_credentials () =
+  with_reaction_auth_base (fun base_path ->
+    List.iter
+      (fun (label, request) ->
+         check bool
+           (label ^ " is detected as a credential")
+           true
+           (Server_auth.request_carries_auth_credential request);
+         match
+           Server_auth.authorize_optional_token_bound_permission_request
+             ~base_path
+             ~permission:Masc_domain.CanReadState
+             request
+         with
+         | Error error ->
+           check bool
+             (label ^ " is unauthorized")
+             true
+             (Server_auth.http_status_of_auth_error error = `Unauthorized)
+         | Ok None -> failf "%s fell back to anonymous" label
+         | Ok (Some actor) -> failf "%s resolved actor %s" label actor)
+      [ ( "malformed Authorization"
+        , reaction_raw_auth_request "authorization" "Basic not-a-bearer" )
+      ; ( "empty internal credential"
+        , reaction_raw_auth_request "x-masc-internal-token" " " )
+      ])
 
 let test_dashboard_dev_token_can_vote_as_credential_owner () =
   with_reaction_auth_base (fun base_path ->
@@ -230,6 +263,10 @@ let () =
             "optional reaction auth rejects invalid internal header"
             `Quick
             test_board_reaction_optional_auth_rejects_invalid_internal_header
+        ; test_case
+            "optional reaction auth rejects malformed credentials"
+            `Quick
+            test_board_reaction_optional_auth_rejects_malformed_credentials
         ; test_case
             "dashboard dev-token can vote as credential owner"
             `Quick

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -30,6 +30,12 @@ let dashboard_board_tool_routes =
   ; "/api/v1/tools/masc_board_comment_vote"
   ]
 
+let dashboard_board_reaction_routes =
+  [ `GET, "/api/v1/board/reactions/catalog"
+  ; `GET, "/api/v1/board/reactions"
+  ; `POST, "/api/v1/board/reactions"
+  ]
+
 (* [add_routes] only registers closures — no fiber is spawned — so the
    [Eio_main.run] just supplies the switch + clock the handlers capture. *)
 let with_router f =
@@ -84,6 +90,33 @@ let test_no_tools_route_drift () =
       expected
       registered)
 
+let test_dashboard_board_reaction_routes_registered () =
+  with_router (fun router ->
+    List.iter
+      (fun (meth, path) ->
+         let request = Httpun.Request.create meth path in
+         match Http.Router.resolve router request with
+         | `Matched { Http.Router.handler = Plain _; _ } -> ()
+         | `Matched { Http.Router.handler = Ws _; _ } ->
+           fail (Printf.sprintf "%s must be a plain HTTP route" path)
+         | `Method_not_allowed ->
+           fail (Printf.sprintf "%s rejects its dashboard HTTP method" path)
+         | `Not_found ->
+           fail (Printf.sprintf "%s is not registered" path))
+      dashboard_board_reaction_routes)
+
+let test_board_reaction_catalog_uses_board_ssot () =
+  match Server_board_reaction_http.catalog_json () with
+  | `Assoc fields ->
+    let actual =
+      match List.assoc_opt "supported_emojis" fields with
+      | Some (`List values) ->
+        List.filter_map (function `String value -> Some value | _ -> None) values
+      | Some _ | None -> fail "supported_emojis must be a JSON array"
+    in
+    check (list string) "catalog" Board.board_reaction_emojis actual
+  | _ -> fail "reaction catalog must be a JSON object"
+
 let () =
   run
     "board_rest_routes"
@@ -96,5 +129,13 @@ let () =
             "no /api/v1/tools/* route drift"
             `Quick
             test_no_tools_route_drift
+        ; test_case
+            "dashboard board reaction routes registered"
+            `Quick
+            test_dashboard_board_reaction_routes_registered
+        ; test_case
+            "reaction catalog uses Board SSOT"
+            `Quick
+            test_board_reaction_catalog_uses_board_ssot
         ] )
     ]

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -138,7 +138,7 @@ let test_board_reaction_catalog_uses_board_ssot () =
         List.filter_map (function `String value -> Some value | _ -> None) values
       | Some _ | None -> fail "supported_emojis must be a JSON array"
     in
-    check (list string) "catalog" Board.board_reaction_emojis actual
+    check (list string) "catalog" Masc.Board.board_reaction_emojis actual
   | _ -> fail "reaction catalog must be a JSON object"
 
 let test_board_reaction_optional_auth_is_anonymous_only_without_header () =

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -39,6 +39,12 @@ let reaction_auth_request ?token () =
   in
   Httpun.Request.create ~headers `GET "/api/v1/board/reactions"
 
+let reaction_internal_auth_request token =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list [ "x-masc-internal-token", token ])
+    `GET
+    "/api/v1/board/reactions"
+
 (* /api/v1/tools/* endpoints called by dashboard/src/api/board.ts.
    Kept in sync with that file — see module doc. *)
 let dashboard_board_tool_routes =
@@ -162,6 +168,20 @@ let test_board_reaction_optional_auth_rejects_invalid_header () =
     | Ok None -> fail "invalid Authorization header fell back to anonymous"
     | Ok (Some actor) -> failf "invalid credential resolved actor %s" actor)
 
+let test_board_reaction_optional_auth_rejects_invalid_internal_header () =
+  with_reaction_auth_base (fun base_path ->
+    match
+      Server_auth.authorize_optional_token_bound_permission_request
+        ~base_path
+        ~permission:Masc_domain.CanReadState
+        (reaction_internal_auth_request "invalid-internal-token")
+    with
+    | Error error ->
+      check bool "invalid internal credential is unauthorized" true
+        (Server_auth.http_status_of_auth_error error = `Unauthorized)
+    | Ok None -> fail "invalid internal bearer fell back to anonymous"
+    | Ok (Some actor) -> failf "invalid internal bearer resolved actor %s" actor)
+
 let test_dashboard_dev_token_can_vote_as_credential_owner () =
   with_reaction_auth_base (fun base_path ->
     match
@@ -206,6 +226,10 @@ let () =
             "optional reaction auth rejects invalid header"
             `Quick
             test_board_reaction_optional_auth_rejects_invalid_header
+        ; test_case
+            "optional reaction auth rejects invalid internal header"
+            `Quick
+            test_board_reaction_optional_auth_rejects_invalid_internal_header
         ; test_case
             "dashboard dev-token can vote as credential owner"
             `Quick

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -21,6 +21,24 @@ open Alcotest
 
 module Http = Masc.Http_server_eio
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let with_reaction_auth_base f =
+  let base_path = Filename.temp_dir "board-reaction-auth-" "" in
+  Auth.save_auth_config
+    base_path
+    { Masc_domain.default_auth_config with enabled = true; require_token = true };
+  f base_path
+
+let reaction_auth_request ?token () =
+  let headers =
+    match token with
+    | None -> Httpun.Headers.of_list []
+    | Some token ->
+      Httpun.Headers.of_list [ "authorization", "Bearer " ^ token ]
+  in
+  Httpun.Request.create ~headers `GET "/api/v1/board/reactions"
+
 (* /api/v1/tools/* endpoints called by dashboard/src/api/board.ts.
    Kept in sync with that file — see module doc. *)
 let dashboard_board_tool_routes =
@@ -117,6 +135,49 @@ let test_board_reaction_catalog_uses_board_ssot () =
     check (list string) "catalog" Board.board_reaction_emojis actual
   | _ -> fail "reaction catalog must be a JSON object"
 
+let test_board_reaction_optional_auth_is_anonymous_only_without_header () =
+  with_reaction_auth_base (fun base_path ->
+    match
+      Server_auth.authorize_optional_token_bound_permission_request
+        ~base_path
+        ~permission:Masc_domain.CanReadState
+        (reaction_auth_request ())
+    with
+    | Ok None -> ()
+    | Ok (Some actor) ->
+      failf "headerless request unexpectedly resolved actor %s" actor
+    | Error error -> fail (Masc_domain.masc_error_to_string error))
+
+let test_board_reaction_optional_auth_rejects_invalid_header () =
+  with_reaction_auth_base (fun base_path ->
+    match
+      Server_auth.authorize_optional_token_bound_permission_request
+        ~base_path
+        ~permission:Masc_domain.CanReadState
+        (reaction_auth_request ~token:"invalid-board-reaction-token" ())
+    with
+    | Error error ->
+      check bool "invalid credential is unauthorized" true
+        (Server_auth.http_status_of_auth_error error = `Unauthorized)
+    | Ok None -> fail "invalid Authorization header fell back to anonymous"
+    | Ok (Some actor) -> failf "invalid credential resolved actor %s" actor)
+
+let test_dashboard_dev_token_can_vote_as_credential_owner () =
+  with_reaction_auth_base (fun base_path ->
+    match
+      Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token base_path
+    with
+    | Error message -> fail message
+    | Ok token ->
+      match
+        Server_auth.authorize_token_bound_permission_request
+          ~base_path
+          ~permission:Masc_domain.CanVote
+          (reaction_auth_request ~token ())
+      with
+      | Ok actor -> check string "dashboard credential owner" "dashboard" actor
+      | Error error -> fail (Masc_domain.masc_error_to_string error))
+
 let () =
   run
     "board_rest_routes"
@@ -137,5 +198,17 @@ let () =
             "reaction catalog uses Board SSOT"
             `Quick
             test_board_reaction_catalog_uses_board_ssot
+        ; test_case
+            "optional reaction auth is anonymous only without header"
+            `Quick
+            test_board_reaction_optional_auth_is_anonymous_only_without_header
+        ; test_case
+            "optional reaction auth rejects invalid header"
+            `Quick
+            test_board_reaction_optional_auth_rejects_invalid_header
+        ; test_case
+            "dashboard dev-token can vote as credential owner"
+            `Quick
+            test_dashboard_dev_token_can_vote_as_credential_owner
         ] )
     ]


### PR DESCRIPTION
## Root cause

The dashboard rendered reaction controls but called an HTTP surface that did not exist. It also supplied a forgeable `user_id` and duplicated the Board emoji catalog in TypeScript, so actor identity and supported reactions had no server-owned contract.

Part of #23925 (item 59).

## What changed

- add one typed Board reaction HTTP projection shared by HTTP/1.1 and HTTP/2
- bind list/toggle operations to the authenticated credential owner
- distinguish a truly anonymous read from malformed, empty, invalid, or underprivileged credentials
- require `CanReadState` for actor-aware summaries and `CanVote` for toggles
- expose the Board domain emoji catalog from its existing SSOT with one `supported_reaction_emojis` wire field
- preserve typed Board failures as stable HTTP status/error-code responses and log storage failures without leaking internal details
- parse the post-detail `format` query once into a typed `Nested | Flat` boundary and reject unsupported values
- remove the dashboard's hard-coded emoji catalog and request-body/query `user_id`
- refresh matching reaction state from SSE without blocking unrelated Board activity
- surface loading and failure states accessibly instead of silently rendering a dead control

## User impact

Reaction clicks now reach the Board domain, update visible count/pressed state, and remain synchronized through `reaction_changed` events. The server, not the browser, owns actor identity and the supported emoji catalog. Invalid credentials fail explicitly instead of silently becoming anonymous.

## Validation

- dashboard TypeScript `tsc --noEmit`
- focused dashboard Vitest: 5 files, 190 tests passed
- `ocamlformat --check` and `ocamlc -stop-after parsing` on touched OCaml files
- all CI meta bug-class scripts: SSOT, SIL, STR, BND, TLA, telemetry, determinism
- `scripts/check-ssot.sh`, `scripts/check-boundary-guard.sh`, boundary mli pair gate, and silent-failure ratchet
- `git diff origin/main...HEAD --check`

Dune compilation is intentionally delegated to PR CI per repository policy.
