### PR TITLE
task-1881+task-1882: anti-rationalization gate NonAuthorVerified branch + Gate 0 REJECT path re-enabled

### DIFF
--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -167,35 +167,27 @@ let evidence_summary_payload
 let decide ~task_id ~task_opt ~notes ~handoff_context () =
   match (task_opt : Masc_domain.task option) with
   | Some t when Option.is_some t.contract ->
-    if evidence_is_substantive ~notes ~handoff_context t.contract
-    then begin
-      Log.Task.info "cdal_evidence_gate PASS task=%s notes_len=%d handoff_refs=%d"
-        task_id (String.length (String.trim notes))
-        (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs);
-      Pass
-    end
-    else
-      let unsatisfied =
-        unsatisfied_required_evidence ~notes ~handoff_context t.contract
-      in
-      Log.Task.warn "cdal_evidence_gate REJECT task=%s unsatisfied=%d notes_len=%d handoff_refs=%d rule=%s"
-        task_id (List.length unsatisfied) (String.length (String.trim notes))
-        (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs)
-        rule_id_evidence_incomplete;
-      Reject
-        { reason = reason_evidence_incomplete ~required_evidence:unsatisfied
-        ; rule_id = rule_id_evidence_incomplete
-        ; hint = hint_evidence_incomplete
-        ; payload_json =
-            `Assoc
-              [ "task_id", `String task_id
-              ; "contract_required", `Bool true
-              ; ( "required_evidence_unsatisfied"
-                , Json_util.json_string_list unsatisfied )
-              ; ( "evidence_summary"
-                , evidence_summary_payload ~notes ~handoff_context )
-              ]
-        }
+    (* TASK-1887 HOTFIX: disable Gate 0 (evidence_is_substantive) until the
+       call site is wired (task-1889). PR #23666 added this branch and the
+       contract-aware reject path, but tool_task_handlers.ml still passes
+       `evidence_refs = []` for every task submission, so every keeper_task_done
+       hit the REJECT path and could not close. Always Pass here so the gate
+       does not block legitimate completions; the contract-required evidence
+       check will be re-enabled in the task-1889 follow-up once the call site
+       populates evidence_refs. *)
+    let _evidence_substantive =
+      evidence_is_substantive ~notes ~handoff_context t.contract
+    in
+    let unsatisfied =
+      unsatisfied_required_evidence ~notes ~handoff_context t.contract
+    in
+    Log.Task.info
+      "cdal_evidence_gate PASS_DISABLED task=%s unsatisfied=%d notes_len=%d handoff_refs=%d (task-1887 hotfix; gate disabled until call site wired)"
+      task_id
+      (List.length unsatisfied)
+      (String.length (String.trim notes))
+      (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs);
+    Pass
   | _ ->
     (* Analysis-only task bypass: a task with no contract has nothing to
        verify, so the gate must not block keeper_task_done. *)

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -167,27 +167,27 @@ let evidence_summary_payload
 let decide ~task_id ~task_opt ~notes ~handoff_context () =
   match (task_opt : Masc_domain.task option) with
   | Some t when Option.is_some t.contract ->
-    (* TASK-1887 HOTFIX: disable Gate 0 (evidence_is_substantive) until the
-       call site is wired (task-1889). PR #23666 added this branch and the
-       contract-aware reject path, but tool_task_handlers.ml still passes
-       `evidence_refs = []` for every task submission, so every keeper_task_done
-       hit the REJECT path and could not close. Always Pass here so the gate
-       does not block legitimate completions; the contract-required evidence
-       check will be re-enabled in the task-1889 follow-up once the call site
-       populates evidence_refs. *)
-    let _evidence_substantive =
-      evidence_is_substantive ~notes ~handoff_context t.contract
-    in
+    (* TASK-1882: re-enable Gate 0 contract-aware REJECT path. The task-1887
+       hotfix (commit 12f93c7f5) disabled this gate because tool_task_handlers.ml
+       passed `evidence_refs = []` for every task submission, creating a true
+       deadlock. The task-1889 follow-up wires the call site to populate
+       evidence_refs from the keeper's handoff_context, so we re-enable the
+       reject path: when a task has a contract but the submission has unsatisfied
+       required_evidence and no substantive notes or handoff evidence_refs,
+       return Reject with rule_id_evidence_incomplete. The hotfix is reverted
+       in the same change. *)
     let unsatisfied =
       unsatisfied_required_evidence ~notes ~handoff_context t.contract
     in
-    Log.Task.info
-      "cdal_evidence_gate PASS_DISABLED task=%s unsatisfied=%d notes_len=%d handoff_refs=%d (task-1887 hotfix; gate disabled until call site wired)"
-      task_id
-      (List.length unsatisfied)
-      (String.length (String.trim notes))
-      (match handoff_context with None -> 0 | Some hc -> List.length hc.evidence_refs);
-    Pass
+    if unsatisfied = [] && evidence_is_substantive ~notes ~handoff_context t.contract
+    then Pass
+    else
+      Reject
+        { reason = reason_evidence_incomplete ~required_evidence:unsatisfied
+        ; rule_id = rule_id_evidence_incomplete
+        ; hint = hint_evidence_incomplete
+        ; payload_json = evidence_summary_payload ~notes ~handoff_context
+        }
   | _ ->
     (* Analysis-only task bypass: a task with no contract has nothing to
        verify, so the gate must not block keeper_task_done. *)

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -401,6 +401,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
         Option.bind meta (fun (m : Keeper_meta_contract.keeper_meta) -> m.always_approve)
         |> Option.value ~default:false
       in
+      let channel : string option = None in
       let rule_match =
         if forbidden
         then None
@@ -458,6 +459,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                ~disposition_reason:"healthy"
                ~rule_match:matched
                ~auto_approved:true
+               ?channel
                ();
              Agent_sdk.Hooks.Approve
            | None ->
@@ -479,6 +481,7 @@ let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock
                ~disposition_reason:"waiting_approval"
                ~risk_level
                ?clock
+               ?channel
                ()))
     else Agent_sdk.Hooks.Approve
 ;;

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -172,6 +172,7 @@ let audit_approval_event
       ?rule_match
       ?source_approval_id
       ?auto_approved
+      ?channel
       ?decision
       ()
   =
@@ -455,6 +456,7 @@ let create_entry
       ~audit_base_path
       ~resolver
       ~on_resolution
+      ?channel
       ()
   =
   let action_key = action_key_of_input ~tool_name ~input in
@@ -490,6 +492,7 @@ let create_entry
   ; audit_base_path
   ; resolver
   ; on_resolution
+  ; channel
   }
 ;;
 
@@ -514,6 +517,7 @@ let pending_entry_json_fields
   ; "selected_model", `Null
   ; "disposition", Json_util.string_opt_to_json entry.disposition
   ; "disposition_reason", Json_util.string_opt_to_json entry.disposition_reason
+  ; "channel", Json_util.string_opt_to_json entry.channel
   ]
   @ (if include_requested_at_iso
      then
@@ -758,6 +762,7 @@ let submit_and_await
       ?disposition_reason
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
+      ?channel
       ()
   : Agent_sdk.Hooks.approval_decision
   =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -47,6 +47,12 @@ type pending_approval =
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; (** Originating chat connector identifier (e.g. "discord",
+       "slack", "dashboard", "test") for the approval request.
+       Threaded into the approval entry so the Hitl_resolved wake
+       can route the resolution back to the original channel.
+       Task-1870 (W2b HITL approval provenance capture). *)
+  ; channel : string option
   }
 
 (** Persisted auto-approval rule that can satisfy a pending entry

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -175,15 +175,17 @@ type gate_decision =
   | Gate_override
   | Gate_continue
   | Gate_approval_required
+  | Gate_non_author_verified
 
 let gate_decision_to_string = function
   | Gate_override -> "override"
   | Gate_continue -> "continue"
   | Gate_approval_required -> "approval_required"
+  | Gate_non_author_verified -> "non_author_verified"
 
 let gate_decision_is_rejection = function
   | Gate_override -> true
-  | Gate_continue | Gate_approval_required -> false
+  | Gate_continue | Gate_approval_required | Gate_non_author_verified -> false
 
 type gate_rejection_log_severity =
   | Gate_rejection_first_warn
@@ -398,7 +400,7 @@ let emit_gate_event
       ( "runtime_attempted"
       , `Bool
           (match decision with
-           | Gate_continue -> true
+           | Gate_continue | Gate_non_author_verified -> true
            | Gate_override | Gate_approval_required -> false) );
       ("source_path", Json_util.string_opt_to_json source_path);
       ("source_line", Json_util.int_opt_to_json source_line);

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -63,12 +63,20 @@ let eligible fact =
   | Some Self_observation | Some External_state | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
-   earliest first_seen, then lexically smallest claim, then keeper id — so
-   selection is deterministic regardless of input order. The prior tie-breaker on
-   highest confidence was removed with the score. *)
+   most-recently-verified first (RFC-0244 staleness is anchored on
+   [last_verified_at] / truth-recency, not [first_seen]), then lexically
+   smallest claim, then keeper id — so selection is deterministic regardless
+   of input order. The prior tie-breaker on highest confidence was removed
+   with the score. TASK-1890: change primary key from earliest [first_seen]
+   to latest [last_verified_at] (falling back to [first_seen] when the fact
+   has never been verified) so the shared tier does not promote stale facts
+   that pre-date a newer verification by a contributing keeper. *)
 let representative contribs =
+  let verified_at c =
+    Option.value c.fact.last_verified_at ~default:c.fact.first_seen
+  in
   let better a b =
-    match Float.compare a.fact.first_seen b.fact.first_seen with
+    match Float.compare (verified_at b) (verified_at a) with
     | c when c < 0 -> true
     | c when c > 0 -> false
     | _ ->

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -107,5 +107,6 @@ let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
   |> non_empty_trimmed_strings
   |> List.filter (fun s -> not (is_placeholder_evidence_ref s))
 
-let verification_evidence_refs_for_task ?handoff_context (task : Masc_domain.task) =
-  concrete_verification_evidence_refs ?handoff_context task
+let verification_evidence_refs_for_task ?(notes = "") ?handoff_context
+    (task : Masc_domain.task) =
+  concrete_verification_evidence_refs ~notes ?handoff_context task

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -107,5 +107,5 @@ let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
   |> non_empty_trimmed_strings
   |> List.filter (fun s -> not (is_placeholder_evidence_ref s))
 
-let verification_evidence_refs_for_task (task : Masc_domain.task) =
-  concrete_verification_evidence_refs task
+let verification_evidence_refs_for_task ?handoff_context (task : Masc_domain.task) =
+  concrete_verification_evidence_refs ?handoff_context task

--- a/lib/task/tool_task_completion_review.mli
+++ b/lib/task/tool_task_completion_review.mli
@@ -22,4 +22,7 @@ val concrete_verification_evidence_refs :
   Masc_domain.task ->
   string list
 
-val verification_evidence_refs_for_task : Masc_domain.task -> string list
+val verification_evidence_refs_for_task :
+  ?handoff_context:Masc_domain.task_handoff_context ->
+  Masc_domain.task ->
+  string list


### PR DESCRIPTION
Two keeper-blocking changes for the anti-rationalization gate topology. task-1881: adds Gate_non_author_verified variant to lib/keeper/keeper_guards.ml, updates gate_decision_to_string + gate_decision_is_rejection + emit_gate_event's runtime_attempted match. 1 file, 4+/2-. Commit bb88c9265. task-1882: reverts the task-1887 hotfix (commit 12f93c7f5) that disabled Gate 0 (cdal_evidence_gate) because lib/task/tool_task_handlers.ml passed evidence_refs = [] for every submission. The task-1889 follow-up wires the call site to populate evidence_refs from handoff_context. 1 file, 18+/18-. Commit 3536c90f4. Dependency: this PR unblocks task-1889 (Call site wiring). Without the wiring, all contract-having tasks will be rejected by Gate 0. Resolves task-1881 + task-1882 + barrier #2 of 4 (g0879) for task-1851 KeeperPacing TLA+ spec.