### PR TITLE
fix(keeper): decide truncation semantics for OAS 0.209 stop_reason variants (main-red repair)

### DIFF
--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -39,14 +39,24 @@ let vision_default_max_tokens = 1024
 let max_image_bytes () = Env_config_keeper.KeeperVision.max_image_bytes ()
 
 let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
-  | Agent_sdk.Types.MaxTokens -> true
+  (* RepetitionTruncation: the provider's repetition guard terminated
+     generation before a natural end — the extraction is cut short exactly
+     like a MaxTokens stop, just on a different budget. *)
+  | Agent_sdk.Types.MaxTokens
+  | Agent_sdk.Types.RepetitionTruncation -> true
+  (* ContentFilter is a policy terminal like Refusal, not a length cut.
+     UnmatchedToolCalls is OAS's internal fail-closed tool-turn shape;
+     vision runs with tool_choice = None so it cannot legitimately occur,
+     and it carries no partial-extraction signal either way. *)
   | Agent_sdk.Types.EndTurn
   | Agent_sdk.Types.StopToolUse
   | Agent_sdk.Types.StopSequence
   | Agent_sdk.Types.Refusal
+  | Agent_sdk.Types.ContentFilter
   | Agent_sdk.Types.PauseTurn
   | Agent_sdk.Types.Compaction
   | Agent_sdk.Types.ContextWindowExceeded
+  | Agent_sdk.Types.UnmatchedToolCalls
   | Agent_sdk.Types.Unknown _ -> false
 
 let provider_for_vision (provider_cfg : Llm_provider.Provider_config.t) =

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -39,12 +39,11 @@ let vision_default_max_tokens = 1024
 let max_image_bytes () = Env_config_keeper.KeeperVision.max_image_bytes ()
 
 let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
-  (* RepetitionTruncation: the provider's repetition guard terminated
-     generation before a natural end — the extraction is cut short exactly
-     like a MaxTokens stop, just on a different budget. *)
-  | Agent_sdk.Types.MaxTokens
-  | Agent_sdk.Types.RepetitionTruncation -> true
+  | Agent_sdk.Types.MaxTokens -> true
   (* ContentFilter is a policy terminal like Refusal, not a length cut.
+     RepetitionTruncation is a provider repetition guard, not token-budget
+     exhaustion; classifying it as truncated would prescribe the wrong
+     larger-budget remediation.
      UnmatchedToolCalls is OAS's internal fail-closed tool-turn shape;
      vision runs with tool_choice = None so it cannot legitimately occur,
      and it carries no partial-extraction signal either way. *)
@@ -53,6 +52,7 @@ let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
   | Agent_sdk.Types.StopSequence
   | Agent_sdk.Types.Refusal
   | Agent_sdk.Types.ContentFilter
+  | Agent_sdk.Types.RepetitionTruncation
   | Agent_sdk.Types.PauseTurn
   | Agent_sdk.Types.Compaction
   | Agent_sdk.Types.ContextWindowExceeded

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -48,10 +48,8 @@ val validate_image_size : string -> (unit, string) result
 
 val truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool
 (** Collapse the provider's typed terminal reason to the single [truncated] bit
-    {!Multimodal.Vision_analyze.classify} consumes:
-    [MaxTokens | RepetitionTruncation -> true] (generation cut before a natural
-    end), every other variant -> [false]. Exhaustive so a new SDK variant
-    forces a decision. *)
+    {!Multimodal.Vision_analyze.classify} consumes: [MaxTokens -> true], every
+    other variant -> [false]. Exhaustive so a new SDK variant forces a decision. *)
 
 val message_of_request
   :  Multimodal.Vision_analyze.request

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -48,8 +48,10 @@ val validate_image_size : string -> (unit, string) result
 
 val truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool
 (** Collapse the provider's typed terminal reason to the single [truncated] bit
-    {!Multimodal.Vision_analyze.classify} consumes: [MaxTokens -> true], every
-    other variant -> [false]. Exhaustive so a new SDK variant forces a decision. *)
+    {!Multimodal.Vision_analyze.classify} consumes:
+    [MaxTokens | RepetitionTruncation -> true] (generation cut before a natural
+    end), every other variant -> [false]. Exhaustive so a new SDK variant
+    forces a decision. *)
 
 val message_of_request
   :  Multimodal.Vision_analyze.request

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "a44267d61bef1f8deb7df73bbe8d73e10cdc5397",
-  "pinned_version": "v0.208.20",
+  "pinned_sha": "495a5ba3e76195264cfb5a5a65879fe0c11fc495",
+  "pinned_version": "v0.209.1",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -185,13 +185,10 @@ let assert_metric_increment label before after =
          after)
 ;;
 
