### PR TITLE
fix(chat): accept markdown and html attachments in the keeper composer (C16 #38)

### DIFF
--- a/dashboard/src/components/chat/attachments.test.ts
+++ b/dashboard/src/components/chat/attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MAX_FILE_SIZE,
   MAX_IMAGE_SIZE,
+  resolveAttachmentMimeType,
   stableAttachmentId,
   validateFile,
 } from './attachments'
@@ -31,6 +32,24 @@ describe('validateFile', () => {
     expect(validateFile(fileOfSize('a.json', 'application/json', 10))).toBeNull()
   })
 
+  it('accepts html files', () => {
+    expect(validateFile(fileOfSize('report.html', 'text/html', 10))).toBeNull()
+  })
+
+  // Browsers commonly report an EMPTY File.type for .md/.html (platform MIME
+  // table gaps) — exact-matching the declared type rejected markdown outright
+  // (campaign #38). The extension fallback must recover the real type.
+  it('accepts blank-MIME markdown and html via the extension fallback', () => {
+    expect(validateFile(fileOfSize('notes.md', '', 10))).toBeNull()
+    expect(validateFile(fileOfSize('notes.markdown', '', 10))).toBeNull()
+    expect(validateFile(fileOfSize('page.html', '', 10))).toBeNull()
+    expect(validateFile(fileOfSize('page.htm', '', 10))).toBeNull()
+  })
+
+  it('still rejects blank-MIME files with unmapped extensions', () => {
+    expect(validateFile(fileOfSize('binary.exe', '', 10))).toContain('지원하지 않는 파일 형식')
+  })
+
   it('accepts allowed audio files within the file size budget', () => {
     expect(validateFile(fileOfSize('clip.webm', 'audio/webm', MAX_FILE_SIZE))).toBeNull()
     expect(validateFile(fileOfSize('clip.wav', 'audio/wav', 10))).toBeNull()
@@ -50,6 +69,23 @@ describe('validateFile', () => {
 
   it('rejects oversized files', () => {
     expect(validateFile(fileOfSize('a.txt', 'text/plain', MAX_FILE_SIZE + 1))).toContain('파일 크기 초과')
+  })
+})
+
+describe('resolveAttachmentMimeType', () => {
+  it('keeps a declared allow-listed type without consulting the extension', () => {
+    expect(resolveAttachmentMimeType(fileOfSize('odd-name.bin', 'text/markdown', 10)))
+      .toBe('text/markdown')
+  })
+
+  it('maps blank-MIME files by extension, case-insensitively', () => {
+    expect(resolveAttachmentMimeType(fileOfSize('README.MD', '', 10))).toBe('text/markdown')
+    expect(resolveAttachmentMimeType(fileOfSize('index.HTML', '', 10))).toBe('text/html')
+  })
+
+  it('keeps the declared type when the extension is unmapped', () => {
+    expect(resolveAttachmentMimeType(fileOfSize('archive.zip', 'application/zip', 10)))
+      .toBe('application/zip')
   })
 })
 

--- a/dashboard/src/components/chat/attachments.test.ts
+++ b/dashboard/src/components/chat/attachments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ATTACHMENT_INPUT_ACCEPT,
   MAX_FILE_SIZE,
   MAX_IMAGE_SIZE,
   resolveAttachmentMimeType,
@@ -86,6 +87,22 @@ describe('resolveAttachmentMimeType', () => {
   it('keeps the declared type when the extension is unmapped', () => {
     expect(resolveAttachmentMimeType(fileOfSize('archive.zip', 'application/zip', 10)))
       .toBe('application/zip')
+  })
+
+  it('never overrides an explicit unsupported MIME type from the extension', () => {
+    expect(resolveAttachmentMimeType(fileOfSize('renamed.md', 'application/x-msdownload', 10)))
+      .toBe('application/x-msdownload')
+    expect(validateFile(fileOfSize('renamed.md', 'application/x-msdownload', 10)))
+      .toContain('지원하지 않는 파일 형식')
+  })
+
+  it('derives the file-picker accept contract from the MIME catalog', () => {
+    expect(ATTACHMENT_INPUT_ACCEPT.split(',')).toEqual(expect.arrayContaining([
+      'text/markdown',
+      'text/html',
+      '.md',
+      '.html',
+    ]))
   })
 })
 

--- a/dashboard/src/components/chat/attachments.ts
+++ b/dashboard/src/components/chat/attachments.ts
@@ -10,22 +10,61 @@
 import type { KeeperConversationAttachment } from '../../types'
 
 export const ALLOWED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
-export const ALLOWED_FILE_TYPES = ['text/plain', 'text/markdown', 'application/json', 'text/csv']
+export const ALLOWED_FILE_TYPES = [
+  'text/plain',
+  'text/markdown',
+  'text/html',
+  'application/json',
+  'text/csv',
+]
 export const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/webm', 'audio/ogg']
+
+// Browsers report File.type from platform MIME tables, which commonly leave
+// .md/.markdown (and sometimes .html) EMPTY or map them to vendor variants —
+// exact-matching file.type alone therefore rejected markdown attachments
+// outright (38-bug campaign #38). When the declared type is not already in an
+// allow-list, fall back to this closed extension map; an extension outside the
+// map keeps the declared type and fails validation as before.
+const EXTENSION_MIME_FALLBACK: Record<string, string> = {
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  html: 'text/html',
+  htm: 'text/html',
+  txt: 'text/plain',
+  json: 'application/json',
+  csv: 'text/csv',
+}
+
+export function resolveAttachmentMimeType(file: File): string {
+  const declared = file.type
+  if (
+    ALLOWED_IMAGE_TYPES.includes(declared) ||
+    ALLOWED_AUDIO_TYPES.includes(declared) ||
+    ALLOWED_FILE_TYPES.includes(declared)
+  ) {
+    return declared
+  }
+  const dot = file.name.lastIndexOf('.')
+  const ext = dot >= 0 ? file.name.slice(dot + 1).toLowerCase() : ''
+  return EXTENSION_MIME_FALLBACK[ext] ?? declared
+}
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024
 export const MAX_FILE_SIZE = 2 * 1024 * 1024
 export const MAX_TOTAL_PAYLOAD = 10 * 1024 * 1024
 export const MAX_ATTACHMENTS = 5
 
 export function validateFile(file: File): string | null {
-  if (file.type.startsWith('image/')) {
-    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) return `지원하지 않는 이미지 형식: ${file.type}`
+  const mimeType = resolveAttachmentMimeType(file)
+  if (mimeType.startsWith('image/')) {
+    if (!ALLOWED_IMAGE_TYPES.includes(mimeType)) return `지원하지 않는 이미지 형식: ${mimeType}`
     if (file.size > MAX_IMAGE_SIZE) return '이미지 크기 초과 (최대 5MB)'
-  } else if (file.type.startsWith('audio/')) {
-    if (!ALLOWED_AUDIO_TYPES.includes(file.type)) return `지원하지 않는 오디오 형식: ${file.type}`
+  } else if (mimeType.startsWith('audio/')) {
+    if (!ALLOWED_AUDIO_TYPES.includes(mimeType)) return `지원하지 않는 오디오 형식: ${mimeType}`
     if (file.size > MAX_FILE_SIZE) return '오디오 크기 초과 (최대 2MB)'
   } else {
-    if (!ALLOWED_FILE_TYPES.includes(file.type)) return `지원하지 않는 파일 형식: ${file.type}`
+    if (!ALLOWED_FILE_TYPES.includes(mimeType)) {
+      return `지원하지 않는 파일 형식: ${mimeType === '' ? file.name : mimeType}`
+    }
     if (file.size > MAX_FILE_SIZE) return '파일 크기 초과 (최대 2MB)'
   }
   return null
@@ -157,21 +196,24 @@ export async function collectAttachments(
       errors.push('총 첨부 크기가 10MB를 초과합니다.')
       break
     }
-    const dims = resized.type.startsWith('image/') ? await readImageDimensions(resized) : null
+    // Resolved (not declared) type, so a blank-MIME .md/.html file carries
+    // its real markdown/html mime downstream to the keeper turn.
+    const mimeType = resolveAttachmentMimeType(resized)
+    const dims = mimeType.startsWith('image/') ? await readImageDimensions(resized) : null
     const baseId = stableAttachmentId({
       name: resized.name,
-      type: resized.type.startsWith('image/') ? 'image' : 'file',
-      mimeType: resized.type,
+      type: mimeType.startsWith('image/') ? 'image' : 'file',
+      mimeType,
       size: base64Size,
       data: dataUrl,
       dims,
     })
     attachments.push({
       id: uniqueStableAttachmentId(baseId, existing, attachments),
-      type: resized.type.startsWith('image/') ? 'image' : 'file',
+      type: mimeType.startsWith('image/') ? 'image' : 'file',
       name: resized.name,
       size: base64Size,
-      mimeType: resized.type,
+      mimeType,
       data: dataUrl,
       dims: dims ?? undefined,
     })

--- a/dashboard/src/components/chat/attachments.ts
+++ b/dashboard/src/components/chat/attachments.ts
@@ -19,12 +19,10 @@ export const ALLOWED_FILE_TYPES = [
 ]
 export const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/webm', 'audio/ogg']
 
-// Browsers report File.type from platform MIME tables, which commonly leave
-// .md/.markdown (and sometimes .html) EMPTY or map them to vendor variants —
-// exact-matching file.type alone therefore rejected markdown attachments
-// outright (38-bug campaign #38). When the declared type is not already in an
-// allow-list, fall back to this closed extension map; an extension outside the
-// map keeps the declared type and fails validation as before.
+// File API permits an EMPTY File.type when the user agent cannot determine a
+// MIME type. Only that absence may use the closed extension catalog. A present
+// but unsupported MIME type is authoritative and must never be overwritten by
+// the filename (for example, application/x-msdownload + renamed .md).
 const EXTENSION_MIME_FALLBACK: Record<string, string> = {
   md: 'text/markdown',
   markdown: 'text/markdown',
@@ -35,18 +33,19 @@ const EXTENSION_MIME_FALLBACK: Record<string, string> = {
   csv: 'text/csv',
 }
 
+export const ATTACHMENT_INPUT_ACCEPT = [
+  ...ALLOWED_IMAGE_TYPES,
+  ...ALLOWED_AUDIO_TYPES,
+  ...ALLOWED_FILE_TYPES,
+  ...Object.keys(EXTENSION_MIME_FALLBACK).map(extension => `.${extension}`),
+].join(',')
+
 export function resolveAttachmentMimeType(file: File): string {
   const declared = file.type
-  if (
-    ALLOWED_IMAGE_TYPES.includes(declared) ||
-    ALLOWED_AUDIO_TYPES.includes(declared) ||
-    ALLOWED_FILE_TYPES.includes(declared)
-  ) {
-    return declared
-  }
+  if (declared !== '') return declared
   const dot = file.name.lastIndexOf('.')
   const ext = dot >= 0 ? file.name.slice(dot + 1).toLowerCase() : ''
-  return EXTENSION_MIME_FALLBACK[ext] ?? declared
+  return EXTENSION_MIME_FALLBACK[ext] ?? ''
 }
 export const MAX_IMAGE_SIZE = 5 * 1024 * 1024
 export const MAX_FILE_SIZE = 2 * 1024 * 1024

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -20,7 +20,8 @@ import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
 import { fetchBoardPost } from '../../api/board'
 
-vi.mock('./attachments', () => ({
+vi.mock('./attachments', async (importOriginal) => ({
+  ...await importOriginal<typeof import('./attachments')>(),
   collectAttachments: vi.fn(),
 }))
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -5,7 +5,7 @@ import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
 import { escapeHtml } from '../../lib/html-escape'
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ringFocusClasses } from '../common/ring'
-import { collectAttachments } from './attachments'
+import { ATTACHMENT_INPUT_ACCEPT, collectAttachments } from './attachments'
 import { linkifyHtmlReferences } from './chat-linkify'
 import { UNREAD_DIVIDER_LABEL, unreadDividerAnchorKey } from './unread-divider'
 import { showToast } from '../common/toast'
@@ -4180,7 +4180,7 @@ export function ChatComposer({
                   <input
                     ref=${fileInputRef}
                     type="file"
-                    accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,text/html,application/json,text/csv,.md,.markdown,.html,.htm,.txt,.json,.csv"
+                    accept=${ATTACHMENT_INPUT_ACCEPT}
                     multiple
                     class="hidden"
                     aria-label="파일 첨부"

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -4180,7 +4180,7 @@ export function ChatComposer({
                   <input
                     ref=${fileInputRef}
                     type="file"
-                    accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,application/json,text/csv"
+                    accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,text/html,application/json,text/csv,.md,.markdown,.html,.htm,.txt,.json,.csv"
                     multiple
                     class="hidden"
                     aria-label="파일 첨부"

--- a/lib/keeper/keeper_multimodal_input.ml
+++ b/lib/keeper/keeper_multimodal_input.ml
@@ -337,7 +337,7 @@ let normalize_media_payload ~kind ~attachment_id ~declared_media_type data =
     in
     Ok (media_type, data)
 
-let media_block_to_oas ~attachments kind make_block media =
+let resolve_media_payload ~attachments kind media =
   match find_attachment ~attachments media.attachment_id with
   | None ->
       Error
@@ -347,9 +347,89 @@ let media_block_to_oas ~attachments kind make_block media =
   | Some att ->
       let declared = declared_media_type media att in
       Result.map
-        (fun (media_type, data) -> make_block ~media_type ~data ())
+        (fun (media_type, data) -> att, media_type, data)
         (normalize_media_payload ~kind ~attachment_id:media.attachment_id
            ~declared_media_type:declared att.data)
+
+let media_block_to_oas ~attachments kind make_block media =
+  Result.map
+    (fun (_att, media_type, data) -> make_block ~media_type ~data ())
+    (resolve_media_payload ~attachments kind media)
+
+type document_projection =
+  | Project_as_text
+  | Preserve_document
+
+(* Catalog the text-like document kinds accepted by the dashboard composer.
+   This is the one untyped MIME boundary; control flow consumes the typed
+   [document_projection] below instead of branching on MIME strings. *)
+let text_document_media_types =
+  Set_util.StringSet.of_list
+    [ "text/plain"
+    ; "text/markdown"
+    ; "text/html"
+    ; "application/json"
+    ; "text/csv"
+    ]
+
+let document_projection_of_media_type media_type =
+  if Set_util.StringSet.mem media_type text_document_media_types
+  then Project_as_text
+  else Preserve_document
+
+let text_block_of_document
+    ~(att : Keeper_chat_store.attachment)
+    ~attachment_id
+    ~media_type
+    data =
+  match Base64.decode data with
+  | Error (`Msg msg) ->
+      Error
+        (Printf.sprintf
+           "invalid base64 payload for textual document user block %S: %s"
+           attachment_id
+           msg)
+  | Ok text ->
+      let sanitized = Safe_ops.sanitize_text_utf8 text in
+      if not (String.equal text sanitized) then
+        Error
+          (Printf.sprintf
+             "textual document user block %S is not valid UTF-8 text or contains unsupported control characters"
+             attachment_id)
+      else
+        let name =
+          match String.trim att.name with
+          | "" -> attachment_id
+          | name -> name
+        in
+        let metadata =
+          Yojson.Safe.to_string
+            (`Assoc
+              [ "kind", `String "user_attachment"
+              ; "name", `String name
+              ; "media_type", `String media_type
+              ])
+        in
+        Ok
+          (Agent_sdk.Types.Text
+             (Printf.sprintf
+                "User-provided attachment metadata: %s\n\n%s"
+                metadata
+                text))
+
+let document_block_to_oas ~attachments media =
+  match resolve_media_payload ~attachments "document" media with
+  | Error _ as error -> error
+  | Ok (att, media_type, data) ->
+      (match document_projection_of_media_type media_type with
+       | Project_as_text ->
+           text_block_of_document
+             ~att
+             ~attachment_id:media.attachment_id
+             ~media_type
+             data
+       | Preserve_document ->
+           Ok (Agent_sdk.Types.document_block ~media_type ~data ()))
 
 let to_oas_blocks ~attachments blocks =
   let rec loop acc = function
@@ -370,12 +450,7 @@ let to_oas_blocks ~attachments blocks =
         | Ok block -> loop (block :: acc) rest
         | Error err -> Error err)
     | User_document media :: rest -> (
-        match
-          media_block_to_oas ~attachments "document"
-            (fun ~media_type ~data () ->
-               Agent_sdk.Types.document_block ~media_type ~data ())
-            media
-        with
+        match document_block_to_oas ~attachments media with
         | Ok block -> loop (block :: acc) rest
         | Error err -> Error err)
     | User_audio media :: rest -> (

--- a/lib/keeper/keeper_multimodal_input.mli
+++ b/lib/keeper/keeper_multimodal_input.mli
@@ -47,4 +47,9 @@ val to_oas_blocks :
 (** Convert semantic MASC input blocks to OAS provider input blocks.  Media
     blocks resolve their payload through [attachments] by [attachment_id].
     Data URLs are normalized to raw base64 payloads before crossing into OAS,
-    and declared MIME types must match any MIME embedded in a data URL. *)
+    and declared MIME types must match any MIME embedded in a data URL.
+
+    Dashboard-supported text documents are base64-decoded and validated as
+    UTF-8 at this MASC boundary, then projected as OAS [Text] blocks so provider
+    fallbacks do not need provider-specific file-input support. Binary and
+    provider-native documents remain OAS [Document] blocks. *)

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -335,6 +335,119 @@ let test_keeper_multimodal_input_converts_user_blocks_to_oas_blocks () =
   | Ok _ -> fail "expected image then text OAS blocks"
   | Error err -> fail ("expected OAS block conversion: " ^ err)
 
+let document_input ~mime_type ~payload =
+  let attachment_id = "att-doc" in
+  let name = "notes.md" in
+  let attachments =
+    [
+      {
+        K.id = attachment_id;
+        att_type = "file";
+        name;
+        size = String.length payload;
+        mime_type;
+        data = Printf.sprintf "data:%s;base64,%s" mime_type payload;
+      };
+    ]
+  in
+  let media =
+    {
+      Keeper_multimodal_input.attachment_id;
+      name;
+      mime_type;
+      size = Some (String.length payload);
+    }
+  in
+  attachments, media
+
+let test_keeper_multimodal_input_projects_text_documents_as_text () =
+  let cases =
+    [ "text/plain", "plain body"
+    ; "text/markdown", "# heading"
+    ; "text/html", "<h1>heading</h1>"
+    ; "application/json", {|{"ok":true}|}
+    ; "text/csv", "name,value\nalpha,1"
+    ]
+  in
+  List.iter
+    (fun (mime_type, body) ->
+       let attachments, media =
+         document_input ~mime_type ~payload:(Base64.encode_string body)
+       in
+       match
+         Keeper_multimodal_input.to_oas_blocks ~attachments
+           [ Keeper_multimodal_input.User_document media ]
+       with
+       | Ok [ Agent_sdk.Types.Text projected ] ->
+           let metadata =
+             Yojson.Safe.to_string
+               (`Assoc
+                 [ "kind", `String "user_attachment"
+                 ; "name", `String "notes.md"
+                 ; "media_type", `String mime_type
+                 ])
+           in
+           check string (mime_type ^ " exact projection")
+             (Printf.sprintf
+                "User-provided attachment metadata: %s\n\n%s"
+                metadata
+                body)
+             projected
+       | Ok _ -> fail (mime_type ^ " should project as one text block")
+       | Error err -> fail (mime_type ^ " projection failed: " ^ err))
+    cases
+
+let test_keeper_multimodal_input_preserves_binary_document () =
+  let payload = Base64.encode_string "%PDF-1.7" in
+  let attachments, media = document_input ~mime_type:"application/pdf" ~payload in
+  match
+    Keeper_multimodal_input.to_oas_blocks ~attachments
+      [ Keeper_multimodal_input.User_document media ]
+  with
+  | Ok [ Agent_sdk.Types.Document { media_type; data; source_type } ] ->
+      check string "media type" "application/pdf" media_type;
+      check string "base64 payload" payload data;
+      check bool "source type" true (source_type = Agent_sdk.Types.Base64)
+  | Ok _ -> fail "PDF should remain one OAS document block"
+  | Error err -> fail ("PDF document projection failed: " ^ err)
+
+let test_keeper_multimodal_input_rejects_invalid_text_document_payload () =
+  let attachments, media =
+    document_input ~mime_type:"text/markdown" ~payload:"%%%"
+  in
+  (match
+     Keeper_multimodal_input.to_oas_blocks ~attachments
+       [ Keeper_multimodal_input.User_document media ]
+   with
+   | Ok _ -> fail "invalid textual document base64 should be rejected"
+   | Error err ->
+       check bool "base64 error is explicit" true
+         (string_contains err "invalid base64 payload"));
+  let invalid_utf8 = String.make 1 (Char.chr 0xff) |> Base64.encode_string in
+  let attachments, media =
+    document_input ~mime_type:"text/html" ~payload:invalid_utf8
+  in
+  match
+    Keeper_multimodal_input.to_oas_blocks ~attachments
+      [ Keeper_multimodal_input.User_document media ]
+  with
+  | Ok _ -> fail "invalid UTF-8 textual document should be rejected"
+  | Error err ->
+      check bool "UTF-8 error is explicit" true
+        (string_contains err "not valid UTF-8 text");
+      let unsupported_control = Base64.encode_string "before\x00after" in
+      let attachments, media =
+        document_input ~mime_type:"text/plain" ~payload:unsupported_control
+      in
+      match
+        Keeper_multimodal_input.to_oas_blocks ~attachments
+          [ Keeper_multimodal_input.User_document media ]
+      with
+      | Ok _ -> fail "text control characters should not be silently repaired"
+      | Error control_err ->
+          check bool "control character error is explicit" true
+            (string_contains control_err "unsupported control characters")
+
 let test_keeper_multimodal_input_accepts_mixed_case_data_url () =
   let attachments =
     [
@@ -2684,6 +2797,12 @@ let () =
             test_parse_keeper_chat_stream_request_rejects_unknown_user_block_type;
           test_case "multimodal input converts user blocks to OAS blocks" `Quick
             test_keeper_multimodal_input_converts_user_blocks_to_oas_blocks;
+          test_case "multimodal input projects text documents as text" `Quick
+            test_keeper_multimodal_input_projects_text_documents_as_text;
+          test_case "multimodal input preserves binary documents" `Quick
+            test_keeper_multimodal_input_preserves_binary_document;
+          test_case "multimodal input rejects invalid text document payload" `Quick
+            test_keeper_multimodal_input_rejects_invalid_text_document_payload;
           test_case "multimodal input accepts mixed-case data URL" `Quick
             test_keeper_multimodal_input_accepts_mixed_case_data_url;
           test_case "multimodal input normalizes inferred data URL MIME" `Quick


### PR DESCRIPTION
## 문제

대시보드가 `.md`/`.html` 첨부를 선택·검증하지 못했고, 기존 구현은 비어 있지 않은 명시적 MIME까지 확장자로 덮어써 `application/x-msdownload` 같은 입력을 `text/markdown`으로 오인할 수 있었습니다. 또한 MASC의 모든 `User_document`가 OAS `Document`로 전달되어, provider별 document dialect가 없는 경로에서는 텍스트 문서가 잘못 직렬화될 수 있었습니다.

## 수정

- `File.type = ""`일 때만 닫힌 확장자 카탈로그를 사용합니다. 비어 있지 않은 MIME은 권위 있는 입력으로 보존하고 허용 목록 밖이면 명시적으로 거절합니다.
- picker `accept`를 MIME/확장자 SSOT에서 파생해 중복 목록을 제거했습니다.
- 대시보드가 허용하는 텍스트 문서 5종은 MASC 경계에서 base64/UTF-8을 검증한 뒤 파일 메타데이터와 함께 OAS `Text`로 투영합니다.
- PDF 등 binary/provider-native 문서는 OAS `Document`로 보존합니다.
- 잘못된 base64, UTF-8, 제어문자는 조용히 보정하지 않고 오류로 반환합니다.
- OAS의 범용 document capability/serializer 정합성은 jeong-sik/oas#2513으로 분리했습니다. OAS는 MASC를 알지 않습니다.

## 검증

- exact head: `9042e857da3222f596487a7d06cbe483f9b9b743`
- dashboard focused tests: 2 files / 145 tests 통과
- dashboard TypeScript typecheck 및 changed-file ESLint 통과
- OCaml parser, `ocamlformat --check`, `git diff --check` 통과
- MASC/OAS boundary, silent-failure, stringly-boundary, determinism ratchet 통과
- 로컬 Dune 미실행; build/test authority는 PR CI

## 공식 계약 근거

- [W3C File API](https://www.w3.org/TR/FileAPI/): MIME을 결정할 수 없으면 `File.type`은 빈 문자열일 수 있습니다.
- [OpenAI file inputs](https://developers.openai.com/api/docs/guides/file-inputs): Responses file input은 파일 유형별 처리 계약을 가집니다.
- [Anthropic PDF support](https://platform.claude.com/docs/en/build-with-claude/pdf-support), [Gemini document processing](https://ai.google.dev/gemini-api/docs/document-processing): 문서 입력 계약이 provider마다 다릅니다.

## 병합 조건

- Draft / `status:do-not-merge` 유지
- exact-head CI green 확인 후 병합 가능
