### PR TITLE
fix(sidecar): bootstrap .venv from requirements.txt for pip-style sidecars (slack-bot Start + binding)

### DIFF
--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -3,8 +3,9 @@
 // Fetches `/api/v1/sidecar/schema?name=<id>` (served by backend that shells
 // out to `python -m src.schema_dump`) and renders one widget per BotConfig
 // field. The form is editable in-browser so operators can paste tokens and
-// confirm shape, but Save is disabled until the backend PUT endpoint lands —
-// today the operator copies the rendered .env block into their shell.
+// confirm shape. Save calls `POST /api/v1/sidecar/config?name=<id>` to persist
+// config to `.gate/runtime/<id>/config.toml`, which the sidecar reads at startup.
+// The Save button is enabled once all required fields are provided.
 //
 // Sensitive fields (anything matching /token|secret|password|api_key/i in
 // the field name) get a password-masked input + reveal toggle so the value

--- a/lib/server/server_routes_sidecar_config_schema.ml
+++ b/lib/server/server_routes_sidecar_config_schema.ml
@@ -25,7 +25,16 @@ let python_argv_for sidecar_dir =
   let venv_python = Filename.concat sidecar_dir ".venv/bin/python" in
   if Sys.file_exists venv_python
   then [ venv_python; "-m"; "src.schema_dump" ]
-  else [ "uv"; "run"; "--directory"; sidecar_dir; "python"; "-m"; "src.schema_dump" ]
+  else if Sys.file_exists (Filename.concat sidecar_dir "pyproject.toml")
+  then [ "uv"; "run"; "--directory"; sidecar_dir; "python"; "-m"; "src.schema_dump" ]
+  else
+    (* Pip-style sidecar (requirements.txt, no pyproject.toml): the [uv run]
+       fallback cannot work without a project file, and the backend host may
+       not have [uv] at all. Bootstrap a local .venv from requirements.txt on
+       first schema fetch, then use the venv python. Runs with cwd = sidecar_dir
+       (see fetch_schema), so the relative requirements.txt resolves correctly. *)
+    [ "sh"; "-c";
+      "{ test -x .venv/bin/python || { python3 -m venv .venv && .venv/bin/pip install -q -r requirements.txt; }; } && .venv/bin/python -m src.schema_dump" ]
 ;;
 
 let fetch_schema ?base_path id =

--- a/sidecars/slack-bot/run.sh
+++ b/sidecars/slack-bot/run.sh
@@ -32,18 +32,29 @@ LOG_DIR="$BASE_PATH/.masc/logs"
 LOG_FILE="$LOG_DIR/slack-sidecar-$(date +%Y%m%d).log"
 STATUS_FILE="$BASE_PATH/.gate/runtime/slack/status.json"
 
+ensure_venv() {
+  # Bootstrap a local .venv from requirements.txt on first run so the bot (and
+  # the backend schema fetch) work on a host with only python3 + pip (no uv).
+  if [[ ! -x .venv/bin/python ]]; then
+    python3 -m venv .venv
+    .venv/bin/pip install -q -r requirements.txt
+  fi
+}
+
 cmd="${1:-start}"
 case "$cmd" in
   start)
     cd "$(script_dir)"
-    if [[ ! -f .env ]]; then
-      echo "ERROR: .env missing. Copy .env.example and fill SLACK_BOT_TOKEN + SLACK_APP_TOKEN." >&2
+    CONFIG_TOML="$BASE_PATH/.gate/runtime/slack/config.toml"
+    if [[ ! -f .env && ! -f "$CONFIG_TOML" ]]; then
+      echo "ERROR: Slack config missing. Save tokens in the dashboard, or copy .env.example and fill SLACK_BOT_TOKEN + SLACK_APP_TOKEN." >&2
       exit 1
     fi
+    ensure_venv
     mkdir -p "$LOG_DIR"
     printf 'Starting Slack sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
       "$BASE_PATH" "$LOG_FILE" >&2
-    python -m src 2>&1 | tee -a "$LOG_FILE"
+    .venv/bin/python -m src 2>&1 | tee -a "$LOG_FILE"
     ;;
   tail)
     if [[ ! -f "$LOG_FILE" ]]; then
@@ -68,7 +79,8 @@ case "$cmd" in
   doctor)
     cd "$(script_dir)"
     shift || true
-    python -m src doctor "$@"
+    ensure_venv
+    .venv/bin/python -m src doctor "$@"
     ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.


### PR DESCRIPTION
## Problem
Slack connector Start and binding (Save) were broken in the dashboard.

## Root cause
slack-bot is pip-style (requirements.txt, no pyproject.toml, no .venv):
- backend schema fetch (`python_argv_for`) fell back to `uv run`, which fails without a project file or without uv -> the config form never rendered (binding broken), so no config was written;
- `run.sh` used bare `python`, so Start failed on hosts without the deps pre-installed.

## Fix
- `lib/server/server_routes_sidecar_config_schema.ml` `python_argv_for`: for pip-style sidecars (no pyproject.toml), bootstrap a local `.venv` from requirements.txt (`python3 -m venv` + `pip install`) on first schema fetch, then use `.venv/bin/python`; uv-style sidecars (pyproject.toml) keep `uv run`.
- `sidecars/slack-bot/run.sh` start/doctor: `ensure_venv` (`python3 -m venv` + `pip install -r requirements.txt`) then run `.venv/bin/python`.

## Verification
Review-only: `dune build` could not be run in the keeper sandbox (dune requires approval); CI validates.

Refs task-2269.