### PR TITLE
fix(ci): restore per-job cache and stale-base contracts

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -39,17 +39,21 @@ runs:
     # The opam cache above only restores the toolchain/switch; every dune
     # build of masc itself still started cold (~50 min Build and Test).
     # Cache dune's content-addressed artifact store so an unchanged module
-    # graph rebuilds incrementally. Keyed by run id so each run REWRITES the
-    # cache with its newest artifacts (a stable key would freeze the first
-    # upload forever); restore always hits the newest same-prefix entry.
+    # graph rebuilds incrementally. Keyed by job and run id so each job publishes
+    # a new immutable cache with its newest artifacts (a stable key would freeze
+    # the first upload forever). [github.job] is part of both the primary key
+    # and restore namespace: Health/Lint/Build run in parallel and produce
+    # different artifact subsets, while GitHub cache entries are immutable
+    # after the first successful save. A shared run-id key would let the fastest, usually
+    # smallest job permanently win that run's save race.
     - name: Cache dune build artifacts (Linux)
       if: runner.os == 'Linux' && inputs.dune-cache == 'true'
       uses: actions/cache@v5
       with:
         path: ~/.cache/dune
-        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
+        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.job }}-${{ github.run_id }}
         restore-keys: |
-          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
+          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.job }}-
 
     - name: Enable dune cache (Linux)
       if: runner.os == 'Linux' && inputs.dune-cache == 'true'

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -60,6 +60,10 @@ jobs:
           python -m pip install --quiet --upgrade pip pyyaml
       - name: Run blocking lints (PR)
         if: github.event_name == 'pull_request'
+        env:
+          # Typed acknowledgement consumed by check-stale-base-revert.py.
+          # Preserve the former dedicated job's intentional-revert contract.
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           bash scripts/ci/run-lint-suite.sh blocking-pr \
             "${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
Follow-up to merged #23996. Related P0 authority incident: #23966.

## Post-merge defects

1. The composite action used one exact Dune cache key for every parallel Linux job in a workflow run. GitHub caches are immutable, so the first successful Health/Lint/Build post-job save could permanently win the shared key; the full Build job's larger artifact set would not replace it.
2. Consolidating the stale-base guard into `run-lint-suite.sh` dropped the `PR_LABELS` environment value. The typed `stale-base-ack` label therefore no longer acknowledged an intentional revert.

## Fix

- Namespace both the Dune primary key and restore prefix by `${{ github.job }}` plus run id. Each job now restores only its own newest artifact lineage and publishes a new immutable entry per run.
- Restore `PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}` on the blocking PR suite step.

No lint semantics, Dune build command, or merge policy is otherwise changed.

## Validation

- YAML parse: PASS
- `actionlint .github/workflows/fundamental-check.yml`: PASS
- `bash -n scripts/ci/run-lint-suite.sh`: PASS
- `python3 scripts/ci/test_check_stale_base_revert.py`: 4/4 PASS, including typed acknowledgement
- `git diff --check`: PASS
- Full workflow/cache proof: exact-head PR CI; a later second run must show job-specific restore keys

## Merge gate

Keep Draft / `p1` / `status:do-not-merge` until exact-head CI and current-head review complete. This fix-forward does not close #23966; #23996 itself merged after a P1/DNM review, which is fresh evidence that labels and Draft state are not a server authorization boundary.

[근거] merged main `817eb5e747`, GitHub workflow diff, stale-base self-test, [GitHub dependency cache reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) checked 2026-07-10 20:49 KST; confidence High.
