### PR TITLE
fix(compaction): preserve unseen transcript tail

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -13,9 +13,16 @@ let summary_max_tokens = 1024
 
 (* Bound the serialized working set handed to the model. A compaction fires
    near the context limit, so the notes text must itself be bounded well below
-   the window; the model classifies by index, so truncation loses tail detail
-   but never the index mapping (the tail simply lands in [kept]). *)
+   the window. Serialization stops at a complete-message boundary and carries
+   the exact visible indices into plan validation; unseen tail indices are only
+   valid in [kept]. *)
 let max_notes_bytes = 24_000
+
+type bounded_transcript =
+  { text : string
+  ; message_count : int
+  ; visible_indices : int list
+  }
 
 type compaction_plan =
   { summary : string
@@ -71,43 +78,69 @@ let plan_schema_supported provider_cfg =
 
 let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
-(* One indexed line per message: "[i] role: <text>". The model must classify
-   every [i] into exactly one of kept/summarized/dropped. *)
-let indexed_messages_text (messages : Agent_sdk.Types.message list) =
-  messages
-  |> List.mapi (fun idx (m : Agent_sdk.Types.message) ->
-    let role =
-      match m.role with
-      | Agent_sdk.Types.System -> "system"
-      | Agent_sdk.Types.User -> "user"
-      | Agent_sdk.Types.Assistant -> "assistant"
-      | Agent_sdk.Types.Tool -> "tool"
-    in
-    let text = Agent_sdk.Types.text_of_message m |> String.trim in
-    Printf.sprintf "[%d] %s: %s" idx role text)
-  |> String.concat "\n"
-  |> String_util.utf8_safe ~max_bytes:max_notes_bytes ~suffix:"..."
-  |> String_util.to_string
+let indexed_message_text idx (m : Agent_sdk.Types.message) =
+  let role =
+    match m.role with
+    | Agent_sdk.Types.System -> "system"
+    | Agent_sdk.Types.User -> "user"
+    | Agent_sdk.Types.Assistant -> "assistant"
+    | Agent_sdk.Types.Tool -> "tool"
+  in
+  let text = Agent_sdk.Types.text_of_message m |> String.trim in
+  Printf.sprintf "[%d] %s: %s" idx role text
 
-let messages_for_plan ~(messages : Agent_sdk.Types.message list) =
-  let count = List.length messages in
+(* Add only complete indexed messages. This makes [visible_indices] the typed
+   provenance of exactly what the model saw instead of inferring visibility
+   after an arbitrary byte truncation. *)
+let serialize_indexed_messages (messages : Agent_sdk.Types.message list) =
+  let message_count = List.length messages in
+  let buffer = Buffer.create max_notes_bytes in
+  let rec add idx visible_indices = function
+    | [] ->
+      { text = Buffer.contents buffer
+      ; message_count
+      ; visible_indices = List.rev visible_indices
+      }
+    | m :: rest ->
+      let indexed = indexed_message_text idx m in
+      let separator_bytes = if Buffer.length buffer = 0 then 0 else 1 in
+      if Buffer.length buffer + separator_bytes + String.length indexed > max_notes_bytes
+      then
+        { text = Buffer.contents buffer
+        ; message_count
+        ; visible_indices = List.rev visible_indices
+        }
+      else (
+        if separator_bytes <> 0 then Buffer.add_char buffer '\n';
+        Buffer.add_string buffer indexed;
+        add (idx + 1) (idx :: visible_indices) rest)
+  in
+  add 0 [] messages
+
+let messages_for_plan ~(transcript : bounded_transcript) =
+  let count = transcript.message_count in
+  let visible_count = List.length transcript.visible_indices in
   let system =
     "You compact a keeper's working context. Classify EVERY message, by its \
      0-based index, into exactly one of: kept (verbatim, still load-bearing), \
      summarized (folded into the summary), or dropped (low value, discard). \
      Every index in range must appear in exactly one list; do not invent \
-     indices. Prefer keeping recent messages and any with concrete code paths, \
-     commands, decisions, or unresolved blockers. Write one durable [summary] \
-     prose block that stands in for the summarized messages. Do not invent \
-     facts. Do not include markdown fences."
+     indices. You receive a bounded prefix of the transcript: only indices in \
+     visible_index_range may be summarized or dropped. Every index outside \
+     visible_index_range MUST be put in kept_indices. Prefer keeping recent \
+     messages and any with concrete code paths, commands, decisions, or \
+     unresolved blockers. Write one durable [summary] prose block that stands \
+     in for the summarized messages. Do not invent facts. Do not include \
+     markdown fences."
   in
   let user =
     Printf.sprintf
-      "message_count: %d\nmessages:\n%s\n\nReturn a JSON object with fields \
+      "message_count: %d\nvisible_index_range: [0, %d)\nmessages:\n%s\n\nReturn a JSON object with fields \
        summary, kept_indices, summarized_indices, dropped_indices covering \
        every index in [0, %d) exactly once."
       count
-      (indexed_messages_text messages)
+      visible_count
+      transcript.text
       count
   in
   [ message Agent_sdk.Types.System system; message Agent_sdk.Types.User user ]
@@ -174,7 +207,30 @@ let validate_non_empty_output ~message_count ~kept ~summarized =
     Error "plan would produce empty compaction output"
   else Ok ()
 
-let plan_of_json ~message_count json =
+let validate_unseen_indices_kept ~(transcript : bounded_transcript) ~kept =
+  let visible =
+    List.fold_left (fun indices idx -> Int_set.add idx indices) Int_set.empty
+      transcript.visible_indices
+  in
+  let kept =
+    List.fold_left (fun indices idx -> Int_set.add idx indices) Int_set.empty kept
+  in
+  let rec first_unkept_unseen idx =
+    if idx >= transcript.message_count
+    then None
+    else if Int_set.mem idx visible || Int_set.mem idx kept
+    then first_unkept_unseen (idx + 1)
+    else Some idx
+  in
+  match first_unkept_unseen 0 with
+  | None -> Ok ()
+  | Some idx ->
+    Error
+      (Printf.sprintf
+         "index %d was omitted from the bounded prompt and must be kept"
+         idx)
+
+let plan_of_json ~(transcript : bounded_transcript) json =
   let* summary = string_field Schema.compaction_plan_field_summary json in
   let summary = String.trim summary in
   let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
@@ -191,7 +247,9 @@ let plan_of_json ~message_count json =
     then Error "summary must be non-empty when summarized indices are present"
     else Ok ()
   in
+  let message_count = transcript.message_count in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
+  let* () = validate_unseen_indices_kept ~transcript ~kept in
   let* () = validate_non_empty_output ~message_count ~kept ~summarized in
   Ok { summary; kept; summarized; dropped }
 
@@ -218,13 +276,13 @@ let apply (plan : compaction_plan) ~(messages : Agent_sdk.Types.message list) =
       if idx = first_summarized then Some summary_msg else None
     else Some m)
 
