### PR TITLE
fix(test): install noop HITL delivery hook in repo-claim test binary (main red)

### DIFF
--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -3,6 +3,18 @@ module AQ = Masc.Keeper_approval_queue
 
 open Repo_manager_types
 
+(* #23956 made nonblocking HITL resolution fail closed when no delivery
+   hook is installed (the durable-lane commit is the acknowledgment
+   point). It installed this no-op hook in the other approval-queue test
+   binaries but missed this one, leaving main's quick suite red with
+   "approval resolution delivery hook is not installed" on every resolve
+   in the repo advisory access group. Mirrors test_hitl_approval.ml. *)
+let () =
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in


### PR DESCRIPTION
## 증상 (main born-red)

main quick suite에서 `repo advisory access` 그룹 5케이스가 `approval resolution delivery hook is not installed`로 실패 (#23918의 신선 base 재실행 CI에서 확인 — merge-ref가 아니라 main 소속 테스트의 실패).

## 근본원인

#23956이 nonblocking HITL resolution을 fail-closed로 전환 (훅 미설치 = 명시 `Delivery_failed`, no-op 기본값 제거). 다른 approval-queue 테스트 바이너리 4개에는 no-op delivery hook을 설치했지만 **`test_keeper_repo_claim_hitl.ml`을 누락** — 부분 갱신(N-of-M) 클래스.

## 수리

같은 패턴의 no-op hook 1개를 파일 상단에 설치 (test_hitl_approval.ml과 동일). 12줄.

## 검증

- 실패 5케이스 전부 resolve 경로가 훅 부재로 죽는 것을 CI 로그로 확인 — 훅 설치로 해소.
- 로컬 dune은 정책상 미실행, CI가 빌드 authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
