### PR TITLE
test(activity): restore dedicated feed regression coverage (#23960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Removed
+- Removed the unused permissive `Activity_feed` JSON decoder surface; the live activity API remains encode-only and its filesystem aggregation, ordering, limit, and agent-filter contracts now have dedicated regression coverage (#23960).
+
 ### Fixed
 - Prompt overrides now persist in a schema-versioned envelope bound to the SHA256 revision of each prompt body and template-variable contract. Legacy or malformed files and contract-drifted entries fail closed with observable fallback, writes use atomic replacement, and dashboard set/clear mutations commit to memory only after persistence succeeds.
 

--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -15,29 +15,17 @@
 
 type activity_item = {
   id: string;
-  kind: string; [@default ""]
-  agent_name: string; [@default ""]
-  summary: string; [@default ""]
-  detail_json: Yojson.Safe.t; [@default `Null]
-  created_at: float; [@default 0.0]
-} [@@deriving yojson { strict = false }]
+  kind: string;
+  agent_name: string;
+  summary: string;
+  detail_json: Yojson.Safe.t;
+  created_at: float;
+} [@@deriving to_yojson]
 
-(** {1 JSON Serialization}
-
-    [activity_item_to_yojson] and [activity_item_of_yojson] are generated
-    by [ppx_deriving_yojson].  Legacy wrappers below keep the [option]
-    API for callers that haven't migrated to [result]. *)
+(** {1 JSON Serialization} *)
 
 let activity_item_to_json : activity_item -> Yojson.Safe.t =
   activity_item_to_yojson
-
-let activity_item_of_json (json : Yojson.Safe.t) : activity_item option =
-  match activity_item_of_yojson json with
-  | Ok item when item.id <> "" -> Some item
-  | Ok _ -> None
-  | Error msg ->
-    Log.Feed.warn "activity_item_of_json: %s" msg;
-    None
 
 (** {1 JSONL Helpers} *)
 

--- a/lib/activity_feed.mli
+++ b/lib/activity_feed.mli
@@ -19,16 +19,8 @@ type activity_item = {
 val activity_item_to_yojson : activity_item -> Yojson.Safe.t
 (** PPX-generated serializer. *)
 
-val activity_item_of_yojson :
-  Yojson.Safe.t -> (activity_item, string) result
-(** PPX-generated deserializer.  Returns [Error msg] on parse failure. *)
-
 val activity_item_to_json : activity_item -> Yojson.Safe.t
 (** Alias for {!activity_item_to_yojson}. *)
-
-val activity_item_of_json : Yojson.Safe.t -> activity_item option
-(** Wraps {!activity_item_of_yojson}. Returns None on parse failure
-    or when [id] is empty. *)
 
 val recent_activity :
   Workspace.config -> ?agent_name:string -> limit:int -> unit -> activity_item list

--- a/test/dune
+++ b/test/dune
@@ -1787,6 +1787,8 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_activity_feed.inc)
+
 (include stanzas/test_anti_rationalization_empty_reject.inc)
 
 (include stanzas/test_exec_policy_cwd_hint.inc)

--- a/test/stanzas/test_activity_feed.inc
+++ b/test/stanzas/test_activity_feed.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_activity_feed)
+ (modules test_activity_feed)
+ (libraries masc_test_deps))

--- a/test/test_activity_feed.ml
+++ b/test/test_activity_feed.ml
@@ -1,7 +1,7 @@
 open Alcotest
 open Masc
 
-let test_activity_item_roundtrip () =
+let test_activity_item_json_contract () =
   let item : Activity_feed.activity_item =
     { id = "act-001"
     ; kind = "task"
@@ -11,63 +11,20 @@ let test_activity_item_roundtrip () =
     ; created_at = 1_700_000_000.0
     }
   in
-  let json = Activity_feed.activity_item_to_json item in
-  match Activity_feed.activity_item_of_json json with
-  | Some decoded ->
-    check string "id" item.id decoded.id;
-    check string "kind" item.kind decoded.kind;
-    check string "agent" item.agent_name decoded.agent_name;
-    check string "summary" item.summary decoded.summary;
-    check bool "detail" true (Yojson.Safe.equal item.detail_json decoded.detail_json);
-    check (float 0.01) "created_at" item.created_at decoded.created_at
-  | None -> fail "roundtrip failed"
-;;
-
-let test_activity_item_empty_id () =
-  let json =
+  let expected =
     `Assoc
-      [ "id", `String ""
-      ; "kind", `String "task"
-      ; "agent_name", `String "a"
-      ; "summary", `String "s"
-      ; "created_at", `Float 1.0
+      [ "id", `String item.id
+      ; "kind", `String item.kind
+      ; "agent_name", `String item.agent_name
+      ; "summary", `String item.summary
+      ; "detail_json", item.detail_json
+      ; "created_at", `Float item.created_at
       ]
   in
-  check (option reject) "empty id" None (Activity_feed.activity_item_of_json json)
-;;
-
-let test_activity_item_missing_detail () =
-  let json =
-    `Assoc
-      [ "id", `String "x"
-      ; "kind", `String "task"
-      ; "agent_name", `String "a"
-      ; "summary", `String "s"
-      ; "created_at", `Float 1.0
-      ]
-  in
-  match Activity_feed.activity_item_of_json json with
-  | Some item -> check bool "detail defaults to null" true (item.detail_json = `Null)
-  | None -> fail "should parse without detail_json"
-;;
-
-let test_activity_item_malformed () =
-  check
-    (option reject)
-    "malformed"
-    None
-    (Activity_feed.activity_item_of_json (`String "not an object"))
-;;
-
-let test_activity_item_defaults () =
-  match Activity_feed.activity_item_of_json (`Assoc [ "id", `String "x" ]) with
-  | Some item ->
-    check string "kind default" "" item.kind;
-    check string "agent default" "" item.agent_name;
-    check string "summary default" "" item.summary;
-    check bool "detail default" true (item.detail_json = `Null);
-    check (float 0.01) "created_at default" 0.0 item.created_at
-  | None -> fail "should parse with defaults"
+  check bool
+    "activity API item wire shape"
+    true
+    (Yojson.Safe.equal expected (Activity_feed.activity_item_to_json item))
 ;;
 
 let rec remove_tree path =
@@ -82,9 +39,7 @@ let rec remove_tree path =
 ;;
 
 let with_temp_dir prefix f =
-  let path = Filename.temp_file prefix "" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
+  let path = Filename.temp_dir prefix "" in
   Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
 ;;
 
@@ -97,7 +52,7 @@ let latest_ring_seq () =
 ;;
 
 let feed_warnings_since seq =
-  Log.Ring.recent ~limit:50 ~module_filter:"Feed" ~since_seq:seq ()
+  Log.Ring.recent ~limit:Log.Ring.capacity ~module_filter:"Feed" ~since_seq:seq ()
   |> List.filter (fun (entry : Log.Ring.entry) -> entry.level = Log.Warn)
 ;;
 
@@ -229,34 +184,32 @@ let test_recent_activity_ignores_backlog_json_without_warning () =
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Eio_guard.enable ();
-  run
-    "activity_feed"
-    [ ( "activity_item"
-      , [ test_case "roundtrip" `Quick test_activity_item_roundtrip
-        ; test_case "empty id" `Quick test_activity_item_empty_id
-        ; test_case "missing detail" `Quick test_activity_item_missing_detail
-        ; test_case "malformed" `Quick test_activity_item_malformed
-        ; test_case "defaults" `Quick test_activity_item_defaults
-        ] )
-    ; ( "filesystem"
-      , [ test_case
-            "skips malformed jsonl lines"
-            `Quick
-            test_recent_activity_skips_malformed_jsonl_lines
-        ; test_case
-            "accepts ISO string created_at"
-            `Quick
-            test_recent_activity_accepts_iso_string_created_at_for_board_posts
-        ; test_case "skips bad task file" `Quick test_recent_activity_skips_bad_task_file
-        ; test_case
-            "falls back from bad task timestamp"
-            `Quick
-            test_recent_activity_falls_back_from_bad_task_timestamp
-        ; test_case
-            "ignores backlog json without warning"
-            `Quick
-            test_recent_activity_ignores_backlog_json_without_warning
-        ] )
-    ]
+  Fun.protect
+    ~finally:Fs_compat.clear_fs
+    (fun () ->
+      Eio_guard.enable ();
+      run
+        "activity_feed"
+        [ ( "wire"
+          , [ test_case "activity item JSON contract" `Quick test_activity_item_json_contract ] )
+        ; ( "filesystem"
+          , [ test_case
+                "skips malformed jsonl lines"
+                `Quick
+                test_recent_activity_skips_malformed_jsonl_lines
+            ; test_case
+                "accepts ISO string created_at"
+                `Quick
+                test_recent_activity_accepts_iso_string_created_at_for_board_posts
+            ; test_case "skips bad task file" `Quick test_recent_activity_skips_bad_task_file
+            ; test_case
+                "falls back from bad task timestamp"
+                `Quick
+                test_recent_activity_falls_back_from_bad_task_timestamp
+            ; test_case
+                "ignores backlog json without warning"
+                `Quick
+                test_recent_activity_ignores_backlog_json_without_warning
+            ] )
+        ])
 ;;

--- a/test/test_activity_feed.ml
+++ b/test/test_activity_feed.ml
@@ -1,0 +1,262 @@
+open Alcotest
+open Masc
+
+let test_activity_item_roundtrip () =
+  let item : Activity_feed.activity_item =
+    { id = "act-001"
+    ; kind = "task"
+    ; agent_name = "agent1"
+    ; summary = "Task completed"
+    ; detail_json = `Assoc [ "status", `String "done" ]
+    ; created_at = 1_700_000_000.0
+    }
+  in
+  let json = Activity_feed.activity_item_to_json item in
+  match Activity_feed.activity_item_of_json json with
+  | Some decoded ->
+    check string "id" item.id decoded.id;
+    check string "kind" item.kind decoded.kind;
+    check string "agent" item.agent_name decoded.agent_name;
+    check string "summary" item.summary decoded.summary;
+    check bool "detail" true (Yojson.Safe.equal item.detail_json decoded.detail_json);
+    check (float 0.01) "created_at" item.created_at decoded.created_at
+  | None -> fail "roundtrip failed"
+;;
+
+let test_activity_item_empty_id () =
+  let json =
+    `Assoc
+      [ "id", `String ""
+      ; "kind", `String "task"
+      ; "agent_name", `String "a"
+      ; "summary", `String "s"
+      ; "created_at", `Float 1.0
+      ]
+  in
+  check (option reject) "empty id" None (Activity_feed.activity_item_of_json json)
+;;
+
+let test_activity_item_missing_detail () =
+  let json =
+    `Assoc
+      [ "id", `String "x"
+      ; "kind", `String "task"
+      ; "agent_name", `String "a"
+      ; "summary", `String "s"
+      ; "created_at", `Float 1.0
+      ]
+  in
+  match Activity_feed.activity_item_of_json json with
+  | Some item -> check bool "detail defaults to null" true (item.detail_json = `Null)
+  | None -> fail "should parse without detail_json"
+;;
+
+let test_activity_item_malformed () =
+  check
+    (option reject)
+    "malformed"
+    None
+    (Activity_feed.activity_item_of_json (`String "not an object"))
+;;
+
+let test_activity_item_defaults () =
+  match Activity_feed.activity_item_of_json (`Assoc [ "id", `String "x" ]) with
+  | Some item ->
+    check string "kind default" "" item.kind;
+    check string "agent default" "" item.agent_name;
+    check string "summary default" "" item.summary;
+    check bool "detail default" true (item.detail_json = `Null);
+    check (float 0.01) "created_at default" 0.0 item.created_at
+  | None -> fail "should parse with defaults"
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Sys.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir prefix f =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
+;;
+
+let write_file = Fs_compat.save_file
+
+let latest_ring_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.seq
+  | [] -> 0
+;;
+
+let feed_warnings_since seq =
+  Log.Ring.recent ~limit:50 ~module_filter:"Feed" ~since_seq:seq ()
+  |> List.filter (fun (entry : Log.Ring.entry) -> entry.level = Log.Warn)
+;;
+
+let test_recent_activity_skips_malformed_jsonl_lines () =
+  with_temp_dir "activity-feed-jsonl" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let masc_dir = Workspace.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let board_posts_path = Filename.concat masc_dir "board_posts.jsonl" in
+  write_file
+    board_posts_path
+    (String.concat
+       "\n"
+       [ Yojson.Safe.to_string
+           (`Assoc
+             [ "id", `String "post-1"
+             ; "author", `String "alice"
+             ; "title", `String "Hello"
+             ; "content", `String "body"
+             ; "created_at", `Float 123.0
+             ])
+       ; "not-json"
+       ]
+     ^ "\n");
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "valid board post survives" 1 (List.length items);
+  match items with
+  | [ item ] ->
+    check string "summary preserved" "Posted: Hello" item.summary;
+    check (float 0.01) "timestamp preserved" 123.0 item.created_at
+  | _ -> fail "expected one activity item"
+;;
+
+let test_recent_activity_accepts_iso_string_created_at_for_board_posts () =
+  with_temp_dir "activity-feed-jsonl-iso" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let masc_dir = Workspace.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let board_posts_path = Filename.concat masc_dir "board_posts.jsonl" in
+  let iso_created_at = "2026-04-22T13:01:48Z" in
+  write_file
+    board_posts_path
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "id", `String "post-iso"
+         ; "author", `String "alice"
+         ; "title", `String "Hello"
+         ; "content", `String "body"
+         ; "created_at", `String iso_created_at
+         ])
+     ^ "\n");
+  let before_seq = latest_ring_seq () in
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "ISO created_at emits no warning" 0 (List.length (feed_warnings_since before_seq));
+  check int "valid ISO board post survives" 1 (List.length items);
+  match items, Masc_domain.parse_iso8601_opt iso_created_at with
+  | [ item ], Some expected_ts ->
+    check string "summary preserved" "Posted: Hello" item.summary;
+    check (float 0.01) "ISO timestamp preserved" expected_ts item.created_at
+  | [ _ ], None -> fail "expected ISO fixture to parse"
+  | _ -> fail "expected one activity item"
+;;
+
+let test_recent_activity_skips_bad_task_file () =
+  with_temp_dir "activity-feed-task" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let tasks_dir = Filename.concat (Workspace.masc_dir config) "tasks" in
+  Fs_compat.mkdir_p tasks_dir;
+  write_file
+    (Filename.concat tasks_dir "good.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "id", `String "task-1"
+         ; "status", `String "done"
+         ; "assignee", `String "bob"
+         ; "title", `String "Write tests"
+         ; "created_at", `String "2026-04-10T01:02:03"
+         ]));
+  write_file (Filename.concat tasks_dir "bad.json") "{\"id\":";
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "malformed task file skipped" 1 (List.length items);
+  match items with
+  | [ item ] ->
+    check string "task summary preserved" "Task task-1: Write tests (done)" item.summary
+  | _ -> fail "expected one task activity item"
+;;
+
+let test_recent_activity_falls_back_from_bad_task_timestamp () =
+  with_temp_dir "activity-feed-ts" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let tasks_dir = Filename.concat (Workspace.masc_dir config) "tasks" in
+  Fs_compat.mkdir_p tasks_dir;
+  write_file
+    (Filename.concat tasks_dir "task.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "id", `String "task-2"
+         ; "status", `String "running"
+         ; "assignee", `String "carol"
+         ; "title", `String "Investigate"
+         ; "created_at", `String "not-a-timestamp"
+         ]));
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "task still included" 1 (List.length items);
+  match items with
+  | [ item ] -> check (float 0.01) "timestamp falls back to epoch" 0.0 item.created_at
+  | _ -> fail "expected one task activity item"
+;;
+
+let test_recent_activity_ignores_backlog_json_without_warning () =
+  with_temp_dir "activity-feed-backlog" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let tasks_dir = Filename.concat (Workspace.masc_dir config) "tasks" in
+  Fs_compat.mkdir_p tasks_dir;
+  write_file
+    (Filename.concat tasks_dir "backlog.json")
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "tasks", `List []
+         ; "last_updated", `String "2026-04-22T13:01:48Z"
+         ; "version", `Int 7
+         ]));
+  let before_seq = latest_ring_seq () in
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "backlog emits no warning" 0 (List.length (feed_warnings_since before_seq));
+  check int "backlog does not become an activity item" 0 (List.length items)
+;;
+
+let () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio_guard.enable ();
+  run
+    "activity_feed"
+    [ ( "activity_item"
+      , [ test_case "roundtrip" `Quick test_activity_item_roundtrip
+        ; test_case "empty id" `Quick test_activity_item_empty_id
+        ; test_case "missing detail" `Quick test_activity_item_missing_detail
+        ; test_case "malformed" `Quick test_activity_item_malformed
+        ; test_case "defaults" `Quick test_activity_item_defaults
+        ] )
+    ; ( "filesystem"
+      , [ test_case
+            "skips malformed jsonl lines"
+            `Quick
+            test_recent_activity_skips_malformed_jsonl_lines
+        ; test_case
+            "accepts ISO string created_at"
+            `Quick
+            test_recent_activity_accepts_iso_string_created_at_for_board_posts
+        ; test_case "skips bad task file" `Quick test_recent_activity_skips_bad_task_file
+        ; test_case
+            "falls back from bad task timestamp"
+            `Quick
+            test_recent_activity_falls_back_from_bad_task_timestamp
+        ; test_case
+            "ignores backlog json without warning"
+            `Quick
+            test_recent_activity_ignores_backlog_json_without_warning
+        ] )
+    ]
+;;

--- a/test/test_activity_feed.ml
+++ b/test/test_activity_feed.ml
@@ -140,26 +140,46 @@ let test_recent_activity_skips_bad_task_file () =
   | _ -> fail "expected one task activity item"
 ;;
 
-let test_recent_activity_falls_back_from_bad_task_timestamp () =
-  with_temp_dir "activity-feed-ts" @@ fun base_path ->
+let test_recent_activity_orders_limits_and_filters () =
+  with_temp_dir "activity-feed-order" @@ fun base_path ->
   let config = Workspace.default_config base_path in
-  let tasks_dir = Filename.concat (Workspace.masc_dir config) "tasks" in
-  Fs_compat.mkdir_p tasks_dir;
+  let masc_dir = Workspace.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let board_posts_path = Filename.concat masc_dir "board_posts.jsonl" in
+  let post ~id ~author ~created_at =
+    `Assoc
+      [ "id", `String id
+      ; "author", `String author
+      ; "title", `String id
+      ; "content", `String "body"
+      ; "created_at", `Float created_at
+      ]
+    |> Yojson.Safe.to_string
+  in
   write_file
-    (Filename.concat tasks_dir "task.json")
-    (Yojson.Safe.to_string
-       (`Assoc
-         [ "id", `String "task-2"
-         ; "status", `String "running"
-         ; "assignee", `String "carol"
-         ; "title", `String "Investigate"
-         ; "created_at", `String "not-a-timestamp"
-         ]));
-  let items = Activity_feed.recent_activity config ~limit:10 () in
-  check int "task still included" 1 (List.length items);
-  match items with
-  | [ item ] -> check (float 0.01) "timestamp falls back to epoch" 0.0 item.created_at
-  | _ -> fail "expected one task activity item"
+    board_posts_path
+    (String.concat
+       "\n"
+       [ post ~id:"old-alice" ~author:"alice" ~created_at:100.0
+       ; post ~id:"middle-bob" ~author:"bob" ~created_at:200.0
+       ; post ~id:"new-alice" ~author:"alice" ~created_at:300.0
+       ]
+     ^ "\n");
+  let ids items = List.map (fun (item : Activity_feed.activity_item) -> item.id) items in
+  let newest_two = Activity_feed.recent_activity config ~limit:2 () |> ids in
+  check
+    (list string)
+    "descending order and limit"
+    [ "act-post-new-alice"; "act-post-middle-bob" ]
+    newest_two;
+  let alice_only =
+    Activity_feed.recent_activity config ~agent_name:"alice" ~limit:10 () |> ids
+  in
+  check
+    (list string)
+    "agent filter preserves descending order"
+    [ "act-post-new-alice"; "act-post-old-alice" ]
+    alice_only
 ;;
 
 let test_recent_activity_ignores_backlog_json_without_warning () =
@@ -203,9 +223,9 @@ let () =
                 test_recent_activity_accepts_iso_string_created_at_for_board_posts
             ; test_case "skips bad task file" `Quick test_recent_activity_skips_bad_task_file
             ; test_case
-                "falls back from bad task timestamp"
+                "orders, limits, and filters"
                 `Quick
-                test_recent_activity_falls_back_from_bad_task_timestamp
+                test_recent_activity_orders_limits_and_filters
             ; test_case
                 "ignores backlog json without warning"
                 `Quick


### PR DESCRIPTION
Closes #23960.

## 문제

#23741이 mixed Auto_recall 테스트 파일을 삭제하면서 live `/api/v1/activity` 경로의 회귀 커버리지까지 함께 지웠습니다.

## 변경

- API 응답 `activity_item_to_json` wire shape
- malformed JSONL 격리와 valid sibling 유지
- board post ISO timestamp 수용
- malformed task file 격리
- aggregate `backlog.json` 무시 및 불필요 WARN 억제
- `created_at` 내림차순 정렬, `limit`, `agent_name` filter 계약
- production caller 0인 permissive decoder wrapper/generated decoder export 삭제
- encoder-only `[@@deriving to_yojson]` 유지
- public decoder surface 제거를 Unreleased에 명시

invalid timestamp를 `0.0`으로 합성하는 기존 휴리스틱은 정상 계약으로 테스트하지 않습니다. typed timestamp parsing 수리는 #23987로 분리했습니다.

Auto_recall 테스트는 부활시키지 않았습니다. 로그 assertion은 typed `Log.Ring`과 `Log.Ring.capacity`를 사용하고, temp filesystem은 명시적 finalizer로 정리합니다.

## 검증

- focused `@test/runtest-test_activity_feed`: 6/6 PASS
- `ocamlformat --check` PASS
- `git diff --check` PASS
- `scripts/check-doc-truth.sh` PASS
- latest main `86ca4b9c80` 반영

## Merge gate

Draft + `p2` + `status:do-not-merge` 유지. current-head CI와 current-head formal approval 전에는 병합하지 않습니다.

[근거] current head `f35bc445c1`, base `86ca4b9c80`; 확인 2026-07-10 KST; 신뢰도 High.
