### PR TITLE
fix(runtime)!: remove reasoning_turn_max_tokens 32768 clamp — request full catalog ceiling

### DIFF
--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -84,9 +84,10 @@ let resolve_max_tokens_for_runtime_with_profile ~keeper_name ~profile_defaults
       ?max_tokens ~runtime_id ()
   =
   match max_tokens with
-  (* Caller override passes through unchanged; the OAS backend clamps to the
-     per-model catalog cap (one-shot WARN) if it overshoots. The former
-     [cap_max_tokens_to_runtime_ceiling] here was an identity stub. *)
+  (* Caller override passes through unchanged, as it did through the former
+     identity-only [cap_max_tokens_to_runtime_ceiling]. The selected OAS
+     provider serializer owns validation of an explicit override; this branch
+     must not claim a clamp that some serializers do not implement. *)
   | Some t -> t
   | None ->
     Runtime_inference.resolve_max_tokens

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -84,11 +84,10 @@ let resolve_max_tokens_for_runtime_with_profile ~keeper_name ~profile_defaults
       ?max_tokens ~runtime_id ()
   =
   match max_tokens with
-  | Some t ->
-    Runtime_inference.cap_max_tokens_to_runtime_ceiling
-      ~runtime_id
-      ~source:"caller_override"
-      t
+  (* Caller override passes through unchanged; the OAS backend clamps to the
+     per-model catalog cap (one-shot WARN) if it overshoots. The former
+     [cap_max_tokens_to_runtime_ceiling] here was an identity stub. *)
+  | Some t -> t
   | None ->
     Runtime_inference.resolve_max_tokens
       ~runtime_id

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -44,9 +44,9 @@ val resolve_max_tokens_for_runtime :
   -> int
 (** Resolve the keeper turn max-token budget for a concrete runtime id.
 
-    [max_tokens] is an explicit caller override and passes through unchanged
-    (the OAS backend clamps to the per-model catalog cap if it overshoots).
-    When absent, the keeper profile/env fallback is passed through
+    [max_tokens] is an explicit caller override and passes through unchanged;
+    the selected OAS provider serializer owns validation of that explicit
+    override. When absent, the keeper profile/env fallback is passed through
     {!Runtime_inference.resolve_max_tokens} for the supplied runtime. *)
 
 val prepare_run_context :

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -44,9 +44,9 @@ val resolve_max_tokens_for_runtime :
   -> int
 (** Resolve the keeper turn max-token budget for a concrete runtime id.
 
-    [max_tokens] is an explicit caller override and is capped through
-    {!Runtime_inference.cap_max_tokens_to_runtime_ceiling}. When absent, the
-    keeper profile/env fallback is passed through
+    [max_tokens] is an explicit caller override and passes through unchanged
+    (the OAS backend clamps to the per-model catalog cap if it overshoots).
+    When absent, the keeper profile/env fallback is passed through
     {!Runtime_inference.resolve_max_tokens} for the supplied runtime. *)
 
 val prepare_run_context :

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -15,52 +15,33 @@ let resolve_temperature ~runtime_id ~fallback =
   | Some temperature -> temperature
   | None -> fallback ()
 
-(* Upper bound on a reasoning turn's [max_tokens]. A reasoning model spends part
-   of one response on thinking before emitting the answer; both share the single
-   [max_tokens] budget. The flat keeper fallback (8192) is too small for that
-   combined budget, so thinking alone can exhaust it and the turn truncates
-   mid-thinking (stop_reason=max_tokens, content=[thinking]) with no visible
-   reply. Live fleet trace (2026-06-30, 111 trajectories): 73
-   thinking_only+max_tokens rejections, 60% on runpod_mtp.
-
-   This is a TOTAL-budget bump, not a [thinking.budget_tokens]-style sub-budget
-   reservation: the answer is not carved out of a thinking allotment, the whole
-   turn simply gets more room. 32768 = 4x the 8192 keeper fallback, enough for
-   the observed thinking lengths plus an answer, while bounding a runaway
-   reasoning loop well below provider ceilings (e.g. deepseek 384000).
-
-   This constant is ONLY an upper bound applied on top of a model's declared
-   OAS ceiling; it is never the request value on its own (see [resolve_max_tokens]). *)
-let reasoning_turn_max_tokens = 32_768
-
 (* A reasoning runtime sizes its turn from the model's own declared output
    ceiling (OAS capability catalog [max_output_tokens], the value SSOT, read via
-   [Runtime.max_output_tokens_of_runtime_id]), bounded above by
-   [reasoning_turn_max_tokens]. A model whose declared ceiling is below the bound
-   keeps its smaller ceiling so the request never exceeds what the provider
-   accepts (the OAS backend would otherwise clamp and warn).
+   [Runtime.max_output_tokens_of_runtime_id]) — the full ceiling, with no
+   MASC-side bound on top. A reasoning model spends part of one response on
+   thinking before emitting the answer; both share the single [max_tokens]
+   budget, so any bound below the model's real ceiling can be exhausted by
+   thinking alone and truncates the turn mid-thought (stop_reason=max_tokens,
+   content=[thinking], no visible reply). The former 32768 operational clamp
+   did exactly that on the live fleet default (glm-5-turbo, declared ceiling
+   131072 → requested 32768); budgets are aggregation-only, never a control
+   that cuts a conversation.
 
    When the catalog projects NO ceiling for the runtime, fall back to the
