### PR TITLE
ci: consolidate ~30 lint jobs into 2 and cache dune artifacts (queue starvation fix)

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -36,6 +36,30 @@ runs:
         restore-keys: |
           opam-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
 
+    # The opam cache above only restores the toolchain/switch; every dune
+    # build of masc itself still started cold (~50 min Build and Test).
+    # Cache dune's content-addressed artifact store so an unchanged module
+    # graph rebuilds incrementally. Keyed by run id so each run REWRITES the
+    # cache with its newest artifacts (a stable key would freeze the first
+    # upload forever); restore always hits the newest same-prefix entry.
+    - name: Cache dune build artifacts (Linux)
+      if: runner.os == 'Linux' && inputs.dune-cache == 'true'
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/dune
+        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
+        restore-keys: |
+          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
+
+    - name: Enable dune cache (Linux)
+      if: runner.os == 'Linux' && inputs.dune-cache == 'true'
+      shell: bash
+      run: |
+        {
+          echo "DUNE_CACHE=enabled"
+          echo "DUNE_CACHE_STORAGE_MODE=copy"
+        } >> "$GITHUB_ENV"
+
     - name: Bootstrap local opam switch (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -2,13 +2,23 @@ name: Fundamental Check
 
 # Regression guards derived from the 2026-05-05 reality check
 # (docs/audit/2026-05-05-fundamental-roadmap-reality-check.md) on
-# fundamental_roadmap.md. Each job protects ground that PR #12986,
+# fundamental_roadmap.md. Each lint protects ground that PR #12986,
 # #12990, and the 10-week re-scoped plan
 # (~/me/planning/claude-plans/joyful-tumbling-dragon.md) already
 # cleared, so the codebase does not silently regress.
 #
 # Dashboard `tsc --noEmit` typecheck is intentionally NOT duplicated
 # here — ci.yml's `dashboard` job already runs it (see ci.yml:834).
+#
+# 2026-07-10 consolidation: these lints used to be ~30 separate jobs.
+# Each was seconds of work behind ~1 minute of checkout/apt setup, and
+# together they held ~30 runner slots per PR event — the main cause of
+# the day's queue starvation (PRs sat `queued` for 25+ minutes). They
+# now run as TWO jobs (blocking + advisory) through
+# scripts/ci/run-lint-suite.sh, which runs every lint to completion and
+# fails with the full failure list, preserving the old "see all
+# failures at once" property of parallel jobs. The lint scripts
+# themselves are unchanged.
 
 on:
   pull_request:
@@ -30,356 +40,42 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  no-roadmap-stale-hardcoding:
-    name: Hardcoded model prefix
+  lint-suite:
+    name: Lint Suite
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-roadmap-stale-hardcoding.sh
-
-  no-raw-font-size-px:
-    name: Raw font-size px (--fs-* token exists)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-raw-font-size-px.sh
-
-  no-ocaml-comment-terminator-trap:
-    name: OCaml comment `*)` terminator trap
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-ocaml-comment-terminator-trap.sh
-
-  timeout-env-ceiling:
-    name: Timeout env knob ceiling ratchet (RFC-0138)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/timeout-env-ceiling.sh
-
-  dashboard-env-knob-count:
-    name: Dashboard env knob count (advisory)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint-timeout-env-count.sh --strict
-
-  no-actionable-signal-bool-context:
-    name: No actionable signal bool context
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-actionable-signal-bool-context.sh
-
-  no-provider-name-hardcoding:
-    name: Provider name hardcoding ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-provider-name-hardcoding.sh --fail
-
-  no-keeper-behavior-hardcoding:
-    name: Keeper behavior hardcoding ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-keeper-behavior-hardcoding.sh
-
-  no-eval-tool-selector-runtime-import:
-    name: Eval tool selector runtime boundary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-eval-tool-selector-runtime-import.sh
-
-  no-legacy-tool-surface-name:
-    name: Legacy tool surface name ratchet (RFC-0064)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-legacy-tool-surface-name.sh --fail
-
-  no-retired-tool-husks:
-    name: Retired tool husk ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-retired-tool-husks.sh --fail
-
-  no-synthetic-tool-call-residue:
-    name: Synthetic tool-call residue ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-synthetic-tool-call-residue.sh --fail
-
-  no-tool-substrate-adapter-surface:
-    name: Tool substrate adapter surface ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
-
-  tool-keeper-boundary:
-    name: Tool -> Keeper dependency-direction ratchet (RFC-0194 §3)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
-
-  masc-domain-boundary:
-    name: MASC domain ownership ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/masc-domain-boundary-ratchet.sh --fail
-
-  no-tool-result-error-printexc:
-    name: RFC-0148 backsliding guard (no Tool_result.error + Printexc.to_string)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-tool-result-error-printexc.sh
-
-  no-runtime-literal-outside-boundary-redaction:
-    name: Boundary redaction SSOT enforcement (RFC-0132 PR-3)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
-
-  no-fabricated-telemetry:
-    name: Math.random in components
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-fabricated-telemetry.sh
-
-  no-oas-prefix-in-lib:
-    name: No oas_* prefix in masc lib/ (RFC-0047)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-oas-prefix-in-lib.sh
-
-  no-inline-ok-envelope:
-    name: No inline ok-envelope literals (T27/T28/T29)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-inline-ok-envelope.sh
-
-  no-inline-error-envelope:
-    name: No inline error-envelope literals (T30)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-inline-error-envelope.sh
-
-  no-inline-json-kind-name:
-    name: No inline json_kind_name (use Json_util.kind_name)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-inline-json-kind-name.sh
-
-  no-yojson-3-dead-arms:
-    name: No yojson 3.0 dead arms (`Tuple/`Variant in Yojson.Safe.t)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/no-yojson-3-dead-arms.sh
-
-  ignore-without-comment-new:
-    name: ignore() justification (new sites)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
         with:
+          # Full history: the PR-only diff guards (env-knob, Fun.protect,
+          # ignore-justification, stale-base revert RFC-0235) need the
+          # merge-base and intervening main commits reachable.
           fetch-depth: 0
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: |
-          bash scripts/ci/check-ignore-without-comment-diff.sh \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD
-
-  magic-number-advisory:
-    name: Magic number repetition (advisory)
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint-magic-number.sh
-
-  yaml-syntax:
-    name: Workflow YAML syntax
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - name: Install PyYAML
-        run: python -m pip install --upgrade pip pyyaml
-      - name: Run lint
-        run: bash scripts/lint/yaml-syntax.sh
-
-  board-slo-extractor-fixture:
-    name: Board SLO extractor fixture
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install jq
-        run: sudo apt-get install -y -qq jq
-      - name: Run fixture test
-        run: bash scripts/test-board-slo-extractor.sh
-
-  env-knob-classification:
-    name: Env knob classification
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Run guard
+      - name: Install lint dependencies
         run: |
-          python3 scripts/ci/check-env-knob-classification.py \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD
+          bash scripts/ci/apt-refresh.sh
+          sudo apt-get install -y -qq ripgrep jq
+          python -m pip install --quiet --upgrade pip pyyaml
+      - name: Run blocking lints (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          bash scripts/ci/run-lint-suite.sh blocking-pr \
+            "${{ github.event.pull_request.base.sha }}"
+      - name: Run blocking lints (push)
+        if: github.event_name != 'pull_request'
+        run: bash scripts/ci/run-lint-suite.sh blocking
 
-  exhaustive-guard-advisory:
-    # RFC-0071 Phase 1 advisory: surfaces new fragile-match sites in PR
-    # checks but never blocks merge. Phase 5 (RFC-0071 §4) flips this
-    # to required-and-blocking once codemod (WS-3) closes the bulk of
-    # the inventory and the allowlist is narrowed to (a)-class sites.
-    name: Fragile-match (advisory)
+  lint-advisory:
+    name: Lint Suite (advisory)
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
-      - name: Run lint
-        run: bash scripts/lint/exhaustive-guard.sh
-
-  fun-protect-finalizer:
-    name: Fun.protect finalizer guard
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Run guard
-        run: |
-          python3 scripts/ci/check-fun-protect-finally-guard.py \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD
-
-  spawn-bounded:
-    name: Spawn-bounded ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint-spawn-bounded.sh
-
-  audit-path-ssot:
-    name: audit-path-ssot
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install ripgrep
+      - name: Install lint dependencies
         run: |
           bash scripts/ci/apt-refresh.sh
           sudo apt-get install -y -qq ripgrep
-      - name: Run path SSOT audit
-        run: bash scripts/audit-path-ssot.sh
-
-  stale-base-revert:
-    # RFC-0235. Blocks a PR that would silently revert recently-merged
-    # work because it was computed against a stale base (the 2026-06-12
-    # #20869 incident: a stale branch dropped #20853's telemetry block,
-    # 19/19 lines, with no conflict). Only meaningful on pull_request;
-    # a push to main has no base to compare against.
-    name: Stale-base revert guard (RFC-0235)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # Full history so the merge-base and the intervening main
-          # commits are reachable; a shallow clone would make the guard
-          # unable to compute the merge-base and fail loud.
-          fetch-depth: 0
-      - name: Self-test the guard
-        run: python3 scripts/ci/test_check_stale_base_revert.py
-      - name: Run guard
-        env:
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-        run: |
-          python3 scripts/ci/check-stale-base-revert.py \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD
+      - name: Run advisory lints
+        run: bash scripts/ci/run-lint-suite.sh advisory

--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Consolidated Fundamental Check driver (issue: runner-slot starvation).
+#
+# Previously each lint below was its own GitHub Actions job: ~30 jobs x
+# (checkout + apt setup) per PR event burned runner slots and queued whole
+# PRs for tens of minutes. This driver runs the same scripts sequentially
+# in ONE job, but does NOT stop at the first failure: every lint runs,
+# failures are collected, and the job fails at the end with the full list —
+# preserving the old "see all failures at once" property.
+#
+# Modes:
+#   run-lint-suite.sh blocking            # every always-on blocking lint
+#   run-lint-suite.sh blocking-pr BASE    # + PR-only diff guards vs BASE
+#   run-lint-suite.sh advisory            # non-blocking lints (job uses
+#                                         # continue-on-error)
+set -uo pipefail
+
+mode="${1:?usage: run-lint-suite.sh <blocking|blocking-pr|advisory> [base-sha]}"
+base_sha="${2:-}"
+
+failures=()
+ran=0
+
+run_lint() {
+  local label="$1"
+  shift
+  ran=$((ran + 1))
+  echo "::group::${label}"
+  if "$@"; then
+    echo "::endgroup::"
+  else
+    local status=$?
+    echo "::endgroup::"
+    echo "::error title=Lint failed::${label} (exit ${status})"
+    failures+=("${label}")
+  fi
+}
+
+blocking_lints() {
+  run_lint "Hardcoded model prefix" bash scripts/lint/no-roadmap-stale-hardcoding.sh
+  run_lint "Raw font-size px" bash scripts/lint/no-raw-font-size-px.sh
+  run_lint "OCaml comment terminator trap" bash scripts/lint/no-ocaml-comment-terminator-trap.sh
+  run_lint "Timeout env knob ceiling (RFC-0138)" bash scripts/lint/timeout-env-ceiling.sh
+  run_lint "No actionable-signal bool context" bash scripts/lint/no-actionable-signal-bool-context.sh
+  run_lint "Provider name hardcoding ratchet" bash scripts/lint/no-provider-name-hardcoding.sh --fail
+  run_lint "Keeper behavior hardcoding" bash scripts/lint/no-keeper-behavior-hardcoding.sh
+  run_lint "Eval tool-selector runtime import" bash scripts/lint/no-eval-tool-selector-runtime-import.sh
+  run_lint "Legacy tool surface name" bash scripts/lint/no-legacy-tool-surface-name.sh --fail
+  run_lint "Retired tool husk ratchet" bash scripts/lint/no-retired-tool-husks.sh --fail
+  run_lint "Synthetic tool-call residue ratchet" bash scripts/lint/no-synthetic-tool-call-residue.sh --fail
+  run_lint "Tool substrate adapter surface" bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail
+  run_lint "Tool -> Keeper dependency-direction ratchet (RFC-0194)" bash scripts/lint/tool-keeper-boundary-ratchet.sh --fail
+  run_lint "MASC domain ownership ratchet" bash scripts/lint/masc-domain-boundary-ratchet.sh --fail
+  run_lint "No Tool_result.error + Printexc (RFC-0148)" bash scripts/lint/no-tool-result-error-printexc.sh
+  run_lint "Boundary redaction SSOT (RFC-0132 PR-3)" bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
+  run_lint "No fabricated telemetry" bash scripts/lint/no-fabricated-telemetry.sh
+  run_lint "No oas_* prefix in lib/ (RFC-0047)" bash scripts/lint/no-oas-prefix-in-lib.sh
+  run_lint "No inline ok-envelope literals" bash scripts/lint/no-inline-ok-envelope.sh
+  run_lint "No inline error-envelope literals" bash scripts/lint/no-inline-error-envelope.sh
+  run_lint "No inline json_kind_name" bash scripts/lint/no-inline-json-kind-name.sh
+  run_lint "No yojson 3.0 dead arms" bash scripts/lint/no-yojson-3-dead-arms.sh
+  run_lint "Workflow YAML syntax" bash scripts/lint/yaml-syntax.sh
+  run_lint "Board SLO extractor fixture" bash scripts/test-board-slo-extractor.sh
+  run_lint "Spawn-bounded ratchet" bash scripts/lint-spawn-bounded.sh
+  run_lint "audit-path-ssot" bash scripts/audit-path-ssot.sh
+}
+
+blocking_pr_lints() {
+  local base="$1"
+  run_lint "Env knob classification" \
+    python3 scripts/ci/check-env-knob-classification.py --base "${base}" --head HEAD
+  run_lint "Fun.protect finalizer guard" \
+    python3 scripts/ci/check-fun-protect-finally-guard.py --base "${base}" --head HEAD
+  run_lint "ignore() justification (new sites)" \
+    bash scripts/ci/check-ignore-without-comment-diff.sh --base "${base}" --head HEAD
+  run_lint "Stale-base revert guard self-test (RFC-0235)" \
+    python3 scripts/ci/test_check_stale_base_revert.py
+  run_lint "Stale-base revert guard (RFC-0235)" \
+    python3 scripts/ci/check-stale-base-revert.py --base "${base}" --head HEAD
+}
+
+advisory_lints() {
+  run_lint "Dashboard env knob count (advisory)" bash scripts/lint-timeout-env-count.sh --strict
+  run_lint "Magic number repetition (advisory)" bash scripts/lint-magic-number.sh
+  run_lint "Fragile-match (advisory, RFC-0071 Phase 1)" bash scripts/lint/exhaustive-guard.sh
+}
+
+case "${mode}" in
+  blocking)
+    blocking_lints
+    ;;
+  blocking-pr)
+    if [[ -z "${base_sha}" ]]; then
+      echo "::error::blocking-pr mode requires the PR base sha" >&2
+      exit 2
+    fi
+    blocking_lints
+    blocking_pr_lints "${base_sha}"
+    ;;
+  advisory)
+    advisory_lints
+    ;;
+  *)
+    echo "::error::unknown mode ${mode}" >&2
+    exit 2
+    ;;
+esac
+
+echo ""
+if [[ ${#failures[@]} -gt 0 ]]; then
+  echo "FAILED ${#failures[@]}/${ran} lints:"
+  printf ' - %s\n' "${failures[@]}"
+  exit 1
+fi
+echo "all ${ran} lints passed"


### PR DESCRIPTION
## 병목 실측 (2026-07-10)

| 병목 | 실측 | 원인 |
|---|---|---|
| 러너 대기열 기아 | PR run이 `queued`로 25분+ | PR 이벤트당 ~48 체크 중 ~30개가 Fundamental Check의 초 단위 lint — 각각 checkout/apt ~1분을 물고 슬롯 점유 |
| Build and Test | ~53분 | opam 캐시는 switch만 복원 — **masc 자체 dune build는 매 run 콜드** |

## 변경

1. **Fundamental Check: ~30 job → 2 job** (`Lint Suite` blocking + `Lint Suite (advisory)`) — 신설 `scripts/ci/run-lint-suite.sh` 드라이버가 전 lint를 **끝까지 실행 후 실패 목록 일괄 보고**하므로, 병렬 job의 "모든 실패가 한 번에 보임" 특성이 보존되오. lint 스크립트 자체는 무변경. PR-전용 diff 가드(env-knob/Fun.protect/ignore-justification/stale-base RFC-0235)는 `blocking-pr` 모드로 base-sha 시맨틱 유지.
2. **dune 아티팩트 캐시**: 합성 액션에 `~/.cache/dune` 캐시(run-id 키 + prefix restore — 안정 키는 첫 업로드에 영구 동결되는 함정 회피) + `DUNE_CACHE=enabled`(copy 모드). build/health/canary 세 job 수혜.

## 기대 효과

- 슬롯 소비: PR 이벤트당 ~30 → 2 (lint) — 대기열 기아의 주범 제거.
- Build and Test: 소규모 diff PR은 증분 빌드로 단축 (첫 run은 캐시 적재라 현행과 동일, 2번째부터 효과).

## 검증

- `bash -n` + PyYAML 파스 + 참조 스크립트 전수 존재 확인.
- 로컬 스모크: blocking 26/26 green, advisory 3/3 완주.
- 체크 컨텍스트 이름이 바뀌지만(개별 lint명 → Lint Suite) **required context는 CI Gate뿐**이라 branch protection 무영향 실측.

## 트레이드오프 (정직 고지)

- 개별 lint의 pass/fail이 PR 체크 목록에서 한 줄로 뭉치오 — 대신 실패 시 `::error` annotation + 실패 목록으로 어떤 lint인지 즉시 식별되오.
- lint 간 직렬 실행이라 단일 job 시간은 ~수 분으로 늘어나오(슬롯 30개 대신 1개를 오래 쓰는 교환) — 순 대기열 효과는 압도적으로 이득.
- dune 캐시 run-id 키는 run마다 새 캐시 entry를 쓰오 — GitHub 캐시 10GB 상한에서 오래된 entry는 LRU 축출되니 관리 불요.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
