### PR TITLE
fix(ci): repair two residual main-red gates (OAS 0.209 round 2 + spec ref)

### DIFF
--- a/specs/bug-models/MemoryCompaction.tla
+++ b/specs/bug-models/MemoryCompaction.tla
@@ -11,7 +11,7 @@
 \*       compact_memory_bank_if_needed entry point
 \*   lib/keeper/keeper_memory_bank.ml:296
 \*       memory_kind_caps_for_compaction (per-target cap derivation)
-\*   lib/keeper/keeper_memory_policy.ml:806
+\*   lib/keeper/keeper_memory_policy.ml:kind_caps
 \*       kind_caps () : (memory_kind * int) list — closed-variant SSOT
 \*
 \* ── Abstraction note ──

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -759,8 +759,13 @@ let test_checkpoint_patch_updates_visible_text_and_clears_working_context () =
     false
     (text_contains "old visible reply" texts);
   let thinking_preserved =
+    (* The param annotation is load-bearing: [message] and [api_response] both
+       declare a [content] field in Agent_sdk.Types, and an unannotated
+       [message.Agent_sdk.Types.content] projection resolves to whichever
+       record OCaml saw last — which flipped to [api_response] under the
+       OAS 0.209 pin and broke this test's compile. *)
     patched.Agent_sdk.Checkpoint.messages
-    |> List.exists (fun message ->
+    |> List.exists (fun (message : Agent_sdk.Types.message) ->
       List.exists
         (function
           | Agent_sdk.Types.Thinking { content; _ } ->


### PR DESCRIPTION
## 무엇이 깨졌나 (main-red 잔여 2건, #23947 후속)

#23947이 병합 이벤트로 자기 CI가 취소된 채 들어가서(Closed PR CI Cleanup), vision match 뒤에 숨어 있던 잔여 red가 이제 드러났소. 트랙 PR들(#23861/#23863 등)의 Health/Meta Guards fail이 이 2건이오.

### 1. pin 낙진 2호 — `test_pbt_context_overflow.ml` 컴파일 에러

`Agent_sdk.Types`에는 `message`와 `api_response` 둘 다 `content` 필드가 있소. thinking-보존 단언의 람다 param이 무주석이라 `.Agent_sdk.Types.content` 투영이 "마지막 정의 레코드" 규칙을 타는데, OAS 0.209에서 그 해석이 `api_response`로 뒤집혀 `message list` vs `api_response list` 타입 에러가 났소. **param 주석 한 줄**로 투영을 결정론화했소 (같은 패턴 전수 스캔: test/ 전체에서 무주석 사이트는 이 1곳뿐, lib/ 소비자는 전부 주석付き).

### 2. spec ref dangling — `MemoryCompaction.tla`

#23929 purge가 `keeper_memory_policy.ml`을 163줄로 줄이면서 `:806` (kind_caps) 라인 앵커가 out-of-range가 됐소. 라인을 149로 갱신하는 대신 **심볼 앵커**(`keeper_memory_policy.ml:kind_caps`)로 전환 — spec-line-refs 게이트가 grep으로 해석하는 형식이라 이후 라인 이동에 면역이오.

## 검증

- `bash scripts/lint/spec-line-refs.sh` 로컬 실행: `68 refs checked, 0 drift, 0 dangling` (수리 전: 1 dangling, exit 2).
- 컴파일 증명은 CI 몫 — 이 PR green이면 트랙 PR들은 branch-update로 살아나오.

## 프로세스 노트

#23947과 동일 교훈의 반복이오: **pin 전진 PR은 자기 CI가 완주한 뒤 병합해야** 낙진이 한 번에 드러나오. 긴급 병합이 연쇄되면 red가 한 겹씩 벗겨지며 트랙 전체가 반복 재검을 치르오 (이번이 그 2회차).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