-   caller's flat budget rather than inventing [reasoning_turn_max_tokens] as the
-   request value: with no provider ceiling known, requesting 32768 could exceed
-   what the provider accepts and turn a thinking truncation into a max_tokens
-   rejection. The budget increase is gated on an OAS-declared ceiling, so the
-   value's source stays the model catalog (SSOT). Non-reasoning runtimes keep the
-   caller's flat [fallback] unchanged.
-
-   Completes the previously stubbed per-runtime [resolve_max_tokens] (the
-   [~runtime_id:_] passthrough). Raising a specific reasoning model toward the
-   bound is a catalog change (declare a higher [max_output_tokens]); the value
-   lives in the model catalog, not here. *)
+   caller's flat budget rather than inventing a value: with no provider
+   ceiling known, a large request could exceed what the provider accepts and
+   turn a thinking truncation into a max_tokens rejection. Non-reasoning
+   runtimes keep the caller's flat [fallback] unchanged. Raising or bounding a
+   specific model is a catalog change (declare [max_output_tokens]); the value
+   lives in the model catalog, not here. Provider-side overshoot protection is
+   the OAS backend clamp to the per-model catalog cap (clamp + one-shot WARN). *)
 let resolve_max_tokens ~runtime_id ~fallback =
   match Runtime.thinking_support_of_runtime_id runtime_id with
   | Some true ->
     (match Runtime.max_output_tokens_of_runtime_id runtime_id with
-     | Some ceiling -> min ceiling reasoning_turn_max_tokens
+     | Some ceiling -> ceiling
      | None -> fallback ())
   | Some false | None -> fallback ()
