### PR TITLE
fix(runtime): preserve lane temperature overrides

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -410,7 +410,7 @@ let messages_for_summary ~mode ~context_bundle =
     provider error. If it cannot, we return the un-schema'd config plus
     [Plain_json_text] so the evaluator still produces a judgment for every
     keeper's model fleet instead of failing outright. *)
-let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_config_for_summary ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
   let summary_max_tokens = Keeper_config.hitl_summary_max_tokens () in
   let max_tokens =
     match provider_cfg.max_tokens with
@@ -421,10 +421,15 @@ let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) 
       Some summary_max_tokens
     | None -> Some summary_max_tokens
   in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:Keeper_config.hitl_summary_temperature
+  in
   let clamped =
     { provider_cfg with
       max_tokens
-    ; temperature = Some (Keeper_config.hitl_summary_temperature ())
+    ; temperature = Some temperature
     ; tool_choice = None
     ; disable_parallel_tool_use = true
     }
@@ -437,8 +442,8 @@ let provider_config_for_summary (provider_cfg : Llm_provider.Provider_config.t) 
   | Error _ -> clamped, Plain_json_text
 ;;
 
-let call_summary_llm ~sw ~net ~provider_config ~context_bundle () =
-  let config, mode = provider_config_for_summary provider_config in
+let call_summary_llm ~sw ~net ~runtime_id ~provider_config ~context_bundle () =
+  let config, mode = provider_config_for_summary ~runtime_id provider_config in
   let messages = messages_for_summary ~mode ~context_bundle in
   match
     Keeper_llm_bridge.run_with_timeout_and_fallback
