### PR TITLE
feat(memory): add typed explicit-root MemoryOS I/O

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -198,6 +198,24 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let write_all_fd ~path fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring
+          fd
+          content
+          offset
+          (String.length content - offset)
+      with
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+      | 0 -> raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+      | wrote -> loop (offset + wrote)
+  in
+  loop 0
+;;
+
 let append_file_durable_unix (path : string) (content : string) : unit =
   let mu = get_append_path_mutex path in
   Stdlib.Mutex.lock mu;
@@ -210,23 +228,65 @@ let append_file_durable_unix (path : string) (content : string) : unit =
       Stdlib.Fun.protect
         ~finally:(fun () -> Unix.close fd)
         (fun () ->
-          let rec write_all offset =
-            if offset < String.length content
-            then
-              match
-                Unix.write_substring
-                  fd
-                  content
-                  offset
-                  (String.length content - offset)
-              with
-              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
-              | 0 ->
-                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
-              | wrote -> write_all (offset + wrote)
-          in
-          write_all 0;
+          write_all_fd ~path fd content;
           Unix.fsync fd);
+      match Atomic_write.fsync_directory (Filename.dirname path) with
+      | Ok () -> ()
+      | Error detail -> raise (Sys_error detail))
+;;
+
+let same_file_identity left right =
+  left.Unix.st_kind = right.Unix.st_kind
+  && left.Unix.st_dev = right.Unix.st_dev
+  && left.Unix.st_ino = right.Unix.st_ino
+;;
+
+let append_file_durable_no_follow_unix path content =
+  let mu = get_append_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let before =
+        try Some (Unix.lstat path) with
+        | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+      in
+      (match before with
+       | Some stat when stat.Unix.st_kind <> Unix.S_REG ->
+         raise
+           (Sys_error
+              (Printf.sprintf "%s: append target is not a regular file" path))
+       | Some _ | None -> ());
+      let fd =
+        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+      in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+          let opened = Unix.fstat fd in
+          let linked = Unix.lstat path in
+          if
+            opened.Unix.st_kind <> Unix.S_REG
+            || linked.Unix.st_kind <> Unix.S_REG
+            || not (same_file_identity opened linked)
+            || not
+                 (Option.for_all
+                    (fun prior -> same_file_identity prior opened)
+                    before)
+          then
+            raise
+              (Sys_error
+                 (Printf.sprintf
+                    "%s: append target changed or resolved through a symlink"
+                    path));
+          write_all_fd ~path fd content;
+          Unix.fsync fd;
+          let after = Unix.lstat path in
+          if not (same_file_identity opened after)
+          then
+            raise
+              (Sys_error
+                 (Printf.sprintf "%s: append target changed during write" path)));
       match Atomic_write.fsync_directory (Filename.dirname path) with
       | Ok () -> ()
       | Error detail -> raise (Sys_error detail))
@@ -349,6 +409,19 @@ let append_file_durable path content =
     (try Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content) with
      | Stdlib.Effect.Unhandled _ -> append_file_durable_unix path content)
   | None -> append_file_durable_unix path content
+;;
+
+let append_file_durable_no_follow path content =
+  test_exec_home_guard ~op:"append_file_durable_no_follow" path;
+  match Atomic.get global_fs with
+  | Some _ ->
+    (try
+       Eio_unix.run_in_systhread (fun () ->
+         append_file_durable_no_follow_unix path content)
+     with
+     | Stdlib.Effect.Unhandled _ ->
+       append_file_durable_no_follow_unix path content)
+  | None -> append_file_durable_no_follow_unix path content
 ;;
 
 (** Check if file exists.

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -102,6 +102,11 @@ val append_file : string -> string -> unit
     a system thread. *)
 val append_file_durable : string -> string -> unit
 
+(** Like {!append_file_durable}, but reject a symlink/non-regular final target
+    and verify the opened descriptor remains linked at [path] before and after
+    the append. Use at explicit-root trust boundaries. *)
+val append_file_durable_no_follow : string -> string -> unit
+
 (** Check if file exists. *)
 val file_exists : string -> bool
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,12 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let ensure_configured_keepers_dir () =
+  let path = keepers_dir () in
+  ensure_dir path;
+  path
+;;
+
 let keeper_name_exn raw =
   match Keeper_id.Keeper_name.of_string raw with
   | Ok keeper_name -> keeper_name
@@ -38,6 +44,70 @@ let keeper_name_exn raw =
 ;;
 
 let keeper_name_string = Keeper_id.Keeper_name.to_string
