### PR TITLE
fix(test): supply ~wake to mark_turn_started (main red, #23918/#23883)

### DIFF
--- a/test/test_keeper_turn_interrupt.ml
+++ b/test/test_keeper_turn_interrupt.ml
@@ -71,7 +71,7 @@ let test_interrupt_cancels_turn () =
   Masc_test_deps.init_eio_clock env;
   let clock = Eio.Stdenv.clock env in
   ignore (Keeper_registry.register ~base_path:base name (make_meta name));
-  Keeper_registry.mark_turn_started ~base_path:base name;
+  Keeper_registry.mark_turn_started ~base_path:base ~wake:Keeper_registry.Proactive_tick name;
   Eio.Switch.run
   @@ fun sw ->
   let cancelled, set_cancelled = Eio.Promise.create () in


### PR DESCRIPTION
## 배경
main born-red: `test/test_keeper_turn_interrupt.ml:74`에서 warning 5 (ignored-partial-application).

#23918이 `Keeper_registry.mark_turn_started`에 required `~wake:wake_reason`을 추가했으나, #23883의 테스트(`test_keeper_turn_interrupt`)가 갱신 누락. 두 PR 연계 충돌(post-merge).

## 변경
`~wake:Keeper_registry.Proactive_tick` 추가 — 다른 테스트 caller와 일관(`test_keeper_composite_live_turn_surface`, `test_keeper_waiting_inventory`, `test_mcp_server_eio_call_tool`가 이미 동일 값 사용).

## 검증
- **caller 전수**: 유일하게 `test_keeper_turn_interrupt:74`만 `~wake` 누락. 나머지 6개 caller는 이미 `~wake:Proactive_tick` (N-of-M 아님).
- 로컬 빌드는 stale `_build/.lock`(잔여 dune)으로 신뢰 불가 → **CI에서 최종 확인**.

## P0-P3
- **P0/P1/P2**: 없음 (post-merge 시그니처 갱신 누락 1줄 fix).
- **P3**: 없음.

Co-Authored-By: Claude <noreply@anthropic.com>
