### PR TITLE
fix(hitl): commit resolution before acknowledgment

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -439,6 +439,16 @@ let approved_action_matches_request
   && String.equal approved.input_hash (normalized_input_hash input)
 ;;
 
+type approval_resolution_delivery_hook =
+  base_path:string
+  -> keeper_name:string
+  -> approval_id:string
+  -> decision:Keeper_event_queue.hitl_resolution_decision
+  -> channel:Keeper_continuation_channel.t
+  -> (unit -> unit, string) result
+
+let approval_resolution_wake_hook : approval_resolution_delivery_hook option ref = ref None
+
 let first_cmd_token (cmd : string) =
   Keeper_tool_command_words.first_token_of_cmd cmd
 ;;
@@ -453,6 +463,7 @@ module For_testing = struct
   let first_cmd_token = first_cmd_token
 
   let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
+  let clear_approval_resolution_wake_hook () = approval_resolution_wake_hook := None
 end
 
 let action_key_of_input ~tool_name ~(input : Yojson.Safe.t) =
@@ -867,38 +878,62 @@ let spawn_hitl_summary_worker_on_root_switch ~(entry : pending_approval) =
    Injected as a hook rather than a direct call to break a dependency cycle:
    this module sits below [Keeper_keepalive_signal], which depends on
    [Keeper_world_observation], which depends back on this module for
-   [has_blocking_pending_for_keeper]. The default is a no-op so unit tests and
-   pre-bootstrap contexts stay wake-free; [Server_bootstrap] installs the real
-   [Keeper_keepalive_signal]-backed wake. *)
-let approval_resolution_wake_hook :
-    (base_path:string ->
-     keeper_name:string ->
-     approval_id:string ->
-     decision:Keeper_event_queue.hitl_resolution_decision ->
-     channel:Keeper_continuation_channel.t option ->
-     unit)
-    ref =
-  ref
-    (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_
-      ~channel:(_ : Keeper_continuation_channel.t option) -> ())
+   [has_blocking_pending_for_keeper]. Until [Server_bootstrap] installs the
+   delivery hook, nonblocking resolution fails explicitly and remains pending. *)
+let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := Some f
 
-let set_approval_resolution_wake_hook f = approval_resolution_wake_hook := f
+let record_resolution_delivery_failure ~keeper_name ~approval_id reason =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ApprovalQueueFailures)
+    ~labels:
+      [ "keeper", keeper_name
+      ; ( "site"
+        , Keeper_approval_queue_failure_site.(to_label Resolution_delivery) )
+      ]
+    ();
+  Log.Keeper.error
+    ~keeper_name
+    "hitl resolution delivery failed approval=%s: %s"
+    approval_id
+    reason
+;;
+
+let signal_resolution_after_commit ~keeper_name ~approval_id signal =
+  try signal () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ApprovalQueueFailures)
+      ~labels:
+        [ "keeper", keeper_name
+        ; "site", Keeper_approval_queue_failure_site.(to_label Resolution_signal)
+        ]
+      ();
+    Log.Keeper.error
+      ~keeper_name
+      "hitl resolution signal failed after durable commit approval=%s: %s"
+      approval_id
+      (Printexc.to_string exn)
+;;
 
 let wake_keeper_on_approval_resolution
     ~base_path ~keeper_name ~approval_id ~decision
-    ~(channel : Keeper_continuation_channel.t option) =
-  try
-    !approval_resolution_wake_hook
-      ~base_path ~keeper_name ~approval_id ~decision ~channel
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Log.Keeper.warn
-      ~keeper_name
-      "hitl resolution wake failed approval=%s: %s"
-      approval_id
-      (Printexc.to_string exn)
+    ~(channel : Keeper_continuation_channel.t) =
+  match !approval_resolution_wake_hook with
+  | None ->
+    let reason = "approval resolution delivery hook is not installed" in
+    record_resolution_delivery_failure ~keeper_name ~approval_id reason;
+    Error reason
+  | Some deliver ->
+    (match
+       try deliver ~base_path ~keeper_name ~approval_id ~decision ~channel with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn -> Error (Printexc.to_string exn)
+     with
+     | Ok signal -> Ok signal
+     | Error reason ->
+       record_resolution_delivery_failure ~keeper_name ~approval_id reason;
+       Error reason)
 ;;
 
 let hitl_resolution_decision_of_approval_decision
@@ -914,7 +949,28 @@ let hitl_resolution_decision_of_approval_decision
   | Agent_sdk.Hooks.Edit _ -> Keeper_event_queue.Hitl_edited
 ;;
 
-let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
+let deliver_resolution ~base_path (entry : pending_approval) decision =
+  match entry.lane_policy with
+  | Blocking -> Ok None
+  | Nonblocking ->
+    (match
+       wake_keeper_on_approval_resolution
+         ~base_path
+         ~keeper_name:entry.keeper_name
+         ~approval_id:entry.id
+         ~decision:(hitl_resolution_decision_of_approval_decision entry decision)
+         ~channel:entry.continuation_channel
+     with
+     | Error _ as err -> err
+     | Ok signal -> Ok (Some signal))
+;;
+
+let resolve_entry
+      ?(before_terminal_publish = fun () -> ())
+      ~base_path
+      (entry : pending_approval)
+      (decision : decision)
+  =
   let decision_str = approval_decision_to_string decision in
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
@@ -960,18 +1016,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
            (Printexc.to_string exn))
        (fun () -> f decision)
    | None -> ());
