### PR TITLE
fix(keeper): strip retired continuity keys from persisted keeper meta on boot

### DIFF
--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -191,27 +191,28 @@ let canonical_keeper_meta_key_names =
     fallback_canonical_keeper_meta_key_names
 ;;
 
-let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
+let unknown_keeper_meta_keys (json : Yojson.Safe.t) : string list =
   match json with
   | `Assoc fields ->
-    let unknown =
-      fields
-      |> List.filter_map (fun (key, _) ->
-        if List.mem key canonical_keeper_meta_key_names
-        then None
-        else Some key)
-      |> dedupe_keep_order
-    in
-    (match unknown with
-     | [] -> ()
-     | _ :: _ ->
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string MetaJsonFailures)
-         ~labels:[("site", "unknown_keys")]
-         ();
-       Log.Keeper.warn
-         "keeper meta %s has unknown keys: %s"
-         path
-         (String.concat ", " unknown))
-  | _ -> ()
+    fields
+    |> List.filter_map (fun (key, _) ->
+      if List.mem key canonical_keeper_meta_key_names
+      then None
+      else Some key)
+    |> dedupe_keep_order
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
+;;
+
+let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
+  match unknown_keeper_meta_keys json with
+  | [] -> ()
+  | unknown ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MetaJsonFailures)
+      ~labels:[("site", "unknown_keys")]
+      ();
+    Log.Keeper.warn
+      "keeper meta %s has unknown keys: %s"
+      path
+      (String.concat ", " unknown)
 ;;

--- a/lib/keeper/keeper_meta_json.mli
+++ b/lib/keeper/keeper_meta_json.mli
@@ -24,6 +24,11 @@ val fallback_canonical_keeper_meta_key_names : string list
     [fallback_canonical_keeper_meta_key_names] if serialization fails. *)
 val canonical_keeper_meta_key_names : string list
 
+(** Top-level keys in [json] that aren't in the canonical key list —
+    retired fields left behind by schema removals, or genuine drift.
+    Returns [[]] for non-object JSON. Pure; no logging. *)
+val unknown_keeper_meta_keys : Yojson.Safe.t -> string list
+
 (** Log a warning for any top-level keys in [json] that aren't in the
     canonical key list — catches schema drift early. *)
 val warn_unknown_keeper_meta_keys :

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -46,37 +46,3 @@ let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t 
   | `Assoc fields -> `Assoc (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ as j -> j
 ;;
-
-let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
-  match json with
-  | `Assoc fields ->
-    let removed_present =
-      fields
-      |> List.filter_map (fun (key, _) ->
-        if List.mem key config_field_names then Some key else None)
-    in
-    if removed_present = []
-    then json, false
-    else (
-      let scrubbed = drop_assoc_keys removed_present json in
-      let content = Yojson.Safe.pretty_to_string scrubbed in
-      (try
-         Fs_compat.save_file path content;
-         Log.Keeper.info
-           "scrubbed TOML-owned keeper meta fields for %s: %s"
-           path
-           (String.concat ", " removed_present)
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string MetaJsonFailures)
-           ~labels:[("site", "scrub")]
-           ();
-         Log.Keeper.warn
-           "failed to scrub removed keeper meta fields for %s: %s"
-           path
-           (Printexc.to_string exn));
-      scrubbed, true)
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ as j -> j, false
-;;

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -12,10 +12,3 @@ val config_field_names : string list
 (** Drop the named keys from a top-level JSON object; passes through
     non-objects unchanged. *)
 val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
-
-(** [scrub_persisted_keeper_meta_json ~path json] removes TOML-owned
-    config fields from persisted keeper meta and writes the scrubbed
-    content back to [path] when changes were needed. Returns the scrubbed
-    JSON and a [bool] indicating whether the file was rewritten. *)
-val scrub_persisted_keeper_meta_json :
-  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -377,6 +377,45 @@ let is_version_conflict_error msg =
   | Not_found -> false
 ;;
 
+(* ── Boot-time canonicalization ─────────────────────────── *)
+
+let canonicalize_persisted_meta_files config =
+  persisted_keeper_names config
+  |> List.iter (fun name ->
+    let path = keeper_meta_path config name in
+    match Safe_ops.read_json_file_safe path with
+    | Error msg ->
+      Log.Keeper.warn "keeper meta canonicalize: unreadable %s: %s" path msg
+    | Ok json ->
+      (match unknown_keeper_meta_keys json with
+       | [] -> ()
+       | unknown ->
+         (match meta_of_json json with
+          | Error msg ->
+            (* A file we cannot fully represent is preserved untouched for
+               operator repair; re-serializing it would destroy the canonical
+               fields alongside the unknown ones. *)
+            Log.Keeper.warn
+              "keeper meta canonicalize: parse failed for %s, leaving file untouched: %s"
+              path
+              msg
+          | Ok meta ->
+            (match write_meta config meta with
+             | Ok () ->
+               Log.Keeper.info
+                 "canonicalized keeper meta %s: dropped retired keys: %s"
+                 path
+                 (String.concat ", " unknown)
+             | Error msg ->
+               (* A CAS conflict means a concurrent writer re-serialized the
+                  file first; write_meta always emits the canonical key set,
+                  so both outcomes converge on a clean file. *)
+               Log.Keeper.info
+                 "keeper meta canonicalize: skipped %s (concurrent writer wins): %s"
+                 path
+                 msg))))
+;;
+
 (* #9769 root fix: CAS retry with explicit field ownership. The
    turn-failure/cycle path uses [Keeper_meta_merge.heartbeat_fields_from_disk]
    now only carries the disk meta_version forward. *)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -379,6 +379,18 @@ let is_version_conflict_error msg =
 
 (* ── Boot-time canonicalization ─────────────────────────── *)
 
