### PR TITLE
fix(keeper): yield autonomous runs to durable stimuli

### DIFF
--- a/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
+++ b/docs/audit/2026-07-10-live-system-keeper-log-bug-audit.html
@@ -40,18 +40,19 @@
 <body>
 <main>
   <h1>MASC live System/Keeper log adversarial audit</h1>
-  <p class="sub">Capture: 2026-07-10 10:24:43 KST / 2026-07-10T01:24:43Z · Runtime root: <code>&lt;base_path&gt;/.masc</code> · Source window: 2026-07-07 through capture time</p>
+  <p class="sub">Capture: 2026-07-10 10:24:43 KST / 2026-07-10T01:24:43Z · Latest recheck: 2026-07-10 16:30:07 KST · Runtime root: <code>&lt;base_path&gt;/.masc</code> · Source window: 2026-07-07 through latest recheck</p>
 
   <div class="summary">
     <div class="stat"><strong>degraded</strong><span>health overall status</span></div>
-    <div class="stat"><strong>2</strong><span>initial durable queue entries: 1 pending, 1 inflight</span></div>
+    <div class="stat"><strong>7</strong><span>latest durable queue entries: 6 pending, 1 inflight</span></div>
     <div class="stat"><strong>4,700+</strong><span>pending-HITL warning records</span></div>
     <div class="stat"><strong>193</strong><span>keeper-cycle failures with no usable progress</span></div>
     <div class="stat"><strong>320</strong><span>release from cancelled transition failures</span></div>
+    <div class="stat"><strong>677</strong><span>latest prompt metadata drift warnings</span></div>
   </div>
 
   <h2>결론</h2>
-  <p>현재 런타임은 프로세스 자체가 죽은 상태는 아니지만, 독립 Keeper lane의 진행 보장과 관측 데이터 보존을 만족하지 못하는 결함이 확인된다. 가장 명확한 소스 결함은 <strong>구조화된 world observation을 tool-token 문자열로 재해석하고 삭제하는 프롬프트 경계</strong>다. 그 다음은 <strong>pending HITL 하나가 Keeper 전체 cycle admission을 막는 전역 차단</strong>이다. 이 두 MASC 수정은 현재 worktree에서 구현·검증했지만 라이브 실행 파일에는 아직 반영하지 않았다.</p>
+  <p>현재 런타임은 프로세스 자체가 죽은 상태는 아니지만, 독립 Keeper lane의 진행 보장과 관측 데이터 보존을 만족하지 못하는 결함이 확인된다. 가장 명확한 소스 결함은 <strong>구조화된 world observation을 tool-token 문자열로 재해석하고 삭제하는 프롬프트 경계</strong>다. HITL 경계에는 <strong>pending approval과 Keeper lane ownership의 혼동</strong>뿐 아니라, <strong>blocking approval을 확인하기 전에 durable event를 lease하여 같은 이벤트를 매 heartbeat마다 consume/requeue하는 순서 결함</strong>도 있다. 또한 장기 autonomous OAS run은 새 durable stimulus가 쌓여도 turn boundary에서 lane을 양보하지 않아 독립 cycle을 기아시킨다. MASC 수정은 worktree에 구현했지만 라이브 실행 파일에는 아직 반영하지 않았다.</p>
   <p>OAS stop reason 문제와 provider의 empty/thinking-only 응답은 MASC가 문자열 예외를 임의로 해석해서 고칠 영역이 아니다. OAS가 provider terminal outcome을 타입으로 보존하고, MASC는 그 타입을 받아 fallback 또는 cycle 결과를 결정해야 한다. 아래에서 MASC/OAS 경계를 분리했다.</p>
 
   <h2>라이브 상태 — initial snapshot</h2>
@@ -106,6 +107,19 @@
   </table>
   <p><code>overall_status=degraded</code>의 현재 원인은 reaction ledger의 pending stimulus와 stale durable queue다. fleet recovery는 확인했지만, paused Keeper의 durable event가 5시간 이상 남은 상태와 source 수정 미배포 사실은 별개다.</p>
 
+  <h3>16:30 KST latest recheck — durable HITL backlog and intake churn reproduced</h3>
+  <table>
+    <tr><th>항목</th><th>현재 관찰값</th><th>판정</th></tr>
+    <tr><td>실행 파일</td><td>commit <code>61a643565b</code>, uptime 59,279초</td><td>이번 source/worktree 수정은 live에 미반영</td></tr>
+    <tr><td>Durable queue</td><td>pending 6, inflight 1, read error 0. <code>issue_king</code> 6개는 모두 immediate <code>hitl_resolved</code>, <code>verifier</code> 1개는 <code>schedule_due</code></td><td>health의 <code>status=ok</code>와 별개로 durable work가 남아 있다. 직접 ack·삭제·resume하지 않음</td></tr>
+    <tr><td>Keeper turn receipt</td><td><code>issue_king</code> cycle <code>06:49:45Z→07:08:01Z</code>, 1,096,626ms, OAS turn count <code>11453→11570</code></td><td>117 provider/tool turns 동안 이미 도착한 durable wake가 새 cycle을 얻지 못한 직접 증거</td></tr>
+    <tr><td>Intake order</td><td>동일 <code>hitl-approval:appr_ec78ca2d4398</code>를 <code>07:08:34Z</code>, <code>07:09:06Z</code>, <code>07:09:41Z</code>, <code>07:10:07Z</code>에 consume; 사이마다 typed Blocking approval warning</td><td>blocking gate가 intake 뒤에 있어 같은 lease가 반복 requeue된 F-07 재현</td></tr>
+    <tr><td>Turn admission</td><td>autonomous in-flight 4개, chat waiting/rejected 0개</td><td>fleet 전체 정지가 아니라 Keeper별 lane/queue 진행성 결함</td></tr>
+    <tr><td>Config</td><td>parse error 0, unknown key 0, schema <code>ok</code>, startup degradation false</td><td class="oktext">현재 bootstrap/config parser 오류는 없음</td></tr>
+  </table>
+  <p>reaction ledger의 <code>durable_event_queue_stale_after_sec=0</code>는 모든 미처리 항목을 보수적으로 stale로 표시하는 명시적 현재 정책이다. 따라서 stale count 7 자체를 timeout 계산 버그로 세지 않았다. F-07은 stale label이 아니라 실제 event lease·receipt·cycle scheduling 순서로 판정했다.</p>
+  <p><strong>[근거]</strong> live <code>/health?full=1</code>, System Log seq 212720–213084, <code>issue_king</code> execution receipts/raw trace, 2026-07-10 16:30 KST read-only 확인, 신뢰도 High. 런타임 state mutation은 수행하지 않았다.</p>
+
   <h2>확인된 버그 및 장애</h2>
 
   <section class="finding p0">
@@ -130,7 +144,7 @@
       <li><a href="../../lib/keeper/keeper_approval_queue.mli">keeper_approval_queue.mli</a>의 <code>submit_and_await</code>는 호출 fiber를 실제로 기다리게 한다. 별도의 <code>submit_pending</code> callback 경로가 있어도 admission precheck가 전체 lane을 다시 막는다.</li>
     </ul>
     <p><strong>스펙 위반:</strong> HITL은 약한 결합이어야 하며, Keeper는 승인 대기 중에도 busy 응답·무관한 reactive wake·다른 작업을 처리해야 한다. 승인에 종속된 continuation만 durable queue에 남기고, lane 전체를 pause하지 않는 typed continuation 구조가 필요하다.</p>