+
+let trace_id_exn raw =
+  match Keeper_id.Trace_id.of_string raw with
+  | Ok trace_id -> trace_id
+  | Error detail -> invalid_arg detail
+;;
+
+let trace_id_string = Keeper_id.Trace_id.to_string
+
+let lstat_if_present path =
+  try Some (Unix.lstat path) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+;;
+
+let require_real_directory path =
+  match lstat_if_present path with
+  | Some stat when stat.Unix.st_kind = Unix.S_DIR -> ()
+  | Some _ ->
+    invalid_arg (Printf.sprintf "expected a real directory, found another file kind: %s" path)
+  | None -> invalid_arg (Printf.sprintf "required directory does not exist: %s" path)
+;;
+
+let require_regular_file_or_missing path =
+  match lstat_if_present path with
+  | None -> ()
+  | Some stat when stat.Unix.st_kind = Unix.S_REG -> ()
+  | Some _ ->
+    invalid_arg
+      (Printf.sprintf "expected a regular file or missing path: %s" path)
+;;
+
+let fsync_directory_exn path =
+  match Fs_compat.fsync_directory path with
+  | Ok () -> ()
+  | Error detail -> raise (Sys_error detail)
+;;
+
+let ensure_real_child_directory ~parent ~child_name =
+  require_real_directory parent;
+  let child = Filename.concat parent child_name in
+  let created =
+    match lstat_if_present child with
+    | Some stat when stat.Unix.st_kind = Unix.S_DIR -> false
+    | Some _ ->
+      invalid_arg
+        (Printf.sprintf
+           "expected a real directory, found another file kind: %s"
+           child)
+    | None ->
+      (try
+         Unix.mkdir child 0o755;
+         true
+       with
+       | Unix.Unix_error (Unix.EEXIST, _, _) -> false)
+  in
+  require_real_directory parent;
+  require_real_directory child;
+  if created then fsync_directory_exn parent;
+  child
+;;
+
+let validate_lock_target base_path =
+  require_regular_file_or_missing (base_path ^ ".lock")
+;;
 
 module For_testing = struct
   let with_keepers_dir path f =
@@ -126,33 +196,79 @@ let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
 ;;
 
 let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  File_lock_eio.with_lock
-    ?clock
-    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    f
+  require_real_directory keepers_dir;
+  let lock_base =
+    episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id
+  in
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
   with_episode_bundle_lock_for_keepers_dir
     ?clock
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     f
 ;;
 
+let facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  facts_path_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:(keeper_name_string keeper_id)
+;;
+
+let with_facts_lock_unhandled_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  require_real_directory keepers_dir;
+  let lock_base = facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing lock_base;
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
+;;
+
+let with_facts_lock_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      ~on_timeout
+      f
+  =
+  try
+    with_facts_lock_unhandled_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      f
+  with
+  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
+    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+;;
+
+let with_facts_lock ?clock ~keeper_id ~on_timeout f =
+  with_facts_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~on_timeout
+    f
+;;
+
+let episodes_directory_name = "episodes"
+
 let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
-  let d =
-    Filename.concat
-      keepers_dir
-      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  let keeper_dir =
+    ensure_real_child_directory
+      ~parent:keepers_dir
+      ~child_name:(keeper_name_string keeper_id)
   in
-  ensure_dir d;
-  d
+  ensure_real_child_directory
+    ~parent:keeper_dir
+    ~child_name:episodes_directory_name
 ;;
 
 let episodes_dir ~keeper_id =
   episodes_dir_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -167,9 +283,10 @@ let tool_result_path ~keeper_id ~tool_call_id =
 ;;
 
 let episode_path ~keeper_id ~trace_id ~generation =
+  let trace_id = trace_id_exn trace_id in
   Filename.concat
     (episodes_dir ~keeper_id)