@@ -554,7 +559,7 @@ let summary_of_response ~generated_at ~mode (response : Agent_sdk.Types.api_resp
 
 (* ── Spawn ──────────────────────────────────────── *)
 
-let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failure () =
+let spawn ~sw ~runtime_id ?provider_config ~(entry : pending_approval) ~on_summary ~on_failure () =
   let generated_at = Time_compat.now () in
   match provider_config with
   | None ->
@@ -578,7 +583,9 @@ let spawn ~sw ?provider_config ~(entry : pending_approval) ~on_summary ~on_failu
             record_outcome ~risk_level:entry.risk_level "no_net";
             emit_fallback ~reason:"HITL summary worker: Eio net unavailable"
           | Some net ->
-            (match call_summary_llm ~sw ~net ~provider_config ~context_bundle () with
+            (match
+               call_summary_llm ~sw ~net ~runtime_id ~provider_config ~context_bundle ()
+             with
              | Ok (response, mode) ->
                (* Record the degradation itself (not just its outcome) so
                   operators can see when the judge fleet lacks native structured

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -1,4 +1,4 @@
-(** Spawn an asynchronous HITL context-summary worker.
+(** Spawn an asynchronous HITL context-summary worker for [runtime_id].
     The worker is fire-and-forget: it calls [on_summary] with either the LLM
     summary or a deterministic request-metadata fallback. [on_failure] is
     reserved for unexpected worker failures where even fallback generation did
@@ -7,6 +7,7 @@
     keeps the worker decoupled from the queue and avoids a module cycle. *)
 val spawn
   :  sw:Eio.Switch.t
+  -> runtime_id:string
   -> ?provider_config:Llm_provider.Provider_config.t
   -> entry:Keeper_approval_queue_rules_types.pending_approval
   -> on_summary:(Keeper_approval_queue_rules_types.hitl_context_summary -> unit)
@@ -46,9 +47,11 @@ module For_testing : sig
 
   (** Returns the clamped config plus the chosen output mode: [Native_structured]
       when {!Llm_provider.Provider_config.validate_output_schema_request} accepts
-      a json_schema request for this endpoint, else [Plain_json_text]. *)
+      a json_schema request for this endpoint, else [Plain_json_text]. The
+      runtime.toml temperature for [runtime_id] overrides the subsystem fallback. *)
   val provider_config_for_summary
-    :  Llm_provider.Provider_config.t
+    :  runtime_id:string
+    -> Llm_provider.Provider_config.t
     -> Llm_provider.Provider_config.t * summary_mode
 
   (** Best-effort single-JSON-object extraction from model text (plain path). *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -210,8 +210,9 @@ end
     @param runtime_id Runtime profile name for model selection
      @param generation Current generation counter
      @param guardrails Optional OAS guardrails for tool safety gates
-    @param temperature MODEL temperature override; when omitted, resolved
-           from [Runtime_inference] with a 0.3 fallback
+    @param temperature Subsystem temperature fallback; a selected runtime model
+           declaration takes precedence. When omitted,
+           [Keeper_config.keeper_unified_temperature] is the fallback.
     @param max_tokens Maximum output tokens override; when omitted, resolved
            from [Runtime_inference] with a 8192 fallback
     @param is_retry When [true], replays the current user message into the

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -135,7 +135,8 @@ val per_provider_timeout_for_turn
     @param history_user_source Source label for user messages in history
     @param history_assistant_source Source label for assistant messages in history
     @param guardrails Optional OAS guardrails for tool safety gates
-    @param temperature MODEL temperature override
+    @param temperature Subsystem temperature fallback; a selected runtime model
+           declaration takes precedence
     @param max_tokens Maximum output tokens override
     @param on_event Optional event callback
     @param trajectory_acc Optional trajectory accumulator for recording

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -799,6 +799,11 @@ let record_summary_failure ~id ~reason ~retryable =
   | None -> ()
 ;;
 
+type summary_provider =
+  { runtime_id : string
+  ; provider_config : Llm_provider.Provider_config.t
+  }
+
 let provider_config_for_summary ~keeper_name =
   (* The HITL evaluator is a dedicated judge (mirroring the memory-os librarian's
      dedicated runtime), not the requesting keeper's own model. Route to the
@@ -807,8 +812,10 @@ let provider_config_for_summary ~keeper_name =
      default, so an operator-selected HITL lane wins and unset deployments keep
      the judge routing. Fall back to the keeper's own runtime only when the
      resolved lane id has no runtime entry. *)
-  let resolve id =
-    Option.map (fun rt -> rt.Runtime.provider_config) (Runtime.get_runtime_by_id id)
+  let resolve runtime_id =
+    Option.map
+      (fun rt -> { runtime_id; provider_config = rt.Runtime.provider_config })
+      (Runtime.get_runtime_by_id runtime_id)
   in
   let keeper_runtime_id () =
     match Runtime.runtime_id_for_keeper keeper_name with
@@ -850,8 +857,9 @@ let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =
     match provider_config_for_summary ~keeper_name:entry.keeper_name with
     | None ->
       on_failure ~reason:"HITL summary: no runtime provider config available" ~retryable:false
-    | Some config ->
-      Hitl_summary_worker.spawn ~sw ~entry ~provider_config:config ~on_summary ~on_failure ()
+    | Some selected ->
+      Hitl_summary_worker.spawn ~sw ~runtime_id:selected.runtime_id ~entry
+        ~provider_config:selected.provider_config ~on_summary ~on_failure ()
 ;;
 
 let spawn_hitl_summary_worker_on_root_switch ~(entry : pending_approval) =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -155,13 +155,19 @@ val approved_action_matches_request :
     This intentionally differs from remembered-rule matching, which has a
     broader persisted-policy contract. *)
 
-(** Resolve the provider config the HITL context-summary worker runs on.
+(** A provider config paired with the exact runtime id that selected it. *)
+type summary_provider = private
+  { runtime_id : string
+  ; provider_config : Llm_provider.Provider_config.t
+  }
+
+(** Resolve the provider config and runtime id the HITL context-summary worker runs on.
     Routes through [Runtime.runtime_id_for_hitl_summary] (fallback chain
     hitl_summary -> structured_judge -> librarian -> default); falls back to
     the keeper's own runtime when the resolved lane id has no runtime entry.
     Returns [None] when no runtime resolves at all. *)
 val provider_config_for_summary :
-  keeper_name:string -> Llm_provider.Provider_config.t option
+  keeper_name:string -> summary_provider option
 
 (** {1 Rule store (persisted)} *)
 

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -42,15 +42,20 @@ let is_direct_completion_provider (provider_cfg : Llm_provider.Provider_config.t
   match provider_cfg.kind with
   | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
 
-let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_plan ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some (min n summary_max_tokens)
     | _ -> Some summary_max_tokens
   in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
+  in
   { provider_cfg with
     max_tokens
-  ; temperature = Some 0.0
+  ; temperature = Some temperature
   ; tool_choice = None
   ; disable_parallel_tool_use = true
   }
@@ -246,7 +251,7 @@ let run_plan
     ~(messages : Agent_sdk.Types.message list)
     () : compaction_plan option =
   let message_count = List.length messages in
-  let provider_cfg = provider_for_plan provider_cfg in
+  let provider_cfg = provider_for_plan ~runtime_id provider_cfg in
   let request = messages_for_plan ~messages in
   match
     with_timeout ?clock ~timeout_sec (fun () ->
@@ -322,3 +327,7 @@ let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) (
       "compaction LLM summarizer skipped: Eio context unavailable runtime=%s"
       runtime_id;
     None
+
+module For_testing = struct
+  let provider_for_plan = provider_for_plan
+end

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -77,3 +77,12 @@ val apply
   :  compaction_plan
   -> messages:Agent_sdk.Types.message list
   -> Agent_sdk.Types.message list
+
+module For_testing : sig
+  (** Apply the compaction request policy while preserving the per-runtime
+      temperature override from runtime.toml. *)
+  val provider_for_plan
+    :  runtime_id:string
+    -> Llm_provider.Provider_config.t
+    -> Llm_provider.Provider_config.t
+end

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -252,7 +252,7 @@ let select_recent_messages ~max_messages messages =
   drop drop_count messages
 ;;
 
-let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_librarian ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
   let configured_librarian_max_tokens = librarian_max_tokens () in
   let max_tokens =
     match provider_cfg.max_tokens with
@@ -260,10 +260,15 @@ let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
     | Some _ -> Some configured_librarian_max_tokens
     | None -> Some configured_librarian_max_tokens
   in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
+  in
   let tuned_cfg =
     { provider_cfg with
       max_tokens
-    ; temperature = Some 0.0
+    ; temperature = Some temperature
     ; tool_choice = None
     ; disable_parallel_tool_use = true
     ; enable_thinking = Some false
@@ -514,6 +519,7 @@ let extract_with_provider_classified
     ?(timeout_sec = librarian_default_timeout_sec)
     ~sw
     ~net
+    ~runtime_id
     ~provider_cfg
     ~generation
     (inp : Keeper_librarian.input)
@@ -524,7 +530,7 @@ let extract_with_provider_classified
     (match messages_for_librarian inp with
      | Error msg -> Error (Prompt_render_failed msg)
      | Ok messages ->
-       let provider_cfg = provider_for_librarian provider_cfg in
+       let provider_cfg = provider_for_librarian ~runtime_id provider_cfg in
        (match
           Llm_provider.Provider_config.validate_output_schema_request provider_cfg
         with
@@ -582,7 +588,17 @@ let extract_with_provider_classified
              Error (Provider_unparseable_response diagnostic.reason))))
 ;;
 
-let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =
+let extract_with_provider
+    ?complete
+    ?clock
+    ?timeout_sec
+    ~sw
+    ~net
+    ~runtime_id
+    ~provider_cfg
+    ~generation
+    inp
+  =
   match
     extract_with_provider_classified
       ?complete
@@ -590,6 +606,7 @@ let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~
       ?timeout_sec
       ~sw
       ~net
+      ~runtime_id
       ~provider_cfg
       ~generation
       inp
@@ -605,6 +622,7 @@ let extract_and_append_with_provider_classified
     ~sw
     ~net
     ~keeper_id
+    ~runtime_id
     ~provider_cfg
     inp
   =
@@ -624,6 +642,7 @@ let extract_and_append_with_provider_classified
          ?timeout_sec
          ~sw
          ~net
+         ~runtime_id
          ~provider_cfg
          ~generation
          inp
@@ -716,6 +735,7 @@ let extract_and_append_with_provider
     ~sw
     ~net
     ~keeper_id
+    ~runtime_id
     ~provider_cfg
     inp
   =
@@ -727,6 +747,7 @@ let extract_and_append_with_provider
       ~sw
       ~net
       ~keeper_id
+      ~runtime_id
       ~provider_cfg
       inp
   with
@@ -787,6 +808,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                    ~sw
                    ~net
                    ~keeper_id
+                   ~runtime_id
                    ~provider_cfg
                    inp)
              with

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -112,12 +112,14 @@ val messages_for_librarian
   -> (Agent_sdk.Types.message list, string) result
 
 val provider_for_librarian
-  :  Llm_provider.Provider_config.t
+  :  runtime_id:string
+  -> Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
 (** Provider config specialized for episode extraction. Caps [max_tokens] at
     the librarian output budget (default 4096, overridable with
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS], floor 1) and requests the
-    structured episode output schema. *)
+    structured episode output schema. The runtime model's declared temperature
+    overrides the deterministic librarian fallback. *)
 
 val librarian_max_parse_retries : int
 (** Additional provider attempts after an initial unparseable response before
@@ -211,6 +213,7 @@ val extract_with_provider
   -> ?timeout_sec:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> runtime_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> generation:int
   -> Keeper_librarian.input
@@ -222,6 +225,7 @@ val extract_with_provider_classified
   -> ?timeout_sec:float
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> runtime_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> generation:int
   -> Keeper_librarian.input
@@ -239,6 +243,7 @@ val extract_and_append_with_provider
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> keeper_id:string
+  -> runtime_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
@@ -250,6 +255,7 @@ val extract_and_append_with_provider_classified
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> keeper_id:string
+  -> runtime_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -61,15 +61,20 @@ let is_direct_completion_provider
   match provider_cfg.kind with
   | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
 
-let provider_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_summary ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some (min n summary_max_tokens)
     | _ -> Some summary_max_tokens
   in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
+  in
   { provider_cfg with
     max_tokens;
-    temperature = Some 0.0;
+    temperature = Some temperature;
     tool_choice = None;
     disable_parallel_tool_use = true;
   }
@@ -192,14 +197,14 @@ let summarize_with_provider
     ?(complete : complete_fn = default_complete)
     ?clock
     ?(timeout_sec = Env_config_governance.Inference.timeout_seconds)
-    ?(runtime_id = "")
+    ~runtime_id
     ~sw
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~trace_id
     ~texts
     () : string option =
-  let provider_cfg = provider_for_summary provider_cfg in
+  let provider_cfg = provider_for_summary ~runtime_id provider_cfg in
   let messages = messages_for_summary ~trace_id ~texts in
   let result, outcome =
     match
@@ -252,7 +257,7 @@ let summarize_with_providers
     ?complete
     ?clock
     ?timeout_sec
-    ?(runtime_id = "")
+    ~runtime_id
     ~sw
     ~net
     ~providers

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -15,7 +15,11 @@ val is_direct_completion_provider :
   Llm_provider.Provider_config.t -> bool
 
 val provider_for_summary :
-  Llm_provider.Provider_config.t -> Llm_provider.Provider_config.t
+  runtime_id:string ->
+  Llm_provider.Provider_config.t ->
+  Llm_provider.Provider_config.t
+(** Tune the summary request while preserving a temperature declared by the
+    selected runtime model; otherwise use the deterministic subsystem fallback. *)
 
 val summary_schema_supported : Llm_provider.Provider_config.t -> bool
 
@@ -44,7 +48,7 @@ module For_testing : sig
     ?complete:complete_fn ->
     ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
     ?timeout_sec:float ->
-    ?runtime_id:string ->
+    runtime_id:string ->
     sw:Eio.Switch.t ->
     net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
     provider_cfg:Llm_provider.Provider_config.t ->

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -72,16 +72,21 @@ let with_facts_lock ?clock ~keeper_id f =
     f
 ;;
 
-let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_consolidation ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some n
     | Some _ | None -> Some consolidation_max_tokens
   in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
+  in
   let tuned_cfg =
     { provider_cfg with
       Llm_provider.Provider_config.max_tokens
-    ; temperature = Some 0.0
+    ; temperature = Some temperature
     ; tool_choice = None
     ; disable_parallel_tool_use = true
     }
@@ -91,6 +96,10 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
     Keeper_structured_output_schema.consolidation_plan_output_schema
     tuned_cfg
 ;;
+
+module For_testing = struct
+  let provider_for_consolidation = provider_for_consolidation
+end
 
 let validate_provider_for_consolidation provider_cfg =
   Llm_provider.Provider_config.validate_output_schema_request provider_cfg
@@ -146,6 +155,7 @@ let consolidate_keeper
       ?(dry_run = false)
       ~sw
       ~net
+      ~runtime_id
       ~provider_cfg
       ~now
       ~keeper_id
@@ -161,7 +171,7 @@ let consolidate_keeper
       match messages_for_consolidation facts with
       | Error msg -> Unparseable msg
       | Ok messages ->
-        let config = provider_for_consolidation provider_cfg in
+        let config = provider_for_consolidation ~runtime_id provider_cfg in
         (match validate_provider_for_consolidation config with
          | Error msg -> Transport_failed ("consolidation provider config rejected: " ^ msg)
          | Ok () ->

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -25,13 +25,21 @@ type outcome =
       ; after : int
       }
 
+module For_testing : sig
+  val provider_for_consolidation
+    :  runtime_id:string
+    -> Llm_provider.Provider_config.t
+    -> Llm_provider.Provider_config.t
+end
+
 (** Read [keeper_id]'s facts, ask the model for a consolidation plan, apply it,
     and (unless [dry_run]) rewrite the store atomically only if the fact snapshot
     still matches the model's input. Below a minimum fact count it skips the LLM
     call. Returns the outcome without raising for the expected failure modes so a
     caller fiber stays alive. If [timeout_sec] is configured but no [clock] is
     available, the provider call is refused as [Transport_failed _] rather than
-    running without a deadline. *)
+    running without a deadline. [runtime_id] remains paired with [provider_cfg]
+    so model-level temperature declarations survive request tuning. *)
 val consolidate_keeper
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
@@ -39,6 +47,7 @@ val consolidate_keeper
   -> ?dry_run:bool
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> runtime_id:string
   -> provider_cfg:Llm_provider.Provider_config.t
   -> now:float
   -> keeper_id:string

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -126,12 +126,15 @@ let prepare_run_context
   in
   let profile_defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
   (* 0. Resolve inference parameters via Runtime_inference *)
-  let temperature =
+  let fallback_temperature () =
     match temperature with
-    | Some t -> t
-    | None ->
-      Runtime_inference.resolve_temperature
-        ~runtime_id ~fallback:(fun () -> 0.3)
+    | Some value -> value
+    | None -> Keeper_config.keeper_unified_temperature ()
+  in
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:fallback_temperature
   in
   let max_tokens =
     resolve_max_tokens_for_runtime_with_profile

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -61,3 +61,5 @@ val prepare_run_context :
   -> generation:int
   -> unit
   -> run_context
+(** Resolve [temperature] as the caller fallback; a temperature declared by the
+    selected runtime model always wins. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -297,7 +297,8 @@ let first_runtime_after_modality_reroute ~keeper_name ~assignment_id
        to_runtime_id, rerouted)
 
 type attempt_inference_policy =
-  { attempt_enable_thinking : bool option
+  { attempt_temperature : float
+  ; attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
   ; attempt_max_tokens : int
   }
@@ -305,11 +306,17 @@ type attempt_inference_policy =
 let attempt_inference_policy
     ?max_tokens_for_runtime
     ~runtime_id
+    ~fallback_temperature
     ~fallback_enable_thinking
     ~fallback_max_tokens
     ()
   =
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
+  let attempt_temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> fallback_temperature)
+  in
   let attempt_enable_thinking =
     match runtime_seed.thinking_enabled with
     | Some _ as enabled -> enabled
@@ -320,7 +327,8 @@ let attempt_inference_policy
     | Some resolver -> resolver ~runtime_id
     | None -> fallback_max_tokens
   in
-  { attempt_enable_thinking
+  { attempt_temperature
+  ; attempt_enable_thinking
   ; attempt_preserve_thinking = runtime_seed.preserve_thinking
   ; attempt_max_tokens
   }
@@ -618,6 +626,7 @@ let run_named
         attempt_inference_policy
           ?max_tokens_for_runtime
           ~runtime_id:attempt_runtime_id
+          ~fallback_temperature:temperature
           ~fallback_enable_thinking:enable_thinking
           ~fallback_max_tokens:max_tokens
           ()
@@ -677,7 +686,7 @@ let run_named
             ; stream_idle_timeout_s
             ; execution_idle_timeout_s
             ; body_timeout_s
-            ; temperature
+            ; temperature = inference_policy.attempt_temperature
             ; max_tokens = inference_policy.attempt_max_tokens
             ; accept
             ; guardrails

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -159,11 +159,13 @@ val run_named :
   (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
 (** Run a single [Agent.run] call with MASC-driven runtime model fallback.
     MASC drives the runtime FSM directly: resolves runtime providers,
-    tries each with OAS, and uses [Runtime_fsm.decide] on failure.
+    resolves each candidate's model temperature before trying it with OAS, and
+    uses [Runtime_fsm.decide] on failure.
     The runtime loop runs inside a capacity-managed queue permit. *)
 
 type attempt_inference_policy =
-  { attempt_enable_thinking : bool option
+  { attempt_temperature : float
+  ; attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
   ; attempt_max_tokens : int
   }
@@ -243,6 +245,7 @@ module For_testing : sig
   val attempt_inference_policy :
     ?max_tokens_for_runtime:(runtime_id:string -> int) ->
     runtime_id:string ->
+    fallback_temperature:float ->
     fallback_enable_thinking:bool option ->
     fallback_max_tokens:int ->
     unit ->

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -59,13 +59,18 @@ let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
   | Agent_sdk.Types.UnmatchedToolCalls
   | Agent_sdk.Types.Unknown _ -> false
 
-let provider_for_vision (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_vision ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
+  let temperature =
+    Runtime_inference.resolve_temperature
+      ~runtime_id
+      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
+  in
   { provider_cfg with
     max_tokens =
       (match provider_cfg.max_tokens with
        | Some _ as configured -> configured
        | None -> Some vision_default_max_tokens)
-  ; temperature = Some 0.0
+  ; temperature = Some temperature
   ; tool_choice = None
   ; disable_parallel_tool_use = true
   ; enable_thinking = Some false
@@ -401,7 +406,7 @@ let run_candidates
          in
          loop ~last_error ~attempt_index []
        | Some timeout_sec ->
-         let config = provider_for_vision rt.Runtime.provider_config in
+         let config = provider_for_vision ~runtime_id rt.Runtime.provider_config in
          (match
             with_timeout ~clock ~timeout_sec (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())
@@ -487,7 +492,7 @@ let run_candidates_outcome
          in
          loop ~last_error ~attempt_index []
        | Some timeout_sec ->
-         let config = provider_for_vision rt.Runtime.provider_config in
+         let config = provider_for_vision ~runtime_id rt.Runtime.provider_config in
          (match
             with_timeout ~clock ~timeout_sec (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -59,13 +59,15 @@ val message_of_request
     [data:<media_type>;base64,<data>]). *)
 
 val provider_for_vision
-  :  Llm_provider.Provider_config.t
+  :  runtime_id:string
+  -> Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
 (** A one-shot, non-thinking, structured-output vision config: thinking off (avoids the
     2026-06-25 gemma4 thinking-budget exhaustion that produced empty replies),
     [response_format = JsonSchema _], [output_schema = Some _],
-    [tool_choice = None], [temperature = 0], and a fallback [max_tokens] only
-    when the selected runtime has not configured one. *)
+    [tool_choice = None], the selected runtime's declared temperature (or the
+    deterministic subsystem fallback), and a fallback [max_tokens] only when
+    the selected runtime has not configured one. *)
 
 val vision_runtime_ids : unit -> string list
 (** Ordered schema-capable image runtime ids: [\[runtime\].media_failover] order

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -1,9 +1,9 @@
 (* Per-runtime sampling temperature. A model may declare a fixed [temperature]
    in runtime.toml ([models.<id>.temperature], read via
    [Runtime.temperature_of_runtime_id]); when set, that value is the request
-   temperature for every turn on the model. Otherwise the caller [fallback]
-   ([Keeper_config.keeper_unified_temperature], i.e. [MASC_KEEPER_UNIFIED_TEMP])
-   stands.
+   temperature at every inference boundary for the model. Otherwise the caller's
+   subsystem fallback stands (keeper turn, deterministic compaction, or HITL
+   summary policy).
 
    Completes the previously stubbed per-runtime [resolve_temperature] (the
    [~runtime_id:_] passthrough), symmetric to [resolve_max_tokens]. Required for

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -1,5 +1,7 @@
 val resolve_temperature :
   runtime_id:string -> fallback:(unit -> float) -> float
+(** Use the runtime.toml model override when present; evaluate [fallback] only
+    when that runtime has no temperature override. *)
 
 val resolve_max_tokens :
   runtime_id:string -> fallback:(unit -> int) -> int

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -45,32 +45,30 @@ let wake_enqueue_counts_of_dispatches dispatches =
     dispatches
 ;;
 
-(* Resolve the provider config for the Memory OS per-keeper consolidation pass.
+(* Resolve the runtime for the Memory OS per-keeper consolidation pass, keeping
+   its identity paired with the provider config through the inference boundary.
    Env var takes precedence; otherwise inherit the librarian runtime so the
    consolidation LLM uses the same JSON-capable model the librarian uses.
    An explicit but unknown runtime ID is logged and falls back to the default
    so typos in operator config are not silently masked. *)
-let provider_cfg_for_memory_os_consolidation () =
-  let default_cfg () =
-    Runtime.get_default_runtime ()
-    |> Option.map (fun rt -> rt.Runtime.provider_config)
-  in
+let runtime_for_memory_os_consolidation () =
+  let default_runtime () = Runtime.get_default_runtime () in
   let runtime_id =
     match Env_config.KeeperMemoryOs.consolidation_runtime_id () with
     | Some id -> Some id
     | None -> Runtime.librarian_runtime_id ()
   in
   match runtime_id with
-  | None -> default_cfg ()
+  | None -> default_runtime ()
   | Some id ->
     (match Runtime.get_runtime_by_id id with
-     | Some rt -> Some rt.Runtime.provider_config
+     | Some rt -> Some rt
      | None ->
        Log.Server.warn
          "memory_os_keeper_consolidation: requested runtime %s not found; \
           falling back to default"
          id;
-       default_cfg ())
+       default_runtime ())
 ;;
 
 (* P0-3: per-keeper maintenance timeout. One slow/corrupt keeper must not starve
@@ -100,6 +98,7 @@ let run_memory_os_consolidation_tick
       ~sw
       ~net
       ?clock
+      ~runtime_id
       ~provider_cfg
       ~now
       ()
@@ -113,6 +112,7 @@ let run_memory_os_consolidation_tick
           ~sw
           ~net
           ?clock
+          ~runtime_id
           ~provider_cfg
           ~now
           ~keeper_id
@@ -401,16 +401,17 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
            so a 10-minute cadence bounds cost while still shrinking stores. *)
         let interval = 600.0 in
         let rec loop () =
-          (match provider_cfg_for_memory_os_consolidation () with
+          (match runtime_for_memory_os_consolidation () with
            | None ->
              Log.Server.warn
                "memory_os_keeper_consolidation: no runtime configured; skipping tick"
-           | Some provider_cfg ->
+           | Some runtime ->
              run_memory_os_consolidation_tick
                ~sw
                ~net:env#net
                ~clock
-               ~provider_cfg
+               ~runtime_id:runtime.Runtime.id
+               ~provider_cfg:runtime.Runtime.provider_config
                ~now:(Time_compat.now ())
                ());
           Eio.Time.sleep clock interval;

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -2,8 +2,9 @@ val fork_logged_fiber :
   sw:Eio.Switch.t -> on_error:(exn -> unit) -> (unit -> unit) -> unit
 val log_server_fiber_crash : string -> exn -> unit
 
-val provider_cfg_for_memory_os_consolidation :
-  unit -> Llm_provider.Provider_config.t option
+val runtime_for_memory_os_consolidation : unit -> Runtime.t option
+(** Resolve the selected consolidation runtime without discarding its identity;
+    an unknown explicit selection is logged before falling back to the default. *)
 
 val run_memory_os_consolidation_tick :
   ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
@@ -11,6 +12,7 @@ val run_memory_os_consolidation_tick :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  runtime_id:string ->
   provider_cfg:Llm_provider.Provider_config.t ->
   now:float ->
   unit ->

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -20,6 +20,57 @@ let plan_json ~summary ~kept ~summarized ~dropped : Yojson.Safe.t =
 let is_ok = function Ok _ -> true | Error _ -> false
 let is_error = function Ok _ -> false | Error _ -> true
 
+let temperature_runtime_id = "local.kimi_like"
+
+let temperature_runtime_toml =
+  "[providers.local]\n\
+   display-name = \"Local\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [models.kimi_like]\n\
+   api-name = \"kimi-like\"\n\
+   max-context = 1024\n\
+   temperature = 1.0\n\
+   \n\
+   [models.kimi_like.capabilities]\n\
+   supports-structured-output = true\n\
+   \n\
+   [local.kimi_like]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.kimi_like\"\n\
+   librarian = \"local.kimi_like\"\n"
+
+let with_temperature_runtime f =
+  let path = Filename.temp_file "compaction_temperature_runtime" ".toml" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  let oc = open_out path in
+  output_string oc temperature_runtime_toml;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+      match Runtime.save_config_text ~runtime_config_path:path temperature_runtime_toml with
+      | Error detail -> Alcotest.failf "runtime config should load: %s" detail
+      | Ok () ->
+        (match Runtime.get_runtime_by_id temperature_runtime_id with
+         | None -> Alcotest.fail "temperature runtime should resolve"
+         | Some runtime -> f runtime.Runtime.provider_config))
+
+let test_provider_for_plan_preserves_runtime_temperature () =
+  with_temperature_runtime (fun provider_cfg ->
+    let cfg =
+      C.For_testing.provider_for_plan ~runtime_id:temperature_runtime_id provider_cfg
+    in
+    Alcotest.(check (option (float 0.0001)))
+      "runtime.toml temperature overrides deterministic compaction fallback"
+      (Some 1.0)
+      cfg.temperature)
+
 (* -- plan_of_json: valid partition accepted -- *)
 
 let test_valid_partition_accepted () =
@@ -154,7 +205,11 @@ let test_apply_all_kept_is_identity () =
 
 let () =
   Alcotest.run "compaction_llm_summarizer"
-    [ ( "plan_of_json"
+    [ ( "provider"
+      , [ Alcotest.test_case "runtime temperature is authoritative" `Quick
+            test_provider_for_plan_preserves_runtime_temperature
+        ] )
+    ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
         ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
         ; Alcotest.test_case "drop-only with kept accepted" `Quick

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -241,7 +241,8 @@ let test_spawn_no_provider_config_uses_fallback_summary () =
       ignore reason;
       ignore retryable
     in
-    H.spawn ~sw ~entry:(dummy_pending_approval ()) ?provider_config:None
+    H.spawn ~sw ~runtime_id:"unconfigured" ~entry:(dummy_pending_approval ())
+      ?provider_config:None
       ~on_summary ~on_failure ();
     check bool "on_failure not called" false !failure_called;
     match !summary_ref with
@@ -343,7 +344,7 @@ let test_build_context_bundle_with_real_workspace () =
 
 (* ── Provider cost/token guard tests ────────────── *)
 
-let test_provider_config_for_summary_caps_tokens_and_temperature () =
+let test_provider_config_for_summary_caps_tokens_and_uses_fallback_temperature () =
   let provider_cfg : Llm_provider.Provider_config.t =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.OpenAI_compat
@@ -356,12 +357,14 @@ let test_provider_config_for_summary_caps_tokens_and_temperature () =
       ~response_format:Llm_provider.Types.JsonMode
       ()
   in
-  let cfg, mode = H.For_testing.provider_config_for_summary provider_cfg in
+  let cfg, mode =
+    H.For_testing.provider_config_for_summary ~runtime_id:"unconfigured" provider_cfg
+  in
   check bool "max_tokens capped to policy" true
     (match cfg.max_tokens with
      | Some n -> n <= Keeper_config.hitl_summary_max_tokens ()
      | None -> false);
-  check (option (float 0.0001)) "temperature set to policy"
+  check (option (float 0.0001)) "unconfigured runtime uses subsystem fallback"
     (Some (Keeper_config.hitl_summary_temperature ())) cfg.temperature;
   check bool "tool_choice cleared" true (Option.is_none cfg.tool_choice);
   check bool "disable_parallel_tool_use true" true cfg.disable_parallel_tool_use;
@@ -560,8 +563,8 @@ let () =
             test_build_context_bundle_includes_ids_and_partial_context
         ; test_case "build_context_bundle with real workspace is not partial" `Quick
             test_build_context_bundle_with_real_workspace
-        ; test_case "provider_config_for_summary caps tokens and temperature" `Quick
-            test_provider_config_for_summary_caps_tokens_and_temperature
+        ; test_case "provider_config_for_summary uses fallback without runtime override" `Quick
+            test_provider_config_for_summary_caps_tokens_and_uses_fallback_temperature
         ] )
     ; ( "graceful_degradation"
       , [ test_case "extract_json_object handles bare/fenced/prose/invalid" `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -8,6 +8,7 @@
 
 module AQ = Masc.Keeper_approval_queue
 module Chat_queue = Masc.Keeper_chat_queue
+module Summary_worker = Masc.Hitl_summary_worker
 
 let install_noop_resolution_delivery_hook () =
   AQ.set_approval_resolution_wake_hook
@@ -77,21 +78,22 @@ let summary_routing_runtime_toml ~with_hitl_summary =
      [models.judge.capabilities]\n\
      supports-structured-output = true\n\
      \n\
-     [models.summary]\n\
-     api-name = \"summary\"\n\
+     [models.kimi_like]\n\
+     api-name = \"kimi-like-summary\"\n\
      max-context = 1024\n\
+     temperature = 1.0\n\
      \n\
      [local.chat]\n\
      \n\
      [local.judge]\n\
      \n\
-     [local.summary]\n\
+     [local.kimi_like]\n\
      \n\
      [runtime]\n\
      default = \"local.chat\"\n\
      structured_judge = \"local.judge\"\n"
   in
-  if with_hitl_summary then base ^ "hitl_summary = \"local.summary\"\n" else base
+  if with_hitl_summary then base ^ "hitl_summary = \"local.kimi_like\"\n" else base
 ;;
 
 (* Proves the HITL summary worker consumes the [runtime].hitl_summary lane
@@ -103,22 +105,43 @@ let test_provider_config_for_summary_routes_hitl_summary_lane () =
     with_temp_runtime_toml text (fun path ->
       match Runtime.save_config_text ~runtime_config_path:path text with
       | Error msg -> Alcotest.failf "runtime config should load: %s" msg
-      | Ok () -> AQ.provider_config_for_summary ~keeper_name:"no-such-keeper")
+      | Ok () ->
+        (match AQ.provider_config_for_summary ~keeper_name:"no-such-keeper" with
+         | None -> None
+         | Some selected ->
+           let worker_cfg, _mode =
+             Summary_worker.For_testing.provider_config_for_summary
+               ~runtime_id:selected.runtime_id
+               selected.provider_config
+           in
+           Some (selected, worker_cfg)))
   in
   (match load_and_resolve ~with_hitl_summary:true with
    | None -> Alcotest.fail "expected a provider config for the hitl_summary lane"
-   | Some cfg ->
+   | Some (selected, worker_cfg) ->
+     Alcotest.(check string)
+       "hitl_summary runtime id is preserved"
+       "local.kimi_like"
+       selected.runtime_id;
      Alcotest.(check string)
        "hitl_summary lane model is used"
-       "summary"
-       cfg.Llm_provider.Provider_config.model_id);
+       "kimi-like-summary"
+       selected.provider_config.Llm_provider.Provider_config.model_id;
+     Alcotest.(check (option (float 0.0001)))
+       "HITL worker preserves runtime.toml temperature"
+       (Some 1.0)
+       worker_cfg.temperature);
   match load_and_resolve ~with_hitl_summary:false with
   | None -> Alcotest.fail "expected structured_judge fallback config"
-  | Some cfg ->
+  | Some (selected, _worker_cfg) ->
+    Alcotest.(check string)
+      "structured_judge fallback runtime id is preserved"
+      "local.judge"
+      selected.runtime_id;
     Alcotest.(check string)
       "structured_judge fallback model is used"
       "judge"
-      cfg.Llm_provider.Provider_config.model_id
+      selected.provider_config.Llm_provider.Provider_config.model_id
 ;;
 
 let pending_id_for_keeper ~keeper_name =
@@ -1095,7 +1118,7 @@ let () =
         ] )
     ; ( "summary"
       , [ Alcotest.test_case
-            "provider_config_for_summary routes the hitl_summary lane"
+            "provider_config_for_summary preserves HITL runtime identity and temperature"
             `Quick
             test_provider_config_for_summary_routes_hitl_summary_lane
         ; Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -8,6 +8,7 @@ module Librarian = Masc.Keeper_librarian
 module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Runtime_resolution = Masc.Keeper_memory_runtime_resolution
 module Memory_summary = Masc.Keeper_memory_llm_summary
+module Consolidation_runtime = Masc.Keeper_memory_os_consolidation_runtime
 module Structured_schema = Masc.Keeper_structured_output_schema
 (* Domain_pool_ref lives in the unwrapped masc_core sublibrary (re_export'd by
    masc_test_deps), so it is referenced bare — there is no Masc.Domain_pool_ref. *)
@@ -18,6 +19,8 @@ module Consolidator = Masc.Keeper_memory_os_consolidator
 module Metrics = Masc.Otel_metric_store
 module Runtime_manifest = Masc.Keeper_runtime_manifest
 module Keeper_user_model = Masc.Keeper_user_model
+
+let unconfigured_runtime_id = "test.unconfigured"
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
@@ -780,6 +783,7 @@ endpoint = "https://p0.example/v1"
 [models.default]
 api-name = "default"
 max-context = 4096
+temperature = 1.0
 
 [p0.default]
 |}
@@ -811,7 +815,41 @@ let test_librarian_provider_for_runtime_errors_on_missing_id () =
       Alcotest.(check bool)
         "error names missing runtime"
         true
-        (contains "missing.runtime" msg))
+      (contains "missing.runtime" msg))
+;;
+
+let test_memory_provider_configs_use_runtime_temperature () =
+  with_runtime_config_toml memory_runtime_resolution_toml (fun () ->
+    match Runtime.get_default_runtime () with
+    | None -> Alcotest.fail "default memory runtime should resolve"
+    | Some runtime ->
+      let summary =
+        Memory_summary.provider_for_summary
+          ~runtime_id:runtime.Runtime.id
+          runtime.Runtime.provider_config
+      in
+      let librarian =
+        Librarian_runtime.provider_for_librarian
+          ~runtime_id:runtime.Runtime.id
+          runtime.Runtime.provider_config
+      in
+      let consolidation =
+        Consolidation_runtime.For_testing.provider_for_consolidation
+          ~runtime_id:runtime.Runtime.id
+          runtime.Runtime.provider_config
+      in
+      Alcotest.(check (option (float 0.0001)))
+        "memory summary keeps runtime.toml temperature"
+        (Some 1.0)
+        summary.temperature;
+      Alcotest.(check (option (float 0.0001)))
+        "librarian keeps runtime.toml temperature"
+        (Some 1.0)
+        librarian.temperature;
+      Alcotest.(check (option (float 0.0001)))
+        "memory consolidation keeps runtime.toml temperature"
+        (Some 1.0)
+        consolidation.temperature)
 ;;
 
 let with_memory_os_env name value f =
@@ -1137,7 +1175,9 @@ let test_librarian_max_tokens_override_env () =
      before the knob was wired to a reader, setting the env var was a silent
      no-op while the config snapshot reported source=env. *)
   let effective_cap () =
-    (Librarian_runtime.provider_for_librarian (test_provider_cfg ()))
+    (Librarian_runtime.provider_for_librarian
+       ~runtime_id:unconfigured_runtime_id
+       (test_provider_cfg ()))
       .Llm_provider.Provider_config.max_tokens
   in
   Fun.protect
@@ -1332,7 +1372,11 @@ let test_librarian_rejects_invalid_claims () =
 ;;
 
 let test_memory_llm_summary_provider_requests_json_schema () =
-  let provider_cfg = Memory_summary.provider_for_summary (test_provider_cfg ()) in
+  let provider_cfg =
+    Memory_summary.provider_for_summary
+      ~runtime_id:unconfigured_runtime_id
+      (test_provider_cfg ())
+  in
   let expected_schema = Structured_schema.memory_bank_summary_output_schema in
   Alcotest.(check (option int))
     "summary max tokens capped"
@@ -1492,6 +1536,7 @@ let test_librarian_runtime_appends_episode_bundle () =
              ~sw
              ~net
              ~keeper_id
+             ~runtime_id:unconfigured_runtime_id
              ~provider_cfg:(test_provider_cfg ())
              inp
          with
@@ -1584,6 +1629,7 @@ let test_librarian_runtime_falls_back_when_schema_unavailable () =
             ~timeout_sec:1.0
             ~sw
             ~net
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(invalid_schema_provider_cfg ())
             ~generation:1
             inp
@@ -1628,6 +1674,7 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
              ~sw
              ~net
              ~keeper_id
+             ~runtime_id:unconfigured_runtime_id
              ~provider_cfg:(test_provider_cfg ())
              inp
          with
@@ -1680,6 +1727,7 @@ let test_librarian_runtime_rejects_unstructured_fallback () =
             ~sw
             ~net
             ~keeper_id
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(test_provider_cfg ())
             inp
         in
@@ -1754,6 +1802,7 @@ let test_librarian_runtime_rejects_unparseable_output_across_empty_retries () =
             ~sw
             ~net
             ~keeper_id
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(test_provider_cfg ())
             inp
         with
@@ -1817,6 +1866,7 @@ let test_librarian_unstructured_fallback_does_not_write_facts () =
               ~sw
               ~net
               ~keeper_id
+              ~runtime_id:unconfigured_runtime_id
               ~provider_cfg:(test_provider_cfg ())
               inp
           with
@@ -1872,6 +1922,7 @@ let test_librarian_runtime_reports_fact_upsert_failure () =
             ~sw
             ~net
             ~keeper_id
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(test_provider_cfg ())
             inp
         with
@@ -5808,6 +5859,10 @@ let () =
             "librarian provider resolution rejects missing runtime id"
             `Quick
             test_librarian_provider_for_runtime_errors_on_missing_id
+        ; Alcotest.test_case
+            "memory provider configs use runtime temperature"
+            `Quick
+            test_memory_provider_configs_use_runtime_temperature
         ; Alcotest.test_case
             "memory os bool env accepts enabled disabled"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -10,6 +10,7 @@ module Agent_sdk_response = Masc.Agent_sdk_response
 module Atypes = Agent_sdk.Types
 
 let now = 1_000_000.0
+let unconfigured_runtime_id = "test.unconfigured"
 
 let contains substring s =
   let sub_len = String.length substring in
@@ -125,6 +126,7 @@ let test_consolidate_applies_plan () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -160,6 +162,7 @@ let test_consolidate_skips_too_few () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -190,6 +193,7 @@ let test_consolidate_dry_run_preserves_store () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -231,6 +235,7 @@ let test_consolidate_rejects_stale_snapshot () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -279,6 +284,7 @@ let test_consolidate_rejects_malformed_fact_store () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -308,6 +314,7 @@ let test_consolidate_classifies_empty_provider_response () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -333,6 +340,7 @@ let test_consolidate_classifies_invalid_structured_response () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -376,6 +384,7 @@ let test_consolidate_requires_clock_before_provider_call () =
             ~timeout_sec:1.0
             ~sw
             ~net:(Eio.Stdenv.net env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ~keeper_id
@@ -440,6 +449,7 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ~max_tokens:512 ())
             ~now
             ~keeper_id

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -145,6 +145,7 @@ endpoint = "http://127.0.0.1:2"
 [models.reasoning_big]
 api-name = "reasoning-big-out"
 max-context = 1000000
+temperature = 1.0
 tools-support = true
 thinking-support = true
 preserve-thinking = true
@@ -360,6 +361,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       Driver.For_testing.attempt_inference_policy
         ~max_tokens_for_runtime
         ~runtime_id:"mixed"
+        ~fallback_temperature:0.25
         ~fallback_enable_thinking:None
         ~fallback_max_tokens:8192
         ()
@@ -368,6 +370,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "lane id has no runtime thinking policy"
       None
       lane_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (float 0.0001))
+      "lane id keeps caller temperature fallback"
+      0.25
+      lane_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "lane id has no preserve thinking policy"
       None
@@ -380,6 +386,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       Driver.For_testing.attempt_inference_policy
         ~max_tokens_for_runtime
         ~runtime_id:"thinking.reasoning_big"
+        ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some false)
         ~fallback_max_tokens:8192
         ()
@@ -388,6 +395,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "thinking candidate enables thinking"
       (Some true)
       thinking_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (float 0.0001))
+      "thinking candidate uses runtime temperature"
+      1.0
+      thinking_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "thinking candidate preserves thinking when configured"
       (Some true)
@@ -400,6 +411,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       Driver.For_testing.attempt_inference_policy
         ~max_tokens_for_runtime
         ~runtime_id:"plain.non_reasoning"
+        ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some true)
         ~fallback_max_tokens:8192
         ()
@@ -408,6 +420,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "non-thinking candidate forces thinking off"
       (Some false)
       non_thinking_policy.Driver.attempt_enable_thinking;
+    Alcotest.(check (float 0.0001))
+      "plain candidate keeps caller temperature fallback"
+      0.25
+      non_thinking_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "non-thinking candidate disables preserve thinking"
       (Some false)

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -1132,13 +1132,13 @@ let () =
   test_unknown_magic_bytes_are_policy_rejection ();
   test_oversize_image_is_runtime_failure_before_provider_call ();
   test_temp_runtime_toml_restores_runtime_cache ();
-  test_provider_for_vision_uses_runtime_temperature ();
   test_schema_unsupported_vision_runtime_is_skipped_before_provider_call ();
   (* These tests drive the synthetic ollama vision runtimes past the
      schema-capability gate to the provider sub-call, so they need an installed
-     model catalog that advertises supports_structured_output (see
+  model catalog that advertises supports_structured_output (see
      [with_vision_model_catalog]). *)
   with_vision_model_catalog (fun () ->
+    test_provider_for_vision_uses_runtime_temperature ();
     test_invalid_structured_vision_response_is_runtime_failure ();
     test_run_vision_invalid_structured_response_is_typed ();
     test_retryable_provider_error_tries_next_runtime ();

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -244,9 +244,17 @@ let test_provider_for_vision_preserves_configured_max_tokens () =
       ~base_url:"http://example.invalid"
       ()
   in
-  let configured = Vt.provider_for_vision { base with max_tokens = Some 4096 } in
+  let configured =
+    Vt.provider_for_vision
+      ~runtime_id:"test.unconfigured"
+      { base with max_tokens = Some 4096 }
+  in
   assert (configured.max_tokens = Some 4096);
-  let fallback = Vt.provider_for_vision { base with max_tokens = None } in
+  let fallback =
+    Vt.provider_for_vision
+      ~runtime_id:"test.unconfigured"
+      { base with max_tokens = None }
+  in
   assert (fallback.max_tokens = Some Vt.vision_default_max_tokens);
   let expected_schema = Structured_schema.vision_analyze_output_schema in
   (match configured.response_format with
@@ -602,6 +610,7 @@ endpoint = "https://p3.example/v1"
 [models.vision-c]
 api-name = "vision-c"
 max-context = 4096
+temperature = 1.0
 
 [models.vision-c.capabilities]
 supports-image-input = true
@@ -610,6 +619,19 @@ supports-structured-output = true
 
 [p3.vision-c]
 |}
+
+let test_provider_for_vision_uses_runtime_temperature () =
+  with_temp_runtime_toml single_vision_runtime_toml (fun () ->
+    match Vt.first_vision_runtime_id () with
+    | Error msg -> failwith ("expected configured vision runtime: " ^ msg)
+    | Ok runtime_id ->
+      (match Runtime.get_runtime_by_id runtime_id with
+       | None -> failwith "selected vision runtime should resolve"
+       | Some runtime ->
+         let configured =
+           Vt.provider_for_vision ~runtime_id runtime.Runtime.provider_config
+         in
+         assert (configured.temperature = Some 1.0)))
 
 let schema_unsupported_vision_runtime_toml =
   {|
@@ -1110,6 +1132,7 @@ let () =
   test_unknown_magic_bytes_are_policy_rejection ();
   test_oversize_image_is_runtime_failure_before_provider_call ();
   test_temp_runtime_toml_restores_runtime_cache ();
+  test_provider_for_vision_uses_runtime_temperature ();
   test_schema_unsupported_vision_runtime_is_skipped_before_provider_call ();
   (* These tests drive the synthetic ollama vision runtimes past the
      schema-capability gate to the provider sub-call, so they need an installed

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -19,6 +19,7 @@ let message_text (m : Atypes.message) =
   |> String.concat "\n"
 
 let now = 1_000_000.0
+let unconfigured_runtime_id = "test.unconfigured"
 
 let fact claim =
   { Types.claim
@@ -104,6 +105,7 @@ let test_accumulate_consolidate_recall () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();
@@ -149,6 +151,7 @@ let test_skips_when_too_few () =
             ~complete:(fake_complete "{\"groups\":[],\"drop_indices\":[]}")
             ~sw
             ~net:(Eio.Stdenv.net env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();
@@ -190,6 +193,7 @@ let test_parallel_timeout_per_keeper () =
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();


### PR DESCRIPTION
Fixes #23970.

## Root cause

선택된 runtime의 모델 temperature 계약이 여러 inference 경계에서 사라졌습니다.

- compaction/HITL 경계가 runtime id를 잃거나 subsystem 기본값으로 덮음
- vision, Memory OS consolidation/summary/librarian provider tuning이 `0.0`을 강제함
- 공통 lane failover driver가 최초 caller temperature를 모든 candidate에 재사용함
- direct Keeper run은 caller temperature를 모델 선언보다 우선함

Kimi-like 모델처럼 특정 temperature만 허용하는 runtime은 올바른 모델을 선택하고도 요청 단계에서 실패할 수 있었습니다.

## What changed

- `Runtime_inference.resolve_temperature`를 runtime.toml 모델 선언의 SSOT로 사용
- caller/subsystem temperature는 모델 선언이 없을 때만 fallback으로 사용
- vision 및 Memory OS 저수준 API에 `runtime_id`를 필수로 전달해 정체성 누락을 타입으로 차단
- consolidation scheduler가 provider config만 투영하지 않고 선택된 `Runtime.t`를 유지
- lane의 각 candidate attempt마다 temperature/thinking/max-token policy를 함께 재해석
- direct Keeper run에도 같은 우선순위 적용
- runtime temperature `1.0` fixture로 vision, memory producers, candidate failover 회귀 검증 추가

Provider/model 문자열 분기는 추가하지 않았습니다.

## Current-head correction

초기 CI에서 새 vision temperature 검증이 실패한 직접 원인은 production selector가 아니라 테스트 fixture 경계였습니다. Vision runtime 후보 선택은 OAS `Model_catalog`의 structured-output capability를 SSOT로 사용합니다. 새 테스트만 기존 `with_vision_model_catalog` 밖에서 실행되어 후보가 capability gate에서 제거됐고, temperature assertion에는 도달하지 못했습니다.

- 새 검증을 기존 catalog fixture 경계 안으로 이동
- production code와 capability gate는 변경하지 않음
- runtime.toml capability를 별도 SSOT로 만들거나 오류를 catch하는 우회 없음

## Validation

- `scripts/dune-local.sh build @test/runtest-test_keeper_vision_tool`: pass (`all assertions passed`)
- changed OCaml parser check: pass
- `ocamlformat --check`: pass
- `git diff --check`: pass
- determinism contract: pass (기존 warning만 존재)
- keeper hardcoding/provider-name/silent-failure/MASC-to-OAS boundary checks: pass
- full build/test authority: exact-head PR CI

## Related PR radius

- #23971도 `keeper_librarian_runtime.ml`을 수정하므로 먼저 병합되는 쪽 이후에 나머지 PR을 rebase해야 합니다.
- current main의 별도 baseline quick-suite 실패군은 이 PR의 source-specific vision fixture 실패와 분리 판정합니다.

## Merge gate

새 exact-head CI가 terminal green이고 current-head review가 끝날 때까지 Draft / `p1` / `status:do-not-merge` 유지.

[근거] `git diff 86ca4b9c80...b00ea1f6fe`, focused test command, GitHub exact-head CI를 2026-07-10 20:17 KST에 확인; 신뢰도 High.