-    <p><strong>현재 worktree 수정:</strong> queue entry에 <code>lane_policy = Blocking | Nonblocking</code>을 명시했다. 일반 Keeper tool approval은 <code>Nonblocking</code>으로 등록한 뒤 typed rejection을 반환하고, 명시적 <code>submit_and_await</code> 및 persisted lifecycle gate만 <code>Blocking</code>으로 분류한다. resolution wake는 independent-cycle entry에만 발행하고, blocking continuation에는 중복 turn을 만들지 않는다. <code>keeper_world_observation</code>, heartbeat board admission, supervisor recovery가 모두 typed blocking policy만 참조한다.</p>
+    <p><strong>현재 worktree 수정:</strong> queue entry에 <code>lane_policy = Blocking | Nonblocking</code>을 명시했다. 일반 Keeper tool approval은 <code>Nonblocking</code>으로 등록한 뒤 typed rejection을 반환하고, 명시적 <code>submit_and_await</code> 및 persisted lifecycle gate만 <code>Blocking</code>으로 분류한다. resolution wake는 independent-cycle entry에만 발행하고, blocking continuation에는 중복 turn을 만들지 않는다. <code>keeper_world_observation</code>, heartbeat board admission, supervisor recovery가 모두 typed blocking policy만 참조한다. 추가로 heartbeat의 <code>turn_intake_admission</code>이 pressure와 typed Blocking approval을 board collection/event dequeue 전에 한 번 분류하므로, block된 cycle은 durable lease를 만들지 않는다.</p>
   </section>
 
   <section class="finding">
@@ -174,6 +188,24 @@
     <p><strong>14:43 KST live 재현:</strong> old binary의 <code>analyst</code>가 cancelled <code>task-1891</code>에 다시 <code>masc_transition release</code>를 호출했고, 응답 JSON에는 <code>self_correction_required=true</code> 키가 중복으로 들어간 채 retry 지시가 남았다. worktree 수정이 아직 live가 아니라는 직접 증거다.</p>
   </section>
 
+  <section class="finding">
+    <h3>F-07 · P1 · Durable stimulus starvation and blocking-gate dequeue/requeue loop</h3>
+    <div class="meta">Confidence: High · Owner boundary: MASC heartbeat intake and autonomous OAS-run scheduling</div>
+    <p><code>issue_king</code>의 <code>hitl-approval:appr_ec78ca2d4398</code> wake는 <code>06:34:17Z</code>에 durable queue로 들어왔지만, <code>06:49:45Z→07:08:01Z</code>의 1,096,626ms autonomous cycle 동안 독립 cycle을 얻지 못했다. 해당 execution receipt의 OAS turn count는 직전 <code>11453</code>에서 <code>11570</code>으로 117 증가했다. 장기 run에는 dashboard/connector chat만 확인하는 yield hook이 있었고 durable event queue는 확인하지 않았다.</p>
+    <p>장기 cycle이 끝난 뒤에는 같은 event를 93초 동안 네 번 consume했다. 각 시도 사이에 <code>keeper:issue_king blocked on 1 pending HITL approval(s)</code>가 기록되고 같은 ID가 다시 consume되므로, source의 lease finalizer가 이를 requeue한 흐름과 일치한다. 마지막 시점에 별도의 Blocking approval <code>appr_b1719d6044e2</code>가 만료되자 즉시 cycle이 시작됐다. 원인은 typed Blocking approval 판단 자체가 아니라, event intake 뒤에 그 gate를 적용한 순서다.</p>
+    <p><strong>현재 worktree 수정:</strong> (1) pressure/typed Blocking approval을 <code>turn_intake_admission</code> closed variant로 분류한 뒤에만 board/event intake를 허용하고, (2) autonomous OAS loop가 exact chat/durable queue를 turn boundary마다 읽어 typed <code>Chat_waiting | Durable_stimulus_waiting</code> reason으로 checkpoint하도록 했다. Scheduled-idle chat만 첫 dispatch 전에 양보하고, reactive chat과 durable backlog는 현재 leased stimulus를 모델이 최소 한 provider turn 관찰한 뒤에만 양보한다. 시작 turn은 0으로 가정하지 않고 captured <code>start_turn_count</code>와 비교한다.</p>
+    <p>OAS의 <code>Agent.check_loop_guard</code>는 provider call 전에 exit condition을 평가하며 공식 regression test도 turn 0 종료를 검증한다. 따라서 첫 dispatch 전에 durable yield를 허용하면 현재 lease를 관찰 없이 ack할 수 있다. 새 경계는 timeout, queue age/count, payload 문자열, turn cap을 사용하지 않고 queue 존재와 channel/lease 의미만 사용한다. MASC가 OAS의 public exit-condition contract를 소비하며 OAS에는 MASC 의존성을 추가하지 않는다.</p>
+    <p><strong>[근거]</strong> OAS <code>lib/agent/agent.ml</code> 및 <code>test/test_multimodal.ml</code>, MASC System Log/receipt/raw trace, 2026-07-10 16:30 KST 확인, 신뢰도 High. Closed variant와 exhaustive pattern match 설계는 <a href="https://ocaml.org/manual/5.4/typedecl.html">OCaml 5.4 type declarations</a> 기준이다.</p>
+  </section>
+
+  <section class="finding p2">
+    <h3>F-08 · P2 · Unified prompt metadata advertises a deleted template variable</h3>
+    <div class="meta">Confidence: High · Owner boundary: MASC prompt catalog SSOT</div>
+    <p>16:30 KST까지 live build <code>61a643565b</code>의 <code>keeper.unified.system</code> metadata에는 <code>trait_lines</code>가 남아 있지만 effective template에는 없어, 같은 drift warning이 677회 발생했다. startup config parser는 정상이며, 이 문제는 prompt schema metadata와 effective template의 SSOT 불일치다.</p>
+    <p>대규모 legacy purge PR <a href="https://github.com/jeong-sik/masc/pull/23929">#23929</a>이 16:30:12 KST에 merge commit <code>434a7f5a76</code>으로 해당 placeholder를 삭제했다. 따라서 source remediation은 main에 landed됐지만 live build에는 아직 배포되지 않았다. 중복 수정과 충돌을 만들지 않기 위해 이 후속 PR에는 같은 제거를 넣지 않는다.</p>
+    <p><strong>[근거]</strong> System Log exact warning count, live build source, merged PR #23929, 2026-07-10 16:31 KST 확인, 신뢰도 High.</p>
+  </section>
+
   <h2>버그로 확정하지 않은 항목</h2>
   <div class="note">
     <ul>
@@ -181,6 +213,7 @@
       <li><strong>deterministic retry/identical-tool guard:</strong> <code>idle_turns=3</code>, 동일 tool 반복 억제, 3회 실패 경고는 현재 무한루프를 제한하는 관측 가능한 안전장치다. 그 자체를 결함으로 세지 않았다.</li>
       <li><strong>legacy sandbox_profile parse reports:</strong> Keeper chat의 과거 기록에는 오류가 있으나 현재 config parse error는 0이다. 현재 장애로 재분류하지 않았다.</li>
       <li><strong>provider capacity/backpressure:</strong> 외부 capacity 오류는 관측되지만, 이를 MASC 내부 로직 결함으로 단정하지 않았다. 다만 해당 call이 다른 lane을 막지 않는지는 F-04/F-05와 함께 검증해야 한다.</li>
+      <li><strong>durable stale threshold 0:</strong> 현재 health schema가 명시적으로 모든 미처리 queue item을 stale로 표시하는 보수적 정책이다. stale label 자체를 age 계산 결함으로 보지 않았고, F-07은 lease/receipt 순서로 별도 입증했다.</li>
     </ul>
   </div>
 
@@ -189,27 +222,36 @@
     <tr><th>순서</th><th>작업</th><th>완료 조건</th></tr>
     <tr><td>1</td><td>MASC prompt segment type boundary</td><td>observation의 <code>keeper_turn_id</code>/<code>masc_oas_error</code> 원문 보존, instruction의 stale tool 검사는 유지, false-positive warning/strip 0, 회귀 테스트 통과</td></tr>
     <tr><td>2</td><td>MASC HITL continuation redesign</td><td>승인 대기 continuation만 block; 같은 Keeper lane에서 busy ack와 무관한 reactive work가 진행; Keeper 전체 pause 없음</td></tr>
