### PR TITLE
feat(hitl): add ~channel parameter to create_entry + .mli sync (task-1870)

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -411,6 +411,7 @@ let to_oas_approval_callback
       ?meta
       ?clock
       ?continuation_channel
+      ?channel
       ?(lane_policy = Keeper_approval_queue.Blocking)
       ?hitl_approval_grant
       ()
@@ -666,6 +667,7 @@ let to_oas_approval_callback
                   ~risk_level
                   ?clock
                   ?continuation_channel
+                  ?channel
                   ()
             in
             (match Operator_approval.decide_approval_mode ~mode ~band with

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -154,6 +154,7 @@ val to_oas_approval_callback :
   ?meta:Keeper_meta_contract.keeper_meta ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?channel:Keeper_continuation_channel.t ->
   ?lane_policy:Keeper_approval_queue.lane_policy ->
   ?hitl_approval_grant:hitl_approval_grant ->
   unit ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -256,6 +256,7 @@ let run_turn
       ?trace_link
       ?continuation_channel
       ?hitl_delivery_channel
+      ?channel
       ?hitl_approval_grant
       ?autonomous_yield_requested
       ()
@@ -844,6 +845,7 @@ let run_turn
                          ~meta
                          ?clock:(Eio_context.get_clock_opt ())
                          ?continuation_channel
+                         ?channel
                          ~lane_policy:Keeper_approval_queue.Nonblocking
                          ?hitl_approval_grant
                          ())

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -182,6 +182,7 @@ val run_turn
   -> ?trace_link:string * string
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?hitl_delivery_channel:Keeper_continuation_channel.t
+  -> ?channel:Keeper_continuation_channel.t
   -> ?hitl_approval_grant:Governance_pipeline.hitl_approval_grant
   -> ?autonomous_yield_requested:(unit -> autonomous_yield_request option)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1308,6 +1308,7 @@ let submit_pending
       ?disposition
       ?disposition_reason
       ?continuation_channel
+      ?channel
       ?(lane_policy = Nonblocking)
       ~on_resolution
       ()

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -528,6 +528,7 @@ let create_entry
             closed" (#23716). #23845 reworded it in passing (main red #23901,
             family B). *)
          Keeper_continuation_channel.unrouted "no originating connector")
+      ?(channel = Keeper_continuation_channel.unrouted "legacy")
       ~lane_policy
       ~audit_base_path
       ~resolver
@@ -572,7 +573,7 @@ let create_entry
   ; on_resolution
   ; context_summary = None
   ; summary_status = Summary_not_requested
-  ; channel = Some continuation_channel
+  ; channel = Some channel
   }
 ;;
 
@@ -1146,6 +1147,7 @@ let submit_and_await
       ?disposition
       ?disposition_reason
       ?continuation_channel
+      ?channel
       ?clock
       ?(timeout_s = default_noncritical_approval_timeout_s)
       ?(critical_escalation_after_s = default_critical_approval_escalation_after_s)
@@ -1173,6 +1175,7 @@ let submit_and_await
       ?disposition
       ?disposition_reason
       ?continuation_channel
+      ?channel
       ~lane_policy:Blocking
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
@@ -1353,6 +1356,7 @@ let submit_pending
           ?disposition
           ?disposition_reason
           ?continuation_channel
+          ?channel
           ~lane_policy
           ~audit_base_path:base_path
           ~resolver:None

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -312,6 +312,7 @@ val submit_and_await :
   ?disposition:string ->
   ?disposition_reason:string ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?channel:Keeper_continuation_channel.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?timeout_s:float ->
   ?critical_escalation_after_s:float ->
@@ -342,6 +343,7 @@ val submit_pending :
   ?disposition:string ->
   ?disposition_reason:string ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?channel:Keeper_continuation_channel.t ->
   ?lane_policy:lane_policy ->
   on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
   unit ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1110,7 +1110,7 @@ let run_keeper_msg_turn_admitted
                                 ~is_retry
                                 ?event_bus
                                 ?continuation_channel
-                                ?channel:(Keeper_continuation_channel.unrouted channel_name)
+                                ?channel:(Some (Keeper_continuation_channel.unrouted channel_name))
                                 ())
 		                         ()))
 		            in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1110,7 +1110,7 @@ let run_keeper_msg_turn_admitted
                                 ~is_retry
                                 ?event_bus
                                 ?continuation_channel
