### PR TITLE
feat: add OperatorBlocked task state (task-2185)

### DIFF
--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -81,7 +81,7 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
         let dominated = match t.task_status with
           | Done _ -> not include_done
           | Cancelled _ -> not include_cancelled
-          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | OperatorBlocked _ -> false
         in
         not dominated
       ) backlog.tasks in

--- a/lib/task/task_transition_state.ml
+++ b/lib/task/task_transition_state.ml
@@ -17,6 +17,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 type transition_action =
   | Claim
@@ -27,6 +28,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 type family =
   | Invalid_transition of
@@ -62,6 +65,7 @@ let status_kind_to_string = function
   | AwaitingVerification_kind -> "awaiting_verification"
   | Done_kind -> "done"
   | Cancelled_kind -> "cancelled"
+  | OperatorBlocked_kind -> "operator_blocked"
 
 let transition_action_to_string = function
   | Claim -> "claim"
@@ -72,6 +76,8 @@ let transition_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve_verification"
   | Reject_verification -> "reject_verification"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 let family_to_string = function
   | Invalid_transition { from_status; action } ->
@@ -98,6 +104,7 @@ let all_status_kinds : status_kind list =
   ; AwaitingVerification_kind
   ; Done_kind
   ; Cancelled_kind
+  ; OperatorBlocked_kind
   ]
 
 let all_transition_actions : transition_action list =
@@ -109,6 +116,8 @@ let all_transition_actions : transition_action list =
   ; Submit_for_verification
   ; Approve_verification
   ; Reject_verification
+  ; Block_for_operator
+  ; Unblock
   ]
 
 let all_families : family list =

--- a/lib/task/task_transition_state.mli
+++ b/lib/task/task_transition_state.mli
@@ -81,6 +81,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 (** Closed-enum mirror of [Types_core.task_action]. Adding a new action
     upstream forces an arm here. Used for both fingerprinting and the
@@ -94,6 +95,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 (** Closed-enum classification of the [InvalidState] error message.
     Derived from the [Tool_task.validate_transition] surface and the

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -313,6 +313,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | OperatorBlocked of { assignee: string; blocked_at: string; reason: string option }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -369,14 +370,14 @@ let task_assignee_of_status = function
     Exhaustive match — adding a constructor forces an update here. *)
 let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | OperatorBlocked _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
     also includes [Cancelled]. Use this when only successful completion
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ | OperatorBlocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -233,6 +233,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 [@@deriving show]
 
 (** RFC-0262: who authorizes a transition that would otherwise require the
@@ -269,6 +271,8 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
+  | "block_for_operator" -> Ok Block_for_operator
+  | "unblock" -> Ok Unblock
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,11 +284,14 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification ]
+    Submit_for_verification; Approve_verification; Reject_verification;
+    Block_for_operator; Unblock ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (* RFC-0220: the verification sub-state (previously a separate request_status

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -55,7 +55,8 @@ let classify_completion_path
   | Masc_domain.Approve_verification -> "via_verification"
   | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action
   | Masc_domain.Cancel | Masc_domain.Release
-  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification ->
+  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification
+  | Masc_domain.Block_for_operator | Masc_domain.Unblock ->
     if force then "forced_done"
     else (match drift with
           | Some Workspace_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
@@ -85,6 +86,7 @@ let working_agents config =
       (fun (t : task) ->
          match t.task_status with
          | Claimed { assignee; _ } | InProgress { assignee; _ } -> Some assignee
+         | OperatorBlocked { assignee; _ } -> Some assignee
          | Todo | Done _ | Cancelled _ | AwaitingVerification _ -> None)
       backlog.tasks
     |> List.sort_uniq String.compare

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -87,7 +87,9 @@ let transition_task_outcome_r
           | Masc_domain.Claim
           | Masc_domain.Start
           | Masc_domain.Cancel
-          | Masc_domain.Release -> Ok ()
+          | Masc_domain.Release
+          | Masc_domain.Block_for_operator
+          | Masc_domain.Unblock -> Ok ()
           | Masc_domain.Done_action
           | Masc_domain.Submit_for_verification ->
             (* #23719 evidence gate, scoped to the RFC-0323 Phase A predicate


### PR DESCRIPTION
## Summary

Add OperatorBlocked variant to task_status type. This state allows keepers to block tasks for operator intervention, breaking the unclaimable critical task cycling problem.

## Changes

- `types_core.ml`: Add `OperatorBlocked of { assignee; blocked_at; reason }` constructor to `task_status`
- `types_core.ml`: Update `task_status_is_terminal` — OperatorBlocked is not terminal
- `types_core.ml`: Update `task_status_is_done` — OperatorBlocked is not done
- `task_dispatch.ml`: Update exhaustive match

## Phase 2 (follow-up)

- Add Block_for_operator / Unblock transition actions to workspace transitions
- Wire into task_transition_state.ml
- Add to GraphQL schema
- Update all remaining exhaustive matches (grep for Todo | Claimed)

## Evidence gate note

OperatorBlocked tasks should NOT be closable via evidence gate — they require operator action to unblock.