-    <tr><td>3</td><td>OAS typed stop outcome</td><td>새 provider terminal reason을 fatal string match 없이 보존; malformed protocol과 분리; MASC fallback receipt가 원인과 함께 관측됨</td></tr>
-    <tr><td>4</td><td>Long-turn phase receipts</td><td>provider/tool/approval/stream별 elapsed와 cancellation이 기록되고, 한 lane의 stall이 전체 fleet을 막지 않음</td></tr>
-    <tr><td>5</td><td>Terminal task rejection contract</td><td>cancelled task에 대한 release 재호출이 typed terminal result로 끝나고 Keeper가 다른 활동으로 이동</td></tr>
+    <tr><td>3</td><td>Durable cooperative yield + pre-intake gate</td><td>blocking cycle은 lease하지 않고, 장기 autonomous run은 현재 stimulus를 한 turn 관찰한 뒤 queued durable work에 checkpoint; exact typed reason이 receipt에 남음</td></tr>
+    <tr><td>4</td><td>OAS typed stop outcome</td><td>새 provider terminal reason을 fatal string match 없이 보존; malformed protocol과 분리; MASC fallback receipt가 원인과 함께 관측됨</td></tr>
+    <tr><td>5</td><td>Long-turn phase receipts</td><td>provider/tool/approval/stream별 elapsed와 cancellation이 기록되고, 한 lane의 stall이 전체 fleet을 막지 않음</td></tr>
+    <tr><td>6</td><td>Terminal task rejection contract</td><td>cancelled task에 대한 release 재호출이 typed terminal result로 끝나고 Keeper가 다른 활동으로 이동</td></tr>
+    <tr><td>7</td><td>Prompt metadata drift deployment proof</td><td>merged #23929의 <code>trait_lines</code> 제거가 live build에 반영되고 warning이 0; 후속 PR에 중복 source 변경 없음</td></tr>
   </table>
 
   <h2>현재 remediation 상태</h2>
   <div class="note">
-    <p><strong>F-01 1차 수정 완료 (worktree only):</strong> unified prompt 경로가 structured world-state user message를 더 이상 token scanner/registry strip에 넣지 않고, system/continuity instruction surfaces만 검사하도록 분리했다. <a href="../../lib/keeper/keeper_unified_prompt.ml">keeper_unified_prompt.ml</a>와 <a href="../../test/test_keeper_unified_verification_surface.ml">verification-surface regression test</a>에 변경이 있다.</p>
-    <p><strong>F-02 1차 수정 완료 (worktree only):</strong> <a href="../../lib/keeper/keeper_approval_queue.ml">keeper_approval_queue.ml</a>에 typed blocking/nonblocking queue boundary를 추가하고, <a href="../../lib/governance_pipeline.ml">governance_pipeline.ml</a>과 <a href="../../lib/keeper/keeper_agent_run.ml">keeper_agent_run.ml</a>의 일반 Keeper tool approval을 nonblocking 경로로 연결했다. 명시적 critical continuation gate의 blocking policy는 유지한다.</p>
-    <p><strong>F-03 1차 수정 구현:</strong> <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/llm_provider/types.ml">OAS stop-reason SSOT</a>에 공식 <code>ContentFilter</code>/<code>RepetitionTruncation</code> constructor를 추가하고 <a href="../../../../../oas/.worktrees/oas-unknown-stop-terminal-20260710/lib/pipeline/pipeline.ml">pipeline</a>은 두 값만 typed terminal result로 보존한다. 임의 <code>Unknown</code>과 tool block 없는 <code>UnmatchedToolCalls</code>은 fail-closed를 유지한다. commit <code>7529dfbfd</code>를 <a href="https://github.com/jeong-sik/oas/pull/2506">OAS draft PR #2506</a>에 게시했다. focused build와 61/4/40/50 테스트가 성공했고 current-head full proof는 PR CI에서 확인한다.</p>
-    <p>검증: MASC approval queue 12개, HITL approval 51개, supervisor 87개, unified verification surface 18개, prompt token integrity 15개, F-06 tool-result 25개, Keeper tool-dispatch runtime 36개 테스트가 성공했다. OAS Types 61개, stop-reason SSOT 4개, OpenAI streaming 40개, pipeline 50개 테스트도 성공했다. 로컬 narrow build의 compiler는 <code>ocamlc 5.5.0</code>였고, OCaml 5.4 공식 manual을 설계 기준으로 삼았으므로 5.4 CI proof는 별도다. Dune full build/CI는 PR에서 수행한다. 테스트 실행 시 packaged model catalog 경고가 있었지만 worktree-only test fixture의 catalog discovery 경고이며, 라이브 health의 startup config warning과는 별개다.</p>
-    <p>현재 live executable은 이 worktree 변경을 포함하지 않으므로 live warning 감소나 runtime 개선으로 해석하면 안 된다. 배포/재시작 및 CI green 전에는 remediation을 완료 상태로 주장하지 않는다.</p>
+    <p><strong>F-01 1차 수정 landed:</strong> merged PR <a href="https://github.com/jeong-sik/masc/pull/23923">#23923</a>에서 unified prompt 경로가 structured world-state user message를 더 이상 token scanner/registry strip에 넣지 않고, system/continuity instruction surfaces만 검사하도록 분리했다.</p>
+    <p><strong>F-02 1차 수정 landed:</strong> merged PR <a href="https://github.com/jeong-sik/masc/pull/23923">#23923</a>에서 approval queue에 typed blocking/nonblocking boundary를 추가하고 일반 Keeper tool approval을 nonblocking 경로로 연결했다. 명시적 critical continuation gate의 blocking policy는 유지한다.</p>
+    <p><strong>F-03 1차 수정 landed:</strong> OAS stop-reason SSOT에 공식 <code>ContentFilter</code>/<code>RepetitionTruncation</code> constructor를 추가하고 pipeline은 두 값만 typed terminal result로 보존한다. 임의 <code>Unknown</code>과 tool block 없는 <code>UnmatchedToolCalls</code>은 fail-closed를 유지한다. <a href="https://github.com/jeong-sik/oas/pull/2506">OAS PR #2506</a>은 merge됐고, 후속 repair를 포함한 current main <code>c4255efe5</code>의 CI run <a href="https://github.com/jeong-sik/oas/actions/runs/29075791219">29075791219</a>가 성공했다.</p>
+    <p><strong>F-07 수정 구현:</strong> Draft PR <a href="https://github.com/jeong-sik/masc/pull/23950">#23950</a>에서 heartbeat가 typed Blocking approval을 event intake 전에 분류하고, autonomous run은 exact durable queue가 비어 있지 않으면 첫 provider turn 뒤 typed checkpoint를 만든다. 새 <code>Yielded_to_durable_stimulus</code> stop reason은 receipt, outcome, metric, dashboard cancellation surface까지 exhaustive하게 전파한다. global OAS turn count를 0으로 가정하지 않는 boundary regression과 queue/intake regression을 추가했다.</p>
+    <p><strong>F-08 source 수정 landed:</strong> prompt metadata의 obsolete <code>trait_lines</code> 제거는 merged PR <a href="https://github.com/jeong-sik/masc/pull/23929">#23929</a>이 소유한다. 이번 후속 변경은 같은 영역을 중복 수정하지 않으며 live 배포 후 warning 소멸만 확인한다.</p>
+    <p>기존 remediation 검증: MASC approval queue 12개, HITL approval 51개, supervisor 87개, unified verification surface 18개, prompt token integrity 15개, F-06 tool-result 25개, Keeper tool-dispatch runtime 36개 테스트가 성공했다. OAS Types 61개, stop-reason SSOT 4개, OpenAI streaming 40개, pipeline 50개 테스트도 성공했다.</p>
+    <p>F-07 current-head 검증: changed OCaml parser, <code>ocamlformat --check</code>, <code>git diff --check</code>, no-actionable-signal policy lint, HTML parse가 성공했다. focused Dune은 unrelated worktree 두 곳이 repo-local lock에서 build 중이어서 대기 프로세스만 중단했고 lock holder를 kill하거나 우회하지 않았다. OCaml 5.4 full build/test proof는 Draft PR #23950 CI authority로 남긴다.</p>
+    <p><strong>[근거]</strong> OAS current main CI run 29075791219, 2026-07-10 16:30 KST 확인, 신뢰도 High.</p>
+    <p>현재 live executable은 이 worktree 변경을 포함하지 않으므로 live warning 감소나 runtime 개선으로 해석하면 안 된다. 배포/재시작 및 후속 MASC PR CI green 전에는 F-07 remediation을 완료 상태로 주장하지 않는다.</p>
   </div>
 
   <h2>검증 근거</h2>
   <pre>curl -fsS 'http://127.0.0.1:8935/health?full=1'
 rg 'keeper cycle FAILED.*no_usable_progress' &lt;base_path&gt;/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
-rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' &lt;base_path&gt;/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl</pre>
-  <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue 파일은 read-only evidence로만 확인했으며 삭제·ack·resume 조작은 하지 않았다. 12:35, 13:11, 14:52 KST recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
+rg 'pending HITL approval|Unrecognized stop_reason|stale_turn_timeout|release.*cancelled' &lt;base_path&gt;/.masc/logs/system_log_2026-07-07.jsonl ... system_log_2026-07-10.jsonl
+rg 'hitl-approval:appr_ec78ca2d4398|latency_ms=1096626|template_variables drift' &lt;base_path&gt;/.masc/logs/system_log_2026-07-10.jsonl
+tail/jq &lt;base_path&gt;/.masc/keepers/issue_king/execution-receipts/2026-07/10.jsonl
+tail/jq &lt;base_path&gt;/.masc/keepers/issue_king/raw-traces/turn-1783665258367-cc61-002882.jsonl</pre>
+  <p class="small">로그 line count는 동일 사건이 structured message/details/supervisor 전파로 여러 번 기록된 경우를 deduplicate하지 않는다. 사건 수를 주장할 때는 위의 패턴과 source flow를 함께 보아야 한다. Durable queue와 Keeper Chat execution receipt/raw trace는 read-only evidence로만 확인했으며 원문 thinking이나 private payload를 보고서에 복제하지 않았다. queue 삭제·ack·resume 및 Keeper restart는 수행하지 않았다. 12:35, 13:11, 14:52, 16:30 KST recheck health evidence는 build commit <code>61a643565b</code> 기준이며, 각 snapshot의 동적 상태 차이를 보존하기 위해 분리했다.</p>
 
-  <footer>이 보고서와 MASC 수정은 <a href="https://github.com/jeong-sik/masc/pull/23923">MASC draft PR #23923</a>, OAS provider-catalog 수정은 <a href="https://github.com/jeong-sik/oas/pull/2506">OAS draft PR #2506</a>에서 추적한다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>
+  <footer>초기 보고서와 F-01/F-02/F-06 MASC 수정은 merged PR <a href="https://github.com/jeong-sik/masc/pull/23923">#23923</a>, OAS provider-catalog 수정은 merged PR <a href="https://github.com/jeong-sik/oas/pull/2506">#2506</a>에서 추적한다. F-07은 최신 main 기반 Draft PR <a href="https://github.com/jeong-sik/masc/pull/23950">#23950</a>, F-08 source 수정은 merged PR <a href="https://github.com/jeong-sik/masc/pull/23929">#23929</a>이 소유한다. Dune full build는 CI authority로 남기고, 소스 수정 후에는 touched target 중심의 narrow validation만 수행한다.</footer>
 </main>
 </body>
 </html>

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -91,6 +91,32 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
+type autonomous_yield_reason =
+  | Chat_waiting
+  | Durable_stimulus_waiting
+
+type autonomous_yield_boundary =
+  | Yield_immediately
+  | Yield_after_current_turn
+
+type autonomous_yield_request =
+  { reason : autonomous_yield_reason
+  ; boundary : autonomous_yield_boundary
+  }
+
+let autonomous_yield_allowed_at_turn ~start_turn ~turn request =
+  match request.boundary with
+  | Yield_immediately -> true
+  | Yield_after_current_turn -> turn > start_turn
+;;
+
+let stop_reason_of_autonomous_yield ~turn request =
+  match request.reason with
+  | Chat_waiting -> Runtime_agent.Yielded_to_chat_waiting { turns_used = turn }
+  | Durable_stimulus_waiting ->
+    Runtime_agent.Yielded_to_durable_stimulus { turns_used = turn }
+;;
+
 let keeper_raw_trace_sink
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -159,6 +185,8 @@ module For_testing = struct
     normalize_response_text_for_finalization
   let keeper_raw_trace_sink = keeper_raw_trace_sink
   let raw_trace_for_dispatch = raw_trace_for_dispatch
+  let autonomous_yield_allowed_at_turn = autonomous_yield_allowed_at_turn
+  let stop_reason_of_autonomous_yield = stop_reason_of_autonomous_yield
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -229,7 +257,7 @@ let run_turn
       ?continuation_channel
       ?hitl_delivery_channel
       ?hitl_approval_grant
-      ?yield_to_chat_waiting
+      ?autonomous_yield_requested
       ()
   : (run_result, Agent_sdk.Error.sdk_error) result
   =
@@ -697,31 +725,64 @@ let run_turn
                   ?max_tokens:requested_max_tokens
                   ()
               in
-              (* Autonomous chat-yield: when the caller supplies
-                 [yield_to_chat_waiting], evaluate it at each OAS agent-loop turn
-                 boundary (the [check_loop_guard] point, beside [max_idle_turns],
-                 before the next model dispatch — never mid tool execution). A
-                 [true] result stops the loop; [runtime_agent] converts that stop
-                 into a graceful [Ok] result *only* when [exit_condition_result]
-                 is also present, so both are wired together — otherwise the SDK
-                 [ExitConditionMet] surfaces as an error and the yield would be
-                 recorded as a turn failure/blocker. The rendered stop reason is
-                 [Yielded_to_chat_waiting], whose disposition is a
-                 [Continuation_checkpoint] (like [MutationBoundaryReached]):
-                 "stopped early, checkpoint saved, resume next cycle". *)
-              let chat_yield_exit_condition, chat_yield_exit_condition_result =
-                match yield_to_chat_waiting with
+              (* Autonomous cooperative yield: OAS checks [exit_condition]
+                 before the first provider dispatch as well as between turns.
+                 A scheduled-idle waiting chat may preempt immediately, but a
+                 reactive chat or durable stimulus may stop this run only after
+                 [turn] advances beyond the checkpoint's [start_turn_count];
+                 otherwise the heartbeat would acknowledge the currently leased
+                 stimulus without the model ever observing it. [observed_request]
+                 bridges OAS's split bool / render callbacks and preserves the
+                 exact typed reason and boundary that made the predicate true,
+                 even if the waiting chat is cancelled before
+                 [exit_condition_result] runs. *)
+              let autonomous_yield_exit_condition,
+                  autonomous_yield_exit_condition_result =
+                match autonomous_yield_requested with
                 | None -> None, None
