### PR TITLE
fix: pass wake reason in turn interrupt test

### DIFF
--- a/test/test_keeper_turn_interrupt.ml
+++ b/test/test_keeper_turn_interrupt.ml
@@ -71,7 +71,10 @@ let test_interrupt_cancels_turn () =
   Masc_test_deps.init_eio_clock env;
   let clock = Eio.Stdenv.clock env in
   ignore (Keeper_registry.register ~base_path:base name (make_meta name));
-  Keeper_registry.mark_turn_started ~base_path:base name;
+  Keeper_registry.mark_turn_started
+    ~base_path:base
+    ~wake:Keeper_registry.Proactive_tick
+    name;
   Eio.Switch.run
   @@ fun sw ->
   let cancelled, set_cancelled = Eio.Promise.create () in


### PR DESCRIPTION
## Summary
- pass the required wake reason when starting the interrupt test turn
- use `Proactive_tick`, matching the test's synthetic turn source

## Verification
- `ocamlformat --enable-outside-detected-project --check test/test_keeper_turn_interrupt.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_turn_interrupt.exe`

Full Dune remains CI-owned.