-let plan_of_response ~message_count response =
+let plan_of_response ~transcript response =
   match
     Agent_sdk_response.structured_json_of_response
       ~schema_name:"keeper_compaction_plan"
       response
   with
-  | Ok json -> plan_of_json ~message_count json
+  | Ok json -> plan_of_json ~transcript json
   | Error detail -> Error ("invalid structured response: " ^ detail)
 
 type 'a timeout_result =
@@ -250,9 +308,9 @@ let run_plan
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(messages : Agent_sdk.Types.message list)
     () : compaction_plan option =
-  let message_count = List.length messages in
+  let transcript = serialize_indexed_messages messages in
   let provider_cfg = provider_for_plan ~runtime_id provider_cfg in
-  let request = messages_for_plan ~messages in
+  let request = messages_for_plan ~transcript in
   match
     with_timeout ?clock ~timeout_sec (fun () ->
       complete ~sw ~net ?clock ~config:provider_cfg ~messages:request ())
@@ -274,7 +332,7 @@ let run_plan
       runtime_id (Provider_http_error.to_message err);
     None
   | Completed (Ok response) ->
-    (match plan_of_response ~message_count response with
+    (match plan_of_response ~transcript response with
      | Ok plan -> Some plan
      | Error detail ->
        Log.Keeper.warn ~keeper_name

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -14,11 +14,23 @@
     fiber-local Eio context captured at construction, and the summarizer type
     stays synchronous+total. *)
 
+(** A byte-bounded, complete-message serialization of a working transcript.
+    [visible_indices] is the exact set of message indices whose content appears
+    in [text]; [message_count] is the full input size. The private constructor
+    prevents callers from separating serialized content from its visibility
+    provenance. *)
+type bounded_transcript = private
+  { text : string
+  ; message_count : int
+  ; visible_indices : int list
+  }
+
 (** A validated compaction plan over a working set of [n] messages. Every
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
     pairwise disjoint, and together they cover every index exactly once. For
     non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. *)
+    applying the plan cannot erase the entire working set. Every index omitted
+    from the bounded transcript is in [kept]. *)
 type compaction_plan = private
   { summary : string
   ; kept : int list
@@ -43,6 +55,12 @@ type complete_fn =
   unit ->
   (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
 
+(** Serialize the longest complete-message prefix that fits the provider input
+    bound, retaining the exact visible-index provenance used by validation. *)
+val serialize_indexed_messages
+  :  Agent_sdk.Types.message list
+  -> bounded_transcript
+
 (** [make ~runtime_id ~keeper_name ()] builds a summarizer bound to the
     librarian lane resolved from [runtime_id], or [None] if the Eio context
     or a schema-capable provider is unavailable. The caller treats [None] as
@@ -56,13 +74,13 @@ val make
   -> unit
   -> summarizer option
 
-(** Parse+validate a raw structured response into a plan over [message_count]
-    messages. Exposed for tests. Returns [Error] with a reason on any
+(** Parse+validate a raw structured response against [transcript]. Exposed for
+    tests. Returns [Error] with a reason on any
     structural violation (out-of-range / negative / duplicate / non-covering
-    indices, empty output for a non-empty working set, or a missing/empty
-    summary). *)
+    indices, any non-kept index omitted from the bounded prompt, empty output
+    for a non-empty working set, or a missing/empty summary). *)
 val plan_of_json
-  :  message_count:int
+  :  transcript:bounded_transcript
   -> Yojson.Safe.t
   -> (compaction_plan, string) result
 

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -71,6 +71,15 @@ let test_provider_for_plan_preserves_runtime_temperature () =
       (Some 1.0)
       cfg.temperature)
 
+let msg role text = Agent_sdk.Types.text_message role text
+
+let parse_plan ~message_count json =
+  let messages =
+    List.init message_count (fun idx -> msg Agent_sdk.Types.User (string_of_int idx))
+  in
+  let transcript = C.serialize_indexed_messages messages in
+  C.plan_of_json ~transcript json
+
 (* -- plan_of_json: valid partition accepted -- *)
 
 let test_valid_partition_accepted () =
@@ -78,21 +87,21 @@ let test_valid_partition_accepted () =
   Alcotest.(check bool)
     "a full disjoint partition of [0,5) parses"
     true
-    (is_ok (C.plan_of_json ~message_count:5 json))
+    (is_ok (parse_plan ~message_count:5 json))
 
 let test_all_kept_accepted () =
   let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
     "kept covering everything parses (summary unused but required non-empty)"
     true
-    (is_ok (C.plan_of_json ~message_count:3 json))
+    (is_ok (parse_plan ~message_count:3 json))
 
 let test_drop_only_with_kept_accepted () =
   let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
   Alcotest.(check bool)
     "drop-only plans are valid when at least one message remains"
     true
-    (is_ok (C.plan_of_json ~message_count:2 json))
+    (is_ok (parse_plan ~message_count:2 json))
 
 (* -- plan_of_json: structural violations rejected (no silent repair) -- *)
 
@@ -101,35 +110,35 @@ let test_out_of_range_rejected () =
   Alcotest.(check bool)
     "an index >= message_count is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 let test_negative_rejected () =
   let json = plan_json ~summary:"x" ~kept:[ -1; 0 ] ~summarized:[ 1 ] ~dropped:[] in
   Alcotest.(check bool)
     "a negative index is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 let test_duplicate_rejected () =
   let json = plan_json ~summary:"x" ~kept:[ 0; 1 ] ~summarized:[ 1 ] ~dropped:[] in
   Alcotest.(check bool)
     "an index appearing in two lists is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 let test_missing_index_rejected () =
   let json = plan_json ~summary:"x" ~kept:[ 0 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
     "a partition that omits an in-range index is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 let test_all_dropped_rejected () =
   let json = plan_json ~summary:"S" ~kept:[] ~summarized:[] ~dropped:[ 0; 1 ] in
   Alcotest.(check bool)
     "a non-empty working set must not compact to empty output"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 (* The summary is only consumed when there are summarized indices. A blank
    summary with an empty [summarized] set is a legitimate "keep everything"
@@ -140,25 +149,24 @@ let test_empty_summary_accepted_when_nothing_summarized () =
   Alcotest.(check bool)
     "a blank summary is accepted when nothing is summarized"
     true
-    (is_ok (C.plan_of_json ~message_count:2 json))
+    (is_ok (parse_plan ~message_count:2 json))
 
 let test_empty_summary_rejected_when_summarizing () =
   let json = plan_json ~summary:"   " ~kept:[ 1 ] ~summarized:[ 0 ] ~dropped:[] in
   Alcotest.(check bool)
     "a blank summary is rejected when there are summarized indices to fold"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (parse_plan ~message_count:2 json))
 
 let test_missing_field_rejected () =
   let json = `Assoc [ "summary", `String "x"; "kept_indices", `List [] ] in
   Alcotest.(check bool)
     "a plan missing summarized_indices/dropped_indices is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:0 json))
+    (is_error (parse_plan ~message_count:0 json))
 
 (* -- apply: reconstruction honours the plan -- *)
 
-let msg role text = Agent_sdk.Types.text_message role text
 let texts (ms : Agent_sdk.Types.message list) =
   List.map (fun m -> Agent_sdk.Types.text_of_message m) ms
 
@@ -172,7 +180,7 @@ let sample =
 let test_apply_keeps_summarizes_drops () =
   (* kept: 3 ; summarized: 0,1 ; dropped: 2 *)
   let json = plan_json ~summary:"S" ~kept:[ 3 ] ~summarized:[ 0; 1 ] ~dropped:[ 2 ] in
-  match C.plan_of_json ~message_count:4 json with
+  match parse_plan ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
@@ -194,7 +202,7 @@ let test_apply_keeps_summarizes_drops () =
 
 let test_apply_all_kept_is_identity () =
   let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2; 3 ] ~summarized:[] ~dropped:[] in
-  match C.plan_of_json ~message_count:4 json with
+  match parse_plan ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
@@ -202,6 +210,42 @@ let test_apply_all_kept_is_identity () =
       "all-kept leaves the working set unchanged"
       (texts sample)
       (texts out)
+
+let test_unseen_tail_cannot_be_dropped () =
+  let large = String.make 13_000 'x' in
+  let messages =
+    [ msg Agent_sdk.Types.User large
+    ; msg Agent_sdk.Types.Assistant large
+    ; msg Agent_sdk.Types.User "unseen-tail-must-survive"
+    ]
+  in
+  Alcotest.(check bool)
+    "fixture exceeds the 24KB transcript bound"
+    true
+    (String.length large * 2 > 24_000);
+  let transcript = C.serialize_indexed_messages messages in
+  Alcotest.(check (list int))
+    "only the first complete indexed message is visible"
+    [ 0 ]
+    transcript.visible_indices;
+  let unsafe = plan_json ~summary:"" ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[ 2 ] in
+  (match C.plan_of_json ~transcript unsafe with
+   | Ok _ -> Alcotest.fail "a syntactically complete plan dropped an unseen tail index"
+   | Error detail ->
+     Alcotest.(check string)
+       "rejection names the exact bounded-prompt visibility violation"
+       "index 2 was omitted from the bounded prompt and must be kept"
+       detail);
+  let safe = plan_json ~summary:"" ~kept:[ 1; 2 ] ~summarized:[] ~dropped:[ 0 ] in
+  match C.plan_of_json ~transcript safe with
+  | Error detail -> Alcotest.failf "expected unseen indices kept, got %s" detail
+  | Ok plan ->
+    let out = C.apply plan ~messages in
+    Alcotest.(check int) "the visible message alone is dropped" 2 (List.length out);
+    Alcotest.(check string)
+      "the unseen tail survives the normal apply path"
+      "unseen-tail-must-survive"
+      (List.nth (texts out) 1)
 
 let () =
   Alcotest.run "compaction_llm_summarizer"
@@ -228,5 +272,7 @@ let () =
     ; ( "apply"
       , [ Alcotest.test_case "keeps/summarizes/drops" `Quick test_apply_keeps_summarizes_drops
         ; Alcotest.test_case "all-kept is identity" `Quick test_apply_all_kept_is_identity
+        ; Alcotest.test_case ">24KB unseen tail cannot be dropped" `Quick
+            test_unseen_tail_cannot_be_dropped
         ] )
     ]


### PR DESCRIPTION
Fixes #23968.

## Root cause

#23908 made LLM compaction the default while truncating the full indexed transcript at 24KB. The plan validator knew only `message_count`, so a syntactically complete response could summarize/drop indices whose content was omitted from the model prompt.

## What changed

- serialize only a complete-message prefix within 24KB
- carry exact visible-index provenance in a private typed `bounded_transcript`
- use the same transcript for prompt construction and response validation
- require every unseen index to be in `kept`; reject unsafe plans explicitly and take the existing lossless fallback
- add a >24KB regression that tries to drop an unseen tail index, then proves a safe plan preserves it through `apply`

## Validation

- OCaml parsing / `ocamlformat --check` / `git diff --check`: pass
- focused wrapper build `test/test_compaction_llm_summarizer.exe`: pass
- executable: **14/14 tests pass**, including the >24KB regression

## Scope

This PR fixes unseen-tail loss only. Runtime temperature SSOT is tracked separately in #23970.

## Merge gate

Keep Draft / `status:do-not-merge` until terminal current-head CI.

[근거] base `ef74e9fd1b`, head `02b9ff8db4`, focused build/test checked 2026-07-10T09:20Z; confidence High.