-                | Some pred ->
-                  ( Some (fun (_turn : int) -> pred ())
+                | Some requested ->
+                  let observed_request = ref None in
+                  ( Some
+                      (fun (turn : int) ->
+                         match requested () with
+                         | Some request
+                           when autonomous_yield_allowed_at_turn
+                                  ~start_turn:start_turn_count
+                                  ~turn
+                                  request ->
+                           observed_request := Some request;
+                           true
+                         | Some _ | None -> false)
                   , Some
                       (fun (turn : int) ->
-                        ( Runtime_agent.Yielded_to_chat_waiting { turns_used = turn }
-                        , Some
-                            (Printf.sprintf
-                               "[yielded turn slot at turn %d to a waiting chat \
-                                request; keeper resumes on the next cycle]"
-                               turn) )) )
+                         match !observed_request with
+                         | Some request ->
+                           let stop_reason =
+                             stop_reason_of_autonomous_yield ~turn request
+                           in
+                           let notice =
+                             match request.reason with
+                             | Chat_waiting ->
+                               Printf.sprintf
+                                 "[yielded turn slot at turn %d to a waiting \
+                                  chat request; keeper resumes on the next \
+                                  cycle]"
+                                 turn
+                             | Durable_stimulus_waiting ->
+                               Printf.sprintf
+                                 "[yielded autonomous run at turn %d because a \
+                                  durable stimulus is waiting; checkpoint saved \
+                                  and keeper resumes on the next cycle]"
+                                 turn
+                           in
+                           stop_reason, Some notice
+                         | None ->
+                           let message =
+                             "autonomous yield result requested without a \
+                              preceding typed yield decision"
+                           in
+                           Log.Keeper.error ~keeper_name:meta.name "%s" message;
+                           invalid_arg message) )
               in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* The keeper turn deadline must own the OAS Agent.run switch.
@@ -787,13 +848,13 @@ let run_turn
                          ?hitl_approval_grant
                          ())
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-                      (* Mutation-boundary is native to OAS now; [exit_condition]
-                         is re-wired here solely for the autonomous chat-yield
-                         (see [chat_yield_exit_condition] above). Both are [None]
-                         on the chat lane, so a chat turn runs to natural
-                         completion (model end_turn) unchanged. *)
-                    ?exit_condition:chat_yield_exit_condition
-                    ?exit_condition_result:chat_yield_exit_condition_result
+                      (* Mutation-boundary is native to OAS now;
+                         [exit_condition] is re-wired here solely for the typed
+                         autonomous cooperative yield above. Both callbacks are
+                         [None] on the chat lane, so chat runs to natural model
+                         completion unchanged. *)
+                    ?exit_condition:autonomous_yield_exit_condition
+                    ?exit_condition_result:autonomous_yield_exit_condition_result
                     ?oas_checkpoint:resume_oas_checkpoint
                     ?event_bus
                     ?trace_link

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -23,6 +23,24 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
+(** Typed reason and boundary for an autonomous Keeper run to release its lane
+    at an OAS turn boundary. Scheduled-idle chat can yield immediately;
+    reactive chat and durable backlog yield only after the current cycle has
+    completed at least one provider turn, so a leased stimulus is never
+    acknowledged without being observed by the model. *)
+type autonomous_yield_reason =
+  | Chat_waiting
+  | Durable_stimulus_waiting
+
+type autonomous_yield_boundary =
+  | Yield_immediately
+  | Yield_after_current_turn
+
+type autonomous_yield_request = {
+  reason : autonomous_yield_reason;
+  boundary : autonomous_yield_boundary;
+}
+
 val completion_contract_result_for_progress_evidence
   :  had_owned_active_task_at_turn_start:bool
   -> actual_keeper_tool_names:string list
@@ -74,6 +92,17 @@ module For_testing : sig
     :  config:Workspace.config
     -> meta:Keeper_meta_contract.keeper_meta
     -> Agent_sdk.Raw_trace.t option
+
+  val autonomous_yield_allowed_at_turn
+    :  start_turn:int
+    -> turn:int
+    -> autonomous_yield_request
+    -> bool
+
+  val stop_reason_of_autonomous_yield
+    :  turn:int
+    -> autonomous_yield_request
+    -> Runtime_agent.stop_reason
 end
 
 val per_provider_timeout_for_turn
@@ -154,14 +183,13 @@ val run_turn
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?hitl_delivery_channel:Keeper_continuation_channel.t
   -> ?hitl_approval_grant:Governance_pipeline.hitl_approval_grant
-  -> ?yield_to_chat_waiting:(unit -> bool)
+  -> ?autonomous_yield_requested:(unit -> autonomous_yield_request option)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
           (the same guard point as [max_idle_turns], before the next model
-          dispatch — never mid tool execution). When it returns [true] the run
-          stops gracefully at that boundary, releasing the turn slot so a
-          dashboard/connector chat request parked behind this turn admits via
-          direct handoff before its shorter budget expires. Only the
-          heartbeat-scheduled path passes it; a chat turn must not yield to a
-          later-queued chat. *)
+          dispatch — never mid tool execution). A typed request stops the run
+          gracefully at the boundary allowed by [autonomous_yield_reason],
+          releasing the lane for queued chat or durable stimulus work. Only the
+          heartbeat-scheduled path passes it; a chat turn never receives this
+          hook. *)
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -24,7 +24,9 @@ let visible_response_text_present ~stop_reason ~response_text_present =
   match stop_reason with
   (* A yield renders only a synthetic status marker, not a deliverable — like
      a budget stop it does not count as a visible reply for the contract. *)
-  | Runtime_agent.TurnBudgetExhausted _ | Runtime_agent.Yielded_to_chat_waiting _ ->
+  | Runtime_agent.TurnBudgetExhausted _
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ ->
     false
   | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ ->
     response_text_present
@@ -39,7 +41,8 @@ let budget_exhausted_contract_status ~stop_reason status =
      as for [Completed]/[MutationBoundaryReached]. *)
   | ( ( Runtime_agent.Completed
       | Runtime_agent.MutationBoundaryReached _
-      | Runtime_agent.Yielded_to_chat_waiting _ )
+      | Runtime_agent.Yielded_to_chat_waiting _
+      | Runtime_agent.Yielded_to_durable_stimulus _ )
     , _ )
   | Runtime_agent.TurnBudgetExhausted _, _ ->
     status

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -8,7 +8,8 @@ let stop_reason_is_turn_budget_exhausted = function
   | Runtime_agent.TurnBudgetExhausted _ -> true
   | Runtime_agent.Completed
   | Runtime_agent.MutationBoundaryReached _
-  | Runtime_agent.Yielded_to_chat_waiting _ -> false
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> false
 ;;
 
 let direct_assistant_source = "direct_assistant"

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -333,6 +333,8 @@ let stop_reason_to_string = function
      | None -> Printf.sprintf "mutation_boundary:%d" turns_used)
   | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
 ;;
 
 let enrich_contract_violation_reason (receipt : t) : string =

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -64,6 +64,20 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
+type turn_intake_admission =
+  | Intake_admitted
+  | Intake_pressure_blocked of Keeper_pressure_admission.block
+  | Intake_blocking_approval_pending
+
+let classify_turn_intake_admission ~pressure ~blocking_approval_pending =
+  match pressure with
+  | Keeper_pressure_admission.Blocked block -> Intake_pressure_blocked block
+  | Keeper_pressure_admission.Admitted ->
+    if blocking_approval_pending
+    then Intake_blocking_approval_pending
+    else Intake_admitted
+;;
+
 let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat_stimulus
 let consume_board_stimulus_batch = Stimulus_intake.consume_board_stimulus_batch
 let heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake
