### PR TITLE
fix(ci): re-land orphaned main-red recovery — 5 hardlink-exposed test fixes (#24013 + #23989)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -67,6 +67,7 @@
   (domain-name (>= 0.4))
   (ca-certs (>= 0.2))
   (ppx_deriving_yojson (>= 3.6))
+  (ppx_enumerate (>= v0.17.0))
   (ppx_let (>= v0.17.0))
   (ppx_deriving (>= 5.2))
   (ppxlib (>= 0.30))

--- a/lib/keeper_metrics/dune
+++ b/lib/keeper_metrics/dune
@@ -19,4 +19,6 @@
   keeper_oas_execution_error_phase
   keeper_operator_compact_result
   keeper_tool_outcome)
+ (preprocess
+  (pps ppx_enumerate))
  (libraries masc_core otel_metric_store time_compat unix yojson))

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -256,6 +256,7 @@ type t =
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
   | WireCaptureRecordSkipped    (* counter: wire-capture record dropped by current-file byte cap *)
+[@@deriving enumerate]
 
 (** String conversion
 
@@ -534,77 +535,6 @@ let to_string = function
     "masc_keeper_wire_capture_response_suppressed_total"
   | WireCaptureWriteFailures -> "masc_keeper_wire_capture_write_failures_total"
   | WireCaptureRecordSkipped -> "masc_keeper_wire_capture_record_skipped_total"
-;;
-
-(* Every constructor of [t], in declaration order.  Consumed by
-   [register_zero_fill] below.  The compiler cannot enforce membership
-   here (no enumerate ppx in this repo): when you add a constructor,
-   exhaustiveness already forces you to edit [to_string] in this file --
-   add the constructor to [all] in the same edit. *)
-let all : t list =
-  [ Turns; InputTokens; OutputTokens; CacheCreationTokens;
-    CacheReadTokens; UsageAnomalies; TotalCostUsd; TurnScheduled;
-    TurnCompleted; PacingShadowEvents; PacingShadowNextDueSec; FailureRoute; FailureDrivenPause; IdleSeconds; ContractViolations; MetricEmitDropped;
-    ContextMaxObserved; TurnStarts; TurnReattempts; TurnRegressions;
-    TurnLivelockBlocks; TurnLivelockBlocksRepeated; TurnLivelockBlocksThresholdPark; TurnLatencyBucket;
-    TurnLatencyByModelBucket; ProviderCooldownSkip; ProviderCooldownRemainingSec; ProviderBlockDurationSec;
-    TurnQueueDepth; SupervisorSweepStarts; SupervisorLastSweepUnixtime; DomainPoolFork;
-    TurnHolderBookkeepingFailures; Compactions; CompactionRatioChange; CompactionSavedTokens;
-    CompactionPairRepairDrops; EmergencyCompactRatioThreshold; OperatorCompact; OperatorClear;
-    CompactionNoop; ToolPairRepair; ToolEmissionRegistrySize; ToolEmissionPushes;
-    ToolUnderusedAllowedCount; ToolUnderusedAllowed; PathRejection; IdeOrphanWrites;
-    PathResolverIdentityMismatch; KeeperMetaOverlayDrift; HeartbeatSuccesses; HeartbeatFailures; CleanupTrackingFailures;
-    DispatchEventFailures; DirectiveFailures; ToolCallDuration; ToolCallDurationBucket; WriteMetaFailures;
-    MetaReadFailures; ApprovalQueueFailures; GuardsFailures; ProfileLoadFailures;
-    CompactAuditFailures; CompactAuditRetentionParse; CompactAuditDrainBatches; CompactAuditDrainBatchSizeBucket;
-    FsFailures; CrashPersistenceFailures; GenerationLineageFailures; KeepaliveSignalFailures;
-    BoardSignalWakeupCappedTotal; BoardSignalNoWakeTotal; BoardSignalAttentionCandidateTotal; MetaJsonFailures; ToolsOasFailures;
-    ToolsOasDeterministicFailures; TurnUpUpdateFailures; AgentToolDispatchRuntimeFailures; CircuitBreakerTrips;
-    PromptFailures; RunContextFailures; SearchFilesFailures; TagDispatchFailures;
-    TraceEmitFailures; TransitionAuditFailures; ExecutionReceiptFailures; OperatorBroadcastSuppressed;
-    LlmBridgeFailures; SessionCleanupFailures; ToolExecuteFailures; RolloverFailures;
-    LifecycleDispatchRejections; RecordingErrorDedup; PausedStatePersistErrors; UnexpectedToolPartialTolerance;
-    ToolCallTotal; ProfileConfigConflicts; OasTimeoutClassifications; NoToolProvider;
-    ProactiveOutcome; OllamaSaturationSkip; TaskLoadFailures; ToolSelectionFailures;
-    ReconcileFailures; DecisionAuditFlushFailures; OasCancel;
-    ClaimAutoProvision; TomlInvalid; PersonaDriftMissing; WorkspaceInitFailures;
-    PresenceSyncFailures; SelfPreservationUniversal; StaleStormPaused; ProviderTimeoutLoopPaused;
-    TurnFailureStreakPaused;
-    CycleExceptions; SnapshotReadFailures; SnapshotWriteFailures; PromptUnknownToolTokens;
-    PromptTokenStripped;
-    ProgressUpdatedLineFailures;
-    SseBroadcastFailures; WorkspaceHeartbeatFailures; TurnMetricsSnapshotFailures; OasExecutionErrors;
-    EpisodeCreateFailures; MemoryActivityEmitFailures; SupervisorSweepFailures; TomlReconcileSweepFailures;
-    TomlReconcileDedup; ReconcileDisabled; ToolUsageFlushFailures; TurnTimeoutCommitted;
-    TurnErrorAfterTools; RuntimeSyncFailures; LocalDiscoveryFailures; ThinkingPersistFailures;
-    CheckpointFailures; DecisionAuditRingOverflows; ReplySkillRouteStrips; ReplySkillRouteLinesRemoved;
-    MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; HitlSummaryOutcomes; UserVisibleReplySource;
-    OasEnvKeyRejections;
-    MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneRanInline; MemoryLaneDropped;
-    MemoryLanePending; MemoryLaneInFlight; MemoryLaneProviderSlotBusy; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
-    MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; KeeperMaterializationFailures; ObservationQueryFailures; OasOnStop;
-    InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
-    TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;
-    EventBusDrain; SupervisorCleanupFailures; SpawnSlotDenied; RegistryUpdateDropped;
-    RegistryOrphanThresholdBreached; RegistryInvalidEntry; DeadTotal; AutoResumedTotal; AutoResumeBlockedTotal;
-    SkipIdleWakeResumed; EventQueueOverride; StimulusConsumed; UnsupportedStimulus;
-    NearExhaustionTotal; RestartAttempts; RestartOutcomes;
-    LastProductiveTs; ProviderTimeoutStrike; StaleTerminationTotal; StaleTerminationByClass;
-    ProviderTimeoutWatchdogTermination; StaleTerminationThresholdBreached; StaleTerminationBatch; StaleBroadcastEmitFailures;
-    OasRunTimeout; RuntimeSaturationSignal; RuntimeSelected; RuntimeRotation; ToolUseFailure; ToolNotAllowed;
-    TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
-    DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
-    UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
-    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; MemoryOsReobserveEchoSuppressed; RuntimeHttpProbeJsonParseFailures;
-    VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
-    KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal; ToolExecutePrActionTotal;
-    GhClassificationTotal; GatedGhLifecycleTotal; GatedGhBlockTimeSeconds;
-  KeeperRepoMappingDefaultScopeAllowed; KeeperRepoMappingDeniedUnregistered;
-  KeeperRepoMappingLoadError;
-  KeeperRepoMappingRepositoryIdentityMismatch; KeeperRepoMappingRepositoryStoreError;
-  RawTraceSinkDegraded; WireCaptureResponseSuppressed; WireCaptureWriteFailures;
-  WireCaptureRecordSkipped
-  ]
 ;;
 
 let emit_runtime_selected ~keeper_name ~runtime_id ~fallback_reason =

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -255,7 +255,7 @@ val emit_runtime_selected :
 val emit_runtime_rotation :
   keeper_name:string -> from_runtime:string -> to_runtime:string -> reason:string -> unit
 
-(** Every constructor of [t] in declaration order.  Keep in sync when
-    adding constructors (the [to_string] exhaustive match in the .ml
-    forces an edit in the same file). *)
+(** Every constructor of [t], generated from the type declaration by
+    [ppx_enumerate].  Membership is compiler-maintained; list order is not a
+    public contract. *)
 val all : t list

--- a/masc.opam
+++ b/masc.opam
@@ -37,6 +37,7 @@ depends: [
   "domain-name" {>= "0.4"}
   "ca-certs" {>= "0.2"}
   "ppx_deriving_yojson" {>= "3.6"}
+  "ppx_enumerate" {>= "v0.17.0"}
   "ppx_let" {>= "v0.17.0"}
   "ppx_deriving" {>= "5.2"}
   "ppxlib" {>= "0.30"}

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -17,9 +17,9 @@ lib/exec/exec_dispatch.ml:378  # argv_dispatch
 lib/exec_policy/exec_policy.ml:148  # parser_consumer
 lib/graphql_client.ml:102  # argv_subsystem
 lib/graphql_client.ml:87  # argv_subsystem
-lib/keeper/keeper_alerting.ml:333  # argv_keeper
-lib/keeper/keeper_alerting.ml:383  # argv_keeper
-lib/keeper/keeper_alerting.ml:477  # argv_keeper
+lib/keeper/keeper_alerting.ml:212  # argv_keeper
+lib/keeper/keeper_alerting.ml:262  # argv_keeper
+lib/keeper/keeper_alerting.ml:356  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:224  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:477  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:196  # argv_keeper

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -47,6 +47,15 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
+(* ci-run-tests.sh sets these itself (isolated build dir, cache disable, RPC
+   unset on retry) and the assertions below record their exact values. Letting
+   them leak in from the ambient environment makes the test observe whatever
+   the runner exports rather than what the script does: the Build and Test job
+   exports DUNE_CACHE=enabled, which turns the first-attempt record from
+   "test|||<cwd>" into "test||enabled|<cwd>". Explicit overrides are applied
+   after this removal, so a test that wants a value can still set one. *)
+let dune_vars_owned_by_script = [ "DUNE_BUILD_DIR"; "DUNE_CACHE"; "DUNE_RPC" ]
+
 let env_array overrides =
   let table = Hashtbl.create 64 in
   Unix.environment ()
@@ -59,6 +68,7 @@ let env_array overrides =
                String.sub entry (idx + 1) (String.length entry - idx - 1)
              in
              Hashtbl.replace table key value);
+  List.iter (Hashtbl.remove table) dune_vars_owned_by_script;
   List.iter (fun (key, value) -> Hashtbl.replace table key value) overrides;
   Hashtbl.fold
     (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1065,45 +1065,46 @@ let () =
      an already-running autonomous OAS loop. The classifier reads the same
      registry queue this test dequeues below; no age, count, or payload text
      heuristic participates. *)
-  let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
-  Fun.protect
-    ~finally:(fun () ->
-      Masc.Keeper_registry.clear ();
-      Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "keeper-event-queue-yield-test" in
-      let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
-      Masc.Keeper_registry.clear ();
-      Masc.Keeper_chat_queue.clear ~keeper_name;
-      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
-      (match
-         Masc.Keeper_unified_turn_execution.autonomous_yield_request
-           ~base_path
-           ~keeper_name
-           ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
-       with
-       | None -> ()
-       | Some _ ->
-         Alcotest.fail "empty work queues must not request an autonomous yield");
-      Masc.Keeper_registry_event_queue.enqueue
-        ~base_path
-        keeper_name
-        bootstrap_stim;
-      match
-        Masc.Keeper_unified_turn_execution.autonomous_yield_request
+  Eio_main.run (fun _env ->
+    let base_path = temp_dir "keeper-event-queue-autonomous-yield" in
+    Fun.protect
+      ~finally:(fun () ->
+        Masc.Keeper_registry.clear ();
+        Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
+        rm_rf base_path)
+      (fun () ->
+        let keeper_name = "keeper-event-queue-yield-test" in
+        let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
+        Masc.Keeper_registry.clear ();
+        Masc.Keeper_chat_queue.clear ~keeper_name;
+        ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+        (match
+           Masc.Keeper_unified_turn_execution.autonomous_yield_request
+             ~base_path
+             ~keeper_name
+             ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
+         with
+         | None -> ()
+         | Some _ ->
+           Alcotest.fail "empty work queues must not request an autonomous yield");
+        Masc.Keeper_registry_event_queue.enqueue
           ~base_path
-          ~keeper_name
-          ~channel:Masc.Keeper_world_observation.Reactive
-      with
-      | Some
-          { Masc.Keeper_agent_run.reason =
-              Masc.Keeper_agent_run.Durable_stimulus_waiting
-          ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
-          } ->
-        ()
-      | None | Some _ ->
-        Alcotest.fail "pending durable stimulus must request a typed yield");
+          keeper_name
+          bootstrap_stim;
+        match
+          Masc.Keeper_unified_turn_execution.autonomous_yield_request
+            ~base_path
+            ~keeper_name
+            ~channel:Masc.Keeper_world_observation.Reactive
+        with
+        | Some
+            { Masc.Keeper_agent_run.reason =
+                Masc.Keeper_agent_run.Durable_stimulus_waiting
+            ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
+            } ->
+          ()
+        | None | Some _ ->
+          Alcotest.fail "pending durable stimulus must request a typed yield"));
 
   (* --- critical delivery: durable enqueue succeeds before registration and
      is replayed when that keeper lane appears. --- *)

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -1,6 +1,17 @@
 module Claim = Masc.Keeper_repo_claim_hitl
 module AQ = Masc.Keeper_approval_queue
 
+(* #23956 made nonblocking resolution fail closed when no delivery hook is
+   installed (the pre-bootstrap default is None). These tests resolve
+   approvals without a server bootstrap, so install the same no-op hook the
+   approval queue's own suite uses; delivery semantics are covered there,
+   not here. *)
+let () =
+  AQ.set_approval_resolution_wake_hook
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+;;
+
 open Repo_manager_types
 
 let contains_substring s needle =

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -17,6 +17,19 @@ module Metrics = Masc.Otel_metric_store
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
+(* #23956 makes nonblocking approval resolution fail closed when no delivery
+   hook is installed. This suite drives [AQ.resolve] to exercise the retry
+   classifier, not to assert on delivery, so install a no-op wake hook.
+   Delivery semantics are covered in [test_keeper_approval_queue.ml].
+   (WORKAROUND: per-file install mirrors [test_keeper_repo_claim_hitl.ml] and
+   [test_keeper_event_queue.ml] from #23989; the root fix is a shared default
+   hook in [test_common], tracked as N-of-M debt in the consolidation PR.) *)
+let () =
+  AQ.set_approval_resolution_wake_hook
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()))
+;;
+
 let reason_testable =
   let pp ppf reason = Format.pp_print_string ppf (D.to_telemetry_key reason) in
   Alcotest.testable pp ( = )

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -56,8 +56,10 @@ let test_chat_transport_metric_zero_filled () =
 let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
