### PR TITLE
fix(ci): repair post-merge main red (approval-queue projection + judge fixture capability)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1700,7 +1700,11 @@ let expire_stale ~max_wait_s =
   in
   let candidates = list_pending_entries () |> List.filter is_stale in
   List.iter
-    (fun candidate ->
+    (* The annotation is load-bearing: [approval_rule] is declared after
+       [pending_approval] in [Keeper_approval_queue_rules_types] and also has
+       an [id] field, so a bare [candidate.id] projection resolves to
+       [approval_rule] and rejects the [pending_approval list] argument. *)
+    (fun (candidate : pending_approval) ->
        let id = candidate.id in
        if claim_resolution id
        then

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -74,6 +74,9 @@ let summary_routing_runtime_toml ~with_hitl_summary =
      api-name = \"judge\"\n\
      max-context = 1024\n\
      \n\
+     [models.judge.capabilities]\n\
+     supports-structured-output = true\n\
+     \n\
      [models.summary]\n\
      api-name = \"summary\"\n\
      max-context = 1024\n\


### PR DESCRIPTION
**둘 다 오늘 CI-미완주 병합의 낙진이오** — 상세는 커밋 메시지에 있소.

1. **컴파일 red (#23956 낙진, 4겹째)**: `expire_stale` 람다의 무주석 `candidate.id` 투영이 `approval_rule`(rules_types에서 pending_approval보다 나중 선언, id 필드 보유)로 해석 — param 주석으로 결정론화. 오늘 같은 클래스(무주석 record 투영) 3번째요.

2. **#23904 P1 후속 반영 (사용자 지시)**: 병합된 summary-routing fixture의 `[models.judge]`에 capabilities 부재 → `validate_structured_judge_runtime`(runtime.ml:195)이 load에서 결정론 거부 → 두 시나리오 모두 'runtime config should load'에서 사망 예정. `[models.judge.capabilities] supports-structured-output = true` 추가(파서 키 확인: runtime_toml.ml:533). #23904에 3회 기록된 P1의 이관이오.

검증: 이 PR의 CI가 증명하오. green이면 즉시 병합 대상이오.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