@@ -484,9 +498,9 @@ let run_keepalive_unified_turn
         then meta_after_triage
         else if should_run_turn
         then (
-          (* fd/disk pressure is pre-checked by the caller's turn-admission gate
-             (Keeper_pressure_admission_observer.decide_observed in run_heartbeat_loop)
-             BEFORE stimulus intake, so this branch is reached only when a turn is
+          (* fd/disk pressure and typed Blocking HITL ownership are pre-checked
+             by [classify_turn_intake_admission] in [run_heartbeat_loop] BEFORE
+             stimulus intake, so this branch is reached only when a turn is
              admitted. The four prior inline pressure gates here were removed: they
              ran AFTER intake had already consumed the stimulus, forcing a
              consume/requeue churn loop, and logged only at DEBUG (a silent skip). *)
@@ -524,9 +538,11 @@ let run_keepalive_unified_turn
           meta_after_cycle)
         else meta_after_triage
       in
-      (* Event intake dequeues before the admission/pressure gates above.
-         Only ack after [run_keeper_cycle] actually returns; otherwise put the
-         lease back so a non-exception skip does not drop the stimulus. *)
+      (* The caller has already admitted intake before this dequeue. Downstream
+         scheduling can still decide not to run (for example provider cooldown
+         or keeper health), so acknowledge only after [run_keeper_cycle]
+         actually returns; otherwise put the lease back rather than dropping
+         the stimulus. *)
       if !consumed_stimuli <> []
       then
         if !consumed_stimuli_turn_completed
@@ -979,12 +995,11 @@ let run_heartbeat_loop
           proactive_warmup_sec <= 0
           || now_ts -. keepalive_started_ts >= float_of_int proactive_warmup_sec
         in
-        (* Turn-admission precondition (fd/disk pressure) is evaluated ONCE here,
-           BEFORE board collection and stimulus intake. A pressure-blocked keeper
-           therefore neither advances the board cursor (collect_keepalive_board_events
-           acks board posts with no requeue) nor dequeues+requeues its event-queue
-           stimulus every cycle — eliminating the consume/requeue churn and its log
-           noise at the source instead of skipping after the work is already done.
+        (* Turn-intake preconditions (fd/disk pressure and a typed Blocking HITL
+           lane) are evaluated ONCE here, BEFORE board collection and durable
+           stimulus intake. A blocked keeper therefore neither advances the
+           board cursor nor leases and requeues the same event every heartbeat.
+           Nonblocking approvals never enter this gate.
            The fleet observer logs one WARN per pressure episode (was four per-turn
            DEBUG gates inside run_keepalive_unified_turn, now removed). last_turn_ts
            is refreshed on the blocked path so the RFC-0250 stale-turn watchdog
@@ -996,14 +1011,19 @@ let run_heartbeat_loop
             ~active_keepers:(Keeper_registry.count_running ())
             ()
         in
-        let admitted_turn =
-          match turn_admission with
-          | Keeper_pressure_admission.Admitted -> true
-          | Keeper_pressure_admission.Blocked _ -> false
-        in
         let approval_pending =
           Keeper_approval_queue.has_blocking_pending_for_keeper
             ~keeper_name:meta_current.name
+        in
+        let intake_admission =
+          classify_turn_intake_admission
+            ~pressure:turn_admission
+            ~blocking_approval_pending:approval_pending
+        in
+        let admitted_turn =
+          match intake_admission with
+          | Intake_admitted -> true
+          | Intake_pressure_blocked _ | Intake_blocking_approval_pending -> false
         in
         let keeper_health_blocker =
           if Health.is_healthy ~agent_name:meta_current.name then None else Some "unhealthy"
@@ -1015,13 +1035,24 @@ let run_heartbeat_loop
             ~runtime_id
         in
         let provider_cooldown_pending = Option.is_some provider_cooldown_remaining_sec in
-        (match turn_admission with
-         | Keeper_pressure_admission.Admitted -> ()
-         | Keeper_pressure_admission.Blocked block ->
+        (match intake_admission with
+         | Intake_admitted -> ()
+         | Intake_pressure_blocked block ->
            Keeper_registry.record_skip_reasons
              ~base_path:ctx.config.base_path
              meta_current.name
              ~reasons:[ Keeper_pressure_admission.skip_reason block ];
+           Keeper_registry.touch_last_turn_ts
+             ~base_path:ctx.config.base_path
+             meta_current.name
+         | Intake_blocking_approval_pending ->
+           Keeper_registry.record_skip_reasons
+             ~base_path:ctx.config.base_path
+             meta_current.name
+             ~reasons:
+               [ Keeper_world_observation.skip_reason_to_string
+                   Keeper_world_observation.Approval_pending
+               ];
            Keeper_registry.touch_last_turn_ts
              ~base_path:ctx.config.base_path
              meta_current.name);

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -58,6 +58,19 @@ type heartbeat_event_intake = {
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
+(** Closed pre-intake admission result. A blocking approval is classified
+    before durable dequeue, just like fd/disk pressure, so a blocked cycle does
+    not repeatedly lease and requeue the same stimulus. *)
+type turn_intake_admission =
+  | Intake_admitted
+  | Intake_pressure_blocked of Keeper_pressure_admission.block
+  | Intake_blocking_approval_pending
+
+val classify_turn_intake_admission :
+  pressure:Keeper_pressure_admission.decision ->
+  blocking_approval_pending:bool ->
+  turn_intake_admission
+
 val heartbeat_event_intake :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->
@@ -125,10 +138,10 @@ val turn_status_event :
   turn_fail_count:int -> max_allowed:int -> Keeper_state_machine.event
 
 (** Runs one keepalive turn (event intake, scheduling, optional cycle dispatch).
-    The fd/disk pressure precondition is pre-checked by the caller via
-    {!Keeper_pressure_admission_observer.decide_observed} BEFORE this is invoked, so
-    this function must NOT re-add inline pressure gates: doing so would reinstate
-    the consume-before-gate churn that hoisting the admission check removed. *)
+    The caller classifies fd/disk pressure and typed Blocking HITL ownership
+    with {!classify_turn_intake_admission} BEFORE this is invoked, so this
+    function must not re-add inline admission gates: doing so would reinstate
+    the consume-before-gate churn that hoisting the decision removed. *)
 val run_keepalive_unified_turn :
   ctx:'a context ->
   meta_after_triage:keeper_meta ->

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -34,14 +34,16 @@ let of_stop_reason = function
   | Runtime_agent.Completed -> Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
-  | Runtime_agent.Yielded_to_chat_waiting _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
 
 let of_result_surface ~response_text = function
   | Runtime_agent.Completed ->
       if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
-  | Runtime_agent.Yielded_to_chat_waiting _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
 
 let of_reply_payload payload =
   match payload with

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -295,6 +295,8 @@ let append_decision_record
                            Printf.sprintf "mutation_boundary(%d)" turns_used)
                   | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
                       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
+                  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+                      Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
                 in
               let inference_fields =
                 match r.inference_telemetry with

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -26,6 +26,31 @@ type retry_loop_input =
   ; attempted_runtimes : string list
   }
 
+let autonomous_yield_request ~base_path ~keeper_name ~channel =
+  if
+    Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
+    || Keeper_chat_queue.length ~keeper_name > 0
+  then
+    let boundary =
+      match channel with
+      | Keeper_world_observation.Scheduled_autonomous ->
+        Keeper_agent_run.Yield_immediately
+      | Keeper_world_observation.Reactive ->
+        Keeper_agent_run.Yield_after_current_turn
+    in
+    Some Keeper_agent_run.{ reason = Chat_waiting; boundary }
+  else
+    let pending = Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+    if Keeper_event_queue.is_empty pending
+    then None
+    else
+      Some
+        Keeper_agent_run.
+          { reason = Durable_stimulus_waiting
+          ; boundary = Yield_after_current_turn
+          }
+;;
+
 (** [run] operates on the immutable [Keeper_unified_turn_types.turn_state]
     accumulator instead of casual [ref] cells. *)
 
@@ -205,18 +230,18 @@ let run (ctx : ctx)
                       reached via [Keeper_turn_admission.run_if_free]); the chat
                       lane runs [run_keeper_msg_turn_admitted] on a separate
                       path. So passing the yield hook here is inherently
-                      lane-gated: an idle-filler turn stops at the next boundary
-                      when a dashboard/connector chat is parked on the slot or
-                      already deferred in [Keeper_chat_queue], but a chat turn
-                      never yields to a later-queued chat. The queue-length
-                      half is what keeps a long autonomous turn from starving a
-                      busy Slack/Discord/Dashboard message that has not parked
-                      on the slot. *)
-                 ~yield_to_chat_waiting:(fun () ->
-                   Keeper_turn_admission.chat_waiting
+                      lane-gated. Scheduled-idle chat can take the slot
+                      immediately; reactive chat and a durable event waiting
+                      behind the event leased by this cycle cause a checkpointed
+                      yield after at least one provider turn. A chat turn receives
+                      neither preemption hook. Both signals are read from the
+                      exact queues their consumers drain, so no cadence, timeout, or
+                      inferred text state participates in the decision. *)
+                 ~autonomous_yield_requested:(fun () ->
+                   autonomous_yield_request
                      ~base_path:config.base_path
                      ~keeper_name:meta.name
-                   || Keeper_chat_queue.length ~keeper_name:meta.name > 0)
+                     ~channel)
                  ()))
     in
     result, turn_state

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -57,7 +57,8 @@ let budget_exhausted_no_progress_threshold_override
     | Runtime_agent.TurnBudgetExhausted _ -> true
     | Runtime_agent.Completed
     | Runtime_agent.MutationBoundaryReached _