-     constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 251
+     constructor, add it to [all] as well.  245 = 253 before the #23929
+     prose/BDI purge minus the 8 constructors it retired (the purge updated
+     this pin to 251, undercounting its own removals by 6). *)
+  check int "Keeper_metrics.all covers every constructor" 245
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -54,13 +54,9 @@ let test_chat_transport_metric_zero_filled () =
     check (float 0.0) "chat transport failure counter starts at 0" 0.0 m.value
 
 let test_keeper_metrics_all_complete () =
-  (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
-     ppx; this count is the drift tripwire.  If this fails after adding a
-     constructor, add it to [all] as well.  245 = 253 before the #23929
-     prose/BDI purge minus the 8 constructors it retired (the purge updated
-     this pin to 251, undercounting its own removals by 6). *)
-  check int "Keeper_metrics.all covers every constructor" 245
-    (List.length Keeper_metrics.all);
+  (* [Keeper_metrics.all] is generated from the variant declaration, so
+     constructor coverage is guaranteed by compilation rather than a numeric
+     pin.  Keep the independent wire-name uniqueness contract here. *)
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"
     (List.length names)


### PR DESCRIPTION
## 목적: orphaned된 main-red 복구 재-랜딩

main은 6개 테스트 그룹에 red다. ENOSPC 인프라(#24009 hardlink)만 고쳐졌고, 나머지 5개를 고치는 검증된 fix(#24013, #23989)와 통합(#24017)이 **미병합·대체 없이 CLOSED**되어 유실됐다. 그 사이 fleet은 red main 위에 새 기능(#24039~)을 쌓는 중이다. 이 PR은 그 5개 fix를 **현재 main 위에 재통합**해 main-green을 복구한다(사용자 승인 하 재-랜딩).

## 진단 (라이브 CI 실측, main run 29114916256)

ENOSPC가 링킹을 통과시키자 드러난 latent 실패:

| 실패 그룹 | 원인 | 처방 |
|---|---|---|
| `script` (ci-run-tests) | 테스트가 dune env 상속 → 비결정 | #24013 |
| `module-init` Keeper_metrics.all pin | #23929 purge+#23863 counter로 수동 pin drift (245→251→…) | #23989: pin 제거 → `[@@deriving enumerate]` |
| `repo advisory access` ×5 | #23956 hook fail-closed에 테스트 hook 미설치 | #23989 |
| `on_worker_aborted` | Eio 큐 assertion | #23989 event-queue |
| `shell_ir_approval_queue` | 같은 hook을 `test_keeper_tool_execute_retry_deterministic_close`가 빠뜨림 (N-of-M) | 이 PR (approval hook) |

## 포함 (closed 브랜치 커밋 재사용, 현재 main 위 재해결)

- `#24013` (`a09fc52c`): `test_ci_run_tests_script.ml` dune env 상속 차단.
- `#23989` (merge): `keeper_metrics` derive-enumerate(수동 카운트 영구 제거, #23863 신규 생성자 포함) + advisory hook + event-queue.
- approval hook (`75363d5c`): deterministic-close suite N-of-M 완성.

`keeper_metrics.ml` 충돌은 **derive 방식으로 해결**(현재 main의 전체 생성자 세트 유지 + `[@@deriving enumerate]`, 수동 `all` 삭제) — pin drift를 영구 제거한다.

## 남은 것 (정직하게)

`executor_pool 34` (`test_dashboard_http_core` `configured_keepers` Expected 3/Received 2)는 이 PR에 **미포함**. 정적분석상 3이 맞으나(base discover+uncached filter+autoboot=true→materializable) 실측 2 — 런타임 전용(테스트 격리 추정). 이 PR의 CI가 executor_pool 34를 **단독 실패로 격리**하면 CI 관측으로 크랙해 follow-up 커밋으로 추가한다. 진단: memory/project-masc-executor-pool-34-configured-keepers-borned-20260711.md.

## 검증

- 눈 검증(dune는 CI): 충돌 마커 0, `[@@deriving enumerate]` 존재, 생성자 세트 main과 일치, ppx_enumerate 3곳 배선.
- 이 PR의 `Build and Test`가 executor_pool 34만 남기고 green이면 5/6 해소 증명.

## 범위 밖

- Branch Protection Watchdog red(enforce_admins drift)는 별개 축 — repo 설정.
- RFC 게이트: credential/operator/sandbox/hooks/workflow 코드 변경 없음(metrics derive + 테스트 hook + CI test). RFC 불요.
- N-of-M 부채: approval hook의 per-file 설치는 [test_common] 공유 default hook으로 근본해결 예정(별도).

Co-Authored-By: keeper-executor-agent <noreply@masc.local>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