+(* A key is retired only when neither side of the codec knows it: the
+   serializer does not emit it (not canonical) AND the parser does not
+   consume it. The parser-consumed-but-never-emitted set is exactly the
+   TOML-owned [config_field_names] (e.g. [autoboot_enabled], [goal],
+   [sandbox_profile]) — dropping those would destroy still-honored
+   values, so they are preserved even though the serializer ignores
+   them. *)
+let retired_keeper_meta_keys json =
+  unknown_keeper_meta_keys json
+  |> List.filter (fun key -> not (List.mem key config_field_names))
+;;
+
 let canonicalize_persisted_meta_files config =
   persisted_keeper_names config
   |> List.iter (fun name ->
@@ -387,31 +399,34 @@ let canonicalize_persisted_meta_files config =
     | Error msg ->
       Log.Keeper.warn "keeper meta canonicalize: unreadable %s: %s" path msg
     | Ok json ->
-      (match unknown_keeper_meta_keys json with
+      (match retired_keeper_meta_keys json with
        | [] -> ()
-       | unknown ->
+       | retired ->
          (match meta_of_json json with
           | Error msg ->
-            (* A file we cannot fully represent is preserved untouched for
-               operator repair; re-serializing it would destroy the canonical
-               fields alongside the unknown ones. *)
+            (* A file the strict parser rejects is preserved untouched for
+               operator repair; editing it could destroy whatever evidence
+               explains the rejection. *)
             Log.Keeper.warn
               "keeper meta canonicalize: parse failed for %s, leaving file untouched: %s"
               path
               msg
-          | Ok meta ->
-            (match write_meta config meta with
+          | Ok _ ->
+            (* Drop only the retired keys from the raw JSON instead of
+               re-serializing the parsed record: every other field —
+               including parser-consumed TOML-owned values the serializer
+               never emits — keeps its exact on-disk value, and
+               [meta_version] is not bumped. *)
+            let cleaned = drop_assoc_keys retired json in
+            (match Keeper_fs.save_json_atomic path cleaned with
              | Ok () ->
                Log.Keeper.info
                  "canonicalized keeper meta %s: dropped retired keys: %s"
                  path
-                 (String.concat ", " unknown)
+                 (String.concat ", " retired)
              | Error msg ->
-               (* A CAS conflict means a concurrent writer re-serialized the
-                  file first; write_meta always emits the canonical key set,
-                  so both outcomes converge on a clean file. *)
-               Log.Keeper.info
-                 "keeper meta canonicalize: skipped %s (concurrent writer wins): %s"
+               Log.Keeper.warn
+                 "keeper meta canonicalize: rewrite failed for %s (file unchanged, unknown-key warning persists): %s"
                  path
                  msg))))
 ;;

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -379,16 +379,31 @@ let is_version_conflict_error msg =
 
 (* ── Boot-time canonicalization ─────────────────────────── *)
 
-(* A key is retired only when neither side of the codec knows it: the
-   serializer does not emit it (not canonical) AND the parser does not
-   consume it. The parser-consumed-but-never-emitted set is exactly the
-   TOML-owned [config_field_names] (e.g. [autoboot_enabled], [goal],
-   [sandbox_profile]) — dropping those would destroy still-honored
-   values, so they are preserved even though the serializer ignores
-   them. *)
+(* Keys deliberately deleted from persisted keeper meta. Dropping is
+   destructive, so membership is EXPLICIT — a key is listed only after
+   BOTH codec sides stopped knowing it. Deriving this set instead
+   (canonical/config complement) was refuted twice: [compaction_mode]
+   (keeper_meta_json_parse.ml, fail-closed persisted override) and
+   [keeper_name] (keeper_identity.ml, wins over [name]) are
+   parser-consumed yet in neither derived list, and a derived drop
+   would silently destroy them. Forgetting to extend THIS list is
+   fail-safe: the file merely keeps triggering the unknown-keys
+   warning until the key is added here. *)
+let retired_keeper_meta_key_names =
+  [ (* #23929 continuity purge left these behind in .masc/keepers/ *)
+    "last_continuity_update_ts"
+  ; "continuity_summary"
+  ]
+;;
+
 let retired_keeper_meta_keys json =
-  unknown_keeper_meta_keys json
-  |> List.filter (fun key -> not (List.mem key config_field_names))
+  match json with
+  | `Assoc fields ->
+    fields
+    |> List.filter_map (fun (key, _) ->
+      if List.mem key retired_keeper_meta_key_names then Some key else None)
+    |> dedupe_keep_order
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
 ;;
 
 let canonicalize_persisted_meta_files config =

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -406,13 +406,13 @@ let retired_keeper_meta_keys json =
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> []
 ;;
 
-let canonicalize_persisted_meta_files config =
+let migrate_retired_keeper_meta_keys config =
   persisted_keeper_names config
   |> List.iter (fun name ->
     let path = keeper_meta_path config name in
     match Safe_ops.read_json_file_safe path with
     | Error msg ->
-      Log.Keeper.warn "keeper meta canonicalize: unreadable %s: %s" path msg
+      Log.Keeper.warn "retired keeper meta key migration: unreadable %s: %s" path msg
     | Ok json ->
       (match retired_keeper_meta_keys json with
        | [] -> ()
@@ -423,7 +423,7 @@ let canonicalize_persisted_meta_files config =
                operator repair; editing it could destroy whatever evidence
                explains the rejection. *)
             Log.Keeper.warn
-              "keeper meta canonicalize: parse failed for %s, leaving file untouched: %s"
+              "retired keeper meta key migration: parse failed for %s, leaving file untouched: %s"
               path
               msg
           | Ok _ ->
@@ -436,12 +436,12 @@ let canonicalize_persisted_meta_files config =
             (match Keeper_fs.save_json_atomic path cleaned with
              | Ok () ->
                Log.Keeper.info
-                 "canonicalized keeper meta %s: dropped retired keys: %s"
+                 "migrated keeper meta %s: dropped retired keys: %s"
                  path
                  (String.concat ", " retired)
              | Error msg ->
                Log.Keeper.warn
-                 "keeper meta canonicalize: rewrite failed for %s (file unchanged, unknown-key warning persists): %s"
+                 "retired keeper meta key migration: rewrite failed for %s (file unchanged, unknown-key warning persists): %s"
                  path
                  msg))))
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -129,19 +129,21 @@ val is_version_conflict_error : string -> bool
     fields left behind by schema removals (e.g. the #23929 continuity
     purge left [last_continuity_update_ts]/[continuity_summary] in
     [.masc/keepers/], re-warning on every read until the next save;
-    dormant keepers never save). A key is retired only when neither
-    codec side knows it: not in the serializer-derived canonical set
-    ([Keeper_meta_json.canonical_keeper_meta_key_names]) and not in the
-    parser-consumed TOML-owned set
-    ([Keeper_meta_json.config_field_names]) — the latter (e.g.
-    [autoboot_enabled]) must survive even though the serializer never
-    emits it. Retired keys are filtered out of the raw JSON in place
+    dormant keepers never save). Deletion is destructive, so the drop
+    set is an explicit in-code list ([retired_keeper_meta_key_names]),
+    not a set derived from the codec: parser-consumed keys the
+    serializer never emits ([autoboot_enabled], [compaction_mode],
+    [keeper_name], ...) must survive, and deriving the complement was
+    twice shown to misclassify them. Forgetting to extend the list is
+    fail-safe — the unknown-keys warning keeps firing until the key is
+    added. Retired keys are filtered out of the raw JSON in place
     ([Keeper_fs.save_json_atomic]); no re-serialization, no
     [meta_version] bump, every surviving field keeps its exact on-disk
     value. Unreadable or parser-rejected files are logged and preserved
-    untouched. Call once at boot BEFORE keeper loops start — the write
-    is not CAS-guarded, so it relies on running ahead of concurrent
-    meta writers. *)
+    untouched. Call once at boot BEFORE keeper loops start; the write is
+    not CAS-guarded, so the only writers that can race it are external
+    request-driven mutations inside the per-file read/save span during
+    boot — a CAS-guarded loser self-heals on its retry path. *)
 val canonicalize_persisted_meta_files : Workspace.config -> unit
 
 (** Retry [write_meta] on CAS version conflicts using caller-declared

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -144,7 +144,7 @@ val is_version_conflict_error : string -> bool
     not CAS-guarded, so the only writers that can race it are external
     request-driven mutations inside the per-file read/save span during
     boot — a CAS-guarded loser self-heals on its retry path. *)
-val canonicalize_persisted_meta_files : Workspace.config -> unit
+val migrate_retired_keeper_meta_keys : Workspace.config -> unit
 
 (** Retry [write_meta] on CAS version conflicts using caller-declared
     field ownership via [merge]. Use [Keeper_meta_merge.caller_wins]

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -125,6 +125,20 @@ val write_meta :
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
 
+(** Rewrite persisted keeper meta files whose raw JSON carries top-level
+    keys outside the canonical serializer key set — retired fields left
+    behind by schema removals (e.g. the #23929 continuity purge left
+    [last_continuity_update_ts]/[continuity_summary] in [.masc/keepers/],
+    re-warning on every read until the next save). The canonical key set
+    ([Keeper_meta_json.canonical_keeper_meta_key_names], derived from the
+    serializer) is the single source of truth, so there is no per-key
+    retirement list to forget. Rewrites go through {!write_meta} (CAS): a
+    version conflict means a concurrent writer already re-serialized the
+    file canonically, so the conflict is logged and skipped — both
+    outcomes converge. Unreadable or unparsable files are logged and
+    preserved untouched. Intended as a boot-time pass. *)
+val canonicalize_persisted_meta_files : Workspace.config -> unit
+
 (** Retry [write_meta] on CAS version conflicts using caller-declared
     field ownership via [merge]. Use [Keeper_meta_merge.caller_wins]
     for payload-wins writes, or a narrower merge such as

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -125,18 +125,23 @@ val write_meta :
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
 
-(** Rewrite persisted keeper meta files whose raw JSON carries top-level
-    keys outside the canonical serializer key set — retired fields left
-    behind by schema removals (e.g. the #23929 continuity purge left
-    [last_continuity_update_ts]/[continuity_summary] in [.masc/keepers/],
-    re-warning on every read until the next save). The canonical key set
-    ([Keeper_meta_json.canonical_keeper_meta_key_names], derived from the
-    serializer) is the single source of truth, so there is no per-key
-    retirement list to forget. Rewrites go through {!write_meta} (CAS): a
-    version conflict means a concurrent writer already re-serialized the
-    file canonically, so the conflict is logged and skipped — both
-    outcomes converge. Unreadable or unparsable files are logged and
-    preserved untouched. Intended as a boot-time pass. *)
+(** Strip retired top-level keys from persisted keeper meta files —
+    fields left behind by schema removals (e.g. the #23929 continuity
+    purge left [last_continuity_update_ts]/[continuity_summary] in
+    [.masc/keepers/], re-warning on every read until the next save;
+    dormant keepers never save). A key is retired only when neither
+    codec side knows it: not in the serializer-derived canonical set
+    ([Keeper_meta_json.canonical_keeper_meta_key_names]) and not in the
+    parser-consumed TOML-owned set
+    ([Keeper_meta_json.config_field_names]) — the latter (e.g.
+    [autoboot_enabled]) must survive even though the serializer never
+    emits it. Retired keys are filtered out of the raw JSON in place
+    ([Keeper_fs.save_json_atomic]); no re-serialization, no
+    [meta_version] bump, every surviving field keeps its exact on-disk
+    value. Unreadable or parser-rejected files are logged and preserved
+    untouched. Call once at boot BEFORE keeper loops start — the write
+    is not CAS-guarded, so it relies on running ahead of concurrent
+    meta writers. *)
 val canonicalize_persisted_meta_files : Workspace.config -> unit
 
 (** Retry [write_meta] on CAS version conflicts using caller-declared

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -849,6 +849,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let t1 = Eio.Time.now clock in
       Log.Server.info "State created (runtime state) in %.1fs" (t1 -. t0);
       bootstrap_server_state_blocking state;
+      (* The retired-key migration performs a raw atomic rewrite without version CAS.
+         Run it before [server_state := Some state] publishes mutation routes,
+         and before connectors, maintenance, or keeper loops can write meta.
+         This makes writer exclusion structural instead of relying on a
+         best-effort boot timing window. *)
+      startup_migrate_retired_keeper_meta_keys state;
       sync_admin_token_env state;
       sync_internal_keeper_token_env state;
       sync_bootable_keeper_credentials state;
@@ -1363,11 +1369,6 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
            cold-start diagnostics do not contend with the shell's first render. *)
         Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock);
       start_lazy_startup state;
-      (* Strip retired keys from persisted keeper meta before any keeper
-         loop starts writing meta: the pass rewrites files without CAS, so
-         it must run ahead of concurrent meta writers (it is a synchronous
-         one-shot over at most a few dozen small files). *)
-      startup_canonicalize_keeper_metas state;
       (* RFC-0206: runtime catalog startup validation removed; Runtime.init_default
          already fail-fasts on an invalid runtime config at boot. *)
       Server_bootstrap_loops.start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -554,6 +554,7 @@ let lazy_startup_plan () =
             "reconcile_active_agents";
             "prompt_bootstrap";
             "keeper_history_migration";
+            "keeper_meta_canonicalize";
           ];
       };
       {
@@ -994,6 +995,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "prompt_bootstrap" -> fun () -> bootstrap_prompt_state state
         | "keeper_history_migration" -> fun () ->
             startup_migrate_keeper_histories state
+        | "keeper_meta_canonicalize" -> fun () ->
+            startup_canonicalize_keeper_metas state
         | "telemetry_warmup" -> fun () ->
             warm_tool_registry_from_telemetry state
         | "tool_metrics_restore" -> fun () ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -554,7 +554,6 @@ let lazy_startup_plan () =
             "reconcile_active_agents";
             "prompt_bootstrap";
             "keeper_history_migration";
-            "keeper_meta_canonicalize";
           ];
       };
       {
@@ -995,8 +994,6 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         | "prompt_bootstrap" -> fun () -> bootstrap_prompt_state state
         | "keeper_history_migration" -> fun () ->
             startup_migrate_keeper_histories state
-        | "keeper_meta_canonicalize" -> fun () ->
-            startup_canonicalize_keeper_metas state
         | "telemetry_warmup" -> fun () ->
             warm_tool_registry_from_telemetry state
         | "tool_metrics_restore" -> fun () ->
@@ -1366,6 +1363,11 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
            cold-start diagnostics do not contend with the shell's first render. *)
         Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock);
       start_lazy_startup state;
+      (* Strip retired keys from persisted keeper meta before any keeper
+         loop starts writing meta: the pass rewrites files without CAS, so
+         it must run ahead of concurrent meta writers (it is a synchronous
+         one-shot over at most a few dozen small files). *)
+      startup_canonicalize_keeper_metas state;
       (* RFC-0206: runtime catalog startup validation removed; Runtime.init_default
          already fail-fasts on an invalid runtime config at boot. *)
       Server_bootstrap_loops.start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -57,15 +57,15 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.warn "startup prune failed: %s (next boot retries; disk impact bounded by retention)" (Printexc.to_string exn))
 
-let startup_canonicalize_keeper_metas (state : Mcp_server.server_state) =
+let startup_migrate_retired_keeper_meta_keys (state : Mcp_server.server_state) =
   (try
-     Keeper_meta_store.canonicalize_persisted_meta_files
+     Keeper_meta_store.migrate_retired_keeper_meta_keys
        (Mcp_server.workspace_config state)
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Misc.warn
-       "startup keeper meta canonicalize failed: %s (next boot retries; stale keys keep warning on read)"
+       "startup retired keeper meta key migration failed: %s (next boot retries; stale keys keep warning on read)"
        (Printexc.to_string exn))
 
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -57,6 +57,17 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn -> Log.Misc.warn "startup prune failed: %s (next boot retries; disk impact bounded by retention)" (Printexc.to_string exn))
 
+let startup_canonicalize_keeper_metas (state : Mcp_server.server_state) =
+  (try
+     Keeper_meta_store.canonicalize_persisted_meta_files
+       (Mcp_server.workspace_config state)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Log.Misc.warn
+       "startup keeper meta canonicalize failed: %s (next boot retries; stale keys keep warning on read)"
+       (Printexc.to_string exn))
+
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
   (try
      let traces_dir =

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -1,3 +1,11 @@
 val startup_prune_jsonl : Mcp_server.server_state -> unit
+
+(** Boot-time pass over [.masc/keepers/*.json]: rewrite files carrying
+    keys outside the canonical serializer key set (see
+    [Keeper_meta_store.canonicalize_persisted_meta_files]). Exceptions
+    are logged and swallowed — the next boot retries, and until then
+    stale keys only keep producing the existing unknown-key warning. *)
+val startup_canonicalize_keeper_metas : Mcp_server.server_state -> unit
+
 val startup_migrate_keeper_histories :
   Mcp_server.server_state -> unit

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -1,11 +1,11 @@
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 
-(** Boot-time pass over [.masc/keepers/*.json]: rewrite files carrying
-    keys outside the canonical serializer key set (see
-    [Keeper_meta_store.canonicalize_persisted_meta_files]). Exceptions
-    are logged and swallowed — the next boot retries, and until then
-    stale keys only keep producing the existing unknown-key warning. *)
-val startup_canonicalize_keeper_metas : Mcp_server.server_state -> unit
+(** Boot-time pass over [.masc/keepers/*.json]: remove only keys in the
+    explicit retired-key set (see
+    [Keeper_meta_store.migrate_retired_keeper_meta_keys]). Exceptions are
+    logged and swallowed — the next boot retries, and until then stale keys
+    only keep producing the existing unknown-key warning. *)
+val startup_migrate_retired_keeper_meta_keys : Mcp_server.server_state -> unit
 
 val startup_migrate_keeper_histories :
   Mcp_server.server_state -> unit

--- a/test/dune
+++ b/test/dune
@@ -2680,6 +2680,8 @@
 
 (include stanzas/test_keeper_wire_capture_suppression.inc)
 
+(include stanzas/test_keeper_meta_canonicalize.inc)
+
 (test
  (name test_keeper_visible_path_projection)
  (modules test_keeper_visible_path_projection)

--- a/test/stanzas/test_keeper_meta_canonicalize.inc
+++ b/test/stanzas/test_keeper_meta_canonicalize.inc
@@ -1,0 +1,10 @@
+; Boot-time keeper meta canonicalization
+; (Keeper_meta_store.canonicalize_persisted_meta_files +
+; Keeper_meta_json.unknown_keeper_meta_keys): #23929's continuity purge left
+; retired keys in .masc/keepers/*.json, re-warning on every read; the boot
+; pass converges every persisted file onto the canonical serializer key set.
+
+(test
+ (name test_keeper_meta_canonicalize)
+ (modules test_keeper_meta_canonicalize)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_keeper_meta_canonicalize.inc
+++ b/test/stanzas/test_keeper_meta_canonicalize.inc
@@ -1,8 +1,8 @@
 ; Boot-time keeper meta canonicalization
-; (Keeper_meta_store.canonicalize_persisted_meta_files +
+; (Keeper_meta_store.migrate_retired_keeper_meta_keys +
 ; Keeper_meta_json.unknown_keeper_meta_keys): #23929's continuity purge left
 ; retired keys in .masc/keepers/*.json, re-warning on every read; the boot
-; pass converges every persisted file onto the canonical serializer key set.
+; pass removes only the explicitly retired keys from every persisted file.
 
 (test
  (name test_keeper_meta_canonicalize)

--- a/test/test_keeper_meta_canonicalize.ml
+++ b/test/test_keeper_meta_canonicalize.ml
@@ -1,28 +1,21 @@
-(** Boot-time keeper meta canonicalization
-    (Keeper_meta_store.canonicalize_persisted_meta_files).
+(** Boot-time retired keeper meta key migration
+    (Keeper_meta_store.migrate_retired_keeper_meta_keys).
 
     Reproduces the post-#23929 incident: the continuity purge removed
     [last_continuity_update_ts]/[continuity_summary] from the serializer
     but left them in persisted [.masc/keepers/*.json], so every meta read
     re-warned "has unknown keys" until an unrelated save happened to
-    rewrite the file — and dormant keepers never saved. The canonicalize
-    pass must converge every persisted file onto the canonical key set
-    exactly once, preserve canonical field values, go through the CAS
-    write path, and leave unreadable files untouched. *)
+    rewrite the file — and dormant keepers never saved. The migration must
+    remove only explicitly retired keys exactly once, preserve every surviving
+    field value, use an atomic raw-JSON
+    rewrite before runtime writers are published, and leave unreadable files
+    untouched. *)
 
 open Alcotest
 open Masc
 
 let temp_dir () =
-  (* PID in the name isolates leftovers from a killed previous run —
-     unseeded Random repeats the same sequence every process start. *)
-  let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "test_meta_canonicalize_%d_%d" (Unix.getpid ())
-         (Random.int 1_000_000))
-  in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-  dir
+  Filename.temp_dir "test_meta_retired_keys_" ""
 
 let cleanup_dir dir =
   let rec rm path =
@@ -33,19 +26,20 @@ let cleanup_dir dir =
       end
       else Sys.remove path
   in
-  (* Swallow cleanup failures: Fun.protect would otherwise wrap them in
-     Finally_raised and mask the assertion that actually failed. *)
-  try rm dir with _ -> ()
+  rm dir
 
 let with_workspace f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> cleanup_dir dir)
+    ~finally:(fun () ->
+      Fun.protect
+        ~finally:Fs_compat.clear_fs
+        (fun () -> cleanup_dir dir))
     (fun () ->
       let config = Workspace.default_config dir in
-      ignore (Workspace.init config ~agent_name:(Some "keeper-canonicalize-agent"));
+      ignore (Workspace.init config ~agent_name:(Some "keeper-meta-migration-agent"));
       f config)
 
 let make_meta name : Keeper_meta_contract.keeper_meta =
@@ -111,7 +105,7 @@ let test_drops_retired_keys_and_preserves_canonical_fields () =
   check bool "retired keys visible before the pass" true
     (Keeper_meta_json.unknown_keeper_meta_keys (raw_json config "stale") <> []);
   let version_before = read_version config "stale" in
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   check (list string) "no unknown keys remain on disk" []
     (Keeper_meta_json.unknown_keeper_meta_keys (raw_json config "stale"));
   (match Keeper_meta_store.read_meta config "stale" with
@@ -123,8 +117,8 @@ let test_drops_retired_keys_and_preserves_canonical_fields () =
      check int "raw filter does not bump meta_version"
        version_before
        meta.Keeper_meta_contract.meta_version
-   | Ok None -> fail "keeper meta vanished after canonicalize"
-   | Error msg -> fail ("read_meta after canonicalize failed: " ^ msg))
+   | Ok None -> fail "keeper meta vanished after retired-key migration"
+   | Error msg -> fail ("read_meta after retired-key migration failed: " ^ msg))
 
 (* Regressions from verify workflows wf_9a9ec740 / wf_ccff1ece: "unknown
    to the serializer" is not "retired". The parser still consumes keys
@@ -143,7 +137,7 @@ let test_parser_consumed_keys_survive_the_pass () =
         ("compaction_mode", `String "llm");
         ("keeper_name", `String "dormant");
       ];
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   let json = raw_json config "dormant" in
   check bool "retired continuity keys dropped" true
     (assoc_field json "last_continuity_update_ts" = None
@@ -157,7 +151,7 @@ let test_parser_consumed_keys_survive_the_pass () =
     | None ->
       fail
         (Printf.sprintf
-           "%s destroyed by canonicalize — parser-consumed value lost" key)
+           "%s destroyed by retired-key migration — parser-consumed value lost" key)
   in
   expect_preserved "autoboot_enabled" (`Bool false);
   expect_preserved "compaction_mode" (`String "llm");
@@ -167,7 +161,7 @@ let test_clean_files_are_not_rewritten () =
   with_workspace @@ fun config ->
   write_keeper config "clean";
   let version_before = read_version config "clean" in
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   check int "clean file keeps its meta_version (no rewrite)"
     version_before
     (read_version config "clean")
@@ -176,11 +170,11 @@ let test_second_pass_is_a_no_op () =
   with_workspace @@ fun config ->
   write_keeper config "stale";
   inject_retired_keys config "stale";
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   (* Byte-level comparison: the raw-filter path never bumps meta_version,
      so a version check could not detect a spurious second rewrite. *)
   let bytes_after_first = Fs_compat.load_file (keeper_file config "stale") in
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   check string "second pass leaves the file byte-identical"
     bytes_after_first
     (Fs_compat.load_file (keeper_file config "stale"))
@@ -191,7 +185,7 @@ let test_unparsable_file_is_preserved_untouched () =
   let corrupt_path = keeper_file config "corrupt" in
   let corrupt_content = "{not-json" in
   Fs_compat.save_file corrupt_path corrupt_content;
-  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  Keeper_meta_store.migrate_retired_keeper_meta_keys config;
   check string "corrupt file content preserved for operator repair"
     corrupt_content
     (Fs_compat.load_file corrupt_path)
@@ -218,9 +212,9 @@ let test_unknown_keys_pure_function () =
     (Keeper_meta_json.unknown_keeper_meta_keys (`String "not an object"))
 
 let () =
-  run "keeper_meta_canonicalize"
+  run "keeper_meta_retired_keys_migration"
     [
-      ( "canonicalize_persisted_meta_files",
+      ( "migrate_retired_keeper_meta_keys",
         [
           test_case "drops retired keys, preserves canonical fields"
             `Quick test_drops_retired_keys_and_preserves_canonical_fields;

--- a/test/test_keeper_meta_canonicalize.ml
+++ b/test/test_keeper_meta_canonicalize.ml
@@ -14,9 +14,12 @@ open Alcotest
 open Masc
 
 let temp_dir () =
+  (* PID in the name isolates leftovers from a killed previous run —
+     unseeded Random repeats the same sequence every process start. *)
   let dir =
     Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "test_meta_canonicalize_%d" (Random.int 1_000_000))
+      (Printf.sprintf "test_meta_canonicalize_%d_%d" (Unix.getpid ())
+         (Random.int 1_000_000))
   in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   dir
@@ -30,7 +33,9 @@ let cleanup_dir dir =
       end
       else Sys.remove path
   in
-  rm dir
+  (* Swallow cleanup failures: Fun.protect would otherwise wrap them in
+     Finally_raised and mask the assertion that actually failed. *)
+  try rm dir with _ -> ()
 
 let with_workspace f =
   Eio_main.run @@ fun env ->
@@ -64,8 +69,10 @@ let write_keeper config name =
   | Error msg -> fail ("write_meta failed: " ^ msg)
 
 (* Re-create the exact on-disk shape #23929 left behind: a valid meta
-   snapshot plus retired top-level keys the serializer no longer emits. *)
-let inject_retired_keys config name =
+   snapshot plus retired top-level keys the serializer no longer emits.
+   [extra] models parser-consumed TOML-owned keys (config_field_names)
+   that a legacy file may still carry — those must survive the pass. *)
+let inject_keys ?(extra = []) config name =
   let path = keeper_file config name in
   match Yojson.Safe.from_string (Fs_compat.load_file path) with
   | `Assoc fields ->
@@ -75,10 +82,18 @@ let inject_retired_keys config name =
          @ [
              ("last_continuity_update_ts", `Float 1780000000.0);
              ("continuity_summary", `String "legacy continuity prose");
-           ])
+           ]
+         @ extra)
     in
     Fs_compat.save_file path (Yojson.Safe.pretty_to_string polluted)
   | _ -> fail "persisted keeper meta is not a JSON object"
+
+let inject_retired_keys config name = inject_keys config name
+
+let assoc_field json key =
+  match json with
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
 
 let read_version config name =
   match Keeper_meta_store.read_meta config name with
@@ -105,11 +120,34 @@ let test_drops_retired_keys_and_preserves_canonical_fields () =
        meta.Keeper_meta_contract.name;
      check string "canonical agent_name preserved" "keeper-stale-agent"
        meta.Keeper_meta_contract.agent_name;
-     check int "rewrite went through the CAS path (version bumped)"
-       (version_before + 1)
+     check int "raw filter does not bump meta_version"
+       version_before
        meta.Keeper_meta_contract.meta_version
    | Ok None -> fail "keeper meta vanished after canonicalize"
    | Error msg -> fail ("read_meta after canonicalize failed: " ^ msg))
+
+(* P2 regression (verify workflow wf_9a9ec740): "unknown to the serializer"
+   is not "retired" — the parser still consumes TOML-owned keys the
+   serializer never emits. A legacy file carrying autoboot_enabled=false
+   plus retired continuity keys must lose ONLY the continuity keys. *)
+let test_parser_consumed_config_keys_survive_the_pass () =
+  with_workspace @@ fun config ->
+  write_keeper config "dormant";
+  inject_keys config "dormant" ~extra:[ ("autoboot_enabled", `Bool false) ];
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  let json = raw_json config "dormant" in
+  check bool "retired continuity keys dropped" true
+    (assoc_field json "last_continuity_update_ts" = None
+     && assoc_field json "continuity_summary" = None);
+  (match assoc_field json "autoboot_enabled" with
+   | Some (`Bool false) -> ()
+   | Some other ->
+     fail
+       ("autoboot_enabled value changed: " ^ Yojson.Safe.to_string other)
+   | None ->
+     fail
+       "autoboot_enabled destroyed by canonicalize — dormant keeper would \
+        autoboot on next boot")
 
 let test_clean_files_are_not_rewritten () =
   with_workspace @@ fun config ->
@@ -168,8 +206,10 @@ let () =
     [
       ( "canonicalize_persisted_meta_files",
         [
-          test_case "drops retired keys, preserves canonical fields, CAS bump"
+          test_case "drops retired keys, preserves canonical fields"
             `Quick test_drops_retired_keys_and_preserves_canonical_fields;
+          test_case "parser-consumed config keys survive the pass" `Quick
+            test_parser_consumed_config_keys_survive_the_pass;
           test_case "clean files are not rewritten" `Quick
             test_clean_files_are_not_rewritten;
           test_case "second pass is a no-op" `Quick test_second_pass_is_a_no_op;

--- a/test/test_keeper_meta_canonicalize.ml
+++ b/test/test_keeper_meta_canonicalize.ml
@@ -126,28 +126,42 @@ let test_drops_retired_keys_and_preserves_canonical_fields () =
    | Ok None -> fail "keeper meta vanished after canonicalize"
    | Error msg -> fail ("read_meta after canonicalize failed: " ^ msg))
 
-(* P2 regression (verify workflow wf_9a9ec740): "unknown to the serializer"
-   is not "retired" — the parser still consumes TOML-owned keys the
-   serializer never emits. A legacy file carrying autoboot_enabled=false
-   plus retired continuity keys must lose ONLY the continuity keys. *)
-let test_parser_consumed_config_keys_survive_the_pass () =
+(* Regressions from verify workflows wf_9a9ec740 / wf_ccff1ece: "unknown
+   to the serializer" is not "retired". The parser still consumes keys
+   the serializer never emits — TOML-owned config (autoboot_enabled),
+   the fail-closed persisted compaction_mode override, and the identity
+   key keeper_name (which wins over name). Only the explicitly listed
+   continuity keys may be dropped; everything else survives even though
+   the unknown-keys warning classifies it as unknown. *)
+let test_parser_consumed_keys_survive_the_pass () =
   with_workspace @@ fun config ->
   write_keeper config "dormant";
-  inject_keys config "dormant" ~extra:[ ("autoboot_enabled", `Bool false) ];
+  inject_keys config "dormant"
+    ~extra:
+      [
+        ("autoboot_enabled", `Bool false);
+        ("compaction_mode", `String "llm");
+        ("keeper_name", `String "dormant");
+      ];
   Keeper_meta_store.canonicalize_persisted_meta_files config;
   let json = raw_json config "dormant" in
   check bool "retired continuity keys dropped" true
     (assoc_field json "last_continuity_update_ts" = None
      && assoc_field json "continuity_summary" = None);
-  (match assoc_field json "autoboot_enabled" with
-   | Some (`Bool false) -> ()
-   | Some other ->
-     fail
-       ("autoboot_enabled value changed: " ^ Yojson.Safe.to_string other)
-   | None ->
-     fail
-       "autoboot_enabled destroyed by canonicalize — dormant keeper would \
-        autoboot on next boot")
+  let expect_preserved key expected =
+    match assoc_field json key with
+    | Some v when v = expected -> ()
+    | Some other ->
+      fail
+        (Printf.sprintf "%s value changed: %s" key (Yojson.Safe.to_string other))
+    | None ->
+      fail
+        (Printf.sprintf
+           "%s destroyed by canonicalize — parser-consumed value lost" key)
+  in
+  expect_preserved "autoboot_enabled" (`Bool false);
+  expect_preserved "compaction_mode" (`String "llm");
+  expect_preserved "keeper_name" (`String "dormant")
 
 let test_clean_files_are_not_rewritten () =
   with_workspace @@ fun config ->
@@ -163,11 +177,13 @@ let test_second_pass_is_a_no_op () =
   write_keeper config "stale";
   inject_retired_keys config "stale";
   Keeper_meta_store.canonicalize_persisted_meta_files config;
-  let version_after_first = read_version config "stale" in
+  (* Byte-level comparison: the raw-filter path never bumps meta_version,
+     so a version check could not detect a spurious second rewrite. *)
+  let bytes_after_first = Fs_compat.load_file (keeper_file config "stale") in
   Keeper_meta_store.canonicalize_persisted_meta_files config;
-  check int "second pass does not rewrite again"
-    version_after_first
-    (read_version config "stale")
+  check string "second pass leaves the file byte-identical"
+    bytes_after_first
+    (Fs_compat.load_file (keeper_file config "stale"))
 
 let test_unparsable_file_is_preserved_untouched () =
   with_workspace @@ fun config ->
@@ -208,8 +224,8 @@ let () =
         [
           test_case "drops retired keys, preserves canonical fields"
             `Quick test_drops_retired_keys_and_preserves_canonical_fields;
-          test_case "parser-consumed config keys survive the pass" `Quick
-            test_parser_consumed_config_keys_survive_the_pass;
+          test_case "parser-consumed keys survive the pass" `Quick
+            test_parser_consumed_keys_survive_the_pass;
           test_case "clean files are not rewritten" `Quick
             test_clean_files_are_not_rewritten;
           test_case "second pass is a no-op" `Quick test_second_pass_is_a_no_op;

--- a/test/test_keeper_meta_canonicalize.ml
+++ b/test/test_keeper_meta_canonicalize.ml
@@ -1,0 +1,184 @@
+(** Boot-time keeper meta canonicalization
+    (Keeper_meta_store.canonicalize_persisted_meta_files).
+
+    Reproduces the post-#23929 incident: the continuity purge removed
+    [last_continuity_update_ts]/[continuity_summary] from the serializer
+    but left them in persisted [.masc/keepers/*.json], so every meta read
+    re-warned "has unknown keys" until an unrelated save happened to
+    rewrite the file — and dormant keepers never saved. The canonicalize
+    pass must converge every persisted file onto the canonical key set
+    exactly once, preserve canonical field values, go through the CAS
+    write path, and leave unreadable files untouched. *)
+
+open Alcotest
+open Masc
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_meta_canonicalize_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  rm dir
+
+let with_workspace f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Workspace.default_config dir in
+      ignore (Workspace.init config ~agent_name:(Some "keeper-canonicalize-agent"));
+      f config)
+
+let make_meta name : Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+          ("trace_id", `String ("trace-" ^ name));
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> fail ("meta_of_json fixture failed: " ^ err)
+
+let keeper_file config name = Keeper_types_profile.keeper_meta_path config name
+
+let write_keeper config name =
+  match Keeper_meta_store.write_meta config (make_meta name) with
+  | Ok () -> ()
+  | Error msg -> fail ("write_meta failed: " ^ msg)
+
+(* Re-create the exact on-disk shape #23929 left behind: a valid meta
+   snapshot plus retired top-level keys the serializer no longer emits. *)
+let inject_retired_keys config name =
+  let path = keeper_file config name in
+  match Yojson.Safe.from_string (Fs_compat.load_file path) with
+  | `Assoc fields ->
+    let polluted =
+      `Assoc
+        (fields
+         @ [
+             ("last_continuity_update_ts", `Float 1780000000.0);
+             ("continuity_summary", `String "legacy continuity prose");
+           ])
+    in
+    Fs_compat.save_file path (Yojson.Safe.pretty_to_string polluted)
+  | _ -> fail "persisted keeper meta is not a JSON object"
+
+let read_version config name =
+  match Keeper_meta_store.read_meta config name with
+  | Ok (Some meta) -> meta.Keeper_meta_contract.meta_version
+  | Ok None -> fail ("keeper meta missing for " ^ name)
+  | Error msg -> fail ("read_meta failed: " ^ msg)
+
+let raw_json config name =
+  Yojson.Safe.from_string (Fs_compat.load_file (keeper_file config name))
+
+let test_drops_retired_keys_and_preserves_canonical_fields () =
+  with_workspace @@ fun config ->
+  write_keeper config "stale";
+  inject_retired_keys config "stale";
+  check bool "retired keys visible before the pass" true
+    (Keeper_meta_json.unknown_keeper_meta_keys (raw_json config "stale") <> []);
+  let version_before = read_version config "stale" in
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  check (list string) "no unknown keys remain on disk" []
+    (Keeper_meta_json.unknown_keeper_meta_keys (raw_json config "stale"));
+  (match Keeper_meta_store.read_meta config "stale" with
+   | Ok (Some meta) ->
+     check string "canonical name preserved" "stale"
+       meta.Keeper_meta_contract.name;
+     check string "canonical agent_name preserved" "keeper-stale-agent"
+       meta.Keeper_meta_contract.agent_name;
+     check int "rewrite went through the CAS path (version bumped)"
+       (version_before + 1)
+       meta.Keeper_meta_contract.meta_version
+   | Ok None -> fail "keeper meta vanished after canonicalize"
+   | Error msg -> fail ("read_meta after canonicalize failed: " ^ msg))
+
+let test_clean_files_are_not_rewritten () =
+  with_workspace @@ fun config ->
+  write_keeper config "clean";
+  let version_before = read_version config "clean" in
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  check int "clean file keeps its meta_version (no rewrite)"
+    version_before
+    (read_version config "clean")
+
+let test_second_pass_is_a_no_op () =
+  with_workspace @@ fun config ->
+  write_keeper config "stale";
+  inject_retired_keys config "stale";
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  let version_after_first = read_version config "stale" in
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  check int "second pass does not rewrite again"
+    version_after_first
+    (read_version config "stale")
+
+let test_unparsable_file_is_preserved_untouched () =
+  with_workspace @@ fun config ->
+  write_keeper config "clean";
+  let corrupt_path = keeper_file config "corrupt" in
+  let corrupt_content = "{not-json" in
+  Fs_compat.save_file corrupt_path corrupt_content;
+  Keeper_meta_store.canonicalize_persisted_meta_files config;
+  check string "corrupt file content preserved for operator repair"
+    corrupt_content
+    (Fs_compat.load_file corrupt_path)
+
+let test_unknown_keys_pure_function () =
+  let canonical_only =
+    `Assoc
+      (List.map
+         (fun key -> (key, `Null))
+         Keeper_meta_json.canonical_keeper_meta_key_names)
+  in
+  check (list string) "all-canonical object has no unknown keys" []
+    (Keeper_meta_json.unknown_keeper_meta_keys canonical_only);
+  check (list string) "retired keys are reported in order"
+    [ "last_continuity_update_ts"; "continuity_summary" ]
+    (Keeper_meta_json.unknown_keeper_meta_keys
+       (`Assoc
+         [
+           ("name", `String "x");
+           ("last_continuity_update_ts", `Float 0.0);
+           ("continuity_summary", `String "y");
+         ]));
+  check (list string) "non-object JSON has no unknown keys" []
+    (Keeper_meta_json.unknown_keeper_meta_keys (`String "not an object"))
+
+let () =
+  run "keeper_meta_canonicalize"
+    [
+      ( "canonicalize_persisted_meta_files",
+        [
+          test_case "drops retired keys, preserves canonical fields, CAS bump"
+            `Quick test_drops_retired_keys_and_preserves_canonical_fields;
+          test_case "clean files are not rewritten" `Quick
+            test_clean_files_are_not_rewritten;
+          test_case "second pass is a no-op" `Quick test_second_pass_is_a_no_op;
+          test_case "unparsable file is preserved untouched" `Quick
+            test_unparsable_file_is_preserved_untouched;
+        ] );
+      ( "unknown_keeper_meta_keys",
+        [
+          test_case "pure key-set classification" `Quick
+            test_unknown_keys_pure_function;
+        ] );
+    ]


