### PR TITLE
fix(ci): derive metric inventory and repair latent-red contracts

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -67,6 +67,7 @@
   (domain-name (>= 0.4))
   (ca-certs (>= 0.2))
   (ppx_deriving_yojson (>= 3.6))
+  (ppx_enumerate (>= v0.17.0))
   (ppx_let (>= v0.17.0))
   (ppx_deriving (>= 5.2))
   (ppxlib (>= 0.30))

--- a/lib/keeper_metrics/dune
+++ b/lib/keeper_metrics/dune
@@ -19,4 +19,6 @@
   keeper_oas_execution_error_phase
   keeper_operator_compact_result
   keeper_tool_outcome)
+ (preprocess
+  (pps ppx_enumerate))
  (libraries masc_core otel_metric_store time_compat unix yojson))

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -256,6 +256,7 @@ type t =
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
   | WireCaptureRecordSkipped    (* counter: wire-capture record dropped by current-file byte cap *)
+[@@deriving enumerate]
 
 (** String conversion
 
@@ -534,77 +535,6 @@ let to_string = function
     "masc_keeper_wire_capture_response_suppressed_total"
   | WireCaptureWriteFailures -> "masc_keeper_wire_capture_write_failures_total"
   | WireCaptureRecordSkipped -> "masc_keeper_wire_capture_record_skipped_total"
-;;
-
-(* Every constructor of [t], in declaration order.  Consumed by
-   [register_zero_fill] below.  The compiler cannot enforce membership
-   here (no enumerate ppx in this repo): when you add a constructor,
-   exhaustiveness already forces you to edit [to_string] in this file --
-   add the constructor to [all] in the same edit. *)
-let all : t list =
-  [ Turns; InputTokens; OutputTokens; CacheCreationTokens;
-    CacheReadTokens; UsageAnomalies; TotalCostUsd; TurnScheduled;
-    TurnCompleted; PacingShadowEvents; PacingShadowNextDueSec; FailureRoute; FailureDrivenPause; IdleSeconds; ContractViolations; MetricEmitDropped;
-    ContextMaxObserved; TurnStarts; TurnReattempts; TurnRegressions;
-    TurnLivelockBlocks; TurnLivelockBlocksRepeated; TurnLivelockBlocksThresholdPark; TurnLatencyBucket;
-    TurnLatencyByModelBucket; ProviderCooldownSkip; ProviderCooldownRemainingSec; ProviderBlockDurationSec;
-    TurnQueueDepth; SupervisorSweepStarts; SupervisorLastSweepUnixtime; DomainPoolFork;
-    TurnHolderBookkeepingFailures; Compactions; CompactionRatioChange; CompactionSavedTokens;
-    CompactionPairRepairDrops; EmergencyCompactRatioThreshold; OperatorCompact; OperatorClear;
-    CompactionNoop; ToolPairRepair; ToolEmissionRegistrySize; ToolEmissionPushes;
-    ToolUnderusedAllowedCount; ToolUnderusedAllowed; PathRejection; IdeOrphanWrites;
-    PathResolverIdentityMismatch; KeeperMetaOverlayDrift; HeartbeatSuccesses; HeartbeatFailures; CleanupTrackingFailures;
-    DispatchEventFailures; DirectiveFailures; ToolCallDuration; ToolCallDurationBucket; WriteMetaFailures;
-    MetaReadFailures; ApprovalQueueFailures; GuardsFailures; ProfileLoadFailures;
-    CompactAuditFailures; CompactAuditRetentionParse; CompactAuditDrainBatches; CompactAuditDrainBatchSizeBucket;
-    FsFailures; CrashPersistenceFailures; GenerationLineageFailures; KeepaliveSignalFailures;
-    BoardSignalWakeupCappedTotal; BoardSignalNoWakeTotal; BoardSignalAttentionCandidateTotal; MetaJsonFailures; ToolsOasFailures;
-    ToolsOasDeterministicFailures; TurnUpUpdateFailures; AgentToolDispatchRuntimeFailures; CircuitBreakerTrips;
-    PromptFailures; RunContextFailures; SearchFilesFailures; TagDispatchFailures;
-    TraceEmitFailures; TransitionAuditFailures; ExecutionReceiptFailures; OperatorBroadcastSuppressed;
-    LlmBridgeFailures; SessionCleanupFailures; ToolExecuteFailures; RolloverFailures;
-    LifecycleDispatchRejections; RecordingErrorDedup; PausedStatePersistErrors; UnexpectedToolPartialTolerance;
-    ToolCallTotal; ProfileConfigConflicts; OasTimeoutClassifications; NoToolProvider;
-    ProactiveOutcome; OllamaSaturationSkip; TaskLoadFailures; ToolSelectionFailures;
-    ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
-    ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
-    PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
-    TurnFailureStreakPaused;
-    CycleExceptions; SnapshotReadFailures; SnapshotWriteFailures; PromptUnknownToolTokens;
-    PromptTokenStripped;
-    ProgressUpdatedLineFailures;
-    SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;
-    EpisodeCreateFailures; MemoryActivityEmitFailures; SupervisorSweepFailures; TomlReconcileSweepFailures;
-    TomlReconcileDedup; ReconcileDisabled; ToolUsageFlushFailures; TurnTimeoutCommitted;
-    TurnErrorAfterTools; RuntimeSyncFailures; LocalDiscoveryFailures; ThinkingPersistFailures;
-    CheckpointFailures; DecisionAuditRingOverflows; ReplySkillRouteStrips; ReplySkillRouteLinesRemoved;
-    MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; HitlSummaryOutcomes; UserVisibleReplySource;
-    OasEnvKeyRejections;
-    MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneRanInline; MemoryLaneDropped;
-    MemoryLanePending; MemoryLaneInFlight; MemoryLaneProviderSlotBusy; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
-    MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; KeeperMaterializationFailures; ObservationQueryFailures; OasOnStop;
-    InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
-    TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;
-    EventBusDrain; SupervisorCleanupFailures; SpawnSlotDenied; RegistryUpdateDropped;
-    RegistryOrphanThresholdBreached; RegistryInvalidEntry; DeadTotal; AutoResumedTotal; AutoResumeBlockedTotal;
-    SkipIdleWakeResumed; EventQueueOverride; StimulusConsumed; UnsupportedStimulus;
-    NearExhaustionTotal; RestartAttempts; RestartOutcomes;
-    LastProductiveTs; ProviderTimeoutStrike; StaleTerminationTotal; StaleTerminationByClass;
-    ProviderTimeoutWatchdogTermination; StaleTerminationThresholdBreached; StaleTerminationBatch; StaleBroadcastEmitFailures;
-    OasRunTimeout; RuntimeSaturationSignal; RuntimeSelected; RuntimeRotation; ToolUseFailure; ToolNotAllowed;
-    TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
-    DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
-    UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
-    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; MemoryOsReobserveEchoSuppressed; RuntimeHttpProbeJsonParseFailures;
-    VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
-    KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;
-    GhClassificationTotal; GatedGhLifecycleTotal; GatedGhBlockTimeSeconds;
-  KeeperRepoMappingDefaultScopeAllowed; KeeperRepoMappingDeniedUnregistered;
-  KeeperRepoMappingLoadError;
-  KeeperRepoMappingRepositoryIdentityMismatch; KeeperRepoMappingRepositoryStoreError;
-  RawTraceSinkDegraded; WireCaptureResponseSuppressed; WireCaptureWriteFailures;
-  WireCaptureRecordSkipped
-  ]
 ;;
 
 let emit_runtime_selected ~keeper_name ~runtime_id ~fallback_reason =

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -255,7 +255,7 @@ val emit_runtime_selected :
 val emit_runtime_rotation :
   keeper_name:string -> from_runtime:string -> to_runtime:string -> reason:string -> unit
 
-(** Every constructor of [t] in declaration order.  Keep in sync when
-    adding constructors (the [to_string] exhaustive match in the .ml
-    forces an edit in the same file). *)
+(** Every constructor of [t], generated from the type declaration by
+    [ppx_enumerate].  Membership is compiler-maintained; list order is not a
+    public contract. *)
 val all : t list

--- a/masc.opam
+++ b/masc.opam
@@ -37,6 +37,7 @@ depends: [
   "domain-name" {>= "0.4"}
   "ca-certs" {>= "0.2"}
   "ppx_deriving_yojson" {>= "3.6"}
+  "ppx_enumerate" {>= "v0.17.0"}
   "ppx_let" {>= "v0.17.0"}
   "ppx_deriving" {>= "5.2"}
   "ppxlib" {>= "0.30"}

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -17,9 +17,9 @@ lib/exec/exec_dispatch.ml:378  # argv_dispatch
 lib/exec_policy/exec_policy.ml:148  # parser_consumer
 lib/graphql_client.ml:102  # argv_subsystem
 lib/graphql_client.ml:87  # argv_subsystem
-lib/keeper/keeper_alerting.ml:333  # argv_keeper
-lib/keeper/keeper_alerting.ml:383  # argv_keeper
-lib/keeper/keeper_alerting.ml:477  # argv_keeper
+lib/keeper/keeper_alerting.ml:212  # argv_keeper
+lib/keeper/keeper_alerting.ml:262  # argv_keeper
+lib/keeper/keeper_alerting.ml:356  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:224  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:477  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:196  # argv_keeper

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1065,45 +1065,46 @@ let () =
      an already-running autonomous OAS loop. The classifier reads the same
      registry queue this test dequeues below; no age, count, or payload text
      heuristic participates. *)
-  let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
-  Fun.protect
-    ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
-      Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "keeper-event-queue-yield-test" in
-      let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
-      Masc.Keeper_registry.clear ();
-      Masc.Keeper_chat_queue.clear ~keeper_name;
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
-      (match
-         Masc.Keeper_unified_turn_execution.autonomous_yield_request
-           ~base_path
-           ~keeper_name
-           ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
-       with
-       | None -> ()
-       | Some _ ->
-         Alcotest.fail "empty work queues must not request an autonomous yield");
-      Masc.Keeper_registry_event_queue.enqueue
-        ~base_path
-        keeper_name
-        bootstrap_stim;
-      match
-        Masc.Keeper_unified_turn_execution.autonomous_yield_request
+  Eio_main.run (fun _env ->
+    let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
+    Fun.protect
+      ~finally:(fun () ->
+        Masc.Keeper_registry.clear ();
+        Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
+        rm_rf base_path)
+      (fun () ->
+        let keeper_name = "keeper-event-queue-yield-test" in
+        let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
+        Masc.Keeper_registry.clear ();
+        Masc.Keeper_chat_queue.clear ~keeper_name;
+        ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+        (match
+           Masc.Keeper_unified_turn_execution.autonomous_yield_request
+             ~base_path
+             ~keeper_name
+             ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+         with
+         | None -> ()
+         | Some _ ->
+           Alcotest.fail "empty work queues must not request an autonomous yield");
+        Masc.Keeper_registry_event_queue.enqueue
           ~base_path
-          ~keeper_name
-          ~channel:Masc.Keeper_world_observation.Reactive
-      with
-      | Some
-          { Masc.Keeper_agent_run.reason =
-              Masc.Keeper_agent_run.Durable_stimulus_waiting
-          ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
-          } ->
-        ()
-      | None | Some _ ->
-        Alcotest.fail "pending durable stimulus must request a typed yield");
+          keeper_name
+          bootstrap_stim;
+        match
+          Masc.Keeper_unified_turn_execution.autonomous_yield_request
+            ~base_path
+            ~keeper_name
+            ~channel:Masc.Keeper_world_observation.Reactive
+        with
+        | Some
+            { Masc.Keeper_agent_run.reason =
+                Masc.Keeper_agent_run.Durable_stimulus_waiting
+            ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
+            } ->
+          ()
+        | None | Some _ ->
+          Alcotest.fail "pending durable stimulus must request a typed yield"));
 
   (* --- critical delivery: durable enqueue succeeds before registration and
      is replayed when that keeper lane appears. --- *)

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -1,6 +1,17 @@
 module Claim = Masc.Keeper_repo_claim_hitl
 module AQ = Masc.Keeper_approval_queue
 
