### PR TITLE
fix(ci): make Dune cache main-owned and prune closed-PR caches

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Whether to enable dune cache
     required: false
     default: "true"
+  dune-cache-save:
+    description: Whether this job is the authoritative main-branch Dune cache writer
+    required: false
+    default: "false"
   cache-prefix:
     description: Prefix for the dune cache key
     required: false
@@ -39,21 +43,29 @@ runs:
     # The opam cache above only restores the toolchain/switch; every dune
     # build of masc itself still started cold (~50 min Build and Test).
     # Cache dune's content-addressed artifact store so an unchanged module
-    # graph rebuilds incrementally. Keyed by job and run id so each job publishes
-    # a new immutable cache with its newest artifacts (a stable key would freeze
-    # the first upload forever). [github.job] is part of both the primary key
-    # and restore namespace: Health/Lint/Build run in parallel and produce
-    # different artifact subsets, while GitHub cache entries are immutable
-    # after the first successful save. A shared run-id key would let the fastest, usually
-    # smallest job permanently win that run's save race.
-    - name: Cache dune build artifacts (Linux)
-      if: runner.os == 'Linux' && inputs.dune-cache == 'true'
+    # graph rebuilds incrementally. Pull requests and non-authoritative jobs are
+    # restore-only: PR caches are ref-scoped and cannot warm other PRs, while
+    # partial Health/Lint artifacts must not race the full Build cache. Exactly
+    # one authoritative job per cache-prefix opts into the main-branch writer.
+    # The run id gives each main publication an immutable key; restore picks the
+    # newest cache in that trusted lineage.
+    - name: Restore dune build artifacts (Linux)
+      if: runner.os == 'Linux' && inputs.dune-cache == 'true' && (inputs.dune-cache-save != 'true' || github.event_name != 'push' || github.ref != 'refs/heads/main')
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.cache/dune
+        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
+        restore-keys: |
+          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
+
+    - name: Cache dune build artifacts (Linux authoritative main writer)
+      if: runner.os == 'Linux' && inputs.dune-cache == 'true' && inputs.dune-cache-save == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: actions/cache@v5
       with:
         path: ~/.cache/dune
-        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.job }}-${{ github.run_id }}
+        key: dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.run_id }}
         restore-keys: |
-          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ github.job }}-
+          dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
 
     # Storage mode is hardlink, not copy. `copy` keeps every artifact twice:
     # once in _build and once in ~/.cache/dune. On ubuntu-latest that
@@ -91,9 +103,6 @@ runs:
         set -euo pipefail
 
         case "${OCAML_COMPILER_INPUT}" in
-          5.5|5.5.x)
-            compiler_pkg="ocaml-base-compiler.5.5.0"
-            ;;
           5.5|5.5.x)
             compiler_pkg="ocaml-base-compiler.5.5.0"
             ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,6 +633,8 @@ jobs:
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml-toolchain
+        with:
+          dune-cache-save: "true"
 
       - name: Pin external OCaml dependencies
         uses: ./.github/actions/pin-ocaml-deps
@@ -970,6 +972,7 @@ jobs:
         with:
           ocaml-compiler: '5.5.0'
           cache-prefix: ocaml55-canary
+          dune-cache-save: "true"
 
       - name: Pin external OCaml dependencies
         uses: ./.github/actions/pin-ocaml-deps

--- a/.github/workflows/prune-pr-caches.yml
+++ b/.github/workflows/prune-pr-caches.yml
@@ -1,0 +1,50 @@
+name: Prune PR caches
+
+# Actions caches are ref-scoped. Entries stored under refs/pull/N/merge become
+# unreachable the moment PR N closes, but they keep occupying the repository's
+# 10 GB cache quota until GitHub evicts them. Eviction is repo-wide and LRU, so
+# those dead bytes push out the refs/heads/main caches that every PR restores
+# from — and a missed main cache costs a ~40 min cold `dune build` in the
+# `Build and Test` job. Reclaiming the quota is therefore a CI *time* saving.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: prune-pr-caches-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune unreachable caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Fork pull requests receive a read-only GITHUB_TOKEN, so cache deletion
+    # cannot succeed there. Skip rather than fail.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Prune caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Empty on workflow_dispatch, which selects the full sweep.
+          CLOSED_PR: ${{ github.event.pull_request.number }}
+        run: bash scripts/ci/prune-pr-caches.sh
+
+      - name: Report remaining quota
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${GH_REPO}/actions/cache/usage" \
+            -q '"active caches: \(.active_caches_count), size: \(.active_caches_size_in_bytes / 1048576 | floor) MiB"'

--- a/.github/workflows/prune-pr-caches.yml
+++ b/.github/workflows/prune-pr-caches.yml
@@ -32,6 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Never execute the closing PR's copy of a script with an
+          # actions:write token. Cleanup code is owned by the default branch.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Prune caches
         env:

--- a/scripts/ci/prune-pr-caches.sh
+++ b/scripts/ci/prune-pr-caches.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# prune-pr-caches.sh — delete GitHub Actions caches that no run can ever
+# restore again.
+#
+# Actions caches are ref-scoped: an entry stored under refs/pull/N/merge is
+# visible only to runs of pull request N. Once that PR closes, the entry is
+# unreachable, yet it keeps consuming the repository's 10 GB cache quota until
+# GitHub evicts it (LRU) or it ages out after 7 days. Because eviction is
+# repo-wide, those dead bytes push out the caches that PRs actually restore
+# from (the ones stored on refs/heads/main).
+#
+# Modes:
+#   CLOSED_PR=<n>   delete every cache under refs/pull/<n>/merge
+#   (unset)         sweep: delete caches for every pull-request ref whose PR
+#                   is no longer open
+#
+# Reopening a pruned PR costs one cold rebuild; nothing is lost, because cache
+# entries are content-addressed build artifacts.
+#
+# Requires: gh with a token holding `actions: write`.
+
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO must be set (owner/repo)}"
+
+CLOSED_PR="${CLOSED_PR:-}"
+
+# Cache metadata for the repository, one "id<TAB>ref<TAB>size" row per entry.
+list_caches() {
+  local page=1
+  while :; do
+    local rows
+    rows="$(gh api "repos/${GH_REPO}/actions/caches?per_page=100&page=${page}" \
+      -q '.actions_caches[] | "\(.id)\t\(.ref)\t\(.size_in_bytes)"')"
+    [ -z "${rows}" ] && break
+    printf '%s\n' "${rows}"
+    page=$((page + 1))
+  done
+}
+
+delete_cache() {
+  gh api --method DELETE "repos/${GH_REPO}/actions/caches/$1" --silent
+}
+
+pr_number_of_ref() {
+  # refs/pull/1234/merge -> 1234 ; anything else -> empty
+  printf '%s' "$1" | sed -n 's|^refs/pull/\([0-9][0-9]*\)/merge$|\1|p'
+}
+
+pr_is_open() {
+  [ "$(gh api "repos/${GH_REPO}/pulls/$1" -q '.state')" = "open" ]
+}
+
+freed=0
+deleted=0
+
+if [ -n "${CLOSED_PR}" ]; then
+  target_ref="refs/pull/${CLOSED_PR}/merge"
+  echo "pruning caches for ${target_ref}"
+  while IFS=$'\t' read -r id ref size; do
+    [ "${ref}" = "${target_ref}" ] || continue
+    delete_cache "${id}"
+    freed=$((freed + size))
+    deleted=$((deleted + 1))
+  done < <(list_caches)
+else
+  echo "sweeping caches whose pull request is no longer open"
+  # Memoise PR state so a PR with several caches costs one API call.
+  open_prs=""
+  closed_prs=""
+  while IFS=$'\t' read -r id ref size; do
+    pr="$(pr_number_of_ref "${ref}")"
+    [ -n "${pr}" ] || continue
+    case " ${open_prs} " in *" ${pr} "*) continue ;; esac
+    case " ${closed_prs} " in
+      *" ${pr} "*) ;;
+      *)
+        if pr_is_open "${pr}"; then
+          open_prs="${open_prs} ${pr}"
+          continue
+        fi
+        closed_prs="${closed_prs} ${pr}"
+        ;;
+    esac
+    delete_cache "${id}"
+    freed=$((freed + size))
+    deleted=$((deleted + 1))
+  done < <(list_caches)
+fi
+
+echo "deleted ${deleted} cache entries, reclaimed $((freed / 1048576)) MiB"

--- a/scripts/ci/prune-pr-caches.sh
+++ b/scripts/ci/prune-pr-caches.sh
@@ -31,8 +31,11 @@ list_caches() {
   local page=1
   while :; do
     local rows
-    rows="$(gh api "repos/${GH_REPO}/actions/caches?per_page=100&page=${page}" \
-      -q '.actions_caches[] | "\(.id)\t\(.ref)\t\(.size_in_bytes)"')"
+    if ! rows="$(gh api "repos/${GH_REPO}/actions/caches?per_page=100&page=${page}" \
+      -q '.actions_caches[] | "\(.id)\t\(.ref)\t\(.size_in_bytes)"')"; then
+      echo "failed to list Actions caches at page ${page}" >&2
+      return 1
+    fi
     [ -z "${rows}" ] && break
     printf '%s\n' "${rows}"
     page=$((page + 1))
@@ -48,12 +51,26 @@ pr_number_of_ref() {
   printf '%s' "$1" | sed -n 's|^refs/pull/\([0-9][0-9]*\)/merge$|\1|p'
 }
 
-pr_is_open() {
-  [ "$(gh api "repos/${GH_REPO}/pulls/$1" -q '.state')" = "open" ]
+pr_state() {
+  local state
+  if ! state="$(gh api "repos/${GH_REPO}/pulls/$1" -q '.state')"; then
+    echo "failed to read pull request $1 state" >&2
+    return 1
+  fi
+  case "${state}" in
+    open|closed) printf '%s\n' "${state}" ;;
+    *)
+      echo "unexpected pull request $1 state: ${state}" >&2
+      return 1
+      ;;
+  esac
 }
 
 freed=0
 deleted=0