### PR DESCRIPTION
## 증상

#23929가 `last_continuity_update_ts` / `continuity_summary`를 serializer에서 제거했지만 `.masc/keepers/*.json`은 마이그레이션하지 않았습니다. 활성 Keeper는 다음 save 때 우연히 정화되지만 휴면 Keeper는 매 read마다 unknown-key WARN과 `MetaJsonFailures{site=unknown_keys}`를 무기한 발생시켰습니다.

## 근본원인

- 영속 schema 제거와 on-disk migration이 분리됨
- 정화가 “다음 save”라는 비결정 이벤트에 의존함
- 같은 목적의 `scrub_persisted_keeper_meta_json`은 호출자 0건인 채 non-atomic rewrite와 별도 key 목록을 남김

## 수리

- 부팅 시 `Keeper_meta_store.migrate_retired_keeper_meta_keys`를 동기 1회 실행
- 삭제 집합은 파괴적 연산에 맞게 **명시 retired-key 목록**으로 유지
- raw JSON에서 해당 키만 filter하고 `Keeper_fs.save_json_atomic`으로 저장
- parser-consumed/serializer-non-emitted 키(`autoboot_enabled`, `compaction_mode`, `keeper_name`)와 `meta_version`은 그대로 보존
- unreadable/parse-rejected 파일은 WARN 후 원본 보존; 다음 boot에서 재시도
- migration을 `server_state := Some state` **이전**에 실행해 HTTP mutation routes, connectors, maintenance, Keeper loop 어떤 writer도 publish되기 전에 완료
- 호출자 0건인 legacy `scrub_persisted_keeper_meta_json` 삭제

`canonicalize`라는 과장된 명칭도 제거했습니다. 이 pass는 canonical 보완집합을 삭제하지 않고, 오직 명시적으로 retired된 키만 migration합니다.

## 검증

- 회귀 테스트 6종: retired-key 제거/생존 필드 보존/clean no-op/2차 pass byte-identical/corrupt 보존/unknown-key 순수 분류
- changed OCaml parser check: pass
- `ocamlformat --check`: pass
- `git diff --check`: pass
- determinism / silent-failure / keeper-hardcoding / MASC→OAS boundary checks: pass (기존 warning만 존재)
- local Dune build/test 미실행 — CI가 build authority

## Merge gate

exact head `525955bee9` CI가 terminal green이 될 때까지 Draft / `p1` / `status:do-not-merge` 유지.

[근거] base `49885b7840`, head `525955bee9`, source/static checks 2026-07-10T10:15:26Z; 신뢰도 High.