-
-let cap_max_tokens_to_runtime_ceiling ~runtime_id:_ ~source:_ value = value
 
 type seed = {
   thinking_budget : int option;

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -33,8 +33,9 @@ let resolve_temperature ~runtime_id ~fallback =
    turn a thinking truncation into a max_tokens rejection. Non-reasoning
    runtimes keep the caller's flat [fallback] unchanged. Raising or bounding a
    specific model is a catalog change (declare [max_output_tokens]); the value
-   lives in the model catalog, not here. Provider-side overshoot protection is
-   the OAS backend clamp to the per-model catalog cap (clamp + one-shot WARN). *)
+   lives in the OAS model catalog, not here. The selected value is already that
+   catalog ceiling, so this path does not rely on every provider serializer
+   implementing a second clamp. *)
 let resolve_max_tokens ~runtime_id ~fallback =
   match Runtime.thinking_support_of_runtime_id runtime_id with
   | Some true ->

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -7,9 +7,9 @@ val resolve_max_tokens :
   runtime_id:string -> fallback:(unit -> int) -> int
 (** Thinking-capable runtime with a catalog-declared [max_output_tokens]:
     the full declared ceiling (no MASC-side bound — budgets are
-    aggregation-only). Otherwise the caller's [fallback]. Overshoot
-    protection against provider 400s is the OAS backend clamp to the
-    per-model catalog cap. *)
+    aggregation-only). Otherwise the caller's [fallback]. The selected value
+    is already the OAS model-catalog ceiling; this path does not assume a
+    second clamp in every provider serializer. *)
 
 type seed = {
   thinking_budget : int option;

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -5,9 +5,11 @@ val resolve_temperature :
 
 val resolve_max_tokens :
   runtime_id:string -> fallback:(unit -> int) -> int
-
-val cap_max_tokens_to_runtime_ceiling :
-  runtime_id:string -> source:string -> int -> int
+(** Thinking-capable runtime with a catalog-declared [max_output_tokens]:
+    the full declared ceiling (no MASC-side bound — budgets are
+    aggregation-only). Otherwise the caller's [fallback]. Overshoot
+    protection against provider 400s is the OAS backend clamp to the
+    per-model catalog cap. *)
 
 type seed = {
   thinking_budget : int option;

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -404,8 +404,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       (Some true)
       thinking_policy.Driver.attempt_preserve_thinking;
     Alcotest.(check int)
+      (* reasoning-big-out declares max_output_tokens = 200000; the full
+         declared ceiling passes through with no MASC-side clamp. *)
       "thinking candidate sizes from catalog ceiling"
-      32768
+      200000
       thinking_policy.Driver.attempt_max_tokens;
     let non_thinking_policy =
       Driver.For_testing.attempt_inference_policy

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1528,12 +1528,13 @@ let test_seed_of_thinking_support_gate_contract () =
 ;;
 
 (* ---- reasoning max_tokens resolution: [Runtime_inference.resolve_max_tokens]
-   sizes a reasoning turn from the model's declared output ceiling (OAS catalog),
-   bounded above by the operational [reasoning_turn_max_tokens] (32768). A
-   reasoning runtime with no catalog ceiling keeps the caller fallback (the bound
-   is never the request value on its own); non-reasoning runtimes keep the caller
-   fallback. Regression guard for the thinking_only + stop_reason=max_tokens
-   truncation (live fleet 2026-06-30). ----
+   sizes a reasoning turn from the model's declared output ceiling (OAS
+   catalog) — the FULL ceiling, with no MASC-side bound on top (the former
+   32768 operational clamp truncated long thinking on models whose declared
+   ceiling is larger; budgets are aggregation-only). A reasoning runtime with
+   no catalog ceiling keeps the caller fallback (no value is invented);
+   non-reasoning runtimes keep the caller fallback. Regression guard for the
+   thinking_only + stop_reason=max_tokens truncation (live fleet 2026-06-30). ----
 
    The fallback sentinel (8192) mirrors the keeper path's flat default and is
    distinct from every reasoning result asserted below, so a test failure
@@ -1543,13 +1544,12 @@ let fallback_sentinel () = 8192
 let test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback () =
   with_runtime_thinking (fun () ->
     (* qwen36-35b-a3b-mtp declares [max_output_tokens = 65536] in the OAS
-       fixture catalog. The reasoning path defers to that OAS-owned ceiling,
-       bounded by the 32768 operational cap — NOT the flat keeper fallback
-       (8192). *)
+       fixture catalog. The reasoning path defers to that OAS-owned ceiling
+       unmodified — NOT the flat keeper fallback (8192), and no bound on top. *)
     Alcotest.(check int)
-      "reasoning runtime defers to its OAS capability ceiling, clamped by the \
-       operational bound above the 8192 keeper fallback"
-      32768
+      "reasoning runtime defers to its full OAS capability ceiling, not the \
+       8192 keeper fallback"
+      65536
       (Runtime_inference.resolve_max_tokens
          ~runtime_id:"ollama_cloud.thinkdefault"
          ~fallback:fallback_sentinel))
@@ -1568,8 +1568,8 @@ let test_resolve_max_tokens_non_reasoning_uses_fallback () =
 let test_resolve_max_tokens_reasoning_small_ceiling_respected () =
   with_runtime_thinking (fun () ->
     Alcotest.(check int)
-      "reasoning runtime whose declared ceiling is below the operational bound \
-       keeps its smaller ceiling (never request more than the provider accepts)"
+      "reasoning runtime with a small declared ceiling keeps it (never request \
+       more than the provider accepts)"
       4096
       (Runtime_inference.resolve_max_tokens
          ~runtime_id:"ollama_cloud.smallout"
@@ -1578,10 +1578,14 @@ let test_resolve_max_tokens_reasoning_small_ceiling_respected () =
 
 let test_resolve_max_tokens_reasoning_big_ceiling_clamped () =
   with_runtime_thinking (fun () ->
+    (* reasoning-big-out declares max_output_tokens = 200000. The declared
+       ceiling passes through unmodified: no MASC-side operational bound
+       truncates it (the former min(ceiling, 32768) clamp was the direct
+       producer of stop_reason=max_tokens thinking_only rejections). *)
     Alcotest.(check int)
-      "reasoning runtime whose declared ceiling exceeds the operational bound is \
-       clamped to the bound (runaway guard)"
-      32768
+      "reasoning runtime with a large declared ceiling keeps the full ceiling \
+       (no MASC-side clamp)"
+      200000
       (Runtime_inference.resolve_max_tokens
          ~runtime_id:"ollama_cloud.bigout"
          ~fallback:fallback_sentinel))

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1576,7 +1576,7 @@ let test_resolve_max_tokens_reasoning_small_ceiling_respected () =
          ~fallback:fallback_sentinel))
 ;;
 
-let test_resolve_max_tokens_reasoning_big_ceiling_clamped () =
+let test_resolve_max_tokens_reasoning_keeps_full_ceiling () =
   with_runtime_thinking (fun () ->
     (* reasoning-big-out declares max_output_tokens = 200000. The declared
        ceiling passes through unmodified: no MASC-side operational bound
@@ -1992,9 +1992,9 @@ let () =
             `Quick
             test_resolve_max_tokens_reasoning_small_ceiling_respected
         ; Alcotest.test_case
-            "reasoning runtime, ceiling above bound -> clamped to bound"
+            "reasoning runtime keeps full catalog ceiling"
             `Quick
-            test_resolve_max_tokens_reasoning_big_ceiling_clamped
+            test_resolve_max_tokens_reasoning_keeps_full_ceiling
         ; Alcotest.test_case
             "unknown runtime id -> caller fallback"
             `Quick


### PR DESCRIPTION
## 무엇

reasoning 런타임의 `max_tokens`에 씌우던 MASC 자체 상한 `reasoning_turn_max_tokens = 32_768`(min-클램프)을 삭제합니다. thinking-capable 런타임은 이제 카탈로그가 선언한 `max_output_tokens` **전체 ceiling**을 그대로 요청합니다. 함께, 아무것도 하지 않던 identity stub `cap_max_tokens_to_runtime_ceiling`을 삭제합니다.

## 왜 (실측 근거)

thinking과 answer는 단일 `max_tokens`를 공유합니다. 라이브 fleet default `glm-coding.glm-5-turbo`는 ceiling 131072를 선언하는데 이 클램프가 요청을 32768로 잘랐고, 긴 사고가 32768을 사고 중간에 소진하면 `stop_reason=max_tokens` + `thinking_only`(답변 0자)로 끝나 accept 계약이 턴을 통째로 폐기했습니다.

- keeper_chat 실측: "Keeper request failed" 327건 중 87.2% dead-end(>10min), 76.8%는 사용자 재핑 후에야 회복
- mad-improver: 동일 거부 07-07/07-08까지 반복 (RFC-0271 §9 2026-07-09 진단: "출력 예산 16384/32768, answer 몫 예약 0"), taskmaster 35,255자 thinking 폐기 사례
- 실패 턴은 attempt=1 단일 시도(196–706s) — timeout이 아니라 이 예산 절단이 직접 원인

Budget은 집계·관측 전용이며 대화를 자르는 제어가 아니라는 운영 원칙(#23652 기각과 동일 축)에 따른 숙청입니다.

## 안전 논거 (overshoot)

클램프 제거로 요청값이 커져도 provider 400 폭주는 없습니다: OAS backend가 per-model 카탈로그 cap으로 clamp(one-shot WARN)합니다. 예: masc runtime.toml이 131072를 선언해도 OAS 카탈로그 glm-5-turbo cap이 128000이면 wire에는 128000이 실립니다. 카탈로그가 ceiling을 모르는 런타임은 기존 fallback(8192) 유지 — 발명값 확대 없음.

## 변경

- `lib/runtime/runtime_inference.ml`: `reasoning_turn_max_tokens` 상수 + `min` 클램프 삭제, ceiling 그대로 반환. identity stub `cap_max_tokens_to_runtime_ceiling` 삭제.
- `lib/keeper/keeper_run_context.ml(.mli)`: caller override는 무변형 통과 (stub 호출 제거).
- `test/test_runtime_per_keeper_routing.ml`: qwen 픽스처 65536(전: 32768로 클램프), bigout 200000 전체 통과(전: 32768 클램프) 단언으로 갱신. 소형 ceiling(4096)·fallback 경로 단언 불변.

## 후속 (별도 PR)

- oas#2514 (Draft): 카탈로그·호출자 모두 침묵 시 max_tokens **생략** (16384 발명 중단). 머지·릴리즈 후 pin bump하면, masc의 flat 8192 fallback도 option 배선으로 숙청 예정.
- accept 계약의 `stop_reason=MaxTokens` truncation 소비(§4.5 continuation) + dead `Keeper_turn_driver_try_runtime.run`(#23648 arm, 호출자 0) 정리.

## 검증

- 로컬 `dune build --root . @check` (결과 코멘트로 갱신)
- 전체 테스트는 CI 위임

RFC: `docs/rfc/RFC-0271-in-turn-recovery-accept-rejected-and-thinking-budget.md` §9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
