### PR TITLE
fix(deps): force ws >= 8.21.0 via pnpm override (Dependabot high)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -74,7 +74,8 @@
   },
   "pnpm": {
     "overrides": {
-      "lodash-es": "^4.18.1"
+      "lodash-es": "^4.18.1",
+      "ws": ">=8.21.0"
     }
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   lodash-es: ^4.18.1
+  ws: '>=8.21.0'
 
 importers:
 
@@ -3061,8 +3062,8 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5050,7 +5051,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6168,7 +6169,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Dependabot alert #32 (high): dashboard lockfile의 전이 dev 의존성 `ws` 8.20.0이 tiny-fragment 메모리 소진 DoS 취약 범위(>=8.0.0, <8.21.0)요. 기존 lodash-es override 옆에 `ws: >=8.21.0` pnpm override를 추가하고 lockfile-only 재해석으로 8.21.0 고정했소 (diff 12줄). dev-scope라 프로덕션 번들 무영향이며, dashboard CI(빌드+테스트)가 회귀를 증명하오.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>