### PR TITLE
fix(media): surface oversize generated media as a dropped placeholder (C5 #10)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1543,6 +1543,24 @@ describe('Keeper v2 chat blocks', () => {
     expect(container.textContent).toContain('unsafe URL')
   })
 
+  it('renders a server-provided attachment failure without claiming it is an image', () => {
+    renderBlocks([
+      {
+        t: 'attach',
+        name: 'generated media unavailable: storage write failed',
+        ph: 'Generated media is unavailable.',
+        mimeType: 'audio/mpeg',
+        size: '128 wire-carrier bytes observed',
+        sizeBytes: 128,
+      },
+    ])
+
+    const attach = container.querySelector('[data-chat-block="attach"]')
+    expect(attach?.textContent).toContain('Generated media is unavailable.')
+    expect(attach?.querySelector('.chat-block-attach-cap')?.textContent)
+      .toBe('첨부 · 128 wire-carrier bytes observed')
+  })
+
   it('renders a voice memo with waveform bars and transcript', () => {
     renderBlocks([
       {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1334,10 +1334,10 @@ function ChatAttachBlock({
           ? html`<img src=${safeSrc} alt=${name} class="chat-block-attach-img" />`
           : svg
             ? html`<span dangerouslySetInnerHTML=${{ __html: sanitizeSvg(svg) }} />`
-            : html`<div class="chat-block-attach-ph">${ph || '첨부 이미지'}${src ? ' (unsafe URL)' : ''}</div>`}
+            : html`<div class="chat-block-attach-ph">${ph || '첨부를 표시할 수 없습니다'}${src ? ' (unsafe URL)' : ''}</div>`}
       </div>
       <figcaption class="chat-block-attach-cap">
-        <span>이미지 첨부</span>${via ? ` · ${via}` : ''}${size ? ` · ${size}` : ''}
+        <span>첨부</span>${via ? ` · ${via}` : ''}${size ? ` · ${size}` : ''}
       </figcaption>
     </figure>
   `

--- a/lib/server/keeper_stream_media_accum.ml
+++ b/lib/server/keeper_stream_media_accum.ml
@@ -17,6 +17,22 @@ type finalized = {
   data : string;
 }
 
+(* A generated media payload the wire cap rejected. Recorded the moment the
+   block is invalidated so the drop surfaces as a reload-visible placeholder
+   block instead of the media silently vanishing from the persisted turn. *)
+type dropped = {
+  index : int;
+  media_type : string;
+  encoded_bytes : int;
+}
+
+(* Why a block index stopped accepting media deltas. [Tool_block] indexes are
+   never media and are skipped without trace (mirrors the SSE bridge);
+   [Oversize] is a real generated payload the reader must still learn about. *)
+type invalid_reason =
+  | Tool_block
+  | Oversize
+
 type block_state =
   | Active_media of
       { media_type : string;
@@ -24,14 +40,24 @@ type block_state =
         chunks : string list;
         encoded_bytes : int
       }
-  | Invalid_block
+  | Invalid_block of invalid_reason
 
 type t = {
   mutable blocks_by_index : (int * block_state) list;
   mutable finalized_rev : finalized list;
+  mutable dropped_rev : dropped list;
 }
 
-let create () = { blocks_by_index = []; finalized_rev = [] }
+let create () = { blocks_by_index = []; finalized_rev = []; dropped_rev = [] }
+
+let record_oversize_drop t ~index ~media_type ~encoded_bytes =
+  Log.Keeper.warn
+    "generated media dropped index=%d media_type=%s: %d encoded bytes exceed the %d-byte wire cap"
+    index
+    media_type
+    encoded_bytes
+    (Keeper_chat_media_store.max_wire_bytes ());
+  t.dropped_rev <- { index; media_type; encoded_bytes } :: t.dropped_rev
 
 let stream_block_for_index t index = List.assoc_opt index t.blocks_by_index
 
@@ -70,7 +96,7 @@ let finalize_open_media t =
       match block with
       | Active_media { media_type; source_type; chunks; encoded_bytes } ->
           finalize_media t index ~media_type ~source_type ~chunks ~encoded_bytes
-      | Invalid_block -> ())
+      | Invalid_block (Tool_block | Oversize) -> ())
     blocks;
   t.blocks_by_index <- []
 
@@ -79,7 +105,7 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
   | Agent_sdk.Types.ContentBlockStart { index; content_type; tool_id; tool_name }
     when stream_start_is_tool ~index ~content_type ~tool_id ~tool_name
          || has_any_tool_identity ~tool_id ~tool_name ->
-      replace_block t index Invalid_block
+      replace_block t index (Invalid_block Tool_block)
   | Agent_sdk.Types.ContentBlockDelta
       { index; delta = Agent_sdk.Types.MediaDelta { media_type; source_type; data } } ->
       (match stream_block_for_index t index with
@@ -90,10 +116,13 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
                 ~encoded_bytes:m.encoded_bytes data
             with
             | Some block -> replace_block t index block
-            | None -> replace_block t index Invalid_block)
+            | None ->
+                record_oversize_drop t ~index ~media_type
+                  ~encoded_bytes:(m.encoded_bytes + String.length data);
+                replace_block t index (Invalid_block Oversize))
        | Some (Active_media _) ->
            ()
-       | Some Invalid_block ->
+       | Some (Invalid_block _) ->
            ()
        | None ->
            (match
@@ -101,20 +130,46 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
                 ~encoded_bytes:0 data
             with
             | Some block -> replace_block t index block
-            | None -> replace_block t index Invalid_block))
+            | None ->
+                record_oversize_drop t ~index ~media_type
+                  ~encoded_bytes:(String.length data);
+                replace_block t index (Invalid_block Oversize)))
   | Agent_sdk.Types.ContentBlockStop { index } -> (
       match stream_block_for_index t index with
       | Some (Active_media { media_type; source_type; chunks; encoded_bytes }) ->
           finalize_media t index ~media_type ~source_type ~chunks ~encoded_bytes
-      | Some Invalid_block ->
+      | Some (Invalid_block (Tool_block | Oversize)) ->
           remove_block t index
       | None -> ())
   | Agent_sdk.Types.MessageStop ->
       finalize_open_media t
   | _ -> ()
 
+(* Reload placeholder for an oversize drop: no payload to serve (src = None),
+   but the reader sees what was generated, its type, and how large it was
+   instead of the media silently missing from the persisted turn. *)
+let dropped_placeholder_block { index = _; media_type; encoded_bytes } =
+  Keeper_chat_blocks.Attach
+    { name =
+        Printf.sprintf
+          "generated media dropped: %s exceeded the %d-byte wire cap"
+          media_type
+          (Keeper_chat_media_store.max_wire_bytes ());
+      dims = None;
+      src = None;
+      svg = None;
+      ph = None;
+      via = None;
+      size = None;
+      data = None;
+      mime_type = Some media_type;
+      size_bytes = Some encoded_bytes;
+      kind = None
+    }
+
 let to_chat_blocks ~base_dir t =
-  List.rev t.finalized_rev
+  let dropped_blocks = List.rev_map dropped_placeholder_block t.dropped_rev in
+  (List.rev t.finalized_rev
   |> List.filter_map (fun { index; media_type; source_type; data } ->
          match
            Keeper_chat_media_store.persist_media_source_result ~base_dir
@@ -156,4 +211,5 @@ let to_chat_blocks ~base_dir t =
                         mime_type = Some media_type;
                         size_bytes = None;
                         kind = None
-                      }))
+                      })))
+  @ dropped_blocks

--- a/lib/server/keeper_stream_media_accum.ml
+++ b/lib/server/keeper_stream_media_accum.ml
@@ -20,11 +20,15 @@ type finalized = {
 (* A generated media payload the wire cap rejected. Recorded the moment the
    block is invalidated so the drop surfaces as a reload-visible placeholder
    block instead of the media silently vanishing from the persisted turn. *)
-type dropped = {
-  index : int;
+type wire_drop = {
   media_type : string;
   encoded_bytes : int;
+  max_wire_bytes : int;
 }
+
+type completed =
+  | Persistable of finalized
+  | Wire_dropped of wire_drop
 
 (* Why a block index stopped accepting media deltas. [Tool_block] indexes are
    never media and are skipped without trace (mirrors the SSE bridge);
@@ -44,20 +48,21 @@ type block_state =
 
 type t = {
   mutable blocks_by_index : (int * block_state) list;
-  mutable finalized_rev : finalized list;
-  mutable dropped_rev : dropped list;
+  mutable completed_rev : completed list;
 }
 
-let create () = { blocks_by_index = []; finalized_rev = []; dropped_rev = [] }
+let create () = { blocks_by_index = []; completed_rev = [] }
 
-let record_oversize_drop t ~index ~media_type ~encoded_bytes =
+let record_oversize_drop t ~index ~media_type ~encoded_bytes ~max_wire_bytes =
   Log.Keeper.warn
-    "generated media dropped index=%d media_type=%s: %d encoded bytes exceed the %d-byte wire cap"
+    "generated media dropped index=%d media_type=%S: %d wire-carrier bytes exceed the %d-byte cap"
     index
     media_type
     encoded_bytes
-    (Keeper_chat_media_store.max_wire_bytes ());
-  t.dropped_rev <- { index; media_type; encoded_bytes } :: t.dropped_rev
+    max_wire_bytes;
+  t.completed_rev <-
+    Wire_dropped { media_type; encoded_bytes; max_wire_bytes }
+    :: t.completed_rev
 
 let stream_block_for_index t index = List.assoc_opt index t.blocks_by_index
 
@@ -79,18 +84,34 @@ let stream_start_is_tool ~index ~content_type ~tool_id ~tool_name =
 
 let add_media_chunk ~media_type ~source_type ~chunks ~encoded_bytes data =
   let encoded_bytes = encoded_bytes + String.length data in
-  if encoded_bytes > Keeper_chat_media_store.max_wire_bytes ()
-  then None
-  else Some (Active_media { media_type; source_type; chunks = data :: chunks; encoded_bytes })
+  let max_wire_bytes = Keeper_chat_media_store.max_wire_bytes () in
+  if encoded_bytes > max_wire_bytes
+  then Error (encoded_bytes, max_wire_bytes)
+  else
+    Ok
+      (Active_media
+         { media_type; source_type; chunks = data :: chunks; encoded_bytes })
 
 let finalize_media t index ~media_type ~source_type ~chunks ~encoded_bytes =
-  if encoded_bytes <= Keeper_chat_media_store.max_wire_bytes () then (
+  let max_wire_bytes = Keeper_chat_media_store.max_wire_bytes () in
+  if encoded_bytes > max_wire_bytes
+  then
+    record_oversize_drop t ~index ~media_type ~encoded_bytes ~max_wire_bytes
+  else (
     let data = String.concat "" (List.rev chunks) in
-    t.finalized_rev <- { index; media_type; source_type; data } :: t.finalized_rev);
+    t.completed_rev <-
+      Persistable { index; media_type; source_type; data } :: t.completed_rev);
   remove_block t index
 
 let finalize_open_media t =
-  let blocks = t.blocks_by_index in
+  (* [MessageStop] terminalizes every still-open block at once. Content-block
+     index is the protocol order and therefore the deterministic tie-breaker. *)
+  let blocks =
+    List.sort
+      (fun (left_index, _) (right_index, _) ->
+         Int.compare left_index right_index)
+      t.blocks_by_index
+  in
   List.iter
     (fun (index, block) ->
       match block with
@@ -115,13 +136,19 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
               add_media_chunk ~media_type ~source_type ~chunks:m.chunks
                 ~encoded_bytes:m.encoded_bytes data
             with
-            | Some block -> replace_block t index block
-            | None ->
-                record_oversize_drop t ~index ~media_type
-                  ~encoded_bytes:(m.encoded_bytes + String.length data);
+            | Ok block -> replace_block t index block
+            | Error (encoded_bytes, max_wire_bytes) ->
+                record_oversize_drop t ~index ~media_type ~encoded_bytes
+                  ~max_wire_bytes;
                 replace_block t index (Invalid_block Oversize))
-       | Some (Active_media _) ->
-           ()
+       | Some (Active_media active) ->
+           Log.Keeper.warn
+             "generated media metadata drift ignored index=%d expected_media_type=%S received_media_type=%S expected_source_type=%s received_source_type=%s"
+             index
+             active.media_type
+             media_type
+             (Agent_sdk.Types.media_source_kind_to_string active.source_type)
+             (Agent_sdk.Types.media_source_kind_to_string source_type)
        | Some (Invalid_block _) ->
            ()
        | None ->
@@ -129,10 +156,10 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
               add_media_chunk ~media_type ~source_type ~chunks:[]
                 ~encoded_bytes:0 data
             with
-            | Some block -> replace_block t index block
-            | None ->
-                record_oversize_drop t ~index ~media_type
-                  ~encoded_bytes:(String.length data);
+            | Ok block -> replace_block t index block
+            | Error (encoded_bytes, max_wire_bytes) ->
+                record_oversize_drop t ~index ~media_type ~encoded_bytes
+                  ~max_wire_bytes;
                 replace_block t index (Invalid_block Oversize)))
   | Agent_sdk.Types.ContentBlockStop { index } -> (
       match stream_block_for_index t index with
@@ -148,68 +175,114 @@ let on_event t (evt : Agent_sdk.Types.sse_event) =
 (* Reload placeholder for an oversize drop: no payload to serve (src = None),
    but the reader sees what was generated, its type, and how large it was
    instead of the media silently missing from the persisted turn. *)
-let dropped_placeholder_block { index = _; media_type; encoded_bytes } =
+let unavailable_attachment ~name ~media_type ~size ~size_bytes =
   Keeper_chat_blocks.Attach
-    { name =
-        Printf.sprintf
-          "generated media dropped: %s exceeded the %d-byte wire cap"
-          media_type
-          (Keeper_chat_media_store.max_wire_bytes ());
+    { name;
       dims = None;
       src = None;
       svg = None;
-      ph = None;
+      ph = Some "Generated media is unavailable.";
       via = None;
-      size = None;
+      size;
       data = None;
       mime_type = Some media_type;
-      size_bytes = Some encoded_bytes;
+      size_bytes;
       kind = None
     }
 
+let wire_drop_placeholder_block
+    { media_type; encoded_bytes; max_wire_bytes } =
+  unavailable_attachment
+    ~name:
+      (Printf.sprintf
+         "generated media unavailable: %s exceeded the %d-byte wire-carrier cap"
+         media_type
+         max_wire_bytes)
+    ~media_type
+    ~size:(Some (Printf.sprintf "%d wire-carrier bytes observed" encoded_bytes))
+    ~size_bytes:(Some encoded_bytes)
+
+let persist_failure_placeholder ~media_type ~encoded_bytes = function
+  | Keeper_chat_media_store.Unsupported_source_type source_type ->
+      unavailable_attachment
+        ~name:
+          (Printf.sprintf
+             "generated media unavailable: unsupported source type %s"
+             (Agent_sdk.Types.media_source_kind_to_string source_type))
+        ~media_type
+        ~size:(Some (Printf.sprintf "%d wire-carrier bytes observed" encoded_bytes))
+        ~size_bytes:(Some encoded_bytes)
+  | Keeper_chat_media_store.Invalid_base64 _ ->
+      unavailable_attachment
+        ~name:"generated media unavailable: provider returned invalid base64"
+        ~media_type
+        ~size:(Some (Printf.sprintf "%d wire-carrier bytes observed" encoded_bytes))
+        ~size_bytes:(Some encoded_bytes)
+  | Keeper_chat_media_store.Media_too_large { size_bytes; max_bytes } ->
+      unavailable_attachment
+        ~name:
+          (Printf.sprintf
+             "generated media unavailable: decoded payload exceeded the %d-byte storage cap"
+             max_bytes)
+        ~media_type
+        ~size:(Some (Printf.sprintf "%d decoded bytes observed" size_bytes))
+        ~size_bytes:(Some size_bytes)
+  | Keeper_chat_media_store.Write_failed _ ->
+      unavailable_attachment
+        ~name:"generated media unavailable: storage write failed"
+        ~media_type
+        ~size:(Some (Printf.sprintf "%d wire-carrier bytes observed" encoded_bytes))
+        ~size_bytes:(Some encoded_bytes)
+
+let persisted_block ~media_type media_ref =
+  match Keeper_chat_media_store.category_of_media_type media_type with
+  | Keeper_chat_media_store.Image ->
+      Keeper_chat_blocks.Image { src = media_ref; cap = None }
+  | Keeper_chat_media_store.Audio ->
+      Keeper_chat_blocks.Voice
+        { secs = None;
+          wave = None;
+          via = None;
+          size = None;
+          transcript = None;
+          src = Some media_ref
+        }
+  | Keeper_chat_media_store.Document | Keeper_chat_media_store.Other ->
+      Keeper_chat_blocks.Attach
+        { name = generic_media_label;
+          dims = None;
+          src = Some media_ref;
+          svg = None;
+          ph = None;
+          via = None;
+          size = None;
+          data = None;
+          mime_type = Some media_type;
+          size_bytes = None;
+          kind = None
+        }
+
+let completed_to_chat_block ~base_dir = function
+  | Wire_dropped dropped -> wire_drop_placeholder_block dropped
+  | Persistable { index; media_type; source_type; data } ->
+      (match
+         Keeper_chat_media_store.persist_media_source_result ~base_dir
+           ~media_type ~source_type ~data
+       with
+       | Ok (_token, media_ref) -> persisted_block ~media_type media_ref
+       | Error err ->
+           Log.Keeper.warn
+             "generated media reload persist failed index=%d media_type=%S source_type=%s: %s"
+             index
+             media_type
+             (Agent_sdk.Types.media_source_kind_to_string source_type)
+             (Keeper_chat_media_store.persist_error_to_string err);
+           persist_failure_placeholder
+             ~media_type
+             ~encoded_bytes:(String.length data)
+             err)
+
 let to_chat_blocks ~base_dir t =
-  let dropped_blocks = List.rev_map dropped_placeholder_block t.dropped_rev in
-  (List.rev t.finalized_rev
-  |> List.filter_map (fun { index; media_type; source_type; data } ->
-         match
-           Keeper_chat_media_store.persist_media_source_result ~base_dir
-             ~media_type ~source_type ~data
-         with
-         | Error err ->
-             Log.Keeper.warn
-               "generated media reload persist failed index=%d media_type=%s source_type=%s: %s"
-               index
-               media_type
-               (Agent_sdk.Types.media_source_kind_to_string source_type)
-               (Keeper_chat_media_store.persist_error_to_string err);
-             None
-         | Ok (_token, media_ref) ->
-             match Keeper_chat_media_store.category_of_media_type media_type with
-             | Keeper_chat_media_store.Image ->
-                 Some (Keeper_chat_blocks.Image { src = media_ref; cap = None })
-             | Keeper_chat_media_store.Audio ->
-                 Some
-                   (Keeper_chat_blocks.Voice
-                      { secs = None;
-                        wave = None;
-                        via = None;
-                        size = None;
-                        transcript = None;
-                        src = Some media_ref
-                      })
-             | Keeper_chat_media_store.Document | Keeper_chat_media_store.Other ->
-                 Some
-                   (Keeper_chat_blocks.Attach
-                      { name = generic_media_label;
-                        dims = None;
-                        src = Some media_ref;
-                        svg = None;
-                        ph = None;
-                        via = None;
-                        size = None;
-                        data = None;
-                        mime_type = Some media_type;
-                        size_bytes = None;
-                        kind = None
-                      })))
-  @ dropped_blocks
+  t.completed_rev
+  |> List.rev
+  |> List.map (completed_to_chat_block ~base_dir)

--- a/lib/server/keeper_stream_media_accum.mli
+++ b/lib/server/keeper_stream_media_accum.mli
@@ -23,9 +23,11 @@ val on_event : t -> Agent_sdk.Types.sse_event -> unit
 val to_chat_blocks : base_dir:string -> t -> Keeper_chat_blocks.chat_block list
 (** Decode and persist each finalized media payload under [base_dir] via
     {!Keeper_chat_media_store.persist_media_source_result}, then return reload
-    chat blocks in completion order: [Image] for image media, [Voice] for audio,
-    [Attach] for documents / unrecognized types. Media rejected by the wire
-    cap is appended after the successful blocks as an [Attach] placeholder
-    with [src = None] carrying the media type and observed byte count, so the
-    reader learns what was generated and why it is absent instead of the
-    payload silently vanishing. Tool-owned block indexes stay traceless. *)
+    chat blocks in stream terminal order: [Image] for image media, [Voice] for
+    audio, [Attach] for documents / unrecognized types. Media rejected by the
+    wire cap or rejected while decoding/persisting becomes an in-order [Attach]
+    placeholder with [src = None], the media type, and a byte count whose label
+    states whether it measures the wire carrier or decoded payload. The wire
+    rejection also retains the decision-time cap, so later configuration changes
+    cannot rewrite the persisted explanation. Tool-owned block indexes stay
+    traceless. *)

--- a/lib/server/keeper_stream_media_accum.mli
+++ b/lib/server/keeper_stream_media_accum.mli
@@ -24,4 +24,8 @@ val to_chat_blocks : base_dir:string -> t -> Keeper_chat_blocks.chat_block list
 (** Decode and persist each finalized media payload under [base_dir] via
     {!Keeper_chat_media_store.persist_media_source_result}, then return reload
     chat blocks in completion order: [Image] for image media, [Voice] for audio,
-    [Attach] for documents / unrecognized types. *)
+    [Attach] for documents / unrecognized types. Media rejected by the wire
+    cap is appended after the successful blocks as an [Attach] placeholder
+    with [src = None] carrying the media type and observed byte count, so the
+    reader learns what was generated and why it is absent instead of the
+    payload silently vanishing. Tool-owned block indexes stay traceless. *)

--- a/test/test_keeper_stream_media_accum.ml
+++ b/test/test_keeper_stream_media_accum.ml
@@ -174,13 +174,12 @@ let test_metadata_drift_preserves_first_media_block () =
         src
   | _ -> fail "expected metadata drift to preserve the first image media block"
 
-let test_oversize_media_not_persisted () =
+let test_oversize_media_surfaces_as_dropped_placeholder () =
   with_env "MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES" "4" (fun () ->
     let open Agent_sdk.Types in
     let accum = A.create () in
-    let oversized =
-      String.make (Masc.Keeper_chat_media_store.max_wire_bytes () + 1) 'A'
-    in
+    let oversized_len = Masc.Keeper_chat_media_store.max_wire_bytes () + 1 in
+    let oversized = String.make oversized_len 'A' in
     List.iter
       (A.on_event accum)
       [
@@ -194,8 +193,19 @@ let test_oversize_media_not_persisted () =
         ContentBlockStop { index = 0 };
       ];
     let base_dir = Filename.temp_dir "media_accum_test" "" in
-    check int "oversize media is not persisted" 0
-      (List.length (A.to_chat_blocks ~base_dir accum)))
+    match A.to_chat_blocks ~base_dir accum with
+    | [ Blocks.Attach { src = None; mime_type; size_bytes; name; _ } ] ->
+        check (option string) "placeholder carries the media type"
+          (Some "image/png") mime_type;
+        check (option int) "placeholder carries the observed byte count"
+          (Some oversized_len) size_bytes;
+        check bool "placeholder name states the drop" true
+          (String.length name > 0)
+    | [] ->
+        fail
+          "oversize media vanished: it must surface as a dropped placeholder \
+           block, never disappear silently"
+    | _ -> fail "expected exactly one dropped-placeholder Attach block")
 
 let () =
   run
@@ -211,7 +221,7 @@ let () =
             test_tool_block_media_not_persisted;
           test_case "metadata drift preserves first media block" `Quick
             test_metadata_drift_preserves_first_media_block;
-          test_case "oversize media not persisted" `Quick
-            test_oversize_media_not_persisted;
+          test_case "oversize media surfaces as dropped placeholder" `Quick
+            test_oversize_media_surfaces_as_dropped_placeholder;
         ] );
     ]

--- a/test/test_keeper_stream_media_accum.ml
+++ b/test/test_keeper_stream_media_accum.ml
@@ -75,33 +75,42 @@ let test_audio_media_as_voice_block () =
 
 let test_open_media_finalized_on_message_stop () =
   (* Mirrors the bridge's message-end safety net: an open media block is still
-     reload-visible when the provider omits ContentBlockStop. *)
+     reload-visible when the provider omits ContentBlockStop. Multiple open
+     blocks use their protocol indexes as the terminal-order tie-breaker. *)
   let open Agent_sdk.Types in
   let accum = A.create () in
   let raw_media = "z" in
-  A.on_event
-    accum
-    (ContentBlockDelta
-       {
-         index = 0;
-         delta =
-           MediaDelta
-             {
-               media_type = "image/png";
-               source_type = Base64;
-               data = Base64.encode_string raw_media;
-             };
-       });
+  List.iter
+    (A.on_event accum)
+    [ ContentBlockDelta
+        { index = 1;
+          delta =
+            MediaDelta
+              { media_type = "audio/mpeg";
+                source_type = Base64;
+                data = Base64.encode_string "audio"
+              }
+        }
+    ; ContentBlockDelta
+        { index = 0;
+          delta =
+            MediaDelta
+              { media_type = "image/png";
+                source_type = Base64;
+                data = Base64.encode_string raw_media
+              }
+        }
+    ];
   A.on_event accum MessageStop;
   let base_dir = Filename.temp_dir "media_accum_test" "" in
   match A.to_chat_blocks ~base_dir accum with
-  | [ Blocks.Image { src; cap = None } ] ->
+  | [ Blocks.Image { src; cap = None }; Blocks.Voice { src = Some _; _ } ] ->
       check
         string
-        "message stop finalizes open media"
+        "message stop finalizes open media in block-index order"
         ("/api/v1/media/" ^ expected_token ~media_type:"image/png" raw_media)
         src
-  | _ -> fail "expected one Image block finalized at message stop"
+  | _ -> fail "expected Image then Voice blocks finalized at message stop"
 
 let test_tool_block_media_not_persisted () =
   let open Agent_sdk.Types in
@@ -175,10 +184,12 @@ let test_metadata_drift_preserves_first_media_block () =
   | _ -> fail "expected metadata drift to preserve the first image media block"
 
 let test_oversize_media_surfaces_as_dropped_placeholder () =
-  with_env "MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES" "4" (fun () ->
+  let cap_env = "MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES" in
+  with_env cap_env "4" (fun () ->
     let open Agent_sdk.Types in
     let accum = A.create () in
-    let oversized_len = Masc.Keeper_chat_media_store.max_wire_bytes () + 1 in
+    let rejected_cap = Masc.Keeper_chat_media_store.max_wire_bytes () in
+    let oversized_len = rejected_cap + 1 in
     let oversized = String.make oversized_len 'A' in
     List.iter
       (A.on_event accum)
@@ -189,23 +200,98 @@ let test_oversize_media_surfaces_as_dropped_placeholder () =
             delta =
               MediaDelta
                 { media_type = "image/png"; source_type = Base64; data = oversized };
-          };
+        };
         ContentBlockStop { index = 0 };
       ];