-    (Printf.sprintf "%s-g%04d.json" trace_id generation)
+    (Printf.sprintf "%s-g%04d.json" (trace_id_string trace_id) generation)
 ;;
 
 (* Raised when a durable atomic write fails. Distinct from [Failure] so the
@@ -211,15 +328,23 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
+let write_file_atomically_in_real_directory path content =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> raise (Atomic_write_failed msg)
+;;
+
 let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   Filename.concat
     (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
-    (Printf.sprintf "%s.generation" trace_id)
+    (Printf.sprintf "%s.generation" (trace_id_string trace_id))
 ;;
 
 let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
-  let prefix = Printf.sprintf "%s-g" trace_id in
+  let prefix = Printf.sprintf "%s-g" (trace_id_string trace_id) in
   Sys.readdir dir
   |> Array.to_list
   |> List.filter_map (fun name ->
@@ -232,15 +357,16 @@ let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id 
 ;;
 
 let read_generation_counter path =
-  if not (Sys.file_exists path)
-  then None
-  else (
+  require_regular_file_or_missing path;
+  match lstat_if_present path with
+  | None -> None
+  | Some _ ->
     let ic = open_in_bin path in
     Fun.protect
       ~finally:(fun () -> close_in_noerr ic)
       (fun () ->
-         let len = in_channel_length ic in
-         really_input_string ic len |> String.trim |> int_of_string_opt))
+        let len = in_channel_length ic in
+        really_input_string ic len |> String.trim |> int_of_string_opt)
 ;;
 
 (** Compute the next generation number for a trace's episode files.
@@ -259,6 +385,8 @@ let next_generation_with_floor_for_keepers_dir
   let counter_path =
     generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
   in
+  require_regular_file_or_missing counter_path;
+  validate_lock_target counter_path;
   File_lock_eio.with_lock counter_path (fun () ->
     let next_from_files =
       max_generation_from_files_for_keepers_dir
@@ -273,23 +401,30 @@ let next_generation_with_floor_for_keepers_dir
       | None -> 0
     in
     let generation = max floor (max next_from_files next_from_counter) in
-    write_file_atomically counter_path (Printf.sprintf "%d\n" (generation + 1));
+    write_file_atomically_in_real_directory
+      counter_path
+      (Printf.sprintf "%d\n" (generation + 1));
     generation)
 ;;
 
 let next_generation_with_floor ~floor ~keeper_id ~trace_id =
   next_generation_with_floor_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~floor
     ~keeper_id:(keeper_name_exn keeper_id)
-    ~trace_id
+    ~trace_id:(trace_id_exn trace_id)
 ;;
 
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
+let unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
@@ -298,7 +433,7 @@ let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
       (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
-         episode.trace_id
+         (trace_id_string trace_id)
          episode.generation
          created_ms)
   in
@@ -324,12 +459,22 @@ let append_json path json =
   append_line path (Yojson.Safe.to_string json)
 ;;
 
+let append_json_no_follow path json =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  Fs_compat.append_file_durable_no_follow
+    path
+    (Yojson.Safe.to_string json ^ "\n")
+;;
+
 let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
 let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  append_json
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  require_real_directory keepers_dir;
+  append_json_no_follow
     (events_path_for_keepers_dir
        ~keepers_dir
        ~keeper_id:(keeper_name_string keeper_id))
@@ -338,40 +483,53 @@ let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
 
 let append_event ~keeper_id episode =
   append_event_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  let trace_id = trace_id_exn episode.trace_id in
+  let path =
+    unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  in
+  write_file_atomically_in_real_directory
+    path
+    (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
   append_episode_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
   with_episode_bundle_lock ~keeper_id (fun () ->
-    File_lock_eio.with_lock (facts_path ~keeper_id) (fun () ->
-      List.iter (append_fact ~keeper_id) episode.claims);
+    with_facts_lock_unhandled_for_keepers_dir
+      ~keepers_dir:(ensure_configured_keepers_dir ())
+      ~keeper_id:(keeper_name_exn keeper_id)
+      (fun () -> List.iter (append_fact ~keeper_id) episode.claims);
     append_episode ~keeper_id episode;
     append_event ~keeper_id episode)
 ;;
 
 let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_real_directory keepers_dir;
+  require_regular_file_or_missing path;
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
     |> String.concat "\n"
   in
   let content = if String.equal content "" then "" else content ^ "\n" in
-  write_file_atomically path content
+  write_file_atomically_in_real_directory path content
 ;;
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
@@ -382,7 +540,10 @@ let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
 ;;
 
 let rewrite_facts_atomically ~keeper_id facts =
-  rewrite_facts_atomically_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id facts
+  rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
+    facts
 ;;
 
 (* ---------- Facts snapshot CAS (optimistic concurrency) ---------- *)
@@ -407,19 +568,6 @@ let rec same_fact_snapshot left right =
   | l :: ls, r :: rs ->
     String.equal (fact_fingerprint l) (fact_fingerprint r) && same_fact_snapshot ls rs
   | [], _ :: _ | _ :: _, [] -> false
-;;
-
-(* Run [f] holding the per-keeper facts lock. On lock-acquisition timeout (another
-   writer holds the flock past the retry budget) [on_timeout msg] decides the
-   caller's result rather than letting [Flock_timeout] escape — callers that want a
-   typed skip/no-op outcome pass it here instead of catching the exception
-   themselves. Non-timeout body exceptions propagate after the lock finalizer runs.
-   Keep [on_timeout] total and non-raising so timeout remains a typed outcome, not
-   a second failure path. *)
-let with_facts_lock ?clock ~keeper_id ~on_timeout f =
-  try File_lock_eio.with_lock ?clock (facts_path ~keeper_id) f with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
 ;;
 
 let save_tool_result ~keeper_id ~tool_call_id json =
@@ -534,17 +682,18 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_lines_all (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  |> List.filter_map (parse_json_line fact_of_json)
-;;
-
-let read_facts_all ~keeper_id =
-  read_facts_all_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+let validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  require_real_directory keepers_dir;
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing path;
+  path
+;;
+
+let read_facts_all_at_path path =
+  read_lines_all path |> List.filter_map (parse_json_line fact_of_json)
+;;
+
+let read_facts_all_strict_at_path path =
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
@@ -554,18 +703,38 @@ let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
   loop 1 [] (read_lines_all path)
 ;;
 
-let read_facts_all_strict ~keeper_id =
-  read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
-  read_lines_tail (facts_path_for_keepers_dir ~keepers_dir ~keeper_id) ~n
+let read_facts_tail_at_path path ~n =
+  read_lines_tail path ~n
   |> List.filter_map (parse_json_line fact_of_json)
   |> take_last n
 ;;
 
+let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all ~keeper_id =
+  read_facts_all_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_strict_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all_strict ~keeper_id =
+  read_facts_all_strict_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
+  read_facts_tail_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~n
+;;
+
 let read_facts_tail ~keeper_id ~n =
-  read_facts_tail_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id ~n
+  read_facts_tail_at_path (facts_path ~keeper_id) ~n
 ;;
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
@@ -628,7 +797,7 @@ let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
 
 let read_facts_for_rewrite ~keeper_id =
   read_facts_for_rewrite_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -773,7 +942,7 @@ let merge_and_cap_facts
       ~rank
   =
   merge_and_cap_facts_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~now
     ~keeper_id:(keeper_name_exn keeper_id)
     ~merge
@@ -847,11 +1016,13 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
 let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  require_real_directory keepers_dir;
   let path =
     events_path_for_keepers_dir
       ~keepers_dir
       ~keeper_id:(keeper_name_string keeper_id)
   in
+  require_regular_file_or_missing path;
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -867,13 +1038,13 @@ let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
       | [] -> ""
       | _ -> String.concat "\n" kept ^ "\n"
     in
-    write_file_atomically path content;
+    write_file_atomically_in_real_directory path content;
     List.length all - List.length kept
 ;;
 
 let cap_events ~keeper_id ~keep ~trigger =
   cap_events_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger
@@ -919,7 +1090,7 @@ let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
 
 let cap_episode_files ~keeper_id ~keep ~trigger =
   cap_episode_files_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,14 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let keeper_name_exn raw =
+  match Keeper_id.Keeper_name.of_string raw with
+  | Ok keeper_name -> keeper_name
+  | Error detail -> invalid_arg detail
+;;
+
+let keeper_name_string = Keeper_id.Keeper_name.to_string
+
 module For_testing = struct
   let with_keepers_dir path f =
     ensure_dir path;
@@ -111,18 +119,41 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat
+    keepers_dir
+    (keeper_name_string keeper_id ^ ".episode-bundle")
+;;
+
+let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  File_lock_eio.with_lock
+    ?clock
+    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
-  File_lock_eio.with_lock ?clock (episode_bundle_lock_path ~keeper_id) f
+  with_episode_bundle_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    f
+;;
+
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  let d =
+    Filename.concat
+      keepers_dir
+      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  in
+  ensure_dir d;
+  d
 ;;
 
 let episodes_dir ~keeper_id =
-  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
-  ensure_dir d;
-  d
+  episodes_dir_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 let tool_results_dir ~keeper_id =
@@ -180,12 +211,14 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let generation_counter_path ~keeper_id ~trace_id =
-  Filename.concat (episodes_dir ~keeper_id) (Printf.sprintf "%s.generation" trace_id)
+let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  Filename.concat
+    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+    (Printf.sprintf "%s.generation" trace_id)
 ;;
 
-let max_generation_from_files ~keeper_id ~trace_id =
-  let dir = episodes_dir ~keeper_id in
+let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   let prefix = Printf.sprintf "%s-g" trace_id in
   Sys.readdir dir
   |> Array.to_list
@@ -217,10 +250,23 @@ let read_generation_counter path =
     lock. The counter intentionally allows gaps when extraction later fails;
     uniqueness is more important than contiguous numbering across fibers or
     processes. *)
-let next_generation_with_floor ~floor ~keeper_id ~trace_id =
-  let counter_path = generation_counter_path ~keeper_id ~trace_id in
+let next_generation_with_floor_for_keepers_dir
+      ~keepers_dir
+      ~floor
+      ~keeper_id
+      ~trace_id
+  =
+  let counter_path =
+    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  in
   File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files = max_generation_from_files ~keeper_id ~trace_id + 1 in
+    let next_from_files =
+      max_generation_from_files_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+        ~trace_id
+      + 1
+    in
     let next_from_counter =
       match read_generation_counter counter_path with
       | Some next -> next
@@ -231,17 +277,25 @@ let next_generation_with_floor ~floor ~keeper_id ~trace_id =
     generation)
 ;;
 
+let next_generation_with_floor ~floor ~keeper_id ~trace_id =
+  next_generation_with_floor_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~floor
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~trace_id
+;;
+
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path ~keeper_id episode =
+let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
     Filename.concat
-      (episodes_dir ~keeper_id)
+      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
          episode.trace_id
@@ -263,8 +317,7 @@ let unique_episode_path ~keeper_id episode =
 
 let append_line path line =
   ensure_dir (Filename.dirname path);
-  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  with_out_channel oc ~f:(fun oc -> output_string oc (line ^ "\n"))
+  Fs_compat.append_file_durable path (line ^ "\n")
 ;;
 
 let append_json path json =
@@ -275,13 +328,31 @@ let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
+let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  append_json
+    (events_path_for_keepers_dir
+       ~keepers_dir
+       ~keeper_id:(keeper_name_string keeper_id))
+    (episode_to_json episode)
+;;
+
 let append_event ~keeper_id episode =
-  append_json (events_path ~keeper_id) (episode_to_json episode)
+  append_event_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
+;;
+
+let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
+  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
-  let path = unique_episode_path ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  append_episode_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
@@ -537,24 +608,28 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite ~keeper_id =
-  (* RFC-0302 (#22823) phase-2b: resolve keepers_dir on the main domain (it touches
-     the Config_dir_resolver plain-ref memo), then offload the blocking full read +
-     strict parse of the fact store off the main Eio scheduler. This is the
-     per-write read on the librarian hot path (merge_and_cap_facts) and cap_facts.
-     Byte-equivalent to [read_facts_all_strict ~keeper_id] (which is exactly
-     [read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ())]) — only
-     the resolution is hoisted to main and the read is offloaded. Callers hold a
+let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
+  (* RFC-0302 (#22823) phase-2b: [keepers_dir] is resolved by the caller before
+     this boundary. Offload the blocking full read + strict parse of the fact
+     store off the main Eio scheduler. This is the per-write read on the
+     librarian hot path ([merge_and_cap_facts]) and [cap_facts]. Callers hold a
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
-     reads only [keepers]/[keeper_id] and no shared mutable state, and the
-     Fs_compat rewrite that follows stays on main. *)
-  let keepers = keepers_dir () in
+     reads only the explicit root and [keeper_id], and the Fs_compat rewrite that
+     follows stays on main. *)
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir ~keepers_dir:keepers ~keeper_id)
+      read_facts_all_strict_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id:(keeper_name_string keeper_id))
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
+;;
+
+let read_facts_for_rewrite ~keeper_id =
+  read_facts_for_rewrite_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -645,8 +720,19 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
-  let existing = read_facts_for_rewrite ~keeper_id in
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  let existing =
+    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
+  in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -670,8 +756,31 @@ let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically ~keeper_id kept;
+    rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+      kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  merge_and_cap_facts_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~now
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~merge
+    ~incoming
+    ~keep
+    ~trigger
+    ~rank
 ;;
 
 let read_events_tail ~keeper_id ~n =
@@ -737,8 +846,12 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events ~keeper_id ~keep ~trigger =
-  let path = events_path ~keeper_id in
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  let path =
+    events_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+  in
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -758,6 +871,14 @@ let cap_events ~keeper_id ~keep ~trigger =
     List.length all - List.length kept
 ;;
 
+let cap_events ~keeper_id ~keep ~trigger =
+  cap_events_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
+;;
+
 (* RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
@@ -766,16 +887,14 @@ let cap_events ~keeper_id ~keep ~trigger =
    best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
    fine, and no lock is taken here that could deadlock with the bundle lock the
    caller already holds. Returns the number unlinked. *)
-let cap_episode_files ~keeper_id ~keep ~trigger =
-  (* RFC-0302 (#22823): resolve [episodes_dir] on the main domain (it touches the
-     Config_dir_resolver plain-ref memo + mkdir), then offload the blocking
-     readdir + per-file episode read + best-effort unlink scan to the shared
-     domain pool so the scan does not starve the main Eio scheduler. The offloaded
-     closure reads only the resolved [dir] string and does no Eio/lock/shared-
-     mutable work (Sys.remove is a filesystem unlink, not OCaml shared state), so
-     it is domain-safe; the caller's bundle flock stays held on main across the
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  (* RFC-0302 (#22823): resolve and create [episodes_dir] from the explicit root
+     on the main domain, then offload the blocking readdir + per-file episode read
+     + best-effort unlink scan to the shared domain pool. The closure captures
+     only immutable [dir]/[keep]/[trigger]; no mutable OCaml state is shared, so
+     it is domain-safe. The caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir ~keeper_id in
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   Domain_pool_ref.submit_io_or_inline (fun () ->
     let parsed =
       Sys.readdir dir
@@ -796,4 +915,12 @@ let cap_episode_files ~keeper_id ~keep ~trigger =
       let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
       List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
       List.length to_drop)
+;;
+
+let cap_episode_files ~keeper_id ~keep ~trigger =
+  cap_episode_files_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -34,6 +34,8 @@ val current_path_for_legacy_memory_filename :
     to the current store path under [keepers_dir], when the filename is a
     supported legacy memory artifact. *)
 val episodes_dir : keeper_id:string -> string
+val episodes_dir_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
@@ -47,7 +49,15 @@ val next_generation : keeper_id:string -> trace_id:string -> int
 
 (** Like {!next_generation}, but preserves a caller-provided generation lower
     bound while still advancing the counter past it. *)
-val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:string -> int
+val next_generation_with_floor :
+  floor:int -> keeper_id:string -> trace_id:string -> int
+
+val next_generation_with_floor_for_keepers_dir :
+  keepers_dir:string ->
+  floor:int ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  trace_id:string ->
+  int
 
 (** {1 Atomic writes} *)
 
@@ -60,13 +70,27 @@ val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
 
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
+val append_event_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+val append_episode_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
     lock, then publish [events_path] last as the reader-visible commit marker. *)
 val with_episode_bundle_lock :
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keeper_id:string ->
+  (unit -> 'a) ->
+  'a
+
+val with_episode_bundle_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  (unit -> 'a) ->
+  'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
@@ -147,12 +171,25 @@ val trim_target : count:int -> keep:int -> trigger:int -> int option
     malformed-line tolerant) and atomically rewrite; otherwise no-op. Returns the
     number of lines dropped. *)
 val cap_events : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_events_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
     recency and best-effort unlink the rest; otherwise no-op. Unparseable files
     are left untouched. Returns the number unlinked. *)
-val cap_episode_files : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files :
+  keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -193,6 +230,17 @@ type fact_merge_stats =
 val merge_and_cap_facts :
   now:float
   -> keeper_id:string
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_for_keepers_dir :
+  keepers_dir:string
+  -> now:float
+  -> keeper_id:Keeper_id.Keeper_name.t
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -56,7 +56,7 @@ val next_generation_with_floor_for_keepers_dir :
   keepers_dir:string ->
   floor:int ->
   keeper_id:Keeper_id.Keeper_name.t ->
-  trace_id:string ->
+  trace_id:Keeper_id.Trace_id.t ->
   int
 
 (** {1 Atomic writes} *)
@@ -78,7 +78,9 @@ val append_episode_for_keepers_dir :
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
-    lock, then publish [events_path] last as the reader-visible commit marker. *)
+    lock, then publish [events_path] last as the reader-visible commit marker.
+    The global lock order is bundle lock, then facts lock; reversing it can
+    deadlock another writer. *)
 val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keeper_id:string ->