-  (* [Blocking] entries own their continuation: [submit_and_await] resumes its
-     resolver, while lifecycle callbacks resume their paused keeper explicitly.
-     Only [Nonblocking] entries need the durable resolution stimulus. *)
-  (match entry.lane_policy with
-   | Blocking -> ()
-   | Nonblocking ->
-     wake_keeper_on_approval_resolution
-       ~base_path
-       ~keeper_name:entry.keeper_name
-       ~approval_id:entry.id
-       ~decision:(hitl_resolution_decision_of_approval_decision entry decision)
-       ~channel:entry.channel);
+  before_terminal_publish ();
   try
     Sse.broadcast
       (`Assoc
@@ -1323,10 +1368,37 @@ let submit_pending
 type resolve_error =
   | Not_found of string
   | Already_resolved of string
+  | Delivery_failed of
+      { approval_id : string
+      ; reason : string
+      }
 
 let resolve_error_to_string = function
   | Not_found id -> Printf.sprintf "approval %s not found" id
   | Already_resolved id -> Printf.sprintf "approval %s already resolved" id
+  | Delivery_failed { approval_id; reason } ->
+    Printf.sprintf "approval %s resolution delivery failed: %s" approval_id reason
+;;
+
+module Resolution_claims = Set_util.StringSet
+
+let resolution_claims : Resolution_claims.t Atomic.t =
+  Atomic.make Resolution_claims.empty
+;;
+
+let rec claim_resolution id =
+  let claims = Atomic.get resolution_claims in
+  if Resolution_claims.mem id claims
+  then false
+  else
+    let claimed = Resolution_claims.add id claims in
+    if Atomic.compare_and_set resolution_claims claims claimed
+    then true
+    else claim_resolution id
+;;
+
+let release_resolution_claim id =
+  atomic_update resolution_claims (fun claims -> Resolution_claims.remove id claims)
 ;;
 
 let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
@@ -1378,30 +1450,50 @@ let resolve_with_policy
       ()
   : (resolution_result, resolve_error) result
   =
-  let result = ref (Error (Not_found id)) in
-  atomic_update pending (fun map ->
-    match SMap.find_opt id map with
-    | None -> map
-    | Some entry ->
-      result := Ok entry;
-      SMap.remove id map);
-  match !result with
-  | Error _ as err -> err
-  | Ok entry ->
-    let remembered_rule =
-      match decision with
-      | Agent_sdk.Hooks.Approve when remember_rule ->
-        remember_rule_for_entry ~base_path ?created_by entry
-      | _ -> None
-    in
-    resolve_entry ~base_path entry decision;
-    Ok { remembered_rule }
+  if not (claim_resolution id)
+  then Error (Already_resolved id)
+  else
+    Fun.protect
+      ~finally:(fun () -> release_resolution_claim id)
+      (fun () ->
+         match SMap.find_opt id (Atomic.get pending) with
+         | None -> Error (Not_found id)
+         | Some entry ->
+           (match deliver_resolution ~base_path entry decision with
+            | Error reason -> Error (Delivery_failed { approval_id = id; reason })
+            | Ok signal ->
+              (* Durable delivery is the commit point for nonblocking entries.
+                 Keep the approval queryable while its callback applies the
+                 approved domain mutation; intake defers this exact resolution
+                 until the pending id is removed below. Blocking entries retain
+                 their original lane-release-before-resume ordering. *)
+              (match entry.lane_policy with
+               | Blocking -> atomic_update pending (fun map -> SMap.remove id map)
+               | Nonblocking -> ());
+              let remembered_rule =
+                match decision with
+                | Agent_sdk.Hooks.Approve when remember_rule ->
+                  remember_rule_for_entry ~base_path ?created_by entry
+                | _ -> None
+              in
+              let before_terminal_publish () =
+                match entry.lane_policy with
+                | Blocking -> ()
+                | Nonblocking -> atomic_update pending (fun map -> SMap.remove id map)
+              in
+              resolve_entry ~before_terminal_publish ~base_path entry decision;
+              Option.iter
+                (signal_resolution_after_commit
+                   ~keeper_name:entry.keeper_name
+                   ~approval_id:id)
+                signal;
+              Ok { remembered_rule }))
 ;;
 
 (** Resolve a pending approval. Returns [Ok ()] if found and resolved,
     [Error (Not_found _)] if the id is not in the queue, or
-    [Error (Already_resolved _)] if the atomic update found no matching
-    entry (concurrent resolve race).
+    [Error (Already_resolved _)] if another resolver currently owns the
+    approval claim. A delivery failure leaves the entry pending for retry.
     Called from the dashboard approval HTTP handler
     ([server_dashboard_http.ml]) and MCP runtime.
 
@@ -1513,6 +1605,63 @@ let has_pending_for_keeper ~keeper_name : bool =
 
 (* ── Timeout cleanup ──────────────────────────────────────── *)
 
+let complete_expiration ~id (entry : pending_approval) ~reason ~decision =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ApprovalQueueFailures)
+    ~labels:
+      [ "keeper", entry.keeper_name
+      ; "site", Keeper_approval_queue_failure_site.(to_label Approval_expired)
+      ]
+    ();
+  Log.Keeper.warn
+    "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
+    id
+    entry.keeper_name
+    entry.tool_name;
+  audit_approval_event
+    ~base_path:entry.audit_base_path
+    ~event_type:"expired"
+    ~id
+    ~keeper_name:entry.keeper_name
+    ~tool_name:entry.tool_name
+    ~risk_level:entry.risk_level
+    ?turn_id:entry.turn_id
+    ?task_id:entry.task_id
+    ?goal_id:entry.goal_id
+    ~goal_ids:entry.goal_ids
+    ~sandbox_target:entry.sandbox_target
+    ?runtime_contract:entry.runtime_contract
+    ?selected_model:entry.selected_model
+    ?disposition:entry.disposition
+    ?disposition_reason:entry.disposition_reason
+    ~decision:(Approval_expired reason)
+    ();
+  (match entry.resolver with
+   | Some resolver -> Eio.Promise.resolve resolver decision
+   | None -> ());
+  match entry.on_resolution with
+  | None -> ()
+  | Some f ->
+    Cancel_safe.observe
+      ~on_exn:(fun exn ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string LifecycleCallbackFailures)
+          ~labels:[ "keeper", entry.keeper_name; "callback", "on_approval_expire" ]
+          ();
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string ApprovalQueueFailures)
+          ~labels:
+            [ "keeper", entry.keeper_name
+            ; "site", Keeper_approval_queue_failure_site.(to_label Expire_callback)
+            ]
+          ();
+        Log.Keeper.warn
+          "approval_queue: expire callback failed id=%s err=%s"
+          id
+          (Printexc.to_string exn))
+      (fun () -> f decision)
+;;
+
 (** Reject all approvals that have been waiting longer than [max_wait_s].
     Call periodically from a health loop.
 
@@ -1537,85 +1686,44 @@ let has_pending_for_keeper ~keeper_name : bool =
     [Low / Medium / High] tool approvals only. *)
 let expire_stale ~max_wait_s =
   let now = Unix.gettimeofday () in
-  let stale_ref = ref [] in
-  atomic_update pending (fun map ->
-    let stale =
-      SMap.fold
-        (fun id entry acc ->
-           match entry.risk_level with
-           | Critical -> acc
-           | Low | Medium | High ->
-             if now -. entry.requested_at > max_wait_s then (id, entry) :: acc else acc)
-        map
-        []
-    in
-    stale_ref := stale;
-    List.fold_left (fun acc (id, _) -> SMap.remove id acc) map stale);
-  let stale = !stale_ref in
+  let is_stale (entry : pending_approval) =
+    match entry.risk_level with
+    | Critical -> false
+    | Low | Medium | High -> now -. entry.requested_at > max_wait_s
+  in
+  let candidates = list_pending_entries () |> List.filter is_stale in
   List.iter
-    (fun (id, entry) ->
-       let reason =
-         Printf.sprintf "approval timed out after %.0fs" (now -. entry.requested_at)
-       in
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string ApprovalQueueFailures)
-         ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Approval_expired) ]
-         ();
-       Log.Keeper.warn
-         "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
-         id
-         entry.keeper_name
-         entry.tool_name;
-       audit_approval_event
-         ~base_path:entry.audit_base_path
-         ~event_type:"expired"
-         ~id
-         ~keeper_name:entry.keeper_name
-         ~tool_name:entry.tool_name
-         ~risk_level:entry.risk_level
-         ?turn_id:entry.turn_id
-         ?task_id:entry.task_id
-         ?goal_id:entry.goal_id
-         ~goal_ids:entry.goal_ids
-         ~sandbox_target:entry.sandbox_target
-         ?runtime_contract:entry.runtime_contract
-         ?selected_model:entry.selected_model
-         ?disposition:entry.disposition
-         ?disposition_reason:entry.disposition_reason
-         ~decision:(Approval_expired reason)
-         ();
-       (* Expiry clears the [Approval_pending] skip for [Nonblocking] entries,
-          so those keepers need the same wake or they stay stalled until an
-          unrelated stimulus. A [Blocking] resolver/callback receives
-          [Reject reason] through its own continuation. *)
-       (match entry.lane_policy with
-        | Blocking -> ()
-        | Nonblocking ->
-          wake_keeper_on_approval_resolution
-            ~base_path:entry.audit_base_path
-            ~keeper_name:entry.keeper_name
-            ~approval_id:id
-            ~decision:Keeper_event_queue.Hitl_rejected
-            ~channel:entry.channel);
-       (match entry.resolver with
-        | Some resolver -> Eio.Promise.resolve resolver (Agent_sdk.Hooks.Reject reason)
-        | None -> ());
-       match entry.on_resolution with
-       | Some f ->
-         Cancel_safe.observe
-           ~on_exn:(fun exn ->
-             Otel_metric_store.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
-               ~labels:[ ("keeper", entry.keeper_name); ("callback", "on_approval_expire") ]
-               ();
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string ApprovalQueueFailures)
-               ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Expire_callback) ]
-               ();
-             Log.Keeper.warn
-               "approval_queue: expire callback failed id=%s err=%s"
-               id
-               (Printexc.to_string exn))
-           (fun () -> f (Agent_sdk.Hooks.Reject reason))
-       | None -> ())
-    stale
+    (fun candidate ->
+       let id = candidate.id in
+       if claim_resolution id
+       then
+         Fun.protect
+           ~finally:(fun () -> release_resolution_claim id)
+           (fun () ->
+              match SMap.find_opt id (Atomic.get pending) with
+              | None -> ()
+              | Some entry when not (is_stale entry) -> ()
+              | Some entry ->
+                let reason =
+                  Printf.sprintf
+                    "approval timed out after %.0fs"
+                    (now -. entry.requested_at)
+                in
+                let decision = Agent_sdk.Hooks.Reject reason in
+                (match deliver_resolution ~base_path:entry.audit_base_path entry decision with
+                 | Error _ -> ()
+                 | Ok signal ->
+                   (match entry.lane_policy with
+                    | Blocking -> atomic_update pending (fun map -> SMap.remove id map)
+                    | Nonblocking -> ());
+                   complete_expiration ~id entry ~reason ~decision;
+                   (match entry.lane_policy with
+                    | Blocking -> ()
+                    | Nonblocking -> atomic_update pending (fun map -> SMap.remove id map));
+                   Option.iter
+                     (signal_resolution_after_commit
+                        ~keeper_name:entry.keeper_name
+                        ~approval_id:id)
+                     signal)) )
+    candidates
 ;;

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -126,6 +126,10 @@ type resolution_result =
 type resolve_error =
   | Not_found of string
   | Already_resolved of string
+  | Delivery_failed of
+      { approval_id : string
+      ; reason : string
+      }
 
 val resolve_error_to_string : resolve_error -> string
 
@@ -264,6 +268,7 @@ val list_recent_resolved_json :
 module For_testing : sig
   val reset_audit_store : unit -> unit
   val first_cmd_token : string -> string option
+  val clear_approval_resolution_wake_hook : unit -> unit
 end
 
 (** {1 Submit & await} *)
@@ -336,26 +341,29 @@ val submit_pending :
 
 (** {1 Resolve (operator action)} *)
 
-(** Install the hook that wakes a keeper when one of its pending approvals is
-    resolved or expires. Injected (rather than a direct
+(** Install the hook that durably delivers a resolved or expired approval to
+    its keeper lane. Injected (rather than a direct
     [Keeper_keepalive_signal] call) to break a dependency cycle: this module
     sits below [Keeper_keepalive_signal], which depends on
     [Keeper_world_observation], which depends back here for
-    [has_blocking_pending_for_keeper]. The default is a no-op;
-    [Server_bootstrap] installs the [Hitl_resolved]-stimulus wake for
-    nonblocking entries. *)
+    [has_blocking_pending_for_keeper]. Before [Server_bootstrap] installs the
+    hook, nonblocking resolution fails explicitly and remains pending. A
+    successful hook returns the wake signal closure; the queue invokes it only
+    after the resolution callback has completed and the pending id is gone. *)
 val set_approval_resolution_wake_hook :
   (base_path:string ->
    keeper_name:string ->
    approval_id:string ->
    decision:Keeper_event_queue.hitl_resolution_decision ->
-   channel:Keeper_continuation_channel.t option ->
-   unit) ->
+   channel:Keeper_continuation_channel.t ->
+   (unit -> unit, string) result) ->
   unit
 
 (** Resolve a pending approval and optionally remember the decision
     as a rule. Returns [Not_found] when [id] is absent or
-    [Already_resolved] on concurrent-resolve race. *)
+    [Already_resolved] on a concurrent-resolve race. [Delivery_failed]
+    preserves the pending entry and reports that no resolution was
+    acknowledged. *)
 val resolve_with_policy :
   base_path:string ->
   id:string ->

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -321,6 +321,25 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
     batch
 ;;
 
+let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
+  match stimulus.payload with
+  | Keeper_event_queue.Hitl_resolved resolution ->
+    Option.is_none
+      (Keeper_approval_queue.get_pending_entry ~id:resolution.approval_id)
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Bootstrap
+  | Keeper_event_queue.No_progress_recovery
+  | Keeper_event_queue.Fusion_completed _
+  | Keeper_event_queue.Bg_completed _
+  | Keeper_event_queue.Schedule_due _
+  | Keeper_event_queue.Connector_attention _
+  | Keeper_event_queue.Goal_verification_failed _
+  | Keeper_event_queue.Failure_judgment _
+  | Keeper_event_queue.Goal_assigned _
+  | Keeper_event_queue.Goal_stagnation _ ->
+    true
+;;
+
 let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
   (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus per
      turn, where the board unit is the turn digest: every queued board
@@ -336,9 +355,10 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
     match board_batch with
     | [] ->
       (match
-         Keeper_registry_event_queue.dequeue
+         Keeper_registry_event_queue.dequeue_when
            ~base_path:ctx.config.base_path
            meta_after_triage.name
+           ~ready:stimulus_ready_for_intake
        with
        | None -> [], []
        | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, [ stim ])

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -80,7 +80,9 @@ val consume_board_stimulus_batch
 (** [heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events]
     drains the Event-Layer queue (per RFC-0020 §3 Rule 4) and merges
     newly-consumed board events with the [pending_board_events] already
-    accumulated by the caller, deduplicating by [post_id]. *)
+    accumulated by the caller, deduplicating by [post_id]. A
+    [Hitl_resolved] head remains queued until its exact approval id has left
+    the pending map, so domain callbacks complete before continuation intake. *)
 val heartbeat_event_intake
   :  ctx:'a context
   -> meta_after_triage:keeper_meta

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -22,6 +22,28 @@ let enqueue_if_missing queue stimulus =
   if queue_contains queue stimulus then queue else Keeper_event_queue.enqueue queue stimulus
 ;;
 
+let rec stimulus_with_post_id queue post_id =
+  match Keeper_event_queue.dequeue queue with
+  | None -> None
+  | Some (stimulus, rest) ->
+    if String.equal stimulus.post_id post_id
+    then Some stimulus
+    else stimulus_with_post_id rest post_id
+;;
+
+let enqueue_external_decision queue stimulus =
+  match stimulus_with_post_id queue stimulus.Keeper_event_queue.post_id with
+  | None -> Ok (Keeper_event_queue.enqueue queue stimulus)
+  | Some committed
+    when Keeper_event_queue.stimulus_identity_equal committed stimulus ->
+    Ok queue
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "conflicting durable stimulus already exists for post_id=%s"
+         stimulus.post_id)
+;;
+
 let requeue_missing_front queue stimuli =
   let missing =
     List.filter (fun stimulus -> not (queue_contains queue stimulus)) stimuli
@@ -34,6 +56,19 @@ let persist_live_queue ~base_path (entry : Keeper_registry.registry_entry) name 
     ~base_path
     ~keeper_name:name
     (fun () -> Atomic.get entry.event_queue)
+;;
+
+let enqueue_live_if_missing (entry : Keeper_registry.registry_entry) stimulus =
+  let rec loop () =
+    let cur = Atomic.get entry.event_queue in
+    let next = enqueue_if_missing cur stimulus in
+    if next = cur
+    then ()
+    else if Atomic.compare_and_set entry.event_queue cur next
+    then ()
+    else loop ()
+  in
+  loop ()
 ;;
 
 let enqueue ~base_path name stimulus =
@@ -71,6 +106,23 @@ let enqueue ~base_path name stimulus =
       else loop ()
     in
     loop ()
+;;
+
+let enqueue_durable_result ~base_path name stimulus =
+  (* Commit the identity-deduplicated durable row before exposing a successful
+     delivery result. This path is intentionally separate from [enqueue]: most
+     stimuli already have an upstream replay source, while HITL resolution is
+     the sole carrier of an operator decision and must fail closed. *)
+  let after_commit =
+    match Keeper_registry.get ~base_path name with
+    | None -> fun () -> ()
+    | Some entry -> fun () -> enqueue_live_if_missing entry stimulus
+  in
+  Keeper_event_queue_persistence.update_checked_result
+    ~base_path
+    ~keeper_name:name
+    ~after_commit
+    (fun queue -> enqueue_external_decision queue stimulus)
 ;;
 
 let requeue_front ~base_path name stimuli =
@@ -153,7 +205,7 @@ let snapshot ~base_path name =
   | Some entry -> Atomic.get entry.event_queue
 ;;
 
-let dequeue ~base_path name =
+let dequeue_when ~base_path name ~ready =
   match Keeper_registry.get ~base_path name with
   | None -> None
   | Some entry ->
@@ -161,6 +213,7 @@ let dequeue ~base_path name =
       let cur = Atomic.get entry.event_queue in
       match Keeper_event_queue.dequeue cur with
       | None -> None
+      | Some (stim, _) when not (ready stim) -> None
       | Some (stim, rest) ->
         Keeper_event_queue_persistence.record_inflight
           ~base_path
@@ -174,6 +227,8 @@ let dequeue ~base_path name =
     in
     loop ()
 ;;
+
+let dequeue ~base_path name = dequeue_when ~base_path name ~ready:(fun _ -> true)
 
 let drain_board ~base_path name =
   match Keeper_registry.get ~base_path name with

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -13,6 +13,18 @@
     restart/register boundary. *)
 val enqueue : base_path:string -> string -> Keeper_event_queue.stimulus -> unit
 
+val enqueue_durable_result :
+  base_path:string
+  -> string
+  -> Keeper_event_queue.stimulus
+  -> (unit, string) result
+(** Identity-deduplicated enqueue with an explicit durable-commit result.
+    Unlike {!enqueue}, this first commits the pending snapshot and only then
+    updates the live queue. Use it when the stimulus is the sole carrier of an
+    external decision and the caller must not acknowledge delivery on a failed
+    write. An existing identical [post_id] is idempotent; the same [post_id]
+    with a different typed payload is an explicit conflict. *)
+
 (** Read-only snapshot of the keeper's queue. If the keeper is not registered,
     read the durable snapshot so diagnostics still expose pending replay. *)
 val snapshot : base_path:string -> string -> Keeper_event_queue.t
@@ -20,6 +32,16 @@ val snapshot : base_path:string -> string -> Keeper_event_queue.t
 (** Remove and return the head stimulus, or [None] when the queue is
     empty or the keeper is unregistered. *)
 val dequeue : base_path:string -> string -> Keeper_event_queue.stimulus option
+
+val dequeue_when :
+  base_path:string
+  -> string
+  -> ready:(Keeper_event_queue.stimulus -> bool)
+  -> Keeper_event_queue.stimulus option
+(** Remove and return the head stimulus only when [ready head] is [true]. A
+    rejected head remains in the live and durable queue without entering the
+    in-flight lease. This is the exact readiness gate for durable events whose
+    producer has not completed its domain callback yet. *)
 
 (** Put previously drained stimuli back at the front of the queue. This is a
     crash-recovery primitive: if the keepalive cycle dies after dequeue/drain

--- a/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.ml
@@ -2,6 +2,8 @@ type t =
   | Upsert_rule_save
   | Matching_rule_save
   | Audit_store_create
+  | Resolution_delivery
+  | Resolution_signal
   | Resolution_callback
   | Remember_rule
   | Approval_expired
@@ -13,6 +15,8 @@ let to_label = function
   | Upsert_rule_save -> "upsert_rule_save"
   | Matching_rule_save -> "matching_rule_save"
   | Audit_store_create -> "audit_store_create"
+  | Resolution_delivery -> "resolution_delivery"
+  | Resolution_signal -> "resolution_signal"
   | Resolution_callback -> "resolution_callback"
   | Remember_rule -> "remember_rule"
   | Approval_expired -> "approval_expired"

--- a/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.mli
@@ -5,6 +5,8 @@ type t =
   | Upsert_rule_save
   | Matching_rule_save
   | Audit_store_create
+  | Resolution_delivery
+  | Resolution_signal
   | Resolution_callback
   | Remember_rule
   | Approval_expired

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -556,22 +556,68 @@ let persist_snapshot ~base_path ~keeper_name snapshot =
          path
          (Printexc.to_string exn))
 
-let update ~base_path ~keeper_name f =
+let snapshot_read_error_to_string (error : snapshot_read_error) =
+  let location =
+    match error.path with
+    | None -> ""
+    | Some path -> " path=" ^ path
+  in
+  Printf.sprintf
+    "%s%s: %s"
+    (snapshot_read_error_kind_to_string error.kind)
+    location
+    error.message
+
+let update_checked_result ?(after_commit = fun () -> ()) ~base_path ~keeper_name f =
   match snapshot_path ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
+  | Error msg -> Error msg
   | Ok path ->
     (try
        with_write_lock (fun () ->
-         let cur = load_from_path ~keeper_name path in
-         persist_to_path ~keeper_name path (f cur))
+         let cur, read_errors = load_from_path_with_errors ~keeper_name path in
+         match read_errors with
+         | _ :: _ ->
+           Error
+             (Printf.sprintf
+                "refusing to overwrite unreadable event queue keeper=%s: %s"
+                keeper_name
+                (String.concat
+                   "; "
+                   (List.map snapshot_read_error_to_string read_errors)))
+         | [] ->
+           (match f cur with
+            | Error _ as err -> err
+            | Ok next ->
+              (match persist_to_path_result ~keeper_name path next with
+               | Error _ as err -> err
+               | Ok () ->
+                 (* Keep the persistence lock through the live publication. Any
+                    ordinary CAS writer can advance the in-memory queue, but its
+                    snapshot is serialized after this callback and therefore
+                    observes the committed stimulus instead of overwriting it. *)
+                 after_commit ();
+                 Ok ())))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
-       Log.Keeper.warn
-         "event_queue_snapshot: update raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn))
+       Error
+         (Printf.sprintf
+            "update raised keeper=%s path=%s: %s"
+            keeper_name
+            path
+            (Printexc.to_string exn)))
+
+let update_result ?after_commit ~base_path ~keeper_name f =
+  update_checked_result
+    ?after_commit
+    ~base_path
+    ~keeper_name
+    (fun queue -> Ok (f queue))
+
+let update ~base_path ~keeper_name f =
+  match update_result ~base_path ~keeper_name f with
+  | Ok () -> ()
+  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
 
 let record_inflight ~base_path ~keeper_name stimuli =
   match stimuli with

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -72,6 +72,26 @@ val update :
     persistence write lock. Use this for pre-registry mutation paths that do not
     have a live registry CAS cell yet. *)
 
+val update_result :
+  ?after_commit:(unit -> unit)
+  -> base_path:string
+  -> keeper_name:string
+  -> (Keeper_event_queue.t -> Keeper_event_queue.t)
+  -> (unit, string) result
+(** Result-returning form of {!update}. Critical delivery paths use this so a
+    failed durable write cannot be reported as a committed wake.
+    [after_commit] runs under the same write lock only after the snapshot is
+    durable, allowing a live queue publication without a generation gap. *)
+
+val update_checked_result :
+  ?after_commit:(unit -> unit)
+  -> base_path:string
+  -> keeper_name:string
+  -> (Keeper_event_queue.t -> (Keeper_event_queue.t, string) result)
+  -> (unit, string) result
+(** Checked transform form of {!update_result}. A transform error leaves the
+    existing durable snapshot and live queue unchanged. *)
+
 val persist_snapshot :
   base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit
 (** Evaluate [snapshot] while holding the persistence write lock, then atomically

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -550,11 +550,11 @@ let start_keeper_loops
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
       ~config:(Mcp_server.workspace_config state)
       signal);
-  (* Wake a keeper when one of its pending HITL approvals resolves/expires.
-     Registered here (composition root) rather than in Keeper_approval_queue to
-     break the Keeper_approval_queue -> Keeper_keepalive_signal ->
-     Keeper_world_observation -> Keeper_approval_queue dependency cycle. Mirrors
-     the Fusion_completed/Bg_completed async-completion wakes. *)
+  (* Commit a resolved HITL decision to the keeper's durable lane, then signal
+     the live fiber as a hint. Registered here (composition root) rather than in
+     Keeper_approval_queue to break the Keeper_approval_queue ->
+     Keeper_keepalive_signal -> Keeper_world_observation ->
+     Keeper_approval_queue dependency cycle. *)
   Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun ~base_path ~keeper_name ~approval_id ~decision ~channel ->
        let resolution =
@@ -562,12 +562,7 @@ let start_keeper_loops
            {
              approval_id;
              decision;
-             channel =
-               Option.value
-                 channel
-                 ~default:
-                   (Keeper_continuation_channel.unrouted
-                      "legacy: no approval continuation channel");
+             channel;
            }
        in
        let decision_label = Keeper_event_queue.hitl_resolution_decision_to_string decision in
@@ -578,12 +573,22 @@ let start_keeper_loops
          ; payload = Keeper_event_queue.Hitl_resolved resolution
          }
        in
-       Log.Keeper.info
-         "hitl resolution wake: keeper=%s approval=%s decision=%s"
-         keeper_name
-         approval_id
-         decision_label;
-       Keeper_keepalive_signal.wakeup_keeper ~base_path ~stimulus keeper_name);
+       match
+         Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           stimulus
+       with
+       | Error _ as err -> err
+       | Ok () ->
+         Ok
+           (fun () ->
+            Log.Keeper.info
+              "hitl resolution committed and signaling: keeper=%s approval=%s decision=%s"
+              keeper_name
+              approval_id
+              decision_label;
+            Keeper_keepalive_signal.wakeup_keeper ~base_path keeper_name));
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in
     Sse.broadcast

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -336,6 +336,7 @@ let dashboard_proof_http_json ~config request : Yojson.Safe.t =
 type approval_resolve_http_error =
   | Bad_request of string
   | Gone of Keeper_approval_queue.resolve_error
+  | Unavailable of Keeper_approval_queue.resolve_error
 
 let approval_resolve_decision_field = "decision"
 let approval_resolve_reason_field = "reason"
@@ -378,6 +379,7 @@ let approval_resolve_decision_of_json args =
 let approval_resolve_http_error_to_string = function
   | Bad_request msg -> msg
   | Gone err -> Keeper_approval_queue.resolve_error_to_string err
+  | Unavailable err -> Keeper_approval_queue.resolve_error_to_string err
 ;;
 
 let dashboard_governance_approval_resolve_http_json ~base_path ~(args : Yojson.Safe.t)
@@ -420,7 +422,12 @@ let dashboard_governance_approval_resolve_http_json ~base_path ~(args : Yojson.S
                     | Some rule -> `String rule.id
                     | None -> `Null )
                 ])
-        | Error err -> Error (Gone err)))
+        | Error (Keeper_approval_queue.Delivery_failed _ as err) ->
+          Error (Unavailable err)
+        | Error
+            (( Keeper_approval_queue.Not_found _
+             | Keeper_approval_queue.Already_resolved _ ) as err) ->
+          Error (Gone err)))
 ;;
 
 let dashboard_governance_approval_rule_delete_http_json ~base_path ~(args : Yojson.Safe.t)

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -41,6 +41,7 @@ end
 type approval_resolve_http_error =
   | Bad_request of string
   | Gone of Keeper_approval_queue.resolve_error
+  | Unavailable of Keeper_approval_queue.resolve_error
 
 val approval_resolve_http_error_to_string :
   approval_resolve_http_error -> string

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1152,6 +1152,8 @@ let add_routes ~sw ~clock router =
                  respond_json_value_with_cors request reqd json
              | Error (Gone _ as err) ->
                  respond_json_value_with_cors ~status:`Not_found request reqd (operator_error_json (approval_resolve_http_error_to_string err))
+             | Error (Unavailable _ as err) ->
+                 respond_json_value_with_cors ~status:`Service_unavailable request reqd (operator_error_json (approval_resolve_http_error_to_string err))
              | Error (Bad_request _ as err) ->
                  respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (approval_resolve_http_error_to_string err))
            with Yojson.Json_error msg ->

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-10T05:04:17Z (HEAD: 1e984f3cea)
+Generated: 2026-07-10T08:27:08Z (HEAD: 178797f1db)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -110,7 +110,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 36bb593bbcf3 |
+| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 46d6c792a0a3 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} | 3f49da13e4a8 |
 | KeeperCompactionCooldown.tla | KeeperCompactionCooldown | manual | 2 | 1 | clean={inv:Safety, inv:NonAppliedDoesNotInventTimestamp} buggy={inv:NonAppliedDoesNotInventTimestamp} | 117cd8f85f7d |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | 004f6c25b9cc |

--- a/specs/keeper-state-machine/KeeperApprovalQueue.tla
+++ b/specs/keeper-state-machine/KeeperApprovalQueue.tla
@@ -28,16 +28,19 @@
 \* callback, returns the id immediately — NO suspended fiber; the
 \* decision is delivered later via the callback).  This spec models the
 \* [submit_and_await] variant — `suspended_fibers` counts those fibers.
-\* The [submit_pending] variant has a different, weaker failure mode (a
-\* dropped [on_resolution] callback, not a permanently blocked fiber);
-\* it is out of scope here.  [expire_stale] handles BOTH via two
+\* The [submit_pending] variant has no suspended fiber. Its decision must
+\* first commit a durable [Hitl_resolved] stimulus, then complete the domain
+\* callback, remove the pending id, and finally signal the keeper. Delivery
+\* failure leaves the id pending. Those durable-delivery and callback-order
+\* invariants are not projected by this count-only model; it remains scoped
+\* to the blocking promise path. [expire_stale] handles BOTH via two
 \* *syntactically* independent matches — `match entry.resolver with
 \* Some r -> Eio.Promise.resolve r (Reject ...) | None -> ()` and,
 \* separately, `match entry.on_resolution with Some f -> f (Reject ...)
 \* | None -> ()`.  The two matches are *control-flow independent* —
 \* neither references the other's field, so the choice on one side
 \* doesn't constrain the other; the four (Some/None x Some/None)
-\* combinations each have a defined branch (we do not promise clean
+\* combinations each have a defined branch after delivery succeeds (we do not promise clean
 \* termination, only structural independence: `Eio.Promise.resolve` and
 \* the `on_resolution` callback are unwrapped here and can still raise
 \* `Eio.Cancel.Cancelled` etc., which the surrounding runtime re-raises
@@ -139,20 +142,13 @@ Done ==
 \* Models the regression where [expire_stale] removes the pending
 \* entry of a [submit_and_await] request but never resolves its
 \* promise — the suspended fiber stays blocked forever.  In the OCaml
-\* runtime, [expire_stale] *already* removes stale entries from
-\* [pending] (via [atomic_update]) before it resolves/invokes anything,
-\* capturing each removed [(id, entry)] in [stale_ref] precisely so it
-\* can still call [Eio.Promise.resolve resolver (Reject ...)] (and
-\* [entry.on_resolution]) afterwards.  The modelled hazard is therefore
-\* NOT a reordering of removal vs resolve (removal is already first by
-\* design) — it is a future refactor that loses or skips the captured
-\* entry/resolver in that post-removal step (the [Some resolver] branch
-\* dropped, [stale_ref] mis-built), leaving the entry gone from
-\* [pending] with the resolve never run.  (NB: an [entry.resolver =
-\* None] entry is a [submit_pending] request — it has NO suspended
-\* fiber, so dropping it does not produce the modelled harm; its weaker
-\* failure mode — a dropped [on_resolution] callback — is out of scope,
-\* see the header.)
+\* runtime, [expire_stale] claims each stale id. A blocking entry is removed
+\* immediately before [complete_expiration] resolves its promise; a
+\* nonblocking entry stays pending through durable delivery and callback
+\* completion. The modelled hazard is a future refactor that loses or skips
+\* the blocking resolver after removal. (NB: [entry.resolver = None] is a
+\* [submit_pending] request with no suspended fiber; its durable-delivery
+\* ordering is explicitly out of scope, see the header.)
 ExpireStaleNoResolve ==
     /\ pending_count > 0
     /\ pending_count' = pending_count - 1

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -7,6 +7,12 @@ module Lib = Masc
 open Alcotest
 open Printf
 
+let () =
+  Lib.Keeper_approval_queue.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+
 let test_dir () =
   let tmp = Filename.temp_file "masc_dashboard_governance" "" in
   Sys.remove tmp;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -18,6 +18,14 @@ module KT = Keeper_types
 module Mcp_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 
+let install_noop_resolution_delivery_hook () =
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+
+let () = install_noop_resolution_delivery_hook ()
+
 let check = Alcotest.(check string)
 
 let temp_dir () =
@@ -840,6 +848,8 @@ let test_approval_resolve_nonexistent () =
       (String.length (AQ.resolve_error_to_string err) > 0)
   | Error (AQ.Already_resolved _) ->
     Alcotest.fail "expected Not_found, got Already_resolved"
+  | Error (AQ.Delivery_failed _) ->
+    Alcotest.fail "expected Not_found, got Delivery_failed"
   | Ok () -> Alcotest.fail "expected error for nonexistent id"
 
 let test_approval_queue_cancel_cleans_up () =
@@ -1415,12 +1425,53 @@ let test_approval_resolve_missing_decision_is_rejected () =
            msg
        | Error (SDH.Gone _) ->
          Alcotest.fail "expected Bad_request, got Gone"
+       | Error (SDH.Unavailable _) ->
+         Alcotest.fail "expected Bad_request, got Unavailable"
        | Ok _ ->
          Alcotest.fail
            "missing decision must NOT resolve the approval (fail-closed, RFC-0305)");
       (* The pending approval must remain unresolved. *)
       Alcotest.(check bool) "pending approval not resolved" true
         (!resolved = None))
+
+let test_approval_delivery_failure_is_unavailable () =
+  let workspace_base = temp_dir () in
+  AQ.For_testing.clear_approval_resolution_wake_hook ();
+  Fun.protect
+    ~finally:(fun () ->
+      install_noop_resolution_delivery_hook ();
+      cleanup_dir workspace_base)
+    (fun () ->
+       let id =
+         AQ.submit_pending
+           ~keeper_name:"dashboard-delivery-failure-keeper"
+           ~tool_name:"masc_transition"
+           ~input:(`Assoc [ "action", `String "claim" ])
+           ~risk_level:AQ.Medium
+           ~base_path:workspace_base
+           ~on_resolution:(fun _ -> ())
+           ()
+       in
+       let args =
+         `Assoc [ "id", `String id; "decision", `String "approve" ]
+       in
+       (match
+          SDH.dashboard_governance_approval_resolve_http_json
+            ~base_path:workspace_base
+            ~args
+        with
+        | Error (SDH.Unavailable (AQ.Delivery_failed failure)) ->
+          Alcotest.(check string)
+            "unavailable identifies approval"
+            id
+            failure.approval_id
+        | Error err ->
+          Alcotest.fail
+            ("expected Unavailable, got "
+             ^ SDH.approval_resolve_http_error_to_string err)
+        | Ok _ -> Alcotest.fail "delivery failure must not return success");
+       Alcotest.(check bool) "unavailable approval remains pending" true
+         (Option.is_some (AQ.get_pending_entry ~id)))
 
 let test_submit_pending_audit_uses_workspace_base_path () =
   let env_base = temp_dir () in
@@ -1701,29 +1752,19 @@ let test_callback_nonblocking_high_returns_without_suspending () =
   let captured_resolution = ref None in
   AQ.set_approval_resolution_wake_hook
     (fun ~base_path:_ ~keeper_name:_ ~approval_id ~decision ~channel ->
-       captured_resolution :=
-         Some
-           Keeper_event_queue.
-             { approval_id
-             ; decision
-             ; channel =
-                 Option.value
-                   channel
-                   ~default:
-                     (Keeper_continuation_channel.unrouted
-                        "test: no approval continuation channel")
-             });
+       Ok
+         (fun () ->
+            captured_resolution :=
+              Some
+                Keeper_event_queue.
+                  { approval_id
+                  ; decision
+                  ; channel
+                  }));
   AQ.For_testing.reset_audit_store ();
   Fun.protect
     ~finally:(fun () ->
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ());
+      install_noop_resolution_delivery_hook ();
       AQ.For_testing.reset_audit_store ();
       cleanup_dir base_path)
     (fun () ->
@@ -2480,6 +2521,8 @@ let () =
         test_dashboard_resolve_and_delete_rules_use_workspace_base_path;
       Alcotest.test_case "resolve without decision is rejected (RFC-0305 fail-closed)" `Quick
         test_approval_resolve_missing_decision_is_rejected;
+      Alcotest.test_case "delivery failure is service unavailable" `Quick
+        test_approval_delivery_failure_is_unavailable;
       Alcotest.test_case "submit_pending audit uses workspace base_path" `Quick
         test_submit_pending_audit_uses_workspace_base_path;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -9,6 +9,15 @@
 module AQ = Masc.Keeper_approval_queue
 module Chat_queue = Masc.Keeper_chat_queue
 
+let install_noop_resolution_delivery_hook () =
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+;;
+
+let () = install_noop_resolution_delivery_hook ()
+
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_" "" in
   Unix.unlink dir;
@@ -134,19 +143,10 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       ~approval_id
       ~decision
       ~channel:_ ->
-      woke := Some (keeper_name, approval_id, decision));
+      Ok (fun () -> woke := Some (keeper_name, approval_id, decision)));
   Fun.protect
     ~finally:(fun () ->
-      (* Reset to the default no-op so the recording closure does not leak into
-         later tests that share this module-level hook. *)
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ());
+      install_noop_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        Eio.Switch.run
@@ -185,6 +185,8 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
   @@ fun _env ->
   let base_path = temp_dir () in
   let woke = ref None in
+  let completion_order = ref [] in
+  let callback_saw_pending = ref false in
   AQ.set_approval_resolution_wake_hook
     (fun
       ~base_path:_
@@ -192,17 +194,13 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
       ~approval_id
       ~decision
       ~channel:_ ->
-      woke := Some (keeper_name, approval_id, decision));
+      Ok
+        (fun () ->
+           completion_order := "signal" :: !completion_order;
+           woke := Some (keeper_name, approval_id, decision)));
   Fun.protect
     ~finally:(fun () ->
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ());
+      install_noop_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "pending-resolve-wake-test" in
@@ -215,7 +213,10 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
            ~input
            ~risk_level:AQ.Critical
            ~base_path
-           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ~on_resolution:(fun decision ->
+             callback_saw_pending := AQ.has_pending_for_keeper ~keeper_name;
+             completion_order := "callback" :: !completion_order;
+             callback_decision := Some decision)
            ()
        in
        (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
@@ -226,6 +227,14 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
          "on_resolution callback ran"
          true
          (Option.is_some !callback_decision);
+       Alcotest.(check (list string))
+         "domain callback completes before wake signal"
+         [ "callback"; "signal" ]
+         (List.rev !completion_order);
+       Alcotest.(check bool)
+         "pending id remains visible throughout domain callback"
+         true
+         !callback_saw_pending;
        (match !woke with
         | Some (kn, aid, decision) ->
           Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
@@ -245,6 +254,48 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
         | None -> Alcotest.fail "non-blocking resolve did not fire the keeper wake hook"))
 ;;
 
+let test_delivery_failure_keeps_nonblocking_approval_pending () =
+  let base_path = temp_dir () in
+  let callback_decision = ref None in
+  AQ.For_testing.clear_approval_resolution_wake_hook ();
+  Fun.protect
+    ~finally:(fun () ->
+      install_noop_resolution_delivery_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending
+           ~keeper_name:"delivery-failure-pending-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ()
+       in
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Error (AQ.Delivery_failed { approval_id; reason }) ->
+          Alcotest.(check string) "failure identifies approval" id approval_id;
+          Alcotest.(check bool) "failure reason is explicit" true
+            (String.length reason > 0)
+        | Error err ->
+          Alcotest.fail
+            ("expected Delivery_failed, got " ^ AQ.resolve_error_to_string err)
+        | Ok () -> Alcotest.fail "resolve must fail without a delivery hook");
+       Alcotest.(check bool) "failed delivery keeps pending entry" true
+         (Option.is_some (AQ.get_pending_entry ~id));
+       Alcotest.(check bool) "failed delivery does not run callback" true
+         (Option.is_none !callback_decision);
+       install_noop_resolution_delivery_hook ();
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.(check bool) "successful retry removes pending entry" true
+         (Option.is_none (AQ.get_pending_entry ~id));
+       Alcotest.(check bool) "successful retry runs callback" true
+         (Option.is_some !callback_decision))
+;;
+
 let test_blocking_callback_policy_owns_lane_without_resolver () =
   let base_path = temp_dir () in
   let woke = ref false in
@@ -252,13 +303,10 @@ let test_blocking_callback_policy_owns_lane_without_resolver () =
   AQ.set_approval_resolution_wake_hook
     (fun
       ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      woke := true);
+      Ok (fun () -> woke := true));
   Fun.protect
     ~finally:(fun () ->
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-          ());
+      install_noop_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "blocking-callback-policy-test" in
@@ -309,24 +357,14 @@ let test_resolution_wake_carries_originating_continuation_channel () =
       ~approval_id
       ~decision
       ~channel ->
-      captured :=
-        Some
-          Keeper_event_queue.
-            { approval_id;
-              decision;
-              channel =
-                Option.value channel
-                  ~default:(Keeper_continuation_channel.unrouted "test: no channel") });
-  let reset_hook () =
-    AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ())
-  in
+      Ok
+        (fun () ->
+           captured :=
+             Some
+               Keeper_event_queue.
+                 { approval_id;
+                   decision;
+                   channel }));
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
     captured := None;
     let id =
@@ -349,7 +387,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
   in
   Fun.protect
     ~finally:(fun () ->
-      reset_hook ();
+      install_noop_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let dashboard_channel =
@@ -407,18 +445,11 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
   AQ.set_approval_resolution_wake_hook
     (fun
       ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      woke := true);
+      Ok (fun () -> woke := true));
   Fun.protect
     ~finally:(fun () ->
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ())
-      ; cleanup_dir base_path)
+      install_noop_resolution_delivery_hook ();
+      cleanup_dir base_path)
     (fun () ->
        let keeper_name = "expire-stale-await-no-wake-test" in
        let result = ref None in
@@ -464,18 +495,11 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       ~approval_id
       ~decision
       ~channel ->
-      woke := Some (keeper_name, approval_id, decision, channel));
+      Ok (fun () -> woke := Some (keeper_name, approval_id, decision, channel)));
   Fun.protect
     ~finally:(fun () ->
-      AQ.set_approval_resolution_wake_hook
-        (fun
-          ~base_path:_
-          ~keeper_name:_
-          ~approval_id:_
-          ~decision:_
-          ~channel:_ ->
-          ())
-      ; cleanup_dir base_path)
+      install_noop_resolution_delivery_hook ();
+      cleanup_dir base_path)
     (fun () ->
        let keeper_name = "expire-stale-pending-wake-test" in
        let id =
@@ -512,11 +536,45 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
             true
             (Keeper_continuation_channel.same_route
                continuation_channel
-               (Option.value wake_channel
-                  ~default:
-                    (Keeper_continuation_channel.unrouted "test: no wake channel")))
+               wake_channel)
         | None -> Alcotest.fail "submit_pending stale expiry must fire wake hook")
        )
+;;
+
+let test_expire_stale_retries_after_delivery_failure () =
+  let base_path = temp_dir () in
+  let callback_decision = ref None in
+  AQ.For_testing.clear_approval_resolution_wake_hook ();
+  Fun.protect
+    ~finally:(fun () ->
+      install_noop_resolution_delivery_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending
+           ~keeper_name:"expire-delivery-failure-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ()
+       in
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool) "failed expiry delivery keeps pending entry" true
+         (Option.is_some (AQ.get_pending_entry ~id));
+       Alcotest.(check bool) "failed expiry delivery does not run callback" true
+         (Option.is_none !callback_decision);
+       install_noop_resolution_delivery_hook ();
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool) "retry removes expired entry" true
+         (Option.is_none (AQ.get_pending_entry ~id));
+       match !callback_decision with
+       | Some (Agent_sdk.Hooks.Reject _) -> ()
+       | Some decision ->
+         Alcotest.fail
+           ("expected Reject, got " ^ AQ.approval_decision_to_string decision)
+       | None -> Alcotest.fail "successful expiry retry did not run callback")
 ;;
 
 let test_critical_entry_phase_becomes_escalated_after_timer () =
@@ -927,6 +985,10 @@ let () =
             `Quick
             test_submit_pending_resolve_fires_keeper_wake_hook
         ; Alcotest.test_case
+            "delivery failure keeps nonblocking approval pending"
+            `Quick
+            test_delivery_failure_keeps_nonblocking_approval_pending
+        ; Alcotest.test_case
             "explicit blocking callback owns a lane without resolver"
             `Quick
             test_blocking_callback_policy_owns_lane_without_resolver
@@ -938,6 +1000,10 @@ let () =
             "expire_stale fires wake for non-blocking submit_pending"
             `Quick
             test_expire_stale_submit_pending_fires_wake_hook
+        ; Alcotest.test_case
+            "expire_stale retries after delivery failure"
+            `Quick
+            test_expire_stale_retries_after_delivery_failure
         ; Alcotest.test_case
             "resolution wake carries originating continuation channel"
             `Quick

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -302,6 +302,25 @@ let () =
       | _ -> Alcotest.fail "Hitl_resolved codec round-trip changed payload shape")
   | Error msg -> Alcotest.fail ("Hitl_resolved stimulus round-trip failed: " ^ msg));
 
+  let hitl_stimulus decision =
+    let resolution =
+      { approval_id = "appr-first-commit"
+      ; decision
+      ; channel = Keeper_continuation_channel.unrouted "identity-test"
+      }
+    in
+    { post_id = hitl_resolution_post_id resolution
+    ; urgency = Immediate
+    ; arrived_at = 4.0
+    ; payload = Hitl_resolved resolution
+    }
+  in
+  assert (
+    not
+      (stimulus_identity_equal
+      (hitl_stimulus (Hitl_approved approved_action))
+      (hitl_stimulus Hitl_rejected)));
+
   (* Goal_verification_failed survives the codec round-trip: the goal-loop wake
      must remain replayable from the durable per-keeper queue. *)
   let goal_failure =
@@ -934,6 +953,16 @@ let () =
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
       let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
       assert (length restored = 1);
+      (match
+         Masc.Keeper_registry_event_queue.dequeue_when
+           ~base_path
+           keeper_name
+           ~ready:(fun _ -> false)
+       with
+       | None -> ()
+       | Some _ -> Alcotest.fail "unready stimulus must remain queued");
+      assert (
+        length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
       let replayed =
         match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
         | Some stim -> stim
@@ -1075,6 +1104,122 @@ let () =
         ()
       | None | Some _ ->
         Alcotest.fail "pending durable stimulus must request a typed yield");
+
+  (* --- critical delivery: durable enqueue succeeds before registration and
+     is replayed when that keeper lane appears. --- *)
+  let base_path = temp_dir "keeper-event-queue-durable-unregistered" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-durable-unregistered-test" in
+      let meta = meta_for_keeper keeper_name "trace-durable-unregistered-test" in
+      Masc.Keeper_registry.clear ();
+      (match
+         Masc.Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           board_stim
+       with
+       | Ok () -> ()
+       | Error msg -> Alcotest.fail ("durable enqueue failed: " ^ msg));
+      assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+      | Some stimulus -> assert (String.equal stimulus.post_id board_stim.post_id)
+      | None -> Alcotest.fail "durable pre-registration stimulus was not replayed");
+
+  (* --- critical delivery: one approval id cannot commit contradictory
+     decisions across an acknowledgement retry. --- *)
+  let base_path = temp_dir "keeper-event-queue-durable-decision-conflict" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-durable-decision-conflict-test" in
+      let approved = hitl_stimulus (Hitl_approved approved_action) in
+      let rejected = hitl_stimulus Hitl_rejected in
+      (match
+         Masc.Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           approved
+       with
+       | Ok () -> ()
+       | Error msg -> Alcotest.fail ("initial durable decision failed: " ^ msg));
+      (match
+         Masc.Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           rejected
+       with
+       | Error msg -> assert (String.length msg > 0)
+       | Ok () -> Alcotest.fail "conflicting approval decision was accepted");
+      match
+        Keeper_event_queue_persistence.load ~base_path ~keeper_name
+        |> Keeper_event_queue.to_list
+      with
+      | [ { payload = Hitl_resolved { decision = Hitl_approved _; _ }; _ } ] -> ()
+      | _ -> Alcotest.fail "first committed approval decision was not preserved");
+
+  (* --- critical delivery: a registered but non-running keeper still owns a
+     durable lane; only the wake hint is phase-gated. --- *)
+  let base_path = temp_dir "keeper-event-queue-durable-offline" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-durable-offline-test" in
+      let meta = meta_for_keeper keeper_name "trace-durable-offline-test" in
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register_offline ~base_path keeper_name meta);
+      (match
+         Masc.Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           board_stim
+       with
+       | Ok () -> ()
+       | Error msg -> Alcotest.fail ("offline durable enqueue failed: " ^ msg));
+      assert (
+        length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
+      assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name)));
+
+  (* --- critical delivery: an unwritable path is an explicit error, never an
+     acknowledged in-memory-only stimulus. --- *)
+  let base_path = temp_dir "keeper-event-queue-durable-write-error" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      write_file (Filename.concat base_path ".masc") "directory blocker";
+      match
+        Masc.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          "keeper-event-queue-durable-write-error-test"
+          board_stim
+      with
+      | Error msg -> assert (String.length msg > 0)
+      | Ok () -> Alcotest.fail "durable enqueue silently accepted an invalid path");
+
+  (* --- critical delivery: a corrupt existing snapshot is preserved for
+     operator repair instead of being silently replaced with a fresh queue. --- *)
+  let base_path = temp_dir "keeper-event-queue-durable-corrupt-snapshot" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-durable-corrupt-snapshot-test" in
+      let path = snapshot_path ~base_path ~keeper_name in
+      Fs_compat.mkdir_p (Filename.dirname path);
+      write_file path "{not-json";
+      match
+        Masc.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          keeper_name
+          board_stim
+      with
+      | Error msg -> assert (String.length msg > 0)
+      | Ok () -> Alcotest.fail "durable enqueue overwrote a corrupt snapshot");
 
   (* --- crash recovery: consumed stimuli can be put back for replay --- *)
   let base_path = temp_dir "keeper-event-queue-requeue-front" in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -20,6 +20,12 @@ module KFP = Keeper_failure_policy
 module KSP = Masc.Keeper_supervisor_self_preservation
 module KSR = Masc.Keeper_supervisor_reconcile_keepalive
 
+let () =
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+
 let supervisor_agent_name = Sup.supervisor_agent_name
 
 let temp_dir () =


### PR DESCRIPTION
## Root cause

Follow-up to #23923. The merged resolution path removed a pending approval before proving delivery, while the installed wake hook:

- defaulted to a no-op before bootstrap,
- swallowed hook failures,
- delegated payload enqueue to `wakeup_keeper`, which only enqueues for a currently `Running` keeper.

A paused, restarting, offline, or temporarily unregistered keeper could therefore receive a successful operator response while the one-shot decision existed in neither the approval queue nor its durable lane.

## What changed

- Claim each approval id with an OCaml `Atomic` CAS so concurrent resolve/expiry cannot own the same decision.
- Commit `Hitl_resolved` to the per-Keeper durable event queue before acknowledging a nonblocking decision.
- Keep the approval pending on write, parse, bootstrap-hook, or decision-conflict failure; expose typed `Delivery_failed` and HTTP 503.
- Preserve the first committed payload for an approval `post_id`; contradictory retries fail explicitly.
- Keep the pending id visible while the domain callback runs, then remove it before terminal publication and signal the Keeper.
- Gate dequeue of that exact `Hitl_resolved` head until its pending id is gone, so repo/catalog and other callbacks complete before continuation intake.
- Treat wakeup as a post-commit hint. Signal failure is observed separately and cannot erase the durable decision.
- Apply the same fail-closed delivery/retry ordering to stale approval expiry.
- Refuse to overwrite unreadable queue snapshots and return durable persistence errors instead of logging-and-continuing.
- Refresh the authoritative `KeeperApprovalQueue.tla` scope prose and generated spec index so they describe the current blocking/nonblocking boundary without claiming the removed `stale_ref` flow.

Blocking approvals retain their existing lane-release-before-resume behavior. The new readiness gate is per approval id and does not block unrelated Keeper lanes.

## Validation

- `ocamlc -stop-after parsing`: 19 changed `.ml/.mli` files passed.
- `ocamlformat --check`: all changed OCaml files passed.
- `git diff --check origin/main...HEAD`: passed.
- Added regressions for missing delivery hook, retained pending/callback ordering, expiry retry, HTTP 503, offline/unregistered durable replay, rejected dequeue readiness, write failure, corrupt snapshot preservation, and contradictory decision rejection.
- Formal nonblocking delivery-state expansion is tracked separately in #23962; the existing TLA+ model body remains the blocking Promise projection.
- Local Dune build/tests intentionally not run; PR CI is the build authority for this repository.

## Evidence

- [근거] OCaml 5.4 `Atomic.compare_and_set` documents physical-equality CAS and retry-oriented optimistic concurrency: https://ocaml.org/manual/5.4/api/Atomic.html — checked 2026-07-10, confidence High.
- [근거] OCaml 5.4 `Fun.protect` guarantees the claim-release finalizer on normal and exceptional exit: https://ocaml.org/manual/5.4/api/Fun.html — checked 2026-07-10, confidence High.
