### PR TITLE
test(ci): stop ci-run-tests script test from inheriting dune env vars

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -51,19 +51,24 @@ runs:
         restore-keys: |
           dune-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
 
+    # Storage mode is hardlink, not copy. `copy` keeps every artifact twice:
+    # once in _build and once in ~/.cache/dune. On ubuntu-latest that
+    # duplication exhausted the runner disk and the Build and Test job of run
+    # 29090394322 (main, the #23996 merge) died while linking a test
+    # executable, with zero free space reported by the runner. Both paths live
+    # on `/`, so dune can hardlink cache entries into _build and keep a single
+    # copy on disk.
+    #
+    # This explanation stays a YAML comment on purpose. GitHub echoes the whole
+    # `run:` script into the job log, so a shell comment quoting the linker and
+    # disk-space messages would plant those exact strings in every job log —
+    # scripts/ci-run-tests.sh matches them in disk_full_detected().
     - name: Enable dune cache (Linux)
       if: runner.os == 'Linux' && inputs.dune-cache == 'true'
       shell: bash
       run: |
         {
           echo "DUNE_CACHE=enabled"
-          # hardlink, not copy: `copy` stores every artifact twice (once in
-          # _build, once in ~/.cache/dune). On ubuntu-latest that duplication
-          # exhausted the runner disk — the Build and Test job of run
-          # 29090394322 (main, #23996) died with `collect2: ld returned 1` and
-          # `##[warning]You are running out of disk space. Free space left: 0 MB`
-          # while linking a test executable. Both paths live on `/`, so dune can
-          # hardlink cache entries into _build and keep a single copy on disk.
           echo "DUNE_CACHE_STORAGE_MODE=hardlink"
         } >> "$GITHUB_ENV"
 

--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -57,7 +57,14 @@ runs:
       run: |
         {
           echo "DUNE_CACHE=enabled"
-          echo "DUNE_CACHE_STORAGE_MODE=copy"
+          # hardlink, not copy: `copy` stores every artifact twice (once in
+          # _build, once in ~/.cache/dune). On ubuntu-latest that duplication
+          # exhausted the runner disk — the Build and Test job of run
+          # 29090394322 (main, #23996) died with `collect2: ld returned 1` and
+          # `##[warning]You are running out of disk space. Free space left: 0 MB`
+          # while linking a test executable. Both paths live on `/`, so dune can
+          # hardlink cache entries into _build and keep a single copy on disk.
+          echo "DUNE_CACHE_STORAGE_MODE=hardlink"
         } >> "$GITHUB_ENV"
 
     - name: Bootstrap local opam switch (Linux)

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -47,6 +47,15 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
+(* ci-run-tests.sh sets these itself (isolated build dir, cache disable, RPC
+   unset on retry) and the assertions below record their exact values. Letting
+   them leak in from the ambient environment makes the test observe whatever
+   the runner exports rather than what the script does: the Build and Test job
+   exports DUNE_CACHE=enabled, which turns the first-attempt record from
+   "test|||<cwd>" into "test||enabled|<cwd>". Explicit overrides are applied
+   after this removal, so a test that wants a value can still set one. *)
+let dune_vars_owned_by_script = [ "DUNE_BUILD_DIR"; "DUNE_CACHE"; "DUNE_RPC" ]
+
 let env_array overrides =
   let table = Hashtbl.create 64 in
   Unix.environment ()
@@ -59,6 +68,7 @@ let env_array overrides =
                String.sub entry (idx + 1) (String.length entry - idx - 1)
              in
              Hashtbl.replace table key value);
+  List.iter (Hashtbl.remove table) dune_vars_owned_by_script;
   List.iter (fun (key, value) -> Hashtbl.replace table key value) overrides;
   Hashtbl.fold
     (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)


### PR DESCRIPTION
## 무엇을 / 왜

`test_ci_run_tests_script`는 `ci-run-tests.sh`가 각 dune 호출에 넘기는 `DUNE_BUILD_DIR`/`DUNE_CACHE` 값을 문자열로 정확히 단언해요. 그런데 `env_array`가 자식 환경을 `Unix.environment ()`에서 통째로 시드해서, **스크립트가 스스로 소유하는 변수까지 주변 job의 export를 그대로 상속**했어요.

#23996이 OCaml 툴체인 액션에서 `DUNE_CACHE=enabled`를 export하기 시작하면서 첫 시도 레코드가 깨졌어요:

```
File "test/test_ci_run_tests_script.ml", line 536
FAIL first attempt uses default build dir
Expected: `"test|||/tmp/build_56d405_dune/ci-run-tests-interfacefe2af0"'
Received: `"test||enabled|/tmp/build_56d405_dune/ci-run-tests-interface..."'
```

세 번째 필드가 `DUNE_CACHE`예요.

## 왜 지금까지 안 보였나

#23996 머지 run(29090394322)의 `Build and Test`는 **링크 중 디스크가 0 MB가 되어 죽었고 quick suite에 도달조차 못 했어요.** 그래서 이 실패는 잠복 상태였어요. 부모 커밋(#24009, `DUNE_CACHE_STORAGE_MODE`를 `copy`→`hardlink`)이 빌드를 살려내자 드러났어요.

즉 #23996은 결함 **두 개**를 들여왔고 둘 다 CI가 죽어서 가려졌어요.

## 수정

상속 환경에서 `DUNE_BUILD_DIR`, `DUNE_CACHE`, `DUNE_RPC` 세 개를 제거해요. 이 셋은 스크립트가 직접 세팅하고 테스트가 단언하는 값이에요. 명시적 override는 제거 **이후**에 적용되니 값을 주고 싶은 테스트는 그대로 줄 수 있어요.

기대값을 `enabled`로 바꾸는 방식은 택하지 않았어요. 그러면 **테스트가 러너 환경에 계속 종속**돼서 다음 env 변경 때 또 깨져요. 비-hermetic이라는 근본을 고치는 게 맞아요.

## 검증

- `ocamlformat --check` 통과.
- 로컬 dune은 안 돌렸어요(프로젝트 규칙: 빌드는 CI에서 검증).
- 이 PR은 **#24009 위에 스택**했어요. main 기준으로는 `Build and Test`가 링크에서 죽어 quick suite까지 못 가므로 **수정을 검증할 수 없어요.** base가 #24009일 때만 `script 3`가 실제로 실행돼요.

## 병합 순서

`#24009` (P0 디스크) → **이 PR** (잠복 테스트 실패) → 그 다음 `#24002`/`#24011`/`#24006`.

RFC-WAIVED: 테스트 hermeticity 수정. credential/identity/operator/keeper-sandbox/hooks/workflow-doc subsystem 미해당. 프로덕션 코드·게이팅 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