+(* #23956 made nonblocking resolution fail closed when no delivery hook is
+   installed (the pre-bootstrap default is None). These tests resolve
+   approvals without a server bootstrap, so install the same no-op hook the
+   approval queue's own suite uses; delivery semantics are covered there,
+   not here. *)
+let () =
+  AQ.set_approval_resolution_wake_hook
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+;;
+
 open Repo_manager_types
 
 let contains_substring s needle =

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -56,8 +56,10 @@ let test_chat_transport_metric_zero_filled () =
 let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
-     constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 251
+     constructor, add it to [all] as well.  245 = 253 before the #23929
+     prose/BDI purge minus the 8 constructors it retired (the purge updated
+     this pin to 251, undercounting its own removals by 6). *)
+  check int "Keeper_metrics.all covers every constructor" 245
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -54,13 +54,9 @@ let test_chat_transport_metric_zero_filled () =
     check (float 0.0) "chat transport failure counter starts at 0" 0.0 m.value
 
 let test_keeper_metrics_all_complete () =
-  (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
-     ppx; this count is the drift tripwire.  If this fails after adding a
-     constructor, add it to [all] as well.  245 = 253 before the #23929
-     prose/BDI purge minus the 8 constructors it retired (the purge updated
-     this pin to 251, undercounting its own removals by 6). *)
-  check int "Keeper_metrics.all covers every constructor" 245
-    (List.length Keeper_metrics.all);
+  (* [Keeper_metrics.all] is generated from the variant declaration, so
+     constructor coverage is guaranteed by compilation rather than a numeric
+     pin.  Keep the independent wire-name uniqueness contract here. *)
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"
     (List.length names)