+    (* The placeholder must report the decision-time cap, even if the process
+       configuration changes before the turn is persisted. *)
+    Unix.putenv cap_env "8";
     let base_dir = Filename.temp_dir "media_accum_test" "" in
     match A.to_chat_blocks ~base_dir accum with
-    | [ Blocks.Attach { src = None; mime_type; size_bytes; name; _ } ] ->
+    | [ Blocks.Attach { src = None; mime_type; size_bytes; name; ph; size; _ } ] ->
         check (option string) "placeholder carries the media type"
           (Some "image/png") mime_type;
         check (option int) "placeholder carries the observed byte count"
           (Some oversized_len) size_bytes;
-        check bool "placeholder name states the drop" true
-          (String.length name > 0)
+        check string "placeholder reports the decision-time cap"
+          (Printf.sprintf
+             "generated media unavailable: image/png exceeded the %d-byte wire-carrier cap"
+             rejected_cap)
+          name;
+        check (option string) "placeholder body is explicit"
+          (Some "Generated media is unavailable.") ph;
+        check (option string) "placeholder distinguishes wire-carrier size"
+          (Some (Printf.sprintf "%d wire-carrier bytes observed" oversized_len))
+          size
     | [] ->
         fail
           "oversize media vanished: it must surface as a dropped placeholder \
            block, never disappear silently"
     | _ -> fail "expected exactly one dropped-placeholder Attach block")
