### PR TITLE
docs(rfc): RFC-0338 lane-per-keeper durable persistence isolation (C9)

### DIFF
--- a/docs/rfc/RFC-0338-lane-per-keeper-persistence-isolation.md
+++ b/docs/rfc/RFC-0338-lane-per-keeper-persistence-isolation.md
@@ -1,0 +1,79 @@
+# RFC-0338: Lane-per-keeper durable persistence isolation
+
+- Status: Draft
+- Author: Claude (38-bug campaign, cluster C9 — bugs #17/#25/#29)
+- Date: 2026-07-10
+- Related: keeper_event_queue_persistence.ml 2026-06-29 audit note, RFC-0334 (board mailbox), KeeperOASAdvanced.tla (CancelledNeverAbsorbed)
+
+## 문제
+
+`lib/keeper_runtime/keeper_event_queue_persistence.ml`의 durable event-queue 스냅샷 I/O는 **프로세스 전역 단일 뮤텍스** 뒤에 있다:
+
+```ocaml
+let eio_write_mu = Eio.Mutex.create ()       (* :11 — process-global *)
+let with_write_lock : type a. (unit -> a) -> a  (* :24, 호출 사이트 13곳 *)
+```
+
+스냅샷 파일은 keeper별로 분리돼 있는데(`.masc/keepers/<name>/…` pending/inflight 쌍) 락은 전역이라, 락의 실제 보호 대상(같은 keeper 스냅샷 쌍의 read-modify-write 원자성)보다 훨씬 넓게 직렬화한다.
+
+관측된/구조적 결과:
+
+1. **Head-of-line blocking (#29)**: 한 keeper의 느린 디스크 I/O(대형 스냅샷, 느린 볼륨, fsync 지연)가 무관한 keeper 전원의 durable 쓰기를 대기시킨다. 14-keeper fleet에서 wake/HITL(#23956 이후 durable enqueue가 승인 acknowledgment의 커밋 포인트) 지연으로 직접 전파된다.
+2. **단일 장애점**: 파일 자체의 주석(:14-16)이 자인하듯 "a poisoned mutex blocks durable event-queue snapshots for EVERY keeper for the lifetime of the process". 현재는 예외를 critical section 안에서 포획해 우회 중이지만, 이 방어는 락 범위가 전역이라서 필요해진 것이다.
+3. **격리 원칙 위반 (#17/#25 연관)**: keeper 장애 격리(서킷브레이커, per-keeper failure policy)의 단위는 keeper인데, 영속 계층의 경합 단위는 프로세스다. 브레이커가 keeper A를 열어도 A가 잡고 있는 전역 락이 B/C를 계속 물고 있을 수 있다.
+
+부수 관찰(스코프 밖, 기록만): `schedule_runner.ml dispatch_candidates`의 순차 `List.map`도 tick 내 head-of-line 직렬화다. dispatch 순서 시맨틱 결정이 선행돼야 하므로 본 RFC에 포함하지 않는다.
+
+## 설계
+
+### 락 구조
+
+전역 뮤텍스 1개 → **per-keeper 뮤텍스 테이블**:
+
+```ocaml
+(* keeper_name → mutex. 테이블 접근 자체는 짧은 전역 락(순수 Hashtbl 조작만,
+   I/O 없음)으로 가드. 뮤텍스는 keeper당 lazy 생성 후 영구 유지 —
+   keeper 수는 유한(수십)이라 GC 불필요. *)
+val with_write_lock : keeper_name:string -> (unit -> 'a) -> 'a
+```
+
+- 시그니처에 `~keeper_name` 추가. 13개 호출 사이트 전부 이미 `keeper_name`을 스코프에 갖고 있다 (스냅샷 경로 계산에 사용 중) — 기계적 전파.
+- poisoned-mutex 방어(critical section 내 예외 포획, Cancelled 재raise — CancelledNeverAbsorbed)는 **그대로 유지**하되, 이제 오염 반경이 keeper 1기로 준다.
+- non-Eio fallback(`Stdlib.Mutex`)도 동일하게 per-keeper 테이블로.
+
+### 불변식
+
+1. 같은 keeper의 pending/inflight 스냅샷 쌍에 대한 read-modify-write는 여전히 상호배제 (기존과 동일).
+2. 서로 다른 keeper의 스냅샷 I/O는 동시 진행 가능 (신규).
+3. 락 순서: 한 critical section은 정확히 1개 keeper 락만 잡는다 — 교차-keeper 연산이 없음을 코드 리뷰로 확인했고, 새로 생기면 컴파일이 아니라 리뷰로 잡아야 하므로 `with_write_lock` 문서에 "nested acquisition 금지"를 명시하고 개발 빌드에서 재진입 감지 assert를 넣는다.
+
+### TLA+ (기존 하네스 확장)
+
+`KeeperOASAdvanced.tla`의 CancelledNeverAbsorbed 모델에 keeper 2기 + per-keeper 락을 추가하고, (a) 데드락 부재, (b) keeper A의 critical-section 예외가 B의 진행을 막지 않음(신규 invariant `IsolatedPoisoning`)을 검사한다. 기존 bug-model 패턴(clean cfg pass + buggy cfg violate)을 따른다.
+
+### 서킷브레이커 정렬 (#17/#25)
+
+영속 락이 keeper 단위가 되면 keeper failure circuit breaker의 "open = 해당 keeper의 durable 쓰기 차단"이 실제로 그 keeper에만 작용한다. 브레이커 로직 자체의 변경은 없고, 격리 보장이 사실이 되는 것이 이 RFC의 효과다. 브레이커 상태 전이 매트릭스의 sparse-match 여부 점검(별도 확인 항목)은 구현 PR에서 exhaustive match로 강제한다.
+
+## 마이그레이션
+
+단일 PR로 가능(내부 모듈 경계 안):
+
+1. `with_write_lock ~keeper_name` 시그니처 변경 + 테이블 도입 — 13 사이트 기계 전파, 컴파일러가 누락을 강제.
+2. 테스트: 기존 persistence 테스트 전부 + 신규 (a) 교차-keeper 동시 쓰기가 서로를 블록하지 않음(타이밍 아닌 순서-관찰 방식), (b) keeper A critical section 예외 후 A/B 모두 후속 쓰기 정상.
+3. TLA+ clean/buggy cfg 쌍.
+
+롤백: 시그니처만 되돌리면 됨 (데이터 형식 무변경).
+
+## 트레이드오프
+
+- **장점**: head-of-line 제거, 오염 반경 축소, 격리 단위 정렬.
+- **단점/비용**: 뮤텍스 수 증가(keeper 수만큼 — 수십 개, 무시 가능), 테이블 조회 오버헤드(짧은 전역 락 1회 — 기존 전역 락보다 좁음), nested-acquisition 규율이 컴파일 강제가 아님(assert + 리뷰).
+- **대안 검토**: (a) 락-프리(파일 rename 원자성에만 의존) — pending/inflight 쌍의 일관성이 깨질 수 있어 기각. (b) 단일 writer 액터(큐 직렬화) — 전역 직렬화를 형태만 바꿔 유지하는 것이라 기각. (c) 현상 유지 + 타임아웃 — cap/cooldown류 증상 억제라 기각.
+
+## 검증 완료 기준
+
+- [ ] 13 사이트 전파 + 컴파일 green
+- [ ] 신규 격리 테스트 2건 green
+- [ ] TLA+ clean pass / buggy violate
+- [ ] 대시보드 persistence 지연 메트릭(기존)에서 fleet-wide 동시 wake 시나리오 회귀 없음

--- a/docs/rfc/RFC-0338-lane-per-keeper-persistence-isolation.md
+++ b/docs/rfc/RFC-0338-lane-per-keeper-persistence-isolation.md
@@ -3,77 +3,164 @@
 - Status: Draft
 - Author: Claude (38-bug campaign, cluster C9 — bugs #17/#25/#29)
 - Date: 2026-07-10
-- Related: keeper_event_queue_persistence.ml 2026-06-29 audit note, RFC-0334 (board mailbox), KeeperOASAdvanced.tla (CancelledNeverAbsorbed)
+- Related: `keeper_event_queue_persistence.ml` 2026-06-29 audit note, RFC-0334 (board mailbox), `KeeperOASAdvanced.tla`
+- Source baseline: `masc/main@817eb5e74786fd166f9d81a4a160e521d6fc37d3`
+
+## 결정
+
+durable event-queue의 락 단위를 프로세스에서 **스냅샷 쌍의 실제 자원 정체성**으로 줄인다. 자원 키는 `keeper_name` 단독이 아니라 `(canonical BasePath, keeper_name)`이다. 같은 자원 키의 pending/inflight read-modify-write는 직렬화하고, 다른 키는 독립적으로 진행한다.
+
+락 레지스트리는 현재 보유자와 대기자가 있는 엔트리만 유지한다. Eio와 non-Eio 접근이 같은 키에서 겹치면 별도 락으로 진행하지 않고 명시적인 typed contract error로 거부한다. 콜백에서 나온 모든 예외는 락 콜백 안에서 값으로 포획한 뒤 락과 레지스트리 lease를 해제하고 원래 backtrace로 다시 발생시킨다.
+
+## 현재 구현에서 확인한 사실
+
+`lib/keeper_runtime/keeper_event_queue_persistence.ml:11`과 `lib/keeper_runtime/keeper_event_queue_persistence.ml:12`에는 하나가 아니라 실행 모드별 프로세스 전역 락 두 개가 있다.
+
+```ocaml
+let eio_write_mu = Eio.Mutex.create ()
+let fallback_write_mu = Stdlib.Mutex.create ()
+```
+
+- Eio 호출끼리, non-Eio 호출끼리는 각각 모든 BasePath와 keeper를 직렬화한다.
+- 두 락 사이에는 상호배제가 없다. 같은 스냅샷 쌍에 Eio와 non-Eio 호출이 동시에 들어오면 현재 계약은 직렬화를 보장하지 않는다.
+- 현재 main에는 `with_write_lock` 정의(`lib/keeper_runtime/keeper_event_queue_persistence.ml:24`) 1곳과 호출 10곳(`lib/keeper_runtime/keeper_event_queue_persistence.ml:321`부터 `lib/keeper_runtime/keeper_event_queue_persistence.ml:701`까지)이 있다. 10개 호출 모두 `base_path`와 `keeper_name`을 이미 스코프에 갖는다.
+- `Eio.Mutex.use_rw ~protect:true`의 콜백은 일반 예외만 값으로 포획하고 `Eio.Cancel.Cancelled`는 콜백 안(`lib/keeper_runtime/keeper_event_queue_persistence.ml:29`)에서 다시 발생시킨다. Eio 계약상 콜백에서 빠져나온 예외는 mutex를 disable/poison하므로 이 경로를 그대로 유지할 수 없다.
+- 기존 poison 회귀 테스트는 디스크 예외 뒤의 재사용만 확인한다. 콜백에서 발생한 `Cancelled`, 락 대기 중 취소, 레지스트리 회수, 교차 실행모드는 검증하지 않는다.
+- 이 모듈과 persistence 경로에는 검증된 per-keeper circuit breaker 연동이나 lock-wait metric이 없다. 본 RFC는 있다고 가정하지 않는다.
+
+[근거] Eio `Mutex.use_rw`와 `protect` 계약: [Eio.Mutex 공식 문서](https://ocaml-multicore.github.io/eio/eio/Eio/Mutex/index.html), 확인일시 2026-07-10, 신뢰도 High.
+
+[근거] 보호된 cancellation context와 promise-origin `Cancelled`: [Eio.Cancel 공식 문서](https://ocaml-multicore.github.io/eio/eio/Eio/Cancel/index.html), 확인일시 2026-07-10, 신뢰도 High.
 
 ## 문제
 
-`lib/keeper_runtime/keeper_event_queue_persistence.ml`의 durable event-queue 스냅샷 I/O는 **프로세스 전역 단일 뮤텍스** 뒤에 있다:
+스냅샷 파일은 BasePath와 keeper별로 분리되지만 현재 Eio 락과 fallback 락은 각각 프로세스 전역이다. 따라서 한 keeper의 파일 I/O가 같은 실행 모드의 무관한 keeper 쓰기를 막는 head-of-line blocking이 구조적으로 가능하다. 반대로 실행 모드가 다르면 같은 파일에 대한 상호배제가 사라진다.
 
-```ocaml
-let eio_write_mu = Eio.Mutex.create ()       (* :11 — process-global *)
-let with_write_lock : type a. (unit -> a) -> a  (* :24, 호출 사이트 13곳 *)
-```
-
-스냅샷 파일은 keeper별로 분리돼 있는데(`.masc/keepers/<name>/…` pending/inflight 쌍) 락은 전역이라, 락의 실제 보호 대상(같은 keeper 스냅샷 쌍의 read-modify-write 원자성)보다 훨씬 넓게 직렬화한다.
-
-관측된/구조적 결과:
-
-1. **Head-of-line blocking (#29)**: 한 keeper의 느린 디스크 I/O(대형 스냅샷, 느린 볼륨, fsync 지연)가 무관한 keeper 전원의 durable 쓰기를 대기시킨다. 14-keeper fleet에서 wake/HITL(#23956 이후 durable enqueue가 승인 acknowledgment의 커밋 포인트) 지연으로 직접 전파된다.
-2. **단일 장애점**: 파일 자체의 주석(:14-16)이 자인하듯 "a poisoned mutex blocks durable event-queue snapshots for EVERY keeper for the lifetime of the process". 현재는 예외를 critical section 안에서 포획해 우회 중이지만, 이 방어는 락 범위가 전역이라서 필요해진 것이다.
-3. **격리 원칙 위반 (#17/#25 연관)**: keeper 장애 격리(서킷브레이커, per-keeper failure policy)의 단위는 keeper인데, 영속 계층의 경합 단위는 프로세스다. 브레이커가 keeper A를 열어도 A가 잡고 있는 전역 락이 B/C를 계속 물고 있을 수 있다.
-
-부수 관찰(스코프 밖, 기록만): `schedule_runner.ml dispatch_candidates`의 순차 `List.map`도 tick 내 head-of-line 직렬화다. dispatch 순서 시맨틱 결정이 선행돼야 하므로 본 RFC에 포함하지 않는다.
+#23956 이후 durable enqueue가 HITL acknowledgment의 커밋 포인트이므로 persistence 대기는 승인 응답 지연으로 전파된다. 다만 현재 lock-wait 관측값은 없으므로 지연의 크기나 fleet 수를 수치로 추정하지 않는다.
 
 ## 설계
 
-### 락 구조
-
-전역 뮤텍스 1개 → **per-keeper 뮤텍스 테이블**:
+### 1. 자원 키와 BasePath SSOT
 
 ```ocaml
-(* keeper_name → mutex. 테이블 접근 자체는 짧은 전역 락(순수 Hashtbl 조작만,
-   I/O 없음)으로 가드. 뮤텍스는 keeper당 lazy 생성 후 영구 유지 —
-   keeper 수는 유한(수십)이라 GC 불필요. *)
-val with_write_lock : keeper_name:string -> (unit -> 'a) -> 'a
+type snapshot_lock_key
+
+val snapshot_lock_key :
+  base_path:string ->
+  keeper_name:string ->
+  (snapshot_lock_key, lock_key_error) result
 ```
 
-- 시그니처에 `~keeper_name` 추가. 13개 호출 사이트 전부 이미 `keeper_name`을 스코프에 갖고 있다 (스냅샷 경로 계산에 사용 중) — 기계적 전파.
-- poisoned-mutex 방어(critical section 내 예외 포획, Cancelled 재raise — CancelledNeverAbsorbed)는 **그대로 유지**하되, 이제 오염 반경이 keeper 1기로 준다.
-- non-Eio fallback(`Stdlib.Mutex`)도 동일하게 per-keeper 테이블로.
+- 키는 `Common.keepers_runtime_dir_of_base ~base_path`가 만드는 실제 snapshot-pair 디렉터리 정체성에서 생성한다. 경로 생성과 별도의 디렉터리 규칙을 하드코딩하지 않는다.
+- `Env_config_core.normalize_masc_base_path_input`은 lexical normalization이며 symlink alias까지 합치지 않는다. 구현 PR은 기존 subsystem-local `realpath existing prefix` 코드를 복사하지 않고, 하나의 shared path-identity SSOT를 세운 뒤 lock key와 기존 사용처가 이를 소비하게 한다.
+- 경로 정체성을 만들 수 없으면 raw string으로 조용히 fallback하지 않고 `lock_key_error`를 반환한다.
+- 같은 이름의 keeper라도 BasePath가 다르면 다른 키다. 같은 물리 BasePath의 lexical/symlink alias는 같은 키가 되어야 한다.
 
-### 불변식
+### 2. lease 기반 레지스트리
 
-1. 같은 keeper의 pending/inflight 스냅샷 쌍에 대한 read-modify-write는 여전히 상호배제 (기존과 동일).
-2. 서로 다른 keeper의 스냅샷 I/O는 동시 진행 가능 (신규).
-3. 락 순서: 한 critical section은 정확히 1개 keeper 락만 잡는다 — 교차-keeper 연산이 없음을 코드 리뷰로 확인했고, 새로 생기면 컴파일이 아니라 리뷰로 잡아야 하므로 `with_write_lock` 문서에 "nested acquisition 금지"를 명시하고 개발 빌드에서 재진입 감지 assert를 넣는다.
+레지스트리는 immutable map 값을 짧은 `Stdlib.Mutex` 구간에서 교체한다. 이 구간에서는 lookup/update만 수행하고 파일 I/O, fiber yield, per-key lock 대기를 하지 않는다. `Stdlib.Mutex`는 Eio 공식 문서가 허용하는 짧고 non-yielding한 critical section에만 사용한다.
 
-### TLA+ (기존 하네스 확장)
+```ocaml
+type backend =
+  | Eio_lock of Eio.Mutex.t
+  | Thread_lock of Stdlib.Mutex.t
 
-`KeeperOASAdvanced.tla`의 CancelledNeverAbsorbed 모델에 keeper 2기 + per-keeper 락을 추가하고, (a) 데드락 부재, (b) keeper A의 critical-section 예외가 B의 진행을 막지 않음(신규 invariant `IsolatedPoisoning`)을 검사한다. 기존 bug-model 패턴(clean cfg pass + buggy cfg violate)을 따른다.
+type entry =
+  { backend : backend
+  ; leases : int
+  }
+```
 
-### 서킷브레이커 정렬 (#17/#25)
+- lease 수는 lock owner와 waiter를 모두 센다. 대기 전에 증가하고, 성공·예외·대기 중 취소 모든 경로에서 `Fun.protect` finalizer로 감소한다.
+- `leases = 0`이면 엔트리를 제거한다. 따라서 레지스트리 크기는 과거 keeper 이름 수가 아니라 현재 owner/waiter 수로 제한된다.
+- “keeper 수는 수십 개라 영구 보관” 같은 운영 규모 추정이나 TTL/GC 휴리스틱을 사용하지 않는다.
+- 기존 엔트리와 요청 backend가 다르면 새 mutex를 만들지 않는다. `Backend_conflict` typed error와 관측 이벤트를 남기고 콜백을 실행하지 않는다. lease가 0이 되어 엔트리가 제거된 뒤의 순차적인 backend 전환은 허용한다.
 
-영속 락이 keeper 단위가 되면 keeper failure circuit breaker의 "open = 해당 keeper의 durable 쓰기 차단"이 실제로 그 keeper에만 작용한다. 브레이커 로직 자체의 변경은 없고, 격리 보장이 사실이 되는 것이 이 RFC의 효과다. 브레이커 상태 전이 매트릭스의 sparse-match 여부 점검(별도 확인 항목)은 구현 PR에서 exhaustive match로 강제한다.
+### 3. 취소와 poison 경계
+
+`Eio.Mutex.use_rw ~protect:true`에 전달하는 콜백은 **모든** 예외를 결과값으로 바꾸는 total callback이어야 한다.
+
+```ocaml
+type lock_contract_error =
+  | Backend_conflict of { requested : backend_kind; active : backend_kind }
+  | Reentrant_lock of snapshot_lock_key
+
+exception Lock_contract_error of lock_contract_error
+```
+
+기존 `with_write_lock`의 callback 반환형과 callback 예외 전파 계약은 유지하고, lock 자체의 계약 위반만 닫힌 variant를 담은 typed exception으로 구분한다. 메시지 문자열 판별로 제어 흐름을 만들지 않는다.
+
+```ocaml
+let guarded token =
+  match f token with
+  | value -> Ok value
+  | exception exn -> Error (exn, Printexc.get_raw_backtrace ())
+```
+
+- `Cancelled`도 `guarded` 안에서는 값으로 포획한다. `use_rw`와 lease finalizer가 끝난 다음 `Printexc.raise_with_backtrace`로 다시 발생시켜 cancellation 전파와 mutex 재사용을 동시에 보장한다.
+- lock 획득을 기다리다 취소되면 `use_rw` 자체가 빠져나올 수 있다. 외부 `Fun.protect`가 lease를 반드시 반환한다.
+- fallback backend에도 같은 total-callback/외부 재발생 규칙을 적용해 두 경로의 예외 계약을 하나로 유지한다.
+- 중첩 획득 금지를 개발용 `assert`에 맡기지 않는다. critical-section helper는 추상 `lock_token`을 요구하고, 같은 실행 주체가 같은 키를 다시 얻으려 하면 production 경로에서 `Reentrant_lock` typed error를 반환한다. 오류는 로그·trace·metric에 드러나야 하며 무한 대기로 바뀌면 안 된다.
+
+### 4. 불변식
+
+1. 같은 `(canonical BasePath, keeper_name)`의 pending/inflight snapshot pair RMW는 상호배제된다.
+2. 다른 키는 서로의 파일 I/O 완료를 기다리지 않는다.
+3. Eio와 non-Eio가 같은 키에서 겹쳐도 두 콜백이 동시에 실행되지 않는다.
+4. 콜백 예외와 `Cancelled`는 원래 backtrace로 호출자에게 전파되고 mutex를 poison하지 않는다.
+5. 대기 취소를 포함한 모든 종료 경로에서 lease가 반환되며, 사용자가 없는 엔트리는 남지 않는다.
+6. 재진입은 typed error로 종료되며 deadlock이나 disabled assertion에 의존하지 않는다.
+
+### 5. 관측성
+
+구현 PR은 lock wait, critical-section duration, active registry entry/lease 수, `Backend_conflict`, `Reentrant_lock`, poisoned-lock 관측을 metric catalog와 trace에 추가한다. 임의 threshold나 inline bucket을 만들지 않고 기존 metric catalog 정책을 따른다. filesystem 경로 전체는 metric label로 복제하지 않으며, BasePath/keeper 문맥은 접근 제어된 trace/log에서 확인 가능하게 한다.
+
+### 6. TLA+
+
+clean/buggy model pair는 최소 두 BasePath, 두 keeper, 두 backend를 모델링한다. registry lease/refcount, lock 대기 중 취소, 콜백 내부 예외·`Cancelled`, backend conflict, cross-key progress를 상태에 포함한다.
+
+- Safety: 같은 키의 두 critical section이 동시에 active가 아님.
+- Safety: lease가 음수가 되지 않고, active owner/waiter가 없으면 registry entry가 없음.
+- Safety: callback exception이 lock을 영구 poison하지 않음.
+- Liveness: 공정성 가정 아래 A 키의 지연·예외가 B 키의 진행을 막지 않음.
+- buggy model은 전역 락 또는 취소 시 lease 누락 중 하나를 의도적으로 복원해 해당 속성을 위반해야 한다.
+
+## 스코프 밖
+
+- persistence 데이터 형식과 pending/inflight 전이 의미는 바꾸지 않는다.
+- 확인되지 않은 per-keeper circuit breaker 연동을 본 RFC의 효과로 주장하지 않는다. 필요하면 실제 admission/persistence 연결 설계를 별도 RFC로 다룬다.
+- `schedule_runner.ml dispatch_candidates`의 순차 dispatch는 순서 의미 결정이 선행돼야 하므로 포함하지 않는다.
+- 락 획득 timeout, keeper 수 cap, TTL은 고정 수치로 장애를 가리는 휴리스틱이라 도입하지 않는다.
 
 ## 마이그레이션
 
-단일 PR로 가능(내부 모듈 경계 안):
+1. shared path-identity SSOT와 opaque `snapshot_lock_key`를 마련한다.
+2. 내부 lock registry를 lease 기반으로 구현하고 backend conflict/reentrancy typed errors를 추가한다.
+3. `with_write_lock ~base_path ~keeper_name`과 추상 `lock_token`을 10개 호출부에 전파한다. pending/inflight를 만지는 unlocked helper는 token을 요구하게 한다.
+4. 모든 예외를 lock callback 안에서 값으로 포획하고 lock/lease 해제 뒤 원래 backtrace로 재발생시킨다.
+5. 관측성, 결정적 concurrency tests, TLA+ clean/buggy pair를 추가한다.
 
-1. `with_write_lock ~keeper_name` 시그니처 변경 + 테이블 도입 — 13 사이트 기계 전파, 컴파일러가 누락을 강제.
-2. 테스트: 기존 persistence 테스트 전부 + 신규 (a) 교차-keeper 동시 쓰기가 서로를 블록하지 않음(타이밍 아닌 순서-관찰 방식), (b) keeper A critical section 예외 후 A/B 모두 후속 쓰기 정상.
-3. TLA+ clean/buggy cfg 쌍.
+데이터 파일 migration은 없다. 롤백은 새 lock module과 호출 시그니처를 되돌리되, 기존의 교차-backend 비상호배제와 `Cancelled` poison 문제가 재도입된다는 점을 rollback evidence에 명시해야 한다.
 
-롤백: 시그니처만 되돌리면 됨 (데이터 형식 무변경).
+## 결정적 테스트
 
-## 트레이드오프
+sleep이나 실행 시간 비교 대신 Eio promise/barrier로 순서를 고정한다.
 
-- **장점**: head-of-line 제거, 오염 반경 축소, 격리 단위 정렬.
-- **단점/비용**: 뮤텍스 수 증가(keeper 수만큼 — 수십 개, 무시 가능), 테이블 조회 오버헤드(짧은 전역 락 1회 — 기존 전역 락보다 좁음), nested-acquisition 규율이 컴파일 강제가 아님(assert + 리뷰).
-- **대안 검토**: (a) 락-프리(파일 rename 원자성에만 의존) — pending/inflight 쌍의 일관성이 깨질 수 있어 기각. (b) 단일 writer 액터(큐 직렬화) — 전역 직렬화를 형태만 바꿔 유지하는 것이라 기각. (c) 현상 유지 + 타임아웃 — cap/cooldown류 증상 억제라 기각.
+- 같은 키: 첫 콜백이 barrier를 잡은 동안 두 번째 콜백이 진입하지 않음.
+- 다른 keeper, 같은 BasePath: A가 정지한 동안 B가 완료됨.
+- 같은 keeper, 다른 BasePath: A가 정지한 동안 B가 완료됨.
+- 같은 물리 BasePath의 alias: 같은 키로 직렬화됨.
+- 일반 예외와 명시적 `Cancelled`: 호출자에게 전파된 뒤 같은 키를 다시 사용할 수 있음.
+- lock 대기 중 취소: callback 미실행, lease 반환, registry baseline 복귀.
+- 교차 backend overlap: 두 번째 callback 미실행, `Backend_conflict` 관측.
+- 재진입: 대기하지 않고 `Reentrant_lock` 관측.
+- 마지막 owner/waiter 종료: registry entry 제거.
 
 ## 검증 완료 기준
 
-- [ ] 13 사이트 전파 + 컴파일 green
-- [ ] 신규 격리 테스트 2건 green
+- [ ] 현재 main의 10개 호출부 전파 및 CI build/test green
+- [ ] parser/format/정적 ratchet green
+- [ ] 위 결정적 concurrency tests green
 - [ ] TLA+ clean pass / buggy violate
-- [ ] 대시보드 persistence 지연 메트릭(기존)에서 fleet-wide 동시 wake 시나리오 회귀 없음
+- [ ] lock/lease/error 관측 항목이 metric catalog와 health/trace 경계에 연결됨
+- [ ] 같은 키 직렬화와 cross-key progress가 CI evidence로 남음


### PR DESCRIPTION
## 요약

대상 head: `5d44c7f2a37fc9a8007df8f277595732ced6a07b`

durable event-queue의 전역 persistence lock을 실제 자원 키 `(canonical BasePath, keeper_name)` 단위로 격리하는 RFC예용. docs-only이며 데이터 형식은 바꾸지 않아용.

## 적대 리뷰 반영

- 호출부 실측을 13곳 → 10곳으로 바로잡았어용.
- 서로 다른 Eio/Stdlib 전역 락 때문에 같은 파일의 교차-backend 상호배제가 없던 계약을 명시했어용.
- `Cancelled`를 Eio mutex callback 안에서 재발생시키면 poison될 수 있어, 모든 예외를 값으로 포획하고 lock/lease 해제 뒤 원래 backtrace로 재발생시키게 했어용.
- keeper 이름 단독 키, 영구 mutex 보관, keeper 수 추정, timeout/TTL 휴리스틱을 제거했어용.
- BasePath path-identity SSOT, lease/refcount 회수, backend conflict·재진입 typed error, 결정적 promise/barrier 테스트와 TLA+ 범위를 추가했어용.
- 근거 없던 per-keeper circuit breaker·기존 lock metric 주장을 제거하고 관측성 구현을 완료 기준으로 넣었어용.

## 검증

- source baseline `main@817eb5e74786fd166f9d81a4a160e521d6fc37d3` 및 10개 호출부 전수 확인
- [Eio.Mutex](https://ocaml-multicore.github.io/eio/eio/Eio/Mutex/index.html), [Eio.Cancel](https://ocaml-multicore.github.io/eio/eio/Eio/Cancel/index.html) 공식 계약 확인(2026-07-10, High)
- `git diff --check` 통과
- RFC enforcer 통과
- 로컬 Dune 미실행; 빌드 권위는 PR CI예용.
