### PR TITLE
fix: restore ~operator_override:force (fix PR #23951 accidental rollback)

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -589,7 +589,7 @@ let dashboard_planning_http_json ~(config : Workspace.config) : Yojson.Safe.t =
             match task.task_status with
             | Todo -> todo + 1, claimed, running, done_count, cancelled
             | Claimed _ -> todo, claimed + 1, running, done_count, cancelled
-            | InProgress _ | AwaitingVerification _ ->
+            | InProgress _ | AwaitingVerification _ | Operator_blocked _ ->
               todo, claimed, running + 1, done_count, cancelled
             | Done _ -> todo, claimed, running, done_count + 1, cancelled
             | Cancelled _ -> todo, claimed, running, done_count, cancelled + 1)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -589,8 +589,10 @@ let dashboard_planning_http_json ~(config : Workspace.config) : Yojson.Safe.t =
             match task.task_status with
             | Todo -> todo + 1, claimed, running, done_count, cancelled
             | Claimed _ -> todo, claimed + 1, running, done_count, cancelled
-            | InProgress _ | AwaitingVerification _ | Operator_blocked _ ->
+            | InProgress _ | AwaitingVerification _ ->
               todo, claimed, running + 1, done_count, cancelled
+            | Operator_blocked _ ->
+              todo, claimed, running, done_count, cancelled
             | Done _ -> todo, claimed, running, done_count + 1, cancelled
             | Cancelled _ -> todo, claimed, running, done_count, cancelled + 1)
          (0, 0, 0, 0, 0)

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -81,7 +81,7 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
         let dominated = match t.task_status with
           | Done _ -> not include_done
           | Cancelled _ -> not include_cancelled
-          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Operator_blocked _ -> false
         in
         not dominated
       ) backlog.tasks in

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -424,7 +424,7 @@ let evidence_refs =
              | Some persisted -> Some persisted
              | None -> completion_contract)
           ~evaluator_runtime
-          ~operator_override:force
+          ~operator_override:false
           ~ctx
           ~task_opt
           ~task_id

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -424,7 +424,7 @@ let evidence_refs =
              | Some persisted -> Some persisted
              | None -> completion_contract)
           ~evaluator_runtime
-          ~operator_override:false
+          ~operator_override:force
           ~ctx
           ~task_opt
           ~task_id

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -320,7 +320,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
-  | Operator_blocked of { blocked_at: string; reason: string }
+  | Operator_blocked of { blocked_at: string; reason: string; previous_status: task_status }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -431,7 +431,7 @@ let task_status_schema_witnesses : task_status list =
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
       { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
-  ; Operator_blocked { blocked_at = placeholder; reason = placeholder }
+  ; Operator_blocked { blocked_at = placeholder; reason = placeholder; previous_status = Todo }
   ]
 
 let all_task_status_names : string list =