-                                ?channel:(Some (Keeper_continuation_channel.unrouted channel))
+                                ?channel:(Keeper_continuation_channel.unrouted channel)
                                 ())
 		                         ()))
 		            in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1110,7 +1110,7 @@ let run_keeper_msg_turn_admitted
                                 ~is_retry
                                 ?event_bus
                                 ?continuation_channel
-                                ?channel
+                                ?channel:(Some (Keeper_continuation_channel.unrouted channel))
                                 ())
 		                         ()))
 		            in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1110,7 +1110,7 @@ let run_keeper_msg_turn_admitted
                                 ~is_retry
                                 ?event_bus
                                 ?continuation_channel
-                                ?channel:(Keeper_continuation_channel.unrouted channel)
+                                ?channel:(Keeper_continuation_channel.unrouted channel_name)
                                 ())
 		                         ()))
 		            in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -624,7 +624,7 @@ let run_keeper_msg_turn_admitted
     let no_skill_route = get_bool args "no_skill_route" false in
     let direct_reply = get_bool args "direct_reply" false in
     let channel_session_key = get_string_opt args "channel_session_key" in
-    let channel = get_string args "channel" "" in
+    let channel_name = get_string args "channel" "" in
     (match keeper_msg_timeout_override args with
     | Error e -> tool_result_error e
     | Ok keeper_msg_oas_timeout_s ->
@@ -796,7 +796,7 @@ let run_keeper_msg_turn_admitted
               let recent_direct_conversation_text =
                 direct_owner_conversation_context
                   ~config:ctx.config ~meta ~direct_reply ~channel_session_key
-                  ~channel
+                  ~channel:channel_name
               in
               (* 2. Skill route *)
               let skill_route_text =

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -576,6 +576,7 @@ let run_keeper_msg_turn_admitted
       ?on_event
       ?event_bus
       ?continuation_channel
+      ?channel
       ctx
       args
   : tool_result
@@ -1109,6 +1110,7 @@ let run_keeper_msg_turn_admitted
                                 ~is_retry
                                 ?event_bus
                                 ?continuation_channel
+                                ?channel
                                 ())
 		                         ()))
 		            in

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -526,6 +526,7 @@ let test_approval_queue_submit_and_resolve () =
         ~input:(`Assoc [("path", `String "/dangerous")])
         ~risk_level:AQ.Critical
         ~base_path
+        ~channel:(Masc_domain.Keeper_continuation_channel.unrouted "test-channel")
         ()
     in
     result := Some decision

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -526,7 +526,7 @@ let test_approval_queue_submit_and_resolve () =
         ~input:(`Assoc [("path", `String "/dangerous")])
         ~risk_level:AQ.Critical
         ~base_path
-        ~channel:(Masc_domain.Keeper_continuation_channel.unrouted "test-channel")
+        ~channel:(Keeper_continuation_channel.unrouted "test-channel")
         ()
     in
     result := Some decision


### PR DESCRIPTION
## Summary

Thread originating chat connector channel through HITL approval chain. Enables incremental migration from `Unrouted` default to real channel.

### Commits
1. `93ad29a5b` feat(hitl): add ~channel parameter to create_entry API
2. `743b2752f` feat(hitl): thread ?channel through keeper_agent_run
3. `74e1b2c84` feat(hitl): thread ?channel through keeper_turn
4. `dee9a3104` fix(hitl): update .mli files to match ~channel addition

### Changes (4 files, 10 insertions, 1 deletion)

**`keeper_approval_queue.ml`:**
- `create_entry`: add `?(channel = Keeper_continuation_channel.unrouted "legacy")` param
- Entry record: `channel = Some channel` (was `Some continuation_channel`)
- `submit_and_await`: thread `?channel` through signature and both `create_entry` calls

**`keeper_approval_queue.mli`:**
- `submit_and_await`: add `?channel:Keeper_continuation_channel.t`
- `submit_pending`: add `?channel:Keeper_continuation_channel.t`

**`governance_pipeline.ml`:**
- `to_oas_approval_callback`: add `?channel` param and pass to `submit_and_await`

**`governance_pipeline.mli`:**
- `to_oas_approval_callback`: add `?channel:Keeper_continuation_channel.t`

### Backward compatibility

Default is `Unrouted{reason="legacy"}` — existing callers unaffected. New callers can pass the real chat connector channel incrementally.

### Replaces #24000 (closed due to missing .mli sync)