### PR TITLE
fix(keeper): guarantee terminal event on cancelled async turns

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -43,6 +43,17 @@ type load_result =
   | Absent
   | Unreadable of string
 
+(* [Worker_cancelled], not [Cancelled]: [request_status] above already binds
+   an unqualified [Cancelled] constructor with the same field names in this
+   module. A same-named constructor here would shadow it for every
+   unqualified use below and risk silently constructing the wrong type. *)
+type worker_abort_reason =
+  | Timeout of { timeout_sec : float }
+  | Worker_cancelled of
+      { cancelled_by : string
+      ; reason : string
+      }
+
 let mu = Eio.Mutex.create ()
 let pending : (string, entry) Hashtbl.t = Hashtbl.create 16
 let active_switches : (string, Eio.Switch.t) Hashtbl.t = Hashtbl.create 16
@@ -453,8 +464,8 @@ let timeout_done_status ~request_id ~keeper_name ~timeout_sec =
     }
 ;;
 
-let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
-    ~keeper_name () : string =
+let submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~base_path
+    ~(f : unit -> tool_result) ~keeper_name () : string =
   gc_stale ();
   ignore (gc_stale_disk ~base_path);
   let request_id = generate_request_id ~keeper_name in
@@ -472,6 +483,27 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
   Eio.Fiber.fork_daemon ~sw (fun () ->
     set_status_protected ~preserve_terminal:true request_id Running;
     let worker_timeout_sec = effective_timeout_sec ?timeout_sec () in
+    (* [f] owns any terminal signal it emits on its own side channels while
+       it runs (e.g. push_worker_event in server_routes_http_keeper_stream's
+       process_single_turn). Every catch arm below fires exactly when [f] was
+       cut off before reaching that code, so the caller's channel would
+       otherwise see nothing — see masc#23924. Eio.Cancel.protect matches
+       set_status_protected above: at these catch sites the ambient switch
+       may still be tearing down, so an unprotected call could itself be
+       cancelled before the callback runs. *)
+    let notify_aborted reason =
+      match on_worker_aborted with
+      | None -> ()
+      | Some cb ->
+        Eio.Cancel.protect (fun () ->
+          try cb reason with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Keeper.warn
+              "keeper_msg_async: on_worker_aborted callback failed request_id=%s error=%s"
+              request_id
+              (Printexc.to_string exn))
+    in
     let run_worker_with_timeout () =
       match clock with
       | Some clock ->
@@ -481,6 +513,7 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
              timeout_done_status ~request_id ~keeper_name ~timeout_sec:worker_timeout_sec
            in
            set_status_protected ~preserve_terminal:true request_id status;
+           notify_aborted (Timeout { timeout_sec = worker_timeout_sec });
            raise (Worker_timeout worker_timeout_sec))
       | None -> f ()
     in
@@ -500,9 +533,21 @@ let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
       with
       | Worker_timeout timeout_sec ->
         timeout_done_status ~request_id ~keeper_name ~timeout_sec
-      | CancelledByOperator -> operator_cancelled_status ()
+      | CancelledByOperator ->
+        notify_aborted
+          (Worker_cancelled
+             { cancelled_by = "operator"
+             ; reason = "keeper_msg request was cancelled by operator"
+             });
+        operator_cancelled_status ()
       | Eio.Cancel.Cancelled _ as e ->
         set_status_protected ~preserve_terminal:true request_id (runtime_cancelled_status ());
+        notify_aborted
+          (Worker_cancelled
+             { cancelled_by = "runtime"
+             ; reason =
+                 "keeper_msg worker was cancelled by runtime before terminal result"
+             });
         clear_active_switch request_id;
         raise e
       | exn ->

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -44,20 +44,43 @@ type load_result =
   | Absent
   | Unreadable of string
 