+
+let test_media_persist_failure_surfaces_as_placeholder () =
+  let open Agent_sdk.Types in
+  let accum = A.create () in
+  let invalid_base64 = "%%%" in
+  List.iter
+    (A.on_event accum)
+    [ ContentBlockDelta
+        { index = 0;
+          delta =
+            MediaDelta
+              { media_type = "image/png";
+                source_type = Base64;
+                data = invalid_base64
+              }
+        }
+    ; ContentBlockStop { index = 0 }
+    ];
+  let base_dir = Filename.temp_dir "media_accum_test" "" in
+  match A.to_chat_blocks ~base_dir accum with
+  | [ Blocks.Attach { src = None; mime_type; size_bytes; name; _ } ] ->
+      check string "decode failure is reader-visible"
+        "generated media unavailable: provider returned invalid base64"
+        name;
+      check (option string) "decode failure carries media type"
+        (Some "image/png") mime_type;
+      check (option int) "decode failure carries observed bytes"
+        (Some (String.length invalid_base64)) size_bytes
+  | _ -> fail "expected one placeholder for a generated-media persist failure"
+
+let test_dropped_and_persisted_media_keep_stream_order () =
+  with_env "MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES" "4" (fun () ->
+    let open Agent_sdk.Types in
+    let accum = A.create () in
+    let oversized =
+      String.make (Masc.Keeper_chat_media_store.max_wire_bytes () + 1) 'A'
+    in
+    List.iter
+      (A.on_event accum)
+      [ ContentBlockDelta
+          { index = 0;
+            delta =
+              MediaDelta
+                { media_type = "image/png";
+                  source_type = Base64;
+                  data = oversized
+                }
+          }
+      ; ContentBlockStop { index = 0 }
+      ; ContentBlockDelta
+          { index = 1;
+            delta =
+              MediaDelta
+                { media_type = "image/png";
+                  source_type = Base64;
+                  data = Base64.encode_string "x"
+                }
+          }
+      ; ContentBlockStop { index = 1 }
+      ];
+    let base_dir = Filename.temp_dir "media_accum_test" "" in
+    match A.to_chat_blocks ~base_dir accum with
+    | [ Blocks.Attach { src = None; _ }; Blocks.Image _ ] -> ()
+    | _ -> fail "dropped and persisted media must retain stream terminal order")
 
 let () =
   run
