### PR TITLE
fix(dashboard): keep semantic channel labels on trace badges (#11)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2317,18 +2317,25 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
 
     const badges = [...container.querySelectorAll('[data-chat-trace-provenance]')]
       .map(node => node.getAttribute('data-chat-trace-provenance'))
-    expect(badges).toContain('OAS #3')
-    expect(badges).toContain('OAS #4')
+    expect(badges).toContain('thinking_delta')
+    expect(badges).toContain('tool_call_id')
     expect(badges).toContain('reply')
 
+    // Bug #11: the visible label stays the stable channel name; the stream
+    // content-block index is provenance detail carried by the hover title and
+    // the data attribute, never the label.
     const think = container.querySelector('[data-chat-trace-step="think"]') as HTMLElement
-    expect(think.getAttribute('data-chat-trace-provenance')).toBe('OAS #3')
+    expect(think.getAttribute('data-chat-trace-provenance')).toBe('thinking_delta')
     expect(think.getAttribute('data-chat-trace-oas-block-index')).toBe('3')
+    expect(think.querySelector('.chat-block-source-badge')?.getAttribute('title'))
+      .toBe('source: KEEPER_THINKING_DELTA, content block 3')
 
     const tool = container.querySelector('[data-chat-trace-step="tool"]') as HTMLElement
-    expect(tool.getAttribute('data-chat-trace-provenance')).toBe('OAS #4')
+    expect(tool.getAttribute('data-chat-trace-provenance')).toBe('tool_call_id')
     expect(tool.getAttribute('data-chat-trace-tool-call-id')).toBe('tc-prov')
     expect(tool.getAttribute('data-chat-trace-oas-block-index')).toBe('4')
+    expect(tool.querySelector('.chat-block-source-badge')?.getAttribute('title'))
+      .toBe('source: TOOL_CALL_*, tool_call_id=tc-prov, content block 4')
     expect(tool.getAttribute('data-chat-trace-link-state')).toBe('trace-only')
     expect(tool.getAttribute('data-chat-trace-output-state')).toBe('ok')
     expect(tool.getAttribute('data-chat-trace-entry-id')).toBeNull()

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -86,20 +86,18 @@ function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'o
   return TRACE_TOOL_STATUS_UI[status ?? 'pending']
 }
 
-function oasBlockBadge(index: number | undefined): string | null {
-  return index === undefined ? null : `OAS #${index}`
-}
-
 function traceSourceBadge(step: ChatTraceStep): TraceSourceBadgeInfo {
-  const oasBlock = step.kind === 'think' || step.kind === 'tool'
-    ? oasBlockBadge(step.oasBlockIndex)
-    : null
+  // The stream content-block index (oasBlockIndex) is provenance detail, not
+  // an identity: it stays in the hover title and in the
+  // data-chat-trace-oas-block-index attribute, while the visible label keeps
+  // the stable channel name. An "OAS #3" badge told the operator nothing
+  // about where the step came from (bug #11).
   if (step.kind === 'think') {
     return {
-      label: oasBlock ?? 'thinking_delta',
-      title: oasBlock
-        ? `source: KEEPER_THINKING_DELTA, content block ${step.oasBlockIndex}`
-        : 'source: KEEPER_THINKING_DELTA',
+      label: 'thinking_delta',
+      title: step.oasBlockIndex === undefined
+        ? 'source: KEEPER_THINKING_DELTA'
+        : `source: KEEPER_THINKING_DELTA, content block ${step.oasBlockIndex}`,
       tone: 'stream',
     }
   }
@@ -113,10 +111,10 @@ function traceSourceBadge(step: ChatTraceStep): TraceSourceBadgeInfo {
   const callId = step.toolCallId?.trim()
   if (callId) {
     return {
-      label: oasBlock ?? 'tool_call_id',
-      title: oasBlock
-        ? `source: TOOL_CALL_*, tool_call_id=${callId}, content block ${step.oasBlockIndex}`
-        : `source: TOOL_CALL_*, tool_call_id=${callId}`,
+      label: 'tool_call_id',
+      title: step.oasBlockIndex === undefined
+        ? `source: TOOL_CALL_*, tool_call_id=${callId}`
+        : `source: TOOL_CALL_*, tool_call_id=${callId}, content block ${step.oasBlockIndex}`,
       tone: 'tool',
     }
   }


### PR DESCRIPTION
## 문제 (38버그 캠페인 #11)

keeper 채팅 타임라인의 trace source 배지가 thinking/tool 스텝에서 `OAS #3` 같은 내부 스트림 블록 인덱스를 라벨로 표시했습니다. 이 인덱스는 OAS content block 순번일 뿐이라 운영자에게 아무 의미가 없고, 원래 있던 의미 있는 채널 라벨(`thinking_delta`, `tool_call_id`)을 **덮어쓰는** 방향으로 동작했습니다.

## 근본 원인

`dashboard/src/components/chat/primitives.ts`의 `oasBlockBadge`가 `oasBlockIndex` 존재 시 라벨을 `OAS #${index}`로 교체 (`label: oasBlock ?? 'thinking_delta'`). 인덱스는 이미 hover title(`content block N`)과 `data-chat-trace-oas-block-index` 속성에 보존되고 있었으므로, 라벨 교체는 정보를 늘리는 게 아니라 지우는 것이었습니다.

## 수정

- `oasBlockBadge` 삭제. 라벨은 항상 안정적인 채널명: think → `thinking_delta`, tool → `tool_call_id`.
- 블록 인덱스는 기존 그대로 hover title + `data-chat-trace-oas-block-index` 속성으로만 노출.
- `data-chat-trace-provenance` 값도 인덱스 의존("OAS #3")에서 안정 채널명으로 바뀌어 셀렉터/테스트가 결정적이 됩니다.

## 테스트

`primitives.test.ts` provenance 테스트를 새 계약으로 갱신: 라벨=채널명 고정 + title에 `content block N` 보존 단언 추가. 로컬 `tsc --noEmit` clean, primitives 테스트 126/126 통과.

38버그 캠페인 #11의 라벨 축. (thinking 소실 축 #10은 oas#2501에서 처리됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
