### PR TITLE
fix(ci): restore branch protection watchdog schedule

### DIFF
--- a/.github/workflows/branch-protection-watchdog.yml
+++ b/.github/workflows/branch-protection-watchdog.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: "17 * * *"
+    - cron: "17 * * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Correct the Branch Protection Watchdog schedule to a valid five-field cron expression.
- Preserve the existing main-push, hourly schedule, and manual fail-closed audit behavior.

## Product impact

- Promise affected: merge safety / branch protection drift detection
- User-visible change: invalid no-job workflow failures disappear; the watchdog can run at minute 17 each hour.

## Evidence

- `actionlint .github/workflows/branch-protection-watchdog.yml`
- `python3 scripts/ci/check-yaml-syntax.py` — 37 YAML files validated
- Live branch protection was restored to `enforce_admins=true`; `scripts/ci/check-main-branch-protection.sh` passes against `jeong-sik/masc/main`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages:
  - actionlint
  - repository-yaml-validation
  - live-branch-protection-contract
```

## Review evidence

- The change is limited to the malformed cron field.
- `17 * * * *` is the intended hourly-at-minute-17 schedule recorded in #23931.
- No token, permission, trigger, or fail-closed audit semantics changed.

## Linked issue

- Fixes #23931
- Supports #23966

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`agent/fix-branch-protection-watchdog-23931` → `main` · 1 commit(s) · synced 2026-07-10T09:07:15Z

| sha | subject | date |
|---|---|---|
| `644ca3c5e` | fix(ci): restore branch protection watchdog schedule | 2026-07-10 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->