### PR TITLE
fix(memory): make per-keeper post-turn lane restart-lossless

### DIFF
--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -3,6 +3,7 @@
 module Mcp_eio = Masc.Mcp_server_eio
 module Server_runtime_bootstrap = Server_runtime_bootstrap
 module Server_bootstrap_loops = Server_bootstrap_loops
+module Server_startup_takeover = Server_startup_takeover
 module Shutdown_hooks = Masc.Shutdown_hooks
 module Board_dispatch = Masc.Board_dispatch
 
@@ -25,6 +26,15 @@ let run_cmd cli_base_path =
   Server_base_path_guard.exit_on_violation
     (Server_base_path_guard.enforce resolved_base_path);
   let base_path = resolved_base_path.normalized_base_path in
+  (match Server_startup_takeover.acquire_base_path_lock base_path with
+   | Server_startup_takeover.Acquired -> ()
+   | Server_startup_takeover.Already_running { pid } ->
+     Log.legacy_stderr ~level:Log.Error ~module_name:"Server"
+       (Printf.sprintf
+          "[FATAL] Another MASC server (PID %d) already owns base path %s"
+          pid
+          base_path);
+     exit 1);
   Unix.putenv "MASC_BASE_PATH_INPUT" resolved_base_path.raw_base_path;
   Unix.putenv "MASC_BASE_PATH" base_path;
   Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE"
@@ -44,6 +54,18 @@ let run_cmd cli_base_path =
         ~mono_clock ~net ~proc_mgr ~fs ~env ())
   in
   Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+  Masc.Runtime_params.restore ~base_path;
+  (match Server_runtime_bootstrap.initialize_memory_lane ~sw ~clock state with
+   | Ok report ->
+     Log.Server.info
+       "stdio memory lane initialized discovered=%d started=%d deferred=%d keeper_errors=%d root_error=%b"
+       report.discovered_keepers
+       report.workers_started
+       report.workers_deferred
+       (List.length report.keeper_discovery_errors)
+       (Option.is_some report.discovery_error)
+   | Error detail ->
+     Log.Server.error "stdio memory lane initialization deferred: %s" detail);
   ignore (Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state);
   Fun.protect
     ~finally:(fun () ->

--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -232,7 +232,7 @@ export interface KeeperMemoryHealthKeeperEntry {
 
 export interface KeeperMemoryHealthResponse {
   generated_at: number
-  cadence_counter_entries: number
+  cadence_clock: 'keeper_turn_id'
   keepers: KeeperMemoryHealthKeeperEntry[]
   totals: {
     facts: number

--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -200,7 +200,6 @@ export type KeeperMemoryHealthAlertCode =
   | 'ttl_expired_on_disk'
   | 'near_duplicate'
   | 'events_to_facts_ratio_high'
-  | 'provider_slot_busy'
 
 export type KeeperMemoryHealthAlertSeverity = 'warn'
 
@@ -208,7 +207,6 @@ export type KeeperMemoryHealthAlertTarget =
   | 'ttl_expired_on_disk'
   | 'near_duplicate'
   | 'events_to_facts_ratio'
-  | 'provider_slot_busy'
 
 export interface KeeperMemoryHealthAlert {
   code: KeeperMemoryHealthAlertCode
@@ -229,7 +227,6 @@ export interface KeeperMemoryHealthKeeperEntry {
   events_to_facts_ratio: number
   ttl_expired_on_disk: number
   near_duplicate: number
-  provider_slot_busy: number
   alerts: KeeperMemoryHealthAlert[]
 }
 
@@ -243,7 +240,6 @@ export interface KeeperMemoryHealthResponse {
     events_bytes: number
     ttl_expired_on_disk: number
     near_duplicate: number
-    provider_slot_busy: number
   }
   alert_summary: {
     total_alerts: number
@@ -252,12 +248,10 @@ export interface KeeperMemoryHealthResponse {
     ttl_expired_keepers: number
     near_duplicate_keepers: number
     high_event_ratio_keepers: number
-    provider_slot_busy_keepers: number
     thresholds: {
       ttl_expired_on_disk: number
       near_duplicate: number
       events_to_facts_ratio: number
-      provider_slot_busy: number
     }
   }
 }

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -46,7 +46,7 @@ function makeResponse(
 ): KeeperMemoryHealthResponse {
   return {
     generated_at: 1_700_000_000,
-    cadence_counter_entries: 3,
+    cadence_clock: 'keeper_turn_id',
     keepers,
     totals: {
       facts: 0,
@@ -278,7 +278,7 @@ describe('KeeperMemoryHealth', () => {
       const rows = container.querySelectorAll('tbody tr')
       expect(rows.length).toBe(2)
       expect(screen.getByText('beta')).not.toBeNull()
-      // The cadence counter total surfaces in the header strip.
+      expect(screen.getByText('keeper_turn_id')).not.toBeNull()
       expect(screen.getByText('키퍼 메모리 상태')).not.toBeNull()
     })
   })

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -34,7 +34,6 @@ function makeEntry(
     events_to_facts_ratio: 0,
     ttl_expired_on_disk: 0,
     near_duplicate: 0,
-    provider_slot_busy: 0,
     alerts: [],
     ...overrides,
   }
@@ -55,7 +54,6 @@ function makeResponse(
       events_bytes: 0,
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
-      provider_slot_busy: 0,
       ...totalsOverrides,
     },
     alert_summary: alertSummary ?? makeAlertSummary(),
@@ -72,12 +70,10 @@ function makeAlertSummary(
     ttl_expired_keepers: 0,
     near_duplicate_keepers: 0,
     high_event_ratio_keepers: 0,
-    provider_slot_busy_keepers: 0,
     thresholds: {
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
       events_to_facts_ratio: 0,
-      provider_slot_busy: 0,
     },
     ...overrides,
   }
@@ -195,16 +191,15 @@ describe('KeeperMemoryHealth', () => {
       expect(screen.getByText('TTL')).not.toBeNull()
     })
 
-    it('does not style raw ttl or provider-slot counts as warnings without backend alerts', async () => {
+    it('does not style a raw ttl count as a warning without a backend alert', async () => {
       mockFetch.mockResolvedValue(
         makeResponse([
           makeEntry({
             keeper_id: 'raw-counts',
             ttl_expired_on_disk: 4,
-            provider_slot_busy: 3,
             alerts: [],
           }),
-        ], { ttl_expired_on_disk: 4, provider_slot_busy: 3 }),
+        ], { ttl_expired_on_disk: 4 }),
       )
       const { container } = render(html`<${KeeperMemoryHealth} />`)
       await waitFor(() => expect(screen.getByText('raw-counts')).not.toBeNull())
@@ -212,9 +207,7 @@ describe('KeeperMemoryHealth', () => {
       expect(container.querySelector('.kmh-row--warn')).toBeNull()
       expect(container.querySelector('.kmh-badge--warn')).toBeNull()
       expect(container.querySelector('[data-stat-key="ttl-expired"] .kmh-stat-value--warn')).toBeNull()
-      expect(container.querySelector('[data-stat-key="provider-slot-busy"] .kmh-stat-value--warn')).toBeNull()
       expect(statValue(container, 'ttl-expired')).toContain('4')
-      expect(statValue(container, 'provider-slot-busy')).toContain('3')
     })
   })
 
@@ -247,37 +240,6 @@ describe('KeeperMemoryHealth', () => {
       await waitFor(() => expect(screen.getByText('alerted')).not.toBeNull())
 
       expect(statValue(container, 'alerts')).toBe('1')
-    })
-
-    it('surfaces provider slot busy alerts per keeper', async () => {
-      mockFetch.mockResolvedValue({
-        ...makeResponse([
-          makeEntry({
-            keeper_id: 'slot-busy',
-            provider_slot_busy: 3,
-            alerts: [{
-              code: 'provider_slot_busy',
-              severity: 'warn',
-              target: 'provider_slot_busy',
-              label: '슬롯',
-              message: 'Memory OS librarian provider slot was busy',
-              value: 3,
-              threshold: 0,
-            }],
-          }),
-        ], { provider_slot_busy: 3 }),
-        alert_summary: makeAlertSummary({
-          total_alerts: 1,
-          warn_alerts: 1,
-          keepers_with_alerts: 1,
-          provider_slot_busy_keepers: 1,
-        }),
-      })
-      const { container } = render(html`<${KeeperMemoryHealth} />`)
-      await waitFor(() => expect(screen.getByText('slot-busy')).not.toBeNull())
-
-      expect(screen.getByText('슬롯')).not.toBeNull()
-      expect(statValue(container, 'provider-slot-busy')).toBe('3')
     })
 
   })

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -1,8 +1,8 @@
 // KeeperMemoryHealth — per-keeper fact-store observability panel.
 //
 // Read-only diagnostic surface for Lab > 키퍼 메모리 상태.
-// Shows fact-store sizes, GC dry-run statistics, and the fleet-wide
-// librarian cadence counter so operators can monitor what the
+// Shows fact-store sizes, GC dry-run statistics, and the durable
+// librarian cadence clock so operators can monitor what the
 // disabled GC leaves on disk.
 
 import { html } from 'htm/preact'
@@ -172,9 +172,9 @@ export function KeeperMemoryHealth() {
               ${totalAlerts}
             </span>
           </div>
-          <div class="kmh-stat" data-stat-key="cadence-counter">
-            <span class="kmh-stat-label">케이던스 카운터</span>
-            <span class="kmh-stat-value">${data.cadence_counter_entries}</span>
+          <div class="kmh-stat" data-stat-key="cadence-clock">
+            <span class="kmh-stat-label">케이던스 기준</span>
+            <span class="kmh-stat-value">${data.cadence_clock}</span>
           </div>
           <div class="kmh-stat" data-stat-key="keeper-count">
             <span class="kmh-stat-label">키퍼 수</span>

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -19,7 +19,6 @@ import { DEFAULT_PANEL_REFRESH_MS, formatAutoRefreshLabel, setupVisibleAutoRefre
 const EVENT_RATIO_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'events_to_facts_ratio'
 const TTL_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'ttl_expired_on_disk'
 const NEAR_DUPLICATE_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'near_duplicate'
-const PROVIDER_SLOT_BUSY_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'provider_slot_busy'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -29,10 +28,6 @@ function formatBytes(bytes: number): string {
 
 function entryAlerts(entry: KeeperMemoryHealthKeeperEntry): KeeperMemoryHealthAlert[] {
   return entry.alerts
-}
-
-function providerSlotBusy(entry: KeeperMemoryHealthKeeperEntry): number {
-  return entry.provider_slot_busy
 }
 
 function hasTargetAlert(alerts: KeeperMemoryHealthAlert[], target: KeeperMemoryHealthAlertTarget): boolean {
@@ -50,8 +45,6 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
   const ratioWarn = hasTargetAlert(alerts, EVENT_RATIO_ALERT_TARGET)
   const ttlWarn = hasTargetAlert(alerts, TTL_ALERT_TARGET)
   const nearDuplicateWarn = hasTargetAlert(alerts, NEAR_DUPLICATE_ALERT_TARGET)
-  const providerSlotBusyWarn = hasTargetAlert(alerts, PROVIDER_SLOT_BUSY_ALERT_TARGET)
-  const providerSlotBusyCount = providerSlotBusy(entry)
 
   return html`
     <tr class=${warn ? 'kmh-row--warn' : ''}>
@@ -72,11 +65,6 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
         ${nearDuplicateWarn
           ? html`<span class="kmh-badge kmh-badge--warn">${entry.near_duplicate}</span>`
           : html`<span class="kmh-badge kmh-badge--ok">${entry.near_duplicate}</span>`}
-      </td>
-      <td>
-        ${providerSlotBusyWarn
-          ? html`<span class="kmh-badge kmh-badge--warn">${providerSlotBusyCount}</span>`
-          : html`<span class="kmh-badge kmh-badge--ok">${providerSlotBusyCount}</span>`}
       </td>
       <td>
         ${alerts.length > 0
@@ -150,8 +138,6 @@ export function KeeperMemoryHealth() {
   const generatedAt = new Date(data.generated_at * 1000).toLocaleTimeString()
   const totalAlerts = data.alert_summary.total_alerts
   const ttlExpiredWarn = data.alert_summary.ttl_expired_keepers > 0
-  const providerSlotBusyWarn = data.alert_summary.provider_slot_busy_keepers > 0
-  const totalProviderSlotBusy = data.totals.provider_slot_busy
 
   return html`
     <div class="kmh-panel">
@@ -179,12 +165,6 @@ export function KeeperMemoryHealth() {
           <div class="kmh-stat" data-stat-key="near-duplicate">
             <span class="kmh-stat-label">근접중복</span>
             <span class="kmh-stat-value">${data.totals.near_duplicate}</span>
-          </div>
-          <div class="kmh-stat" data-stat-key="provider-slot-busy">
-            <span class="kmh-stat-label">슬롯 실패</span>
-            <span class=${`kmh-stat-value${providerSlotBusyWarn ? ' kmh-stat-value--warn' : ''}`}>
-              ${totalProviderSlotBusy}
-            </span>
           </div>
           <div class="kmh-stat" data-stat-key="alerts">
             <span class="kmh-stat-label">경보</span>
@@ -219,7 +199,6 @@ export function KeeperMemoryHealth() {
                   <th>events:facts 비율</th>
                   <th>만료(디스크)</th>
                   <th>근접중복</th>
-                  <th>슬롯 실패</th>
                   <th>경보</th>
                 </tr>
               </thead>

--- a/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
+++ b/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
@@ -32,8 +32,8 @@ Give each keeper its own memory execution lane, detached from the turn lane.
 New module `Keeper_memory_lane` mirroring `keeper_turn_admission`:
 
 - Per-keeper entry keyed by `Keeper_registry_types.registry_key ~base_path keeper_name`:
-  `{ state_mu; jobs; pending; active_worker_id }`.
-- One drain worker consumes each keeper's explicit FIFO, preserving turn N before turn N+1.
+  `{ state_mu; jobs; pending; active_worker }`.
+- One drain daemon consumes each keeper's explicit FIFO, preserving turn N before turn N+1.
 - Different keepers run concurrently (independent lanes).
 - Accepted units are not discarded because earlier memory work is slow. The pending gauge reports
   backlog directly; only executor shutdown or worker-spawn failure can abandon queued work, and
@@ -48,8 +48,8 @@ lib/server/server_runtime_bootstrap.ml:139
   Eio_context.set_switch sw   (* server root switch *)
 ```
 
-`Keeper_memory_lane.init ~sw` records this switch. The first queued unit starts one drain worker
-with `Eio.Fiber.fork ~sw`; that worker re-binds the switch via
+`Keeper_memory_lane.init ~sw` records this switch. The first queued unit starts one drain daemon
+with `Eio.Fiber.fork_daemon ~sw`; that daemon re-binds the switch via
 `Eio_context.with_turn_switch sw` for every unit so that
 `run_best_effort` (which reads `sw`/`net`/`clock` from `Eio_context`, `keeper_librarian_runtime.ml:331,347`)
 issues its provider call under the executor switch. `net`/`clock` are global atomics set at the
@@ -57,8 +57,9 @@ same startup point, available everywhere.
 
 Leak-safety follows `keeper_turn_admission.run_locked`: the in-flight and pending decrements are
 bound to every unit exit including `Eio.Cancel.Cancelled`, while a switch release atomically clears
-and reports any queue it still owns. A cancelled executor therefore cannot leak worker ownership
-or counters.
+and reports any queue it still owns. The daemon does not keep normal server shutdown alive; when
+the executor has no non-daemon work left, Eio cancels the drain and the same abandonment path runs.
+A cancelled or normally released executor therefore cannot leak worker ownership or counters.
 
 ### What moves to the lane vs stays inline
 
@@ -76,13 +77,17 @@ memory-bank-touching work — move onto the lane** (serialized by the keeper's F
 inline**: it only reads the typed turn history and writes the *decision* log, a separate
 file independent of (1)(2)(3).
 
-### Separate keeper ordering from provider-pool protection
+### Separate keeper ordering from provider-call protection
 
 The old global slot mixed two concerns: per-keeper memory ordering and provider-pool
-protection. Per-keeper ordering now comes from `Keeper_memory_lane`'s FIFO worker. Provider-pool
-protection remains as a separate, optional fleet-wide gate around the provider round-trip only.
-That gate is not a memory-ordering primitive and does not serialize deterministic writes or
-compaction.
+protection. Per-keeper ordering now comes from `Keeper_memory_lane`'s FIFO worker. A later
+per-keeper provider semaphore duplicated that same ordering because the only production
+`run_best_effort` caller is already inside the Keeper's memory lane. Its fixed acquisition window
+could only discard work; it could not protect fleet-wide capacity.
+
+The duplicate semaphore and `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` knob are retired.
+Provider/model capacity, health, and fallback belong to the OAS provider/runtime boundary. MASC
+keeps independent Keeper lanes and does not recreate a cross-Keeper provider scheduler.
 
 ### Correctness under detachment
 
@@ -104,55 +109,34 @@ on the lane. The data the unit reads must not race that later turn:
 ## Accepted consequence
 
 Detaching memory work means a keeper can have a chat turn and a memory unit queued or in flight at
-the same time. Without a fleet-wide bound, N keepers could issue N concurrent provider calls to the
-shared flash/glm librarian pool. Measured production data (2026-06-16, issue #21230) showed that
-this exact pattern spiked the librarian empty-response rate to 62%, so an unbounded concurrency
-increase cannot be treated as a pure operator concern.
-
-To reconcile the lane independence goal with that measurement, this design adds a **separate fleet-wide
-provider concurrency gate** around librarian calls:
-
-- `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` (default `1`): maximum simultaneous librarian
-  provider round-trips across all keepers. `0` disables the gate.
-- The wait is a fixed 0.25s best-effort acquisition window. It is deliberately not another
-  environment knob; the capacity is the operator-controlled variable.
-
-Per-keeper lane fairness is preserved (one FIFO worker orders each keeper's units), while the shared
-pool is protected from the empty-response storm observed in #21230. Lane independence and provider
-pool protection are now handled on separate axes rather than pretending one implies the other.
+the same time. Without a MASC-wide gate, N keepers may issue N concurrent provider calls. That is
+the intended lane-independence boundary. Measured provider saturation remains observable, but
+provider capacity and fallback must be enforced by the selected runtime/provider implementation
+rather than by discarding Keeper memory after a hardcoded wait.
 
 Memory writes become eventually consistent: a keeper's turn N+1 can begin before turn N's
 deterministic note lands, so recall on turn N+1 may miss turn N's note. Ordering within a keeper is
 preserved by the FIFO (turn N completes before turn N+1 on the lane).
 
-## Relationship to #21408 (mutually exclusive)
+## Relationship to #21408
 
-PR #21408 is a competing solution to the same underlying problem: the old process-global
-`provider_slot` serialized every keeper's librarian work fleet-wide. #21408 keeps the slot concept
-but re-implements it as a per-keeper `Hashtbl` registry of slots (`provider_slot_for keeper_id`),
-while #21376 (this RFC) removes the slot entirely and moves serialization into the per-keeper
-memory lane (`Keeper_memory_lane`). The two PRs touch the same lines in
-`keeper_librarian_runtime.ml` in opposite directions (one modifies `provider_slot`; the other deletes
-it), so they are textually and semantically mutually exclusive — both cannot merge.
-
-**Recommendation: keep #21376 and close #21408.** The per-keeper lane in #21376 already subsumes the
-per-keeper serialization goal of #21408 (one FIFO worker orders each keeper's units independently),
-and it does so with a cleaner architecture (lane ownership + explicit queue + leak-safety tests). The
-fleet-wide provider-pool gate added above covers the shared-pool protection that #21408 was trying
-to re-introduce. Merging both would create two concurrent primitives for the same concern.
-
-If #21376 is deemed too large to land first, the alternative is to close #21376, merge #21408 as a
-minimal fix, and then rework #21376 on top of it — but simultaneous open competition between the two
-PRs must end before either merges.
+PR #21376 merged the per-Keeper memory lane and closed competing PR #21408. Later source drift
+reintroduced #21408's per-Keeper semaphore shape even though the lane already serialized its only
+production caller. This revision restores one ownership primitive: the memory lane owns Keeper
+ordering; the OAS provider runtime owns provider capacity.
 
 ## Known limitations
 
-- Drain workers are owned by the server root switch, not the per-keeper supervisor switch
+- Drain daemons are owned by the server root switch, not the per-keeper supervisor switch
   (`keeper_supervisor_launch.ml`). If a keeper is stopped/recovered while a memory unit is in flight,
   that unit runs to completion rather than being cancelled with the keeper.
 - The FIFO preserves accepted work during the current server lifetime but stores closures in memory.
   Root-switch shutdown explicitly abandons and counts unfinished units; restart replay requires the
   durable due/start/success/failure receipt tracked by production-hardening issue #23925 item 31.
+- The in-memory FIFO is not admission-bounded. Sustained producer/drain imbalance or a stalled job
+  can therefore grow one keeper's closure backlog until it threatens the process. Item 31 must move
+  accepted work to a durable, replayable queue with explicit admission and terminal receipts; an
+  arbitrary drop threshold is not an acceptable substitute.
 
 ## Runtime tunables and metrics
 
@@ -164,28 +148,25 @@ Per-keeper lane:
 - `masc_keeper_memory_lane_pending` (gauge, per-keeper)
 - `masc_keeper_memory_lane_in_flight` (gauge, per-keeper)
 
-Fleet-wide librarian provider gate:
-
-- `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` (default `1`)
-- `masc_keeper_memory_lane_provider_slot_busy_total`
-
-Exceptional queue abandonment and provider-slot-busy events are also logged at WARN level with the
-keeper name.
+Exceptional queue abandonment is logged at WARN level with the keeper name. If the retired
+`MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` variable is still configured, startup logs and
+counts the ignored setting explicitly.
 
 ## Tests
 
 `test/test_keeper_memory_lane.ml`:
 
 - ungated path when executor not initialized falls back to inline (no lost work in tests).
-- one FIFO worker serializes submissions for the same keeper.
+- one FIFO daemon serializes submissions for the same keeper.
 - two different keepers run concurrently (no cross-keeper blocking).
 - a backlog larger than two units is accepted, drained without loss, and preserves FIFO order.
 - a submitted unit that raises decrements `pending` and the worker continues (no leak).
 - cancelling the executor switch while a unit is in flight clears worker ownership and decrements
   `pending`.
+- replacing the lane's initialized executor switch is rejected explicitly.
 
 ## Rollback
 
-Revert is a single commit: restore `provider_slot` in `keeper_librarian_runtime.ml`, re-inline the
-memory series in `keeper_agent_run_post_turn_memory.ml`, drop `Keeper_memory_lane` and its `init`
-call. No schema or on-disk format changes.
+Reverting the lane requires re-inlining the memory series in
+`keeper_agent_run_post_turn_memory.ml` and dropping `Keeper_memory_lane` plus its `init` call.
+It must not restore the retired timeout/drop gate. No schema or on-disk format changes.

--- a/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
+++ b/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
@@ -29,53 +29,78 @@ Give each keeper its own memory execution lane, detached from the turn lane.
 
 ### Lane registry
 
-New module `Keeper_memory_lane` mirroring `keeper_turn_admission`:
+`Keeper_memory_lane` owns execution; `Keeper_memory_job_store` owns durable
+state:
 
-- Per-keeper entry keyed by `Keeper_registry_types.registry_key ~base_path keeper_name`:
-  `{ state_mu; jobs; pending; active_worker }`.
-- One drain daemon consumes each keeper's explicit FIFO, preserving turn N before turn N+1.
+- Per-keeper in-process entries contain only worker/wake ownership. They never
+  retain a closure or payload backlog on the OCaml heap.
+- One domain-safe `Eio.Mutex` per keeper serializes filesystem state
+  transitions and yields while contended; short worker-token and registry
+  critical sections use `Stdlib.Mutex` and never perform I/O or switch fibers.
+- A typed job is atomically staged below
+  `<BasePath>/.masc/keepers/<keeper>/memory-jobs/awaiting-turn-commit/` before
+  turn finalization returns. This outbox state is not runnable.
+- The owning execution receipt includes the job id and is appended with file
+  and directory fsync. Only after that commit does the job move
+  `awaiting-turn-commit -> pending -> inflight -> terminal receipt`. Receipt
+  failure aborts the awaiting row. A crash between receipt append and activation
+  is recovered by a strict receipt scan; malformed receipt rows fail explicitly
+  with path and line evidence rather than authorizing work.
+- If receipt append reports an error after an uncertain filesystem boundary,
+  the same strict scan classifies the exact job id before abort or activation.
+  A proof-read failure preserves the awaiting payload and starts reconciliation;
+  it never guesses that the receipt committed or silently drops the outbox.
+- The full
+  SHA-256 job id is derived from the typed Keeper/trace/generation/turn/OAS-turn
+  identity; a conflicting payload for the same identity is rejected.
+- One drain daemon validates and sorts the current pending batch once, leases
+  it in Keeper turn order, and executes it serially. This preserves turn N
+  before turn N+1 without re-reading and re-sorting the full directory for
+  every job.
 - Different keepers run concurrently (independent lanes).
-- Accepted units are not discarded because earlier memory work is slow. The pending gauge reports
-  backlog directly; only executor shutdown or worker-spawn failure can abandon queued work, and
-  those exceptional outcomes are counted and logged.
+- Executor shutdown or worker-spawn failure leaves committed work durable.
+  Startup discovery or activation wakes it; retryable execution/store failures
+  self-schedule from the shared typed Keeper backoff policy without requiring a
+  later submission. A post-receipt activation failure starts the same strict
+  receipt reconciliation loop immediately rather than waiting for restart.
 
 ### Executor switch
 
 The detached fibers are owned by the server root switch, established at startup:
 
-```
-lib/server/server_runtime_bootstrap.ml:139
-  Eio_context.set_switch sw   (* server root switch *)
-```
+The server composition root installs `sw` in `Eio_context` before runtime
+restoration and memory-lane initialization.
 
-`Keeper_memory_lane.init ~sw` records this switch. The first queued unit starts one drain daemon
+`Keeper_memory_lane.init ~sw ~clock ~base_path ~execute` records this switch only
+after Runtime/config restoration. It discovers pending/inflight jobs and starts
+one drain daemon
 with `Eio.Fiber.fork_daemon ~sw`; that daemon re-binds the switch via
 `Eio_context.with_turn_switch sw` for every unit so that
 `run_best_effort` (which reads `sw`/`net`/`clock` from `Eio_context`, `keeper_librarian_runtime.ml:331,347`)
 issues its provider call under the executor switch. `net`/`clock` are global atomics set at the
 same startup point, available everywhere.
 
-Leak-safety follows `keeper_turn_admission.run_locked`: the in-flight and pending decrements are
-bound to every unit exit including `Eio.Cancel.Cancelled`, while a switch release atomically clears
-and reports any queue it still owns. The daemon does not keep normal server shutdown alive; when
-the executor has no non-daemon work left, Eio cancels the drain and the same abandonment path runs.
-A cancelled or normally released executor therefore cannot leak worker ownership or counters.
+The daemon does not keep normal server shutdown alive. Cancellation releases
+only process-local worker ownership; the inflight file deliberately remains.
+On restart, receipt-less inflight jobs return to pending, while an inflight job
+whose terminal receipt already committed is acknowledged without re-execution.
 
 ### What moves to the lane vs stays inline
 
-`Keeper_agent_run_post_turn_memory.run` does four things:
+`Keeper_agent_run_post_turn_memory.run` does five things:
 
 1. typed tool-result memory promotion (`Memory.append_from_tool_results`)
 2. librarian extraction (`Keeper_librarian_runtime.run_best_effort`)
-3. memory-bank compaction (`Memory.compact_if_needed`)
-4. post-turn quality metrics → decision log (`append_jsonl_line` to `keeper_decision_log_path`)
+3. advisory draft-skill projection (`Skill_candidate_store.write_all_post_turn_candidates`)
+4. memory-bank compaction (`Memory.compact_if_needed`)
+5. post-turn quality metrics → decision log (`append_jsonl_line` to `keeper_decision_log_path`)
 
 `Memory.append_from_tool_results` / `compact_if_needed` carry no internal lock; they are safe today only
-because the turn lane calls them single-fiber-per-keeper. Detaching (3) while (1) still ran inline
-would let two fibers touch the same keeper's memory bank concurrently. Therefore **(1) (2) (3) — all
-memory-bank-touching work — move onto the lane** (serialized by the keeper's FIFO worker). **(4) stays
+because the turn lane calls them single-fiber-per-keeper. Detaching (4) while (1) still ran inline
+would let two fibers touch the same keeper's memory bank concurrently. Therefore **(1)–(4) — all
+memory-system work — move onto the lane** (serialized by the keeper's FIFO worker). **(5) stays
 inline**: it only reads the typed turn history and writes the *decision* log, a separate
-file independent of (1)(2)(3).
+file independent of (1)–(4).
 
 ### Separate keeper ordering from provider-call protection
 
@@ -94,17 +119,54 @@ keeps independent Keeper lanes and does not recreate a cross-Keeper provider sch
 Detaching means a keeper's turn N+1 can run while turn N's memory unit is still
 on the lane. The data the unit reads must not race that later turn:
 
-- `Keeper_meta_contract.keeper_meta` and `Workspace.config` have no `mutable`
-  fields; updates return new records (`map_usage`, `reset_runtime_state` are
-  `keeper_meta -> keeper_meta`). Turn N's unit closes over turn N's immutable
-  record; turn N+1 gets its own. No race.
-- The one mutable per-keeper read in the deterministic write is the tool-emission
-  accumulator (`Keeper_tool_emission_hook.snapshot (accumulator_for_keeper
-  meta.name)`). It is snapshotted **synchronously at turn end**, before submit,
-  and the immutable snapshot is passed into the unit — so a later turn's
-  emissions cannot fold into this turn's notes.
-- The remaining shared mutable state is the on-disk memory bank, which the
-  lane's single per-keeper worker serializes.
+- `Keeper_meta_contract.keeper_meta` is serialized through its canonical JSON
+  codec. Replay reconstructs the exact immutable turn snapshot and validates
+  Keeper/trace identity against the durable envelope.
+- The one mutable per-keeper read in the deterministic write is the
+  tool-emission accumulator. Finalization consumes it exactly once with
+  `take_all`; the immutable value fans out to the durable memory job and, after
+  successful admission, the post-turn multimodal working context. On admission
+  failure, or when the owning execution receipt fails and aborts the staged
+  outbox, it is restored behind any concurrently captured items. This prevents
+  later-turn bleed, receipt-failure loss, and stale-checkpoint re-snapshot
+  duplication.
+- The librarian checkpoint is an OAS checkpoint value reduced to the same
+  bounded raw-message window the librarian consumes. Tool schemas, MCP
+  sessions, working context, and unbounded history are not copied into each
+  job.
+- Tool-result promotion de-duplicates persisted `artifact_id` values under the
+  memory-bank lock. Librarian extraction stages the provider episode under
+  `memory-jobs/operations/<job-id>.json` before publishing facts/events; the
+  event carries that operation id as its commit marker. Inspection has three
+  typed states (`absent`, `staged`, `committed`). A staged result bypasses all
+  enablement/cadence/runtime/provider gates and enters publication directly.
+  The terminal job receipt commits before operation/pending/inflight cleanup.
+  Cleanup errors are reported as debt but cannot roll back the receipt or block
+  later jobs. It therefore does not duplicate a provider call or expose an
+  uncommitted stage through episode recall.
+- The librarian enablement/cadence decision is encoded in the immutable job
+  payload at admission. Cadence is a pure function of the Keeper's durable
+  timeline turn id; there is no process-local cadence table for restart, detached
+  execution, or admission failure to corrupt. Replay consumes the typed
+  decision verbatim.
+- Every Memory OS path used by the detached executor receives the worker's
+  explicit BasePath-derived `keepers_dir`; no librarian write consults ambient
+  config-dir state. Startup performs an explicit byte-preserving migration from
+  the historical canonical `<BasePath>/.masc/config/keepers` runtime artifacts;
+  divergent destinations remain untouched and are reported individually
+  without stopping unrelated Keeper/artifact migrations or healthy lane
+  startup. Keeper TOML remains in the config root.
+- Facts publish atomically and event rows use a durable append as the episode
+  commit marker. A retryable persistence failure keeps the job inflight. A
+  malformed historical event row is first durably quarantined, then the valid
+  rows are atomically rewritten under the episode-bundle lock.
+- Queue envelopes are accepted only when their typed keeper, job id filename,
+  and state directory agree. Atomic-write temp orphans use the filesystem SSOT:
+  zero-length files are removed and non-empty files are moved to a private
+  forensic directory with an explicit error log.
+- Startup discovery isolates malformed Keeper-local backlogs and starts every
+  healthy Keeper lane. Only failure to inspect the Keeper root itself prevents
+  fleet discovery.
 
 ## Accepted consequence
 
@@ -125,30 +187,53 @@ reintroduced #21408's per-Keeper semaphore shape even though the lane already se
 production caller. This revision restores one ownership primitive: the memory lane owns Keeper
 ordering; the OAS provider runtime owns provider capacity.
 
-## Known limitations
+## Failure and replay semantics
 
-- Drain daemons are owned by the server root switch, not the per-keeper supervisor switch
-  (`keeper_supervisor_launch.ml`). If a keeper is stopped/recovered while a memory unit is in flight,
-  that unit runs to completion rather than being cancelled with the keeper.
-- The FIFO preserves accepted work during the current server lifetime but stores closures in memory.
-  Root-switch shutdown explicitly abandons and counts unfinished units; restart replay requires the
-  durable due/start/success/failure receipt tracked by production-hardening issue #23925 item 31.
-- The in-memory FIFO is not admission-bounded. Sustained producer/drain imbalance or a stalled job
-  can therefore grow one keeper's closure backlog until it threatens the process. Item 31 must move
-  accepted work to a durable, replayable queue with explicit admission and terminal receipts; an
-  arbitrary drop threshold is not an acceptable substitute.
+- A terminal-only stage failure produces a failed terminal job receipt; it does
+  not block the Keeper turn lane or the next memory job. If weakly-coupled
+  stages contain both terminal and retryable failures, retryable persistence
+  wins at the job boundary so the terminal stage cannot acknowledge and discard
+  the other stage's work. Typed retryable failures keep the inflight job and
+  self-schedule. Disabled/not-due librarian work is a typed skip, not a failure.
+  Tool-result promotion and librarian publication carry unique turn input and
+  therefore retry persistence failures. Draft-skill projection and compaction
+  are derivable hygiene; their failure is recorded for this job and a later job
+  recomputes them without holding the Keeper lane indefinitely.
+- The retained terminal receipt carries typed turn identity, the original
+  enqueue timestamp, a canonical payload SHA-256 (never the checkpoint/tool
+  payload itself), worker start/end timestamps, and per-stage outcomes.
+  Queue directories are mode `0700` and atomic files finish at mode `0600`.
+  Librarian detail includes the
+  resolved runtime/model, measured latency, typed error or skip reason, and the
+  exact turn-count distance to the next cadence decision (`null` while
+  disabled). Accepted jobs have no drop transition; admission rejection is a
+  separate typed result and metric.
+- If terminal receipt persistence itself fails, the worker leaves the inflight
+  job intact and retries with the typed Keeper backoff even when no new wake
+  arrives. All lane store transitions share one domain-safe, fiber-yielding
+  mutex per Keeper. Other Keepers continue independently.
+- A crash after a provider response but before its atomic staged-episode write
+  may repeat the external provider call. No local side effect has committed at
+  that point. Once staging succeeds, replay is idempotent through the operation
+  event marker.
+- Terminal receipt files are retained as audit evidence. Retention must be an
+  explicit operator/storage policy; the execution path does not invent a
+  heuristic count cap or silently delete receipts.
 
 ## Runtime tunables and metrics
 
 Per-keeper lane:
 
 - `masc_keeper_memory_lane_submitted_total`
-- `masc_keeper_memory_lane_ran_inline_total`
-- `masc_keeper_memory_lane_dropped_total`
+- `masc_keeper_memory_lane_admission_rejected_total`
+- `masc_keeper_memory_lane_replayed_total`
+- `masc_keeper_memory_lane_completed_total`
+- `masc_keeper_memory_lane_failed_total`
 - `masc_keeper_memory_lane_pending` (gauge, per-keeper)
 - `masc_keeper_memory_lane_in_flight` (gauge, per-keeper)
 
-Exceptional queue abandonment is logged at WARN level with the keeper name. If the retired
+Admission, claim, replay, and terminal-receipt failures are logged with the
+Keeper/job identity; no accepted job has an abandonment path. If the retired
 `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` variable is still configured, startup logs and
 counts the ignored setting explicitly.
 
@@ -156,17 +241,38 @@ counts the ignored setting explicitly.
 
 `test/test_keeper_memory_lane.ml`:
 
-- ungated path when executor not initialized falls back to inline (no lost work in tests).
+- an awaiting outbox row is runnable after restart only when its strict
+  execution-receipt proof exists; an uncommitted row is explicitly aborted.
+- duplicate staging is idempotent; conflicting payloads are rejected.
+- queue files whose typed state disagrees with their directory are rejected.
+- queue files whose Keeper or filename coordinate disagrees with their envelope
+  are rejected.
+- zero-length atomic orphans are removed and non-empty ones are preserved
+  outside the queue.
+- terminal receipts omit the full job payload and receipt acknowledgement
+  removes the staged provider journal only after the receipt is durable.
 - one FIFO daemon serializes submissions for the same keeper.
 - two different keepers run concurrently (no cross-keeper blocking).
-- a backlog larger than two units is accepted, drained without loss, and preserves FIFO order.
-- a submitted unit that raises decrements `pending` and the worker continues (no leak).
-- cancelling the executor switch while a unit is in flight clears worker ownership and decrements
-  `pending`.
-- replacing the lane's initialized executor switch is rejected explicitly.
+- one malformed Keeper backlog does not suppress healthy Keeper discovery.
+- a failed job commits a failed receipt and the next job still runs.
+- cancelling the executor with an inflight job leaves it durable; a fresh
+  executor replays it and commits one success receipt.
+- a receipt-backed inflight artifact is acknowledged without execution.
+- cleanup failure after a terminal receipt is surfaced as debt without blocking
+  the lane.
+- a retryable failure self-schedules without a later submit signal.
+- a post-receipt activation failure self-reconciles without a later turn or
+  restart.
+- legacy Memory OS runtime artifacts migrate byte-for-byte, divergent
+  destinations are reported without stopping independent artifacts, and
+  malformed event rows are quarantined before repair.
+- a receipt-write failure racing with a second submit replays inflight work and
+  continues to the second job without losing the wake.
+- librarian operation replay makes one provider call and one event; a staged
+  result is a distinct typed state and commits without provider replay gates.
 
 ## Rollback
 
-Reverting the lane requires re-inlining the memory series in
-`keeper_agent_run_post_turn_memory.ml` and dropping `Keeper_memory_lane` plus its `init` call.
-It must not restore the retired timeout/drop gate. No schema or on-disk format changes.
+Rollback must drain or explicitly migrate the on-disk memory-job schema before
+removing the executor. Re-inlining while pending jobs exist would orphan
+accepted work and is therefore not a valid source-only revert.

--- a/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
+++ b/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
@@ -32,12 +32,12 @@ Give each keeper its own memory execution lane, detached from the turn lane.
 New module `Keeper_memory_lane` mirroring `keeper_turn_admission`:
 
 - Per-keeper entry keyed by `Keeper_registry_types.registry_key ~base_path keeper_name`:
-  `{ mem_mu : Eio.Mutex.t; state_mu : Stdlib.Mutex.t; mutable pending : int }`.
-- `mem_mu` serializes memory work *within* a keeper (ordering preserved: turn N before turn N+1).
+  `{ state_mu; jobs; pending; active_worker_id }`.
+- One drain worker consumes each keeper's explicit FIFO, preserving turn N before turn N+1.
 - Different keepers run concurrently (independent lanes).
-- `pending` is bounded (`max_pending`, a named constant). Over the bound the submission is
-  dropped and logged — memory extraction is opt-in/best-effort, so dropping under saturation is
-  acceptable; the drop is counted, never silent.
+- Accepted units are not discarded because earlier memory work is slow. The pending gauge reports
+  backlog directly; only executor shutdown or worker-spawn failure can abandon queued work, and
+  those exceptional outcomes are counted and logged.
 
 ### Executor switch
 
@@ -48,15 +48,17 @@ lib/server/server_runtime_bootstrap.ml:139
   Eio_context.set_switch sw   (* server root switch *)
 ```
 
-`Keeper_memory_lane.init ~sw` records this switch. Each submitted unit is run with
-`Eio.Fiber.fork ~sw` and the switch re-bound via `Eio_context.with_turn_switch sw` so that
+`Keeper_memory_lane.init ~sw` records this switch. The first queued unit starts one drain worker
+with `Eio.Fiber.fork ~sw`; that worker re-binds the switch via
+`Eio_context.with_turn_switch sw` for every unit so that
 `run_best_effort` (which reads `sw`/`net`/`clock` from `Eio_context`, `keeper_librarian_runtime.ml:331,347`)
 issues its provider call under the executor switch. `net`/`clock` are global atomics set at the
 same startup point, available everywhere.
 
-Leak-safety follows `keeper_turn_admission.run_locked`: `pending` decrement and `mem_mu` release
-are bound to every exit path including `Eio.Cancel.Cancelled`, so a cancelled executor (server
-shutdown) cannot leak a permit or a counter.
+Leak-safety follows `keeper_turn_admission.run_locked`: the in-flight and pending decrements are
+bound to every unit exit including `Eio.Cancel.Cancelled`, while a switch release atomically clears
+and reports any queue it still owns. A cancelled executor therefore cannot leak worker ownership
+or counters.
 
 ### What moves to the lane vs stays inline
 
@@ -70,14 +72,14 @@ shutdown) cannot leak a permit or a counter.
 `Memory.append_from_tool_results` / `compact_if_needed` carry no internal lock; they are safe today only
 because the turn lane calls them single-fiber-per-keeper. Detaching (3) while (1) still ran inline
 would let two fibers touch the same keeper's memory bank concurrently. Therefore **(1) (2) (3) — all
-memory-bank-touching work — move onto the lane** (serialized per keeper by `mem_mu`). **(4) stays
+memory-bank-touching work — move onto the lane** (serialized by the keeper's FIFO worker). **(4) stays
 inline**: it only reads the typed turn history and writes the *decision* log, a separate
 file independent of (1)(2)(3).
 
 ### Separate keeper ordering from provider-pool protection
 
 The old global slot mixed two concerns: per-keeper memory ordering and provider-pool
-protection. Per-keeper ordering now comes from `Keeper_memory_lane.mem_mu`. Provider-pool
+protection. Per-keeper ordering now comes from `Keeper_memory_lane`'s FIFO worker. Provider-pool
 protection remains as a separate, optional fleet-wide gate around the provider round-trip only.
 That gate is not a memory-ordering primitive and does not serialize deterministic writes or
 compaction.
@@ -97,7 +99,7 @@ on the lane. The data the unit reads must not race that later turn:
   and the immutable snapshot is passed into the unit — so a later turn's
   emissions cannot fold into this turn's notes.
 - The remaining shared mutable state is the on-disk memory bank, which the
-  lane's per-keeper mutex serializes.
+  lane's single per-keeper worker serializes.
 
 ## Accepted consequence
 
@@ -115,13 +117,13 @@ provider concurrency gate** around librarian calls:
 - The wait is a fixed 0.25s best-effort acquisition window. It is deliberately not another
   environment knob; the capacity is the operator-controlled variable.
 
-Per-keeper lane fairness is preserved (`mem_mu` still orders each keeper's units), while the shared
+Per-keeper lane fairness is preserved (one FIFO worker orders each keeper's units), while the shared
 pool is protected from the empty-response storm observed in #21230. Lane independence and provider
 pool protection are now handled on separate axes rather than pretending one implies the other.
 
 Memory writes become eventually consistent: a keeper's turn N+1 can begin before turn N's
 deterministic note lands, so recall on turn N+1 may miss turn N's note. Ordering within a keeper is
-preserved by `mem_mu` (turn N completes before turn N+1 on the lane).
+preserved by the FIFO (turn N completes before turn N+1 on the lane).
 
 ## Relationship to #21408 (mutually exclusive)
 
@@ -129,13 +131,13 @@ PR #21408 is a competing solution to the same underlying problem: the old proces
 `provider_slot` serialized every keeper's librarian work fleet-wide. #21408 keeps the slot concept
 but re-implements it as a per-keeper `Hashtbl` registry of slots (`provider_slot_for keeper_id`),
 while #21376 (this RFC) removes the slot entirely and moves serialization into the per-keeper
-memory lane (`Keeper_memory_lane.mem_mu`). The two PRs touch the same lines in
+memory lane (`Keeper_memory_lane`). The two PRs touch the same lines in
 `keeper_librarian_runtime.ml` in opposite directions (one modifies `provider_slot`; the other deletes
 it), so they are textually and semantically mutually exclusive — both cannot merge.
 
 **Recommendation: keep #21376 and close #21408.** The per-keeper lane in #21376 already subsumes the
-per-keeper serialization goal of #21408 (`mem_mu` orders each keeper's units independently), and it
-does so with a cleaner architecture (lane admission + bounded queue + leak-safety tests). The
+per-keeper serialization goal of #21408 (one FIFO worker orders each keeper's units independently),
+and it does so with a cleaner architecture (lane ownership + explicit queue + leak-safety tests). The
 fleet-wide provider-pool gate added above covers the shared-pool protection that #21408 was trying
 to re-introduce. Merging both would create two concurrent primitives for the same concern.
 
@@ -145,18 +147,17 @@ PRs must end before either merges.
 
 ## Known limitations
 
-- Executor fibers are owned by the server root switch, not the per-keeper supervisor switch
+- Drain workers are owned by the server root switch, not the per-keeper supervisor switch
   (`keeper_supervisor_launch.ml`). If a keeper is stopped/recovered while a memory unit is in flight,
-  that unit runs to completion rather than being cancelled with the keeper. The work is bounded and
-  best-effort, writing only to that keeper's own memory bank, so the blast radius is one stale
-  extraction. Tying memory units to keeper lifecycle is deferred.
+  that unit runs to completion rather than being cancelled with the keeper.
+- The FIFO preserves accepted work during the current server lifetime but stores closures in memory.
+  Root-switch shutdown explicitly abandons and counts unfinished units; restart replay requires the
+  durable due/start/success/failure receipt tracked by production-hardening issue #23925 item 31.
 
 ## Runtime tunables and metrics
 
 Per-keeper lane:
 
-- `MASC_KEEPER_MEMORY_LANE_MAX_PENDING` (default `2`): reservation bound per keeper. Values `< 1`
-  are clamped to `1`.
 - `masc_keeper_memory_lane_submitted_total`
 - `masc_keeper_memory_lane_ran_inline_total`
 - `masc_keeper_memory_lane_dropped_total`
@@ -168,18 +169,19 @@ Fleet-wide librarian provider gate:
 - `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` (default `1`)
 - `masc_keeper_memory_lane_provider_slot_busy_total`
 
-Saturation and provider-slot-busy events are also logged at WARN level with the keeper name.
+Exceptional queue abandonment and provider-slot-busy events are also logged at WARN level with the
+keeper name.
 
 ## Tests
 
 `test/test_keeper_memory_lane.ml`:
 
 - ungated path when executor not initialized falls back to inline (no lost work in tests).
-- `mem_mu` serializes two submissions for the same keeper (second runs after the first releases).
+- one FIFO worker serializes submissions for the same keeper.
 - two different keepers run concurrently (no cross-keeper blocking).
-- `pending` over `max_pending` drops and counts the submission.
-- a submitted unit that raises releases `mem_mu` and decrements `pending` (no leak).
-- cancelling the executor switch while a unit is in flight releases `mem_mu` and decrements
+- a backlog larger than two units is accepted, drained without loss, and preserves FIFO order.
+- a submitted unit that raises decrements `pending` and the worker continues (no leak).
+- cancelling the executor switch while a unit is in flight clears worker ownership and decrements
   `pending`.
 
 ## Rollback

--- a/docs/rfc/RFC-0260-provider-health-gate-audited-failover.md
+++ b/docs/rfc/RFC-0260-provider-health-gate-audited-failover.md
@@ -2,18 +2,15 @@
 
 - Status: Draft
 - Date: 2026-06-19
-- Related: RFC-0257 (per-keeper memory lane / fleet-wide librarian provider gate), RFC-0153 (runtime backpressure and admission)
+- Related: RFC-0257 (per-keeper memory lane), RFC-0153 (runtime backpressure and admission)
 - Origin: 2026-06-19 product adversarial audit — re-verification of P0-1 (runtime provider control) and P0-4 (librarian).
 
 ## Why this exists (and why it is NOT a librarian RFC)
 
-The 2026-06-19 audit raised P0-4 "librarian not trustable." Re-verification found the librarian's
-concurrency/slot concern is already owned and implemented by RFC-0257
-(`lib/keeper/keeper_memory_lane.ml`; the `with_provider_slot` capacity gate in
-`keeper_librarian_runtime.ml` is deliberately retained as a fleet-wide provider gate, not a bug).
-The `slot busy (capacity=1)` drop is an **accepted consequence** documented in RFC-0257
-§"Accepted consequence" (unbounded concurrency spiked empty-response to 62%, #21230). A new
-librarian RFC would duplicate RFC-0257.
+The 2026-06-19 audit raised P0-4 "librarian not trustable." RFC-0257 owns Keeper-local ordering
+through `Keeper_memory_lane`. It does not own provider-fleet admission: the later per-Keeper
+`with_provider_slot` gate duplicated the lane and discarded extraction after a hardcoded wait, so
+it was retired. Provider capacity, health, and fallback belong to this runtime/provider boundary.
 
 What is NOT owned anywhere is the **provider-availability** axis that actually produced the live
 residual. After the 2026-06-19 dawn RunPod outage and the 12:25 restart, librarian routing was
@@ -36,8 +33,8 @@ provider health and failover, not the librarian.
 
 3. **Failover overloads the shared librarian pool.** Routing the whole fleet onto `ollama_cloud`
    put every keeper's librarian round-trip onto one provider. Even after `librarian=minimax-m3`
-   went live, librarian still logged empty/timeout — a provider-availability symptom the RFC-0257
-   slot gate can backpressure but cannot cure.
+   went live, librarian still logged empty/timeout. A Keeper-local gate cannot represent provider
+   capacity; the runtime must expose and enforce that capacity without coupling Keeper lanes.
 
 Net: provider outages are (a) undetected, (b) recovered by untracked manual edits with no audit
 trail, (c) followed by degraded dependent subsystems (librarian) until the operator manually
@@ -45,7 +42,7 @@ reverts.
 
 ## Non-goals
 
-- Librarian concurrency / lane / slot — owned by RFC-0257 (implemented). Do not re-touch.
+- Keeper-local librarian ordering — owned by RFC-0257. Do not add a second MASC lane or slot.
 - Librarian model JSON capability — already fixed (`deepseek-flash` JSON gap → `minimax-m3`, #21521).
 - Mutex poison hardening — separate latent-defect concern, scoped out by RFC-0256.
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 361 unique knobs across 10 modules.
+**Total**: 360 unique knobs across 10 modules.
 
-**Typed getter classification**: 54/223 tagged (`operator`: 54, `algorithm`: 0, `unclassified`: 169).
+**Typed getter classification**: 53/222 tagged (`operator`: 53, `algorithm`: 0, `unclassified`: 169).
 
 ## Env_config_core (27 knobs; typed classification 3/8)
 
@@ -85,17 +85,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (94 knobs; typed classification 31/81)
+## Env_config_keeper (93 knobs; typed classification 30/80)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 599 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 975 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 1010 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 1011 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 1012 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 1013 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 1016 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 585 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 961 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 996 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 997 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 998 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 999 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 1002 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 148 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 145 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 151 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 167 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 158 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 160 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 846 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 898 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 832 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 884 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,67 +122,66 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 918 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 429 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 455 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 445 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 465 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 435 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 904 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 415 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 441 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 431 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 451 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 421 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 201 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 209 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 215 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 669 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 879 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 552 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 541 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 563 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 929 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 937 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 604 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 739 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 713 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 964 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 720 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 754 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 761 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 619 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATE` | typed:bool | Policies | operator | 392 | Tier-2 shared Memory OS consolidator kill switch. Default: false; invalid values fail closed to false. This gates the... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 403 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 413 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 380 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 300 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 312 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 368 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 324 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 346 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 356 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 334 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 288 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 655 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 865 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 538 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 527 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 549 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 915 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 923 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 590 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 725 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 699 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 950 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 706 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 740 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 747 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 605 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATE` | typed:bool | Policies | operator | 378 | Tier-2 shared Memory OS consolidator kill switch. Default: false; invalid values fail closed to false. This gates the... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 389 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 399 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 366 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 298 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 310 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 322 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 344 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 354 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 332 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 286 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 807 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_IDLE_DECAY_MAX_PERIODS` | typed:int | Timeouts | operator | 696 | Maximum idle-decay periods applied after a keeper has been idle longer than its effective proactive base cooldown. De... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 947 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_PROACTIVE_NOOP_BACKOFF_MAX_SHIFT` | typed:int | Timeouts | operator | 685 | Maximum exponent used by no-op cooldown backoff: [base_cooldown * (1 lsl min consecutive_noop_count value)]. Default ... |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 582 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 591 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 731 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 629 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 793 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_IDLE_DECAY_MAX_PERIODS` | typed:int | Timeouts | operator | 682 | Maximum idle-decay periods applied after a keeper has been idle longer than its effective proactive base cooldown. De... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 933 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_PROACTIVE_NOOP_BACKOFF_MAX_SHIFT` | typed:int | Timeouts | operator | 671 | Maximum exponent used by no-op cooldown backoff: [base_cooldown * (1 lsl min consecutive_noop_count value)]. Default ... |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 568 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 577 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 717 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 615 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 219 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 953 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 855 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_CHAT_WAITING_CAP` | typed:int | Concurrency | operator | 651 | Maximum chat requests allowed to park behind one keeper's admitted turn. Default preserves the previous per-keeper ca... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 793 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 636 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 502 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 512 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 492 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 939 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 841 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_CHAT_WAITING_CAP` | typed:int | Concurrency | operator | 637 | Maximum chat requests allowed to park behind one keeper's admitted turn. Default preserves the previous per-keeper ca... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 779 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 622 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 488 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 498 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 478 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 93 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 119 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 108 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 613 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 1034 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 1048 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 599 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 1020 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 1034 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -356,9 +355,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 684 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 688 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 690 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 680 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 684 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 686 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 206 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 296 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 298 |  |
@@ -367,8 +366,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 260 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 314 |  |
 | `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 316 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 638 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 640 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 634 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 636 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 300 |  |
 | `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 197 |  |
 | `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 196 |  |
@@ -381,8 +380,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 371 |  |
 | `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 373 |  |
 | `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 375 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 792 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 642 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 788 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 638 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
 | `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 199 |  |
 | `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 198 |  |
@@ -403,25 +402,25 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 173 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 172 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 200 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 768 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 804 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 644 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 764 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 800 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 640 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 449 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 814 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 726 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 728 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 730 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 732 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 794 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 748 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 810 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 722 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 724 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 726 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 728 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 790 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 744 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 54 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 51 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 784 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 786 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 780 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 782 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 158 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 846 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 848 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 850 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 842 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 844 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 846 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 92 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 116 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -237,7 +237,6 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec_default = 600.0
   let librarian_max_tokens_default = 4096
   let librarian_runtime_id_default = None
-  let librarian_global_slot_default = 1
   let gc_enabled_default = true
   let shared_consolidator_enabled_default = false
   let consolidation_enabled_default = false
@@ -254,7 +253,6 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
   let librarian_max_tokens_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
   let librarian_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
-  let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
   let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
   let shared_consolidator_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATE"
   let consolidation_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
@@ -355,18 +353,6 @@ module KeeperMemoryOs = struct
       ~default:(optional_string_default librarian_runtime_id_default)
       librarian_runtime_id_env_key
     |> nonempty_string
-  ;;
-
-  (** Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0
-      disables the gate.
-      @category Concurrency
-      @ops_class operator *)
-  let librarian_global_slot () =
-    max
-      0
-      (get_int_logged
-         librarian_global_slot_env_key
-         ~default:librarian_global_slot_default)
   ;;
 
   (** Per-keeper Memory OS GC maintenance fiber kill switch. Default: true;

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -102,7 +102,6 @@ module KeeperMemoryOs : sig
   val librarian_timeout_sec_env_key : string
   val librarian_max_tokens_env_key : string
   val librarian_runtime_id_env_key : string
-  val librarian_global_slot_env_key : string
   val gc_env_key : string
   val shared_consolidator_env_key : string
   val consolidation_env_key : string
@@ -115,7 +114,6 @@ module KeeperMemoryOs : sig
   val librarian_timeout_sec_default : float
   val librarian_max_tokens_default : int
   val librarian_runtime_id_default : string option
-  val librarian_global_slot_default : int
   val gc_enabled_default : bool
   val shared_consolidator_enabled_default : bool
   val consolidation_enabled_default : bool
@@ -136,7 +134,6 @@ module KeeperMemoryOs : sig
       provider max_tokens. Default: 4096, floored to 1. *)
 
   val librarian_runtime_id : unit -> string option
-  val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool
   val shared_consolidator_enabled : unit -> bool
   val consolidation_enabled : unit -> bool

--- a/lib/config/env_config_keeper_retry_backoff.ml
+++ b/lib/config/env_config_keeper_retry_backoff.ml
@@ -37,7 +37,12 @@ let transient_backoff_cap_sec () =
 let transient_backoff_sec (attempt : int) : float =
   let base = transient_backoff_base_sec () in
   let cap = transient_backoff_cap_sec () in
-  Float.min cap (base *. Float.of_int (1 lsl (attempt - 1)))
+  let rec grow remaining delay =
+    if remaining <= 0 || delay >= cap
+    then Float.min cap delay
+    else grow (remaining - 1) (Float.min cap (delay *. 2.0))
+  in
+  grow (max 0 (attempt - 1)) base
 ;;
 
 (** Productive retry-phase budget (seconds).  PR #13120: when a

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -602,10 +602,6 @@ let memory_entries =
       Memory_os_defaults.librarian_runtime_id_env_key
       "Optional runtime id override for librarian extraction; (none) displays the empty default";
     entry
-      ~default:(string_of_int Memory_os_defaults.librarian_global_slot_default)
-      Memory_os_defaults.librarian_global_slot_env_key
-      "Fleet-wide concurrency gate for librarian provider calls; 0 disables";
-    entry
       ~default:(string_of_bool Memory_os_defaults.gc_enabled_default)
       Memory_os_defaults.gc_env_key
       "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -102,12 +102,15 @@ let list_subdirs path =
     with Sys_error _ -> []
 
 (** Month directories matching [YYYY-MM] pattern, newest first. *)
+let is_month_dir_name d =
+  String.length d = 7
+  && d.[4] = '-'
+  && Option.is_some (int_of_string_opt (String.sub d 0 4))
+;;
+
 let list_month_dirs base_dir =
   list_subdirs base_dir
-  |> List.filter (fun d ->
-    String.length d = 7
-    && d.[4] = '-'
-    && Option.is_some (int_of_string_opt (String.sub d 0 4)))
+  |> List.filter is_month_dir_name
 
 (** Day files matching [DD.jsonl], newest first. *)
 let list_day_files month_path =
@@ -288,7 +291,7 @@ let prune_to_max_bytes_unlocked t ~max_bytes ~keep_path =
 
 (* ── Public API ───────────────────────────────────────── *)
 
-let append_unlocked ?max_current_file_bytes t json =
+let append_unlocked ?max_current_file_bytes ?(durable = false) t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
      IO failure, so retry paths can keep using the same registry entry.
@@ -310,27 +313,38 @@ let append_unlocked ?max_current_file_bytes t json =
     if not fits_current_file
     then false
     else begin
-      Jsonl_writer.append_jsonl ~path:dated.path json;
-      (match t.retention_days with
-       | None -> ()
-       | Some days ->
-         let today = dated.month_dir ^ "/" ^ dated.day_file in
-         if
-           not
-             (Option.equal String.equal
-                (Atomic.get t.last_prune_day)
-                (Some today))
-         then begin
-           (* See retention pruning is opportunistic after append durability. *)
-           ignore (prune_unlocked t ~days : int);
-           Atomic.set t.last_prune_day (Some today)
-         end);
-      (match t.max_bytes with
-       | None -> ()
-       | Some max_bytes ->
-         (* See byte-budget pruning is best-effort cleanup after append. *)
-         ignore
-           (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int));
+      if durable
+      then Jsonl_writer.append_jsonl_durable ~path:dated.path json
+      else Jsonl_writer.append_jsonl ~path:dated.path json;
+      let cleanup label f =
+        try f () with
+        | exn ->
+          Stdlib.Printf.eprintf
+            "[dated_jsonl] post-append %s failed store=%s: %s\n%!"
+            label
+            t.base_dir
+            (Printexc.to_string exn)
+      in
+      cleanup "retention" (fun () ->
+        match t.retention_days with
+        | None -> ()
+        | Some days ->
+          let today = dated.month_dir ^ "/" ^ dated.day_file in
+          if
+            not
+              (Option.equal String.equal
+                 (Atomic.get t.last_prune_day)
+                 (Some today))
+          then begin
+            ignore (prune_unlocked t ~days : int);
+            Atomic.set t.last_prune_day (Some today)
+          end);
+      cleanup "byte-budget" (fun () ->
+        match t.max_bytes with
+        | None -> ()
+        | Some max_bytes ->
+          ignore
+            (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int));
       true
     end)
 
@@ -338,6 +352,10 @@ let append_inner t json = ignore (append_unlocked t json : bool)
 
 let append t json =
   (Atomic.get append_guard) (fun () -> append_inner t json)
+
+let append_durable t json =
+  (Atomic.get append_guard) (fun () ->
+    ignore (append_unlocked ~durable:true t json : bool))
 
 let append_if_current_file_fits t ~max_current_file_bytes json =
   let appended = ref false in
@@ -431,6 +449,112 @@ let iter_all t f =
          (fun d -> iter_json_file (Filename.concat month_path d) f)
          days)
     months
+
+type strict_read_error =
+  { path : string
+  ; line_number : int option
+  ; detail : string
+  }
+
+let strict_read_error ?line_number path detail =
+  Error { path; line_number; detail }
+;;
+
+let strict_dated_paths base_dir =
+  match Unix.lstat base_dir with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok []
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+  | exception exn -> strict_read_error base_dir (Printexc.to_string exn)
+  | root_stat when root_stat.Unix.st_kind <> Unix.S_DIR ->
+    strict_read_error base_dir "dated JSONL root is not a real directory"
+  | _ ->
+    (try
+        let months =
+          Sys.readdir base_dir
+          |> Array.to_list
+          |> List.filter is_month_dir_name
+          |> List.sort String.compare
+        in
+        let rec collect_months paths = function
+          | [] -> Ok (List.rev paths)
+          | month :: rest ->
+            let month_path = Filename.concat base_dir month in
+            let month_stat = Unix.lstat month_path in
+            if month_stat.Unix.st_kind <> Unix.S_DIR
+            then
+              strict_read_error
+                month_path
+                "dated JSONL month is not a real directory"
+            else
+              let days =
+                Sys.readdir month_path
+                |> Array.to_list
+                |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+                |> List.sort String.compare
+              in
+              let rec collect_days month_paths = function
+                | [] ->
+                  let month_paths = List.rev month_paths in
+                  collect_months (List.rev_append month_paths paths) rest
+                | day :: remaining ->
+                  let path = Filename.concat month_path day in
+                  let stat = Unix.lstat path in
+                  if stat.Unix.st_kind <> Unix.S_REG
+                  then strict_read_error path "dated JSONL day is not a regular file"
+                  else collect_days (path :: month_paths) remaining
+              in
+              collect_days [] days
+        in
+        collect_months [] months
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> strict_read_error base_dir (Printexc.to_string exn))
+;;
+
+let fold_file_strict path ~init ~f =
+  try
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let rec loop line_number acc =
+           match input_line ic with
+           | line ->
+             if String.equal (String.trim line) ""
+             then loop (line_number + 1) acc
+             else
+               (match
+                  try Ok (Yojson.Safe.from_string line) with
+                  | Yojson.Json_error detail -> Error detail
+                with
+                | Error detail -> strict_read_error ~line_number path detail
+                | Ok json ->
+                  (match f acc json with
+                   | Ok next -> loop (line_number + 1) next
+                   | Error detail -> strict_read_error ~line_number path detail))
+           | exception End_of_file -> Ok acc
+         in
+         loop 1 init)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> strict_read_error path (Printexc.to_string exn)
+;;
+
+let fold_all_strict t ~init ~f =
+  let mutex = Atomic.get t.mutex in
+  Eio.Mutex.use_ro mutex (fun () ->
+    match strict_dated_paths t.base_dir with
+    | Error _ as error -> error
+    | Ok paths ->
+      let rec loop acc = function
+        | [] -> Ok acc
+        | path :: rest ->
+          (match fold_file_strict path ~init:acc ~f with
+           | Error _ as error -> error
+           | Ok next -> loop next rest)
+      in
+      loop init paths)
+;;
 
 let iter_range t ~since ~until f =
   match parse_date since, parse_date until with

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -29,6 +29,10 @@ val append : t -> Yojson.Safe.t -> unit
 (** Append [json] to today's [DD.jsonl] inside [YYYY-MM/].
     Creates directories as needed.  Thread-safe via internal mutex. *)
 
+val append_durable : t -> Yojson.Safe.t -> unit
+(** Append one row and fsync the current day file before returning. Retention
+    and byte-budget cleanup run only after that durability boundary. *)
+
 val append_if_current_file_fits :
   t -> max_current_file_bytes:int -> Yojson.Safe.t -> bool
 (** Append [json] only when today's current [DD.jsonl] would remain at or
@@ -76,6 +80,20 @@ val iter_all : t -> (Yojson.Safe.t -> unit) -> unit
 (** [iter_all t f] calls [f] for every parseable JSONL entry in chronological
     order without loading a whole day-file into memory. Malformed rows are
     skipped, matching {!read_recent} and {!read_range}. *)
+
+type strict_read_error =
+  { path : string
+  ; line_number : int option
+  ; detail : string
+  }
+
+val fold_all_strict :
+  t ->
+  init:'acc ->
+  f:('acc -> Yojson.Safe.t -> ('acc, string) result) ->
+  ('acc, strict_read_error) result
+(** Fold every dated row without skipping malformed JSON, I/O failures, or
+    callback schema errors. The first failure carries its exact path and line. *)
 
 val iter_range : t -> since:string -> until:string -> (Yojson.Safe.t -> unit) -> unit
 (** Streaming variant of {!read_range}. Invalid dates iterate zero rows. *)

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -22,6 +22,15 @@ let fsync_path path =
         ())
 ;;
 
+let fsync_directory path =
+  try
+    fsync_path path;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "fsync directory %s: %s" path (Printexc.to_string exn))
+;;
+
 (* #10205 finding 2: keep the atomic-tmp filename shape in one place
    so the writer ([save_file_atomic]) and the orphan-sweep matcher
    ([is_atomic_orphan_name]) cannot drift independently. A
@@ -45,8 +54,7 @@ let save_file_atomic
     save_file tmp content;
     fsync_path tmp;
     Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
+    fsync_path dir;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->
@@ -68,6 +76,44 @@ let is_atomic_orphan_name name =
   && String.ends_with ~suffix:atomic_tmp_suffix name
 ;;
 
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~mkdir_p_unix ~path ~recovered_dir =
+  let name = Stdlib.Filename.basename path in
+  if not (is_atomic_orphan_name name)
+  then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
+  else
+    try
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind <> Unix.S_REG
+      then Error (Printf.sprintf "atomic-write orphan is not a regular file: %s" path)
+      else if stat.Unix.st_size = 0
+      then (
+        Stdlib.Sys.remove path;
+        fsync_path (Stdlib.Filename.dirname path);
+        Ok Deleted_zero_length)
+      else (
+        mkdir_p_unix recovered_dir;
+        let destination = Stdlib.Filename.concat recovered_dir name in
+        if Stdlib.Sys.file_exists destination
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery destination already exists: %s"
+               destination)
+        else (
+          Stdlib.Sys.rename path destination;
+          fsync_path (Stdlib.Filename.dirname path);
+          if not (String.equal recovered_dir (Stdlib.Filename.dirname path))
+          then fsync_path recovered_dir;
+          Ok (Preserved_nonempty destination)))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
+;;
+
 let cleanup_atomic_orphans
   ~(mkdir_p_unix : string -> unit)
   ~(base_path : string)
@@ -83,32 +129,40 @@ let cleanup_atomic_orphans
      [mkdir_p_unix] is recursive, idempotent (handles [EEXIST] precisely
      instead of swallowing every [Unix_error]), and correct when
      [base_path] itself does not exist yet (boot-time race). *)
-  let ensure_recovered_dir () =
-    try mkdir_p_unix recovered_dir with
-    | Unix.Unix_error _ -> ()
+  let report_error detail =
+    Stdlib.Printf.eprintf "[fs_compat] atomic orphan sweep: %s\n%!" detail
+  in
+  let ensure_recovered_dir path =
+    try
+      mkdir_p_unix path;
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Printf.sprintf
+           "cannot create recovered directory %s: %s"
+           path
+           (Printexc.to_string exn))
   in
   let handle_file dir name =
     let path = Stdlib.Filename.concat dir name in
-    match Unix.stat path with
-    | exception Unix.Unix_error _ -> ()
-    | stat when stat.Unix.st_size = 0 ->
-      (try
-         Stdlib.Sys.remove path;
-         incr deleted
+    let bucket =
+      if String.equal dir base_path then "root" else Stdlib.Filename.basename dir
+    in
+    let file_recovered_dir = Stdlib.Filename.concat recovered_dir bucket in
+    match ensure_recovered_dir file_recovered_dir with
+    | Error detail -> report_error detail
+    | Ok () ->
+      (match
+         recover_atomic_orphan
+           ~mkdir_p_unix
+           ~path
+           ~recovered_dir:file_recovered_dir
        with
-       | Sys_error _ -> ())
-    | _stat ->
-      ensure_recovered_dir ();
-      let target =
-        Stdlib.Filename.concat
-          recovered_dir
-          (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
-      in
-      (try
-         Stdlib.Sys.rename path target;
-         incr preserved
-       with
-       | Sys_error _ | Unix.Unix_error _ -> ())
+       | Ok Deleted_zero_length -> incr deleted
+       | Ok (Preserved_nonempty _) -> incr preserved
+       | Error detail -> report_error detail)
   in
   let scan_dir dir entries =
     Array.iter
@@ -117,7 +171,9 @@ let cleanup_atomic_orphans
   in
   let read_dir_entries dir =
     match Stdlib.Sys.readdir dir with
-    | exception Sys_error _ -> [||]
+    | exception Sys_error detail ->
+      report_error (Printf.sprintf "cannot list %s: %s" dir detail);
+      [||]
     | entries -> entries
   in
   (* #10205 finding 4: previous body called [Stdlib.Sys.readdir base_path]
@@ -132,8 +188,15 @@ let cleanup_atomic_orphans
       then ()
       else (
         let sub = Stdlib.Filename.concat base_path name in
-        match Unix.stat sub with
-        | exception Unix.Unix_error _ -> ()
+        match Unix.lstat sub with
+        | exception Unix.Unix_error (error, operation, argument) ->
+          report_error
+            (Printf.sprintf
+               "cannot inspect %s: %s (%s %s)"
+               sub
+               (Unix.error_message error)
+               operation
+               argument)
         | stat when stat.Unix.st_kind = Unix.S_DIR ->
           scan_dir sub (read_dir_entries sub)
         | _ -> ()))

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -30,11 +30,28 @@ val save_file_atomic
   -> string
   -> (unit, string) Result.t
 
+val fsync_directory : string -> (unit, string) result
+(** Durably publish prior directory-entry changes. Unsupported-filesystem
+    [EINVAL]/[EOPNOTSUPP] is treated as success by the underlying portability
+    boundary; every other failure is returned explicitly. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] shape produced
     by {!save_file_atomic}. Exposed so a periodic sweep can match
     the same filename pattern without re-deriving the prefix and
     suffix — #10205 finding 2. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  mkdir_p_unix:(string -> unit)
+  -> path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan. Zero-length files are
+    deleted; non-empty files are moved without overwrite for forensic review. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 
@@ -42,8 +59,8 @@ val is_atomic_orphan_name : string -> bool
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted (they lost the rename race
       but never held data).
-    - Non-zero orphans are MOVED to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are MOVED into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -198,6 +198,39 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let append_file_durable_unix (path : string) (content : string) : unit =
+  let mu = get_append_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let fd =
+        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+      in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+          let rec write_all offset =
+            if offset < String.length content
+            then
+              let wrote =
+                Unix.write_substring
+                  fd
+                  content
+                  offset
+                  (String.length content - offset)
+              in
+              if wrote = 0
+              then raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+              else write_all (offset + wrote)
+          in
+          write_all 0;
+          Unix.fsync fd);
+      match Atomic_write.fsync_directory (Filename.dirname path) with
+      | Ok () -> ()
+      | Error detail -> raise (Sys_error detail))
+;;
+
 let mkdir_p_unix (path : string) : unit =
   let rec ensure_dir (p : string) : unit =
     if String.equal p "" || String.equal p "." || String.equal p "/"
@@ -241,7 +274,20 @@ let save_file_atomic path content =
   Atomic_write.save_file_atomic ~save_file path content
 ;;
 
+let fsync_directory path = Atomic_write.fsync_directory path
+
 let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
+
+type atomic_orphan_recovery = Atomic_write.atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~path ~recovered_dir =
+  Atomic_write.recover_atomic_orphan
+    ~mkdir_p_unix
+    ~path
+    ~recovered_dir
+;;
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
   Atomic_write.cleanup_atomic_orphans ~mkdir_p_unix ~base_path ?recovered_subdir ()
@@ -258,6 +304,13 @@ let append_file (path : string) (content : string) : unit =
     (fun fs ->
        let eio_path = Eio.Path.(fs / path) in
        Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
+;;
+
+let append_file_durable path content =
+  test_exec_home_guard ~op:"append_file_durable" path;
+  match Atomic.get global_fs with
+  | Some _ -> Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content)
+  | None -> append_file_durable_unix path content
 ;;
 
 (** Check if file exists.

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -38,11 +38,26 @@ val save_file : string -> string -> unit
     Returns [Error msg] on I/O failure instead of raising. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
+val fsync_directory : string -> (unit, string) result
+(** Durably publish directory-entry changes without hiding unsupported I/O
+    failures. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
     {!save_file_atomic}.  Exposed for tests and for a potential
     periodic sweep. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan using the same policy as
+    {!cleanup_atomic_orphans}, while preserving failures as typed results. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
@@ -52,8 +67,8 @@ val is_atomic_orphan_name : string -> bool
     Scans [base_path] and its immediate subdirectories (skipping
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted.
-    - Non-zero orphans are moved to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are moved into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 
@@ -68,6 +83,11 @@ val cleanup_atomic_orphans
 
 (** Append string to file. *)
 val append_file : string -> string -> unit
+
+(** Append the complete byte string under the per-path append lock and fsync the
+    file before returning. Runtime calls execute the blocking fd operations in
+    a system thread. *)
+val append_file_durable : string -> string -> unit
 
 (** Check if file exists. *)
 val file_exists : string -> bool

--- a/lib/jsonl_writer/jsonl_writer.ml
+++ b/lib/jsonl_writer/jsonl_writer.ml
@@ -24,6 +24,28 @@ let dated_path_now ~base_dir =
 let append_jsonl ~path json =
   Fs_compat.append_jsonl path json
 
+let ensure_parent_durable path =
+  let dir = Filename.dirname path in
+  let rec missing current acc =
+    if Fs_compat.file_exists current
+       || String.equal current (Filename.dirname current)
+    then acc
+    else missing (Filename.dirname current) (current :: acc)
+  in
+  let created = missing dir [] in
+  Fs_compat.mkdir_p dir;
+  List.iter
+    (fun created_dir ->
+       match Fs_compat.fsync_directory (Filename.dirname created_dir) with
+       | Ok () -> ()
+       | Error detail -> raise (Sys_error detail))
+    created
+;;
+
+let append_jsonl_durable ~path json =
+  ensure_parent_durable path;
+  Fs_compat.append_file_durable path (Yojson.Safe.to_string json ^ "\n")
+
 let append_dated_jsonl ~base_dir ~ts json =
   let dated = dated_path ~base_dir ~ts in
   append_jsonl ~path:dated.path json;

--- a/lib/jsonl_writer/jsonl_writer.mli
+++ b/lib/jsonl_writer/jsonl_writer.mli
@@ -22,6 +22,9 @@ val dated_path_now : base_dir:string -> dated_path
 val append_jsonl : path:string -> Yojson.Safe.t -> unit
 (** Append one JSON value as a JSONL row using the common per-path writer. *)
 
+val append_jsonl_durable : path:string -> Yojson.Safe.t -> unit
+(** Append one JSON value and fsync the file before returning. *)
+
 val append_dated_jsonl :
   base_dir:string -> ts:float -> Yojson.Safe.t -> dated_path
 (** Append one JSON value to the timestamp-selected dated path and return the

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -24,6 +24,11 @@ type operator_disposition =
   ; reason : Keeper_execution_receipt.operator_disposition_reason
   }
 
+type post_turn_memory_job =
+  { durable_job : Keeper_memory_job_store.job
+  ; tool_results_to_restore : Yojson.Safe.t list
+  }
+
 let tool_call_detail_to_json (detail : tool_call_detail) =
   let route_evidence_field =
     match detail.route_evidence with
@@ -86,6 +91,7 @@ type run_result =
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
   ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
+  ; post_turn_memory_job : post_turn_memory_job option
   ; tool_surface : tool_surface_metrics
   ; pre_dispatch_compacted : bool
   ; pre_dispatch_compaction_trigger : string option

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -23,6 +23,14 @@ type operator_disposition =
   ; reason : Keeper_execution_receipt.operator_disposition_reason
   }
 
+type post_turn_memory_job =
+  { durable_job : Keeper_memory_job_store.job
+  ; tool_results_to_restore : Yojson.Safe.t list
+  }
+(** Turn-local ownership for a staged durable job. The immutable tool snapshot
+    is restored to the Keeper accumulator only when the owning execution
+    receipt fails and the non-runnable outbox is aborted. *)
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -41,6 +49,7 @@ type run_result =
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
   ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
+  ; post_turn_memory_job : post_turn_memory_job option
   ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   ; pre_dispatch_compacted : bool
   ; pre_dispatch_compaction_trigger : string option

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -435,7 +435,7 @@ let finalize
                         completion_contract_result) );
                ])
            Keeper_runtime_manifest.Checkpoint_saved;
-         Ok (Some patched)
+         Ok (Some patched, patched)
        | Ok (Keeper_checkpoint_store.Stale_noop
                 { incoming_turn_count; known_turn_count }) ->
          Log.Keeper.warn ~keeper_name:meta.name
@@ -446,7 +446,11 @@ let finalize
            "masc_keeper_checkpoint_stale_noop_total"
            ~labels:[ "keeper", meta.name; "site", "finalize" ]
            ();
-         Ok None
+         (* The canonical checkpoint remains at the newer watermark, but this
+            turn's immutable patched checkpoint is still the exact input for
+            its durable post-turn memory job. It is never written back to the
+            canonical OAS path. *)
+         Ok (None, patched)
        | Error e ->
          Log.Keeper.error ~keeper_name:meta.name
            "runtime=%s OAS checkpoint save failed: %s"
@@ -475,28 +479,74 @@ let finalize
   in
   match saved_checkpoint_result with
   | Error e -> Error e
-  | Ok saved_checkpoint ->
+  | Ok (saved_checkpoint, librarian_checkpoint) ->
+    (* Consume the per-keeper hook accumulator exactly once. The immutable
+       snapshot fans out to the durable memory job and, after durable admission,
+       to the post-turn multimodal working context. This also covers stale-noop
+       checkpoint saves, where the later lifecycle has [checkpoint=None] and
+       therefore cannot drain the accumulator itself. *)
+    let tool_emission_accumulator =
+      Keeper_tool_emission_hook.accumulator_for_keeper meta.name
+    in
+    let taken_tool_results =
+      Keeper_tool_emission_hook.take_all tool_emission_accumulator
+    in
+    let tool_results_snapshot =
+      if Keeper_tool_emission_hook.masc_tool_emission_enabled ()
+      then Some taken_tool_results
+      else None
+    in
     (* Contract-verification proof evaluation / verdict-ledger persistence removed: task/goal
        completion is verified by [Task_completion_gate] (evidence-substantiveness),
        not by an internal proof/verdict pipeline. *)
-    let librarian_messages =
-      match saved_checkpoint with
-      | Some checkpoint -> checkpoint.Agent_sdk.Checkpoint.messages
-      | None -> Option.to_list assistant_msg
+    let memory_submission =
+      Keeper_agent_run_post_turn_memory.run
+        ~config
+        ~meta
+        ~generation
+        ~turn:manifest_keeper_turn_id
+        ~oas_turn_count:result.turns
+        ~response_text
+        ~actual_tools:actual_keeper_tool_names
+        ~librarian_checkpoint
+        ~tool_results_snapshot
+        ~post_turn_t0
+        ~runtime_id:runtime_id_string
+        ~inference_telemetry:result.response.telemetry
+        ()
     in
-    Keeper_agent_run_post_turn_memory.run
-      ~config
-      ~meta
-      ~generation
-      ~turn:manifest_keeper_turn_id
-      ~oas_turn_count:result.turns
-      ~response_text
-      ~actual_tools:actual_keeper_tool_names
-      ~librarian_messages
-      ~post_turn_t0
-      ~runtime_id:runtime_id_string
-      ~inference_telemetry:result.response.telemetry
-      ();
+    let saved_checkpoint =
+      match memory_submission, tool_results_snapshot, saved_checkpoint with
+      | Keeper_agent_run_post_turn_memory.Durable _, Some items, Some checkpoint ->
+        let working_context =
+          Keeper_tool_emission_hook.emit_snapshot_into_working_context
+            items
+            ~working_context:checkpoint.Agent_sdk.Checkpoint.working_context
+        in
+        Some
+          { checkpoint with
+            Agent_sdk.Checkpoint.working_context = working_context
+          }
+      | Keeper_agent_run_post_turn_memory.Not_durable, Some items, checkpoint ->
+        Keeper_tool_emission_hook.restore tool_emission_accumulator items;
+        checkpoint
+      | ( Keeper_agent_run_post_turn_memory.Durable _
+        | Keeper_agent_run_post_turn_memory.Not_durable )
+        , None
+        , checkpoint -> checkpoint
+      | Keeper_agent_run_post_turn_memory.Durable _, Some _, None -> None
+    in
+    let post_turn_memory_job =
+      match memory_submission with
+      | Keeper_agent_run_post_turn_memory.Durable durable_job ->
+        Some
+          Keeper_agent_result.
+            { durable_job
+            ; tool_results_to_restore =
+                Option.value tool_results_snapshot ~default:[]
+            }
+      | Keeper_agent_run_post_turn_memory.Not_durable -> None
+    in
     Ok
       { response_text
       ; model_used = model
@@ -514,6 +564,7 @@ let finalize
       ; run_validation = result.run_validation
       ; stop_reason = result.stop_reason
       ; inference_telemetry = result.response.telemetry
+      ; post_turn_memory_job
       ; tool_surface = acc.tool_surface
       ; pre_dispatch_compacted
       ; pre_dispatch_compaction_trigger

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -2,203 +2,650 @@
 
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-4). *)
 
-let default_post_turn_procedure_candidate_limit = 8
+let post_turn_job_payload_schema = "masc.keeper_post_turn_memory_job.v2"
+
+type stage_name =
+  | Tool_result_promotion
+  | Librarian_extraction
+  | Skill_candidate_projection
+  | Memory_bank_compaction
+
+type stage_status =
+  | Stage_succeeded
+  | Stage_skipped
+  | Stage_failed
+
+type submission_outcome =
+  | Durable of Keeper_memory_job_store.job
+  | Not_durable
+
+type stage_result =
+  { name : stage_name
+  ; status : stage_status
+  ; failure_retryability : Keeper_memory_lane.retryability option
+  ; detail : Yojson.Safe.t
+  ; error : string option
+  }
+
+type job_payload =
+  { meta : Keeper_meta_contract.keeper_meta
+  ; runtime_id : string
+  ; librarian_admission : Keeper_librarian_runtime.librarian_admission_decision
+  ; librarian_checkpoint : Agent_sdk.Checkpoint.t
+  ; tool_results : Yojson.Safe.t list option
+  }
+
+let stage_name_to_string = function
+  | Tool_result_promotion -> "tool_result_promotion"
+  | Librarian_extraction -> "librarian_extraction"
+  | Skill_candidate_projection -> "skill_candidate_projection"
+  | Memory_bank_compaction -> "memory_bank_compaction"
+;;
+
+let stage_status_to_string = function
+  | Stage_succeeded -> "succeeded"
+  | Stage_skipped -> "skipped"
+  | Stage_failed -> "failed"
+;;
+
+let stage_to_json stage =
+  `Assoc
+    [ "name", `String (stage_name_to_string stage.name)
+    ; "status", `String (stage_status_to_string stage.status)
+    ; ( "failure_retryability"
+      , match stage.failure_retryability with
+        | None -> `Null
+        | Some Keeper_memory_lane.Retryable -> `String "retryable"
+        | Some Keeper_memory_lane.Terminal -> `String "terminal" )
+    ; "detail", stage.detail
+    ; "error", Json_util.string_opt_to_json stage.error
+    ]
+;;
+
+let stage_succeeded name detail =
+  { name
+  ; status = Stage_succeeded
+  ; failure_retryability = None
+  ; detail
+  ; error = None
+  }
+;;
+
+let stage_skipped name detail =
+  { name
+  ; status = Stage_skipped
+  ; failure_retryability = None
+  ; detail
+  ; error = None
+  }
+;;
+
+let stage_failed ?(retryability = Keeper_memory_lane.Terminal) name ~detail error =
+  { name
+  ; status = Stage_failed
+  ; failure_retryability = Some retryability
+  ; detail
+  ; error = Some error
+  }
+;;
+
+let protect_stage name f =
+  try f () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    stage_failed
+      name
+      ~detail:`Null
+      (Printexc.to_string exn)
+;;
+
+let librarian_checkpoint_for_job (checkpoint : Agent_sdk.Checkpoint.t) =
+  { checkpoint with
+    messages =
+      Keeper_librarian_runtime.prompt_window_messages checkpoint.messages
+  ; system_prompt = None
+  ; tools = []
+  ; tool_choice = None
+  ; context = Agent_sdk.Context.create_sync ()
+  ; mcp_sessions = []
+  ; working_context = None
+  }
+;;
+
+let payload_to_json
+      ~meta
+      ~runtime_id
+      ~librarian_admission
+      ~librarian_checkpoint
+      ~tool_results
+  =
+  `Assoc
+    [ "schema", `String post_turn_job_payload_schema
+    ; "meta", Keeper_meta_json.meta_to_json meta
+    ; "runtime_id", `String runtime_id
+    ; ( "librarian_admission"
+      , Keeper_librarian_runtime.librarian_admission_decision_to_json
+          librarian_admission )
+    ; "librarian_checkpoint"
+      , Agent_sdk.Checkpoint.to_json
+          (librarian_checkpoint_for_job librarian_checkpoint)
+    ; ( "tool_results"
+      , match tool_results with
+        | None -> `Null
+        | Some results -> `List results )
+    ]
+;;
+
+let payload_string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be a string" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let payload_json_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let ( let* ) = Result.bind
+
+let payload_of_json = function
+  | `Assoc fields ->
+    let* schema = payload_string_field "schema" fields in
+    if not (String.equal schema post_turn_job_payload_schema)
+    then Error (Printf.sprintf "unsupported post-turn memory job schema: %s" schema)
+    else
+      let* meta_json = payload_json_field "meta" fields in
+      let* meta = Keeper_meta_json_parse.meta_of_json meta_json in
+      let* runtime_id = payload_string_field "runtime_id" fields in
+      let* librarian_admission_json =
+        payload_json_field "librarian_admission" fields
+      in
+      let* librarian_admission =
+        Keeper_librarian_runtime.librarian_admission_decision_of_json
+          librarian_admission_json
+      in
+      let* checkpoint_json = payload_json_field "librarian_checkpoint" fields in
+      let* librarian_checkpoint =
+        Agent_sdk.Checkpoint.of_json checkpoint_json
+        |> Result.map_error Agent_sdk.Error.to_string
+      in
+      let* tool_results_json = payload_json_field "tool_results" fields in
+      let* tool_results =
+        match tool_results_json with
+        | `Null -> Ok None
+        | `List results -> Ok (Some results)
+        | _ -> Error "field tool_results must be null or a list"
+      in
+      Ok
+        { meta
+        ; runtime_id
+        ; librarian_admission
+        ; librarian_checkpoint
+        ; tool_results
+        }
+  | _ -> Error "post-turn memory job payload must be an object"
+;;
+
+let compaction_error_to_string = function
+  | Memory.Read_error -> "memory bank read failed"
+  | Memory.Write_error detail -> "memory bank write failed: " ^ detail
+  | Memory.Schema_mismatch -> "memory bank schema mismatch"
+;;
+
+let run_tool_result_stage
+      (config : Workspace.config)
+      (meta : Keeper_meta_contract.keeper_meta)
+      turn
+  = function
+  | None ->
+    stage_skipped
+      Tool_result_promotion
+      (`Assoc [ "reason", `String "tool_emission_disabled" ])
+  | Some tool_results ->
+    (match Memory.append_from_tool_results config meta ~turn ~results:tool_results with
+     | Error error ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string MemoryWriteFailures)
+         ~labels:[ "keeper", meta.name ]
+         ();
+       stage_failed
+         ~retryability:Keeper_memory_lane.Retryable
+         Tool_result_promotion
+         ~detail:`Null
+         error
+     | Ok notes_written ->
+       if notes_written > 0
+       then
+         Keeper_turn_telemetry.log_keeper_memory_write
+           ~keeper_name:meta.name
+           ~notes_written
+           ~kinds_written:[ "long_term" ];
+       stage_succeeded
+         Tool_result_promotion
+         (`Assoc [ "notes_written", `Int notes_written ]))
+;;
+
+let run_librarian_stage
+      ~base_path
+      (meta : Keeper_meta_contract.keeper_meta)
+      operation_id
+      generation
+      runtime_id
+      librarian_admission
+      librarian_checkpoint
+  =
+  let started_at = Time_compat.now () in
+  let latency_ms () =
+    Keeper_timing.round1 ((Time_compat.now () -. started_at) *. 1000.0)
+  in
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let keepers_dir =
+    Common.keepers_runtime_dir_of_base ~base_path
+  in
+  match
+    Keeper_memory_os_io.inspect_operation_episode
+      ~clock:(Eio_context.get_clock_opt ())
+      ~keepers_dir
+      ~keeper_id:meta.name
+      ~operation_id
+  with
+  | Error error ->
+    stage_failed
+      ~retryability:Keeper_memory_lane.Retryable
+      Librarian_extraction
+      ~detail:
+         (`Assoc
+           [ "operation_id", `String operation_id
+           ; "runtime_id", `String runtime_id
+           ; "model_id", `Null
+           ; "provider_latency_ms", `Null
+           ; "latency_ms", `Float (latency_ms ())
+           ; "next_due_after_turns", `Int 0
+           ])
+      error
+  | Ok (Keeper_memory_os_io.Operation_committed staged) ->
+    let episode = staged.Keeper_memory_os_io.episode in
+    stage_succeeded
+      Librarian_extraction
+      (`Assoc
+         [ "status", `String "succeeded"
+         ; "runtime_id", `String runtime_id
+         ; "model_id", `String staged.model_id
+         ; "operation_id", `String operation_id
+         ; "replayed_from_commit", `Bool true
+         ; "episode_generation", `Int episode.Keeper_memory_os_types.generation
+         ; "claim_count", `Int (List.length episode.claims)
+         ; "provider_latency_ms", `Float staged.provider_latency_ms
+         ; "latency_ms", `Float (latency_ms ())
+         ; "next_due_after_turns"
+           , `Int (Keeper_librarian_runtime.cadence_turns ())
+         ])
+  | Ok (Keeper_memory_os_io.Operation_staged staged) ->
+    (match
+       Keeper_librarian_runtime.commit_staged_operation
+         ~keepers_dir
+         ?clock:(Eio_context.get_clock_opt ())
+         ~keeper_id:meta.name
+         ~operation_id
+         staged
+     with
+     | Error error ->
+       stage_failed
+         ~retryability:Keeper_memory_lane.Retryable
+         Librarian_extraction
+         ~detail:
+           (`Assoc
+              [ "operation_id", `String operation_id
+              ; "runtime_id", `String runtime_id
+              ; "model_id", `String staged.model_id
+              ; "provider_latency_ms", `Float staged.provider_latency_ms
+              ; "latency_ms", `Float (latency_ms ())
+              ; "next_due_after_turns", `Int 0
+              ])
+         (Keeper_librarian_runtime.extraction_error_to_string error)
+     | Ok () ->
+       let episode = staged.Keeper_memory_os_io.episode in
+       stage_succeeded
+         Librarian_extraction
+         (`Assoc
+            [ "status", `String "succeeded"
+            ; "runtime_id", `String runtime_id
+            ; "model_id", `String staged.model_id
+            ; "operation_id", `String operation_id
+            ; "replayed_from_stage", `Bool true
+            ; "episode_generation", `Int episode.Keeper_memory_os_types.generation
+            ; "claim_count", `Int (List.length episode.claims)
+            ; "provider_latency_ms", `Float staged.provider_latency_ms
+            ; "latency_ms", `Float (latency_ms ())
+            ; "next_due_after_turns"
+              , `Int (Keeper_librarian_runtime.cadence_turns ())
+            ]))
+  | Ok Keeper_memory_os_io.Operation_absent ->
+    let input : Keeper_librarian.input =
+      { trace_id
+      ; generation
+      ; messages = librarian_checkpoint.Agent_sdk.Checkpoint.messages
+      }
+    in
+    let outcome =
+      Keeper_librarian_runtime.run_best_effort
+        ~operation_id
+        ~keepers_dir
+        ~admission_decision:librarian_admission
+        ~runtime_id
+        ~keeper_id:meta.name
+        input
+    in
+    let detail = Keeper_librarian_runtime.run_outcome_to_json outcome in
+    (match outcome with
+     | Keeper_librarian_runtime.Run_skipped _ ->
+       stage_skipped Librarian_extraction detail
+     | Keeper_librarian_runtime.Run_succeeded _ ->
+       stage_succeeded Librarian_extraction detail
+     | Keeper_librarian_runtime.Run_failed { error; _ } ->
+       let retryability =
+         match error with
+         | Keeper_librarian_runtime.Eio_context_unavailable
+         | Keeper_librarian_runtime.Runtime_resolution_failed _ ->
+           Keeper_memory_lane.Retryable
+         | Keeper_librarian_runtime.Provider_not_direct_completion
+         | Keeper_librarian_runtime.Unexpected_failure _ ->
+           Keeper_memory_lane.Terminal
+         | Keeper_librarian_runtime.Extraction_failed extraction_error ->
+           (match extraction_error with
+            | Keeper_librarian_runtime.Provider_clock_unavailable
+            | Keeper_librarian_runtime.Provider_timeout
+            | Keeper_librarian_runtime.Provider_transport_failed _
+            | Keeper_librarian_runtime.Memory_fact_upsert_failed _
+            | Keeper_librarian_runtime.Memory_episode_persistence_failed _ ->
+              Keeper_memory_lane.Retryable
+            | Keeper_librarian_runtime.Prompt_render_failed _
+            | Keeper_librarian_runtime.Provider_config_rejected _
+            | Keeper_librarian_runtime.Provider_empty_response
+            | Keeper_librarian_runtime.Provider_unparseable_response _ ->
+              Keeper_memory_lane.Terminal)
+       in
+       stage_failed
+         ~retryability
+         Librarian_extraction
+         ~detail
+         "librarian extraction failed")
+;;
+
+let run_skill_candidate_stage
+      (config : Workspace.config)
+      (meta : Keeper_meta_contract.keeper_meta)
+  =
+  match
+    Skill_candidate_store.write_all_post_turn_candidates
+      ~base_path:config.base_path
+      ~keeper_id:meta.name
+      ~fact_tail_limit:Keeper_memory_os_io.fact_store_max
+  with
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:[ "keeper", meta.name; "site", "draft_skill_candidates" ]
+      ();
+    (* Projection is fully derivable from durable facts/procedures and runs on
+       later jobs. Record this job's failure, but do not hold the Keeper's
+       linear memory lane behind advisory output. *)
+    stage_failed
+      Skill_candidate_projection
+      ~detail:`Null
+      error
+  | Ok stored ->
+    if stored <> []
+    then
+      Log.Keeper.info ~keeper_name:meta.name
+        "draft_skill_candidates wrote=%d dir=%s"
+        (List.length stored)
+        (Skill_candidate_store.drafts_dir ~base_path:config.base_path);
+    stage_succeeded
+      Skill_candidate_projection
+      (`Assoc [ "written", `Int (List.length stored) ])
+;;
+
+let run_compaction_stage
+      (config : Workspace.config)
+      (meta : Keeper_meta_contract.keeper_meta)
+      runtime_id
+  =
+  let memory_summarizer =
+    Keeper_memory_llm_summary.make ~runtime_id ~keeper_name:meta.name ()
+  in
+  let compaction =
+    Memory.compact_if_needed ?summarizer:memory_summarizer config meta
+  in
+  if compaction.performed
+  then
+    Log.Keeper.info ~keeper_name:meta.name
+      "memory_compacted before=%d after=%d dropped=%d"
+      compaction.before_notes
+      compaction.after_notes
+      compaction.dropped_notes;
+  let detail = Memory.compaction_to_json compaction in
+  match compaction.error with
+  | None -> stage_succeeded Memory_bank_compaction detail
+  | Some error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:[ "keeper", meta.name; "site", "memory_bank_compaction" ]
+      ();
+    (* Compaction is hygiene over the durable bank, not unique turn input. A
+       later job retries it from source state; blocking the lane here would
+       prevent non-derivable tool/librarian work from advancing. *)
+    stage_failed
+      Memory_bank_compaction
+      ~detail
+      (compaction_error_to_string error)
+;;
+
+let validate_payload_identity
+      (job : Keeper_memory_job_store.job)
+      (payload : job_payload)
+  =
+  let trace_id =
+    Keeper_id.Trace_id.to_string payload.meta.Keeper_meta_contract.runtime.trace_id
+  in
+  if not (String.equal payload.meta.name job.keeper_name)
+  then Error "payload keeper name does not match durable job identity"
+  else if not (String.equal trace_id job.trace_id)
+  then Error "payload trace id does not match durable job identity"
+  else if payload.meta.runtime.generation <> job.generation
+  then Error "payload generation does not match durable job identity"
+  else if
+    not
+      (String.equal
+         payload.librarian_checkpoint.Agent_sdk.Checkpoint.session_id
+         job.trace_id)
+  then Error "librarian checkpoint session id does not match durable job identity"
+  else if
+    not
+      (String.equal
+         payload.librarian_checkpoint.Agent_sdk.Checkpoint.agent_name
+         payload.meta.agent_name)
+  then Error "librarian checkpoint agent name does not match keeper metadata"
+  else if
+    payload.librarian_checkpoint.Agent_sdk.Checkpoint.turn_count
+    <> job.oas_turn_count
+  then Error "librarian checkpoint turn count does not match durable job identity"
+  else if String.equal (String.trim payload.runtime_id) ""
+  then Error "payload runtime id must be non-empty"
+  else Ok ()
+;;
+
+let execute_job ~base_path (job : Keeper_memory_job_store.job) =
+  match payload_of_json job.payload with
+  | Error message ->
+    Error
+      Keeper_memory_lane.
+        { retryability = Keeper_memory_lane.Terminal
+        ; kind = "job_payload_decode_failed"
+        ; message
+        ; detail = `Null
+        }
+  | Ok payload ->
+    (match validate_payload_identity job payload with
+     | Error message ->
+       Error
+         Keeper_memory_lane.
+           { retryability = Keeper_memory_lane.Terminal
+           ; kind = "job_identity_mismatch"
+           ; message
+           ; detail = `Null
+           }
+     | Ok () ->
+       let config = Workspace.default_config base_path in
+       (* OCaml does not specify constructor-argument evaluation order. Bind
+          every stage explicitly so the required deterministic sequence cannot
+          be reversed by list-literal evaluation. *)
+       let tool_result_stage =
+         protect_stage Tool_result_promotion (fun () ->
+           run_tool_result_stage
+             config
+             payload.meta
+             job.turn
+             payload.tool_results)
+       in
+       let librarian_stage =
+         protect_stage Librarian_extraction (fun () ->
+           run_librarian_stage
+             ~base_path:config.base_path
+             payload.meta
+             job.id
+             job.generation
+             payload.runtime_id
+             payload.librarian_admission
+             payload.librarian_checkpoint)
+       in
+       let skill_candidate_stage =
+         protect_stage Skill_candidate_projection (fun () ->
+           run_skill_candidate_stage config payload.meta)
+       in
+       let compaction_stage =
+         protect_stage Memory_bank_compaction (fun () ->
+           run_compaction_stage config payload.meta payload.runtime_id)
+       in
+       let stages =
+         [ tool_result_stage
+         ; librarian_stage
+         ; skill_candidate_stage
+         ; compaction_stage
+         ]
+       in
+       let detail =
+         `Assoc
+           [ "schema", `String "masc.keeper_post_turn_memory_receipt.v1"
+           ; "job_id", `String job.id
+           ; "keeper_name", `String job.keeper_name
+           ; "trace_id", `String job.trace_id
+           ; "generation", `Int job.generation
+           ; "turn", `Int job.turn
+           ; "oas_turn_count", `Int job.oas_turn_count
+           ; "runtime_id", `String payload.runtime_id
+           ; "stages", `List (List.map stage_to_json stages)
+           ]
+       in
+       let failed =
+         List.filter
+           (fun stage -> stage.status = Stage_failed)
+           stages
+       in
+       match failed with
+       | [] -> Ok detail
+       | _ ->
+         (* A terminal failure in one weakly-coupled stage must not acknowledge
+            another stage's retryable persistence failure. Keep the job
+            inflight until every retryable stage succeeds; a remaining
+            terminal-only failure can then commit its failed receipt and let
+            the next Keeper memory job proceed. *)
+         let names =
+           List.map (fun stage -> stage_name_to_string stage.name) failed
+         in
+         Error
+           Keeper_memory_lane.
+             { retryability =
+                 (if
+                    List.exists
+                      (fun stage ->
+                         stage.failure_retryability
+                         = Some Keeper_memory_lane.Retryable)
+                      failed
+                  then Keeper_memory_lane.Retryable
+                  else Keeper_memory_lane.Terminal)
+             ; kind = "post_turn_stage_failure"
+             ; message = String.concat "," names
+             ; detail
+             })
+;;
 
 let run
-  ~config
-  ~meta
+  ~(config : Workspace.config)
+  ~(meta : Keeper_meta_contract.keeper_meta)
   ~generation
   ~turn
   ~oas_turn_count
   ~response_text
   ~actual_tools
-  ~librarian_messages
+  ~librarian_checkpoint
+  ~tool_results_snapshot
   ~post_turn_t0
   ~runtime_id
   ~inference_telemetry
-  ?deliberation_execution
   ()
   =
-  (* RFC-0257: snapshot the per-keeper tool-emission accumulator synchronously
-     at turn end, before the memory series detaches onto the memory lane.
-     Reading the live accumulator from a detached fiber could fold a later
-     turn's emissions into this turn's notes. *)
-  let tool_results_snapshot =
-    if Keeper_tool_emission_hook.masc_tool_emission_enabled ()
-    then
-      Some
-        (Keeper_tool_emission_hook.snapshot
-           (Keeper_tool_emission_hook.accumulator_for_keeper
-              meta.Keeper_meta_contract.name))
-    else None
+  let payload =
+    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let librarian_admission =
+      Keeper_librarian_runtime.decide_librarian_admission
+        ~keeper_turn:turn
+    in
+    payload_to_json
+      ~meta
+      ~runtime_id
+      ~librarian_admission
+      ~librarian_checkpoint
+      ~tool_results:tool_results_snapshot
   in
-  (* (1) deterministic write, (2) librarian extraction, (3) compaction run on
-     this keeper's memory lane (RFC-0257), detached from the turn lane. All
-     three touch the keeper's memory bank (no internal lock); the lane's
-     per-keeper mutex serializes them. meta/config are immutable snapshots, so
-     using them after the turn returns does not race a later turn.
-     See RFC #3646 Section 3: Det/NonDet boundary. *)
-  let memory_series () =
-  (try
-     let notes_written =
-       match tool_results_snapshot with
-       | Some tool_results ->
-         Memory.append_from_tool_results config meta ~turn ~results:tool_results
-       | None -> 0
-     in
-     let kinds_written =
-       if notes_written > 0 then [ "long_term" ] else []
-     in
-     if notes_written > 0
-     then
-       Keeper_turn_telemetry.log_keeper_memory_write
-         ~keeper_name:meta.name
-         ~notes_written
-         ~kinds_written
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let submission_outcome =
+    match
+     Keeper_memory_job_store.make_job
+       ~keeper_name:meta.name
+       ~trace_id
+       ~generation
+       ~turn
+       ~oas_turn_count
+       ~enqueued_at:(Time_compat.now ())
+       ~payload
    with
-   | exn ->
-     Log.Keeper.error ~keeper_name:meta.name
-       "memory_write failed: %s"
-       (Printexc.to_string exn);
+   | Error error ->
      Otel_metric_store.inc_counter
        Keeper_metrics.(to_string MemoryWriteFailures)
        ~labels:[ "keeper", meta.name ]
-       ());
-
-  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. *)
-  let librarian_input : Keeper_librarian.input =
-    { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
-    ; generation
-    ; messages = librarian_messages
-    }
-  in
-  Keeper_librarian_runtime.run_best_effort
-    ~runtime_id
-    ~keeper_id:meta.name
-    librarian_input;
-
-  (* Advisory delegation request drafts: keep review artifact persistence on the
-     same bounded post-turn memory lane as draft-skill projection, not on the
-     decision-record append path. *)
-  (try
-     match deliberation_execution with
-     | None -> ()
-     | Some execution -> (
-       match
-         Keeper_delegation_request_store.write_execution_result
-           ~base_path:config.base_path
-           ~requester:meta.name
-           ~goal:meta.goal
-           execution
-       with
-       | Ok [] -> ()
-       | Ok stored ->
-         Log.Keeper.info ~keeper_name:meta.name
-           "delegation_requests wrote=%d dir=%s"
-           (List.length stored)
-           (Keeper_delegation_request_store.requests_dir
-              ~base_path:config.base_path)
-       | Error msg ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string DispatchEventFailures)
-           ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
-           ();
-         Log.Keeper.warn ~keeper_name:meta.name
-           "delegation_requests failed: %s"
-           msg)
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
        ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "delegation_requests failed: %s"
-       (Printexc.to_string exn));
-
-  (* Memory OS -> draft skill loop: after librarian facts are durable, project
-     validated approaches / lessons into reviewable draft skill artifacts. This
-     stays advisory and never mutates the keeper tool surface. *)
-  (try
-     match
-       Skill_candidate_store.write_post_turn_candidates
-         ~base_path:config.base_path
-         ~keeper_id:meta.name
-         ~fact_tail_limit:Keeper_memory_os_io.fact_store_max
-         ~procedure_limit:default_post_turn_procedure_candidate_limit
-     with
-     | Ok [] -> ()
-     | Ok stored ->
-       Log.Keeper.info ~keeper_name:meta.name
-         "draft_skill_candidates wrote=%d dir=%s"
-         (List.length stored)
-         (Skill_candidate_store.drafts_dir ~base_path:config.base_path)
-     | Error msg ->
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string DispatchEventFailures)
-         ~labels:[ "keeper", meta.name; "site", "draft_skill_candidates" ]
-         ();
-       Log.Keeper.warn ~keeper_name:meta.name
-         "draft_skill_candidates failed: %s"
-         msg
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "draft_skill_candidates" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "draft_skill_candidates failed: %s"
-       (Printexc.to_string exn));
-
-  (* Memory bank compaction: dedup + consolidate if over threshold. *)
-  (try
-     let memory_summarizer =
-       Keeper_memory_llm_summary.make
-         ~runtime_id
-         ~keeper_name:meta.name
-         ()
-     in
-     let compaction =
-       Memory.compact_if_needed
-         ?summarizer:memory_summarizer
-         config
-         meta
-     in
-     if compaction.performed
-     then
-       Log.Keeper.info ~keeper_name:meta.name
-         "memory_compacted before=%d after=%d dropped=%d"
-         compaction.before_notes
-         compaction.after_notes
-         compaction.dropped_notes
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "memory_bank_compaction" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "runtime=%s compaction failed: %s"
-       (Keeper_meta_contract.runtime_id_of_meta meta)
-       (Printexc.to_string exn))
-  in
-  (* RFC-0257: detach (1)-(3) onto the per-keeper memory lane. When the executor
-     switch is not initialized (tests, early startup) the lane runs them inline,
-     so no memory work is lost. *)
-  let (_ : Keeper_memory_lane.outcome) =
-    Keeper_memory_lane.submit
-      ~base_path:config.base_path
-      ~keeper_name:meta.name
-      memory_series
+     Log.Keeper.error ~keeper_name:meta.name
+       "memory lane job construction failed: %s"
+       (Keeper_memory_job_store.error_to_string error);
+     Not_durable
+   | Ok job ->
+     (match Keeper_memory_lane.stage ~base_path:config.base_path job with
+      | Keeper_memory_lane.Stage_rejected _ -> Not_durable
+      | Keeper_memory_lane.Staged _ -> Durable job)
   in
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try
      let used_search =
-       List.exists (fun t -> t = "keeper_memory_search") actual_tools
+       List.exists
+         (fun name ->
+            match Keeper_tool_name.of_string name with
+            | Some Keeper_tool_name.Memory_search -> true
+            | Some _ | None -> false)
+         actual_tools
      in
      let recall_eval =
        if used_search
@@ -282,5 +729,6 @@ let run
        ();
      Log.Keeper.warn ~keeper_name:meta.name
        "post_turn_eval jsonl append failed: %s"
-       (Printexc.to_string exn))
+       (Printexc.to_string exn));
+  submission_outcome
 ;;

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -1,12 +1,17 @@
 (** Post-turn memory write series for [Keeper_agent_run.run_turn].
 
-    Extracts the four post-turn side-effect stages from Step 8 body
-    (deterministic write, episodic record, compaction, quality-metrics
-    JSONL append) into a single typed boundary so that the orchestrator
-    only sees [run ~config ~meta ...].
+    Extracts the durable post-turn side-effect stages from Step 8 body
+    (tool-result promotion, episodic record, draft-skill projection, and
+    compaction) into a typed job boundary. Quality-metrics JSONL append remains
+    synchronous because it targets the separate decision log.
 
-    Each sub-stage is best-effort: non-cancel exceptions are logged and
-    counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)
+    Each durable sub-stage has an explicit succeeded/skipped/failed outcome in
+    the terminal receipt. Non-cancel exceptions become failed stage evidence;
+    [Eio.Cancel.Cancelled] is re-raised so the inflight job can replay. *)
+
+type submission_outcome =
+  | Durable of Keeper_memory_job_store.job
+  | Not_durable
 
 val run :
   config:Workspace.config ->
@@ -16,13 +21,13 @@ val run :
   oas_turn_count:int ->
   response_text:string ->
   actual_tools:string list ->
-  librarian_messages:Agent_sdk.Types.message list ->
+  librarian_checkpoint:Agent_sdk.Checkpoint.t ->
+  tool_results_snapshot:Yojson.Safe.t list option ->
   post_turn_t0:float ->
   runtime_id:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
-  ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
-  unit
+  submission_outcome
 (** Run the full post-turn memory series.
 
     [post_turn_t0] is the timestamp (from [Time_compat.now ()]) taken
@@ -32,6 +37,9 @@ val run :
     [inference_telemetry] is [result.response.telemetry] from the OAS
     result; it is optional because some providers do not emit telemetry.
 
-    [deliberation_execution], when available, is persisted as advisory
-    delegation request artifacts on this post-turn memory lane rather than on
-    the decision-record append path. *)
+    The OAS checkpoint is reduced to the librarian's bounded message window
+    before durable admission; replay therefore uses the exact turn snapshot
+    without duplicating unbounded conversation/tool state. *)
+
+val execute_job : Keeper_memory_lane.execute
+(** Durable job handler installed once by server bootstrap. *)

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -142,6 +142,14 @@ let finalize
     ; oas_turn_count = !receipt_turn_count_ref
     ; oas_dispatch_mode = Some "single_provider_agent_run"
     ; oas_internal_runtime_disabled = true
+    ; post_turn_memory_job_id =
+        (match turn_result with
+         | Ok result ->
+           Option.map
+             (fun (submission : Keeper_agent_result.post_turn_memory_job) ->
+                submission.durable_job.id)
+             result.post_turn_memory_job
+         | Error _ -> None)
     ; current_task_id =
         Option.map Keeper_id.Task_id.to_string acc.meta.current_task_id
     ; goal_ids = meta.active_goal_ids
@@ -276,6 +284,69 @@ let finalize
           ~site:"receipt_appended"
           Keeper_runtime_manifest.Receipt_appended)
   in
+  let finalize_post_turn_memory_submission
+        (submission : Keeper_agent_result.post_turn_memory_job)
+    =
+    let job = submission.durable_job in
+    let commit_state =
+      match receipt_append_outcome with
+      | Ok () -> `Committed
+      | Error append_error ->
+        (match
+           Keeper_execution_receipt.committed_post_turn_memory_job_ids
+             config
+             ~keeper_name:meta.name
+             ~candidate_ids:[ job.id ]
+         with
+         | Ok committed_ids when List.mem job.id committed_ids ->
+           Log.Keeper.warn ~keeper_name:meta.name
+             "execution receipt append reported failure but strict durable proof exists; activating memory outbox job_id=%s append_error=%s"
+             job.id
+             append_error;
+           `Committed
+         | Ok _ -> `Not_committed
+         | Error proof_error ->
+           Log.Keeper.error ~keeper_name:meta.name
+             "execution receipt append failed and memory outbox commit is unknown job_id=%s append_error=%s proof_error=%s"
+             job.id
+             append_error
+             proof_error;
+           `Unknown)
+    in
+    match commit_state with
+    | `Committed ->
+      (match Keeper_memory_lane.activate ~base_path:config.base_path job with
+       | Keeper_memory_lane.Admitted _ -> ()
+       | Keeper_memory_lane.Rejected error ->
+         Log.Keeper.error ~keeper_name:meta.name
+           "execution receipt committed but memory outbox activation is deferred job_id=%s: %s"
+           job.id
+           (Keeper_memory_job_store.error_to_string error))
+    | `Not_committed ->
+      (match Keeper_memory_lane.abort ~base_path:config.base_path job with
+       | Ok () -> ()
+       | Error error ->
+         Log.Keeper.error ~keeper_name:meta.name
+           "execution receipt failed and memory outbox abort is deferred job_id=%s: %s"
+           job.id
+           (Keeper_memory_job_store.error_to_string error));
+      (match submission.tool_results_to_restore with
+       | [] -> ()
+       | items ->
+         Keeper_tool_emission_hook.restore
+           (Keeper_tool_emission_hook.accumulator_for_keeper meta.name)
+           items)
+    | `Unknown ->
+      Keeper_memory_lane.request_reconciliation
+        ~base_path:config.base_path
+        ~keeper_name:meta.name
+  in
+  (match turn_result with
+   | Error _ -> ()
+   | Ok result ->
+     (match result.post_turn_memory_job with
+      | None -> ()
+      | Some submission -> finalize_post_turn_memory_submission submission));
   Keeper_agent_run_phase5_task_link.run ~config ~meta ~acc ();
   let final_result =
     match turn_result_with_operator_disposition, receipt_append_outcome with

--- a/lib/keeper/keeper_agent_run_receipt_append.ml
+++ b/lib/keeper/keeper_agent_run_receipt_append.ml
@@ -6,14 +6,30 @@ let append_with_coverage_gap
       ~on_appended
   : (unit, string) result
   =
-  try
-    Keeper_execution_receipt.append config receipt;
-    on_appended ();
+  let append_result =
+    try
+      Keeper_execution_receipt.append config receipt;
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+  in
+  match append_result with
+  | Ok () ->
+    (* The durable receipt is the transaction commit. Manifest projection is a
+       post-commit observer and cannot roll that commit back or cause the
+       awaiting memory outbox to be aborted. *)
+    (try on_appended () with
+     | exn ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string DispatchEventFailures)
+         ~labels:[ "keeper", keeper_name; "site", "receipt_manifest_post_commit" ]
+         ();
+       Log.Keeper.error ~keeper_name
+         "execution_receipt committed but post-commit manifest append failed: %s"
+         (Printexc.to_string exn));
     Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    let err_msg = Printexc.to_string exn in
+  | Error err_msg ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string DispatchEventFailures)
       ~labels:[ "keeper", keeper_name; "site", "receipt_append" ]

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -516,6 +516,8 @@ let to_json (receipt : t) =
     ; ( "oas_dispatch_mode", string_opt_json receipt.oas_dispatch_mode )
     ; ( "oas_internal_runtime_disabled"
       , `Bool receipt.oas_internal_runtime_disabled )
+    ; ( "post_turn_memory_job_id"
+      , string_opt_json receipt.post_turn_memory_job_id )
     ; ( "current_task_id", string_opt_json receipt.current_task_id )
     ; "goal_ids", list_json receipt.goal_ids
     ; "outcome", `String (outcome_kind_to_tla_receipt receipt.outcome)
@@ -590,6 +592,66 @@ let to_json (receipt : t) =
     ; ( "pre_dispatch_compaction_after_tokens"
       , Json_util.int_opt_to_json receipt.pre_dispatch_compaction_after_tokens )
     ]
+;;
+
+let committed_post_turn_memory_job_ids
+      (config : Workspace.config)
+      ~keeper_name
+      ~candidate_ids
+  =
+  match
+    List.find_opt
+      (fun id -> not (Keeper_memory_job_store.is_valid_job_id id))
+      candidate_ids
+  with
+  | Some id -> Error (Printf.sprintf "invalid candidate memory job id: %S" id)
+  | None ->
+    let store =
+      Keeper_types_support.keeper_execution_receipt_store config keeper_name
+    in
+    let parse found = function
+      | `Assoc fields ->
+        (match List.assoc_opt "schema" fields with
+         | Some (`String schema)
+           when String.equal schema Keeper_types_support.execution_receipt_schema ->
+           (match List.assoc_opt "keeper_name" fields with
+            | Some (`String row_keeper_name)
+              when String.equal row_keeper_name keeper_name ->
+              (match List.assoc_opt "post_turn_memory_job_id" fields with
+               | None | Some `Null -> Ok found
+               | Some (`String id)
+                 when Keeper_memory_job_store.is_valid_job_id id ->
+                 if List.mem id candidate_ids && not (List.mem id found)
+                 then Ok (id :: found)
+                 else Ok found
+               | Some (`String id) ->
+                 Error (Printf.sprintf "invalid post_turn_memory_job_id: %S" id)
+               | Some _ ->
+                 Error "post_turn_memory_job_id must be a string or null")
+            | Some (`String row_keeper_name) ->
+              Error
+                (Printf.sprintf
+                   "execution receipt keeper coordinate mismatch expected=%s actual=%s"
+                   keeper_name
+                   row_keeper_name)
+            | Some _ -> Error "execution receipt keeper_name must be a string"
+            | None -> Error "execution receipt keeper_name is missing")
+         | Some (`String schema) ->
+           Error (Printf.sprintf "unexpected execution receipt schema: %s" schema)
+         | Some _ -> Error "execution receipt schema must be a string"
+         | None -> Error "execution receipt schema is missing")
+      | _ -> Error "execution receipt row must be a JSON object"
+    in
+    (match Dated_jsonl.fold_all_strict store ~init:[] ~f:parse with
+     | Ok ids -> Ok (List.rev ids)
+     | Error error ->
+       let location =
+         match error.Dated_jsonl.line_number with
+         | None -> error.path
+         | Some line_number ->
+           Printf.sprintf "%s:%d" error.path line_number
+       in
+       Error (Printf.sprintf "%s: %s" location error.detail))
 ;;
 
 (* Operator broadcast hook (#fleet-stall 2026-04-26): operator_disposition
@@ -917,7 +979,7 @@ let append (config : Workspace.config) (receipt : t) =
     Keeper_types_support.keeper_execution_receipt_store config receipt.keeper_name
   in
   let receipt_json = to_json receipt in
-  Dated_jsonl.append store receipt_json;
+  Dated_jsonl.append_durable store receipt_json;
   (try
      Keeper_reaction_ledger.record_execution_receipt_reaction
        config
@@ -931,7 +993,6 @@ let append (config : Workspace.config) (receipt : t) =
        ~receipt_json
        ()
    with
-   | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Keeper.warn
        ~keeper_name:receipt.keeper_name
@@ -960,7 +1021,6 @@ let append (config : Workspace.config) (receipt : t) =
            reason_s
            (operator_broadcast_turn_key receipt.turn_count)
      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
         (* fail-closed: log loud, do not silently swallow. The append itself
            has already persisted the receipt; the broadcast failure is its

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -171,6 +171,7 @@ type t =
   ; oas_turn_count : int option
   ; oas_dispatch_mode : string option
   ; oas_internal_runtime_disabled : bool
+  ; post_turn_memory_job_id : string option
   ; current_task_id : string option
   ; goal_ids : string list
   ; outcome : outcome_kind
@@ -218,6 +219,15 @@ val to_json : t -> Yojson.Safe.t
 
 (** Return the receipt terminal reason without deriving extra tool evidence. *)
 val enrich_contract_violation_reason : t -> string
+
+val committed_post_turn_memory_job_ids :
+  Workspace.config ->
+  keeper_name:string ->
+  candidate_ids:string list ->
+  (string list, string) result
+(** Strictly scan durable execution receipts for candidate post-turn outbox
+    ids. Malformed JSON/schema rows fail with path+line evidence; they are never
+    skipped when deciding whether an awaiting job may activate. *)
 
 (** Operator-facing classification of a finished turn. Closed set.
 

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -270,6 +270,7 @@ type t =
   ; oas_turn_count : int option
   ; oas_dispatch_mode : string option
   ; oas_internal_runtime_disabled : bool
+  ; post_turn_memory_job_id : string option
   ; current_task_id : string option
   ; goal_ids : string list
   ; outcome : outcome_kind

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -72,6 +72,7 @@ type t = {
   oas_turn_count : int option;
   oas_dispatch_mode : string option;
   oas_internal_runtime_disabled : bool;
+  post_turn_memory_job_id : string option;
   current_task_id : string option;
   goal_ids : string list;
   outcome : outcome_kind;

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -31,74 +31,6 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 ;;
 
-(* RFC-0257 / P0-4 adversarial hardening: per-keeper librarian provider slot.
-   The previous process-global slot allowed one slow keeper to starve the fleet.
-   Capacity is still read from [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT]
-   (default 1), but the semaphore is now keyed by [keeper_id] so each keeper
-   gets its own concurrency budget. A capacity of 0 disables the gate entirely. *)
-let per_keeper_slot_capacity () =
-  Env_config.KeeperMemoryOs.librarian_global_slot ()
-;;
-
-let memory_os_librarian_provider_slot_site = "memory_os_librarian_provider_slot"
-
-let provider_slot_wait_sec = 0.25
-
-type provider_slot =
-  { capacity : int
-  ; sem : Eio.Semaphore.t option
-  }
-
-let provider_slots_mu = Eio.Mutex.create ()
-let provider_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 64
-
-let provider_slot_for_keeper ~keeper_id capacity =
-  Eio_guard.with_mutex provider_slots_mu (fun () ->
-    match Hashtbl.find_opt provider_slots keeper_id with
-    | Some slot when slot.capacity = capacity -> slot
-    | _ ->
-      let slot =
-        { capacity
-        ; sem =
-            (match capacity with
-             | 0 -> None
-             | n -> Some (Eio.Semaphore.make n))
-        }
-      in
-      Hashtbl.replace provider_slots keeper_id slot;
-      slot)
-;;
-
-let with_provider_slot ~keeper_id ~clock f =
-  let capacity = per_keeper_slot_capacity () in
-  let slot = provider_slot_for_keeper ~keeper_id capacity in
-  match slot.sem with
-  | None -> Some (f ())
-  | Some sem ->
-    let acquired = ref false in
-    (try
-       (try
-          Eio.Time.with_timeout_exn clock provider_slot_wait_sec (fun () ->
-            Eio.Semaphore.acquire sem);
-         acquired := true
-        with
-        | Eio.Time.Timeout -> ())
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.warn
-         "librarian provider slot acquisition failed keeper=%s: %s"
-         keeper_id
-         (Printexc.to_string exn));
-    if !acquired
-    then
-      Some
-        (Eio.Switch.run (fun cleanup_sw ->
-           Eio.Switch.on_release cleanup_sw (fun () -> Eio.Semaphore.release sem);
-           f ()))
-    else None
-;;
-
 let enabled () =
   (* Default on: a keeper without conversation ingestion is the pathology
      the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
@@ -777,37 +709,26 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  "memory os librarian failed runtime=%s: %s"
                  runtime_id
                  librarian_provider_clock_unavailable_error
-             | Some clock -> (
-             match
-               with_provider_slot ~keeper_id ~clock (fun () ->
-                 extract_and_append_with_provider_classified
-                   ?complete
-                   ~clock
-                   ~timeout_sec
-                   ~sw
-                   ~net
-                   ~keeper_id
-                   ~provider_cfg
-                   inp)
-             with
-             | None ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-                ~labels:
-                  [ "keeper", keeper_id; "site", memory_os_librarian_provider_slot_site ]
-                 ();
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
-                 runtime_id
-                 (per_keeper_slot_capacity ())
-             | Some (Ok episode) ->
+             | Some clock ->
+               (match
+                  extract_and_append_with_provider_classified
+                    ?complete
+                    ~clock
+                    ~timeout_sec
+                    ~sw
+                    ~net
+                    ~keeper_id
+                    ~provider_cfg
+                    inp
+                with
+                | Ok episode ->
                cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.info ~keeper_name:keeper_id
                  "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
                  episode.Keeper_memory_os_types.trace_id
                  episode.generation
                  (List.length episode.claims)
-             | Some (Error err) ->
+                | Error err ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)
                  ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -63,92 +63,69 @@ let cadence_turns () =
   Env_config.KeeperMemoryOs.librarian_cadence_turns ()
 ;;
 
-(* Per-keeper "turns since last successful extraction" counter, paired with the
-   trace it belongs to. Keyed by [keeper_id] (the long-lived owner), NOT by
-   (keeper_id, trace_id): trace_id rotates on every keeper run, so a pair-keyed
-   table mints a fresh row per rotation and never reclaims the previous one,
-   growing without bound over the process lifetime. Keying by keeper_id bounds
-   the table to one row per live keeper; a rotated trace is detected as a stored
-   mismatch and resets the schedule in place.
+type cadence_decision =
+  | Due
+  | Not_due of { turns_remaining : int }
 
-   [Eio_guard.with_mutex]: the cadence table is reachable from concurrent keeper
-   fibers, and a blocking stdlib mutex can stall unrelated Eio work if a fiber
-   holds that lock while waiting on another Eio resource. [Eio_guard] gives
-   runtime fibers cooperative locking while preserving a direct path for focused
-   tests that call the pure cadence helpers before the Eio runtime is enabled. *)
-let cadence_mu = Eio.Mutex.create ()
-let cadence_counters : (string, string * int) Hashtbl.t = Hashtbl.create 16
-
-(* A counter value below 0 means the keeper has never had a successful
-   extraction on the current trace: the next turn is due immediately. *)
-let fresh_counter = -1
-
-(* Pure cadence decision. Given the keeper's current [counter] (turns since its
-   last successful extraction) and the [cadence], return the updated counter and
-   whether extraction is due now.
-
-   - counter < 0 (fresh) is due immediately.
-   - cadence <= 1 is always due with the counter pinned at 0.
-   - When due, the counter is set to [cadence] and stays there until
-     [cadence_record_success] or [cadence_record_attempt] resets it to 0. This
-     keeps the keeper due across skipped work, while completed non-success
-     provider attempts can defer the next attempt to the cadence window instead
-     of retrying on every keeper turn. *)
-let cadence_step ~cadence ~counter =
-  if cadence <= 1
-  then 0, true
-  else if counter < 0
-  then cadence, true
-  else (
-    let next = counter + 1 in
-    if next >= cadence then cadence, true else next, false)
+(* The Keeper timeline turn id is the durable cadence clock. It starts at one;
+   zero is the explicit pre-turn state and is also due. No process-local table
+   is involved, so restart,
+   BasePath multiplexing, detached execution order, and admission failure cannot
+   change a turn's decision. *)
+let cadence_decision_for_keeper_turn ~cadence ~keeper_turn =
+  if cadence <= 1 || keeper_turn <= 1
+  then Due
+  else
+    let offset = (keeper_turn - 1) mod cadence in
+    if offset = 0
+    then Due
+    else Not_due { turns_remaining = cadence - offset }
 ;;
 
-(* Pure keyed cadence decision. Given a keeper's [prior] stored (trace, counter)
-   and the [current_trace], a stored entry from a different (rotated) trace is
-   treated as fresh — due immediately, not inheriting the old trace's schedule —
-   exactly like an unseen keeper ([prior = None]). Returns the value to store and
-   whether extraction is due now. Exposed for testing the rollover decision
-   without the global table. *)
-let cadence_step_keyed ~cadence ~current_trace ~prior =
-  let counter =
-    (* sound-partial: allow — an unseen keeper or a rotated trace is fresh
-       (due immediately via [fresh_counter]); fresh-state init, not a default
-       hiding a parse error. *)
-    match prior with
-    | Some (t, c) when String.equal t current_trace -> c
-    | _ -> fresh_counter
-  in
-  let updated, due = cadence_step ~cadence ~counter in
-  (current_trace, updated), due
+type librarian_admission_decision =
+  | Admission_disabled
+  | Admission_not_due of { turns_remaining : int }
+  | Admission_due
+
+let decide_librarian_admission ~keeper_turn =
+  if not (enabled ())
+  then Admission_disabled
+  else
+    match
+      cadence_decision_for_keeper_turn
+        ~cadence:(cadence_turns ())
+        ~keeper_turn
+    with
+    | Due -> Admission_due
+    | Not_due { turns_remaining } -> Admission_not_due { turns_remaining }
 ;;
 
-let cadence_due ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    let prior = Hashtbl.find_opt cadence_counters keeper_id in
-    let value, due =
-      cadence_step_keyed ~cadence:(cadence_turns ()) ~current_trace:trace_id ~prior
-    in
-    Hashtbl.replace cadence_counters keeper_id value;
-    due)
+let librarian_admission_decision_to_json = function
+  | Admission_disabled -> `Assoc [ "kind", `String "disabled" ]
+  | Admission_due -> `Assoc [ "kind", `String "due" ]
+  | Admission_not_due { turns_remaining } ->
+    `Assoc
+      [ "kind", `String "not_due"
+      ; "turns_remaining", `Int turns_remaining
+      ]
 ;;
 
-let cadence_record_success ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters keeper_id (trace_id, 0))
-;;
-
-let cadence_record_attempt ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters keeper_id (trace_id, 0))
-;;
-
-(* Live per-keeper cadence rows. Bounded by the number of keepers that have run
-   (one row each), so it doubles as a leak-regression signal: it must not grow
-   with trace rotations. Read-only; consumed by the cadence test and the
-   dashboard memory-health panel. *)
-let cadence_counter_entries () =
-  Eio_guard.with_mutex_ro cadence_mu (fun () -> Hashtbl.length cadence_counters)
+let librarian_admission_decision_of_json = function
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "disabled") -> Ok Admission_disabled
+     | Some (`String "due") -> Ok Admission_due
+     | Some (`String "not_due") ->
+       (match List.assoc_opt "turns_remaining" fields with
+        | Some (`Int turns_remaining) when turns_remaining > 0 ->
+          Ok (Admission_not_due { turns_remaining })
+        | Some _ -> Error "librarian admission turns_remaining must be positive"
+        | None -> Error "librarian admission missing turns_remaining")
+     | Some (`String kind) ->
+       Error (Printf.sprintf "unknown librarian admission kind: %s" kind)
+     | Some _ -> Error "librarian admission kind must be a string"
+     | None -> Error "librarian admission missing kind")
+  | _ -> Error "librarian admission decision must be an object"
 ;;
 
 let max_messages () =
@@ -158,7 +135,13 @@ let max_messages () =
 (* Scale the prompt window by the cadence so skipped turns stay visible until
    the next due extraction. Without this, a tool-heavy skipped turn can scroll
    out of the per-turn cap before its first successful extraction. *)
-let prompt_max_messages () = max_messages () * cadence_turns ()
+let prompt_max_messages () =
+  let per_turn = max_messages () in
+  let cadence = cadence_turns () in
+  if per_turn > Int.max_int / cadence
+  then Int.max_int
+  else per_turn * cadence
+;;
 ;;
 
 let default_timeout_sec () =
@@ -182,6 +165,10 @@ let select_recent_messages ~max_messages messages =
       | _ :: rest -> drop (n - 1) rest)
   in
   drop drop_count messages
+;;
+
+let prompt_window_messages messages =
+  select_recent_messages ~max_messages:(prompt_max_messages ()) messages
 ;;
 
 let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
@@ -327,6 +314,7 @@ type extraction_error =
   | Provider_empty_response
   | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
+  | Memory_episode_persistence_failed of string
 
 let librarian_provider_clock_unavailable_error =
   "memory os librarian provider clock unavailable"
@@ -342,6 +330,8 @@ let extraction_error_to_string = function
   | Provider_unparseable_response msg ->
     "librarian provider returned unparseable structured response: " ^ msg
   | Memory_fact_upsert_failed msg -> "memory os fact upsert failed: " ^ msg
+  | Memory_episode_persistence_failed msg ->
+    "memory os episode persistence failed: " ^ msg
 ;;
 
 type unparseable_response =
@@ -360,19 +350,6 @@ type attempt_outcome =
 type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
-
-let should_record_cadence_backoff_after_error = function
-  | Provider_timeout
-  | Provider_transport_failed _
-  | Provider_empty_response
-  | Provider_unparseable_response _ ->
-    true
-  | Provider_clock_unavailable
-  | Provider_config_rejected _
-  | Prompt_render_failed _
-  | Memory_fact_upsert_failed _ ->
-    false
-;;
 
 let prefer_unparseable_response prior current =
   match current.raw_evidence with
@@ -414,7 +391,7 @@ let render_prompt key variables =
 
 let messages_for_librarian (inp : Keeper_librarian.input) =
   let input =
-    { inp with messages = select_recent_messages ~max_messages:(prompt_max_messages ()) inp.messages }
+    { inp with messages = prompt_window_messages inp.messages }
   in
   match render_prompt Keeper_prompt_names.librarian_system [] with
   | Error _ as e -> e
@@ -530,9 +507,215 @@ let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~
   | Ok episode -> Ok episode
 ;;
 
-let extract_and_append_with_provider_classified
+let publish_episode
+    ?operation_id
+    ?clock
+    ?keepers_dir
+    ~keeper_id
+    ~operation_model_id
+    ~provider_latency_ms
+    episode
+  =
+  let now = episode.Keeper_memory_os_types.created_at in
+  (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
+     re-extracted across turns is folded into the existing row
+     (Keeper_memory_os_policy.reobserve_fact: RFC-0247 refreshes
+     [last_verified_at] only) rather than accumulating as a duplicate. The same
+     call applies the RFC-0239 Q4 retention cap (ranked by the structural
+     [retention_rank]) in one atomic rewrite. Only after the facts are durable
+     do we publish the episode file and append the event row; the event row is
+     the reader-visible commit marker for [read_episodes_tail].
+
+     RFC-0285 §8: before folding, decide each claim's provenance. A claim
+     whose identity was recall-injected into this keeper's recent prompts is
+     an echo — the model restating what it just read — and must not advance
+     the truth anchor recall's recency ranking reads. The judgment (window
+     join + metric) lives here at the write boundary; the fold itself stays
+     a pure function of the decision. *)
+  let with_bundle_lock f =
+    match keepers_dir with
+    | Some keepers_dir ->
+      Keeper_memory_os_io.with_episode_bundle_lock_for_keepers_dir
+        ?clock
+        ~keepers_dir
+        ~keeper_id
+        f
+    | None ->
+      Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id f
+  in
+  let facts_path () =
+    match keepers_dir with
+    | Some keepers_dir ->
+      Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
+    | None -> Keeper_memory_os_io.facts_path ~keeper_id
+  in
+  with_bundle_lock (fun () ->
+    let committed =
+      match operation_id with
+      | None -> Ok false
+      | Some operation_id ->
+        (match keepers_dir with
+         | None ->
+           Error
+             (Memory_episode_persistence_failed
+                "operation-backed publication requires an explicit keepers_dir")
+         | Some keepers_dir ->
+        Keeper_memory_os_io.operation_event_committed
+          ~keepers_dir
+          ~keeper_id
+          ~operation_id
+        |> Result.map_error (fun detail ->
+          Memory_episode_persistence_failed detail))
+    in
+    match committed with
+    | Error _ as error -> error
+    | Ok true -> Ok (episode, operation_model_id, provider_latency_ms)
+    | Ok false ->
+      (match
+         try
+           let window = Keeper_memory_os_io.fact_recall_window in
+           let merge ~existing ~incoming =
+             let provenance =
+               let key = Keeper_memory_os_types.claim_identity incoming in
+               if Keeper_recall_injection_window.recently_injected ~keeper_id ~key
+               then (
+                 Otel_metric_store.inc_counter
+                   Keeper_metrics.(to_string MemoryOsReobserveEchoSuppressed)
+                   ~labels:[ "keeper", keeper_id ]
+                   ();
+                 Keeper_memory_os_policy.Recalled_echo)
+               else Keeper_memory_os_policy.Independent_observation
+             in
+             Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
+           in
+           let (_ : Keeper_memory_os_io.fact_merge_stats) =
+             File_lock_eio.with_lock
+               ?clock
+               (facts_path ())
+               (fun () ->
+                  match keepers_dir with
+                  | Some keepers_dir ->
+                    Keeper_memory_os_io.merge_and_cap_facts_for_keepers_dir
+                      ~keepers_dir
+                      ~now
+                      ~keeper_id
+                      ~merge
+                      ~incoming:episode.Keeper_memory_os_types.claims
+                      ~keep:window
+                      ~trigger:Keeper_memory_os_io.fact_store_max
+                      ~rank:(Keeper_memory_os_policy.retention_rank ~now)
+                  | None ->
+                    Keeper_memory_os_io.merge_and_cap_facts
+                      ~now
+                      ~keeper_id
+                      ~merge
+                      ~incoming:episode.Keeper_memory_os_types.claims
+                      ~keep:window
+                      ~trigger:Keeper_memory_os_io.fact_store_max
+                      ~rank:(Keeper_memory_os_policy.retention_rank ~now))
+           in
+           Ok ()
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           let message = Printexc.to_string exn in
+           Log.Keeper.warn
+             "memory os fact upsert failed keeper=%s: %s"
+             keeper_id
+             message;
+           Error message
+       with
+       | Error message -> Error (Memory_fact_upsert_failed message)
+       | Ok () ->
+         let publication =
+           match operation_id with
+           | None ->
+             (try
+                (match keepers_dir with
+                 | Some keepers_dir ->
+                   Keeper_memory_os_io.append_episode_for_keepers_dir
+                     ~keepers_dir
+                     ~keeper_id
+                     episode;
+                   Keeper_memory_os_io.append_event_for_keepers_dir
+                     ~keepers_dir
+                     ~keeper_id
+                     episode
+                 | None ->
+                   Keeper_memory_os_io.append_episode ~keeper_id episode;
+                   Keeper_memory_os_io.append_event ~keeper_id episode);
+                Ok ()
+              with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | exn -> Error (Printexc.to_string exn))
+           | Some operation_id ->
+             (match keepers_dir with
+              | None ->
+                Error
+                  "operation-backed publication requires an explicit keepers_dir"
+              | Some keepers_dir ->
+                Keeper_memory_os_io.append_operation_event
+                  ~keepers_dir
+                  ~keeper_id
+                  ~operation_id
+                  ~model_id:operation_model_id
+                  ~provider_latency_ms
+                  episode)
+         in
+         (match publication with
+          | Error detail -> Error (Memory_episode_persistence_failed detail)
+          | Ok () ->
+            (* RFC-0272 (defect D): bound the append-only episode log under the
+               same bundle lock that serialized the writes above. *)
+            (match keepers_dir with
+             | Some keepers_dir ->
+               ignore
+                 (Keeper_memory_os_io.cap_events_for_keepers_dir
+                    ~keepers_dir
+                    ~keeper_id
+                    ~keep:Keeper_memory_os_io.event_recall_window
+                    ~trigger:Keeper_memory_os_io.event_store_max
+                  : int);
+               ignore
+                 (Keeper_memory_os_io.cap_episode_files_for_keepers_dir
+                    ~keepers_dir
+                    ~keeper_id
+                    ~keep:Keeper_memory_os_io.episode_file_window
+                    ~trigger:Keeper_memory_os_io.episode_file_store_max
+                  : int)
+             | None ->
+               ignore
+                 (Keeper_memory_os_io.cap_events
+                    ~keeper_id
+                    ~keep:Keeper_memory_os_io.event_recall_window
+                    ~trigger:Keeper_memory_os_io.event_store_max
+                  : int);
+               ignore
+                 (Keeper_memory_os_io.cap_episode_files
+                    ~keeper_id
+                    ~keep:Keeper_memory_os_io.episode_file_window
+                    ~trigger:Keeper_memory_os_io.episode_file_store_max
+                  : int));
+            Ok (episode, operation_model_id, provider_latency_ms))))
+;;
+
+let commit_staged_operation ~keepers_dir ?clock ~keeper_id ~operation_id staged =
+  publish_episode
+    ~operation_id
+    ?clock
+    ~keepers_dir
+    ~keeper_id
+    ~operation_model_id:staged.Keeper_memory_os_io.model_id
+    ~provider_latency_ms:staged.provider_latency_ms
+    staged.episode
+  |> Result.map (fun _ -> ())
+;;
+
+let extract_and_append_with_provider_classified_with_model
+    ?operation_id
     ?complete
     ?clock
+    ?keepers_dir
     ?timeout_sec
     ~sw
     ~net
@@ -542,108 +725,134 @@ let extract_and_append_with_provider_classified
   =
   match clock with
   | None -> Error Provider_clock_unavailable
-  | Some _ ->
-    let generation =
-      Keeper_memory_os_io.next_generation_with_floor
-        ~floor:inp.Keeper_librarian.generation
-        ~keeper_id
-        ~trace_id:inp.Keeper_librarian.trace_id
+  | Some clock ->
+    let extract_new_episode () =
+      let provider_started_at = Eio.Time.now clock in
+      let generation =
+        match keepers_dir with
+        | Some keepers_dir ->
+          Keeper_memory_os_io.next_generation_with_floor_for_keepers_dir
+            ~keepers_dir
+            ~floor:inp.Keeper_librarian.generation
+            ~keeper_id
+            ~trace_id:inp.Keeper_librarian.trace_id
+        | None ->
+          Keeper_memory_os_io.next_generation_with_floor
+            ~floor:inp.Keeper_librarian.generation
+            ~keeper_id
+            ~trace_id:inp.Keeper_librarian.trace_id
+      in
+      extract_with_provider_classified
+        ?complete
+        ~clock
+        ?timeout_sec
+        ~sw
+        ~net
+        ~provider_cfg
+        ~generation
+        inp
+      |> Result.map (fun episode ->
+        let provider_latency_ms =
+          max 0.0 (Eio.Time.now clock -. provider_started_at)
+          *. 1000.0
+          |> Keeper_timing.round1
+        in
+        episode, provider_latency_ms)
     in
-    (match
-       extract_with_provider_classified
-         ?complete
+    let episode_result =
+      match operation_id with
+      | None ->
+        extract_new_episode ()
+        |> Result.map (fun (episode, provider_latency_ms) ->
+          episode, provider_cfg.model_id, provider_latency_ms)
+      | Some operation_id ->
+        (match keepers_dir with
+         | None ->
+           Error
+             (Memory_episode_persistence_failed
+                "operation-backed extraction requires an explicit keepers_dir")
+         | Some keepers_dir ->
+        (match
+           Keeper_memory_os_io.load_operation_episode
+             ~keepers_dir
+             ~keeper_id
+             ~operation_id
+         with
+         | Error detail -> Error (Memory_episode_persistence_failed detail)
+         | Ok (Some staged) ->
+           Ok
+             ( staged.Keeper_memory_os_io.episode
+             , staged.model_id
+             , staged.provider_latency_ms )
+         | Ok None ->
+           (match extract_new_episode () with
+            | Error _ as error -> error
+            | Ok (episode, provider_latency_ms) ->
+              (match
+                 Keeper_memory_os_io.stage_operation_episode_once
+                   ?clock
+                   ~keepers_dir
+                   ~keeper_id
+                   ~operation_id
+                   ~model_id:provider_cfg.model_id
+                   ~provider_latency_ms
+                   episode
+               with
+               | Ok winner ->
+                 Ok
+                   ( winner.Keeper_memory_os_io.episode
+                   , winner.model_id
+                   , winner.provider_latency_ms )
+               | Error detail ->
+                 Error (Memory_episode_persistence_failed detail)))))
+    in
+    (match episode_result with
+     | Error _ as error -> error
+     | Ok (episode, operation_model_id, provider_latency_ms) ->
+       publish_episode
+         ?operation_id
          ?clock
-         ?timeout_sec
-         ~sw
-         ~net
-         ~provider_cfg
-         ~generation
-         inp
-     with
-  | Error _ as e -> e
-  | Ok episode ->
-    let now = episode.Keeper_memory_os_types.created_at in
-    (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
-       re-extracted across turns is folded into the existing row
-       (Keeper_memory_os_policy.reobserve_fact: RFC-0247 refreshes
-       [last_verified_at] only) rather than accumulating as a duplicate. The same
-       call applies the RFC-0239 Q4 retention cap (ranked by the structural
-       [retention_rank]) in one atomic rewrite. Only after the facts are durable
-       do we publish the episode file and append the event row; the event row is
-       the reader-visible commit marker for [read_episodes_tail].
+         ?keepers_dir
+         ~keeper_id
+         ~operation_model_id
+         ~provider_latency_ms
+         episode)
+;;
 
-       RFC-0285 §8: before folding, decide each claim's provenance. A claim
-       whose identity was recall-injected into this keeper's recent prompts is
-       an echo — the model restating what it just read — and must not advance
-       the truth anchor recall's recency ranking reads. The judgment (window
-       join + metric) lives here at the write boundary; the fold itself stays
-       a pure function of the decision. *)
-    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun () ->
-      match
-        try
-          let window = Keeper_memory_os_io.fact_recall_window in
-          let merge ~existing ~incoming =
-            let provenance =
-              let key = Keeper_memory_os_types.claim_identity incoming in
-              if Keeper_recall_injection_window.recently_injected ~keeper_id ~key
-              then (
-                Otel_metric_store.inc_counter
-                  Keeper_metrics.(to_string MemoryOsReobserveEchoSuppressed)
-                  ~labels:[ "keeper", keeper_id ]
-                  ();
-                Keeper_memory_os_policy.Recalled_echo)
-              else Keeper_memory_os_policy.Independent_observation
-            in
-            Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
-          in
-          let (_ : Keeper_memory_os_io.fact_merge_stats) =
-            File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
-              Keeper_memory_os_io.merge_and_cap_facts
-                ~now
-                ~keeper_id
-                ~merge
-                ~incoming:episode.Keeper_memory_os_types.claims
-                ~keep:window
-                ~trigger:Keeper_memory_os_io.fact_store_max
-                ~rank:(Keeper_memory_os_policy.retention_rank ~now))
-          in
-          Ok ()
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          let message = Printexc.to_string exn in
-          Log.Keeper.warn "memory os fact upsert failed keeper=%s: %s" keeper_id message;
-          Error message
-      with
-      | Ok () ->
-        Keeper_memory_os_io.append_episode ~keeper_id episode;
-        Keeper_memory_os_io.append_event ~keeper_id episode;
-        (* RFC-0272 (defect D): bound the append-only episode log under the same
-           bundle lock that serialized the writes above, so a re-extraction cannot
-           grow events.jsonl / episodes/ without limit. Hysteresis-gated: the trim
-           is a no-op until the high-water, so this is off the per-turn hot path. *)
-        ignore
-          (Keeper_memory_os_io.cap_events
-             ~keeper_id
-             ~keep:Keeper_memory_os_io.event_recall_window
-             ~trigger:Keeper_memory_os_io.event_store_max
-            : int);
-        ignore
-          (Keeper_memory_os_io.cap_episode_files
-             ~keeper_id
-             ~keep:Keeper_memory_os_io.episode_file_window
-             ~trigger:Keeper_memory_os_io.episode_file_store_max
-            : int);
-        (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
-           (dark-by-default, no recall consumer), so the fact upsert above is the only
-           post-merge work. *)
-        Ok episode
-      | Error message -> Error (Memory_fact_upsert_failed message)))
+let extract_and_append_with_provider_classified
+    ?operation_id
+    ?complete
+    ?clock
+    ?keepers_dir
+    ?timeout_sec
+    ~sw
+    ~net
+    ~keeper_id
+    ~provider_cfg
+    inp
+  =
+  match
+    extract_and_append_with_provider_classified_with_model
+      ?operation_id
+      ?complete
+      ?clock
+      ?keepers_dir
+      ?timeout_sec
+      ~sw
+      ~net
+      ~keeper_id
+      ~provider_cfg
+      inp
+  with
+  | Error _ as error -> error
+  | Ok (episode, _, _) -> Ok episode
 ;;
 
 let extract_and_append_with_provider
+    ?operation_id
     ?complete
     ?clock
+    ?keepers_dir
     ?timeout_sec
     ~sw
     ~net
@@ -653,8 +862,10 @@ let extract_and_append_with_provider
   =
   match
     extract_and_append_with_provider_classified
+      ?operation_id
       ?complete
       ?clock
+      ?keepers_dir
       ?timeout_sec
       ~sw
       ~net
@@ -670,30 +881,184 @@ let provider_for_runtime ~runtime_id =
   Keeper_memory_runtime_resolution.provider_for_runtime ~runtime_id
 ;;
 
-let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_librarian.input) =
-  (* [cadence_due] short-circuits after [enabled]: a disabled keeper never
-     advances its cadence counter, and a not-due turn skips extraction entirely
-     (the messages remain in the window for the next due turn). The cadence
-     counter is scoped to the active trace so a rollover does not inherit the
-     previous trace's schedule. *)
-  if enabled () && cadence_due ~keeper_id ~trace_id:inp.trace_id
-  then (
-    try
+type skip_reason =
+  | Librarian_disabled
+  | Cadence_not_due
+
+type run_error =
+  | Eio_context_unavailable
+  | Runtime_resolution_failed of string
+  | Provider_not_direct_completion
+  | Extraction_failed of extraction_error
+  | Unexpected_failure of string
+
+type run_outcome =
+  | Run_skipped of
+      { runtime_id : string
+      ; model_id : string option
+      ; reason : skip_reason
+      ; latency_ms : float
+      ; next_due_after_turns : int option
+      }
+  | Run_succeeded of
+      { runtime_id : string
+      ; model_id : string
+      ; episode : Keeper_memory_os_types.episode
+      ; provider_latency_ms : float
+      ; latency_ms : float
+      ; next_due_after_turns : int
+      }
+  | Run_failed of
+      { runtime_id : string
+      ; model_id : string option
+      ; error : run_error
+      ; latency_ms : float
+      ; next_due_after_turns : int
+      }
+
+let skip_reason_to_string = function
+  | Librarian_disabled -> "disabled"
+  | Cadence_not_due -> "cadence_not_due"
+;;
+
+let run_error_to_string = function
+  | Eio_context_unavailable -> "Eio context unavailable"
+  | Runtime_resolution_failed detail -> "runtime resolution failed: " ^ detail
+  | Provider_not_direct_completion -> "provider does not support direct completion"
+  | Extraction_failed error -> extraction_error_to_string error
+  | Unexpected_failure detail -> detail
+;;
+
+let next_due_after_turns_to_json = function
+  | None -> `Null
+  | Some turns -> `Int turns
+;;
+
+let run_outcome_to_json = function
+  | Run_skipped
+      { runtime_id
+      ; model_id
+      ; reason
+      ; latency_ms
+      ; next_due_after_turns
+      } ->
+    `Assoc
+      [ "status", `String "skipped"
+      ; "runtime_id", `String runtime_id
+      ; "model_id", Json_util.string_opt_to_json model_id
+      ; "reason", `String (skip_reason_to_string reason)
+      ; "latency_ms", `Float latency_ms
+      ; "next_due_after_turns"
+        , next_due_after_turns_to_json next_due_after_turns
+      ]
+  | Run_succeeded
+      { runtime_id
+      ; model_id
+      ; episode
+      ; provider_latency_ms
+      ; latency_ms
+      ; next_due_after_turns
+      } ->
+    `Assoc
+      [ "status", `String "succeeded"
+      ; "runtime_id", `String runtime_id
+      ; "model_id", `String model_id
+      ; "episode_generation", `Int episode.Keeper_memory_os_types.generation
+      ; "claim_count", `Int (List.length episode.claims)
+      ; "provider_latency_ms", `Float provider_latency_ms
+      ; "latency_ms", `Float latency_ms
+      ; "next_due_after_turns", `Int next_due_after_turns
+      ]
+  | Run_failed
+      { runtime_id
+      ; model_id
+      ; error
+      ; latency_ms
+      ; next_due_after_turns
+      } ->
+    `Assoc
+      [ "status", `String "failed"
+      ; "runtime_id", `String runtime_id
+      ; "model_id", Json_util.string_opt_to_json model_id
+      ; "error", `String (run_error_to_string error)
+      ; "latency_ms", `Float latency_ms
+      ; "next_due_after_turns", `Int next_due_after_turns
+      ]
+;;
+
+let run_outcome_is_failure = function
+  | Run_failed _ -> true
+  | Run_skipped _ | Run_succeeded _ -> false
+;;
+
+let run_best_effort
+      ?operation_id
+      ?complete
+      ?timeout_sec
+      ~keepers_dir
+      ~admission_decision
+      ~runtime_id
+      ~keeper_id
+      (inp : Keeper_librarian.input)
+  =
+  let started_at = Time_compat.now () in
+  let latency_ms () =
+    Keeper_timing.round1 ((Time_compat.now () -. started_at) *. 1000.0)
+  in
+  let cadence = cadence_turns () in
+  (* The admission decision was made synchronously with the durable job payload.
+     Replay consumes that typed decision verbatim; runtime restart or a failed
+     receipt write can never turn one admitted provider attempt into a later
+     cadence skip. *)
+  match admission_decision with
+  | Admission_disabled ->
+    Run_skipped
+      { runtime_id
+      ; model_id = None
+      ; reason = Librarian_disabled
+      ; latency_ms = latency_ms ()
+      ; next_due_after_turns = None
+      }
+  | Admission_not_due { turns_remaining } ->
+       Run_skipped
+         { runtime_id
+         ; model_id = None
+         ; reason = Cadence_not_due
+         ; latency_ms = latency_ms ()
+         ; next_due_after_turns = Some turns_remaining
+         }
+  | Admission_due ->
+      try
       match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
       | Some sw, Some net ->
         let runtime_id = runtime_id_for_librarian ~runtime_id in
         (match provider_for_runtime ~runtime_id with
          | Error err ->
            Log.Keeper.warn ~keeper_name:keeper_id
-             "memory os librarian skipped runtime=%s: %s"
+             "memory os librarian failed runtime=%s: %s"
              runtime_id
-             err
+             err;
+           Run_failed
+             { runtime_id
+             ; model_id = None
+             ; error = Runtime_resolution_failed err
+             ; latency_ms = latency_ms ()
+             ; next_due_after_turns = cadence
+             }
          | Ok provider_cfg ->
            if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
-           then
+           then (
              Log.Keeper.warn ~keeper_name:keeper_id
-               "memory os librarian skipped runtime=%s: provider does not support direct completion"
+               "memory os librarian failed runtime=%s model=%s: provider does not support direct completion"
                runtime_id
+               provider_cfg.model_id;
+             Run_failed
+               { runtime_id
+               ; model_id = Some provider_cfg.model_id
+               ; error = Provider_not_direct_completion
+               ; latency_ms = latency_ms ()
+               ; next_due_after_turns = cadence
+               })
            else (
              let clock = Eio_context.get_clock_opt () in
              let timeout_sec =
@@ -708,11 +1073,20 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                Log.Keeper.warn ~keeper_name:keeper_id
                  "memory os librarian failed runtime=%s: %s"
                  runtime_id
-                 librarian_provider_clock_unavailable_error
+                 librarian_provider_clock_unavailable_error;
+               Run_failed
+                 { runtime_id
+                 ; model_id = Some provider_cfg.model_id
+                 ; error = Extraction_failed Provider_clock_unavailable
+                 ; latency_ms = latency_ms ()
+                 ; next_due_after_turns = cadence
+                 }
              | Some clock ->
                (match
-                  extract_and_append_with_provider_classified
+                  extract_and_append_with_provider_classified_with_model
+                    ?operation_id
                     ?complete
+                    ~keepers_dir
                     ~clock
                     ~timeout_sec
                     ~sw
@@ -721,29 +1095,47 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                     ~provider_cfg
                     inp
                 with
-                | Ok episode ->
-               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
+                | Ok (episode, operation_model_id, provider_latency_ms) ->
                Log.Keeper.info ~keeper_name:keeper_id
                  "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
                  episode.Keeper_memory_os_types.trace_id
                  episode.generation
-                 (List.length episode.claims)
+                 (List.length episode.claims);
+               Run_succeeded
+                 { runtime_id
+                 ; model_id = operation_model_id
+                 ; episode
+                 ; provider_latency_ms
+                 ; latency_ms = latency_ms ()
+                 ; next_due_after_turns = cadence
+                 }
                 | Error err ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)
                  ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
                  ();
-               if should_record_cadence_backoff_after_error err
-               then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian failed runtime=%s: %s; cadence deferred=%b"
+                 "memory os librarian failed runtime=%s: %s"
                  runtime_id
-                 (extraction_error_to_string err)
-                 (should_record_cadence_backoff_after_error err))))
+                 (extraction_error_to_string err);
+               Run_failed
+                 { runtime_id
+                 ; model_id = Some provider_cfg.model_id
+                 ; error = Extraction_failed err
+                 ; latency_ms = latency_ms ()
+                 ; next_due_after_turns = cadence
+                 })))
       | _ ->
         Log.Keeper.warn ~keeper_name:keeper_id
-          "memory os librarian skipped: Eio context unavailable runtime=%s"
-          runtime_id
+          "memory os librarian failed: Eio context unavailable runtime=%s"
+          runtime_id;
+        Run_failed
+          { runtime_id
+          ; model_id = None
+          ; error = Eio_context_unavailable
+          ; latency_ms = latency_ms ()
+          ; next_due_after_turns = cadence
+          }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
@@ -754,5 +1146,12 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
       Log.Keeper.warn ~keeper_name:keeper_id
         "memory os librarian failed runtime=%s: %s"
         runtime_id
-        (Printexc.to_string exn))
+        (Printexc.to_string exn);
+      Run_failed
+        { runtime_id
+        ; model_id = None
+        ; error = Unexpected_failure (Printexc.to_string exn)
+        ; latency_ms = latency_ms ()
+        ; next_due_after_turns = cadence
+        }
 ;;

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -14,74 +14,37 @@ type complete_fn =
   (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
 
 val enabled : unit -> bool
-(** Opt-in gate controlled by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
+(** Default-on gate with [MASC_KEEPER_MEMORY_OS_LIBRARIAN] as the explicit kill
+    switch. *)
 
 val cadence_turns : unit -> int
 (** Turns between librarian extractions per keeper. Default 3, floored at 1,
     overridable with [MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS]. 1 restores
     per-turn extraction. *)
 
-val cadence_step : cadence:int -> counter:int -> int * bool
-(** Pure cadence decision. [(updated_counter, due)] for a keeper whose counter
-    (turns since last successful extraction) is [counter] under [cadence].
-    [counter < 0] is treated as fresh and is due immediately.
-    cadence<=1 is always due with the counter pinned at 0. When due, the updated
-    counter is set to [cadence] and stays there until [cadence_record_success] or
-    [cadence_record_attempt] resets it. Skipped work leaves the counter due;
-    completed non-success attempts may be recorded to wait for the next cadence
-    window. Exposed for testing the cadence logic without the per-keeper counter
-    table. *)
+type cadence_decision =
+  | Due
+  | Not_due of { turns_remaining : int }
 
-val cadence_step_keyed
-  :  cadence:int
-  -> current_trace:string
-  -> prior:(string * int) option
-  -> (string * int) * bool
-(** Pure keyed cadence decision. Given a keeper's [prior] stored
-    [(trace, counter)] and the [current_trace], returns the [(trace, counter)]
-    value to store and whether extraction is due now. A [prior] from a different
-    (rotated) trace, or [None], is treated as fresh — due immediately, not
-    inheriting the old trace's schedule. Exposed for testing the rollover
-    decision without the global table. *)
+val cadence_decision_for_keeper_turn :
+  cadence:int -> keeper_turn:int -> cadence_decision
+(** Pure, restart-stable cadence decision derived from the Keeper's durable
+    timeline turn id. Turn ids zero and one are the initial due state;
+    subsequent due turns are spaced exactly [cadence] turns apart. *)
 
-val cadence_due : keeper_id:string -> trace_id:string -> bool
-(** Advance the persistent cadence counter for [keeper_id] by one turn and
-    report whether extraction is due now. This is what [run_best_effort] gates
-    on. The counter is keyed by [keeper_id] and stores the active [trace_id]
-    alongside it, so a handoff rollover (a new [trace_id]) resets the cadence
-    cycle in place — bounding the table to one row per keeper. First call for an
-    unseen keeper, or the first call after a rollover, is due immediately.
+type librarian_admission_decision =
+  | Admission_disabled
+  | Admission_not_due of { turns_remaining : int }
+  | Admission_due
 
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
+val decide_librarian_admission :
+  keeper_turn:int -> librarian_admission_decision
 
-val cadence_record_success : keeper_id:string -> trace_id:string -> unit
-(** Record a successful structured extraction for [keeper_id] on [trace_id] so
-    the cadence counter resets and the next cycle can begin. Must only be called
-    after a due turn actually produced a structured episode; skipped, failed, or
-    unparseable provider attempts must not call this.
+val librarian_admission_decision_to_json :
+  librarian_admission_decision -> Yojson.Safe.t
 
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
-
-val cadence_record_attempt : keeper_id:string -> trace_id:string -> unit
-(** Record a completed non-success extraction attempt for [keeper_id] on
-    [trace_id] so transient provider failures and unparseable structured-output
-    failures do not immediately retry every keeper turn. This intentionally does
-    not mark the extraction as semantically successful. Skipped work such as a
-    busy provider slot must not call this, because no provider attempt happened.
-
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
-
-val cadence_counter_entries : unit -> int
-(** Number of live per-keeper cadence rows. Bounded by the number of keepers
-    that have run (one row each), independent of trace rotations — so it is the
-    leak-regression signal for the keeper-keyed cadence table and a memory-health
-    metric for the dashboard. Read-only.
-
-    Uses [Eio_guard.with_mutex_ro] so runtime fibers take a cooperative mutex
-    while focused pre-Eio tests keep a direct single-threaded path. *)
+val librarian_admission_decision_of_json :
+  Yojson.Safe.t -> (librarian_admission_decision, string) result
 
 val max_messages : unit -> int
 (** Base per-turn cap on checkpoint messages sent to the librarian prompt. The
@@ -101,6 +64,14 @@ val select_recent_messages
   :  max_messages:int
   -> Agent_sdk.Types.message list
   -> Agent_sdk.Types.message list
+
+val prompt_window_messages
+  :  Agent_sdk.Types.message list
+  -> Agent_sdk.Types.message list
+(** Snapshot exactly the bounded raw-message window that
+    {!messages_for_librarian} will consume. Durable memory jobs use this helper
+    so the cadence/window policy has one SSOT and job payloads do not duplicate
+    an entire unbounded checkpoint history. *)
 
 val messages_for_librarian
   :  Keeper_librarian.input
@@ -136,6 +107,7 @@ type extraction_error =
   | Provider_empty_response
   | Provider_unparseable_response of string
   | Memory_fact_upsert_failed of string
+  | Memory_episode_persistence_failed of string
 
 val extraction_error_to_string : extraction_error -> string
 
@@ -157,11 +129,6 @@ type attempt_outcome =
 type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
-
-val should_record_cadence_backoff_after_error : extraction_error -> bool
-(** Whether an extraction error represents enough completed work to defer the
-    next attempt until the next cadence window. Only completed provider-attempt
-    failures should defer cadence; local deterministic failures stay due. *)
 
 val run_with_parse_retries
   :  max_retries:int
@@ -210,8 +177,10 @@ val extract_with_provider_classified
     production calls cannot silently run without timeout enforcement. *)
 
 val extract_and_append_with_provider
-  :  ?complete:complete_fn
+  :  ?operation_id:string
+  -> ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?keepers_dir:string
   -> ?timeout_sec:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -221,8 +190,10 @@ val extract_and_append_with_provider
   -> (Keeper_memory_os_types.episode, string) result
 
 val extract_and_append_with_provider_classified
-  :  ?complete:complete_fn
+  :  ?operation_id:string
+  -> ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?keepers_dir:string
   -> ?timeout_sec:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -231,13 +202,66 @@ val extract_and_append_with_provider_classified
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result
 
+val commit_staged_operation
+  :  keepers_dir:string
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keeper_id:string
+  -> operation_id:string
+  -> Keeper_memory_os_io.operation_episode
+  -> (unit, extraction_error) result
+(** Publish an already staged provider result without re-running enablement,
+    cadence, runtime resolution, or provider gates. *)
+
+type skip_reason =
+  | Librarian_disabled
+  | Cadence_not_due
+
+type run_error =
+  | Eio_context_unavailable
+  | Runtime_resolution_failed of string
+  | Provider_not_direct_completion
+  | Extraction_failed of extraction_error
+  | Unexpected_failure of string
+
+type run_outcome =
+  | Run_skipped of
+      { runtime_id : string
+      ; model_id : string option
+      ; reason : skip_reason
+      ; latency_ms : float
+      ; next_due_after_turns : int option
+      }
+  | Run_succeeded of
+      { runtime_id : string
+      ; model_id : string
+      ; episode : Keeper_memory_os_types.episode
+      ; provider_latency_ms : float
+      ; latency_ms : float
+      ; next_due_after_turns : int
+      }
+  | Run_failed of
+      { runtime_id : string
+      ; model_id : string option
+      ; error : run_error
+      ; latency_ms : float
+      ; next_due_after_turns : int
+      }
+
+val run_outcome_to_json : run_outcome -> Yojson.Safe.t
+val run_outcome_is_failure : run_outcome -> bool
+
 val run_best_effort
-  :  ?complete:complete_fn
+  :  ?operation_id:string
+  -> ?complete:complete_fn
   -> ?timeout_sec:float
+  -> keepers_dir:string
+  -> admission_decision:librarian_admission_decision
   -> runtime_id:string
   -> keeper_id:string
   -> Keeper_librarian.input
-  -> unit
-(** Run the opt-in post-turn librarian path.
+  -> run_outcome
+(** Run the opt-in post-turn librarian path and return its typed terminal
+    outcome.
 
-    Non-cancel failures are logged and counted, never raised. *)
+    Non-cancel failures are logged and counted, never raised or flattened into
+    a successful unit result. *)

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -83,11 +83,6 @@ val cadence_counter_entries : unit -> int
     Uses [Eio_guard.with_mutex_ro] so runtime fibers take a cooperative mutex
     while focused pre-Eio tests keep a direct single-threaded path. *)
 
-val memory_os_librarian_provider_slot_site : string
-(** OTel [site] label used when the fleet-wide librarian provider slot is busy.
-    The producer and dashboard health reader share this value so label drift
-    cannot silently hide provider-slot-busy alerts. *)
-
 val max_messages : unit -> int
 (** Base per-turn cap on checkpoint messages sent to the librarian prompt. The
     effective prompt window is this value scaled by [cadence_turns] so skipped

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -182,24 +182,6 @@ val run_with_parse_retries
     retry. Pure given a pure [attempt] — the provider side effect lives in the
     [attempt] supplied by {!extract_with_provider}. *)
 
-val per_keeper_slot_capacity : unit -> int
-(** Per-keeper librarian provider slot capacity from
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT] (default 1, 0 disables the
-    gate). The capacity is applied per keeper, not fleet-wide. *)
-
-val with_provider_slot
-  :  keeper_id:string
-  -> clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> (unit -> 'a)
-  -> 'a option
-(** Run [f] under the per-keeper librarian provider slot — the #21230/P0-4
-    storm guard. At capacity N per keeper, the (N+1)-th concurrent entrant for
-    the same keeper returns [None] after [provider_slot_wait_sec] (drop, not
-    block); capacity 0 disables the gate so [f] always runs ([Some]). The
-    provider slot registry is guarded through [Eio_guard.with_mutex], avoiding
-    blocking stdlib locks on keeper runtime fibers. Exposed for storm-guard
-    regression coverage (#21376). *)
-
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian
     extraction is called without a clock. Exposed so callers/tests do not

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -856,52 +856,95 @@ let append_memory_notes_from_tool_results
     (config : Workspace.config)
     (meta : keeper_meta)
     ~(turn : int)
-    ~(results : Yojson.Safe.t list) : int =
+    ~(results : Yojson.Safe.t list) : (int, string) result =
   let now_ts = Time_compat.now () in
   let path = Keeper_types_support.keeper_memory_bank_path config meta.name in
-  let seen_artifacts : (string, unit) Hashtbl.t = Hashtbl.create 16 in
-  let written = ref 0 in
-  with_memory_bank_lock path (fun () ->
-    List.iter
-      (fun result ->
-         match
-           ( Multimodal.Tool_emission.extract_kind_from_result result,
-             Multimodal.Tool_emission.extract_id_from_result result )
-         with
-         | Some kind_tag, Some artifact_id
-           when String.trim artifact_id <> ""
-                && not (Hashtbl.mem seen_artifacts artifact_id) ->
-           Hashtbl.add seen_artifacts artifact_id ();
-           let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
-           let payload_preview = tool_result_payload_preview result in
-           let text = tool_result_memory_text ~kind ~artifact_id ~payload_preview in
-           if is_meaningful_memory_text text then begin
-             Keeper_types_support.append_jsonl_line path
-               (`Assoc
-                 [ ("ts", `String (now_iso ()))
-                 ; ("ts_unix", `Float now_ts)
-                 ; ("name", `String meta.name)
-                 ; ( "trace_id",
-                     `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
-                 ; ("generation", `Int meta.runtime.generation)
-                 ; ("turn", `Int turn)
-                 ; ("kind", `String (memory_kind_to_wire Long_term))
-                 ; ("horizon", `String (memory_horizon_of_kind Long_term))
-                 ; ("source", `String (memory_row_source_to_string Tool_result))
-                 ; ("schema_version", `Int keeper_memory_schema_version)
-                 ; ( "priority",
-                     `Int (tuned_priority_for_candidate ~kind:Long_term ~text) )
-                 ; ("text", `String text)
-                 ; ("artifact_id", `String artifact_id)
-                 ; ("artifact_kind", `String kind)
-                 ; ("payload_preview", `String payload_preview)
-                 ; ("metadata", tool_result_metadata result)
-                 ]);
-             incr written
-           end
-         | _ -> ())
-      results);
-  !written
+  try
+    with_memory_bank_lock path (fun () ->
+      let seen_artifacts : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+      let existing_rows =
+        if not (Fs_compat.file_exists path)
+        then Ok []
+        else
+          match Safe_ops.read_file_safe path with
+          | Error detail ->
+            Error
+              (Printf.sprintf
+                 "failed to read memory bank before idempotent tool-result append: %s"
+                 detail)
+          | Ok content ->
+            let rows, invalid = parse_memory_bank_content content in
+            if invalid = 0
+            then Ok rows
+            else
+              Error
+                (Printf.sprintf
+                   "refusing idempotent tool-result append with %d malformed memory-bank row(s)"
+                   invalid)
+      in
+      match existing_rows with
+      | Error _ as error -> error
+      | Ok rows ->
+        List.iter
+          (fun (row : keeper_memory_row_raw) ->
+             match row.source, row.json with
+             | Tool_result, `Assoc fields ->
+               (match List.assoc_opt "artifact_id" fields with
+                | Some (`String artifact_id)
+                  when not (String.equal (String.trim artifact_id) "") ->
+                  Hashtbl.replace seen_artifacts artifact_id ()
+                | Some _ | None -> ())
+             | ( Progress_consolidation
+               | Cross_trace_recurrence
+               | Explicit_memory_write
+               | Voice_output
+               | Other _ ), _ -> ()
+             | Tool_result, _ -> ())
+          rows;
+        let written = ref 0 in
+        List.iter
+          (fun result ->
+             match
+               ( Multimodal.Tool_emission.extract_kind_from_result result,
+                 Multimodal.Tool_emission.extract_id_from_result result )
+             with
+             | Some kind_tag, Some artifact_id
+               when String.trim artifact_id <> ""
+                    && not (Hashtbl.mem seen_artifacts artifact_id) ->
+               Hashtbl.replace seen_artifacts artifact_id ();
+               let kind = Multimodal.Artifact.kind_tag_to_string kind_tag in
+               let payload_preview = tool_result_payload_preview result in
+               let text = tool_result_memory_text ~kind ~artifact_id ~payload_preview in
+               if is_meaningful_memory_text text then begin
+                 Keeper_types_support.append_jsonl_line path
+                   (`Assoc
+                     [ ("ts", `String (now_iso ()))
+                     ; ("ts_unix", `Float now_ts)
+                     ; ("name", `String meta.name)
+                     ; ( "trace_id",
+                         `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) )
+                     ; ("generation", `Int meta.runtime.generation)
+                     ; ("turn", `Int turn)
+                     ; ("kind", `String (memory_kind_to_wire Long_term))
+                     ; ("horizon", `String (memory_horizon_of_kind Long_term))
+                     ; ("source", `String (memory_row_source_to_string Tool_result))
+                     ; ("schema_version", `Int keeper_memory_schema_version)
+                     ; ( "priority",
+                         `Int (tuned_priority_for_candidate ~kind:Long_term ~text) )
+                     ; ("text", `String text)
+                     ; ("artifact_id", `String artifact_id)
+                     ; ("artifact_kind", `String kind)
+                     ; ("payload_preview", `String payload_preview)
+                     ; ("metadata", tool_result_metadata result)
+                     ]);
+                 incr written
+               end
+             | _ -> ())
+          results;
+        Ok !written)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
 
 let append_voice_output
     (config : Workspace.config)

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -231,7 +231,11 @@ val append_memory_notes_from_tool_results :
   Keeper_meta_contract.keeper_meta ->
   turn:int ->
   results:Yojson.Safe.t list ->
-  int
+  (int, string) result
+(** Idempotently promote tool-result artifacts. Existing [tool_result] rows are
+    keyed by their typed [artifact_id], so replaying a durable post-turn job
+    writes only artifacts that are not already in the bank. Read/write failures
+    are explicit. *)
 
 val append_voice_output :
   Workspace.config ->

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -1,0 +1,1418 @@
+(** Durable per-keeper post-turn memory jobs. *)
+
+let job_schema = "masc.keeper_memory_job.v1"
+let envelope_schema = "masc.keeper_memory_job_envelope.v1"
+let receipt_schema = "masc.keeper_memory_job_receipt.v2"
+let jobs_dirname = "memory-jobs"
+let awaiting_dirname = "awaiting-turn-commit"
+let pending_dirname = "pending"
+let inflight_dirname = "inflight"
+let receipts_dirname = "receipts"
+let operations_dirname = "operations"
+let recovered_atomic_writes_dirname = "recovered-atomic-writes"
+let json_suffix = ".json"
+let private_directory_mode = 0o700
+let private_file_mode = 0o600
+
+type job =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease =
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt =
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Rename
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_job_id of string
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Turn_receipt_error of
+      { keeper_name : string
+      ; detail : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+let io_operation_to_string = function
+  | Ensure_directory -> "ensure_directory"
+  | Set_permissions -> "set_permissions"
+  | Inspect -> "inspect"
+  | List_directory -> "list_directory"
+  | Read -> "read"
+  | Write -> "write"
+  | Rename -> "rename"
+  | Remove -> "remove"
+;;
+
+let error_to_string = function
+  | Invalid_keeper_name name ->
+    Printf.sprintf "invalid keeper name: %S" name
+  | Invalid_trace_id detail -> detail
+  | Invalid_turn_identity { generation; turn; oas_turn_count } ->
+    Printf.sprintf
+      "invalid memory job turn identity generation=%d turn=%d oas_turn_count=%d"
+      generation
+      turn
+      oas_turn_count
+  | Invalid_enqueue_time value ->
+    Printf.sprintf "invalid memory job enqueue time: %g" value
+  | Invalid_job_id id -> Printf.sprintf "invalid memory job id: %S" id
+  | Unexpected_queue_entry path ->
+    Printf.sprintf "unexpected entry in memory job queue: %s" path
+  | Decode_error { path; detail } ->
+    Printf.sprintf "memory job decode failed path=%s: %s" path detail
+  | Identity_conflict { job_id; path } ->
+    Printf.sprintf
+      "memory job identity conflict id=%s path=%s"
+      job_id
+      path
+  | Turn_receipt_error { keeper_name; detail } ->
+    Printf.sprintf
+      "memory job turn-receipt reconciliation failed keeper=%s: %s"
+      keeper_name
+      detail
+  | Io_error { operation; path; detail } ->
+    Printf.sprintf
+      "memory job %s failed path=%s: %s"
+      (io_operation_to_string operation)
+      path
+      detail
+;;
+
+let ( let* ) = Result.bind
+
+let keeper_name_is_valid keeper_name =
+  Result.is_ok (Keeper_id.Keeper_name.of_string keeper_name)
+;;
+
+let protect_io operation path f =
+  try Ok (f ()) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let keeper_jobs_dir ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       keeper_name)
+    jobs_dirname
+;;
+
+let pending_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) pending_dirname
+;;
+
+let awaiting_dir ~base_path ~keeper_name =
+  Filename.concat
+    (keeper_jobs_dir ~base_path ~keeper_name)
+    awaiting_dirname
+;;
+
+let inflight_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) inflight_dirname
+;;
+
+let receipts_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) receipts_dirname
+;;
+
+let operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat keepers_dir keeper_name)
+       jobs_dirname)
+    operations_dirname
+;;
+
+let operations_dir ~base_path ~keeper_name =
+  operation_stages_dir_for_keepers_dir
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
+    ~keeper_name
+;;
+
+let path_for_id dir id = Filename.concat dir (id ^ json_suffix)
+
+let pending_path ~base_path (job : job) =
+  path_for_id (pending_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let awaiting_path ~base_path (job : job) =
+  path_for_id (awaiting_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let inflight_path ~base_path (job : job) =
+  path_for_id (inflight_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path ~base_path (job : job) =
+  path_for_id (receipts_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path_for_identity ~base_path (identity : receipt_identity) =
+  path_for_id
+    (receipts_dir ~base_path ~keeper_name:identity.keeper_name)
+    identity.id
+;;
+
+let operation_stage_path_for_keepers_dir ~keepers_dir ~keeper_name ~operation_id =
+  path_for_id
+    (operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name)
+    operation_id
+;;
+
+let operation_stage_path ~base_path ~keeper_name ~operation_id =
+  path_for_id (operations_dir ~base_path ~keeper_name) operation_id
+;;
+
+let ensure_store_dirs ~base_path ~keeper_name =
+  let dirs =
+    [ keeper_jobs_dir ~base_path ~keeper_name
+    ; pending_dir ~base_path ~keeper_name
+    ; awaiting_dir ~base_path ~keeper_name
+    ; inflight_dir ~base_path ~keeper_name
+    ; receipts_dir ~base_path ~keeper_name
+    ; operations_dir ~base_path ~keeper_name
+    ]
+  in
+  let rec loop = function
+    | [] -> Ok ()
+    | dir :: rest ->
+      let* () =
+        protect_io Ensure_directory dir (fun () ->
+          ignore (Keeper_fs.ensure_dir dir))
+      in
+      let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+      let* () =
+        if stat.Unix.st_kind = Unix.S_DIR
+        then Ok ()
+        else
+          Error
+            (Io_error
+               { operation = Inspect
+               ; path = dir
+               ; detail = "memory job store path is not a real directory"
+               })
+      in
+      let* () =
+        protect_io Set_permissions dir (fun () ->
+          Unix.chmod dir private_directory_mode)
+      in
+      loop rest
+  in
+  loop dirs
+;;
+
+let valid_job_id id =
+  String.length id = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       id
+;;
+
+let is_valid_job_id = valid_job_id
+
+let job_identity_string ~keeper_name ~trace_id ~generation ~turn ~oas_turn_count =
+  String.concat
+    "\000"
+    [ keeper_name
+    ; trace_id
+    ; string_of_int generation
+    ; string_of_int turn
+    ; string_of_int oas_turn_count
+    ]
+;;
+
+let make_job
+      ~keeper_name
+      ~trace_id
+      ~generation
+      ~turn
+      ~oas_turn_count
+      ~enqueued_at
+      ~payload
+  =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ -> Error (Invalid_keeper_name keeper_name)
+  | Ok keeper_name_t ->
+    (match Keeper_id.Trace_id.of_string trace_id with
+     | Error detail -> Error (Invalid_trace_id detail)
+     | Ok trace_id_t ->
+       if generation < 0 || turn < 0 || oas_turn_count < 0
+       then Error (Invalid_turn_identity { generation; turn; oas_turn_count })
+       else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+       then Error (Invalid_enqueue_time enqueued_at)
+       else
+         let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_t in
+         let trace_id = Keeper_id.Trace_id.to_string trace_id_t in
+         let id =
+           job_identity_string
+             ~keeper_name
+             ~trace_id
+             ~generation
+             ~turn
+             ~oas_turn_count
+           |> Digestif.SHA256.digest_string
+           |> Digestif.SHA256.to_hex
+         in
+         Ok
+           { id
+           ; keeper_name
+           ; trace_id
+           ; generation
+           ; turn
+           ; oas_turn_count
+           ; enqueued_at
+           ; payload
+           })
+;;
+
+let job_to_json (job : job) =
+  `Assoc
+    [ "schema", `String job_schema
+    ; "id", `String job.id
+    ; "keeper_name", `String job.keeper_name
+    ; "trace_id", `String job.trace_id
+    ; "generation", `Int job.generation
+    ; "turn", `Int job.turn
+    ; "oas_turn_count", `Int job.oas_turn_count
+    ; "enqueued_at", `Float job.enqueued_at
+    ; "payload", job.payload
+    ]
+;;
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (key, value) -> key, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _) as json ->
+    json
+;;
+
+let payload_sha256 payload =
+  canonical_json payload
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let receipt_identity_of_job (job : job) =
+  { id = job.id
+  ; keeper_name = job.keeper_name
+  ; trace_id = job.trace_id
+  ; generation = job.generation
+  ; turn = job.turn
+  ; oas_turn_count = job.oas_turn_count
+  ; enqueued_at = job.enqueued_at
+  ; payload_sha256 = payload_sha256 job.payload
+  }
+;;
+
+let receipt_identity_matches_job identity (job : job) =
+  String.equal identity.id job.id
+  && String.equal identity.keeper_name job.keeper_name
+  && String.equal identity.trace_id job.trace_id
+  && identity.generation = job.generation
+  && identity.turn = job.turn
+  && identity.oas_turn_count = job.oas_turn_count
+  && String.equal identity.payload_sha256 (payload_sha256 job.payload)
+;;
+
+let receipt_identity_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && Float.equal left.enqueued_at right.enqueued_at
+  && String.equal left.payload_sha256 right.payload_sha256
+;;
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be a string" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let int_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be an int" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some _ -> Error (Printf.sprintf "field %s must be a number" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let json_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let job_of_json = function
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema job_schema)
+    then Error (Printf.sprintf "unsupported memory job schema: %s" schema)
+    else
+      let* id = string_field "id" fields in
+      let* keeper_name = string_field "keeper_name" fields in
+      let* trace_id = string_field "trace_id" fields in
+      let* generation = int_field "generation" fields in
+      let* turn = int_field "turn" fields in
+      let* oas_turn_count = int_field "oas_turn_count" fields in
+      let* enqueued_at = float_field "enqueued_at" fields in
+      let* payload = json_field "payload" fields in
+      if not (valid_job_id id)
+      then Error (Printf.sprintf "invalid memory job id: %S" id)
+      else
+        let* keeper_name =
+          Keeper_id.Keeper_name.of_string keeper_name
+        in
+        let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+        if generation < 0 || turn < 0 || oas_turn_count < 0
+        then Error "turn identity values must be non-negative"
+        else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+        then Error "enqueued_at must be finite and non-negative"
+        else
+          let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+          let trace_id = Keeper_id.Trace_id.to_string trace_id in
+          let expected_id =
+            job_identity_string
+              ~keeper_name
+              ~trace_id
+              ~generation
+              ~turn
+              ~oas_turn_count
+            |> Digestif.SHA256.digest_string
+            |> Digestif.SHA256.to_hex
+          in
+          if not (String.equal id expected_id)
+          then Error "memory job id does not match its typed turn identity"
+          else
+            Ok
+              { id
+              ; keeper_name
+              ; trace_id
+              ; generation
+              ; turn
+              ; oas_turn_count
+              ; enqueued_at
+              ; payload
+              }
+  | _ -> Error "memory job must be a JSON object"
+;;
+
+type persisted_state =
+  | Awaiting_turn_commit
+  | Pending
+  | Inflight of { started_at : float }
+
+type envelope =
+  { job : job
+  ; state : persisted_state
+  }
+
+let state_to_json = function
+  | Awaiting_turn_commit ->
+    `Assoc [ "kind", `String "awaiting_turn_commit" ]
+  | Pending -> `Assoc [ "kind", `String "pending" ]
+  | Inflight { started_at } ->
+    `Assoc
+      [ "kind", `String "inflight"
+      ; "started_at", `Float started_at
+      ]
+;;
+
+let envelope_to_json envelope =
+  `Assoc
+    [ "schema", `String envelope_schema
+    ; "job", job_to_json envelope.job
+    ; "state", state_to_json envelope.state
+    ]
+;;
+
+let state_of_json = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "awaiting_turn_commit" -> Ok Awaiting_turn_commit
+     | "pending" -> Ok Pending
+     | "inflight" ->
+       let* started_at = float_field "started_at" fields in
+       Ok (Inflight { started_at })
+     | other -> Error (Printf.sprintf "unknown memory job state: %s" other))
+  | _ -> Error "memory job state must be an object"
+;;
+
+let envelope_of_json = function
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema envelope_schema)
+    then Error (Printf.sprintf "unsupported memory job envelope schema: %s" schema)
+    else
+      let* job_json = json_field "job" fields in
+      let* state_json = json_field "state" fields in
+      let* job = job_of_json job_json in
+      let* state = state_of_json state_json in
+      Ok { job; state }
+  | _ -> Error "memory job envelope must be a JSON object"
+;;
+
+let terminal_outcome_to_string = function
+  | Succeeded -> "succeeded"
+  | Failed -> "failed"
+;;
+
+let terminal_outcome_of_string = function
+  | "succeeded" -> Ok Succeeded
+  | "failed" -> Ok Failed
+  | value -> Error (Printf.sprintf "unknown terminal outcome: %s" value)
+;;
+
+let receipt_identity_to_json identity =
+  `Assoc
+    [ "id", `String identity.id
+    ; "keeper_name", `String identity.keeper_name
+    ; "trace_id", `String identity.trace_id
+    ; "generation", `Int identity.generation
+    ; "turn", `Int identity.turn
+    ; "oas_turn_count", `Int identity.oas_turn_count
+    ; "enqueued_at", `Float identity.enqueued_at
+    ; "payload_sha256", `String identity.payload_sha256
+    ]
+;;
+
+let receipt_identity_of_json = function
+  | `Assoc fields ->
+    let* id = string_field "id" fields in
+    let* keeper_name = string_field "keeper_name" fields in
+    let* trace_id = string_field "trace_id" fields in
+    let* generation = int_field "generation" fields in
+    let* turn = int_field "turn" fields in
+    let* oas_turn_count = int_field "oas_turn_count" fields in
+    let* enqueued_at = float_field "enqueued_at" fields in
+    let* payload_sha256 = string_field "payload_sha256" fields in
+    let* keeper_name = Keeper_id.Keeper_name.of_string keeper_name in
+    let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+    let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+    let trace_id = Keeper_id.Trace_id.to_string trace_id in
+    let expected_id =
+      job_identity_string
+        ~keeper_name
+        ~trace_id
+        ~generation
+        ~turn
+        ~oas_turn_count
+      |> Digestif.SHA256.digest_string
+      |> Digestif.SHA256.to_hex
+    in
+    if generation < 0 || turn < 0 || oas_turn_count < 0
+    then Error "receipt turn identity values must be non-negative"
+    else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+    then Error "receipt enqueued_at must be finite and non-negative"
+    else if not (valid_job_id id) || not (String.equal id expected_id)
+    then Error "receipt id does not match its typed turn identity"
+    else if not (valid_job_id payload_sha256)
+    then Error "receipt payload_sha256 must be a lowercase SHA-256 digest"
+    else
+      Ok
+        { id
+        ; keeper_name
+        ; trace_id
+        ; generation
+        ; turn
+        ; oas_turn_count
+        ; enqueued_at
+        ; payload_sha256
+        }
+  | _ -> Error "receipt job identity must be a JSON object"
+;;
+
+let receipt_to_json (receipt : terminal_receipt) =
+  `Assoc
+    [ "schema", `String receipt_schema
+    ; "job_identity", receipt_identity_to_json receipt.identity
+    ; "started_at", `Float receipt.started_at
+    ; "ended_at", `Float receipt.ended_at
+    ; "outcome", `String (terminal_outcome_to_string receipt.outcome)
+    ; "detail", receipt.detail
+    ]
+;;
+
+let receipt_of_json = function
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema receipt_schema)
+    then Error (Printf.sprintf "unsupported memory job receipt schema: %s" schema)
+    else
+      let* identity_json = json_field "job_identity" fields in
+      let* identity = receipt_identity_of_json identity_json in
+      let* started_at = float_field "started_at" fields in
+      let* ended_at = float_field "ended_at" fields in
+      let* outcome_string = string_field "outcome" fields in
+      let* outcome = terminal_outcome_of_string outcome_string in
+      let* detail = json_field "detail" fields in
+      if
+        (not (Float.is_finite started_at))
+        || started_at < 0.0
+        || not (Float.is_finite ended_at)
+        || ended_at < started_at
+      then Error "receipt timestamps must be finite, non-negative, and ordered"
+      else Ok { identity; started_at; ended_at; outcome; detail }
+  | _ -> Error "memory job receipt must be a JSON object"
+;;
+
+let read_json path =
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  if stat.Unix.st_kind <> Unix.S_REG
+  then
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = "memory job artifact is not a regular file"
+         })
+  else
+    match Safe_ops.read_json_file_safe path with
+    | Ok json -> Ok json
+    | Error detail -> Error (Io_error { operation = Read; path; detail })
+;;
+
+let read_envelope path =
+  let* json = read_json path in
+  envelope_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let read_receipt path =
+  let* json = read_json path in
+  receipt_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let save_json path json =
+  match Keeper_fs.save_json_atomic path json with
+  | Ok () ->
+    protect_io Set_permissions path (fun () -> Unix.chmod path private_file_mode)
+  | Error detail -> Error (Io_error { operation = Write; path; detail })
+;;
+
+let file_exists path =
+  try
+    ignore (Unix.lstat path);
+    Ok true
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let remove_if_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else protect_io Remove path (fun () -> Sys.remove path)
+;;
+
+let cleanup_paths paths =
+  List.fold_left
+    (fun errors path ->
+       match remove_if_exists path with
+       | Ok () -> errors
+       | Error error -> error :: errors)
+    []
+    paths
+  |> List.rev
+;;
+
+let reconcile_atomic_orphan dir name =
+  let path = Filename.concat dir name in
+  let recovered_dir =
+    Filename.concat
+      (Filename.concat (Filename.dirname dir) recovered_atomic_writes_dirname)
+      (Filename.basename dir)
+  in
+  match Fs_compat.recover_atomic_orphan ~path ~recovered_dir with
+  | Error detail -> Error (Io_error { operation = Inspect; path; detail })
+  | Ok Fs_compat.Deleted_zero_length ->
+    Log.Keeper.warn "memory job queue removed zero-length atomic orphan path=%s" path;
+    Ok ()
+  | Ok (Fs_compat.Preserved_nonempty destination) ->
+    (match
+       protect_io Set_permissions recovered_dir (fun () ->
+         Unix.chmod recovered_dir private_directory_mode)
+     with
+     | Error _ as error -> error
+     | Ok () ->
+       let* () =
+         protect_io Set_permissions destination (fun () ->
+           Unix.chmod destination private_file_mode)
+       in
+       Log.Keeper.error
+         "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
+         path
+         destination;
+       Ok ())
+;;
+
+let list_json_paths dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok []
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec validate acc = function
+      | [] -> Ok (List.sort String.compare acc)
+      | name :: rest ->
+        let path = Filename.concat dir name in
+        if Filename.check_suffix name json_suffix
+        then validate (path :: acc) rest
+        else if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          validate acc rest
+        else Error (Unexpected_queue_entry path)
+    in
+    validate [] entries
+;;
+
+let reconcile_atomic_orphans_in_dir dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok ()
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec loop = function
+      | [] -> Ok ()
+      | name :: rest ->
+        if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          loop rest
+        else loop rest
+    in
+    loop entries
+;;
+
+let job_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && Yojson.Safe.equal left.payload right.payload
+;;
+
+let ensure_same_job ~expected ~path envelope =
+  if job_equal expected envelope.job
+  then Ok ()
+  else Error (Identity_conflict { job_id = expected.id; path })
+;;
+
+type expected_envelope_state =
+  | Expect_awaiting
+  | Expect_pending
+  | Expect_inflight
+
+let ensure_expected_state ~expected ~path envelope =
+  match expected, envelope.state with
+  | Expect_awaiting, Awaiting_turn_commit
+  | Expect_pending, Pending
+  | Expect_inflight, Inflight _ -> Ok ()
+  | Expect_awaiting, (Pending | Inflight _)
+  | Expect_pending, (Awaiting_turn_commit | Inflight _)
+  | Expect_inflight, (Awaiting_turn_commit | Pending) ->
+    let expected_label =
+      match expected with
+      | Expect_awaiting -> "awaiting-turn-commit"
+      | Expect_pending -> "pending"
+      | Expect_inflight -> "inflight"
+    in
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "%s directory contains an envelope with a different state"
+               expected_label
+         })
+;;
+
+let ensure_queue_coordinates ~expected_keeper_name ~path envelope =
+  let expected_name = envelope.job.id ^ json_suffix in
+  let actual_name = Filename.basename path in
+  if not (String.equal envelope.job.keeper_name expected_keeper_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue keeper coordinate mismatch expected=%s actual=%s"
+               expected_keeper_name
+               envelope.job.keeper_name
+         })
+  else if not (String.equal actual_name expected_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue filename coordinate mismatch expected=%s actual=%s"
+               expected_name
+               actual_name
+         })
+  else Ok ()
+;;
+
+let classify_existing_envelope ~expected_job ~expected_state ~path outcome =
+  let* exists = file_exists path in
+  if not exists
+  then Ok None
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:expected_job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:expected_job ~path envelope in
+    let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+    Ok (Some outcome)
+;;
+
+let stage_awaiting_turn_commit ~base_path job =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let receipt_path = receipt_path ~base_path job in
+  let* receipt_exists = file_exists receipt_path in
+  if receipt_exists
+  then
+    let* receipt = read_receipt receipt_path in
+    if receipt_identity_matches_job receipt.identity job
+    then
+      let cleanup_errors =
+        cleanup_paths
+          [ awaiting_path ~base_path job
+          ; pending_path ~base_path job
+          ; inflight_path ~base_path job
+          ; operation_stage_path
+              ~base_path
+              ~keeper_name:job.keeper_name
+              ~operation_id:job.id
+          ]
+      in
+      List.iter
+        (fun error ->
+           Log.Keeper.error ~keeper_name:job.keeper_name
+             "memory job completed-state cleanup debt job_id=%s: %s"
+             job.id
+             (error_to_string error))
+        cleanup_errors;
+      Ok Already_completed
+    else Error (Identity_conflict { job_id = job.id; path = receipt_path })
+  else
+    let awaiting_path = awaiting_path ~base_path job in
+    let pending_path = pending_path ~base_path job in
+    let inflight_path = inflight_path ~base_path job in
+    let* awaiting =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_awaiting
+        ~path:awaiting_path
+        Already_awaiting
+    in
+    match awaiting with
+    | Some outcome -> Ok outcome
+    | None ->
+    let* pending =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending_path
+        Already_pending
+    in
+    match pending with
+    | Some outcome -> Ok outcome
+    | None ->
+      let* inflight =
+        classify_existing_envelope
+          ~expected_job:job
+          ~expected_state:Expect_inflight
+          ~path:inflight_path
+          Already_inflight
+      in
+      (match inflight with
+       | Some outcome -> Ok outcome
+       | None ->
+         let envelope = { job; state = Awaiting_turn_commit } in
+         let* () = save_json awaiting_path (envelope_to_json envelope) in
+         Ok Staged_awaiting_turn_commit)
+;;
+
+let compare_job_order left right =
+  let by_turn = Int.compare left.turn right.turn in
+  if by_turn <> 0
+  then by_turn
+  else
+    let by_generation = Int.compare left.generation right.generation in
+    if by_generation <> 0
+    then by_generation
+    else
+      let by_oas_turn = Int.compare left.oas_turn_count right.oas_turn_count in
+      if by_oas_turn <> 0
+      then by_oas_turn
+      else
+        let by_enqueued = Float.compare left.enqueued_at right.enqueued_at in
+        if by_enqueued <> 0 then by_enqueued else String.compare left.id right.id
+;;
+
+let load_envelopes ~expected_keeper_name ~expected_state paths =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | path :: rest ->
+      let* envelope = read_envelope path in
+      let* () =
+        ensure_queue_coordinates ~expected_keeper_name ~path envelope
+      in
+      let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+      loop ((path, envelope) :: acc) rest
+  in
+  loop [] paths
+;;
+
+let list_awaiting ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* paths = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        paths
+    in
+    Ok (List.map (fun (_, envelope) -> envelope.job) envelopes)
+;;
+
+let activate ~base_path (job : job) =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let awaiting = awaiting_path ~base_path job in
+  let pending = pending_path ~base_path job in
+  let inflight = inflight_path ~base_path job in
+  let receipt = receipt_path ~base_path job in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:job.keeper_name
+      ~operation_id:job.id
+  in
+  let* receipt_exists = file_exists receipt in
+  if receipt_exists
+  then
+    let* terminal = read_receipt receipt in
+    if not (receipt_identity_matches_job terminal.identity job)
+    then Error (Identity_conflict { job_id = job.id; path = receipt })
+    else
+      let cleanup_errors = cleanup_paths [ awaiting; pending; inflight; operation ] in
+      Ok (Activation_already_completed, { cleanup_errors })
+  else
+    let* pending_state =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending
+        Activation_already_pending
+    in
+    (match pending_state with
+     | Some activation ->
+       let cleanup_errors = cleanup_paths [ awaiting ] in
+       Ok (activation, { cleanup_errors })
+     | None ->
+       let* inflight_state =
+         classify_existing_envelope
+           ~expected_job:job
+           ~expected_state:Expect_inflight
+           ~path:inflight
+           Activation_already_inflight
+       in
+       (match inflight_state with
+        | Some activation ->
+          let cleanup_errors = cleanup_paths [ awaiting ] in
+          Ok (activation, { cleanup_errors })
+        | None ->
+          let* awaiting_exists = file_exists awaiting in
+          if not awaiting_exists
+          then
+            Error
+              (Decode_error
+                 { path = awaiting
+                 ; detail =
+                     "cannot activate a memory job without its awaiting-turn-commit envelope"
+                 })
+          else
+            let* envelope = read_envelope awaiting in
+            let* () =
+              ensure_queue_coordinates
+                ~expected_keeper_name:job.keeper_name
+                ~path:awaiting
+                envelope
+            in
+            let* () = ensure_same_job ~expected:job ~path:awaiting envelope in
+            let* () =
+              ensure_expected_state
+                ~expected:Expect_awaiting
+                ~path:awaiting
+                envelope
+            in
+            let* () =
+              save_json pending (envelope_to_json { job; state = Pending })
+            in
+            let cleanup_errors = cleanup_paths [ awaiting ] in
+            Ok (Activated, { cleanup_errors })))
+;;
+
+let abort_awaiting ~base_path (job : job) =
+  let path = awaiting_path ~base_path job in
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:job ~path envelope in
+    let* () =
+      ensure_expected_state ~expected:Expect_awaiting ~path envelope
+    in
+    remove_if_exists path
+;;
+
+let recover_one ~base_path (inflight_path, envelope) =
+  match envelope.state with
+  | Awaiting_turn_commit | Pending ->
+    Error
+      (Decode_error
+         { path = inflight_path
+         ; detail = "inflight directory contains a pending envelope"
+         })
+  | Inflight _ ->
+    let job = envelope.job in
+    let receipt_path = receipt_path ~base_path job in
+    let* receipt_exists = file_exists receipt_path in
+    if receipt_exists
+    then
+      let* receipt = read_receipt receipt_path in
+      if not (receipt_identity_matches_job receipt.identity job)
+      then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+      else
+        let cleanup_errors =
+          cleanup_paths
+            [ operation_stage_path
+                ~base_path
+                ~keeper_name:job.keeper_name
+                ~operation_id:job.id
+            ; awaiting_path ~base_path job
+            ; pending_path ~base_path job
+            ; inflight_path
+            ]
+        in
+        Ok (false, cleanup_errors)
+    else
+      let pending_path = pending_path ~base_path job in
+      let* pending_exists = file_exists pending_path in
+      let* () =
+        if pending_exists
+        then
+          let* pending = read_envelope pending_path in
+          let* () = ensure_same_job ~expected:job ~path:pending_path pending in
+          ensure_expected_state
+            ~expected:Expect_pending
+            ~path:pending_path
+            pending
+        else save_json pending_path (envelope_to_json { job; state = Pending })
+      in
+      let cleanup_errors = cleanup_paths [ inflight_path ] in
+      Ok (true, cleanup_errors)
+;;
+
+let recover_inflight ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (receipts_dir ~base_path ~keeper_name)
+    in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (operations_dir ~base_path ~keeper_name)
+    in
+    let dir = inflight_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        paths
+    in
+    let rec loop replayed cleanup_errors = function
+      | [] -> Ok { replayed; cleanup_errors = List.rev cleanup_errors }
+      | item :: rest ->
+        let* did_recover, item_cleanup_errors = recover_one ~base_path item in
+        loop
+          (if did_recover then replayed + 1 else replayed)
+          (List.rev_append item_cleanup_errors cleanup_errors)
+          rest
+    in
+    loop 0 [] envelopes
+;;
+
+let claim_all ~base_path ~keeper_name ~now =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let dir = pending_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        paths
+    in
+    let ordered =
+      envelopes
+      |> List.map (fun (path, envelope) -> path, envelope.job)
+      |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
+    in
+    let rec claim leases cleanup_errors = function
+      | [] ->
+        Ok
+          { leases = List.rev leases
+          ; cleanup_errors = List.rev cleanup_errors
+          }
+      | (path, job) :: rest ->
+        let receipt_path = receipt_path ~base_path job in
+        let* receipt_exists = file_exists receipt_path in
+        if receipt_exists
+        then
+          let* receipt = read_receipt receipt_path in
+          if not (receipt_identity_matches_job receipt.identity job)
+          then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+          else
+            let item_cleanup_errors =
+              cleanup_paths
+                [ path
+                ; awaiting_path ~base_path job
+                ; inflight_path ~base_path job
+                ; operation_stage_path
+                    ~base_path
+                    ~keeper_name:job.keeper_name
+                    ~operation_id:job.id
+                ]
+            in
+            claim
+              leases
+              (List.rev_append item_cleanup_errors cleanup_errors)
+              rest
+        else
+          let lease = { job; started_at = now } in
+          let destination = inflight_path ~base_path job in
+          let* () =
+            save_json
+              destination
+              (envelope_to_json
+                 { job
+                 ; state = Inflight { started_at = lease.started_at }
+                 })
+          in
+          let item_cleanup_errors = cleanup_paths [ path ] in
+          claim
+            (lease :: leases)
+            (List.rev_append item_cleanup_errors cleanup_errors)
+            rest
+    in
+    claim [] [] ordered
+;;
+
+let finish ~base_path (receipt : terminal_receipt) =
+  let identity = receipt.identity in
+  let* () = ensure_store_dirs ~base_path ~keeper_name:identity.keeper_name in
+  let path = receipt_path_for_identity ~base_path identity in
+  let* exists = file_exists path in
+  let* () =
+    if exists
+    then
+      let* current = read_receipt path in
+      if receipt_identity_equal current.identity identity
+         && current.outcome = receipt.outcome
+         && Yojson.Safe.equal current.detail receipt.detail
+      then Ok ()
+      else Error (Identity_conflict { job_id = identity.id; path })
+    else save_json path (receipt_to_json receipt)
+  in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:identity.keeper_name
+      ~operation_id:identity.id
+  in
+  let awaiting =
+    path_for_id
+      (awaiting_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let pending =
+    path_for_id
+      (pending_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let inflight =
+    path_for_id
+      (inflight_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let cleanup_errors = cleanup_paths [ operation; awaiting; pending; inflight ] in
+  Ok { cleanup_errors }
+;;
+
+let backlog_count ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
+    let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
+    let* awaiting_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        awaiting
+    in
+    let* pending_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        pending
+    in
+    let* inflight_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        inflight
+    in
+    Ok
+      (List.length awaiting_envelopes
+       + List.length pending_envelopes
+       + List.length inflight_envelopes)
+;;
+
+let directory_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok false
+  else
+    let* is_directory =
+      protect_io Inspect path (fun () ->
+        (Unix.lstat path).Unix.st_kind = Unix.S_DIR)
+    in
+    if is_directory
+    then Ok true
+    else
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path
+           ; detail = "expected a directory but found a non-directory entry"
+           })
+;;
+
+let discover_keeper_names ~base_path =
+  let root = Common.keepers_runtime_dir_of_base ~base_path in
+  let* root_exists = directory_exists root in
+  if not root_exists
+  then Ok ([], [])
+  else
+    let* entries =
+      protect_io List_directory root (fun () -> Sys.readdir root |> Array.to_list)
+    in
+    let rec loop keepers errors = function
+      | [] ->
+        Ok
+          ( List.sort_uniq String.compare keepers
+          , List.rev errors )
+      | keeper_name :: rest ->
+        let jobs_dir = keeper_jobs_dir ~base_path ~keeper_name in
+        (match directory_exists jobs_dir with
+         | Error error -> loop keepers (error :: errors) rest
+         | Ok false -> loop keepers errors rest
+         | Ok true ->
+           if not (keeper_name_is_valid keeper_name)
+           then loop keepers (Invalid_keeper_name keeper_name :: errors) rest
+           else
+             (match backlog_count ~base_path ~keeper_name with
+              | Error error -> loop keepers (error :: errors) rest
+              | Ok count ->
+                loop
+                  (if count > 0 then keeper_name :: keepers else keepers)
+                  errors
+                  rest))
+    in
+    loop [] [] entries
+;;
+
+module For_testing = struct
+  let awaiting_dir = awaiting_dir
+  let pending_dir = pending_dir
+  let inflight_dir = inflight_dir
+  let receipts_dir = receipts_dir
+  let receipt_path = receipt_path
+end

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,0 +1,192 @@
+(** Durable per-keeper post-turn memory jobs.
+
+    The store is rooted exclusively from [base_path]. A job moves through
+    [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
+    execution receipt gates the first transition; the terminal memory receipt
+    gates acknowledgement. Recovery requeues only inflight jobs that have no
+    terminal memory receipt.
+    Callers serialize access for one keeper; files are still written atomically
+    so process crashes cannot expose partial JSON. *)
+
+type job = private
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease =
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt =
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Rename
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_job_id of string
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Turn_receipt_error of
+      { keeper_name : string
+      ; detail : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+val error_to_string : error -> string
+val is_valid_job_id : string -> bool
+
+val make_job :
+  keeper_name:string ->
+  trace_id:string ->
+  generation:int ->
+  turn:int ->
+  oas_turn_count:int ->
+  enqueued_at:float ->
+  payload:Yojson.Safe.t ->
+  (job, error) result
+(** Construct a job with a deterministic full SHA-256 id over its typed turn
+    identity. Re-admitting the same turn is therefore idempotent. *)
+
+val job_to_json : job -> Yojson.Safe.t
+val job_of_json : Yojson.Safe.t -> (job, string) result
+val receipt_identity_of_job : job -> receipt_identity
+val receipt_to_json : terminal_receipt -> Yojson.Safe.t
+val receipt_of_json : Yojson.Safe.t -> (terminal_receipt, string) result
+
+val stage_awaiting_turn_commit :
+  base_path:string -> job -> (admission, error) result
+(** Persist the job in a non-runnable outbox before returning. It cannot be
+    claimed until {!activate} runs after the owning execution receipt commits. *)
+
+val list_awaiting :
+  base_path:string -> keeper_name:string -> (job list, error) result
+
+val activate :
+  base_path:string -> job -> (activation * cleanup_report, error) result
+(** Durably move an awaiting job into [pending]. Writing [pending] is the
+    activation commit; failure to remove the old awaiting envelope is reported
+    as cleanup debt and cannot block the runnable lane. *)
+
+val abort_awaiting : base_path:string -> job -> (unit, error) result
+(** Remove a non-runnable job when its owning execution receipt failed. *)
+
+val recover_inflight :
+  base_path:string -> keeper_name:string -> (recovery_report, error) result
+(** Move every receipt-less inflight job back to pending. Inflight jobs with a
+    terminal receipt are acknowledged without replay. Cleanup failures are
+    returned as debt and never stop recovery of later jobs. *)
+
+val claim_all :
+  base_path:string -> keeper_name:string -> now:float -> (claim_report, error) result
+(** Claim the current pending batch with one validated scan and one sort. The
+    returned leases preserve the keeper's linear turn order. *)
+
+val finish :
+  base_path:string -> terminal_receipt -> (cleanup_report, error) result
+(** Atomically persist the terminal receipt before acknowledging queue/stage
+    files. Repeating [finish] for the same receipt is idempotent. Post-commit
+    cleanup errors are returned as debt, not as commit failure. *)
+
+val backlog_count :
+  base_path:string -> keeper_name:string -> (int, error) result
+
+val discover_keeper_names :
+  base_path:string -> (string list * error list, error) result
+(** Discover keeper directories with awaiting, pending, or inflight memory jobs. A
+    keeper-local malformed queue is returned in the error list without
+    suppressing healthy keepers; an outer [Error] means the keepers root itself
+    could not be inspected. *)
+
+val operation_stage_path_for_keepers_dir :
+  keepers_dir:string -> keeper_name:string -> operation_id:string -> string
+(** SSOT path for a provider result staged until its memory-job terminal receipt
+    is durable. *)
+
+module For_testing : sig
+  val awaiting_dir : base_path:string -> keeper_name:string -> string
+  val pending_dir : base_path:string -> keeper_name:string -> string
+  val inflight_dir : base_path:string -> keeper_name:string -> string
+  val receipts_dir : base_path:string -> keeper_name:string -> string
+  val receipt_path : base_path:string -> job -> string
+end

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,77 +1,85 @@
-(** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
+(** Restart-durable per-keeper memory execution lane. *)
 
-(* Generative identity avoids a process-lifetime numeric counter for Keepers
-   that are expected to live indefinitely. Tokens are compared physically and
-   their contents are never mutated. *)
 type worker_token = unit ref
+type wake_token = unit ref
 
-type entry =
-  { state_mu : Stdlib.Mutex.t
-    (* Guards the FIFO and worker ownership. Critical sections never yield. *)
-  ; jobs : (unit -> unit) Stdlib.Queue.t
-  ; mutable pending : int
-  ; mutable active_worker : worker_token option
+type retryability =
+  | Retryable
+  | Terminal
+
+type execution_error =
+  { retryability : retryability
+  ; kind : string
+  ; message : string
+  ; detail : Yojson.Safe.t
   }
 
-type outcome =
-  | Submitted
-  | Ran_inline
-  | Dropped
+type execute =
+  base_path:string ->
+  Keeper_memory_job_store.job ->
+  (Yojson.Safe.t, execution_error) result
 
-type abandonment_reason =
-  | Executor_switch_unavailable
+type worker_deferred_reason =
+  | Executor_not_initialized
+  | Executor_base_path_mismatch
   | Executor_switch_released
-  | Worker_cancelled
-  | Worker_failed
   | Hook_registration_failed
   | Fork_failed
 
-let abandonment_reason_label = function
-  | Executor_switch_unavailable -> "executor_switch_unavailable"
-  | Executor_switch_released -> "executor_switch_released"
-  | Worker_cancelled -> "worker_cancelled"
-  | Worker_failed -> "worker_failed"
-  | Hook_registration_failed -> "hook_registration_failed"
-  | Fork_failed -> "fork_failed"
-;;
+type worker_state =
+  | Started
+  | Already_running
+  | Not_needed
+  | Deferred of worker_deferred_reason
+
+type admission =
+  | Admitted of
+      { job_id : string
+      ; activation : Keeper_memory_job_store.activation
+      ; worker : worker_state
+      }
+  | Rejected of Keeper_memory_job_store.error
+
+type staging =
+  | Staged of
+      { job_id : string
+      ; durable : Keeper_memory_job_store.admission
+      }
+  | Stage_rejected of Keeper_memory_job_store.error
+
+type init_report =
+  { discovered_keepers : int
+  ; workers_started : int
+  ; workers_deferred : int
+  ; discovery_error : Keeper_memory_job_store.error option
+  ; keeper_discovery_errors : Keeper_memory_job_store.error list
+  }
+
+type entry =
+  { state_mu : Stdlib.Mutex.t
+  ; store_mu : Eio.Mutex.t
+  ; mutable wake : wake_token
+  ; mutable active_worker : worker_token option
+  ; mutable reconciliation_active : bool
+  }
+
+type executor =
+  { sw : Eio.Switch.t
+  ; clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; base_path : string
+  ; execute : execute
+  }
 
 let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
-
-(* Module-level singleton table: Stdlib.Mutex because lookup is reachable
-   outside an Eio context (test setup) and the critical section never yields. *)
 let registry_mu = Stdlib.Mutex.create ()
+let installed_executor : executor option ref = ref None
 
-(* Set once by [init] at startup, before keepers run. Guarded by [registry_mu]
-   so a reader sees the write. *)
-let executor_sw : Eio.Switch.t option ref = ref None
-
-let init ~sw =
-  Stdlib.Mutex.protect registry_mu (fun () ->
-    match !executor_sw with
-    | None -> executor_sw := Some sw
-    | Some current when current == sw -> ()
-    | Some _ ->
-      invalid_arg
-        "Keeper_memory_lane.init: executor switch already initialized")
-;;
-
-let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
-
-let entry_for ~base_path ~keeper_name =
-  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
-  Stdlib.Mutex.protect registry_mu (fun () ->
-    match Hashtbl.find_opt entries key with
-    | Some entry -> entry
-    | None ->
-      let entry =
-        { state_mu = Stdlib.Mutex.create ()
-        ; jobs = Stdlib.Queue.create ()
-        ; pending = 0
-        ; active_worker = None
-        }
-      in
-      Hashtbl.add entries key entry;
-      entry)
+let worker_deferred_reason_to_string = function
+  | Executor_not_initialized -> "executor_not_initialized"
+  | Executor_base_path_mismatch -> "executor_base_path_mismatch"
+  | Executor_switch_released -> "executor_switch_released"
+  | Hook_registration_failed -> "hook_registration_failed"
+  | Fork_failed -> "fork_failed"
 ;;
 
 let metric_name metric = Keeper_metrics.(to_string metric)
@@ -93,313 +101,693 @@ let record_counter_delta ~keeper_name metric count =
       ()
 ;;
 
-let inc_pending ~keeper_name () =
-  Otel_metric_store.inc_gauge
+let set_pending ~keeper_name count =
+  Otel_metric_store.set_gauge
     (metric_name MemoryLanePending)
     ~labels:[ "keeper", keeper_name ]
-    ()
+    (float_of_int count)
 ;;
 
-let dec_pending ~keeper_name () =
-  Otel_metric_store.dec_gauge
-    (metric_name MemoryLanePending)
-    ~labels:[ "keeper", keeper_name ]
-    ()
-;;
-
-let dec_pending_by ~keeper_name count =
-  if count > 0
-  then
-    Otel_metric_store.dec_gauge
-      (metric_name MemoryLanePending)
-      ~labels:[ "keeper", keeper_name ]
-      ~delta:(float_of_int count)
-      ()
-;;
-
-let inc_in_flight ~keeper_name () =
+let inc_in_flight ~keeper_name =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLaneInFlight)
     ~labels:[ "keeper", keeper_name ]
     ()
 ;;
 
-let dec_in_flight ~keeper_name () =
+let dec_in_flight ~keeper_name =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLaneInFlight)
     ~labels:[ "keeper", keeper_name ]
     ()
 ;;
 
-let protect_cleanup ~keeper_name label f =
-  try f () with
-  | exn ->
+let current_executor () =
+  Stdlib.Mutex.protect registry_mu (fun () -> !installed_executor)
+;;
+
+let entry_for ~base_path ~keeper_name =
+  let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+  Stdlib.Mutex.protect registry_mu (fun () ->
+    match Hashtbl.find_opt entries key with
+    | Some entry -> entry
+    | None ->
+      let entry =
+        { state_mu = Stdlib.Mutex.create ()
+        ; store_mu = Eio.Mutex.create ()
+        ; wake = ref ()
+        ; active_worker = None
+        ; reconciliation_active = false
+        }
+      in
+      Hashtbl.add entries key entry;
+      entry)
+;;
+
+let with_store : type a. entry -> (unit -> a) -> a =
+ fun entry f ->
+  let guarded () =
+    match f () with
+    | value -> Ok value
+    | exception exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  (* Filesystem operations may suspend the current fiber. [Eio.Mutex] is
+     domain-safe and lets sibling fibers run while waiting; [use_ro] is the
+     non-poisoning form because every store transition is crash-consistent and
+     may be retried after an exception. It also permits the uncontended,
+     pre-Eio staging path used before [init]. *)
+  let outcome = Eio.Mutex.use_ro entry.store_mu guarded in
+  match outcome with
+  | Ok value -> value
+  | Error (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+;;
+
+let refresh_pending ~base_path ~keeper_name entry =
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.backlog_count ~base_path ~keeper_name)
+  with
+  | Ok count -> set_pending ~keeper_name count
+  | Error error ->
     record_counter ~keeper_name MemoryLaneUnitFailures;
     Log.Keeper.warn ~keeper_name
-      "memory lane cleanup failed (%s): %s"
-      label
-      (Printexc.to_string exn)
+      "memory lane backlog observation failed: %s"
+      (Keeper_memory_job_store.error_to_string error)
 ;;
 
-let enqueue ~keeper_name entry job =
+let signal_worker entry =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
-    Stdlib.Queue.add job entry.jobs;
-    entry.pending <- entry.pending + 1;
-    inc_pending ~keeper_name ();
+    entry.wake <- ref ();
     match entry.active_worker with
-    | Some _ -> None
+    | Some _ -> `Running
     | None ->
       let worker = ref () in
       entry.active_worker <- Some worker;
-      Some worker)
+      `Start worker)
 ;;
 
-let take_next entry ~worker =
+let clear_worker entry worker =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     match entry.active_worker with
-    | Some active when active == worker ->
-      (match Stdlib.Queue.take_opt entry.jobs with
-       | Some job -> Some job
-       | None ->
-         entry.active_worker <- None;
-         None)
-    | Some _ | None -> None)
+    | Some active when active == worker -> entry.active_worker <- None
+    | Some _ | None -> ())
 ;;
 
-let release_job ~keeper_name entry =
-  let released =
-    Stdlib.Mutex.protect entry.state_mu (fun () ->
-      if entry.pending <= 0
-      then false
-      else (
-        entry.pending <- entry.pending - 1;
-        true))
-  in
-  if released
-  then dec_pending ~keeper_name ()
-  else (
-    record_counter ~keeper_name MemoryLaneUnitFailures;
-    Log.Keeper.error ~keeper_name "memory lane pending counter underflow prevented")
+let wake_snapshot entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () -> entry.wake)
 ;;
 
-let worker_is_active entry ~worker =
+let release_if_quiet entry ~worker ~observed_wake =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     match entry.active_worker with
-    | Some active -> active == worker
-    | None -> false)
+    | Some active when active == worker && entry.wake == observed_wake ->
+      entry.active_worker <- None;
+      true
+    | Some _ | None -> false)
 ;;
 
-let abandon_queued ~keeper_name entry ~worker ~reason =
-  let abandoned =
-    Stdlib.Mutex.protect entry.state_mu (fun () ->
-      match entry.active_worker with
-      | Some active when active == worker ->
-        let count = Stdlib.Queue.length entry.jobs in
-        Stdlib.Queue.clear entry.jobs;
-        entry.pending <- entry.pending - count;
-        entry.active_worker <- None;
-        count
-      | Some _ | None -> 0)
-  in
-  if abandoned > 0
-  then (
-    record_counter_delta ~keeper_name MemoryLaneDropped abandoned;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string DispatchEventFailures)
-      ~labels:
-        [ "keeper", keeper_name
-        ; "site", "memory_lane_abandoned"
-        ; "reason", abandonment_reason_label reason
-        ]
-      ~delta:(float_of_int abandoned)
-      ();
-    dec_pending_by ~keeper_name abandoned;
-    Log.Keeper.warn ~keeper_name
-      "memory lane worker abandoned queued units count=%d reason=%s"
-      abandoned
-      (abandonment_reason_label reason))
+type worker_exit =
+  | Released_quietly
+  | Retry_required
 ;;
 
-let disarm_switch_hook hook =
-  (* RFC-0257: hook cleanup is idempotent; an already-run hook needs no retry. *)
-  ignore (Eio.Switch.try_remove_hook hook)
+let next_retry_attempt attempt =
+  if attempt = Int.max_int then Int.max_int else attempt + 1
 ;;
 
-let run_job ~keeper_name entry ~sw job =
-  inc_in_flight ~keeper_name ();
-  Fun.protect
-    ~finally:(fun () ->
-      protect_cleanup ~keeper_name "dec_in_flight" (fun () ->
-        dec_in_flight ~keeper_name ());
-      protect_cleanup ~keeper_name "release_job" (fun () ->
-        release_job ~keeper_name entry))
-    (fun () ->
-      try Eio_context.with_turn_switch sw job with
-      | Eio.Cancel.Cancelled _ as exn ->
-        record_counter ~keeper_name MemoryLaneDropped;
-        Log.Keeper.warn ~keeper_name
-          "memory lane in-flight unit cancelled before completion";
-        raise exn
-      | exn ->
+let execution_error_to_json error =
+  `Assoc
+    [ ( "retryability"
+      , `String
+          (match error.retryability with
+           | Retryable -> "retryable"
+           | Terminal -> "terminal") )
+    ; "kind", `String error.kind
+    ; "message", `String error.message
+    ; "detail", error.detail
+    ]
+;;
+
+let unexpected_execution_error exn =
+  { retryability = Terminal
+  ; kind = "uncaught_exception"
+  ; message = Printexc.to_string exn
+  ; detail = `Null
+  }
+;;
+
+let log_cleanup_errors ~keeper_name ~job_id errors =
+  List.iter
+    (fun error ->
+       record_counter ~keeper_name MemoryLaneUnitFailures;
+       Log.Keeper.error ~keeper_name
+         "memory lane cleanup debt job_id=%s: %s"
+         job_id
+         (Keeper_memory_job_store.error_to_string error))
+    errors
+;;
+
+type worker_failure =
+  | Store_failure of Keeper_memory_job_store.error
+  | Retryable_execution of execution_error
+
+let run_lease executor entry (lease : Keeper_memory_job_store.lease) =
+  let keeper_name = lease.job.keeper_name in
+  inc_in_flight ~keeper_name;
+  let result =
+    Fun.protect
+      (* Do not perform filesystem/Eio work in cancellation cleanup. The
+         inflight file intentionally remains and its pending gauge value does
+         not change. *)
+      ~finally:(fun () -> dec_in_flight ~keeper_name)
+      (fun () ->
+      let execution =
+        try
+          Eio_context.with_turn_switch executor.sw (fun () ->
+            executor.execute ~base_path:executor.base_path lease.job)
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Error (unexpected_execution_error exn)
+      in
+      match execution with
+      | Error ({ retryability = Retryable; _ } as error) ->
         record_counter ~keeper_name MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
-          "memory lane unit failed: %s"
-          (Printexc.to_string exn))
-;;
-
-let rec drain_worker ~keeper_name entry ~worker ~sw =
-  match take_next entry ~worker with
-  | None -> ()
-  | Some job ->
-    run_job ~keeper_name entry ~sw job;
-    drain_worker ~keeper_name entry ~worker ~sw
-;;
-
-let start_worker ~keeper_name entry ~worker sw =
-  let release_from_switch () =
-    abandon_queued
-      ~keeper_name
-      entry
-      ~worker
-      ~reason:Executor_switch_released
+          "memory lane job will retry job_id=%s turn=%d kind=%s: %s"
+          lease.job.id
+          lease.job.turn
+          error.kind
+          error.message;
+        Error (Retryable_execution error)
+      | (Ok _ | Error { retryability = Terminal; _ }) as execution ->
+        let outcome, detail =
+          match execution with
+          | Ok detail -> Keeper_memory_job_store.Succeeded, detail
+          | Error error ->
+            Keeper_memory_job_store.Failed, execution_error_to_json error
+        in
+        let receipt : Keeper_memory_job_store.terminal_receipt =
+          { identity = Keeper_memory_job_store.receipt_identity_of_job lease.job
+          ; started_at = lease.started_at
+          ; ended_at = Time_compat.now ()
+          ; outcome
+          ; detail
+          }
+        in
+        (match
+           with_store entry (fun () ->
+             Keeper_memory_job_store.finish
+               ~base_path:executor.base_path
+               receipt)
+         with
+         | Error error ->
+           record_counter ~keeper_name MemoryLaneUnitFailures;
+           Log.Keeper.error ~keeper_name
+             "memory lane terminal receipt commit failed job_id=%s: %s"
+             lease.job.id
+             (Keeper_memory_job_store.error_to_string error);
+           Error (Store_failure error)
+         | Ok cleanup ->
+           log_cleanup_errors
+             ~keeper_name
+             ~job_id:lease.job.id
+             cleanup.cleanup_errors;
+           (match execution with
+            | Ok _ ->
+              record_counter ~keeper_name MemoryLaneCompleted;
+              Log.Keeper.info ~keeper_name
+                "memory lane job completed job_id=%s turn=%d"
+                lease.job.id
+                lease.job.turn
+            | Error error ->
+              record_counter ~keeper_name MemoryLaneUnitFailures;
+              record_counter ~keeper_name MemoryLaneFailed;
+              Log.Keeper.warn ~keeper_name
+                "memory lane job failed job_id=%s turn=%d kind=%s: %s"
+                lease.job.id
+                lease.job.turn
+                error.kind
+                error.message);
+           Ok ()))
   in
-  match Eio.Switch.get_error sw with
-  | Some _ ->
-    abandon_queued
+  refresh_pending
+    ~base_path:executor.base_path
+    ~keeper_name
+    entry;
+  result
+;;
+
+let rec drain_keeper executor entry ~worker ~keeper_name =
+  let observed_wake = wake_snapshot entry in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.claim_all
+        ~base_path:executor.base_path
+        ~keeper_name
+        ~now:(Time_compat.now ()))
+  with
+  | Error error ->
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.error ~keeper_name
+      "memory lane claim failed: %s"
+      (Keeper_memory_job_store.error_to_string error);
+    Retry_required
+  | Ok { leases = []; cleanup_errors } ->
+    log_cleanup_errors ~keeper_name ~job_id:"claim-sweep" cleanup_errors;
+    if release_if_quiet entry ~worker ~observed_wake
+    then (
+      refresh_pending ~base_path:executor.base_path ~keeper_name entry;
+      Released_quietly)
+    else drain_keeper executor entry ~worker ~keeper_name
+  | Ok { leases; cleanup_errors } ->
+    log_cleanup_errors ~keeper_name ~job_id:"claim-sweep" cleanup_errors;
+    let rec run_batch = function
+      | [] -> drain_keeper executor entry ~worker ~keeper_name
+      | lease :: rest ->
+        (match run_lease executor entry lease with
+         | Ok () -> run_batch rest
+         | Error _ -> Retry_required)
+    in
+    run_batch leases
+;;
+
+let run_worker executor entry ~worker ~keeper_name =
+  let observed_wake = wake_snapshot entry in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.recover_inflight
+        ~base_path:executor.base_path
+        ~keeper_name)
+  with
+  | Error error ->
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.error ~keeper_name
+      "memory lane recovery failed: %s"
+      (Keeper_memory_job_store.error_to_string error);
+    Retry_required
+  | Ok recovery ->
+    log_cleanup_errors
       ~keeper_name
+      ~job_id:"recovery-sweep"
+      recovery.cleanup_errors;
+    if recovery.replayed > 0
+    then (
+      record_counter_delta ~keeper_name MemoryLaneReplayed recovery.replayed;
+      Log.Keeper.warn ~keeper_name
+        "memory lane replaying durable inflight jobs count=%d"
+        recovery.replayed);
+    refresh_pending ~base_path:executor.base_path ~keeper_name entry;
+    drain_keeper executor entry ~worker ~keeper_name
+;;
+
+let rec run_worker_until_quiet executor entry ~worker ~keeper_name ~retry_attempt =
+  match run_worker executor entry ~worker ~keeper_name with
+  | Released_quietly -> ()
+  | Retry_required ->
+    let retry_attempt = next_retry_attempt retry_attempt in
+    let delay =
+      Env_config_keeper.KeeperRetryBackoff.transient_backoff_sec retry_attempt
+    in
+    Log.Keeper.warn ~keeper_name
+      "memory lane retry scheduled attempt=%d delay_sec=%.3f"
+      retry_attempt
+      delay;
+    Eio.Time.sleep executor.clock delay;
+    run_worker_until_quiet
+      executor
       entry
       ~worker
-      ~reason:Executor_switch_unavailable;
-    false
+      ~keeper_name
+      ~retry_attempt
+;;
+
+let start_worker executor entry ~worker ~keeper_name =
+  let release_worker () = clear_worker entry worker in
+  match Eio.Switch.get_error executor.sw with
+  | Some _ ->
+    clear_worker entry worker;
+    Deferred Executor_switch_released
   | None ->
     let hook =
-      try Some (Eio.Switch.on_release_cancellable sw release_from_switch) with
-      | Eio.Cancel.Cancelled _ as exn ->
-        abandon_queued
-          ~keeper_name
-          entry
-          ~worker
-          ~reason:Worker_cancelled;
-        raise exn
+      try
+        Some
+          (Eio.Switch.on_release_cancellable
+             executor.sw
+             release_worker)
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
-        abandon_queued
-          ~keeper_name
-          entry
-          ~worker
-          ~reason:Hook_registration_failed;
-        Log.Keeper.warn ~keeper_name
-          "memory lane worker release hook registration failed: %s"
+        clear_worker entry worker;
+        record_counter ~keeper_name MemoryLaneUnitFailures;
+        Log.Keeper.error ~keeper_name
+          "memory lane switch hook registration failed: %s"
           (Printexc.to_string exn);
         None
     in
     (match hook with
-     | None -> false
+     | None -> Deferred Hook_registration_failed
      | Some hook ->
-       if not (worker_is_active entry ~worker)
-       then (
-         disarm_switch_hook hook;
-         false)
-       else (
-         let worker_started = Atomic.make false in
-         try
-           Eio.Fiber.fork_daemon ~sw (fun () ->
-             Atomic.set worker_started true;
-             Fun.protect
-               ~finally:(fun () -> disarm_switch_hook hook)
-               (fun () ->
-                 try
-                   (* [Fiber.fork_daemon] runs the child immediately. Yield once so
-                      [submit] returns before deterministic disk work or a
-                      provider call begins on the memory worker. *)
-                   Eio.Fiber.yield ();
-                   drain_worker ~keeper_name entry ~worker ~sw
-                 with
-                 | Eio.Cancel.Cancelled _ as exn ->
-                   abandon_queued
-                     ~keeper_name
-                     entry
-                     ~worker
-                     ~reason:Worker_cancelled;
-                   raise exn
-                 | exn ->
-                   abandon_queued
-                     ~keeper_name
-                     entry
-                     ~worker
-                     ~reason:Worker_failed;
-                   record_counter ~keeper_name MemoryLaneUnitFailures;
-                   Log.Keeper.error ~keeper_name
-                     "memory lane worker failed: %s"
-                     (Printexc.to_string exn));
-             `Stop_daemon);
-           let started = Atomic.get worker_started in
-           let active = worker_is_active entry ~worker in
-           if not started
-           then
-             abandon_queued
-               ~keeper_name
-               entry
-               ~worker
-               ~reason:Executor_switch_unavailable;
-           started && active
-         with
-         | Eio.Cancel.Cancelled _ as exn ->
-           disarm_switch_hook hook;
-           abandon_queued
-             ~keeper_name
-             entry
-             ~worker
-             ~reason:Worker_cancelled;
-           raise exn
-         | exn ->
-           disarm_switch_hook hook;
-           abandon_queued
-             ~keeper_name
-             entry
-             ~worker
-             ~reason:Fork_failed;
-           Log.Keeper.error ~keeper_name
-             "memory lane worker fork failed: %s"
-             (Printexc.to_string exn);
-           false))
+       (try
+          Eio.Fiber.fork_daemon ~sw:executor.sw (fun () ->
+            Fun.protect
+              ~finally:(fun () ->
+                ignore (Eio.Switch.try_remove_hook hook);
+                clear_worker entry worker)
+              (fun () ->
+                Eio.Fiber.yield ();
+                run_worker_until_quiet
+                  executor
+                  entry
+                  ~worker
+                  ~keeper_name
+                  ~retry_attempt:0);
+            `Stop_daemon);
+          Started
+        with
+        | Eio.Cancel.Cancelled _ as exn ->
+          ignore (Eio.Switch.try_remove_hook hook);
+          clear_worker entry worker;
+          raise exn
+        | exn ->
+          ignore (Eio.Switch.try_remove_hook hook);
+          clear_worker entry worker;
+          record_counter ~keeper_name MemoryLaneUnitFailures;
+          Log.Keeper.error ~keeper_name
+            "memory lane worker fork failed: %s"
+            (Printexc.to_string exn);
+          Deferred Fork_failed))
 ;;
 
-let submit ~base_path ~keeper_name job =
-  match current_sw () with
+let wake_or_start executor ~keeper_name =
+  let entry =
+    entry_for ~base_path:executor.base_path ~keeper_name
+  in
+  match signal_worker entry with
+  | `Running -> Already_running
+  | `Start worker -> start_worker executor entry ~worker ~keeper_name
+;;
+
+let stage ~base_path (job : Keeper_memory_job_store.job) =
+  let entry = entry_for ~base_path ~keeper_name:job.keeper_name in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.stage_awaiting_turn_commit ~base_path job)
+  with
+  | Error error ->
+    record_counter ~keeper_name:job.keeper_name MemoryLaneAdmissionRejected;
+    Log.Keeper.error ~keeper_name:job.keeper_name
+      "memory lane admission rejected job_id=%s: %s"
+      job.id
+      (Keeper_memory_job_store.error_to_string error);
+    Stage_rejected error
+  | Ok durable ->
+    record_counter ~keeper_name:job.keeper_name MemoryLaneSubmitted;
+    refresh_pending ~base_path ~keeper_name:job.keeper_name entry;
+    Staged { job_id = job.id; durable }
+;;
+
+let abort ~base_path (job : Keeper_memory_job_store.job) =
+  let entry = entry_for ~base_path ~keeper_name:job.keeper_name in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.abort_awaiting ~base_path job)
+  with
+  | Ok () ->
+    refresh_pending ~base_path ~keeper_name:job.keeper_name entry;
+    Ok ()
+  | Error error ->
+    record_counter ~keeper_name:job.keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.error ~keeper_name:job.keeper_name
+      "memory lane awaiting-turn abort failed job_id=%s: %s"
+      job.id
+      (Keeper_memory_job_store.error_to_string error);
+    Error error
+;;
+
+let install_executor ~sw ~clock ~base_path ~execute =
+  Stdlib.Mutex.protect registry_mu (fun () ->
+    match !installed_executor with
+    | None ->
+      let executor = { sw; clock; base_path; execute } in
+      installed_executor := Some executor;
+      executor
+    | Some current
+      when current.sw == sw
+           && current.clock == clock
+           && String.equal current.base_path base_path
+           && current.execute == execute ->
+      current
+    | Some _ ->
+      invalid_arg
+        "Keeper_memory_lane.init: executor already initialized with different ownership")
+;;
+
+let compare_awaiting_jobs
+      (left : Keeper_memory_job_store.job)
+      (right : Keeper_memory_job_store.job)
+  =
+  let by_turn = Int.compare left.turn right.turn in
+  if by_turn <> 0
+  then by_turn
+  else
+    let by_generation = Int.compare left.generation right.generation in
+    if by_generation <> 0
+    then by_generation
+    else Int.compare left.oas_turn_count right.oas_turn_count
+;;
+
+let reconcile_awaiting_jobs executor ~keeper_name =
+  let entry =
+    entry_for ~base_path:executor.base_path ~keeper_name
+  in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.list_awaiting
+        ~base_path:executor.base_path
+        ~keeper_name)
+  with
+  | Error error -> [ error ]
+  | Ok [] -> []
+  | Ok jobs ->
+    let jobs = List.sort compare_awaiting_jobs jobs in
+    let candidate_ids = List.map (fun job -> job.Keeper_memory_job_store.id) jobs in
+    let config = Workspace.default_config executor.base_path in
+    (match
+       Keeper_execution_receipt.committed_post_turn_memory_job_ids
+         config
+         ~keeper_name
+         ~candidate_ids
+     with
+     | Error detail ->
+       [ Keeper_memory_job_store.Turn_receipt_error
+           { keeper_name; detail }
+       ]
+     | Ok committed_ids ->
+       with_store entry (fun () ->
+         let rec reconcile errors = function
+           | [] -> List.rev errors
+           | job :: rest ->
+             if List.mem job.Keeper_memory_job_store.id committed_ids
+             then
+               (match
+                  Keeper_memory_job_store.activate
+                    ~base_path:executor.base_path
+                    job
+                with
+                | Error error -> reconcile (error :: errors) rest
+                | Ok (_, cleanup) ->
+                  log_cleanup_errors
+                    ~keeper_name
+                    ~job_id:job.id
+                    cleanup.cleanup_errors;
+                  reconcile errors rest)
+             else
+               (match
+                  Keeper_memory_job_store.abort_awaiting
+                    ~base_path:executor.base_path
+                    job
+                with
+                | Error error -> reconcile (error :: errors) rest
+                | Ok () ->
+                  Log.Keeper.warn ~keeper_name
+                    "memory lane discarded uncommitted awaiting job job_id=%s turn=%d"
+                    job.id
+                    job.turn;
+                  reconcile errors rest)
+         in
+         reconcile [] jobs))
+;;
+
+let start_reconciliation_retry executor ~keeper_name =
+  let entry = entry_for ~base_path:executor.base_path ~keeper_name in
+  let should_start =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      if entry.reconciliation_active
+      then false
+      else (
+        entry.reconciliation_active <- true;
+        true))
+  in
+  if should_start
+  then
+    try
+      Eio.Fiber.fork_daemon ~sw:executor.sw (fun () ->
+        Fun.protect
+          ~finally:(fun () ->
+            Stdlib.Mutex.protect entry.state_mu (fun () ->
+              entry.reconciliation_active <- false))
+          (fun () ->
+             let rec retry attempt =
+               let delay =
+                 Env_config_keeper.KeeperRetryBackoff.transient_backoff_sec
+                   attempt
+               in
+               Eio.Time.sleep executor.clock delay;
+               match reconcile_awaiting_jobs executor ~keeper_name with
+               | [] ->
+                 ignore (wake_or_start executor ~keeper_name : worker_state)
+               | errors ->
+                 List.iter
+                   (fun error ->
+                      record_counter ~keeper_name MemoryLaneUnitFailures;
+                      Log.Keeper.error ~keeper_name
+                        "memory lane awaiting-turn reconciliation retry failed attempt=%d: %s"
+                        attempt
+                        (Keeper_memory_job_store.error_to_string error))
+                   errors;
+                 retry (next_retry_attempt attempt)
+             in
+             retry 1);
+        `Stop_daemon)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Stdlib.Mutex.protect entry.state_mu (fun () ->
+        entry.reconciliation_active <- false);
+      record_counter ~keeper_name MemoryLaneUnitFailures;
+      Log.Keeper.error ~keeper_name
+        "memory lane awaiting-turn reconciliation retry fork failed: %s"
+        (Printexc.to_string exn)
+;;
+
+let request_reconciliation ~base_path ~keeper_name =
+  match current_executor () with
   | None ->
-    (* Not initialized: run inline. The caller is still inside the per-keeper
-       turn lane, so single-fiber-per-keeper memory access is preserved. A
-       raising unit is contained and counted rather than escaping. *)
-    (try job () with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       record_counter ~keeper_name MemoryLaneUnitFailures;
-       Log.Keeper.warn ~keeper_name
-         "memory lane unit failed (inline): %s"
-         (Printexc.to_string exn));
-    record_counter ~keeper_name MemoryLaneRanInline;
-    Ran_inline
-  | Some sw ->
-    let entry = entry_for ~base_path ~keeper_name in
-    let worker = enqueue ~keeper_name entry job in
-    record_counter ~keeper_name MemoryLaneSubmitted;
+    Log.Keeper.warn ~keeper_name
+      "memory lane awaiting-turn reconciliation deferred reason=%s"
+      (worker_deferred_reason_to_string Executor_not_initialized)
+  | Some executor when not (String.equal executor.base_path base_path) ->
+    Log.Keeper.error ~keeper_name
+      "memory lane awaiting-turn reconciliation deferred reason=%s expected_base_path=%s actual_base_path=%s"
+      (worker_deferred_reason_to_string Executor_base_path_mismatch)
+      base_path
+      executor.base_path
+  | Some executor -> start_reconciliation_retry executor ~keeper_name
+;;
+
+let activate ~base_path (job : Keeper_memory_job_store.job) =
+  let entry = entry_for ~base_path ~keeper_name:job.keeper_name in
+  match
+    with_store entry (fun () ->
+      Keeper_memory_job_store.activate ~base_path job)
+  with
+  | Error error ->
+    record_counter ~keeper_name:job.keeper_name MemoryLaneAdmissionRejected;
+    Log.Keeper.error ~keeper_name:job.keeper_name
+      "memory lane activation rejected job_id=%s: %s"
+      job.id
+      (Keeper_memory_job_store.error_to_string error);
+    (* The execution receipt is already durable at this boundary. Keep the
+       awaiting envelope and reconcile it without requiring another turn,
+       signal, or process restart. *)
+    request_reconciliation ~base_path ~keeper_name:job.keeper_name;
+    Rejected error
+  | Ok (activation, cleanup) ->
+    log_cleanup_errors
+      ~keeper_name:job.keeper_name
+      ~job_id:job.id
+      cleanup.cleanup_errors;
+    refresh_pending ~base_path ~keeper_name:job.keeper_name entry;
+    let worker =
+      match activation with
+      | Keeper_memory_job_store.Activation_already_completed -> Not_needed
+      | Keeper_memory_job_store.Activated
+      | Keeper_memory_job_store.Activation_already_pending
+      | Keeper_memory_job_store.Activation_already_inflight ->
+        (match current_executor () with
+         | None -> Deferred Executor_not_initialized
+         | Some executor when not (String.equal executor.base_path base_path) ->
+           Deferred Executor_base_path_mismatch
+         | Some executor -> wake_or_start executor ~keeper_name:job.keeper_name)
+    in
     (match worker with
-     | None -> Submitted
-     | Some worker ->
-       if start_worker ~keeper_name entry ~worker sw then Submitted else Dropped)
+     | Deferred reason ->
+       Log.Keeper.warn ~keeper_name:job.keeper_name
+         "memory lane job persisted without active worker job_id=%s reason=%s"
+         job.id
+         (worker_deferred_reason_to_string reason)
+     | Started | Already_running | Not_needed -> ());
+    Admitted { job_id = job.id; activation; worker }
+;;
+
+let init ~sw ~clock ~base_path ~execute =
+  let executor = install_executor ~sw ~clock ~base_path ~execute in
+  match Keeper_memory_job_store.discover_keeper_names ~base_path with
+  | Error error ->
+    Log.Keeper.error
+      "memory lane durable backlog discovery failed: %s"
+      (Keeper_memory_job_store.error_to_string error);
+    { discovered_keepers = 0
+    ; workers_started = 0
+    ; workers_deferred = 0
+    ; discovery_error = Some error
+    ; keeper_discovery_errors = []
+    }
+  | Ok (keeper_names, keeper_discovery_errors) ->
+    let reconciliation_errors =
+      List.concat_map
+        (fun keeper_name ->
+           let errors = reconcile_awaiting_jobs executor ~keeper_name in
+           if errors <> []
+           then start_reconciliation_retry executor ~keeper_name;
+           errors)
+        keeper_names
+    in
+    let keeper_discovery_errors =
+      keeper_discovery_errors @ reconciliation_errors
+    in
+    List.iter
+      (fun error ->
+         Log.Keeper.error
+           "memory lane skipped one malformed keeper backlog during discovery: %s"
+           (Keeper_memory_job_store.error_to_string error))
+      keeper_discovery_errors;
+    let started, deferred =
+      List.fold_left
+        (fun (started, deferred) keeper_name ->
+           match wake_or_start executor ~keeper_name with
+           | Started | Already_running -> started + 1, deferred
+           | Deferred _ -> started, deferred + 1
+           | Not_needed -> started, deferred)
+        (0, 0)
+        keeper_names
+    in
+    { discovered_keepers = List.length keeper_names
+    ; workers_started = started
+    ; workers_deferred = deferred
+    ; discovery_error = None
+    ; keeper_discovery_errors
+    }
 ;;
 
 module For_testing = struct
   let reset () =
     Stdlib.Mutex.protect registry_mu (fun () ->
       Hashtbl.reset entries;
-      executor_sw := None)
+      installed_executor := None)
   ;;
 
-  let pending ~base_path ~keeper_name =
-    let key = Keeper_registry_types.registry_key ~base_path keeper_name in
-    Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
-    |> Option.map (fun entry ->
-      Stdlib.Mutex.protect entry.state_mu (fun () -> entry.pending))
+  let backlog_count ~base_path ~keeper_name =
+    Keeper_memory_job_store.backlog_count ~base_path ~keeper_name
   ;;
 end

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -207,8 +207,12 @@ let abandon_queued ~keeper_name entry ~worker_id ~reason =
     Log.Keeper.warn ~keeper_name
       "memory lane worker abandoned queued units count=%d reason=%s"
       abandoned
-      (abandonment_reason_label reason));
-  abandoned
+      (abandonment_reason_label reason))
+;;
+
+let disarm_switch_hook hook =
+  (* RFC-0257: hook cleanup is idempotent; an already-run hook needs no retry. *)
+  ignore (Eio.Switch.try_remove_hook hook)
 ;;
 
 let run_job ~keeper_name entry ~sw job =
@@ -243,32 +247,29 @@ let rec drain_worker ~keeper_name entry ~worker_id ~sw =
 
 let start_worker ~keeper_name entry ~worker_id sw =
   let release_from_switch () =
-    ignore
-      (abandon_queued
-         ~keeper_name
-         entry
-         ~worker_id
-         ~reason:Executor_switch_released)
+    abandon_queued
+      ~keeper_name
+      entry
+      ~worker_id
+      ~reason:Executor_switch_released
   in
   match Eio.Switch.get_error sw with
   | Some _ ->
-    ignore
-      (abandon_queued
-         ~keeper_name
-         entry
-         ~worker_id
-         ~reason:Executor_switch_unavailable);
+    abandon_queued
+      ~keeper_name
+      entry
+      ~worker_id
+      ~reason:Executor_switch_unavailable;
     false
   | None ->
     let hook =
       try Some (Eio.Switch.on_release_cancellable sw release_from_switch) with
       | exn ->
-        ignore
-          (abandon_queued
-             ~keeper_name
-             entry
-             ~worker_id
-             ~reason:Hook_registration_failed);
+        abandon_queued
+          ~keeper_name
+          entry
+          ~worker_id
+          ~reason:Hook_registration_failed;
         Log.Keeper.warn ~keeper_name
           "memory lane worker release hook registration failed: %s"
           (Printexc.to_string exn);
@@ -279,13 +280,13 @@ let start_worker ~keeper_name entry ~worker_id sw =
      | Some hook ->
        if not (worker_is_active entry ~worker_id)
        then (
-         ignore (Eio.Switch.try_remove_hook hook);
+         disarm_switch_hook hook;
          false)
        else (
          try
            Eio.Fiber.fork ~sw (fun () ->
              Fun.protect
-               ~finally:(fun () -> ignore (Eio.Switch.try_remove_hook hook))
+               ~finally:(fun () -> disarm_switch_hook hook)
                (fun () ->
                  try
                    (* [Fiber.fork] runs the child immediately. Yield once so
@@ -295,20 +296,18 @@ let start_worker ~keeper_name entry ~worker_id sw =
                    drain_worker ~keeper_name entry ~worker_id ~sw
                  with
                  | Eio.Cancel.Cancelled _ as exn ->
-                   ignore
-                     (abandon_queued
-                        ~keeper_name
-                        entry
-                        ~worker_id
-                        ~reason:Worker_cancelled);
+                   abandon_queued
+                     ~keeper_name
+                     entry
+                     ~worker_id
+                     ~reason:Worker_cancelled;
                    raise exn
                  | exn ->
-                   ignore
-                     (abandon_queued
-                        ~keeper_name
-                        entry
-                        ~worker_id
-                        ~reason:Worker_failed);
+                   abandon_queued
+                     ~keeper_name
+                     entry
+                     ~worker_id
+                     ~reason:Worker_failed;
                    record_counter ~keeper_name MemoryLaneUnitFailures;
                    Log.Keeper.error ~keeper_name
                      "memory lane worker failed: %s"
@@ -316,22 +315,20 @@ let start_worker ~keeper_name entry ~worker_id sw =
            true
          with
          | Eio.Cancel.Cancelled _ as exn ->
-           ignore (Eio.Switch.try_remove_hook hook);
-           ignore
-             (abandon_queued
-                ~keeper_name
-                entry
-                ~worker_id
-                ~reason:Worker_cancelled);
+           disarm_switch_hook hook;
+           abandon_queued
+             ~keeper_name
+             entry
+             ~worker_id
+             ~reason:Worker_cancelled;
            raise exn
          | exn ->
-           ignore (Eio.Switch.try_remove_hook hook);
-           ignore
-             (abandon_queued
-                ~keeper_name
-                entry
-                ~worker_id
-                ~reason:Fork_failed);
+           disarm_switch_hook hook;
+           abandon_queued
+             ~keeper_name
+             entry
+             ~worker_id
+             ~reason:Fork_failed;
            Log.Keeper.error ~keeper_name
              "memory lane worker fork failed: %s"
              (Printexc.to_string exn);

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,12 +1,16 @@
 (** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
 
+(* Generative identity avoids a process-lifetime numeric counter for Keepers
+   that are expected to live indefinitely. Tokens are compared physically and
+   their contents are never mutated. *)
+type worker_token = unit ref
+
 type entry =
   { state_mu : Stdlib.Mutex.t
     (* Guards the FIFO and worker ownership. Critical sections never yield. *)
   ; jobs : (unit -> unit) Stdlib.Queue.t
   ; mutable pending : int
-  ; mutable next_worker_id : int
-  ; mutable active_worker_id : int option
+  ; mutable active_worker : worker_token option
   }
 
 type outcome =
@@ -42,7 +46,13 @@ let registry_mu = Stdlib.Mutex.create ()
 let executor_sw : Eio.Switch.t option ref = ref None
 
 let init ~sw =
-  Stdlib.Mutex.protect registry_mu (fun () -> executor_sw := Some sw)
+  Stdlib.Mutex.protect registry_mu (fun () ->
+    match !executor_sw with
+    | None -> executor_sw := Some sw
+    | Some current when current == sw -> ()
+    | Some _ ->
+      invalid_arg
+        "Keeper_memory_lane.init: executor switch already initialized")
 ;;
 
 let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
@@ -57,8 +67,7 @@ let entry_for ~base_path ~keeper_name =
         { state_mu = Stdlib.Mutex.create ()
         ; jobs = Stdlib.Queue.create ()
         ; pending = 0
-        ; next_worker_id = 0
-        ; active_worker_id = None
+        ; active_worker = None
         }
       in
       Hashtbl.add entries key entry;
@@ -137,23 +146,22 @@ let enqueue ~keeper_name entry job =
     Stdlib.Queue.add job entry.jobs;
     entry.pending <- entry.pending + 1;
     inc_pending ~keeper_name ();
-    match entry.active_worker_id with
+    match entry.active_worker with
     | Some _ -> None
     | None ->
-      entry.next_worker_id <- entry.next_worker_id + 1;
-      let worker_id = entry.next_worker_id in
-      entry.active_worker_id <- Some worker_id;
-      Some worker_id)
+      let worker = ref () in
+      entry.active_worker <- Some worker;
+      Some worker)
 ;;
 
-let take_next entry ~worker_id =
+let take_next entry ~worker =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
-    match entry.active_worker_id with
-    | Some active when active = worker_id ->
+    match entry.active_worker with
+    | Some active when active == worker ->
       (match Stdlib.Queue.take_opt entry.jobs with
        | Some job -> Some job
        | None ->
-         entry.active_worker_id <- None;
+         entry.active_worker <- None;
          None)
     | Some _ | None -> None)
 ;;
@@ -174,20 +182,22 @@ let release_job ~keeper_name entry =
     Log.Keeper.error ~keeper_name "memory lane pending counter underflow prevented")
 ;;
 
-let worker_is_active entry ~worker_id =
+let worker_is_active entry ~worker =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
-    entry.active_worker_id = Some worker_id)
+    match entry.active_worker with
+    | Some active -> active == worker
+    | None -> false)
 ;;
 
-let abandon_queued ~keeper_name entry ~worker_id ~reason =
+let abandon_queued ~keeper_name entry ~worker ~reason =
   let abandoned =
     Stdlib.Mutex.protect entry.state_mu (fun () ->
-      match entry.active_worker_id with
-      | Some active when active = worker_id ->
+      match entry.active_worker with
+      | Some active when active == worker ->
         let count = Stdlib.Queue.length entry.jobs in
         Stdlib.Queue.clear entry.jobs;
         entry.pending <- entry.pending - count;
-        entry.active_worker_id <- None;
+        entry.active_worker <- None;
         count
       | Some _ | None -> 0)
   in
@@ -237,20 +247,20 @@ let run_job ~keeper_name entry ~sw job =
           (Printexc.to_string exn))
 ;;
 
-let rec drain_worker ~keeper_name entry ~worker_id ~sw =
-  match take_next entry ~worker_id with
+let rec drain_worker ~keeper_name entry ~worker ~sw =
+  match take_next entry ~worker with
   | None -> ()
   | Some job ->
     run_job ~keeper_name entry ~sw job;
-    drain_worker ~keeper_name entry ~worker_id ~sw
+    drain_worker ~keeper_name entry ~worker ~sw
 ;;
 
-let start_worker ~keeper_name entry ~worker_id sw =
+let start_worker ~keeper_name entry ~worker sw =
   let release_from_switch () =
     abandon_queued
       ~keeper_name
       entry
-      ~worker_id
+      ~worker
       ~reason:Executor_switch_released
   in
   match Eio.Switch.get_error sw with
@@ -258,17 +268,24 @@ let start_worker ~keeper_name entry ~worker_id sw =
     abandon_queued
       ~keeper_name
       entry
-      ~worker_id
+      ~worker
       ~reason:Executor_switch_unavailable;
     false
   | None ->
     let hook =
       try Some (Eio.Switch.on_release_cancellable sw release_from_switch) with
+      | Eio.Cancel.Cancelled _ as exn ->
+        abandon_queued
+          ~keeper_name
+          entry
+          ~worker
+          ~reason:Worker_cancelled;
+        raise exn
       | exn ->
         abandon_queued
           ~keeper_name
           entry
-          ~worker_id
+          ~worker
           ~reason:Hook_registration_failed;
         Log.Keeper.warn ~keeper_name
           "memory lane worker release hook registration failed: %s"
@@ -278,48 +295,60 @@ let start_worker ~keeper_name entry ~worker_id sw =
     (match hook with
      | None -> false
      | Some hook ->
-       if not (worker_is_active entry ~worker_id)
+       if not (worker_is_active entry ~worker)
        then (
          disarm_switch_hook hook;
          false)
        else (
+         let worker_started = Atomic.make false in
          try
-           Eio.Fiber.fork ~sw (fun () ->
+           Eio.Fiber.fork_daemon ~sw (fun () ->
+             Atomic.set worker_started true;
              Fun.protect
                ~finally:(fun () -> disarm_switch_hook hook)
                (fun () ->
                  try
-                   (* [Fiber.fork] runs the child immediately. Yield once so
+                   (* [Fiber.fork_daemon] runs the child immediately. Yield once so
                       [submit] returns before deterministic disk work or a
                       provider call begins on the memory worker. *)
                    Eio.Fiber.yield ();
-                   drain_worker ~keeper_name entry ~worker_id ~sw
+                   drain_worker ~keeper_name entry ~worker ~sw
                  with
                  | Eio.Cancel.Cancelled _ as exn ->
                    abandon_queued
                      ~keeper_name
                      entry
-                     ~worker_id
+                     ~worker
                      ~reason:Worker_cancelled;
                    raise exn
                  | exn ->
                    abandon_queued
                      ~keeper_name
                      entry
-                     ~worker_id
+                     ~worker
                      ~reason:Worker_failed;
                    record_counter ~keeper_name MemoryLaneUnitFailures;
                    Log.Keeper.error ~keeper_name
                      "memory lane worker failed: %s"
-                     (Printexc.to_string exn)));
-           true
+                     (Printexc.to_string exn));
+             `Stop_daemon);
+           let started = Atomic.get worker_started in
+           let active = worker_is_active entry ~worker in
+           if not started
+           then
+             abandon_queued
+               ~keeper_name
+               entry
+               ~worker
+               ~reason:Executor_switch_unavailable;
+           started && active
          with
          | Eio.Cancel.Cancelled _ as exn ->
            disarm_switch_hook hook;
            abandon_queued
              ~keeper_name
              entry
-             ~worker_id
+             ~worker
              ~reason:Worker_cancelled;
            raise exn
          | exn ->
@@ -327,7 +356,7 @@ let start_worker ~keeper_name entry ~worker_id sw =
            abandon_queued
              ~keeper_name
              entry
-             ~worker_id
+             ~worker
              ~reason:Fork_failed;
            Log.Keeper.error ~keeper_name
              "memory lane worker fork failed: %s"
@@ -352,12 +381,12 @@ let submit ~base_path ~keeper_name job =
     Ran_inline
   | Some sw ->
     let entry = entry_for ~base_path ~keeper_name in
-    let worker_id = enqueue ~keeper_name entry job in
+    let worker = enqueue ~keeper_name entry job in
     record_counter ~keeper_name MemoryLaneSubmitted;
-    (match worker_id with
+    (match worker with
      | None -> Submitted
-     | Some worker_id ->
-       if start_worker ~keeper_name entry ~worker_id sw then Submitted else Dropped)
+     | Some worker ->
+       if start_worker ~keeper_name entry ~worker sw then Submitted else Dropped)
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,13 +1,12 @@
 (** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
 
 type entry =
-  { mem_mu : Eio.Mutex.t
-    (* Serializes memory work within one keeper; held across a provider round
-       trip (seconds), hence the fiber-cooperative Eio.Mutex. Raw lock/unlock,
-       not [use_rw]: a raising unit must not poison the lane. *)
-  ; state_mu : Stdlib.Mutex.t
-    (* Guards [pending]. Critical sections never yield. *)
+  { state_mu : Stdlib.Mutex.t
+    (* Guards the FIFO and worker ownership. Critical sections never yield. *)
+  ; jobs : (unit -> unit) Stdlib.Queue.t
   ; mutable pending : int
+  ; mutable next_worker_id : int
+  ; mutable active_worker_id : int option
   }
 
 type outcome =
@@ -15,21 +14,21 @@ type outcome =
   | Ran_inline
   | Dropped
 
-type reservation =
-  { release_mu : Stdlib.Mutex.t
-  ; mutable released : bool
-  ; mutable switch_hook : Eio.Switch.hook option
-  }
+type abandonment_reason =
+  | Executor_switch_unavailable
+  | Executor_switch_released
+  | Worker_cancelled
+  | Worker_failed
+  | Hook_registration_failed
+  | Fork_failed
 
-(* Per-keeper reservation bound: 1 in-flight (holding [mem_mu]) plus 1 queued.
-   A third concurrent post-turn unit for the same keeper means turns outpace
-   extraction; the excess is best-effort and dropped rather than piling up
-   fibers. Tunable via environment for fleet-wide capacity experiments. *)
-let max_pending () =
-  Keeper_memory_bank_env.memory_env_int_logged
-    "MASC_KEEPER_MEMORY_LANE_MAX_PENDING"
-    ~default:2
-  |> max 1
+let abandonment_reason_label = function
+  | Executor_switch_unavailable -> "executor_switch_unavailable"
+  | Executor_switch_released -> "executor_switch_released"
+  | Worker_cancelled -> "worker_cancelled"
+  | Worker_failed -> "worker_failed"
+  | Hook_registration_failed -> "hook_registration_failed"
+  | Fork_failed -> "fork_failed"
 ;;
 
 let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
@@ -52,25 +51,37 @@ let entry_for ~base_path ~keeper_name =
   let key = Keeper_registry_types.registry_key ~base_path keeper_name in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
-    | Some e -> e
+    | Some entry -> entry
     | None ->
-      let e =
-        { mem_mu = Eio.Mutex.create ()
-        ; state_mu = Stdlib.Mutex.create ()
+      let entry =
+        { state_mu = Stdlib.Mutex.create ()
+        ; jobs = Stdlib.Queue.create ()
         ; pending = 0
+        ; next_worker_id = 0
+        ; active_worker_id = None
         }
       in
-      Hashtbl.add entries key e;
-      e)
+      Hashtbl.add entries key entry;
+      entry)
 ;;
 
-let metric_name m = Keeper_metrics.(to_string m)
+let metric_name metric = Keeper_metrics.(to_string metric)
 
 let record_counter ~keeper_name metric =
   Otel_metric_store.inc_counter
     (metric_name metric)
     ~labels:[ "keeper", keeper_name ]
     ()
+;;
+
+let record_counter_delta ~keeper_name metric count =
+  if count > 0
+  then
+    Otel_metric_store.inc_counter
+      (metric_name metric)
+      ~labels:[ "keeper", keeper_name ]
+      ~delta:(float_of_int count)
+      ()
 ;;
 
 let inc_pending ~keeper_name () =
@@ -87,6 +98,16 @@ let dec_pending ~keeper_name () =
     ()
 ;;
 
+let dec_pending_by ~keeper_name count =
+  if count > 0
+  then
+    Otel_metric_store.dec_gauge
+      (metric_name MemoryLanePending)
+      ~labels:[ "keeper", keeper_name ]
+      ~delta:(float_of_int count)
+      ()
+;;
+
 let inc_in_flight ~keeper_name () =
   Otel_metric_store.inc_gauge
     (metric_name MemoryLaneInFlight)
@@ -101,53 +122,6 @@ let dec_in_flight ~keeper_name () =
     ()
 ;;
 
-let try_reserve ~keeper_name entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    let bound = max_pending () in
-    if entry.pending >= bound
-    then None
-    else (
-      entry.pending <- entry.pending + 1;
-      inc_pending ~keeper_name ();
-      Some bound))
-;;
-
-let release_reservation ~keeper_name entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    entry.pending <- entry.pending - 1;
-    dec_pending ~keeper_name ())
-;;
-
-let make_reservation () =
-  { release_mu = Stdlib.Mutex.create (); released = false; switch_hook = None }
-;;
-
-let reservation_released reservation =
-  Stdlib.Mutex.protect reservation.release_mu (fun () -> reservation.released)
-;;
-
-let release_reservation_once ~keeper_name entry reservation =
-  let should_release =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then false
-      else (
-        reservation.released <- true;
-        true))
-  in
-  if should_release then release_reservation ~keeper_name entry
-;;
-
-let disarm_switch_hook reservation =
-  let hook =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      let hook = reservation.switch_hook in
-      reservation.switch_hook <- None;
-      hook)
-  in
-  Option.iter (fun hook -> ignore (Eio.Switch.try_remove_hook hook)) hook
-;;
-
 let protect_cleanup ~keeper_name label f =
   try f () with
   | exn ->
@@ -158,55 +132,100 @@ let protect_cleanup ~keeper_name label f =
       (Printexc.to_string exn)
 ;;
 
-let release_after_run ~keeper_name entry reservation ~acquired ~in_flight =
-  if !in_flight
-  then protect_cleanup ~keeper_name "dec_in_flight" (fun () -> dec_in_flight ~keeper_name ());
-  if !acquired
-  then protect_cleanup ~keeper_name "unlock" (fun () -> Eio.Mutex.unlock entry.mem_mu);
-  protect_cleanup ~keeper_name "release_reservation" (fun () ->
-    release_reservation_once ~keeper_name entry reservation)
+let enqueue ~keeper_name entry job =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    Stdlib.Queue.add job entry.jobs;
+    entry.pending <- entry.pending + 1;
+    inc_pending ~keeper_name ();
+    match entry.active_worker_id with
+    | Some _ -> None
+    | None ->
+      entry.next_worker_id <- entry.next_worker_id + 1;
+      let worker_id = entry.next_worker_id in
+      entry.active_worker_id <- Some worker_id;
+      Some worker_id)
 ;;
 
-let arm_switch_release ~keeper_name entry reservation sw =
-  let release_from_switch () =
-    protect_cleanup ~keeper_name "executor_switch_release" (fun () ->
-      release_reservation_once ~keeper_name entry reservation)
+let take_next entry ~worker_id =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match entry.active_worker_id with
+    | Some active when active = worker_id ->
+      (match Stdlib.Queue.take_opt entry.jobs with
+       | Some job -> Some job
+       | None ->
+         entry.active_worker_id <- None;
+         None)
+    | Some _ | None -> None)
+;;
+
+let release_job ~keeper_name entry =
+  let released =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      if entry.pending <= 0
+      then false
+      else (
+        entry.pending <- entry.pending - 1;
+        true))
   in
-  try
-    let hook = Eio.Switch.on_release_cancellable sw release_from_switch in
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then ignore (Eio.Switch.try_remove_hook hook)
-      else reservation.switch_hook <- Some hook)
-  with
-  | _exn ->
-    (* Finished switches can raise while running the release callback; any hook
-       registration failure means the executor cannot own this reservation. *)
-    release_from_switch ()
+  if released
+  then dec_pending ~keeper_name ()
+  else (
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.error ~keeper_name "memory lane pending counter underflow prevented")
 ;;
 
-(* Runs on a forked fiber owned by the executor switch. Holds [mem_mu] across
-   the unit. Releases the mutex (only if acquired) and the reservation on every
-   exit, including cancellation at shutdown. No exception escapes: a best-effort
-   unit must never propagate into the executor switch — that would cancel the
-   fleet. *)
-let run_unit ~keeper_name entry reservation sw f =
-  let acquired = ref false in
-  let in_flight = ref false in
-  Eio.Switch.run (fun cleanup_sw ->
-    Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
-      disarm_switch_hook reservation;
-      try
-        Eio.Mutex.lock entry.mem_mu;
-        (* No suspension point between [lock] returning and this assignment, so
-           cancellation cannot strand a held mutex with [acquired = false]. *)
-        acquired := true;
-        inc_in_flight ~keeper_name ();
-        in_flight := true;
-        Eio_context.with_turn_switch sw f
-      with
-      | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
+let worker_is_active entry ~worker_id =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    entry.active_worker_id = Some worker_id)
+;;
+
+let abandon_queued ~keeper_name entry ~worker_id ~reason =
+  let abandoned =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      match entry.active_worker_id with
+      | Some active when active = worker_id ->
+        let count = Stdlib.Queue.length entry.jobs in
+        Stdlib.Queue.clear entry.jobs;
+        entry.pending <- entry.pending - count;
+        entry.active_worker_id <- None;
+        count
+      | Some _ | None -> 0)
+  in
+  if abandoned > 0
+  then (
+    record_counter_delta ~keeper_name MemoryLaneDropped abandoned;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:
+        [ "keeper", keeper_name
+        ; "site", "memory_lane_abandoned"
+        ; "reason", abandonment_reason_label reason
+        ]
+      ~delta:(float_of_int abandoned)
+      ();
+    dec_pending_by ~keeper_name abandoned;
+    Log.Keeper.warn ~keeper_name
+      "memory lane worker abandoned queued units count=%d reason=%s"
+      abandoned
+      (abandonment_reason_label reason));
+  abandoned
+;;
+
+let run_job ~keeper_name entry ~sw job =
+  inc_in_flight ~keeper_name ();
+  Fun.protect
+    ~finally:(fun () ->
+      protect_cleanup ~keeper_name "dec_in_flight" (fun () ->
+        dec_in_flight ~keeper_name ());
+      protect_cleanup ~keeper_name "release_job" (fun () ->
+        release_job ~keeper_name entry))
+    (fun () ->
+      try Eio_context.with_turn_switch sw job with
+      | Eio.Cancel.Cancelled _ as exn ->
+        record_counter ~keeper_name MemoryLaneDropped;
+        Log.Keeper.warn ~keeper_name
+          "memory lane in-flight unit cancelled before completion";
+        raise exn
       | exn ->
         record_counter ~keeper_name MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
@@ -214,14 +233,119 @@ let run_unit ~keeper_name entry reservation sw f =
           (Printexc.to_string exn))
 ;;
 
-let submit ~base_path ~keeper_name f =
+let rec drain_worker ~keeper_name entry ~worker_id ~sw =
+  match take_next entry ~worker_id with
+  | None -> ()
+  | Some job ->
+    run_job ~keeper_name entry ~sw job;
+    drain_worker ~keeper_name entry ~worker_id ~sw
+;;
+
+let start_worker ~keeper_name entry ~worker_id sw =
+  let release_from_switch () =
+    ignore
+      (abandon_queued
+         ~keeper_name
+         entry
+         ~worker_id
+         ~reason:Executor_switch_released)
+  in
+  match Eio.Switch.get_error sw with
+  | Some _ ->
+    ignore
+      (abandon_queued
+         ~keeper_name
+         entry
+         ~worker_id
+         ~reason:Executor_switch_unavailable);
+    false
+  | None ->
+    let hook =
+      try Some (Eio.Switch.on_release_cancellable sw release_from_switch) with
+      | exn ->
+        ignore
+          (abandon_queued
+             ~keeper_name
+             entry
+             ~worker_id
+             ~reason:Hook_registration_failed);
+        Log.Keeper.warn ~keeper_name
+          "memory lane worker release hook registration failed: %s"
+          (Printexc.to_string exn);
+        None
+    in
+    (match hook with
+     | None -> false
+     | Some hook ->
+       if not (worker_is_active entry ~worker_id)
+       then (
+         ignore (Eio.Switch.try_remove_hook hook);
+         false)
+       else (
+         try
+           Eio.Fiber.fork ~sw (fun () ->
+             Fun.protect
+               ~finally:(fun () -> ignore (Eio.Switch.try_remove_hook hook))
+               (fun () ->
+                 try
+                   (* [Fiber.fork] runs the child immediately. Yield once so
+                      [submit] returns before deterministic disk work or a
+                      provider call begins on the memory worker. *)
+                   Eio.Fiber.yield ();
+                   drain_worker ~keeper_name entry ~worker_id ~sw
+                 with
+                 | Eio.Cancel.Cancelled _ as exn ->
+                   ignore
+                     (abandon_queued
+                        ~keeper_name
+                        entry
+                        ~worker_id
+                        ~reason:Worker_cancelled);
+                   raise exn
+                 | exn ->
+                   ignore
+                     (abandon_queued
+                        ~keeper_name
+                        entry
+                        ~worker_id
+                        ~reason:Worker_failed);
+                   record_counter ~keeper_name MemoryLaneUnitFailures;
+                   Log.Keeper.error ~keeper_name
+                     "memory lane worker failed: %s"
+                     (Printexc.to_string exn)));
+           true
+         with
+         | Eio.Cancel.Cancelled _ as exn ->
+           ignore (Eio.Switch.try_remove_hook hook);
+           ignore
+             (abandon_queued
+                ~keeper_name
+                entry
+                ~worker_id
+                ~reason:Worker_cancelled);
+           raise exn
+         | exn ->
+           ignore (Eio.Switch.try_remove_hook hook);
+           ignore
+             (abandon_queued
+                ~keeper_name
+                entry
+                ~worker_id
+                ~reason:Fork_failed);
+           Log.Keeper.error ~keeper_name
+             "memory lane worker fork failed: %s"
+             (Printexc.to_string exn);
+           false))
+;;
+
+let submit ~base_path ~keeper_name job =
   match current_sw () with
   | None ->
     (* Not initialized: run inline. The caller is still inside the per-keeper
        turn lane, so single-fiber-per-keeper memory access is preserved. A
        raising unit is contained and counted rather than escaping. *)
-    (try f () with
-     | Eio.Cancel.Cancelled _ as e -> raise e
+    (try job () with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
        record_counter ~keeper_name MemoryLaneUnitFailures;
        Log.Keeper.warn ~keeper_name
@@ -231,44 +355,12 @@ let submit ~base_path ~keeper_name f =
     Ran_inline
   | Some sw ->
     let entry = entry_for ~base_path ~keeper_name in
-    (match try_reserve ~keeper_name entry with
-     | None ->
-       record_counter ~keeper_name MemoryLaneDropped;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string DispatchEventFailures)
-         ~labels:[ "keeper", keeper_name; "site", "memory_lane_saturated" ]
-         ();
-       Log.Keeper.warn ~keeper_name
-         "memory lane saturated (pending>=%d): dropping post-turn memory unit"
-         (max_pending ());
-       Dropped
-     | Some _bound ->
-       let reservation = make_reservation () in
-       arm_switch_release ~keeper_name entry reservation sw;
-       if reservation_released reservation
-       then (
-         record_counter ~keeper_name MemoryLaneDropped;
-         Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable: dropping post-turn memory unit";
-         Dropped)
-       else (
-         try
-           record_counter ~keeper_name MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation sw f);
-           Submitted
-         with
-         | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           raise e
-         | exn ->
-           protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           record_counter ~keeper_name MemoryLaneUnitFailures;
-           Log.Keeper.warn ~keeper_name
-             "memory lane fork failed: %s"
-             (Printexc.to_string exn);
-           Dropped))
+    let worker_id = enqueue ~keeper_name entry job in
+    record_counter ~keeper_name MemoryLaneSubmitted;
+    (match worker_id with
+     | None -> Submitted
+     | Some worker_id ->
+       if start_worker ~keeper_name entry ~worker_id sw then Submitted else Dropped)
 ;;
 
 module For_testing = struct
@@ -281,6 +373,7 @@ module For_testing = struct
   let pending ~base_path ~keeper_name =
     let key = Keeper_registry_types.registry_key ~base_path keeper_name in
     Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
-    |> Option.map (fun e -> Stdlib.Mutex.protect e.state_mu (fun () -> e.pending))
+    |> Option.map (fun entry ->
+      Stdlib.Mutex.protect entry.state_mu (fun () -> entry.pending))
   ;;
 end

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -1,67 +1,103 @@
-(** Per-keeper memory execution lane (RFC-0257).
+(** Restart-durable per-keeper memory execution lane (RFC-0257).
 
-    Detaches post-turn memory work (deterministic write, librarian extraction,
-    compaction) from the keeper turn lane. Each keeper has one FIFO drain
-    daemon, so memory work is serialized within a keeper and runs independently
-    across keepers without keeping the server executor switch alive during
-    shutdown. This replaces the process-global [Eio.Semaphore.make 1] in
-    [Keeper_librarian_runtime] that previously serialized every keeper's
-    librarian work fleet-wide — the opposite of the lane-per-keeper model
-    (RFC-0225).
+    The lane keeps only worker ownership in process memory. Accepted work is a
+    typed {!Keeper_memory_job_store.job} persisted under its BasePath before
+    [submit] returns. Each keeper has one drain daemon; different keepers drain
+    independently. A process crash leaves pending/inflight jobs replayable and
+    never requires retaining an unbounded closure FIFO on the OCaml heap. *)
 
-    The unit submitted must be self-contained over immutable values: it reads
-    its Eio capabilities from [Eio_context] (the lane binds the executor switch
-    via [Eio_context.with_turn_switch] before running it), and must not close
-    over mutable turn-local state that a later turn can overwrite. The OCaml
-    type system cannot enforce this immutability precondition; callers are
-    responsible for passing a closure that only closes over immutable snapshots
-    (e.g. [Keeper_meta_contract.keeper_meta], [Workspace.config]) and never over
-    mutable turn-local references.
+type retryability =
+  | Retryable
+  | Terminal
 
-    Submissions append immutable work closures and return without waiting for
-    earlier memory work; the worker processes every accepted unit in turn
-    order. Submission outcomes are counted under [masc_keeper_memory_lane_*]
-    and per-keeper pending / in-flight gauges are exported.
+type execution_error =
+  { retryability : retryability
+  ; kind : string
+  ; message : string
+  ; detail : Yojson.Safe.t
+  }
 
-    The FIFO owns closures for the lifetime of the server executor switch; it
-    is not a restart-durable job store. Switch shutdown explicitly abandons,
-    counts, and logs unfinished units. *)
+type execute =
+  base_path:string ->
+  Keeper_memory_job_store.job ->
+  (Yojson.Safe.t, execution_error) result
 
-type outcome =
-  | Submitted
-      (** Accepted by the keeper's FIFO and owned by its drain daemon. *)
-  | Ran_inline
-      (** Executor switch not initialized; the unit ran synchronously in the
-          caller so no work is lost (tests, or startup before {!init}). A
-          raising unit is contained and emits a metric instead of escaping. *)
-  | Dropped
-      (** The executor switch could not own the unit (shutdown or worker-spawn
-          failure). Accepted work is never dropped merely because earlier
-          memory work is still running. Exceptional abandonment is counted and
-          logged. *)
+type worker_deferred_reason =
+  | Executor_not_initialized
+  | Executor_base_path_mismatch
+  | Executor_switch_released
+  | Hook_registration_failed
+  | Fork_failed
 
-val init : sw:Eio.Switch.t -> unit
-(** Record the long-lived switch that owns detached memory fibers. Call once at
-    server startup, after [Eio_context.set_switch]. Repeating [init] with the
-    same switch is idempotent; replacing it with another switch is an explicit
-    programming error. *)
+type worker_state =
+  | Started
+  | Already_running
+  | Not_needed
+  | Deferred of worker_deferred_reason
 
-val submit
-  :  base_path:string
-  -> keeper_name:string
-  -> (unit -> unit)
-  -> outcome
-(** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s memory lane.
-    When the executor switch is set, [f] is appended to that keeper's FIFO and
-    drained by one daemon. The caller does not wait for earlier work. When the
-    executor is not initialized, [f] runs inline and any exception is contained
-    and counted rather than escaping. Outcomes and per-keeper pending/in-flight
-    state are exported as metrics. *)
+type admission =
+  | Admitted of
+      { job_id : string
+      ; activation : Keeper_memory_job_store.activation
+      ; worker : worker_state
+      }
+  | Rejected of Keeper_memory_job_store.error
+
+type staging =
+  | Staged of
+      { job_id : string
+      ; durable : Keeper_memory_job_store.admission
+      }
+  | Stage_rejected of Keeper_memory_job_store.error
+
+type init_report =
+  { discovered_keepers : int
+  ; workers_started : int
+  ; workers_deferred : int
+  ; discovery_error : Keeper_memory_job_store.error option
+  ; keeper_discovery_errors : Keeper_memory_job_store.error list
+  }
+
+val init :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  base_path:string ->
+  execute:execute ->
+  init_report
+(** Install the one long-lived executor and start workers for every keeper with
+    durable backlog. Repeating with the same switch/BasePath/handler is
+    idempotent; replacing any of them is a programming error. A root discovery
+    failure is returned in [discovery_error]. Keeper-local malformed backlogs
+    are isolated in [keeper_discovery_errors], while healthy keepers still
+    start. Every error is logged, never hidden. *)
+
+val stage :
+  base_path:string ->
+  Keeper_memory_job_store.job ->
+  staging
+(** Durably admit a non-runnable awaiting-turn-commit job. *)
+
+val activate :
+  base_path:string -> Keeper_memory_job_store.job -> admission
+(** Activate a staged job only after the owning execution receipt committed,
+    then wake its Keeper lane. *)
+
+val abort :
+  base_path:string ->
+  Keeper_memory_job_store.job ->
+  (unit, Keeper_memory_job_store.error) result
+(** Remove a staged job after execution-receipt failure. *)
+
+val request_reconciliation :
+  base_path:string -> keeper_name:string -> unit
+(** Start or retain the self-retrying strict execution-receipt reconciliation
+    loop for one Keeper. Used when the caller cannot safely classify an
+    awaiting outbox as committed or aborted. Missing/mismatched executor
+    ownership is logged explicitly and the durable outbox remains untouched. *)
+
+val worker_deferred_reason_to_string : worker_deferred_reason -> string
 
 module For_testing : sig
   val reset : unit -> unit
-  (** Clear the lane registry and the executor switch. *)
-
-  val pending : base_path:string -> keeper_name:string -> int option
-  (** Current pending count for a keeper ([None] if the keeper has no entry). *)
+  val backlog_count : base_path:string -> keeper_name:string -> (int, Keeper_memory_job_store.error) result
 end

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -2,8 +2,9 @@
 
     Detaches post-turn memory work (deterministic write, librarian extraction,
     compaction) from the keeper turn lane. Each keeper has one FIFO drain
-    worker, so memory work is serialized within a keeper and runs independently
-    across keepers. This replaces the process-global [Eio.Semaphore.make 1] in
+    daemon, so memory work is serialized within a keeper and runs independently
+    across keepers without keeping the server executor switch alive during
+    shutdown. This replaces the process-global [Eio.Semaphore.make 1] in
     [Keeper_librarian_runtime] that previously serialized every keeper's
     librarian work fleet-wide — the opposite of the lane-per-keeper model
     (RFC-0225).
@@ -28,7 +29,7 @@
 
 type outcome =
   | Submitted
-      (** Accepted by the keeper's FIFO and owned by its drain worker. *)
+      (** Accepted by the keeper's FIFO and owned by its drain daemon. *)
   | Ran_inline
       (** Executor switch not initialized; the unit ran synchronously in the
           caller so no work is lost (tests, or startup before {!init}). A
@@ -41,7 +42,9 @@ type outcome =
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
-    server startup, after [Eio_context.set_switch]. *)
+    server startup, after [Eio_context.set_switch]. Repeating [init] with the
+    same switch is idempotent; replacing it with another switch is an explicit
+    programming error. *)
 
 val submit
   :  base_path:string
@@ -50,7 +53,7 @@ val submit
   -> outcome
 (** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s memory lane.
     When the executor switch is set, [f] is appended to that keeper's FIFO and
-    drained by one worker. The caller does not wait for earlier work. When the
+    drained by one daemon. The caller does not wait for earlier work. When the
     executor is not initialized, [f] runs inline and any exception is contained
     and counted rather than escaping. Outcomes and per-keeper pending/in-flight
     state are exported as metrics. *)

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -1,9 +1,9 @@
 (** Per-keeper memory execution lane (RFC-0257).
 
     Detaches post-turn memory work (deterministic write, librarian extraction,
-    compaction) from the keeper turn lane. Each keeper has its own mutex, so
-    memory work is serialized within a keeper and runs independently across
-    keepers. This replaces the process-global [Eio.Semaphore.make 1] in
+    compaction) from the keeper turn lane. Each keeper has one FIFO drain
+    worker, so memory work is serialized within a keeper and runs independently
+    across keepers. This replaces the process-global [Eio.Semaphore.make 1] in
     [Keeper_librarian_runtime] that previously serialized every keeper's
     librarian work fleet-wide — the opposite of the lane-per-keeper model
     (RFC-0225).
@@ -17,22 +17,27 @@
     (e.g. [Keeper_meta_contract.keeper_meta], [Workspace.config]) and never over
     mutable turn-local references.
 
-    The per-keeper reservation bound is controlled by
-    [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Submission outcomes
-    are counted under [masc_keeper_memory_lane_*] and per-keeper pending /
-    in-flight gauges are exported. *)
+    Submissions append immutable work closures and return without waiting for
+    earlier memory work; the worker processes every accepted unit in turn
+    order. Submission outcomes are counted under [masc_keeper_memory_lane_*]
+    and per-keeper pending / in-flight gauges are exported.
+
+    The FIFO owns closures for the lifetime of the server executor switch; it
+    is not a restart-durable job store. Switch shutdown explicitly abandons,
+    counts, and logs unfinished units. *)
 
 type outcome =
   | Submitted
-      (** Forked onto the keeper's lane and serialized behind its mutex. *)
+      (** Accepted by the keeper's FIFO and owned by its drain worker. *)
   | Ran_inline
       (** Executor switch not initialized; the unit ran synchronously in the
           caller so no work is lost (tests, or startup before {!init}). A
           raising unit is contained and emits a metric instead of escaping. *)
   | Dropped
-      (** The keeper's lane was saturated (pending at the bound); the unit was
-          discarded. Memory extraction is best-effort, so saturation drops
-          rather than blocking the turn. The drop is counted, never silent. *)
+      (** The executor switch could not own the unit (shutdown or worker-spawn
+          failure). Accepted work is never dropped merely because earlier
+          memory work is still running. Exceptional abandonment is counted and
+          logged. *)
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
@@ -44,11 +49,11 @@ val submit
   -> (unit -> unit)
   -> outcome
 (** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s memory lane.
-    When the executor switch is set, [f] is forked and serialized behind that
-    keeper's mutex; over the pending bound it is dropped and counted. When the
+    When the executor switch is set, [f] is appended to that keeper's FIFO and
+    drained by one worker. The caller does not wait for earlier work. When the
     executor is not initialized, [f] runs inline and any exception is contained
-    and counted rather than escaping. The bound, outcomes, and per-keeper
-    pending/in-flight state are exported as metrics. *)
+    and counted rather than escaping. Outcomes and per-keeper pending/in-flight
+    state are exported as metrics. *)
 
 module For_testing : sig
   val reset : unit -> unit

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -7,6 +7,13 @@
 open Keeper_memory_os_types
 open Result.Syntax
 
+let facts_file_suffix = ".facts.jsonl"
+let events_file_suffix = ".events.jsonl"
+let episodes_directory_name = "episodes"
+let tool_results_directory_name = "tool-results"
+let private_memory_directory_mode = 0o700
+let private_memory_file_mode = 0o600
+
 let rec ensure_dir path =
   if path = "" || path = Filename.current_dir_name
   then ()
@@ -28,7 +35,9 @@ let keepers_dir_override : string option ref = ref None
 let keepers_dir () =
   match !keepers_dir_override with
   | Some path -> path
-  | None -> Config_dir_resolver.keepers_dir ()
+  | None ->
+    Common.keepers_runtime_dir_of_base
+      ~base_path:(Env_config_core.base_path ())
 ;;
 
 module For_testing = struct
@@ -43,7 +52,7 @@ module For_testing = struct
 end
 
 let facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".facts.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ facts_file_suffix)
 ;;
 
 let facts_path ~keeper_id =
@@ -64,7 +73,7 @@ let list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir =
     Sys.readdir dir
     |> Array.to_list
     |> List.filter_map (fun name ->
-      match Filename.chop_suffix_opt ~suffix:".facts.jsonl" name with
+      match Filename.chop_suffix_opt ~suffix:facts_file_suffix name with
       | Some id when not (String.equal id shared_store_id) -> Some id
       | Some _ | None -> None)
     |> List.sort String.compare
@@ -76,11 +85,11 @@ let list_fact_store_keeper_ids () =
 
 let list_fact_store_keeper_ids_for_base_path ~base_path =
   list_fact_store_keeper_ids_for_keepers_dir
-    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
 ;;
 
 let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ events_file_suffix)
 ;;
 
 type legacy_memory_file =
@@ -107,26 +116,369 @@ let current_path_for_legacy_memory_filename ~keepers_dir ~keeper_id ~filename =
   | None -> None
 ;;
 
+type migration_stats =
+  { moved_files : int
+  ; deduplicated_files : int
+  }
+
+type migration_error =
+  { source : string
+  ; destination : string
+  ; detail : string
+  }
+
+type migration_report =
+  { stats : migration_stats
+  ; errors : migration_error list
+  }
+
+let migration_error_to_string error =
+  Printf.sprintf
+    "Memory OS migration failed source=%s destination=%s: %s"
+    error.source
+    error.destination
+    error.detail
+;;
+
+let migration_error ~source ~destination detail =
+  Error { source; destination; detail }
+;;
+
+let migration_protect ~source ~destination f =
+  try Ok (f ()) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> migration_error ~source ~destination (Printexc.to_string exn)
+;;
+
+let add_migration_stats left right =
+  { moved_files = left.moved_files + right.moved_files
+  ; deduplicated_files =
+      left.deduplicated_files + right.deduplicated_files
+  }
+;;
+
+let empty_migration_stats = { moved_files = 0; deduplicated_files = 0 }
+
+let empty_migration_report =
+  { stats = empty_migration_stats; errors = [] }
+;;
+
+let add_migration_report left right =
+  { stats = add_migration_stats left.stats right.stats
+  ; errors = left.errors @ right.errors
+  }
+;;
+
+let migration_report_of_result = function
+  | Ok stats -> { stats; errors = [] }
+  | Error error -> { stats = empty_migration_stats; errors = [ error ] }
+;;
+
+let migration_lstat_opt ~source ~destination =
+  try Ok (Some (Unix.lstat source)) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> migration_error ~source ~destination (Printexc.to_string exn)
+;;
+
+let ensure_private_migration_directory ~source path =
+  let* () =
+    migration_protect ~source ~destination:path (fun () -> ensure_dir path)
+  in
+  migration_protect ~source ~destination:path (fun () ->
+    Unix.chmod path private_memory_directory_mode)
+;;
+
+let remove_migrated_source ~source ~destination =
+  let* () =
+    migration_protect ~source ~destination (fun () -> Sys.remove source)
+  in
+  match Fs_compat.fsync_directory (Filename.dirname source) with
+  | Ok () -> Ok ()
+  | Error detail -> migration_error ~source ~destination detail
+;;
+
+let migrate_memory_file ~source ~destination =
+  let* source_content =
+    migration_protect ~source ~destination (fun () -> Fs_compat.load_file source)
+  in
+  let* destination_exists =
+    migration_protect ~source ~destination (fun () ->
+      Fs_compat.file_exists destination)
+  in
+  let* disposition =
+    if destination_exists
+    then
+      let* destination_stat =
+        migration_protect ~source ~destination (fun () -> Unix.lstat destination)
+      in
+      if destination_stat.Unix.st_kind <> Unix.S_REG
+      then
+        migration_error
+          ~source
+          ~destination
+          "destination exists but is not a regular file"
+      else
+      let* destination_content =
+        migration_protect ~source ~destination (fun () ->
+          Fs_compat.load_file destination)
+      in
+      if String.equal source_content destination_content
+      then Ok `Deduplicated
+      else
+        migration_error
+          ~source
+          ~destination
+          "destination exists with different bytes; refusing overwrite or merge"
+    else
+      let* () =
+        ensure_private_migration_directory
+          ~source
+          (Filename.dirname destination)
+      in
+      (match Fs_compat.save_file_atomic destination source_content with
+       | Error detail -> migration_error ~source ~destination detail
+       | Ok () ->
+         let* () =
+           migration_protect ~source ~destination (fun () ->
+             Unix.chmod destination private_memory_file_mode)
+         in
+         Ok `Moved)
+  in
+  let* () = remove_migrated_source ~source ~destination in
+  match disposition with
+  | `Moved -> Ok { moved_files = 1; deduplicated_files = 0 }
+  | `Deduplicated -> Ok { moved_files = 0; deduplicated_files = 1 }
+;;
+
+let rec migrate_memory_directory ~source ~destination =
+  match ensure_private_migration_directory ~source destination with
+  | Error error -> migration_report_of_result (Error error)
+  | Ok () ->
+    (match
+       migration_protect ~source ~destination (fun () ->
+         Sys.readdir source |> Array.to_list |> List.sort String.compare)
+     with
+     | Error error -> migration_report_of_result (Error error)
+     | Ok entries ->
+       let report =
+         List.fold_left
+           (fun report name ->
+              let source_entry = Filename.concat source name in
+              let destination_entry = Filename.concat destination name in
+              let entry_report =
+                match
+                  migration_protect
+                    ~source:source_entry
+                    ~destination:destination_entry
+                    (fun () -> Unix.lstat source_entry)
+                with
+                | Error error -> migration_report_of_result (Error error)
+                | Ok stat ->
+                  (match stat.Unix.st_kind with
+                   | Unix.S_REG ->
+                     migrate_memory_file
+                       ~source:source_entry
+                       ~destination:destination_entry
+                     |> migration_report_of_result
+                   | Unix.S_DIR ->
+                     migrate_memory_directory
+                       ~source:source_entry
+                       ~destination:destination_entry
+                   | Unix.S_CHR
+                   | Unix.S_BLK
+                   | Unix.S_LNK
+                   | Unix.S_FIFO
+                   | Unix.S_SOCK ->
+                     migration_error
+                       ~source:source_entry
+                       ~destination:destination_entry
+                       "unsupported non-regular Memory OS artifact"
+                     |> migration_report_of_result)
+              in
+              add_migration_report report entry_report)
+           empty_migration_report
+           entries
+       in
+       if report.errors <> []
+       then report
+       else
+         let removal_report =
+           match
+             migration_protect ~source ~destination (fun () -> Unix.rmdir source)
+           with
+           | Error error -> migration_report_of_result (Error error)
+           | Ok () ->
+             (match Fs_compat.fsync_directory (Filename.dirname source) with
+              | Ok () -> empty_migration_report
+              | Error detail ->
+                migration_error ~source ~destination detail
+                |> migration_report_of_result)
+         in
+         add_migration_report report removal_report)
+;;
+
+let migrate_legacy_config_store ~base_path =
+  let config_root =
+    Config_dir_resolver.base_path_config_root ~cwd:base_path base_path
+  in
+  let source_root = Filename.concat config_root "keepers" in
+  let destination_root = Common.keepers_runtime_dir_of_base ~base_path in
+  let runtime_flat_file name =
+    Filename.check_suffix name facts_file_suffix
+    || Filename.check_suffix name events_file_suffix
+  in
+  let migrate_keeper_directory ~keeper_name ~source ~destination =
+    let selected_subdirectories =
+      [ episodes_directory_name; tool_results_directory_name ]
+    in
+    List.fold_left
+      (fun report child ->
+         let source_child = Filename.concat source child in
+         let destination_child = Filename.concat destination child in
+         let child_report =
+           match
+             migration_lstat_opt
+               ~source:source_child
+               ~destination:destination_child
+           with
+           | Error error -> migration_report_of_result (Error error)
+           | Ok None -> empty_migration_report
+           | Ok (Some child_stat) ->
+             (match Keeper_id.Keeper_name.of_string keeper_name with
+              | Error detail ->
+                migration_error
+                  ~source:source_child
+                  ~destination:destination_child
+                  detail
+                |> migration_report_of_result
+              | Ok _ ->
+                if child_stat.Unix.st_kind <> Unix.S_DIR
+                then
+                  migration_error
+                    ~source:source_child
+                    ~destination:destination_child
+                    "selected Memory OS artifact is not a directory"
+                  |> migration_report_of_result
+                else
+                  migrate_memory_directory
+                    ~source:source_child
+                    ~destination:destination_child)
+         in
+         add_migration_report report child_report)
+      empty_migration_report
+      selected_subdirectories
+  in
+  if String.equal source_root destination_root
+  then empty_migration_report
+  else
+    match migration_lstat_opt ~source:source_root ~destination:destination_root with
+    | Error error -> migration_report_of_result (Error error)
+    | Ok None -> empty_migration_report
+    | Ok (Some source_stat) when source_stat.Unix.st_kind <> Unix.S_DIR ->
+      migration_error
+        ~source:source_root
+        ~destination:destination_root
+        "legacy Memory OS root is not a directory"
+      |> migration_report_of_result
+    | Ok (Some _) ->
+      (match
+         ensure_private_migration_directory ~source:source_root destination_root
+       with
+       | Error error -> migration_report_of_result (Error error)
+       | Ok () ->
+         (match
+            migration_protect ~source:source_root ~destination:destination_root
+              (fun () ->
+                 Sys.readdir source_root
+                 |> Array.to_list
+                 |> List.sort String.compare)
+          with
+          | Error error -> migration_report_of_result (Error error)
+          | Ok entries ->
+            List.fold_left
+              (fun report name ->
+                 let source = Filename.concat source_root name in
+                 let destination = Filename.concat destination_root name in
+                 let entry_report =
+                   match
+                     migration_protect ~source ~destination (fun () ->
+                       Unix.lstat source)
+                   with
+                   | Error error -> migration_report_of_result (Error error)
+                   | Ok stat ->
+                     (match stat.Unix.st_kind with
+                      | Unix.S_REG when runtime_flat_file name ->
+                        migrate_memory_file ~source ~destination
+                        |> migration_report_of_result
+                      | Unix.S_DIR ->
+                        migrate_keeper_directory
+                          ~keeper_name:name
+                          ~source
+                          ~destination
+                      | Unix.S_REG -> empty_migration_report
+                      | Unix.S_CHR
+                      | Unix.S_BLK
+                      | Unix.S_LNK
+                      | Unix.S_FIFO
+                      | Unix.S_SOCK ->
+                        if runtime_flat_file name
+                        then
+                          migration_error
+                            ~source
+                            ~destination
+                            "legacy Memory OS artifact is not a regular file"
+                          |> migration_report_of_result
+                        else empty_migration_report)
+                 in
+                 add_migration_report report entry_report)
+              empty_migration_report
+              entries))
+;;
+
 let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat keepers_dir (keeper_id ^ ".episode-bundle")
+;;
+
+let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  File_lock_eio.with_lock
+    ?clock
+    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
-  File_lock_eio.with_lock ?clock (episode_bundle_lock_path ~keeper_id) f
+  with_episode_bundle_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
+    f
 ;;
 
-let episodes_dir ~keeper_id =
-  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  let d =
+    Filename.concat
+      keepers_dir
+      (Filename.concat keeper_id episodes_directory_name)
+  in
   ensure_dir d;
   d
 ;;
 
+let episodes_dir ~keeper_id =
+  episodes_dir_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
+;;
+
 let tool_results_dir ~keeper_id =
-  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "tool-results") in
+  let d =
+    Filename.concat
+      (keepers_dir ())
+      (Filename.concat keeper_id tool_results_directory_name)
+  in
   ensure_dir d;
   d
 ;;
@@ -180,12 +532,14 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let generation_counter_path ~keeper_id ~trace_id =
-  Filename.concat (episodes_dir ~keeper_id) (Printf.sprintf "%s.generation" trace_id)
+let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  Filename.concat
+    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+    (Printf.sprintf "%s.generation" trace_id)
 ;;
 
-let max_generation_from_files ~keeper_id ~trace_id =
-  let dir = episodes_dir ~keeper_id in
+let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   let prefix = Printf.sprintf "%s-g" trace_id in
   Sys.readdir dir
   |> Array.to_list
@@ -217,10 +571,23 @@ let read_generation_counter path =
     lock. The counter intentionally allows gaps when extraction later fails;
     uniqueness is more important than contiguous numbering across fibers or
     processes. *)
-let next_generation_with_floor ~floor ~keeper_id ~trace_id =
-  let counter_path = generation_counter_path ~keeper_id ~trace_id in
+let next_generation_with_floor_for_keepers_dir
+      ~keepers_dir
+      ~floor
+      ~keeper_id
+      ~trace_id
+  =
+  let counter_path =
+    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  in
   File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files = max_generation_from_files ~keeper_id ~trace_id + 1 in
+    let next_from_files =
+      max_generation_from_files_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+        ~trace_id
+      + 1
+    in
     let next_from_counter =
       match read_generation_counter counter_path with
       | Some next -> next
@@ -231,17 +598,25 @@ let next_generation_with_floor ~floor ~keeper_id ~trace_id =
     generation)
 ;;
 
+let next_generation_with_floor ~floor ~keeper_id ~trace_id =
+  next_generation_with_floor_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~floor
+    ~keeper_id
+    ~trace_id
+;;
+
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path ~keeper_id episode =
+let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
     Filename.concat
-      (episodes_dir ~keeper_id)
+      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
          episode.trace_id
@@ -263,8 +638,7 @@ let unique_episode_path ~keeper_id episode =
 
 let append_line path line =
   ensure_dir (Filename.dirname path);
-  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  with_out_channel oc ~f:(fun oc -> output_string oc (line ^ "\n"))
+  Fs_compat.append_file_durable path (line ^ "\n")
 ;;
 
 let append_json path json =
@@ -275,13 +649,431 @@ let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
+let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  append_json
+    (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    (episode_to_json episode)
+;;
+
 let append_event ~keeper_id episode =
-  append_json (events_path ~keeper_id) (episode_to_json episode)
+  append_event_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
+    episode
+;;
+
+let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
+  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
-  let path = unique_episode_path ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  append_episode_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
+    episode
+;;
+
+let operation_id_field = "memory_operation_id"
+let operation_model_id_field = "memory_operation_model_id"
+let operation_provider_latency_ms_field = "memory_operation_provider_latency_ms"
+let event_quarantine_directory_name = "memory-event-quarantine"
+(* Legacy episode-directory prefix retained only so readers/caps never expose
+   or delete a stage written by an interrupted pre-journal runtime. *)
+let operation_episode_prefix = "operation-"
+let private_operation_directory_mode = 0o700
+
+let is_operation_episode_name name =
+  String.starts_with name ~prefix:operation_episode_prefix
+  && Filename.check_suffix name ".json"
+;;
+
+type operation_episode =
+  { episode : episode
+  ; model_id : string
+  ; provider_latency_ms : float
+  }
+
+let operation_episode_path ~keepers_dir ~keeper_id ~operation_id =
+  if not (Keeper_config.validate_name operation_id)
+  then Error (Printf.sprintf "invalid memory operation id: %S" operation_id)
+  else
+    Ok
+      (Keeper_memory_job_store.operation_stage_path_for_keepers_dir
+         ~keepers_dir
+         ~keeper_name:keeper_id
+         ~operation_id)
+;;
+
+let operation_episode_json
+      ~operation_id
+      ~model_id
+      ~provider_latency_ms
+      episode
+  =
+  match episode_to_json episode with
+  | `Assoc fields ->
+    `Assoc
+      ((operation_id_field, `String operation_id)
+       :: (operation_model_id_field, `String model_id)
+       :: (operation_provider_latency_ms_field, `Float provider_latency_ms)
+       :: fields)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _) as json ->
+    json
+;;
+
+let save_operation_episode
+      ~keepers_dir
+      ~keeper_id
+      ~operation_id
+      ~model_id
+      ~provider_latency_ms
+      episode
+  =
+  if String.equal (String.trim model_id) ""
+  then Error "memory operation model id must be non-empty"
+  else if (not (Float.is_finite provider_latency_ms)) || provider_latency_ms < 0.0
+  then Error "memory operation provider latency must be finite and non-negative"
+  else match operation_episode_path ~keepers_dir ~keeper_id ~operation_id with
+  | Error _ as error -> error
+  | Ok path ->
+    (try
+      let dir = Filename.dirname path in
+      ensure_dir dir;
+      Unix.chmod dir private_operation_directory_mode;
+       write_file_atomically
+         path
+         (Yojson.Safe.pretty_to_string
+            (operation_episode_json
+               ~operation_id
+               ~model_id
+               ~provider_latency_ms
+               episode));
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn)))
+;;
+
+let load_operation_episode ~keepers_dir ~keeper_id ~operation_id =
+  match operation_episode_path ~keepers_dir ~keeper_id ~operation_id with
+  | Error _ as error -> error
+  | Ok path ->
+    if not (Fs_compat.file_exists path)
+    then Ok None
+    else
+      (match Safe_ops.read_json_file_safe path with
+       | Error detail -> Error (Printf.sprintf "%s: %s" path detail)
+       | Ok json ->
+         (match json with
+          | `Assoc fields ->
+            (match
+               ( List.assoc_opt operation_model_id_field fields
+               , List.assoc_opt operation_provider_latency_ms_field fields )
+             with
+             | ( Some (`String model_id)
+               , Some (`Float provider_latency_ms) )
+               when not (String.equal (String.trim model_id) "")
+                    && Float.is_finite provider_latency_ms
+                    && provider_latency_ms >= 0.0 ->
+               (match episode_of_json json with
+                | Some episode ->
+                  Ok (Some { episode; model_id; provider_latency_ms })
+                | None -> Error (Printf.sprintf "%s: invalid episode JSON" path))
+             | ( Some (`String model_id)
+               , Some (`Int provider_latency_ms) )
+               when not (String.equal (String.trim model_id) "")
+                    && provider_latency_ms >= 0 ->
+               (match episode_of_json json with
+                | Some episode ->
+                  Ok
+                    (Some
+                       { episode
+                       ; model_id
+                       ; provider_latency_ms = float_of_int provider_latency_ms
+                       })
+                | None -> Error (Printf.sprintf "%s: invalid episode JSON" path))
+             | _ ->
+               Error
+                 (Printf.sprintf
+                    "%s: missing or invalid operation model/latency"
+                    path))
+          | _ -> Error (Printf.sprintf "%s: invalid operation episode JSON" path)))
+;;
+
+let stage_operation_episode_once
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      ~operation_id
+      ~model_id
+      ~provider_latency_ms
+      episode
+  =
+  match operation_episode_path ~keepers_dir ~keeper_id ~operation_id with
+  | Error _ as error -> error
+  | Ok path ->
+    (try
+       File_lock_eio.with_lock ?clock path (fun () ->
+         match load_operation_episode ~keepers_dir ~keeper_id ~operation_id with
+         | Error _ as error -> error
+         | Ok (Some winner) -> Ok winner
+         | Ok None ->
+           (match
+              save_operation_episode
+                ~keepers_dir
+                ~keeper_id
+                ~operation_id
+                ~model_id
+                ~provider_latency_ms
+                episode
+            with
+            | Error _ as error -> error
+            | Ok () -> Ok { episode; model_id; provider_latency_ms }))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn)))
+;;
+
+let operation_id_of_event = function
+  | `Assoc fields ->
+    (match List.assoc_opt operation_id_field fields with
+     | Some (`String operation_id) -> Some operation_id
+     | Some _ | None -> None)
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
+type parsed_event_line =
+  { raw : string
+  ; json : Yojson.Safe.t
+  }
+
+type malformed_event_line =
+  { line_number : int
+  ; raw : string
+  ; detail : string
+  }
+
+let parse_event_log_strict path =
+  let lines =
+    Fs_compat.load_file path
+    |> String.split_on_char '\n'
+  in
+  let rec loop line_number valid malformed = function
+    | [] -> List.rev valid, List.rev malformed
+    | raw :: rest when String.equal (String.trim raw) "" ->
+      loop (line_number + 1) valid malformed rest
+    | raw :: rest ->
+      let parsed =
+        try
+          let json = Yojson.Safe.from_string raw in
+          match episode_of_json json with
+          | Some _ -> Ok { raw; json }
+          | None -> Error "row does not satisfy the episode schema"
+        with
+        | Yojson.Json_error detail -> Error detail
+      in
+      (match parsed with
+       | Ok event -> loop (line_number + 1) (event :: valid) malformed rest
+       | Error detail ->
+         loop
+           (line_number + 1)
+           valid
+           ({ line_number; raw; detail } :: malformed)
+           rest)
+  in
+  loop 1 [] [] lines
+;;
+
+let quarantine_malformed_events
+      ~keepers_dir
+      ~keeper_id
+      ~events_path
+      malformed
+  =
+  let quarantine_dir =
+    Filename.concat
+      (Filename.concat keepers_dir keeper_id)
+      event_quarantine_directory_name
+  in
+  let rows =
+    List.map
+      (fun row ->
+         `Assoc
+           [ "source", `String events_path
+           ; "line_number", `Int row.line_number
+           ; "detail", `String row.detail
+           ; "raw", `String row.raw
+           ])
+      malformed
+  in
+  let content =
+    rows
+    |> List.map Yojson.Safe.to_string
+    |> String.concat "\n"
+    |> fun body -> body ^ "\n"
+  in
+  let digest =
+    Digestif.SHA256.digest_string content
+    |> Digestif.SHA256.to_hex
+  in
+  let destination = Filename.concat quarantine_dir (digest ^ ".jsonl") in
+  try
+    ensure_dir quarantine_dir;
+    Unix.chmod quarantine_dir private_memory_directory_mode;
+    if Fs_compat.file_exists destination
+    then
+      let existing = Fs_compat.load_file destination in
+      if not (String.equal existing content)
+      then
+        Error
+          (Printf.sprintf
+             "event quarantine digest collision at %s"
+             destination)
+      else Ok destination
+    else
+      (match Fs_compat.save_file_atomic destination content with
+       | Error detail -> Error detail
+       | Ok () ->
+         Unix.chmod destination private_memory_file_mode;
+         Ok destination)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let load_and_repair_event_log ~keepers_dir ~keeper_id path =
+  try
+    let valid, malformed = parse_event_log_strict path in
+    match malformed with
+    | [] -> Ok (List.map (fun event -> event.json) valid)
+    | _ ->
+      (match
+         quarantine_malformed_events
+           ~keepers_dir
+           ~keeper_id
+           ~events_path:path
+           malformed
+       with
+       | Error detail ->
+         Error
+           (Printf.sprintf
+              "%s: cannot quarantine %d malformed event row(s): %s"
+              path
+              (List.length malformed)
+              detail)
+       | Ok quarantine_path ->
+         let repaired_content =
+           match valid with
+           | [] -> ""
+           | _ ->
+             valid
+             |> List.map (fun event -> event.raw)
+             |> String.concat "\n"
+             |> fun body -> body ^ "\n"
+         in
+         (match Fs_compat.save_file_atomic path repaired_content with
+          | Error detail ->
+            Error
+              (Printf.sprintf
+                 "%s: quarantined malformed rows at %s but repair failed: %s"
+                 path
+                 quarantine_path
+                 detail)
+          | Ok () ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string MemoryWriteFailures)
+              ~labels:[ "keeper", keeper_id; "site", "event_log_repair" ]
+              ~delta:(float_of_int (List.length malformed))
+              ();
+            Log.Keeper.error ~keeper_name:keeper_id
+              "memory event log repaired malformed_rows=%d source=%s quarantine=%s"
+              (List.length malformed)
+              path
+              quarantine_path;
+            Ok (List.map (fun event -> event.json) valid)))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
+;;
+
+let operation_event_committed ~keepers_dir ~keeper_id ~operation_id =
+  if not (Keeper_config.validate_name operation_id)
+  then Error (Printf.sprintf "invalid memory operation id: %S" operation_id)
+  else
+    let path = events_path_for_keepers_dir ~keepers_dir ~keeper_id in
+    if not (Fs_compat.file_exists path)
+    then Ok false
+    else
+      let* events = load_and_repair_event_log ~keepers_dir ~keeper_id path in
+      Ok
+        (List.exists
+           (fun event ->
+              Option.equal
+                String.equal
+                (operation_id_of_event event)
+                (Some operation_id))
+           events)
+;;
+
+type operation_episode_state =
+  | Operation_absent
+  | Operation_staged of operation_episode
+  | Operation_committed of operation_episode
+
+let inspect_operation_episode ~clock ~keepers_dir ~keeper_id ~operation_id =
+  match load_operation_episode ~keepers_dir ~keeper_id ~operation_id with
+  | Error _ as error -> error
+  | Ok None -> Ok Operation_absent
+  | Ok (Some _) ->
+    with_episode_bundle_lock_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      (fun () ->
+      match load_operation_episode ~keepers_dir ~keeper_id ~operation_id with
+      | Error _ as error -> error
+      | Ok None ->
+        Error
+          (Printf.sprintf
+             "memory operation %s lost its staged episode during commit inspection"
+             operation_id)
+      | Ok (Some episode) ->
+        (match
+           operation_event_committed ~keepers_dir ~keeper_id ~operation_id
+         with
+         | Error _ as error -> error
+         | Ok false -> Ok (Operation_staged episode)
+         | Ok true -> Ok (Operation_committed episode)))
+;;
+
+let append_operation_event
+      ~keepers_dir
+      ~keeper_id
+      ~operation_id
+      ~model_id
+      ~provider_latency_ms
+      episode
+  =
+  if String.equal (String.trim model_id) ""
+  then Error "memory operation model id must be non-empty"
+  else if (not (Float.is_finite provider_latency_ms)) || provider_latency_ms < 0.0
+  then Error "memory operation provider latency must be finite and non-negative"
+  else if not (Keeper_config.validate_name operation_id)
+  then Error (Printf.sprintf "invalid memory operation id: %S" operation_id)
+  else
+    try
+      append_json
+        (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
+        (operation_episode_json
+           ~operation_id
+           ~model_id
+           ~provider_latency_ms
+           episode);
+      Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
 ;;
 
 let append_episode_bundle ~keeper_id episode =
@@ -305,7 +1097,7 @@ let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
   rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
     ~keeper_id
     facts
 ;;
@@ -499,7 +1291,7 @@ let read_facts_tail ~keeper_id ~n =
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
   read_facts_tail_for_keepers_dir
-    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
     ~keeper_id
     ~n
 ;;
@@ -537,7 +1329,7 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite ~keeper_id =
+let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
   (* RFC-0302 (#22823) phase-2b: resolve keepers_dir on the main domain (it touches
      the Config_dir_resolver plain-ref memo), then offload the blocking full read +
      strict parse of the fact store off the main Eio scheduler. This is the
@@ -548,13 +1340,18 @@ let read_facts_for_rewrite ~keeper_id =
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
      reads only [keepers]/[keeper_id] and no shared mutable state, and the
      Fs_compat rewrite that follows stays on main. *)
-  let keepers = keepers_dir () in
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir ~keepers_dir:keepers ~keeper_id)
+      read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
+;;
+
+let read_facts_for_rewrite ~keeper_id =
+  read_facts_for_rewrite_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -645,8 +1442,19 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
-  let existing = read_facts_for_rewrite ~keeper_id in
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  let existing =
+    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
+  in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -670,8 +1478,31 @@ let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically ~keeper_id kept;
+    rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  merge_and_cap_facts_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~now
+    ~keeper_id
+    ~merge
+    ~incoming
+    ~keep
+    ~trigger
+    ~rank
 ;;
 
 let read_events_tail ~keeper_id ~n =
@@ -712,7 +1543,9 @@ let read_episode_files_tail ~keeper_id ~n =
   else (
     Sys.readdir dir
     |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
+    |> List.filter (fun name ->
+      Filename.check_suffix name ".json"
+      && not (is_operation_episode_name name))
     |> List.map (fun name -> Filename.concat dir name)
     |> List.filter Sys.file_exists
     |> List.filter_map read_episode_file
@@ -737,8 +1570,8 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events ~keeper_id ~keep ~trigger =
-  let path = events_path ~keeper_id in
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  let path = events_path_for_keepers_dir ~keepers_dir ~keeper_id in
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -758,6 +1591,14 @@ let cap_events ~keeper_id ~keep ~trigger =
     List.length all - List.length kept
 ;;
 
+let cap_events ~keeper_id ~keep ~trigger =
+  cap_events_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
+    ~keep
+    ~trigger
+;;
+
 (* RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
@@ -766,7 +1607,7 @@ let cap_events ~keeper_id ~keep ~trigger =
    best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
    fine, and no lock is taken here that could deadlock with the bundle lock the
    caller already holds. Returns the number unlinked. *)
-let cap_episode_files ~keeper_id ~keep ~trigger =
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
   (* RFC-0302 (#22823): resolve [episodes_dir] on the main domain (it touches the
      Config_dir_resolver plain-ref memo + mkdir), then offload the blocking
      readdir + per-file episode read + best-effort unlink scan to the shared
@@ -775,12 +1616,14 @@ let cap_episode_files ~keeper_id ~keep ~trigger =
      mutable work (Sys.remove is a filesystem unlink, not OCaml shared state), so
      it is domain-safe; the caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir ~keeper_id in
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   Domain_pool_ref.submit_io_or_inline (fun () ->
     let parsed =
       Sys.readdir dir
       |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
+      |> List.filter (fun name ->
+        Filename.check_suffix name ".json"
+        && not (is_operation_episode_name name))
       |> List.map (fun name -> Filename.concat dir name)
       |> List.filter Sys.file_exists
       |> List.filter_map (fun p ->
@@ -796,4 +1639,12 @@ let cap_episode_files ~keeper_id ~keep ~trigger =
       let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
       List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
       List.length to_drop)
+;;
+
+let cap_episode_files ~keeper_id ~keep ~trigger =
+  cap_episode_files_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id
+    ~keep
+    ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -33,7 +33,35 @@ val current_path_for_legacy_memory_filename :
 (** Map a legacy per-keeper Memory OS filename under [.masc/keepers/<keeper>/]
     to the current store path under [keepers_dir], when the filename is a
     supported legacy memory artifact. *)
+
+type migration_stats =
+  { moved_files : int
+  ; deduplicated_files : int
+  }
+
+type migration_error =
+  { source : string
+  ; destination : string
+  ; detail : string
+  }
+
+type migration_report =
+  { stats : migration_stats
+  ; errors : migration_error list
+  }
+
+val migration_error_to_string : migration_error -> string
+
+val migrate_legacy_config_store :
+  base_path:string -> migration_report
+(** Move Memory OS runtime artifacts from the canonical historical
+    [<base>/.masc/config/keepers] root into the BasePath runtime root. Config
+    files remain in place. Existing byte-identical destinations are
+    deduplicated; divergent destinations are preserved and reported without
+    stopping migration of unrelated keepers or artifacts. *)
+
 val episodes_dir : keeper_id:string -> string
+val episodes_dir_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
@@ -47,7 +75,11 @@ val next_generation : keeper_id:string -> trace_id:string -> int
 
 (** Like {!next_generation}, but preserves a caller-provided generation lower
     bound while still advancing the counter past it. *)
-val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:string -> int
+val next_generation_with_floor :
+  floor:int -> keeper_id:string -> trace_id:string -> int
+
+val next_generation_with_floor_for_keepers_dir :
+  keepers_dir:string -> floor:int -> keeper_id:string -> trace_id:string -> int
 
 (** {1 Atomic writes} *)
 
@@ -60,13 +92,99 @@ val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
 
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
+val append_event_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+val append_episode_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> episode -> unit
+
+type operation_episode =
+  { episode : episode
+  ; model_id : string
+  ; provider_latency_ms : float
+  }
+
+val save_operation_episode :
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  model_id:string ->
+  provider_latency_ms:float ->
+  episode ->
+  (unit, string) result
+(** Atomically stage one provider-produced episode under a deterministic
+    operation id before publishing facts/events. *)
+
+val load_operation_episode :
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  (operation_episode option, string) result
+
+val stage_operation_episode_once :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  model_id:string ->
+  provider_latency_ms:float ->
+  episode ->
+  (operation_episode, string) result
+(** Atomically install the first stage for an operation and return the winning
+    stage. Concurrent producers never overwrite one another. *)
+
+val operation_event_committed :
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  (bool, string) result
+(** Check the events commit log for [operation_id]. Malformed event rows are an
+    explicit recovery event: raw rows are durably quarantined before the valid
+    prefix/set is atomically rewritten. A quarantine or rewrite failure is
+    returned and is never treated as "not committed". Call while holding
+    {!with_episode_bundle_lock_for_keepers_dir}. *)
+
+type operation_episode_state =
+  | Operation_absent
+  | Operation_staged of operation_episode
+  | Operation_committed of operation_episode
+
+val inspect_operation_episode :
+  clock:float Eio.Time.clock_ty Eio.Resource.t option ->
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  (operation_episode_state, string) result
+(** Inspect an operation and atomically distinguish absence, a provider result
+    staged before publication, and a fully committed event. Missing staged
+    operations avoid an event-log scan. *)
+
+val append_operation_event :
+  keepers_dir:string ->
+  keeper_id:string ->
+  operation_id:string ->
+  model_id:string ->
+  provider_latency_ms:float ->
+  episode ->
+  (unit, string) result
+(** Append an episode event carrying [operation_id]. Call only after
+    {!operation_event_committed} returned [false], under the bundle lock. *)
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
     lock, then publish [events_path] last as the reader-visible commit marker. *)
 val with_episode_bundle_lock :
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keeper_id:string ->
+  (unit -> 'a) ->
+  'a
+
+val with_episode_bundle_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keepers_dir:string ->
+  keeper_id:string ->
+  (unit -> 'a) ->
+  'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
@@ -147,12 +265,17 @@ val trim_target : count:int -> keep:int -> trigger:int -> int option
     malformed-line tolerant) and atomically rewrite; otherwise no-op. Returns the
     number of lines dropped. *)
 val cap_events : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_events_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> keep:int -> trigger:int -> int
 
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
     recency and best-effort unlink the rest; otherwise no-op. Unparseable files
     are left untouched. Returns the number unlinked. *)
-val cap_episode_files : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files :
+  keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files_for_keepers_dir :
+  keepers_dir:string -> keeper_id:string -> keep:int -> trigger:int -> int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -192,6 +315,17 @@ type fact_merge_stats =
     store free of expired rows even below the cap; they count toward [dropped]. *)
 val merge_and_cap_facts :
   now:float
+  -> keeper_id:string
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_for_keepers_dir :
+  keepers_dir:string
+  -> now:float
   -> keeper_id:string
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -29,9 +29,8 @@ let masc_tool_emission_enabled () =
   | _ -> false
 
 let push acc (json : Yojson.Safe.t) : unit =
-  Stdlib.Mutex.lock acc.mutex;
-  acc.items <- json :: acc.items;
-  Stdlib.Mutex.unlock acc.mutex;
+  Stdlib.Mutex.protect acc.mutex (fun () ->
+    acc.items <- json :: acc.items);
   (* Tier K6 — emit per-keeper push counter. Counter is incremented
      OUTSIDE the accumulator mutex so the metric write does not
      extend the critical section. The [keeper_name] field is read-
@@ -45,23 +44,24 @@ let push acc (json : Yojson.Safe.t) : unit =
       ()
 
 let drain acc : Yojson.Safe.t list =
-  Stdlib.Mutex.lock acc.mutex;
-  let items = List.rev acc.items in
-  acc.items <- [];
-  Stdlib.Mutex.unlock acc.mutex;
-  items
+  Stdlib.Mutex.protect acc.mutex (fun () ->
+    let items = List.rev acc.items in
+    acc.items <- [];
+    items)
+
+let take_all = drain
+
+let restore acc items =
+  Stdlib.Mutex.protect acc.mutex (fun () ->
+    (* [items] is oldest-first while [acc.items] is newest-first. Items captured
+       after [take_all] stay newer than the restored batch. *)
+    acc.items <- acc.items @ List.rev items)
 
 let snapshot acc : Yojson.Safe.t list =
-  Stdlib.Mutex.lock acc.mutex;
-  let items = List.rev acc.items in
-  Stdlib.Mutex.unlock acc.mutex;
-  items
+  Stdlib.Mutex.protect acc.mutex (fun () -> List.rev acc.items)
 
 let accumulator_size acc =
-  Stdlib.Mutex.lock acc.mutex;
-  let n = List.length acc.items in
-  Stdlib.Mutex.unlock acc.mutex;
-  n
+  Stdlib.Mutex.protect acc.mutex (fun () -> List.length acc.items)
 
 let try_parse (s : string) : Yojson.Safe.t option =
   try Some (Yojson.Safe.from_string s)
@@ -108,6 +108,15 @@ let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
     else
       Multimodal.Tool_emission.emit_from_tool_results
         ~emit:Multimodal.Keeper_emitter.emit ~working_context items
+
+let emit_snapshot_into_working_context items ~working_context =
+  match items with
+  | [] -> working_context
+  | _ ->
+    Multimodal.Tool_emission.emit_from_tool_results
+      ~emit:Multimodal.Keeper_emitter.emit
+      ~working_context
+      items
 
 let global_accumulator = create_accumulator ()
 

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -91,6 +91,20 @@ val drain_into_working_context :
     The returned list preserves capture order. *)
 val snapshot : accumulator -> Yojson.Safe.t list
 
+(** Atomically remove and return all captured items in capture order. *)
+val take_all : accumulator -> Yojson.Safe.t list
+
+(** Restore a previously taken oldest-first batch behind any items captured
+    since the take. Used only when durable admission fails. *)
+val restore : accumulator -> Yojson.Safe.t list -> unit
+
+(** Emit an immutable captured batch into a working context without reading or
+    mutating an accumulator. *)
+val emit_snapshot_into_working_context :
+  Yojson.Safe.t list ->
+  working_context:Yojson.Safe.t option ->
+  Yojson.Safe.t option
+
 (** Number of items currently held in the accumulator. Useful for
     tests and metrics. *)
 val accumulator_size : accumulator -> int

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -230,6 +230,7 @@ let record_pre_dispatch_terminal_observation
     ; oas_turn_count = None
     ; oas_dispatch_mode = None
     ; oas_internal_runtime_disabled = true
+    ; post_turn_memory_job_id = None
     ; current_task_id = Option.map Keeper_id.Task_id.to_string meta.current_task_id
     ; goal_ids = meta.active_goal_ids
     ; outcome

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -160,8 +160,10 @@ type t =
   | MemoryLaneUnitFailures
   | MemoryConsolidations
   | MemoryLaneSubmitted
-  | MemoryLaneRanInline
-  | MemoryLaneDropped
+  | MemoryLaneAdmissionRejected
+  | MemoryLaneReplayed
+  | MemoryLaneCompleted
+  | MemoryLaneFailed
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryBankCompactionFailures
@@ -425,8 +427,11 @@ let to_string = function
   | MemoryLaneUnitFailures -> "masc_keeper_memory_lane_unit_failures_total"
   | MemoryConsolidations -> "masc_keeper_memory_consolidations_total"
   | MemoryLaneSubmitted -> "masc_keeper_memory_lane_submitted_total"
-  | MemoryLaneRanInline -> "masc_keeper_memory_lane_ran_inline_total"
-  | MemoryLaneDropped -> "masc_keeper_memory_lane_dropped_total"
+  | MemoryLaneAdmissionRejected ->
+    "masc_keeper_memory_lane_admission_rejected_total"
+  | MemoryLaneReplayed -> "masc_keeper_memory_lane_replayed_total"
+  | MemoryLaneCompleted -> "masc_keeper_memory_lane_completed_total"
+  | MemoryLaneFailed -> "masc_keeper_memory_lane_failed_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
@@ -580,7 +585,7 @@ let all : t list =
     CheckpointFailures; DecisionAuditRingOverflows; ReplySkillRouteStrips; ReplySkillRouteLinesRemoved;
     MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; HitlSummaryOutcomes; UserVisibleReplySource;
     OasEnvKeyRejections;
-    MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneRanInline; MemoryLaneDropped;
+    MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneAdmissionRejected; MemoryLaneReplayed; MemoryLaneCompleted; MemoryLaneFailed;
     MemoryLanePending; MemoryLaneInFlight; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
     MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; KeeperMaterializationFailures; ObservationQueryFailures; OasOnStop;
     InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -164,7 +164,6 @@ type t =
   | MemoryLaneDropped
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
@@ -224,6 +223,7 @@ type t =
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures
+  | RetiredEnvIgnored
   | PostTurnWireinFailures
   | RecurringFailures
   | TurnCleanupFailures
@@ -429,7 +429,6 @@ let to_string = function
   | MemoryLaneDropped -> "masc_keeper_memory_lane_dropped_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
-  | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"
@@ -493,6 +492,7 @@ let to_string = function
   | UsageTrust -> "masc_keeper_usage_trust_total"
   | UsageAnomalyReason -> "masc_keeper_usage_anomaly_reason_total"
   | ConfigEnvParseFailures -> "masc_keeper_config_env_parse_failures_total"
+  | RetiredEnvIgnored -> "masc_keeper_retired_env_ignored_total"
   | PostTurnWireinFailures -> "masc_keeper_post_turn_wirein_failures_total"
   | RecurringFailures -> "masc_keeper_recurring_failures_total"
   | TurnCleanupFailures -> "masc_keeper_turn_cleanup_failures_total"
@@ -581,7 +581,7 @@ let all : t list =
     MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; HitlSummaryOutcomes; UserVisibleReplySource;
     OasEnvKeyRejections;
     MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneRanInline; MemoryLaneDropped;
-    MemoryLanePending; MemoryLaneInFlight; MemoryLaneProviderSlotBusy; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
+    MemoryLanePending; MemoryLaneInFlight; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
     MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; KeeperMaterializationFailures; ObservationQueryFailures; OasOnStop;
     InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
     TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;
@@ -594,7 +594,7 @@ let all : t list =
     OasRunTimeout; RuntimeSaturationSignal; RuntimeSelected; RuntimeRotation; ToolUseFailure; ToolNotAllowed;
     TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
     DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
-    UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
+    UsageAnomalyReason; ConfigEnvParseFailures; RetiredEnvIgnored; PostTurnWireinFailures; RecurringFailures;
     TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; MemoryOsReobserveEchoSuppressed; RuntimeHttpProbeJsonParseFailures;
     VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
     KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -155,7 +155,6 @@ type t =
   | MemoryLaneDropped
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
@@ -215,6 +214,7 @@ type t =
   | UsageTrust
   | UsageAnomalyReason
   | ConfigEnvParseFailures
+  | RetiredEnvIgnored
   | PostTurnWireinFailures
   | RecurringFailures
   | TurnCleanupFailures

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -151,8 +151,10 @@ type t =
   | MemoryLaneUnitFailures
   | MemoryConsolidations
   | MemoryLaneSubmitted
-  | MemoryLaneRanInline
-  | MemoryLaneDropped
+  | MemoryLaneAdmissionRejected
+  | MemoryLaneReplayed
+  | MemoryLaneCompleted
+  | MemoryLaneFailed
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryBankCompactionFailures

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -88,7 +88,7 @@ val append_from_tool_results :
   Keeper_meta_contract.keeper_meta ->
   turn:int ->
   results:Yojson.Safe.t list ->
-  int
+  (int, string) result
 
 val compact_if_needed :
   ?summarizer:consolidation_summarizer ->

--- a/lib/retired_env_warnings.ml
+++ b/lib/retired_env_warnings.ml
@@ -1,25 +1,62 @@
 let shell_ir_path_jail_env_key = "MASC_SHELL_IR_PATH_JAIL_ENABLED"
-let shell_ir_path_jail_reported = Atomic.make false
+let memory_os_librarian_global_slot_env_key =
+  "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+;;
 
-let shell_ir_path_jail_env_configured ?(getenv = Sys.getenv_opt) () =
-  match Option.bind (getenv shell_ir_path_jail_env_key) String_util.trim_to_option with
+let shell_ir_path_jail_reported = Atomic.make false
+let memory_os_librarian_global_slot_reported = Atomic.make false
+
+let env_configured ?(getenv = Sys.getenv_opt) env_key =
+  match Option.bind (getenv env_key) String_util.trim_to_option with
   | None -> false
   | Some _ -> true
+;;
+
+let report_if_set ~reported ~env_key ~reason ?(source = "runtime") () =
+  if env_configured env_key && not (Atomic.exchange reported true)
+  then (
+    Log.Keeper.warn "retired env knob ignored env=%s; %s" env_key reason;
+    Otel_metric_store.inc_counter
+      (Keeper_metrics.to_string Keeper_metrics.RetiredEnvIgnored)
+      ~labels:[ "env", env_key; "source", source ]
+      ())
+;;
+
+let shell_ir_path_jail_env_configured ?getenv () =
+  env_configured ?getenv shell_ir_path_jail_env_key
+;;
+
+let memory_os_librarian_global_slot_env_configured ?getenv () =
+  env_configured ?getenv memory_os_librarian_global_slot_env_key
+;;
 
 let report_shell_ir_path_jail_if_set ?(source = "runtime") () =
-  if
-    shell_ir_path_jail_env_configured ()
-    && not (Atomic.exchange shell_ir_path_jail_reported true)
-  then (
-    Log.Keeper.warn
-      "retired env knob ignored env=%s; Shell IR path jail is permanent and \
-       cannot be disabled at runtime"
-      shell_ir_path_jail_env_key;
-    Otel_metric_store.inc_counter
-      (Keeper_metrics.to_string Keeper_metrics.ShellIrEffectTotal)
-      ~labels:[ "kind", "retired_path_jail_env_ignored"; "source", source ]
-      ())
+  report_if_set
+    ~reported:shell_ir_path_jail_reported
+    ~env_key:shell_ir_path_jail_env_key
+    ~reason:"Shell IR path jail is permanent and cannot be disabled at runtime"
+    ~source
+    ()
+;;
+
+let report_memory_os_librarian_global_slot_if_set ?(source = "runtime") () =
+  report_if_set
+    ~reported:memory_os_librarian_global_slot_reported
+    ~env_key:memory_os_librarian_global_slot_env_key
+    ~reason:
+      "librarian calls are serialized by each Keeper's memory lane; provider capacity and fallback belong to the OAS provider/runtime boundary"
+    ~source
+    ()
+;;
 
 module For_testing = struct
+  let shell_ir_path_jail_env_key = shell_ir_path_jail_env_key
+  let memory_os_librarian_global_slot_env_key =
+    memory_os_librarian_global_slot_env_key
+  ;;
+
   let shell_ir_path_jail_env_configured = shell_ir_path_jail_env_configured
+  let memory_os_librarian_global_slot_env_configured =
+    memory_os_librarian_global_slot_env_configured
+  ;;
 end

--- a/lib/retired_env_warnings.mli
+++ b/lib/retired_env_warnings.mli
@@ -5,7 +5,17 @@ val report_shell_ir_path_jail_if_set : ?source:string -> unit -> unit
 (** Warn and emit telemetry once per process when the retired
     [MASC_SHELL_IR_PATH_JAIL_ENABLED] env var is still configured. *)
 
+val report_memory_os_librarian_global_slot_if_set : ?source:string -> unit -> unit
+(** Warn and emit telemetry once per process when the retired
+    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT] env var is still configured. *)
+
 module For_testing : sig
+  val shell_ir_path_jail_env_key : string
+  val memory_os_librarian_global_slot_env_key : string
+
   val shell_ir_path_jail_env_configured :
+    ?getenv:(string -> string option) -> unit -> bool
+
+  val memory_os_librarian_global_slot_env_configured :
     ?getenv:(string -> string option) -> unit -> bool
 end

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -448,6 +448,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   Tool_dispatch.set_span_wrapper Tool_telemetry.with_span;
   Otel_metric_store.register_otel_source_once ();
   Retired_env_warnings.report_shell_ir_path_jail_if_set ~source:"startup" ();
+  Retired_env_warnings.report_memory_os_librarian_global_slot_if_set
+    ~source:"startup"
+    ();
   Otel_runtime_observables.register_once
     ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
     ();

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -11,8 +11,6 @@
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
     - [Keeper_memory_os_gc.run_gc ~dry_run:true] for TTL-expired and
       near-duplicate counts without mutating the store.
-    - [Otel_metric_store] provider-slot-busy counters for skipped librarian
-      extraction attempts, grouped by keeper.
     - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
       size (one fleet-wide value). *)
 
@@ -25,14 +23,12 @@ type keeper_health =
   ; events_to_facts_ratio : float
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
-  ; provider_slot_busy : int
   }
 
 type alert_code =
   | Ttl_expired_on_disk
   | Near_duplicate
   | Events_to_facts_ratio_high
-  | Provider_slot_busy
 
 type alert_severity = Warn
 
@@ -40,7 +36,6 @@ type alert_target =
   | Ttl_expired_on_disk_target
   | Near_duplicate_target
   | Events_to_facts_ratio_target
-  | Provider_slot_busy_target
 
 type keeper_alert =
   { code : alert_code
@@ -63,16 +58,10 @@ let events_to_facts_ratio_warn_threshold =
   Keeper_memory_os_policy.events_to_facts_ratio_attention_threshold
 ;;
 
-let provider_slot_busy_threshold = 0.0
-
-let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-
 let alert_code_to_string = function
   | Ttl_expired_on_disk -> "ttl_expired_on_disk"
   | Near_duplicate -> "near_duplicate"
   | Events_to_facts_ratio_high -> "events_to_facts_ratio_high"
-  | Provider_slot_busy -> "provider_slot_busy"
 ;;
 
 let alert_severity_to_string = function
@@ -83,7 +72,6 @@ let alert_target_to_string = function
   | Ttl_expired_on_disk_target -> "ttl_expired_on_disk"
   | Near_duplicate_target -> "near_duplicate"
   | Events_to_facts_ratio_target -> "events_to_facts_ratio"
-  | Provider_slot_busy_target -> "provider_slot_busy"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -93,7 +81,6 @@ let alert_label = function
   | Ttl_expired_on_disk -> "TTL"
   | Near_duplicate -> "중복"
   | Events_to_facts_ratio_high -> "비율"
-  | Provider_slot_busy -> "슬롯"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -133,18 +120,6 @@ let keeper_alerts h =
         ~message:"Memory OS event bytes are high relative to fact bytes."
         ~value:h.events_to_facts_ratio
         ~threshold:events_to_facts_ratio_warn_threshold
-      :: alerts
-    else alerts)
-  |> (fun alerts ->
-    if h.provider_slot_busy > 0
-    then
-      alert
-        ~code:Provider_slot_busy
-        ~target:Provider_slot_busy_target
-        ~message:
-          "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
-        ~value:(float_of_int h.provider_slot_busy)
-        ~threshold:provider_slot_busy_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -189,17 +164,6 @@ let file_size_bytes path =
   if not (Sys.file_exists path) then 0 else (Unix.stat path).Unix.st_size
 ;;
 
-let provider_slot_busy_for_keeper keeper_id =
-  (* MemoryLaneProviderSlotBusy is emitted through [inc_counter], so values are
-     integral counts even though the metric store carries floats. Keep the JSON
-     field as an int to match the rest of this count-oriented health snapshot. *)
-  Otel_metric_store.metric_value_or_zero
-    provider_slot_busy_metric
-    ~labels:[ "keeper", keeper_id; "site", provider_slot_busy_site ]
-    ()
-  |> int_of_float
-;;
-
 let keeper_health ~keepers_dir ~now keeper_id =
   let facts =
     (* [read_facts_all] raises on malformed JSONL — treated as a read failure
@@ -234,7 +198,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
       float_of_int events_bytes /. float_of_int (max 1 facts_bytes)
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = gc_report.dedup_removed
-  ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
   }
 ;;
 
@@ -248,7 +211,6 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "events_to_facts_ratio", `Float h.events_to_facts_ratio
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
-    ; "provider_slot_busy", `Int h.provider_slot_busy
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -295,7 +257,6 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "events_bytes", `Int (sum (fun h -> h.events_bytes))
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
-          ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -314,13 +275,11 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "near_duplicate_keepers", `Int (alert_count_by_code Near_duplicate)
           ; ( "high_event_ratio_keepers"
             , `Int (alert_count_by_code Events_to_facts_ratio_high) )
-          ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
                 ; "events_to_facts_ratio", `Float events_to_facts_ratio_warn_threshold
-                ; "provider_slot_busy", `Float provider_slot_busy_threshold
                 ] )
           ] )
     ]

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -1,18 +1,17 @@
 (** Keeper Memory Health dashboard HTTP JSON helper.
 
     Produces a read-only snapshot of per-keeper fact-store sizes, GC-dry-run
-    statistics, and the fleet-wide librarian cadence counter for the
+    statistics, and the librarian cadence clock contract for the
     /api/v1/dashboard/keeper-memory-health endpoint.
 
     Data sources:
-    - [Config_dir_resolver.keepers_dir_for_base_path] for request-scoped paths.
+    - [Common.keepers_runtime_dir_of_base] for request-scoped output paths.
     - [Keeper_memory_os_io.list_fact_store_keeper_ids] for the keeper list.
     - [Keeper_memory_os_io.read_facts_all] and file stat for facts count/bytes.
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
     - [Keeper_memory_os_gc.run_gc ~dry_run:true] for TTL-expired and
       near-duplicate counts without mutating the store.
-    - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
-      size (one fleet-wide value). *)
+    - Keeper timeline turn ids as the stateless cadence clock. *)
 
 type keeper_health =
   { keeper_id : string
@@ -220,8 +219,7 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
      scans; no retention or control logic depends on the exact value. *)
   (* NDT-OK: diagnostic snapshot timestamp only. *)
   let now = Unix.gettimeofday () in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
-  let cadence_counter_entries = Keeper_librarian_runtime.cadence_counter_entries () in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
   let entries =
     Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir
     |> List.filter_map (fun keeper_id ->
@@ -248,7 +246,7 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
   in
   `Assoc
     [ "generated_at", `Float now
-    ; "cadence_counter_entries", `Int cadence_counter_entries
+    ; "cadence_clock", `String "keeper_turn_id"
     ; "keepers", `List (List.map keeper_health_entry_to_json entries)
     ; ( "totals"
       , `Assoc

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -159,7 +159,7 @@ let synapse_saturation_facts = 10.0
 let compute_hebbian ~base_path ~now () =
   try
     let keepers_dir =
-      Config_dir_resolver.keepers_dir_for_base_path ~base_path
+      Common.keepers_runtime_dir_of_base ~base_path
     in
     let shared_facts =
       Keeper_memory_os_io.read_facts_all_for_keepers_dir

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -433,10 +433,6 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;
   Masc_eio_env.init ~sw ~net ~clock ();
-  (* RFC-0257: own detached per-keeper memory-lane fibers on the server root
-     switch. After [set_switch] so the lane and provider calls it forks share
-     the same long-lived switch (cancelled together at shutdown). *)
-  Keeper_memory_lane.init ~sw;
   (* RFC-0107 Phase D.2c — record full Eio.Stdenv for piaf-backed
      Pool in Masc_http_client.  Optional: tests / pre-bootstrap
      callers may omit [env], in which case Pool falls back to a
@@ -530,6 +526,32 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
   Config_dir_resolver.reset ();
   let (_init_msg : string) = Workspace.init (Mcp_server.workspace_config state) ~agent_name:None in
   Mcp_server.set_sse_callback state Sse.broadcast
+
+let initialize_memory_lane ~sw ~clock (state : Mcp_server.server_state) =
+  let base_path = (Mcp_server.workspace_config state).base_path in
+  let migration = Keeper_memory_os_io.migrate_legacy_config_store ~base_path in
+  if migration.stats.moved_files > 0 || migration.stats.deduplicated_files > 0
+  then
+    Log.Server.warn
+      "Memory OS runtime-root migration moved=%d deduplicated=%d errors=%d"
+      migration.stats.moved_files
+      migration.stats.deduplicated_files
+      (List.length migration.errors);
+  List.iter
+    (fun error ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string DispatchEventFailures)
+         ~labels:[ "site", "memory_os_runtime_root_migration" ]
+         ();
+       Log.Server.error "%s" (Keeper_memory_os_io.migration_error_to_string error))
+    migration.errors;
+  Ok
+    (Keeper_memory_lane.init
+       ~sw
+       ~clock
+       ~base_path
+       ~execute:Keeper_agent_run_post_turn_memory.execute_job)
+;;
 
 
 type lazy_startup_execution =
@@ -873,6 +895,27 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Governance_registry.ensure_init ();
       Runtime_params.restore ~base_path;
       Log.Server.info "Runtime_params restored from %s" base_path;
+      (* RFC-0257: install the durable memory-job executor only after Runtime
+         default/config restoration. Replayed jobs may call the librarian
+         immediately, so starting the worker earlier would race provider/model
+         resolution during bootstrap. The executor owns no in-memory job FIFO;
+         it discovers BasePath-backed pending/inflight jobs here. *)
+      let memory_lane_init =
+        initialize_memory_lane ~sw ~clock state
+      in
+      (match memory_lane_init with
+       | Error detail ->
+         Log.Server.error
+           "memory lane initialization deferred: %s"
+           detail
+       | Ok report ->
+         Log.Server.info
+           "memory lane initialized discovered=%d started=%d deferred=%d keeper_errors=%d root_error=%b"
+           report.discovered_keepers
+           report.workers_started
+           report.workers_deferred
+           (List.length report.keeper_discovery_errors)
+           (Option.is_some report.discovery_error));
       Keeper_crash_persistence.start_drain_fiber ~sw ~clock;
       (* #10130: sweep [save_file_atomic] orphan temp files left by
          SIGKILL'd or ENFILE-crashed prior processes.  Zero-byte

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -125,6 +125,11 @@ val runtime_path_diagnostics :
 val restore_persisted_sessions : Mcp_server.server_state -> unit
 val reconcile_active_agents_gauge : Mcp_server.server_state -> unit
 val bootstrap_server_state_blocking : Mcp_server.server_state -> unit
+val initialize_memory_lane :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Mcp_server.server_state ->
+  (Keeper_memory_lane.init_report, string) result
 val bootstrap_prompt_state : Mcp_server.server_state -> unit
 
 (** {1 Startup Tasks} *)

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -290,7 +290,11 @@ let dedup_candidates candidates =
     candidates
 ;;
 
-let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure_limit =
+let fact_candidates facts ~keeper_id =
+  Skill_candidate_projection.candidates_of_memory_facts ~agent_name:keeper_id facts
+;;
+
+let fact_candidates_for_post_turn ~base_path ~keeper_id ~fact_tail_limit =
   let facts =
     if fact_tail_limit <= 0
     then []
@@ -298,17 +302,29 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
       Keeper_memory_os_io.read_facts_tail_for_base_path ~base_path ~keeper_id
         ~n:fact_tail_limit
   in
-  let fact_candidates =
-    Skill_candidate_projection.candidates_of_memory_facts ~agent_name:keeper_id facts
-  in
-  let procedure_candidates =
-    if procedure_limit <= 0
-    then []
-    else
-      Skill_candidate_projection.top_candidates ~base_path ~agent_name:keeper_id
-        ~limit:procedure_limit
-  in
-  let candidates = dedup_candidates (fact_candidates @ procedure_candidates) in
+  fact_candidates facts ~keeper_id
+;;
+
+let strict_fact_candidates_for_post_turn ~base_path ~keeper_id ~fact_tail_limit =
+  if fact_tail_limit <= 0
+  then Ok []
+  else
+    let keepers_dir =
+      Common.keepers_runtime_dir_of_base ~base_path
+    in
+    let* facts =
+      Keeper_memory_os_io.read_facts_all_strict_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+    in
+    Ok
+      (facts
+       |> List_util.take_last fact_tail_limit
+       |> fact_candidates ~keeper_id)
+;;
+
+let write_projected_candidates ~base_path candidates =
+  let candidates = dedup_candidates candidates in
   let* index_keys = load_index_keys ~index_path:(index_path ~base_path) in
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
@@ -322,6 +338,59 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
       loop acc rest
   in
   loop [] candidates
+;;
+
+let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure_limit =
+  let fact_candidates =
+    fact_candidates_for_post_turn ~base_path ~keeper_id ~fact_tail_limit
+  in
+  let procedure_candidates =
+    if procedure_limit <= 0
+    then []
+    else
+      Skill_candidate_projection.top_candidates ~base_path ~agent_name:keeper_id
+        ~limit:procedure_limit
+  in
+  write_projected_candidates
+    ~base_path
+    (fact_candidates @ procedure_candidates)
+;;
+
+let procedural_load_error_to_string
+      (error : Procedural_memory.load_error)
+  =
+  Printf.sprintf
+    "%s:%d: %s"
+    error.path
+    error.line_number
+    error.message
+;;
+
+let write_all_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit =
+  let* fact_candidates =
+    strict_fact_candidates_for_post_turn
+      ~base_path
+      ~keeper_id
+      ~fact_tail_limit
+  in
+  let* procedures =
+    Procedural_memory.load_procedures_strict
+      ~base_path
+      ~agent_name:keeper_id
+      ()
+    |> Result.map_error (fun errors ->
+      String.concat
+        "; "
+        (List.map procedural_load_error_to_string errors))
+  in
+  let procedure_candidates =
+    procedures
+    |> List.filter Procedural_memory.is_crystallized
+    |> Skill_candidate_projection.candidates_of_procedures
+  in
+  write_projected_candidates
+    ~base_path
+    (fact_candidates @ procedure_candidates)
 ;;
 
 let json_float_opt name json =

--- a/lib/skill_candidate_store.mli
+++ b/lib/skill_candidate_store.mli
@@ -72,6 +72,16 @@ val write_post_turn_candidates
   -> procedure_limit:int
   -> (stored_draft list, string) result
 
+val write_all_post_turn_candidates
+  :  base_path:string
+  -> keeper_id:string
+  -> fact_tail_limit:int
+  -> (stored_draft list, string) result
+(** Production post-turn projection with no arbitrary procedure-count cap.
+    Every crystallized procedure is considered. Fact and procedure JSONL are
+    both loaded via strict parsers so malformed persisted rows are explicit
+    errors rather than silent omissions. *)
+
 (** Read the latest unique candidate rows from [.masc/draft-skills/index.jsonl],
     newest first. Missing index files return an empty listing. *)
 val list_drafts : base_path:string -> limit:int -> (draft_listing, string) result

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -209,6 +209,7 @@ let run_result
   ; run_validation
   ; stop_reason
   ; inference_telemetry = None
+  ; post_turn_memory_job = None
   ; tool_surface
   ; pre_dispatch_compacted = false
   ; pre_dispatch_compaction_trigger = None

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -195,175 +195,72 @@ let test_nonempty_unparseable_evidence_outlives_empty_retry () =
       e.R.raw_evidence;
     check int "initial attempt + max_retries" 3 !calls
 
-(* Drive [cadence_step] sequentially from a fresh keeper (counter -1) for
-   [turns] turns, collecting the [due] decision each turn. When a turn is due
-   we simulate a successful extraction by resetting the counter to 0, matching
-   the behavior of [run_best_effort] calling [cadence_record_success]. *)
-let run_cadence ~cadence ~turns =
-  let counter = ref (-1) in
-  List.init turns (fun _ ->
-    let next, due = R.cadence_step ~cadence ~counter:!counter in
-    counter := next;
-    if due then counter := 0;
-    due)
+let cadence_is_due ~cadence ~keeper_turn =
+  match R.cadence_decision_for_keeper_turn ~cadence ~keeper_turn with
+  | R.Due -> true
+  | R.Not_due _ -> false
+;;
 
 let test_cadence_fresh_then_every_cadence () =
-  (* cadence 3: first turn is due immediately, then wait three turns between
-     subsequent extractions. *)
   check (list bool) "fresh due immediately, then every third turn"
     [ true; false; false; true; false; false; true; false; false ]
-    (run_cadence ~cadence:3 ~turns:9)
+    (List.init 9 (fun index ->
+       cadence_is_due ~cadence:3 ~keeper_turn:(index + 1)))
 
 let test_cadence_one_always_due () =
-  (* cadence 1 (and the floored <=1 case) restores per-turn extraction. *)
   check (list bool) "cadence 1 is due every turn"
     [ true; true; true; true ]
-    (run_cadence ~cadence:1 ~turns:4);
-  check (pair int bool) "cadence<=1 pins counter at 0"
-    (0, true)
-    (R.cadence_step ~cadence:1 ~counter:5)
+    (List.init 4 (fun index ->
+       cadence_is_due ~cadence:1 ~keeper_turn:(index + 1)))
+;;
 
-let test_cadence_step_transitions () =
-  (* A fresh counter is due immediately and moves to the due threshold. *)
-  check (pair int bool) "fresh keeper is due immediately"
-    (3, true)
-    (R.cadence_step ~cadence:3 ~counter:(-1));
-  (* A due threshold stays due until reset by a successful extraction. *)
-  check (pair int bool) "due counter stays at threshold"
-    (3, true)
-    (R.cadence_step ~cadence:3 ~counter:3);
-  (* Mid-cycle advances without firing. *)
-  check (pair int bool) "mid-cycle advances without firing"
-    (2, false)
-    (R.cadence_step ~cadence:3 ~counter:1)
+let test_cadence_remaining_is_exact () =
+  let remaining turn =
+    match R.cadence_decision_for_keeper_turn ~cadence:3 ~keeper_turn:turn with
+    | R.Due -> None
+    | R.Not_due { turns_remaining } -> Some turns_remaining
+  in
+  check (option int) "turn 2 has two turns remaining" (Some 2) (remaining 2);
+  check (option int) "turn 3 has one turn remaining" (Some 1) (remaining 3);
+  check (option int) "turn 4 is due" None (remaining 4)
+;;
 
-let test_cadence_record_success_resets () =
-  let kid = "test-cadence-record-success" and tid = "trace-record-success" in
-  check bool "fresh (keeper, trace) is due" true
-    (R.cadence_due ~keeper_id:kid ~trace_id:tid);
-  R.cadence_record_success ~keeper_id:kid ~trace_id:tid;
-  check bool "after success the next turn is not due" false
-    (R.cadence_due ~keeper_id:kid ~trace_id:tid)
+let test_cadence_is_restart_stable () =
+  let first =
+    List.init 128 (fun turn ->
+      R.cadence_decision_for_keeper_turn ~cadence:7 ~keeper_turn:turn)
+  in
+  let second =
+    List.init 128 (fun turn ->
+      R.cadence_decision_for_keeper_turn ~cadence:7 ~keeper_turn:turn)
+  in
+  check bool "same durable turn inputs reproduce decisions" true (first = second)
+;;
 
-let test_cadence_record_attempt_defers () =
-  let kid = "test-cadence-record-attempt" and tid = "trace-record-attempt" in
-  check bool "fresh (keeper, trace) is due" true
-    (R.cadence_due ~keeper_id:kid ~trace_id:tid);
-  R.cadence_record_attempt ~keeper_id:kid ~trace_id:tid;
-  check bool "after a completed non-success attempt the next turn is not due" false
-    (R.cadence_due ~keeper_id:kid ~trace_id:tid)
-
-let test_cadence_error_backoff_policy () =
-  check bool "empty provider response defers cadence" true
-    (R.should_record_cadence_backoff_after_error R.Provider_empty_response);
-  check bool "provider timeout defers cadence" true
-    (R.should_record_cadence_backoff_after_error R.Provider_timeout);
-  check bool "provider transport failure defers cadence" true
-    (R.should_record_cadence_backoff_after_error
-       (R.Provider_transport_failed "http timeout"));
-  check bool "unparseable provider response defers cadence" true
-    (R.should_record_cadence_backoff_after_error
-       (R.Provider_unparseable_response "invalid_json"));
-  check bool "prompt render failure stays due" false
-    (R.should_record_cadence_backoff_after_error
-       (R.Prompt_render_failed "missing template"));
-  check bool "fact upsert failure stays due" false
-    (R.should_record_cadence_backoff_after_error
-       (R.Memory_fact_upsert_failed "permission denied"));
-  check bool "missing provider clock does not claim a completed attempt" false
-    (R.should_record_cadence_backoff_after_error R.Provider_clock_unavailable)
-
-(* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
-   [run_best_effort] uses). A fresh pair is due immediately, and successful
-   structured extractions are due once per configured period. Asserted as
-   period-invariants so they hold for any configured cadence. *)
-let test_cadence_due_periodic () =
-  let kid = "test-cadence-due-periodic" and tid = "trace-periodic" in
-  let cadence = R.cadence_turns () in
-  let periods = 4 in
-  let dues = ref 0 in
-  for _ = 1 to cadence * periods do
-    if R.cadence_due ~keeper_id:kid ~trace_id:tid
-    then (
-      incr dues;
-      R.cadence_record_success ~keeper_id:kid ~trace_id:tid)
-  done;
-  check int "exactly one extraction per cadence period" periods !dues
-
-let test_cadence_due_independent_keepers () =
-  let cadence = R.cadence_turns () in
-  if cadence <= 1
-  then () (* cadence 1: both due every turn, independence is trivial *)
-  else (
-    let ka = "test-cadence-due-ind-a" and ta = "trace-a"
-    and kb = "test-cadence-due-ind-b" and tb = "trace-b" in
-    (* Put ka into a persistent due state without recording a completed attempt. *)
-    ignore (R.cadence_due ~keeper_id:ka ~trace_id:ta);
-    (* Put kb at counter 0 by recording success on its fresh due turn. *)
-    ignore (R.cadence_due ~keeper_id:kb ~trace_id:tb);
-    R.cadence_record_success ~keeper_id:kb ~trace_id:tb;
-    (* ka remains due after skipped work; kb is mid-cycle and not due. *)
-    check bool "ka stays due after skipped attempt" true
-      (R.cadence_due ~keeper_id:ka ~trace_id:ta);
-    R.cadence_record_attempt ~keeper_id:ka ~trace_id:ta;
-    check bool "ka backs off after completed non-success attempt" false
-      (R.cadence_due ~keeper_id:ka ~trace_id:ta);
-    check bool "kb advances on its own counter, not due on ka's schedule" false
-      (R.cadence_due ~keeper_id:kb ~trace_id:tb))
-
-(* A handoff rollover (a new trace_id for the same keeper) resets the cadence
-   schedule in place. The table is keyed by keeper_id, so the rotated trace
-   overwrites the keeper's single row rather than minting a new one — the
-   previous trace's counter is intentionally not preserved (production never has
-   two live traces for one keeper; meta.runtime.trace_id is the single active
-   trace and rolls over sequentially). *)
-let test_cadence_due_resets_on_trace_rollover () =
-  let cadence = R.cadence_turns () in
-  if cadence <= 1
-  then () (* cadence 1: every turn due, rollover semantics are trivial *)
-  else (
-    let kid = "test-cadence-rollover" and ta = "trace-a" and tb = "trace-b" in
-    (* Advance trace a past its fresh-due turn to a non-due turn. *)
-    if R.cadence_due ~keeper_id:kid ~trace_id:ta
-    then R.cadence_record_success ~keeper_id:kid ~trace_id:ta;
-    check bool "trace a is mid-cycle, not due" false
-      (R.cadence_due ~keeper_id:kid ~trace_id:ta);
-    (* A new trace (rollover) is fresh and due immediately, overwriting the row. *)
-    check bool "rolled-over trace is due immediately" true
-      (R.cadence_due ~keeper_id:kid ~trace_id:tb);
-    (* Rolling back to trace a is itself a rollover off trace b: fresh, due
-       immediately — the old trace-a counter was not retained. *)
-    check bool "returning to the prior trace is a fresh rollover, due immediately"
-      true
-      (R.cadence_due ~keeper_id:kid ~trace_id:ta))
-
-(* Leak regression: the cadence table is keyed by keeper_id, so an unbounded
-   number of trace rotations for one keeper must add exactly one row (the
-   pre-fix (keeper, trace) keying added one row per rotation and never reclaimed
-   it). Measured as a delta so concurrent rows from other tests do not matter. *)
-let test_cadence_table_bounded_under_trace_rotation () =
-  let kid = "test-cadence-rotation-bound" in
-  let before = R.cadence_counter_entries () in
-  for i = 1 to 64 do
-    ignore (R.cadence_due ~keeper_id:kid ~trace_id:(Printf.sprintf "rot-trace-%d" i))
-  done;
-  check int "64 trace rotations add exactly one keeper row" 1
-    (R.cadence_counter_entries () - before)
-
-(* Pure rollover decision: a stored entry from a different trace, or no entry,
-   is fresh (due immediately) and the returned value carries the current trace;
-   a matching trace advances the stored counter. *)
-let test_cadence_step_keyed () =
-  check (pair (pair string int) bool) "unseen keeper is fresh, due, carries trace"
-    (("t1", 3), true)
-    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t1" ~prior:None);
-  check (pair (pair string int) bool) "matching trace advances mid-cycle, not due"
-    (("t1", 2), false)
-    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t1" ~prior:(Some ("t1", 1)));
-  check (pair (pair string int) bool)
-    "rotated trace is fresh (due), discards prior counter, carries new trace"
-    (("t2", 3), true)
-    (R.cadence_step_keyed ~cadence:3 ~current_trace:"t2" ~prior:(Some ("t1", 2)))
+let test_cadence_admission_codec_round_trips () =
+  let decisions =
+    [ R.Admission_disabled
+    ; R.Admission_not_due { turns_remaining = 2 }
+    ; R.Admission_due
+    ]
+  in
+  List.iter
+    (fun expected ->
+       let json = R.librarian_admission_decision_to_json expected in
+       match R.librarian_admission_decision_of_json json with
+       | Ok actual -> check bool "typed admission round-trip" true (actual = expected)
+       | Error error -> Alcotest.fail error)
+    decisions;
+  match
+    R.librarian_admission_decision_of_json
+      (`Assoc
+         [ "kind", `String "not_due"
+         ; "turns_remaining", `Int 0
+         ])
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "not-due admission accepted a zero remaining distance"
+;;
 
 (* Strict parsing with bounded compatibility for real-world librarian provider
    drift. We accept exact JSON and exact JSON-string wrapping only. Markdown
@@ -551,17 +448,10 @@ let () =
         [
           test_case "fresh then every cadence" `Quick test_cadence_fresh_then_every_cadence;
           test_case "cadence 1 always due" `Quick test_cadence_one_always_due;
-          test_case "step transitions" `Quick test_cadence_step_transitions;
-          test_case "record success resets" `Quick test_cadence_record_success_resets;
-          test_case "record attempt defers" `Quick test_cadence_record_attempt_defers;
-          test_case "error backoff policy" `Quick test_cadence_error_backoff_policy;
-          test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
-          test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
-          test_case "cadence_due resets on trace rollover" `Quick
-            test_cadence_due_resets_on_trace_rollover;
-          test_case "cadence table bounded under trace rotation" `Quick
-            test_cadence_table_bounded_under_trace_rotation;
-          test_case "cadence_step_keyed rollover decision" `Quick test_cadence_step_keyed;
+          test_case "remaining turns are exact" `Quick test_cadence_remaining_is_exact;
+          test_case "decision is restart-stable" `Quick test_cadence_is_restart_stable;
+          test_case "typed admission codec round-trips" `Quick
+            test_cadence_admission_codec_round_trips;
         ] );
       ( "strict_parsing",
         [

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -37,8 +37,32 @@ let test_inline_contains_raise () =
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
 ;;
 
-(* Two units for the same keeper run one after another: the second only starts
-   after the first releases the keeper's mutex. *)
+(* [submit] must return control to the keeper turn before the detached memory
+   unit begins. Eio.Fiber.fork runs the child immediately unless it yields. *)
+let test_submit_detaches_before_job_runs () =
+  Lane.For_testing.reset ();
+  let submit_returned = ref false in
+  let job_observed_submit_returned = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let outcome =
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          job_observed_submit_returned := !submit_returned)
+      in
+      (match outcome with
+       | Lane.Submitted -> ()
+       | Lane.Ran_inline -> Alcotest.fail "detachment test ran inline"
+       | Lane.Dropped -> Alcotest.fail "detachment test was dropped");
+      submit_returned := true));
+  Alcotest.(check bool)
+    "job began after submit returned"
+    true
+    !job_observed_submit_returned
+;;
+
+(* Two units for the same keeper run one after another: the worker does not
+   begin the second until the first completes. *)
 let test_serializes_within_keeper () =
   Lane.For_testing.reset ();
   let order = ref [] in
@@ -103,50 +127,79 @@ let test_independent_across_keepers () =
   Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
 ;;
 
-(* With max_pending = 2, a third concurrent unit for one keeper is dropped. *)
-let test_saturation_drops () =
+(* Backlog is kept in FIFO order instead of being discarded at an arbitrary
+   pending bound. The turn-side submitter does not wait for the first unit. *)
+let test_backlog_is_queued_without_loss () =
   Lane.For_testing.reset ();
+  let order = ref [] in
+  let outcomes = ref [] in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
+      let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
       let o1 =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.await p_release)
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await p_release;
+          order := "a" :: !order)
       in
-      let o2 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
-      let o3 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
-      (match o1 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o1 not submitted");
-      (match o2 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o2 not submitted");
-      (match o3 with
-       | Lane.Dropped -> ()
-       | Lane.Submitted -> Alcotest.fail "o3 should be Dropped, got Submitted"
-       | Lane.Ran_inline -> Alcotest.fail "o3 should be Dropped, got Ran_inline");
+      Eio.Promise.await p_started;
+      let o2 =
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          order := "b" :: !order)
+      in
+      let o3 =
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          order := "c" :: !order)
+      in
+      outcomes := [ o1; o2; o3 ];
+      Alcotest.(check (option int))
+        "all three units remain pending"
+        (Some 3)
+        (Lane.For_testing.pending ~base_path ~keeper_name:"k1");
       Eio.Promise.resolve set_release ()))
+  ;
+  List.iter
+    (function
+      | Lane.Submitted -> ()
+      | Lane.Ran_inline -> Alcotest.fail "queued unit unexpectedly ran inline"
+      | Lane.Dropped -> Alcotest.fail "accepted backlog unit was dropped")
+    !outcomes;
+  Alcotest.(check (list string))
+    "FIFO order preserved"
+    [ "a"; "b"; "c" ]
+    (List.rev !order);
+  Alcotest.(check (option int))
+    "pending drained"
+    (Some 0)
+    (Lane.For_testing.pending ~base_path ~keeper_name:"k1")
 ;;
 
-(* A unit that raises releases the mutex and the pending slot, so the lane
-   recovers and later units run. *)
+(* A unit that raises releases its pending slot, so the worker continues and
+   later units run. *)
 let test_releases_on_raise () =
   Lane.For_testing.reset ();
   let ran_after = ref false in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
+      let started, set_started = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      let first =
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          Eio.Promise.resolve set_started ();
+          Eio.Promise.await release;
+          raise Test_boom)
       in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
-      let _ =
+      Eio.Promise.await started;
+      let second =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran_after := true)
       in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ()));
+      (match first, second with
+       | Lane.Submitted, Lane.Submitted -> ()
+       | _ -> Alcotest.fail "raising unit backlog was not submitted");
+      Eio.Promise.resolve set_release ()));
   Alcotest.(check bool) "lane recovered after raise" true !ran_after;
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
@@ -157,6 +210,7 @@ let test_releases_on_raise () =
 (* Cancellation during shutdown releases both the mutex and the pending slot. *)
 let test_releases_on_cancel () =
   Lane.For_testing.reset ();
+  let queued_unit_ran = ref false in
   (try
      Eio_main.run (fun _env ->
        Eio.Switch.run (fun sw ->
@@ -173,9 +227,25 @@ let test_releases_on_cancel () =
          | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
          | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
          Eio.Promise.await started;
+         let queued =
+           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+             queued_unit_ran := true)
+         in
+         (match queued with
+          | Lane.Submitted -> ()
+          | Lane.Ran_inline -> Alcotest.fail "queued cancel unit ran inline"
+          | Lane.Dropped -> Alcotest.fail "queued cancel unit was not accepted");
+         Alcotest.(check (option int))
+           "in-flight and queued before cancellation"
+           (Some 2)
+           (Lane.For_testing.pending ~base_path ~keeper_name:"k1");
          Eio.Switch.fail sw Cancel_lane_test))
    with
    | Cancel_lane_test -> ());
+  Alcotest.(check bool)
+    "queued unit did not run after cancellation"
+    false
+    !queued_unit_ran;
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
   | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
@@ -224,6 +294,10 @@ let () =
             `Quick
             test_inline_contains_raise
         ; Alcotest.test_case
+            "submit detaches before job runs"
+            `Quick
+            test_submit_detaches_before_job_runs
+        ; Alcotest.test_case
             "serializes within keeper"
             `Quick
             test_serializes_within_keeper
@@ -231,7 +305,10 @@ let () =
             "independent across keepers"
             `Quick
             test_independent_across_keepers
-        ; Alcotest.test_case "saturation drops" `Quick test_saturation_drops
+        ; Alcotest.test_case
+            "backlog queued without loss"
+            `Quick
+            test_backlog_is_queued_without_loss
         ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
         ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
         ; Alcotest.test_case

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -1,358 +1,895 @@
-(** Tests for Keeper_memory_lane (RFC-0257).
-
-    The lane detaches post-turn memory work from the keeper turn lane:
-    serialized within a keeper, independent across keepers, queued, and
-    leak-safe on a raising unit. *)
+(** Durable Keeper memory-lane regression tests (RFC-0257). *)
 
 module Lane = Masc.Keeper_memory_lane
+module Store = Masc.Keeper_memory_job_store
 
-exception Test_boom
-exception Cancel_lane_test
+let with_temp_dir label f =
+  let path = Filename.temp_file ("masc-" ^ label ^ "-") "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree path)
+    (fun () -> f path)
+;;
 
-let base_path = Filename.concat (Filename.get_temp_dir_name ()) "test-memory-lane"
-
-(* No executor switch set -> submit runs inline so no work is lost. *)
-let test_inline_when_uninitialized () =
-  Lane.For_testing.reset ();
-  let ran = ref false in
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran := true)
+let make_job
+      ?(keeper_name = "k1")
+      ?payload
+      ?enqueued_at
+      turn
+  =
+  let trace_id = "trace-" ^ keeper_name in
+  let payload =
+    Option.value
+      payload
+      ~default:(`Assoc [ "turn", `Int turn ])
   in
-  Alcotest.(check bool) "unit ran inline" true !ran;
-  match outcome with
-  | Lane.Ran_inline -> ()
-  | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
-  | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
+  match
+    Store.make_job
+      ~keeper_name
+      ~trace_id
+      ~generation:1
+      ~turn
+      ~oas_turn_count:turn
+      ~enqueued_at:
+        (Option.value enqueued_at ~default:(float_of_int turn))
+      ~payload
+  with
+  | Ok job -> job
+  | Error error ->
+    Alcotest.failf "job construction failed: %s" (Store.error_to_string error)
 ;;
 
-(* A raising unit in the inline path is contained and returns Ran_inline. *)
-let test_inline_contains_raise () =
-  Lane.For_testing.reset ();
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
+let execution_ok job =
+  Ok (`Assoc [ "turn", `Int job.Store.turn ])
+;;
+
+let admitted = function
+  | Lane.Admitted { job_id; activation; worker } -> job_id, activation, worker
+  | Lane.Rejected error ->
+    Alcotest.failf "admission rejected: %s" (Store.error_to_string error)
+;;
+
+let staged = function
+  | Lane.Staged { job_id; durable } -> job_id, durable
+  | Lane.Stage_rejected error ->
+    Alcotest.failf "staging rejected: %s" (Store.error_to_string error)
+;;
+
+let submit_committed ~base_path job =
+  ignore (Lane.stage ~base_path job |> staged);
+  Lane.activate ~base_path job |> admitted
+;;
+
+let check_backlog ~base_path ~keeper_name expected =
+  match Lane.For_testing.backlog_count ~base_path ~keeper_name with
+  | Ok actual -> Alcotest.(check int) "durable backlog" expected actual
+  | Error error ->
+    Alcotest.failf "backlog read failed: %s" (Store.error_to_string error)
+;;
+
+let read_receipt ~base_path job =
+  let path = Store.For_testing.receipt_path ~base_path job in
+  match Safe_ops.read_json_file_safe path with
+  | Error error -> Alcotest.failf "receipt read failed: %s" error
+  | Ok json ->
+    (match Store.receipt_of_json json with
+     | Ok receipt -> receipt
+     | Error error -> Alcotest.failf "receipt decode failed: %s" error)
+;;
+
+let write_json path json =
+  match Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) with
+  | Ok () -> ()
+  | Error error -> Alcotest.failf "json write failed path=%s: %s" path error
+;;
+
+let write_text path text =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc text)
+;;
+
+let rec json_contains_string needle = function
+  | `String value -> String.equal value needle
+  | `Assoc fields ->
+    List.exists (fun (_, value) -> json_contains_string needle value) fields
+  | `List values -> List.exists (json_contains_string needle) values
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null -> false
+;;
+
+let replace_assoc_field name value = function
+  | `Assoc fields ->
+    `Assoc
+      ((name, value)
+       :: List.filter (fun (field, _) -> not (String.equal field name)) fields)
+  | _ -> Alcotest.fail "expected JSON object"
+;;
+
+let pending_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.pending_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let awaiting_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.awaiting_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let execution_receipt_path ~base_path job =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat
+          (Filename.concat
+             (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+             job.Store.keeper_name)
+          Masc.Keeper_types_support.execution_receipts_dirname)
+       "2026-01")
+    "01.jsonl"
+;;
+
+let write_execution_receipt_commit ~base_path job =
+  let path = execution_receipt_path ~base_path job in
+  ignore (Masc.Keeper_fs.ensure_dir (Filename.dirname path));
+  Fs_compat.append_file_durable
+    path
+    (Yojson.Safe.to_string
+       (`Assoc
+          [ "schema", `String Masc.Keeper_types_support.execution_receipt_schema
+          ; "keeper_name", `String job.keeper_name
+          ; "post_turn_memory_job_id", `String job.id
+          ])
+     ^ "\n")
+;;
+
+let test_staged_before_init_recovers_only_from_turn_receipt () =
+  with_temp_dir "memory-lane-uninitialized" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    let _job_id, durable = Lane.stage ~base_path job |> staged in
+    (match durable with
+     | Store.Staged_awaiting_turn_commit -> ()
+     | _ -> Alcotest.fail "expected awaiting-turn-commit staging");
+    let awaiting = awaiting_path ~base_path job in
+    let awaiting_mode = (Unix.stat awaiting).Unix.st_perm land 0o777 in
+    let awaiting_dir_mode =
+      (Unix.stat (Filename.dirname awaiting)).Unix.st_perm land 0o777
+    in
+    let jobs_root_mode =
+      (Unix.stat (Filename.dirname (Filename.dirname awaiting))).Unix.st_perm
+      land 0o777
+    in
+    Alcotest.(check int) "awaiting payload mode" 0o600 awaiting_mode;
+    Alcotest.(check int) "awaiting queue directory mode" 0o700 awaiting_dir_mode;
+    Alcotest.(check int) "memory job root mode" 0o700 jobs_root_mode;
+    check_backlog ~base_path ~keeper_name:"k1" 1;
+    write_execution_receipt_commit ~base_path job;
+    let completed = ref false in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let done_p, done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          completed := true;
+          Eio.Promise.resolve done_r ();
+          execution_ok job
+        in
+        let report = Lane.init ~sw ~clock ~base_path ~execute in
+        Alcotest.(check int) "discovered keeper" 1 report.discovered_keepers;
+        Eio.Promise.await done_p));
+    Alcotest.(check bool) "persisted job replayed" true !completed;
+    check_backlog ~base_path ~keeper_name:"k1" 0;
+    let receipt = read_receipt ~base_path job in
+    Alcotest.(check bool)
+      "terminal success"
+      true
+      (receipt.outcome = Store.Succeeded))
+;;
+
+let test_duplicate_admission_is_idempotent () =
+  with_temp_dir "memory-lane-dedup" (fun base_path ->
+    Lane.For_testing.reset ();
+    let first = make_job ~enqueued_at:1.0 1 in
+    let duplicate = make_job ~enqueued_at:2.0 1 in
+    let _, first_durable = Lane.stage ~base_path first |> staged in
+    let _, duplicate_durable = Lane.stage ~base_path duplicate |> staged in
+    Alcotest.(check bool)
+      "first enqueue"
+      true
+      (first_durable = Store.Staged_awaiting_turn_commit);
+    Alcotest.(check bool)
+      "duplicate awaiting"
+      true
+      (duplicate_durable = Store.Already_awaiting);
+    check_backlog ~base_path ~keeper_name:"k1" 1;
+    let conflict = make_job ~payload:(`String "different") 1 in
+    (match Lane.stage ~base_path conflict with
+     | Lane.Stage_rejected (Store.Identity_conflict _) -> ()
+     | Lane.Stage_rejected error ->
+       Alcotest.failf "wrong conflict error: %s" (Store.error_to_string error)
+     | Lane.Staged _ -> Alcotest.fail "conflicting payload was admitted"))
+;;
+
+let test_malformed_execution_receipt_preserves_awaiting_outbox () =
+  with_temp_dir "memory-lane-malformed-turn-receipt" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    ignore (Lane.stage ~base_path job |> staged);
+    let receipt_path = execution_receipt_path ~base_path job in
+    ignore (Masc.Keeper_fs.ensure_dir (Filename.dirname receipt_path));
+    write_text receipt_path "{malformed-receipt\n";
+    let executed = ref false in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let execute ~base_path:_ _job =
+          executed := true;
+          Ok `Null
+        in
+        let report = Lane.init ~sw ~clock ~base_path ~execute in
+        (match report.keeper_discovery_errors with
+         | [ Store.Turn_receipt_error _ ] -> ()
+         | [ error ] ->
+           Alcotest.failf
+             "wrong strict receipt error: %s"
+             (Store.error_to_string error)
+         | errors ->
+           Alcotest.failf
+             "expected one strict receipt error, got %d"
+             (List.length errors));
+        Eio.Fiber.yield ()));
+    Alcotest.(check bool) "malformed receipt never authorizes work" false !executed;
+    Alcotest.(check bool)
+      "awaiting payload preserved"
+      true
+      (Sys.file_exists (awaiting_path ~base_path job)))
+;;
+
+let test_admission_rejects_wrong_state_in_pending_directory () =
+  with_temp_dir "memory-lane-state" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    ignore (submit_committed ~base_path job);
+    let path = pending_path ~base_path job in
+    let envelope =
+      match Safe_ops.read_json_file_safe path with
+      | Ok json -> json
+      | Error error -> Alcotest.failf "pending read failed: %s" error
+    in
+    write_json
+      path
+      (replace_assoc_field
+         "state"
+         (`Assoc
+            [ "kind", `String "inflight"
+            ; "started_at", `Float 1.0
+            ])
+         envelope);
+    match Lane.stage ~base_path job with
+    | Lane.Stage_rejected (Store.Decode_error _) -> ()
+    | Lane.Stage_rejected error ->
+      Alcotest.failf "wrong state error: %s" (Store.error_to_string error)
+    | Lane.Staged _ ->
+      Alcotest.fail "pending directory accepted an inflight envelope")
+;;
+
+let test_store_rejects_symlinked_memory_job_root () =
+  with_temp_dir "memory-lane-symlink-root" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir
+        ~base_path
+        ~keeper_name:job.keeper_name
+    in
+    let jobs_root = Filename.dirname awaiting_dir in
+    let target = Filename.concat base_path "outside-job-root" in
+    Unix.mkdir target 0o700;
+    ignore (Masc.Keeper_fs.ensure_dir (Filename.dirname jobs_root));
+    Unix.symlink target jobs_root;
+    (match Lane.stage ~base_path job with
+     | Lane.Stage_rejected
+         (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Lane.Stage_rejected error ->
+       Alcotest.failf
+         "wrong symlink rejection: %s"
+         (Store.error_to_string error)
+     | Lane.Staged _ -> Alcotest.fail "symlinked memory-jobs root was accepted");
+    Alcotest.(check int)
+      "symlink target remains untouched"
+      0
+      (Array.length (Sys.readdir target)))
+;;
+
+let test_receipt_backed_inflight_is_acknowledged_without_replay () =
+  with_temp_dir "memory-lane-receipt-recovery" (fun base_path ->
+    let job = make_job 1 in
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Ok Store.Staged_awaiting_turn_commit -> ()
+     | Ok _ -> Alcotest.fail "expected new durable job"
+     | Error error ->
+       Alcotest.failf "job admission failed: %s" (Store.error_to_string error));
+    (match Store.activate ~base_path job with
+     | Ok (Store.Activated, _) -> ()
+     | Ok _ -> Alcotest.fail "expected job activation"
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    let lease =
+      match Store.claim_all ~base_path ~keeper_name:"k1" ~now:2.0 with
+      | Ok { leases = [ lease ]; _ } -> lease
+      | Ok _ -> Alcotest.fail "expected one claimed job"
+      | Error error ->
+        Alcotest.failf "job claim failed: %s" (Store.error_to_string error)
+    in
+    let receipt : Store.terminal_receipt =
+      { identity = Store.receipt_identity_of_job job
+      ; started_at = lease.started_at
+      ; ended_at = 3.0
+      ; outcome = Store.Succeeded
+      ; detail = `Assoc [ "test", `Bool true ]
+      }
+    in
+    let operation_stage_path =
+      Store.operation_stage_path_for_keepers_dir
+        ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+        ~keeper_name:job.keeper_name
+        ~operation_id:job.id
+    in
+    ignore (Masc.Keeper_fs.ensure_dir (Filename.dirname operation_stage_path));
+    write_text operation_stage_path "staged provider payload";
+    write_json
+      (Store.For_testing.receipt_path ~base_path job)
+      (Store.receipt_to_json receipt);
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Ok recovery ->
+       Alcotest.(check int)
+         "receipt-backed job was not replayed"
+         0
+         recovery.replayed
+     | Error error ->
+       Alcotest.failf "recovery failed: %s" (Store.error_to_string error));
+    Alcotest.(check bool)
+      "receipt acknowledgement removes operation stage"
+      false
+      (Sys.file_exists operation_stage_path);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_terminal_receipt_cleanup_debt_does_not_block_lane () =
+  with_temp_dir "memory-lane-cleanup-debt" (fun base_path ->
+    let job = make_job 1 in
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Ok Store.Staged_awaiting_turn_commit -> ()
+     | Ok _ -> Alcotest.fail "expected staged job"
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    (match Store.activate ~base_path job with
+     | Ok (Store.Activated, _) -> ()
+     | Ok _ -> Alcotest.fail "expected activated job"
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    let lease =
+      match Store.claim_all ~base_path ~keeper_name:"k1" ~now:2.0 with
+      | Ok { leases = [ lease ]; _ } -> lease
+      | Ok _ -> Alcotest.fail "expected one claimed job"
+      | Error error -> Alcotest.fail (Store.error_to_string error)
+    in
+    let operation_stage_path =
+      Store.operation_stage_path_for_keepers_dir
+        ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+        ~keeper_name:job.keeper_name
+        ~operation_id:job.id
+    in
+    ignore (Masc.Keeper_fs.ensure_dir operation_stage_path);
+    let receipt : Store.terminal_receipt =
+      { identity = Store.receipt_identity_of_job job
+      ; started_at = lease.started_at
+      ; ended_at = 3.0
+      ; outcome = Store.Succeeded
+      ; detail = `Null
+      }
+    in
+    (match Store.finish ~base_path receipt with
+     | Error error ->
+       Alcotest.failf
+         "terminal receipt was incorrectly blocked by cleanup: %s"
+         (Store.error_to_string error)
+     | Ok report ->
+       Alcotest.(check bool)
+         "cleanup debt surfaced"
+         true
+         (report.cleanup_errors <> []));
+    Alcotest.(check bool)
+      "terminal receipt committed"
+      true
+      (Sys.file_exists (Store.For_testing.receipt_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:job.keeper_name 0)
+;;
+
+let test_malformed_keeper_discovery_does_not_block_healthy_keeper () =
+  with_temp_dir "memory-lane-discovery-isolation" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    ignore (submit_committed ~base_path job);
+    let malformed_jobs_dir =
+      Filename.concat
+        (Filename.concat
+           (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+           "bad.name")
+        "memory-jobs"
+    in
+    let (_ : string) = Masc.Keeper_fs.ensure_dir malformed_jobs_dir in
+    let completed = ref false in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let done_p, done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          completed := true;
+          Eio.Promise.resolve done_r ();
+          execution_ok job
+        in
+        let report = Lane.init ~sw ~clock ~base_path ~execute in
+        Alcotest.(check int) "healthy keeper discovered" 1 report.discovered_keepers;
+        Alcotest.(check int)
+          "malformed keeper isolated"
+          1
+          (List.length report.keeper_discovery_errors);
+        Eio.Promise.await done_p));
+    Alcotest.(check bool) "healthy keeper replayed" true !completed;
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_receipt_omits_job_payload () =
+  let secret = "secret-checkpoint-payload" in
+  let job = make_job ~payload:(`Assoc [ "secret", `String secret ]) 1 in
+  let receipt : Store.terminal_receipt =
+    { identity = Store.receipt_identity_of_job job
+    ; started_at = 1.0
+    ; ended_at = 2.0
+    ; outcome = Store.Succeeded
+    ; detail = `Assoc [ "status", `String "ok" ]
+    }
   in
-  match outcome with
-  | Lane.Ran_inline -> ()
-  | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
-  | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
-;;
-
-let test_init_rejects_switch_replacement () =
-  Lane.For_testing.reset ();
-  let rejected = ref false in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun owner_sw ->
-      Lane.init ~sw:owner_sw;
-      Lane.init ~sw:owner_sw;
-      Eio.Switch.run (fun replacement_sw ->
-        try Lane.init ~sw:replacement_sw with
-        | Invalid_argument _ -> rejected := true)));
+  let json = Store.receipt_to_json receipt in
   Alcotest.(check bool)
-    "a live lane registry has one executor switch"
-    true
-    !rejected
-;;
-
-(* [submit] must return control to the keeper turn before the detached memory
-   unit begins. Eio.Fiber.fork_daemon runs the child immediately unless it
-   yields. *)
-let test_submit_detaches_before_job_runs () =
-  Lane.For_testing.reset ();
-  let submit_returned = ref false in
-  let job_observed_submit_returned = ref false in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let completed, set_completed = Eio.Promise.create () in
-      let outcome =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          job_observed_submit_returned := !submit_returned;
-          Eio.Promise.resolve set_completed ())
-      in
-      (match outcome with
-       | Lane.Submitted -> ()
-       | Lane.Ran_inline -> Alcotest.fail "detachment test ran inline"
-       | Lane.Dropped -> Alcotest.fail "detachment test was dropped");
-      submit_returned := true;
-      Eio.Promise.await completed));
-  Alcotest.(check bool)
-    "job began after submit returned"
-    true
-    !job_observed_submit_returned
-;;
-
-(* Two units for the same keeper run one after another: the worker does not
-   begin the second until the first completes. *)
-let test_serializes_within_keeper () =
-  Lane.For_testing.reset ();
-  let order = ref [] in
-  let add s = order := s :: !order in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let p_started, set_started = Eio.Promise.create () in
-      let p_release, set_release = Eio.Promise.create () in
-      let b_done, set_b_done = Eio.Promise.create () in
-      let oa =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          add "a-start";
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await p_release;
-          add "a-end")
-      in
-      Eio.Promise.await p_started;
-      let ob =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          add "b";
-          Eio.Promise.resolve set_b_done ())
-      in
-      add "before-release";
-      Eio.Promise.resolve set_release ();
-      Eio.Promise.await b_done;
-      (match oa with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "unit A not submitted");
-      match ob with
-      | Lane.Submitted -> ()
-      | _ -> Alcotest.fail "unit B not submitted"));
-  Alcotest.(check (list string))
-    "B serialized behind A"
-    [ "a-start"; "before-release"; "a-end"; "b" ]
-    (List.rev !order)
-;;
-
-(* A unit for one keeper does not block a unit for another keeper. *)
-let test_independent_across_keepers () =
-  Lane.For_testing.reset ();
-  let order = ref [] in
-  let add s = order := s :: !order in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let p_started, set_started = Eio.Promise.create () in
-      let p_release, set_release = Eio.Promise.create () in
-      let k1_done, set_k1_done = Eio.Promise.create () in
-      let k2_done, set_k2_done = Eio.Promise.create () in
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await p_release;
-          add "k1";
-          Eio.Promise.resolve set_k1_done ())
-      in
-      Eio.Promise.await p_started;
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k2" (fun () ->
-          add "k2";
-          Eio.Promise.resolve set_k2_done ())
-      in
-      (* k2 runs to completion while k1 is still holding its own lane. *)
-      Eio.Promise.await k2_done;
-      Alcotest.(check bool) "k2 ran while k1 blocked" true (List.mem "k2" !order);
-      Eio.Promise.resolve set_release ();
-      Eio.Promise.await k1_done));
-  Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
-;;
-
-(* Backlog is kept in FIFO order instead of being discarded at an arbitrary
-   pending bound. The turn-side submitter does not wait for the first unit. *)
-let test_backlog_is_queued_without_loss () =
-  Lane.For_testing.reset ();
-  let order = ref [] in
-  let outcomes = ref [] in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let p_started, set_started = Eio.Promise.create () in
-      let p_release, set_release = Eio.Promise.create () in
-      let drained, set_drained = Eio.Promise.create () in
-      let o1 =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await p_release;
-          order := "a" :: !order)
-      in
-      Eio.Promise.await p_started;
-      let o2 =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          order := "b" :: !order)
-      in
-      let o3 =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          order := "c" :: !order;
-          Eio.Promise.resolve set_drained ())
-      in
-      outcomes := [ o1; o2; o3 ];
-      Alcotest.(check (option int))
-        "all three units remain pending"
-        (Some 3)
-        (Lane.For_testing.pending ~base_path ~keeper_name:"k1");
-      Eio.Promise.resolve set_release ();
-      Eio.Promise.await drained))
-  ;
-  List.iter
-    (function
-      | Lane.Submitted -> ()
-      | Lane.Ran_inline -> Alcotest.fail "queued unit unexpectedly ran inline"
-      | Lane.Dropped -> Alcotest.fail "accepted backlog unit was dropped")
-    !outcomes;
-  Alcotest.(check (list string))
-    "FIFO order preserved"
-    [ "a"; "b"; "c" ]
-    (List.rev !order);
-  Alcotest.(check (option int))
-    "pending drained"
-    (Some 0)
-    (Lane.For_testing.pending ~base_path ~keeper_name:"k1")
-;;
-
-(* A unit that raises releases its pending slot, so the worker continues and
-   later units run. *)
-let test_releases_on_raise () =
-  Lane.For_testing.reset ();
-  let ran_after = ref false in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      let started, set_started = Eio.Promise.create () in
-      let release, set_release = Eio.Promise.create () in
-      let finished, set_finished = Eio.Promise.create () in
-      let first =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await release;
-          raise Test_boom)
-      in
-      Eio.Promise.await started;
-      let second =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          ran_after := true;
-          Eio.Promise.resolve set_finished ())
-      in
-      (match first, second with
-       | Lane.Submitted, Lane.Submitted -> ()
-       | _ -> Alcotest.fail "raising unit backlog was not submitted");
-      Eio.Promise.resolve set_release ();
-      Eio.Promise.await finished));
-  Alcotest.(check bool) "lane recovered after raise" true !ran_after;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked: %d" n
-  | None -> Alcotest.fail "keeper entry missing"
-;;
-
-(* Cancellation during shutdown releases both the mutex and the pending slot. *)
-let test_releases_on_cancel () =
-  Lane.For_testing.reset ();
-  let queued_unit_ran = ref false in
-  (try
-     Eio_main.run (fun _env ->
-       Eio.Switch.run (fun sw ->
-         Lane.init ~sw;
-         let started, set_started = Eio.Promise.create () in
-         let never, _set_never = Eio.Promise.create () in
-         let outcome =
-           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-             Eio.Promise.resolve set_started ();
-             Eio.Promise.await never)
-         in
-         (match outcome with
-          | Lane.Submitted -> ()
-         | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
-         | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
-         Eio.Promise.await started;
-         let queued =
-           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-             queued_unit_ran := true)
-         in
-         (match queued with
-          | Lane.Submitted -> ()
-          | Lane.Ran_inline -> Alcotest.fail "queued cancel unit ran inline"
-          | Lane.Dropped -> Alcotest.fail "queued cancel unit was not accepted");
-         Alcotest.(check (option int))
-           "in-flight and queued before cancellation"
-           (Some 2)
-           (Lane.For_testing.pending ~base_path ~keeper_name:"k1");
-         Eio.Switch.fail sw Cancel_lane_test))
-   with
-   | Cancel_lane_test -> ());
-  Alcotest.(check bool)
-    "queued unit did not run after cancellation"
+    "receipt does not retain payload string"
     false
-    !queued_unit_ran;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
-  | None -> Alcotest.fail "keeper entry missing after cancel"
+    (json_contains_string secret json);
+  match json with
+  | `Assoc fields ->
+    Alcotest.(check bool)
+      "receipt has no job payload object"
+      false
+      (List.mem_assoc "job" fields)
+  | _ -> Alcotest.fail "receipt must be an object"
 ;;
 
-(* Submitting against a finished executor switch must not leak the pending
-   reservation. Eio.Fiber.fork_daemon does not raise to the caller for an off
-   switch, so the lane needs its own executor-switch release fallback. *)
-let test_finished_switch_drops_without_leak () =
-  Lane.For_testing.reset ();
-  let finished_sw = ref None in
-  Eio_main.run (fun _env ->
-    Eio.Switch.run (fun sw ->
-      Lane.init ~sw;
-      finished_sw := Some sw));
-  let sw =
-    match !finished_sw with
-    | Some sw -> sw
-    | None -> Alcotest.fail "missing captured switch"
-  in
-  Lane.init ~sw;
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
-  in
-  (match outcome with
-   | Lane.Dropped -> ()
-   | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
-   | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
-  | None -> Alcotest.fail "keeper entry missing after finished switch submit"
+let test_queue_rejects_filename_coordinate_mismatch () =
+  with_temp_dir "memory-lane-coordinate" (fun base_path ->
+    let job = make_job 1 in
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Ok Store.Staged_awaiting_turn_commit -> ()
+     | Ok _ -> Alcotest.fail "expected new durable job"
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    let source = awaiting_path ~base_path job in
+    let destination =
+      Filename.concat
+        (Filename.dirname source)
+        (String.make 64 'a' ^ ".json")
+    in
+    Sys.rename source destination;
+    match Store.backlog_count ~base_path ~keeper_name:job.keeper_name with
+    | Error (Store.Decode_error _) -> ()
+    | Error error ->
+      Alcotest.failf "wrong coordinate error: %s" (Store.error_to_string error)
+    | Ok _ -> Alcotest.fail "queue accepted a mismatched filename coordinate")
+;;
+
+let test_queue_reconciles_atomic_write_orphans () =
+  with_temp_dir "memory-lane-atomic-orphan" (fun base_path ->
+    let job = make_job 1 in
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Ok Store.Staged_awaiting_turn_commit -> ()
+     | Ok _ -> Alcotest.fail "expected new durable job"
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:job.keeper_name
+    in
+    let empty_orphan = Filename.concat awaiting_dir ".atomic_empty.tmp" in
+    let nonempty_orphan = Filename.concat awaiting_dir ".atomic_data.tmp" in
+    write_text empty_orphan "";
+    write_text nonempty_orphan "forensic payload";
+    (match Store.backlog_count ~base_path ~keeper_name:job.keeper_name with
+     | Ok count -> Alcotest.(check int) "real backlog remains" 1 count
+     | Error error -> Alcotest.fail (Store.error_to_string error));
+    Alcotest.(check bool) "zero orphan removed" false (Sys.file_exists empty_orphan);
+    Alcotest.(check bool)
+      "nonempty orphan moved"
+      false
+      (Sys.file_exists nonempty_orphan);
+    let recovered =
+      Filename.concat
+        (Filename.concat
+           (Filename.dirname awaiting_dir)
+           "recovered-atomic-writes/awaiting-turn-commit")
+        ".atomic_data.tmp"
+    in
+    Alcotest.(check bool) "nonempty orphan preserved" true (Sys.file_exists recovered))
+;;
+
+let test_receipt_failure_with_concurrent_wake_replays_and_continues () =
+  with_temp_dir "memory-lane-lost-wake" (fun base_path ->
+    Lane.For_testing.reset ();
+    let first = make_job 1 in
+    let second = make_job 2 in
+    let receipts_dir =
+      Store.For_testing.receipts_dir ~base_path ~keeper_name:first.keeper_name
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        if Sys.file_exists receipts_dir then Unix.chmod receipts_dir 0o700)
+      (fun () ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             let clock = Eio.Stdenv.clock env in
+             let first_started, first_started_r = Eio.Promise.create () in
+             let release_first, release_first_r = Eio.Promise.create () in
+             let second_done, second_done_r = Eio.Promise.create () in
+             let first_calls = ref 0 in
+             let execute ~base_path:_ job =
+               if job.Store.turn = first.turn
+               then (
+                 incr first_calls;
+                 if !first_calls = 1
+                 then (
+                   Eio.Promise.resolve first_started_r ();
+                   Eio.Promise.await release_first)
+                 else Unix.chmod receipts_dir 0o700;
+                 execution_ok job)
+               else (
+                 Eio.Promise.resolve second_done_r ();
+                 execution_ok job)
+             in
+             ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+             ignore (submit_committed ~base_path first);
+             Eio.Promise.await first_started;
+             ignore (submit_committed ~base_path second);
+             Unix.chmod receipts_dir 0o500;
+             Eio.Promise.resolve release_first_r ();
+             Eio.Promise.await second_done;
+             Alcotest.(check int) "failed receipt job replayed" 2 !first_calls));
+         check_backlog ~base_path ~keeper_name:first.keeper_name 0;
+         Alcotest.(check bool)
+           "first terminal receipt committed after replay"
+           true
+           ((read_receipt ~base_path first).outcome = Store.Succeeded);
+         Alcotest.(check bool)
+           "concurrent wake job completed"
+           true
+           ((read_receipt ~base_path second).outcome = Store.Succeeded)))
+;;
+
+let test_serializes_within_keeper () =
+  with_temp_dir "memory-lane-serial" (fun base_path ->
+    Lane.For_testing.reset ();
+    let order = ref [] in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let first_started, first_started_r = Eio.Promise.create () in
+        let release_first, release_first_r = Eio.Promise.create () in
+        let second_done, second_done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          if job.Store.turn = 1
+          then (
+            order := !order @ [ "first-start" ];
+            Eio.Promise.resolve first_started_r ();
+            Eio.Promise.await release_first;
+            order := !order @ [ "first-end" ])
+          else (
+            order := !order @ [ "second" ];
+            Eio.Promise.resolve second_done_r ());
+          execution_ok job
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        ignore (submit_committed ~base_path (make_job 1));
+        Eio.Promise.await first_started;
+        ignore (submit_committed ~base_path (make_job 2));
+        Eio.Fiber.yield ();
+        Alcotest.(check (list string))
+          "second has not started"
+          [ "first-start" ]
+          !order;
+        Eio.Promise.resolve release_first_r ();
+        Eio.Promise.await second_done));
+    Alcotest.(check (list string))
+      "FIFO order"
+      [ "first-start"; "first-end"; "second" ]
+      !order;
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_independent_keepers_run_concurrently () =
+  with_temp_dir "memory-lane-independent" (fun base_path ->
+    Lane.For_testing.reset ();
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let k1_started, k1_started_r = Eio.Promise.create () in
+        let release_k1, release_k1_r = Eio.Promise.create () in
+        let k2_done, k2_done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          if String.equal job.Store.keeper_name "k1"
+          then (
+            Eio.Promise.resolve k1_started_r ();
+            Eio.Promise.await release_k1)
+          else Eio.Promise.resolve k2_done_r ();
+          execution_ok job
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        ignore (submit_committed ~base_path (make_job ~keeper_name:"k1" 1));
+        Eio.Promise.await k1_started;
+        ignore (submit_committed ~base_path (make_job ~keeper_name:"k2" 1));
+        Eio.Promise.await k2_done;
+        Eio.Promise.resolve release_k1_r ())))
+;;
+
+let test_failed_job_receipt_does_not_block_next () =
+  with_temp_dir "memory-lane-failure" (fun base_path ->
+    Lane.For_testing.reset ();
+    let first = make_job 1 in
+    let second = make_job 2 in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let second_done, second_done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          if job.Store.turn = 1
+          then
+            Error
+              Lane.
+                { retryability = Lane.Terminal
+                ; kind = "test_failure"
+                ; message = "expected"
+                ; detail = `Null
+                }
+          else (
+            Eio.Promise.resolve second_done_r ();
+            execution_ok job)
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        ignore (submit_committed ~base_path first);
+        ignore (submit_committed ~base_path second);
+        Eio.Promise.await second_done));
+    Alcotest.(check bool)
+      "first failed"
+      true
+      ((read_receipt ~base_path first).outcome = Store.Failed);
+    Alcotest.(check bool)
+      "second succeeded"
+      true
+      ((read_receipt ~base_path second).outcome = Store.Succeeded);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_cancelled_inflight_replays_after_restart () =
+  with_temp_dir "memory-lane-restart" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let started, started_r = Eio.Promise.create () in
+        let never, _never_r = Eio.Promise.create () in
+        let execute ~base_path:_ _job =
+          Eio.Promise.resolve started_r ();
+          Eio.Promise.await never;
+          Ok `Null
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        ignore (submit_committed ~base_path job);
+        Eio.Promise.await started));
+    check_backlog ~base_path ~keeper_name:"k1" 1;
+    Lane.For_testing.reset ();
+    let replayed = ref false in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let done_p, done_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          replayed := true;
+          Eio.Promise.resolve done_r ();
+          execution_ok job
+        in
+        let report = Lane.init ~sw ~clock ~base_path ~execute in
+        Alcotest.(check int) "restart discovered keeper" 1 report.discovered_keepers;
+        Eio.Promise.await done_p));
+    Alcotest.(check bool) "inflight replayed" true !replayed;
+    Alcotest.(check bool)
+      "replay terminal success"
+      true
+      ((read_receipt ~base_path job).outcome = Store.Succeeded);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_uncommitted_awaiting_job_is_aborted_on_startup () =
+  with_temp_dir "memory-lane-uncommitted-outbox" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    ignore (Lane.stage ~base_path job |> staged);
+    let executed = ref false in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let execute ~base_path:_ _job =
+          executed := true;
+          Ok `Null
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        Eio.Fiber.yield ()));
+    Alcotest.(check bool) "uncommitted job never executed" false !executed;
+    Alcotest.(check bool)
+      "awaiting envelope removed"
+      false
+      (Sys.file_exists (awaiting_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:job.keeper_name 0)
+;;
+
+let test_retryable_failure_self_schedules_without_new_signal () =
+  with_temp_dir "memory-lane-self-retry" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    let calls = ref 0 in
+    Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+        let clock = Eio.Stdenv.clock env in
+        let completed, completed_r = Eio.Promise.create () in
+        let execute ~base_path:_ job =
+          incr calls;
+          if !calls = 1
+          then
+            Error
+              Lane.
+                { retryability = Lane.Retryable
+                ; kind = "transient_test_failure"
+                ; message = "retry without a second submit"
+                ; detail = `Null
+                }
+          else (
+            Eio.Promise.resolve completed_r ();
+            execution_ok job)
+        in
+        ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+        ignore (submit_committed ~base_path job);
+        Eio.Promise.await completed));
+    Alcotest.(check int) "self retry count" 2 !calls;
+    check_backlog ~base_path ~keeper_name:job.keeper_name 0)
+;;
+
+let test_post_receipt_activation_failure_self_reconciles () =
+  with_temp_dir "memory-lane-activation-reconcile" (fun base_path ->
+    Lane.For_testing.reset ();
+    let job = make_job 1 in
+    let blocked_pending_path = pending_path ~base_path job in
+    Fun.protect
+      ~finally:(fun () ->
+        if Sys.file_exists blocked_pending_path
+           && Sys.is_directory blocked_pending_path
+        then Unix.rmdir blocked_pending_path)
+      (fun () ->
+         Eio_main.run (fun env ->
+           Eio.Switch.run (fun sw ->
+             let clock = Eio.Stdenv.clock env in
+             let completed, completed_r = Eio.Promise.create () in
+             let execute ~base_path:_ job =
+               Eio.Promise.resolve completed_r ();
+               execution_ok job
+             in
+             ignore (Lane.init ~sw ~clock ~base_path ~execute : Lane.init_report);
+             ignore (Lane.stage ~base_path job |> staged);
+             write_execution_receipt_commit ~base_path job;
+             Unix.mkdir blocked_pending_path 0o700;
+             (match Lane.activate ~base_path job with
+              | Lane.Rejected _ -> ()
+              | Lane.Admitted _ ->
+                Alcotest.fail
+                  "activation unexpectedly succeeded through blocked queue path");
+             Unix.rmdir blocked_pending_path;
+             Eio.Promise.await completed));
+         check_backlog ~base_path ~keeper_name:job.keeper_name 0;
+         Alcotest.(check bool)
+           "reconciled job terminal receipt committed"
+           true
+           ((read_receipt ~base_path job).outcome = Store.Succeeded)))
 ;;
 
 let () =
   Alcotest.run
     "keeper_memory_lane"
-    [ ( "lane"
+    [ ( "durability"
       , [ Alcotest.test_case
-            "inline when uninitialized"
+            "staged outbox recovers from turn receipt"
             `Quick
-            test_inline_when_uninitialized
+            test_staged_before_init_recovers_only_from_turn_receipt
         ; Alcotest.test_case
-            "inline contains raise"
+            "duplicate admission is idempotent"
             `Quick
-            test_inline_contains_raise
+            test_duplicate_admission_is_idempotent
         ; Alcotest.test_case
-            "init rejects switch replacement"
+            "malformed turn receipt preserves outbox"
             `Quick
-            test_init_rejects_switch_replacement
+            test_malformed_execution_receipt_preserves_awaiting_outbox
         ; Alcotest.test_case
-            "submit detaches before job runs"
+            "cancelled inflight replays after restart"
             `Quick
-            test_submit_detaches_before_job_runs
+            test_cancelled_inflight_replays_after_restart
         ; Alcotest.test_case
+            "pending directory rejects inflight state"
+            `Quick
+            test_admission_rejects_wrong_state_in_pending_directory
+        ; Alcotest.test_case
+            "symlinked memory job root is rejected"
+            `Quick
+            test_store_rejects_symlinked_memory_job_root
+        ; Alcotest.test_case
+            "receipt-backed inflight is acknowledged"
+            `Quick
+            test_receipt_backed_inflight_is_acknowledged_without_replay
+        ; Alcotest.test_case
+            "terminal cleanup debt does not block"
+            `Quick
+            test_terminal_receipt_cleanup_debt_does_not_block_lane
+        ; Alcotest.test_case
+            "malformed keeper does not block healthy discovery"
+            `Quick
+            test_malformed_keeper_discovery_does_not_block_healthy_keeper
+        ; Alcotest.test_case
+            "receipt omits durable payload"
+            `Quick
+            test_receipt_omits_job_payload
+        ; Alcotest.test_case
+            "queue rejects filename coordinate mismatch"
+            `Quick
+            test_queue_rejects_filename_coordinate_mismatch
+        ; Alcotest.test_case
+            "queue reconciles atomic write orphans"
+            `Quick
+            test_queue_reconciles_atomic_write_orphans
+        ; Alcotest.test_case
+            "uncommitted outbox is aborted"
+            `Quick
+            test_uncommitted_awaiting_job_is_aborted_on_startup
+        ] )
+    ; ( "lane"
+      , [ Alcotest.test_case
             "serializes within keeper"
             `Quick
             test_serializes_within_keeper
         ; Alcotest.test_case
-            "independent across keepers"
+            "keepers run independently"
             `Quick
-            test_independent_across_keepers
+            test_independent_keepers_run_concurrently
         ; Alcotest.test_case
-            "backlog queued without loss"
+            "failed job does not block next"
             `Quick
-            test_backlog_is_queued_without_loss
-        ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
-        ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
+            test_failed_job_receipt_does_not_block_next
         ; Alcotest.test_case
-            "finished switch drops without leak"
+            "receipt failure concurrent wake continues"
             `Quick
-            test_finished_switch_drops_without_leak
+            test_receipt_failure_with_concurrent_wake_replays_and_continues
+        ; Alcotest.test_case
+            "retryable failure self schedules"
+            `Quick
+            test_retryable_failure_self_schedules_without_new_signal
+        ; Alcotest.test_case
+            "post-receipt activation self reconciles"
+            `Quick
+            test_post_receipt_activation_failure_self_reconciles
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -1,7 +1,7 @@
 (** Tests for Keeper_memory_lane (RFC-0257).
 
     The lane detaches post-turn memory work from the keeper turn lane:
-    serialized within a keeper, independent across keepers, bounded, and
+    serialized within a keeper, independent across keepers, queued, and
     leak-safe on a raising unit. *)
 
 module Lane = Masc.Keeper_memory_lane
@@ -37,8 +37,25 @@ let test_inline_contains_raise () =
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
 ;;
 
+let test_init_rejects_switch_replacement () =
+  Lane.For_testing.reset ();
+  let rejected = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun owner_sw ->
+      Lane.init ~sw:owner_sw;
+      Lane.init ~sw:owner_sw;
+      Eio.Switch.run (fun replacement_sw ->
+        try Lane.init ~sw:replacement_sw with
+        | Invalid_argument _ -> rejected := true)));
+  Alcotest.(check bool)
+    "a live lane registry has one executor switch"
+    true
+    !rejected
+;;
+
 (* [submit] must return control to the keeper turn before the detached memory
-   unit begins. Eio.Fiber.fork runs the child immediately unless it yields. *)
+   unit begins. Eio.Fiber.fork_daemon runs the child immediately unless it
+   yields. *)
 let test_submit_detaches_before_job_runs () =
   Lane.For_testing.reset ();
   let submit_returned = ref false in
@@ -46,15 +63,18 @@ let test_submit_detaches_before_job_runs () =
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
+      let completed, set_completed = Eio.Promise.create () in
       let outcome =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          job_observed_submit_returned := !submit_returned)
+          job_observed_submit_returned := !submit_returned;
+          Eio.Promise.resolve set_completed ())
       in
       (match outcome with
        | Lane.Submitted -> ()
        | Lane.Ran_inline -> Alcotest.fail "detachment test ran inline"
        | Lane.Dropped -> Alcotest.fail "detachment test was dropped");
-      submit_returned := true));
+      submit_returned := true;
+      Eio.Promise.await completed));
   Alcotest.(check bool)
     "job began after submit returned"
     true
@@ -72,6 +92,7 @@ let test_serializes_within_keeper () =
       Lane.init ~sw;
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
+      let b_done, set_b_done = Eio.Promise.create () in
       let oa =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           add "a-start";
@@ -81,12 +102,13 @@ let test_serializes_within_keeper () =
       in
       Eio.Promise.await p_started;
       let ob =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> add "b")
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          add "b";
+          Eio.Promise.resolve set_b_done ())
       in
-      (* Let B attempt (and fail) to acquire the keeper mutex held by A. *)
-      Eio.Fiber.yield ();
       add "before-release";
       Eio.Promise.resolve set_release ();
+      Eio.Promise.await b_done;
       (match oa with
        | Lane.Submitted -> ()
        | _ -> Alcotest.fail "unit A not submitted");
@@ -109,21 +131,26 @@ let test_independent_across_keepers () =
       Lane.init ~sw;
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
+      let k1_done, set_k1_done = Eio.Promise.create () in
+      let k2_done, set_k2_done = Eio.Promise.create () in
       let _ =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
           Eio.Promise.await p_release;
-          add "k1")
+          add "k1";
+          Eio.Promise.resolve set_k1_done ())
       in
       Eio.Promise.await p_started;
       let _ =
-        Lane.submit ~base_path ~keeper_name:"k2" (fun () -> add "k2")
+        Lane.submit ~base_path ~keeper_name:"k2" (fun () ->
+          add "k2";
+          Eio.Promise.resolve set_k2_done ())
       in
       (* k2 runs to completion while k1 is still holding its own lane. *)
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
+      Eio.Promise.await k2_done;
       Alcotest.(check bool) "k2 ran while k1 blocked" true (List.mem "k2" !order);
-      Eio.Promise.resolve set_release ()));
+      Eio.Promise.resolve set_release ();
+      Eio.Promise.await k1_done));
   Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
 ;;
 
@@ -138,6 +165,7 @@ let test_backlog_is_queued_without_loss () =
       Lane.init ~sw;
       let p_started, set_started = Eio.Promise.create () in
       let p_release, set_release = Eio.Promise.create () in
+      let drained, set_drained = Eio.Promise.create () in
       let o1 =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
@@ -151,14 +179,16 @@ let test_backlog_is_queued_without_loss () =
       in
       let o3 =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          order := "c" :: !order)
+          order := "c" :: !order;
+          Eio.Promise.resolve set_drained ())
       in
       outcomes := [ o1; o2; o3 ];
       Alcotest.(check (option int))
         "all three units remain pending"
         (Some 3)
         (Lane.For_testing.pending ~base_path ~keeper_name:"k1");
-      Eio.Promise.resolve set_release ()))
+      Eio.Promise.resolve set_release ();
+      Eio.Promise.await drained))
   ;
   List.iter
     (function
@@ -186,6 +216,7 @@ let test_releases_on_raise () =
       Lane.init ~sw;
       let started, set_started = Eio.Promise.create () in
       let release, set_release = Eio.Promise.create () in
+      let finished, set_finished = Eio.Promise.create () in
       let first =
         Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
           Eio.Promise.resolve set_started ();
@@ -194,12 +225,15 @@ let test_releases_on_raise () =
       in
       Eio.Promise.await started;
       let second =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran_after := true)
+        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
+          ran_after := true;
+          Eio.Promise.resolve set_finished ())
       in
       (match first, second with
        | Lane.Submitted, Lane.Submitted -> ()
        | _ -> Alcotest.fail "raising unit backlog was not submitted");
-      Eio.Promise.resolve set_release ()));
+      Eio.Promise.resolve set_release ();
+      Eio.Promise.await finished));
   Alcotest.(check bool) "lane recovered after raise" true !ran_after;
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
   | Some 0 -> ()
@@ -253,8 +287,8 @@ let test_releases_on_cancel () =
 ;;
 
 (* Submitting against a finished executor switch must not leak the pending
-   reservation. Eio.Fiber.fork does not raise to the caller for an off switch, so
-   the lane needs its own executor-switch release fallback. *)
+   reservation. Eio.Fiber.fork_daemon does not raise to the caller for an off
+   switch, so the lane needs its own executor-switch release fallback. *)
 let test_finished_switch_drops_without_leak () =
   Lane.For_testing.reset ();
   let finished_sw = ref None in
@@ -293,6 +327,10 @@ let () =
             "inline contains raise"
             `Quick
             test_inline_contains_raise
+        ; Alcotest.test_case
+            "init rejects switch replacement"
+            `Quick
+            test_init_rejects_switch_replacement
         ; Alcotest.test_case
             "submit detaches before job runs"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -993,8 +993,6 @@ let memory_os_knob_readers : (string * (unit -> unit)) list =
   ; ( Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
     , fun () ->
         ignore (Env_config.KeeperMemoryOs.librarian_runtime_id () : string option) )
-  ; ( Env_config.KeeperMemoryOs.librarian_global_slot_env_key
-    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_global_slot () : int) )
   ; ( Env_config.KeeperMemoryOs.gc_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.gc_enabled () : bool) )
   ; ( Env_config.KeeperMemoryOs.shared_consolidator_env_key
@@ -4333,109 +4331,6 @@ let test_recall_waits_for_shared_fact_lock () =
                 (contains "locked recall shared fact" block)
             | None -> Alcotest.fail "expected recall block")))))
 ;;
-let test_librarian_provider_slot_gate_caps_at_capacity () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1: while one entrant holds the slot, a concurrent entrant drops
-         ([None]) after [provider_slot_wait_sec] instead of blocking — the #21230
-         storm-guard the per-keeper lane keeps as an optional fleet-wide gate. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "concurrent entrant drops at capacity 1"
-        None
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_disabled_at_zero () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "0" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 0 disables the gate: a held slot does not cap a concurrent
-         entrant — both run ([Some]). *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "gate disabled: concurrent entrant also ran"
-        (Some "ran")
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_is_per_keeper () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1 is per keeper: a slot held by keeper-a must not block
-         keeper-b. This is the P0-4 isolation contract. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let other_keeper =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-b" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "different keeper runs despite capacity 1 held"
-        (Some "ran")
-        other_keeper;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
 (* ---------- External refs are context-only ---------- *)
 
 let test_fact_valid_until_external_ref_is_context_only () =
@@ -6232,18 +6127,6 @@ let () =
             "unstructured fallback does not write facts"
             `Quick
             test_librarian_unstructured_fallback_does_not_write_facts
-        ; Alcotest.test_case
-            "provider slot gate caps concurrency at capacity (#21376/#21230)"
-            `Quick
-            test_librarian_provider_slot_gate_caps_at_capacity
-        ; Alcotest.test_case
-            "provider slot gate disabled at capacity 0"
-            `Quick
-            test_librarian_provider_slot_gate_disabled_at_zero
-        ; Alcotest.test_case
-            "provider slot gate isolates keepers (P0-4)"
-            `Quick
-            test_librarian_provider_slot_gate_is_per_keeper
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1560,6 +1560,138 @@ let test_librarian_runtime_appends_episode_bundle () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
+let test_librarian_runtime_operation_id_replays_without_provider_or_duplicate () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      with_eio (fun ~sw ~net ~clock ->
+        let keeper_id = "runtime-librarian-idempotent-keeper" in
+        let operation_id = "memory-job-idempotency-1" in
+        let calls = ref 0 in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          incr calls;
+          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+        in
+        let inp : Librarian.input =
+          { Librarian.trace_id = "trace-runtime-idempotent"
+          ; generation = 3
+          ; messages = [ text_message "Persist this exactly once." ]
+          }
+        in
+        let run () =
+          Librarian_runtime.extract_and_append_with_provider_classified
+            ~operation_id
+            ~keepers_dir
+            ~complete
+            ~clock
+            ~timeout_sec:1.0
+            ~sw
+            ~net
+            ~keeper_id
+            ~provider_cfg:(test_provider_cfg ())
+            inp
+        in
+        (match run () with
+         | Ok _ -> ()
+         | Error error ->
+           Alcotest.fail
+             (Librarian_runtime.extraction_error_to_string error));
+        (match
+           Memory_io.inspect_operation_episode
+             ~clock:(Some clock)
+             ~keepers_dir
+             ~keeper_id
+             ~operation_id
+         with
+         | Ok (Memory_io.Operation_committed _) -> ()
+         | Ok Memory_io.Operation_absent ->
+           Alcotest.fail "expected committed operation episode"
+         | Ok (Memory_io.Operation_staged _) ->
+           Alcotest.fail "expected operation event commit marker"
+         | Error error -> Alcotest.fail error);
+        (match run () with
+         | Ok _ -> ()
+         | Error error ->
+           Alcotest.fail
+             (Librarian_runtime.extraction_error_to_string error));
+        Alcotest.(check int) "provider called once" 1 !calls;
+        Alcotest.(check int)
+          "one committed event"
+          1
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
+        Alcotest.(check int)
+          "operation journal is not a recall episode file"
+          0
+          (json_episode_file_count ~keeper_id))))
+;;
+
+let test_staged_operation_is_typed_and_commits_without_provider () =
+  with_temp_keepers_dir (fun keepers_dir ->
+    with_eio (fun ~sw:_ ~net:_ ~clock ->
+      let keeper_id = "runtime-librarian-staged-keeper" in
+      let operation_id = "memory-job-staged-1" in
+      let episode =
+        episode_fixture
+          ~now:1_000_000.0
+          ~trace_id:"trace-runtime-staged"
+          ~generation:7
+          ~summary:"Staged result survives replay gates"
+      in
+      let staged =
+        match
+          Memory_io.stage_operation_episode_once
+            ~clock
+            ~keepers_dir
+            ~keeper_id
+            ~operation_id
+            ~model_id:"test-model"
+            ~provider_latency_ms:12.5
+            episode
+        with
+        | Ok staged -> staged
+        | Error error -> Alcotest.fail error
+      in
+      (match
+         Memory_io.inspect_operation_episode
+           ~clock:(Some clock)
+           ~keepers_dir
+           ~keeper_id
+           ~operation_id
+       with
+       | Ok (Memory_io.Operation_staged _) -> ()
+       | Ok Memory_io.Operation_absent -> Alcotest.fail "staged operation disappeared"
+       | Ok (Memory_io.Operation_committed _) ->
+         Alcotest.fail "stage was visible as committed before event publication"
+       | Error error -> Alcotest.fail error);
+      (match
+         Librarian_runtime.commit_staged_operation
+           ~keepers_dir
+           ~clock
+           ~keeper_id
+           ~operation_id
+           staged
+       with
+       | Ok () -> ()
+       | Error error ->
+         Alcotest.fail (Librarian_runtime.extraction_error_to_string error));
+      match
+        Memory_io.inspect_operation_episode
+          ~clock:(Some clock)
+          ~keepers_dir
+          ~keeper_id
+          ~operation_id
+      with
+      | Ok (Memory_io.Operation_committed committed) ->
+        Alcotest.(check string) "staged model retained" "test-model" committed.model_id;
+        Alcotest.(check (float 0.0))
+          "provider latency retained"
+          12.5
+          committed.provider_latency_ms
+      | Ok Memory_io.Operation_absent -> Alcotest.fail "committed operation disappeared"
+      | Ok (Memory_io.Operation_staged _) ->
+        Alcotest.fail "staged operation was not committed"
+      | Error error -> Alcotest.fail error))
+;;
+
 let test_librarian_runtime_falls_back_when_schema_unavailable () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -1666,10 +1798,6 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
           ; messages = [ text_message "Please remember the fallback path." ]
           }
         in
-        Alcotest.(check bool)
-          "production cadence gate is due before provider attempt"
-          true
-          (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id);
         let fallback_result =
           Librarian_runtime.extract_and_append_with_provider_classified
             ~complete
@@ -1683,7 +1811,7 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
         in
         (match fallback_result with
          | Ok _ -> Alcotest.fail "unstructured provider output must not persist"
-         | Error (Librarian_runtime.Provider_unparseable_response reason as err) ->
+         | Error (Librarian_runtime.Provider_unparseable_response reason) ->
            Alcotest.(check int)
              "initial attempt + parse retries"
              (1 + Librarian_runtime.librarian_max_parse_retries)
@@ -1698,15 +1826,7 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
              "typed provider error preserves JSON parser detail"
              true
              (contains "JSON parse error" reason);
-           Alcotest.(check bool)
-             "unparseable provider error enters cadence backoff path"
-             true
-             (Librarian_runtime.should_record_cadence_backoff_after_error err);
-           Librarian_runtime.cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
-           Alcotest.(check bool)
-             "cadence attempt defers the next provider retry"
-             false
-             (Librarian_runtime.cadence_due ~keeper_id ~trace_id:inp.trace_id)
+           ()
          | Error err ->
            Alcotest.failf
              "expected Provider_unparseable_response, got %s"
@@ -5651,6 +5771,156 @@ let test_self_observation_excluded_from_user_model () =
       (List.hd model.Keeper_user_model.preferences).Keeper_user_model.claim)
 ;;
 
+let with_temp_base_path label f =
+  let marker = Filename.temp_file ("keeper-memory-os-" ^ label ^ "-") ".tmp" in
+  Sys.remove marker;
+  Unix.mkdir marker 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree marker)
+    (fun () -> f marker)
+;;
+
+let test_memory_store_migration_moves_only_runtime_artifacts () =
+  with_temp_base_path "migration" (fun base_path ->
+    let config_root =
+      Config_dir_resolver.base_path_config_root ~cwd:base_path base_path
+    in
+    let source_root = Filename.concat config_root "keepers" in
+    let destination_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+    let source_facts = Filename.concat source_root "keeper-a.facts.jsonl" in
+    let source_episode =
+      Filename.concat source_root "keeper-a/episodes/episode.json"
+    in
+    let config_file = Filename.concat source_root "keeper-a.toml" in
+    write_text_file source_facts "{\"fact\":true}\n";
+    write_text_file source_episode "{\"episode\":true}\n";
+    write_text_file config_file "name = \"keeper-a\"\n";
+    let migration = Memory_io.migrate_legacy_config_store ~base_path in
+    (match migration.errors with
+     | error :: _ -> Alcotest.fail (Memory_io.migration_error_to_string error)
+     | [] -> ());
+    Alcotest.(check int) "moved runtime files" 2 migration.stats.moved_files;
+    Alcotest.(check int)
+      "no dedup on first migration"
+      0
+      migration.stats.deduplicated_files;
+    Alcotest.(check bool) "source facts removed" false (Sys.file_exists source_facts);
+    Alcotest.(check bool)
+      "source episode removed"
+      false
+      (Sys.file_exists source_episode);
+    Alcotest.(check bool) "keeper config remains" true (Sys.file_exists config_file);
+    Alcotest.(check string)
+      "facts moved byte-for-byte"
+      "{\"fact\":true}\n"
+      (Fs_compat.load_file (Filename.concat destination_root "keeper-a.facts.jsonl"));
+    Alcotest.(check string)
+      "episode moved byte-for-byte"
+      "{\"episode\":true}\n"
+      (Fs_compat.load_file
+         (Filename.concat destination_root "keeper-a/episodes/episode.json")))
+;;
+
+let test_memory_store_migration_rejects_divergent_destination () =
+  with_temp_base_path "migration-conflict" (fun base_path ->
+    let config_root =
+      Config_dir_resolver.base_path_config_root ~cwd:base_path base_path
+    in
+    let source =
+      Filename.concat config_root "keepers/keeper-a.events.jsonl"
+    in
+    let destination =
+      Filename.concat
+        (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+        "keeper-a.events.jsonl"
+    in
+    let independent_source =
+      Filename.concat config_root "keepers/keeper-b.facts.jsonl"
+    in
+    let independent_destination =
+      Filename.concat
+        (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+        "keeper-b.facts.jsonl"
+    in
+    write_text_file source "source\n";
+    write_text_file destination "destination\n";
+    write_text_file independent_source "independent\n";
+    let migration = Memory_io.migrate_legacy_config_store ~base_path in
+    Alcotest.(check int)
+      "divergent destination reported"
+      1
+      (List.length migration.errors);
+    Alcotest.(check int)
+      "independent artifact still moved"
+      1
+      migration.stats.moved_files;
+    Alcotest.(check string) "source preserved" "source\n" (Fs_compat.load_file source);
+    Alcotest.(check string)
+      "destination preserved"
+      "destination\n"
+      (Fs_compat.load_file destination);
+    Alcotest.(check bool)
+      "independent source removed"
+      false
+      (Sys.file_exists independent_source);
+    Alcotest.(check string)
+      "independent destination preserved"
+      "independent\n"
+      (Fs_compat.load_file independent_destination))
+;;
+
+let test_operation_commit_quarantines_malformed_event_rows () =
+  with_temp_keepers_dir (fun keepers_dir ->
+    let keeper_id = "keeper-event-repair" in
+    let operation_id = "memory-job-repair-1" in
+    let episode =
+      episode_fixture
+        ~now:1_000_000.0
+        ~trace_id:"trace-event-repair"
+        ~generation:1
+        ~summary:"valid event survives repair"
+    in
+    let valid =
+      match Types.episode_to_json episode with
+      | `Assoc fields ->
+        `Assoc (("memory_operation_id", `String operation_id) :: fields)
+      | _ -> Alcotest.fail "episode JSON must be an object"
+    in
+    let events_path =
+      Memory_io.events_path_for_keepers_dir ~keepers_dir ~keeper_id
+    in
+    write_text_file
+      events_path
+      ("{torn-json\n" ^ Yojson.Safe.to_string valid ^ "\n");
+    let committed =
+      Memory_io.with_episode_bundle_lock_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+        (fun () ->
+           Memory_io.operation_event_committed
+             ~keepers_dir
+             ~keeper_id
+             ~operation_id)
+    in
+    (match committed with
+     | Ok true -> ()
+     | Ok false -> Alcotest.fail "valid operation marker was lost during repair"
+     | Error detail -> Alcotest.fail detail);
+    let events, malformed = Fs_compat.load_jsonl_diagnostics events_path in
+    Alcotest.(check int) "malformed rows removed" 0 malformed;
+    Alcotest.(check int) "valid event retained" 1 (List.length events);
+    let quarantine_dir =
+      Filename.concat
+        (Filename.concat keepers_dir keeper_id)
+        "memory-event-quarantine"
+    in
+    Alcotest.(check bool)
+      "malformed evidence quarantined"
+      true
+      (Sys.file_exists quarantine_dir
+       && Array.length (Sys.readdir quarantine_dir) = 1))
+;;
+
 let test_gc_default_on () =
   (* Defaults are module-load constants; env overrides are tested separately. *)
   Alcotest.(check bool) "gc default is true" true Env_config.KeeperMemoryOs.gc_enabled_default
@@ -5760,6 +6030,14 @@ let () =
             `Quick
             test_librarian_runtime_appends_episode_bundle
         ; Alcotest.test_case
+            "librarian operation replay is idempotent"
+            `Quick
+            test_librarian_runtime_operation_id_replays_without_provider_or_duplicate
+        ; Alcotest.test_case
+            "staged operation commits without provider replay gates"
+            `Quick
+            test_staged_operation_is_typed_and_commits_without_provider
+        ; Alcotest.test_case
             "librarian runtime falls back when schema unavailable"
             `Quick
             test_librarian_runtime_falls_back_when_schema_unavailable
@@ -5832,6 +6110,18 @@ let () =
         ] )
     ; ( "io"
       , [ Alcotest.test_case
+            "legacy config store migrates runtime artifacts"
+            `Quick
+            test_memory_store_migration_moves_only_runtime_artifacts
+        ; Alcotest.test_case
+            "migration rejects divergent destination"
+            `Quick
+            test_memory_store_migration_rejects_divergent_destination
+        ; Alcotest.test_case
+            "malformed event rows are quarantined"
+            `Quick
+            test_operation_commit_quarantines_malformed_event_rows
+        ; Alcotest.test_case
             "episode files do not overwrite generation"
             `Quick
             test_episode_files_do_not_overwrite_generation

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -266,7 +266,10 @@ let test_retired_path_jail_env_detection () =
   let configured value =
     Retired_env_warnings.For_testing.shell_ir_path_jail_env_configured
       ~getenv:(fun name ->
-        if String.equal name "MASC_SHELL_IR_PATH_JAIL_ENABLED"
+        if
+          String.equal
+            name
+            Retired_env_warnings.For_testing.shell_ir_path_jail_env_key
         then value
         else None)
       ()
@@ -274,6 +277,23 @@ let test_retired_path_jail_env_detection () =
   check bool "absent retired path jail env" false (configured None);
   check bool "blank retired path jail env" false (configured (Some "  "));
   check bool "non-empty retired path jail env" true (configured (Some "false"))
+
+let test_retired_memory_librarian_global_slot_env_detection () =
+  let configured value =
+    Retired_env_warnings.For_testing.memory_os_librarian_global_slot_env_configured
+      ~getenv:(fun name ->
+        if
+          String.equal
+            name
+            Retired_env_warnings.For_testing.memory_os_librarian_global_slot_env_key
+        then value
+        else None)
+      ()
+  in
+  check bool "absent retired librarian slot env" false (configured None);
+  check bool "blank retired librarian slot env" false (configured (Some "  "));
+  check bool "non-empty retired librarian slot env" true (configured (Some "1"))
+;;
 
 (* Source-level pin: assert that no [("cwd", `String <ident>)]
    literal remains in keeper_sandbox_docker.ml. The four sites
@@ -353,5 +373,9 @@ let () =
           test_case
             "path jail retired env detection ignores blanks"
             `Quick test_retired_path_jail_env_detection
+        ; test_case
+            "librarian slot retired env detection ignores blanks"
+            `Quick
+            test_retired_memory_librarian_global_slot_env_detection
         ] )
     ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -352,6 +352,7 @@ let base_receipt : R.t =
   ; oas_turn_count = None
   ; oas_dispatch_mode = None
   ; oas_internal_runtime_disabled = false
+  ; post_turn_memory_job_id = None
   ; current_task_id = None
   ; goal_ids = []
   ; outcome = `Error
@@ -892,6 +893,7 @@ let () =
     ; run_validation = None
     ; stop_reason
     ; inference_telemetry = None
+    ; post_turn_memory_job = None
     ; tool_surface
     ; pre_dispatch_compacted = false
     ; pre_dispatch_compaction_trigger = None

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -192,6 +192,30 @@ let test_snapshot_preserves_accumulator () =
         (H.accumulator_size acc));
   print_endline "  snapshot_preserves_accumulator: OK"
 
+let test_take_restore_preserves_capture_order () =
+  with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
+      let acc = H.create_accumulator () in
+      let hook = H.make_post_tool_use_hook acc in
+      let first = `Assoc [ "sequence", `Int 1 ] in
+      let second = `Assoc [ "sequence", `Int 2 ] in
+      let third = `Assoc [ "sequence", `Int 3 ] in
+      List.iter
+        (fun json ->
+           let _ : THooks.hook_decision =
+             hook (make_post_tool_use ~content:(Yojson.Safe.to_string json))
+           in
+           ())
+        [ first; second ];
+      let taken = H.take_all acc in
+      assert_eq_int ~label:"take_clears" 0 (H.accumulator_size acc);
+      let _ : THooks.hook_decision =
+        hook (make_post_tool_use ~content:(Yojson.Safe.to_string third))
+      in
+      H.restore acc taken;
+      let restored = H.take_all acc in
+      assert (List.equal Yojson.Safe.equal [ first; second; third ] restored));
+  print_endline "  take_restore_preserves_capture_order: OK"
+
 let test_drain_skips_untagged () =
   with_env_set "MASC_TOOL_EMISSION" "1" (fun () ->
       let acc = H.create_accumulator () in
@@ -358,6 +382,7 @@ let () =
   test_other_events_ignored ();
   test_drain_empties_accumulator ();
   test_snapshot_preserves_accumulator ();
+  test_take_restore_preserves_capture_order ();
   test_drain_skips_untagged ();
   test_install_chain_preserves_decision ();
   test_install_no_existing_hook ();
@@ -366,4 +391,4 @@ let () =
   test_registry_registered_names_sorted ();
   test_registry_drop_keeper_unknown_name_ok ();
   test_registry_drop_then_recreate_yields_fresh_accumulator ();
-  print_endline "=== Keeper_tool_emission_hook: 15/15 OK ==="
+  print_endline "=== Keeper_tool_emission_hook: 16/16 OK ==="

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -54,11 +54,10 @@ let test_chat_transport_metric_zero_filled () =
     check (float 0.0) "chat transport failure counter starts at 0" 0.0 m.value
 
 let test_keeper_metrics_all_complete () =
-  (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
-     ppx; this count is the drift tripwire.  If this fails after adding a
-     constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 251
-    (List.length Keeper_metrics.all);
+  (* A literal constructor count duplicates the variant declaration and became
+     stale during unrelated metric removals. Keep the invariant that can be
+     checked from the exported SSOT: every enumerated metric has one unique wire
+     name. Exhaustiveness of [to_string] remains compiler-enforced. *)
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"
     (List.length names)

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -408,6 +408,32 @@ let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
   check int "unchanged candidate skipped" 0 (List.length second)
 ;;
 
+let test_skill_candidate_store_production_projection_rejects_malformed_fact () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-strict-skill" ~turn:15
+      ~tool_call_id:"tool-strict-skill"
+      "When production projection reads facts, malformed rows must be explicit"
+  in
+  write_facts_for_base_path ~base_path ~keeper_id:"keeper" [ fact ];
+  let keepers_dir =
+    Masc.Common.keepers_runtime_dir_of_base ~base_path
+  in
+  let facts_path =
+    Memory_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id:"keeper"
+  in
+  Fs_compat.append_file facts_path "not-json\n";
+  match
+    Store.write_all_post_turn_candidates
+      ~base_path
+      ~keeper_id:"keeper"
+      ~fact_tail_limit:16
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "production projection silently accepted a malformed fact row"
+;;
+
 let noisy_index_event ~i =
   let suffix = Printf.sprintf "%03d" i in
   let noise_path name = Filename.concat "/tmp/masc-skill-candidate-noise" name in
@@ -760,6 +786,8 @@ let () =
             test_skill_candidate_store_keeps_same_id_distinct_sources;
           test_case "writes post-turn memory fact candidates" `Quick
             test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
+          test_case "production projection rejects malformed fact rows" `Quick
+            test_skill_candidate_store_production_projection_rejects_malformed_fact;
           test_case "skips unchanged candidate with noisy index" `Quick
             test_skill_candidate_store_skips_unchanged_candidate_with_noisy_index;
           test_case "recovers partial candidate artifacts" `Quick

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -121,10 +121,10 @@ let test_uses_explicit_base_path_not_ambient_resolver () =
   let target_base = fresh_dir "masc-memory-health-target" in
   let ambient_base = fresh_dir "masc-memory-health-ambient" in
   let target_keepers_dir =
-    Config_dir_resolver.keepers_dir_for_base_path ~base_path:target_base
+    Common.keepers_runtime_dir_of_base ~base_path:target_base
   in
   let ambient_keepers_dir =
-    Config_dir_resolver.keepers_dir_for_base_path ~base_path:ambient_base
+    Common.keepers_runtime_dir_of_base ~base_path:ambient_base
   in
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir:target_keepers_dir
@@ -149,7 +149,7 @@ let test_reports_per_keeper_metric_values () =
   @@ fun _env ->
   let now = test_now in
   let base = fresh_dir "masc-memory-health-metrics" in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir
     ~keeper_id:"solo"
@@ -179,10 +179,10 @@ let test_reports_per_keeper_metric_values () =
     "totals.facts_bytes positive"
     true
     (int_field "facts_bytes" (totals json) > 0);
-  Alcotest.(check bool)
-    "cadence_counter_entries non-negative"
-    true
-    (int_field "cadence_counter_entries" json >= 0);
+  Alcotest.(check string)
+    "cadence clock is the durable Keeper timeline"
+    "keeper_turn_id"
+    (string_field "cadence_clock" json);
   Alcotest.(check bool)
     "generated_at is present as wall-clock float"
     true
@@ -194,7 +194,7 @@ let test_dry_run_gc_reports_expired_and_duplicates () =
   @@ fun _env ->
   let now = test_now in
   let base = fresh_dir "masc-memory-health-gc" in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir
     ~keeper_id:"gc"
@@ -238,7 +238,7 @@ let test_sorts_keepers_by_facts_bytes_desc () =
   @@ fun _env ->
   let now = test_now in
   let base = fresh_dir "masc-memory-health-sort" in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id:"small" [ fact ~now "x" ];
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir
@@ -269,7 +269,7 @@ let test_skips_corrupt_jsonl_keeper () =
   @@ fun _env ->
   let now = test_now in
   let base = fresh_dir "masc-memory-health-corrupt" in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir
     ~keeper_id:"good"

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -2,9 +2,6 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
-module Metrics = Masc.Otel_metric_store
-module KeeperMetrics = Keeper_metrics
-module LibrarianRuntime = Masc.Keeper_librarian_runtime
 module Health = Server_dashboard_http_keeper_memory_health
 
 let test_now = 1_700_000_000.0
@@ -176,7 +173,6 @@ let test_reports_per_keeper_metric_values () =
     (float_field "events_to_facts_ratio" k);
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
-  Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -235,52 +231,6 @@ let test_dry_run_gc_reports_expired_and_duplicates () =
   (* dry_run must NOT rewrite the store: a fresh read still sees all 4 rows. *)
   let reread = Io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id:"gc" in
   Alcotest.(check int) "store untouched by dry-run gc" 4 (List.length reread)
-;;
-
-let test_reports_provider_slot_busy_metric_as_alert () =
-  Eio_main.run
-  @@ fun _env ->
-  let now = test_now in
-  let base = fresh_dir "masc-memory-health-provider-slot" in
-  (* Otel_metric_store is process-global. Use a temp-derived keeper label so
-     repeated test runs in one process cannot inherit this counter cell. *)
-  let keeper_id = "slotbusy-health-" ^ Filename.basename base in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
-  Io.rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id
-    [ fact ~now "slot busy metric keeper fact" ];
-  Metrics.inc_counter
-    KeeperMetrics.(to_string MemoryLaneProviderSlotBusy)
-    ~labels:
-      [ "keeper", keeper_id
-      ; "site", LibrarianRuntime.memory_os_librarian_provider_slot_site
-      ]
-    ~delta:3.0
-    ();
-  let json = Health.keeper_memory_health_http_json ~base_path:base in
-  let k = keeper_obj keeper_id json in
-  Alcotest.(check int) "provider slot busy projected" 3 (int_field "provider_slot_busy" k);
-  Alcotest.(check int)
-    "totals provider slot busy"
-    3
-    (int_field "provider_slot_busy" (totals json));
-  let alerts = list_field "alerts" k in
-  Alcotest.(check (list string))
-    "provider slot alert code"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "code") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert target"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "target") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert label"
-    [ "슬롯" ]
-    (List.map (string_field "label") alerts);
-  let summary = alert_summary json in
-  Alcotest.(check int) "summary provider slot keepers" 1 (int_field "provider_slot_busy_keepers" summary);
-  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
 let test_sorts_keepers_by_facts_bytes_desc () =
@@ -354,10 +304,6 @@ let () =
             "dry-run gc reports expired and duplicate rows"
             `Quick
             test_dry_run_gc_reports_expired_and_duplicates
-        ; Alcotest.test_case
-            "reports provider slot busy metric as alert"
-            `Quick
-            test_reports_provider_slot_busy_metric_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -112,7 +112,7 @@ let test_http_json_surfaces_user_model_projection () =
     (fun () ->
       let config = Workspace_utils.default_config dir in
       let keepers_dir =
-        Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+        Common.keepers_runtime_dir_of_base ~base_path:config.base_path
       in
       Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
         Memory_io.append_fact
@@ -164,7 +164,7 @@ let test_http_json_user_model_uses_config_base_path () =
     (fun () ->
       let config = Workspace_utils.default_config dir in
       let base_keepers_dir =
-        Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+        Common.keepers_runtime_dir_of_base ~base_path:config.base_path
       in
       Memory_io.For_testing.with_keepers_dir base_keepers_dir (fun () ->
         Memory_io.append_fact
@@ -487,7 +487,7 @@ let test_http_json_hebbian_derives_from_shared_facts () =
     (fun () ->
        let config = Workspace_utils.default_config dir in
        let keepers_dir =
-         Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+         Common.keepers_runtime_dir_of_base ~base_path:config.base_path
        in
        Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
          Memory_io.append_fact
@@ -546,7 +546,7 @@ let test_http_json_hebbian_dedupes_duplicate_observers () =
     (fun () ->
        let config = Workspace_utils.default_config dir in
        let keepers_dir =
-         Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+         Common.keepers_runtime_dir_of_base ~base_path:config.base_path
        in
        Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
          (* A duplicate observer in a single fact must not inflate the edge. *)


### PR DESCRIPTION
## 변경 사항

- turn 실행 영수증을 commit gate로 사용하는 `awaiting-turn-commit -> pending -> inflight -> terminal receipt` durable outbox를 추가했습니다.
- Keeper별 단일 drain daemon과 domain-safe `Eio.Mutex`로 같은 Keeper의 직선 timeline을 보존하면서 다른 Keeper lane은 독립 실행합니다.
- retryable 실행/저장 실패, receipt 불확실성, activation 실패가 새 turn·신호·재시작 없이 자체 재조정됩니다.
- provider 결과를 operation journal에 먼저 stage하고 facts/episode/event를 commit marker 순서로 게시하여 replay 시 provider 중복 호출을 막습니다.
- malformed event row는 원문을 durable quarantine한 뒤 valid row만 atomic repair하며, malformed execution receipt는 path/line 오류로 outbox activation을 거부합니다.
- Memory OS runtime 경로를 BasePath의 `.masc/keepers`로 통일하고, legacy config store migration은 충돌 항목을 보존·보고하면서 다른 Keeper/artifact와 lane startup을 계속합니다.
- atomic write/JSONL에 file+directory fsync, queue coordinate/state 검증, private mode, symlink 거부, cleanup debt 관측을 추가했습니다.
- HTTP와 stdio bootstrap 모두 Runtime params 복구 후 동일한 memory lane 초기화를 수행합니다.
- process-local librarian cadence table을 제거하고 durable Keeper turn id 기반 typed cadence decision으로 통일했습니다.

## 경계

- MASC-only 변경입니다. OAS는 변경하지 않았고 OAS는 MASC를 알지 않습니다.
- Keeper ordering/durable work ownership은 MASC lane이 소유합니다.
- provider/model capacity, health, fallback은 기존 OAS runtime/provider 경계를 그대로 사용합니다.
- 임의 queue cap, turn/cost stop, hardcoded drop window를 추가하지 않았습니다.

## 검증

현재 head: `2321d54084d3baa8b2a43ee9b6eabdd885687529`

- [x] `git diff --check`
- [x] changed OCaml 전체 `ocamlc -stop-after parsing`
- [x] changed OCaml 전체 `ocamlformat --check`
- [x] changed OCaml `ocamldep -sort`
- [x] dashboard `tsc --noEmit`
- [x] keeper-memory-health focused Vitest 12/12
- [ ] GitHub Actions OCaml 5.4/5.5 Dune CI — 빌드 권위
- [ ] 최신 head 독립 적대적 리뷰

로컬 Dune은 실행하지 않았습니다. CI와 최신 head 리뷰가 끝날 때까지 Draft + `status:do-not-merge`를 유지합니다.