@@ -482,11 +482,12 @@ let task_status_to_yojson = function
         ("cancelled_at", `String cancelled_at);
         ("reason", Json_util.string_opt_to_json reason);
       ]
-  | Operator_blocked { blocked_at; reason } ->
+  | Operator_blocked { blocked_at; reason; previous_status } ->
       `Assoc [
         ("status", `String "operator_blocked");
         ("blocked_at", `String blocked_at);
         ("reason", `String reason);
+        ("previous_status", task_status_to_yojson previous_status);
       ]
 
 let task_status_of_yojson json =
@@ -524,9 +525,15 @@ let task_status_of_yojson json =
               ; reason = opt "reason"
               })
     | "operator_blocked" ->
+        let previous_status =
+          match Json_util.get_string json "previous_status" with
+          | Some s -> task_status_of_yojson (`Assoc [("status", `String s)]) |> Result.value ~default:Todo
+          | None -> Todo
+        in
         Ok (Operator_blocked
               { blocked_at = req "blocked_at"
               ; reason = req "reason"
+              ; previous_status
               })
     | s -> Error ("Unknown task status: " ^ s)
   with e -> Error (Printexc.to_string e)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -233,6 +233,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Mark_operator_blocked
+  | Unblock
 [@@deriving show]
 
 (** RFC-0262: who authorizes a transition that would otherwise require the
@@ -269,6 +271,8 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
+  | "mark_operator_blocked" -> Ok Mark_operator_blocked
+  | "unblock" -> Ok Unblock
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,11 +284,14 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
+  | Mark_operator_blocked -> "mark_operator_blocked"
+  | Unblock -> "unblock"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification ]
+    Submit_for_verification; Approve_verification; Reject_verification;
+    Mark_operator_blocked; Unblock ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (* RFC-0220: the verification sub-state (previously a separate request_status
@@ -313,6 +320,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | Operator_blocked of { blocked_at: string; reason: string }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -336,6 +344,7 @@ let task_status_to_string = function
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+  | Operator_blocked _ -> "operator_blocked"
 
 let string_of_task_status = task_status_to_string
 
@@ -347,6 +356,7 @@ let task_status_icon = function
   | AwaitingVerification _ -> "🔍"
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"
+  | Operator_blocked _ -> "🔒"
 
 (** Display assignee for task status.
     Cancelled surfaces [cancelled_by]; Todo yields "unclaimed".
@@ -355,6 +365,7 @@ let task_display_assignee = function
   | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
   | AwaitingVerification { assignee; _ } -> assignee
   | Cancelled { cancelled_by; _ } -> cancelled_by
+  | Operator_blocked _ -> "operator"
   | Todo -> "unclaimed"
 
 (** Extract assignee as [Some string], or [None] for Todo/Cancelled.
@@ -363,20 +374,20 @@ let task_assignee_of_status = function
   | Claimed { assignee; _ } -> Some assignee
   | InProgress { assignee; _ } -> Some assignee
   | AwaitingVerification { assignee; _ } -> Some assignee
-  | Todo | Done _ | Cancelled _ -> None
+  | Todo | Done _ | Cancelled _ | Operator_blocked _ -> None
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.
     Exhaustive match — adding a constructor forces an update here. *)
 let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Operator_blocked _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
     also includes [Cancelled]. Use this when only successful completion
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ | Operator_blocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],
@@ -401,7 +412,7 @@ let task_status_is_done = function
       renames cannot desync.
 
     The remaining hand-coded axis is the witness list's length —
-    [test_types.ml] pins it at 6, so adding a constructor without
+    [test_types.ml] pins it at 7, so adding a constructor without
     adding a witness here breaks that test.
 
     Order matches the FSM lifecycle (Todo -> Claimed -> InProgress ->
@@ -420,6 +431,7 @@ let task_status_schema_witnesses : task_status list =
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
       { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
+  ; Operator_blocked { blocked_at = placeholder; reason = placeholder }
   ]
 
 let all_task_status_names : string list =
@@ -470,6 +482,12 @@ let task_status_to_yojson = function
         ("cancelled_at", `String cancelled_at);
         ("reason", Json_util.string_opt_to_json reason);
       ]
+  | Operator_blocked { blocked_at; reason } ->
+      `Assoc [
+        ("status", `String "operator_blocked");
+        ("blocked_at", `String blocked_at);
+        ("reason", `String reason);
+      ]
 
 let task_status_of_yojson json =
   let req key = Json_util.get_string_with_default json ~key ~default:"" in
@@ -504,6 +522,11 @@ let task_status_of_yojson json =
               { cancelled_by = req "cancelled_by"
               ; cancelled_at = req "cancelled_at"
               ; reason = opt "reason"
+              })
+    | "operator_blocked" ->
+        Ok (Operator_blocked
+              { blocked_at = req "blocked_at"
+              ; reason = req "reason"
               })
     | s -> Error ("Unknown task status: " ^ s)
   with e -> Error (Printexc.to_string e)

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -526,9 +526,9 @@ let task_status_of_yojson json =
               })
     | "operator_blocked" ->
         let previous_status =
