### PR TITLE
fix(specs): refresh MemoryCompaction fingerprint

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-10T08:27:08Z (HEAD: 178797f1db)
+Generated: 2026-07-10T08:42:40Z (HEAD: c4e0c0764b)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -84,7 +84,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTurnSingleFlight.tla | KeeperTurnSingleFlight | manual | 2 | 1 | clean={inv:TypeOK, inv:SingleFlight} buggy={inv:TypeOK, inv:SingleFlight} | b9c881db6540 |
 | KeeperWorkPipelineBug.tla | KeeperWorkPipelineBug | manual | 2 | 1 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent} buggy={inv:TypeOK, inv:WorkspaceAlwaysBounded} | dc1e83209ec5 |
 | KeeperWorktreeContainment.tla | KeeperWorktreeContainment | manual | 3 | 2 | clean={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} other-playground-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} server-root-buggy={inv:KeeperWorktreeKind, inv:KeeperWorktreeOwner, inv:TypeOK} | fc57677b6dc2 |
-| MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} buggy={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} | 621212475148 |
+| MemoryCompaction.tla | MemoryCompaction | manual | 2 | 1 | clean={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} buggy={inv:GoalsPreserved NeverEmpty ResultBounded LongTermProtected RecentFloorRespected} | b4bc443cc7a6 |
 | OllamaBodyIntegrity.tla | OllamaBodyIntegrity | manual | 2 | 1 | clean={inv:BalancedNeverFails, inv:ParseErrorImpliesUnbalanced} buggy={inv:BalancedNeverFails} | 4b99edc99fe1 |
 | ReMintResetsAnchor.tla | ReMintResetsAnchor | manual | 2 | 1 | clean={inv:TypeOK, inv:NoUnverifiedVolatileClaimSurvivesBeyondHorizon} buggy={inv:TypeOK, inv:NoUnverifiedVolatileClaimSurvivesBeyondHorizon} | d900937ff999 |
 | SSEBroadcastBlock.tla | SSEBroadcastBlock | manual | 2 | 1 | clean={inv:TypeOK, inv:NoPermanentBlock} buggy={inv:TypeOK, inv:NoPermanentBlock} | baa8b016ef40 |


### PR DESCRIPTION
## What changed

- regenerate `specs/INDEX.md` after #23954 changed `MemoryCompaction.tla`
- update the tracked source fingerprint from `621212475148` to `b4bc443cc7a6`
- rebase the one-file correction onto current main after #23956/#23908/#23934/#23803/#23861/#23904

## Root cause

#23954 merged with the TLA index drift check already failing. Later main moves did not repair the `MemoryCompaction.tla` fingerprint, so current main still carried a stale generated index.

## Validation

- `scripts/gen-tla-index.sh > /tmp/masc-index-c4.md`: exit 0
- CI-equivalent diff excluding dynamic `Generated:` line: clean
- `scripts/lint/spec-line-refs.sh`: 68 refs, 0 drift, 0 dangling
- `git diff --check origin/main...HEAD`: clean
- diff scope: one generated file, one fingerprint correction

## Merge gate

Keep Draft / `status:do-not-merge` until terminal current-head CI. The separate #23956 HITL source P1 remains a blocker and is not hidden by this generated-index repair.

[근거] `git ls-remote origin refs/heads/main` = `c4e0c0764ba2224402d2300915527290c090de1b`; PR head = `3deace3181999d44169b84c5177eee4a646cb3d7`; generator and lint checked 2026-07-10T08:43Z; confidence High.