### PR TITLE
fix(build): close post-merge exhaustive gaps

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -246,6 +246,9 @@ let outcome_of_stop (sr : Runtime_agent.stop_reason) : Trajectory.trajectory_out
       (Printf.sprintf "mutation_boundary:turns=%d,tool=%s" turns_used t)
   | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
     Trajectory.Gated (Printf.sprintf "yielded_to_chat_waiting:turns=%d" turns_used)
+  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
+    Trajectory.Gated
+      (Printf.sprintf "yielded_to_durable_stimulus:turns=%d" turns_used)
 ;;
 
 let build_eval_run (scenario : EH.scenario) ~run_index

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1040,13 +1040,13 @@ let () =
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_registry.clear ();
-      Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
+      Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-yield-test" in
       let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
       Masc.Keeper_registry.clear ();
-      Keeper_chat_queue.clear ~keeper_name;
+      Masc.Keeper_chat_queue.clear ~keeper_name;
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
       (match
          Masc.Keeper_unified_turn_execution.autonomous_yield_request

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -760,7 +760,7 @@ let test_checkpoint_patch_updates_visible_text_and_clears_working_context () =
     (text_contains "old visible reply" texts);
   let thinking_preserved =
     patched.Agent_sdk.Checkpoint.messages
-    |> List.exists (fun message ->
+    |> List.exists (fun (message : Agent_sdk.Types.message) ->
       List.exists
         (function
           | Agent_sdk.Types.Thinking { content; _ } ->


### PR DESCRIPTION
## What changed

- handle `Runtime_agent.Yielded_to_durable_stimulus` exhaustively in the completion-trust evaluator
- qualify `Keeper_chat_queue` through the wrapped `Masc` library in the durable-stimulus regression
- restore the explicit `Agent_sdk.Types.message` type at the checkpoint replay boundary

## Root cause

Merged PR #23950 added a closed `Runtime_agent.stop_reason` constructor but the evaluator binary was outside the reviewed propagation set, so warning-as-error builds rejected the non-exhaustive match. Its new test also referenced a wrapped library module without the `Masc.` prefix. The checkpoint record ambiguity was an earlier main residual exposed by the same integrated Health build.

## Impact

This closes the three source-level OCaml failures reported by integrated main CI run 29077958423. The independent `dune-project` / `masc.opam` version-truth failure is intentionally not mixed into this compile repair.

## Validation

- `git diff HEAD^ --check`
- `ocamlformat --check bin/masc_completion_trust_eval.ml test/test_keeper_event_queue.ml test/test_pbt_context_overflow.ml`
- focused/full Dune proof remains GitHub CI authority per repository workflow