-    | Runtime_agent.Yielded_to_chat_waiting _ -> false
+    | Runtime_agent.Yielded_to_chat_waiting _
+    | Runtime_agent.Yielded_to_durable_stimulus _ -> false
   in
   if
     budget_exhausted
@@ -219,7 +220,8 @@ let completion_contract_terminal_failure_reason_code result =
          result.Keeper_agent_run.completion_contract_result
      | Runtime_agent.Completed
      | Runtime_agent.MutationBoundaryReached _
-     | Runtime_agent.Yielded_to_chat_waiting _ -> None)
+     | Runtime_agent.Yielded_to_chat_waiting _
+     | Runtime_agent.Yielded_to_durable_stimulus _ -> None)
   | Some _ -> None
   | None ->
     Some
@@ -235,7 +237,8 @@ let terminal_outcome_of_result result =
      | Runtime_agent.Completed -> Terminal_done
      | Runtime_agent.TurnBudgetExhausted _
      | Runtime_agent.MutationBoundaryReached _
-     | Runtime_agent.Yielded_to_chat_waiting _ ->
+     | Runtime_agent.Yielded_to_chat_waiting _
+     | Runtime_agent.Yielded_to_durable_stimulus _ ->
        Terminal_checkpoint)
 ;;
 
@@ -446,6 +449,8 @@ let emit_usage_metrics_and_log
        | None -> Printf.sprintf "mutation_boundary(%d)" turns_used)
     | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
+    | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+      Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
   in
   let outcome_label =
     match terminal_outcome with
@@ -456,6 +461,8 @@ let emit_usage_metrics_and_log
        | Runtime_agent.TurnBudgetExhausted _ -> "budget_exhausted"
        | Runtime_agent.MutationBoundaryReached _ -> "mutation_boundary"
        | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
+       | Runtime_agent.Yielded_to_durable_stimulus _ ->
+         "yielded_to_durable_stimulus"
        | Runtime_agent.Completed -> "success")
   in
   Otel_metric_store.inc_counter
@@ -575,6 +582,7 @@ let terminal_reason_of_outcome result = function
             { detail = None; used = turns_used; limit })
      | Runtime_agent.MutationBoundaryReached _
      | Runtime_agent.Yielded_to_chat_waiting _
+     | Runtime_agent.Yielded_to_durable_stimulus _
      | Runtime_agent.Completed ->
        Keeper_turn_terminal.success ())
   | Terminal_failed_completion_contract _ ->
@@ -662,6 +670,12 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Log.Keeper.info ~keeper_name:updated_meta.name
       "yielded turn slot to a waiting chat request after %d turn(s), checkpoint \
        saved — will resume next cycle"
+      turns_used;
+    reset_failure_state ()
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    Log.Keeper.info ~keeper_name:updated_meta.name
+      "yielded autonomous run for a pending durable stimulus after %d turn(s), \
+       checkpoint saved — will resume next cycle"
       turns_used;
     reset_failure_state ()
   | Runtime_agent.Completed -> reset_failure_state ()

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -65,6 +65,7 @@ type stop_reason =
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
   | Yielded_to_chat_waiting of { turns_used : int }
+  | Yielded_to_durable_stimulus of { turns_used : int }
 
 type config =
   Runtime_agent_context.config = {
@@ -996,6 +997,8 @@ let dashboard_status_of_stop_reason = function
       Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
   | Yielded_to_chat_waiting _ ->
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
+  | Yielded_to_durable_stimulus _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "yielded_to_durable_stimulus" }
 
 let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
     ~status (response : Agent_sdk.Types.api_response) =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -34,6 +34,7 @@ type stop_reason = Runtime_agent_context.stop_reason =
       tool_name : string option;
     }
   | Yielded_to_chat_waiting of { turns_used : int }
+  | Yielded_to_durable_stimulus of { turns_used : int }
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path; [TurnBudgetExhausted] means the per-call
     turn budget checkpoint was reached. It is not a completed
@@ -43,9 +44,11 @@ type stop_reason = Runtime_agent_context.stop_reason =
     keeper hit a mutation tool while in read-only mode (the [tool_name]
     surfaces which tool triggered the gate). [Yielded_to_chat_waiting]
     fires when an autonomous-lane run stopped at a turn boundary to hand
-    the keeper's turn slot to a parked dashboard/connector chat request;
-    like [MutationBoundaryReached] it is a continuation checkpoint, not a
-    completed deliverable, and the keeper resumes on the next cycle. *)
+    the keeper's turn slot to a parked dashboard/connector chat request.
+    [Yielded_to_durable_stimulus] fires after at least one provider turn when
+    another durable event is waiting behind the event currently leased by the
+    cycle. Both yields are continuation checkpoints, not completed
+    deliverables, and the keeper resumes on the next cycle. *)
 
 (** {1 Config} *)
 

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -23,6 +23,10 @@ type stop_reason =
        Progress is checkpointed and the keeper resumes on the next cycle — the
        same disposition as [MutationBoundaryReached], but a distinct reason so
        receipts do not conflate an on-demand yield with a budget/mutation stop. *)
+  | Yielded_to_durable_stimulus of { turns_used : int }
+    (* The current autonomous cycle completed at least one OAS provider turn,
+       then released its lane because another durable stimulus was queued
+       behind the stimulus already leased by this cycle. *)
 
 type config =
   { name : string

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -24,6 +24,7 @@ type stop_reason =
       tool_name : string option;
     }
   | Yielded_to_chat_waiting of { turns_used : int }
+  | Yielded_to_durable_stimulus of { turns_used : int }
 
 (** {1 Per-worker config} *)
 

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -947,6 +947,24 @@ let test_pacing_block_delays_requested_turn () =
   in
   check bool "default pacing closure never blocks" true admitted.should_run_turn
 