@@ -223,5 +309,9 @@ let () =
             test_metadata_drift_preserves_first_media_block;
           test_case "oversize media surfaces as dropped placeholder" `Quick
             test_oversize_media_surfaces_as_dropped_placeholder;
+          test_case "persist failure surfaces as dropped placeholder" `Quick
+            test_media_persist_failure_surfaces_as_placeholder;
+          test_case "dropped and persisted media retain stream order" `Quick
+            test_dropped_and_persisted_media_keep_stream_order;
         ] );
     ]


### PR DESCRIPTION
## 문제

모델 생성 미디어가 wire cap을 넘으면 payload뿐 아니라 실패 사실도 reload에서 사라졌습니다. 기존 구현은 `Invalid_block` 하나로 tool block과 media rejection을 합쳤고, 성공 결과와 drop을 별도 리스트로 모아 Keeper의 직선 타임라인 순서도 보존하지 못했습니다. decode/persist 실패 역시 로그만 남기고 reload 블록에서는 사라졌습니다.

## 수정

- `invalid_reason = Tool_block | Oversize`와 `completed = Persistable | Wire_dropped`로 전이를 닫힌 타입에 올렸습니다.
- wire 거절 시 관측 carrier bytes와 **결정 시점 cap**을 함께 저장합니다. 이후 설정이 바뀌어도 설명을 다시 계산하지 않습니다.
- 성공/거절을 단일 완료 시퀀스에 기록해 stream terminal order를 보존합니다. `MessageStop`이 여러 open block을 한꺼번에 닫을 때는 protocol index가 결정적 tie-breaker입니다.
- wire 초과뿐 아니라 unsupported source, invalid base64, decoded payload cap, storage write failure도 payload 없이 reload-visible `Attach`로 남깁니다. 내부 write 오류 문자열은 사용자에게 노출하지 않습니다.
- generic `Attach` UI가 audio/document 실패도 “이미지 첨부”라고 표시하던 오표기를 “첨부”로 바로잡았습니다.
- metadata drift는 더 이상 조용히 무시하지 않고 index/expected/received metadata를 WARN으로 기록합니다.

## 검증

- exact head: `c117c78c05f487a4dddfcd53a7d70784c3f168f3`
- dashboard focused test: 127 tests 통과
- changed-file ESLint 및 dashboard TypeScript typecheck 통과
- OCaml parser, `ocamlformat --check`, `git diff --check` 통과
- MASC/OAS boundary, silent-failure, stringly-boundary, determinism ratchet 통과
- 테스트 계약: decision-time cap, decode 실패 가시성, drop/success 순서, MessageStop index tie-break
- 로컬 Dune 미실행; build/test authority는 PR CI

## 병합 조건

- Draft / `status:do-not-merge` 유지
- exact-head CI green 및 최신 main 동기화 후 병합 가능