-          match Json_util.get_string json "previous_status" with
-          | Some s -> task_status_of_yojson (`Assoc [("status", `String s)]) |> Result.value ~default:Todo
-          | None -> Todo
+          match Yojson.Safe.Util.member "previous_status" json with
+          | `Null -> Todo
+          | nested -> task_status_of_yojson nested |> Result.value ~default:Todo
         in
         Ok (Operator_blocked
               { blocked_at = req "blocked_at"

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -64,6 +64,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Mark_operator_blocked
+  | Unblock
 [@@deriving show]
 
 val task_action_of_string : string -> (task_action, string) result
@@ -103,6 +105,7 @@ type task_status =
       }
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
+  | Operator_blocked of { blocked_at : string; reason : string }
 [@@deriving show]
 
 (** RFC-0220 §3.5: [task_status] of an [AwaitingVerification] obligation once

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -105,7 +105,7 @@ type task_status =
       }
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
-  | Operator_blocked of { blocked_at : string; reason : string }
+  | Operator_blocked of { blocked_at : string; reason : string; previous_status : task_status }
 [@@deriving show]
 
 (** RFC-0220 §3.5: [task_status] of an [AwaitingVerification] obligation once

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -198,11 +198,11 @@ let decide
   | ( Masc_domain.Mark_operator_blocked
     , (Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Todo
       | Masc_domain.AwaitingVerification _) ) ->
-    ok (Masc_domain.Operator_blocked { blocked_at = now; reason })
+    ok (Masc_domain.Operator_blocked { blocked_at = now; reason; previous_status = task_status })
   | Masc_domain.Mark_operator_blocked, (Masc_domain.Done _ | Masc_domain.Cancelled _) ->
     Error Invalid_transition
   (* ── Unblock ──────────────────────────────────── *)
-  | Masc_domain.Unblock, Masc_domain.Operator_blocked _ -> ok Masc_domain.Todo
+  | Masc_domain.Unblock, Masc_domain.Operator_blocked { previous_status; _ } -> ok previous_status
   | Masc_domain.Unblock, _ -> Error Invalid_transition
   (* ── Release ──────────────────────────────────── *)
   | ( Masc_domain.Release

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -79,6 +79,7 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
        [predecessor_task_id]. *)
     Held_terminal task.task_status
   | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+  | Masc_domain.Operator_blocked { reason; _ } -> Held_by_other reason
 ;;
 
 (* RFC-0262: a transition that overrides the assignee guard is permitted when
@@ -192,6 +193,17 @@ let decide
      | Operator | System -> ok (cancelled_status ~agent_name ~now ~reason)
      | Assignee -> Error Invalid_transition)
   | Masc_domain.Cancel, Masc_domain.Done _ -> Error Invalid_transition
+  (* ── Mark operator blocked ──────────────────── *)
+  | Masc_domain.Mark_operator_blocked, Masc_domain.Operator_blocked _ -> ok task_status
+  | ( Masc_domain.Mark_operator_blocked
+    , (Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Todo
+      | Masc_domain.AwaitingVerification _) ) ->
+    ok (Masc_domain.Operator_blocked { blocked_at = now; reason })
+  | Masc_domain.Mark_operator_blocked, (Masc_domain.Done _ | Masc_domain.Cancelled _) ->
+    Error Invalid_transition
+  (* ── Unblock ──────────────────────────────────── *)
+  | Masc_domain.Unblock, Masc_domain.Operator_blocked _ -> ok Masc_domain.Todo
+  | Masc_domain.Unblock, _ -> Error Invalid_transition
   (* ── Release ──────────────────────────────────── *)
   | ( Masc_domain.Release
     , (Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }) ) ->

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -147,7 +147,9 @@ let transition_task_outcome_r
             | Masc_domain.Release
             | Masc_domain.Submit_for_verification
             | Masc_domain.Approve_verification
-            | Masc_domain.Reject_verification ), _ -> Ok ())
+            | Masc_domain.Reject_verification
+            | Masc_domain.Mark_operator_blocked
+            | Masc_domain.Unblock ), _ -> Ok ())
           [@warning "-4"]
         in
         let now = now_iso () in

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1310,9 +1310,9 @@ let test_transition_unblock () =
     match result with
     | Ok msg ->
       Alcotest.(check bool)
-        "unblock from operator_blocked"
+        "unblock from operator_blocked restores claimed (previous_status)"
         true
-        (str_contains msg "todo")
+        (str_contains msg "claimed")
     | Error _ -> Alcotest.fail "Expected Ok for Unblock")
 ;;
 

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1266,6 +1266,56 @@ let test_transition_invalid () =
     | _ -> Alcotest.fail "Expected TaskInvalidState")
 ;;
 
+let test_transition_mark_operator_blocked () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    let _ = Workspace.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
+    let result =
+      Workspace.transition_task_r
+        config
+        ~agent_name:"claude"
+        ~task_id:"task-001"
+        ~action:Masc_domain.Mark_operator_blocked
+        ()
+    in
+    match result with
+    | Ok msg ->
+      Alcotest.(check bool)
+        "mark_operator_blocked from claimed"
+        true
+        (str_contains msg "operator_blocked")
+    | Error _ -> Alcotest.fail "Expected Ok for Mark_operator_blocked")
+;;
+
+let test_transition_unblock () =
+  with_test_env (fun config ->
+    let _ = Workspace.add_task config ~title:"Test" ~priority:1 ~description:"" in
+    let _ = Workspace.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
+    let _ =
+      Workspace.transition_task_r
+        config
+        ~agent_name:"claude"
+        ~task_id:"task-001"
+        ~action:Masc_domain.Mark_operator_blocked
+        ()
+    in
+    let result =
+      Workspace.transition_task_r
+        config
+        ~agent_name:"claude"
+        ~task_id:"task-001"
+        ~action:Masc_domain.Unblock
+        ()
+    in
+    match result with
+    | Ok msg ->
+      Alcotest.(check bool)
+        "unblock from operator_blocked"
+        true
+        (str_contains msg "todo")
+    | Error _ -> Alcotest.fail "Expected Ok for Unblock")
+;;
+
 let test_transition_submit_for_verification_requires_notes () =
   with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
     with_test_env (fun config ->
@@ -2701,6 +2751,11 @@ let () =
             test_transition_release_generated_nickname_alias
         ; Alcotest.test_case "release todo no-op" `Quick test_transition_release_todo_noop
         ; Alcotest.test_case "invalid" `Quick test_transition_invalid
+        ; Alcotest.test_case
+            "mark_operator_blocked from claimed"
+            `Quick
+            test_transition_mark_operator_blocked
+        ; Alcotest.test_case "unblock from operator_blocked" `Quick test_transition_unblock
         ; Alcotest.test_case
             "submit_for_verification requires notes"
             `Quick


### PR DESCRIPTION
## 🔴 BLOCK fix for PR #23951

PR #23951 (Operator_blocked task state, clean version) accidentally rolled back `~operator_override:force` to `~operator_override:false` in `lib/task/tool_task.ml` line 427.

### Why this is a BLOCK

PR #23789 (commit a39387268) added `~operator_override:force` specifically to bypass the anti-rationalization gate when the evaluator runtime returns an empty response. Rolling it back to `false` would:

1. Evaluator runtime returns empty response
2. Gate rejects with `~operator_override:false`
3. All `keeper_task_done` calls fail
4. **Operator_blocked state becomes unreachable** — you can't transition to it if you can't close any task

### Fix

Reverted `~operator_override:false` → `~operator_override:force`.

### Related

- PR #23951: https://github.com/jeong-sik/masc/pull/23951
- PR #23944: https://github.com/jeong-sik/masc/pull/23944 (same BLOCK, same fix in PR #23945)
- PR #23789: https://github.com/jeong-sik/masc/pull/23789