### PR TITLE
test(guards): expect block telemetry for hard-forbidden critical code

### DIFF
--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -881,7 +881,7 @@ let test_governance_approval_critical_code_blocks_with_legacy_exemption () =
     match !observed with
     | [ event ] ->
       check string "stage" "governance_approval" event.KG.stage;
-      check string "decision" "override"
+      check string "decision" "block"
         (KG.gate_decision_to_string event.KG.decision);
       check string "reason_code" "hard_forbidden" event.KG.reason_code;
       check string "tool_name" "tool_execute" event.KG.tool_name;
@@ -1124,7 +1124,7 @@ let () = run "Keeper_guards" [
       test_governance_approval_legacy_exemption_cannot_bypass_high;
     test_case "critical code blocks with legacy exemption" `Quick
       test_governance_approval_critical_code_blocks_with_legacy_exemption;
-    test_case "hard-forbidden overrides without HITL" `Quick
+    test_case "hard-forbidden blocks without HITL" `Quick
       test_governance_approval_hard_forbidden_blocks_without_hitl;
     test_case "serious last_blocker overrides without HITL" `Quick
       test_governance_approval_serious_blocker_overrides;


### PR DESCRIPTION
## 문제

main quick suite에서 `governance_approval_guard[1] "critical code blocks with legacy exemption"`이 실패하고 있습니다 (#23918, #23908 등 무관 PR CI에서 공통 재현 → main born-red).

원인: #23909(hard block telemetry 구분)가 governance hard_forbidden 경로의 gate decision을 `Gate_override` → `Gate_block`으로 바꾸면서 자매 케이스(`hard-forbidden ... without HITL`, :915)는 `"block"` 기대로 갱신했지만, legacy-exemption 케이스(:884)는 `"override"` 기대로 남겼습니다.

- 구현: `lib/keeper/keeper_guards.ml:945` — `~decision:Gate_block ~reason_code:"hard_forbidden"`
- 매핑: `gate_decision_to_string Gate_block = "block"` (:181)
- 테스트: `test/test_keeper_guards.ml:884` — `"override"` 기대 (불일치)

## 수정

- :884 기대값을 `"override"` → `"block"`으로 정렬 (자매 케이스와 동일).
- :1127 케이스명 `"hard-forbidden overrides without HITL"` → `"hard-forbidden blocks without HITL"` — 함수명(`..._blocks_without_hitl`)과 실제 `"block"` 검증에 맞게 정정.

동작 변경 없음, 테스트 전용 2줄.

## 검증

- 로컬 dune 빌드는 CI 전용 정책이라 미실행. 실패 케이스 식별은 CI 로그의 그룹 index(governance_approval_guard[1])와 등록 순서(:1122-1128) 대조로 확정.
- #23928(round 2 repair)가 고친 3계열(defaults/docker_cleanup/coverage)과 함께, 이 건이 마지막 남은 born-red 계열입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
