### PR TITLE
chore(dashboard): delete settings→routing keeper-assignments panel, SSOT-deep (#53)

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -3262,7 +3262,6 @@ describe('fetchRuntimeDefaults', () => {
         { id: 'openai.gpt-4o', provider: 'OpenAI', model: 'gpt-4o', max_context: 128000, is_default: true },
       ],
       model_routing: {
-        keeper_assignments: [{ keeper: 'analyst', runtime_id: 'openai.gpt-4o' }],
         librarian_runtime_id: null,
         structured_judge_runtime_id: null,
         cross_verifier_runtime_id: null,
@@ -3283,6 +3282,5 @@ describe('fetchRuntimeDefaults', () => {
     expect(result.default_runtime_id).toBe('openai.gpt-4o')
     expect(result.default_model).toBe('gpt-4o')
     expect(result.runtimes[0]?.is_default).toBe(true)
-    expect(result.model_routing.keeper_assignments[0]?.keeper).toBe('analyst')
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -8,7 +8,6 @@ import { type LogEntry, type LogsResponse } from './schemas/logs'
 import {
   type RuntimeDefaultsResponse,
   type RuntimeEntry,
-  type KeeperAssignment,
   type ModelRouting,
 } from './schemas/runtime-defaults'
 import {
@@ -64,7 +63,7 @@ export { decodeDashboardFeedMetadata } from './dashboard-shared'
 // --- System logs ---
 
 export type { LogEntry, LogsResponse }
-export type { RuntimeDefaultsResponse, RuntimeEntry, KeeperAssignment, ModelRouting }
+export type { RuntimeDefaultsResponse, RuntimeEntry, ModelRouting }
 export type {
   RuntimeResolvedResponse,
   RuntimeResolution,

--- a/dashboard/src/api/schemas/runtime-defaults.test.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.test.ts
@@ -19,7 +19,6 @@ function validResponse(overrides: Record<string, unknown> = {}): Record<string, 
       { id: 'anthropic.sonnet', provider: 'Anthropic', model: 'claude-sonnet-4', max_context: 200000, is_default: false },
     ],
     model_routing: {
-      keeper_assignments: [{ keeper: 'analyst', runtime_id: 'anthropic.sonnet' }],
       librarian_runtime_id: 'openai.gpt-4o',
       structured_judge_runtime_id: 'openai.gpt-4o',
       hitl_summary_runtime_id: 'anthropic.sonnet',
@@ -37,10 +36,6 @@ describe('parseRuntimeDefaultsResponse', () => {
     expect(out.default_model).toBe('gpt-4o')
     expect(out.runtimes).toHaveLength(2)
     expect(out.runtimes[0]!.is_default).toBe(true)
-    expect(out.model_routing.keeper_assignments[0]).toEqual({
-      keeper: 'analyst',
-      runtime_id: 'anthropic.sonnet',
-    })
     expect(out.model_routing.structured_judge_runtime_id).toBe('openai.gpt-4o')
     expect(out.model_routing.hitl_summary_runtime_id).toBe('anthropic.sonnet')
     expect(out.model_routing.cross_verifier_runtime_id).toBeNull()
@@ -55,7 +50,6 @@ describe('parseRuntimeDefaultsResponse', () => {
         default_max_context: null,
         runtimes: [],
         model_routing: {
-          keeper_assignments: [],
           librarian_runtime_id: null,
           structured_judge_runtime_id: null,
           hitl_summary_runtime_id: null,
@@ -67,7 +61,6 @@ describe('parseRuntimeDefaultsResponse', () => {
     expect(out.default_runtime_id).toBeNull()
     expect(out.default_model).toBeNull()
     expect(out.runtimes).toHaveLength(0)
-    expect(out.model_routing.keeper_assignments).toHaveLength(0)
   })
 
   it('throws schema drift when a runtime entry is missing a required field', () => {

--- a/dashboard/src/api/schemas/runtime-defaults.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.ts
@@ -29,13 +29,7 @@ const RuntimeEntrySchema = object({
   is_default: boolean(),
 })
 
-const KeeperAssignmentSchema = object({
-  keeper: string(),
-  runtime_id: string(),
-})
-
 const ModelRoutingSchema = object({
-  keeper_assignments: array(KeeperAssignmentSchema),
   librarian_runtime_id: nullable(string()),
   structured_judge_runtime_id: nullable(string()),
   hitl_summary_runtime_id: optional(nullable(string())),
@@ -56,7 +50,6 @@ const RuntimeDefaultsResponseSchema = object({
 })
 
 export type RuntimeEntry = InferOutput<typeof RuntimeEntrySchema>
-export type KeeperAssignment = InferOutput<typeof KeeperAssignmentSchema>
 export type ModelRouting = InferOutput<typeof ModelRoutingSchema>
 export type RuntimeDefaultsResponse = InferOutput<typeof RuntimeDefaultsResponseSchema>
 

--- a/dashboard/src/components/keeper-runtime-model-editor.test.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.test.ts
@@ -487,7 +487,9 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
     await flush()
 
     const badge = container.querySelector('[data-testid="keeper-runtime-assignment-source"]')
-    expect(badge?.textContent?.trim()).toBe('explicit')
+    expect(badge?.textContent?.trim()).toBe('explicit → a.one')
+    expect(badge?.getAttribute('data-assignment-source')).toBe('explicit')
+    expect(badge?.getAttribute('data-assignment-target-kind')).toBe('single_runtime')
   })
 
   it('shows a default assignment_source badge for a keeper riding [runtime].default with no explicit entry', async () => {
@@ -505,10 +507,10 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
     await flush()
 
     const badge = container.querySelector('[data-testid="keeper-runtime-assignment-source"]')
-    expect(badge?.textContent?.trim()).toBe('default')
+    expect(badge?.textContent?.trim()).toBe('default → a.one')
   })
 
-  it('renders no assignment_source badge when the resolved endpoint has no entry for this keeper', async () => {
+  it('surfaces a missing assignment projection instead of hiding it', async () => {
     refs.config = makeConfig({ selected_runtime_id: 'a.one' })
     refs.resolved.mockResolvedValue(makeRuntimeResolved({ assignments: [] }))
     render(
@@ -519,5 +521,21 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
     await flush()
 
     expect(container.querySelector('[data-testid="keeper-runtime-assignment-source"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-runtime-assignment-missing"]')?.textContent)
+      .toContain('assignment projection에 Keeper가 없습니다')
+  })
+
+  it('surfaces a runtime-resolved fetch error instead of rendering an absent badge', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    refs.resolved.mockRejectedValue(new Error('runtime resolved unavailable'))
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="error-keeper" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
+    await flush()
+    await flush()
+
+    expect(container.querySelector('[data-testid="keeper-runtime-assignment-error"]')?.textContent)
+      .toContain('runtime resolved unavailable')
   })
 })

--- a/dashboard/src/components/keeper-runtime-model-editor.test.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.test.ts
@@ -9,6 +9,7 @@ const refs = vi.hoisted(() => ({
   config: null as unknown,
   status: 'loaded' as string,
   providers: vi.fn(),
+  resolved: vi.fn(),
   load: vi.fn(),
   // Spy for the deep-link tab focus. The card is read-only; it no longer writes
   // runtime_id — it only opens the config modal pre-focused on the 런타임 tab.
@@ -21,6 +22,7 @@ const refs = vi.hoisted(() => ({
 vi.mock('../api/dashboard', () => ({
   patchKeeperConfig: vi.fn(),
   fetchRuntimeProviders: refs.providers,
+  fetchRuntimeResolved: refs.resolved,
   fetchKeeperConfig: vi.fn(),
   fetchDashboardGoalsTree: vi.fn(),
 }))
@@ -42,6 +44,8 @@ vi.mock('./keeper-config-panel', async () => {
 vi.mock('./common/toast', () => ({ showToast: vi.fn() }))
 
 import { KeeperRuntimeModelEditor } from './keeper-runtime-model-editor'
+import { resetRuntimeResolved } from '../lib/runtime-resolved-resource'
+import type { RuntimeResolvedResponse } from '../api/dashboard'
 import { resetRuntimeCatalog } from '../lib/runtime-catalog-resource'
 
 async function flush() {
@@ -269,6 +273,22 @@ function makeRuntimeProvider(runtimeId: string, providerName: string, modelName:
   }
 }
 
+// Minimal RuntimeResolvedResponse fixture — only [assignments] drives the
+// badge under test here; the other fields are exercised by
+// runtime-resolved.ts's own schema tests.
+function makeRuntimeResolved(
+  overrides: Partial<RuntimeResolvedResponse> = {},
+): RuntimeResolvedResponse {
+  return {
+    config_path: '/cfg/runtime.toml',
+    default_runtime: null,
+    runtimes: [],
+    lanes: [],
+    assignments: [],
+    ...overrides,
+  }
+}
+
 describe('KeeperRuntimeModelEditor (read-only card)', () => {
   let container: HTMLDivElement
 
@@ -285,6 +305,9 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
         makeRuntimeProvider('b.two', 'Provider B', 'model-b'),
       ],
     })
+    refs.resolved.mockReset()
+    refs.resolved.mockResolvedValue(makeRuntimeResolved())
+    resetRuntimeResolved()
     refs.load.mockReset()
     refs.focusTab.mockReset()
   })
@@ -293,6 +316,7 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
     render(null, container)
     container.remove()
     resetRuntimeCatalog()
+    resetRuntimeResolved()
   })
 
   it('renders the current runtime + catalog summary read-only, with no editable <select>', async () => {
@@ -441,5 +465,59 @@ describe('KeeperRuntimeModelEditor (read-only card)', () => {
     render(html`<${KeeperRuntimeModelEditor} keeperName="loading-keeper" />`, container)
     await flush()
     expect(container.textContent).toContain('불러오는 중')
+  })
+
+  // The settings→routing "Keeper assignments" panel used to be the only place
+  // showing whether a keeper's runtime came from an explicit
+  // [runtime.assignments] entry or the [runtime].default rider. Deleting that
+  // panel must not lose the fact — this card now surfaces it via
+  // GET /api/v1/runtime/resolved (assignments), read-only.
+  it('shows an explicit assignment_source badge for a keeper with a [runtime.assignments] entry', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    refs.resolved.mockResolvedValue(makeRuntimeResolved({
+      assignments: [
+        { keeper: 'explicit-keeper', assignment_source: 'explicit', resolved: { kind: 'single_runtime', id: 'a.one' } },
+      ],
+    }))
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="explicit-keeper" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
+    await flush()
+    await flush()
+
+    const badge = container.querySelector('[data-testid="keeper-runtime-assignment-source"]')
+    expect(badge?.textContent?.trim()).toBe('explicit')
+  })
+
+  it('shows a default assignment_source badge for a keeper riding [runtime].default with no explicit entry', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    refs.resolved.mockResolvedValue(makeRuntimeResolved({
+      assignments: [
+        { keeper: 'default-rider', assignment_source: 'default', resolved: { kind: 'single_runtime', id: 'a.one' } },
+      ],
+    }))
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="default-rider" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
+    await flush()
+    await flush()
+
+    const badge = container.querySelector('[data-testid="keeper-runtime-assignment-source"]')
+    expect(badge?.textContent?.trim()).toBe('default')
+  })
+
+  it('renders no assignment_source badge when the resolved endpoint has no entry for this keeper', async () => {
+    refs.config = makeConfig({ selected_runtime_id: 'a.one' })
+    refs.resolved.mockResolvedValue(makeRuntimeResolved({ assignments: [] }))
+    render(
+      html`<${KeeperRuntimeModelEditor} keeperName="unlisted-keeper" onOpenRuntimeConfig=${vi.fn()} />`,
+      container,
+    )
+    await flush()
+    await flush()
+
+    expect(container.querySelector('[data-testid="keeper-runtime-assignment-source"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -37,6 +37,7 @@ import {
   loadRuntimeResolved,
   runtimeResolvedState,
 } from '../lib/runtime-resolved-resource'
+import type { RuntimeAssignment } from '../api/schemas/runtime-resolved'
 import {
   runtimeCatalogDeclaredSpec,
   runtimeCatalogEffectiveCapabilities,
@@ -168,18 +169,40 @@ function EditorHeader() {
 // did not. Sourced from GET /api/v1/runtime/resolved (read-only; no new write
 // path, no string matching — the resolved endpoint already types this as a
 // closed 'explicit' | 'default' union).
-function AssignmentSourceBadge({ source }: { source: 'explicit' | 'default' }) {
-  const tone = source === 'explicit'
+function AssignmentSourceBadge({ assignment }: { assignment: RuntimeAssignment }) {
+  const tone = assignment.assignment_source === 'explicit'
     ? 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
     : 'border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'
+  const target = assignment.resolved.id ?? assignment.resolved.kind
   return html`
     <span
       class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${tone}"
       data-testid="keeper-runtime-assignment-source"
+      data-assignment-source=${assignment.assignment_source}
+      data-assignment-target-kind=${assignment.resolved.kind}
     >
-      ${source}
+      ${assignment.assignment_source} → ${target}
     </span>
   `
+}
+
+function AssignmentTruth({
+  state,
+  keeperName,
+}: {
+  state: typeof runtimeResolvedState.value
+  keeperName: string
+}) {
+  if (state.status === 'idle' || state.status === 'loading') {
+    return html`<span class="text-3xs text-[var(--color-fg-muted)]" data-testid="keeper-runtime-assignment-loading">assignment 불러오는 중</span>`
+  }
+  if (state.status === 'error') {
+    return html`<span class="text-3xs text-[var(--color-status-danger)]" data-testid="keeper-runtime-assignment-error">assignment 확인 실패: ${state.message}</span>`
+  }
+  const assignment = state.data.assignments.find(item => item.keeper === keeperName)
+  return assignment
+    ? html`<${AssignmentSourceBadge} assignment=${assignment} />`
+    : html`<span class="text-3xs text-[var(--color-status-warn)]" data-testid="keeper-runtime-assignment-missing">assignment projection에 Keeper가 없습니다.</span>`
 }
 
 export function KeeperRuntimeModelEditor({
@@ -214,15 +237,9 @@ export function KeeperRuntimeModelEditor({
   const catalog = catalogState.status === 'loaded' ? catalogState.data : []
   const runtimeEntry = findRuntimeCatalogEntry(catalog, current)
 
-  loadRuntimeResolved()
+  void loadRuntimeResolved()
   const resolvedState = runtimeResolvedState.value
-  const assignment =
-    resolvedState.status === 'loaded'
-      ? (resolvedState.data.assignments.find(a => a.keeper === keeperName) ?? null)
-      : null
-  const assignmentBadge = assignment
-    ? html`<${AssignmentSourceBadge} source=${assignment.assignment_source} />`
-    : null
+  const assignmentTruth = html`<${AssignmentTruth} state=${resolvedState} keeperName=${keeperName} />`
 
   const canonicalRow =
     canonical && canonical !== current
@@ -241,7 +258,7 @@ export function KeeperRuntimeModelEditor({
         <${EditorHeader} />
         <div class="flex flex-wrap items-center gap-2">
           <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</div>
-          ${assignmentBadge}
+          ${assignmentTruth}
         </div>
         ${canonicalRow}
         ${summary}
@@ -261,7 +278,7 @@ export function KeeperRuntimeModelEditor({
       <${EditorHeader} />
       <div class="flex flex-wrap items-center gap-2">
         <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</span></div>
-        ${assignmentBadge}
+        ${assignmentTruth}
       </div>
       ${canonicalRow}
       ${summary}

--- a/dashboard/src/components/keeper-runtime-model-editor.ts
+++ b/dashboard/src/components/keeper-runtime-model-editor.ts
@@ -34,6 +34,10 @@ import {
   runtimeCatalogState,
 } from '../lib/runtime-catalog-resource'
 import {
+  loadRuntimeResolved,
+  runtimeResolvedState,
+} from '../lib/runtime-resolved-resource'
+import {
   runtimeCatalogDeclaredSpec,
   runtimeCatalogEffectiveCapabilities,
   runtimeCatalogParameterPolicy,
@@ -158,6 +162,26 @@ function EditorHeader() {
   `
 }
 
+// assignment_source distinguishes an explicit [runtime.assignments] entry from
+// a keeper riding [runtime].default with no entry of its own — the one fact
+// the deleted settings→routing fleet panel showed that this per-keeper card
+// did not. Sourced from GET /api/v1/runtime/resolved (read-only; no new write
+// path, no string matching — the resolved endpoint already types this as a
+// closed 'explicit' | 'default' union).
+function AssignmentSourceBadge({ source }: { source: 'explicit' | 'default' }) {
+  const tone = source === 'explicit'
+    ? 'border-[var(--accent-20)] bg-[var(--accent-10)] text-[var(--color-accent-fg)]'
+    : 'border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'
+  return html`
+    <span
+      class="rounded-[var(--r-1)] border px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] ${tone}"
+      data-testid="keeper-runtime-assignment-source"
+    >
+      ${source}
+    </span>
+  `
+}
+
 export function KeeperRuntimeModelEditor({
   keeperName,
   onOpenRuntimeConfig,
@@ -190,6 +214,16 @@ export function KeeperRuntimeModelEditor({
   const catalog = catalogState.status === 'loaded' ? catalogState.data : []
   const runtimeEntry = findRuntimeCatalogEntry(catalog, current)
 
+  loadRuntimeResolved()
+  const resolvedState = runtimeResolvedState.value
+  const assignment =
+    resolvedState.status === 'loaded'
+      ? (resolvedState.data.assignments.find(a => a.keeper === keeperName) ?? null)
+      : null
+  const assignmentBadge = assignment
+    ? html`<${AssignmentSourceBadge} source=${assignment.assignment_source} />`
+    : null
+
   const canonicalRow =
     canonical && canonical !== current
       ? html`<div class="text-2xs text-[var(--color-fg-muted)]">정규화: ${canonical}</div>`
@@ -205,7 +239,10 @@ export function KeeperRuntimeModelEditor({
     return html`
       <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--color-border-default)]/60 bg-[var(--color-bg-surface)]/35 px-4 py-3">
         <${EditorHeader} />
-        <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</div>
+        <div class="flex flex-wrap items-center gap-2">
+          <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</div>
+          ${assignmentBadge}
+        </div>
         ${canonicalRow}
         ${summary}
         <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2 text-2xs leading-relaxed text-[var(--color-status-warn)]">
@@ -222,7 +259,10 @@ export function KeeperRuntimeModelEditor({
   return html`
     <div class="v2-monitoring-card flex flex-col gap-2 rounded-[var(--r-4)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-4 py-3">
       <${EditorHeader} />
-      <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</span></div>
+      <div class="flex flex-wrap items-center gap-2">
+        <div class="text-2xs text-[var(--color-fg-muted)]">현재 <span class="font-semibold text-[var(--color-fg-primary)]">${current || MISSING_DATA_DASH}</span></div>
+        ${assignmentBadge}
+      </div>
       ${canonicalRow}
       ${summary}
       ${onOpenRuntimeConfig

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -166,7 +166,6 @@ function makeRuntimeDefaults(
       { id: 'rt-c', provider: 'P', model: 'm3', max_context: 128000, is_default: false },
     ],
     model_routing: {
-      keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
       librarian_runtime_id: null,
       structured_judge_runtime_id: null,
       hitl_summary_runtime_id: null,
@@ -1250,11 +1249,10 @@ describe('SettingsSurface', () => {
     expect(container.querySelectorAll('[data-testid="runtime-catalog-card"]').length).toBe(0)
   })
 
-  it('routing section shows resolved model routing controls and keeper assignments', async () => {
+  it('routing section shows resolved model routing controls', async () => {
     stubRuntimeDefaults(
       makeRuntimeDefaults({
         model_routing: {
-          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
           librarian_runtime_id: 'rt-b',
           structured_judge_runtime_id: 'rt-c',
           hitl_summary_runtime_id: 'rt-a',
@@ -1263,13 +1261,7 @@ describe('SettingsSurface', () => {
         },
       }),
     )
-    stubRuntimeResolved(
-      makeRuntimeResolved({
-        assignments: [
-          { keeper: 'analyst', assignment_source: 'explicit', resolved: { kind: 'single_runtime', id: 'rt-b' } },
-        ],
-      }),
-    )
+    stubRuntimeResolved(makeRuntimeResolved())
     render(html`<${SettingsSurface} />`, container)
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement)
@@ -1290,10 +1282,6 @@ describe('SettingsSurface', () => {
         .toBe('rt-a')
       expect(container.querySelector('[data-testid="runtime-routing-cross-verifier"]')).not.toBeNull()
       expect(container.querySelector('[data-testid="runtime-media-failover-editor"]')).not.toBeNull()
-      const assignments = Array.from(
-        container.querySelectorAll('[data-testid="routing-assignment"]'),
-      ).map(n => n.textContent)
-      expect(assignments).toEqual(['rt-b'])
     })
   })
 
@@ -1303,7 +1291,6 @@ describe('SettingsSurface', () => {
       .mockResolvedValueOnce(makeRuntimeDefaults())
       .mockResolvedValueOnce(makeRuntimeDefaults({
         model_routing: {
-          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
           librarian_runtime_id: 'rt-b',
           structured_judge_runtime_id: null,
           hitl_summary_runtime_id: null,
@@ -1339,7 +1326,6 @@ describe('SettingsSurface', () => {
       .mockResolvedValueOnce(makeRuntimeDefaults())
       .mockResolvedValueOnce(makeRuntimeDefaults({
         model_routing: {
-          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
           librarian_runtime_id: null,
           structured_judge_runtime_id: null,
           hitl_summary_runtime_id: 'rt-c',
@@ -1424,7 +1410,6 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeDefaults
       .mockResolvedValueOnce(makeRuntimeDefaults({
         model_routing: {
-          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
           librarian_runtime_id: null,
           structured_judge_runtime_id: null,
           hitl_summary_runtime_id: null,
@@ -1434,7 +1419,6 @@ describe('SettingsSurface', () => {
       }))
       .mockResolvedValueOnce(makeRuntimeDefaults({
         model_routing: {
-          keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
           librarian_runtime_id: null,
           structured_judge_runtime_id: null,
           hitl_summary_runtime_id: null,
@@ -1467,42 +1451,13 @@ describe('SettingsSurface', () => {
     apiMock.fetchRuntimeResolved.mockRejectedValue(new Error('resolved runtime unavailable'))
     render(html`<${SettingsSurface} />`, container)
 
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="routing-assignments-error"]')).not.toBeNull()
+      expect(container.querySelector('[data-testid="runtime-resolved-error"]')).not.toBeNull()
     })
-    expect(container.querySelector('[data-testid="routing-assignments-empty"]')).toBeNull()
-    expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement)
-    expect(container.querySelector('[data-testid="runtime-resolved-error"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="runtime-default-model"]')?.textContent).toBe('—')
     expect(container.querySelector('[data-testid="runtime-default-context"]')?.textContent).toBe('ctx 미수집')
-  })
-
-  it('routing section shows a keeper riding [runtime].default with no explicit assignment (bug #14)', async () => {
-    stubRuntimeResolved(
-      makeRuntimeResolved({
-        assignments: [
-          { keeper: 'analyst', assignment_source: 'explicit', resolved: { kind: 'single_runtime', id: 'rt-b' } },
-          { keeper: 'unassigned-keeper', assignment_source: 'default', resolved: { kind: 'single_runtime', id: 'rt-a' } },
-        ],
-      }),
-    )
-    render(html`<${SettingsSurface} />`, container)
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement)
-
-    await waitFor(() => {
-      const sources = Array.from(
-        container.querySelectorAll('[data-testid="routing-assignment-source"]'),
-      ).map(n => n.textContent)
-      expect(sources).toEqual(['explicit', 'default'])
-      const targets = Array.from(
-        container.querySelectorAll('[data-testid="routing-assignment"]'),
-      ).map(n => n.textContent)
-      expect(targets).toEqual(['rt-b', 'rt-a'])
-    })
   })
 
   it('renders prompt settings from the live prompt registry instead of prototype placeholders', async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1258,13 +1258,7 @@ export function SettingsSurface() {
   const runtimeCatalogEntries = runtimeProviders?.providers ?? []
   const runtimeConfigPath = runtimeResolved?.config_path ?? null
   const defaultRuntimeId = runtimeResolved?.default_runtime?.id ?? null
-  // bug #14: the full keeper fleet joined against [runtime.assignments],
-  // including keepers riding [runtime].default with no explicit entry
-  // (assignment_source: "explicit" | "default") — not an assignments-only
-  // listing.
-  const keeperAssignments = runtimeResolved?.assignments ?? []
   const runtimeCount = runtimeResolved?.runtimes.length ?? 0
-  const keeperAssignmentCount = keeperAssignments.length
   const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
   const structuredJudgeRuntime = runtimeDefaults?.model_routing.structured_judge_runtime_id ?? null
   const hitlSummaryRuntime = runtimeDefaults?.model_routing.hitl_summary_runtime_id ?? null
@@ -1428,10 +1422,6 @@ export function SettingsSurface() {
                       <span class="v mono">${runtimeCatalogEntries.length}</span>
                       <span class="k">catalog entries</span>
                     </div>
-                    <div class="set-rt-launch-stat">
-                      <span class="v mono">${keeperAssignmentCount}</span>
-                      <span class="k">keeper assignments</span>
-                    </div>
                   </div>
                   ${runtimeSelectOptions.length > 0
                     ? html`
@@ -1569,29 +1559,6 @@ export function SettingsSurface() {
                       : runtimeRoutingMessage
                         ? html`<div class=${runtimeRoutingStatus === 'error' ? 'set-err' : 'set-ok'} data-testid="runtime-routing-message">${runtimeRoutingMessage}</div>`
                         : null}
-                  </div>
-                </div>
-
-                <div class="settings-runtime-section" data-runtime-section="assignments" data-testid="runtime-assignments-section">
-                  <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
-                  ${runtimeResolvedStatus === 'loading'
-                    ? html`<div class="set-hint" data-testid="routing-assignments-loading">resolved assignments 불러오는 중...</div>`
-                    : runtimeResolvedStatus === 'error'
-                      ? html`<div class="set-hint" data-testid="routing-assignments-error">resolved assignments를 불러오지 못했습니다.</div>`
-                      : keeperAssignments.length === 0
-                        ? html`<div class="set-hint" data-testid="routing-assignments-empty">등록된 keeper assignment가 없습니다.</div>`
-                        : html`<div class="settings-runtime-routing" data-testid="routing-assignments-list">
-                      ${keeperAssignments.map(a => html`
-                        <div class="set-routing-row" key=${a.keeper}>
-                          <span class="mono">${a.keeper}</span>
-                          <span class="set-hint" data-testid="routing-assignment-source">${a.assignment_source}</span>
-                          <span class="set-routing-arrow">→</span>
-                          <span class="mono" data-testid="routing-assignment">${a.resolved.id ?? '—'}</span>
-                        </div>
-                      `)}
-                    </div>`}
-                  <div class="set-hint" style=${{ marginTop: '8px' }}>
-                    키퍼별 고정 배정(<span class="mono">[runtime.assignments]</span>) 편집은 런타임 관리에서.
                   </div>
                 </div>
               </div>

--- a/dashboard/src/lib/runtime-config-refresh.test.ts
+++ b/dashboard/src/lib/runtime-config-refresh.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const refreshMock = vi.hoisted(() => ({
   refreshKeeperRuntimeStatus: vi.fn<() => Promise<void>>(async () => {}),
   reloadRuntimeCatalog: vi.fn<() => Promise<void>>(async () => {}),
+  reloadRuntimeResolved: vi.fn<() => Promise<void>>(async () => {}),
 }))
 
 vi.mock('../store', () => ({
@@ -13,12 +14,17 @@ vi.mock('./runtime-catalog-resource', () => ({
   reloadRuntimeCatalog: refreshMock.reloadRuntimeCatalog,
 }))
 
+vi.mock('./runtime-resolved-resource', () => ({
+  reloadRuntimeResolved: refreshMock.reloadRuntimeResolved,
+}))
+
 import { refreshRuntimeConfigConsumers } from './runtime-config-refresh'
 
 describe('refreshRuntimeConfigConsumers', () => {
   beforeEach(() => {
     refreshMock.refreshKeeperRuntimeStatus.mockClear()
     refreshMock.reloadRuntimeCatalog.mockClear()
+    refreshMock.reloadRuntimeResolved.mockClear()
   })
 
   it('waits for both the shared catalog and keeper runtime projection', async () => {
@@ -36,6 +42,7 @@ describe('refreshRuntimeConfigConsumers', () => {
     await Promise.resolve()
     expect(settled).toBe(false)
     expect(refreshMock.refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
+    expect(refreshMock.reloadRuntimeResolved).toHaveBeenCalledTimes(1)
 
     resolveCatalog()
     await refresh

--- a/dashboard/src/lib/runtime-config-refresh.ts
+++ b/dashboard/src/lib/runtime-config-refresh.ts
@@ -1,9 +1,11 @@
 import { refreshKeeperRuntimeStatus } from '../store'
 import { reloadRuntimeCatalog } from './runtime-catalog-resource'
+import { reloadRuntimeResolved } from './runtime-resolved-resource'
 
 export async function refreshRuntimeConfigConsumers(): Promise<void> {
   await Promise.all([
     reloadRuntimeCatalog(),
+    reloadRuntimeResolved(),
     refreshKeeperRuntimeStatus({ force: true }),
   ])
 }

--- a/dashboard/src/lib/runtime-resolved-resource.ts
+++ b/dashboard/src/lib/runtime-resolved-resource.ts
@@ -1,0 +1,23 @@
+// Shared runtime-resolved resource.
+//
+// GET /api/v1/runtime/resolved carries the fleet-wide keeper/runtime
+// assignment truth (explicit [runtime.assignments] entries plus keepers
+// riding [runtime].default — see dashboard/src/api/schemas/runtime-resolved.ts).
+// The keeper runtime card needs only the assignment_source for the one keeper
+// it renders; a module-level resource avoids a per-card fetch of the same
+// fleet-wide document.
+
+import { createAsyncResource } from './async-state'
+import { fetchRuntimeResolved, type RuntimeResolvedResponse } from '../api/dashboard'
+
+const runtimeResolvedResource = createAsyncResource<RuntimeResolvedResponse>()
+export const runtimeResolvedState = runtimeResolvedResource.state
+
+export function loadRuntimeResolved(): void {
+  if (runtimeResolvedState.value.status !== 'idle') return
+  void runtimeResolvedResource.load(fetchRuntimeResolved)
+}
+
+export function resetRuntimeResolved(): void {
+  runtimeResolvedResource.reset()
+}

--- a/dashboard/src/lib/runtime-resolved-resource.ts
+++ b/dashboard/src/lib/runtime-resolved-resource.ts
@@ -13,11 +13,25 @@ import { fetchRuntimeResolved, type RuntimeResolvedResponse } from '../api/dashb
 const runtimeResolvedResource = createAsyncResource<RuntimeResolvedResponse>()
 export const runtimeResolvedState = runtimeResolvedResource.state
 
-export function loadRuntimeResolved(): void {
-  if (runtimeResolvedState.value.status !== 'idle') return
-  void runtimeResolvedResource.load(fetchRuntimeResolved)
+export function loadRuntimeResolved(): Promise<void> {
+  if (runtimeResolvedState.value.status !== 'idle') return Promise.resolve()
+  return runtimeResolvedResource.load(fetchRuntimeResolved)
 }
 
 export function resetRuntimeResolved(): void {
   runtimeResolvedResource.reset()
+}
+
+export async function reloadRuntimeResolved(): Promise<void> {
+  runtimeResolvedResource.reset()
+  let loadError: unknown = null
+  await runtimeResolvedResource.load(async () => {
+    try {
+      return await fetchRuntimeResolved()
+    } catch (error) {
+      loadError = error
+      throw error
+    }
+  })
+  if (loadError) throw loadError
 }

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -401,7 +401,6 @@
   min-width: 0;
 }
 
-.settings-runtime-routing,
 .set-route-summary {
   display: grid;
   gap: 8px;
@@ -416,8 +415,7 @@
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.set-route-summary > span,
-.set-routing-row {
+.set-route-summary > span {
   align-items: center;
   background: var(--bg-card);
   border: 1px solid var(--border-soft);
@@ -426,15 +424,6 @@
   gap: 8px;
   min-width: 0;
   padding: 8px 10px;
-}
-
-.set-routing-row {
-  justify-content: space-between;
-}
-
-.set-routing-arrow {
-  color: var(--text-dim);
-  flex: none;
 }
 
 .set-runtime-route-select {

--- a/lib/server/server_dashboard_runtime_defaults_json.ml
+++ b/lib/server/server_dashboard_runtime_defaults_json.ml
@@ -30,7 +30,6 @@ type resolved =
   ; default_model : string option
   ; default_max_context : int option
   ; runtimes : runtime_entry list
-  ; keeper_assignments : (string * string) list
   ; librarian_runtime_id : string option
   ; structured_judge_runtime_id : string option
   ; hitl_summary_runtime_id : string option
@@ -59,10 +58,6 @@ let runtime_entry_json (e : runtime_entry) : Yojson.Safe.t =
     ]
 ;;
 
-let keeper_assignment_json (keeper, runtime_id) : Yojson.Safe.t =
-  `Assoc [ "keeper", `String keeper; "runtime_id", `String runtime_id ]
-;;
-
 let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
   `Assoc
     [ "generated_at_iso", `String generated_at_iso
@@ -75,9 +70,7 @@ let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
     ; "runtimes", `List (List.map runtime_entry_json r.runtimes)
     ; ( "model_routing"
       , `Assoc
-          [ ( "keeper_assignments"
-            , `List (List.map keeper_assignment_json r.keeper_assignments) )
-          ; "librarian_runtime_id", string_opt_json r.librarian_runtime_id
+          [ "librarian_runtime_id", string_opt_json r.librarian_runtime_id
           ; ( "structured_judge_runtime_id"
             , string_opt_json r.structured_judge_runtime_id )
           ; "hitl_summary_runtime_id", string_opt_json r.hitl_summary_runtime_id
@@ -102,7 +95,6 @@ let resolved_of_runtime () : resolved =
   ; default_max_context =
       Option.map Runtime.max_context_of_runtime default
   ; runtimes = List.map entry (Runtime.get_runtimes ())
-  ; keeper_assignments = Runtime.keeper_assignments ()
   ; librarian_runtime_id = Runtime.librarian_runtime_id ()
   ; structured_judge_runtime_id = Runtime.structured_judge_runtime_id ()
   ; hitl_summary_runtime_id = Runtime.hitl_summary_runtime_id ()

--- a/lib/server/server_dashboard_runtime_defaults_json.mli
+++ b/lib/server/server_dashboard_runtime_defaults_json.mli
@@ -17,7 +17,6 @@ type resolved =
   ; default_model : string option
   ; default_max_context : int option
   ; runtimes : runtime_entry list
-  ; keeper_assignments : (string * string) list
   ; librarian_runtime_id : string option
   ; structured_judge_runtime_id : string option
   ; hitl_summary_runtime_id : string option

--- a/test/test_runtime_defaults_json.ml
+++ b/test/test_runtime_defaults_json.ml
@@ -21,7 +21,6 @@ let test_build_resolved_serializes_defaults_and_routing () =
           ; is_default = false
           }
         ]
-    ; keeper_assignments = [ "analyst", "anthropic.sonnet" ]
     ; librarian_runtime_id = Some "openai.gpt-4o"
     ; structured_judge_runtime_id = Some "openai.gpt-4o"
     ; hitl_summary_runtime_id = Some "anthropic.sonnet"
@@ -51,12 +50,6 @@ let test_build_resolved_serializes_defaults_and_routing () =
   Alcotest.(check bool) "runtime is_default" true
     (member "is_default" first |> Yojson.Safe.Util.to_bool);
   let routing = member "model_routing" json in
-  let assignments = member "keeper_assignments" routing |> Yojson.Safe.Util.to_list in
-  Alcotest.(check int) "assignments length" 1 (List.length assignments);
-  Alcotest.(check string) "assignment keeper" "analyst"
-    (member "keeper" (List.hd assignments) |> Yojson.Safe.Util.to_string);
-  Alcotest.(check string) "assignment runtime_id" "anthropic.sonnet"
-    (member "runtime_id" (List.hd assignments) |> Yojson.Safe.Util.to_string);
   Alcotest.(check string) "librarian routing" "openai.gpt-4o"
     (member "librarian_runtime_id" routing |> Yojson.Safe.Util.to_string);
   Alcotest.(check string) "structured judge routing" "openai.gpt-4o"
@@ -72,7 +65,6 @@ let test_build_uninitialized_emits_null_not_fabricated_default () =
     ; default_model = None
     ; default_max_context = None
     ; runtimes = []
-    ; keeper_assignments = []
     ; librarian_runtime_id = None
     ; structured_judge_runtime_id = None
     ; hitl_summary_runtime_id = None
@@ -89,8 +81,6 @@ let test_build_uninitialized_emits_null_not_fabricated_default () =
   Alcotest.(check int) "runtimes empty" 0
     (member "runtimes" json |> Yojson.Safe.Util.to_list |> List.length);
   let routing = member "model_routing" json in
-  Alcotest.(check int) "assignments empty" 0
-    (member "keeper_assignments" routing |> Yojson.Safe.Util.to_list |> List.length);
   Alcotest.(check bool) "cross_verifier null" true
     (member "cross_verifier_runtime_id" routing = `Null);
   Alcotest.(check bool) "structured_judge null" true


### PR DESCRIPTION
## 목적 (캠페인 #53)

설정→라우팅의 "Keeper assignments" 패널은 per-keeper 진실의 중복 fleet-wide 투영 — keeper 설정(RFC-0207 read 카드 + config modal write)이 이미 read/write 전부 커버한다. 화살표 삐뚤어짐 = 공유 컬럼 grid 없는 독립 flexbox 행, 뒤죽박죽 정렬 = 서버 hash 순서 방출. 진단 판정(KILL)대로 통삭제.

## 변경

- **SSOT-깊이 삭제** (UI 숨김 아님): resolved payload에서 `keeper_assignments` 평행 투영 자체를 제거 (`server_dashboard_runtime_defaults_json` record 필드 + emitter + 테스트).
- settings-surface에서 섹션 + KPI 셀 + CSS + 핀 테스트 삭제.
- **삭제 전 커버리지 보장**: keeper 런타임 카드가 `GET /api/v1/runtime/resolved`(공유 module-level resource, per-card fetch 방지)에서 `assignment_source`("explicit" vs "default rider")를 렌더 — 패널이 유일하게 보여주던 정보가 per-keeper 표면으로 이동.

## 검증

- dashboard `tsc` 클린 + 관련 스위트 128/128 (오케스트레이터 재검증).
- `dune build @check lib/server test` (5.5.0) 클린 + ocamlformat 클린.

## 주의

- `settings-surface.ts`는 #24051(#54 알림)과 같은 파일의 다른 섹션 수정 — 늦게 랜딩하는 쪽 rebase 필요.

진단·적대검증: workflow wf_e047f03f (캠페인 원장 masc#23925).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
