### PR TITLE
ci: fail-closed Merge Guard for blocker labels and draft state (#23966)

### DIFF
--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -34,7 +34,10 @@ permissions:
   pull-requests: read
 
 # Rapid label/draft transitions fire one run per event; only the newest
-# verdict matters, so collapse the backlog per PR instead of queueing it.
+# live-state verdict matters, so collapse the backlog per PR instead of
+# queueing it. GitHub does not guarantee concurrency-run ordering; every
+# surviving run therefore reads the current PR state from the API rather than
+# trusting the event snapshot that happened to dispatch it.
 concurrency:
   group: merge-guard-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -47,28 +50,52 @@ jobs:
       - name: Fail on live blocker labels or draft state
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # Event snapshot, logged for forensics only — the verdict below
-          # never uses it.
-          EVENT_DRAFT: ${{ github.event.pull_request.draft }}
-          EVENT_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BLOCKER_LABELS_JSON: '["status:do-not-merge","p0","p1"]'
         run: |
           set -euo pipefail
-          echo "event snapshot: draft=${EVENT_DRAFT} labels=[${EVENT_LABELS}]"
-          live="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-            --jq '{draft: .draft, labels: [.labels[].name]}')"
-          echo "live state: ${live}"
-          draft="$(jq -r '.draft' <<<"${live}")"
-          blockers="$(jq -r '.labels[] | select(. == "status:do-not-merge" or . == "p0" or . == "p1")' <<<"${live}")"
+
+          if ! pr_json="$(
+            gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/${REPOSITORY}/pulls/${PR_NUMBER}"
+          )"; then
+            echo "::error title=Merge guard unavailable::failed to read live PR state"
+            exit 1
+          fi
+
+          if ! jq -e '
+            (.draft | type == "boolean")
+            and (.labels | type == "array")
+            and all(.labels[]; (.name | type == "string"))
+          ' <<< "${pr_json}" >/dev/null; then
+            echo "::error title=Merge guard unavailable::live PR state has an unexpected shape"
+            exit 1
+          fi
+
+          if ! blocked_labels="$(
+            jq -c --argjson blockers "${BLOCKER_LABELS_JSON}" '
+              [.labels[].name as $label
+               | select($blockers | index($label))
+               | $label]
+            ' <<< "${pr_json}"
+          )"; then
+            echo "::error title=Merge guard unavailable::failed to evaluate blocker labels"
+            exit 1
+          fi
+
           blocked=0
-          if [[ -n "${blockers}" ]]; then
+          if [[ "$(jq 'length' <<< "${blocked_labels}")" -gt 0 ]]; then
+            blocked=1
             while IFS= read -r label; do
               echo "::error title=Merge blocked::blocker label present: ${label}"
-            done <<<"${blockers}"
-            blocked=1
+            done < <(jq -r '.[]' <<< "${blocked_labels}")
           fi
-          if [[ "${draft}" == "true" ]]; then
+
+          if [[ "$(jq -r '.draft' <<< "${pr_json}")" == "true" ]]; then
             echo "::error title=Merge blocked::pull request is a draft"
             blocked=1
           fi

--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -5,6 +5,12 @@
 # verdict re-computes the moment a blocker is added or removed, without
 # re-running the full CI matrix.
 #
+# The verdict reads LIVE PR state from the API at job execution, not the
+# triggering event's payload: event snapshots from rapid label flips can
+# complete out of order on the same head and leave a stale green
+# (#23966 P1). The event only decides WHEN to re-evaluate; the API decides
+# WHAT the state is.
+#
 # This check only binds merges once two repository settings hold
 # (operator-approved, see #23966):
 #   1. "Merge Guard" is in the branch-protection required contexts.
@@ -25,6 +31,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Rapid label/draft transitions fire one run per event; only the newest
 # verdict matters, so collapse the backlog per PR instead of queueing it.
@@ -37,29 +44,35 @@ jobs:
     name: Merge Guard
     runs-on: ubuntu-latest
     steps:
-      - name: Fail on blocker labels or draft state
+      - name: Fail on live blocker labels or draft state
         env:
-          # Snapshot from the triggering event, not a later API read, so the
-          # verdict is tied to the state transition that fired this run.
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Event snapshot, logged for forensics only — the verdict below
+          # never uses it.
+          EVENT_DRAFT: ${{ github.event.pull_request.draft }}
+          EVENT_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           set -euo pipefail
+          echo "event snapshot: draft=${EVENT_DRAFT} labels=[${EVENT_LABELS}]"
+          live="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '{draft: .draft, labels: [.labels[].name]}')"
+          echo "live state: ${live}"
+          draft="$(jq -r '.draft' <<<"${live}")"
+          blockers="$(jq -r '.labels[] | select(. == "status:do-not-merge" or . == "p0" or . == "p1")' <<<"${live}")"
           blocked=0
-          IFS=',' read -ra labels <<< "${PR_LABELS}"
-          for label in "${labels[@]:-}"; do
-            case "$label" in
-              status:do-not-merge|p0|p1)
-                echo "::error title=Merge blocked::blocker label present: $label"
-                blocked=1
-                ;;
-            esac
-          done
-          if [[ "${PR_DRAFT}" == "true" ]]; then
+          if [[ -n "${blockers}" ]]; then
+            while IFS= read -r label; do
+              echo "::error title=Merge blocked::blocker label present: ${label}"
+            done <<<"${blockers}"
+            blocked=1
+          fi
+          if [[ "${draft}" == "true" ]]; then
             echo "::error title=Merge blocked::pull request is a draft"
             blocked=1
           fi
-          if [[ "$blocked" == "1" ]]; then
+          if [[ "${blocked}" == "1" ]]; then
             exit 1
           fi
           echo "no blocker labels, not a draft — merge guard clean"

--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -1,0 +1,59 @@
+# Merge Guard — fail-closed blocker-label / draft gate (issue #23966).
+#
+# Exits non-zero while the PR carries a blocker label (status:do-not-merge,
+# p0, p1) or is a draft. Listens to label and draft-state events so the
+# verdict re-computes the moment a blocker is added or removed, without
+# re-running the full CI matrix.
+#
+# This check only binds merges once two repository settings hold
+# (operator-approved, see #23966):
+#   1. "Merge Guard" is in the branch-protection required contexts.
+#   2. enforce_admins is enabled — otherwise any admin merge bypasses
+#      every required context including this one.
+name: Merge Guard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+
+jobs:
+  merge-guard:
+    name: Merge Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on blocker labels or draft state
+        env:
+          # Snapshot from the triggering event, not a later API read, so the
+          # verdict is tied to the state transition that fired this run.
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          blocked=0
+          IFS=',' read -ra labels <<< "${PR_LABELS}"
+          for label in "${labels[@]:-}"; do
+            case "$label" in
+              status:do-not-merge|p0|p1)
+                echo "::error title=Merge blocked::blocker label present: $label"
+                blocked=1
+                ;;
+            esac
+          done
+          if [[ "${PR_DRAFT}" == "true" ]]; then
+            echo "::error title=Merge blocked::pull request is a draft"
+            blocked=1
+          fi
+          if [[ "$blocked" == "1" ]]; then
+            exit 1
+          fi
+          echo "no blocker labels, not a draft — merge guard clean"

--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -26,6 +26,12 @@ on:
 permissions:
   contents: read
 
+# Rapid label/draft transitions fire one run per event; only the newest
+# verdict matters, so collapse the backlog per PR instead of queueing it.
+concurrency:
+  group: merge-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   merge-guard:
     name: Merge Guard


### PR DESCRIPTION
#23966 수용 기준의 코드-측 조각이오. `status:do-not-merge`/`p0`/`p1` 라벨 또는 draft 상태에서 fail하는 경량 required-context 후보 워크플로요. 라벨/draft 전이 이벤트에 반응하므로 5초-병합 봇이 ready를 뒤집는 순간 이 체크가 pending으로 떨어져 병합이 구조적으로 막히오.

**결선 전제 (운영자 설정 2건, #23966 코멘트 참조)**: (1) branch protection required contexts에 "Merge Guard" 추가, (2) **enforce_admins ON** — 이게 없으면 admin 병합이 모든 required context를 우회하므로 이 워크플로도 장식이오.

한계: 라벨 오용(사후 p1 제거)이나 설정 자체의 롤백은 Watchdog 층의 몫이오.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