+if ! cache_rows="$(list_caches)"; then
+  exit 1
+fi
 
 if [ -n "${CLOSED_PR}" ]; then
   target_ref="refs/pull/${CLOSED_PR}/merge"
@@ -63,7 +80,7 @@ if [ -n "${CLOSED_PR}" ]; then
     delete_cache "${id}"
     freed=$((freed + size))
     deleted=$((deleted + 1))
-  done < <(list_caches)
+  done <<< "${cache_rows}"
 else
   echo "sweeping caches whose pull request is no longer open"
   # Memoise PR state so a PR with several caches costs one API call.
@@ -76,7 +93,10 @@ else
     case " ${closed_prs} " in
       *" ${pr} "*) ;;
       *)
-        if pr_is_open "${pr}"; then
+        if ! state="$(pr_state "${pr}")"; then
+          exit 1
+        fi
+        if [ "${state}" = "open" ]; then
           open_prs="${open_prs} ${pr}"
           continue
         fi
@@ -86,7 +106,7 @@ else
     delete_cache "${id}"
     freed=$((freed + size))
     deleted=$((deleted + 1))
-  done < <(list_caches)
+  done <<< "${cache_rows}"
 fi
 
 echo "deleted ${deleted} cache entries, reclaimed $((freed / 1048576)) MiB"


### PR DESCRIPTION
## 문제

merged #24002는 Dune cache key에 `${{ github.job }}`을 넣어 job별 저장 경쟁을 막으려 했지만 `github` context에는 `job` 이름 property가 없습니다. 실제 main cache key도 `dune-linux-...-<run_id>`로 생성되어 namespace가 사라졌습니다. 더 근본적으로 `actions/cache`를 모든 PR/Health/Lint/Build에서 사용해 ref-scoped PR cache와 partial cache를 계속 저장했습니다.

2026-07-11 KST 실측에서 cache list는 짧은 시간에 main-ref 4개에서 10개로 증가했고 10GB quota를 넘었습니다. 닫힌 PR cache 정리만으로는 새 쓰기 폭증을 막지 못합니다.

## 수정

- composite action의 기본을 `actions/cache/restore` 전용으로 바꿨습니다.
- `dune-cache-save`를 명시한 authoritative job도 **main push에서만** `actions/cache` writer가 됩니다.
- 기본 prefix는 full `Build and Test`, canary prefix는 `OCaml 5.5 Build Canary`만 writer입니다. Health/Lint/PR/기타 workflow는 최신 main lineage를 restore만 합니다.
- 존재하지 않는 `${{ github.job }}` key 계약과 중복 compiler case arm을 제거했습니다.
- PR close 시 해당 merge-ref cache를 삭제하고, manual sweep은 닫힌 PR ref만 삭제합니다.
- 삭제 전에 cache 목록 전체를 snapshot해 pagination 중 삭제로 row가 건너뛰지 않게 했습니다.
- cache-list/PR-state API 오류와 unknown state는 삭제로 해석하지 않고 즉시 fail-closed합니다.
- `actions:write` workflow는 closing PR 코드를 실행하지 않고 default branch의 script를 checkout하며 git credential persistence를 끕니다.

## 검증

- exact head: `fabe552fa6dc5efec34c07e6341a5b535f7d030f`
- `actionlint -ignore SC2129` 통과. 제외한 SC2129 세 건은 변경 전 `ci.yml`의 기존 style 경고입니다.
- YAML parse, `bash -n`, shellcheck, `git diff --check` 통과
- stale-base guard self-test 4/4 통과
- network-free fixture: sweep/closed mode가 대상 PR cache만 삭제
- network-free fixture: cache-list 실패와 PR-state 실패 모두 0건 삭제 후 nonzero 종료
- 로컬 Dune 미실행; workflow/build authority는 PR CI

## 공식 계약 근거

- [GitHub contexts reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts): `job` context는 status/services/container이고 `github.job` 이름 property를 제공하지 않습니다.
- [GitHub dependency cache reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching): cache는 immutable이며 PR merge-ref scope이고, trusted default-branch workflow가 cache를 갱신하며 low-trust/PR 경로는 restore-only를 사용할 수 있습니다.
- [GitHub managing caches](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manage-caches): closed PR의 `refs/pull/<n>/merge` cache 삭제가 공식 운영 패턴입니다.

[근거] 위 공식 문서 + `gh cache list --repo jeong-sik/masc --limit 100` + `gh api repos/jeong-sik/masc/actions/cache/usage`, 확인 2026-07-11 KST, 신뢰도 High.

## 병합 조건

- Draft / `p1` / `status:do-not-merge` 유지
- exact-head workflow가 restore-only/save 조건을 실제 log와 key로 증명한 뒤 병합 가능