### PR TITLE
feat: add OperatorBlocked task status (task-2185, phase 1: type definition)

### DIFF
--- a/lib/task/task_transition_state.ml
+++ b/lib/task/task_transition_state.ml
@@ -28,6 +28,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 type family =
   | Invalid_transition of
@@ -74,6 +76,8 @@ let transition_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve_verification"
   | Reject_verification -> "reject_verification"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 let family_to_string = function
   | Invalid_transition { from_status; action } ->
@@ -112,6 +116,8 @@ let all_transition_actions : transition_action list =
   ; Submit_for_verification
   ; Approve_verification
   ; Reject_verification
+  ; Block_for_operator
+  ; Unblock
   ]
 
 let all_families : family list =
@@ -186,6 +192,8 @@ let parse_transition_action_token (s : string) : transition_action option =
   | "submit_for_verification" -> Some Submit_for_verification
   | "approve_verification" | "approve" -> Some Approve_verification
   | "reject_verification" | "reject" -> Some Reject_verification
+  | "block_for_operator" -> Some Block_for_operator
+  | "unblock" -> Some Unblock
   | _ -> None
 
 (* Find the substring between [prefix] and the first occurrence of

--- a/lib/task/task_transition_state.ml
+++ b/lib/task/task_transition_state.ml
@@ -17,6 +17,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 type transition_action =
   | Claim
@@ -62,6 +63,7 @@ let status_kind_to_string = function
   | AwaitingVerification_kind -> "awaiting_verification"
   | Done_kind -> "done"
   | Cancelled_kind -> "cancelled"
+  | OperatorBlocked_kind -> "operator_blocked"
 
 let transition_action_to_string = function
   | Claim -> "claim"
@@ -98,6 +100,7 @@ let all_status_kinds : status_kind list =
   ; AwaitingVerification_kind
   ; Done_kind
   ; Cancelled_kind
+  ; OperatorBlocked_kind
   ]
 
 let all_transition_actions : transition_action list =

--- a/lib/task/task_transition_state.mli
+++ b/lib/task/task_transition_state.mli
@@ -81,6 +81,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 (** Closed-enum mirror of [Types_core.task_action]. Adding a new action
     upstream forces an arm here. Used for both fingerprinting and the

--- a/lib/task/task_transition_state.mli
+++ b/lib/task/task_transition_state.mli
@@ -95,6 +95,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 (** Closed-enum classification of the [InvalidState] error message.
     Derived from the [Tool_task.validate_transition] surface and the

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -313,6 +313,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | OperatorBlocked of { blocked_by: string; blocked_at: string; reason: string option }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -233,6 +233,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 [@@deriving show]
 
 (** RFC-0262: who authorizes a transition that would otherwise require the
@@ -269,6 +271,8 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
+  | "block_for_operator" -> Ok Block_for_operator
+  | "unblock" -> Ok Unblock
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,11 +284,14 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification ]
+    Submit_for_verification; Approve_verification; Reject_verification;
+    Block_for_operator; Unblock ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (* RFC-0220: the verification sub-state (previously a separate request_status

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -103,6 +103,7 @@ type task_status =
       }
   | Done of { assignee : string; completed_at : string; notes : string option }
   | Cancelled of { cancelled_by : string; cancelled_at : string; reason : string option }
+  | OperatorBlocked of { blocked_by : string; blocked_at : string; reason : string option }
 [@@deriving show]
 
 (** RFC-0220 §3.5: [task_status] of an [AwaitingVerification] obligation once

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -64,6 +64,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 [@@deriving show]
 
 val task_action_of_string : string -> (task_action, string) result


### PR DESCRIPTION
## Phase 1: Type Definition

Add `OperatorBlocked` variant to `task_status` to provide a structured parking state for tasks blocked by operator-level decisions (evidence gate, approval requirements, etc.).

**Why:** Keepers currently cycle through claim/release on blocked tasks, creating noise. `OperatorBlocked` gives a dedicated state for 'waiting for operator action' without losing context.

**Files:** types_core.ml/mli, task_transition_state.ml/mli

**Follow-up (not in this PR):**
- Transition logic in tool_task.ml (block_for_operator / unblock actions)
- JSON serialization for OperatorBlocked
- Exhaustive match site updates (OCaml compiler will identify these)
- Block transition rules: from Claimed/InProgress/AwaitingVerification → OperatorBlocked, and OperatorBlocked → Todo

**Depends on:** PR #24040 (evidence gate liveness fallback) for the practical use case.