### PR TITLE
perf(ci): unpin DUNE_JOBS on compile-only Build step (~42min→parallel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,10 +672,15 @@ jobs:
         # Test execution steps below are also required: any failing test suite
         # now fails the Build and Test job and blocks merge via the CI Gate.
         # See: PR #11721 followup, memory feedback_admin_merge_can_bypass_build_ci.md.
-        env:
-          # Reduce parallelism to minimize Eio fiber scheduling flakes in tests.
-          # See: https://github.com/jeong-sik/masc/issues/2957
-          DUNE_JOBS: 1
+        #
+        # DUNE_JOBS is intentionally NOT pinned on this step: @default @check
+        # only COMPILES (it never runs tests), so it cannot hit the Eio fiber
+        # scheduling flakes that motivate DUNE_JOBS=1 on the test-running steps
+        # below (issue #2957). Serial compile measured ~42min at DUNE_JOBS=1
+        # (this step, run 29081003730); dune's default (per-core) parallelism
+        # removes that serialization. Compile output is deterministic
+        # regardless of job count, so parallel compile carries no correctness
+        # risk. Test-execution steps keep their own DUNE_JOBS=1.
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## 무엇을 (commit 0b4e638368)

`Build and Test` job의 `Build` 스텝에서 `DUNE_JOBS: 1` 고정을 제거했어요. 테스트 실행 스텝들의 `DUNE_JOBS: 1`은 그대로 둬요.

## 왜

`Build` 스텝은 `dune build @default @check`로 **컴파일만** 해요(모든 lib/exe/test를 타입체크·빌드하되 실행하진 않아요). 그런데 고정 근거로 달린 주석의 #2957은 **테스트 실행 중** Eio fiber 스케줄링 flake 문제예요. 컴파일에는 돌아가는 fiber가 없으니, 이 스텝의 `DUNE_JOBS: 1`은 flake 방어 효과가 0이고 **컴파일만 직렬화**해서 느리게 만들었어요.

## 실측 (근거)

| 항목 | 대상 | 소요 |
|------|------|------|
| Build 스텝 (`@default @check`, DUNE_JOBS=1) | run 29081003730 step 8 | **41.6분** (09:10:40→09:52:16) |
| OCaml 5.5 Build Canary (`@install`) | 같은 시기 | ~7분 |
| Run tests (quick suite) 이하 전체 테스트 | run 29081003730 step 15~21 | ~9분 |

즉 "빌드 1시간"의 대부분은 테스트가 아니라 **직렬 컴파일 41.6분**이었어요. dune 기본 병렬(코어 수)로 풀면 이 직렬화가 사라져요. 컴파일 산출물(.cmi/.cmx)은 job 수와 무관하게 결정론적이라 correctness 위험은 없어요.

## 안전성

- 커버리지/게이팅 **제거 없음** — 같은 `@default @check` 그대로 컴파일해요.
- 테스트 flake 방어(#2957)는 테스트 실행 스텝들이 각자 `DUNE_JOBS: 1`을 갖고 있어 **변화 없음**.
- required context는 `CI Gate` 하나뿐이고, 이 변경은 그 gate의 통과 조건(컴파일+테스트 성공)을 바꾸지 않아요.

## 트레이드오프 / 리스크

- 병렬 컴파일은 동시 컴파일러 프로세스가 늘어 **peak RAM이 올라가요**. ubuntu-latest(4 vCPU/16GB)에서 OCaml 모듈 컴파일은 모듈당 RAM이 크지 않아 여유가 있을 것으로 보지만, **측정값이 아니라 추정**이에요. 이 draft의 CI run이 실제 소요와 OOM 여부를 검증하는 하네스예요 — green이면 병렬 안전이 증명돼요.
- follow-up 후보: `OCaml 5.5 Build Canary`도 같은 이유로 `DUNE_JOBS: 1`(compile-only `@install`)인데, ~7분이라 이번 범위에선 제외했어요.

## 동결 상태

enforce_admins 우회 사고 대응 **머지 동결 중**이라 draft로 유지하고 병합하지 않아요. CI 검증(소요 단축 + green)만 확인해요.

RFC-WAIVED: ci.yml 워크플로 성능 변경으로 credential/identity/operator/keeper-sandbox/hooks/workflow-doc subsystem 미해당. 게이팅·커버리지 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
