### PR TITLE
fix(dashboard): persist Work-board task claim via masc_transition (#46)

### DIFF
--- a/dashboard/src/api/actions.test.ts
+++ b/dashboard/src/api/actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// claimTask must reach the server. The pre-existing Work-board bug was that a
+// claim only touched local React state and vanished on refresh (#46); this
+// test pins the contract that a claim is routed through the persisted
+// masc_transition FSM tool.
+vi.mock('./mcp', () => ({ callMcpTool: vi.fn(() => Promise.resolve('{}')) }))
+vi.mock('./core', () => ({ get: vi.fn(), post: vi.fn(() => Promise.resolve({ ok: true })) }))
+
+import { callMcpTool } from './mcp'
+import { claimTask, deleteTask } from './actions'
+
+describe('claimTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes an operator claim through masc_transition (todo -> claimed)', async () => {
+    await claimTask('task-123')
+    expect(callMcpTool).toHaveBeenCalledTimes(1)
+    expect(callMcpTool).toHaveBeenCalledWith('masc_transition', {
+      task_id: 'task-123',
+      action: 'claim',
+    })
+  })
+
+  it('propagates a transition failure so the caller can roll back the optimistic flag', async () => {
+    vi.mocked(callMcpTool).mockRejectedValueOnce(new Error('todo -> claimed rejected'))
+    await expect(claimTask('task-err')).rejects.toThrow('todo -> claimed rejected')
+  })
+})
+
+describe('deleteTask (unchanged path, regression guard)', () => {
+  it('posts to the dashboard delete route', async () => {
+    const ok = await deleteTask('task-9')
+    expect(ok).toBe(true)
+  })
+})

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -49,6 +49,16 @@ export async function deleteTask(taskId: string): Promise<boolean> {
   return resp.ok
 }
 
+// Route an operator claim through the shared FSM transition tool so it is
+// persisted server-side (todo -> claimed, assignee = the dashboard actor).
+// Before this, the Work board's claim button only mutated local React state,
+// so a claim vanished on refresh. masc_transition emits a task_resource
+// notification, so the dashboard's task signal refreshes over SSE with the
+// real assignee — the caller does not need a manual refetch.
+export async function claimTask(taskId: string): Promise<void> {
+  await callMcpTool('masc_transition', { task_id: taskId, action: 'claim' })
+}
+
 export interface PurgeAgentResponse {
   ok: boolean
   target_kind: 'agent' | 'keeper' | string

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -21,6 +21,9 @@ import { KeeperBadge } from './keeper-badge'
 import { openTaskDetail } from './goals/task-detail-state'
 import { GoalCreateForm } from './goals/goal-create-form'
 import { showGoalCreate, GOAL_PRIORITY_MAX } from './goals/goal-create-state'
+import { claimTask as claimTaskAction } from '../api/actions'
+import { showToast } from './common/toast'
+import { errorToString } from '../lib/format-string'
 import type { Goal, GoalTreeNode, GoalTreeTask, Task, Keeper } from '../types'
 
 type WorkSection = 'work' | 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
@@ -652,7 +655,7 @@ function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void 
                 class="wk-task-claim"
                 data-testid="job-claim"
                 onClick=${(e: Event) => { e.stopPropagation(); onClaim(task.id) }}
-                title="keeper_task_claim — 미배정 task claim"
+                title="미배정 task를 claim (masc_transition, 나에게 배정)"
               >
                 ＋ claim
               </button>
@@ -1380,13 +1383,27 @@ function WorkSurfaceV2() {
     })
   }, [displayGoals, allTasks])
 
-  const claimTask = (taskId: string) => {
+  const claimTask = useCallback((taskId: string) => {
+    // Optimistically flag the task as claimed so the row updates instantly,
+    // then persist through masc_transition. On failure, roll the flag back so
+    // the board does not lie about an unpersisted claim (the pre-existing bug:
+    // the claim only lived in local state and vanished on refresh). On success
+    // the server emits a task_resource notification and the tasks signal
+    // refreshes over SSE with the real assignee, superseding this flag.
     setClaimed(prev => {
       const next = new Set(prev)
       next.add(taskId)
       return next
     })
-  }
+    void claimTaskAction(taskId).catch((err: unknown) => {
+      setClaimed(prev => {
+        const next = new Set(prev)
+        next.delete(taskId)
+        return next
+      })
+      showToast(`claim 실패: ${errorToString(err)}`, 'error')
+    })
+  }, [])
 
   const claimedTasks = useMemo(() => {
     if (claimed.size === 0) return allTasks


### PR DESCRIPTION
## 요약

`#46`(Goal/Task 보드에서 claim하면 새로고침에 되돌아감)의 근본 수정입니다.

## 근본원인 (라이브 진단)

`work.ts`의 `Work` 컴포넌트(대시보드 Goal/Task 탭, `dashboard-shell.ts:74`에서 lazy-load되는 **실제 라이브 화면**)는 `work.jsx`/`data.jsx`에서 이식된 **읽기 전용 프로토타입**입니다 — 파일 전체에 `fetch`/`post`/`api` 호출이 **0건**이고 10개의 "prototype" 주석이 이를 자백합니다.

`claimTask`(work.ts:1383)는 로컬 React `Set`에 task id만 추가하고, 렌더 시점에 가짜 `status:'claimed', assignee:'operator'`를 합성했습니다. 서버로 아무것도 보내지 않아 새로고침 시 소실됩니다. 이건 **Goal/Task 보드가 전반적으로 안 되는 공통 뿌리**입니다(#44/#45/#47도 같은 read-only 프로토타입).

## 수정

기존 `masc_transition` FSM tool(`todo → claimed`, assignee = dashboard actor)에 배선 — `sendBroadcast`가 이미 쓰는 `callMcpTool` 경로와 동일. **서버 변경 0**.

- `masc_transition`은 성공 시 `task_resource` notification을 emit → tasks signal이 SSE로 갱신되어 실제 assignee 반영 (수동 refetch 불필요)
- 낙관적 로컬 flag는 즉시 피드백용으로 유지하되 **실패 시 롤백 + toast** — 보드가 영속되지 않은 claim으로 거짓말하지 않음
- 버튼 title이 `keeper_task_claim`(배선된 적 없는 keeper-runtime tool)을 잘못 지목한 것도 정정

## 변경 파일

- `dashboard/src/api/actions.ts`: `claimTask()` 추가 (masc_transition 배선)
- `dashboard/src/components/work.ts`: claimTask 콜백을 낙관적 + 서버 영속 + 롤백으로
- `dashboard/src/api/actions.test.ts`: claim이 서버(masc_transition)에 도달하는 계약 회귀 테스트

## 완료 기준 (#46)

- [x] claim이 `masc_transition`으로 서버 영속 (`todo → claimed`)
- [x] 실패 시 낙관적 flag 롤백 + 사용자 알림
- [x] 새로고침 시 서버가 claimed 반환 → UI 유지
- [x] actions.test.ts 3/3 통과, tsc 에러 0

## 후속

나머지 Work 보드 액션(start/done/release)과 #44/#45/#47은 동일 배선이 필요합니다. 사용자가 보고한 claim 하나로 범위를 한정했습니다.

## 검증

로컬: `vitest run src/api/actions.test.ts` 3/3 pass, `tsc --noEmit` 에러 0. (dune 빌드는 CI에서 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
