### PR TITLE
refactor(keeper): remove orphan progress writer

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -541,7 +541,7 @@ clock을 갱신하지 않는다.
 
 ### 15.2 keeper_types.ml include chain
 
-`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation/delete-action/trace-path/memory/progress/decision-log support helper를 `Keeper_types_support` 소유로 돌렸지만, 구현 include chain 자체는 남아 있어 가독성이 낮다.
+`keeper_types.ml`이 `include Keeper_types_profile`과 `include Keeper_types_support`를 연쇄적으로 포함하여, 실제 타입 정의가 3개 파일에 분산된다. 공개 `keeper_types.mli`는 JSONL/history-source/metrics/API-key/alert-path/rotation/delete-action/trace-path/memory/decision-log support helper를 `Keeper_types_support` 소유로 돌렸지만, 구현 include chain 자체는 남아 있어 가독성이 낮다.
 
 ### 15.3 keeper_memory 계층의 include chain
 

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -295,49 +295,11 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
   read_candidate requested_name
 ;;
 
-let is_missing_progress_file_error exn =
-  match exn with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> true
-  | _ ->
-    let message = Printexc.to_string exn in
-    String_util.contains_substring message "ENOENT"
-    || String_util.contains_substring message "No such file"
-;;
-
-let refresh_progress_updated_line config name =
-  let progress_path = Keeper_types_support.keeper_progress_path config name in
-  if Fs_compat.file_exists progress_path then try
-    let content = Fs_compat.load_file progress_path in
-    let now_str = Masc_domain.now_iso () in
-    let updated =
-      String.split_on_char '\n' content
-      |> List.map (fun line ->
-        if String.starts_with ~prefix:"Updated:" (String.trim line)
-        then "Updated: " ^ now_str
-        else line)
-      |> String.concat "\n"
-    in
-    Fs_compat.save_file progress_path updated
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn when is_missing_progress_file_error exn -> ()
-  | exn ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ProgressUpdatedLineFailures)
-      ~labels:[("keeper", name)]
-      ();
-    Log.Keeper.warn ~keeper_name:name
-      "progress Updated line refresh failed for %s: %s"
-      progress_path
-      (Printexc.to_string exn)
-;;
-
 let persist_meta config path persisted =
   let json = meta_to_json persisted in
   match Keeper_fs.save_json_atomic path json with
   | Ok () ->
     Atomic.get runtime_meta_write_sync_hook_atomic config persisted;
-    refresh_progress_updated_line config persisted.name;
     Ok ()
   | Error msg -> Error (Printf.sprintf "failed to write meta %s: %s" path msg)
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -100,15 +100,8 @@ val read_meta_if_changed :
   last_mtime:float ->
   (Keeper_meta_contract.keeper_meta * float) option
 
-(** Refresh the [Updated:] line in the keeper progress markdown.
-    Best-effort: a missing progress file is a no-op; other failures
-    increment [metric_keeper_progress_updated_line_failures] and log a
-    warning. *)
-val refresh_progress_updated_line : Workspace.config -> string -> unit
-
 (** Atomic write of [persisted] to [path]; runs the
-    [runtime_meta_write_sync_hook] and refreshes the progress
-    timestamp on success. *)
+    [runtime_meta_write_sync_hook] on success. *)
 val persist_meta :
   Workspace.config -> string -> Keeper_meta_contract.keeper_meta -> (unit, string) result
 

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -196,11 +196,6 @@ let prune_keeper_raw_trace_turn_files config name =
 let keeper_memory_bank_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")
 
-let keeper_progress_path config name =
-  let d = Filename.concat (keeper_dir_ config) name in
-  ignore (ensure_dir_ d);
-  Filename.concat d "progress.md"
-
 let keeper_generation_index_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".generation_index.jsonl")
 

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -69,7 +69,6 @@ val keeper_raw_trace_turn_path : Workspace.config -> string -> string
 val prune_keeper_raw_trace_turn_files : Workspace.config -> string -> int
 
 val keeper_memory_bank_path : Workspace.config -> string -> string
-val keeper_progress_path : Workspace.config -> string -> string
 val keeper_generation_index_path : Workspace.config -> string -> string
 
 (** Per-trace session directory under [.masc/traces/<trace_id>]. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -130,7 +130,6 @@ type t =
   | SnapshotWriteFailures
   | PromptUnknownToolTokens
   | PromptTokenStripped
-  | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures
   | TurnMetricsSnapshotFailures
@@ -393,7 +392,6 @@ let to_string = function
     "masc_keeper_prompt_unknown_tool_tokens_total"
   | PromptTokenStripped ->
     "masc_keeper_prompt_token_stripped_total"
-  | ProgressUpdatedLineFailures -> "masc_keeper_progress_updated_line_failures_total"
   | SseBroadcastFailures -> "masc_keeper_sse_broadcast_failures_total"
   | WorkspaceHeartbeatFailures -> "masc_keeper_workspace_heartbeat_failures_total"
   | TurnMetricsSnapshotFailures -> "masc_keeper_turn_metrics_snapshot_failures_total"
@@ -572,7 +570,6 @@ let all : t list =
     TurnFailureStreakPaused;
     CycleExceptions; SnapshotReadFailures; SnapshotWriteFailures; PromptUnknownToolTokens;
     PromptTokenStripped;
-    ProgressUpdatedLineFailures;
     SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;
     EpisodeCreateFailures; MemoryActivityEmitFailures; SupervisorSweepFailures; TomlReconcileSweepFailures;
     TomlReconcileDedup; ReconcileDisabled; ToolUsageFlushFailures; TurnTimeoutCommitted;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -121,7 +121,6 @@ type t =
   | SnapshotWriteFailures
   | PromptUnknownToolTokens
   | PromptTokenStripped
-  | ProgressUpdatedLineFailures
   | SseBroadcastFailures
   | WorkspaceHeartbeatFailures
   | TurnMetricsSnapshotFailures

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -128,38 +128,6 @@ let test_config_keys_are_warned_before_parse () =
         true
         (after > before))
 
-let fresh_tmpdir () =
-  let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
-  Sys.remove path;
-  let (_ : string) = Keeper_fs.ensure_dir path in
-  path
-
-let cleanup_tmpdir path =
-  Fs_compat.remove_tree path
-
-let test_progress_updated_line_failure_is_observable () =
-  let dir = fresh_tmpdir () in
-  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
-    let config = Workspace.default_config dir in
-    let keeper_name = "progress-refresh-failure" in
-    let progress_path =
-      Keeper_types_support.keeper_progress_path config keeper_name
-    in
-    let (_ : string) = Keeper_fs.ensure_dir progress_path in
-    let before =
-      Otel_metric_store.metric_total
-        Keeper_metrics.(to_string ProgressUpdatedLineFailures)
-    in
-    Keeper_meta_store.refresh_progress_updated_line config keeper_name;
-    let after =
-      Otel_metric_store.metric_total
-        Keeper_metrics.(to_string ProgressUpdatedLineFailures)
-    in
-    Alcotest.(check bool)
-      "progress Updated-line refresh failure increments counter"
-      true
-      (after > before))
-
 let () =
   Alcotest.run
     "keeper_meta_unknown_keys_warn"
@@ -184,10 +152,6 @@ let () =
             "config keys are warned before parse"
             `Quick
             test_config_keys_are_warned_before_parse
