### PR TITLE
feat(schedule): standing grants — one approval covers digest-identical recurrences (#33)

### DIFF
--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -240,11 +240,11 @@ export function setApprovalMode(mode: ApprovalMode): Promise<SetApprovalModeResp
   return post('/api/v1/dashboard/governance/approval-mode', { mode })
 }
 
-export type DashboardScheduleDecision = 'approve' | 'reject'
+export type DashboardScheduleDecision = 'approve' | 'reject' | 'revoke_standing'
 
 // Mirror of the server grant_scope: 'occurrence' approves only the current
 // due occurrence; 'standing' keeps covering future occurrences while the
-// schedule's payload digest and risk class stay unchanged.
+// schedule remains unchanged and the operator has not revoked the grant.
 export type DashboardScheduleGrantScope = 'occurrence' | 'standing'
 
 export interface DashboardScheduleResolveResponse {
@@ -253,6 +253,7 @@ export interface DashboardScheduleResolveResponse {
   decision: DashboardScheduleDecision
   approved_by?: unknown
   schedule?: unknown
+  revoked_grant_count?: number
 }
 
 export function resolveScheduleApproval(

--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -242,6 +242,11 @@ export function setApprovalMode(mode: ApprovalMode): Promise<SetApprovalModeResp
 
 export type DashboardScheduleDecision = 'approve' | 'reject'
 
+// Mirror of the server grant_scope: 'occurrence' approves only the current
+// due occurrence; 'standing' keeps covering future occurrences while the
+// schedule's payload digest and risk class stay unchanged.
+export type DashboardScheduleGrantScope = 'occurrence' | 'standing'
+
 export interface DashboardScheduleResolveResponse {
   ok: boolean
   schedule_id: string
@@ -254,11 +259,13 @@ export function resolveScheduleApproval(
   scheduleId: string,
   decision: DashboardScheduleDecision,
   reason?: string,
+  scope?: DashboardScheduleGrantScope,
 ): Promise<DashboardScheduleResolveResponse> {
   return post('/api/v1/dashboard/schedule/resolve', {
     schedule_id: scheduleId,
     decision,
     reason,
+    ...(scope != null && decision === 'approve' ? { scope } : {}),
   })
 }
 

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -164,6 +164,15 @@ export interface DashboardScheduledAutomationActor {
   display_name?: string | null
 }
 
+export interface DashboardScheduledAutomationStandingGrant {
+  grant_id: string
+  scope: 'standing'
+  approved_by: DashboardScheduledAutomationActor
+  approved_at: number
+  approved_at_iso?: string | null
+  payload_digest: string
+}
+
 export interface DashboardScheduledAutomationSignal {
   signal_id: string
   kind: string
@@ -218,6 +227,7 @@ export interface DashboardScheduledAutomationRequest {
   recurrence_summary?: string | null
   requires_separate_human_grant?: boolean
   approval_policy?: string | null
+  active_standing_grant?: DashboardScheduledAutomationStandingGrant | null
   last_execution?: DashboardScheduledAutomationExecution | null
   dispatch_receipt?: DashboardScheduledAutomationDispatchReceipt | null
   keeper_queue_evidence?: DashboardScheduledAutomationKeeperQueueEvidence | null

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -184,6 +184,33 @@ describe('resolveScheduleApproval', () => {
       decision: 'approve',
     })
   })
+
+  it('sends standing scope only for approval and sends explicit revocation', async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true, schedule_id: 'sched-1' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await resolveScheduleApproval('sched-1', 'approve', undefined, 'standing')
+    await resolveScheduleApproval('sched-1', 'revoke_standing', undefined, 'standing')
+
+    const approveInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(JSON.parse(String(approveInit.body))).toEqual({
+      schedule_id: 'sched-1',
+      decision: 'approve',
+      scope: 'standing',
+    })
+    const revokeInit = fetchMock.mock.calls[1]?.[1] as RequestInit
+    expect(JSON.parse(String(revokeInit.body))).toEqual({
+      schedule_id: 'sched-1',
+      decision: 'revoke_standing',
+    })
+  })
 })
 
 describe('fetchDashboardExecutionTrust', () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -126,6 +126,7 @@ export {
 
 export type {
   DashboardScheduleDecision,
+  DashboardScheduleGrantScope,
   DashboardScheduleResolveResponse,
   SetApprovalModeResponse,
 } from './dashboard-governance'

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -367,12 +367,64 @@ describe('ScheduledAutomationPanel approval actions', () => {
     expect(approve).not.toBeNull()
     expect(reject).not.toBeNull()
 
+    // one_shot schedule: no standing button, plain approve carries no scope
+    expect(
+      container.querySelector('[data-testid="schedule-approve-standing-sched-1"]'),
+    ).toBeNull()
+
     approve?.click()
     await flush()
 
-    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith('sched-1', 'approve', undefined)
+    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith(
+      'sched-1',
+      'approve',
+      undefined,
+      undefined,
+    )
     expect(onResolved).toHaveBeenCalledTimes(1)
     expect(mocks.showToast).toHaveBeenCalledWith('sched-1 approved', 'success')
+  })
+
+  it('offers a standing approval for recurring schedules and sends the scope', async () => {
+    mocks.resolveScheduleApproval.mockResolvedValue({
+      ok: true,
+      schedule_id: 'sched-1',
+      decision: 'approve',
+    })
+    const onResolved = vi.fn()
+    const automation = approvalAutomationFixture()
+    const first = automation.requests[0]
+    if (first == null) throw new Error('fixture has no requests')
+    first.recurrence = { kind: 'interval', interval_sec: 60 }
+    first.recurrence_kind = 'interval'
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${automation}
+        onResolved=${onResolved}
+      />`,
+      container,
+    )
+
+    const once = container.querySelector(
+      '[data-testid="schedule-approve-sched-1"]',
+    ) as HTMLButtonElement | null
+    const standing = container.querySelector(
+      '[data-testid="schedule-approve-standing-sched-1"]',
+    ) as HTMLButtonElement | null
+    expect(once?.textContent).toContain('Approve once')
+    expect(standing).not.toBeNull()
+
+    standing?.click()
+    await flush()
+
+    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith(
+      'sched-1',
+      'approve',
+      undefined,
+      'standing',
+    )
+    expect(onResolved).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -426,6 +426,116 @@ describe('ScheduledAutomationPanel approval actions', () => {
     )
     expect(onResolved).toHaveBeenCalledTimes(1)
   })
+
+  it('offers standing approval from the production v2 detail surface', async () => {
+    mocks.resolveScheduleApproval.mockResolvedValue({
+      ok: true,
+      schedule_id: 'sched-1',
+      decision: 'approve',
+    })
+    const onResolved = vi.fn()
+    const auto = approvalAutomationFixture()
+    const first = auto.requests[0]
+    if (first == null) throw new Error('fixture has no requests')
+    first.recurrence = { kind: 'interval', interval_sec: 60 }
+    first.recurrence_kind = 'interval'
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${auto}
+        variant="v2"
+        onResolved=${onResolved}
+      />`,
+      container,
+    )
+
+    const openDetail = container.querySelector(
+      '[data-schedule-detail="sched-1"]',
+    ) as HTMLButtonElement | null
+    expect(openDetail).not.toBeNull()
+    openDetail?.click()
+    await flush()
+
+    const standing = container.querySelector(
+      '[data-testid="schedule-approve-standing-sched-1"]',
+    ) as HTMLButtonElement | null
+    expect(standing).not.toBeNull()
+    standing?.click()
+    await flush()
+
+    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith(
+      'sched-1',
+      'approve',
+      undefined,
+      'standing',
+    )
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows and revokes an active standing grant from the v2 detail surface', async () => {
+    mocks.resolveScheduleApproval.mockResolvedValue({
+      ok: true,
+      schedule_id: 'sched-1',
+      decision: 'revoke_standing',
+      revoked_grant_count: 1,
+    })
+    const onResolved = vi.fn()
+    const auto = approvalAutomationFixture()
+    const first = auto.requests[0]
+    if (first == null) throw new Error('fixture has no requests')
+    first.status = 'scheduled'
+    first.effective_status = 'scheduled'
+    first.execution_readiness = 'approved'
+    first.operator_action = null
+    first.recurrence = { kind: 'interval', interval_sec: 60 }
+    first.recurrence_kind = 'interval'
+    first.active_standing_grant = {
+      grant_id: 'grant-standing-1',
+      scope: 'standing',
+      approved_by: { id: 'dashboard-admin', kind: 'human_operator' },
+      approved_at: 1000,
+      approved_at_iso: '2026-06-21T00:00:00Z',
+      payload_digest: 'sha256:standing',
+    }
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${auto}
+        variant="v2"
+        onResolved=${onResolved}
+      />`,
+      container,
+    )
+
+    const scheduledTab = container.querySelector(
+      '[data-schedule-filter="scheduled"]',
+    ) as HTMLButtonElement | null
+    scheduledTab?.click()
+    await flush()
+    const openDetail = container.querySelector(
+      '[data-schedule-detail="sched-1"]',
+    ) as HTMLButtonElement | null
+    openDetail?.click()
+    await flush()
+
+    const detail = container.querySelector('[data-schedule-detail-panel="sched-1"]')
+    expect(detail?.textContent).toContain('grant-standing-1')
+    expect(detail?.textContent).toContain('dashboard-admin')
+    const revoke = container.querySelector(
+      '[data-testid="schedule-revoke-standing-sched-1"]',
+    ) as HTMLButtonElement | null
+    expect(revoke).not.toBeNull()
+    revoke?.click()
+    await flush()
+
+    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith(
+      'sched-1',
+      'revoke_standing',
+      undefined,
+      undefined,
+    )
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
 })
 
 function sampleAutomation(): DashboardScheduledAutomation {

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -820,6 +820,11 @@ function isApprovalActionable(request: DashboardScheduledAutomationRequest): boo
     || request.effective_status === 'awaiting_approval'
 }
 
+function isRecurringSchedule(request: DashboardScheduledAutomationRequest): boolean {
+  const recurrenceKind = request.recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
+  return recurrenceKind !== 'one_shot'
+}
+
 function ApprovalCell({
   request,
   onResolved,
@@ -830,11 +835,9 @@ function ApprovalCell({
   const [pendingDecision, setPendingDecision] = useState<DashboardScheduleDecision | null>(null)
   const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
   const actionable = isApprovalActionable(request)
+  const activeStandingGrant = request.active_standing_grant ?? null
   const busy = pendingDecision !== null
-  // A standing grant only means something for recurring schedules: a
-  // one-shot's single occurrence is already covered by a plain approve.
-  const recurrenceKind = request.recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
-  const isRecurring = recurrenceKind !== 'one_shot'
+  const isRecurring = isRecurringSchedule(request)
 
   async function decide(
     decision: DashboardScheduleDecision,
@@ -850,8 +853,10 @@ function ApprovalCell({
       )
       showToast(
         decision === 'approve'
-          ? `${request.schedule_id} approved${scope === 'standing' ? ' (standing: covers recurrences until the payload changes)' : ''}`
-          : `${request.schedule_id} rejected`,
+          ? `${request.schedule_id} approved${scope === 'standing' ? ' (standing: active until update or revocation)' : ''}`
+          : decision === 'revoke_standing'
+            ? `${request.schedule_id} standing grant revoked`
+            : `${request.schedule_id} rejected`,
         'success',
       )
       await onResolved?.()
@@ -865,6 +870,24 @@ function ApprovalCell({
   return html`
     <div class="grid gap-1">
       <span>${enumLabel(approval)}</span>
+      ${activeStandingGrant
+        ? html`
+            <div
+              class="flex flex-wrap items-center gap-1 text-3xs text-[var(--color-fg-muted)]"
+              data-testid=${`schedule-active-standing-${request.schedule_id}`}
+            >
+              <span>standing · ${actorLabel(activeStandingGrant.approved_by)}</span>
+              <${ActionButton}
+                variant="danger"
+                size="sm"
+                disabled=${busy}
+                ariaBusy=${pendingDecision === 'revoke_standing'}
+                testId=${`schedule-revoke-standing-${request.schedule_id}`}
+                onClick=${() => { void decide('revoke_standing') }}
+              >Revoke recurring<//>
+            </div>
+          `
+        : null}
       ${actionable
         ? html`
             <div class="flex flex-wrap gap-1">
@@ -884,7 +907,7 @@ function ApprovalCell({
                       disabled=${busy}
                       ariaBusy=${pendingDecision === 'approve'}
                       testId=${`schedule-approve-standing-${request.schedule_id}`}
-                      title="Covers every future occurrence while the payload stays unchanged; a payload edit re-blocks on approval"
+                      title="Covers future occurrences until the schedule is updated or the grant is explicitly revoked"
                       onClick=${() => { void decide('approve', 'standing') }}
                     >Approve recurring<//>
                   `
@@ -2041,6 +2064,13 @@ export function SchDetail({
               <div class="sch-kv"><span class="k">approval_policy</span><span class="v mono">${enumLabel(approval)}</span></div>
               <div class="sch-kv"><span class="k">운영자 조치</span><span class="v mono">${enumLabel(request.operator_action)}</span></div>
               <div class="sch-kv"><span class="k">실행 준비</span><span class="v mono">${enumLabel(request.execution_readiness)}</span></div>
+              ${request.active_standing_grant
+                ? html`
+                    <div class="sch-kv"><span class="k">standing grant</span><span class="v mono">${request.active_standing_grant.grant_id}</span></div>
+                    <div class="sch-kv"><span class="k">standing 승인자</span><span class="v mono">${actorLabel(request.active_standing_grant.approved_by)}</span></div>
+                    <div class="sch-kv"><span class="k">standing 승인 시각</span><span class="v mono">${formatDateTimeKo(request.active_standing_grant.approved_at_iso ?? null)}</span></div>
+                  `
+                : null}
             </div>
           </div>
 
@@ -2125,18 +2155,32 @@ function SchDetailActions({
   onClose: () => void
 }) {
   const [pendingDecision, setPendingDecision] = useState<DashboardScheduleDecision | null>(null)
-  if (!onResolved || !isApprovalActionable(request)) return null
+  const actionable = isApprovalActionable(request)
+  const activeStandingGrant = request.active_standing_grant ?? null
+  if (!onResolved || (!actionable && !activeStandingGrant)) return null
   const busy = pendingDecision !== null
+  const isRecurring = isRecurringSchedule(request)
 
-  async function decide(decision: DashboardScheduleDecision) {
+  async function decide(
+    decision: DashboardScheduleDecision,
+    scope?: DashboardScheduleGrantScope,
+  ) {
     setPendingDecision(decision)
     try {
       await resolveScheduleApproval(
         request.schedule_id,
         decision,
         decision === 'reject' ? 'rejected from dashboard' : undefined,
+        scope,
       )
-      showToast(`${request.schedule_id} ${decision === 'approve' ? 'approved' : 'rejected'}`, 'success')
+      showToast(
+        decision === 'approve'
+          ? `${request.schedule_id} approved${scope === 'standing' ? ' (standing)' : ''}`
+          : decision === 'revoke_standing'
+            ? `${request.schedule_id} standing grant revoked`
+            : `${request.schedule_id} rejected`,
+        'success',
+      )
       await onResolved?.()
       onClose()
     } catch (err) {
@@ -2148,24 +2192,54 @@ function SchDetailActions({
 
   return html`
     <div class="turn-sec sch-detail-actions">
-      <button
-        type="button"
-        class="sch-act approve"
-        data-schedule-mutation="approve"
-        data-testid=${`schedule-approve-${request.schedule_id}`}
-        disabled=${busy}
-        aria-busy=${pendingDecision === 'approve' ? 'true' : 'false'}
-        onClick=${() => { void decide('approve') }}
-      >승인 — grant 발급</button>
-      <button
-        type="button"
-        class="sch-act deny"
-        data-schedule-mutation="reject"
-        data-testid=${`schedule-reject-${request.schedule_id}`}
-        disabled=${busy}
-        aria-busy=${pendingDecision === 'reject' ? 'true' : 'false'}
-        onClick=${() => { void decide('reject') }}
-      >거부</button>
+      ${activeStandingGrant
+        ? html`
+            <button
+              type="button"
+              class="sch-act deny"
+              data-schedule-mutation="revoke-standing"
+              data-testid=${`schedule-revoke-standing-${request.schedule_id}`}
+              disabled=${busy}
+              aria-busy=${pendingDecision === 'revoke_standing' ? 'true' : 'false'}
+              onClick=${() => { void decide('revoke_standing') }}
+            >반복 승인 철회</button>
+          `
+        : null}
+      ${actionable
+        ? html`
+            <button
+              type="button"
+              class="sch-act approve"
+              data-schedule-mutation="approve"
+              data-testid=${`schedule-approve-${request.schedule_id}`}
+              disabled=${busy}
+              aria-busy=${pendingDecision === 'approve' ? 'true' : 'false'}
+              onClick=${() => { void decide('approve') }}
+            >${isRecurring ? '이번 발생만 승인' : '승인 — grant 발급'}</button>
+            ${isRecurring
+              ? html`
+                  <button
+                    type="button"
+                    class="sch-act approve"
+                    data-schedule-mutation="approve-standing"
+                    data-testid=${`schedule-approve-standing-${request.schedule_id}`}
+                    disabled=${busy}
+                    aria-busy=${pendingDecision === 'approve' ? 'true' : 'false'}
+                    onClick=${() => { void decide('approve', 'standing') }}
+                  >반복 승인</button>
+                `
+              : null}
+            <button
+              type="button"
+              class="sch-act deny"
+              data-schedule-mutation="reject"
+              data-testid=${`schedule-reject-${request.schedule_id}`}
+              disabled=${busy}
+              aria-busy=${pendingDecision === 'reject' ? 'true' : 'false'}
+              onClick=${() => { void decide('reject') }}
+            >거부</button>
+          `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'preact/hooks'
 import {
   resolveScheduleApproval,
   type DashboardScheduleDecision,
+  type DashboardScheduleGrantScope,
   type DashboardScheduledAutomationActor,
   type DashboardScheduledAutomation,
   type DashboardScheduledAutomationDispatchReceipt,
@@ -830,17 +831,27 @@ function ApprovalCell({
   const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
   const actionable = isApprovalActionable(request)
   const busy = pendingDecision !== null
+  // A standing grant only means something for recurring schedules: a
+  // one-shot's single occurrence is already covered by a plain approve.
+  const recurrenceKind = request.recurrence?.kind ?? request.recurrence_kind ?? 'one_shot'
+  const isRecurring = recurrenceKind !== 'one_shot'
 
-  async function decide(decision: DashboardScheduleDecision) {
+  async function decide(
+    decision: DashboardScheduleDecision,
+    scope?: DashboardScheduleGrantScope,
+  ) {
     setPendingDecision(decision)
     try {
       await resolveScheduleApproval(
         request.schedule_id,
         decision,
         decision === 'reject' ? 'rejected from dashboard' : undefined,
+        scope,
       )
       showToast(
-        `${request.schedule_id} ${decision === 'approve' ? 'approved' : 'rejected'}`,
+        decision === 'approve'
+          ? `${request.schedule_id} approved${scope === 'standing' ? ' (standing: covers recurrences until the payload changes)' : ''}`
+          : `${request.schedule_id} rejected`,
         'success',
       )
       await onResolved?.()
@@ -864,7 +875,20 @@ function ApprovalCell({
                 ariaBusy=${pendingDecision === 'approve'}
                 testId=${`schedule-approve-${request.schedule_id}`}
                 onClick=${() => { void decide('approve') }}
-              >Approve<//>
+              >${isRecurring ? 'Approve once' : 'Approve'}<//>
+              ${isRecurring
+                ? html`
+                    <${ActionButton}
+                      variant="ok"
+                      size="sm"
+                      disabled=${busy}
+                      ariaBusy=${pendingDecision === 'approve'}
+                      testId=${`schedule-approve-standing-${request.schedule_id}`}
+                      title="Covers every future occurrence while the payload stays unchanged; a payload edit re-blocks on approval"
+                      onClick=${() => { void decide('approve', 'standing') }}
+                    >Approve recurring<//>
+                  `
+                : null}
               <${ActionButton}
                 variant="danger"
                 size="sm"

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -95,13 +95,22 @@ type execution_evidence =
 (* How many due occurrences one approval covers. [Grant_occurrence] is the
    single due_at captured in the grant evidence. [Grant_standing] covers
    every future occurrence whose payload_digest and risk_class still match
-   the evidence: the digest is the identity of the approved action, so the
-   grant dies exactly when the schedule starts doing something different.
-   Without it, a recurring side-effecting schedule re-blocks on a human
-   click for every occurrence of an unchanged action. *)
+   the evidence until a schedule update or explicit revocation permanently
+   invalidates it. Without it, a recurring side-effecting schedule re-blocks
+   on a human click for every occurrence of an unchanged action. *)
 type grant_scope =
   | Grant_occurrence
   | Grant_standing
+
+type grant_revocation_reason =
+  | Operator_revoked
+  | Schedule_updated
+
+type grant_revocation =
+  { revoked_by : actor
+  ; revoked_at : float
+  ; reason : grant_revocation_reason
+  }
 
 type execution_grant =
   { grant_id : string
@@ -111,6 +120,7 @@ type execution_grant =
   ; decision : execution_decision
   ; scope : grant_scope
   ; evidence : execution_evidence
+  ; revocation : grant_revocation option
   }
 
 type execution_status =
@@ -141,6 +151,7 @@ type grant_error =
   | Evidence_payload_digest_mismatch
   | Evidence_due_at_mismatch
   | Evidence_risk_class_mismatch
+  | Standing_scope_requires_recurring
 
 let ( let* ) = Result.bind
 
@@ -257,6 +268,8 @@ let grant_error_to_string = function
   | Evidence_payload_digest_mismatch -> "grant evidence payload_digest mismatch"
   | Evidence_due_at_mismatch -> "grant evidence due_at mismatch"
   | Evidence_risk_class_mismatch -> "grant evidence risk_class mismatch"
+  | Standing_scope_requires_recurring ->
+    "standing approval requires a recurring schedule"
 ;;
 
 let is_terminal = function
@@ -796,6 +809,36 @@ let grant_scope_of_string = function
   | other -> Error ("unknown grant_scope: " ^ other)
 ;;
 
+let grant_revocation_reason_to_string = function
+  | Operator_revoked -> "operator_revoked"
+  | Schedule_updated -> "schedule_updated"
+;;
+
+let grant_revocation_reason_of_string = function
+  | "operator_revoked" -> Ok Operator_revoked
+  | "schedule_updated" -> Ok Schedule_updated
+  | other -> Error ("unknown grant_revocation_reason: " ^ other)
+;;
+
+let grant_revocation_to_yojson (revocation : grant_revocation) =
+  `Assoc
+    [ "revoked_by", actor_to_yojson revocation.revoked_by
+    ; "revoked_at", float_to_yojson revocation.revoked_at
+    ; "reason", `String (grant_revocation_reason_to_string revocation.reason)
+    ]
+;;
+
+let grant_revocation_of_yojson = function
+  | `Assoc fields ->
+    let* revoked_by_json = assoc_field "revoked_by" fields in
+    let* revoked_by = actor_of_yojson revoked_by_json in
+    let* revoked_at = float_field "revoked_at" fields in
+    let* reason_name = string_field "reason" fields in
+    let* reason = grant_revocation_reason_of_string reason_name in
+    Ok { revoked_by; revoked_at; reason }
+  | _ -> Error "expected grant_revocation object"
+;;
+
 let execution_evidence_to_yojson (evidence : execution_evidence) =
   `Assoc
     [ "schedule_id", `String evidence.schedule_id
@@ -825,6 +868,7 @@ let execution_grant_to_yojson (grant : execution_grant) =
     ; "decision", execution_decision_to_yojson grant.decision
     ; "scope", `String (grant_scope_to_string grant.scope)
     ; "evidence", execution_evidence_to_yojson grant.evidence
+    ; "revocation", option_to_yojson grant_revocation_to_yojson grant.revocation
     ]
 ;;
 
@@ -849,7 +893,22 @@ let execution_grant_of_yojson = function
     in
     let* evidence_json = assoc_field "evidence" fields in
     let* evidence = execution_evidence_of_yojson evidence_json in
-    Ok { grant_id; schedule_id; approved_by; approved_at; decision; scope; evidence }
+    let* revocation =
+      match List.assoc_opt "revocation" fields with
+      | None | Some `Null -> Ok None
+      | Some json ->
+        Result.map (fun revocation -> Some revocation) (grant_revocation_of_yojson json)
+    in
+    Ok
+      { grant_id
+      ; schedule_id
+      ; approved_by
+      ; approved_at
+      ; decision
+      ; scope
+      ; evidence
+      ; revocation
+      }
   | _ -> Error "expected execution_grant object"
 ;;
 
@@ -1023,6 +1082,7 @@ let create_execution_grant
   ; decision
   ; scope
   ; evidence = evidence_of_request request
+  ; revocation = None
   }
 ;;
 
@@ -1038,6 +1098,8 @@ let validate_execution_grant (request : schedule_request) (grant : execution_gra
   else if expired_at ~now:grant.approved_at request then Error Schedule_terminal
   else if request.status <> Pending_approval && request.status <> Due then
     Error Schedule_not_pending_approval
+  else if grant.scope = Grant_standing && not (is_recurring request.recurrence) then
+    Error Standing_scope_requires_recurring
   else if requires_separate_human_grant request && grant.approved_by.kind <> Human_operator
   then Error Approver_not_human
   else if requires_separate_human_grant request

--- a/lib/schedule/schedule_domain.ml
+++ b/lib/schedule/schedule_domain.ml
@@ -92,12 +92,24 @@ type execution_evidence =
   ; risk_class : risk_class
   }
 
+(* How many due occurrences one approval covers. [Grant_occurrence] is the
+   single due_at captured in the grant evidence. [Grant_standing] covers
+   every future occurrence whose payload_digest and risk_class still match
+   the evidence: the digest is the identity of the approved action, so the
+   grant dies exactly when the schedule starts doing something different.
+   Without it, a recurring side-effecting schedule re-blocks on a human
+   click for every occurrence of an unchanged action. *)
+type grant_scope =
+  | Grant_occurrence
+  | Grant_standing
+
 type execution_grant =
   { grant_id : string
   ; schedule_id : string
   ; approved_by : actor
   ; approved_at : float
   ; decision : execution_decision
+  ; scope : grant_scope
   ; evidence : execution_evidence
   }
 
@@ -773,6 +785,17 @@ let execution_decision_of_yojson = function
   | _ -> Error "expected execution_decision object"
 ;;
 
+let grant_scope_to_string = function
+  | Grant_occurrence -> "occurrence"
+  | Grant_standing -> "standing"
+;;
+
+let grant_scope_of_string = function
+  | "occurrence" -> Ok Grant_occurrence
+  | "standing" -> Ok Grant_standing
+  | other -> Error ("unknown grant_scope: " ^ other)
+;;
+
 let execution_evidence_to_yojson (evidence : execution_evidence) =
   `Assoc
     [ "schedule_id", `String evidence.schedule_id
@@ -800,6 +823,7 @@ let execution_grant_to_yojson (grant : execution_grant) =
     ; "approved_by", actor_to_yojson grant.approved_by
     ; "approved_at", float_to_yojson grant.approved_at
     ; "decision", execution_decision_to_yojson grant.decision
+    ; "scope", `String (grant_scope_to_string grant.scope)
     ; "evidence", execution_evidence_to_yojson grant.evidence
     ]
 ;;
@@ -813,9 +837,19 @@ let execution_grant_of_yojson = function
     let* approved_at = float_field "approved_at" fields in
     let* decision_json = assoc_field "decision" fields in
     let* decision = execution_decision_of_yojson decision_json in
+    let* scope =
+      (* Grants persisted before [scope] existed were all bound to the
+         single due_at in their evidence, so absent = [Grant_occurrence]
+         is the historically accurate (and narrower) reading, not a
+         permissive default. A present-but-unknown value is an error. *)
+      match List.assoc_opt "scope" fields with
+      | None -> Ok Grant_occurrence
+      | Some (`String name) -> grant_scope_of_string name
+      | Some _ -> Error "expected grant scope string"
+    in
     let* evidence_json = assoc_field "evidence" fields in
     let* evidence = execution_evidence_of_yojson evidence_json in
-    Ok { grant_id; schedule_id; approved_by; approved_at; decision; evidence }
+    Ok { grant_id; schedule_id; approved_by; approved_at; decision; scope; evidence }
   | _ -> Error "expected execution_grant object"
 ;;
 
@@ -979,6 +1013,7 @@ let create_execution_grant
   ~approved_by
   ~approved_at
   ~decision
+  ~scope
   (request : schedule_request)
   =
   { grant_id
@@ -986,6 +1021,7 @@ let create_execution_grant
   ; approved_by
   ; approved_at
   ; decision
+  ; scope
   ; evidence = evidence_of_request request
   }
 ;;

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -104,12 +104,21 @@ type execution_evidence =
 (** How many due occurrences one approval covers. [Grant_occurrence] is
     the single [due_at] captured in the grant evidence. [Grant_standing]
     covers every future occurrence whose [payload_digest] and
-    [risk_class] still match the evidence — the digest is the identity
-    of the approved action, so the grant stops matching exactly when the
-    schedule starts doing something different. *)
+    [risk_class] still match the evidence until a schedule update or explicit
+    revocation permanently invalidates the grant. *)
 type grant_scope =
   | Grant_occurrence
   | Grant_standing
+
+type grant_revocation_reason =
+  | Operator_revoked
+  | Schedule_updated
+
+type grant_revocation =
+  { revoked_by : actor
+  ; revoked_at : float
+  ; reason : grant_revocation_reason
+  }
 
 type execution_grant =
   { grant_id : string
@@ -119,6 +128,7 @@ type execution_grant =
   ; decision : execution_decision
   ; scope : grant_scope
   ; evidence : execution_evidence
+  ; revocation : grant_revocation option
   }
 
 type execution_status =
@@ -149,6 +159,7 @@ type grant_error =
   | Evidence_payload_digest_mismatch
   | Evidence_due_at_mismatch
   | Evidence_risk_class_mismatch
+  | Standing_scope_requires_recurring
 
 val create_request :
   schedule_id:string ->
@@ -219,6 +230,8 @@ val execution_status_to_string : execution_status -> string
 val execution_status_of_string : string -> (execution_status, string) result
 val grant_scope_to_string : grant_scope -> string
 val grant_scope_of_string : string -> (grant_scope, string) result
+val grant_revocation_reason_to_string : grant_revocation_reason -> string
+val grant_revocation_reason_of_string : string -> (grant_revocation_reason, string) result
 val grant_error_to_string : grant_error -> string
 
 val actor_to_yojson : actor -> Yojson.Safe.t

--- a/lib/schedule/schedule_domain.mli
+++ b/lib/schedule/schedule_domain.mli
@@ -101,12 +101,23 @@ type execution_evidence =
   ; risk_class : risk_class
   }
 
+(** How many due occurrences one approval covers. [Grant_occurrence] is
+    the single [due_at] captured in the grant evidence. [Grant_standing]
+    covers every future occurrence whose [payload_digest] and
+    [risk_class] still match the evidence — the digest is the identity
+    of the approved action, so the grant stops matching exactly when the
+    schedule starts doing something different. *)
+type grant_scope =
+  | Grant_occurrence
+  | Grant_standing
+
 type execution_grant =
   { grant_id : string
   ; schedule_id : string
   ; approved_by : actor
   ; approved_at : float
   ; decision : execution_decision
+  ; scope : grant_scope
   ; evidence : execution_evidence
   }
 
@@ -176,6 +187,7 @@ val create_execution_grant :
   approved_by:actor ->
   approved_at:float ->
   decision:execution_decision ->
+  scope:grant_scope ->
   schedule_request ->
   execution_grant
 
@@ -205,6 +217,8 @@ val recurrence_summary : recurrence -> string
     typed [recurrence] value. *)
 val execution_status_to_string : execution_status -> string
 val execution_status_of_string : string -> (execution_status, string) result
+val grant_scope_to_string : grant_scope -> string
+val grant_scope_of_string : string -> (grant_scope, string) result
 val grant_error_to_string : grant_error -> string
 
 val actor_to_yojson : actor -> Yojson.Safe.t

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -124,7 +124,16 @@ let revoke_standing config ?revoked_at ~schedule_id ~revoked_by () =
   |> map_store
 ;;
 
-let update config ?updated_at ~schedule_id ~due_at ~expires_at ~payload ~updated_by =
+let update
+      config
+      ?updated_at
+      ~schedule_id
+      ~due_at
+      ~expires_at
+      ~payload
+      ~updated_by
+      ()
+  =
   (* NDT-OK: service mutation boundary timestamp. The deterministic store never
      samples time and records this explicit value in any grant invalidation. *)
   let updated_at = Option.value updated_at ~default:(now ()) in

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -83,6 +83,7 @@ let decision_grant
   config
   ?grant_id:provided_grant_id
   ?approved_at
+  ?(scope = Schedule_domain.Grant_occurrence)
   ~schedule_id
   ~approved_by
   ~decision
@@ -95,13 +96,13 @@ let decision_grant
     let grant_id = grant_id provided_grant_id in
     let grant =
       Schedule_domain.create_execution_grant ~grant_id ~approved_by
-        ~approved_at ~decision request
+        ~approved_at ~decision ~scope request
     in
     Schedule_store.record_grant config grant |> map_store
 ;;
 
-let approve config ?grant_id ?approved_at ~schedule_id ~approved_by () =
-  decision_grant config ?grant_id ?approved_at ~schedule_id ~approved_by
+let approve config ?grant_id ?approved_at ?scope ~schedule_id ~approved_by () =
+  decision_grant config ?grant_id ?approved_at ?scope ~schedule_id ~approved_by
     ~decision:Schedule_domain.Approve ()
 ;;
 

--- a/lib/schedule/schedule_service.ml
+++ b/lib/schedule/schedule_service.ml
@@ -115,8 +115,21 @@ let cancel config ~schedule_id =
   Schedule_store.cancel_request config ~schedule_id |> map_store
 ;;
 
-let update config ~schedule_id ~due_at ~expires_at ~payload =
+let revoke_standing config ?revoked_at ~schedule_id ~revoked_by () =
+  (* NDT-OK: service mutation boundary timestamp. Callers may provide it for
+     deterministic replay/tests; the store receives and persists the value. *)
+  let revoked_at = Option.value revoked_at ~default:(now ()) in
+  Schedule_store.revoke_standing_grants config ~schedule_id ~revoked_by
+    ~revoked_at ()
+  |> map_store
+;;
+
+let update config ?updated_at ~schedule_id ~due_at ~expires_at ~payload ~updated_by =
+  (* NDT-OK: service mutation boundary timestamp. The deterministic store never
+     samples time and records this explicit value in any grant invalidation. *)
+  let updated_at = Option.value updated_at ~default:(now ()) in
   Schedule_store.update_request config ~schedule_id ~due_at ~expires_at ~payload
+    ~updated_by ~updated_at ()
   |> map_store
 ;;
 

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -84,6 +84,7 @@ val update :
   expires_at:float option ->
   payload:Schedule_domain.payload ->
   updated_by:Schedule_domain.actor ->
+  unit ->
   (Schedule_domain.schedule_request, service_error) result
 
 val due_candidates :

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -39,7 +39,8 @@ val get :
 (** Record an approval grant. [scope] defaults to
     [Schedule_domain.Grant_occurrence] (this due occurrence only);
     [Grant_standing] keeps covering future occurrences while the
-    schedule's payload digest and risk class stay unchanged. *)
+    schedule's payload digest and risk class stay unchanged and the grant has
+    not been invalidated by an update or explicit revocation. *)
 val approve :
   Workspace_utils.config ->
   ?grant_id:string ->
@@ -65,12 +66,24 @@ val cancel :
   schedule_id:string ->
   (Schedule_domain.schedule_request, service_error) result
 
+val revoke_standing :
+  Workspace_utils.config ->
+  ?revoked_at:float ->
+  schedule_id:string ->
+  revoked_by:Schedule_domain.actor ->
+  unit ->
+  (Schedule_domain.schedule_request * int, service_error) result
+(** Revokes all active standing grants for the schedule while preserving their
+    approval and revocation evidence in the durable ledger. *)
+
 val update :
   Workspace_utils.config ->
+  ?updated_at:float ->
   schedule_id:string ->
   due_at:float ->
   expires_at:float option ->
   payload:Schedule_domain.payload ->
+  updated_by:Schedule_domain.actor ->
   (Schedule_domain.schedule_request, service_error) result
 
 val due_candidates :

--- a/lib/schedule/schedule_service.mli
+++ b/lib/schedule/schedule_service.mli
@@ -36,10 +36,15 @@ val get :
   schedule_id:string ->
   Schedule_domain.schedule_request option
 
+(** Record an approval grant. [scope] defaults to
+    [Schedule_domain.Grant_occurrence] (this due occurrence only);
+    [Grant_standing] keeps covering future occurrences while the
+    schedule's payload digest and risk class stay unchanged. *)
 val approve :
   Workspace_utils.config ->
   ?grant_id:string ->
   ?approved_at:float ->
+  ?scope:Schedule_domain.grant_scope ->
   schedule_id:string ->
   approved_by:Schedule_domain.actor ->
   unit ->

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -366,9 +366,11 @@ let revoke_active_standing_grants
   List.fold_right
     (fun (grant : execution_grant) (updated, count) ->
        match grant.decision, grant.scope, grant.revocation with
-       | Approve, Grant_standing, None
-         when String.equal grant.schedule_id schedule_id ->
-         { grant with revocation = Some revocation } :: updated, count + 1
+       | Approve, Grant_standing, None ->
+         if String.equal grant.schedule_id schedule_id then
+           { grant with revocation = Some revocation } :: updated, count + 1
+         else
+           grant :: updated, count
        | Approve, Grant_occurrence, _
        | Approve, Grant_standing, Some _
        | Reject _, _, _ ->

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -16,6 +16,9 @@ type store_error =
   | Invalid_status_transition of string
   | Schedule_not_due_candidate
   | Schedule_not_running
+  | No_active_standing_grant
+  | Revoker_not_human
+  | Revoker_id_empty
   | Grant_validation_failed of Schedule_domain.grant_error
   | Persistence_failed of string
   | Corrupt_ledger of
@@ -78,6 +81,9 @@ let store_error_to_string = function
   | Invalid_status_transition reason -> "invalid schedule status transition: " ^ reason
   | Schedule_not_due_candidate -> "schedule is not an approved due candidate"
   | Schedule_not_running -> "schedule is not running"
+  | No_active_standing_grant -> "schedule has no active standing grant"
+  | Revoker_not_human -> "standing grant revoker must be a human operator"
+  | Revoker_id_empty -> "standing grant revoker id must be non-empty"
   | Grant_validation_failed err ->
     "grant validation failed: " ^ Schedule_domain.grant_error_to_string err
   | Persistence_failed msg -> "schedule persistence failed: " ^ msg
@@ -302,9 +308,9 @@ let grant_matches_current_request (request : schedule_request) (grant : executio
   let expected = Schedule_domain.evidence_of_request request in
   String.equal grant.schedule_id request.schedule_id
   &&
-  match grant.decision with
-  | Reject _ -> false
-  | Approve ->
+  match grant.revocation, grant.decision with
+  | Some _, _ | None, Reject _ -> false
+  | None, Approve ->
     String.equal grant.evidence.schedule_id expected.schedule_id
     && String.equal grant.evidence.payload_digest expected.payload_digest
     && grant.evidence.risk_class = expected.risk_class
@@ -312,10 +318,32 @@ let grant_matches_current_request (request : schedule_request) (grant : executio
     (* [Grant_standing] covers every occurrence of the digest-identical
        action; [Grant_occurrence] stays bound to the single due_at it was
        approved for. Digest and risk_class are compared for BOTH scopes
-       above, so a payload or risk edit always re-blocks on approval. *)
+       above, and explicit revocation above prevents an old digest from
+       becoming authorized again after an update is reverted. *)
     (match grant.scope with
      | Schedule_domain.Grant_standing -> true
      | Schedule_domain.Grant_occurrence -> grant.evidence.due_at = expected.due_at)
+;;
+
+let newer_grant (left : execution_grant) (right : execution_grant) =
+  match Float.compare left.approved_at right.approved_at with
+  | 0 -> String.compare left.grant_id right.grant_id > 0
+  | comparison -> comparison > 0
+;;
+
+let active_standing_grant state (request : schedule_request) =
+  List.fold_left
+    (fun latest (grant : execution_grant) ->
+       if grant.scope = Grant_standing && grant_matches_current_request request grant
+       then
+         match latest with
+         | None -> Some grant
+         | Some current when newer_grant grant current -> Some grant
+         | Some _ -> latest
+       else
+         latest)
+    None
+    state.grants
 ;;
 
 let has_current_approved_grant state (request : schedule_request) =
@@ -323,6 +351,30 @@ let has_current_approved_grant state (request : schedule_request) =
     (fun (grant : execution_grant) ->
       grant_matches_current_request request grant)
     state.grants
+;;
+
+let revoke_active_standing_grants
+      grants
+      ~schedule_id
+      ~revoked_by
+      ~revoked_at
+      ~reason
+  =
+  let revocation : Schedule_domain.grant_revocation =
+    { revoked_by; revoked_at; reason }
+  in
+  List.fold_right
+    (fun (grant : execution_grant) (updated, count) ->
+       match grant.decision, grant.scope, grant.revocation with
+       | Approve, Grant_standing, None
+         when String.equal grant.schedule_id schedule_id ->
+         { grant with revocation = Some revocation } :: updated, count + 1
+       | Approve, Grant_occurrence, _
+       | Approve, Grant_standing, Some _
+       | Reject _, _, _ ->
+         grant :: updated, count)
+    grants
+    ([], 0)
 ;;
 
 let is_due_execution_candidate state (request : schedule_request) =
@@ -483,7 +535,42 @@ let cancel_request config ~schedule_id =
         Ok updated_request)
 ;;
 
-let update_request config ~schedule_id ~due_at ~expires_at ~payload =
+let revoke_standing_grants config ~schedule_id ~revoked_by ~revoked_at () =
+  if revoked_by.Schedule_domain.kind <> Schedule_domain.Human_operator then
+    Error Revoker_not_human
+  else if String.equal (String.trim revoked_by.id) "" then
+    Error Revoker_id_empty
+  else
+    Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
+      let* state = load_for_mutation config in
+      match find_schedule state schedule_id with
+      | None -> Error Schedule_not_found
+      | Some request ->
+        let grants, revoked_count =
+          revoke_active_standing_grants state.grants ~schedule_id ~revoked_by
+            ~revoked_at ~reason:Schedule_domain.Operator_revoked
+        in
+        if revoked_count = 0 then
+          Error No_active_standing_grant
+        else
+          let next_state =
+            bump_state state ~schedules:state.schedules ~grants
+              ~executions:state.executions
+          in
+          let* () = write_state config next_state in
+          Ok (request, revoked_count))
+;;
+
+let update_request
+      config
+      ~schedule_id
+      ~due_at
+      ~expires_at
+      ~payload
+      ~updated_by
+      ~updated_at
+      ()
+  =
   Workspace_utils.with_file_lock config (schedules_path config) (fun () ->
     let* state = load_for_mutation config in
     match find_schedule state schedule_id with
@@ -504,12 +591,22 @@ let update_request config ~schedule_id ~due_at ~expires_at ~payload =
           ; payload
           }
         in
+        let grants, invalidated_count =
+          revoke_active_standing_grants state.grants ~schedule_id
+            ~revoked_by:updated_by ~revoked_at:updated_at
+            ~reason:Schedule_domain.Schedule_updated
+        in
         let schedules = replace_schedule state.schedules updated_request in
         let next_state =
-          bump_state state ~schedules ~grants:state.grants
+          bump_state state ~schedules ~grants
             ~executions:state.executions
         in
         let* () = write_state config next_state in
+        if invalidated_count > 0 then
+          Log.Misc.info
+            "schedule_store: update invalidated %d standing grant(s) for %s"
+            invalidated_count
+            schedule_id;
         Ok updated_request)
 ;;
 

--- a/lib/schedule/schedule_store.ml
+++ b/lib/schedule/schedule_store.ml
@@ -307,8 +307,15 @@ let grant_matches_current_request (request : schedule_request) (grant : executio
   | Approve ->
     String.equal grant.evidence.schedule_id expected.schedule_id
     && String.equal grant.evidence.payload_digest expected.payload_digest
-    && grant.evidence.due_at = expected.due_at
     && grant.evidence.risk_class = expected.risk_class
+    &&
+    (* [Grant_standing] covers every occurrence of the digest-identical
+       action; [Grant_occurrence] stays bound to the single due_at it was
+       approved for. Digest and risk_class are compared for BOTH scopes
+       above, so a payload or risk edit always re-blocks on approval. *)
+    (match grant.scope with
+     | Schedule_domain.Grant_standing -> true
+     | Schedule_domain.Grant_occurrence -> grant.evidence.due_at = expected.due_at)
 ;;
 
 let has_current_approved_grant state (request : schedule_request) =

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -173,9 +173,12 @@ val due_execution_candidates :
 val has_current_approved_grant :
   state -> Schedule_domain.schedule_request -> bool
 (** Whether [state] contains an approved grant whose evidence matches the
-    request's current [schedule_id], payload digest, [risk_class], and [due_at].
-    Recurring requests therefore need fresh approval for each new occurrence
-    when they require a separate human grant. *)
+    request's current [schedule_id], payload digest, and [risk_class]. An
+    occurrence-scoped grant additionally requires the evidence [due_at] to
+    equal the request's current [due_at], so recurring requests need fresh
+    approval for each occurrence; a standing-scoped grant skips the [due_at]
+    comparison and keeps covering occurrences until the payload digest or
+    risk class changes. *)
 
 val prune_completed :
   Workspace_utils.config ->

--- a/lib/schedule/schedule_store.mli
+++ b/lib/schedule/schedule_store.mli
@@ -19,6 +19,9 @@ type store_error =
   | Invalid_status_transition of string
   | Schedule_not_due_candidate
   | Schedule_not_running
+  | No_active_standing_grant
+  | Revoker_not_human
+  | Revoker_id_empty
   | Grant_validation_failed of Schedule_domain.grant_error
   | Persistence_failed of string
   | Corrupt_ledger of
@@ -102,16 +105,31 @@ val cancel_request :
   schedule_id:string ->
   (Schedule_domain.schedule_request, store_error) result
 
+val revoke_standing_grants :
+  Workspace_utils.config ->
+  schedule_id:string ->
+  revoked_by:Schedule_domain.actor ->
+  revoked_at:float ->
+  unit ->
+  (Schedule_domain.schedule_request * int, store_error) result
+(** Revokes every still-active standing grant for [schedule_id] in one durable
+    mutation. The approval records remain in the ledger with typed revocation
+    evidence, so a later payload reversion cannot reactivate them. *)
+
 val update_request :
   Workspace_utils.config ->
   schedule_id:string ->
   due_at:float ->
   expires_at:float option ->
   payload:Schedule_domain.payload ->
+  updated_by:Schedule_domain.actor ->
+  updated_at:float ->
+  unit ->
   (Schedule_domain.schedule_request, store_error) result
 (** Replaces [due_at], [expires_at], and [payload] of a pending or scheduled
-    request. Returns [Invalid_status_transition] for due, terminal, or [Running]
-    requests. *)
+    request and revokes all active standing grants with [Schedule_updated]
+    evidence. Returns [Invalid_status_transition] for due, terminal, or
+    [Running] requests. *)
 
 val refresh_due :
   Workspace_utils.config ->
@@ -177,8 +195,15 @@ val has_current_approved_grant :
     occurrence-scoped grant additionally requires the evidence [due_at] to
     equal the request's current [due_at], so recurring requests need fresh
     approval for each occurrence; a standing-scoped grant skips the [due_at]
-    comparison and keeps covering occurrences until the payload digest or
-    risk class changes. *)
+    comparison while its evidence still matches and no update or explicit
+    revocation has invalidated it. *)
+
+val active_standing_grant :
+  state ->
+  Schedule_domain.schedule_request ->
+  Schedule_domain.execution_grant option
+(** The newest non-revoked standing grant matching the request's current
+    schedule id, payload digest, and risk class. *)
 
 val prune_completed :
   Workspace_utils.config ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -3072,6 +3072,19 @@ let schedule_request_dashboard_json
   let keeper_next_tool =
     Schedule_projection.keeper_next_tool_for_execution_readiness execution_readiness
   in
+  let active_standing_grant =
+    match Schedule_store.active_standing_grant state request with
+    | None -> `Null
+    | Some grant ->
+      `Assoc
+        [ "grant_id", `String grant.grant_id
+        ; "scope", `String (Schedule_domain.grant_scope_to_string grant.scope)
+        ; "approved_by", Schedule_domain.actor_to_yojson grant.approved_by
+        ; "approved_at", `Float grant.approved_at
+        ; "approved_at_iso", unix_iso_json grant.approved_at
+        ; "payload_digest", `String grant.evidence.payload_digest
+        ]
+  in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -3110,6 +3123,7 @@ let schedule_request_dashboard_json
           (if requires_grant
            then "separate_human_grant_required"
            else "no_separate_grant_required") )
+    ; "active_standing_grant", active_standing_grant
     ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
     ; ( "payload_kind"
       , match Schedule_payload_projection.kind request with

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -143,7 +143,7 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
         let* payload_json = required_payload "payload" args in
         let* payload = Schedule_domain.payload_of_yojson payload_json in
         Schedule_service.update config ~schedule_id ~due_at ~expires_at ~payload
-          ~updated_by:approved_by
+          ~updated_by:approved_by ()
         |> map_service_error
         |> Result.map (fun schedule -> schedule, [])
     in

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -54,6 +54,17 @@ let decision_to_string = function
   | Update -> "update"
 ;;
 
+(* Absent means the narrow historical semantics (this occurrence only);
+   an unknown value is a request error, never a silent default. *)
+let grant_scope_of_json json =
+  match string_opt "scope" json with
+  | None -> Ok Schedule_domain.Grant_occurrence
+  | Some raw ->
+    (match Schedule_domain.grant_scope_of_string (String.lowercase_ascii raw) with
+     | Ok scope -> Ok scope
+     | Error _ -> Error "scope must be 'occurrence' or 'standing'")
+;;
+
 let default_rejection_reason ~operator_name =
   "rejected from dashboard by " ^ operator_name
 ;;
@@ -84,7 +95,8 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
       in
       match decision with
       | Approve ->
-        Schedule_service.approve config ~schedule_id ~approved_by ()
+        let* scope = grant_scope_of_json args in
+        Schedule_service.approve config ~schedule_id ~approved_by ~scope ()
         |> map_service_error
       | Reject ->
         let reason =

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -55,14 +55,24 @@ let decision_to_string = function
 ;;
 
 (* Absent means the narrow historical semantics (this occurrence only);
-   an unknown value is a request error, never a silent default. *)
-let grant_scope_of_json json =
-  match string_opt "scope" json with
-  | None -> Ok Schedule_domain.Grant_occurrence
-  | Some raw ->
-    (match Schedule_domain.grant_scope_of_string (String.lowercase_ascii raw) with
+   any present but invalid value — wrong type, blank, or unknown — is a
+   request error, never a silent default. *)
+let grant_scope_of_json (json : Yojson.Safe.t) =
+  let field =
+    match json with
+    | `Assoc fields -> List.assoc_opt "scope" fields
+    | _ -> None
+  in
+  match field with
+  | None | Some `Null -> Ok Schedule_domain.Grant_occurrence
+  | Some (`String raw) ->
+    (match
+       Schedule_domain.grant_scope_of_string
+         (String.lowercase_ascii (String.trim raw))
+     with
      | Ok scope -> Ok scope
      | Error _ -> Error "scope must be 'occurrence' or 'standing'")
+  | Some _ -> Error "scope must be 'occurrence' or 'standing'"
 ;;
 
 let default_rejection_reason ~operator_name =

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -1,6 +1,7 @@
 type schedule_decision =
   | Approve
   | Reject
+  | Revoke_standing
   | Cancel
   | Update
 
@@ -42,14 +43,19 @@ let decision_of_json json =
   match String.lowercase_ascii raw with
   | "approve" -> Ok Approve
   | "reject" -> Ok Reject
+  | "revoke_standing" -> Ok Revoke_standing
   | "cancel" -> Ok Cancel
   | "update" -> Ok Update
-  | _ -> Error "decision must be 'approve', 'reject', 'cancel', or 'update'"
+  | _ ->
+    Error
+      "decision must be 'approve', 'reject', 'revoke_standing', 'cancel', or \
+       'update'"
 ;;
 
 let decision_to_string = function
   | Approve -> "approve"
   | Reject -> "reject"
+  | Revoke_standing -> "revoke_standing"
   | Cancel -> "cancel"
   | Update -> "update"
 ;;
@@ -64,7 +70,7 @@ let grant_scope_of_json (json : Yojson.Safe.t) =
     | _ -> None
   in
   match field with
-  | None | Some `Null -> Ok Schedule_domain.Grant_occurrence
+  | None -> Ok Schedule_domain.Grant_occurrence
   | Some (`String raw) ->
     (match
        Schedule_domain.grant_scope_of_string
@@ -108,6 +114,7 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
         let* scope = grant_scope_of_json args in
         Schedule_service.approve config ~schedule_id ~approved_by ~scope ()
         |> map_service_error
+        |> Result.map (fun schedule -> schedule, [])
       | Reject ->
         let reason =
           match string_opt "reason" args with
@@ -119,25 +126,37 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
         in
         Schedule_service.reject config ~schedule_id ~approved_by ~reason ()
         |> map_service_error
+        |> Result.map (fun schedule -> schedule, [])
+      | Revoke_standing ->
+        Schedule_service.revoke_standing config ~schedule_id
+          ~revoked_by:approved_by ()
+        |> map_service_error
+        |> Result.map (fun (schedule, revoked_count) ->
+          schedule, [ "revoked_grant_count", `Int revoked_count ])
       | Cancel ->
-        Schedule_service.cancel config ~schedule_id |> map_service_error
+        Schedule_service.cancel config ~schedule_id
+        |> map_service_error
+        |> Result.map (fun schedule -> schedule, [])
       | Update ->
         let* due_at = required_number "due_at" args in
         let expires_at = number_opt "expires_at" args in
         let* payload_json = required_payload "payload" args in
         let* payload = Schedule_domain.payload_of_yojson payload_json in
         Schedule_service.update config ~schedule_id ~due_at ~expires_at ~payload
+          ~updated_by:approved_by
         |> map_service_error
+        |> Result.map (fun schedule -> schedule, [])
     in
     service_result
-    |> Result.map (fun schedule ->
+    |> Result.map (fun (schedule, extra_fields) ->
       `Assoc
-        [ "ok", `Bool true
-        ; "schedule_id", `String schedule_id
-        ; "decision", `String (decision_to_string decision)
-        ; "approved_by", Schedule_domain.actor_to_yojson approved_by
-        ; "schedule", Schedule_domain.schedule_request_to_yojson schedule
-        ])
+        ([ "ok", `Bool true
+         ; "schedule_id", `String schedule_id
+         ; "decision", `String (decision_to_string decision)
+         ; "approved_by", Schedule_domain.actor_to_yojson approved_by
+         ; "schedule", Schedule_domain.schedule_request_to_yojson schedule
+         ]
+         @ extra_fields))
   in
   result
 ;;

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -35,11 +35,11 @@ let request
   | Error msg -> fail msg
 ;;
 
-let grant ?decision ?approved_by request =
+let grant ?decision ?approved_by ?(scope = Grant_occurrence) request =
   let decision = Option.value ~default:Approve decision in
   let approved_by = Option.value ~default:(human "approver") approved_by in
   create_execution_grant ~grant_id:"grant-1" ~approved_by ~approved_at:150.0
-    ~decision request
+    ~decision ~scope request
 ;;
 
 let check_status label expected actual =
@@ -342,6 +342,49 @@ let test_grant_roundtrip () =
       decoded.evidence.payload_digest
 ;;
 
+let test_grant_scope_codec () =
+  let req = request () in
+  (match
+     grant ~scope:Grant_standing req
+     |> execution_grant_to_yojson
+     |> execution_grant_of_yojson
+   with
+   | Error msg -> fail msg
+   | Ok decoded ->
+     check string "standing scope roundtrip" "standing"
+       (grant_scope_to_string decoded.scope));
+  (* Grants persisted before the scope field existed were all bound to the
+     single due_at in their evidence: absent must decode as occurrence. *)
+  (match grant ~scope:Grant_occurrence req |> execution_grant_to_yojson with
+   | `Assoc fields ->
+     let without_scope =
+       `Assoc (List.filter (fun (key, _) -> key <> "scope") fields)
+     in
+     (match execution_grant_of_yojson without_scope with
+      | Error msg -> fail msg
+      | Ok decoded ->
+        check string "absent scope decodes as occurrence" "occurrence"
+          (grant_scope_to_string decoded.scope))
+   | _ -> fail "grant json is not an object");
+  (* A present-but-unknown scope is an explicit decode error, never a
+     silent default. *)
+  match grant req |> execution_grant_to_yojson with
+  | `Assoc fields ->
+    let bad_scope =
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             if key = "scope" then key, `String "forever" else key, value)
+           fields)
+    in
+    (match execution_grant_of_yojson bad_scope with
+     | Ok _ -> fail "unknown scope must not decode"
+     | Error msg ->
+       check bool "unknown scope is an explicit error" true
+         (String.length msg > 0))
+  | _ -> fail "grant json is not an object"
+;;
+
 let test_execution_record_roundtrip () =
   let req = request ~risk_class:Read_only () in
   let execution =
@@ -425,6 +468,8 @@ let () =
           test_case "missing recurrence defaults one-shot" `Quick
             test_missing_recurrence_defaults_one_shot;
           test_case "grant roundtrip" `Quick test_grant_roundtrip;
+          test_case "grant scope codec: roundtrip, absent, unknown" `Quick
+            test_grant_scope_codec;
           test_case "execution record roundtrip" `Quick
             test_execution_record_roundtrip;
         ] );

--- a/test/test_schedule_domain.ml
+++ b/test/test_schedule_domain.ml
@@ -171,6 +171,14 @@ let test_terminal_schedule_blocks_grant () =
     (validate_execution_grant req grant)
 ;;
 
+let test_standing_scope_requires_recurring_schedule () =
+  let req = request () in
+  check_error
+    "one-shot standing grant"
+    Standing_scope_requires_recurring
+    (apply_execution_grant req (grant ~scope:Grant_standing req))
+;;
+
 let test_mark_due_only_scheduled () =
   let scheduled = request ~risk_class:Read_only () in
   let due = mark_due ~now:201.0 scheduled in
@@ -358,13 +366,18 @@ let test_grant_scope_codec () =
   (match grant ~scope:Grant_occurrence req |> execution_grant_to_yojson with
    | `Assoc fields ->
      let without_scope =
-       `Assoc (List.filter (fun (key, _) -> key <> "scope") fields)
+       `Assoc
+         (List.filter
+            (fun (key, _) -> key <> "scope" && key <> "revocation")
+            fields)
      in
      (match execution_grant_of_yojson without_scope with
       | Error msg -> fail msg
       | Ok decoded ->
         check string "absent scope decodes as occurrence" "occurrence"
-          (grant_scope_to_string decoded.scope))
+          (grant_scope_to_string decoded.scope);
+        check bool "absent revocation decodes as active" true
+          (Option.is_none decoded.revocation))
    | _ -> fail "grant json is not an object");
   (* A present-but-unknown scope is an explicit decode error, never a
      silent default. *)
@@ -383,6 +396,31 @@ let test_grant_scope_codec () =
        check bool "unknown scope is an explicit error" true
          (String.length msg > 0))
   | _ -> fail "grant json is not an object"
+;;
+
+let test_grant_revocation_roundtrip () =
+  let req = request ~recurrence:(Interval { interval_sec = 60 }) () in
+  let revoked_by = human "revoker" in
+  let original =
+    { (grant ~scope:Grant_standing req) with
+      revocation =
+        Some
+          { revoked_by
+          ; revoked_at = 175.0
+          ; reason = Operator_revoked
+          }
+    }
+  in
+  match execution_grant_to_yojson original |> execution_grant_of_yojson with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    (match decoded.revocation with
+     | None -> fail "revocation disappeared during roundtrip"
+     | Some revocation ->
+       check string "revoker" revoked_by.id revocation.revoked_by.id;
+       check (float 0.001) "revoked_at" 175.0 revocation.revoked_at;
+       check string "reason" "operator_revoked"
+         (grant_revocation_reason_to_string revocation.reason))
 ;;
 
 let test_execution_record_roundtrip () =
@@ -459,6 +497,8 @@ let () =
           test_case "evidence mismatch rejected" `Quick test_evidence_mismatch_rejected;
           test_case "terminal schedule blocks grant" `Quick
             test_terminal_schedule_blocks_grant;
+          test_case "standing scope requires recurring schedule" `Quick
+            test_standing_scope_requires_recurring_schedule;
         ] );
       ( "codec",
         [
@@ -470,6 +510,8 @@ let () =
           test_case "grant roundtrip" `Quick test_grant_roundtrip;
           test_case "grant scope codec: roundtrip, absent, unknown" `Quick
             test_grant_scope_codec;
+          test_case "grant revocation roundtrip" `Quick
+            test_grant_revocation_roundtrip;
           test_case "execution record roundtrip" `Quick
             test_execution_record_roundtrip;
         ] );

--- a/test/test_schedule_service.ml
+++ b/test/test_schedule_service.ml
@@ -165,7 +165,8 @@ let test_update_scheduled_request () =
   let payload = payload_exn payload_json in
   match
     update config ~schedule_id:request.schedule_id ~due_at:260.0
-      ~expires_at:(Some 360.0) ~payload
+      ~expires_at:(Some 360.0) ~payload ~updated_at:175.0
+      ~updated_by:request.requested_by ()
   with
   | Ok updated ->
     check_status "updated stays scheduled" Scheduled updated.status;
@@ -192,7 +193,8 @@ let test_update_due_request_reports_store_error () =
        (Schedule_store.Invalid_status_transition
           "only pending or scheduled requests can be updated"))
     (update config ~schedule_id:request.schedule_id ~due_at:260.0
-       ~expires_at:None ~payload:(updated_payload ()))
+       ~expires_at:None ~payload:(updated_payload ()) ~updated_at:210.0
+       ~updated_by:request.requested_by ())
 ;;
 
 let test_due_candidates_do_not_execute_and_require_approval () =

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -39,6 +39,11 @@ let schedules_recovery_path config = schedules_path config ^ ".last-good"
 
 let human ?display_name id = { id; kind = Human_operator; display_name }
 
+let update_request config ~schedule_id ~due_at ~expires_at ~payload =
+  Schedule_store.update_request config ~schedule_id ~due_at ~expires_at ~payload
+    ~updated_by:(human "updater") ~updated_at:175.0 ()
+;;
+
 let payload_json () =
   `Assoc
     [ "kind", `String "consumer.note"
@@ -577,12 +582,9 @@ let test_recurring_grant_is_scoped_to_current_due_at () =
     (List.length (due_execution_candidates (read_state config)))
 ;;
 
-(* The standing counterpart of the test above: one approval covers every
-   later occurrence of the SAME payload digest, and stops covering as soon
-   as the payload (and therefore the digest) changes. This is the fix for
-   the live friction where a recurring workspace_write wake re-blocked on a
-   human click for every single occurrence of an unchanged action. *)
-let test_standing_grant_covers_recurrences_until_payload_changes () =
+(* One standing approval covers later occurrences until an explicit schedule
+   update revokes it. Reverting the payload must not reactivate the old grant. *)
+let test_standing_grant_covers_recurrences_until_schedule_changes () =
   with_workspace
   @@ fun config ->
   let req =
@@ -614,6 +616,8 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
   in
   check bool "standing grant still current on second occurrence" true
     (has_current_approved_grant state due);
+  check bool "active standing grant is projected" true
+    (Option.is_some (active_standing_grant state due));
   check int "second occurrence dispatches without a fresh grant" 1
     (List.length (due_execution_candidates state));
   (match start_due_candidate config ~now:261.0 ~schedule_id:req.schedule_id with
@@ -622,9 +626,8 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
   (match complete_running config ~now:262.0 ~schedule_id:req.schedule_id () with
    | Ok stored -> check_status "rescheduled again" Scheduled stored.status
    | Error err -> fail (store_error_to_string err));
-  (* Change the action while Scheduled (update_request rejects Due/Running):
-     the digest moves, so the standing grant must stop matching and the next
-     occurrence must re-block on approval. *)
+  (* Change the action while Scheduled (update_request rejects Due/Running).
+     The update records a typed revocation before the next occurrence. *)
   let scheduled =
     match get_schedule config ~schedule_id:req.schedule_id with
     | Some scheduled -> scheduled
@@ -633,6 +636,30 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
   (match
      update_request config ~schedule_id:req.schedule_id ~due_at:scheduled.due_at
        ~expires_at:None ~payload:(updated_payload ())
+   with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  let after_update = read_state config in
+  let invalidated =
+    match
+      List.find_opt
+        (fun (grant : execution_grant) -> String.equal grant.grant_id "grant-1")
+        after_update.grants
+    with
+    | None -> fail "standing grant disappeared after update"
+    | Some grant -> grant
+  in
+  (match invalidated.revocation with
+   | None -> fail "schedule update did not revoke standing grant"
+   | Some revocation ->
+     check string "update revoker" "updater" revocation.revoked_by.id;
+     check string "update revocation reason" "schedule_updated"
+       (grant_revocation_reason_to_string revocation.reason));
+  (* Restore the exact original payload before due. The revoked grant must stay
+     dead even though its old digest matches again. *)
+  (match
+     update_request config ~schedule_id:req.schedule_id ~due_at:scheduled.due_at
+       ~expires_at:None ~payload:(payload_exn (payload_json ()))
    with
    | Ok _ -> ()
    | Error err -> fail (store_error_to_string err));
@@ -645,10 +672,70 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
     | Some updated -> updated
     | None -> fail "updated request missing"
   in
-  check bool "standing grant dies with the payload digest" false
+  check bool "revoked standing grant cannot reactivate after payload revert" false
     (has_current_approved_grant state updated);
-  check int "changed payload re-blocks the next occurrence" 0
+  check bool "no active standing grant remains" true
+    (Option.is_none (active_standing_grant state updated));
+  check int "updated schedule re-blocks the next occurrence" 0
     (List.length (due_execution_candidates state))
+;;
+
+let test_revoke_standing_grant_is_durable_and_explicit () =
+  with_workspace
+  @@ fun config ->
+  let req =
+    make_request ~schedule_id:"write-loop-revoke" ~risk_class:Workspace_write
+      ~recurrence:(Interval { interval_sec = 60 })
+      ()
+  in
+  ignore (insert_ok config req);
+  (match record_grant config (grant ~scope:Grant_standing req) with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  let automated_revoker : actor =
+    { id = "scheduler-bot"; kind = Automated_actor; display_name = None }
+  in
+  check_error "automated revocation rejected" Revoker_not_human
+    (revoke_standing_grants config ~schedule_id:req.schedule_id
+       ~revoked_by:automated_revoker ~revoked_at:174.0 ());
+  check_error "blank revoker rejected" Revoker_id_empty
+    (revoke_standing_grants config ~schedule_id:req.schedule_id
+       ~revoked_by:(human " ") ~revoked_at:174.0 ());
+  let revoker = human "security-operator" in
+  (match
+     revoke_standing_grants config ~schedule_id:req.schedule_id
+       ~revoked_by:revoker ~revoked_at:175.0 ()
+   with
+   | Error err -> fail (store_error_to_string err)
+   | Ok (stored, count) ->
+     check_status "schedule remains scheduled" Scheduled stored.status;
+     check int "one grant revoked" 1 count);
+  let state = read_state config in
+  let stored =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some stored -> stored
+    | None -> fail "schedule missing after revocation"
+  in
+  check bool "revoked grant is inactive" true
+    (Option.is_none (active_standing_grant state stored));
+  (match List.hd state.grants with
+   | { revocation = None; _ } -> fail "revocation evidence was not persisted"
+   | { revocation = Some revocation; _ } ->
+     check string "revoker persisted" revoker.id revocation.revoked_by.id;
+     check (float 0.001) "revoked_at persisted" 175.0 revocation.revoked_at;
+     check string "operator reason persisted" "operator_revoked"
+       (grant_revocation_reason_to_string revocation.reason));
+  let before_repeat = state.version in
+  check_error "repeat revocation fails explicitly" No_active_standing_grant
+    (revoke_standing_grants config ~schedule_id:req.schedule_id
+       ~revoked_by:revoker ~revoked_at:176.0 ());
+  check int "failed repeat does not bump version" before_repeat
+    (read_state config).version;
+  (match refresh_due config ~now:201.0 with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  check int "revoked schedule is blocked at due" 0
+    (List.length (due_execution_candidates (read_state config)))
 ;;
 
 let test_load_corrupt_when_both_unparseable () =
@@ -831,8 +918,10 @@ let () =
             test_fail_due_candidate_records_failed_execution;
           test_case "recurring grant is scoped to current due_at" `Quick
             test_recurring_grant_is_scoped_to_current_due_at;
-          test_case "standing grant covers recurrences until payload changes"
-            `Quick test_standing_grant_covers_recurrences_until_payload_changes;
+          test_case "standing grant survives recurrences but not schedule changes"
+            `Quick test_standing_grant_covers_recurrences_until_schedule_changes;
+          test_case "standing grant revocation is durable and explicit" `Quick
+            test_revoke_standing_grant_is_durable_and_explicit;
         ] );
     ]
 ;;

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -616,11 +616,27 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
     (has_current_approved_grant state due);
   check int "second occurrence dispatches without a fresh grant" 1
     (List.length (due_execution_candidates state));
-  (* Change the action: digest moves, standing grant must stop matching. *)
+  (match start_due_candidate config ~now:261.0 ~schedule_id:req.schedule_id with
+   | Ok running -> check_status "running second occurrence" Running running.status
+   | Error err -> fail (store_error_to_string err));
+  (match complete_running config ~now:262.0 ~schedule_id:req.schedule_id () with
+   | Ok stored -> check_status "rescheduled again" Scheduled stored.status
+   | Error err -> fail (store_error_to_string err));
+  (* Change the action while Scheduled (update_request rejects Due/Running):
+     the digest moves, so the standing grant must stop matching and the next
+     occurrence must re-block on approval. *)
+  let scheduled =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some scheduled -> scheduled
+    | None -> fail "rescheduled request missing"
+  in
   (match
-     update_request config ~schedule_id:req.schedule_id ~due_at:due.due_at
+     update_request config ~schedule_id:req.schedule_id ~due_at:scheduled.due_at
        ~expires_at:None ~payload:(updated_payload ())
    with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:scheduled.due_at with
    | Ok _ -> ()
    | Error err -> fail (store_error_to_string err));
   let state = read_state config in
@@ -630,7 +646,9 @@ let test_standing_grant_covers_recurrences_until_payload_changes () =
     | None -> fail "updated request missing"
   in
   check bool "standing grant dies with the payload digest" false
-    (has_current_approved_grant state updated)
+    (has_current_approved_grant state updated);
+  check int "changed payload re-blocks the next occurrence" 0
+    (List.length (due_execution_candidates state))
 ;;
 
 let test_load_corrupt_when_both_unparseable () =

--- a/test/test_schedule_store.ml
+++ b/test/test_schedule_store.ml
@@ -80,9 +80,9 @@ let make_request
   | Error msg -> fail msg
 ;;
 
-let grant ?(approved_by = human "approver") request =
+let grant ?(approved_by = human "approver") ?(scope = Grant_occurrence) request =
   create_execution_grant ~grant_id:"grant-1" ~approved_by ~approved_at:150.0
-    ~decision:Approve request
+    ~decision:Approve ~scope request
 ;;
 
 let insert_ok config request =
@@ -568,13 +568,69 @@ let test_recurring_grant_is_scoped_to_current_due_at () =
     (List.length (due_execution_candidates state));
   let fresh_grant =
     create_execution_grant ~grant_id:"grant-2" ~approved_by:(human "approver-2")
-      ~approved_at:261.0 ~decision:Approve due
+      ~approved_at:261.0 ~decision:Approve ~scope:Grant_occurrence due
   in
   (match record_grant config fresh_grant with
    | Ok stored -> check_status "fresh due grant keeps due" Due stored.status
    | Error err -> fail (store_error_to_string err));
   check int "second occurrence candidate after fresh grant" 1
     (List.length (due_execution_candidates (read_state config)))
+;;
+
+(* The standing counterpart of the test above: one approval covers every
+   later occurrence of the SAME payload digest, and stops covering as soon
+   as the payload (and therefore the digest) changes. This is the fix for
+   the live friction where a recurring workspace_write wake re-blocked on a
+   human click for every single occurrence of an unchanged action. *)
+let test_standing_grant_covers_recurrences_until_payload_changes () =
+  with_workspace
+  @@ fun config ->
+  let req =
+    make_request ~schedule_id:"write-loop-standing" ~risk_class:Workspace_write
+      ~recurrence:(Interval { interval_sec = 60 })
+      ()
+  in
+  ignore (insert_ok config req);
+  (match record_grant config (grant ~scope:Grant_standing req) with
+   | Ok stored -> check_status "approved with standing scope" Scheduled stored.status
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:201.0 with
+   | Ok (_, changed) -> check int "first due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  (match start_due_candidate config ~now:202.0 ~schedule_id:req.schedule_id with
+   | Ok running -> check_status "running first occurrence" Running running.status
+   | Error err -> fail (store_error_to_string err));
+  (match complete_running config ~now:203.0 ~schedule_id:req.schedule_id () with
+   | Ok stored -> check_status "rescheduled" Scheduled stored.status
+   | Error err -> fail (store_error_to_string err));
+  (match refresh_due config ~now:260.0 with
+   | Ok (_, changed) -> check int "second due" 1 changed
+   | Error err -> fail (store_error_to_string err));
+  let state = read_state config in
+  let due =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some due -> due
+    | None -> fail "rescheduled request missing"
+  in
+  check bool "standing grant still current on second occurrence" true
+    (has_current_approved_grant state due);
+  check int "second occurrence dispatches without a fresh grant" 1
+    (List.length (due_execution_candidates state));
+  (* Change the action: digest moves, standing grant must stop matching. *)
+  (match
+     update_request config ~schedule_id:req.schedule_id ~due_at:due.due_at
+       ~expires_at:None ~payload:(updated_payload ())
+   with
+   | Ok _ -> ()
+   | Error err -> fail (store_error_to_string err));
+  let state = read_state config in
+  let updated =
+    match get_schedule config ~schedule_id:req.schedule_id with
+    | Some updated -> updated
+    | None -> fail "updated request missing"
+  in
+  check bool "standing grant dies with the payload digest" false
+    (has_current_approved_grant state updated)
 ;;
 
 let test_load_corrupt_when_both_unparseable () =
@@ -757,6 +813,8 @@ let () =
             test_fail_due_candidate_records_failed_execution;
           test_case "recurring grant is scoped to current due_at" `Quick
             test_recurring_grant_is_scoped_to_current_due_at;
+          test_case "standing grant covers recurrences until payload changes"
+            `Quick test_standing_grant_covers_recurrences_until_payload_changes;
         ] );
     ]
 ;;

--- a/test/test_server_dashboard_http_schedule_actions.ml
+++ b/test/test_server_dashboard_http_schedule_actions.ml
@@ -45,12 +45,17 @@ let payload_json text =
     ]
 ;;
 
-let create_ok ?(risk_class = Schedule_domain.Read_only) ~schedule_id config =
+let create_ok
+      ?(risk_class = Schedule_domain.Read_only)
+      ?recurrence
+      ~schedule_id
+      config
+  =
   match
     Schedule_service.create config ~schedule_id ~requested_at:100.0
       ~requested_by:(human "requester") ~scheduled_by:(human "scheduler")
       ~due_at:200.0 ~payload:(payload_json "before") ~risk_class
-      ~source:Schedule_domain.Operator_request ()
+      ~source:Schedule_domain.Operator_request ?recurrence ()
   with
   | Ok request -> request
   | Error err -> fail (Schedule_service.service_error_to_string err)
@@ -165,6 +170,136 @@ let test_cancel_decision_marks_cancelled () =
          (Schedule_domain.schedule_status_to_string stored.status))
 ;;
 
+let test_standing_scope_is_strict_and_requires_recurrence () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"http-standing-strict"
+      ~risk_class:Schedule_domain.Workspace_write config
+  in
+  let approve_with scope =
+    resolve config
+      (`Assoc
+        [ "schedule_id", `String request.schedule_id
+        ; "decision", `String "approve"
+        ; "scope", scope
+        ])
+  in
+  check_resolve_error "null scope" "scope must be 'occurrence' or 'standing'"
+    (approve_with `Null);
+  check_resolve_error "blank scope" "scope must be 'occurrence' or 'standing'"
+    (approve_with (`String " "));
+  check_resolve_error "numeric scope" "scope must be 'occurrence' or 'standing'"
+    (approve_with (`Int 1));
+  check_resolve_error "one-shot standing scope"
+    "grant validation failed: standing approval requires a recurring schedule"
+    (approve_with (`String "standing"))
+;;
+
+let test_standing_approval_projects_and_revokes () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"http-standing-revoke"
+      ~risk_class:Schedule_domain.Workspace_write
+      ~recurrence:(Schedule_domain.Interval { interval_sec = 60 })
+      config
+  in
+  let approve =
+    `Assoc
+      [ "schedule_id", `String request.schedule_id
+      ; "decision", `String "approve"
+      ; "scope", `String "standing"
+      ]
+  in
+  (match resolve config approve with
+   | Error message -> fail message
+   | Ok _ -> ());
+  let open Yojson.Safe.Util in
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> List.find (fun row ->
+      String.equal
+        (row |> member "schedule_id" |> to_string)
+        request.schedule_id)
+  in
+  let active = row |> member "active_standing_grant" in
+  check string "projected scope" "standing" (active |> member "scope" |> to_string);
+  check string "projected approver" "dashboard-admin"
+    (active |> member "approved_by" |> member "id" |> to_string);
+  let revoke =
+    `Assoc
+      [ "schedule_id", `String request.schedule_id
+      ; "decision", `String "revoke_standing"
+      ]
+  in
+  (match resolve config revoke with
+   | Error message -> fail message
+   | Ok json ->
+     check string "decision" "revoke_standing"
+       (json |> member "decision" |> to_string);
+     check int "revoked count" 1 (json |> member "revoked_grant_count" |> to_int));
+  let state = Schedule_store.read_state config in
+  let stored =
+    match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+    | None -> fail "schedule missing after revoke"
+    | Some stored -> stored
+  in
+  check bool "standing grant no longer active" true
+    (Option.is_none (Schedule_store.active_standing_grant state stored));
+  (match List.hd state.grants with
+   | { revocation = None; _ } -> fail "revoke evidence missing"
+   | { revocation = Some revocation; _ } ->
+     check string "revoker identity" "dashboard-admin" revocation.revoked_by.id);
+  check_resolve_error "repeat revoke is explicit"
+    "schedule has no active standing grant"
+    (resolve config revoke)
+;;
+
+let test_update_revokes_standing_grant_with_operator_identity () =
+  with_workspace
+  @@ fun config ->
+  let request =
+    create_ok ~schedule_id:"http-standing-update"
+      ~risk_class:Schedule_domain.Workspace_write
+      ~recurrence:(Schedule_domain.Interval { interval_sec = 60 })
+      config
+  in
+  (match
+     resolve config
+       (`Assoc
+         [ "schedule_id", `String request.schedule_id
+         ; "decision", `String "approve"
+         ; "scope", `String "standing"
+         ])
+   with
+   | Error message -> fail message
+   | Ok _ -> ());
+  (match
+     resolve config
+       (`Assoc
+         [ "schedule_id", `String request.schedule_id
+         ; "decision", `String "update"
+         ; "due_at", `Float 260.0
+         ; "payload", payload_json "after"
+         ])
+   with
+   | Error message -> fail message
+   | Ok _ -> ());
+  let state = Schedule_store.read_state config in
+  match List.hd state.grants with
+  | { revocation = None; _ } -> fail "update did not revoke standing grant"
+  | { revocation = Some revocation; _ } ->
+    check string "update actor" "dashboard-admin" revocation.revoked_by.id;
+    check string "update reason" "schedule_updated"
+      (Schedule_domain.grant_revocation_reason_to_string revocation.reason)
+;;
+
 let () =
   run "Server_dashboard_http_schedule_actions"
     [ ( "update",
@@ -180,6 +315,15 @@ let () =
         [
           test_case "decision marks cancelled" `Quick
             test_cancel_decision_marks_cancelled;
+        ] );
+      ( "standing",
+        [
+          test_case "scope is strict and requires recurrence" `Quick
+            test_standing_scope_is_strict_and_requires_recurrence;
+          test_case "approval projects and revokes" `Quick
+            test_standing_approval_projects_and_revokes;
+          test_case "update revokes with operator identity" `Quick
+            test_update_revokes_standing_grant_with_operator_identity;
         ] );
     ]
 ;;


### PR DESCRIPTION
## 문제

반복 side-effecting schedule은 occurrence grant가 exact due_at에 묶여 있어 payload가 같아도 매 발생마다 human 승인을 다시 요구했습니다. 반대로 standing 승인을 단순히 payload digest 매칭으로만 구현하면 update 후 payload를 원복할 때 과거 grant가 다시 살아나고, 생성한 무기한 권한을 철회할 수 없는 문제가 생깁니다.

## 변경

- typed grant_scope: Grant_occurrence | Grant_standing
  - occurrence는 기존 exact due_at 계약과 과거 persistence 호환을 유지합니다.
  - standing은 recurring schedule에서만 발급됩니다. one-shot standing 요청은 domain error입니다.
- typed grant revocation을 execution_grant에 보존합니다.
  - Operator_revoked: dashboard의 명시적 철회
  - Schedule_updated: due_at, expires_at, payload update 시 자동 무효화
  - 승인 원본은 삭제하지 않고 revoked_by, revoked_at, reason을 같은 durable ledger에 기록합니다.
- revoked grant는 matching에서 제외되므로 payload를 예전 digest로 되돌려도 재활성화되지 않습니다.
- 시간 관측은 service mutation boundary에서 한 번만 수행하고 deterministic store에는 명시적 timestamp를 전달합니다.
- dashboard scheduled_automation projection에 active_standing_grant를 추가했습니다.
- diagnostics와 실제 기본 v2 detail surface 모두 다음 동작을 제공합니다.
  - recurring: 이번 발생만 승인 / 반복 승인
  - active standing grant: 승인자와 승인 시각 표시 / 반복 승인 철회
- HTTP scope는 absent만 occurrence로 해석합니다. null, blank, wrong type, unknown은 모두 명시적 400입니다.
- 기존 human approver 및 requester/scheduler separation-of-duties 불변식은 유지합니다.
- OCaml 5.x compile contract를 닫았습니다.
  - optional `updated_at` API 뒤에 trailing `unit`을 두어 호출이 부분 적용 함수로 남지 않습니다.
  - guarded standing-grant match를 완전한 variant 분기로 바꿔 `-warn-error +8`을 통과합니다.

## 반례 검증

- 동일 payload의 두 번째 recurrence는 standing grant로 실행 가능합니다.
- schedule update는 active standing grant를 Schedule_updated로 영구 무효화합니다.
- update 후 원래 payload로 되돌려도 과거 grant는 살아나지 않습니다.
- explicit revoke는 Operator_revoked 증거를 보존하고 이후 due execution을 차단합니다.
- 반복 revoke와 non-human/blank revoker는 silent no-op 없이 typed error입니다.
- active standing grant가 dashboard projection과 v2 UI에 나타나고 revoke 요청이 실제 API로 전달됩니다.

## 검증

- OCaml changed files parser: PASS
- ocamlformat --check: PASS
- git diff --check: PASS
- focused Dune `@test/runtest-test_schedule_domain`: 31/31 PASS
- focused Dune `@test/runtest-test_schedule_store`: 28/28 PASS
- focused Dune `@test/runtest-test_server_dashboard_http_schedule_actions`: 7/7 PASS
- 기존 head의 focused Vitest: 113/113 PASS
- full Dune은 실행하지 않았습니다. build authority는 PR CI입니다.

Closes #23995.

[근거] exact head f9856d49ea, focused wrapper 결과와 GitHub Actions를 2026-07-11 KST에 확인; 신뢰도 High.