+let test_blocking_approval_is_classified_before_intake () =
+  (match
+     KHL.classify_turn_intake_admission
+       ~pressure:Keeper_pressure_admission.Admitted
+       ~blocking_approval_pending:true
+   with
+   | KHL.Intake_blocking_approval_pending -> ()
+   | KHL.Intake_admitted | KHL.Intake_pressure_blocked _ ->
+     fail "blocking approval must stop intake before durable dequeue");
+  match
+    KHL.classify_turn_intake_admission
+      ~pressure:Keeper_pressure_admission.Admitted
+      ~blocking_approval_pending:false
+  with
+  | KHL.Intake_admitted -> ()
+  | KHL.Intake_blocking_approval_pending | KHL.Intake_pressure_blocked _ ->
+    fail "no blocking approval should leave intake admitted"
+
 let test_crashed_cycle_records_health_failure () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1030,6 +1048,8 @@ let () =
         test_keeper_health_backpressure_uses_keeper_name;
       test_case "pacing block delays requested turn (RFC-0313 W3)" `Quick
         test_pacing_block_delays_requested_turn;
+      test_case "blocking approval is classified before intake" `Quick
+        test_blocking_approval_is_classified_before_intake;
       test_case "crashed cycles feed agent health breaker" `Quick
         test_crashed_cycle_records_health_failure;
     ];

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1032,6 +1032,50 @@ let () =
         [ first; second ];
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
+  (* A pending durable stimulus is the structural cooperative-yield signal for
+     an already-running autonomous OAS loop. The classifier reads the same
+     registry queue this test dequeues below; no age, count, or payload text
+     heuristic participates. *)
+  let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-yield-test" in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
+      Masc.Keeper_registry.clear ();
+      Keeper_chat_queue.clear ~keeper_name;
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      (match
+         Masc.Keeper_unified_turn_execution.autonomous_yield_request
+           ~base_path
+           ~keeper_name
+           ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+       with
+       | None -> ()
+       | Some _ ->
+         Alcotest.fail "empty work queues must not request an autonomous yield");
+      Masc.Keeper_registry_event_queue.enqueue
+        ~base_path
+        keeper_name
+        bootstrap_stim;
+      match
+        Masc.Keeper_unified_turn_execution.autonomous_yield_request
+          ~base_path
+          ~keeper_name
+          ~channel:Masc.Keeper_world_observation.Reactive
+      with
+      | Some
+          { Masc.Keeper_agent_run.reason =
+              Masc.Keeper_agent_run.Durable_stimulus_waiting
+          ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
+          } ->
+        ()
+      | None | Some _ ->
+        Alcotest.fail "pending durable stimulus must request a typed yield");
+
   (* --- crash recovery: consumed stimuli can be put back for replay --- *)
   let base_path = temp_dir "keeper-event-queue-requeue-front" in
   Fun.protect

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -46,7 +46,13 @@ let test_of_stop_reason () =
   check outcome "mutation boundary -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.MutationBoundaryReached
-          { turns_used = 2; tool_name = Some "masc_add_task" }))
+          { turns_used = 2; tool_name = Some "masc_add_task" }));
+  check outcome "chat yield -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_stop_reason
+       (Runtime_agent.Yielded_to_chat_waiting { turns_used = 2 }));
+  check outcome "durable stimulus yield -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_stop_reason
+       (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }))
 
 let test_of_result_surface () =
   check outcome "completed with text -> visible" TO.Visible_reply
@@ -57,6 +63,58 @@ let test_of_result_surface () =
   check outcome "budget exhausted -> checkpoint" TO.Continuation_checkpoint
     (TO.of_result_surface ~response_text:"done"
        (Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 }))
+
+let test_autonomous_yield_boundary_contract () =
+  let module F = Masc.Keeper_agent_run.For_testing in
+  let start_turn = 11570 in
+  let immediate_chat : Masc.Keeper_agent_run.autonomous_yield_request =
+    { reason = Masc.Keeper_agent_run.Chat_waiting
+    ; boundary = Masc.Keeper_agent_run.Yield_immediately
+    }
+  in
+  let reactive_chat : Masc.Keeper_agent_run.autonomous_yield_request =
+    { reason = Masc.Keeper_agent_run.Chat_waiting
+    ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
+    }
+  in
+  let durable_stimulus : Masc.Keeper_agent_run.autonomous_yield_request =
+    { reason = Masc.Keeper_agent_run.Durable_stimulus_waiting
+    ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
+    }
+  in
+  check bool "chat may yield before first provider dispatch" true
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:start_turn
+       immediate_chat);
+  check bool "reactive chat cannot skip the leased stimulus" false
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:start_turn
+       reactive_chat);
+  check bool "durable backlog cannot skip the leased stimulus" false
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:start_turn
+       durable_stimulus);
+  check bool "durable backlog yields after one provider turn" true
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:(start_turn + 1)
+       durable_stimulus);
+  match
+    F.stop_reason_of_autonomous_yield
+      ~turn:(start_turn + 1)
+      durable_stimulus
+  with
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    check int "typed durable yield carries the OAS turn" (start_turn + 1)
+      turns_used
+  | Runtime_agent.Completed
+  | Runtime_agent.TurnBudgetExhausted _
+  | Runtime_agent.MutationBoundaryReached _
+  | Runtime_agent.Yielded_to_chat_waiting _ ->
+    fail "durable request mapped to the wrong stop reason"
 
 let payload fields = Some (`Assoc fields)
 
@@ -185,6 +243,8 @@ let () =
         [
           test_case "of_stop_reason" `Quick test_of_stop_reason;
           test_case "of_result_surface" `Quick test_of_result_surface;
+          test_case "autonomous yield boundary contract" `Quick
+            test_autonomous_yield_boundary_contract;
         ] );
       ( "payload_decode",
         [


### PR DESCRIPTION
## Summary

- Classify fd/disk pressure and typed Blocking HITL ownership before board collection or durable-event dequeue.
- Cooperatively checkpoint a long autonomous OAS run when the exact Keeper durable queue becomes non-empty.
- Preserve the currently leased reactive stimulus by allowing reactive chat and durable backlog yields only after at least one provider turn.
- Propagate a typed Yielded_to_durable_stimulus outcome through receipts, metrics, turn outcome, failure reset, and dashboard status.
- Extend the live System/Keeper log audit with the reproduced starvation and dequeue/requeue sequence.

## Confirmed runtime evidence

- issue_king received durable HITL resolution wake appr_ec78ca2d4398 at 2026-07-10T06:34:17Z.
- A later autonomous cycle ran from 06:49:45Z to 07:08:01Z for 1,096,626 ms while OAS turn count advanced from 11453 to 11570.
- After that cycle, the same durable event was consumed at 07:08:34Z, 07:09:06Z, 07:09:41Z, and 07:10:07Z.
- A typed Blocking approval warning followed each early intake. When the blocking approval expired, the cycle admitted.
- At the 16:30 KST read-only recheck, durable queue state was pending 6 and inflight 1 with read errors 0.

## Boundary contract

OAS checks exit_condition before the first provider dispatch. MASC therefore captures the run start turn and uses a closed boundary:

- Scheduled-idle chat: Yield_immediately
- Reactive chat: Yield_after_current_turn
- Durable stimulus: Yield_after_current_turn

The decision reads the same typed queues consumed by the lane. It uses no timeout, queue-age/count threshold, payload text match, turn cap, or provider-specific heuristic. OAS remains unaware of MASC.

## Validation

Passed on current source based on main 434a7f5a76:

- OCaml parser-only validation for every changed .ml and .mli
- ocamlformat --check
- git diff --check
- no-actionable-signal-bool-context
- pandoc HTML parse
- no stale yield_to_chat_waiting call sites

Focused Dune was attempted after the earlier shared build ended, but the repo-local lock is currently held by unrelated worktrees building test_keeper_vision_tool and test_keeper_approval_queue. The lock was not bypassed and those builds were not killed. Full Dune build and tests remain PR CI authority.

## Runtime safety

This work only read health, logs, receipts, raw traces, and queue snapshots. It did not ack or delete durable events, resume paused Keepers, restart the runtime, or mutate live Keeper state.