-        ; Alcotest.test_case
-            "progress Updated-line refresh failure is observable"
-            `Quick
-            test_progress_updated_line_failure_is_observable
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

#23929에서 `progress.md`의 모든 reader가 제거됐지만 `persist_meta`는 성공할 때마다 `refresh_progress_updated_line`을 호출해 아무도 소비하지 않는 파일을 계속 읽고 다시 썼습니다.

이 경로는 다음 레거시까지 연명했습니다.

- `keeper_progress_path`
- missing-file 문자열/예외 휴리스틱
- `ProgressUpdatedLineFailures` metric
- 고아 writer 실패를 검증하는 테스트

## 변경

- meta 저장 성공 후 `progress.md` 갱신 호출 제거
- `refresh_progress_updated_line`과 missing-file 판별 삭제
- reader/writer 0건인 path helper 삭제
- 이 writer 전용 metric variant 및 전용 실패 테스트 삭제
- `persist_meta` 문서를 실제 계약(runtime sync hook만 실행)에 맞춤
- live Keeper spec의 support-helper 목록에서 retired `progress` 항목 제거

`progress.md`를 새 형식으로 마이그레이션하거나 호환 writer를 남기지 않습니다. live consumer가 없는 영속 side effect를 완전히 숙청합니다.

## 검증

- repo-wide active references 0 (`refresh_progress_updated_line`, `keeper_progress_path`, metric)
- `ocamlformat --check` PASS
- `git diff --check` PASS
- `scripts/check-doc-truth.sh` PASS
- focused build `test/test_keeper_meta_unknown_keys_warn.exe` PASS
- focused test 5/5 PASS

Refs #23955 P2-1.

[근거] current head `5cd1e8d2e9`, current main `86ca4b9c80`; 확인 2026-07-10 KST; 신뢰도 High.