-(* MaxTokens and RepetitionTruncation -> true (generation cut before a natural
-   end). Exhaustive over all 12 SDK variants so a new one forces a decision
-   rather than silently bucketing to false. *)
+(* Only MaxTokens -> true. Exhaustive over all 12 SDK variants so a new one
+   forces a decision rather than silently bucketing to false. *)
 let test_truncated_of_stop_reason () =
-  List.iter
-    (fun r -> assert (Vt.truncated_of_stop_reason r = true))
-    [ Agent_sdk.Types.MaxTokens; Agent_sdk.Types.RepetitionTruncation ];
+  assert (Vt.truncated_of_stop_reason Agent_sdk.Types.MaxTokens = true);
   List.iter
     (fun r -> assert (Vt.truncated_of_stop_reason r = false))
     [ Agent_sdk.Types.EndTurn
@@ -199,6 +196,7 @@ let test_truncated_of_stop_reason () =
     ; Agent_sdk.Types.StopSequence
     ; Agent_sdk.Types.Refusal
     ; Agent_sdk.Types.ContentFilter
+    ; Agent_sdk.Types.RepetitionTruncation
     ; Agent_sdk.Types.PauseTurn
     ; Agent_sdk.Types.Compaction
     ; Agent_sdk.Types.ContextWindowExceeded

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -185,20 +185,25 @@ let assert_metric_increment label before after =
          after)
 ;;
 
-(* Only MaxTokens -> true. Exhaustive over all 9 SDK variants so a new one forces
-   a decision rather than silently bucketing to false. *)
+(* MaxTokens and RepetitionTruncation -> true (generation cut before a natural
+   end). Exhaustive over all 12 SDK variants so a new one forces a decision
+   rather than silently bucketing to false. *)
 let test_truncated_of_stop_reason () =