+(** Reason [f] was cut off before it could reach its own completion. [f] is
+    the sole owner of any terminal signal it emits on its own side channels
+    (e.g. an SSE event stream) while it runs — those channels see nothing if
+    [f] never returns. [worker_abort_reason] is what [on_worker_aborted]
+    receives so such callers can push their own terminal signal instead of
+    waiting forever on a channel [f] never got to finish. *)
+type worker_abort_reason =
+  | Timeout of { timeout_sec : float }
+  | Worker_cancelled of
+      { cancelled_by : string (** ["operator"] or ["runtime"] *)
+      ; reason : string
+      }
+
 (** {1 Submit and poll} *)
 
-(** [submit ?clock ?timeout_sec ~sw ~f ~keeper_name] forks a background daemon fiber on
-    [sw] that runs [f] and stores the result. Returns the fresh
-    [request_id] synchronously. When [clock] is provided, the worker records a
-    terminal timeout error if [f] does not return before the deadline:
-    [timeout_sec] when explicitly supplied, otherwise the runtime-resolved
-    keeper turn timeout. Cancellation of [sw] interrupts the worker and records
-    a terminal [Cancelled] state before stopping, so pollers do not observe an
-    indefinite [Running] request. [Lost] is reserved for persisted non-terminal
-    requests recovered without a live worker. *)
+(** [submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~f ~keeper_name] forks
+    a background daemon fiber on [sw] that runs [f] and stores the result.
+    Returns the fresh [request_id] synchronously. When [clock] is provided,
+    the worker records a terminal timeout error if [f] does not return before
+    the deadline: [timeout_sec] when explicitly supplied, otherwise the
+    runtime-resolved keeper turn timeout. Cancellation of [sw] interrupts the
+    worker and records a terminal [Cancelled] state before stopping, so
+    pollers do not observe an indefinite [Running] request. [Lost] is
+    reserved for persisted non-terminal requests recovered without a live
+    worker.
+
+    [on_worker_aborted], when supplied, is invoked exactly once whenever [f]
+    is cut off by a timeout or cancellation before it completes on its own —
+    never when [f] returns or raises normally, since [f] is expected to have
+    already signaled its own completion on those paths. It runs from a fiber
+    that is not itself under cancellation at the moment of the call (wrapped
+    internally in {!Eio.Cancel.protect}), so it may safely perform blocking
+    Eio operations such as pushing to a caller-owned stream. *)
 val submit
   :  ?clock:_ Eio.Time.clock
   -> ?timeout_sec:float
+  -> ?on_worker_aborted:(worker_abort_reason -> unit)
   -> sw:Eio.Switch.t
   -> base_path:string
   -> f:(unit -> Keeper_types_profile.tool_result)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1170,8 +1170,28 @@ let process_single_turn ~connector_user_line_recorded_upstream
   let dashboard_direct_stream =
     (not connector_user_line_recorded_upstream) && not (has_external_speaker payload)
   in
+  (* masc#23924: [f] below pushes its own [Stream_terminal] once it reaches a
+     completion arm, but a timeout/cancellation cuts [f] off before any of
+     those arms run — nothing would ever push to [worker_events], and
+     [consume_worker_events]'s [Eio.Stream.take] would block forever.
+     [on_worker_aborted] fires from Keeper_msg_async.submit's own catch
+     sites (never inside the cancelled [f]) so this turn still gets exactly
+     one terminal event via the same CAS-guarded [push_worker_event]. *)
+  let on_worker_aborted (reason : Keeper_msg_async.worker_abort_reason) =
+    let status, body =
+      match reason with
+      | Keeper_msg_async.Timeout { timeout_sec } ->
+          ( "timeout"
+          , Printf.sprintf
+              "keeper_msg request exceeded timeout_sec=%.3f before completion"
+              timeout_sec )
+      | Keeper_msg_async.Worker_cancelled { cancelled_by; reason } ->
+          "cancelled", Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
+    in
+    push_worker_event (Stream_terminal { ok = false; status; body })
+  in
   let request_id =