### PR DESCRIPTION
## 문제

#23929 이후 quick-suite에서 독립적인 latent-red 네 계열이 드러났습니다.

1. `Keeper_metrics.t`와 수동 `all` 목록, 숫자 count pin이 동일 사실을 세 번 보유해 purge 때 drift했습니다.
2. repo-claim HITL 테스트는 #23956의 fail-closed wake delivery 이후 bootstrap 없이 resolution을 수행했습니다.
3. shell parse-site baseline은 동일한 세 argv site의 줄 이동을 새 site로 오인했습니다.
4. autonomous-yield 테스트가 Eio 런타임 밖에서 `Keeper_chat_queue`의 Eio.Mutex를 호출해 global registry mutex를 poison했습니다.

## 수리

- `Keeper_metrics.t`에 `ppx_enumerate`를 적용해 `all`을 variant 선언에서 컴파일 타임 생성합니다.
  - 수동 70여 줄 목록 제거
  - 245/251 숫자 pin 제거
  - `to_string` wire-name injectivity 테스트 유지
- direct preprocessor dependency를 `dune-project`에 선언하고 generated `masc.opam`을 재생성해 lockfile-only 의존을 제거했습니다.
- repo-claim HITL suite에 테스트 범위용 명시적 no-op wake hook을 설치합니다. 실제 delivery semantics는 approval queue suite가 소유합니다.
- keeper_alerting baseline은 실제 현재 세 호출 위치만 반영합니다.
- autonomous-yield 구간 전체를 `Eio_main.run` 안에서 실행해 queue mutex의 runtime 전제를 지킵니다.

## 검증

- `scripts/dune-local.sh build masc.opam`: PASS; `masc.opam` generated from `dune-project`
- `git diff --check`: PASS
- direct dependency truth: `dune-project`, generated `masc.opam`, locked `masc.opam.locked`, library stanza 일치
- previous current-head static checks: ocamlformat/parser/determinism/silent-failure PASS
- full build/test authority: exact-head PR CI

## 상태

Latest main `86ca4b9c80` 동기화. Draft + `p1` + `status:do-not-merge` 유지. current-head CI와 formal review 완료 전 병합하지 않습니다.

[근거] head `ccfd452c34bb6c390ddbd089481920ba5ea4b51a`, base `86ca4b9c80084c4db0b8e1d8e8d95975fba79393`, generated-opam focused target를 2026-07-10 20:27 KST에 확인; 신뢰도 High.