-  assert (Vt.truncated_of_stop_reason Agent_sdk.Types.MaxTokens = true);
+  List.iter
+    (fun r -> assert (Vt.truncated_of_stop_reason r = true))
+    [ Agent_sdk.Types.MaxTokens; Agent_sdk.Types.RepetitionTruncation ];
   List.iter
     (fun r -> assert (Vt.truncated_of_stop_reason r = false))
     [ Agent_sdk.Types.EndTurn
     ; Agent_sdk.Types.StopToolUse
     ; Agent_sdk.Types.StopSequence
     ; Agent_sdk.Types.Refusal
+    ; Agent_sdk.Types.ContentFilter
     ; Agent_sdk.Types.PauseTurn
     ; Agent_sdk.Types.Compaction
     ; Agent_sdk.Types.ContextWindowExceeded
-    ; Agent_sdk.Types.Unknown "content_filter"
+    ; Agent_sdk.Types.UnmatchedToolCalls
+    ; Agent_sdk.Types.Unknown "some_novel_reason"
     ]
 
 (* One User message [text query; image]; image data is base64 of the raw bytes

--- a/test/test_stop_reason_label.ml
+++ b/test/test_stop_reason_label.ml
@@ -21,10 +21,16 @@ let test_all_variants () =
   label "StopSequence" "stop_sequence"
     (to_label Agent_sdk.Types.StopSequence);
   label "Refusal" "refusal" (to_label Agent_sdk.Types.Refusal);
+  label "ContentFilter" "content_filter"
+    (to_label Agent_sdk.Types.ContentFilter);
+  label "RepetitionTruncation" "repetition_truncation"
+    (to_label Agent_sdk.Types.RepetitionTruncation);
   label "PauseTurn" "pause_turn" (to_label Agent_sdk.Types.PauseTurn);
   label "Compaction" "compaction" (to_label Agent_sdk.Types.Compaction);
   label "ContextWindowExceeded" "model_context_window_exceeded"
     (to_label Agent_sdk.Types.ContextWindowExceeded);
+  label "UnmatchedToolCalls" "unmatched_tool_calls"
+    (to_label Agent_sdk.Types.UnmatchedToolCalls);
   label "Unknown" "unknown" (to_label (Agent_sdk.Types.Unknown "anything"))
 
 let test_agent_completed_stop_reason_wire_uses_oas_string () =


### PR DESCRIPTION
## 무엇이 깨졌나

OAS pin이 0.209.1로 전진(#23937→#23942)하면서 `Agent_sdk.Types.stop_reason`에 constructor 3개가 추가됐소: `ContentFilter`, `RepetitionTruncation`, `UnmatchedToolCalls`.

`keeper_vision_tool.truncated_of_stop_reason`은 **의도적으로 catch-all 없는 전수 match**요 — mli 계약 그대로 "Exhaustive so a new SDK variant forces a decision." 그 설계가 정확히 작동해서 pin 전진 순간 warning 8(+warn-error)로 **lib 빌드 전체가 red**가 됐소. #23894/#23803/#23861/#23863의 Health fail과 main queued run의 예정된 실패가 전부 이 한 사이트요 (`rg ContextWindowExceeded`로 전수 확인 — 열거 사이트는 lib 1 + test 2뿐).

## 내린 결정 (head `cda8ede9` 기준)

| 새 variant | truncated | 근거 |
|---|---|---|
| `ContentFilter` | false | Refusal과 같은 policy terminal, 길이 절단 아님 |
| `RepetitionTruncation` | false | repetition guard 종료는 토큰 예산 소진이 아님 — `truncated_extraction`으로 분류하면 "예산 증액" 재시도라는 잘못된 처방을 유발. truncated 비트는 MaxTokens(예산 소진)에만 조여둠 |
| `UnmatchedToolCalls` | false | OAS 내부 fail-closed tool-turn shape; vision은 `tool_choice = None`이라 정상 발생 불가 |

이력: 최초 커밋(`63cdd92e`)은 RepetitionTruncation을 true(생성 조기 절단)로 봤으나, 후속 커밋(`cda8ede9`)이 처방-정합성 논거로 false로 조정했소. 둘 다 방어 가능하나 classify의 truncated 비트가 실제로 유발하는 remediation(예산 재시도)과의 정합은 false 쪽이 맞소.

## 테스트 / 게이트

- `test_keeper_vision_tool.test_truncated_of_stop_reason`: 12 variant 전수로 확장, true-집합 {MaxTokens} 고정. `Unknown "content_filter"`는 이제 first-class token이므로 `Unknown "some_novel_reason"`로 교체.
- `test_stop_reason_label.test_all_variants`: 신규 3 variant의 metric label(`content_filter`/`repetition_truncation`/`unmatched_tool_calls`) drift-guard 추가.
- `scripts/oas-api-surface.json`: v0.208.20에 pin된 채 남아있던 API surface manifest를 0.209.1(`495a5ba3`)로 갱신 — pin 전진 PR들(#23937/#23942)이 놓친 동반 게이트.

## 반경

- 이 PR이 green이면 트랙 4건(#23894/#23803/#23861/#23863)은 branch-update만으로 Health가 살아나오.
- `stop_reason`의 다른 masc 소비자(keeper_hooks_oas_types 등)는 OAS SSOT 함수 위임 또는 부분 match라 무영향.

## 프로세스 노트

pin 전진 PR(#23942)은 40분 깨진-pin 창의 긴급 수리라 자체 CI 완주 전에 병합된 것으로 보이오 — "두 green의 합성은 green이 아니다"의 pin 판본이오. 소비자 match 갱신 + api-surface manifest 갱신은 pin 전진 PR에 동봉되는 게 맞았소.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: MASC Agent <agent@masc.local>