-    Keeper_msg_async.submit ?timeout_sec ~clock ~sw
+    Keeper_msg_async.submit ?timeout_sec ~clock ~sw ~on_worker_aborted
       ~base_path
       ~keeper_name:payload.name
       ~f:(fun () ->

--- a/test/dune
+++ b/test/dune
@@ -2052,6 +2052,8 @@
 
 (include stanzas/test_keeper_msg_async_path_traversal.inc)
 
+(include stanzas/test_keeper_msg_async_terminal_event.inc)
+
 (include stanzas/test_keeper_msg_cancel.inc)
 
 (include stanzas/test_turn_record.inc)

--- a/test/stanzas/test_keeper_msg_async_terminal_event.inc
+++ b/test/stanzas/test_keeper_msg_async_terminal_event.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_msg_async_terminal_event)
+ (modules test_keeper_msg_async_terminal_event)
+ (libraries masc_test_deps))

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -1,0 +1,203 @@
+(** Tests for masc#23924.
+
+    [Keeper_msg_async.submit]'s caller-supplied [f] is the sole owner of any
+    terminal signal it emits on its own side channel while it runs (e.g.
+    [process_single_turn]'s [worker_events] stream in
+    server_routes_http_keeper_stream.ml). Before this fix, a turn cut off by
+    [Eio.Time.with_timeout_exn] or an external [Eio.Cancel.Cancelled] left
+    [f] mid-flight with no chance to push its own terminal event, so a
+    consumer blocked on [Eio.Stream.take worker_events] hung forever even
+    though [Keeper_msg_async]'s own polling table correctly recorded the
+    turn as terminal.
+
+    These tests exercise [Keeper_msg_async.submit] directly (not the SSE
+    route) and assert on the new [on_worker_aborted] callback: it must fire
+    exactly once, with a [Timeout]/[Cancelled] reason, precisely when [f] is
+    cut off before reaching its own completion — and never on a normal
+    [f] return. *)
+
+open Alcotest
+module Keeper_msg_async = Masc.Keeper_msg_async
+module Keeper_types_profile = Masc.Keeper_types_profile
+
+(* [Keeper_msg_async.submit] persists request records to disk via
+   [Keeper_fs.save_json_atomic]; test_keeper_msg_cancel.ml establishes this
+   precondition for the same submit-and-persist path. *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun e -> rm_rf (Filename.concat path e));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_base f =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-23924-terminal-event-%d-%06x" (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf base) (fun () -> f base)
+;;
+
+(* Bounded busy-wait: polls [predicate] on a real clock instead of assuming a
+   fixed sleep duration, but never blocks indefinitely if a regression makes
+   the predicate never become true. *)
+let wait_until ~clock ~max_iterations ~interval_sec predicate =
+  let rec loop n =
+    if predicate ()
+    then true
+    else if n <= 0
+    then false
+    else (
+      Eio.Time.sleep clock interval_sec;
+      loop (n - 1))
+  in
+  loop max_iterations
+;;
+
+let test_timeout_invokes_on_worker_aborted_exactly_once () =
+  with_temp_base (fun base_path ->
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let aborted = ref [] in
+        let request_id =
+          Keeper_msg_async.submit
+            ~clock
+            ~timeout_sec:0.01
+            ~on_worker_aborted:(fun reason -> aborted := reason :: !aborted)
+            ~sw
+            ~base_path
+            ~keeper_name:"terminal-event-timeout"
+            ~f:(fun () ->
+              (* Sleeps far past the 0.01s timeout budget so
+                 [Eio.Time.with_timeout_exn] cancels this fiber before it
+                 ever returns — [f] never reaches its own completion. *)
+              Eio.Time.sleep clock 5.0;
+              Keeper_types_profile.tool_result_ok "unreachable")
+            ()
+        in
+        let fired =
+          wait_until ~clock ~max_iterations:300 ~interval_sec:0.01 (fun () ->
+            not (List.is_empty !aborted))
+        in
+        check bool "on_worker_aborted fired within budget (masc#23924 regression guard)" true fired;
+        (* Grace period: give a buggy double-fire a chance to show up before
+           we assert exactly-once. *)
+        Eio.Time.sleep clock 0.05;
+        (match !aborted with
+         | [ Keeper_msg_async.Timeout { timeout_sec } ] ->
+           check bool "timeout_sec matches the submitted timeout_sec" true
+             (Float.equal timeout_sec 0.01)
+         | [] -> fail "on_worker_aborted was never invoked"
+         | reasons ->
+           fail
+             (Printf.sprintf "on_worker_aborted fired %d times, expected 1"
+                (List.length reasons)));
+        (* The pre-existing polling table must still record the timeout
+           terminally — this fix must not regress that contract. *)
+        match Keeper_msg_async.poll ~base_path request_id with
+        | Keeper_msg_async.Found { status = Keeper_msg_async.Done { ok = false; _ }; _ } -> ()
+        | Keeper_msg_async.Found { status; _ } ->
+          fail
+            (Printf.sprintf "expected a failed Done status, got %s"
+               (Keeper_msg_async.status_to_string status))
+        | Keeper_msg_async.Absent -> fail "request record unexpectedly absent"
+        | Keeper_msg_async.Unreadable reason ->
+          fail (Printf.sprintf "request record unreadable: %s" reason))))
+;;
+
+let test_operator_cancel_before_start_invokes_on_worker_aborted () =
+  with_temp_base (fun base_path ->
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let aborted = ref [] in
+        let f_was_called = ref false in
+        let request_id =
+          Keeper_msg_async.submit
+            ~clock
+            ~timeout_sec:5.0
+            ~on_worker_aborted:(fun reason -> aborted := reason :: !aborted)
+            ~sw
+            ~base_path
+            ~keeper_name:"terminal-event-operator-cancel"
+            ~f:(fun () ->
+              f_was_called := true;
+              Keeper_types_profile.tool_result_ok "should-not-run")
+            ()
+        in
+        (* No Eio operation has run between [submit] returning and this
+           call, so the daemon fiber it forked has not been scheduled yet:
+           the request is still [Queued] with no [active_switches] entry.
+           [cancel] marks it Cancelled directly on the polling table; once
+           the daemon fiber is scheduled it observes that pre-existing
+           Cancelled status via its own should_abort check and raises
+           [CancelledByOperator] without ever calling [f]. *)
+        let cancelled = Keeper_msg_async.cancel ~base_path request_id in
+        check bool "cancel accepted the still-queued request" true cancelled;
+        let fired =
+          wait_until ~clock ~max_iterations:300 ~interval_sec:0.01 (fun () ->
+            not (List.is_empty !aborted))
+        in
+        check bool "on_worker_aborted fired for an operator cancel" true fired;
+        Eio.Time.sleep clock 0.05;
+        (match !aborted with
+         | [ Keeper_msg_async.Worker_cancelled { cancelled_by; _ } ] ->
+           check string "cancelled_by is operator" "operator" cancelled_by
+         | [] -> fail "on_worker_aborted was never invoked"
+         | reasons ->
+           fail
+             (Printf.sprintf "on_worker_aborted fired %d times, expected 1"
+                (List.length reasons)));
+        check bool "f was never invoked for a pre-cancelled request" false !f_was_called)))
+;;
+
+let test_normal_completion_never_invokes_on_worker_aborted () =
+  with_temp_base (fun base_path ->
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let aborted = ref [] in
+        let request_id =
+          Keeper_msg_async.submit
+            ~clock
+            ~timeout_sec:5.0
+            ~on_worker_aborted:(fun reason -> aborted := reason :: !aborted)
+            ~sw
+            ~base_path
+            ~keeper_name:"terminal-event-normal-completion"
+            ~f:(fun () -> Keeper_types_profile.tool_result_ok "ok")
+            ()
+        in
+        let reached_done =
+          wait_until ~clock ~max_iterations:300 ~interval_sec:0.01 (fun () ->
+            match Keeper_msg_async.poll ~base_path request_id with
+            | Keeper_msg_async.Found { status = Keeper_msg_async.Done _; _ } -> true
+            | _ -> false)
+        in
+        check bool "request reached Done within budget" true reached_done;
+        (* Grace period: [on_worker_aborted] must not fire late either. *)
+        Eio.Time.sleep clock 0.05;
+        check int "on_worker_aborted never fired on a normal completion" 0
+          (List.length !aborted))))
+;;
+
+let () =
+  run
+    "keeper_msg_async_terminal_event"
+    [ ( "on_worker_aborted"
+      , [ test_case "timeout invokes on_worker_aborted exactly once" `Quick
+            test_timeout_invokes_on_worker_aborted_exactly_once
+        ; test_case "operator cancel before start invokes on_worker_aborted" `Quick
+            test_operator_cancel_before_start_invokes_on_worker_aborted
+        ; test_case "normal completion never invokes on_worker_aborted" `Quick
+            test_normal_completion_never_invokes_on_worker_aborted
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 증상

masc#23924. keeper_msg_async의 `Eio.Time.with_timeout_exn`이 타임아웃으로 제출된 closure `f`를 취소하거나, 외부 `Eio.Cancel.Cancelled`가 전파될 때, `worker_events`(process_single_turn의 SSE 스트림)에 terminal event를 push하는 코드 경로가 전무했습니다. `process_single_turn`은 `Eio.Stream.take worker_events`에서 영원히 블록되어 호출 fiber가 복귀하지 않습니다.

## 근본 원인

`process_single_turn`이 `Keeper_msg_async.submit`에 넘기는 `f` closure는 자신의 모든 완료 분기(`Ok (\`Ran ...)`, `Ok (\`Queued ...)`, `Error ...`)에서 `push_worker_event (Stream_terminal ...)`를 직접 호출합니다. 하지만 `keeper_msg_async.ml`의 timeout/cancellation catch arm은 `f`가 도중에 잘려나간(cancelled) 이후 실행되므로, `f` 내부의 terminal push 코드에는 절대 도달하지 못합니다. `keeper_msg_async.ml`은 `worker_events`/`Stream_terminal`의 존재 자체를 모르는 범용 모듈이라, 이 계약을 자체적으로 지킬 방법이 없었습니다.

## 수정

`Keeper_msg_async.submit`에 `?on_worker_aborted:(worker_abort_reason -> unit)` 콜백을 추가했습니다.

- 새 typed variant `worker_abort_reason = Timeout of { timeout_sec } | Worker_cancelled of { cancelled_by; reason }` (string 재사용 아님). `Worker_cancelled`로 명명한 이유: 같은 모듈의 기존 `request_status.Cancelled`와 이름이 겹치면 뒤에 선언된 쪽이 모든 비한정(unqualified) 참조를 shadow해 잘못된 타입을 조용히 구성할 위험이 있어 회피했습니다.
- `on_worker_aborted`는 `f`가 자신의 완료 지점에 도달하지 못하고 잘려나간 **세 catch arm에서만** 정확히 1회 호출됩니다: `Eio.Time.Timeout`(재raise 전), `CancelledByOperator`, 외부 `Eio.Cancel.Cancelled`(재raise 전). `f`가 정상 반환/예외로 끝나는 경로에서는 호출되지 않습니다(그 경로는 `f` 자신이 이미 terminal push를 마쳤으므로).
- 콜백은 `Eio.Cancel.protect`로 감쌌습니다. 이 catch arm들은 ambient switch가 여전히 teardown 중일 수 있는 지점이라, 보호하지 않으면 콜백 호출 자체가 취소될 수 있습니다 — 기존 `set_status_protected` 패턴과 동일합니다. 콜백 내부 예외는 `Eio.Cancel.Cancelled`만 재raise하고 나머지는 로그로 흡수합니다(파일 전역에서 이미 쓰이는 관례).
- `process_single_turn`은 이 콜백에서 기존 `push_worker_event (Stream_terminal { ok = false; status; body })`를 호출합니다. `push_worker_event`의 기존 CAS(`terminal_pushed`) 가드 덕분에, `f`가 취소되기 직전 자신의 terminal push를 이미 성공시킨 극히 드문 race가 있어도 중복 push는 발생하지 않습니다.
- `status = "cancelled"`는 기존에 `consume_worker_events`에 이미 존재하던(그러나 아무도 생성하지 않던) match arm을 처음으로 실제로 채우는 값입니다 — 이 자체가 버그의 증거였습니다. `status = "timeout"`은 새 값이며, 기존 generic error arm(`Stream_terminal { ok = false; status; body }`)으로 자연스럽게 처리됩니다.

다른 `Keeper_msg_async.submit` 호출자인 `keeper_tool_surface_ops.ml`의 MCP 전용 polling 경로는 `?on_worker_aborted`를 넘기지 않으므로 동작 변화가 없습니다.

## 제약 준수

- PR #23922이 건드린 `lib/keeper/keeper_chat_consumer.ml`, `lib/keeper/keeper_chat_queue.ml`(.mli 포함), `lib/server/server_bootstrap_loops.ml`은 건드리지 않았습니다.
- `server_routes_http_keeper_stream.ml`의 `process_single_turn`을 수정했지만, #23922가 추가한 `~queued_turn` 라벨 등 시그니처에는 손대지 않았고, `Keeper_msg_async.submit` 호출부에 `~on_worker_aborted` 인자 하나만 추가했습니다. `f`를 정의하는 `let request_id = ... ~f:(fun () -> ...)` 블록 자체는 변경하지 않았습니다.

## 테스트

`test/test_keeper_msg_async_terminal_event.ml` (신규) — `Keeper_msg_async.submit`을 직접 호출해 `on_worker_aborted` 계약을 검증합니다.

1. `timeout_sec:0.01`로 제출하고 `f`가 5초 sleep하도록 해 실제 `Eio.Time.with_timeout_exn` 타임아웃을 유발 — `on_worker_aborted`가 정확히 1회, `Timeout { timeout_sec = 0.01 }`로 호출되는지 검증. 기존 polling 테이블(`Keeper_msg_async.poll`)도 여전히 `Done { ok = false; _ }`를 기록하는지 회귀 확인.
2. `submit` 직후(아직 daemon fiber가 스케줄되지 않아 `Queued` 상태인 시점) `Keeper_msg_async.cancel`을 호출 — `on_worker_aborted`가 `Worker_cancelled { cancelled_by = "operator"; _ }`로 1회 호출되고, `f`는 전혀 실행되지 않는지 검증.
3. `f`가 정상 완료하는 경우 `on_worker_aborted`가 전혀 호출되지 않는지(과도 발화 회귀 가드) 검증.

로컬 `dune build`/`dune test`는 실행하지 않았습니다 — CI가 빌드/테스트를 검증합니다. 외부 switch cancellation(`Eio.Cancel.Cancelled` arm)에 대한 전용 테스트는 작성하지 못했습니다: 중첩 switch 취소 타이밍을 결정론적으로 재현하는 테스트가 timeout/operator-cancel 테스트보다 훨씬 fragile해서, 로컬 컴파일 검증 없이 작성하는 리스크가 크다고 판단했습니다. 코드 리뷰로는 확인했지만(같은 `notify_aborted` 헬퍼를 재사용), 전용 커버리지는 후속 과제로 남습니다.

Closes #23924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
