### PR TITLE
fix(ci): dune cache hardlink mode — copy mode filled runner disk (ENOSPC)

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -55,9 +55,15 @@ runs:
       if: runner.os == 'Linux' && inputs.dune-cache == 'true'
       shell: bash
       run: |
+        # hardlink, NOT copy: copy mode duplicates every artifact into
+        # ~/.cache/dune, roughly doubling disk while the cache populates.
+        # The first cache-cold Build and Test after #23996 died at link time
+        # with "/usr/bin/ld: final link failed: No space left on device"
+        # (run 29091172837). ~/.cache/dune and the workspace share one
+        # filesystem on GitHub runners, so hardlinks add no meaningful space.
         {
           echo "DUNE_CACHE=enabled"
-          echo "DUNE_CACHE_STORAGE_MODE=copy"
+          echo "DUNE_CACHE_STORAGE_MODE=hardlink"
         } >> "$GITHUB_ENV"
 
     - name: Bootstrap local opam switch (Linux)


### PR DESCRIPTION
## 증상 (P0 — 전 PR의 Build and Test 차단)

#23996 이후 첫 캐시-콜드 Build and Test(run 29091172837, #23989 branch)가 링크 단계에서 전멸:

```
/usr/bin/ld: final link failed: No space left on device
```

수십 개 테스트 실행파일 링크가 연쇄 실패 (12:46~12:49Z).

## 근본원인

#23996(내 PR)이 켠 dune cache가 `DUNE_CACHE_STORAGE_MODE=copy`였소. copy 모드는 빌드가 `_build`를 쓰는 동안 **모든 아티팩트를 `~/.cache/dune`에 복제** — 캐시 적재 run에서 디스크 사용량이 사실상 2배요. masc는 `-linkall` 테스트 실행파일 수백 개를 만드니 러너 가용 디스크를 초과하오. (같은 run은 DUNE_JOBS=1이라 병렬성과 무관 — 순수 공간 문제.)

## 수리

`hardlink` 모드로 전환. GitHub 러너에서 `~/.cache/dune`과 workspace는 같은 파일시스템이라 hardlink는 아티팩트를 물리적으로 1회만 저장 — 적재 중 공간 증가가 사실상 0이오.

## 검증

- 이 PR 자체의 Build and Test run이 하네스요: 캐시 적재를 hardlink로 수행하면서 ENOSPC 없이 완주하면 증명이오.
- YAML 파스 확인 완료.

## 후속 (이 diff에 없음, 정직 고지)

- 캐시 디렉토리는 "복원분 ∪ 신규분"이라 run을 거듭하며 단조 증가하오 — 업로드 크기가 커지면 빌드 후 `dune cache trim --size <bound>` 스텝 추가가 다음 수리요.
- #24002(per-job key 격리)와 독립·양립 — 둘 다 필요하오.

## 우선순위 주장

이게 landing하기 전까지 **모든 PR의 캐시-콜드 Build and Test가 ENOSPC 룰렛**이오. #23989(사용자 관리, 잠재-red 수리)의 rerun도 이것 이후여야 의미가 있소. CI-인프라 트랙 최우선을 요청하오.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