@@ -124,6 +126,19 @@ val with_facts_lock :
   -> on_timeout:(string -> 'a)
   -> (unit -> 'a)
   -> 'a
+
+(** Explicit-root form of {!with_facts_lock}. [keeper_id] is already validated,
+    [keepers_dir] must be an existing real directory, and symlink/non-regular
+    fact and lock targets are rejected. When both locks are needed, acquire
+    {!with_episode_bundle_lock_for_keepers_dir} first and this lock second. *)
+val with_facts_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keepers_dir:string
+  -> keeper_id:Keeper_id.Keeper_name.t
+  -> on_timeout:(string -> 'a)
+  -> (unit -> 'a)
+  -> 'a
+
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
 
@@ -237,6 +252,9 @@ val merge_and_cap_facts :
   -> rank:(fact -> float)
   -> fact_merge_stats
 
+(** The explicit-root merge is a read-modify-rewrite operation. Its caller must
+    hold {!with_facts_lock_for_keepers_dir}; if an episode bundle is also being
+    published, the caller must hold the bundle lock before the facts lock. *)
 val merge_and_cap_facts_for_keepers_dir :
   keepers_dir:string
   -> now:float

--- a/test/dune
+++ b/test/dune
@@ -36,6 +36,7 @@
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_job_store
+  test_keeper_memory_os_explicit_root
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_keeper_verification_audit

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -104,6 +104,28 @@ let test_save_file_atomic_overwrites_existing () =
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
 ;;
 
+let test_append_file_durable_no_follow_appends_regular_file () =
+  with_tmp_dir
+  @@ fun base ->
+  let target = Filename.concat base "events.jsonl" in
+  Fs_compat.append_file_durable_no_follow target "first\n";
+  Fs_compat.append_file_durable_no_follow target "second\n";
+  check string "both rows persisted" "first\nsecond\n" (Fs_compat.load_file target)
+;;
+
+let test_append_file_durable_no_follow_rejects_symlink () =
+  with_tmp_dir
+  @@ fun base ->
+  let outside = Filename.concat base "outside.jsonl" in
+  let link = Filename.concat base "events.jsonl" in
+  Fs_compat.save_file outside "sentinel\n";
+  Unix.symlink outside link;
+  (match Fs_compat.append_file_durable_no_follow link "escaped\n" with
+   | () -> fail "expected Sys_error for symlink append target"
+   | exception Sys_error _ -> ());
+  check string "symlink target unchanged" "sentinel\n" (Fs_compat.load_file outside)
+;;
+
 let with_redirected_stderr (f : unit -> 'a) : 'a * string =
   let tmp = Filename.temp_file "masc_stderr_" ".log" in
   let saved = Unix.dup Unix.stderr in
@@ -323,6 +345,16 @@ let () =
             "overwrites existing target"
             `Quick
             test_save_file_atomic_overwrites_existing
+        ] )
+    ; ( "append_file_durable_no_follow"
+      , [ test_case
+            "appends a regular file"
+            `Quick
+            test_append_file_durable_no_follow_appends_regular_file
+        ; test_case
+            "rejects a symlink target"
+            `Quick
+            test_append_file_durable_no_follow_rejects_symlink
         ] )
     ; ( "load_jsonl_diagnostics"
       , [ test_case

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -53,23 +53,36 @@ let episode_file_count ~keepers_dir ~keeper_id =
   |> List.length
 ;;
 
+let expect_invalid_argument label f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected Invalid_argument" label
+  | exception Invalid_argument _ -> ()
+;;
+
 let test_explicit_root_isolates_append_and_generation () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
       Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-root-trace" in
-    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-root-trace" |> Result.get_ok
+    in
+    let first_episode =
+      episode
+        ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+        ~generation:0
+        ~created_at:1_000.0
+    in
     Memory_io.with_episode_bundle_lock_for_keepers_dir
       ~keepers_dir:first
       ~keeper_id
       (fun () ->
-         Memory_io.append_event_for_keepers_dir
+         Memory_io.append_episode_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode;
-         Memory_io.append_episode_for_keepers_dir
+         Memory_io.append_event_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode);
@@ -124,23 +137,36 @@ let test_explicit_root_scopes_merge_and_retention () =
       |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-retention-trace" in
-    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
-    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
-    Memory_io.rewrite_facts_atomically_for_keepers_dir
-      ~keepers_dir:first
-      ~keeper_id:keeper_id_string
-      [ existing ];
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-retention-trace"
+      |> Result.get_ok
+    in
+    let trace_id_string = Keeper_id.Trace_id.to_string trace_id in
+    let existing =
+      fact ~claim:"existing" ~trace_id:trace_id_string ~turn:0 ~observed_at:1.0
+    in
+    let incoming =
+      fact ~claim:"incoming" ~trace_id:trace_id_string ~turn:1 ~observed_at:2.0
+    in
     let stats =
-      Memory_io.merge_and_cap_facts_for_keepers_dir
+      Memory_io.with_facts_lock_for_keepers_dir
         ~keepers_dir:first
-        ~now:3.0
         ~keeper_id
-        ~merge:(fun ~existing:_ ~incoming -> incoming)
-        ~incoming:[ incoming ]
-        ~keep:2
-        ~trigger:2
-        ~rank:(fun persisted -> persisted.Types.first_seen)
+        ~on_timeout:Alcotest.fail
+        (fun () ->
+          Memory_io.rewrite_facts_atomically_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string
+            [ existing ];
+          Memory_io.merge_and_cap_facts_for_keepers_dir
+            ~keepers_dir:first
+            ~now:3.0
+            ~keeper_id
+            ~merge:(fun ~existing:_ ~incoming -> incoming)
+            ~incoming:[ incoming ]
+            ~keep:2
+            ~trigger:2
+            ~rank:(fun persisted -> persisted.Types.first_seen))
     in
     Alcotest.(check int) "one fact appended" 1 stats.appended;
     Alcotest.(check int) "no fact merged" 0 stats.merged;
@@ -152,31 +178,43 @@ let test_explicit_root_scopes_merge_and_retention () =
      with
      | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
      | Error detail -> Alcotest.fail detail);
-    List.iter
-      (fun generation ->
-         Memory_io.append_event_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation));
-         Memory_io.append_episode_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation)))
-      [ 0; 1; 2 ];
+    let event_dropped, episode_dropped =
+      Memory_io.with_episode_bundle_lock_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (fun () ->
+          List.iter
+            (fun generation ->
+              let persisted =
+                episode
+                  ~trace_id:trace_id_string
+                  ~generation
+                  ~created_at:(10.0 +. float_of_int generation)
+              in
+              Memory_io.append_episode_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted;
+              Memory_io.append_event_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted)
+            [ 0; 1; 2 ];
+          ( Memory_io.cap_events_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2
+          , Memory_io.cap_episode_files_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2 ))
+    in
     Alcotest.(check int)
       "event cap reports removed rows"
       2
-      (Memory_io.cap_events_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      event_dropped;
     Alcotest.(check int)
       "event cap retains one row"
       1
@@ -188,15 +226,88 @@ let test_explicit_root_scopes_merge_and_retention () =
     Alcotest.(check int)
       "episode cap reports removed files"
       2
-      (Memory_io.cap_episode_files_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      episode_dropped;
     Alcotest.(check int)
       "episode cap retains one file"
       1
       (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let test_invalid_episode_trace_is_rejected_before_io () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "invalid-trace-keeper" |> Result.get_ok
+    in
+    let invalid_episode = episode ~trace_id:"../escape" ~generation:0 ~created_at:1.0 in
+    expect_invalid_argument "invalid episode trace" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        invalid_episode);
+    Alcotest.(check bool)
+      "invalid trace creates no keeper directory"
+      false
+      (Sys.file_exists
+         (Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id))))
+;;
+
+let test_symlinked_episodes_directory_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-episodes-keeper" |> Result.get_ok
+    in
+    let keeper_dir =
+      Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id)
+    in
+    Unix.mkdir keeper_dir 0o700;
+    let outside = Filename.concat second "outside-episodes" in
+    Unix.mkdir outside 0o700;
+    Unix.symlink outside (Filename.concat keeper_dir "episodes");
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-episodes-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked episodes directory" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check (list string))
+      "outside directory remains empty"
+      []
+      (Sys.readdir outside |> Array.to_list))
+;;
+
+let test_symlinked_events_file_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-events-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let outside = Filename.concat second "outside-events.jsonl" in
+    Fs_compat.save_file outside "sentinel\n";
+    Unix.symlink
+      outside
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string);
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-events-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked events file" (fun () ->
+      Memory_io.append_event_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check string)
+      "outside file remains unchanged"
+      "sentinel\n"
+      (Fs_compat.load_file outside))
 ;;
 
 let () =
@@ -211,6 +322,18 @@ let () =
             "merge and retention are root-scoped"
             `Quick
             test_explicit_root_scopes_merge_and_retention
+        ; Alcotest.test_case
+            "invalid episode trace is rejected before I/O"
+            `Quick
+            test_invalid_episode_trace_is_rejected_before_io
+        ; Alcotest.test_case
+            "symlinked episodes directory is rejected"
+            `Quick
+            test_symlinked_episodes_directory_is_rejected
+        ; Alcotest.test_case
+            "symlinked events file is rejected"
+            `Quick
+            test_symlinked_events_file_is_rejected
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,5 +1,5 @@
-module Types = Keeper_memory_os_types
-module Memory_io = Keeper_memory_os_io
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
 
 let with_temp_roots f =
   let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,0 +1,216 @@
+module Types = Keeper_memory_os_types
+module Memory_io = Keeper_memory_os_io
+
+let with_temp_roots f =
+  let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in
+  Sys.remove root;
+  Unix.mkdir root 0o700;
+  let first = Filename.concat root "first" in
+  let second = Filename.concat root "second" in
+  Unix.mkdir first 0o700;
+  Unix.mkdir second 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree root)
+    (fun () -> f ~first ~second)
+;;
+
+let fact ~claim ~trace_id ~turn ~observed_at =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = Some Types.Durable_knowledge
+  ; source = { Types.trace_id; turn; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen = observed_at
+  ; valid_until = None
+  ; last_verified_at = Some observed_at
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let episode ~trace_id ~generation ~created_at =
+  { Types.trace_id
+  ; generation
+  ; episode_summary = Printf.sprintf "episode-%d" generation
+  ; claims = []
+  ; open_items = []
+  ; constraints = []
+  ; preserved_tool_refs = []
+  ; source_turn_range = Some (generation, generation)
+  ; created_at
+  ; valid_until = None
+  ; terminal_marker = None
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let episode_file_count ~keepers_dir ~keeper_id =
+  Memory_io.episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id
+  |> Sys.readdir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.length
+;;
+
+let test_explicit_root_isolates_append_and_generation () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-root-trace" in
+    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun () ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode;
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode);
+    Alcotest.(check bool)
+      "first root receives event"
+      true
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check bool)
+      "second root remains untouched"
+      false
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:second
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check int)
+      "episode written only to explicit root"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id);
+    Alcotest.(check int)
+      "first generation starts at floor"
+      4
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:4
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "first generation advances"
+      5
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:0
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "second root has an independent counter"
+      0
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:second
+         ~floor:0
+         ~keeper_id
+         ~trace_id))
+;;
+
+let test_explicit_root_scopes_merge_and_retention () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-retention-keeper"
+      |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-retention-trace" in
+    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
+    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
+    Memory_io.rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id:keeper_id_string
+      [ existing ];
+    let stats =
+      Memory_io.merge_and_cap_facts_for_keepers_dir
+        ~keepers_dir:first
+        ~now:3.0
+        ~keeper_id
+        ~merge:(fun ~existing:_ ~incoming -> incoming)
+        ~incoming:[ incoming ]
+        ~keep:2
+        ~trigger:2
+        ~rank:(fun persisted -> persisted.Types.first_seen)
+    in
+    Alcotest.(check int) "one fact appended" 1 stats.appended;
+    Alcotest.(check int) "no fact merged" 0 stats.merged;
+    Alcotest.(check int) "no fact dropped" 0 stats.dropped;
+    (match
+       Memory_io.read_facts_all_strict_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+     with
+     | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
+     | Error detail -> Alcotest.fail detail);
+    List.iter
+      (fun generation ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation));
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation)))
+      [ 0; 1; 2 ];
+    Alcotest.(check int)
+      "event cap reports removed rows"
+      2
+      (Memory_io.cap_events_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "event cap retains one row"
+      1
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+       |> Fs_compat.load_jsonl
+       |> List.length);
+    Alcotest.(check int)
+      "episode cap reports removed files"
+      2
+      (Memory_io.cap_episode_files_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "episode cap retains one file"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os_explicit_root"
+    [ ( "explicit-root"
+      , [ Alcotest.test_case
+            "append and generation are root-scoped"
+            `Quick
+            test_explicit_root_isolates_append_and_generation
+        ; Alcotest.test_case
+            "merge and retention are root-scoped"
+            `Quick
+            test_explicit_root_scopes_merge_and_retention
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- add typed `keepers_dir` variants for MemoryOS bundle locking, generation reservation, event/episode append, fact merge, and retention
- require `Keeper_id.Keeper_name.t` at every new explicit-root boundary
- route JSONL writes through the durable append primitive from the parent stack
- preserve every existing ambient API by delegating through the typed boundary
- add focused two-root isolation and retention regressions

## Why

Lane Per Keeper work must address one BasePath-derived runtime root explicitly. Ambient config lookup makes multi-workspace execution and independent Keeper lanes vulnerable to cross-root writes.

This slice is intentionally additive. It does not relocate the default store, migrate legacy data, or add the operation journal.

## Stack

Depends on #24043 (`codex/memory-durable-foundation-20260711`).

## Validation

- `ocamlformat --check` on touched OCaml files
- parser-only `ocamlc -stop-after parsing` checks
- `ocamldep -modules`
- `git diff --check`
- full Dune build and tests are delegated to GitHub CI by project policy
