### PR TITLE
fix(keeper): make HITL gates durable and exact

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -61,7 +61,10 @@ let build_forest ~(config : Workspace.config) ~goals ~tasks =
            | Ok None | Error _ -> None)
   in
   let pending_approvals =
-    match Keeper_approval_queue.list_pending_dashboard_json () with
+    match
+      Keeper_approval_queue.list_pending_dashboard_json
+        ~base_path:config.Workspace.base_path
+    with
     | `List items -> items
     | _ -> []
   in
@@ -337,7 +340,10 @@ let goal_detail_json ~(config : Workspace.config) ~goal_id :
                | Ok None | Error _ | Ok (Some _) -> None)
       in
       let approvals =
-        match Keeper_approval_queue.list_pending_dashboard_json () with
+        match
+          Keeper_approval_queue.list_pending_dashboard_json
+            ~base_path:config.Workspace.base_path
+        with
         | `List items ->
             items |> List.filter (approval_matches_goal goal_id)
         | _ -> []
@@ -411,7 +417,10 @@ let dashboard_goals_tree_json ~(config : Workspace.config) : Yojson.Safe.t =
     |> List.length
   in
   let pending_approval_total =
-    match Keeper_approval_queue.list_pending_dashboard_json () with
+    match
+      Keeper_approval_queue.list_pending_dashboard_json
+        ~base_path:config.Workspace.base_path
+    with
     | `List items -> List.length items
     | _ -> 0
   in

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -36,21 +36,16 @@ let judge_json_of_runtime (runtime : Dashboard_governance_judge.runtime_snapshot
         Judge_diagnostics.lenient_fallback_metrics_json ~judge_label:"Governance" );
     ]
 
-let summary_json_of_runtime ?base_path
+let summary_json_of_runtime ~base_path
     (runtime : Dashboard_governance_judge.runtime_snapshot) =
-  let pending_approval_count = Keeper_approval_queue.pending_count () in
+  let pending_approval_count = Keeper_approval_queue.pending_count ~base_path in
   let pending_ruling, oldest_json =
-    match base_path with
-    | None -> 0, `Null
-    | Some base_path ->
-      let n =
-        Governance_cases_snapshot.pending_ruling_count ~base_path
-      in
-      let oldest =
-        Governance_cases_snapshot.oldest_pending_ruling_age_s ~base_path
-          ~now_ts:(Unix.gettimeofday ())
-      in
-      n, Option.fold ~none:`Null ~some:(fun v -> `Float v) oldest
+    let n = Governance_cases_snapshot.pending_ruling_count ~base_path in
+    let oldest =
+      Governance_cases_snapshot.oldest_pending_ruling_age_s ~base_path
+        ~now_ts:(Unix.gettimeofday ())
+    in
+    n, Option.fold ~none:`Null ~some:(fun v -> `Float v) oldest
   in
   `Assoc
     [
@@ -124,7 +119,9 @@ let hitl_status_json ~base_path =
 let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
   let runtime = Dashboard_governance_judge.runtime_status base_path in
   let judgments = Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit in
-  let approval_queue = Keeper_approval_queue.list_pending_dashboard_json () in
+  let approval_queue =
+    Keeper_approval_queue.list_pending_dashboard_json ~base_path
+  in
   let recent_resolved =
     Keeper_approval_queue.list_recent_resolved_json
       ~base_path

--- a/lib/dashboard/dashboard_governance_metrics.ml
+++ b/lib/dashboard/dashboard_governance_metrics.ml
@@ -7,7 +7,7 @@
        to capture the same (tool_name, reason_code) emitted on SSE. The ring
        gives operators a "last N minutes" view without tailing JSONL.
     2. Live approval queue state returned by
-       [Keeper_approval_queue.list_pending_json ()]. Approval queue metrics
+       [Keeper_approval_queue.list_pending_json ~base_path]. Approval queue metrics
        are computed from the current pending set; this module does not parse
        the approval audit JSONL.
 
@@ -175,8 +175,8 @@ type approval_summary = {
   oldest_pending_sec : float option;
 }
 
-let approval_queue_summary () : approval_summary =
-  let pending_json = Keeper_approval_queue.list_pending_json () in
+let approval_queue_summary ~base_path : approval_summary =
+  let pending_json = Keeper_approval_queue.list_pending_json ~base_path in
   let waits =
     match pending_json with
     | `List items ->
@@ -234,9 +234,9 @@ let approval_queue_json (summary : approval_summary) : Yojson.Safe.t =
 
 (** Top-level endpoint payload. *)
 let governance_tool_events_json ?(now_ts = Unix.gettimeofday ())
-    ~window_minutes () : Yojson.Safe.t =
+    ~base_path ~window_minutes () : Yojson.Safe.t =
   let rejections = tool_rejections_json ~window_minutes ~now_ts () in
-  let approval = approval_queue_summary () in
+  let approval = approval_queue_summary ~base_path in
   `Assoc [
     ("generated_at", `String (Masc_domain.iso8601_of_unix_seconds now_ts));
     ("window_minutes", `Int window_minutes);

--- a/lib/dashboard/dashboard_governance_metrics.mli
+++ b/lib/dashboard/dashboard_governance_metrics.mli
@@ -30,12 +30,12 @@ val record_tool_skipped :
     {!Keeper_metrics.(to_string LifecycleCallbackFailures)} and logged
     without failing the SSE broadcast path. *)
 
-val approval_queue_summary : unit -> approval_summary
+val approval_queue_summary : base_path:string -> approval_summary
 (** Read the current approval queue and produce depth + wait-time
     percentiles. *)
 
 val governance_tool_events_json :
-  ?now_ts:float -> window_minutes:int -> unit -> Yojson.Safe.t
+  ?now_ts:float -> base_path:string -> window_minutes:int -> unit -> Yojson.Safe.t
 (** Top-level HTTP endpoint payload combining tool-rejection counts
     over the [window_minutes] window with the approval queue summary.
     [now_ts] is injectable for testing. *)

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -615,7 +615,7 @@ let to_oas_approval_callback
               match lane_policy with
               | Keeper_approval_queue.Nonblocking ->
                 let approval_id =
-                  Keeper_approval_queue.submit_pending
+                  Keeper_approval_queue.submit_pending_observer
                     ~keeper_name
                     ~tool_name
                     ~input
@@ -632,9 +632,8 @@ let to_oas_approval_callback
                     ~disposition:"Blocked"
                     ~disposition_reason
                     ?continuation_channel
-                    ~lane_policy
                     ~risk_level
-                    ~on_resolution:(fun decision ->
+                    ~on_resolution_observer:(fun decision ->
                       Log.Governance.info
                         "nonblocking HITL approval resolved keeper=%s tool=%s decision=%s"
                         keeper_name

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -166,7 +166,8 @@ val to_oas_approval_callback :
     With [lane_policy = Blocking] (the compatibility default), a tool that
     exceeds the governance threshold suspends via
     [Keeper_approval_queue.submit_and_await]. With [Nonblocking], the approval
-    is registered with [submit_pending], the callback returns a
+    is registered with [Keeper_approval_queue.submit_pending_observer], the
+    approval callback returns a
     typed-in-protocol rejection, and the resolution wake starts a later
     independent Keeper cycle. Production Keeper runs use [Nonblocking] so
     ordinary tool approval cannot monopolize the Keeper lane.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -84,6 +84,7 @@ type raw_trace_sink_outcome =
 type autonomous_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | Blocking_approval_waiting
 
 type autonomous_yield_boundary =
   | Yield_immediately
@@ -100,11 +101,29 @@ let autonomous_yield_allowed_at_turn ~start_turn ~turn request =
   | Yield_after_current_turn -> turn > start_turn
 ;;
 
-let stop_reason_of_autonomous_yield ~turn request =
+let blocking_approval_yield_request ~base_path ~keeper_name =
+  if
+    Keeper_approval_queue.has_blocking_pending_for_keeper
+      ~base_path
+      ~keeper_name
+  then
+    Some
+      { reason = Blocking_approval_waiting
+      ; boundary = Yield_immediately
+      }
+  else None
+;;
+
+let stop_reason_of_autonomous_yield ~start_turn ~turn request =
   match request.reason with
   | Chat_waiting -> Runtime_agent.Yielded_to_chat_waiting { turns_used = turn }
   | Durable_stimulus_waiting ->
     Runtime_agent.Yielded_to_durable_stimulus { turns_used = turn }
+  | Blocking_approval_waiting ->
+    Runtime_agent.Yielded_to_blocking_approval
+      { turns_used = turn
+      ; provider_turns_completed = max 0 (turn - start_turn)
+      }
 ;;
 
 let keeper_raw_trace_sink
@@ -176,6 +195,7 @@ module For_testing = struct
   let keeper_raw_trace_sink = keeper_raw_trace_sink
   let raw_trace_for_dispatch = raw_trace_for_dispatch
   let autonomous_yield_allowed_at_turn = autonomous_yield_allowed_at_turn
+  let blocking_approval_yield_request = blocking_approval_yield_request
   let stop_reason_of_autonomous_yield = stop_reason_of_autonomous_yield
 end
 
@@ -719,64 +739,81 @@ let run_turn
                   ?max_tokens:requested_max_tokens
                   ()
               in
-              (* Autonomous cooperative yield: OAS checks [exit_condition]
-                 before the first provider dispatch as well as between turns.
-                 A scheduled-idle waiting chat may preempt immediately, but a
-                 reactive chat or durable stimulus may stop this run only after
+              (* Cooperative yield: OAS checks [exit_condition] before the first
+                 provider dispatch as well as between turns. Every lane first
+                 checks the authoritative workspace-scoped Blocking approval
+                 owner. The autonomous lane additionally checks chat/durable
+                 work. A scheduled-idle waiting chat may preempt immediately,
+                 but a reactive chat or durable stimulus may stop only after
                  [turn] advances beyond the checkpoint's [start_turn_count];
                  otherwise the heartbeat would acknowledge the currently leased
                  stimulus without the model ever observing it. [observed_request]
                  bridges OAS's split bool / render callbacks and preserves the
                  exact typed reason and boundary that made the predicate true,
-                 even if the waiting chat is cancelled before
+                 even if the waiting work is resolved before
                  [exit_condition_result] runs. *)
               let autonomous_yield_exit_condition,
                   autonomous_yield_exit_condition_result =
-                match autonomous_yield_requested with
-                | None -> None, None
-                | Some requested ->
-                  let observed_request = ref None in
-                  ( Some
-                      (fun (turn : int) ->
-                         match requested () with
-                         | Some request
-                           when autonomous_yield_allowed_at_turn
-                                  ~start_turn:start_turn_count
-                                  ~turn
-                                  request ->
-                           observed_request := Some request;
-                           true
-                         | Some _ | None -> false)
-                  , Some
-                      (fun (turn : int) ->
-                         match !observed_request with
-                         | Some request ->
-                           let stop_reason =
-                             stop_reason_of_autonomous_yield ~turn request
-                           in
-                           let notice =
-                             match request.reason with
-                             | Chat_waiting ->
-                               Printf.sprintf
-                                 "[yielded turn slot at turn %d to a waiting \
-                                  chat request; keeper resumes on the next \
-                                  cycle]"
-                                 turn
-                             | Durable_stimulus_waiting ->
-                               Printf.sprintf
-                                 "[yielded autonomous run at turn %d because a \
-                                  durable stimulus is waiting; checkpoint saved \
-                                  and keeper resumes on the next cycle]"
-                                 turn
-                           in
-                           stop_reason, Some notice
-                         | None ->
-                           let message =
-                             "autonomous yield result requested without a \
-                              preceding typed yield decision"
-                           in
-                           Log.Keeper.error ~keeper_name:meta.name "%s" message;
-                           invalid_arg message) )
+                let requested () =
+                  match
+                    blocking_approval_yield_request
+                      ~base_path:config.base_path
+                      ~keeper_name:meta.name
+                  with
+                  | Some _ as request -> request
+                  | None ->
+                    Option.bind autonomous_yield_requested (fun request -> request ())
+                in
+                let observed_request = ref None in
+                ( Some
+                    (fun (turn : int) ->
+                       match requested () with
+                       | Some request
+                         when autonomous_yield_allowed_at_turn
+                                ~start_turn:start_turn_count
+                                ~turn
+                                request ->
+                         observed_request := Some request;
+                         true
+                       | Some _ | None -> false)
+                , Some
+                    (fun (turn : int) ->
+                       match !observed_request with
+                       | Some request ->
+                         let stop_reason =
+                           stop_reason_of_autonomous_yield
+                             ~start_turn:start_turn_count
+                             ~turn
+                             request
+                         in
+                         let notice =
+                           match request.reason with
+                           | Chat_waiting ->
+                             Printf.sprintf
+                               "[yielded turn slot at turn %d to a waiting chat \
+                                request; keeper resumes on the next cycle]"
+                               turn
+                           | Durable_stimulus_waiting ->
+                             Printf.sprintf
+                               "[yielded autonomous run at turn %d because a \
+                                durable stimulus is waiting; checkpoint saved \
+                                and keeper resumes on the next cycle]"
+                               turn
+                           | Blocking_approval_waiting ->
+                             Printf.sprintf
+                               "[yielded keeper run at turn %d because a Blocking \
+                                approval owns the lane; operator resolution \
+                                resumes the continuation]"
+                               turn
+                         in
+                         stop_reason, Some notice
+                       | None ->
+                         let message =
+                           "keeper yield result requested without a preceding \
+                            typed yield decision"
+                         in
+                         Log.Keeper.error ~keeper_name:meta.name "%s" message;
+                         invalid_arg message) )
               in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* The keeper turn deadline must own the OAS Agent.run switch.

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -23,14 +23,16 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
-(** Typed reason and boundary for an autonomous Keeper run to release its lane
-    at an OAS turn boundary. Scheduled-idle chat can yield immediately;
-    reactive chat and durable backlog yield only after the current cycle has
-    completed at least one provider turn, so a leased stimulus is never
-    acknowledged without being observed by the model. *)
+(** Typed reason and boundary for a Keeper run to release its lane at an OAS
+    turn boundary. Blocking approval and scheduled-idle chat can yield
+    immediately; reactive chat and durable backlog yield only after the current
+    cycle has completed at least one provider turn. A Blocking yield records how
+    many provider turns completed so autonomous intake can retain an unobserved
+    leased stimulus. *)
 type autonomous_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
+  | Blocking_approval_waiting
 
 type autonomous_yield_boundary =
   | Yield_immediately
@@ -99,8 +101,14 @@ module For_testing : sig
     -> autonomous_yield_request
     -> bool
 
+  val blocking_approval_yield_request
+    :  base_path:string
+    -> keeper_name:string
+    -> autonomous_yield_request option
+
   val stop_reason_of_autonomous_yield
-    :  turn:int
+    :  start_turn:int
+    -> turn:int
     -> autonomous_yield_request
     -> Runtime_agent.stop_reason
 end
@@ -185,12 +193,11 @@ val run_turn
   -> ?hitl_delivery_channel:Keeper_continuation_channel.t
   -> ?hitl_approval_grant:Governance_pipeline.hitl_approval_grant
   -> ?autonomous_yield_requested:(unit -> autonomous_yield_request option)
-       (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
-          (the same guard point as [max_idle_turns], before the next model
-          dispatch — never mid tool execution). A typed request stops the run
-          gracefully at the boundary allowed by [autonomous_yield_reason],
-          releasing the lane for queued chat or durable stimulus work. Only the
-          heartbeat-scheduled path passes it; a chat turn never receives this
-          hook. *)
+       (* Optional autonomous-lane signals layered behind the built-in Blocking
+          approval gate. Every lane evaluates the combined typed request at
+          each OAS agent-loop turn boundary (the same guard point as
+          [max_idle_turns], before the next model dispatch — never mid tool
+          execution). The heartbeat-scheduled path supplies chat and durable
+          stimulus signals; direct chat relies on the built-in Blocking gate. *)
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -26,7 +26,8 @@ let visible_response_text_present ~stop_reason ~response_text_present =
      a budget stop it does not count as a visible reply for the contract. *)
   | Runtime_agent.TurnBudgetExhausted _
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_blocking_approval _ ->
     false
   | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ ->
     response_text_present
@@ -42,7 +43,8 @@ let budget_exhausted_contract_status ~stop_reason status =
   | ( ( Runtime_agent.Completed
       | Runtime_agent.MutationBoundaryReached _
       | Runtime_agent.Yielded_to_chat_waiting _
-      | Runtime_agent.Yielded_to_durable_stimulus _ )
+      | Runtime_agent.Yielded_to_durable_stimulus _
+      | Runtime_agent.Yielded_to_blocking_approval _ )
     , _ )
   | Runtime_agent.TurnBudgetExhausted _, _ ->
     status

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -9,7 +9,8 @@ let stop_reason_is_turn_budget_exhausted = function
   | Runtime_agent.Completed
   | Runtime_agent.MutationBoundaryReached _
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> false
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_blocking_approval _ -> false
 ;;
 
 let direct_assistant_source = "direct_assistant"

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -449,6 +449,21 @@ type approval_resolution_delivery_hook =
 
 let approval_resolution_wake_hook : approval_resolution_delivery_hook option ref = ref None
 
+type resolution_claim_owner =
+  | Operator_resolution
+  | Await_timeout
+  | Await_cancellation
+  | Expiration
+  | Terminal_state_cancellation
+
+let resolution_claim_hook : (resolution_claim_owner -> string -> unit) option ref =
+  ref None
+;;
+
+let run_resolution_claim_hook owner id =
+  Option.iter (fun hook -> hook owner id) !resolution_claim_hook
+;;
+
 let first_cmd_token (cmd : string) =
   Keeper_tool_command_words.first_token_of_cmd cmd
 ;;
@@ -460,9 +475,53 @@ module For_testing = struct
       Hashtbl.clear recent_audit_cache)
   ;;
 
+  let reset_pending () = Atomic.set pending SMap.empty
+
   let first_cmd_token = first_cmd_token
 
   let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
+  let pending_base_path ~id =
+    match SMap.find_opt id (Atomic.get pending) with
+    | Some entry -> Some entry.audit_base_path
+    | None -> None
+  ;;
+
+  let list_pending_entries () =
+    SMap.fold (fun _ entry acc -> entry :: acc) (Atomic.get pending) []
+  ;;
+
+  let pending_count () = SMap.cardinal (Atomic.get pending)
+
+  let pending_count_for_keeper ~keeper_name =
+    SMap.fold
+      (fun _ (entry : pending_approval) count ->
+         if String.equal entry.keeper_name keeper_name then count + 1 else count)
+      (Atomic.get pending)
+      0
+  ;;
+
+  let blocking_pending_count_for_keeper ~keeper_name =
+    SMap.fold
+      (fun _ (entry : pending_approval) count ->
+         if String.equal entry.keeper_name keeper_name
+            && entry.lane_policy = Blocking
+         then count + 1
+         else count)
+      (Atomic.get pending)
+      0
+  ;;
+
+  let has_blocking_pending_for_keeper ~keeper_name =
+    blocking_pending_count_for_keeper ~keeper_name > 0
+  ;;
+
+  let has_pending_for_keeper ~keeper_name =
+    pending_count_for_keeper ~keeper_name > 0
+  ;;
+
+  let set_resolution_claim_hook hook = resolution_claim_hook := Some hook
+  let clear_resolution_claim_hook () = resolution_claim_hook := None
+
   let clear_approval_resolution_wake_hook () = approval_resolution_wake_hook := None
 end
 
@@ -531,7 +590,8 @@ let create_entry
       ~lane_policy
       ~audit_base_path
       ~resolver
-      ~on_resolution
+      ~on_resolution_callback
+      ~on_resolution_observer
       ()
   =
   let action_key = action_key_of_input ~tool_name ~input in
@@ -569,10 +629,11 @@ let create_entry
   ; continuation_channel
   ; audit_base_path
   ; resolver
-  ; on_resolution
+  ; on_resolution_callback
+  ; on_resolution_observer
+  ; blocking_resolution_state = Blocking_resolution_open
   ; context_summary = None
   ; summary_status = Summary_not_requested
-  ; channel = Some continuation_channel
   }
 ;;
 
@@ -613,6 +674,11 @@ let pending_entry_json_fields
   ; "risk_level", `String (risk_level_to_string entry.risk_level)
   ; "phase", `String (pending_phase_to_string entry.phase)
   ; "lane_policy", `String (lane_policy_to_string entry.lane_policy)
+  ; ( "blocking_resolution_state"
+    , `String
+        (match entry.blocking_resolution_state with
+         | Blocking_resolution_open -> "open"
+         | Blocking_resolution_committed _ -> "decision_committed") )
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -665,7 +731,7 @@ let pending_entry_json_fields
 
 let broadcast_pending entry =
   try
-    Sse.broadcast
+    Sse.broadcast_workspace_observers ~base_path:entry.audit_base_path
       (`Assoc
           [ "type", `String approval_sse_pending_event
           ; ( "payload"
@@ -755,7 +821,7 @@ let record_summary_updated ~now (entry : pending_approval) =
        ~event_type:approval_audit_summary_event
        exn);
   try
-    Sse.broadcast
+    Sse.broadcast_workspace_observers ~base_path:entry.audit_base_path
       (`Assoc
          [ "type", `String approval_sse_summary_event
          ; ( "payload"
@@ -778,8 +844,17 @@ let record_summary_updated ~now (entry : pending_approval) =
 
 (* ── In-place entry updates (copy-on-write) ──────────────── *)
 
-(** Read a pending entry by id. Returns [None] if already resolved. *)
-let get_pending_entry ~id : pending_approval option = SMap.find_opt id (Atomic.get pending)
+(** Read a pending entry by id without applying caller scope. Internal queue
+    workers use this only after obtaining the id from the entry itself. *)
+let get_pending_entry_unscoped ~id : pending_approval option =
+  SMap.find_opt id (Atomic.get pending)
+;;
+
+let get_pending_entry ~base_path ~id : pending_approval option =
+  match get_pending_entry_unscoped ~id with
+  | Some entry when String.equal entry.audit_base_path base_path -> Some entry
+  | Some _ | None -> None
+;;
 
 (** Apply [f] to the pending entry with [id] if it still exists.
     Used by the HITL context-summary worker for non-blocking updates. *)
@@ -794,7 +869,7 @@ let record_summary_failure ~id ~reason ~retryable =
   let now = Time_compat.now () in
   update_pending_entry ~id (fun e ->
     { e with summary_status = Summary_failed { reason; retryable } });
-  match get_pending_entry ~id with
+  match get_pending_entry_unscoped ~id with
   | Some updated -> record_summary_updated ~now updated
   | None -> ()
 ;;
@@ -847,7 +922,7 @@ let spawn_hitl_summary_worker ~sw ~(entry : pending_approval) =
           context_summary = Some summary
         ; summary_status = Summary_available summary
         });
-      match get_pending_entry ~id:entry.id with
+      match get_pending_entry_unscoped ~id:entry.id with
       | Some updated -> record_summary_updated ~now updated
       | None -> ()
     in
@@ -980,12 +1055,115 @@ let deliver_resolution ~base_path (entry : pending_approval) decision =
      | Ok signal -> Ok (Some signal))
 ;;
 
-let resolve_entry
-      ?(before_terminal_publish = fun () -> ())
-      ~base_path
+let ensure_resolution_delivery_hook (entry : pending_approval) =
+  match entry.lane_policy, !approval_resolution_wake_hook with
+  | Blocking, _ | Nonblocking, Some _ -> Ok ()
+  | Nonblocking, None ->
+    let reason = "approval resolution delivery hook is not installed" in
+    record_resolution_delivery_failure
+      ~keeper_name:entry.keeper_name
+      ~approval_id:entry.id
+      reason;
+    Error reason
+;;
+
+let record_resolution_callback_failure
+      ~callback_site
+      ~failure_site
+      (entry : pending_approval)
+      exn
+  =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string LifecycleCallbackFailures)
+    ~labels:[ "keeper", entry.keeper_name; "callback", callback_site ]
+    ();
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ApprovalQueueFailures)
+    ~labels:
+      [ "keeper", entry.keeper_name
+      ; "site", Keeper_approval_queue_failure_site.to_label failure_site
+      ]
+    ();
+  let reason = Printexc.to_string exn in
+  Log.Keeper.error
+    "approval_queue: resolution callback failed id=%s callback=%s err=%s"
+    entry.id
+    callback_site
+    reason;
+  reason
+;;
+
+let apply_blocking_resolution_callback
+      ~callback_site
+      ~failure_site
       (entry : pending_approval)
       (decision : decision)
   =
+  match entry.on_resolution_callback with
+  | None -> Error "blocking approval callback is missing"
+  | Some callback ->
+    Cancel_safe.protect
+      ~on_exn:(fun exn ->
+        Error
+          (record_resolution_callback_failure
+             ~callback_site
+             ~failure_site
+             entry
+             exn))
+      (fun () ->
+         Ok (callback ~approval_id:entry.id decision))
+;;
+
+let observe_nonblocking_resolution
+      ~callback_site
+      ~failure_site
+      (entry : pending_approval)
+      decision
+  =
+  Option.iter
+    (fun observer ->
+       Cancel_safe.observe
+         ~on_exn:(fun exn ->
+           ignore
+             (record_resolution_callback_failure
+                ~callback_site
+                ~failure_site
+                entry
+                exn))
+         (fun () -> observer decision))
+    entry.on_resolution_observer
+;;
+
+let observe_and_signal_nonblocking_resolution
+      ~callback_site
+      ~failure_site
+      (entry : pending_approval)
+      decision
+      signal
+  =
+  let deferred_cancellation =
+    match
+      observe_nonblocking_resolution
+        ~callback_site
+        ~failure_site
+        entry
+        decision
+    with
+    | () -> None
+    | exception (Eio.Cancel.Cancelled _ as exn) ->
+      Some (exn, Printexc.get_raw_backtrace ())
+  in
+  Option.iter
+    (signal_resolution_after_commit
+       ~keeper_name:entry.keeper_name
+       ~approval_id:entry.id)
+    signal;
+  match deferred_cancellation with
+  | None -> ()
+  | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+;;
+
+let publish_resolution ~base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
@@ -1011,29 +1189,8 @@ let resolve_entry
     ?disposition_reason:entry.disposition_reason
     ~decision:(Approval_resolved decision)
     ();
-  (match entry.resolver with
-   | Some resolver -> Eio.Promise.resolve resolver decision
-   | None -> ());
-  (match entry.on_resolution with
-   | Some f ->
-     Cancel_safe.observe
-       ~on_exn:(fun exn ->
-         Otel_metric_store.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
-           ~labels:[ ("keeper", entry.keeper_name); ("callback", "on_resolution") ]
-           ();
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string ApprovalQueueFailures)
-           ~labels:[ "keeper", entry.keeper_name; "site", Keeper_approval_queue_failure_site.(to_label Resolution_callback) ]
-           ();
-         Log.Keeper.warn
-           "approval_queue: resolution callback failed id=%s err=%s"
-           entry.id
-           (Printexc.to_string exn))
-       (fun () -> f decision)
-   | None -> ());
-  before_terminal_publish ();
   try
-    Sse.broadcast
+    Sse.broadcast_workspace_observers ~base_path:entry.audit_base_path
       (`Assoc
           [ "type", `String approval_sse_resolved_event
           ; ( "payload"
@@ -1069,12 +1226,14 @@ let pending_entry_matches
       ~goal_id
       ~sandbox_target
       ~lane_policy
+      ~audit_base_path
   =
   String.equal entry.keeper_name keeper_name
   && String.equal entry.tool_name tool_name
   && String.equal entry.action_key action_key
   && String.equal entry.input_hash input_hash
   && String.equal entry.sandbox_target sandbox_target
+  && String.equal entry.audit_base_path audit_base_path
   && entry.lane_policy = lane_policy
   && entry.task_id = task_id
   && entry.goal_id = goal_id
@@ -1090,6 +1249,7 @@ let find_pending_id_in_map
       ~goal_id
       ~sandbox_target
       ~lane_policy
+      ~audit_base_path
   =
   SMap.fold
     (fun id (entry : pending_approval) acc ->
@@ -1107,6 +1267,7 @@ let find_pending_id_in_map
              ~goal_id
              ~sandbox_target
              ~lane_policy
+             ~audit_base_path
          then Some id
          else None)
     map
@@ -1119,6 +1280,123 @@ let sort_entries_by_requested_at entries =
        let ts_of_json json = (match Json_util.assoc_member_opt "requested_at" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0) in
        Float.compare (ts_of_json left) (ts_of_json right))
     entries
+;;
+
+module Resolution_claims = Set_util.StringSet
+
+let resolution_claims : Resolution_claims.t Atomic.t =
+  Atomic.make Resolution_claims.empty
+;;
+
+let rec claim_resolution id =
+  let claims = Atomic.get resolution_claims in
+  if Resolution_claims.mem id claims
+  then false
+  else
+    let claimed = Resolution_claims.add id claims in
+    if Atomic.compare_and_set resolution_claims claims claimed
+    then true
+    else claim_resolution id
+;;
+
+let release_resolution_claim id =
+  atomic_update resolution_claims (fun claims -> Resolution_claims.remove id claims)
+;;
+
+let run_resolution_transaction f =
+  match Eio_context.get_switch_opt () with
+  | Some _ -> Eio.Cancel.protect f
+  | None -> f ()
+;;
+
+let with_resolution_claim_cleanup ~id f =
+  match f () with
+  | result ->
+    release_resolution_claim id;
+    result
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    release_resolution_claim id;
+    Printexc.raise_with_backtrace exn backtrace
+;;
+
+let remove_pending_entry ~id =
+  atomic_update pending (fun map -> SMap.remove id map)
+;;
+
+let rec take_pending_entry ~id =
+  let map = Atomic.get pending in
+  match SMap.find_opt id map with
+  | None -> None
+  | Some entry ->
+    if Atomic.compare_and_set pending map (SMap.remove id map)
+    then Some entry
+    else take_pending_entry ~id
+;;
+
+let restore_pending_entry (entry : pending_approval) =
+  atomic_update pending (fun map ->
+    if SMap.mem entry.id map then map else SMap.add entry.id entry map)
+;;
+
+let resolve_claimed_promise_entry (entry : pending_approval) decision =
+  match take_pending_entry ~id:entry.id with
+  | None -> Error "blocking promise disappeared before pending removal"
+  | Some removed_entry ->
+    (match
+       ( removed_entry.resolver
+       , removed_entry.on_resolution_callback
+       , removed_entry.on_resolution_observer )
+     with
+     | Some resolver, None, None ->
+       (match Eio.Promise.resolve resolver decision with
+        | () -> Ok ()
+        | exception (Eio.Cancel.Cancelled _ as exn) ->
+          restore_pending_entry removed_entry;
+          raise exn
+        | exception exn ->
+          restore_pending_entry removed_entry;
+          Error (Printexc.to_string exn))
+     | _ ->
+       restore_pending_entry removed_entry;
+       Error "blocking promise entry has an invalid delivery shape")
+;;
+
+let resolve_terminal_promise ~owner ~id ~decision =
+  if not (claim_resolution id)
+  then `Claimed_by_other
+  else
+    with_resolution_claim_cleanup ~id (fun () ->
+      run_resolution_claim_hook owner id;
+      run_resolution_transaction (fun () ->
+        match SMap.find_opt id (Atomic.get pending) with
+        | None -> `Missing
+        | Some entry ->
+          (match resolve_claimed_promise_entry entry decision with
+           | Ok () -> `Resolved
+           | Error reason -> `Failed reason)))
+;;
+
+let settle_terminal_promise ~owner ~id ~decision ~promise =
+  (* A competing resolver is not proof that the promise will be completed: an
+     authoritative callback, audit hook, or persistence step can still fail
+     and release its claim. Wait cooperatively for either the promise or the
+     claim, then retry under cancellation protection so timeout/cancel cleanup
+     cannot leave a resolver-backed entry orphaned. *)
+  Eio.Cancel.protect (fun () ->
+    let rec loop () =
+      match resolve_terminal_promise ~owner ~id ~decision with
+      | `Resolved -> `Resolved_by_owner
+      | `Missing -> `Missing
+      | `Failed detail -> `Failed detail
+      | `Claimed_by_other ->
+        (match Eio.Promise.peek promise with
+         | Some observed -> `Resolved_by_other observed
+         | None ->
+           Eio.Fiber.yield ();
+           loop ())
+    in
+    loop ())
 ;;
 
 (* ── Submit & await ───────────────────────────────────────── *)
@@ -1184,23 +1462,52 @@ let submit_and_await
       ~lane_policy:Blocking
       ~audit_base_path:base_path
       ~resolver:(Some resolver)
-      ~on_resolution:None
+      ~on_resolution_callback:None
+      ~on_resolution_observer:None
       ()
   in
   atomic_update pending (fun map -> SMap.add id entry map);
   record_pending entry;
   spawn_hitl_summary_worker_on_root_switch ~entry;
-  let timeout_decision reason =
+  let audit_terminal ~event_type reason =
+    audit_approval_event
+      ~base_path:entry.audit_base_path
+      ~event_type
+      ~id
+      ~keeper_name
+      ~tool_name
+      ~risk_level
+      ?turn_id
+      ?task_id
+      ?goal_id
+      ~goal_ids
+      ~sandbox_target:entry.sandbox_target
+      ?runtime_contract
+      ?selected_model
+      ?disposition
+      ?disposition_reason
+      ~decision:(Approval_expired reason)
+      ()
+  in
+  let resolve_timeout reason =
     let decision = Agent_sdk.Hooks.Reject reason in
-    match Eio.Promise.peek promise with
-    | Some observed -> observed
-    | None ->
-      (try Eio.Promise.resolve resolver decision with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | _ -> ());
+    match
+      settle_terminal_promise
+        ~owner:Await_timeout
+        ~id
+        ~decision
+        ~promise
+    with
+    | `Resolved_by_owner ->
+      audit_terminal ~event_type:"approval_timeout" reason;
+      decision
+    | `Resolved_by_other observed -> observed
+    | `Missing ->
       (match Eio.Promise.peek promise with
        | Some observed -> observed
-       | None -> decision)
+       | None -> failwith "approval disappeared without resolving its promise")
+    | `Failed detail ->
+      failwith ("approval timeout delivery failed: " ^ detail)
   in
   let await_with_timeout () =
     match clock, risk_level with
@@ -1215,25 +1522,7 @@ let submit_and_await
        | `Decision d -> d
        | `Timeout ->
          let reason = Printf.sprintf "approval timeout after %.0fs" timeout_s in
-         audit_approval_event
-           ~base_path:entry.audit_base_path
-           ~event_type:"approval_timeout"
-           ~id
-           ~keeper_name
-           ~tool_name
-           ~risk_level
-           ?turn_id
-           ?task_id
-           ?goal_id
-           ~goal_ids
-           ~sandbox_target:entry.sandbox_target
-           ?runtime_contract
-           ?selected_model
-           ~decision:(Approval_expired reason)
-           ();
-         (* Mirror expire_stale's teardown, but preserve any concurrent
-            operator decision that wins the promise resolution race. *)
-         timeout_decision reason)
+         resolve_timeout reason)
     | Some clock, Critical ->
       (match
          Eio.Fiber.first
@@ -1274,28 +1563,24 @@ let submit_and_await
        | Some _ -> ()
        | None ->
          let reason = "approval await cancelled before operator decision" in
-         audit_approval_event
-           ~base_path:entry.audit_base_path
-           ~event_type:"cancelled"
-           ~id
-           ~keeper_name
-           ~tool_name
-           ~risk_level
-           ?turn_id
-           ?task_id
-           ?goal_id
-           ~goal_ids
-           ~sandbox_target:entry.sandbox_target
-           ?runtime_contract
-           ?selected_model
-           ?disposition
-           ?disposition_reason
-           ~decision:(Approval_expired reason)
-           ());
-      atomic_update pending (fun map -> SMap.remove id map)))
+         (match
+            settle_terminal_promise
+              ~owner:Await_cancellation
+              ~id
+              ~decision:(Agent_sdk.Hooks.Reject reason)
+              ~promise
+          with
+          | `Resolved_by_owner -> audit_terminal ~event_type:"cancelled" reason
+          | `Resolved_by_other _ | `Missing -> ()
+          | `Failed detail ->
+            Log.Keeper.error
+              ~keeper_name
+              "approval cancellation delivery failed id=%s: %s"
+              id
+              detail))))
 ;;
 
-let submit_pending
+let submit_pending_internal
       ~keeper_name
       ~tool_name
       ~input
@@ -1313,8 +1598,9 @@ let submit_pending
       ?disposition
       ?disposition_reason
       ?continuation_channel
-      ?(lane_policy = Nonblocking)
-      ~on_resolution
+      ~lane_policy
+      ~on_resolution_callback
+      ~on_resolution_observer
       ()
   : string
   =
@@ -1338,6 +1624,7 @@ let submit_pending
         ~goal_id
         ~sandbox_target
         ~lane_policy
+        ~audit_base_path:base_path
     with
     | Some id -> id
     | None ->
@@ -1364,7 +1651,8 @@ let submit_pending
           ~lane_policy
           ~audit_base_path:base_path
           ~resolver:None
-          ~on_resolution:(Some on_resolution)
+          ~on_resolution_callback
+          ~on_resolution_observer
           ()
       in
       let updated = SMap.add id entry map in
@@ -1376,6 +1664,103 @@ let submit_pending
       else submit ()
   in
   submit ()
+;;
+
+let submit_pending_observer
+      ~keeper_name
+      ~tool_name
+      ~input
+      ~risk_level
+      ~base_path
+      ?turn_id
+      ?task_id
+      ?goal_id
+      ?goal_ids
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
+      ?runtime_contract
+      ?selected_model
+      ?disposition
+      ?disposition_reason
+      ?continuation_channel
+      ~on_resolution_observer
+      ()
+  =
+  submit_pending_internal
+    ~keeper_name
+    ~tool_name
+    ~input
+    ~risk_level
+    ~base_path
+    ?turn_id
+    ?task_id
+    ?goal_id
+    ?goal_ids
+    ?sandbox_target
+    ?sandbox_profile
+    ?backend
+    ?runtime_contract
+    ?selected_model
+    ?disposition
+    ?disposition_reason
+    ?continuation_channel
+    ~lane_policy:Nonblocking
+    ~on_resolution_callback:None
+    ~on_resolution_observer:(Some on_resolution_observer)
+    ()
+;;
+
+let blocking_resolution_plan ~effect_key ~commit =
+  let effect_key = String.trim effect_key in
+  if String.equal effect_key ""
+  then invalid_arg "blocking resolution effect_key must not be empty"
+  else { effect_key; commit }
+;;
+
+let submit_pending_blocking
+      ~keeper_name
+      ~tool_name
+      ~input
+      ~risk_level
+      ~base_path
+      ?turn_id
+      ?task_id
+      ?goal_id
+      ?goal_ids
+      ?sandbox_target
+      ?sandbox_profile
+      ?backend
+      ?runtime_contract
+      ?selected_model
+      ?disposition
+      ?disposition_reason
+      ?continuation_channel
+      ~on_resolution
+      ()
+  =
+  submit_pending_internal
+    ~keeper_name
+    ~tool_name
+    ~input
+    ~risk_level
+    ~base_path
+    ?turn_id
+    ?task_id
+    ?goal_id
+    ?goal_ids
+    ?sandbox_target
+    ?sandbox_profile
+    ?backend
+    ?runtime_contract
+    ?selected_model
+    ?disposition
+    ?disposition_reason
+    ?continuation_channel
+    ~lane_policy:Blocking
+    ~on_resolution_callback:(Some on_resolution)
+    ~on_resolution_observer:None
+    ()
 ;;
 
 (* ── Resolve (operator action) ────────────────────────────── *)
@@ -1395,25 +1780,132 @@ let resolve_error_to_string = function
     Printf.sprintf "approval %s resolution delivery failed: %s" approval_id reason
 ;;
 
-module Resolution_claims = Set_util.StringSet
-
-let resolution_claims : Resolution_claims.t Atomic.t =
-  Atomic.make Resolution_claims.empty
+let approval_decision_equal left right =
+  match left, right with
+  | Agent_sdk.Hooks.Approve, Agent_sdk.Hooks.Approve -> true
+  | Agent_sdk.Hooks.Reject _, Agent_sdk.Hooks.Reject _ -> true
+  | Agent_sdk.Hooks.Edit left, Agent_sdk.Hooks.Edit right ->
+    Yojson.Safe.equal left right
+  | (Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _), _ ->
+    false
 ;;
 
-let rec claim_resolution id =
-  let claims = Atomic.get resolution_claims in
-  if Resolution_claims.mem id claims
-  then false
-  else
-    let claimed = Resolution_claims.add id claims in
-    if Atomic.compare_and_set resolution_claims claims claimed
-    then true
-    else claim_resolution id
+let rec latch_blocking_resolution ~id ~decision ~plan =
+  let map = Atomic.get pending in
+  match SMap.find_opt id map with
+  | None -> Error "blocking approval disappeared before decision commit"
+  | Some entry ->
+    (match entry.blocking_resolution_state with
+     | Blocking_resolution_committed committed ->
+       if approval_decision_equal committed.decision decision
+       then Ok entry
+       else Error "blocking approval already committed a different decision"
+     | Blocking_resolution_open ->
+       let entry =
+         { entry with
+           blocking_resolution_state =
+             Blocking_resolution_committed { decision; plan }
+         }
+       in
+       if Atomic.compare_and_set pending map (SMap.add id entry map)
+       then Ok entry
+       else latch_blocking_resolution ~id ~decision ~plan)
 ;;
 
-let release_resolution_claim id =
-  atomic_update resolution_claims (fun claims -> Resolution_claims.remove id claims)
+let complete_latched_blocking_resolution
+      ~callback_site
+      ~failure_site
+      ~before_remove
+      (entry : pending_approval)
+      (plan : blocking_resolution_plan)
+  =
+  match plan.commit () with
+  | after_pending_removal ->
+    before_remove ();
+    remove_pending_entry ~id:entry.id;
+    Ok after_pending_removal
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+  | exception exn ->
+    Error
+      (record_resolution_callback_failure
+         ~callback_site:(callback_site ^ "_commit")
+         ~failure_site
+         entry
+         exn)
+;;
+
+let complete_blocking_resolution
+      ~callback_site
+      ~failure_site
+      ~before_remove
+      (entry : pending_approval)
+      decision
+  =
+  match
+    entry.resolver, entry.on_resolution_callback, entry.on_resolution_observer
+  with
+  | Some resolver, None, None ->
+    ignore resolver;
+    (* The shared terminal claim excludes timeout/cancel/expiry. Persist a
+       remembered allow rule only after the promise commit succeeds. *)
+    (match resolve_claimed_promise_entry entry decision with
+     | Ok () ->
+       before_remove ();
+       Ok (decision, fun () -> ())
+     | Error reason ->
+       Error
+         (record_resolution_callback_failure
+            ~callback_site:"resolver"
+            ~failure_site
+            entry
+            (Failure reason)))
+  | None, Some _, None ->
+    (match entry.blocking_resolution_state with
+     | Blocking_resolution_committed committed ->
+       if approval_decision_equal committed.decision decision
+       then
+         Result.map
+           (fun after_pending_removal ->
+             committed.decision, after_pending_removal)
+           (complete_latched_blocking_resolution
+              ~callback_site
+              ~failure_site
+              ~before_remove
+              entry
+              committed.plan)
+       else Error "blocking approval already committed a different decision"
+     | Blocking_resolution_open ->
+       (match
+          apply_blocking_resolution_callback
+            ~callback_site
+            ~failure_site
+            entry
+            decision
+        with
+        | Error _ as err -> err
+        | Ok plan ->
+          (match
+             latch_blocking_resolution
+               ~id:entry.id
+               ~decision
+               ~plan
+           with
+           | Error _ as err -> err
+           | Ok committed_entry ->
+             Result.map
+               (fun after_pending_removal -> decision, after_pending_removal)
+               (complete_latched_blocking_resolution
+                  ~callback_site
+                  ~failure_site
+                  ~before_remove
+                  committed_entry
+                  plan))))
+  | Some _, Some _, _ ->
+    Error "blocking approval has both resolver and authoritative callback"
+  | (Some _ | None), _, Some _ ->
+    Error "blocking approval has a non-authoritative observer"
+  | None, None, None ->
+    Error "blocking approval has neither resolver nor callback"
 ;;
 
 let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
@@ -1456,6 +1948,20 @@ let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
       None)
 ;;
 
+let workspace_mismatch_error ~base_path ~id (entry : pending_approval) =
+  let reason =
+    Printf.sprintf
+      "caller workspace mismatch: expected %S, got %S"
+      entry.audit_base_path
+      base_path
+  in
+  record_resolution_delivery_failure
+    ~keeper_name:entry.keeper_name
+    ~approval_id:id
+    reason;
+  Error (Delivery_failed { approval_id = id; reason })
+;;
+
 let resolve_with_policy
       ~base_path
       ~id
@@ -1465,105 +1971,140 @@ let resolve_with_policy
       ()
   : (resolution_result, resolve_error) result
   =
-  if not (claim_resolution id)
-  then Error (Already_resolved id)
-  else
-    Fun.protect
-      ~finally:(fun () -> release_resolution_claim id)
-      (fun () ->
-         match SMap.find_opt id (Atomic.get pending) with
-         | None -> Error (Not_found id)
-         | Some entry ->
-           (match deliver_resolution ~base_path entry decision with
-            | Error reason -> Error (Delivery_failed { approval_id = id; reason })
-            | Ok signal ->
-              (* Durable delivery is the commit point for nonblocking entries.
-                 Keep the approval queryable while its callback applies the
-                 approved domain mutation; intake defers this exact resolution
-                 until the pending id is removed below. Blocking entries retain
-                 their original lane-release-before-resume ordering. *)
-              (match entry.lane_policy with
-               | Blocking -> atomic_update pending (fun map -> SMap.remove id map)
-               | Nonblocking -> ());
-              let remembered_rule =
-                match decision with
-                | Agent_sdk.Hooks.Approve when remember_rule ->
-                  remember_rule_for_entry ~base_path ?created_by entry
-                | _ -> None
-              in
-              let before_terminal_publish () =
-                match entry.lane_policy with
-                | Blocking -> ()
-                | Nonblocking -> atomic_update pending (fun map -> SMap.remove id map)
-              in
-              resolve_entry ~before_terminal_publish ~base_path entry decision;
-              Option.iter
-                (signal_resolution_after_commit
-                   ~keeper_name:entry.keeper_name
-                   ~approval_id:id)
-                signal;
-              Ok { remembered_rule }))
+  match SMap.find_opt id (Atomic.get pending) with
+  | None -> Error (Not_found id)
+  | Some entry when not (String.equal base_path entry.audit_base_path) ->
+    workspace_mismatch_error ~base_path ~id entry
+  | Some _ ->
+    if not (claim_resolution id)
+    then Error (Already_resolved id)
+    else
+      with_resolution_claim_cleanup ~id (fun () ->
+      run_resolution_claim_hook Operator_resolution id;
+      run_resolution_transaction (fun () ->
+        match SMap.find_opt id (Atomic.get pending) with
+        | None -> Error (Not_found id)
+        | Some entry when not (String.equal base_path entry.audit_base_path) ->
+          workspace_mismatch_error ~base_path ~id entry
+        | Some entry ->
+          let base_path = entry.audit_base_path in
+          let remembered_rule = ref None in
+          let remember_before_remove () =
+            remembered_rule :=
+              (match decision with
+               | Agent_sdk.Hooks.Approve when remember_rule ->
+                 remember_rule_for_entry ~base_path ?created_by entry
+               | Agent_sdk.Hooks.Approve
+               | Agent_sdk.Hooks.Reject _
+               | Agent_sdk.Hooks.Edit _ ->
+                 None)
+          in
+          (match entry.lane_policy with
+           | Blocking ->
+             (match
+                complete_blocking_resolution
+                  ~callback_site:"on_resolution"
+                  ~failure_site:Keeper_approval_queue_failure_site.Resolution_callback
+                  ~before_remove:remember_before_remove
+                  entry
+                  decision
+              with
+              | Error reason ->
+                Error (Delivery_failed { approval_id = id; reason })
+              | Ok (committed_decision, after_pending_removal) ->
+                publish_resolution ~base_path entry committed_decision;
+                signal_resolution_after_commit
+                  ~keeper_name:entry.keeper_name
+                  ~approval_id:entry.id
+                  after_pending_removal;
+                Ok { remembered_rule = !remembered_rule })
+           | Nonblocking ->
+             (* Public nonblocking submission accepts only an observer, never
+                an authoritative domain callback. Therefore the durable
+                [Hitl_resolved] event is the sole replayable decision carrier;
+                commit it before acknowledgement and invoke the observer only
+                after the pending id is gone. *)
+             (match ensure_resolution_delivery_hook entry with
+              | Error reason -> Error (Delivery_failed { approval_id = id; reason })
+              | Ok () ->
+                (match deliver_resolution ~base_path entry decision with
+                 | Error reason ->
+                   Error (Delivery_failed { approval_id = id; reason })
+                 | Ok signal ->
+                   remember_before_remove ();
+                   remove_pending_entry ~id;
+                   publish_resolution ~base_path entry decision;
+                   observe_and_signal_nonblocking_resolution
+                     ~callback_site:"on_resolution_observer"
+                     ~failure_site:Keeper_approval_queue_failure_site.Resolution_callback
+                     entry
+                     decision
+                     signal;
+                   Ok { remembered_rule = !remembered_rule })))))
 ;;
 
-(** Resolve a pending approval. Returns [Ok ()] if found and resolved,
+(** Resolve a workspace-scoped pending approval. Returns [Ok ()] if found and resolved,
     [Error (Not_found _)] if the id is not in the queue, or
     [Error (Already_resolved _)] if another resolver currently owns the
     approval claim. A delivery failure leaves the entry pending for retry.
-    Called from the dashboard approval HTTP handler
-    ([server_dashboard_http.ml]) and MCP runtime.
-
-    [base_path] is sourced from the entry's captured [audit_base_path]
-    rather than threaded from the caller: the convenience wrapper takes
-    only an [id], so the entry is the authoritative workspace source
-    (RFC-0274 Wave A). *)
-let resolve ~id ~(decision : Agent_sdk.Hooks.approval_decision)
+    The caller must provide the workspace authority; id uniqueness is not an
+    authorization boundary. *)
+let resolve ~base_path ~id ~(decision : Agent_sdk.Hooks.approval_decision)
   : (unit, resolve_error) result
   =
-  (* The entry is the authoritative base_path source for the convenience
-     wrapper: it has no caller-threaded [base_path], and the pending map
-     is per-workspace so the entry's captured [audit_base_path] is the
-     workspace that owns the approval. RFC-0274 Wave A. *)
-  match SMap.find_opt id (Atomic.get pending) with
-  | None -> Error (Not_found id)
-  | Some entry ->
-    (match resolve_with_policy ~base_path:entry.audit_base_path ~id ~decision () with
-     | Ok _ -> Ok ()
-     | Error _ as err -> err)
+  match resolve_with_policy ~base_path ~id ~decision () with
+  | Ok _ -> Ok ()
+  | Error _ as err -> err
 ;;
 
 (* ── Query ────────────────────────────────────────────────── *)
 
-(** List all pending approvals as JSON. *)
-let list_pending_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc -> `Assoc (pending_entry_json_fields entry) :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+let entry_in_workspace ~base_path (entry : pending_approval) =
+  String.equal entry.audit_base_path base_path
 ;;
 
-let list_pending_dashboard_json () : Yojson.Safe.t =
+(** List pending approvals for one workspace as JSON. *)
+let list_pending_json ~base_path : Yojson.Safe.t =
   let entries =
     SMap.fold
       (fun _id entry acc ->
-         `Assoc
-           (pending_entry_json_fields
-              ~include_requested_at_iso:true
-              ~include_runtime_contract:true
-              ~include_input:true
-              entry)
-         :: acc)
+         if entry_in_workspace ~base_path entry
+         then `Assoc (pending_entry_json_fields entry) :: acc
+         else acc)
       (Atomic.get pending)
       []
   in
   `List (sort_entries_by_requested_at entries)
 ;;
 
-let list_pending_entries () : pending_approval list =
+let list_pending_dashboard_json ~base_path : Yojson.Safe.t =
+  let entries =
+    SMap.fold
+      (fun _id entry acc ->
+         if entry_in_workspace ~base_path entry
+         then
+           `Assoc
+             (pending_entry_json_fields
+                ~include_requested_at_iso:true
+                ~include_runtime_contract:true
+                ~include_input:true
+                entry)
+           :: acc
+         else acc)
+      (Atomic.get pending)
+      []
+  in
+  `List (sort_entries_by_requested_at entries)
+;;
+
+let list_pending_entries_unscoped () : pending_approval list =
   SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
   |> List.sort (fun left right -> Float.compare left.requested_at right.requested_at)
+;;
+
+let list_pending_entries ~base_path : pending_approval list =
+  list_pending_entries_unscoped ()
+  |> List.filter (entry_in_workspace ~base_path)
 ;;
 
 let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =
@@ -1575,18 +2116,28 @@ let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =
        entry)
 ;;
 
-let get_pending_json ~id : Yojson.Safe.t option =
+let get_pending_json ~base_path ~id : Yojson.Safe.t option =
   match SMap.find_opt id (Atomic.get pending) with
-  | None -> None
-  | Some entry -> Some (pending_entry_detail_json entry)
+  | Some entry when entry_in_workspace ~base_path entry ->
+    Some (pending_entry_detail_json entry)
+  | Some _ | None -> None
 ;;
 
-let pending_count () : int = SMap.cardinal (Atomic.get pending)
+let pending_count ~base_path : int =
+  SMap.fold
+    (fun _ entry count ->
+       if entry_in_workspace ~base_path entry then count + 1 else count)
+    (Atomic.get pending)
+    0
+;;
 
-let pending_count_for_keeper ~keeper_name : int =
+let pending_count_for_keeper ~base_path ~keeper_name : int =
   SMap.fold
     (fun _ (entry : pending_approval) count ->
-       if String.equal entry.keeper_name keeper_name then count + 1 else count)
+       if entry_in_workspace ~base_path entry
+          && String.equal entry.keeper_name keeper_name
+       then count + 1
+       else count)
     (Atomic.get pending)
     0
 ;;
@@ -1595,10 +2146,11 @@ let pending_count_for_keeper ~keeper_name : int =
    lifecycle continuation (for example, a persisted partial-commit gate).
    Keep that distinction typed at the queue boundary instead of inferring lane
    ownership from a resolver or from tool names. *)
-let blocking_pending_count_for_keeper ~keeper_name : int =
+let blocking_pending_count_for_keeper ~base_path ~keeper_name : int =
   SMap.fold
     (fun _ (entry : pending_approval) count ->
-       if String.equal entry.keeper_name keeper_name
+       if entry_in_workspace ~base_path entry
+          && String.equal entry.keeper_name keeper_name
           && entry.lane_policy = Blocking
        then count + 1
        else count)
@@ -1606,21 +2158,59 @@ let blocking_pending_count_for_keeper ~keeper_name : int =
     0
 ;;
 
-let has_blocking_pending_for_keeper ~keeper_name : bool =
-  blocking_pending_count_for_keeper ~keeper_name > 0
+let has_blocking_pending_for_keeper ~base_path ~keeper_name : bool =
+  blocking_pending_count_for_keeper ~base_path ~keeper_name > 0
 ;;
 
-let has_pending_for_keeper ~keeper_name : bool =
+let has_pending_for_keeper ~base_path ~keeper_name : bool =
   SMap.fold
     (fun _ (entry : pending_approval) acc ->
-       acc || String.equal entry.keeper_name keeper_name)
+       acc
+       || (entry_in_workspace ~base_path entry
+           && String.equal entry.keeper_name keeper_name))
     (Atomic.get pending)
     false
 ;;
 
+let cancel_callback_owned_for_terminal_keeper ~base_path ~keeper_name ~reason =
+  let candidates =
+    list_pending_entries ~base_path
+    |> List.filter (fun (entry : pending_approval) ->
+      String.equal entry.keeper_name keeper_name
+      && entry.lane_policy = Blocking
+      && Option.is_some entry.on_resolution_callback
+      && Option.is_none entry.resolver)
+  in
+  List.fold_left
+    (fun cancelled (candidate : pending_approval) ->
+       let id = candidate.id in
+       if not (claim_resolution id)
+       then cancelled
+       else
+         with_resolution_claim_cleanup ~id (fun () ->
+           run_resolution_claim_hook Terminal_state_cancellation id;
+           run_resolution_transaction (fun () ->
+             match SMap.find_opt id (Atomic.get pending) with
+             | Some entry
+               when entry_in_workspace ~base_path entry
+                    && String.equal entry.keeper_name keeper_name
+                    && entry.lane_policy = Blocking
+                    && Option.is_some entry.on_resolution_callback
+                    && Option.is_none entry.resolver ->
+               remove_pending_entry ~id;
+               publish_resolution
+                 ~base_path
+                 entry
+                 (Agent_sdk.Hooks.Reject reason);
+               cancelled + 1
+             | Some _ | None -> cancelled)))
+    0
+    candidates
+;;
+
 (* ── Timeout cleanup ──────────────────────────────────────── *)
 
-let complete_expiration ~id (entry : pending_approval) ~reason ~decision =
+let publish_expiration ~id (entry : pending_approval) ~reason =
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
     ~labels:
@@ -1650,31 +2240,7 @@ let complete_expiration ~id (entry : pending_approval) ~reason ~decision =
     ?disposition:entry.disposition
     ?disposition_reason:entry.disposition_reason
     ~decision:(Approval_expired reason)
-    ();
-  (match entry.resolver with
-   | Some resolver -> Eio.Promise.resolve resolver decision
-   | None -> ());
-  match entry.on_resolution with
-  | None -> ()
-  | Some f ->
-    Cancel_safe.observe
-      ~on_exn:(fun exn ->
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string LifecycleCallbackFailures)
-          ~labels:[ "keeper", entry.keeper_name; "callback", "on_approval_expire" ]
-          ();
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string ApprovalQueueFailures)
-          ~labels:
-            [ "keeper", entry.keeper_name
-            ; "site", Keeper_approval_queue_failure_site.(to_label Expire_callback)
-            ]
-          ();
-        Log.Keeper.warn
-          "approval_queue: expire callback failed id=%s err=%s"
-          id
-          (Printexc.to_string exn))
-      (fun () -> f decision)
+    ()
 ;;
 
 (** Reject all approvals that have been waiting longer than [max_wait_s].
@@ -1706,7 +2272,7 @@ let expire_stale ~max_wait_s =
     | Critical -> false
     | Low | Medium | High -> now -. entry.requested_at > max_wait_s
   in
-  let candidates = list_pending_entries () |> List.filter is_stale in
+  let candidates = list_pending_entries_unscoped () |> List.filter is_stale in
   List.iter
     (* The annotation is load-bearing: [approval_rule] is declared after
        [pending_approval] in [Keeper_approval_queue_rules_types] and also has
@@ -1716,33 +2282,60 @@ let expire_stale ~max_wait_s =
        let id = candidate.id in
        if claim_resolution id
        then
-         Fun.protect
-           ~finally:(fun () -> release_resolution_claim id)
-           (fun () ->
-              match SMap.find_opt id (Atomic.get pending) with
-              | None -> ()
-              | Some entry when not (is_stale entry) -> ()
-              | Some entry ->
-                let reason =
-                  Printf.sprintf
-                    "approval timed out after %.0fs"
-                    (now -. entry.requested_at)
-                in
-                let decision = Agent_sdk.Hooks.Reject reason in
-                (match deliver_resolution ~base_path:entry.audit_base_path entry decision with
-                 | Error _ -> ()
-                 | Ok signal ->
-                   (match entry.lane_policy with
-                    | Blocking -> atomic_update pending (fun map -> SMap.remove id map)
-                    | Nonblocking -> ());
-                   complete_expiration ~id entry ~reason ~decision;
-                   (match entry.lane_policy with
-                    | Blocking -> ()
-                    | Nonblocking -> atomic_update pending (fun map -> SMap.remove id map));
-                   Option.iter
-                     (signal_resolution_after_commit
-                        ~keeper_name:entry.keeper_name
-                        ~approval_id:id)
-                     signal)) )
+         with_resolution_claim_cleanup ~id (fun () ->
+           run_resolution_claim_hook Expiration id;
+           run_resolution_transaction (fun () ->
+             match SMap.find_opt id (Atomic.get pending) with
+             | None -> ()
+             | Some entry when not (is_stale entry) -> ()
+             | Some entry ->
+               let reason =
+                 Printf.sprintf
+                   "approval timed out after %.0fs"
+                   (now -. entry.requested_at)
+               in
+               let decision = Agent_sdk.Hooks.Reject reason in
+               (match entry.lane_policy with
+                | Blocking ->
+                  (match
+                     complete_blocking_resolution
+                       ~callback_site:"on_approval_expire"
+                       ~failure_site:Keeper_approval_queue_failure_site.Expire_callback
+                       ~before_remove:(fun () -> ())
+                       entry
+                       decision
+                   with
+                   | Error _ -> ()
+                   | Ok (committed_decision, after_pending_removal) ->
+                     let committed_reason =
+                       match committed_decision with
+                       | Agent_sdk.Hooks.Reject reason -> reason
+                       | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ -> reason
+                     in
+                     publish_expiration ~id entry ~reason:committed_reason;
+                     signal_resolution_after_commit
+                       ~keeper_name:entry.keeper_name
+                       ~approval_id:entry.id
+                       after_pending_removal)
+                | Nonblocking ->
+                  (match ensure_resolution_delivery_hook entry with
+                   | Error _ -> ()
+                   | Ok () ->
+                     (match
+                        deliver_resolution
+                          ~base_path:entry.audit_base_path
+                          entry
+                          decision
+                      with
+                      | Error _ -> ()
+                      | Ok signal ->
+                        remove_pending_entry ~id;
+                        publish_expiration ~id entry ~reason;
+                        observe_and_signal_nonblocking_resolution
+                          ~callback_site:"on_approval_expire_observer"
+                          ~failure_site:Keeper_approval_queue_failure_site.Expire_callback
+                          entry
+                          decision
+                          signal))))))
     candidates
 ;;

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -48,6 +48,25 @@ type lane_policy =
   | Nonblocking
   | Blocking
 
+type resolution_claim_owner =
+  | Operator_resolution
+  | Await_timeout
+  | Await_cancellation
+  | Expiration
+  | Terminal_state_cancellation
+
+type blocking_resolution_plan =
+  { effect_key : string
+  ; commit : unit -> (unit -> unit)
+  }
+
+type blocking_resolution_state =
+  | Blocking_resolution_open
+  | Blocking_resolution_committed of
+      { decision : Agent_sdk.Hooks.approval_decision
+      ; plan : blocking_resolution_plan
+      }
+
 (** [Agent_sdk.Hooks.approval_decision] alias used as the resolver type. *)
 type decision = Agent_sdk.Hooks.approval_decision
 
@@ -86,10 +105,15 @@ type pending_approval =
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
-  ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; on_resolution_callback :
+      (approval_id:string ->
+       Agent_sdk.Hooks.approval_decision ->
+       blocking_resolution_plan)
+        option
+  ; on_resolution_observer : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; blocking_resolution_state : blocking_resolution_state
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : Keeper_continuation_channel.t option
   }
 
 (** Persisted auto-approval rule that can satisfy a pending entry
@@ -281,7 +305,18 @@ val list_recent_resolved_json :
 
 module For_testing : sig
   val reset_audit_store : unit -> unit
+  val reset_pending : unit -> unit
   val first_cmd_token : string -> string option
+  val pending_base_path : id:string -> string option
+  val list_pending_entries : unit -> pending_approval list
+  val pending_count : unit -> int
+  val pending_count_for_keeper : keeper_name:string -> int
+  val blocking_pending_count_for_keeper : keeper_name:string -> int
+  val has_blocking_pending_for_keeper : keeper_name:string -> bool
+  val has_pending_for_keeper : keeper_name:string -> bool
+  val set_resolution_claim_hook :
+    (resolution_claim_owner -> string -> unit) -> unit
+  val clear_resolution_claim_hook : unit -> unit
   val clear_approval_resolution_wake_hook : unit -> unit
 end
 
@@ -324,13 +359,12 @@ val submit_and_await :
   unit ->
   Agent_sdk.Hooks.approval_decision
 
-(** Submit a tool call for approval without suspending the caller —
-    the supplied [on_resolution] callback is invoked when the
-    operator resolves. [lane_policy] defaults to [Nonblocking]; lifecycle
-    gates that deliberately pause a keeper must pass [Blocking] and resume
-    that pause from their callback. Returns the new pending entry's id, or
-    the existing id when an equivalent entry with the same policy is pending. *)
-val submit_pending :
+(** Submit a nonblocking approval. [on_resolution_observer] is explicitly
+    non-authoritative: the durable [Hitl_resolved] event is the sole replayable
+    decision carrier, and the observer runs only after durable commit and
+    pending removal. Domain mutations must use {!submit_pending_blocking} until
+    they have a typed replayable effect. *)
+val submit_pending_observer :
   keeper_name:string ->
   tool_name:string ->
   input:Yojson.Safe.t ->
@@ -348,8 +382,47 @@ val submit_pending :
   ?disposition:string ->
   ?disposition_reason:string ->
   ?continuation_channel:Keeper_continuation_channel.t ->
-  ?lane_policy:lane_policy ->
-  on_resolution:(Agent_sdk.Hooks.approval_decision -> unit) ->
+  on_resolution_observer:(Agent_sdk.Hooks.approval_decision -> unit) ->
+  unit ->
+  string
+
+(** Build a side-effect-free blocking resolution plan. [commit] must be an
+    idempotent durable domain mutation. It returns a non-authoritative recovery
+    hint that runs only after pending removal and terminal audit publication. *)
+val blocking_resolution_plan :
+  effect_key:string ->
+  commit:(unit -> (unit -> unit)) ->
+  blocking_resolution_plan
+
+(** Submit a callback-owned blocking approval. [on_resolution] receives the
+    approval id and must only prepare a side-effect-free plan. The queue then
+    latches the decision before invoking the plan's idempotent durable commit.
+    Commit failure preserves the entry for a same-decision retry; a
+    contradictory retry is rejected. After commit, the queue removes the id,
+    publishes the terminal audit, and invokes the plan's best-effort recovery
+    hint. *)
+val submit_pending_blocking :
+  keeper_name:string ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  risk_level:risk_level ->
+  base_path:string ->
+  ?turn_id:int ->
+  ?task_id:string ->
+  ?goal_id:string ->
+  ?goal_ids:string list ->
+  ?sandbox_target:string ->
+  ?sandbox_profile:string ->
+  ?backend:string ->
+  ?runtime_contract:Yojson.Safe.t ->
+  ?selected_model:string ->
+  ?disposition:string ->
+  ?disposition_reason:string ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
+  on_resolution:
+    (approval_id:string ->
+     Agent_sdk.Hooks.approval_decision ->
+     blocking_resolution_plan) ->
   unit ->
   string
 
@@ -363,7 +436,7 @@ val submit_pending :
     [has_blocking_pending_for_keeper]. Before [Server_bootstrap] installs the
     hook, nonblocking resolution fails explicitly and remains pending. A
     successful hook returns the wake signal closure; the queue invokes it only
-    after the resolution callback has completed and the pending id is gone. *)
+    after the pending id is gone and the non-authoritative observer has run. *)
 val set_approval_resolution_wake_hook :
   (base_path:string ->
    keeper_name:string ->
@@ -377,7 +450,15 @@ val set_approval_resolution_wake_hook :
     as a rule. Returns [Not_found] when [id] is absent or
     [Already_resolved] on a concurrent-resolve race. [Delivery_failed]
     preserves the pending entry and reports that no resolution was
-    acknowledged. *)
+    acknowledged. The caller [base_path] must match the pending entry's
+    captured [audit_base_path]; after that check the entry path is the SSOT for
+    callback, audit, rule, and durable-delivery work. A blocking plan's typed
+    decision is latched before its idempotent durable commit; commit failure
+    preserves the entry for the same decision, while a contradictory retry is
+    rejected. After commit, removal and terminal audit precede the
+    non-authoritative recovery hint. Nonblocking resolution commits the
+    replayable [Hitl_resolved] event before removal and invokes only a
+    non-authoritative observer afterward. *)
 val resolve_with_policy :
   base_path:string ->
   id:string ->
@@ -387,39 +468,48 @@ val resolve_with_policy :
   unit ->
   (resolution_result, resolve_error) result
 
-(** Convenience over [resolve_with_policy] that discards the
-    resolution result. Called from the dashboard approval HTTP
-    handler and the MCP runtime. *)
+(** Workspace-scoped convenience over [resolve_with_policy] that discards the
+    resolution result. Id uniqueness is not an authorization boundary. *)
 val resolve :
+  base_path:string ->
   id:string ->
   decision:Agent_sdk.Hooks.approval_decision ->
   (unit, resolve_error) result
 
 (** {1 Query} *)
 
-val list_pending_json : unit -> Yojson.Safe.t
-val list_pending_dashboard_json : unit -> Yojson.Safe.t
-val list_pending_entries : unit -> pending_approval list
+val list_pending_json : base_path:string -> Yojson.Safe.t
+val list_pending_dashboard_json : base_path:string -> Yojson.Safe.t
+val list_pending_entries : base_path:string -> pending_approval list
 
 (** Detail view of a single pending entry with input + runtime
     contract included. *)
-val get_pending_json : id:string -> Yojson.Safe.t option
+val get_pending_json : base_path:string -> id:string -> Yojson.Safe.t option
 
-(** Read a pending entry by id. Returns [None] if already resolved. *)
-val get_pending_entry : id:string -> pending_approval option
+(** Read a pending entry by id within [base_path]. Returns [None] when absent,
+    already resolved, or owned by another workspace. *)
+val get_pending_entry : base_path:string -> id:string -> pending_approval option
 
 (** Apply a copy-on-write update to a pending entry if it still exists. *)
 val update_pending_entry : id:string -> (pending_approval -> pending_approval) -> unit
 
-val pending_count : unit -> int
-val pending_count_for_keeper : keeper_name:string -> int
-val blocking_pending_count_for_keeper : keeper_name:string -> int
+val pending_count : base_path:string -> int
+val pending_count_for_keeper : base_path:string -> keeper_name:string -> int
+val blocking_pending_count_for_keeper : base_path:string -> keeper_name:string -> int
 (** Number of pending approvals with [Blocking] lane policy. *)
 
-val has_blocking_pending_for_keeper : keeper_name:string -> bool
+val has_blocking_pending_for_keeper : base_path:string -> keeper_name:string -> bool
 (** Whether a [Blocking] approval currently owns a live Keeper lane. *)
 
-val has_pending_for_keeper : keeper_name:string -> bool
+val has_pending_for_keeper : base_path:string -> keeper_name:string -> bool
+
+val cancel_callback_owned_for_terminal_keeper :
+  base_path:string -> keeper_name:string -> reason:string -> int
+(** Terminal-cancel callback-owned Blocking entries for [keeper_name] without
+    invoking their domain callbacks. Uses the shared resolution claim, removes
+    only entries still owned by this workspace/keeper, and publishes one
+    terminal Reject audit per cancelled entry. Promise-owned and observer
+    entries are left untouched. *)
 
 (** {1 Timeout cleanup} *)
 

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -15,19 +15,24 @@
     Tier B3, PR #11417).
 
     The spec preamble cites this module by function name
-    ([submit_and_await], [submit_pending], [expire_stale]).  It used to
+    ([submit_and_await], [submit_pending_blocking],
+    [submit_pending_observer], [expire_stale]).  It used to
     carry line numbers (751 / 772 / 941) but iter 64 N-2.a removed them
     after the OCaml line drift reached +245..+413 — function names are
     stable, line numbers are not.  This block is the reverse-direction
     citation so code search for "KeeperApprovalQueue" lands here.
 
     Action mapping (TLA+ -> OCaml):
-      Submit                 [submit_and_await] / [submit_pending]
-                             record a new pending entry. [submit_and_await]
-                             suspends the caller on [Eio.Promise.await];
-                             [submit_pending] invokes its callback later and
-                             defaults to an independent Keeper cycle unless
-                             an explicit lifecycle [Blocking] policy is used.
+      Submit                 [submit_and_await], [submit_pending_blocking],
+                             and [submit_pending_observer] record a new pending
+                             entry. [submit_and_await] suspends the caller on
+                             [Eio.Promise.await]. A blocking callback prepares
+                             a side-effect-free plan; the queue latches its
+                             decision, runs the idempotent durable commit, then
+                             removes the entry. Its recovery hint runs only
+                             after terminal audit publication. The
+                             nonblocking observer runs only after durable
+                             [Hitl_resolved] commit and pending removal.
       Resolve                operator approves/rejects via the HTTP
                              handler in [server_dashboard_http.ml],
                              which calls [resolve] on the queue and
@@ -36,14 +41,13 @@
                              and forces
                              [Eio.Promise.resolve resolver (Reject ...)]
                              so no fiber is left blocked indefinitely.
-      ExpireStaleNoResolve   bug action — entries are removed from
-                             [pending] without resolving the promise.
+      ExpireStaleNoResolve   promise-lane bug action — an entry is removed
+                             from [pending] without resolving its promise.
                              Spec invariants SuspensionMatchesPending
-                             and QuiescentImpliesResolved catch this;
-                             in code, the structural invariant is
-                             that every removal from [pending] is
-                             paired with an [Eio.Promise.resolve]
-                             on the same control-flow path.
+                             and QuiescentImpliesResolved catch this. The model
+                             does not cover callback decision latching,
+                             workspace routing, or durable observer delivery;
+                             focused OCaml tests own those contracts.
 
     @since 2.262.0 (#5907) *)
 

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -10,6 +10,24 @@ type lease_finalization =
   | Ack
   | Nack
 
+type queue_lane_admission =
+  | Queue_lane_available
+  | Queue_lane_owned_by_blocking_approval
+
+let classify_queue_lane_admission ~base_path ~keeper_name =
+  if
+    Keeper_approval_queue.has_blocking_pending_for_keeper
+      ~base_path
+      ~keeper_name
+  then Queue_lane_owned_by_blocking_approval
+  else Queue_lane_available
+
+(* Deterministic seam for the post-lease admission race. Production keeps the
+   no-op hook; focused tests install a Blocking approval after the durable
+   lease is acquired and before the second typed admission check. *)
+let after_lease_hook =
+  ref (fun ~base_path:_ ~keeper_name:_ ~lease_id:_ -> ())
+
 type dispatch_state = {
   mutex : Eio.Mutex.t;
   running_by_keeper : (string, unit) Hashtbl.t;
@@ -65,6 +83,9 @@ module For_testing = struct
   let is_dispatching = is_dispatching
   let mark_dispatching = mark_dispatching
   let clear_dispatching = clear_dispatching
+  let set_after_lease_hook hook = after_lease_hook := hook
+  let clear_after_lease_hook () =
+    after_lease_hook := (fun ~base_path:_ ~keeper_name:_ ~lease_id:_ -> ())
 end
 
 (* Single broadcast site for every queue-depth-affecting mutation this module
@@ -208,6 +229,79 @@ let dispatch_queued_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn ~o
             keeper_name
             (Printexc.to_string exn))
 
+let dispatch_available_lease state ~sw ~clock ~dispatch_deadline_sec ~handle_turn
+    ~on_stalled ~keeper_name ~lease_id ~messages =
+  broadcast_queue_changed ~keeper_name;
+  (match messages with
+   | _ :: _ :: _ ->
+     Log.Keeper.info
+       "keeper_chat_consumer: coalesced %d queued messages into one turn for \
+        keeper=%s"
+       (List.length messages)
+       keeper_name
+   | [] | [ _ ] -> ());
+  match Keeper_chat_queue.merge_batch messages with
+  | None ->
+    (* Unreachable in practice: [lease_batch] only returns [`Leased] with a
+       non-empty [messages]. Nack rather than silently drop, and let the log
+       carry the invariant violation for triage. *)
+    Log.Keeper.error
+      "keeper_chat_consumer: lease=%s for keeper=%s carried zero messages; \
+       nacking"
+      lease_id
+      keeper_name;
+    nack_or_warn state ~keeper_name ~lease_id;
+    clear_dispatching state keeper_name
+  | Some queued ->
+    (try
+       dispatch_queued_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn
+         ~on_stalled ~keeper_name ~lease_id ~queued
+     with
+     | Eio.Cancel.Cancelled _ as e ->
+       Eio.Cancel.protect (fun () -> nack_or_warn state ~keeper_name ~lease_id);
+       clear_dispatching state keeper_name;
+       raise e
+     | exn ->
+       nack_or_warn state ~keeper_name ~lease_id;
+       clear_dispatching state keeper_name;
+       Log.Keeper.warn
+         "keeper_chat_consumer: dispatch fork failed for keeper=%s: %s"
+         keeper_name
+         (Printexc.to_string exn))
+
+let handle_leased_batch state ~sw ~clock ~base_path ~dispatch_deadline_sec
+    ~handle_turn ~on_stalled ~keeper_name ~lease_id ~messages =
+  match (!after_lease_hook) ~base_path ~keeper_name ~lease_id with
+  | () ->
+    (match classify_queue_lane_admission ~base_path ~keeper_name with
+     | Queue_lane_owned_by_blocking_approval ->
+       (* The lane changed ownership after the pre-lease check. Return the
+          durable lease to the queue; dispatching it would turn the direct-turn
+          precondition into a Transport_failure and ACK away an unanswered user
+          message. *)
+       Log.Keeper.info
+         "keeper_chat_consumer: blocking approval took ownership after lease=%s \
+          for keeper=%s; nacking for retry after resolution"
+         lease_id
+         keeper_name;
+       nack_or_warn state ~keeper_name ~lease_id;
+       clear_dispatching state keeper_name
+     | Queue_lane_available ->
+       dispatch_available_lease state ~sw ~clock ~dispatch_deadline_sec
+         ~handle_turn ~on_stalled ~keeper_name ~lease_id ~messages)
+  | exception (Eio.Cancel.Cancelled _ as e) ->
+    Eio.Cancel.protect (fun () -> nack_or_warn state ~keeper_name ~lease_id);
+    clear_dispatching state keeper_name;
+    raise e
+  | exception exn ->
+    nack_or_warn state ~keeper_name ~lease_id;
+    clear_dispatching state keeper_name;
+    Log.Keeper.warn
+      "keeper_chat_consumer: after-lease hook failed for keeper=%s: %s; nacked \
+       for retry"
+      keeper_name
+      (Printexc.to_string exn)
+
 let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled =
   let dispatch_state = create_dispatch_state () in
   let rec poll_loop () =
@@ -225,9 +319,12 @@ let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled 
            match retry_pending_finalization dispatch_state ~keeper_name with
            | true -> ()
            | false -> (
-             match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
-             | Some _ -> ()
-             | None -> (
+             match classify_queue_lane_admission ~base_path ~keeper_name with
+             | Queue_lane_owned_by_blocking_approval -> ()
+             | Queue_lane_available -> (
+               match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
+               | Some _ -> ()
+               | None -> (
                if mark_dispatching dispatch_state keeper_name
                then (
                  let leased =
@@ -256,55 +353,17 @@ let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled 
                        "keeper_chat_consumer: lease_batch persist failed for keeper=%s: \
                         %s; retrying next poll"
                        keeper_name
-                       msg;
+                     msg;
                      clear_dispatching dispatch_state keeper_name
                  | `Leased { Keeper_chat_queue.lease_id; messages } ->
-                     broadcast_queue_changed ~keeper_name;
-                     (match messages with
-                      | _ :: _ :: _ ->
-                          Log.Keeper.info
-                            "keeper_chat_consumer: coalesced %d queued messages \
-                             into one turn for keeper=%s"
-                            (List.length messages)
-                            keeper_name
-                      | [] | [ _ ] -> ());
-                     (match Keeper_chat_queue.merge_batch messages with
-                      | None ->
-                          (* Unreachable in practice: [lease_batch] only returns
-                             [`Leased] with a non-empty [messages]. Nack rather
-                             than silently drop, and let the log carry the
-                             invariant violation for triage. *)
-                          Log.Keeper.error
-                            "keeper_chat_consumer: lease=%s for keeper=%s carried \
-                             zero messages; nacking"
-                            lease_id
-                            keeper_name;
-                          nack_or_warn dispatch_state ~keeper_name ~lease_id;
-                          clear_dispatching dispatch_state keeper_name
-                      | Some queued ->
-                          (try
-                             dispatch_queued_turn dispatch_state ~sw ~clock
-                               ~dispatch_deadline_sec ~handle_turn ~on_stalled
-                               ~keeper_name ~lease_id ~queued
-                           with
-                           | Eio.Cancel.Cancelled _ as e ->
-                               Eio.Cancel.protect (fun () ->
-                                   nack_or_warn dispatch_state ~keeper_name ~lease_id);
-                               clear_dispatching dispatch_state keeper_name;
-                               raise e
-                           | exn ->
-                               nack_or_warn dispatch_state ~keeper_name ~lease_id;
-                               clear_dispatching dispatch_state keeper_name;
-                               Log.Keeper.warn
-                                 "keeper_chat_consumer: dispatch fork failed for \
-                                  keeper=%s: %s"
-                                 keeper_name
-                                 (Printexc.to_string exn))))
+                   handle_leased_batch dispatch_state ~sw ~clock ~base_path
+                     ~dispatch_deadline_sec ~handle_turn ~on_stalled
+                     ~keeper_name ~lease_id ~messages)
                else
                  Log.Keeper.warn
                    "keeper_chat_consumer: duplicate dispatch suppressed for \
                     keeper=%s"
-                   keeper_name)))
+                   keeper_name))))
       keeper_names;
     Eio.Time.sleep clock poll_interval_sec;
     poll_loop ()

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -14,13 +14,17 @@
     every [MASC_KEEPER_QUEUE_POLL_SEC] seconds (default 1.0).
 
     Per keeper and per tick: when a turn is in flight
-    ([Keeper_turn_admission.in_flight]), queued messages are left to
-    accumulate; once the slot is free, the head run of same-source messages
-    is leased ([Keeper_chat_queue.lease_batch]) and merged into ONE
-    coalesced message ([Keeper_chat_queue.merge_batch]).  The merged turn
-    then runs in a keeper-scoped child fiber, so a slow queued turn for one
-    keeper does not block polling or delivery for other keepers.  A
-    keeper-local dispatch gate preserves the single follow-up turn contract
+    ([Keeper_turn_admission.in_flight]) or a workspace-scoped Blocking HITL
+    approval owns the lane, queued messages are left to accumulate. Once the
+    slot is free, the head run of same-source messages is leased
+    ([Keeper_chat_queue.lease_batch]) and the Blocking predicate is checked
+    again before dispatch. A Blocking approval that wins that race nacks the
+    lease for retry after resolution; it is not dispatched as a failed turn
+    and therefore cannot create a transport-failure row. Otherwise the leased
+    run is merged into ONE coalesced message ([Keeper_chat_queue.merge_batch]).
+    The merged turn then runs in a keeper-scoped child fiber, so a slow queued
+    turn for one keeper does not block polling or delivery for other keepers.
+    A keeper-local dispatch gate preserves the single follow-up turn contract
     for messages sent during an existing queued turn.
 
     Delivery is at-least-once: the lease is acked only once [handle_turn]
@@ -62,4 +66,11 @@ module For_testing : sig
   val is_dispatching : dispatch_state -> string -> bool
   val mark_dispatching : dispatch_state -> string -> bool
   val clear_dispatching : dispatch_state -> string -> unit
+
+  val set_after_lease_hook :
+    (base_path:string -> keeper_name:string -> lease_id:string -> unit) -> unit
+  (** Install a deterministic hook between lease acquisition and the second
+      Blocking-lane admission check. Focused TOCTOU tests only. *)
+
+  val clear_after_lease_hook : unit -> unit
 end

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -335,6 +335,8 @@ let stop_reason_to_string = function
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
     Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
+  | Runtime_agent.Yielded_to_blocking_approval { turns_used; _ } ->
+    Printf.sprintf "yielded_to_blocking_approval:%d" turns_used
 ;;
 
 let enrich_contract_violation_reason (receipt : t) : string =

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -326,6 +326,7 @@ let run_keepalive_unified_turn
         decide_keepalive_scheduling
           ~reactive_wake
           ~event_queue_triggers:event_intake.event_queue_triggers
+          ~base_path:ctx.config.base_path
           ~keeper_resilience_of_name:(fun keeper_name ->
             if Health.is_healthy ~agent_name:keeper_name then None
             else Some "unhealthy")
@@ -540,10 +541,21 @@ let run_keepalive_unified_turn
                    !consumed_stimuli)
             else Keeper_registry.Proactive_tick
           in
+          let retain_unobserved_stimuli = ref false in
           let meta_after_cycle =
             run_keeper_cycle
               ?event_bus
               ?hitl_resolution
+              ~on_stop_reason:(function
+                | Runtime_agent.Yielded_to_blocking_approval
+                    { provider_turns_completed = 0; _ } ->
+                  retain_unobserved_stimuli := true
+                | Runtime_agent.Completed
+                | Runtime_agent.TurnBudgetExhausted _
+                | Runtime_agent.MutationBoundaryReached _
+                | Runtime_agent.Yielded_to_chat_waiting _
+                | Runtime_agent.Yielded_to_durable_stimulus _
+                | Runtime_agent.Yielded_to_blocking_approval _ -> ())
               ~ctx
               ~meta_after_triage
               ~stop
@@ -553,7 +565,14 @@ let run_keepalive_unified_turn
               ~wake
               ()
           in
-          consumed_stimuli_turn_completed := true;
+          consumed_stimuli_turn_completed := not !retain_unobserved_stimuli;
+          if !retain_unobserved_stimuli && !consumed_stimuli <> []
+          then
+            Log.Keeper.info
+              "%s: retaining %d leased stimulus/stimuli after a pre-dispatch \
+               Blocking approval yield"
+              meta_after_triage.name
+              (List.length !consumed_stimuli);
           meta_after_cycle)
         else meta_after_triage
       in
@@ -1032,6 +1051,7 @@ let run_heartbeat_loop
         in
         let approval_pending =
           Keeper_approval_queue.has_blocking_pending_for_keeper
+            ~base_path:ctx.config.base_path
             ~keeper_name:meta_current.name
         in
         let intake_admission =

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -95,6 +95,7 @@ val decide_keepalive_scheduling :
   ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->
+  base_path:string ->
   meta:keeper_meta ->
   Keeper_world_observation.world_observation ->
   keepalive_scheduling_decision

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -46,6 +46,7 @@ module Observations = Keeper_heartbeat_loop_observations
 let run_keeper_cycle_admitted
       ?event_bus
       ?hitl_resolution
+      ?on_stop_reason
       ~ctx
       ~meta_after_triage
       ~stop
@@ -70,6 +71,7 @@ let run_keeper_cycle_admitted
         ~turn_decision
         ~shared_context
         ?event_bus
+        ?on_stop_reason
         ())
   with
   | Error err ->
@@ -137,6 +139,7 @@ let run_keeper_cycle_admitted
 let run_keeper_cycle
       ?event_bus
       ?hitl_resolution
+      ?on_stop_reason
       ~ctx
       ~meta_after_triage
       ~stop
@@ -159,7 +162,8 @@ let run_keeper_cycle
          ~shared_context
          ~wake
          ?event_bus
-         ?hitl_resolution)
+         ?hitl_resolution
+         ?on_stop_reason)
   with
   | `Ran updated -> updated
   | `Busy in_flight ->

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -3,6 +3,7 @@
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?on_stop_reason:(Runtime_agent.stop_reason -> unit)
   -> ctx:_ Keeper_types_profile.context
   -> meta_after_triage:Keeper_meta_contract.keeper_meta
   -> stop:bool Atomic.t

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -80,16 +80,18 @@ let repair_identity_drift_for_keepalive ~(ctx : _ context) (meta : keeper_meta)
         }
       in
       (match
-         write_meta_with_merge
-           ~merge:Keeper_meta_merge.monotonic_usage_counters ctx.config repaired
+         write_meta_with_merge_returning
+           ~merge:Keeper_meta_merge.identity_repair_fields_from_caller
+           ctx.config
+           repaired
        with
-       | Ok () ->
+       | Ok persisted ->
          Log.Keeper.warn
            "keepalive repaired identity drift for %s: %s -> %s"
            meta.name
            meta.agent_name
            expected_agent_name;
-         Some repaired
+         Some persisted
        | Error err ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string WriteMetaFailures)
@@ -153,12 +155,12 @@ let sync_keeper_presence
       ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
     match
-      write_meta_with_merge
-        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+      write_meta_with_merge_returning
+        ~merge:Keeper_meta_merge.non_operator_control_fields_from_disk
         ctx.config
         synced
     with
-    | Ok () -> synced
+    | Ok persisted -> persisted
     | Error e ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string WriteMetaFailures)

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -33,6 +33,7 @@ let decide_keepalive_scheduling
       ?(reactive_wake = false)
       ?(event_queue_triggers = [])
       ~stop
+      ~base_path
       ~meta
       obs
   =
@@ -40,6 +41,7 @@ let decide_keepalive_scheduling
     Keeper_world_observation.keeper_cycle_decision
       ~reactive_wake
       ~event_queue_triggers
+      ~base_path
       ~meta
       obs
   in

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -21,6 +21,7 @@ val decide_keepalive_scheduling :
   ?reactive_wake:bool ->
   ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   stop:bool Atomic.t ->
+  base_path:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_world_observation.world_observation ->
   keepalive_scheduling_decision

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -321,11 +321,13 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
     batch
 ;;
 
-let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
+let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus) =
   match stimulus.payload with
   | Keeper_event_queue.Hitl_resolved resolution ->
     Option.is_none
-      (Keeper_approval_queue.get_pending_entry ~id:resolution.approval_id)
+      (Keeper_approval_queue.get_pending_entry
+         ~base_path
+         ~id:resolution.approval_id)
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.No_progress_recovery
@@ -358,7 +360,7 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
          Keeper_registry_event_queue.dequeue_when
            ~base_path:ctx.config.base_path
            meta_after_triage.name
-           ~ready:stimulus_ready_for_intake
+           ~ready:(stimulus_ready_for_intake ~base_path:ctx.config.base_path)
        with
        | None -> [], []
        | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, [ stim ])

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -82,7 +82,8 @@ val consume_board_stimulus_batch
     newly-consumed board events with the [pending_board_events] already
     accumulated by the caller, deduplicating by [post_id]. A
     [Hitl_resolved] head remains queued until its exact approval id has left
-    the pending map, so domain callbacks complete before continuation intake. *)
+    the pending map, so continuation intake cannot overtake the approval
+    queue's durable commit and removal boundary. *)
 val heartbeat_event_intake
   :  ctx:'a context
   -> meta_after_triage:keeper_meta

--- a/lib/keeper/keeper_hitl_continue_gate.ml
+++ b/lib/keeper/keeper_hitl_continue_gate.ml
@@ -1,0 +1,166 @@
+open Keeper_meta_contract
+
+type decision =
+  | Approve
+  | Reject
+
+let ( let* ) = Result.bind
+
+let generate_id () = Random_id.prefixed ~prefix:"continue-" ~bytes:16
+
+let owns ~gate_id (meta : keeper_meta) =
+  meta.paused
+  &&
+  match meta.latched_reason with
+  | Some (Keeper_latched_reason.Continue_gate_pending { gate_id = current; _ }) ->
+    String.equal current gate_id
+  | Some _ | None -> false
+;;
+
+let preserve_latest_control_fields
+      ~(latest : keeper_meta)
+      ~(caller : keeper_meta)
+  =
+  let merged = Keeper_meta_merge.monotonic_usage_counters ~latest ~caller in
+  { merged with
+    paused = latest.paused
+  ; latched_reason = latest.latched_reason
+  ; auto_resume_after_sec = latest.auto_resume_after_sec
+  ; runtime = { merged.runtime with last_blocker = latest.runtime.last_blocker }
+  }
+;;
+
+let legacy_unowned (meta : keeper_meta) = meta.paused && Option.is_none meta.latched_reason
+
+let install_merge
+      ~allow_legacy_unowned
+      ~gate_id
+      ~(latest : keeper_meta)
+      ~(caller : keeper_meta)
+  =
+  if
+    latest.paused
+    && not (owns ~gate_id latest)
+    && not (allow_legacy_unowned && legacy_unowned latest)
+  then preserve_latest_control_fields ~latest ~caller
+  else Keeper_meta_merge.operator_control_fields_from_caller ~latest ~caller
+;;
+
+let resolution_merge ~gate_id ~(latest : keeper_meta) ~(caller : keeper_meta) =
+  if owns ~gate_id latest
+  then Keeper_meta_merge.operator_control_fields_from_caller ~latest ~caller
+  else preserve_latest_control_fields ~latest ~caller
+;;
+
+let read_required config keeper_name =
+  match Keeper_meta_store.read_meta config keeper_name with
+  | Ok (Some meta) -> Ok meta
+  | Ok None -> Error (Printf.sprintf "keeper metadata unavailable: %s" keeper_name)
+  | Error err -> Error ("keeper metadata read failed: " ^ err)
+;;
+
+let install_with
+      ~allow_legacy_unowned
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~gate_id
+      ~origin
+      ~committed_tools
+  =
+  if String.trim gate_id = ""
+  then Error "continue gate id must not be empty"
+  else
+    let* latest = read_required config meta.name in
+    if
+      latest.paused
+      && not (owns ~gate_id latest)
+      && not (allow_legacy_unowned && legacy_unowned latest)
+    then Error "keeper is already paused by a different authoritative gate"
+    else
+      let caller =
+        Keeper_meta_merge.monotonic_usage_counters ~latest ~caller:meta
+      in
+      let gated =
+        { caller with
+          paused = true
+        ; latched_reason =
+            Some
+              (Keeper_latched_reason.Continue_gate_pending
+                 { gate_id; origin; committed_tools })
+        ; auto_resume_after_sec = None
+        ; updated_at = now_iso ()
+        }
+      in
+      let* persisted =
+        Keeper_meta_store.write_meta_with_merge_returning
+          ~merge:(install_merge ~allow_legacy_unowned ~gate_id)
+          config
+          gated
+      in
+      Keeper_registry.sync_persisted_meta_if_newer
+        ~base_path:config.base_path
+        persisted.name
+        persisted;
+      if owns ~gate_id persisted
+      then Ok persisted
+      else Error "continue gate install lost exact ownership"
+;;
+
+let install = install_with ~allow_legacy_unowned:false
+let migrate_legacy = install_with ~allow_legacy_unowned:true
+
+let resolve ~(config : Workspace.config) ~keeper_name ~gate_id ~decision =
+  let* latest = read_required config keeper_name in
+  if not (owns ~gate_id latest)
+  then Error "continue gate is stale or no longer owns the keeper pause"
+  else
+    let caller =
+      match decision with
+      | Approve ->
+        { latest with
+          paused = false
+        ; latched_reason = None
+        ; auto_resume_after_sec = None
+        ; updated_at = now_iso ()
+        ; runtime = { latest.runtime with last_blocker = None }
+        }
+      | Reject ->
+        { latest with
+          paused = true
+        ; latched_reason =
+            Some
+              (Keeper_latched_reason.Operator_paused
+                 { operator_actor = Keeper_latched_reason.Hitl_rejection })
+        ; auto_resume_after_sec = None
+        ; updated_at = now_iso ()
+        ; runtime = { latest.runtime with last_blocker = None }
+        }
+    in
+    let* persisted =
+      Keeper_meta_store.write_meta_with_merge_returning
+        ~merge:(resolution_merge ~gate_id)
+        config
+        caller
+    in
+    Keeper_registry.sync_persisted_meta_if_newer
+      ~base_path:config.base_path
+      persisted.name
+      persisted;
+    let postcondition =
+      match decision with
+      | Approve -> (not persisted.paused) && Option.is_none persisted.latched_reason
+      | Reject ->
+        persisted.paused
+        &&
+        match persisted.latched_reason with
+        | Some
+            (Keeper_latched_reason.Operator_paused
+              { operator_actor = Keeper_latched_reason.Hitl_rejection }) ->
+          true
+        | Some (Keeper_latched_reason.Operator_paused _)
+        | Some _ | None -> false
+    in
+    if postcondition
+    then Ok persisted
+    else Error "continue gate resolution was superseded by newer authoritative state"
+;;

--- a/lib/keeper/keeper_hitl_continue_gate.mli
+++ b/lib/keeper/keeper_hitl_continue_gate.mli
@@ -1,0 +1,39 @@
+(** Exact-identity lifecycle for partial-commit and reconcile HITL gates. *)
+
+type decision =
+  | Approve
+  | Reject
+
+val generate_id : unit -> string
+
+val owns :
+  gate_id:string -> Keeper_meta_contract.keeper_meta -> bool
+
+val install :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  gate_id:string ->
+  origin:Keeper_latched_reason.continue_gate_origin ->
+  committed_tools:string list ->
+  (Keeper_meta_contract.keeper_meta, string) result
+(** Persist a typed pause before an in-memory approval is queued. Existing
+    operator, repository, dead, or different continue-gate ownership wins. *)
+
+val migrate_legacy :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  gate_id:string ->
+  origin:Keeper_latched_reason.continue_gate_origin ->
+  committed_tools:string list ->
+  (Keeper_meta_contract.keeper_meta, string) result
+(** Claim only a legacy [paused=true; latched_reason=None] reconcile pause.
+    Any typed owner that appears during the CAS race wins. *)
+
+val resolve :
+  config:Workspace.config ->
+  keeper_name:string ->
+  gate_id:string ->
+  decision:decision ->
+  (Keeper_meta_contract.keeper_meta, string) result
+(** Resolve only the exact gate. Concurrent replacement or a dead tombstone is
+    returned as an error and its control fields remain authoritative. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -65,46 +65,21 @@ let with_keeper_entry_by_identity ~identity ~on_missing f =
 let persist_directive_meta_update
       (entry : Keeper_registry.registry_entry)
       ~(updated_meta : keeper_meta)
-  : (unit, string) result
+  : (keeper_meta, string) result
   =
-  let keeper_filename = entry.name ^ ".json" in
-  let masc_root = Workspace_utils.masc_dir_from_base_path ~base_path:entry.base_path in
-  let default_path =
-    Filename.concat (Filename.concat masc_root "keepers") keeper_filename
-  in
-  let persisted_path =
-    if Fs_compat.file_exists default_path
-    then default_path
-    else (
-      let clusters_dir = Filename.concat masc_root "clusters" in
-      let cluster_paths =
-        match Safe_ops.list_dir_safe clusters_dir with
-        | Ok names ->
-          names
-          |> List.map (fun cluster_name ->
-            Filename.concat
-              (Filename.concat (Filename.concat clusters_dir cluster_name) "keepers")
-              keeper_filename)
-          |> List.filter Fs_compat.file_exists
-        | Error _ -> []
-      in
-      match cluster_paths with
-      | [] -> default_path
-      | [ path ] -> path
-      | paths ->
-        let by_mtime_desc a b =
-          let a_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime a) in
-          let b_mtime = Option.value ~default:0.0 (Fs_compat.file_mtime b) in
-          Float.compare b_mtime a_mtime
-        in
-        (match List.sort by_mtime_desc paths with
-         | latest_path :: _ -> latest_path
-         | [] -> default_path))
-  in
-  match Keeper_fs.save_json_atomic persisted_path (Keeper_meta_json.meta_to_json updated_meta) with
-  | Ok () ->
-    Keeper_registry.update_meta ~base_path:entry.base_path entry.name updated_meta;
-    Ok ()
+  let config = Workspace.default_config entry.base_path in
+  match
+    write_meta_with_merge_returning
+      ~merge:Keeper_meta_merge.operator_control_fields_from_caller
+      config
+      updated_meta
+  with
+  | Ok persisted_meta ->
+    Keeper_registry.sync_persisted_meta_if_newer
+      ~base_path:entry.base_path
+      entry.name
+      persisted_meta;
+    Ok persisted_meta
   | Error msg ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string WriteMetaFailures)
@@ -151,7 +126,7 @@ let clear_no_progress_loop_for_operator_resume (entry : Keeper_registry.registry
     if updated_meta == entry.meta then Ok updated_meta
     else (
       match persist_directive_meta_update entry ~updated_meta with
-      | Ok () -> Ok updated_meta
+      | Ok persisted_meta -> Ok persisted_meta
       | Error msg ->
         (* RFC-0303 Phase 3: restore the prior failure_reason on persist failure.
            The no-progress detector re-latch that used to run here is gone with
@@ -340,14 +315,8 @@ let set_keeper_paused_state ~agent_name paused =
             (if paused then "pause" else "resume")
             entry.name
             err
-        | Ok () ->
-          Keeper_registry.dispatch_event_unit
-            ~base_path:entry.base_path
-            entry.name
-            (if paused
-             then Keeper_state_machine.Operator_pause
-             else Keeper_state_machine.Operator_resume);
-          if not paused
+        | Ok persisted_meta ->
+          if not persisted_meta.paused
           then (
             Keeper_turn_livelock.reset_keeper_livelock
               ~base_path:entry.base_path
@@ -397,13 +366,13 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
            entry.name
            task_id_string
            err
-       | Ok () ->
+       | Ok persisted_meta ->
          (* Cycle 44: KeeperTaskAcquisition.tla SubmitTask post-action
             guard pins that the directive successfully attached the
             [task_id] to the keeper's meta. The [@@fsm_guard] PPX
             routes the assertion through [wrap_unit ~stage:"guard"]
             automatically. *)
-         post_submit_task ~meta:updated_meta ~task_id;
+         post_submit_task ~meta:persisted_meta ~task_id;
          wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 
@@ -607,10 +576,12 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
       }
     in
     (match
-       write_meta_with_merge
-         ~merge:Keeper_meta_merge.monotonic_usage_counters ctx.config synced
+       write_meta_with_merge_returning
+         ~merge:Keeper_meta_merge.non_operator_control_fields_from_disk
+         ctx.config
+         synced
      with
-     | Ok () -> ()
+     | Ok persisted -> persisted
      | Error e ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string WriteMetaFailures)
@@ -620,8 +591,8 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
          Log.Warn
          ~category:Log.Heartbeat
          ~details:(`Assoc [ "keeper", `String synced.name; "error", `String e ])
-         (Printf.sprintf "write_meta failed (bootstrap): %s" e));
-    synced
+         (Printf.sprintf "write_meta failed (bootstrap): %s" e);
+       synced)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -54,6 +54,52 @@ let preserve_operator_pause_from_disk
 
 let heartbeat_fields_from_disk = preserve_operator_pause_from_disk
 
+let operator_control_fields_from_caller
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = monotonic_usage_counters ~latest ~caller in
+  { merged with
+    paused = caller.paused
+  ; latched_reason = caller.latched_reason
+  ; auto_resume_after_sec = caller.auto_resume_after_sec
+  ; runtime = { merged.runtime with last_blocker = caller.runtime.last_blocker }
+  }
+
+let non_operator_control_fields_from_disk
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = monotonic_usage_counters ~latest ~caller in
+  { merged with
+    paused = latest.paused
+  ; latched_reason = latest.latched_reason
+  ; auto_resume_after_sec = latest.auto_resume_after_sec
+  ; runtime = { merged.runtime with last_blocker = latest.runtime.last_blocker }
+  }
+
+let identity_repair_fields_from_caller
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let usage = (monotonic_usage_counters ~latest ~caller).runtime.usage in
+  let trace_history =
+    Json_util.dedupe_keep_order
+      (caller.runtime.trace_history @ latest.runtime.trace_history)
+  in
+  { latest with
+    meta_version = latest.meta_version
+  ; agent_name = caller.agent_name
+  ; updated_at = caller.updated_at
+  ; runtime =
+      { latest.runtime with
+        trace_id = caller.runtime.trace_id
+      ; trace_history
+      ; generation = max latest.runtime.generation caller.runtime.generation
+      ; usage
+      }
+  }
+
 (* Dead-tombstone cleanup is the authoritative writer of [paused] and
    [latched_reason]: it records that the supervisor is tearing the keeper down
    as a dead tombstone. This is the inverse ownership of

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -17,6 +17,24 @@ val heartbeat_fields_from_disk : t
     already present on disk. This prevents stale turn/heartbeat writers from
     clearing [paused=true] after an operator paused the keeper. *)
 
+val operator_control_fields_from_caller : t
+(** {!monotonic_usage_counters}, with the operator-control cluster
+    ([paused], [latched_reason], [auto_resume_after_sec], and
+    [runtime.last_blocker]) owned by the caller. Used by an explicit current
+    operator directive, whose pause/resume decision must win a CAS retry. *)
+
+val non_operator_control_fields_from_disk : t
+(** {!monotonic_usage_counters}, with the operator-control cluster always
+    preserved from the latest disk snapshot. Use for heartbeat/bootstrap
+    writers that own runtime observations but must never pause, resume, clear a
+    typed gate, or replace a newer blocker during a CAS retry. *)
+
+val identity_repair_fields_from_caller : t
+(** Preserve the latest disk snapshot except for the caller-owned keeper
+    identity fields ([agent_name], trace id/history/generation, and update
+    timestamp). Usage counters remain monotonic. This prevents a stale identity
+    repair from replacing a concurrent operator/continue/repository/Dead gate. *)
+
 val dead_tombstone_cleanup_from_disk : t
 (** {!monotonic_usage_counters}, with [paused] and [latched_reason] owned by the
     caller. Used by the dead-tombstone cleanup so a CAS retry that re-reads an

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -23,6 +23,19 @@ let register_runtime_meta_write_sync f =
 
 let version_conflict_re = Re.Pcre.re "meta version conflict" |> Re.compile
 
+let with_meta_cas_lock path f =
+  let lock_key = path ^ ".cas" in
+  Fs_compat.mkdir_p (Filename.dirname lock_key);
+  try File_lock_eio.with_lock lock_key f with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "failed to acquire meta CAS lock %s.lock: %s"
+         lock_key
+         (Printexc.to_string exn))
+;;
+
 let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string) result =
   if not (Fs_compat.file_exists path)
   then Ok None
@@ -308,27 +321,33 @@ let persist_meta config path persisted =
    counters are a monotone invariant (RFC-0225 §3.2, RFC-0237); a caller that
    lost the race must resolve the conflict through [write_meta_with_merge],
    never overwrite the disk snapshot. *)
-let write_meta config (m : Keeper_meta_contract.keeper_meta) : (unit, string) result =
+let write_meta_returning config (m : Keeper_meta_contract.keeper_meta)
+    : (Keeper_meta_contract.keeper_meta, string) result =
   let path = keeper_meta_path config m.name in
-  match read_meta_file_path path with
-  | Ok (Some existing) ->
-    if existing.meta_version <> m.meta_version
-    then
-      Error
-        (Printf.sprintf
-           "meta version conflict for %s: expected %d, disk has %d"
-           m.name
-           m.meta_version
-           existing.meta_version)
-    else (
-      let persisted = { m with meta_version = m.meta_version + 1 } in
-      persist_meta config path persisted)
-  | Ok None ->
-    (* No existing file: initial write. *)
-    let persisted = { m with meta_version = 1 } in
-    persist_meta config path persisted
-  | Error msg ->
-    Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)
+  with_meta_cas_lock path (fun () ->
+    match read_meta_file_path path with
+    | Ok (Some existing) ->
+      if existing.meta_version <> m.meta_version
+      then
+        Error
+          (Printf.sprintf
+             "meta version conflict for %s: expected %d, disk has %d"
+             m.name
+             m.meta_version
+             existing.meta_version)
+      else (
+        let persisted = { m with meta_version = m.meta_version + 1 } in
+        Result.map (fun () -> persisted) (persist_meta config path persisted))
+    | Ok None ->
+      (* No existing file: initial write. *)
+      let persisted = { m with meta_version = 1 } in
+      Result.map (fun () -> persisted) (persist_meta config path persisted)
+    | Error msg ->
+      Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg))
+;;
+
+let write_meta config m =
+  Result.map (fun _persisted -> ()) (write_meta_returning config m)
 ;;
 
 let is_version_conflict_error msg =
@@ -411,17 +430,17 @@ let migrate_retired_keeper_meta_keys config =
 (* #9769 root fix: CAS retry with explicit field ownership. The
    turn-failure/cycle path uses [Keeper_meta_merge.heartbeat_fields_from_disk]
    now only carries the disk meta_version forward. *)
-let write_meta_with_merge
+let write_meta_with_merge_returning
       ?(max_retries = 3)
       ~(merge : latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta)
       config
       (m : Keeper_meta_contract.keeper_meta)
-  : (unit, string) result
+  : (Keeper_meta_contract.keeper_meta, string) result
   =
   let path = keeper_meta_path config m.name in
   let rec attempt n (caller : Keeper_meta_contract.keeper_meta) =
-    match write_meta config caller with
-    | Ok () -> Ok ()
+    match write_meta_returning config caller with
+    | Ok persisted -> Ok persisted
     | Error msg when n >= max_retries -> Error msg
     | Error msg when not (is_version_conflict_error msg) -> Error msg
     | Error _ ->
@@ -446,4 +465,9 @@ let write_meta_with_merge
          Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
   in
   attempt 0 m
+;;
+
+let write_meta_with_merge ?max_retries ~merge config m =
+  write_meta_with_merge_returning ?max_retries ~merge config m
+  |> Result.map (fun _persisted -> ())
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -105,15 +105,26 @@ val read_meta_if_changed :
 val persist_meta :
   Workspace.config -> string -> Keeper_meta_contract.keeper_meta -> (unit, string) result
 
-(** Persist [m] with a CAS bump on [meta_version]: the write is rejected
-    if the on-disk version has moved since [m] was read. There is no force
-    / bypass path — cumulative usage counters are a monotone invariant
-    (RFC-0225 §3.2, RFC-0237), so callers that lost a race must resolve the
-    conflict through {!write_meta_with_merge}, not overwrite the disk. *)
+(** Persist [m] with a CAS bump on [meta_version]. Once Eio is active, the
+    complete read/version-check/write transaction is serialized by the
+    cooperative per-path mutex plus a cross-process file lock; pre-Eio startup
+    is single-threaded and uses the same file lock. The write is rejected if
+    the on-disk version moved since [m] was read. There is no force / bypass
+    path — cumulative usage counters are a monotone invariant (RFC-0225 §3.2,
+    RFC-0237), so callers that lost a race must resolve the conflict through
+    {!write_meta_with_merge}, not overwrite the disk. *)
 val write_meta :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
+
+(** CAS-write metadata and return the exact persisted snapshot, including the
+    incremented [meta_version]. In-memory SSOT projections should consume this
+    result instead of assuming the caller record won a merge unchanged. *)
+val write_meta_returning :
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (Keeper_meta_contract.keeper_meta, string) result
 
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
@@ -150,3 +161,12 @@ val write_meta_with_merge :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
+
+(** As {!write_meta_with_merge}, returning the authoritative snapshot written
+    by the winning CAS attempt. *)
+val write_meta_with_merge_returning :
+  ?max_retries:int ->
+  merge:(latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta) ->
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (Keeper_meta_contract.keeper_meta, string) result

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -122,6 +122,13 @@ val update_entry_if_registered :
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
 
+(** Atomically project an authoritative persisted snapshot into a registered
+    keeper when its [meta_version] is not older than the live projection. The
+    FSM [operator_paused] condition and derived phase are updated in the same
+    CAS. No-op for an unregistered keeper or stale snapshot. *)
+val sync_persisted_meta_if_newer :
+  base_path:string -> string -> keeper_meta -> unit
+
 (** Reload a registered keeper's meta from disk and replace the in-memory
     registry copy. Returns [Ok None] when the keeper is not registered or has
     no persisted meta. *)

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -71,6 +71,32 @@ let enqueue_live_if_missing (entry : Keeper_registry.registry_entry) stimulus =
   loop ()
 ;;
 
+let before_durable_live_publication_hook : (unit -> unit) option ref = ref None
+
+let publish_durable_to_current_live ~base_path name stimulus =
+  Option.iter (fun hook -> hook ()) !before_durable_live_publication_hook;
+  let rec loop () =
+    match Keeper_registry.get ~base_path name with
+    | None -> ()
+    | Some entry ->
+      enqueue_live_if_missing entry stimulus;
+      (* A concurrent register/restart may replace the registry entry after our
+         lookup. Publish again when that happened; registrations that install
+         after this check rehydrate from the durable snapshot before returning. *)
+      (match Keeper_registry.get ~base_path name with
+       | Some current when current == entry -> ()
+       | None -> ()
+       | Some _ -> loop ())
+  in
+  loop ()
+;;
+
+module For_testing = struct
+  let set_before_durable_live_publication_hook hook =
+    before_durable_live_publication_hook := hook
+  ;;
+end
+
 let enqueue ~base_path name stimulus =
   match Keeper_registry.get ~base_path name with
   | None ->
@@ -113,15 +139,11 @@ let enqueue_durable_result ~base_path name stimulus =
      delivery result. This path is intentionally separate from [enqueue]: most
      stimuli already have an upstream replay source, while HITL resolution is
      the sole carrier of an operator decision and must fail closed. *)
-  let after_commit =
-    match Keeper_registry.get ~base_path name with
-    | None -> fun () -> ()
-    | Some entry -> fun () -> enqueue_live_if_missing entry stimulus
-  in
   Keeper_event_queue_persistence.update_checked_result
     ~base_path
     ~keeper_name:name
-    ~after_commit
+    ~after_commit:(fun () ->
+      publish_durable_to_current_live ~base_path name stimulus)
     (fun queue -> enqueue_external_decision queue stimulus)
 ;;
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -25,6 +25,12 @@ val enqueue_durable_result :
     write. An existing identical [post_id] is idempotent; the same [post_id]
     with a different typed payload is an explicit conflict. *)
 
+module For_testing : sig
+  val set_before_durable_live_publication_hook : (unit -> unit) option -> unit
+  (** Install a deterministic interleaving point after durable commit and
+      before publication to the current registry entry. Tests must reset it. *)
+end
+
 (** Read-only snapshot of the keeper's queue. If the keeper is not registered,
     read the durable snapshot so diagnostics still expose pending replay. *)
 val snapshot : base_path:string -> string -> Keeper_event_queue.t
@@ -40,8 +46,7 @@ val dequeue_when :
   -> Keeper_event_queue.stimulus option
 (** Remove and return the head stimulus only when [ready head] is [true]. A
     rejected head remains in the live and durable queue without entering the
-    in-flight lease. This is the exact readiness gate for durable events whose
-    producer has not completed its domain callback yet. *)
+    in-flight lease. *)
 
 (** Put previously drained stimuli back at the front of the queue. This is a
     crash-recovery primitive: if the keepalive cycle dies after dequeue/drain

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -279,6 +279,66 @@ let update_entry_if_registered_unit ~base_path name f =
   ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 
+(** Project an authoritative persisted meta snapshot into the live registry
+    only when it is at least as new as the current projection. The pause bit is
+    also projected into the FSM conditions in the same registry CAS, so
+    metadata and phase cannot split. This is the registration/resolution
+    handshake for HITL pause transitions: a registrar with a stale captured
+    meta cannot overwrite a newer durable approval decision. *)
+let sync_persisted_meta_if_newer ~base_path name (meta : keeper_meta) =
+  match validate_registry_meta ~base_path name meta with
+  | Error reason ->
+    record_invalid_registry_entry ~operation:"sync_persisted_meta_if_newer" ~name reason
+  | Ok () ->
+    let key = registry_key ~base_path name in
+    let rec loop () =
+      let current = Atomic.get registry in
+      match StringMap.find_opt key current with
+      | None -> ()
+      | Some entry when meta.meta_version < entry.meta.meta_version -> ()
+      | Some entry ->
+        let conditions =
+          { entry.conditions with operator_paused = meta.paused }
+        in
+        let phase = Keeper_state_machine.derive_phase conditions in
+        let updated_entry = { entry with meta; conditions; phase } in
+        (match validate_registry_entry ~base_path name updated_entry with
+         | Error reason ->
+           record_invalid_registry_entry
+             ~operation:"sync_persisted_meta_if_newer"
+             ~name
+             reason
+         | Ok () ->
+           let updated = StringMap.add key updated_entry current in
+           if Atomic.compare_and_set registry current updated
+           then (
+             if entry.phase = Keeper_state_machine.Running
+                && phase <> Keeper_state_machine.Running
+             then decr_running_count_clamped ()
+             else if entry.phase <> Keeper_state_machine.Running
+                     && phase = Keeper_state_machine.Running
+             then Atomic.incr running_count_atomic;
+             Keeper_registry_broadcast.composite_changed
+               ~name
+               ~ts_unix:(Time_compat.now ()))
+           else loop ())
+    in
+    loop ()
+;;
+
+let refresh_registered_meta_from_persistence ~base_path name =
+  let config = Workspace.default_config base_path in
+  match read_meta config name with
+  | Ok (Some persisted) -> sync_persisted_meta_if_newer ~base_path name persisted
+  | Ok None -> ()
+  | Error err ->
+    Log.Keeper.warn
+      "registry: post-install durable meta refresh failed name=%s base_path=%s: %s"
+      name
+      base_path
+      err
+;;
+
 let rec queue_contains_stimulus queue stimulus =
   match Keeper_event_queue.dequeue queue with
   | None -> false
@@ -326,6 +386,8 @@ let register_with_state
       ~(conditions : Keeper_state_machine.conditions)
   =
   let meta = canonicalize_registry_meta ~operation:"register" ~base_path name meta in
+  let conditions = { conditions with operator_paused = meta.paused } in
+  let phase = Keeper_state_machine.derive_phase conditions in
   Log.Keeper.info
     "registry: registering keeper name=%s base_path=%s phase=%s"
     name
@@ -389,6 +451,7 @@ let register_with_state
     "registry: keeper registered name=%s running_count=%d"
     name
     (Atomic.get running_count_atomic);
+  refresh_registered_meta_from_persistence ~base_path name;
   refresh_entry_event_queue_from_persistence ~base_path name entry;
   entry
 ;;
@@ -429,6 +492,7 @@ let register_restarting ~base_path name meta
     { Keeper_state_machine.default_conditions with
       restart_budget_remaining = true
     ; backoff_elapsed = true
+    ; operator_paused = meta.paused
     }
   in
   let phase = Keeper_state_machine.derive_phase conditions in
@@ -492,6 +556,7 @@ let register_restarting ~base_path name meta
           name
           base_path
           (Keeper_state_machine.phase_to_string phase);
+        refresh_registered_meta_from_persistence ~base_path name;
         refresh_entry_event_queue_from_persistence ~base_path name new_entry;
         Ok new_entry)
       else loop ()

--- a/lib/keeper/keeper_repo_claim_hitl.ml
+++ b/lib/keeper/keeper_repo_claim_hitl.ml
@@ -3,11 +3,21 @@ type access_result =
   | Access_denied of string
   | Access_denied_hitl_pending of { detail : string; approval_id : string }
 
+type registration_restore_outcome =
+  | No_registration_record
+  | Registration_restored
+  | Registration_superseded
+  | Registration_corrupt of string
+
 let repository_registration_tool_name = "keeper_repository_registration"
+let repository_registration_recovery_tool_name =
+  "keeper_repository_registration_recovery"
+;;
 let repository_registration_kind = "repository_registration"
 let repository_registration_disposition = "operator_action_required"
 let repository_registration_reason = "repository_unregistered"
-let repository_registration_next_action = "wait_for_operator_approval"
+let repository_registration_next_action = "update_repository_catalog_then_approve"
+let ( let* ) = Result.bind
 
 type registration_candidate =
   { repository_id : Repo_manager_types.repository_id
@@ -50,10 +60,6 @@ let candidate_identity_is_valid ~keeper_id candidate =
   Keeper_repo_mapping.repository_url_basename_matches_identity repo
 ;;
 
-let add_string_once value values =
-  if List.exists (String.equal value) values then values else values @ [ value ]
-;;
-
 let canonical_url_equal left right =
   match
     ( Agent_observation.canonical_url_of_remote left
@@ -93,7 +99,7 @@ let candidate_expected_repo_root_mismatch candidate =
            expected_repo_root)
 ;;
 
-let revalidate_registration_candidate candidate =
+let revalidate_candidate_git_identity candidate =
   match Repo_git.worktree_root ~local_path:candidate.repo_root with
   | Error reason -> Error ("worktree root recheck failed: " ^ reason)
   | Ok repo_root ->
@@ -104,10 +110,7 @@ let revalidate_registration_candidate candidate =
            "worktree root changed from %s to %s"
            candidate.repo_root
            repo_root)
-    else (
-      match candidate_expected_repo_root_mismatch { candidate with repo_root } with
-      | Some reason -> Error reason
-      | None ->
+    else
       match Repo_git.get_origin_url ~local_path:repo_root with
       | Error reason -> Error ("origin recheck failed: " ^ reason)
       | Ok origin_url ->
@@ -129,7 +132,13 @@ let revalidate_registration_candidate candidate =
                    "default branch changed from %s to %s"
                    candidate.default_branch
                    default_branch)
-            else Ok { candidate with repo_root; origin_url; default_branch }))
+            else Ok { candidate with repo_root; origin_url; default_branch })
+;;
+
+let revalidate_registration_candidate candidate =
+  match candidate_expected_repo_root_mismatch candidate with
+  | Some reason -> Error reason
+  | None -> revalidate_candidate_git_identity candidate
 ;;
 
 let find_existing_repository_by_origin ~base_path origin_url =
@@ -141,18 +150,6 @@ let find_existing_repository_by_origin ~base_path origin_url =
          (fun (repo : Repo_manager_types.repository) ->
             canonical_url_equal repo.url origin_url)
          repos)
-;;
-
-let log_stale_approved_candidate ~keeper_id candidate detail =
-  Log.Keeper.warn
-    "keeper repo registration approved but git metadata recheck failed; \
-     skipping catalog mutation keeper=%s repository=%s repo_root=%s \
-     source=%s error=%s"
-    keeper_id
-    candidate.repository_id
-    candidate.repo_root
-    Config_dir_resolver.repositories_toml_basename
-    detail
 ;;
 
 let registration_operation ~keeper_id ~base_path candidate =
@@ -180,142 +177,693 @@ let operation_candidate = function
 ;;
 
 let operation_name = function
-  | Register_new _ -> "register_repository"
-  | Add_alias_to_existing _ -> "add_repository_alias"
-  | Manual_catalog_review _ -> "review_repository_catalog"
+  | Register_new _ -> "verify_repository_catalog_registration"
+  | Add_alias_to_existing _ -> "verify_repository_catalog_alias"
+  | Manual_catalog_review _ -> "verify_repository_catalog_review"
 ;;
 
-let persist_alias ~keeper_id ~base_path ~(existing : Repo_manager_types.repository) ~alias =
-  let updated =
-    { existing with
-      aliases = add_string_once alias existing.aliases
-    ; keepers = add_string_once keeper_id existing.keepers
-    }
+let pending_operation_schema = "masc.repository_registration_pending.v2"
+
+let candidate_to_json candidate =
+  `Assoc
+    [ "repository_id", `String candidate.repository_id
+    ; "repo_root", `String candidate.repo_root
+    ; ( "expected_repo_root"
+      , match candidate.expected_repo_root with
+        | Some path -> `String path
+        | None -> `Null )
+    ; "origin_url", `String candidate.origin_url
+    ; "default_branch", `String candidate.default_branch
+    ]
+;;
+
+let registration_operation_to_json operation =
+  let kind, fields =
+    match operation with
+    | Register_new candidate -> "register_new", [ "candidate", candidate_to_json candidate ]
+    | Add_alias_to_existing { existing_repository_id; alias; candidate } ->
+      ( "add_alias_to_existing"
+      , [ "existing_repository_id", `String existing_repository_id
+        ; "alias", `String alias
+        ; "candidate", candidate_to_json candidate
+        ] )
+    | Manual_catalog_review { reason; candidate } ->
+      ( "manual_catalog_review"
+      , [ "reason", `String reason; "candidate", candidate_to_json candidate ] )
   in
-  match Repo_store.update ~base_path existing.id updated with
-  | Ok _ ->
-    Log.Keeper.info
-      "keeper repo alias approved keeper=%s repository=%s alias=%s source=%s"
-      keeper_id
-      existing.id
-      alias
-      Config_dir_resolver.repositories_toml_basename
-  | Error detail ->
-    Log.Keeper.warn
-      "keeper repo alias approved but catalog update failed keeper=%s \
-       repository=%s alias=%s source=%s error=%s"
-      keeper_id
-      existing.id
-      alias
-      Config_dir_resolver.repositories_toml_basename
-      detail
+  `Assoc ([ "kind", `String kind ] @ fields)
 ;;
 
-let approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias ~candidate =
-  match revalidate_registration_candidate candidate with
-  | Error detail -> log_stale_approved_candidate ~keeper_id candidate detail
-  | Ok current_candidate -> (
-    match Repo_store.find ~base_path existing_repository_id with
-  | Error detail ->
-    Log.Keeper.warn
-      "keeper repo alias approved but catalog read failed keeper=%s \
-       repository=%s alias=%s source=%s error=%s"
-      keeper_id
-      existing_repository_id
-      alias
-      Config_dir_resolver.repositories_toml_basename
-      detail
-  | Ok existing ->
-    if not (origin_url_matches existing.url current_candidate.origin_url)
-    then
-      Log.Keeper.warn
-        "keeper repo alias approved but current clone origin does not match \
-         target repository; skipping catalog mutation keeper=%s repository=%s \
-         alias=%s source=%s target_origin=%s current_origin=%s"
-        keeper_id
-        existing.id
-        alias
-        Config_dir_resolver.repositories_toml_basename
-        existing.url
-        current_candidate.origin_url
-    else persist_alias ~keeper_id ~base_path ~existing ~alias)
+let required_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) when String.trim value <> "" -> Ok value
+  | Some _ -> Error (Printf.sprintf "repository pending operation field %s is invalid" key)
+  | None -> Error (Printf.sprintf "repository pending operation field %s is missing" key)
 ;;
 
-let approve_new_registration ~keeper_id ~base_path candidate =
-  match revalidate_registration_candidate candidate with
-  | Error detail -> log_stale_approved_candidate ~keeper_id candidate detail
-  | Ok candidate -> (
-  match find_existing_repository_by_origin ~base_path candidate.origin_url with
-  | Error detail ->
-    Log.Keeper.warn
-      "keeper repo registration approved but catalog recheck failed keeper=%s \
-       repository=%s source=%s error=%s"
-      keeper_id
-      candidate.repository_id
-      Config_dir_resolver.repositories_toml_basename
-      detail
-  | Ok (Some existing) ->
-    persist_alias ~keeper_id ~base_path ~existing ~alias:candidate.repository_id
-  | Ok None ->
-    if candidate_identity_is_valid ~keeper_id candidate then (
-      let repo = repository_record_of_candidate ~keeper_id candidate in
-      match Repo_store.add ~base_path repo with
-      | Ok _ ->
-        Log.Keeper.info
-          "keeper repo registration approved keeper=%s repository=%s source=%s"
-          keeper_id
-          candidate.repository_id
-          Config_dir_resolver.repositories_toml_basename
-      | Error detail ->
-        Log.Keeper.warn
-          "keeper repo registration approved but catalog update failed keeper=%s \
-           repository=%s source=%s error=%s"
-          keeper_id
-          candidate.repository_id
-          Config_dir_resolver.repositories_toml_basename
-          detail)
+let candidate_of_json = function
+  | `Assoc fields ->
+    let* repository_id = required_string fields "repository_id" in
+    let* repo_root = required_string fields "repo_root" in
+    let* origin_url = required_string fields "origin_url" in
+    let* default_branch = required_string fields "default_branch" in
+    let* expected_repo_root =
+      match List.assoc_opt "expected_repo_root" fields with
+      | Some (`String path) when String.trim path <> "" -> Ok (Some path)
+      | Some `Null | None -> Ok None
+      | Some _ ->
+        Error "repository pending operation expected_repo_root must be a string or null"
+    in
+    Ok { repository_id; repo_root; expected_repo_root; origin_url; default_branch }
+  | _ -> Error "repository pending operation candidate must be an object"
+;;
+
+let registration_operation_of_json = function
+  | `Assoc fields ->
+    let* kind = required_string fields "kind" in
+      let* candidate =
+        match List.assoc_opt "candidate" fields with
+        | Some json -> candidate_of_json json
+        | None -> Error "repository pending operation candidate is missing"
+      in
+    (match kind with
+       | "register_new" -> Ok (Register_new candidate)
+       | "add_alias_to_existing" ->
+         let* existing_repository_id = required_string fields "existing_repository_id" in
+         let* alias = required_string fields "alias" in
+         Ok (Add_alias_to_existing { existing_repository_id; alias; candidate })
+       | "manual_catalog_review" ->
+         let* reason = required_string fields "reason" in
+         Ok (Manual_catalog_review { reason; candidate })
+       | _ -> Error ("unsupported repository pending operation kind: " ^ kind))
+  | _ -> Error "repository pending operation must be an object"
+;;
+
+type durable_operation_status =
+  | Pending
+  | Approving
+  | Approved
+  | Rejecting of string
+  | Rejected of string
+  | Cancelled
+
+type durable_operation =
+  { keeper_id : string
+  ; operation_id : string
+  ; operation : registration_operation
+  ; status : durable_operation_status
+  }
+
+let operation_id ~keeper_id operation =
+  let canonical =
+    Yojson.Safe.to_string (registration_operation_to_json operation)
+  in
+  Digestif.SHA256.(digest_string (keeper_id ^ "\000" ^ canonical) |> to_hex)
+;;
+
+let durable_status_to_string = function
+  | Pending -> "pending"
+  | Approving -> "approving"
+  | Approved -> "approved"
+  | Rejecting _ -> "rejecting"
+  | Rejected _ -> "rejected"
+  | Cancelled -> "cancelled"
+;;
+
+let durable_status_of_json fields = function
+  | "pending" -> Ok Pending
+  | "approving" -> Ok Approving
+  | "approved" -> Ok Approved
+  | ("rejecting" | "rejected") as status ->
+    let* reason = required_string fields "rejection_reason" in
+    if String.equal status "rejecting" then Ok (Rejecting reason) else Ok (Rejected reason)
+  | "cancelled" -> Ok Cancelled
+  | value -> Error ("unsupported repository pending operation status: " ^ value)
+;;
+
+let durable_operation_to_json record =
+  let rejection_fields =
+    match record.status with
+    | Rejecting reason | Rejected reason -> [ "rejection_reason", `String reason ]
+    | Pending | Approving | Approved | Cancelled -> []
+  in
+  `Assoc
+    ([ "schema", `String pending_operation_schema
+     ; "keeper_id", `String record.keeper_id
+     ; "operation_id", `String record.operation_id
+     ; "status", `String (durable_status_to_string record.status)
+     ; "operation", registration_operation_to_json record.operation
+     ]
+     @ rejection_fields)
+;;
+
+let durable_operation_of_json ~expected_keeper_id = function
+  | `Assoc fields ->
+    let* schema = required_string fields "schema" in
+    if not (String.equal schema pending_operation_schema)
+    then Error ("unsupported repository pending operation schema: " ^ schema)
     else
-      Log.Keeper.warn
-        "keeper repo registration approved but identity check failed keeper=%s \
-         repository=%s url=%s"
-        keeper_id
-        candidate.repository_id
-        candidate.origin_url)
+      let* keeper_id = required_string fields "keeper_id" in
+      if not (String.equal keeper_id expected_keeper_id)
+      then
+        Error
+          (Printf.sprintf
+             "repository pending operation keeper mismatch: expected=%S actual=%S"
+             expected_keeper_id
+             keeper_id)
+      else
+        let* stored_operation_id = required_string fields "operation_id" in
+        let* status_wire = required_string fields "status" in
+        let* status = durable_status_of_json fields status_wire in
+        let* operation =
+          match List.assoc_opt "operation" fields with
+          | Some json -> registration_operation_of_json json
+          | None -> Error "repository pending operation payload is missing"
+        in
+        let expected_operation_id = operation_id ~keeper_id operation in
+        if not (String.equal stored_operation_id expected_operation_id)
+        then Error "repository pending operation identity digest mismatch"
+        else
+          Ok
+            { keeper_id
+            ; operation_id = stored_operation_id
+            ; operation
+            ; status
+            }
+  | _ -> Error "repository pending operation record must be an object"
+;;
+
+let pending_operation_path ~keeper_id ~base_path =
+  let root = Workspace_utils.masc_dir_from_base_path ~base_path in
+  let keeper_digest = Digestif.SHA256.(digest_string keeper_id |> to_hex) in
+  Filename.concat
+    (Filename.concat root "approvals/repository-registration")
+    (keeper_digest ^ ".json")
+;;
+
+let with_durable_operation_lock ~keeper_id ~base_path f =
+  let path = pending_operation_path ~keeper_id ~base_path in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  try File_lock_eio.with_lock path f with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "repository durable operation lock failed for keeper %s: %s"
+         keeper_id
+         (Printexc.to_string exn))
+;;
+
+let persist_durable_operation ~base_path record =
+  let keeper_id = record.keeper_id in
+  let path = pending_operation_path ~keeper_id ~base_path in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Keeper_fs.save_json_atomic path (durable_operation_to_json record)
+;;
+
+let load_durable_operation ~keeper_id ~base_path =
+  let path = pending_operation_path ~keeper_id ~base_path in
+  if not (Fs_compat.file_exists path)
+  then Ok None
+  else
+    match Safe_ops.read_json_file_safe path with
+    | Error err -> Error err
+    | Ok json ->
+      Result.map Option.some (durable_operation_of_json ~expected_keeper_id:keeper_id json)
+;;
+
+let durable_pending_operation ~keeper_id operation =
+  { keeper_id
+  ; operation_id = operation_id ~keeper_id operation
+  ; operation
+  ; status = Pending
+  }
+;;
+
+let durable_operation_with_status record status = { record with status }
+
+let remove_terminal_operation_if_matching ~keeper_id ~base_path ~operation_id =
+  match
+    with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+      let* current = load_durable_operation ~keeper_id ~base_path in
+      match current with
+      | Some record
+        when String.equal record.operation_id operation_id
+             && not (record.status = Pending || record.status = Approving) ->
+        let path = pending_operation_path ~keeper_id ~base_path in
+        (try
+           Sys.remove path;
+           Ok ()
+         with
+         | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+         | Sys_error detail | Unix.Unix_error (_, _, detail) ->
+           Error
+             (Printf.sprintf
+                "failed to remove terminal repository operation %s: %s"
+                path
+                detail))
+      | Some _ | None -> Ok ())
+  with
+  | Ok () -> ()
+  | Error err ->
+    Log.Keeper.warn
+      "repository terminal operation cleanup deferred keeper=%s operation_id=%s: %s"
+      keeper_id
+      operation_id
+      err
+;;
+
+let latched_repository_operation_id = function
+  | Some (Keeper_latched_reason.Repository_registration_pending { operation_id }) ->
+    Some operation_id
+  | Some _ | None -> None
+;;
+
+let meta_owns_repository_gate ~operation_id (meta : Keeper_meta_contract.keeper_meta) =
+  meta.paused
+  &&
+  match latched_repository_operation_id meta.latched_reason with
+  | Some current -> String.equal current operation_id
+  | None -> false
+;;
+
+let repository_gate_merge
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = Keeper_meta_merge.monotonic_usage_counters ~latest ~caller in
+  let same_gate =
+    match
+      latched_repository_operation_id latest.latched_reason,
+      latched_repository_operation_id caller.latched_reason
+    with
+    | Some left, Some right -> String.equal left right
+    | Some _, None | None, Some _ | None, None -> false
+  in
+  if latest.paused && not same_gate
+  then
+    { merged with
+      paused = latest.paused
+    ; latched_reason = latest.latched_reason
+    ; auto_resume_after_sec = latest.auto_resume_after_sec
+    ; runtime = { merged.runtime with last_blocker = latest.runtime.last_blocker }
+    }
+  else
+    { merged with
+      paused = true
+    ; latched_reason = caller.latched_reason
+    ; auto_resume_after_sec = None
+    ; runtime = { merged.runtime with last_blocker = caller.runtime.last_blocker }
+    }
+;;
+
+let current_keeper_meta ~keeper_id ~base_path =
+  let config = Workspace.default_config base_path in
+  match Keeper_meta_store.read_meta config keeper_id with
+  | Ok (Some meta) -> Ok (config, meta)
+  | Ok None ->
+    (match Keeper_registry.get ~base_path keeper_id with
+     | Some entry -> Ok (config, entry.meta)
+     | None -> Error (Printf.sprintf "keeper metadata unavailable: %s" keeper_id))
+  | Error err -> Error err
+;;
+
+let persist_registration_gate ~keeper_id ~base_path ~operation_id =
+  let* config, meta = current_keeper_meta ~keeper_id ~base_path in
+  if meta.paused && not (meta_owns_repository_gate ~operation_id meta)
+  then Ok false
+  else
+    let blocker =
+      Keeper_meta_contract.blocker_info_of_class
+        ~detail:"repository registration approval pending"
+        Keeper_meta_contract.Ambiguous_post_commit_failure
+    in
+    let gated_meta =
+      { meta with
+        paused = true
+      ; latched_reason =
+          Some (Keeper_latched_reason.Repository_registration_pending { operation_id })
+      ; auto_resume_after_sec = None
+      ; updated_at = Keeper_meta_contract.now_iso ()
+      ; runtime = { meta.runtime with last_blocker = Some blocker }
+      }
+    in
+    let* persisted =
+      Keeper_meta_store.write_meta_with_merge_returning
+        ~merge:repository_gate_merge
+        config
+        gated_meta
+    in
+    Keeper_registry.sync_persisted_meta_if_newer ~base_path keeper_id persisted;
+    Ok (meta_owns_repository_gate ~operation_id persisted)
+;;
+
+let repository_gate_resolution_merge ~operation_id
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  let merged = Keeper_meta_merge.monotonic_usage_counters ~latest ~caller in
+  match latched_repository_operation_id latest.latched_reason with
+  | Some current when String.equal current operation_id ->
+    { merged with
+      paused = caller.paused
+    ; latched_reason = caller.latched_reason
+    ; auto_resume_after_sec = caller.auto_resume_after_sec
+    ; runtime = { merged.runtime with last_blocker = caller.runtime.last_blocker }
+    }
+  | Some _ | None ->
+    { merged with
+      paused = latest.paused
+    ; latched_reason = latest.latched_reason
+    ; auto_resume_after_sec = latest.auto_resume_after_sec
+    ; runtime = { merged.runtime with last_blocker = latest.runtime.last_blocker }
+    }
+;;
+
+let persist_registration_gate_replacement
+      ~keeper_id
+      ~base_path
+      ~from_operation_id
+      ~to_operation_id
+  =
+  let* config, meta = current_keeper_meta ~keeper_id ~base_path in
+  if not (meta_owns_repository_gate ~operation_id:from_operation_id meta)
+  then Error "repository recovery gate was superseded before replacement"
+  else
+    let replacement =
+      { meta with
+        paused = true
+      ; latched_reason =
+          Some
+            (Keeper_latched_reason.Repository_registration_pending
+               { operation_id = to_operation_id })
+      ; auto_resume_after_sec = None
+      ; updated_at = Keeper_meta_contract.now_iso ()
+      }
+    in
+    let* persisted =
+      Keeper_meta_store.write_meta_with_merge_returning
+        ~merge:(repository_gate_resolution_merge ~operation_id:from_operation_id)
+        config
+        replacement
+    in
+    Keeper_registry.sync_persisted_meta_if_newer ~base_path keeper_id persisted;
+    if meta_owns_repository_gate ~operation_id:to_operation_id persisted
+    then Ok ()
+    else Error "repository recovery gate replacement lost exact ownership"
+;;
+
+let persist_registration_resume ~keeper_id ~base_path ~operation_id =
+  let* config, meta = current_keeper_meta ~keeper_id ~base_path in
+  match latched_repository_operation_id meta.latched_reason with
+  | Some current when String.equal current operation_id ->
+    let resumed_meta =
+      { meta with
+        paused = false
+      ; latched_reason = None
+      ; auto_resume_after_sec = None
+      ; updated_at = Keeper_meta_contract.now_iso ()
+      ; runtime = { meta.runtime with last_blocker = None }
+      }
+    in
+    let* persisted =
+      Keeper_meta_store.write_meta_with_merge_returning
+        ~merge:(repository_gate_resolution_merge ~operation_id)
+        config
+        resumed_meta
+    in
+    Keeper_registry.sync_persisted_meta_if_newer ~base_path keeper_id persisted;
+    Ok ((not persisted.paused) && Option.is_none persisted.latched_reason, persisted)
+  | Some _ | None -> Ok (false, meta)
+;;
+
+let persist_registration_rejection ~keeper_id ~base_path ~operation_id =
+  let* config, meta = current_keeper_meta ~keeper_id ~base_path in
+  match latched_repository_operation_id meta.latched_reason with
+  | Some current when String.equal current operation_id ->
+    let rejected_meta =
+      { meta with
+        paused = true
+      ; latched_reason =
+          Some
+            (Keeper_latched_reason.Operator_paused
+               { operator_actor = Keeper_latched_reason.Hitl_rejection })
+      ; auto_resume_after_sec = None
+      ; updated_at = Keeper_meta_contract.now_iso ()
+      ; runtime = { meta.runtime with last_blocker = None }
+      }
+    in
+    let* persisted =
+      Keeper_meta_store.write_meta_with_merge_returning
+        ~merge:(repository_gate_resolution_merge ~operation_id)
+        config
+        rejected_meta
+    in
+    Keeper_registry.sync_persisted_meta_if_newer ~base_path keeper_id persisted;
+    let rejected =
+      persisted.paused
+      &&
+      match persisted.latched_reason with
+      | Some
+          (Keeper_latched_reason.Operator_paused
+            { operator_actor = Keeper_latched_reason.Hitl_rejection }) ->
+        true
+      | Some (Keeper_latched_reason.Operator_paused _)
+      | Some _ | None -> false
+    in
+    Ok (rejected, persisted)
+  | Some _ | None -> Ok (false, meta)
+;;
+
+type approved_operation_error =
+  | Candidate_revalidation_failed of string
+  | Catalog_read_failed of string
+  | Target_origin_mismatch of
+      { target_origin : string
+      ; current_origin : string
+      }
+  | Manual_catalog_review_unresolved of
+      { repository_id : string
+      ; manual_review_reason : string
+      ; access_denial : Keeper_repo_mapping.access_denial
+      }
+  | Manual_catalog_binding_mismatch of
+      { repository_id : string
+      ; field : string
+      ; expected : string
+      ; actual : string
+      }
+  | Unsupported_edit_decision
+
+let approved_operation_error_to_string = function
+  | Candidate_revalidation_failed detail ->
+    "repository candidate revalidation failed: " ^ detail
+  | Catalog_read_failed detail -> "repository catalog read failed: " ^ detail
+  | Target_origin_mismatch { target_origin; current_origin } ->
+    Printf.sprintf
+      "repository target origin mismatch: target=%s current=%s"
+      target_origin
+      current_origin
+  | Manual_catalog_review_unresolved
+      { repository_id; manual_review_reason; access_denial } ->
+    Printf.sprintf
+      "manual repository catalog review unresolved: repository=%s reason=%s access=%s"
+      repository_id
+      manual_review_reason
+      (Keeper_repo_mapping.access_denial_to_string access_denial)
+  | Manual_catalog_binding_mismatch { repository_id; field; expected; actual } ->
+    Printf.sprintf
+      "manual repository catalog binding mismatch: repository=%s field=%s expected=%s actual=%s"
+      repository_id
+      field
+      expected
+      actual
+  | Unsupported_edit_decision ->
+    "repository registration does not support edited approval payloads"
+;;
+
+let manual_catalog_binding_mismatch
+      ~base_path
+      (candidate : registration_candidate)
+      (repository : Repo_manager_types.repository)
+  =
+  let mismatch field expected actual =
+    Some
+      (Manual_catalog_binding_mismatch
+         { repository_id = candidate.repository_id; field; expected; actual })
+  in
+  if not (origin_url_matches repository.url candidate.origin_url)
+  then mismatch "origin_url" candidate.origin_url repository.url
+  else if
+    not
+      (String.equal
+         (normalized_root_for_compare (Repo_store.local_path ~base_path repository))
+         (normalized_root_for_compare candidate.repo_root))
+  then
+    mismatch
+      "local_path"
+      candidate.repo_root
+      (Repo_store.local_path ~base_path repository)
+  else if not (String.equal repository.default_branch candidate.default_branch)
+  then mismatch "default_branch" candidate.default_branch repository.default_branch
+  else None
+;;
+
+let validate_catalog_access ~keeper_id ~base_path ~repository_id ~reason =
+  match Keeper_repo_mapping.access_decision ~keeper_id ~repository_id ~base_path with
+  | Keeper_repo_mapping.Access_allowed -> Ok ()
+  | Keeper_repo_mapping.Access_denied access_denial ->
+    Error
+      (Manual_catalog_review_unresolved
+         { repository_id; manual_review_reason = reason; access_denial })
+;;
+
+let validate_registered_candidate ~keeper_id ~base_path candidate =
+  match revalidate_registration_candidate candidate with
+  | Error detail -> Error (Candidate_revalidation_failed detail)
+  | Ok current_candidate ->
+    (match Repo_store.find ~base_path current_candidate.repository_id with
+     | Error detail -> Error (Catalog_read_failed detail)
+     | Ok repository ->
+       (match manual_catalog_binding_mismatch ~base_path current_candidate repository with
+        | Some error -> Error error
+        | None ->
+          validate_catalog_access
+            ~keeper_id
+            ~base_path
+            ~repository_id:current_candidate.repository_id
+            ~reason:"operator catalog registration not yet exact"))
+;;
+
+let validate_registered_alias
+      ~keeper_id
+      ~base_path
+      ~existing_repository_id
+      ~alias
+      candidate
+  =
+  match revalidate_registration_candidate candidate with
+  | Error detail -> Error (Candidate_revalidation_failed detail)
+  | Ok current_candidate ->
+    (match Repo_store.find ~base_path existing_repository_id with
+     | Error detail -> Error (Catalog_read_failed detail)
+     | Ok repository ->
+       if not (origin_url_matches repository.url current_candidate.origin_url)
+       then
+         Error
+           (Target_origin_mismatch
+              { target_origin = repository.url
+              ; current_origin = current_candidate.origin_url
+              })
+       else if not (List.exists (String.equal alias) repository.aliases)
+       then
+         Error
+           (Manual_catalog_binding_mismatch
+              { repository_id = existing_repository_id
+              ; field = "alias"
+              ; expected = alias
+              ; actual = String.concat "," repository.aliases
+              })
+       else
+         validate_catalog_access
+           ~keeper_id
+           ~base_path
+           ~repository_id:existing_repository_id
+           ~reason:"operator catalog alias not yet exact")
 ;;
 
 let apply_approved_operation ~keeper_id ~base_path = function
-  | Register_new candidate -> approve_new_registration ~keeper_id ~base_path candidate
+  | Register_new candidate -> validate_registered_candidate ~keeper_id ~base_path candidate
   | Add_alias_to_existing { existing_repository_id; alias; candidate } ->
-    approve_alias ~keeper_id ~base_path ~existing_repository_id ~alias ~candidate
+    validate_registered_alias
+      ~keeper_id
+      ~base_path
+      ~existing_repository_id
+      ~alias
+      candidate
   | Manual_catalog_review { reason; candidate } ->
-    Log.Keeper.warn
-      "keeper repo catalog review approved but no automatic mutation is safe \
-       keeper=%s repository=%s reason=%s"
-      keeper_id
-      candidate.repository_id
-      reason
+    (match revalidate_candidate_git_identity candidate with
+     | Error detail -> Error (Candidate_revalidation_failed detail)
+     | Ok current_candidate ->
+       (match Repo_store.find ~base_path current_candidate.repository_id with
+        | Error detail -> Error (Catalog_read_failed detail)
+        | Ok repository ->
+          (match manual_catalog_binding_mismatch ~base_path current_candidate repository with
+           | Some error -> Error error
+           | None ->
+             match
+               Keeper_repo_mapping.access_decision
+                 ~keeper_id
+                 ~repository_id:current_candidate.repository_id
+                 ~base_path
+             with
+             | Keeper_repo_mapping.Access_allowed ->
+               Log.Keeper.info
+                 "keeper repo catalog review approved after exact operator catalog update \
+                  keeper=%s repository=%s reason=%s"
+                 keeper_id
+                 current_candidate.repository_id
+                 reason;
+               Ok ()
+             | Keeper_repo_mapping.Access_denied access_denial ->
+               Log.Keeper.warn
+                 "keeper repo catalog review approval retained because exact repository \
+                  access remains denied keeper=%s repository=%s reason=%s access=%s"
+                 keeper_id
+                 current_candidate.repository_id
+                 reason
+                 (Keeper_repo_mapping.access_denial_to_string access_denial);
+               Error
+                 (Manual_catalog_review_unresolved
+                    { repository_id = current_candidate.repository_id
+                    ; manual_review_reason = reason
+                    ; access_denial
+                    }))))
 ;;
 
-let register_candidate_on_approval ~keeper_id ~base_path operation decision =
+let reject_unsupported_edit_decision ~keeper_id operation =
   let candidate = operation_candidate operation in
-  match decision with
-  | Agent_sdk.Hooks.Approve ->
-    apply_approved_operation ~keeper_id ~base_path operation
-  | Agent_sdk.Hooks.Reject reason ->
-    Log.Keeper.info
-      "keeper repo registration rejected keeper=%s repository=%s reason=%s"
-      keeper_id
-      candidate.repository_id
-      reason
-  | Agent_sdk.Hooks.Edit _ ->
-    Log.Keeper.warn
-      "keeper repo registration edit decision ignored keeper=%s repository=%s; \
-       dashboard approval resolver supports approve/reject only"
-      keeper_id
-      candidate.repository_id
+  Log.Keeper.warn
+    "keeper repo registration edit decision rejected keeper=%s repository=%s; \
+     no typed edit contract is defined"
+    keeper_id
+    candidate.repository_id;
+  failwith (approved_operation_error_to_string Unsupported_edit_decision)
 ;;
 
-let registration_operation_input ~keeper_id ~base_path operation =
+let wake_keeper_after_registration ~keeper_id ~base_path () =
+  match Keeper_registry.get ~base_path keeper_id with
+  | Some entry -> Atomic.set entry.fiber_wakeup true
+  | None ->
+    Log.Keeper.warn
+      "keeper repo registration resolved but no live keeper fiber was available keeper=%s"
+      keeper_id
+;;
+
+let refresh_and_wake_if_unpaused ~keeper_id ~base_path () =
+  let config = Workspace.default_config base_path in
+  match Keeper_meta_store.read_meta config keeper_id with
+  | Error err ->
+    Log.Keeper.error
+      "repository registration resolved but durable keeper refresh failed keeper=%s: %s"
+      keeper_id
+      err
+  | Ok None ->
+    Log.Keeper.error
+      "repository registration resolved but durable keeper metadata disappeared keeper=%s"
+      keeper_id
+  | Ok (Some meta) ->
+    Keeper_registry.sync_persisted_meta_if_newer ~base_path keeper_id meta;
+    if not meta.paused then wake_keeper_after_registration ~keeper_id ~base_path ()
+;;
+
+let registration_operation_input
+      ~keeper_id
+      ~base_path
+      ~operation_id
+      ~status
+      operation
+  =
   let candidate = operation_candidate operation in
   let operation_fields =
     match operation with
@@ -324,9 +872,17 @@ let registration_operation_input ~keeper_id ~base_path operation =
       [ "target_repository_id", `String existing_repository_id; "alias", `String alias ]
     | Manual_catalog_review { reason; _ } -> [ "manual_review_reason", `String reason ]
   in
+  let decision_fields =
+    [ "decision_state", `String (durable_status_to_string status) ]
+    @
+    match status with
+    | Rejecting reason | Rejected reason -> [ "rejection_reason", `String reason ]
+    | Pending | Approving | Approved | Cancelled -> []
+  in
   `Assoc
     ([ "kind", `String repository_registration_kind
      ; "keeper_id", `String keeper_id
+     ; "operation_id", `String operation_id
      ; "repository_id", `String candidate.repository_id
      ; "policy_source", `String Config_dir_resolver.repositories_toml_basename
      ; "requested_action", `String (operation_name operation)
@@ -340,21 +896,633 @@ let registration_operation_input ~keeper_id ~base_path operation =
 	     ; "default_branch", `String candidate.default_branch
 	     ; "identity_valid", `Bool (candidate_identity_is_valid ~keeper_id candidate)
      ]
+     @ decision_fields
      @ operation_fields)
 ;;
 
-let submit_registration_hitl ~keeper_id ~base_path operation =
-  Keeper_approval_queue.submit_pending
+type matching_registration_approval =
+  | No_registration_approval
+  | Matching_registration_approval of string
+  | Conflicting_registration_approval of string
+
+let registration_approval_operation_id (entry : Keeper_approval_queue.pending_approval) =
+  match Yojson.Safe.Util.member "operation_id" entry.input with
+  | `String value when String.trim value <> "" -> Some value
+  | `String _ | `Null
+  | `Assoc _ | `List _ | `Int _ | `Intlit _ | `Float _ | `Bool _ -> None
+;;
+
+let existing_registration_approval ~keeper_id ~base_path ~operation_id =
+  let entries =
+    Keeper_approval_queue.list_pending_entries ~base_path
+    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+      String.equal entry.keeper_name keeper_id
+      && String.equal entry.tool_name repository_registration_tool_name)
+  in
+  match entries with
+  | [] -> No_registration_approval
+  | [ entry ] ->
+    (match registration_approval_operation_id entry with
+     | Some current when String.equal current operation_id ->
+       Matching_registration_approval entry.id
+     | Some current -> Conflicting_registration_approval current
+     | None -> Conflicting_registration_approval "missing-operation-id")
+  | _ -> Conflicting_registration_approval "multiple-repository-approvals"
+;;
+
+let durable_operation_file_remove ~keeper_id ~base_path =
+  let path = pending_operation_path ~keeper_id ~base_path in
+  try
+    Sys.remove path;
+    Ok ()
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+  | Sys_error detail -> Error detail
+  | Unix.Unix_error (err, _, _) -> Error (Unix.error_message err)
+;;
+
+let current_meta_owns_repository_gate ~keeper_id ~base_path ~operation_id =
+  let* _, meta = current_keeper_meta ~keeper_id ~base_path in
+  Ok (meta_owns_repository_gate ~operation_id meta)
+;;
+
+type repository_resolution_outcome =
+  | Resolution_applied
+  | Resolution_cancelled
+
+let approve_durable_operation ~keeper_id ~base_path ~operation_id =
+  with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+    let* current = load_durable_operation ~keeper_id ~base_path in
+    match current with
+    | None -> Error "repository approval lost its durable operation record"
+    | Some record when not (String.equal record.operation_id operation_id) ->
+      Error
+        (Printf.sprintf
+           "repository approval operation changed: expected=%s actual=%s"
+           operation_id
+           record.operation_id)
+    | Some record ->
+      let cancel () =
+        let* () =
+          persist_durable_operation
+            ~base_path
+            (durable_operation_with_status record Cancelled)
+        in
+        Ok Resolution_cancelled
+      in
+      let finish_approved () =
+        let* applied, _ =
+          persist_registration_resume ~keeper_id ~base_path ~operation_id
+        in
+        if applied then Ok Resolution_applied else cancel ()
+      in
+      let finish_approving () =
+         let* owns_gate =
+           current_meta_owns_repository_gate ~keeper_id ~base_path ~operation_id
+         in
+         if not owns_gate
+         then cancel ()
+         else
+           let* () =
+             apply_approved_operation ~keeper_id ~base_path record.operation
+             |> Result.map_error approved_operation_error_to_string
+           in
+           let* () =
+             persist_durable_operation
+               ~base_path
+               (durable_operation_with_status record Approved)
+           in
+           finish_approved ()
+      in
+      (match record.status with
+       | Rejecting _ | Rejected _ -> Error "repository operation was already rejected"
+       | Cancelled -> Ok Resolution_cancelled
+       | Approved -> finish_approved ()
+       | Approving -> finish_approving ()
+       | Pending ->
+         let* () =
+           persist_durable_operation
+             ~base_path
+             (durable_operation_with_status record Approving)
+         in
+         finish_approving ()))
+;;
+
+let reject_durable_operation ~keeper_id ~base_path ~operation_id ~reason =
+  with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+    let* current = load_durable_operation ~keeper_id ~base_path in
+    match current with
+    | None -> Error "repository rejection lost its durable operation record"
+    | Some record when not (String.equal record.operation_id operation_id) ->
+      Error
+        (Printf.sprintf
+           "repository rejection operation changed: expected=%s actual=%s"
+           operation_id
+           record.operation_id)
+    | Some record ->
+      let cancel () =
+        let* () =
+          persist_durable_operation
+            ~base_path
+            (durable_operation_with_status record Cancelled)
+        in
+        Ok Resolution_cancelled
+      in
+      let finish_rejected () =
+        let* applied, _ =
+          persist_registration_rejection ~keeper_id ~base_path ~operation_id
+        in
+        if applied then Ok Resolution_applied else cancel ()
+      in
+      let finish_rejecting () =
+         let* owns_gate =
+           current_meta_owns_repository_gate ~keeper_id ~base_path ~operation_id
+         in
+         if not owns_gate
+         then cancel ()
+         else
+           let* () =
+             persist_durable_operation
+               ~base_path
+               (durable_operation_with_status record (Rejected reason))
+           in
+           finish_rejected ()
+      in
+      (match record.status with
+       | Approved | Approving -> Error "repository operation was already approved"
+       | Cancelled -> Ok Resolution_cancelled
+       | Rejected stored_reason | Rejecting stored_reason
+         when not (String.equal stored_reason reason) ->
+         Error "repository rejection reason contradicts the durable decision"
+       | Rejected _ -> finish_rejected ()
+       | Rejecting _ -> finish_rejecting ()
+       | Pending ->
+         let* () =
+           persist_durable_operation
+             ~base_path
+             (durable_operation_with_status record (Rejecting reason))
+         in
+         finish_rejecting ()))
+;;
+
+let ensure_resolution_direction ~keeper_id ~base_path ~operation_id decision =
+  with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+    let* current = load_durable_operation ~keeper_id ~base_path in
+    match current with
+    | None -> Error "repository approval lost its durable operation record"
+    | Some record when not (String.equal record.operation_id operation_id) ->
+      Error "repository approval no longer owns the durable operation record"
+    | Some record ->
+      (match record.status, decision with
+       | (Pending | Cancelled), _ -> Ok ()
+       | (Approving | Approved), Agent_sdk.Hooks.Approve -> Ok ()
+       | (Approving | Approved), (Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _) ->
+         Error "repository operation already has a durable Approve decision"
+       | (Rejecting stored | Rejected stored), Agent_sdk.Hooks.Reject reason
+         when String.equal stored reason ->
+         Ok ()
+       | (Rejecting _ | Rejected _),
+         (Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _) ->
+         Error "repository operation already has a different durable Reject decision")
+  )
+;;
+
+let submit_registration_hitl_in_memory ~keeper_id ~base_path record =
+  let operation = record.operation in
+  let operation_id = record.operation_id in
+  Keeper_approval_queue.submit_pending_blocking
     ~keeper_name:keeper_id
     ~tool_name:repository_registration_tool_name
-    ~input:(registration_operation_input ~keeper_id ~base_path operation)
+    ~input:
+      (registration_operation_input
+         ~keeper_id
+         ~base_path
+         ~operation_id
+         ~status:record.status
+         operation)
     ~risk_level:Keeper_approval_queue.High
     ~base_path
     ~sandbox_target:"repository_catalog"
     ~disposition:repository_registration_disposition
     ~disposition_reason:repository_registration_reason
-    ~on_resolution:(register_candidate_on_approval ~keeper_id ~base_path operation)
+    ~on_resolution:(fun ~approval_id:_ decision ->
+      (match ensure_resolution_direction ~keeper_id ~base_path ~operation_id decision with
+       | Ok () -> ()
+       | Error err -> failwith err);
+      match decision with
+      | Agent_sdk.Hooks.Edit _ ->
+        reject_unsupported_edit_decision ~keeper_id operation
+      | Agent_sdk.Hooks.Approve ->
+        Keeper_approval_queue.blocking_resolution_plan
+          ~effect_key:(repository_registration_kind ^ ":" ^ operation_id)
+          ~commit:(fun () ->
+            let outcome =
+              match approve_durable_operation ~keeper_id ~base_path ~operation_id with
+              | Ok outcome -> outcome
+              | Error err -> failwith ("repository registration approval failed: " ^ err)
+            in
+            fun () ->
+              remove_terminal_operation_if_matching ~keeper_id ~base_path ~operation_id;
+              (match outcome with
+               | Resolution_applied ->
+                 refresh_and_wake_if_unpaused ~keeper_id ~base_path ()
+               | Resolution_cancelled -> ()))
+      | Agent_sdk.Hooks.Reject reason ->
+        Keeper_approval_queue.blocking_resolution_plan
+          ~effect_key:(repository_registration_kind ^ ":" ^ operation_id)
+          ~commit:(fun () ->
+            let outcome =
+              match
+                reject_durable_operation
+                  ~keeper_id
+                  ~base_path
+                  ~operation_id
+                  ~reason
+              with
+              | Ok outcome -> outcome
+              | Error err -> failwith ("repository registration rejection failed: " ^ err)
+            in
+            fun () ->
+              remove_terminal_operation_if_matching ~keeper_id ~base_path ~operation_id;
+              (match outcome with
+               | Resolution_cancelled -> ()
+               | Resolution_applied ->
+                 refresh_and_wake_if_unpaused ~keeper_id ~base_path ();
+                 Log.Keeper.info
+                   "keeper repo registration rejected keeper=%s repository=%s reason=%s"
+                   keeper_id
+                   (operation_candidate operation).repository_id
+                   reason)))
     ()
+;;
+
+let corrupt_registration_operation_id ~keeper_id =
+  let digest =
+    Digestif.SHA256.(digest_string ("corrupt-repository-operation\000" ^ keeper_id) |> to_hex)
+  in
+  "corrupt-" ^ digest
+;;
+
+let existing_registration_recovery_approval ~keeper_id ~base_path ~operation_id =
+  Keeper_approval_queue.list_pending_entries ~base_path
+  |> List.find_map (fun (entry : Keeper_approval_queue.pending_approval) ->
+    if
+      String.equal entry.keeper_name keeper_id
+      && String.equal entry.tool_name repository_registration_recovery_tool_name
+      && Option.equal
+           String.equal
+           (registration_approval_operation_id entry)
+           (Some operation_id)
+    then Some entry.id
+    else None)
+;;
+
+let submit_corrupt_registration_recovery ~keeper_id ~base_path ~operation_id ~detail =
+  Keeper_approval_queue.submit_pending_blocking
+    ~keeper_name:keeper_id
+    ~tool_name:repository_registration_recovery_tool_name
+    ~input:
+      (`Assoc
+         [ "kind", `String "repository_registration_recovery"
+         ; "keeper_id", `String keeper_id
+         ; "operation_id", `String operation_id
+         ; "durable_path", `String (pending_operation_path ~keeper_id ~base_path)
+         ; "error_detail", `String detail
+         ; "required_action", `String "repair_or_remove_corrupt_record_then_approve"
+         ])
+    ~risk_level:Keeper_approval_queue.Critical
+    ~base_path
+    ~sandbox_target:"repository_catalog"
+    ~disposition:repository_registration_disposition
+    ~disposition_reason:"repository_registration_state_corrupt"
+    ~on_resolution:(fun ~approval_id:_ decision ->
+      match decision with
+      | Agent_sdk.Hooks.Edit _ | Agent_sdk.Hooks.Reject _ ->
+        failwith
+          "corrupt repository recovery supports Approve only after the durable record is repaired or removed"
+      | Agent_sdk.Hooks.Approve ->
+        Keeper_approval_queue.blocking_resolution_plan
+          ~effect_key:(repository_registration_kind ^ ":" ^ operation_id)
+          ~commit:(fun () ->
+            let next_record =
+              match
+                with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+                  load_durable_operation ~keeper_id ~base_path)
+              with
+              | Ok record -> record
+              | Error err ->
+                failwith ("repository recovery record is still unreadable: " ^ err)
+            in
+            (match next_record with
+             | None ->
+               (match persist_registration_resume ~keeper_id ~base_path ~operation_id with
+                | Ok (true, _) ->
+                  fun () -> refresh_and_wake_if_unpaused ~keeper_id ~base_path ()
+                | Ok (false, _) ->
+                  failwith "repository recovery gate was superseded before resolution"
+                | Error err -> failwith ("repository recovery resume failed: " ^ err))
+             | Some record ->
+               (match
+                  persist_registration_gate_replacement
+                    ~keeper_id
+                    ~base_path
+                    ~from_operation_id:operation_id
+                    ~to_operation_id:record.operation_id
+                with
+                | Error err -> failwith err
+                | Ok () ->
+                  (match
+                     existing_registration_approval
+                       ~keeper_id
+                       ~base_path
+                       ~operation_id:record.operation_id
+                   with
+                   | Matching_registration_approval _ -> ()
+                   | Conflicting_registration_approval current_id ->
+                     failwith
+                       (Printf.sprintf
+                          "conflicting repository approval exists during recovery: %s"
+                          current_id)
+                   | No_registration_approval ->
+                     ignore
+                       (submit_registration_hitl_in_memory
+                          ~keeper_id
+                          ~base_path
+                          record));
+                  fun () -> ()))))
+    ()
+;;
+
+let ensure_corrupt_registration_recovery ~keeper_id ~base_path ~detail =
+  let operation_id = corrupt_registration_operation_id ~keeper_id in
+  let* _, meta = current_keeper_meta ~keeper_id ~base_path in
+  let* owns_gate =
+    match meta.paused, latched_repository_operation_id meta.latched_reason with
+    | true, Some current when String.equal current operation_id -> Ok true
+    | true, Some current ->
+      let* () =
+        persist_registration_gate_replacement
+          ~keeper_id
+          ~base_path
+          ~from_operation_id:current
+          ~to_operation_id:operation_id
+      in
+      Ok true
+    | true, None -> Ok false
+    | false, Some _ | false, None ->
+      persist_registration_gate ~keeper_id ~base_path ~operation_id
+  in
+  if not owns_gate
+  then Error "keeper is paused by a different authoritative operation"
+  else
+    match
+      existing_registration_recovery_approval ~keeper_id ~base_path ~operation_id
+    with
+    | Some _ -> Ok ()
+    | None ->
+      ignore
+        (submit_corrupt_registration_recovery
+           ~keeper_id
+           ~base_path
+           ~operation_id
+           ~detail);
+      Ok ()
+;;
+
+let keeper_has_terminal_hitl_rejection ~keeper_id ~base_path =
+  match current_keeper_meta ~keeper_id ~base_path with
+  | Error err -> Error err
+  | Ok (_, meta) ->
+    Ok
+      (meta.paused
+       &&
+       match meta.latched_reason with
+       | Some
+           (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.Hitl_rejection }) ->
+         true
+       | Some (Keeper_latched_reason.Operator_paused _)
+       | Some _ | None -> false)
+;;
+
+let submit_registration_hitl ~keeper_id ~base_path operation =
+  let requested = durable_pending_operation ~keeper_id operation in
+  with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+    let* existing = load_durable_operation ~keeper_id ~base_path in
+    match existing with
+    | Some current when current.status = Pending || current.status = Approving ->
+      if not (String.equal current.operation_id requested.operation_id)
+      then
+        Error
+          (Printf.sprintf
+             "another repository operation is already pending for keeper %s: %s"
+             keeper_id
+             current.operation_id)
+      else
+        let* owns_gate =
+          persist_registration_gate
+            ~keeper_id
+            ~base_path
+            ~operation_id:current.operation_id
+        in
+        if not owns_gate
+        then Error "keeper is paused by a different authoritative operation"
+        else
+          (match
+             existing_registration_approval
+               ~keeper_id
+               ~base_path
+               ~operation_id:current.operation_id
+           with
+           | Matching_registration_approval id -> Ok id
+           | Conflicting_registration_approval current_id ->
+             Error
+               (Printf.sprintf
+                  "conflicting repository approval already exists for keeper %s: %s"
+                  keeper_id
+                  current_id)
+           | No_registration_approval ->
+             Ok (submit_registration_hitl_in_memory ~keeper_id ~base_path current))
+    | Some current ->
+      (match
+         existing_registration_approval
+           ~keeper_id
+           ~base_path
+           ~operation_id:current.operation_id
+       with
+       | Matching_registration_approval id -> Ok id
+       | Conflicting_registration_approval current_id ->
+         Error
+           (Printf.sprintf
+              "conflicting repository approval already exists for keeper %s: %s"
+              keeper_id
+              current_id)
+       | No_registration_approval ->
+         let* projection_applied =
+           match current.status with
+           | Approved ->
+             persist_registration_resume
+               ~keeper_id
+               ~base_path
+               ~operation_id:current.operation_id
+             |> Result.map fst
+           | Rejected _ ->
+             persist_registration_rejection
+               ~keeper_id
+               ~base_path
+               ~operation_id:current.operation_id
+             |> Result.map fst
+           | Cancelled -> Ok true
+           | Pending | Approving | Rejecting _ ->
+             Error "nonterminal repository operation reached terminal cleanup"
+         in
+         let* () =
+           if projection_applied || current.status = Cancelled
+           then Ok ()
+           else
+             persist_durable_operation
+               ~base_path
+               (durable_operation_with_status current Cancelled)
+         in
+         let* () = durable_operation_file_remove ~keeper_id ~base_path in
+         let* terminal_rejection =
+           keeper_has_terminal_hitl_rejection ~keeper_id ~base_path
+         in
+         let rejected =
+           match current.status with
+           | Rejected _ -> projection_applied
+           | Pending | Approving | Approved | Rejecting _ | Cancelled -> false
+         in
+         if rejected || terminal_rejection
+         then
+           Error
+             "keeper is terminally paused after a rejected HITL decision; explicitly resume before requesting repository registration again"
+         else
+           let* () = persist_durable_operation ~base_path requested in
+           let* owns_gate =
+             persist_registration_gate
+               ~keeper_id
+               ~base_path
+               ~operation_id:requested.operation_id
+           in
+           if not owns_gate
+           then Error "keeper is paused by a different authoritative operation"
+           else
+             Ok (submit_registration_hitl_in_memory ~keeper_id ~base_path requested))
+    | None ->
+      let* terminal_rejection =
+        keeper_has_terminal_hitl_rejection ~keeper_id ~base_path
+      in
+      if terminal_rejection
+      then
+        Error
+          "keeper is terminally paused after a rejected HITL decision; explicitly resume before requesting repository registration again"
+      else
+        let* () = persist_durable_operation ~base_path requested in
+        let* owns_gate =
+          persist_registration_gate
+            ~keeper_id
+            ~base_path
+            ~operation_id:requested.operation_id
+        in
+        if not owns_gate
+        then Error "keeper is paused by a different authoritative operation"
+        else Ok (submit_registration_hitl_in_memory ~keeper_id ~base_path requested))
+;;
+
+let restore_pending_registration_hitl ~(config : Workspace.config)
+    (meta : Keeper_meta_contract.keeper_meta) =
+  let keeper_id = meta.name in
+  let base_path = config.base_path in
+  match
+    with_durable_operation_lock ~keeper_id ~base_path (fun () ->
+      let* current = load_durable_operation ~keeper_id ~base_path in
+      match current with
+      | None -> Ok No_registration_record
+      | Some record ->
+        let cancel_and_remove () =
+          let* () =
+            persist_durable_operation
+              ~base_path
+              (durable_operation_with_status record Cancelled)
+          in
+          let* () = durable_operation_file_remove ~keeper_id ~base_path in
+          Ok Registration_superseded
+        in
+        let restore_active () =
+           let* owns_gate =
+             persist_registration_gate
+               ~keeper_id
+               ~base_path
+               ~operation_id:record.operation_id
+           in
+           if not owns_gate
+           then cancel_and_remove ()
+           else
+             (match
+                existing_registration_approval
+                  ~keeper_id
+                  ~base_path
+                  ~operation_id:record.operation_id
+              with
+              | Matching_registration_approval _ -> Ok Registration_restored
+              | Conflicting_registration_approval current_id ->
+                Error
+                  (Printf.sprintf
+                     "repository operation restore found conflicting queue entry keeper=%s operation_id=%s current=%s"
+                     keeper_id
+                     record.operation_id
+                     current_id)
+              | No_registration_approval ->
+                let _approval_id =
+                  submit_registration_hitl_in_memory ~keeper_id ~base_path record
+                in
+                Ok Registration_restored)
+        in
+        (match record.status with
+         | Pending | Approving | Rejecting _ -> restore_active ()
+         | Approved ->
+           let* applied, _ =
+             persist_registration_resume
+               ~keeper_id
+               ~base_path
+               ~operation_id:record.operation_id
+           in
+           if applied
+           then
+             let* () = durable_operation_file_remove ~keeper_id ~base_path in
+             Ok Registration_restored
+           else cancel_and_remove ()
+         | Rejected _ ->
+           let* applied, _ =
+             persist_registration_rejection
+               ~keeper_id
+               ~base_path
+               ~operation_id:record.operation_id
+           in
+           if applied
+           then
+             let* () = durable_operation_file_remove ~keeper_id ~base_path in
+             Ok Registration_restored
+           else cancel_and_remove ()
+         | Cancelled ->
+           let* () = durable_operation_file_remove ~keeper_id ~base_path in
+           Ok Registration_superseded))
+  with
+  | Ok outcome -> outcome
+  | Error err ->
+    Log.Keeper.error
+      "repository registration pending state is unreadable; keeper remains fail-closed keeper=%s: %s"
+      keeper_id
+      err;
+    (match ensure_corrupt_registration_recovery ~keeper_id ~base_path ~detail:err with
+     | Ok () -> ()
+     | Error recovery_err ->
+       Log.Keeper.error
+         "repository registration corrupt-state approval could not be installed keeper=%s: %s"
+         keeper_id
+         recovery_err);
+    Registration_corrupt err
 ;;
 
 let path_for_git_probe path =
@@ -456,12 +1624,23 @@ let repository_registration_action_fields =
   ]
 ;;
 
+let repository_registration_lane_policy = Keeper_approval_queue.Blocking
+
 let approval_pending_json approval_id =
+  let non_blocking =
+    match repository_registration_lane_policy with
+    | Keeper_approval_queue.Nonblocking -> true
+    | Keeper_approval_queue.Blocking -> false
+  in
   `Assoc
     [ "id", `String approval_id
     ; "kind", `String repository_registration_kind
     ; "reason", `String repository_registration_reason
-    ; "non_blocking", `Bool true
+    ; ( "lane_policy"
+      , `String
+          (Keeper_approval_queue.lane_policy_to_string
+             repository_registration_lane_policy) )
+    ; "non_blocking", `Bool non_blocking
     ]
 ;;
 
@@ -477,8 +1656,14 @@ let request_repository_access ~keeper_id ~base_path ~repository_id =
         with
         | Clone_candidate candidate ->
           let operation = registration_operation ~keeper_id ~base_path candidate in
-          let approval_id = submit_registration_hitl ~keeper_id ~base_path operation in
-          Access_denied_hitl_pending { detail; approval_id }
+          (match submit_registration_hitl ~keeper_id ~base_path operation with
+           | Ok approval_id -> Access_denied_hitl_pending { detail; approval_id }
+           | Error err ->
+             Access_denied
+               (Printf.sprintf
+                  "%s; repository approval could not be durably submitted: %s"
+                  detail
+                  err))
         | No_clone_candidate -> Access_denied detail
         | Invalid_clone_candidate reason ->
           Access_denied
@@ -499,8 +1684,14 @@ let request_path_access ~keeper_id ~base_path ~path =
        (match registration_candidate_of_path ~repository_id ~expected_repo_root ~path with
         | Ok candidate ->
           let operation = registration_operation ~keeper_id ~base_path candidate in
-          let approval_id = submit_registration_hitl ~keeper_id ~base_path operation in
-          Access_denied_hitl_pending { detail; approval_id }
+          (match submit_registration_hitl ~keeper_id ~base_path operation with
+           | Ok approval_id -> Access_denied_hitl_pending { detail; approval_id }
+           | Error err ->
+             Access_denied
+               (Printf.sprintf
+                  "%s; repository approval could not be durably submitted: %s"
+                  detail
+                  err))
         | Error reason ->
           Log.Keeper.warn
             "keeper repo registration candidate unavailable keeper=%s repository=%s \

--- a/lib/keeper/keeper_repo_claim_hitl.mli
+++ b/lib/keeper/keeper_repo_claim_hitl.mli
@@ -13,6 +13,12 @@ type access_result =
   | Access_denied of string
   | Access_denied_hitl_pending of { detail : string; approval_id : string }
 
+type registration_restore_outcome =
+  | No_registration_record
+  | Registration_restored
+  | Registration_superseded
+  | Registration_corrupt of string
+
 val request_repository_access :
   keeper_id:string ->
   base_path:string ->
@@ -22,8 +28,18 @@ val request_repository_access :
     allowed even when outside the keeper's advisory/default mapping scope. Hard
     fail-closed cases return [Access_denied]. When [repository_id] is not
     registered but the keeper already has a verifiable sandbox clone with the
-    same repository component, this queues a non-blocking operator repository
-    registration request instead of silently collapsing to a terminal denial. *)
+    same repository component, this durably pauses the keeper and queues a
+    Blocking operator repository-registration request instead of silently
+    collapsing to a terminal denial. *)
+
+val restore_pending_registration_hitl :
+  config:Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  registration_restore_outcome
+(** Restore a callback-owned Blocking repository approval from its typed
+    durable operation record. The typed outcome distinguishes absence, an
+    installed/replayed gate, supersession by newer keeper state, and corrupt
+    durable state requiring operator repair. *)
 
 val request_path_access :
   keeper_id:string -> base_path:string -> path:string -> access_result

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -426,7 +426,9 @@ let next_human_action_or_terminal ~needs_attention ~latest_next_action
 let disposition_fields_json ~(config : Workspace.config) ~(meta : keeper_meta) :
     Yojson.Safe.t =
   let pending_approval_count =
-    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+    Keeper_approval_queue.pending_count_for_keeper
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
   in
   let runtime_blocker_fields =
     Keeper_status_bridge.runtime_blocker_fields_json config meta
@@ -742,7 +744,9 @@ let summary_json ~(config : Workspace.config) ~(meta : keeper_meta) =
     | [] -> None
   in
   let pending_approval_count =
-    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+    Keeper_approval_queue.pending_count_for_keeper
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
   in
   let runtime_blocker_fields =
     Keeper_status_bridge.runtime_blocker_fields_json config meta
@@ -892,7 +896,7 @@ let causal_timeline_json ~base_path ~meta ~latest_decision ~latest_receipt
     else item :: acc
   in
   let live_pending_events =
-    match pending_approval_json ~keeper_name:meta.name with
+    match pending_approval_json ~base_path ~keeper_name:meta.name with
     | `List entries -> List.filter_map live_pending_approval_timeline_event entries
     | _ -> []
   in
@@ -919,7 +923,9 @@ let snapshot_json_inner ~(config : Workspace.config) ~(meta : keeper_meta) =
     | json :: _ -> Some json
     | [] -> None
   in
-  let pending_approvals = pending_approval_json ~keeper_name:meta.name in
+  let pending_approvals =
+    pending_approval_json ~base_path:config.base_path ~keeper_name:meta.name
+  in
   let pending_approval_count =
     match pending_approvals with
     | `List entries -> List.length entries

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -435,8 +435,8 @@ let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
 let latest_tool_call_json ~(keeper_name : string) =
   Keeper_tool_call_log.read_latest ~keeper_name ()
 
-let pending_approval_json ~(keeper_name : string) =
-  match Keeper_approval_queue.list_pending_dashboard_json () with
+let pending_approval_json ~base_path ~(keeper_name : string) =
+  match Keeper_approval_queue.list_pending_dashboard_json ~base_path with
   | `List entries ->
       entries
       |> List.filter (fun json ->

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -68,7 +68,7 @@ val blocker_timeline_event :
 
 val latest_tool_call_json : keeper_name:string -> Yojson.Safe.t option
 
-val pending_approval_json : keeper_name:string -> Yojson.Safe.t
+val pending_approval_json : base_path:string -> keeper_name:string -> Yojson.Safe.t
 
 val sort_timeline_events : Yojson.Safe.t list -> Yojson.Safe.t list
 

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -229,7 +229,9 @@ let runtime_state_fields_json (config : Workspace_utils.config) (meta : keeper_m
 
 let attention_fields_json (config : Workspace_utils.config) (meta : keeper_meta) =
   let pending_approval_count =
-    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+    Keeper_approval_queue.pending_count_for_keeper
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
   in
   let runtime_blocker = runtime_blocker_surface_opt config meta in
   let needs_attention, attention_reason, next_human_action =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -220,7 +220,9 @@ let release_dead_keeper_owned_tasks (ctx : _ context) (entry : Keeper_registry.r
 ;;
 
 let pending_hitl_approval_counts config =
-  let pending_entries = Keeper_approval_queue.list_pending_entries () in
+  let pending_entries =
+    Keeper_approval_queue.list_pending_entries ~base_path:config.Workspace.base_path
+  in
   keeper_names config
   |> List.filter_map (fun name ->
        let blocking_count, nonblocking_count =
@@ -841,20 +843,41 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
          (* K4c — restart-meta read failure: keeper abandoned, drop. *)
          Keeper_tool_emission_hook.drop_keeper_accumulator old_entry.name)
     restart_list;
-  (* Phase 2: restore paused reconcile gates whose approval queue was lost
-     on restart. The queue itself is in-memory, but paused keeper meta is
-     durable, so rebuild the human gate from persisted blocker evidence. *)
+  (* Phase 2: restore durable repository operations before ordinary reconcile
+     gates. Repository state is written before its pause, so every persisted
+     keeper must be scanned to close a crash between those two writes. The
+     queue itself is in-memory; rebuild the appropriate human gate from the
+     durable operation or paused blocker evidence. *)
   let sweep_names_ym = Eio_guard.create_yield_meter () in
   Keeper_meta_store.keeper_names ctx.config
   |> List.iter (fun name ->
     (match read_meta ctx.config name with
-     | Ok (Some meta)
-       when paused_meta_requires_reconcile_recovery meta
-            && not
-                 (Keeper_approval_queue.has_blocking_pending_for_keeper
-                    ~keeper_name:meta.name)
-       -> restore_reconcile_continue_gate ctx meta
-     | Ok (Some _)
+     | Ok (Some meta) ->
+       let repo_outcome =
+         Keeper_repo_claim_hitl.restore_pending_registration_hitl
+           ~config:ctx.config
+           meta
+       in
+       let repo_gate_restored =
+         match repo_outcome with
+         | Keeper_repo_claim_hitl.Registration_restored -> true
+         | Keeper_repo_claim_hitl.No_registration_record
+         | Keeper_repo_claim_hitl.Registration_superseded -> false
+         | Keeper_repo_claim_hitl.Registration_corrupt detail ->
+           Log.Keeper.error
+             "%s: corrupt repository registration recovery state requires operator repair: %s"
+             meta.name
+             detail;
+           false
+       in
+       if
+         (not repo_gate_restored)
+         && paused_meta_requires_reconcile_recovery meta
+         && not
+              (Keeper_approval_queue.has_blocking_pending_for_keeper
+                 ~base_path
+                 ~keeper_name:meta.name)
+       then restore_reconcile_continue_gate ctx meta
      | Ok None
      | Error _ -> ());
     Eio_guard.yield_step sweep_names_ym);
@@ -870,8 +893,10 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
       | Ok (Some meta)
         when is_stale_paused_meta ~now ~paused_ttl_sec meta
              && (not (paused_meta_requires_reconcile_recovery meta))
+             && (not (paused_meta_latched_terminal_pause meta))
              && not
                   (Keeper_approval_queue.has_blocking_pending_for_keeper
+                     ~base_path
                      ~keeper_name:meta.name)
         ->
         let path = Keeper_types_profile.keeper_meta_path ctx.config name in
@@ -950,6 +975,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
         when Keeper_supervisor_types.paused_meta_auto_resume_due ~now meta
              && not
                   (Keeper_approval_queue.has_blocking_pending_for_keeper
+                     ~base_path
                      ~keeper_name:meta.name)
         ->
         (match

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -89,6 +89,12 @@ let cleanup_dead_tombstone
     Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
     if persisted_paused
     then (
+      let cancelled =
+        Keeper_approval_queue.cancel_callback_owned_for_terminal_keeper
+          ~base_path:ctx.config.base_path
+          ~keeper_name:entry.name
+          ~reason:"superseded by durable keeper Dead tombstone"
+      in
       publish_lifecycle
         ~event:
           (Keeper_lifecycle_events.Custom_event
@@ -96,7 +102,10 @@ let cleanup_dead_tombstone
         entry.name
         "paused meta persisted"
         ();
-      Log.Keeper.info "%s: dead tombstone cleaned up" entry.name)
+      Log.Keeper.info
+        "%s: dead tombstone cleaned up; cancelled_callback_approvals=%d"
+        entry.name
+        cancelled)
     else (
       publish_lifecycle
         ~event:

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -614,11 +614,12 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_m
     meta
 ;;
 
-let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
+let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) ~gate_id =
   Keeper_supervisor_resume_reconcile_gate.resume_keeper_after_reconcile_gate
     ~supervise_keepalive
     ctx
     meta
+    ~gate_id
 ;;
 
 let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
@@ -3,11 +3,12 @@
 
     [restore_reconcile_continue_gate] rehydrates a pending
     "keeper_continue_after_reconcile" approval entry from the
-    persisted paused meta. On [Approve | Edit], it forwards to
+    persisted paused meta. On [Approve], it forwards to
     [resume_keeper_after_reconcile_gate] (which itself lives in
     [Keeper_supervisor_resume_reconcile_gate] — we call it directly
     here, passing the injected [~supervise_keepalive] callback, to
-    avoid bouncing through the parent's wrapper).
+    avoid bouncing through the parent's wrapper). [Edit] has no typed
+    lifecycle meaning and fails closed, leaving the approval pending.
 
     On [Reject], it logs the reason, increments
     [metric_keeper_supervisor_cleanup_failures] tagged
@@ -19,6 +20,9 @@ open Keeper_types_profile
 module Startup_helpers = Keeper_supervisor_startup_helpers
 module Resume_reconcile_gate = Keeper_supervisor_resume_reconcile_gate
 
+exception Reconcile_gate_edit_unsupported
+exception Reconcile_gate_rejection_persistence_failed of string
+
 let restore_reconcile_continue_gate
       ~(supervise_keepalive : proactive_warmup_sec:int -> _ context -> keeper_meta -> unit)
       (ctx : _ context)
@@ -29,61 +33,131 @@ let restore_reconcile_continue_gate
     | Some info -> String.trim info.detail, Some info.klass
     | None -> "", None
   in
-  let committed_tools =
-    Startup_helpers.committed_tools_of_ambiguous_blocker blocker_detail
+  let gate_context =
+    match meta.latched_reason with
+    | Some
+        (Keeper_latched_reason.Continue_gate_pending
+          { gate_id; origin; committed_tools }) ->
+      Ok (meta, gate_id, origin, committed_tools)
+    | None ->
+      let gate_id = Keeper_hitl_continue_gate.generate_id () in
+      let committed_tools =
+        (* Explicit one-way adapter for pre-typed persisted blockers. New
+           continue gates carry [committed_tools] in their typed latch. *)
+        Startup_helpers.committed_tools_of_ambiguous_blocker blocker_detail
+      in
+      (match
+         Keeper_hitl_continue_gate.migrate_legacy
+           ~config:ctx.config
+           ~meta
+           ~gate_id
+           ~origin:Keeper_latched_reason.Reconcile_recovery
+           ~committed_tools
+       with
+       | Ok migrated ->
+         Ok
+           ( migrated
+           , gate_id
+           , Keeper_latched_reason.Reconcile_recovery
+           , committed_tools )
+       | Error err -> Error err)
+    | Some _ -> Error "paused keeper has a different typed latch owner"
   in
-  let failure_reason =
-    match blocker_klass with
-    | Some Ambiguous_post_commit_timeout ->
-      "ambiguous_partial_commit(post_commit_timeout)"
-    | Some Ambiguous_post_commit_failure ->
-      "ambiguous_partial_commit(post_commit_failure)"
-    | Some _ | None -> "ambiguous_partial_commit(post_commit_failure)"
-  in
-  let blocker = blocker_detail in
-  let input =
-    `Assoc
-      [ "kind", `String "reconcile_required"
-      ; "keeper_name", `String meta.name
-      ; "failure_reason", `String failure_reason
-      ; "error_detail", `String blocker
-      ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
-      ]
-  in
-  let _approval_id =
-    Keeper_approval_queue.submit_pending
-      ~keeper_name:meta.name
-      ~tool_name:"keeper_continue_after_reconcile"
-      ~input
-      ~risk_level:Keeper_approval_queue.Critical
-      ~base_path:ctx.config.base_path
-      ~lane_policy:Keeper_approval_queue.Blocking
-      ~on_resolution:(fun decision ->
-        match decision with
-        | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ ->
-          Resume_reconcile_gate.resume_keeper_after_reconcile_gate
-            ~supervise_keepalive
-            ctx
-            meta;
-          Log.Keeper.info
-            "%s: restored reconcile continue gate approved; keeper resumed"
-            meta.name
-        | Agent_sdk.Hooks.Reject reason ->
-          Log.Keeper.warn
-            "%s: restored reconcile continue gate rejected; keeper remains paused (%s)"
-            meta.name
-            reason;
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string SupervisorCleanupFailures)
-            ~labels:
-              [ "keeper", meta.name
-              ; ( "site"
-                , Keeper_supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) )
-              ]
-            ())
-      ()
-  in
-  Log.Keeper.warn
-    "%s: restored reconcile continue gate from persisted paused meta"
-    meta.name
+  match gate_context with
+  | Error err ->
+    Log.Keeper.error
+      "%s: reconcile continue gate not restored because typed ownership changed: %s"
+      meta.name
+      err
+  | Ok (gated_meta, gate_id, origin, committed_tools) ->
+    let failure_reason =
+      match blocker_klass with
+      | Some Ambiguous_post_commit_timeout ->
+        "ambiguous_partial_commit(post_commit_timeout)"
+      | Some Ambiguous_post_commit_failure ->
+        "ambiguous_partial_commit(post_commit_failure)"
+      | Some _ | None -> "ambiguous_partial_commit(post_commit_failure)"
+    in
+    let input =
+      `Assoc
+        [ "kind", `String "reconcile_required"
+        ; "keeper_name", `String gated_meta.name
+        ; "gate_id", `String gate_id
+        ; ( "gate_origin"
+          , `String
+              (match origin with
+               | Keeper_latched_reason.Partial_commit -> "partial_commit"
+               | Reconcile_recovery -> "reconcile_recovery") )
+        ; "failure_reason", `String failure_reason
+        ; "error_detail", `String blocker_detail
+        ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
+        ]
+    in
+    let tool_name =
+      match origin with
+      | Keeper_latched_reason.Partial_commit -> "keeper_continue_after_partial_commit"
+      | Reconcile_recovery -> "keeper_continue_after_reconcile"
+    in
+    ignore
+      (Keeper_approval_queue.submit_pending_blocking
+         ~keeper_name:gated_meta.name
+         ~tool_name
+         ~input
+         ~risk_level:Keeper_approval_queue.Critical
+         ~base_path:ctx.config.base_path
+         ~on_resolution:(fun ~approval_id:_ decision ->
+           let plan commit =
+             Keeper_approval_queue.blocking_resolution_plan
+               ~effect_key:("continue_gate:" ^ gate_id)
+               ~commit
+           in
+           match decision with
+           | Agent_sdk.Hooks.Edit _ -> raise Reconcile_gate_edit_unsupported
+           | Agent_sdk.Hooks.Approve ->
+             plan (fun () ->
+               let wake =
+                 Resume_reconcile_gate.resume_keeper_after_reconcile_gate
+                   ~supervise_keepalive
+                   ctx
+                   gated_meta
+                   ~gate_id
+               in
+               fun () ->
+                 wake ();
+                 Log.Keeper.info
+                   "%s: restored continue gate approved; keeper resumed"
+                   gated_meta.name)
+           | Agent_sdk.Hooks.Reject reason ->
+             plan (fun () ->
+               match
+                 Keeper_hitl_continue_gate.resolve
+                   ~config:ctx.config
+                   ~keeper_name:gated_meta.name
+                   ~gate_id
+                   ~decision:Keeper_hitl_continue_gate.Reject
+               with
+               | Error err -> raise (Reconcile_gate_rejection_persistence_failed err)
+               | Ok rejected_meta ->
+                 fun () ->
+                   Keeper_registry.set_failure_reason
+                     ~base_path:ctx.config.base_path
+                     rejected_meta.name
+                     None;
+                   Log.Keeper.warn
+                     "%s: restored continue gate rejected; keeper remains operator-paused (%s)"
+                     rejected_meta.name
+                     reason;
+                   Otel_metric_store.inc_counter
+                     Keeper_metrics.(to_string SupervisorCleanupFailures)
+                     ~labels:
+                       [ "keeper", rejected_meta.name
+                       ; ( "site"
+                         , Keeper_supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) )
+                       ]
+                     ()))
+         ());
+    Log.Keeper.warn
+      "%s: restored exact continue gate id=%s from persisted paused meta"
+      gated_meta.name
+      gate_id
 ;;

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -14,70 +14,38 @@ open Keeper_meta_contract
 open Keeper_meta_store
 open Keeper_types_profile
 
+exception Reconcile_resume_persistence_failed of string
+
 let resume_keeper_after_reconcile_gate
       ~(supervise_keepalive : proactive_warmup_sec:int -> _ context -> keeper_meta -> unit)
       (ctx : _ context)
       (meta : keeper_meta)
+      ~gate_id
   =
-  let latest_meta =
-    match read_meta ctx.config meta.name with
-    | Ok (Some latest) -> latest
-    | _ -> meta
-  in
-  (* RFC-0047 §3.2 / plan hypothesis B: clear the completion-contract
-     detector latch *before* the paused/last_blocker reset so the helper
-     sees the un-mutated disk klass. Otherwise the unconditional
-     [runtime.last_blocker = None] below hides the violation and the
-     helper becomes a no-op. *)
-  let latest_meta =
-    Keeper_unified_turn_completion_contract.clear_for_operator_resume
-      ~base_path:ctx.config.base_path
-      latest_meta
-  in
   let resumed_meta =
-    { latest_meta with
-      paused = false
-    ; latched_reason = None
-    ; updated_at = now_iso ()
-    ; runtime = { latest_meta.runtime with last_blocker = None }
-    }
+    match
+      Keeper_hitl_continue_gate.resolve
+        ~config:ctx.config
+        ~keeper_name:meta.name
+        ~gate_id
+        ~decision:Keeper_hitl_continue_gate.Approve
+    with
+    | Ok persisted -> persisted
+    | Error err ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string WriteMetaFailures)
+        ~labels:[ "keeper", meta.name; "phase", "reconcile_resume" ]
+        ();
+      Log.Keeper.error "%s: exact reconcile gate resume failed: %s" meta.name err;
+      raise (Reconcile_resume_persistence_failed err)
   in
-  (* #9733: same race shape as keeper_msg/overflow-pause/sync paths
-     already migrated by #10135 / #10145.  The supervisor reconcile
-     fiber clears [paused] and [runtime.last_blocker] (cycle-owned
-     fields); a heartbeat fiber bumping heartbeat-owned metadata in
-     parallel can still steal the CAS write and silently leave the keeper paused while
-     [Keeper_registry.update_meta] applies the resume in-memory —
-     a registry/disk split that hides the failure. *)
-  (match
-     write_meta_with_merge
-       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-       ctx.config
-       resumed_meta
-   with
-   | Ok () -> ()
-   | Error err when is_version_conflict_error err ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string WriteMetaFailures)
-       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume_cas_race" ]
-       ();
-     Log.Keeper.warn
-       "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
-       resumed_meta.name
-       err
-   | Error err ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string WriteMetaFailures)
-       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume" ]
-       ();
-     Log.Keeper.error
-       "%s: reconcile gate resume write_meta failed: %s"
-       resumed_meta.name
-       err);
-  Keeper_registry.update_meta
-    ~base_path:ctx.config.base_path
-    resumed_meta.name
-    resumed_meta;
+  (* [clear_for_operator_resume] also clears the live registry failure latch;
+     run it only after the durable metadata write succeeds. Pass the original
+     meta so the helper still sees the pre-resume blocker classification. *)
+  ignore
+    (Keeper_unified_turn_completion_contract.clear_for_operator_resume
+       ~base_path:ctx.config.base_path
+       meta);
   Keeper_registry.set_failure_reason
     ~base_path:ctx.config.base_path
     resumed_meta.name
@@ -90,16 +58,41 @@ let resume_keeper_after_reconcile_gate
      resume path so the resumed keeper's first livelock block emits at
      ERROR (not silently demoted to DEBUG from a previous lifetime). *)
   Keeper_livelock_state.reset_for_keeper ~keeper:resumed_meta.name;
-  Keeper_registry.dispatch_event_unit
-    ~base_path:ctx.config.base_path
-    resumed_meta.name
-    Keeper_state_machine.Operator_resume;
-  match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
-  | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
-    (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)
-    Atomic.set entry.fiber_wakeup true
-  | Some _ ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path resumed_meta.name;
-    supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
-  | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+  fun () ->
+    (* The post-removal hint is non-authoritative. Re-read durable truth so an
+       operator pause/resume committed between the approval write and this
+       closure wins, then version-gate the live projection. *)
+    match read_meta ctx.config resumed_meta.name with
+    | Error err ->
+      Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+        ~config:ctx.config
+        ~keeper_name:resumed_meta.name
+        ~side_effect:"reconcile resume post-removal meta refresh"
+        ~severity:`Error
+        err
+    | Ok None ->
+      Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+        ~config:ctx.config
+        ~keeper_name:resumed_meta.name
+        ~side_effect:"reconcile resume post-removal meta refresh"
+        ~severity:`Error
+        "persisted keeper metadata disappeared after approval"
+    | Ok (Some authoritative_meta) ->
+      Keeper_registry.sync_persisted_meta_if_newer
+        ~base_path:ctx.config.base_path
+        authoritative_meta.name
+        authoritative_meta;
+      if authoritative_meta.paused
+      then ()
+      else
+        match Keeper_registry.get ~base_path:ctx.config.base_path authoritative_meta.name with
+        | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
+          (* tla-lint: allow-mutation: post-removal keeper resume signal *)
+          Atomic.set entry.fiber_wakeup true
+        | Some _ ->
+          Keeper_registry.unregister
+            ~base_path:ctx.config.base_path
+            authoritative_meta.name;
+          supervise_keepalive ~proactive_warmup_sec:0 ctx authoritative_meta
+        | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx authoritative_meta
 ;;

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.mli
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.mli
@@ -8,5 +8,8 @@ val resume_keeper_after_reconcile_gate :
      unit) ->
   'a Keeper_types_profile.context ->
   Keeper_meta_contract.keeper_meta ->
+  gate_id:string ->
+  unit ->
   unit
-(** Clear the persisted reconcile blocker/latch and resume or relaunch the keeper. *)
+(** Clear the persisted reconcile blocker/latch and return the wake/relaunch
+    action that must run only after the blocking approval leaves the queue. *)

--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -112,14 +112,23 @@ let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
 let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   meta.paused
   &&
-  match meta.runtime.last_blocker with
-  | Some info -> blocker_class_continue_gate info.klass
-  | None -> false
+  (match meta.latched_reason with
+   | Some (Keeper_latched_reason.Continue_gate_pending _) -> true
+   | Some (Keeper_latched_reason.Repository_registration_pending _) -> true
+   | Some _ -> false
+   | None ->
+     match meta.runtime.last_blocker with
+     | Some info -> blocker_class_continue_gate info.klass
+     | None -> false)
 ;;
 
 let paused_meta_latched_terminal_pause (meta : keeper_meta) =
   match meta.latched_reason with
   | Some Keeper_latched_reason.Dead_tombstone -> true
+  | Some
+      (Keeper_latched_reason.Operator_paused
+        { operator_actor = Keeper_latched_reason.Hitl_rejection }) ->
+    true
   | Some _
   | None -> false
 ;;

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -62,9 +62,13 @@ val is_stale_paused_meta :
   now:float -> paused_ttl_sec:float -> keeper_meta -> bool
 (** Check if a paused keeper meta file on disk is stale enough to remove. *)
 
+(** Internal: predicate identifying paused metas whose blocker or typed gate
+    requires reconcile recovery instead of straight resume. *)
 val paused_meta_requires_reconcile_recovery : keeper_meta -> bool
-(** Internal: predicate identifying paused metas whose last_blocker class
-    requires reconcile-recovery rather than straight resume. *)
+
+(** [true] when a paused keeper owns a terminal latch that must survive the
+    ordinary stale-paused cleanup sweep until explicit operator recovery. *)
+val paused_meta_latched_terminal_pause : keeper_meta -> bool
 
 val paused_meta_auto_resume_due : now:float -> keeper_meta -> bool
 (** True when [meta] is an auto-paused keeper whose self-healing backoff has

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -549,7 +549,7 @@ let submit_shell_ir_approval_pending
       cmd
   in
   let approval_id =
-    Keeper_approval_queue.submit_pending
+    Keeper_approval_queue.submit_pending_observer
       ~keeper_name
       ~tool_name:"tool_execute"
       ~input
@@ -561,7 +561,7 @@ let submit_shell_ir_approval_pending
       ~sandbox_profile
       ~disposition:"requires_approval"
       ~disposition_reason:summary
-      ~on_resolution
+      ~on_resolution_observer:on_resolution
       ()
   in
   record_gated_gh_lifecycle ~keeper_name ~event:"requested" ~risk_class ~typed_hit;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -385,7 +385,18 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
         (Printf.sprintf "[Co-view context]\n%s"
            (Yojson.Safe.pretty_to_string json))
 
+let direct_turn_blocked_by_approval ~base_path (meta : keeper_meta) =
+  Keeper_turn_up_update.paused_state_requires_approval ~base_path meta
+;;
+
+let direct_turn_blocking_approval_message keeper_name =
+  Printf.sprintf
+    "keeper %s has a blocking HITL approval pending; resolve it before starting a direct turn"
+    keeper_name
+;;
+
 module For_testing = struct
+  let direct_turn_blocked_by_approval = direct_turn_blocked_by_approval
   let direct_owner_conversation_context = direct_owner_conversation_context
   let surface_context_to_instructions = surface_context_to_instructions
   let direct_success_may_clear_no_progress_pause =
@@ -456,6 +467,11 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     | Ok _ ->
     match ensure_keeper_exists ~ctx ~name with
     | Error e -> Error e
+    | Ok meta
+      when direct_turn_blocked_by_approval
+             ~base_path:ctx.config.base_path
+             meta ->
+        Error (direct_turn_blocking_approval_message meta.name)
     | Ok meta ->
       match resolve_turn_runtime_id meta with
       | Error e -> Error e
@@ -644,6 +660,15 @@ let run_keeper_msg_turn_admitted
       ~ctx ~name
     with
     | Error e -> tool_result_error ("" ^ e)
+    | Ok meta0
+      when direct_turn_blocked_by_approval
+             ~base_path:ctx.config.base_path
+             meta0 ->
+        tool_result_error
+          ~class_:Tool_result.Workflow_rejection
+          (error_response_typed
+             ~code:Precondition_failed
+             (direct_turn_blocking_approval_message meta0.name))
     | Ok meta0 ->
       (* RFC vision-delegation §2.3 site 1 (fresh input). For a Delegate keeper,
          evict each image to the artifact store + an eager analyze_image reading

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -31,6 +31,13 @@ val keeper_msg_timeout_override : Yojson.Safe.t -> (float option, string) result
     lifecycle exposed via [masc_keeper_msg_result]. *)
 
 module For_testing : sig
+  val direct_turn_blocked_by_approval :
+    base_path:string -> Keeper_meta_contract.keeper_meta -> bool
+  (** Exact workspace-scoped direct-turn gate. Blocking approvals own the
+      keeper lane; before the in-memory queue is restored after restart, a
+      persisted typed continue-gate blocker owns it as defense in depth.
+      Nonblocking observers and ordinary paused states do not reject chat. *)
+
   val direct_owner_conversation_context :
     config:Workspace.config ->
     meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -35,7 +35,8 @@ let of_stop_reason = function
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_blocking_approval _ -> Continuation_checkpoint
 
 let of_result_surface ~response_text = function
   | Runtime_agent.Completed ->
@@ -43,7 +44,8 @@ let of_result_surface ~response_text = function
   | Runtime_agent.TurnBudgetExhausted _ -> Continuation_checkpoint
   | Runtime_agent.MutationBoundaryReached _ -> Continuation_checkpoint
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _
+  | Runtime_agent.Yielded_to_blocking_approval _ -> Continuation_checkpoint
 
 let of_reply_payload payload =
   match payload with

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -11,6 +11,10 @@ open Keeper_types_profile
 open Keeper_context_runtime
 module EC = Keeper_error_classify
 module StringMap = Set_util.StringMap
+let ( let* ) = Result.bind
+
+exception Partial_commit_gate_sync_failed of string
+exception Partial_commit_gate_edit_unsupported
 
 type runtime_execution = {
   runtime_id : string;
@@ -734,7 +738,21 @@ let pause_keeper_for_overflow
       Keeper_state_machine.Operator_pause;
     paused_meta)
 
+let wake_resumed_keeper_fiber ~(config : Workspace.config) ~keeper_name () =
+  match Keeper_registry.get ~base_path:config.base_path keeper_name with
+  | Some entry ->
+    (* tla-lint: allow-mutation: keeper resume signal after durable state commit *)
+    Atomic.set entry.fiber_wakeup true
+  | None ->
+    Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+      ~config
+      ~keeper_name
+      ~side_effect:"resume sync fiber wakeup"
+      "registry entry missing after metadata update"
+;;
+
 let sync_keeper_paused_state_impl
+    ~wake_after_resume
     ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy option)
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -743,15 +761,18 @@ let sync_keeper_paused_state_impl
     match paused, resume_policy with
     | true, Some policy ->
       Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy meta policy
-    | _ -> meta.auto_resume_after_sec
+    | true, None -> meta.auto_resume_after_sec
+    | false, _ -> None
   in
   let synced_meta =
-    {
-      meta with
-      paused;
-      auto_resume_after_sec;
-      updated_at = now_iso ();
-    }
+    let base = { meta with paused; auto_resume_after_sec; updated_at = now_iso () } in
+    if paused
+    then base
+    else
+      { base with
+        latched_reason = None
+      ; runtime = { base.runtime with last_blocker = None }
+      }
   in
   (* #9733: pause/resume sync is operator-driven; the [paused]
      field is cycle-owned at this site, so use the same merged-CAS
@@ -761,9 +782,10 @@ let sync_keeper_paused_state_impl
      reports failure) which leaves the registry update unsync'd
      with disk. *)
   match
-    write_meta_with_merge
-      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-      config synced_meta
+    write_meta_with_merge_returning
+         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+         config
+         synced_meta
   with
   | Error err ->
       Otel_metric_store.inc_counter
@@ -779,31 +801,28 @@ let sync_keeper_paused_state_impl
                         (if paused then "pause" else "resume"))
         ~severity:`Error
         err;
-      Error (Printf.sprintf "failed to write meta: %s" err)
-  | Ok () ->
-      Keeper_registry.update_meta ~base_path:config.base_path meta.name synced_meta;
-      Keeper_turn_helpers.dispatch_keeper_phase_event_checked
-        ~config
-        ~keeper_name:meta.name
-        ~side_effect:(Printf.sprintf "%s sync phase update"
-                        (if paused then "pause" else "resume"))
-        (if paused
-         then Keeper_state_machine.Operator_pause
-         else Keeper_state_machine.Operator_resume);
-      let synced_meta =
-        if paused
-        then
-          match
+    Error (Printf.sprintf "failed to write meta: %s" err)
+  | Ok persisted_meta ->
+    (* The merge may preserve a newer, distinct operator pause. Project the
+       exact persisted version into the registry; the version-gated CAS also
+       participates in registration, closing stale-entry installation races. *)
+    Keeper_registry.sync_persisted_meta_if_newer
+      ~base_path:config.base_path
+      meta.name
+      persisted_meta;
+    if paused
+    then
+      (match
             Keeper_supervisor_pause_policy.release_owned_active_tasks_after_typed_pause
               ~config
-              ~meta:synced_meta
+              ~meta:persisted_meta
               ~reason_tag:"pause_sync"
           with
-          | Ok released_meta -> released_meta
+          | Ok released_meta -> Ok released_meta
           | Error err ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RuntimeSyncFailures)
-              ~labels:[("keeper", meta.name); ("site", "pause_sync_task_release")]
+              ~labels:[ "keeper", meta.name; "site", "pause_sync_task_release" ]
               ();
             Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
               ~config
@@ -811,24 +830,20 @@ let sync_keeper_paused_state_impl
               ~side_effect:"pause sync task release"
               ~severity:`Error
               err;
-            synced_meta
-        else synced_meta
-      in
-      (if not paused then
-         match Keeper_registry.get ~base_path:config.base_path meta.name with
-         (* tla-lint: allow-mutation: fiber signal — wake on resume from runtime budget gate *)
-         | Some entry -> Atomic.set entry.fiber_wakeup true
-         | None ->
-             Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
-               ~config
-               ~keeper_name:meta.name
-               ~side_effect:"resume sync fiber wakeup"
-               "registry entry missing after metadata update");
-      Ok synced_meta
+            Error ("failed to release paused keeper tasks: " ^ err))
+    else (
+      if wake_after_resume && not persisted_meta.paused
+      then wake_resumed_keeper_fiber ~config ~keeper_name:meta.name ();
+      Ok persisted_meta)
 
 let sync_keeper_paused_state ~(config : Workspace.config) ~(meta : keeper_meta) ~paused
   =
-  sync_keeper_paused_state_impl ~resume_policy:None ~config ~meta ~paused
+  sync_keeper_paused_state_impl
+    ~wake_after_resume:true
+    ~resume_policy:None
+    ~config
+    ~meta
+    ~paused
 
 let sync_keeper_paused_state_with_resume_policy
     ~(config : Workspace.config)
@@ -838,6 +853,7 @@ let sync_keeper_paused_state_with_resume_policy
   : (keeper_meta, string) result
   =
   sync_keeper_paused_state_impl
+    ~wake_after_resume:true
     ~resume_policy:(Some resume_policy)
     ~config
     ~meta
@@ -1038,67 +1054,141 @@ let post_turn_resilience_handles
           sync_lifecycle_meta;
         }
 
-let enqueue_partial_commit_continue_gate
+let persist_and_enqueue_partial_commit_continue_gate
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
     ~(failure_reason : Keeper_registry.failure_reason)
     ~(committed_tools : string list)
-    ~(error_detail : string) : string =
+    ~(error_detail : string) : ((keeper_meta * string), string) result =
+  let gate_id = Keeper_hitl_continue_gate.generate_id () in
+  let* paused_meta =
+    Keeper_hitl_continue_gate.install
+      ~config
+      ~meta
+      ~gate_id
+      ~origin:Keeper_latched_reason.Partial_commit
+      ~committed_tools
+  in
   let reason_text = Keeper_registry.failure_reason_to_string failure_reason in
   let input =
     `Assoc [
       ("kind", `String "continue_gate_required");
-      ("keeper_name", `String meta.name);
+      ("keeper_name", `String paused_meta.name);
+      ("gate_id", `String gate_id);
       ("failure_reason", `String reason_text);
       ("error_detail", `String error_detail);
       ("committed_tools", `List (List.map (fun tool -> `String tool) committed_tools));
     ]
   in
-  Keeper_approval_queue.submit_pending
-    ~keeper_name:meta.name
-    ~tool_name:"keeper_continue_after_partial_commit"
-    ~input
-    ~risk_level:Keeper_approval_queue.Critical
-    ~base_path:config.base_path
-    ~lane_policy:Keeper_approval_queue.Blocking
-    ~on_resolution:(fun decision ->
-      let latest_meta = current_keeper_meta ~config ~fallback_meta:meta in
-      match decision with
-      | Agent_sdk.Hooks.Approve
-      | Agent_sdk.Hooks.Edit _ ->
-        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:false with
-         | Ok resumed_meta ->
-             Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name None;
-             Keeper_registry.reset_turn_failures ~base_path:config.base_path meta.name;
-             Log.Keeper.info
-               "%s: partial-commit continue gate approved; auto-resumed keeper"
-               resumed_meta.name
-         | Error err ->
-             Log.Keeper.error
-               "%s: partial-commit continue gate approved but keeper resume sync failed: %s"
-               meta.name err);
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string RuntimeSyncFailures)
-               ~labels:[("keeper", meta.name); ("site", "resume_sync")]
-               ()
-      | Agent_sdk.Hooks.Reject reason ->
-        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
-         | Ok paused_meta ->
-             Keeper_registry.set_failure_reason
-               ~base_path:config.base_path meta.name
-               (Some failure_reason);
-             Log.Keeper.warn
-               "%s: partial-commit continue gate rejected; keeper remains paused (%s)"
-               paused_meta.name reason
-         | Error err ->
-             Log.Keeper.error
-               "%s: partial-commit continue gate rejected but keeper pause sync failed: %s (reason=%s)"
-               meta.name err reason);
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string RuntimeSyncFailures)
-               ~labels:[("keeper", meta.name); ("site", "pause_sync")]
-               ())
-    ()
+  let approval_id =
+    Keeper_approval_queue.submit_pending_blocking
+      ~keeper_name:paused_meta.name
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input
+      ~risk_level:Keeper_approval_queue.Critical
+      ~base_path:config.base_path
+      ~on_resolution:(fun ~approval_id:_ decision ->
+        let plan commit =
+          Keeper_approval_queue.blocking_resolution_plan
+            ~effect_key:("continue_gate:" ^ gate_id)
+            ~commit
+        in
+        match decision with
+        | Agent_sdk.Hooks.Edit _ -> raise Partial_commit_gate_edit_unsupported
+        | Agent_sdk.Hooks.Approve ->
+          plan (fun () ->
+            match
+              Keeper_hitl_continue_gate.resolve
+                ~config
+                ~keeper_name:paused_meta.name
+                ~gate_id
+                ~decision:Keeper_hitl_continue_gate.Approve
+            with
+            | Ok resumed_meta ->
+            Keeper_registry.set_failure_reason
+              ~base_path:config.base_path
+              paused_meta.name
+              None;
+            Keeper_registry.reset_turn_failures
+              ~base_path:config.base_path
+              paused_meta.name;
+            fun () ->
+              (match read_meta config resumed_meta.name with
+               | Ok (Some authoritative_meta) ->
+                 Keeper_registry.sync_persisted_meta_if_newer
+                   ~base_path:config.base_path
+                   authoritative_meta.name
+                   authoritative_meta;
+                 if authoritative_meta.paused
+                 then
+                   Log.Keeper.info
+                     "%s: partial-commit gate approved; a newer operator pause remains authoritative"
+                     authoritative_meta.name
+                 else (
+                   wake_resumed_keeper_fiber
+                     ~config
+                     ~keeper_name:authoritative_meta.name
+                     ();
+                   Log.Keeper.info
+                     "%s: partial-commit continue gate approved; auto-resumed keeper"
+                     authoritative_meta.name)
+               | Ok None ->
+                 Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+                   ~config
+                   ~keeper_name:resumed_meta.name
+                   ~side_effect:"partial-commit resume post-removal meta refresh"
+                   ~severity:`Error
+                   "persisted keeper metadata disappeared after approval"
+               | Error err ->
+                 Keeper_turn_helpers.report_keeper_cycle_side_effect_issue
+                   ~config
+                   ~keeper_name:resumed_meta.name
+                   ~side_effect:"partial-commit resume post-removal meta refresh"
+                   ~severity:`Error
+                   err)
+            | Error err ->
+            Log.Keeper.error
+              "%s: partial-commit continue gate approved but keeper resume sync failed: %s"
+              paused_meta.name
+              err;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RuntimeSyncFailures)
+              ~labels:[ "keeper", meta.name; "site", "resume_sync" ]
+              ();
+            raise (Partial_commit_gate_sync_failed err))
+        | Agent_sdk.Hooks.Reject reason ->
+          plan (fun () ->
+            match
+              Keeper_hitl_continue_gate.resolve
+                ~config
+                ~keeper_name:paused_meta.name
+                ~gate_id
+                ~decision:Keeper_hitl_continue_gate.Reject
+            with
+            | Ok rejected_meta ->
+            fun () ->
+              Keeper_registry.set_failure_reason
+                ~base_path:config.base_path
+                rejected_meta.name
+                None;
+              Log.Keeper.warn
+                "%s: partial-commit continue gate rejected; keeper remains operator-paused (%s)"
+                rejected_meta.name
+                reason
+            | Error err ->
+            Log.Keeper.error
+              "%s: partial-commit continue gate rejection persistence failed: %s (reason=%s)"
+              paused_meta.name
+              err
+              reason;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RuntimeSyncFailures)
+              ~labels:[ "keeper", meta.name; "site", "pause_sync" ]
+              ();
+            raise (Partial_commit_gate_sync_failed err)))
+      ()
+  in
+  Ok (paused_meta, approval_id)
 
 (* Dedupe "mixed runtime context budget" log: the values are constant
    per (keeper_name, primary_budget, runtime_budget) because runtime config

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -345,13 +345,16 @@ val post_turn_resilience_handles :
     per keeper to respect [Shared_audit.Store]'s single-writer chain
     contract. *)
 
-val enqueue_partial_commit_continue_gate :
+val persist_and_enqueue_partial_commit_continue_gate :
   config:Workspace.config ->
   meta:keeper_meta ->
   failure_reason:Keeper_registry.failure_reason ->
   committed_tools:string list ->
   error_detail:string ->
-  string
+  ((keeper_meta * string), string) result
+(** Persist an exact typed partial-commit gate before installing its in-memory
+    approval callback. This ordering lets supervisor restart recovery rebuild
+    the same [gate_id] after a crash. *)
 
 val resolved_max_context_for_turn : meta:keeper_meta -> int
 (** Resolve the initial keeper turn context budget from the keeper's routed

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -32,14 +32,11 @@ let resolve_active_goal_ids config p old_ids =
           (Printf.sprintf "unknown active_goal_ids: %s"
              (String.concat ", " missing))
 
-let blocker_requires_continue_gate (old : keeper_meta) =
-  match old.runtime.last_blocker with
-  | Some info -> blocker_class_continue_gate info.klass
-  | None -> false
-
-let paused_state_requires_approval (old : keeper_meta) =
-  Keeper_approval_queue.has_blocking_pending_for_keeper ~keeper_name:old.name
-  || blocker_requires_continue_gate old
+let paused_state_requires_approval ~base_path (old : keeper_meta) =
+  Keeper_approval_queue.has_blocking_pending_for_keeper
+    ~base_path
+    ~keeper_name:old.name
+  || Keeper_supervisor_types.paused_meta_requires_reconcile_recovery old
 
 let update_keeper ?(preserve_prompt_defaults = false)
     (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool_result
@@ -134,7 +131,8 @@ let update_keeper ?(preserve_prompt_defaults = false)
       ~fallback:profile_or_old
   in
   let resume_paused_keeper =
-    old.paused && not (paused_state_requires_approval old)
+    old.paused
+    && not (paused_state_requires_approval ~base_path:ctx.config.base_path old)
   in
   if resume_paused_keeper then (
     let blocker_class, blocker_detail =

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -14,6 +14,13 @@ val resolve_active_goal_ids :
   string list ->
   (string list, string) result
 
+(** Defense-in-depth gate shared by keeper reconfiguration and direct-turn
+    admission. A Blocking in-memory approval owns the keeper lane; after a
+    restart, the typed persisted ambiguous-commit blocker keeps that ownership
+    until the approval queue has been rehydrated. *)
+val paused_state_requires_approval :
+  base_path:string -> Keeper_meta_contract.keeper_meta -> bool
+
 (** Update an existing keeper's meta record. Validates tool-access
     transitions, resolves active goals, applies parsed-arg overrides,
     persists the new meta, and broadcasts state-machine events.

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -85,7 +85,9 @@ let append_decision_record
     Keeper_runtime_contract.runtime_observability_contract_json ~config meta
   in
   let pending_approval_count =
-    Keeper_approval_queue.pending_count_for_keeper ~keeper_name:meta.name
+    Keeper_approval_queue.pending_count_for_keeper
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
   in
   let claim_executed =
     List.exists Keeper_tool_progress.is_claim_tool_name tool_names
@@ -297,6 +299,8 @@ let append_decision_record
                       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
                   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
                       Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
+                  | Runtime_agent.Yielded_to_blocking_approval { turns_used; _ } ->
+                      Printf.sprintf "yielded_to_blocking_approval(%d)" turns_used
                 in
               let inference_fields =
                 match r.inference_telemetry with

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -630,7 +630,6 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     ~(observation : Keeper_world_observation.world_observation)
     () : string * string
     =
-  ignore base_path;
   (* Total deterministic resolution between two known instruction sources
      (profile default else meta), not a permissive unknown-input default;
      pre-existing pattern, was the 4th tuple element before RFC-0282. *)
@@ -805,7 +804,8 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
        for callers that predate the threading. *)
     match turn_decision with
     | Some decision -> decision
-    | None -> Keeper_world_observation.keeper_cycle_decision ~meta observation
+    | None ->
+      Keeper_world_observation.keeper_cycle_decision ~base_path ~meta observation
   in
   let autonomous_trigger =
     autonomous_trigger_lines ~decision:turn_decision ~observation

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -31,6 +31,7 @@ let run_keeper_cycle
       ?shared_context
       ?event_bus
       ?hitl_resolution
+      ?on_stop_reason
       ()
   : (keeper_meta, Agent_sdk.Error.sdk_error) result
   =
@@ -781,17 +782,14 @@ let run_keeper_cycle
                         meta.name
                         (Some failure_reason);
                       match
-                        sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true
+                        persist_and_enqueue_partial_commit_continue_gate
+                          ~config
+                          ~meta:updated_meta
+                          ~failure_reason
+                          ~committed_tools
+                          ~error_detail:e_str
                       with
-                      | Ok paused_meta ->
-                        let approval_id =
-                          enqueue_partial_commit_continue_gate
-                            ~config
-                            ~meta:paused_meta
-                            ~failure_reason
-                            ~committed_tools
-                            ~error_detail:e_str
-                        in
+                      | Ok (paused_meta, approval_id) ->
                         Otel_metric_store.inc_counter
                           Keeper_metrics.(to_string TurnErrorAfterTools)
                           ~labels:[ "keeper", meta.name; "reason", "ambiguous_partial" ]
@@ -1013,6 +1011,7 @@ dominant source of the observed CAS race exhaustion after
                     ();
                   Error err, turn_state)
                 | Ok result ->
+                  Option.iter (fun observe -> observe result.stop_reason) on_stop_reason;
                   (match
                      require_last_execution_for_finalize
                        ~keeper_name:meta.name

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -207,6 +207,7 @@ val run_keeper_cycle
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?on_stop_reason:(Runtime_agent.stop_reason -> unit)
   -> unit
   -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result
 
@@ -230,4 +231,7 @@ val run_keeper_cycle
     @param turn_decision The scheduler's cycle decision that fired this turn
     (RFC-0315). Threaded into [Keeper_unified_prompt.build_prompt] so the
     prompt renders the real wake reason instead of a context-blind recompute.
-    Callers that predate the threading may omit it. *)
+    Callers that predate the threading may omit it.
+    @param on_stop_reason Synchronous terminal observation hook for the
+    heartbeat intake owner. It is invoked once for a successful OAS result
+    before success finalization and must not perform fallible side effects. *)

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -58,7 +58,8 @@ let budget_exhausted_no_progress_threshold_override
     | Runtime_agent.Completed
     | Runtime_agent.MutationBoundaryReached _
     | Runtime_agent.Yielded_to_chat_waiting _
-    | Runtime_agent.Yielded_to_durable_stimulus _ -> false
+    | Runtime_agent.Yielded_to_durable_stimulus _
+    | Runtime_agent.Yielded_to_blocking_approval _ -> false
   in
   if
     budget_exhausted
@@ -221,7 +222,8 @@ let completion_contract_terminal_failure_reason_code result =
      | Runtime_agent.Completed
      | Runtime_agent.MutationBoundaryReached _
      | Runtime_agent.Yielded_to_chat_waiting _
-     | Runtime_agent.Yielded_to_durable_stimulus _ -> None)
+     | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Yielded_to_blocking_approval _ -> None)
   | Some _ -> None
   | None ->
     Some
@@ -238,7 +240,8 @@ let terminal_outcome_of_result result =
      | Runtime_agent.TurnBudgetExhausted _
      | Runtime_agent.MutationBoundaryReached _
      | Runtime_agent.Yielded_to_chat_waiting _
-     | Runtime_agent.Yielded_to_durable_stimulus _ ->
+     | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Yielded_to_blocking_approval _ ->
        Terminal_checkpoint)
 ;;
 
@@ -451,6 +454,8 @@ let emit_usage_metrics_and_log
       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
     | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
       Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
+    | Runtime_agent.Yielded_to_blocking_approval { turns_used; _ } ->
+      Printf.sprintf "yielded_to_blocking_approval(%d)" turns_used
   in
   let outcome_label =
     match terminal_outcome with
@@ -463,6 +468,8 @@ let emit_usage_metrics_and_log
        | Runtime_agent.Yielded_to_chat_waiting _ -> "yielded_to_chat_waiting"
        | Runtime_agent.Yielded_to_durable_stimulus _ ->
          "yielded_to_durable_stimulus"
+       | Runtime_agent.Yielded_to_blocking_approval _ ->
+         "yielded_to_blocking_approval"
        | Runtime_agent.Completed -> "success")
   in
   Otel_metric_store.inc_counter
@@ -583,6 +590,7 @@ let terminal_reason_of_outcome result = function
      | Runtime_agent.MutationBoundaryReached _
      | Runtime_agent.Yielded_to_chat_waiting _
      | Runtime_agent.Yielded_to_durable_stimulus _
+     | Runtime_agent.Yielded_to_blocking_approval _
      | Runtime_agent.Completed ->
        Keeper_turn_terminal.success ())
   | Terminal_failed_completion_contract _ ->
@@ -676,6 +684,12 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Log.Keeper.info ~keeper_name:updated_meta.name
       "yielded autonomous run for a pending durable stimulus after %d turn(s), \
        checkpoint saved — will resume next cycle"
+      turns_used;
+    reset_failure_state ()
+  | Runtime_agent.Yielded_to_blocking_approval { turns_used; _ } ->
+    Log.Keeper.info ~keeper_name:updated_meta.name
+      "yielded keeper run for a Blocking approval after %d turn(s), checkpoint \
+       saved — operator resolution owns continuation"
       turns_used;
     reset_failure_state ()
   | Runtime_agent.Completed -> reset_failure_state ()

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1350,6 +1350,7 @@ let keeper_cycle_decision
       ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
       ?(reactive_wake = false)
       ?(event_queue_triggers = [])
+      ~base_path
       ~(meta : keeper_meta)
       (observation : world_observation)
   =
@@ -1395,7 +1396,9 @@ let keeper_cycle_decision
   if meta.paused
   then blocked Keeper_paused
   else if
-    Keeper_approval_queue.has_blocking_pending_for_keeper ~keeper_name:meta.name
+    Keeper_approval_queue.has_blocking_pending_for_keeper
+      ~base_path
+      ~keeper_name:meta.name
   then blocked Approval_pending
   else (
     let scheduled_autonomous_decision () =
@@ -1693,6 +1696,7 @@ let keeper_cycle_decision
         })
 ;;
 
-let should_run_keeper_cycle ~(meta : keeper_meta) (observation : world_observation) =
-  (keeper_cycle_decision ~meta observation).should_run
+let should_run_keeper_cycle ~base_path ~(meta : keeper_meta) (observation : world_observation)
+  =
+  (keeper_cycle_decision ~base_path ~meta observation).should_run
 ;;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -427,6 +427,7 @@ val keeper_cycle_decision :
     (keeper_name:string -> runtime_id:string -> int option) ->
   ?reactive_wake:bool ->
   ?event_queue_triggers:event_queue_trigger list ->
+  base_path:string ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 (** [reactive_wake] (default [false]) marks evaluations triggered by an external
     broadcast wakeup rather than the keeper's own cadence timer. When set, a
@@ -435,4 +436,7 @@ val keeper_cycle_decision :
     and time-based liveness reasons are unaffected. *)
 
 val should_run_keeper_cycle :
-  meta:Keeper_meta_contract.keeper_meta -> world_observation -> bool
+  base_path:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  world_observation ->
+  bool

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -42,6 +42,18 @@ type lane_policy =
   | Nonblocking
   | Blocking
 
+type blocking_resolution_plan =
+  { effect_key : string
+  ; commit : unit -> (unit -> unit)
+  }
+
+type blocking_resolution_state =
+  | Blocking_resolution_open
+  | Blocking_resolution_committed of
+      { decision : Agent_sdk.Hooks.approval_decision
+      ; plan : blocking_resolution_plan
+      }
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -67,10 +79,15 @@ type pending_approval =
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
-  ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; on_resolution_callback :
+      (approval_id:string ->
+       Agent_sdk.Hooks.approval_decision ->
+       blocking_resolution_plan)
+        option
+  ; on_resolution_observer : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; blocking_resolution_state : blocking_resolution_state
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -37,6 +37,18 @@ type lane_policy =
   | Nonblocking
   | Blocking
 
+type blocking_resolution_plan =
+  { effect_key : string
+  ; commit : unit -> (unit -> unit)
+  }
+
+type blocking_resolution_state =
+  | Blocking_resolution_open
+  | Blocking_resolution_committed of
+      { decision : Agent_sdk.Hooks.approval_decision
+      ; plan : blocking_resolution_plan
+      }
+
 type pending_approval =
   { id : string
   ; keeper_name : string
@@ -62,10 +74,15 @@ type pending_approval =
   ; continuation_channel : Keeper_continuation_channel.t
   ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
-  ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; on_resolution_callback :
+      (approval_id:string ->
+       Agent_sdk.Hooks.approval_decision ->
+       blocking_resolution_plan)
+        option
+  ; on_resolution_observer : (Agent_sdk.Hooks.approval_decision -> unit) option
+  ; blocking_resolution_state : blocking_resolution_state
   ; context_summary : hitl_context_summary option
   ; summary_status : summary_status
-  ; channel : Keeper_continuation_channel.t option
   }
 
 type decision = Agent_sdk.Hooks.approval_decision

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -44,6 +44,11 @@ type turn_budget_exhausted =
 type operator_actor =
   | Grpc_directive
   | Keeper_down
+  | Hitl_rejection
+
+type continue_gate_origin =
+  | Partial_commit
+  | Reconcile_recovery
 
 type t =
   | No_progress_loop of
@@ -61,6 +66,12 @@ type t =
   | Stale_storm
   | Provider_timeout_loop of { consecutive_timeouts : int }
   | Operator_paused of { operator_actor : operator_actor }
+  | Continue_gate_pending of
+      { gate_id : string
+      ; origin : continue_gate_origin
+      ; committed_tools : string list
+      }
+  | Repository_registration_pending of { operation_id : string }
   | Dead_tombstone
 
 (* -------------------------------------------------------------------- *)
@@ -141,7 +152,21 @@ let equal a b =
     (match (a1, a2) with
      | Grpc_directive, Grpc_directive -> true
      | Keeper_down, Keeper_down -> true
-     | (Grpc_directive | Keeper_down), _ -> false)
+     | Hitl_rejection, Hitl_rejection -> true
+     | (Grpc_directive | Keeper_down | Hitl_rejection), _ -> false)
+  | ( Continue_gate_pending
+        { gate_id = left_id; origin = left_origin; committed_tools = left_tools }
+    , Continue_gate_pending
+        { gate_id = right_id; origin = right_origin; committed_tools = right_tools } ) ->
+    String.equal left_id right_id
+    && List.equal String.equal left_tools right_tools
+    &&
+    (match left_origin, right_origin with
+     | Partial_commit, Partial_commit | Reconcile_recovery, Reconcile_recovery -> true
+     | (Partial_commit | Reconcile_recovery), _ -> false)
+  | ( Repository_registration_pending { operation_id = left }
+    , Repository_registration_pending { operation_id = right } ) ->
+    String.equal left right
   | Dead_tombstone, Dead_tombstone -> true
   | ( ( No_progress_loop _
       | Completion_contract_violation _
@@ -151,6 +176,8 @@ let equal a b =
       | Stale_storm
       | Provider_timeout_loop _
       | Operator_paused _
+      | Continue_gate_pending _
+      | Repository_registration_pending _
       | Dead_tombstone )
     , _ ) ->
     false
@@ -199,8 +226,18 @@ let hash = function
       ( 7
       , match operator_actor with
         | Grpc_directive -> 0
-        | Keeper_down -> 1 )
-  | Dead_tombstone -> 8
+        | Keeper_down -> 1
+        | Hitl_rejection -> 2 )
+  | Continue_gate_pending { gate_id; origin; committed_tools } ->
+    Hashtbl.hash
+      ( 8
+      , gate_id
+      , committed_tools
+      , match origin with
+        | Partial_commit -> 0
+        | Reconcile_recovery -> 1 )
+  | Repository_registration_pending { operation_id } -> Hashtbl.hash (9, operation_id)
+  | Dead_tombstone -> 10
 ;;
 
 (* -------------------------------------------------------------------- *)
@@ -246,14 +283,27 @@ let pp_runtime_exhaustion ppf = function
 
 let operator_actor_grpc_directive = Grpc_directive
 let operator_actor_keeper_down = Keeper_down
+let operator_actor_hitl_rejection = Hitl_rejection
 
 let operator_actor_to_wire = function
   | Grpc_directive -> "grpc_directive"
   | Keeper_down -> "keeper_down"
+  | Hitl_rejection -> "hitl_rejection"
+
+let continue_gate_origin_to_wire = function
+  | Partial_commit -> "partial_commit"
+  | Reconcile_recovery -> "reconcile_recovery"
+
+let continue_gate_origin_of_wire = function
+  | "partial_commit" -> Ok Partial_commit
+  | "reconcile_recovery" -> Ok Reconcile_recovery
+  | other ->
+    Error (Printf.sprintf "Keeper_latched_reason: unknown continue gate origin %S" other)
 
 let operator_actor_of_wire = function
   | "grpc_directive" -> Ok Grpc_directive
   | "keeper_down" -> Ok Keeper_down
+  | "hitl_rejection" -> Ok Hitl_rejection
   | other -> Error (Printf.sprintf "Keeper_latched_reason: unknown operator actor %S" other)
 
 (* -------------------------------------------------------------------- *)
@@ -292,6 +342,15 @@ let pp ppf = function
     Format.fprintf ppf "Provider_timeout_loop{count=%d}" consecutive_timeouts
   | Operator_paused { operator_actor } ->
     Format.fprintf ppf "Operator_paused{actor=%s}" (operator_actor_to_wire operator_actor)
+  | Continue_gate_pending { gate_id; origin; committed_tools } ->
+    Format.fprintf
+      ppf
+      "Continue_gate_pending{gate_id=%S,origin=%s,committed_tools=[%s]}"
+      gate_id
+      (continue_gate_origin_to_wire origin)
+      (String.concat "," committed_tools)
+  | Repository_registration_pending { operation_id } ->
+    Format.fprintf ppf "Repository_registration_pending{operation_id=%S}" operation_id
   | Dead_tombstone -> Format.fprintf ppf "Dead_tombstone"
 ;;
 
@@ -350,6 +409,18 @@ let to_wire = function
     Printf.sprintf "provider_timeout_loop:count=%d" consecutive_timeouts
   | Operator_paused { operator_actor } ->
     Printf.sprintf "operator_paused:actor=%s" (operator_actor_to_wire operator_actor)
+  | Continue_gate_pending { gate_id; origin; committed_tools } ->
+    let payload =
+      Yojson.Safe.to_string
+        (`Assoc
+           [ "gate_id", `String gate_id
+           ; "origin", `String (continue_gate_origin_to_wire origin)
+           ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
+           ])
+    in
+    Printf.sprintf "continue_gate_pending:payload=%S" payload
+  | Repository_registration_pending { operation_id } ->
+    Printf.sprintf "repository_registration_pending:operation_id=%S" operation_id
   | Dead_tombstone -> "dead_tombstone"
 ;;
 
@@ -478,6 +549,51 @@ let of_wire wire =
        let+ operator_actor = operator_actor_of_wire actor_wire in
        Operator_paused { operator_actor }
      | None -> errorf "Keeper_latched_reason.of_wire: malformed operator pause wire %S" wire)
+  | "continue_gate_pending" :: _ ->
+    let prefix = "continue_gate_pending:payload=" in
+    let* encoded =
+      match chop_prefix ~prefix wire with
+      | Some value -> Ok value
+      | None -> errorf "Keeper_latched_reason.of_wire: malformed continue gate wire %S" wire
+    in
+    let* payload = parse_string_literal encoded in
+    let* json =
+      try Ok (Yojson.Safe.from_string payload) with
+      | Yojson.Json_error detail -> errorf "Keeper_latched_reason.of_wire: invalid continue gate payload: %s" detail
+    in
+    (match json with
+     | `Assoc
+         [ "gate_id", `String gate_id
+         ; "origin", `String origin_wire
+         ; "committed_tools", `List tools_json
+         ] ->
+       let* committed_tools =
+         let rec collect acc = function
+           | [] -> Ok (List.rev acc)
+           | `String tool :: rest -> collect (tool :: acc) rest
+           | _ :: _ -> errorf "Keeper_latched_reason.of_wire: continue gate tools must be strings"
+         in
+         collect [] tools_json
+       in
+       let* origin = continue_gate_origin_of_wire origin_wire in
+       if String.trim gate_id = ""
+       then errorf "Keeper_latched_reason.of_wire: continue gate id is empty"
+       else Ok (Continue_gate_pending { gate_id; origin; committed_tools })
+     | _ -> errorf "Keeper_latched_reason.of_wire: invalid continue gate payload shape")
+  | "repository_registration_pending" :: _ ->
+    let prefix = "repository_registration_pending:operation_id=" in
+    let* encoded =
+      match chop_prefix ~prefix wire with
+      | Some value -> Ok value
+      | None ->
+        errorf
+          "Keeper_latched_reason.of_wire: malformed repository registration wire %S"
+          wire
+    in
+    let* operation_id = parse_string_literal encoded in
+    if String.trim operation_id = ""
+    then errorf "Keeper_latched_reason.of_wire: repository operation id is empty"
+    else Ok (Repository_registration_pending { operation_id })
   | _ ->
     errorf "Keeper_latched_reason.of_wire: unknown wire form %S" wire
 ;;
@@ -605,6 +721,18 @@ module Stable = struct
         [ "kind", `String "operator_paused"
         ; "actor", `String (operator_actor_to_wire operator_actor)
         ]
+    | Continue_gate_pending { gate_id; origin; committed_tools } ->
+      `Assoc
+        [ "kind", `String "continue_gate_pending"
+        ; "gate_id", `String gate_id
+        ; "origin", `String (continue_gate_origin_to_wire origin)
+        ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
+        ]
+    | Repository_registration_pending { operation_id } ->
+      `Assoc
+        [ "kind", `String "repository_registration_pending"
+        ; "operation_id", `String operation_id
+        ]
     | Dead_tombstone -> `Assoc [ "kind", `String "dead_tombstone" ]
   ;;
 
@@ -639,6 +767,29 @@ module Stable = struct
     | `Assoc [ "kind", `String "operator_paused"; "actor", `String actor ] ->
       let+ operator_actor = operator_actor_of_wire actor in
       Operator_paused { operator_actor }
+    | `Assoc
+        [ "kind", `String "continue_gate_pending"
+        ; "gate_id", `String gate_id
+        ; "origin", `String origin_wire
+        ; "committed_tools", `List tools_json
+        ]
+      when String.trim gate_id <> "" ->
+      let* committed_tools =
+        let rec collect acc = function
+          | [] -> Ok (List.rev acc)
+          | `String tool :: rest -> collect (tool :: acc) rest
+          | _ :: _ -> Error "Keeper_latched_reason: continue gate tools must be strings"
+        in
+        collect [] tools_json
+      in
+      let+ origin = continue_gate_origin_of_wire origin_wire in
+      Continue_gate_pending { gate_id; origin; committed_tools }
+    | `Assoc
+        [ "kind", `String "repository_registration_pending"
+        ; "operation_id", `String operation_id
+        ]
+      when String.trim operation_id <> "" ->
+      Ok (Repository_registration_pending { operation_id })
     | `Assoc [ "kind", `String "dead_tombstone" ] -> Ok Dead_tombstone
     | _ ->
       Error

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -34,6 +34,12 @@ type t =
   | Stale_storm
   | Provider_timeout_loop of { consecutive_timeouts : int }
   | Operator_paused of { operator_actor : operator_actor }
+  | Continue_gate_pending of
+      { gate_id : string
+      ; origin : continue_gate_origin
+      ; committed_tools : string list
+      }
+  | Repository_registration_pending of { operation_id : string }
   | Dead_tombstone
       (** The supervisor reaped a dead keeper and left [paused = true] on
           disk as a tombstone (see
@@ -80,6 +86,11 @@ and turn_budget_detail =
 and operator_actor =
   | Grpc_directive
   | Keeper_down
+  | Hitl_rejection
+
+and continue_gate_origin =
+  | Partial_commit
+  | Reconcile_recovery
 
 (** {1 Wire format}
 
@@ -115,6 +126,7 @@ val pp : Format.formatter -> t -> unit
 
 val operator_actor_grpc_directive : operator_actor
 val operator_actor_keeper_down : operator_actor
+val operator_actor_hitl_rejection : operator_actor
 val operator_actor_to_wire : operator_actor -> string
 
 module Stable : sig

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -1,12 +1,12 @@
-(** File_lock_eio — Cooperative per-key locking via Eio.Mutex + flock.
+(** File_lock_eio — Cooperative per-key atomic locking + flock.
 
     Two-layer locking for local filesystem paths:
-    1. Eio.Mutex (cooperative) — prevents blocking the Eio fiber scheduler
+    1. Atomic per-path ownership — cross-domain safe; contended Eio fibers yield
     2. Unix.lockf F_TLOCK (non-blocking) — preserves cross-process safety
 
-    The Eio.Mutex serializes fibers within the process so most contention
-    is resolved cooperatively.  The flock is acquired non-blocking after
-    the Eio.Mutex; if another process holds it, we yield and retry.
+    Atomic ownership serializes callers within the process without depending on
+    global Eio runtime registration. The flock is acquired non-blocking after
+    that lock; if another process holds it, we yield and retry.
 
     Distributed backend paths (Some key in workspace_utils_ops.ml) are not
     affected — this only replaces the local filesystem lock path. *)
@@ -63,19 +63,10 @@ let rec atomic_update atomic f =
     atomic_update atomic f
   end
 
-let rec atomic_update_with_result atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then result
-  else begin
-    observe_cas_retry ();
-    atomic_update_with_result atomic f
-  end
-
 type lock_entry = {
-  mu : Eio.Mutex.t;
+  held : bool Atomic.t;
   mutable last_used : float;
-  active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
+  active : int Atomic.t;   (** Number of fibers currently holding or waiting on this lock *)
 }
 
 type table_state = {
@@ -114,22 +105,51 @@ let prune_stale_entries () =
     (e.g. in unit tests that don't use Eio_main.run). *)
 let get_entry path =
   prune_stale_entries ();
-  let entry =
-    atomic_update_with_result table (fun state ->
+  let rec acquire_reference () =
+    let state = Atomic.get table in
+    let entry, updated_state =
       match SMap.find_opt path state.entries with
-      | Some entry ->
-        entry.last_used <- Time_compat.now ();
-        (state, entry)
+      | Some entry -> entry, state
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
-        let entries = SMap.add path entry state.entries in
-        (publish_entries state entries, entry))
+        let entry =
+          { held = Atomic.make false
+          ; last_used = Time_compat.now ()
+          ; active = Atomic.make 0
+          }
+        in
+        entry, publish_entries state (SMap.add path entry state.entries)
+    in
+    (* Mark the entry active before publishing/confirming the table snapshot.
+       Otherwise a concurrent prune can remove an inactive entry after lookup
+       but before this increment, allowing a second lock for the same path. *)
+    Atomic.incr entry.active;
+    if Atomic.compare_and_set table state updated_state
+    then (
+      entry.last_used <- Time_compat.now ();
+      entry)
+    else (
+      let _previous_active = Atomic.fetch_and_add entry.active (-1) in
+      observe_cas_retry ();
+      acquire_reference ())
   in
-  Atomic.incr entry.active;
-  entry
+  acquire_reference ()
 
 let release_entry entry =
-  ignore (Atomic.fetch_and_add entry.active (-1))
+  let _previous_active = Atomic.fetch_and_add entry.active (-1) in
+  ()
+
+let yield_while_contended () =
+  try Eio.Fiber.yield () with
+  | Effect.Unhandled _ -> Unix.sleepf 0.0005
+
+let rec acquire_entry_lock entry =
+  if Atomic.compare_and_set entry.held false true
+  then ()
+  else (
+    yield_while_contended ();
+    acquire_entry_lock entry)
+
+let release_entry_lock entry = Atomic.set entry.held false
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 
@@ -225,16 +245,22 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
-(** Run [f] while holding only the cooperative per-path mutex.
+(** Run [f] while holding only the cooperative per-path atomic lock.
     Use this for in-memory backends that need single-process fiber
     serialization but do not have a real filesystem artifact to flock. *)
 let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () ->
+      acquire_entry_lock entry;
+      Common.protect
+        ~module_name:"file_lock_eio"
+        ~finally_label:"release_entry_lock"
+        ~finally:(fun () -> release_entry_lock entry)
+        f)
 
-(** Run [f] while holding both the cooperative Eio.Mutex and an
+(** Run [f] while holding both the cooperative per-path lock and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
     retries; sleep/yield stays scheduler-friendly whether or not a clock
     is provided. Max 200 attempts (~2s with sleeps). *)
@@ -249,7 +275,7 @@ let with_lock ?clock path f =
       ~finally:(fun () -> release_flock_fd fd)
       f
   in
-  with_mutex path (fun () -> run_with_flock ())
+  with_mutex path run_with_flock
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -1,12 +1,11 @@
-(** File_lock_eio — cooperative per-key locking via [Eio.Mutex] + [flock].
+(** File_lock_eio — cooperative per-key atomic locking + [flock].
 
     Two-layer locking for local filesystem paths:
 
-    + {b Eio.Mutex} (cooperative) — prevents blocking the Eio fiber
-      scheduler; serialises fibers within the process so most contention
-      is resolved cooperatively.
+    + {b Atomic per-path ownership} — cross-domain safe; contended Eio fibers
+      yield, and callers do not depend on global Eio runtime registration.
     + {b Unix.lockf F_TLOCK} (non-blocking) — preserves cross-process
-      safety; acquired after the Eio.Mutex. If another process holds
+      safety; acquired after the per-path lock. If another process holds
       the flock the caller yields and retries.
 
     Distributed backend paths (non-local keys in
@@ -71,14 +70,15 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
-(** [with_mutex path f] runs [f] while holding the cooperative
-    per-[path] Eio.Mutex only. Use for in-memory backends that need
-    single-process fiber serialisation but have no filesystem
+(** [with_mutex path f] runs [f] while holding the cooperative,
+    cross-domain-safe per-[path] lock only. Contended Eio callers yield; callers
+    outside an Eio runtime use a short blocking backoff. Use for in-memory
+    backends that need single-process serialisation but have no filesystem
     artifact to flock. *)
 val with_mutex : string -> (unit -> 'a) -> 'a
 
 (** [with_lock ?clock path f] runs [f] while holding both the
-    cooperative Eio.Mutex and an OS-level flock on [path ^ ".lock"].
+    cooperative per-path lock and an OS-level flock on [path ^ ".lock"].
     The flock uses non-blocking F_TLOCK retries — max 200 attempts,
     ~2s total with default sleeps. *)
 val with_lock :

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -66,6 +66,10 @@ type stop_reason =
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Yielded_to_blocking_approval of
+      { turns_used : int
+      ; provider_turns_completed : int
+      }
 
 type config =
   Runtime_agent_context.config = {
@@ -999,6 +1003,8 @@ let dashboard_status_of_stop_reason = function
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
   | Yielded_to_durable_stimulus _ ->
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_durable_stimulus" }
+  | Yielded_to_blocking_approval _ ->
+      Dashboard_oas_bridge.Cancelled { reason = "yielded_to_blocking_approval" }
 
 let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
     ~status (response : Agent_sdk.Types.api_response) =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -35,6 +35,10 @@ type stop_reason = Runtime_agent_context.stop_reason =
     }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Yielded_to_blocking_approval of {
+      turns_used : int;
+      provider_turns_completed : int;
+    }
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path; [TurnBudgetExhausted] means the per-call
     turn budget checkpoint was reached. It is not a completed
@@ -47,8 +51,12 @@ type stop_reason = Runtime_agent_context.stop_reason =
     the keeper's turn slot to a parked dashboard/connector chat request.
     [Yielded_to_durable_stimulus] fires after at least one provider turn when
     another durable event is waiting behind the event currently leased by the
-    cycle. Both yields are continuation checkpoints, not completed
-    deliverables, and the keeper resumes on the next cycle. *)
+    cycle. [Yielded_to_blocking_approval] fires on every keeper lane when a
+    Blocking HITL approval owns it; operator resolution, not another provider
+    loop, resumes the continuation. Its [provider_turns_completed] field lets
+    autonomous intake distinguish a pre-dispatch yield from a gate created by
+    the current provider/tool turn. All three yields are continuation checkpoints,
+    not completed deliverables. *)
 
 (** {1 Config} *)
 

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -27,6 +27,13 @@ type stop_reason =
     (* The current autonomous cycle completed at least one OAS provider turn,
        then released its lane because another durable stimulus was queued
        behind the stimulus already leased by this cycle. *)
+  | Yielded_to_blocking_approval of
+      { turns_used : int
+      ; provider_turns_completed : int
+      }
+    (* A Blocking HITL approval owns this keeper lane. The current provider/tool
+       turn reached its boundary, then stopped before another provider dispatch
+       so only operator resolution can resume the continuation. *)
 
 type config =
   { name : string

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -25,6 +25,10 @@ type stop_reason =
     }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
+  | Yielded_to_blocking_approval of {
+      turns_used : int;
+      provider_turns_completed : int;
+    }
 
 (** {1 Per-worker config} *)
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -230,11 +230,14 @@ let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
 
 (** Read the optional [?window=<minutes>] query param.
     Defaults to 60 minutes; clamped to [5..1440]. *)
-let dashboard_governance_tool_events_http_json request : Yojson.Safe.t =
+let dashboard_governance_tool_events_http_json ~base_path request : Yojson.Safe.t =
   let window =
     int_query_param request "window" ~default:60 |> clamp ~min_v:5 ~max_v:1440
   in
-  Dashboard_governance_metrics.governance_tool_events_json ~window_minutes:window ()
+  Dashboard_governance_metrics.governance_tool_events_json
+    ~base_path
+    ~window_minutes:window
+    ()
 ;;
 
 (* /api/v1/dashboard/proof was measured at 28-60s (timeout) under

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -87,7 +87,7 @@ val dashboard_governance_http_json :
   Httpun.Request.t -> base_path:string -> Yojson.Safe.t
 
 val dashboard_governance_tool_events_http_json :
-  Httpun.Request.t -> Yojson.Safe.t
+  base_path:string -> Httpun.Request.t -> Yojson.Safe.t
 
 val dashboard_proof_http_json :
   config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1075,8 +1075,9 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance/tool-events" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let json = dashboard_governance_tool_events_http_json req in
+       with_public_read (fun state req reqd ->
+         let base_path = (Mcp_server.workspace_config state).base_path in
+         let json = dashboard_governance_tool_events_http_json ~base_path req in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance/approval-mode" (fun request reqd ->

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -751,7 +751,10 @@ let dashboard_json config =
   let keeper_names, keeper_name_read_error_rows =
     keeper_names_or_error_rows config
   in
-  let pending_approvals = Keeper_approval_queue.list_pending_entries () in
+  let pending_approvals =
+    Keeper_approval_queue.list_pending_entries
+      ~base_path:config.Workspace.base_path
+  in
   let fusion_runs = Fusion_run_registry.list_runs (Fusion_run_registry.global ()) in
   let pending_confirms, pending_confirm_read_error_rows =
     pending_confirms_or_error_rows config

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -81,6 +81,7 @@ type session_kind =
 type broadcast_target =
   | All          (** Every connected session (backward-compatible default) *)
   | Observers    (** Only [Observer] sessions *)
+  | Workspace_observers of string (** [Observer] sessions for one workspace *)
   | Agent_streams (** Only [Agent_stream] sessions *)
   | Presence_only (** Only [Presence] sessions; never replay-buffered *)
 
@@ -116,6 +117,7 @@ let stream_capacity =
 type client = {
   id: int;
   kind: session_kind;
+  base_path: string;
   event_stream: string Eio.Stream.t;
   last_event_id: int Atomic.t;
   created_at: float;
@@ -552,6 +554,7 @@ let register ?(kind = Agent_stream) ?on_disconnect ~(auth : registration_auth) s
   let base_client = {
     id = client_id;
     kind;
+    base_path = auth.config;
     event_stream;
     last_event_id;
     created_at = 0.0;
@@ -710,6 +713,8 @@ let client_matches_target target ~jsonrpc_payload (client : client) =
       | Agent_stream -> jsonrpc_payload
       | Presence -> false)
   | Observers -> client.kind = Observer
+  | Workspace_observers base_path ->
+      client.kind = Observer && String.equal client.base_path base_path
   | Agent_streams -> client.kind = Agent_stream && jsonrpc_payload
   | Presence_only -> client.kind = Presence
 
@@ -946,6 +951,7 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
   let target_label = match target with
     | All -> "all"
     | Observers -> "observers"
+    | Workspace_observers _ -> "workspace_observers"
     | Agent_streams -> "agent_streams"
     | Presence_only -> "presence"
   in
@@ -1015,6 +1021,17 @@ let broadcast json = broadcast_impl All json
     - [Observers]: dashboard / read-only viewers only
     - [Agent_streams]: MCP agent sessions only *)
 let broadcast_to target json = broadcast_impl target json
+
+let broadcast_workspace_observers ~base_path json =
+  (* Workspace refresh hints are intentionally live-only. The replay buffer
+     and external-subscriber registry are fleet-wide and cannot preserve the
+     workspace authority carried by the connected observer. *)
+  broadcast_impl
+    ~buffer:false
+    ~notify_external:false
+    (Workspace_observers base_path)
+    json
+;;
 
 (** Broadcast an ephemeral presence/awareness event. Presence events are live
     only: they are not replay-buffered and do not fan out through generic

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -18,12 +18,14 @@ type session_kind =
 type broadcast_target =
   | All
   | Observers
+  | Workspace_observers of string
   | Agent_streams
   | Presence_only
 
 type client = {
   id : int;
   kind : session_kind;
+  base_path : string;
   event_stream : string Eio.Stream.t;
   last_event_id : int Atomic.t;
   created_at : float;
@@ -131,6 +133,10 @@ val current_id : unit -> int
 
 val broadcast : Yojson.Safe.t -> unit
 val broadcast_to : broadcast_target -> Yojson.Safe.t -> unit
+val broadcast_workspace_observers : base_path:string -> Yojson.Safe.t -> unit
+(** Broadcast a live-only refresh hint to observer sessions authenticated for
+    exactly [base_path]. Fleet-wide replay and external subscribers are skipped
+    because those paths cannot preserve workspace authority. *)
 val broadcast_presence : Yojson.Safe.t -> unit
 val send_to : string -> Yojson.Safe.t -> unit
 val pop : string -> string option

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-10T08:42:40Z (HEAD: c4e0c0764b)
+Generated: 2026-07-10T18:45:23Z (HEAD: 8033528ee3)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -110,7 +110,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 46d6c792a0a3 |
+| KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 2e375055dfc9 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} | 3f49da13e4a8 |
 | KeeperCompactionCooldown.tla | KeeperCompactionCooldown | manual | 2 | 1 | clean={inv:Safety, inv:NonAppliedDoesNotInventTimestamp} buggy={inv:NonAppliedDoesNotInventTimestamp} | 117cd8f85f7d |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | 004f6c25b9cc |

--- a/specs/keeper-state-machine/KeeperApprovalQueue.tla
+++ b/specs/keeper-state-machine/KeeperApprovalQueue.tla
@@ -3,54 +3,52 @@
 \* [lib/keeper/keeper_approval_queue.ml].
 \*
 \* Runtime entities modelled (see functions [submit_and_await],
-\* [submit_pending], [expire_stale]; iter 64 N-2.a removed line numbers
+\* [submit_pending_blocking], [submit_pending_observer], [expire_stale];
+\* iter 64 N-2.a removed line numbers
 \* because OCaml line drift had reached +245..+413 from the original
 \* cites — function names are stable, line numbers are not.  The drift
 \* was audited in iter 63 #14919; iter 64 N-2.c adds a structural guard
 \* at scripts/audit-tla-ml-line-refs.sh):
 \*
 \*   pending  : SMap from id to entry, holding submitted-but-unresolved
-\*              approval requests. The two submit paths are represented
-\*              by two separate optional fields on the entry, exactly one
-\*              of which is populated:
+\*              approval requests. The three submit paths are represented
+\*              by three separate optional fields on the entry, exactly one
+\*              of which is populated by a public submission path:
 \*                - [entry.resolver : ... Eio.Promise.u option]
-\*                  — the [submit_and_await] case (Some r, on_resolution = None)
-\*                - [entry.on_resolution : (approval_decision -> unit) option]
-\*                  — the [submit_pending] case (resolver = None, on_resolution = Some f)
+\*                  — the [submit_and_await] blocking case
+\*                - [entry.on_resolution_callback :
+\*                     (approval_id -> approval_decision ->
+\*                      blocking_resolution_plan) option]
+\*                  — the [submit_pending_blocking] authoritative-plan case
+\*                - [entry.on_resolution_observer :
+\*                     (approval_decision -> unit) option]
+\*                  — the [submit_pending_observer] non-authoritative case
 \*   resolver : Eio.Promise resolver tied to a fiber blocked on
 \*              [Eio.Promise.await]. Resolving wakes the fiber.
 \*
-\* Scope (which path is modelled).  keeper_approval_queue.ml has two
-\* submit entry points: [submit_and_await] (creates an [Eio.Promise],
-\* registers the entry with [~resolver:(Some resolver)], then blocks the
-\* caller on [Eio.Promise.await] — the entry has a SUSPENDED FIBER) and
-\* [submit_pending] (registers with [~resolver:None] + an [on_resolution]
-\* callback, returns the id immediately — NO suspended fiber; the
-\* decision is delivered later via the callback).  This spec models the
-\* [submit_and_await] variant — `suspended_fibers` counts those fibers.
-\* The [submit_pending] variant has no suspended fiber. Its decision must
-\* first commit a durable [Hitl_resolved] stimulus, then complete the domain
-\* callback, remove the pending id, and finally signal the keeper. Delivery
-\* failure leaves the id pending. Those durable-delivery and callback-order
-\* invariants are not projected by this count-only model; it remains scoped
-\* to the blocking promise path. [expire_stale] handles BOTH via two
-\* *syntactically* independent matches — `match entry.resolver with
-\* Some r -> Eio.Promise.resolve r (Reject ...) | None -> ()` and,
-\* separately, `match entry.on_resolution with Some f -> f (Reject ...)
-\* | None -> ()`.  The two matches are *control-flow independent* —
-\* neither references the other's field, so the choice on one side
-\* doesn't constrain the other; the four (Some/None x Some/None)
-\* combinations each have a defined branch after delivery succeeds (we do not promise clean
-\* termination, only structural independence: `Eio.Promise.resolve` and
-\* the `on_resolution` callback are unwrapped here and can still raise
-\* `Eio.Cancel.Cancelled` etc., which the surrounding runtime re-raises
-\* per its own policy).  Under the *current* runtime invariant exactly
-\* one field is populated (submit_and_await sets resolver=Some,
-\* on_resolution=None; submit_pending sets the reverse), so [resolver =
-\* None] does imply [on_resolution = Some]; the independent-match shape
-\* is defensive against a future refactor that might relax the producer
-\* invariant.  The model abstracts only the effect on the
-\* suspended-fiber population.
+\* Scope (which path is modelled). keeper_approval_queue.ml has three
+\* submit entry points. [submit_and_await] creates an [Eio.Promise], registers
+\* [resolver=Some], then blocks on [Eio.Promise.await].
+\* [submit_pending_blocking] registers an authoritative plan builder. The
+\* builder must be side-effect-free. The queue latches its typed decision,
+\* invokes the plan's idempotent durable commit, removes the pending id,
+\* publishes terminal audit, and only then runs the non-authoritative recovery
+\* hint. Commit exception/cancellation leaves the latched entry pending for a
+\* same-decision retry; a contradictory retry is rejected.
+\* [submit_pending_observer] registers only a non-authoritative observer. Its
+\* durable [Hitl_resolved] stimulus is the sole replayable decision carrier:
+\* durable commit precedes pending removal, audit publication, observer, and
+\* live signal. Observer failure is recorded but cannot restore, alter, or
+\* retry the committed decision. Domain mutations therefore use the blocking
+\* callback API until represented as a typed replayable effect.
+\*
+\* This count-only spec models only the [submit_and_await] variant;
+\* `suspended_fibers` counts those fibers. It is not formal proof of blocking
+\* callback decision latching, workspace isolation, callback/observer ordering,
+\* or durable delivery. Focused OCaml tests own those contracts. Expiry is
+\* processed per entry with the same lane-specific completion rules, so one
+\* callback failure cannot discard its id or prevent a healthy neighbour from
+\* expiring.
 \*
 \* The boundary critique flagged this as a black-box area: a tool call
 \* submits an approval request and gets suspended on
@@ -142,12 +140,14 @@ Done ==
 \* Models the regression where [expire_stale] removes the pending
 \* entry of a [submit_and_await] request but never resolves its
 \* promise — the suspended fiber stays blocked forever.  In the OCaml
-\* runtime, [expire_stale] claims each stale id. A blocking entry is removed
-\* immediately before [complete_expiration] resolves its promise; a
-\* nonblocking entry stays pending through durable delivery and callback
-\* completion. The modelled hazard is a future refactor that loses or skips
-\* the blocking resolver after removal. (NB: [entry.resolver = None] is a
-\* [submit_pending] request with no suspended fiber; its durable-delivery
+\* runtime, [expire_stale] claims each stale id. A blocking promise entry is
+\* removed immediately before [Eio.Promise.resolve] and restored if resolution
+\* raises; a blocking callback entry is removed only after its authoritative
+\* callback succeeds. A nonblocking entry commits durable delivery, is removed,
+\* and only then runs its non-authoritative observer. The modelled hazard is a
+\* future refactor that loses or skips the blocking resolver after removal.
+\* (NB: [entry.resolver = None] is a
+\* [submit_pending_observer] request with no suspended fiber; its durable-delivery
 \* ordering is explicitly out of scope, see the header.)
 ExpireStaleNoResolve ==
     /\ pending_count > 0

--- a/test/dune
+++ b/test/dune
@@ -752,6 +752,11 @@
 ; Operator snapshot cache: stale-while-revalidate + background refresh.
 
 (test
+ (name test_keeper_registry_event_queue_race)
+ (modules test_keeper_registry_event_queue_race)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_operator_control_snapshot_cache)
  (modules test_operator_control_snapshot_cache)
  (libraries alcotest yojson masc_test_deps eio_main))

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -7,11 +7,28 @@ module Lib = Masc
 open Alcotest
 open Printf
 
-let () =
+let install_durable_resolution_delivery_hook () =
   Lib.Keeper_approval_queue.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      Ok (fun () -> ()))
+      ~base_path ~keeper_name ~approval_id ~decision ~channel ->
+      let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+      let stimulus : Keeper_event_queue.stimulus =
+        { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+        ; urgency = Keeper_event_queue.Immediate
+        ; arrived_at = Unix.gettimeofday ()
+        ; payload = Keeper_event_queue.Hitl_resolved resolution
+        }
+      in
+      match
+        Lib.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          keeper_name
+          stimulus
+      with
+      | Error _ as err -> err
+      | Ok () -> Ok (fun () -> ()))
+
+let () = install_durable_resolution_delivery_hook ()
 
 let test_dir () =
   let tmp = Filename.temp_file "masc_dashboard_governance" "" in
@@ -1000,7 +1017,12 @@ let test_dashboard_exposes_keeper_approval_queue () =
         {|{"path":"/tmp/danger"}|}
         (approval |> member "input_preview" |> to_string);
       let id = approval |> member "id" |> to_string in
-      (match Lib.Keeper_approval_queue.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+      (match
+         Lib.Keeper_approval_queue.resolve
+           ~base_path:dir
+           ~id
+           ~decision:Agent_sdk.Hooks.Approve
+       with
        | Ok () -> ()
        | Error err ->
          fail ("resolve failed: " ^ Lib.Keeper_approval_queue.resolve_error_to_string err));
@@ -1080,7 +1102,7 @@ let test_approval_queue_surfaces_action_key_and_sandbox_target () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let id =
-        Lib.Keeper_approval_queue.submit_pending
+        Lib.Keeper_approval_queue.submit_pending_observer
           ~keeper_name:"governance-judge"
           ~tool_name:"tool_execute"
           ~input:
@@ -1093,13 +1115,13 @@ let test_approval_queue_surfaces_action_key_and_sandbox_target () =
           ~runtime_contract:
             (`Assoc [("backend", `String "docker"); ("sandbox_target", `String "docker")])
           ~base_path:dir
-          ~on_resolution:(fun _ -> ())
+          ~on_resolution_observer:(fun _ -> ())
           ()
       in
       Fun.protect
         ~finally:(fun () ->
           ignore
-            (Lib.Keeper_approval_queue.resolve ~id
+            (Lib.Keeper_approval_queue.resolve ~base_path:dir ~id
                ~decision:(Agent_sdk.Hooks.Reject "cleanup")))
         (fun () ->
           Eio_main.run @@ fun env ->

--- a/test/test_dashboard_governance_metrics.ml
+++ b/test/test_dashboard_governance_metrics.ml
@@ -63,14 +63,20 @@ let test_ring_caps_oldest_event () =
   check int "kept count" max_ring_size count
 
 let test_approval_summary_empty () =
-  let summary = GM.approval_queue_summary () in
+  let summary = GM.approval_queue_summary ~base_path:"" in
   check int "empty queue depth" 0 summary.depth;
   check bool "p50 None" true (Option.is_none summary.p50_wait_sec);
   check bool "oldest None" true (Option.is_none summary.oldest_pending_sec)
 
 let test_json_shape () =
   inject ~tool:"bash" ~reason:"policy" ();
-  let json = GM.governance_tool_events_json ~now_ts:(now +. 1.0) ~window_minutes:60 () in
+  let json =
+    GM.governance_tool_events_json
+      ~now_ts:(now +. 1.0)
+      ~base_path:""
+      ~window_minutes:60
+      ()
+  in
   let open Yojson.Safe.Util in
   let rejections = json |> member "tool_rejections" |> to_list in
   check bool "has rejections" true (List.length rejections > 0);

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -59,6 +59,27 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_concurrent_fibers_serialize_without_guard_registration () =
+  with_temp_path @@ fun path ->
+  Eio_main.run @@ fun _env ->
+  let inside = Atomic.make 0 in
+  let max_inside = Atomic.make 0 in
+  let enter () =
+    File_lock_eio.with_lock path (fun () ->
+        let current = Atomic.fetch_and_add inside 1 + 1 in
+        let rec record_max () =
+          let previous = Atomic.get max_inside in
+          if current > previous
+             && not (Atomic.compare_and_set max_inside previous current)
+          then record_max ()
+        in
+        record_max ();
+        Eio.Fiber.yield ();
+        ignore (Atomic.fetch_and_add inside (-1)))
+  in
+  Eio.Fiber.both enter enter;
+  check int "one fiber owns the path lock at a time" 1 (Atomic.get max_inside)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +89,7 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case "serializes concurrent fibers without guard registration" `Quick
+            test_concurrent_fibers_serialize_without_guard_registration;
         ] );
     ]

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -7,7 +7,32 @@ module Tool_result = Tool_result
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_types_profile = Masc.Keeper_types_profile
 module Keeper_id = Keeper_id
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 16
+
+  let base_path_for_id id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some base_path -> base_path
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         base_path
+       | None -> "")
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve ~base_path:(base_path_for_id id) ~id ~decision
+  ;;
+
+  let pending_count = For_testing.pending_count
+  let pending_count_for_keeper = For_testing.pending_count_for_keeper
+  let list_pending_entries = For_testing.list_pending_entries
+end
 
 let explicit_claim_tool = "keeper_task_claim"
 let generic_transition_tool = "masc_transition"
@@ -54,28 +79,9 @@ let rec yield_until ?(attempts = 50) predicate =
     yield_until ~attempts:(attempts - 1) predicate)
 
 let pending_id_for_keeper ~keeper_name =
-  match AQ.list_pending_json () with
-  | `List entries ->
-    List.find_map
-      (function
-        | `Assoc fields -> (
-          match
-            List.assoc_opt "keeper_name" fields,
-            List.assoc_opt "id" fields
-          with
-          | Some (`String name), Some (`String id) when String.equal name keeper_name ->
-            Some id
-          | Some (`String _), Some _
-          | Some _, Some _
-          | Some _, None
-          | None, Some _
-          | None, None ->
-            None)
-        | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
-          None)
-      entries
-  | `Assoc _ | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ ->
-    None
+  AQ.list_pending_entries ()
+  |> List.find_map (fun (entry : AQ.pending_approval) ->
+    if String.equal entry.keeper_name keeper_name then Some entry.id else None)
 
 let resolve_pending_or_fail ~id ~decision =
   match AQ.resolve ~id ~decision with

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -868,6 +868,7 @@ let test_runtime_backpressure_blocks_requested_turn () =
   in
   let decision =
     KHL.decide_keepalive_scheduling
+      ~base_path:""
       ~runtime_id_of_meta:(fun _ -> "runtime-test")
       ~runtime_resilience_of_name:(fun _ -> Some "provider_capacity")
       ~stop:(Atomic.make false)
@@ -890,6 +891,7 @@ let test_keeper_health_backpressure_uses_keeper_name () =
   let consulted = ref [] in
   let decision =
     KHL.decide_keepalive_scheduling
+      ~base_path:""
       ~runtime_id_of_meta:(fun _ -> "runtime-test")
       ~runtime_resilience_of_name:(fun _ ->
         fail "runtime resilience should not be consulted after keeper health blocks")
@@ -920,6 +922,7 @@ let test_pacing_block_delays_requested_turn () =
   let consulted = ref [] in
   let decision =
     KHL.decide_keepalive_scheduling
+      ~base_path:""
       ~runtime_id_of_meta:(fun _ -> "runtime-test")
       ~pacing_block_of_name:(fun keeper_name ->
         consulted := keeper_name :: !consulted;
@@ -940,6 +943,7 @@ let test_pacing_block_delays_requested_turn () =
     (List.mem "pacing_pending" decision.verdict_reasons);
   let admitted =
     KHL.decide_keepalive_scheduling
+      ~base_path:""
       ~runtime_id_of_meta:(fun _ -> "runtime-test")
       ~stop:(Atomic.make false)
       ~meta

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -11,20 +11,77 @@ module Types = Masc_domain
 
 module GP = Masc.Governance_pipeline
 module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 64
+
+  let base_path_for_id_opt id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some _ as scope -> scope
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         Some base_path
+       | None -> None)
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve
+      ~base_path:(Option.value ~default:"" (base_path_for_id_opt id))
+      ~id
+      ~decision
+  ;;
+
+  let get_pending_entry ~id =
+    match base_path_for_id_opt id with
+    | Some base_path -> Raw_AQ.get_pending_entry ~base_path ~id
+    | None -> None
+  ;;
+
+  let get_pending_json ~id =
+    match base_path_for_id_opt id with
+    | Some base_path -> Raw_AQ.get_pending_json ~base_path ~id
+    | None -> None
+  ;;
+
+  let pending_count = For_testing.pending_count
+  let pending_count_for_keeper = For_testing.pending_count_for_keeper
+  let has_blocking_pending_for_keeper = For_testing.has_blocking_pending_for_keeper
+  let has_pending_for_keeper = For_testing.has_pending_for_keeper
+  let list_pending_entries = For_testing.list_pending_entries
+end
 module OA = Masc.Operator_approval
 module SDH = Server_dashboard_http
 module KT = Keeper_types
 module Mcp_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 
-let install_noop_resolution_delivery_hook () =
+let install_durable_resolution_delivery_hook () =
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      Ok (fun () -> ()))
+      ~base_path ~keeper_name ~approval_id ~decision ~channel ->
+      let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+      let stimulus : Keeper_event_queue.stimulus =
+        { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+        ; urgency = Keeper_event_queue.Immediate
+        ; arrived_at = Unix.gettimeofday ()
+        ; payload = Keeper_event_queue.Hitl_resolved resolution
+        }
+      in
+      match
+        Masc.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          keeper_name
+          stimulus
+      with
+      | Error _ as err -> err
+      | Ok () -> Ok (fun () -> ()))
 
-let () = install_noop_resolution_delivery_hook ()
+let () = install_durable_resolution_delivery_hook ()
 
 let check = Alcotest.(check string)
 
@@ -84,21 +141,9 @@ let approval_decision_is_reject = function
 ;;
 
 let pending_id_for_keeper ~keeper_name =
-  match AQ.list_pending_json () with
-  | `List entries ->
-    List.find_map
-      (function
-        | `Assoc kvs ->
-          (match
-             List.assoc_opt "keeper_name" kvs,
-             List.assoc_opt "id" kvs
-           with
-           | Some (`String name), Some (`String id)
-             when String.equal name keeper_name -> Some id
-           | _ -> None)
-        | _ -> None)
-      entries
-  | _ -> None
+  AQ.list_pending_entries ()
+  |> List.find_map (fun (entry : AQ.pending_approval) ->
+    if String.equal entry.keeper_name keeper_name then Some entry.id else None)
 
 let with_env key value f =
   let old = Sys.getenv_opt key in
@@ -536,7 +581,7 @@ let test_approval_queue_submit_and_resolve () =
   let pending_count = AQ.pending_count () in
   Alcotest.(check bool) "1 pending" true (pending_count >= 1);
   (* Get pending list to find ID *)
-  let pending_json = AQ.list_pending_json () in
+  let pending_json = AQ.list_pending_json ~base_path in
   let entries = match pending_json with
     | `List entries -> entries
     | _ -> Alcotest.fail "expected list"
@@ -584,7 +629,7 @@ let test_approval_queue_reject () =
     result := Some decision
   );
   Eio.Fiber.yield ();
-  let pending_json = AQ.list_pending_json () in
+  let pending_json = AQ.list_pending_json ~base_path in
   let id = match pending_json with
     | `List (`Assoc kvs :: _) ->
       (match List.assoc_opt "id" kvs with
@@ -645,13 +690,13 @@ let test_approval_queue_expire_skips_critical () =
     (fun () ->
   let resolution = ref None in
   let id =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"test-keeper-critical"
       ~tool_name:"keeper_continue_after_reconcile"
       ~input:(`Assoc [])
       ~base_path
       ~risk_level:AQ.Critical
-      ~on_resolution:(fun decision -> resolution := Some decision)
+      ~on_resolution_observer:(fun decision -> resolution := Some decision)
       ()
   in
   let pending_before = AQ.pending_count_for_keeper ~keeper_name:"test-keeper-critical" in
@@ -962,13 +1007,13 @@ let test_background_pending_callback_and_keeper_lookup () =
   let initial_count = AQ.pending_count () in
   let callback_result = ref None in
   let id =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"gate-keeper"
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~base_path
-      ~on_resolution:(fun decision -> callback_result := Some decision)
+      ~on_resolution_observer:(fun decision -> callback_result := Some decision)
       ()
   in
   Alcotest.(check bool) "keeper has pending approval" true
@@ -997,24 +1042,24 @@ let test_background_pending_reuses_existing_entry () =
   let first_callback = ref None in
   let second_callback = ref None in
   let id1 =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"gate-keeper"
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~base_path
-      ~on_resolution:(fun decision -> first_callback := Some decision)
+      ~on_resolution_observer:(fun decision -> first_callback := Some decision)
       ()
   in
   let after_first = AQ.pending_count () in
   let id2 =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"gate-keeper"
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
       ~base_path
-      ~on_resolution:(fun decision -> second_callback := Some decision)
+      ~on_resolution_observer:(fun decision -> second_callback := Some decision)
       ()
   in
   Alcotest.(check string) "existing pending id reused" id1 id2;
@@ -1039,7 +1084,7 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
   let initial_count = AQ.pending_count () in
   let callback_result = ref [] in
   let id1 =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"gate-keeper"
       ~tool_name:"tool_execute"
       ~input:
@@ -1049,11 +1094,11 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
           ])
       ~risk_level:AQ.Medium
       ~base_path
-      ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
+      ~on_resolution_observer:(fun decision -> callback_result := decision :: !callback_result)
       ()
   in
   let id2 =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"gate-keeper"
       ~tool_name:"tool_execute"
       ~input:
@@ -1063,7 +1108,7 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
           ])
       ~risk_level:AQ.High
       ~base_path
-      ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
+      ~on_resolution_observer:(fun decision -> callback_result := decision :: !callback_result)
       ()
   in
   Alcotest.(check bool) "distinct pending ids" true (id1 <> id2);
@@ -1090,7 +1135,7 @@ let test_approval_queue_get_pending_detail () =
     ]
   in
   let id =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"detail-keeper"
       ~tool_name:"tool_edit_file"
       ~base_path
@@ -1101,7 +1146,7 @@ let test_approval_queue_get_pending_detail () =
       ~goal_id:"goal-runtime-trust"
       ~goal_ids:[ "goal-runtime-trust"; "goal-mid" ]
       ~runtime_contract:(`Assoc [ ("backend", `String "docker") ])
-      ~on_resolution:(fun decision -> callback_result := Some decision)
+      ~on_resolution_observer:(fun decision -> callback_result := Some decision)
       ()
   in
   let open Yojson.Safe.Util in
@@ -1168,7 +1213,7 @@ let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
     false
     (has_assoc_key "sandbox_profile" runtime_contract);
   let id =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~keeper_name:"redacted-contract-keeper"
       ~tool_name:"tool_execute"
       ~input:(`Assoc [ ("cmd", `String "git status") ])
@@ -1178,7 +1223,7 @@ let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
       ~backend:"docker"
       ~runtime_contract
       ~base_path
-      ~on_resolution:(fun _ -> ())
+      ~on_resolution_observer:(fun _ -> ())
       ()
   in
   let open Yojson.Safe.Util in
@@ -1206,13 +1251,13 @@ let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
 let test_resolve_with_policy_remembers_medium_allow () =
   with_eio_base_path @@ fun base_path ->
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~base_path
           ~keeper_name:"remember-keeper"
           ~tool_name:"masc_transition"
           ~input:(`Assoc [ ("action", `String "claim") ])
           ~risk_level:AQ.Medium
-          ~on_resolution:(fun _ -> ())
+          ~on_resolution_observer:(fun _ -> ())
           ()
       in
       match
@@ -1234,13 +1279,13 @@ let test_resolve_with_policy_remembers_medium_allow () =
 let test_resolve_with_policy_does_not_remember_high_allow () =
   with_eio_base_path @@ fun base_path ->
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~base_path
           ~keeper_name:"remember-keeper"
           ~tool_name:"tool_edit_file"
           ~input:(`Assoc [("path", `String "lib/example.ml")])
           ~risk_level:AQ.High
-          ~on_resolution:(fun _ -> ())
+          ~on_resolution_observer:(fun _ -> ())
           ()
       in
       match
@@ -1273,13 +1318,13 @@ let test_runtime_contract_policy_uses_workspace_base_path () =
           with_env "MASC_BASE_PATH_INPUT" env_base @@ fun () ->
           let keeper_name = "runtime-contract-policy-keeper" in
           let id =
-            AQ.submit_pending
+            AQ.submit_pending_observer
               ~base_path:config.base_path
               ~keeper_name
               ~tool_name:"masc_transition"
               ~input:(`Assoc [ ("action", `String "claim") ])
               ~risk_level:AQ.Medium
-              ~on_resolution:(fun _ -> ())
+              ~on_resolution_observer:(fun _ -> ())
               ()
           in
           (match
@@ -1341,7 +1386,7 @@ let test_dashboard_resolve_and_delete_rules_use_workspace_base_path () =
       cleanup_dir workspace_base)
     (fun () ->
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~keeper_name:"dashboard-workspace-keeper"
           ~tool_name:"masc_transition"
           ~input:
@@ -1352,7 +1397,7 @@ let test_dashboard_resolve_and_delete_rules_use_workspace_base_path () =
               ])
           ~risk_level:AQ.Medium
           ~base_path:workspace_base
-          ~on_resolution:(fun _ -> ())
+          ~on_resolution_observer:(fun _ -> ())
           ()
       in
       let resolve_args =
@@ -1403,13 +1448,13 @@ let test_approval_resolve_missing_decision_is_rejected () =
     (fun () ->
       let resolved = ref None in
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~keeper_name:"failclosed-keeper"
           ~tool_name:"masc_transition"
           ~input:(`Assoc [ ("action", `String "claim") ])
           ~risk_level:AQ.Medium
           ~base_path:workspace_base
-          ~on_resolution:(fun d -> resolved := Some d)
+          ~on_resolution_observer:(fun d -> resolved := Some d)
           ()
       in
       (* [decision] intentionally omitted. *)
@@ -1439,17 +1484,17 @@ let test_approval_delivery_failure_is_unavailable () =
   AQ.For_testing.clear_approval_resolution_wake_hook ();
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir workspace_base)
     (fun () ->
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_observer
            ~keeper_name:"dashboard-delivery-failure-keeper"
            ~tool_name:"masc_transition"
            ~input:(`Assoc [ "action", `String "claim" ])
            ~risk_level:AQ.Medium
            ~base_path:workspace_base
-           ~on_resolution:(fun _ -> ())
+           ~on_resolution_observer:(fun _ -> ())
            ()
        in
        let args =
@@ -1495,7 +1540,7 @@ let test_submit_pending_audit_uses_workspace_base_path () =
       cleanup_dir workspace_base)
     (fun () ->
       ignore
-        (AQ.submit_pending
+        (AQ.submit_pending_observer
            ~keeper_name
            ~tool_name:"masc_transition"
            ~input:
@@ -1506,7 +1551,7 @@ let test_submit_pending_audit_uses_workspace_base_path () =
                ])
            ~risk_level:AQ.High
            ~base_path:workspace_base
-           ~on_resolution:(fun _ -> ())
+           ~on_resolution_observer:(fun _ -> ())
            ());
       AQ.expire_stale ~max_wait_s:(-1.0);
       let workspace_events = audit_event_names ~base_path:workspace_base ~keeper_name in
@@ -1764,7 +1809,7 @@ let test_callback_nonblocking_high_returns_without_suspending () =
   AQ.For_testing.reset_audit_store ();
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       AQ.For_testing.reset_audit_store ();
       cleanup_dir base_path)
     (fun () ->
@@ -1896,13 +1941,13 @@ let test_callback_manual_mode_preserves_remembered_medium_policy () =
   Eio.Switch.run @@ fun sw ->
       let keeper_name = "remember-keeper" in
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~base_path
           ~keeper_name
           ~tool_name:"masc_transition"
           ~input:(`Assoc [ ("action", `String "claim") ])
           ~risk_level:AQ.Medium
-          ~on_resolution:(fun _ -> ())
+          ~on_resolution_observer:(fun _ -> ())
           ()
       in
       (match
@@ -1940,13 +1985,13 @@ let test_callback_manual_mode_preserves_remembered_soft_forbidden () =
     "low"
     (GP.assess_risk ~tool_name ~input |> GP.risk_level_to_string);
   let id =
-    AQ.submit_pending
+    AQ.submit_pending_observer
       ~base_path
       ~keeper_name
       ~tool_name
       ~input
       ~risk_level:AQ.Low
-      ~on_resolution:(fun _ -> ())
+      ~on_resolution_observer:(fun _ -> ())
       ()
   in
   (match

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -88,10 +88,11 @@ let dummy_pending_approval
   ; continuation_channel = Keeper_continuation_channel.unrouted "test fixture"
   ; audit_base_path
   ; resolver = None
-  ; on_resolution = None
+  ; on_resolution_callback = None
+  ; on_resolution_observer = None
+  ; blocking_resolution_state = Q.Blocking_resolution_open
   ; context_summary = None
   ; summary_status = Q.Summary_not_requested
-  ; channel = None
   }
 ;;
 

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -6,18 +6,79 @@
     3. Critical approvals transition to [Escalated] when the escalation timer
        fires, and the updated phase is reflected in-memory and in JSON. *)
 
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 32
+
+  let base_path_for_id_opt id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some base_path -> Some base_path
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         Some base_path
+       | None -> None)
+  ;;
+
+  let base_path_for_id id =
+    match base_path_for_id_opt id with
+    | Some base_path -> base_path
+    | None -> Alcotest.failf "pending approval %s has no workspace" id
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve ~base_path:(base_path_for_id id) ~id ~decision
+  ;;
+
+  let get_pending_entry ~id =
+    match base_path_for_id_opt id with
+    | Some base_path -> Raw_AQ.get_pending_entry ~base_path ~id
+    | None -> None
+  ;;
+
+  let get_pending_json ~id =
+    match base_path_for_id_opt id with
+    | Some base_path -> Raw_AQ.get_pending_json ~base_path ~id
+    | None -> None
+  ;;
+
+  let list_pending_entries = For_testing.list_pending_entries
+  let pending_count = For_testing.pending_count
+  let pending_count_for_keeper = For_testing.pending_count_for_keeper
+  let blocking_pending_count_for_keeper = For_testing.blocking_pending_count_for_keeper
+  let has_blocking_pending_for_keeper = For_testing.has_blocking_pending_for_keeper
+  let has_pending_for_keeper = For_testing.has_pending_for_keeper
+end
 module Chat_queue = Masc.Keeper_chat_queue
 module Summary_worker = Masc.Hitl_summary_worker
 
-let install_noop_resolution_delivery_hook () =
+let install_durable_resolution_delivery_hook () =
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      Ok (fun () -> ()))
+      ~base_path ~keeper_name ~approval_id ~decision ~channel ->
+      let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+      let stimulus : Keeper_event_queue.stimulus =
+        { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+        ; urgency = Keeper_event_queue.Immediate
+        ; arrived_at = Unix.gettimeofday ()
+        ; payload = Keeper_event_queue.Hitl_resolved resolution
+        }
+      in
+      match
+        Masc.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          keeper_name
+          stimulus
+      with
+      | Error _ as err -> err
+      | Ok () -> Ok (fun () -> ()))
 ;;
 
-let () = install_noop_resolution_delivery_hook ()
+let () = install_durable_resolution_delivery_hook ()
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_approval_queue_" "" in
@@ -36,6 +97,15 @@ let cleanup_dir dir =
   in
   try rm_rf dir with
   | _ -> ()
+;;
+
+let blocking_callback ?(effect_key = "test-blocking-effect") callback
+    ~approval_id decision =
+  AQ.blocking_resolution_plan
+    ~effect_key:(effect_key ^ ":" ^ approval_id)
+    ~commit:(fun () ->
+      callback decision;
+      fun () -> ())
 ;;
 
 let rec yield_until ?(attempts = 50) predicate =
@@ -145,18 +215,9 @@ let test_provider_config_for_summary_routes_hitl_summary_lane () =
 ;;
 
 let pending_id_for_keeper ~keeper_name =
-  match AQ.list_pending_json () with
-  | `List entries ->
-    List.find_map
-      (function
-        | `Assoc kvs ->
-          (match List.assoc_opt "keeper_name" kvs, List.assoc_opt "id" kvs with
-           | Some (`String name), Some (`String id) when String.equal name keeper_name ->
-             Some id
-           | _ -> None)
-        | _ -> None)
-      entries
-  | _ -> None
+  AQ.list_pending_entries ()
+  |> List.find_map (fun (entry : AQ.pending_approval) ->
+    if String.equal entry.keeper_name keeper_name then Some entry.id else None)
 ;;
 
 let phase_in_json json =
@@ -245,7 +306,7 @@ let test_resolve_with_live_resolver_does_not_fire_keeper_wake_hook () =
       Ok (fun () -> woke := Some (keeper_name, approval_id, decision)));
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        Eio.Switch.run
@@ -285,7 +346,7 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
   let base_path = temp_dir () in
   let woke = ref None in
   let completion_order = ref [] in
-  let callback_saw_pending = ref false in
+  let observer_saw_pending = ref true in
   AQ.set_approval_resolution_wake_hook
     (fun
       ~base_path:_
@@ -299,22 +360,22 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
            woke := Some (keeper_name, approval_id, decision)));
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "pending-resolve-wake-test" in
        let callback_decision = ref None in
        let input = `Assoc [ "kind", `String "critical_gate" ] in
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_observer
            ~keeper_name
            ~tool_name:"keeper_continue_after_reconcile"
            ~input
            ~risk_level:AQ.Critical
            ~base_path
-           ~on_resolution:(fun decision ->
-             callback_saw_pending := AQ.has_pending_for_keeper ~keeper_name;
-             completion_order := "callback" :: !completion_order;
+           ~on_resolution_observer:(fun decision ->
+             observer_saw_pending := AQ.has_pending_for_keeper ~keeper_name;
+             completion_order := "observer" :: !completion_order;
              callback_decision := Some decision)
            ()
        in
@@ -323,17 +384,17 @@ let test_submit_pending_resolve_fires_keeper_wake_hook () =
         | Error err ->
           Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
        Alcotest.(check bool)
-         "on_resolution callback ran"
+         "nonblocking resolution observer ran"
          true
          (Option.is_some !callback_decision);
        Alcotest.(check (list string))
-         "domain callback completes before wake signal"
-         [ "callback"; "signal" ]
+         "observer runs before wake signal"
+         [ "observer"; "signal" ]
          (List.rev !completion_order);
        Alcotest.(check bool)
-         "pending id remains visible throughout domain callback"
-         true
-         !callback_saw_pending;
+         "pending id is gone before observer"
+         false
+         !observer_saw_pending;
        (match !woke with
         | Some (kn, aid, decision) ->
           Alcotest.(check string) "wake targets the waiting keeper" keeper_name kn;
@@ -359,17 +420,17 @@ let test_delivery_failure_keeps_nonblocking_approval_pending () =
   AQ.For_testing.clear_approval_resolution_wake_hook ();
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_observer
            ~keeper_name:"delivery-failure-pending-test"
            ~tool_name:"keeper_continue_after_reconcile"
            ~input:(`Assoc [ "kind", `String "medium_gate" ])
            ~risk_level:AQ.Medium
            ~base_path
-           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ~on_resolution_observer:(fun decision -> callback_decision := Some decision)
            ()
        in
        (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
@@ -385,7 +446,7 @@ let test_delivery_failure_keeps_nonblocking_approval_pending () =
          (Option.is_some (AQ.get_pending_entry ~id));
        Alcotest.(check bool) "failed delivery does not run callback" true
          (Option.is_none !callback_decision);
-       install_noop_resolution_delivery_hook ();
+       install_durable_resolution_delivery_hook ();
        (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
         | Ok () -> ()
         | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
@@ -393,6 +454,280 @@ let test_delivery_failure_keeps_nonblocking_approval_pending () =
          (Option.is_none (AQ.get_pending_entry ~id));
        Alcotest.(check bool) "successful retry runs callback" true
          (Option.is_some !callback_decision))
+;;
+
+let test_nonblocking_observer_runs_after_durable_commit_and_removal () =
+  let base_path = temp_dir () in
+  let completion_order = ref [] in
+  let observer_saw_pending = ref true in
+  let approval_id = ref None in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      completion_order := "durable" :: !completion_order;
+      Ok (fun () -> completion_order := "signal" :: !completion_order));
+  Fun.protect
+    ~finally:(fun () ->
+      install_durable_resolution_delivery_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending_observer
+           ~keeper_name:"observer-after-delivery-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution_observer:(fun _decision ->
+             observer_saw_pending :=
+               (match !approval_id with
+                | Some id -> Option.is_some (AQ.get_pending_entry ~id)
+                | None -> true);
+             completion_order := "observer" :: !completion_order)
+           ()
+       in
+       approval_id := Some id;
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.(check bool)
+         "observer runs after pending removal"
+         false
+         !observer_saw_pending;
+       Alcotest.(check (list string))
+         "durable commit precedes observer and live signal"
+         [ "durable"; "observer"; "signal" ]
+         (List.rev !completion_order))
+;;
+
+let test_nonblocking_observer_failure_is_non_authoritative () =
+  let base_path = temp_dir () in
+  let durable_committed = ref false in
+  let signal_fired = ref false in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      durable_committed := true;
+      Ok (fun () -> signal_fired := true));
+  Fun.protect
+    ~finally:(fun () ->
+      install_durable_resolution_delivery_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending_observer
+           ~keeper_name:"observer-failure-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution_observer:(fun _decision ->
+             failwith "synthetic observer failure")
+           ()
+       in
+       (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       Alcotest.(check bool) "durable decision committed" true !durable_committed;
+       Alcotest.(check bool)
+         "observer failure cannot restore the pending approval"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id));
+       Alcotest.(check bool)
+         "observer failure cannot suppress the committed wake signal"
+         true
+         !signal_fired)
+;;
+
+let test_nonblocking_observer_cancellation_defers_until_after_signal () =
+  let base_path = temp_dir () in
+  let signal_fired = ref false in
+  AQ.set_approval_resolution_wake_hook
+    (fun
+      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> signal_fired := true));
+  Fun.protect
+    ~finally:(fun () ->
+      install_durable_resolution_delivery_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending_observer
+           ~keeper_name:"observer-cancellation-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "medium_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution_observer:(fun _decision ->
+             raise (Eio.Cancel.Cancelled (Failure "synthetic observer cancellation")))
+           ()
+       in
+       let cancellation_propagated =
+         match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+         | exception Eio.Cancel.Cancelled _ -> true
+         | Ok () | Error _ -> false
+       in
+       Alcotest.(check bool)
+         "observer cancellation propagates after commit"
+         true
+         cancellation_propagated;
+       Alcotest.(check bool)
+         "observer cancellation cannot restore the pending approval"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id));
+       Alcotest.(check bool)
+         "observer cancellation cannot suppress the committed wake signal"
+         true
+         !signal_fired)
+;;
+
+let test_blocking_callback_failure_and_cancellation_keep_pending () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let submit keeper_name callback =
+         AQ.submit_pending_blocking
+           ~keeper_name
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String keeper_name ])
+           ~risk_level:AQ.Critical
+           ~base_path
+           ~on_resolution:(blocking_callback callback)
+           ()
+       in
+       let callback_should_fail = ref true in
+       let failed_id =
+         submit "blocking-callback-exception-test" (fun _ ->
+           if !callback_should_fail then failwith "synthetic callback")
+       in
+       (match AQ.resolve ~id:failed_id ~decision:Agent_sdk.Hooks.Approve with
+        | Error (AQ.Delivery_failed _) -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+        | Ok () -> Alcotest.fail "callback exception must fail resolution");
+       Alcotest.(check bool)
+         "callback exception keeps blocking entry pending"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:failed_id));
+       callback_should_fail := false;
+       (match AQ.resolve ~id:failed_id ~decision:Agent_sdk.Hooks.Approve with
+        | Ok () -> ()
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+       let callback_should_cancel = ref true in
+       let cancelled_id =
+         submit "blocking-callback-cancel-test" (fun _ ->
+           if !callback_should_cancel
+           then raise (Eio.Cancel.Cancelled (Failure "synthetic callback cancellation")))
+       in
+       let cancelled_propagated =
+         match AQ.resolve ~id:cancelled_id ~decision:Agent_sdk.Hooks.Approve with
+         | exception Eio.Cancel.Cancelled _ -> true
+         | Ok () | Error _ -> false
+       in
+       Alcotest.(check bool) "callback cancellation propagates" true cancelled_propagated;
+       Alcotest.(check bool)
+         "callback cancellation keeps blocking entry pending"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:cancelled_id));
+       callback_should_cancel := false;
+       match AQ.resolve ~id:cancelled_id ~decision:Agent_sdk.Hooks.Approve with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail (AQ.resolve_error_to_string err))
+;;
+
+let test_resolve_with_policy_rejects_wrong_workspace () =
+  let owner_base_path = temp_dir () in
+  let caller_base_path = temp_dir () in
+  let callback_called = ref false in
+  let claim_hook_called = ref false in
+  Raw_AQ.For_testing.set_resolution_claim_hook (fun _ _ -> claim_hook_called := true);
+  Fun.protect
+    ~finally:(fun () ->
+      Raw_AQ.For_testing.clear_resolution_claim_hook ();
+      cleanup_dir owner_base_path;
+      cleanup_dir caller_base_path)
+    (fun () ->
+       let id =
+         AQ.submit_pending_observer
+           ~keeper_name:"wrong-workspace-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "workspace_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path:owner_base_path
+           ~on_resolution_observer:(fun _ -> callback_called := true)
+           ()
+       in
+       (match
+          AQ.resolve_with_policy
+            ~base_path:caller_base_path
+            ~id
+            ~decision:Agent_sdk.Hooks.Approve
+            ()
+        with
+        | Error (AQ.Delivery_failed { reason; _ }) ->
+          Alcotest.(check bool)
+            "mismatch reason names the caller contract"
+            true
+            (String.starts_with ~prefix:"caller workspace mismatch" reason)
+        | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+        | Ok _ -> Alcotest.fail "wrong workspace must not resolve an approval");
+       Alcotest.(check bool) "wrong workspace does not run callback" false !callback_called;
+       Alcotest.(check bool)
+         "wrong workspace is rejected before terminal claim"
+         false
+         !claim_hook_called;
+       Alcotest.(check bool)
+         "wrong workspace keeps owner entry pending"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id));
+       match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail (AQ.resolve_error_to_string err))
+;;
+
+let test_identical_approvals_do_not_dedupe_across_workspaces () =
+  let first_base_path = temp_dir () in
+  let second_base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir first_base_path;
+      cleanup_dir second_base_path)
+    (fun () ->
+       let submit base_path =
+         AQ.submit_pending_observer
+           ~keeper_name:"cross-workspace-dedupe-test"
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String "identical_gate" ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution_observer:(fun _ -> ())
+           ()
+       in
+       let first_id = submit first_base_path in
+       let second_id = submit second_base_path in
+       Alcotest.(check bool)
+         "identical approvals in different workspaces get distinct ids"
+         true
+         (not (String.equal first_id second_id));
+       let entry_base_path id =
+         match AQ.get_pending_entry ~id with
+         | Some entry -> entry.audit_base_path
+         | None -> Alcotest.failf "pending approval %s disappeared" id
+       in
+       Alcotest.(check string)
+         "first approval retains its workspace"
+         first_base_path
+         (entry_base_path first_id);
+       Alcotest.(check string)
+         "second approval retains its workspace"
+         second_base_path
+         (entry_base_path second_id);
+       List.iter
+         (fun id ->
+            match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+            | Ok () -> ()
+            | Error err -> Alcotest.fail (AQ.resolve_error_to_string err))
+         [ first_id; second_id ])
 ;;
 
 let test_blocking_callback_policy_owns_lane_without_resolver () =
@@ -405,19 +740,19 @@ let test_blocking_callback_policy_owns_lane_without_resolver () =
       Ok (fun () -> woke := true));
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "blocking-callback-policy-test" in
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_blocking
            ~keeper_name
            ~tool_name:"keeper_continue_after_reconcile"
            ~input:(`Assoc [ "kind", `String "lifecycle_gate" ])
            ~risk_level:AQ.Critical
            ~base_path
-           ~lane_policy:AQ.Blocking
-           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ~on_resolution:
+             (blocking_callback (fun decision -> callback_decision := Some decision))
            ()
        in
        Alcotest.(check bool)
@@ -467,14 +802,14 @@ let test_resolution_wake_carries_originating_continuation_channel () =
   let submit_resolve_capture ?continuation_channel ~keeper_name () =
     captured := None;
     let id =
-      AQ.submit_pending
+      AQ.submit_pending_observer
         ~keeper_name
         ~tool_name:"keeper_continue_after_reconcile"
         ~input:(`Assoc [ "kind", `String "medium_gate" ])
         ~risk_level:AQ.Medium
         ~base_path
         ?continuation_channel
-        ~on_resolution:(fun _decision -> ())
+        ~on_resolution_observer:(fun _decision -> ())
         ()
     in
     (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
@@ -486,7 +821,7 @@ let test_resolution_wake_carries_originating_continuation_channel () =
   in
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let dashboard_channel =
@@ -547,7 +882,7 @@ let test_expire_stale_submit_and_await_does_not_fire_wake_hook () =
       Ok (fun () -> woke := true));
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "expire-stale-await-no-wake-test" in
@@ -597,19 +932,19 @@ let test_expire_stale_submit_pending_fires_wake_hook () =
       Ok (fun () -> woke := Some (keeper_name, approval_id, decision, channel)));
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let keeper_name = "expire-stale-pending-wake-test" in
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_observer
            ~keeper_name
            ~tool_name:"keeper_continue_after_reconcile"
            ~input:(`Assoc [ "kind", `String "medium_gate" ])
            ~risk_level:AQ.Medium
            ~base_path
            ~continuation_channel
-           ~on_resolution:(fun decision -> resolved := Some decision)
+           ~on_resolution_observer:(fun decision -> resolved := Some decision)
            ()
        in
        AQ.expire_stale ~max_wait_s:0.0;
@@ -646,17 +981,17 @@ let test_expire_stale_retries_after_delivery_failure () =
   AQ.For_testing.clear_approval_resolution_wake_hook ();
   Fun.protect
     ~finally:(fun () ->
-      install_noop_resolution_delivery_hook ();
+      install_durable_resolution_delivery_hook ();
       cleanup_dir base_path)
     (fun () ->
        let id =
-         AQ.submit_pending
+         AQ.submit_pending_observer
            ~keeper_name:"expire-delivery-failure-test"
            ~tool_name:"keeper_continue_after_reconcile"
            ~input:(`Assoc [ "kind", `String "medium_gate" ])
            ~risk_level:AQ.Medium
            ~base_path
-           ~on_resolution:(fun decision -> callback_decision := Some decision)
+           ~on_resolution_observer:(fun decision -> callback_decision := Some decision)
            ()
        in
        AQ.expire_stale ~max_wait_s:0.0;
@@ -664,7 +999,7 @@ let test_expire_stale_retries_after_delivery_failure () =
          (Option.is_some (AQ.get_pending_entry ~id));
        Alcotest.(check bool) "failed expiry delivery does not run callback" true
          (Option.is_none !callback_decision);
-       install_noop_resolution_delivery_hook ();
+       install_durable_resolution_delivery_hook ();
        AQ.expire_stale ~max_wait_s:0.0;
        Alcotest.(check bool) "retry removes expired entry" true
          (Option.is_none (AQ.get_pending_entry ~id));
@@ -674,6 +1009,73 @@ let test_expire_stale_retries_after_delivery_failure () =
          Alcotest.fail
            ("expected Reject, got " ^ AQ.approval_decision_to_string decision)
        | None -> Alcotest.fail "successful expiry retry did not run callback")
+;;
+
+let test_expire_stale_is_per_entry_and_preserves_callback_failures () =
+  let base_path = temp_dir () in
+  let healthy_callback = ref false in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let submit keeper_name callback =
+         AQ.submit_pending_blocking
+           ~keeper_name
+           ~tool_name:"keeper_continue_after_reconcile"
+           ~input:(`Assoc [ "kind", `String keeper_name ])
+           ~risk_level:AQ.Medium
+           ~base_path
+           ~on_resolution:(blocking_callback callback)
+           ()
+       in
+       let callback_should_fail = ref true in
+       let failed_id =
+         submit "expire-callback-exception-test" (fun _ ->
+           if !callback_should_fail then failwith "synthetic expiry")
+       in
+       let healthy_id =
+         submit "expire-healthy-neighbor-test" (fun _ -> healthy_callback := true)
+       in
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool)
+         "failed expiry callback keeps its entry"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:failed_id));
+       Alcotest.(check bool)
+         "one failed entry does not block the next expiry"
+         true
+         !healthy_callback;
+       Alcotest.(check bool)
+         "healthy neighboring entry is removed"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:healthy_id));
+       callback_should_fail := false;
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool)
+         "retry removes entry after callback completes"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:failed_id));
+       let callback_should_cancel = ref true in
+       let cancelled_id =
+         submit "expire-callback-cancel-test" (fun _ ->
+           if !callback_should_cancel
+           then raise (Eio.Cancel.Cancelled (Failure "synthetic expiry cancellation")))
+       in
+       let cancelled_propagated =
+         match AQ.expire_stale ~max_wait_s:0.0 with
+         | exception Eio.Cancel.Cancelled _ -> true
+         | () -> false
+       in
+       Alcotest.(check bool) "expiry cancellation propagates" true cancelled_propagated;
+       Alcotest.(check bool)
+         "expiry cancellation keeps the claimed entry pending"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:cancelled_id));
+       callback_should_cancel := false;
+       AQ.expire_stale ~max_wait_s:0.0;
+       Alcotest.(check bool)
+         "expiry claim is released after cancellation"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:cancelled_id)))
 ;;
 
 let test_critical_entry_phase_becomes_escalated_after_timer () =
@@ -842,7 +1244,9 @@ let test_summary_survives_include_input_paths () =
          });
        let dashboard_entry =
          match
-           entry_json_for_keeper ~keeper_name (AQ.list_pending_dashboard_json ())
+           entry_json_for_keeper
+             ~keeper_name
+             (AQ.list_pending_dashboard_json ~base_path)
          with
          | Some json -> json
          | None -> Alcotest.fail "entry missing from list_pending_dashboard_json"
@@ -853,7 +1257,7 @@ let test_summary_survives_include_input_paths () =
          | None -> Alcotest.fail "pending detail JSON not found"
        in
        let list_entry =
-         match entry_json_for_keeper ~keeper_name (AQ.list_pending_json ()) with
+         match entry_json_for_keeper ~keeper_name (AQ.list_pending_json ~base_path) with
          | Some json -> json
          | None -> Alcotest.fail "entry missing from list_pending_json"
        in
@@ -897,13 +1301,13 @@ let test_summary_worker_missing_root_switch_is_explicit_failure () =
        let keeper_name = "summary-root-switch-missing-test" in
        let id =
          Eio_context.with_turn_switch turn_sw (fun () ->
-           AQ.submit_pending
+           AQ.submit_pending_observer
              ~keeper_name
              ~tool_name:"keeper_continue_after_reconcile"
              ~input:(`Assoc [ "kind", `String "medium_gate" ])
              ~risk_level:AQ.Medium
              ~base_path
-             ~on_resolution:(fun _decision -> ())
+             ~on_resolution_observer:(fun _decision -> ())
              ())
        in
        let entry =
@@ -1061,6 +1465,423 @@ let test_w3c_reply_delivery_effect_requires_success () =
           "keeper_tasks_list"))
 ;;
 
+let test_workspace_scope_isolates_queries_and_lane_gates () =
+  let base_a = temp_dir () in
+  let base_b = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_dir base_a;
+      cleanup_dir base_b)
+    (fun () ->
+       let keeper_name = "same-name-two-workspaces" in
+       let id_a =
+         Raw_AQ.submit_pending_blocking
+           ~keeper_name
+           ~tool_name:"workspace-a-gate"
+           ~input:(`Assoc [ "scope", `String "a" ])
+           ~risk_level:Raw_AQ.Critical
+           ~base_path:base_a
+           ~on_resolution:(blocking_callback (fun _ -> ()))
+           ()
+       in
+       let id_b =
+         Raw_AQ.submit_pending_observer
+           ~keeper_name
+           ~tool_name:"workspace-b-observer"
+           ~input:(`Assoc [ "scope", `String "b" ])
+           ~risk_level:Raw_AQ.Low
+           ~base_path:base_b
+           ~on_resolution_observer:(fun _ -> ())
+           ()
+       in
+       Alcotest.(check int) "workspace A count" 1
+         (Raw_AQ.pending_count ~base_path:base_a);
+       Alcotest.(check int) "workspace B count" 1
+         (Raw_AQ.pending_count ~base_path:base_b);
+       Alcotest.(check bool) "workspace A owns blocking lane" true
+         (Raw_AQ.has_blocking_pending_for_keeper
+            ~base_path:base_a
+            ~keeper_name);
+       Alcotest.(check bool) "workspace B ignores A blocking lane" false
+         (Raw_AQ.has_blocking_pending_for_keeper
+            ~base_path:base_b
+            ~keeper_name);
+       Alcotest.(check bool) "A entry is hidden from B detail" true
+         (Option.is_none (Raw_AQ.get_pending_json ~base_path:base_b ~id:id_a));
+       Alcotest.(check bool) "B entry is hidden from A detail" true
+         (Option.is_none (Raw_AQ.get_pending_json ~base_path:base_a ~id:id_b));
+       (match
+          Raw_AQ.resolve
+            ~base_path:base_b
+            ~id:id_a
+            ~decision:Agent_sdk.Hooks.Approve
+        with
+        | Error (Raw_AQ.Delivery_failed _) -> ()
+        | Error err ->
+          Alcotest.failf
+            "wrong-workspace resolve returned %s"
+            (Raw_AQ.resolve_error_to_string err)
+        | Ok () -> Alcotest.fail "wrong workspace resolved A approval");
+       Alcotest.(check bool) "wrong workspace preserves A entry" true
+         (Option.is_some (Raw_AQ.get_pending_entry ~base_path:base_a ~id:id_a));
+       (match
+          Raw_AQ.resolve
+            ~base_path:base_a
+            ~id:id_a
+            ~decision:Agent_sdk.Hooks.Approve
+        with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.failf "A cleanup failed: %s" (Raw_AQ.resolve_error_to_string err));
+       match
+         Raw_AQ.resolve
+           ~base_path:base_b
+           ~id:id_b
+           ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       with
+       | Ok () -> ()
+       | Error err ->
+         Alcotest.failf "B cleanup failed: %s" (Raw_AQ.resolve_error_to_string err))
+;;
+
+let test_blocking_decision_latches_before_idempotent_commit () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let prepare_calls = ref 0 in
+       let commit_calls = ref 0 in
+       let after_remove_saw_absent = ref false in
+       let id_ref = ref "" in
+       let id =
+         Raw_AQ.submit_pending_blocking
+           ~keeper_name:"decision-latch-test"
+           ~tool_name:"decision-latch-effect"
+           ~input:(`Assoc [ "kind", `String "decision_latch" ])
+           ~risk_level:Raw_AQ.Critical
+           ~base_path
+           ~on_resolution:(fun ~approval_id decision ->
+             incr prepare_calls;
+             Raw_AQ.blocking_resolution_plan
+               ~effect_key:("decision-latch:" ^ approval_id)
+               ~commit:(fun () ->
+                 incr commit_calls;
+                 if !commit_calls = 1
+                 then failwith "synthetic partial commit failure"
+                 else (
+                   ignore decision;
+                   fun () ->
+                     after_remove_saw_absent :=
+                       Option.is_none
+                         (Raw_AQ.get_pending_entry ~base_path ~id:!id_ref))))
+           ()
+       in
+       id_ref := id;
+       (match
+          Raw_AQ.resolve ~base_path ~id ~decision:Agent_sdk.Hooks.Approve
+        with
+        | Error (Raw_AQ.Delivery_failed _) -> ()
+        | Error err ->
+          Alcotest.failf
+            "first commit returned %s"
+            (Raw_AQ.resolve_error_to_string err)
+        | Ok () -> Alcotest.fail "first synthetic commit unexpectedly succeeded");
+       Alcotest.(check int) "plan prepared once" 1 !prepare_calls;
+       Alcotest.(check int) "commit attempted once" 1 !commit_calls;
+       (match
+          Raw_AQ.resolve
+            ~base_path
+            ~id
+            ~decision:(Agent_sdk.Hooks.Reject "contradictory retry")
+        with
+        | Error (Raw_AQ.Delivery_failed _) -> ()
+        | Error err ->
+          Alcotest.failf
+            "contradictory retry returned %s"
+            (Raw_AQ.resolve_error_to_string err)
+        | Ok () -> Alcotest.fail "contradictory retry bypassed decision latch");
+       Alcotest.(check int) "contradiction does not prepare again" 1 !prepare_calls;
+       Alcotest.(check int) "contradiction does not commit" 1 !commit_calls;
+       (match
+          Raw_AQ.resolve ~base_path ~id ~decision:Agent_sdk.Hooks.Approve
+        with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.failf
+            "same-decision retry failed: %s"
+            (Raw_AQ.resolve_error_to_string err));
+       Alcotest.(check int) "same decision reuses prepared plan" 1 !prepare_calls;
+       Alcotest.(check int) "same decision retries idempotent commit" 2 !commit_calls;
+       Alcotest.(check bool) "post action observes pending removal" true
+         !after_remove_saw_absent;
+       Alcotest.(check bool) "successful retry removes entry" true
+         (Option.is_none (Raw_AQ.get_pending_entry ~base_path ~id)))
+;;
+
+let test_timeout_terminal_claim_excludes_operator_rule_commit () =
+  Eio_main.run @@ fun env ->
+  let base_path = temp_dir () in
+  let claimed_p, claimed_u = Eio.Promise.create () in
+  let release_p, release_u = Eio.Promise.create () in
+  let hook owner id =
+    match owner with
+    | Raw_AQ.Await_timeout ->
+      Eio.Promise.resolve claimed_u id;
+      Eio.Promise.await release_p
+    | Raw_AQ.Operator_resolution
+    | Raw_AQ.Await_cancellation
+    | Raw_AQ.Expiration
+    | Raw_AQ.Terminal_state_cancellation -> ()
+  in
+  Raw_AQ.For_testing.set_resolution_claim_hook hook;
+  Fun.protect
+    ~finally:(fun () ->
+      Raw_AQ.For_testing.clear_resolution_claim_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let result = ref None in
+       Eio.Fiber.fork ~sw (fun () ->
+         result :=
+           Some
+             (Raw_AQ.submit_and_await
+                ~keeper_name:"timeout-claim-test"
+                ~tool_name:"timeout-claim-tool"
+                ~input:(`Assoc [ "kind", `String "timeout_claim" ])
+                ~risk_level:Raw_AQ.Low
+                ~base_path
+                ~clock:(Eio.Stdenv.clock env)
+                ~timeout_s:0.001
+                ())) ;
+       let id = Eio.Promise.await claimed_p in
+       (match
+          Raw_AQ.resolve_with_policy
+            ~base_path
+            ~id
+            ~decision:Agent_sdk.Hooks.Approve
+            ~remember_rule:true
+            ()
+        with
+        | Error (Raw_AQ.Already_resolved claimed_id)
+          when String.equal claimed_id id -> ()
+        | Error err ->
+          Alcotest.failf
+            "operator race returned %s"
+            (Raw_AQ.resolve_error_to_string err)
+        | Ok _ -> Alcotest.fail "operator bypassed timeout terminal claim");
+       Alcotest.(check int) "timeout winner has not persisted allow rule" 0
+         (List.length (Raw_AQ.list_rules ~base_path ()));
+       Eio.Promise.resolve release_u ();
+       yield_until (fun () -> Option.is_some !result);
+       (match !result with
+        | Some (Agent_sdk.Hooks.Reject _) -> ()
+        | Some Agent_sdk.Hooks.Approve ->
+          Alcotest.fail "timeout winner returned operator Approve"
+        | Some (Agent_sdk.Hooks.Edit _) ->
+          Alcotest.fail "timeout winner returned Edit"
+        | None -> Alcotest.fail "timeout result did not complete");
+       Alcotest.(check int) "timeout leaves no pending orphan" 0
+         (Raw_AQ.pending_count ~base_path);
+       Alcotest.(check int) "timeout still leaves no allow rule" 0
+         (List.length (Raw_AQ.list_rules ~base_path ()));
+       let terminal_events =
+         Raw_AQ.read_recent_audit
+           ~base_path
+           ~keeper_name:"timeout-claim-test"
+           ~n:10
+           ()
+         |> List.filter (fun json ->
+           match Json_util.assoc_member_opt "event" json with
+           | Some (`String ("approval_timeout" | "resolved" | "cancelled")) -> true
+           | Some _ | None -> false)
+       in
+       Alcotest.(check int) "exactly one terminal audit" 1
+         (List.length terminal_events))
+;;
+
+let test_timeout_retries_after_competing_operator_failure () =
+  Eio_main.run @@ fun env ->
+  let base_path = temp_dir () in
+  let operator_claimed_p, operator_claimed_u = Eio.Promise.create () in
+  let release_operator_p, release_operator_u = Eio.Promise.create () in
+  let hook owner id =
+    match owner with
+    | Raw_AQ.Operator_resolution ->
+      Eio.Promise.resolve operator_claimed_u id;
+      Eio.Promise.await release_operator_p;
+      failwith "synthetic operator failure after terminal claim"
+    | Raw_AQ.Await_timeout
+    | Raw_AQ.Await_cancellation
+    | Raw_AQ.Expiration
+    | Raw_AQ.Terminal_state_cancellation -> ()
+  in
+  Raw_AQ.For_testing.set_resolution_claim_hook hook;
+  Fun.protect
+    ~finally:(fun () ->
+      Raw_AQ.For_testing.clear_resolution_claim_hook ();
+      cleanup_dir base_path)
+    (fun () ->
+       Eio.Switch.run @@ fun sw ->
+       let timeout_result = ref None in
+       Eio.Fiber.fork ~sw (fun () ->
+         timeout_result :=
+           Some
+             (Raw_AQ.submit_and_await
+                ~keeper_name:"timeout-retry-claim-test"
+                ~tool_name:"timeout-retry-claim-tool"
+                ~input:(`Assoc [ "kind", `String "timeout_retry_claim" ])
+                ~risk_level:Raw_AQ.Low
+                ~base_path
+                ~clock:(Eio.Stdenv.clock env)
+                ~timeout_s:0.001
+                ()));
+       yield_until (fun () -> Raw_AQ.pending_count ~base_path = 1);
+       let id =
+         match Raw_AQ.list_pending_entries ~base_path with
+         | [ entry ] -> entry.id
+         | _ -> Alcotest.fail "expected one resolver-backed approval"
+       in
+       let operator_failed = ref false in
+       Eio.Fiber.fork ~sw (fun () ->
+         match
+           Raw_AQ.resolve_with_policy
+             ~base_path
+             ~id
+             ~decision:Agent_sdk.Hooks.Approve
+             ()
+         with
+         | exception Failure _ -> operator_failed := true
+         | Ok _ | Error _ -> ());
+       let claimed_id = Eio.Promise.await operator_claimed_p in
+       Alcotest.(check string) "operator claimed expected approval" id claimed_id;
+       Eio.Time.sleep (Eio.Stdenv.clock env) 0.01;
+       Eio.Promise.resolve release_operator_u ();
+       yield_until (fun () -> !operator_failed && Option.is_some !timeout_result);
+       (match !timeout_result with
+        | Some (Agent_sdk.Hooks.Reject _) -> ()
+        | Some Agent_sdk.Hooks.Approve ->
+          Alcotest.fail "failed operator claimant leaked Approve"
+        | Some (Agent_sdk.Hooks.Edit _) ->
+          Alcotest.fail "failed operator claimant leaked Edit"
+        | None -> Alcotest.fail "timeout retry did not settle");
+       Alcotest.(check int) "timeout retry leaves no pending orphan" 0
+         (Raw_AQ.pending_count ~base_path))
+;;
+
+let test_post_removal_wake_failure_does_not_restore_committed_approval () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let id =
+         Raw_AQ.submit_pending_blocking
+           ~keeper_name:"post-removal-failure-test"
+           ~tool_name:"post-removal-failure-effect"
+           ~input:(`Assoc [ "kind", `String "post_removal_failure" ])
+           ~risk_level:Raw_AQ.Critical
+           ~base_path
+           ~on_resolution:(fun ~approval_id _decision ->
+             Raw_AQ.blocking_resolution_plan
+               ~effect_key:("post-removal-failure:" ^ approval_id)
+               ~commit:(fun () ->
+                 fun () -> failwith "synthetic best-effort wake failure"))
+           ()
+       in
+       (match
+          Raw_AQ.resolve ~base_path ~id ~decision:Agent_sdk.Hooks.Approve
+        with
+        | Ok () -> ()
+        | Error err ->
+          Alcotest.failf
+            "best-effort wake failure changed terminal result: %s"
+            (Raw_AQ.resolve_error_to_string err));
+       Alcotest.(check bool) "committed approval stays removed" true
+         (Option.is_none (Raw_AQ.get_pending_entry ~base_path ~id)))
+;;
+
+let test_terminal_cancellation_and_operator_resolution_have_one_owner () =
+  Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Raw_AQ.For_testing.reset_pending ();
+  Raw_AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      Raw_AQ.For_testing.reset_pending ();
+      Raw_AQ.For_testing.reset_audit_store ();
+      cleanup_dir base_path)
+    (fun () ->
+       let callback_commits = Atomic.make 0 in
+       let id =
+         Raw_AQ.submit_pending_blocking
+           ~keeper_name:"terminal-cancel-race"
+           ~tool_name:"keeper_continue_after_partial_commit"
+           ~input:
+             (`Assoc
+                [ "kind", `String "continue_gate_required"
+                ; "gate_id", `String "continue-race"
+                ])
+           ~risk_level:Raw_AQ.Critical
+           ~base_path
+           ~on_resolution:(fun ~approval_id decision ->
+             Raw_AQ.blocking_resolution_plan
+               ~effect_key:("terminal-cancel-race:" ^ approval_id)
+               ~commit:(fun () ->
+                 ignore (Atomic.fetch_and_add callback_commits 1);
+                 (match decision with
+                  | Agent_sdk.Hooks.Approve
+                  | Agent_sdk.Hooks.Reject _
+                  | Agent_sdk.Hooks.Edit _ -> ());
+                 fun () -> ()))
+           ()
+       in
+       let cancelled = ref None in
+       let operator_result = ref None in
+       Eio.Fiber.both
+         (fun () ->
+            Eio.Fiber.yield ();
+            cancelled :=
+              Some
+                (Raw_AQ.cancel_callback_owned_for_terminal_keeper
+                   ~base_path
+                   ~keeper_name:"terminal-cancel-race"
+                   ~reason:"superseded by Dead tombstone"))
+         (fun () ->
+            Eio.Fiber.yield ();
+            operator_result :=
+              Some
+                (Raw_AQ.resolve
+                   ~base_path
+                   ~id
+                   ~decision:Agent_sdk.Hooks.Approve));
+       let cancelled = Option.value ~default:(-1) !cancelled in
+       let operator_result =
+         Option.value
+           ~default:(Error (Raw_AQ.Not_found id))
+           !operator_result
+       in
+       let operator_committed =
+         match operator_result with
+         | Ok () -> 1
+         | Error (Raw_AQ.Not_found _ | Raw_AQ.Already_resolved _) -> 0
+         | Error err ->
+           Alcotest.failf
+             "unexpected operator race result: %s"
+             (Raw_AQ.resolve_error_to_string err)
+       in
+       Alcotest.(check int)
+         "exactly one terminal owner commits"
+         1
+         (cancelled + operator_committed);
+       Alcotest.(check int)
+         "domain callback runs only when operator owns the claim"
+         operator_committed
+         (Atomic.get callback_commits);
+       Alcotest.(check bool)
+         "terminal race leaves no pending approval"
+         true
+         (Option.is_none (Raw_AQ.get_pending_entry ~base_path ~id)))
+;;
+
 let () =
   Alcotest.run
     "Keeper_approval_queue"
@@ -1088,6 +1909,54 @@ let () =
             `Quick
             test_delivery_failure_keeps_nonblocking_approval_pending
         ; Alcotest.test_case
+            "nonblocking observer runs after durable commit and removal"
+            `Quick
+            test_nonblocking_observer_runs_after_durable_commit_and_removal
+        ; Alcotest.test_case
+            "nonblocking observer failure is non-authoritative"
+            `Quick
+            test_nonblocking_observer_failure_is_non_authoritative
+        ; Alcotest.test_case
+            "nonblocking observer cancellation signals before propagating"
+            `Quick
+            test_nonblocking_observer_cancellation_defers_until_after_signal
+        ; Alcotest.test_case
+            "blocking callback failure and cancellation keep pending"
+            `Quick
+            test_blocking_callback_failure_and_cancellation_keep_pending
+        ; Alcotest.test_case
+            "resolve_with_policy rejects a wrong workspace"
+            `Quick
+            test_resolve_with_policy_rejects_wrong_workspace
+        ; Alcotest.test_case
+            "identical approvals do not dedupe across workspaces"
+            `Quick
+            test_identical_approvals_do_not_dedupe_across_workspaces
+        ; Alcotest.test_case
+            "workspace scope isolates queries and blocking lane gates"
+            `Quick
+            test_workspace_scope_isolates_queries_and_lane_gates
+        ; Alcotest.test_case
+            "blocking decision latches before idempotent commit"
+            `Quick
+            test_blocking_decision_latches_before_idempotent_commit
+        ; Alcotest.test_case
+            "timeout terminal claim excludes operator rule commit"
+            `Quick
+            test_timeout_terminal_claim_excludes_operator_rule_commit
+        ; Alcotest.test_case
+            "timeout retries after a competing operator claim fails"
+            `Quick
+            test_timeout_retries_after_competing_operator_failure
+        ; Alcotest.test_case
+            "post-removal wake failure cannot restore committed approval"
+            `Quick
+            test_post_removal_wake_failure_does_not_restore_committed_approval
+        ; Alcotest.test_case
+            "terminal cancellation and operator resolution have one owner"
+            `Quick
+            test_terminal_cancellation_and_operator_resolution_have_one_owner
+        ; Alcotest.test_case
             "explicit blocking callback owns a lane without resolver"
             `Quick
             test_blocking_callback_policy_owns_lane_without_resolver
@@ -1103,6 +1972,10 @@ let () =
             "expire_stale retries after delivery failure"
             `Quick
             test_expire_stale_retries_after_delivery_failure
+        ; Alcotest.test_case
+            "expire_stale is per-entry and preserves callback failures"
+            `Quick
+            test_expire_stale_is_per_entry_and_preserves_callback_failures
         ; Alcotest.test_case
             "resolution wake carries originating continuation channel"
             `Quick

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -45,6 +45,7 @@ let with_env body =
   Unix.mkdir base 0o755;
   Fun.protect
     ~finally:(fun () ->
+      Keeper_chat_consumer.For_testing.clear_after_lease_hook ();
       ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
     (fun () ->
       Eio_main.run @@ fun env ->
@@ -53,6 +54,7 @@ let with_env body =
       let config = Workspace.default_config base in
       ignore (Workspace.init config ~agent_name:(Some keeper_name));
       Keeper_turn_admission.For_testing.reset ();
+      Keeper_chat_consumer.For_testing.clear_after_lease_hook ();
       (* Full registry reset, not just [clear ~keeper_name]: several tests
          below use derived names ([keeper_name ^ "-a"/"-b"]) that a prior
          test's dispatch fiber can leave with a message requeued by
@@ -126,6 +128,153 @@ exception Stop
 
 let with_consumer_switch f =
   try Eio.Switch.run (fun sw -> f sw; raise Stop) with Stop -> ()
+
+let submit_blocking_approval ~base ~keeper_name ~kind =
+  Keeper_approval_queue.submit_pending_blocking
+    ~keeper_name
+    ~tool_name:"queued_chat_blocking_gate_test"
+    ~input:(`Assoc [ "kind", `String kind ])
+    ~risk_level:Keeper_approval_queue.Critical
+    ~base_path:base
+    ~on_resolution:(fun ~approval_id decision ->
+      Keeper_approval_queue.blocking_resolution_plan
+        ~effect_key:("queued_chat_gate_test:" ^ approval_id)
+        ~commit:(fun () ->
+          let (_ : Agent_sdk.Hooks.approval_decision) = decision in
+          fun () -> ()))
+    ()
+
+let resolve_blocking_approval ~base id =
+  match
+    Keeper_approval_queue.resolve
+      ~base_path:base
+      ~id
+      ~decision:(Agent_sdk.Hooks.Reject "focused queued-chat test cleanup")
+  with
+  | Ok () -> ()
+  | Error err ->
+      check
+        ("Blocking approval cleanup: "
+         ^ Keeper_approval_queue.resolve_error_to_string err)
+        false
+
+let has_transport_failure_row ~base ~keeper_name =
+  Keeper_chat_store.load ~base_dir:base ~keeper_name
+  |> List.exists (fun message ->
+         Keeper_chat_store.Row_kind.equal
+           message.Keeper_chat_store.kind
+           Keeper_chat_store.Row_kind.Transport_failure)
+
+(* Sentinel for the historical failure path: if the consumer dispatches while
+   a Blocking approval owns the lane, this writes the exact durable row the
+   production body guard used to create before the consumer ACKed the lease. *)
+let transport_failure_sentinel ~base calls ~sw:_ ~keeper_name ~queued_message =
+  incr calls;
+  Keeper_chat_store.append_turn
+    ~base_dir:base
+    ~keeper_name
+    ~user_content:queued_message.Keeper_chat_queue.content
+    ~user_attachments:queued_message.attachments
+    ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+    ~assistant_content:"sentinel: Blocking precondition was dispatched"
+    ()
+
+let drain_after_resolution ~base ~clock ~keeper_name =
+  let captured, first, handle_turn = capturing () in
+  with_consumer_switch (fun sw ->
+    Keeper_chat_consumer.start ~sw ~clock ~base_path:base
+      ~dispatch_deadline_sec:test_dispatch_deadline_sec
+      ~on_stalled:unexpected_on_stalled ~handle_turn;
+    match await_or_timeout ~clock ~secs:5.0 first with
+    | `Got -> ()
+    | `Timeout -> check "deferred lease drains after approval resolution" false);
+  check "deferred lease is delivered exactly once after resolution"
+    (List.length !captured = 1);
+  check "resolved Blocking gate permits ACK" (Keeper_chat_queue.length ~keeper_name = 0)
+
+let test_prelease_blocking_approval_leaves_message_retryable () =
+  Printf.printf
+    "Test: pre-lease Blocking ownership leaves queued chat retryable\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_chat_queue.configure_persistence ~base_path:base;
+    ignore
+      (Keeper_chat_queue.enqueue ~keeper_name
+         (discord_msg ~content:"wait for approval" ~channel_id:"chan-prelease"
+            ~user_id:"u-prelease" ~ts:1.0)
+        : string);
+    let approval_id =
+      submit_blocking_approval ~base ~keeper_name ~kind:"prelease"
+    in
+    let calls = ref 0 in
+    let handle_turn = transport_failure_sentinel ~base calls in
+    with_consumer_switch (fun sw ->
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
+        ~dispatch_deadline_sec:test_dispatch_deadline_sec
+        ~on_stalled:unexpected_on_stalled ~handle_turn;
+      (* The consumer polls immediately; this bounded window lets that first
+         admission decision run without waiting for the one-second cadence. *)
+      Eio.Time.sleep clock 0.3);
+    check "pre-lease gate does not dispatch the queued turn" (!calls = 0);
+    check "pre-lease gate leaves the message queued"
+      (Keeper_chat_queue.length ~keeper_name = 1);
+    check "pre-lease gate creates no transport-failure row"
+      (not (has_transport_failure_row ~base ~keeper_name));
+    resolve_blocking_approval ~base approval_id;
+    drain_after_resolution ~base ~clock ~keeper_name)
+
+let test_postlease_blocking_approval_nacks_without_failure_row () =
+  Printf.printf
+    "Test: Blocking ownership won after lease nacks queued chat for retry\n%!";
+  with_env (fun ~base ~clock ->
+    Keeper_chat_queue.configure_persistence ~base_path:base;
+    ignore
+      (Keeper_chat_queue.enqueue ~keeper_name
+         (discord_msg ~content:"approval raced the lease"
+            ~channel_id:"chan-postlease" ~user_id:"u-postlease" ~ts:1.0)
+        : string);
+    let hook_ran, set_hook_ran = Eio.Promise.create () in
+    let approval_id = ref None in
+    Keeper_chat_consumer.For_testing.set_after_lease_hook
+      (fun ~base_path ~keeper_name:leased_keeper ~lease_id ->
+        check "post-lease hook receives the active workspace"
+          (String.equal base_path base);
+        check "post-lease hook receives the leased keeper"
+          (String.equal leased_keeper keeper_name);
+        check "post-lease hook receives a concrete lease id"
+          (String.trim lease_id <> "");
+        approval_id :=
+          Some
+            (submit_blocking_approval ~base:base_path
+               ~keeper_name:leased_keeper ~kind:"postlease");
+        Eio.Promise.resolve set_hook_ran ());
+    let calls = ref 0 in
+    let handle_turn = transport_failure_sentinel ~base calls in
+    with_consumer_switch (fun sw ->
+      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
+        ~dispatch_deadline_sec:test_dispatch_deadline_sec
+        ~on_stalled:unexpected_on_stalled ~handle_turn;
+      (match await_or_timeout ~clock ~secs:5.0 hook_ran with
+       | `Got -> ()
+       | `Timeout -> check "post-lease race hook ran" false);
+      match
+        await_queue_depth_or_timeout ~clock ~keeper_name ~expected:1 ~secs:3.0
+      with
+      | `Got -> ()
+      | `Timeout -> check "post-lease Blocking winner nacks the lease" false);
+    Keeper_chat_consumer.For_testing.clear_after_lease_hook ();
+    check "post-lease Blocking winner does not dispatch" (!calls = 0);
+    check "post-lease Blocking winner keeps the message retryable"
+      (Keeper_chat_queue.length ~keeper_name = 1);
+    check "post-lease Blocking winner creates no transport-failure row"
+      (not (has_transport_failure_row ~base ~keeper_name));
+    Keeper_chat_queue.For_testing.reset ();
+    Keeper_chat_queue.configure_persistence ~base_path:base;
+    check "nacked lease replays as queued after restart"
+      (Keeper_chat_queue.length ~keeper_name = 1);
+    (match !approval_id with
+     | Some id -> resolve_blocking_approval ~base id
+     | None -> check "post-lease Blocking approval was installed" false);
+    drain_after_resolution ~base ~clock ~keeper_name)
 
 let test_drains_discord_to_handle_turn () =
   Printf.printf "Test: consumer drains a Discord queue entry to handle_turn\n%!";
@@ -354,6 +503,8 @@ let test_failed_nack_persist_retries_without_wedging_keeper () =
         check "failed nack persistence is retried and requeues" false))
 
 let () =
+  test_prelease_blocking_approval_leaves_message_retryable ();
+  test_postlease_blocking_approval_nacks_without_failure_row ();
   test_drains_discord_to_handle_turn ();
   test_coalesces_same_source_run ();
   test_gates_while_turn_in_flight ();

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -137,6 +137,7 @@ let reasons_of_verdict = function
 
 let decide ?(event_queue_triggers = []) () =
   WO.keeper_cycle_decision
+    ~base_path:""
     ~provider_cooldown_remaining_sec:no_provider_cooldown
     ~event_queue_triggers
     ~meta:(make_meta "conn-keeper")

--- a/test/test_keeper_failed_task_not_proactive_driver.ml
+++ b/test/test_keeper_failed_task_not_proactive_driver.ml
@@ -109,6 +109,7 @@ let base_obs : WO.world_observation =
 let decide ~since_sec (obs : WO.world_observation) =
   let meta = warm_meta ~since_sec () in
   (WO.keeper_cycle_decision
+     ~base_path:""
      ~provider_cooldown_remaining_sec:no_provider_cooldown
      ~reactive_wake:false
      ~meta

--- a/test/test_keeper_failed_task_orphan_does_not_livelock.ml
+++ b/test/test_keeper_failed_task_orphan_does_not_livelock.ml
@@ -109,6 +109,7 @@ let orphan_obs : WO.world_observation =
 let decide ~since_sec =
   let meta = warm_meta ~since_sec () in
   (WO.keeper_cycle_decision
+     ~base_path:""
      ~provider_cooldown_remaining_sec:no_provider_cooldown
      ~reactive_wake:false
      ~meta

--- a/test/test_keeper_latched_reason.ml
+++ b/test/test_keeper_latched_reason.ml
@@ -41,6 +41,22 @@ let round_trippable =
   ; "stale storm", R.Stale_storm
   ; "provider timeout loop", R.Provider_timeout_loop { consecutive_timeouts = 2 }
   ; "operator paused", R.Operator_paused { operator_actor = R.operator_actor_grpc_directive }
+  ; ( "operator paused by HITL rejection"
+    , R.Operator_paused { operator_actor = R.operator_actor_hitl_rejection } )
+  ; ( "partial commit continue gate"
+    , R.Continue_gate_pending
+        { gate_id = "continue-gate-123"
+        ; origin = R.Partial_commit
+        ; committed_tools = [ "write_file"; "git_push" ]
+        } )
+  ; ( "reconcile recovery continue gate"
+    , R.Continue_gate_pending
+        { gate_id = "continue-gate-456"
+        ; origin = R.Reconcile_recovery
+        ; committed_tools = []
+        } )
+  ; ( "repository registration pending"
+    , R.Repository_registration_pending { operation_id = "repo-operation-123" } )
   ; "dead tombstone", R.Dead_tombstone
   ]
 ;;
@@ -63,6 +79,8 @@ let test_wire_parse_fail_closed () =
   ; "completion_contract_violation:code=galactic:summary=\"raw text\""
   ; "completion_contract_violation:code=unspecified:summary=raw_text"
   ; "operator_paused:actor=dashboard:play"
+  ; "continue_gate_pending:payload=\"not-json\""
+  ; "repository_registration_pending:operation_id=\"\""
   ]
   |> List.iter (fun wire -> expect_error wire (R.of_wire wire))
 ;;
@@ -93,7 +111,32 @@ let test_stable_json_rejects_unknown_tags () =
   expect_error
     "unknown operator actor"
     (R.Stable.of_yojson
-       (`Assoc [ "kind", `String "operator_paused"; "actor", `String "dashboard:play" ]))
+       (`Assoc [ "kind", `String "operator_paused"; "actor", `String "dashboard:play" ]));
+  expect_error
+    "empty repository operation id"
+    (R.Stable.of_yojson
+       (`Assoc
+          [ "kind", `String "repository_registration_pending"
+          ; "operation_id", `String ""
+          ]));
+  expect_error
+    "empty continue gate id"
+    (R.Stable.of_yojson
+       (`Assoc
+          [ "kind", `String "continue_gate_pending"
+          ; "gate_id", `String ""
+          ; "origin", `String "partial_commit"
+          ; "committed_tools", `List []
+          ]));
+  expect_error
+    "unknown continue gate origin"
+    (R.Stable.of_yojson
+       (`Assoc
+          [ "kind", `String "continue_gate_pending"
+          ; "gate_id", `String "gate"
+          ; "origin", `String "unknown"
+          ; "committed_tools", `List []
+          ]))
 ;;
 
 (* ── Polymorphic-variant differentiation via [equal] ────────── *)

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -142,6 +142,7 @@ let without_overrides f =
 
 let decide ~meta obs =
   WO.keeper_cycle_decision
+    ~base_path:""
     ~provider_cooldown_remaining_sec:no_provider_cooldown
     ~reactive_wake:false
     ~meta

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -201,7 +201,11 @@ let test_operator_pause_survives_stale_heartbeat_retry () =
   ensure_fs env;
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
     let config = Workspace.default_config base_dir in
     ignore (Workspace.init config ~agent_name:(Some "operator"));
     let m0 = make_meta ~name:"operator-pause-cas" in
@@ -240,21 +244,145 @@ let test_operator_pause_survives_stale_heartbeat_retry () =
         updated_at = Keeper_meta_contract.now_iso ();
       }
     in
-    (match
-       Keeper_meta_store.write_meta_with_merge
-         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk config stale_completion
-     with
-     | Ok () -> ()
-     | Error e -> fail ("stale retry write failed: " ^ e));
+    let persisted =
+      match
+        Keeper_meta_store.write_meta_with_merge_returning
+          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+          config
+          stale_completion
+      with
+      | Ok persisted -> persisted
+      | Error e -> fail ("stale retry write failed: " ^ e)
+    in
     let final = match Keeper_meta_store.read_meta config "operator-pause-cas" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
     check bool "operator pause survives stale retry" true final.paused;
+    check bool "returned snapshot reports preserved operator pause" true persisted.paused;
+    check int
+      "returned snapshot carries authoritative version"
+      final.meta_version
+      persisted.meta_version;
     check bool "auto resume stays disabled" true
       (Option.is_none final.auto_resume_after_sec);
     check bool "stale blocker stays cleared" true
-      (Option.is_none final.runtime.last_blocker))
+      (Option.is_none final.runtime.last_blocker);
+    ignore
+      (Keeper_registry.register
+         ~base_path:config.base_path
+         final.name
+         stale_completion);
+    let live =
+      match Keeper_registry.get ~base_path:config.base_path final.name with
+      | Some entry -> entry
+      | None -> fail "post-install durable reconciliation lost registry entry"
+    in
+    check int
+      "stale registrar refreshes authoritative meta version"
+      final.meta_version
+      live.meta.meta_version;
+    check bool
+      "stale registrar preserves durable pause"
+      true
+      live.meta.paused;
+    check bool
+      "stale registrar derives Paused FSM"
+      true
+      (live.phase = Keeper_state_machine.Paused))
+
+let test_concurrent_stale_writers_have_one_cas_winner () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let guard_was_ready = Eio_guard.is_ready () in
+  Eio_guard.disable ();
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      if guard_was_ready then Eio_guard.enable () else Eio_guard.disable ();
+      cleanup_dir base_dir)
+    (fun () ->
+    let config = Workspace.default_config base_dir in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let initial = make_meta ~name:"concurrent-cas" in
+    (match Keeper_meta_store.write_meta config initial with
+     | Ok () -> ()
+     | Error err -> fail ("seed write failed: " ^ err));
+    let stale =
+      match Keeper_meta_store.read_meta config initial.name with
+      | Ok (Some meta) -> meta
+      | Ok None -> fail "seed meta disappeared"
+      | Error err -> fail ("seed read failed: " ^ err)
+    in
+    let first = { stale with active_goal_ids = [ "first" ] } in
+    let second = { stale with active_goal_ids = [ "second" ] } in
+    let launch candidate =
+      Eio.Fiber.yield ();
+      Keeper_meta_store.write_meta_returning config candidate
+    in
+    let first_result = ref None in
+    let second_result = ref None in
+    Eio.Fiber.both
+      (fun () -> first_result := Some (launch first))
+      (fun () -> second_result := Some (launch second));
+    let first_result =
+      Option.value
+        ~default:(Error "first concurrent writer did not complete")
+        !first_result
+    in
+    let second_result =
+      Option.value
+        ~default:(Error "second concurrent writer did not complete")
+        !second_result
+    in
+    let successes, conflicts =
+      List.fold_left
+        (fun (successes, conflicts) result ->
+           match result with
+           | Ok persisted -> persisted :: successes, conflicts
+           | Error err when Keeper_meta_store.is_version_conflict_error err ->
+             successes, err :: conflicts
+           | Error err -> fail ("unexpected concurrent CAS error: " ^ err))
+        ([], [])
+        [ first_result; second_result ]
+    in
+    check int "exactly one stale writer commits" 1 (List.length successes);
+    check int "the other stale writer conflicts" 1 (List.length conflicts);
+    let losing_candidate =
+      match first_result, second_result with
+      | Error _, Ok _ -> first
+      | Ok _, Error _ -> second
+      | (Ok _ | Error _), (Ok _ | Error _) -> fail "unexpected CAS result split"
+    in
+    let retried =
+      match
+        Keeper_meta_store.write_meta_with_merge_returning
+          ~merge:Keeper_meta_merge.caller_wins
+          config
+          losing_candidate
+      with
+      | Ok persisted -> persisted
+      | Error err -> fail ("losing writer retry failed: " ^ err)
+    in
+    let final =
+      match Keeper_meta_store.read_meta config initial.name with
+      | Ok (Some meta) -> meta
+      | Ok None -> fail "final meta disappeared"
+      | Error err -> fail ("final read failed: " ^ err)
+    in
+    check int
+      "serialized winner and retry advance two distinct versions"
+      (stale.meta_version + 2)
+      final.meta_version;
+    check int
+      "returned retry snapshot is authoritative"
+      final.meta_version
+      retried.meta_version;
+    check (list string)
+      "retry preserves the losing caller payload"
+      losing_candidate.active_goal_ids
+      final.active_goal_ids)
 
 (* RFC-0237: the [write_meta ~force:true] escape hatch is removed, so the
    counter-rewind path the four keeper-internal sites carried
@@ -311,6 +439,68 @@ let test_stale_write_conflicts_without_force () =
     check int "advanced disk counter survives (no rewind without force)"
       42 final.runtime.usage.total_turns)
 
+let test_non_operator_merges_preserve_typed_control_state () =
+  let base = make_meta ~name:"typed-control-merge" in
+  let blocker =
+    Keeper_meta_contract.blocker_info_of_class
+      ~detail:"operator decision required"
+      Keeper_meta_contract.Ambiguous_post_commit_timeout
+  in
+  let gate =
+    Keeper_latched_reason.Continue_gate_pending
+      { gate_id = "continue-exact"
+      ; origin = Keeper_latched_reason.Partial_commit
+      ; committed_tools = [ "keeper_board_post" ]
+      }
+  in
+  let latest =
+    { base with
+      meta_version = 7
+    ; paused = true
+    ; latched_reason = Some gate
+    ; auto_resume_after_sec = None
+    ; runtime = { base.runtime with last_blocker = Some blocker; generation = 2 }
+    }
+  in
+  let caller_trace = (make_meta ~name:"caller-trace").runtime.trace_id in
+  let caller =
+    { latest with
+      meta_version = 6
+    ; agent_name = "keeper-typed-control-merge-agent"
+    ; paused = false
+    ; latched_reason = None
+    ; auto_resume_after_sec = Some 30.
+    ; runtime =
+        { latest.runtime with
+          trace_id = caller_trace
+        ; generation = 3
+        ; last_blocker = None
+        }
+    }
+  in
+  let presence =
+    Keeper_meta_merge.non_operator_control_fields_from_disk ~latest ~caller
+  in
+  check bool "presence merge preserves durable pause" true presence.paused;
+  check bool "presence merge preserves exact typed gate" true
+    (presence.latched_reason = latest.latched_reason);
+  check bool "presence merge preserves durable blocker" true
+    (presence.runtime.last_blocker = latest.runtime.last_blocker);
+  let repaired =
+    Keeper_meta_merge.identity_repair_fields_from_caller ~latest ~caller
+  in
+  check bool "identity repair preserves durable pause" true repaired.paused;
+  check bool "identity repair preserves exact typed gate" true
+    (repaired.latched_reason = latest.latched_reason);
+  check bool "identity repair preserves durable blocker" true
+    (repaired.runtime.last_blocker = latest.runtime.last_blocker);
+  check string "identity repair copies caller-owned agent name"
+    caller.agent_name repaired.agent_name;
+  check bool "identity repair copies caller-owned trace id" true
+    (repaired.runtime.trace_id = caller.runtime.trace_id);
+  check int "identity repair advances generation"
+    caller.runtime.generation repaired.runtime.generation
+
 let test_is_version_conflict_error_classifies () =
   let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
   let other_msg = "failed to write meta /tmp/x: Permission denied" in
@@ -332,6 +522,10 @@ let () =
             `Quick test_monotonic_usage_counters_on_cas_retry;
           test_case "operator pause survives stale heartbeat retry"
             `Quick test_operator_pause_survives_stale_heartbeat_retry;
+          test_case "concurrent stale writers have one CAS winner"
+            `Quick test_concurrent_stale_writers_have_one_cas_winner;
+          test_case "non-operator merges preserve typed control state"
+            `Quick test_non_operator_merges_preserve_typed_control_state;
           test_case "stale write conflicts without force (RFC-0237 escape hatch closed)"
             `Quick test_stale_write_conflicts_without_force;
         ] );

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -128,6 +128,7 @@ let no_signal_obs : WO.world_observation =
 let decide_no_signal () =
   let meta = warm_meta () in
   WO.keeper_cycle_decision
+    ~base_path:""
     ~provider_cooldown_remaining_sec:no_provider_cooldown
     ~reactive_wake:false
     ~meta
@@ -196,6 +197,7 @@ let test_scheduled_automation_attention_runs_after_task_cooldown () =
   let meta = schedule_ready_meta () in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~meta
@@ -209,6 +211,7 @@ let test_bootstrap_event_queue_trigger_runs_warm_keeper () =
   let meta = warm_meta () in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
@@ -227,6 +230,7 @@ let test_no_progress_event_queue_trigger_runs_warm_keeper () =
   let meta = warm_meta () in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~event_queue_triggers:[ WO.No_progress_recovery_stimulus ]
@@ -241,6 +245,7 @@ let test_scheduled_event_queue_trigger_runs_warm_keeper () =
   let meta = warm_meta () in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~event_queue_triggers:[ WO.Scheduled_automation_stimulus ]
@@ -284,6 +289,7 @@ let test_elapsed_min_interval_no_signal_stays_silent () =
   let meta = elapsed_min_interval_meta () in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~meta
@@ -313,6 +319,7 @@ let test_elapsed_min_interval_with_claimed_task_runs () =
   let meta = { (elapsed_min_interval_meta ()) with current_task_id = Some task_id } in
   let d =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~provider_cooldown_remaining_sec:no_provider_cooldown
       ~reactive_wake:false
       ~meta

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -357,9 +357,9 @@ let test_heartbeat_presence_uses_cas_retry_merge () =
   let src = load_source heartbeat_presence_file in
   check bool "heartbeat presence uses CAS retry writer" true
     (count_occurrences ~needle:"write_meta_with_merge" src >= 1);
-  check bool "heartbeat presence preserves disk-owned heartbeat fields" true
+  check bool "heartbeat presence preserves all disk-owned control fields" true
     (count_occurrences
-       ~needle:"Keeper_meta_merge.heartbeat_fields_from_disk"
+       ~needle:"Keeper_meta_merge.non_operator_control_fields_from_disk"
        src
      >= 1);
   check int "plain heartbeat write_meta call removed" 0

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -118,6 +118,7 @@ let global_backlog_obs : WO.world_observation =
 let decide ~reactive_wake =
   let meta = warm_backlog_meta () in
   WO.keeper_cycle_decision
+    ~base_path:""
     ~provider_cooldown_remaining_sec:no_provider_cooldown
     ~reactive_wake
     ~meta
@@ -158,12 +159,19 @@ let test_live_keeper_count_ignores_empty_agent_registry () =
   let agents_dir = Filename.concat masc_dir "agents" in
   Unix.mkdir masc_dir 0o755;
   Unix.mkdir agents_dir 0o755;
+  let rec remove_tree path =
+    if Sys.is_directory path
+    then (
+      Array.iter
+        (fun name -> remove_tree (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+  in
   Fun.protect
     ~finally:(fun () ->
       Masc.Keeper_registry.clear ();
-      Unix.rmdir agents_dir;
-      Unix.rmdir masc_dir;
-      Unix.rmdir base_path)
+      remove_tree base_path)
     (fun () ->
       Masc.Keeper_registry.clear ();
       let config = Masc.Workspace.default_config base_path in

--- a/test/test_keeper_registry_event_queue_race.ml
+++ b/test/test_keeper_registry_event_queue_race.ml
@@ -1,0 +1,111 @@
+let temp_dir () = Filename.temp_dir "keeper-registry-event-queue-race" ""
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let meta_for_keeper keeper_name trace_id =
+  match
+    Masc.Keeper_meta_json_parse.meta_of_json
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "agent_name", `String keeper_name
+        ; "trace_id", `String trace_id
+        ; "last_model_used", `String "llama:auto"
+        ; "tool_access", `List []
+        ])
+  with
+  | Ok meta -> meta
+  | Error msg -> Alcotest.fail ("meta parse failed: " ^ msg)
+;;
+
+let hitl_stimulus keeper_name =
+  let resolution =
+    Keeper_event_queue.
+      { approval_id = "approval-register-race"
+      ; decision =
+          Hitl_approved
+            { keeper_name
+            ; tool_name = "keeper_continue_after_reconcile"
+            ; input_hash = String.make 64 'a'
+            }
+      ; channel = Keeper_continuation_channel.unrouted "registry race test"
+      }
+  in
+  Keeper_event_queue.
+    { post_id = hitl_resolution_post_id resolution
+    ; urgency = Immediate
+    ; arrived_at = Unix.gettimeofday ()
+    ; payload = Hitl_resolved resolution
+    }
+;;
+
+let test_publish_to_replacement_registry_entry () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry_event_queue.For_testing.set_before_durable_live_publication_hook
+        None;
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+       let keeper_name = "keeper-registry-event-queue-race-test" in
+       let first =
+         Masc.Keeper_registry.register
+           ~base_path
+           keeper_name
+           (meta_for_keeper keeper_name "trace-register-race-first")
+       in
+       let replacement =
+         Masc.Keeper_registry.register
+           ~base_path
+           keeper_name
+           (meta_for_keeper keeper_name "trace-register-race-replacement")
+       in
+       Masc.Keeper_registry.For_testing.unsafe_put_entry
+         ~base_path
+         keeper_name
+         first;
+       Masc.Keeper_registry_event_queue.For_testing.set_before_durable_live_publication_hook
+         (Some (fun () ->
+            Masc.Keeper_registry.For_testing.unsafe_put_entry
+              ~base_path
+              keeper_name
+              replacement));
+       (match
+          Masc.Keeper_registry_event_queue.enqueue_durable_result
+            ~base_path
+            keeper_name
+            (hitl_stimulus keeper_name)
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.fail ("durable enqueue failed: " ^ msg));
+       let current =
+         match Masc.Keeper_registry.get ~base_path keeper_name with
+         | Some entry -> entry
+         | None -> Alcotest.fail "replacement registry entry disappeared"
+       in
+       Alcotest.(check bool) "replacement remains current" true (current == replacement);
+       Alcotest.(check int)
+         "committed stimulus is published to current entry"
+         1
+         (Keeper_event_queue.length (Atomic.get current.event_queue)))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_registry_event_queue_race"
+    [ ( "durable publication"
+      , [ Alcotest.test_case
+            "registry replacement receives committed stimulus"
+            `Quick
+            test_publish_to_replacement_registry_entry
+        ] )
+    ]
+;;

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -1,7 +1,40 @@
 module Claim = Masc.Keeper_repo_claim_hitl
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 16
+
+  let base_path_for_id id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some base_path -> base_path
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         base_path
+       | None -> Alcotest.failf "pending approval %s has no workspace" id)
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve ~base_path:(base_path_for_id id) ~id ~decision
+  ;;
+
+  let get_pending_entry ~id =
+    Raw_AQ.get_pending_entry ~base_path:(base_path_for_id id) ~id
+  ;;
+
+  let pending_count = For_testing.pending_count
+  let list_pending_entries = For_testing.list_pending_entries
+end
 
 open Repo_manager_types
+
+let reset_approval_state () =
+  AQ.For_testing.reset_pending ();
+  AQ.For_testing.reset_audit_store ()
+;;
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -112,6 +145,35 @@ let with_temp_base_path f =
   Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
 ;;
 
+let seed_keeper_meta base_path keeper_id =
+  let config = Masc.Workspace.default_config base_path in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "repo-claim-test"));
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+          [ "name", `String keeper_id
+          ; "agent_name", `String ("agent-" ^ keeper_id)
+          ; "trace_id", `String ("trace-" ^ keeper_id)
+          ])
+    with
+    | Ok meta -> meta
+    | Error err -> Alcotest.fail ("seed keeper meta: " ^ err)
+  in
+  let meta = { meta with name = keeper_id } in
+  let path = Masc.Keeper_types_profile.keeper_meta_path config keeper_id in
+  write_file path (Yojson.Safe.pretty_to_string (Masc.Keeper_meta_json.meta_to_json meta));
+  match Masc.Keeper_meta_store.read_meta config keeper_id with
+  | Ok (Some _) -> ()
+  | Ok None ->
+    Alcotest.failf
+      "seed keeper meta was not durably readable path=%s exists=%b config_base=%s"
+      path
+      (Sys.file_exists path)
+      config.base_path
+  | Error err -> Alcotest.fail ("read seeded keeper meta: " ^ err)
+;;
+
 let sample_repo ~base_path id =
   let local_path = Filename.concat base_path ("repo-" ^ id) in
   ensure_dir local_path;
@@ -131,20 +193,9 @@ let sample_repo ~base_path id =
 ;;
 
 let write_repositories base_path repos =
-  let repo_block (repo : repository) =
-    Printf.sprintf
-      "[repository.%s]\nname = \"%s\"\nurl = \"%s\"\nlocal_path = \"%s\"\n\
-       default_branch = \"%s\"\nkeepers = []\nstatus = \"Active\"\nauto_sync = false\n\
-       sync_interval = 0\n"
-      repo.id
-      repo.name
-      repo.url
-      repo.local_path
-      repo.default_branch
-  in
-  write_file
-    (Filename.concat base_path ".masc/config/repositories.toml")
-    (String.concat "\n" (List.map repo_block repos))
+  match Repo_store.save_all ~base_path repos with
+  | Ok () -> ()
+  | Error detail -> Alcotest.fail ("write repositories: " ^ detail)
 ;;
 
 let write_mapping base_path keeper_id repo_ids =
@@ -155,8 +206,8 @@ let write_mapping base_path keeper_id repo_ids =
 ;;
 
 let test_registered_repo_outside_advisory_mapping_is_allowed () =
-  AQ.For_testing.reset_audit_store ();
-  Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+  reset_approval_state ();
+  Fun.protect ~finally:reset_approval_state @@ fun () ->
   with_temp_base_path @@ fun base_path ->
   let keeper_id = "keeper-repo-advisory-scope" in
   let repo_a = sample_repo ~base_path "repo-a" in
@@ -186,8 +237,8 @@ let playground_repo_root ~base_path ~keeper_id ~repository_id =
 ;;
 
 let test_unregistered_repository_without_clone_does_not_request_hitl () =
-  AQ.For_testing.reset_audit_store ();
-  Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+  reset_approval_state ();
+  Fun.protect ~finally:reset_approval_state @@ fun () ->
   with_temp_base_path @@ fun base_path ->
   let keeper_id = "keeper-repo-unregistered" in
   let repo_a = sample_repo ~base_path "repo-a" in
@@ -236,13 +287,87 @@ let string_field key json =
       (Yojson.Safe.to_string other)
 ;;
 
+let read_keeper_meta base_path keeper_id =
+  let config = Masc.Workspace.default_config base_path in
+  match Masc.Keeper_meta_store.read_meta config keeper_id with
+  | Ok (Some meta) -> meta
+  | Ok None -> Alcotest.failf "keeper meta disappeared: %s" keeper_id
+  | Error err -> Alcotest.fail err
+;;
+
+let write_keeper_meta_direct base_path (meta : Masc.Keeper_meta_contract.keeper_meta) =
+  let config = Masc.Workspace.default_config base_path in
+  let path = Masc.Keeper_types_profile.keeper_meta_path config meta.name in
+  write_file path (Yojson.Safe.pretty_to_string (Masc.Keeper_meta_json.meta_to_json meta))
+;;
+
+let repository_operation_path base_path =
+  let dir =
+    Filename.concat
+      base_path
+      ".masc/approvals/repository-registration"
+  in
+  let files =
+    if Sys.file_exists dir
+    then
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (String.ends_with ~suffix:".json")
+    else []
+  in
+  match files with
+  | [ file ] -> Filename.concat dir file
+  | files ->
+    Alcotest.failf
+      "expected one durable repository operation, got %d"
+      (List.length files)
+;;
+
+let repository_operation_record_exists base_path =
+  let dir =
+    Filename.concat
+      base_path
+      ".masc/approvals/repository-registration"
+  in
+  Sys.file_exists dir
+  && (Sys.readdir dir
+      |> Array.exists (String.ends_with ~suffix:".json"))
+;;
+
+let repository_gate_operation_id (meta : Masc.Keeper_meta_contract.keeper_meta) =
+  match meta.latched_reason with
+  | Some (Keeper_latched_reason.Repository_registration_pending { operation_id }) ->
+    operation_id
+  | Some reason ->
+    Alcotest.failf
+      "expected repository gate, got %s"
+      (Keeper_latched_reason.to_wire reason)
+  | None -> Alcotest.fail "expected repository gate, got no latch"
+;;
+
+let request_clone_registration ~base_path ~keeper_id ~repository_id =
+  let repo_root = playground_repo_root ~base_path ~keeper_id ~repository_id in
+  init_git_repo repo_root ("https://github.com/test/" ^ repository_id ^ ".git");
+  match
+    Claim.request_repository_access
+      ~keeper_id
+      ~base_path
+      ~repository_id
+  with
+  | Claim.Access_denied_hitl_pending { approval_id; _ } -> approval_id, repo_root
+  | Claim.Access_allowed -> Alcotest.fail "expected repository registration HITL"
+  | Claim.Access_denied detail ->
+    Alcotest.fail ("expected repository registration HITL: " ^ detail)
+;;
+
 let test_unregistered_repository_id_with_clone_requests_hitl () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-direct-register" in
+    let keeper_id = "repo-direct-register" in
+    seed_keeper_meta base_path keeper_id;
     write_repositories base_path [];
     let repo_root =
       playground_repo_root ~base_path ~keeper_id ~repository_id:"not-registered"
@@ -269,7 +394,7 @@ let test_unregistered_repository_id_with_clone_requests_hitl () =
     let pending = require_one_pending ~keeper_id in
     Alcotest.(check string)
       "requested action"
-      "register_repository"
+      "verify_repository_catalog_registration"
       (string_field "requested_action" pending.input);
     Alcotest.(check string)
       "repo root"
@@ -280,10 +405,11 @@ let test_unregistered_repository_id_with_clone_requests_hitl () =
 let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-register-clone" in
+    let keeper_id = "repo-register-clone" in
+    seed_keeper_meta base_path keeper_id;
     write_repositories base_path [];
     let repo_root =
       Filename.concat
@@ -309,15 +435,83 @@ let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
     let pending = require_one_pending ~keeper_id in
     Alcotest.(check string)
       "requested action"
-      "register_repository"
+      "verify_repository_catalog_registration"
       (string_field "requested_action" pending.input);
     Alcotest.(check string)
       "policy source"
       Config_dir_resolver.repositories_toml_basename
       (string_field "policy_source" pending.input);
-    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+    Alcotest.(check bool)
+      "repository mutation uses the authoritative blocking lane"
+      true
+      (pending.lane_policy = AQ.Blocking);
+    Alcotest.(check bool)
+      "repository mutation owns an authoritative callback"
+      true
+      (Option.is_some pending.on_resolution_callback);
+    Alcotest.(check bool)
+      "repository mutation is not a non-authoritative observer"
+      true
+      (Option.is_none pending.on_resolution_observer);
+    (match
+       AQ.resolve
+         ~id:pending.id
+         ~decision:(Agent_sdk.Hooks.Edit (`Assoc [ "unexpected", `Bool true ]))
+     with
+     | Error (AQ.Delivery_failed _) -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+     | Ok () -> Alcotest.fail "unsupported edit must retain the approval");
+    Alcotest.(check bool)
+      "unsupported repository edit keeps approval pending"
+      true
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
+    let config = Masc.Workspace.default_config base_path in
+    let persisted_gate =
+      match Masc.Keeper_meta_store.read_meta config keeper_id with
+      | Ok (Some meta) -> meta
+      | Ok None -> Alcotest.fail "repository gate keeper meta disappeared"
+      | Error err -> Alcotest.fail err
+    in
+    Alcotest.(check bool) "repository approval durably pauses keeper" true persisted_gate.paused;
+    Alcotest.(check bool)
+      "repository approval persists a typed continue gate"
+      true
+      (Masc.Keeper_supervisor_types.paused_meta_requires_reconcile_recovery
+         persisted_gate);
+    AQ.For_testing.reset_pending ();
+    (match Claim.restore_pending_registration_hitl ~config persisted_gate with
+     | Claim.Registration_restored -> ()
+     | Claim.No_registration_record -> Alcotest.fail "durable operation disappeared"
+     | Claim.Registration_superseded -> Alcotest.fail "durable operation was superseded"
+     | Claim.Registration_corrupt detail ->
+       Alcotest.fail ("durable operation became corrupt: " ^ detail));
+    let restored_pending = require_one_pending ~keeper_id in
+    Alcotest.(check bool)
+      "restored approval receives a fresh queue identity"
+      true
+      (not (String.equal pending.id restored_pending.id));
+    let operator_registered =
+      { (sample_repo ~base_path "not-registered") with
+        url = "https://github.com/test/not-registered.git"
+      ; local_path = canonical_path repo_root
+      ; keepers = [ keeper_id ]
+      }
+    in
+    write_repositories base_path [ operator_registered ];
+    (match AQ.resolve ~id:restored_pending.id ~decision:Agent_sdk.Hooks.Approve with
      | Ok () -> ()
      | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    let resumed_meta =
+      match Masc.Keeper_meta_store.read_meta config keeper_id with
+      | Ok (Some meta) -> meta
+      | Ok None -> Alcotest.fail "approved repository keeper meta disappeared"
+      | Error err -> Alcotest.fail err
+    in
+    Alcotest.(check bool) "approved repository gate resumes keeper" false resumed_meta.paused;
+    Alcotest.(check bool)
+      "approved repository gate clears typed blocker"
+      true
+      (Option.is_none resumed_meta.runtime.last_blocker);
     match Repo_store.find ~base_path "not-registered" with
     | Error detail -> Alcotest.fail ("approved registration did not persist: " ^ detail)
     | Ok repo ->
@@ -331,10 +525,11 @@ let test_unregistered_clone_requests_hitl_and_approval_registers_repo () =
 let test_registration_approval_rechecks_clone_origin () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-register-stale-origin" in
+    let keeper_id = "repo-register-stale-origin" in
+    seed_keeper_meta base_path keeper_id;
     write_repositories base_path [];
     let repo_root =
       Filename.concat
@@ -352,20 +547,41 @@ let test_registration_approval_rechecks_clone_origin () =
     let pending = require_one_pending ~keeper_id in
     set_git_origin_url repo_root "https://github.com/test/renamed.git";
     (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Error (AQ.Delivery_failed _) -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+     | Ok () -> Alcotest.fail "failed revalidation must retain the approval");
+    Alcotest.(check bool)
+      "failed revalidation keeps registration approval pending"
+      true
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
+    (match Repo_store.find ~base_path "not-registered" with
+     | Error _ -> ()
+    | Ok _ -> Alcotest.fail "stale approved registration must not persist");
+    set_git_origin_url repo_root "https://github.com/test/not-registered.git";
+    let operator_registered =
+      { (sample_repo ~base_path "not-registered") with
+        url = "https://github.com/test/not-registered.git"
+      ; local_path = canonical_path repo_root
+      ; keepers = [ keeper_id ]
+      }
+    in
+    write_repositories base_path [ operator_registered ];
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
      | Ok () -> ()
      | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
     match Repo_store.find ~base_path "not-registered" with
-    | Error _ -> ()
-    | Ok _ -> Alcotest.fail "stale approved registration must not persist")
+    | Ok _ -> ()
+    | Error detail -> Alcotest.fail ("retry did not persist registration: " ^ detail))
 ;;
 
 let test_unregistered_clone_matching_existing_remote_requests_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-alias-clone" in
+    let keeper_id = "repo-alias-clone" in
+    seed_keeper_meta base_path keeper_id;
     let registered = sample_repo ~base_path "masc" in
     let registered =
       { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
@@ -388,13 +604,14 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
     let pending = require_one_pending ~keeper_id in
     Alcotest.(check string)
       "requested action"
-      "add_repository_alias"
+      "verify_repository_catalog_alias"
       (string_field "requested_action" pending.input);
     Alcotest.(check string)
       "target repository"
       "masc"
       (string_field "target_repository_id" pending.input);
     Alcotest.(check string) "alias" "masc-mcp" (string_field "alias" pending.input);
+    write_repositories base_path [ { registered with aliases = [ "masc-mcp" ] } ];
     (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
      | Ok () -> ()
      | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
@@ -410,10 +627,11 @@ let test_unregistered_clone_matching_existing_remote_requests_alias () =
 let test_unregistered_repository_id_clone_matching_existing_remote_requests_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-direct-alias" in
+    let keeper_id = "repo-direct-alias" in
+    seed_keeper_meta base_path keeper_id;
     let registered = sample_repo ~base_path "masc" in
     let registered =
       { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
@@ -437,7 +655,7 @@ let test_unregistered_repository_id_clone_matching_existing_remote_requests_alia
     let pending = require_one_pending ~keeper_id in
     Alcotest.(check string)
       "requested action"
-      "add_repository_alias"
+      "verify_repository_catalog_alias"
       (string_field "requested_action" pending.input);
     Alcotest.(check string)
       "target repository"
@@ -470,10 +688,11 @@ let test_unregistered_repository_id_empty_clone_reports_verification_failure () 
 let test_nested_git_root_queues_manual_review_without_alias () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-nested-root" in
+    let keeper_id = "repo-nested-root" in
+    seed_keeper_meta base_path keeper_id;
     let registered = sample_repo ~base_path "masc" in
     let registered =
       { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
@@ -496,7 +715,7 @@ let test_nested_git_root_queues_manual_review_without_alias () =
     let pending = require_one_pending ~keeper_id in
     Alcotest.(check string)
       "requested action"
-      "review_repository_catalog"
+      "verify_repository_catalog_review"
       (string_field "requested_action" pending.input);
     Alcotest.(check string)
       "expected repo root"
@@ -507,13 +726,55 @@ let test_nested_git_root_queues_manual_review_without_alias () =
       (canonical_path nested_root)
       (string_field "repo_root" pending.input);
     (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Error (AQ.Delivery_failed { reason; _ }) ->
+       Alcotest.(check bool)
+         "unresolved manual review reports missing exact catalog binding"
+         true
+         (contains_substring reason "repository catalog read failed")
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+     | Ok () -> Alcotest.fail "manual review must remain pending until catalog access is allowed");
+    Alcotest.(check bool)
+      "unresolved manual review remains pending"
+      true
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
+    let manually_registered =
+      { registered with
+        id = "masc-mcp"
+      ; name = "masc-mcp"
+      ; local_path = nested_root
+      }
+    in
+    let wrong_binding =
+      { manually_registered with url = "https://github.com/wrong/repository.git" }
+    in
+    (match Repo_store.add ~base_path wrong_binding with
+     | Ok _ -> ()
+     | Error detail -> Alcotest.fail ("operator catalog update failed: " ^ detail));
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Error (AQ.Delivery_failed { reason; _ }) ->
+       Alcotest.(check bool)
+         "wrong catalog row is rejected by exact candidate binding"
+         true
+         (contains_substring reason "catalog binding mismatch")
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+     | Ok () -> Alcotest.fail "wrong repository binding must retain manual approval");
+    Alcotest.(check bool)
+      "wrong binding keeps manual approval pending"
+      true
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
+    write_repositories base_path [ registered; manually_registered ];
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
      | Ok () -> ()
      | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    Alcotest.(check bool)
+      "manual review is removed after exact catalog access becomes allowed"
+      false
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
       Alcotest.(check bool)
-        "manual review approval does not persist alias"
+        "manual review resolution does not auto-mutate the original repository"
         false
         (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
@@ -521,10 +782,11 @@ let test_nested_git_root_queues_manual_review_without_alias () =
 let test_alias_approval_rechecks_clone_origin () =
   if not (git_available ()) then Alcotest.skip ()
   else (
-    AQ.For_testing.reset_audit_store ();
-    Fun.protect ~finally:AQ.For_testing.reset_audit_store @@ fun () ->
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
     with_temp_base_path @@ fun base_path ->
-    let keeper_id = "keeper-repo-alias-stale-origin" in
+    let keeper_id = "repo-alias-stale-origin" in
+    seed_keeper_meta base_path keeper_id;
     let registered = sample_repo ~base_path "masc" in
     let registered =
       { registered with url = "https://github.com/jeong-sik/masc.git"; aliases = [] }
@@ -546,18 +808,265 @@ let test_alias_approval_rechecks_clone_origin () =
     let pending = require_one_pending ~keeper_id in
     set_git_origin_url repo_root "https://github.com/jeong-sik/not-masc.git";
     (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Error (AQ.Delivery_failed _) -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err)
+     | Ok () -> Alcotest.fail "failed alias revalidation must retain the approval");
+    Alcotest.(check bool)
+      "failed alias revalidation keeps approval pending"
+      true
+      (Option.is_some (AQ.get_pending_entry ~id:pending.id));
+    set_git_origin_url repo_root registered.url;
+    write_repositories base_path [ { registered with aliases = [ "masc-mcp" ] } ];
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
      | Ok () -> ()
      | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
     match Repo_store.find ~base_path "masc" with
     | Error detail -> Alcotest.fail ("existing repo disappeared: " ^ detail)
     | Ok repo ->
       Alcotest.(check bool)
-        "stale alias not persisted"
-        false
+        "retry persists alias after revalidation succeeds"
+        true
         (List.exists (String.equal "masc-mcp") repo.aliases))
 ;;
 
+let test_pending_record_restores_gate_after_store_before_pause_crash () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "repo-crash-gap" in
+    seed_keeper_meta base_path keeper_id;
+    write_repositories base_path [];
+    let _, _ =
+      request_clone_registration
+        ~base_path
+        ~keeper_id
+        ~repository_id:"crash-gap-repo"
+    in
+    let pending = require_one_pending ~keeper_id in
+    let operation_id = string_field "operation_id" pending.input in
+    let paused_meta = read_keeper_meta base_path keeper_id in
+    Alcotest.(check string)
+      "durable file and typed gate share exact operation identity"
+      operation_id
+      (repository_gate_operation_id paused_meta);
+    let ungated_meta =
+      { paused_meta with
+        paused = false
+      ; latched_reason = None
+      ; runtime = { paused_meta.runtime with last_blocker = None }
+      }
+    in
+    write_keeper_meta_direct base_path ungated_meta;
+    AQ.For_testing.reset_pending ();
+    let config = Masc.Workspace.default_config base_path in
+    (match Claim.restore_pending_registration_hitl ~config ungated_meta with
+     | Claim.Registration_restored -> ()
+     | Claim.No_registration_record -> Alcotest.fail "crash-gap record disappeared"
+     | Claim.Registration_superseded -> Alcotest.fail "crash-gap record was superseded"
+     | Claim.Registration_corrupt detail -> Alcotest.fail detail);
+    let restored_meta = read_keeper_meta base_path keeper_id in
+    Alcotest.(check bool) "restore reinstalls durable pause" true restored_meta.paused;
+    Alcotest.(check string)
+      "restore reuses exact operation identity"
+      operation_id
+      (repository_gate_operation_id restored_meta);
+    let restored = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "restored queue entry reuses exact operation identity"
+      operation_id
+      (string_field "operation_id" restored.input))
+;;
+
+let test_reject_persists_terminal_pause_and_blocks_requeue () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "repo-reject-terminal" in
+    seed_keeper_meta base_path keeper_id;
+    write_repositories base_path [];
+    let _, _ =
+      request_clone_registration
+        ~base_path
+        ~keeper_id
+        ~repository_id:"rejected-repo"
+    in
+    let pending = require_one_pending ~keeper_id in
+    (match
+       AQ.resolve
+         ~id:pending.id
+         ~decision:(Agent_sdk.Hooks.Reject "operator denied exact registration")
+     with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    let rejected_meta = read_keeper_meta base_path keeper_id in
+    let terminal_rejection =
+      rejected_meta.paused
+      &&
+      match rejected_meta.latched_reason with
+      | Some
+          (Keeper_latched_reason.Operator_paused
+            { operator_actor = Keeper_latched_reason.Hitl_rejection }) ->
+        true
+      | Some (Keeper_latched_reason.Operator_paused _)
+      | Some _ | None -> false
+    in
+    Alcotest.(check bool) "Reject persists terminal HITL pause" true terminal_rejection;
+    Alcotest.(check bool)
+      "Reject removes terminal durable operation only after commit"
+      false
+      (repository_operation_record_exists base_path);
+    (match
+       Claim.request_repository_access
+         ~keeper_id
+         ~base_path
+         ~repository_id:"rejected-repo"
+     with
+     | Claim.Access_denied detail ->
+       Alcotest.(check bool)
+         "same operation cannot requeue before explicit resume"
+         true
+         (contains_substring detail "terminally paused")
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "rejected repository operation must not requeue"
+     | Claim.Access_allowed -> Alcotest.fail "unregistered rejected repository was allowed");
+    Alcotest.(check int) "no replacement approval queued" 0 (AQ.pending_count ()))
+;;
+
+let test_stale_approve_preserves_dead_tombstone () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "repo-dead-supersedes" in
+    seed_keeper_meta base_path keeper_id;
+    write_repositories base_path [];
+    let _, _ =
+      request_clone_registration
+        ~base_path
+        ~keeper_id
+        ~repository_id:"dead-supersedes-repo"
+    in
+    let pending = require_one_pending ~keeper_id in
+    let gated_meta = read_keeper_meta base_path keeper_id in
+    let dead_meta =
+      { gated_meta with
+        paused = true
+      ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+      ; auto_resume_after_sec = None
+      ; runtime = { gated_meta.runtime with last_blocker = None }
+      }
+    in
+    write_keeper_meta_direct base_path dead_meta;
+    (match AQ.resolve ~id:pending.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    let authoritative = read_keeper_meta base_path keeper_id in
+    let dead_preserved =
+      authoritative.paused
+      &&
+      match authoritative.latched_reason with
+      | Some Keeper_latched_reason.Dead_tombstone -> true
+      | Some _ | None -> false
+    in
+    Alcotest.(check bool) "newer Dead tombstone wins stale Approve" true dead_preserved;
+    Alcotest.(check bool)
+      "stale approval terminalizes its own durable record"
+      false
+      (repository_operation_record_exists base_path);
+    Alcotest.(check int) "stale approval is removed" 0 (AQ.pending_count ()))
+;;
+
+let test_distinct_operations_are_single_flight_per_keeper () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "repo-single-flight" in
+    seed_keeper_meta base_path keeper_id;
+    write_repositories base_path [];
+    let _, _ =
+      request_clone_registration
+        ~base_path
+        ~keeper_id
+        ~repository_id:"first-repo"
+    in
+    let second_root =
+      playground_repo_root ~base_path ~keeper_id ~repository_id:"second-repo"
+    in
+    init_git_repo second_root "https://github.com/test/second-repo.git";
+    (match
+       Claim.request_repository_access
+         ~keeper_id
+         ~base_path
+         ~repository_id:"second-repo"
+     with
+     | Claim.Access_denied detail ->
+       Alcotest.(check bool)
+         "second exact operation reports the active single-flight owner"
+         true
+         (contains_substring detail "another repository operation is already pending")
+     | Claim.Access_denied_hitl_pending _ ->
+       Alcotest.fail "distinct repository operation must not dedupe to the first approval"
+     | Claim.Access_allowed -> Alcotest.fail "second unregistered repository was allowed");
+    Alcotest.(check int) "one repository approval remains" 1 (AQ.pending_count ()))
+;;
+
+let test_corrupt_record_installs_actionable_recovery_gate () =
+  if not (git_available ()) then Alcotest.skip ()
+  else (
+    reset_approval_state ();
+    Fun.protect ~finally:reset_approval_state @@ fun () ->
+    with_temp_base_path @@ fun base_path ->
+    let keeper_id = "repo-corrupt-recovery" in
+    seed_keeper_meta base_path keeper_id;
+    write_repositories base_path [];
+    let _, _ =
+      request_clone_registration
+        ~base_path
+        ~keeper_id
+        ~repository_id:"corrupt-repo"
+    in
+    let gated_meta = read_keeper_meta base_path keeper_id in
+    let durable_path = repository_operation_path base_path in
+    AQ.For_testing.reset_pending ();
+    write_file durable_path "{not-valid-json";
+    let config = Masc.Workspace.default_config base_path in
+    (match Claim.restore_pending_registration_hitl ~config gated_meta with
+     | Claim.Registration_corrupt detail ->
+       Alcotest.(check bool)
+         "corrupt outcome keeps parse evidence"
+         true
+         (String.trim detail <> "")
+     | Claim.No_registration_record -> Alcotest.fail "corrupt record disappeared"
+     | Claim.Registration_restored -> Alcotest.fail "corrupt record was treated as valid"
+     | Claim.Registration_superseded -> Alcotest.fail "corrupt record was silently dropped");
+    let recovery = require_one_pending ~keeper_id in
+    Alcotest.(check string)
+      "corrupt record exposes dedicated operator recovery"
+      "keeper_repository_registration_recovery"
+      recovery.tool_name;
+    let recovery_meta = read_keeper_meta base_path keeper_id in
+    Alcotest.(check bool) "corrupt record remains fail-closed" true recovery_meta.paused;
+    Sys.remove durable_path;
+    (match AQ.resolve ~id:recovery.id ~decision:Agent_sdk.Hooks.Approve with
+     | Ok () -> ()
+     | Error err -> Alcotest.fail (AQ.resolve_error_to_string err));
+    let resumed_meta = read_keeper_meta base_path keeper_id in
+    Alcotest.(check bool)
+      "operator repair and Approve clears only the corrupt recovery gate"
+      false
+      resumed_meta.paused)
+;;
+
 let () =
+  Fs_compat.clear_fs ();
+  Eio_guard.disable ();
   Alcotest.run
     "Keeper_repo_claim_hitl"
     [ ( "repo advisory access"
@@ -601,5 +1110,25 @@ let () =
             "alias approval rechecks clone origin"
             `Quick
             test_alias_approval_rechecks_clone_origin
+        ; Alcotest.test_case
+            "store-before-pause crash restores exact repository gate"
+            `Quick
+            test_pending_record_restores_gate_after_store_before_pause_crash
+        ; Alcotest.test_case
+            "Reject persists terminal pause and blocks requeue"
+            `Quick
+            test_reject_persists_terminal_pause_and_blocks_requeue
+        ; Alcotest.test_case
+            "stale Approve preserves newer Dead tombstone"
+            `Quick
+            test_stale_approve_preserves_dead_tombstone
+        ; Alcotest.test_case
+            "distinct repository operations are single-flight per keeper"
+            `Quick
+            test_distinct_operations_are_single_flight_per_keeper
+        ; Alcotest.test_case
+            "corrupt durable record exposes operator recovery gate"
+            `Quick
+            test_corrupt_record_installs_actionable_recovery_gate
         ] )
     ]

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -11,7 +11,40 @@ module Keeper_types_profile = Masc.Keeper_types_profile
 module Reg = Masc.Keeper_registry
 module KT = Keeper_types
 module KR = Masc.Keeper_runtime
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 16
+
+  let base_path_for_id_opt id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some _ as scope -> scope
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         Some base_path
+       | None -> None)
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve
+      ~base_path:(Option.value ~default:"" (base_path_for_id_opt id))
+      ~id
+      ~decision
+  ;;
+
+  let get_pending_entry ~id =
+    match base_path_for_id_opt id with
+    | Some base_path -> Raw_AQ.get_pending_entry ~base_path ~id
+    | None -> None
+  ;;
+
+  let pending_count = For_testing.pending_count
+  let has_pending_for_keeper = For_testing.has_pending_for_keeper
+end
 module KSM = Keeper_state_machine
 module KLH = Masc.Keeper_lifecycle_hooks
 module FD = Keeper_fd_pressure
@@ -20,11 +53,28 @@ module KFP = Keeper_failure_policy
 module KSP = Masc.Keeper_supervisor_self_preservation
 module KSR = Masc.Keeper_supervisor_reconcile_keepalive
 
-let () =
+let install_durable_resolution_delivery_hook () =
   AQ.set_approval_resolution_wake_hook
     (fun
-      ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
-      Ok (fun () -> ()))
+      ~base_path ~keeper_name ~approval_id ~decision ~channel ->
+      let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+      let stimulus : Keeper_event_queue.stimulus =
+        { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+        ; urgency = Keeper_event_queue.Immediate
+        ; arrived_at = Unix.gettimeofday ()
+        ; payload = Keeper_event_queue.Hitl_resolved resolution
+        }
+      in
+      match
+        Masc.Keeper_registry_event_queue.enqueue_durable_result
+          ~base_path
+          keeper_name
+          stimulus
+      with
+      | Error _ as err -> err
+      | Ok () -> Ok (fun () -> ()))
+
+let () = install_durable_resolution_delivery_hook ()
 
 let supervisor_agent_name = Sup.supervisor_agent_name
 
@@ -554,13 +604,13 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
         [ blocked; clear ];
       let submit keeper_name =
         let id =
-          AQ.submit_pending
+          AQ.submit_pending_observer
             ~keeper_name
             ~tool_name:"keeper_continue_after_reconcile"
             ~input:(`Assoc [])
             ~risk_level:AQ.Critical
             ~base_path:config.base_path
-            ~on_resolution:(fun _ -> ())
+            ~on_resolution_observer:(fun _ -> ())
             ()
         in
         approval_ids := id :: !approval_ids
@@ -1414,7 +1464,7 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check int "approval count incremented"
         (pending_before + 1) (AQ.pending_count ());
       let approval_id =
-        match AQ.list_pending_json () with
+        match AQ.list_pending_json ~base_path:base_dir with
         | `List entries ->
             entries
             |> List.find_map (function
@@ -1429,9 +1479,80 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
         | _ -> ""
       in
       check bool "approval id present" true (approval_id <> "");
+      (match
+         AQ.resolve
+           ~id:approval_id
+           ~decision:(Agent_sdk.Hooks.Edit (`Assoc [ "unexpected", `Bool true ]))
+       with
+       | Error (AQ.Delivery_failed _) -> ()
+       | Error err -> fail (AQ.resolve_error_to_string err)
+       | Ok () -> fail "unsupported reconcile edit must retain the approval");
+      check bool
+        "unsupported reconcile edit keeps approval pending"
+        true
+        (Option.is_some (AQ.get_pending_entry ~id:approval_id));
+      ignore (Reg.register ~base_path:config.base_path meta.name meta);
+      Reg.set_failure_reason
+        ~base_path:config.base_path
+        meta.name
+        (Some (Reg.Completion_contract_violation { detail = "test latch" }));
+      let meta_path = Keeper_types_profile.keeper_meta_path config meta.name in
+      let backup_path = meta_path ^ ".approval-test-backup" in
+      Sys.rename meta_path backup_path;
+      Unix.mkdir meta_path 0o755;
+      (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+       | Error (AQ.Delivery_failed _) -> ()
+       | Error err -> fail (AQ.resolve_error_to_string err)
+       | Ok () -> fail "failed resume persistence must retain the approval");
+      check bool
+        "failed resume persistence keeps approval pending"
+        true
+        (Option.is_some (AQ.get_pending_entry ~id:approval_id));
+      let failure_latch_preserved =
+        match Reg.get ~base_path:config.base_path meta.name with
+        | Some { Reg.last_failure_reason =
+                   Some (Reg.Completion_contract_violation _)
+               ; _
+               } -> true
+        | Some _ | None -> false
+      in
+      check bool
+        "failed resume persistence keeps the live completion-contract latch"
+        true
+        failure_latch_preserved;
+      let live_gate_still_paused, wake_still_clear =
+        match Reg.get ~base_path:config.base_path meta.name with
+        | Some entry -> entry.meta.paused, not (Atomic.get entry.fiber_wakeup)
+        | None -> false, false
+      in
+      check bool
+        "failed resume persistence keeps live metadata paused"
+        true
+        live_gate_still_paused;
+      check bool
+        "failed resume persistence does not wake the keeper"
+        true
+        wake_still_clear;
+      Unix.rmdir meta_path;
+      Sys.rename backup_path meta_path;
+      Reg.unregister ~base_path:config.base_path meta.name;
       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
        | Ok () -> ()
-       | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
+       | Error err ->
+         fail ("restart-restored approve failed: " ^ AQ.resolve_error_to_string err));
+      check bool
+        "restart-restored approve removes reconcile approval"
+        false
+        (Option.is_some (AQ.get_pending_entry ~id:approval_id));
+      let failure_latch_cleared =
+        match Reg.get ~base_path:config.base_path meta.name with
+        | Some { Reg.last_failure_reason = None; _ } -> true
+        | Some _ | None -> false
+      in
+      check bool
+        "successful durable resume clears the live completion-contract latch"
+        true
+        failure_latch_cleared;
       let resumed_meta =
         match Keeper_meta_store.read_meta config meta.name with
         | Ok (Some value) -> value
@@ -1442,7 +1563,257 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
       check bool "blocker cleared after approval" true
         (Option.is_none resumed_meta.runtime.last_blocker);
       check bool "keeper registered after approval" true
-        (Reg.is_registered ~base_path:config.base_path meta.name))
+        (Reg.is_registered ~base_path:config.base_path meta.name);
+      let partial_paused_meta, partial_approval_id =
+        match
+          Masc.Keeper_turn_runtime_budget.persist_and_enqueue_partial_commit_continue_gate
+            ~config
+            ~meta:resumed_meta
+            ~failure_reason:
+              (Reg.Ambiguous_partial_commit
+                 { kind = Reg.Post_commit_failure; detail = "edit regression" })
+            ~committed_tools:[ "keeper_board_post" ]
+            ~error_detail:"edit regression"
+        with
+        | Ok value -> value
+        | Error err -> fail err
+      in
+      (match
+         AQ.resolve
+           ~id:partial_approval_id
+           ~decision:(Agent_sdk.Hooks.Edit (`Assoc [ "unexpected", `Bool true ]))
+       with
+       | Error (AQ.Delivery_failed _) -> ()
+       | Error err -> fail (AQ.resolve_error_to_string err)
+       | Ok () -> fail "unsupported partial-commit edit must retain the approval");
+      check bool
+        "unsupported partial-commit edit keeps approval pending"
+        true
+        (Option.is_some (AQ.get_pending_entry ~id:partial_approval_id));
+      (match
+         Reg.dispatch_event
+           ~base_path:config.base_path
+           partial_paused_meta.name
+           KSM.Operator_pause
+       with
+       | Ok _ -> ()
+       | Error err -> fail (KSM.transition_error_to_string err));
+      Reg.unregister ~base_path:config.base_path partial_paused_meta.name;
+      (match AQ.resolve ~id:partial_approval_id ~decision:Agent_sdk.Hooks.Approve with
+       | Ok () -> ()
+       | Error err ->
+         fail ("offline partial-commit approve failed: " ^ AQ.resolve_error_to_string err));
+      check bool
+        "offline partial-commit approve removes approval"
+        false
+        (Option.is_some (AQ.get_pending_entry ~id:partial_approval_id));
+      let persisted_partial_gate =
+        match Keeper_meta_store.read_meta config partial_paused_meta.name with
+        | Ok (Some value) -> value
+        | Ok None -> fail "expected persisted partial-commit gate"
+        | Error err -> fail err
+      in
+      check bool
+        "offline partial-commit approve clears durable pause"
+        false
+        persisted_partial_gate.paused)
+
+let test_rejected_continue_gates_become_terminal_operator_pauses () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _workspace =
+        Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
+      in
+      let paused_meta name =
+        let base = make_meta name in
+        { base with
+          paused = true
+        ; auto_resume_after_sec = Some 60.0
+        ; runtime =
+            { base.runtime with
+              last_blocker =
+                Some
+                  (Keeper_meta_contract.blocker_info_of_class
+                     ~detail:"operator decision required"
+                     Keeper_meta_contract.Ambiguous_post_commit_failure)
+            }
+        }
+      in
+      let reconcile_meta = paused_meta "reconcile-reject-terminal" in
+      let partial_meta =
+        let meta = paused_meta "partial-reject-terminal" in
+        { meta with paused = false; auto_resume_after_sec = None }
+      in
+      List.iter
+        (fun meta ->
+           match Keeper_meta_store.write_meta config meta with
+           | Ok () -> ()
+           | Error err -> fail err)
+        [ reconcile_meta; partial_meta ];
+      let _partial_paused, partial_id =
+        match
+          Masc.Keeper_turn_runtime_budget.persist_and_enqueue_partial_commit_continue_gate
+            ~config
+            ~meta:partial_meta
+            ~failure_reason:
+              (Reg.Ambiguous_partial_commit
+                 { kind = Reg.Post_commit_failure; detail = "operator rejected" })
+            ~committed_tools:[ "keeper_board_post" ]
+            ~error_detail:"operator rejected"
+        with
+        | Ok value -> value
+        | Error err -> fail err
+      in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        }
+      in
+      sweep_and_recover_no_materialize ctx;
+      let reconcile_id =
+        AQ.list_pending_entries ~base_path:base_dir
+        |> List.find_map (fun (entry : AQ.pending_approval) ->
+          if String.equal entry.keeper_name reconcile_meta.name
+          then Some entry.id
+          else None)
+        |> Option.value ~default:""
+      in
+      check bool "reconcile rejection approval restored" true (reconcile_id <> "");
+      List.iter
+        (fun id ->
+           match
+             AQ.resolve
+               ~id
+               ~decision:(Agent_sdk.Hooks.Reject "remain paused")
+           with
+           | Ok () -> ()
+           | Error err -> fail (AQ.resolve_error_to_string err))
+        [ reconcile_id; partial_id ];
+      let expected_latch =
+        Keeper_latched_reason.Operator_paused
+          { operator_actor = Keeper_latched_reason.operator_actor_hitl_rejection }
+      in
+      List.iter
+        (fun name ->
+           let persisted =
+             match Keeper_meta_store.read_meta config name with
+             | Ok (Some meta) -> meta
+             | Ok None -> fail ("missing rejected keeper meta: " ^ name)
+             | Error err -> fail err
+           in
+           check bool (name ^ " remains durably paused") true persisted.paused;
+           check bool
+             (name ^ " clears the resolved reconcile blocker")
+             true
+             (Option.is_none persisted.runtime.last_blocker);
+           check bool
+             (name ^ " records typed HITL rejection")
+             true
+             (match persisted.latched_reason with
+              | Some reason -> Keeper_latched_reason.equal reason expected_latch
+              | None -> false);
+           check (option (float 0.001))
+             (name ^ " disables auto-resume")
+             None
+             persisted.auto_resume_after_sec)
+        [ reconcile_meta.name; partial_meta.name ];
+      sweep_and_recover_no_materialize ctx;
+      check int
+        "rejected terminal pauses do not re-enqueue approvals"
+        0
+        (AQ.pending_count ()))
+
+let test_stale_continue_approval_preserves_dead_and_terminal_cancels () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Raw_AQ.For_testing.reset_pending ();
+  Raw_AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:(fun () ->
+      Raw_AQ.For_testing.reset_pending ();
+      Raw_AQ.For_testing.reset_audit_store ();
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       let meta = make_meta "continue-dead-supersedes" in
+       (match Keeper_meta_store.write_meta config meta with
+        | Ok () -> ()
+        | Error err -> fail err);
+       let paused_meta, approval_id =
+         match
+           Masc.Keeper_turn_runtime_budget.persist_and_enqueue_partial_commit_continue_gate
+             ~config
+             ~meta
+             ~failure_reason:
+               (Reg.Ambiguous_partial_commit
+                  { kind = Reg.Post_commit_failure; detail = "dead supersedes" })
+             ~committed_tools:[ "keeper_board_post" ]
+             ~error_detail:"dead supersedes"
+         with
+         | Ok value -> value
+         | Error err -> fail err
+       in
+       let dead =
+         { paused_meta with
+           paused = true
+         ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+         ; auto_resume_after_sec = None
+         ; runtime = { paused_meta.runtime with last_blocker = None }
+         }
+       in
+       (match Keeper_meta_store.write_meta config dead with
+        | Ok () -> ()
+        | Error err -> fail err);
+       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+        | Error (AQ.Delivery_failed _) -> ()
+        | Error err -> fail (AQ.resolve_error_to_string err)
+        | Ok () -> fail "stale continue approval must not resume Dead keeper");
+       let persisted =
+         match Keeper_meta_store.read_meta config meta.name with
+         | Ok (Some value) -> value
+         | Ok None -> fail "Dead keeper metadata disappeared"
+         | Error err -> fail err
+       in
+       check bool "stale Approve preserves durable Dead pause" true persisted.paused;
+       check bool
+         "stale Approve preserves exact Dead tombstone"
+         true
+         (match persisted.latched_reason with
+          | Some Keeper_latched_reason.Dead_tombstone -> true
+          | Some _ | None -> false);
+       check bool
+         "failed stale callback remains pending until terminal cancellation"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:approval_id));
+       let cancelled =
+         Raw_AQ.cancel_callback_owned_for_terminal_keeper
+           ~base_path:base_dir
+           ~keeper_name:meta.name
+           ~reason:"superseded by durable keeper Dead tombstone"
+       in
+       check int "terminal cancellation removes exact stale callback" 1 cancelled;
+       check bool
+         "terminal cancellation leaves no stale approval"
+         true
+         (Option.is_none (AQ.get_pending_entry ~id:approval_id)))
 
 let test_sweep_reports_pending_hitl_approval () =
   Eio_main.run @@ fun env ->
@@ -1473,13 +1844,13 @@ let test_sweep_reports_pending_hitl_approval () =
        | Error err -> fail err);
       let callback_result = ref None in
       let id =
-        AQ.submit_pending
+        AQ.submit_pending_observer
           ~keeper_name:name
           ~tool_name:"keeper_continue_after_partial_commit"
           ~input:(`Assoc [ ("kind", `String "visibility_probe") ])
           ~risk_level:AQ.Critical
           ~base_path:config.base_path
-          ~on_resolution:(fun decision -> callback_result := Some decision)
+          ~on_resolution_observer:(fun decision -> callback_result := Some decision)
           ()
       in
       approval_id := Some id;
@@ -3825,6 +4196,10 @@ let () =
         test_pending_hitl_approval_keeper_names_filters_persisted_pending;
       test_case "sweep restores reconcile gate for paused keeper" `Quick
         test_sweep_restores_reconcile_gate_for_paused_keeper;
+      test_case "rejected continue gates become terminal operator pauses" `Quick
+        test_rejected_continue_gates_become_terminal_operator_pauses;
+      test_case "stale continue approval preserves Dead and terminal-cancels" `Quick
+        test_stale_continue_approval_preserves_dead_and_terminal_cancels;
       test_case "sweep warns for pending HITL approval" `Quick
         test_sweep_reports_pending_hitl_approval;
     ];

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -12,8 +12,60 @@
 module D = Masc.Keeper_tool_deterministic_error
 module Execute_runtime = Masc.Keeper_tool_execute_runtime.For_testing
 module Shell_dispatch = Keeper_tool_execute_shell_ir
-module AQ = Masc.Keeper_approval_queue
+module Raw_AQ = Masc.Keeper_approval_queue
+
+module AQ = struct
+  include Raw_AQ
+
+  let pending_scopes : (string, string) Hashtbl.t = Hashtbl.create 8
+
+  let base_path_for_id id =
+    match Hashtbl.find_opt pending_scopes id with
+    | Some base_path -> base_path
+    | None ->
+      (match For_testing.pending_base_path ~id with
+       | Some base_path ->
+         Hashtbl.replace pending_scopes id base_path;
+         base_path
+       | None -> "")
+  ;;
+
+  let resolve ~id ~decision =
+    Raw_AQ.resolve ~base_path:(base_path_for_id id) ~id ~decision
+  ;;
+
+  let get_pending_entry ~id =
+    let base_path = base_path_for_id id in
+    if String.equal base_path "" then None
+    else Raw_AQ.get_pending_entry ~base_path ~id
+  ;;
+
+  let pending_count = For_testing.pending_count
+end
 module Metrics = Masc.Otel_metric_store
+
+let install_durable_resolution_delivery_hook () =
+  AQ.set_approval_resolution_wake_hook
+    (fun ~base_path ~keeper_name ~approval_id ~decision ~channel ->
+       let resolution = Keeper_event_queue.{ approval_id; decision; channel } in
+       let stimulus : Keeper_event_queue.stimulus =
+         { post_id = Keeper_event_queue.hitl_resolution_post_id resolution
+         ; urgency = Keeper_event_queue.Immediate
+         ; arrived_at = Unix.gettimeofday ()
+         ; payload = Keeper_event_queue.Hitl_resolved resolution
+         }
+       in
+       match
+         Masc.Keeper_registry_event_queue.enqueue_durable_result
+           ~base_path
+           keeper_name
+           stimulus
+       with
+       | Error _ as err -> err
+       | Ok () -> Ok (fun () -> ()))
+;;
+
+let () = install_durable_resolution_delivery_hook ()
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -192,10 +192,15 @@ let assert_repository_registration_policy_response ~raw =
     (Json.member "approval_pending" json |> Json.member "reason"
     |> Json.to_string_option);
   Alcotest.(check (option bool))
-    "approval is non-blocking"
-    (Some true)
+    "approval owns the blocking lane"
+    (Some false)
     (Json.member "approval_pending" json |> Json.member "non_blocking"
     |> Json.to_bool_option);
+  Alcotest.(check (option string))
+    "approval lane policy"
+    (Some "blocking")
+    (Json.member "approval_pending" json |> Json.member "lane_policy"
+    |> Json.to_string_option);
   Alcotest.(check (option string))
     "deterministic retry reason"
     (Some "policy_blocked")
@@ -864,7 +869,7 @@ let test_rg_unregistered_clone_queues_repository_hitl () =
     in
     assert_repository_registration_policy_response ~raw;
     match
-      AQ.list_pending_entries ()
+      AQ.list_pending_entries ~base_path:config.base_path
       |> List.filter (fun (entry : AQ.pending_approval) ->
         String.equal entry.keeper_name meta.name)
     with
@@ -911,7 +916,7 @@ let test_read_unregistered_clone_surfaces_repository_hitl () =
     in
     assert_repository_registration_policy_response ~raw;
     match
-      AQ.list_pending_entries ()
+      AQ.list_pending_entries ~base_path:config.base_path
       |> List.filter (fun (entry : AQ.pending_approval) ->
         String.equal entry.keeper_name meta.name)
     with

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -23,6 +23,247 @@ let base_path = "/tmp/masc_test_turn_admission"
 let keeper_name = "admission-keeper"
 let reset () = Keeper_turn_admission.For_testing.reset ()
 
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String ("agent-" ^ name)
+        ; "trace_id", `String ("trace-" ^ name)
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> failwith ("make_meta: " ^ err)
+;;
+
+let test_direct_turn_respects_blocking_approval_lane () =
+  Printf.printf "Test 0: direct chat respects workspace-scoped Blocking approvals\n%!";
+  let other_base_path = base_path ^ "-other" in
+  let meta = make_meta keeper_name in
+  let blocked () =
+    Keeper_turn.For_testing.direct_turn_blocked_by_approval
+      ~base_path
+      meta
+  in
+  check "direct chat starts unblocked" (not (blocked ()));
+  let blocking_id =
+    Keeper_approval_queue.submit_pending_blocking
+      ~keeper_name
+      ~tool_name:"keeper_continue_after_reconcile"
+      ~input:(`Assoc [ "kind", `String "direct_turn_gate_test" ])
+      ~risk_level:Keeper_approval_queue.Critical
+      ~base_path
+      ~on_resolution:(fun ~approval_id decision ->
+        Keeper_approval_queue.blocking_resolution_plan
+          ~effect_key:("direct_turn_gate_test:" ^ approval_id)
+          ~commit:(fun () ->
+            let (_ : Agent_sdk.Hooks.approval_decision) = decision in
+            fun () -> ()))
+      ()
+  in
+  check "Blocking approval rejects direct chat in its workspace" (blocked ());
+  check
+    "Blocking approval does not leak into another workspace"
+    (not
+       (Keeper_turn.For_testing.direct_turn_blocked_by_approval
+          ~base_path:other_base_path
+          meta));
+  check
+    "Blocking approval does not block a different keeper"
+    (not
+       (Keeper_turn.For_testing.direct_turn_blocked_by_approval
+          ~base_path
+          (make_meta (keeper_name ^ "-other"))));
+  (match
+     Keeper_approval_queue.resolve
+       ~base_path
+       ~id:blocking_id
+       ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+   with
+   | Ok () -> ()
+  | Error err ->
+    check
+      ("blocking approval cleanup: "
+       ^ Keeper_approval_queue.resolve_error_to_string err)
+       false);
+  check "resolved Blocking approval releases direct chat" (not (blocked ()));
+  let persisted_gate_meta =
+    { meta with
+      paused = true
+    ; runtime =
+        { meta.runtime with
+          last_blocker =
+            Some
+              (Keeper_meta_contract.blocker_info_of_class
+                 ~detail:"approval queue restore pending"
+                 Keeper_meta_contract.Ambiguous_post_commit_failure)
+        }
+    }
+  in
+  check
+    "typed persisted continue gate blocks before queue rehydration"
+    (Keeper_turn.For_testing.direct_turn_blocked_by_approval
+       ~base_path
+       persisted_gate_meta);
+  let ordinary_paused_meta =
+    { meta with
+      paused = true
+    ; runtime =
+        { meta.runtime with
+          last_blocker =
+            Some
+              (Keeper_meta_contract.blocker_info_of_class
+                 ~detail:"ordinary recovery chat remains available"
+                 Keeper_meta_contract.No_progress_loop)
+        }
+    }
+  in
+  check
+    "ordinary paused recovery state still allows direct chat"
+    (not
+       (Keeper_turn.For_testing.direct_turn_blocked_by_approval
+          ~base_path
+          ordinary_paused_meta));
+  Keeper_approval_queue.set_approval_resolution_wake_hook
+    (fun ~base_path:_ ~keeper_name:_ ~approval_id:_ ~decision:_ ~channel:_ ->
+      Ok (fun () -> ()));
+  let nonblocking_id =
+    Keeper_approval_queue.submit_pending_observer
+      ~keeper_name
+      ~tool_name:"keeper_observation"
+      ~input:(`Assoc [ "kind", `String "direct_turn_observer_test" ])
+      ~risk_level:Keeper_approval_queue.Medium
+      ~base_path
+      ~on_resolution_observer:(fun _ -> ())
+      ()
+  in
+  check "Nonblocking approval keeps direct chat available" (not (blocked ()));
+  match
+    Keeper_approval_queue.resolve
+      ~base_path
+      ~id:nonblocking_id
+      ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+  with
+  | Ok () -> ()
+  | Error err ->
+    check
+      ("nonblocking approval cleanup: "
+       ^ Keeper_approval_queue.resolve_error_to_string err)
+      false
+;;
+
+let test_inflight_blocking_approval_stops_before_next_provider_turn () =
+  Printf.printf
+    "Test 0b: tool-created Blocking approval stops the in-flight OAS loop\n%!";
+  let module F = Keeper_agent_run.For_testing in
+  let gate_base_path = base_path ^ "-inflight-gate" in
+  let gate_keeper_name = keeper_name ^ "-inflight-gate" in
+  let provider_turns = ref 0 in
+  let blocking_id = ref None in
+  let rec run_provider_loop ~turn ~remaining =
+    if remaining = 0
+    then `Budget_exhausted
+    else
+      match
+        F.blocking_approval_yield_request
+          ~base_path:gate_base_path
+          ~keeper_name:gate_keeper_name
+      with
+      | Some request
+        when F.autonomous_yield_allowed_at_turn
+               ~start_turn:0
+               ~turn
+               request ->
+        `Yielded
+          (F.stop_reason_of_autonomous_yield
+             ~start_turn:0
+             ~turn
+             request)
+      | Some _ | None ->
+        incr provider_turns;
+        (* Deterministic stand-in for the first provider response invoking a
+           MASC tool whose callback publishes a non-suspending Blocking gate.
+           OAS checks the same typed request before dispatching provider turn 2. *)
+        if !provider_turns = 1
+        then
+          blocking_id :=
+            Some
+              (Keeper_approval_queue.submit_pending_blocking
+                 ~keeper_name:gate_keeper_name
+                 ~tool_name:"keeper_continue_after_partial_commit"
+                 ~input:(`Assoc [ "kind", `String "tool_created_gate" ])
+                 ~risk_level:Keeper_approval_queue.Critical
+                 ~base_path:gate_base_path
+                 ~on_resolution:(fun ~approval_id decision ->
+                   Keeper_approval_queue.blocking_resolution_plan
+                     ~effect_key:("inflight_gate_test:" ^ approval_id)
+                     ~commit:(fun () ->
+                       let (_ : Agent_sdk.Hooks.approval_decision) = decision in
+                       fun () -> ()))
+                 ());
+        run_provider_loop ~turn:(turn + 1) ~remaining:(remaining - 1)
+  in
+  let preexisting_id =
+    Keeper_approval_queue.submit_pending_blocking
+      ~keeper_name:gate_keeper_name
+      ~tool_name:"keeper_continue_after_partial_commit"
+      ~input:(`Assoc [ "kind", `String "preexisting_gate" ])
+      ~risk_level:Keeper_approval_queue.Critical
+      ~base_path:gate_base_path
+      ~on_resolution:(fun ~approval_id decision ->
+        Keeper_approval_queue.blocking_resolution_plan
+          ~effect_key:("preexisting_gate_test:" ^ approval_id)
+          ~commit:(fun () ->
+            let (_ : Agent_sdk.Hooks.approval_decision) = decision in
+            fun () -> ()))
+      ()
+  in
+  (match run_provider_loop ~turn:0 ~remaining:3 with
+   | `Yielded
+       (Runtime_agent.Yielded_to_blocking_approval
+          { turns_used = 0; provider_turns_completed = 0 }) ->
+     check "preexisting Blocking gate stopped before provider turn 1" true
+   | `Yielded _ | `Budget_exhausted ->
+     check "preexisting Blocking gate stopped before provider turn 1" false);
+  check "preexisting gate allowed zero provider turns" (!provider_turns = 0);
+  (match
+     Keeper_approval_queue.resolve
+       ~base_path:gate_base_path
+       ~id:preexisting_id
+       ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+   with
+   | Ok () -> ()
+   | Error err ->
+     check
+       ("preexisting Blocking approval cleanup: "
+        ^ Keeper_approval_queue.resolve_error_to_string err)
+       false);
+  provider_turns := 0;
+  (match run_provider_loop ~turn:0 ~remaining:3 with
+   | `Yielded
+       (Runtime_agent.Yielded_to_blocking_approval
+          { turns_used = 1; provider_turns_completed = 1 }) ->
+     check "typed Blocking boundary stopped before provider turn 2" true
+   | `Yielded _ | `Budget_exhausted ->
+     check "typed Blocking boundary stopped before provider turn 2" false);
+  check "only the gate-creating provider turn ran" (!provider_turns = 1);
+  match !blocking_id with
+  | None -> check "tool-created Blocking gate was published" false
+  | Some id ->
+    (match
+       Keeper_approval_queue.resolve
+         ~base_path:gate_base_path
+         ~id
+         ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+     with
+     | Ok () -> ()
+     | Error err ->
+       check
+         ("in-flight Blocking approval cleanup: "
+          ^ Keeper_approval_queue.resolve_error_to_string err)
+         false)
+;;
+
 let test_free_slot_admits () =
   reset ();
   Printf.printf "Test 1: free slot admits both lanes\n%!";
@@ -440,6 +681,8 @@ let test_autonomous_yields_to_queued_connector_message () =
 
 let () =
   Eio_main.run @@ fun _env ->
+  test_direct_turn_respects_blocking_approval_lane ();
+  test_inflight_blocking_approval_stops_before_next_provider_turn ();
   test_free_slot_admits ();
   test_chat_if_free_never_parks ();
   test_autonomous_skips_in_flight_chat ();

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -52,7 +52,11 @@ let test_of_stop_reason () =
        (Runtime_agent.Yielded_to_chat_waiting { turns_used = 2 }));
   check outcome "durable stimulus yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
-       (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }))
+       (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }));
+  check outcome "blocking approval yield -> checkpoint" TO.Continuation_checkpoint
+    (TO.of_stop_reason
+       (Runtime_agent.Yielded_to_blocking_approval
+          { turns_used = 2; provider_turns_completed = 1 }))
 
 let test_of_result_surface () =
   check outcome "completed with text -> visible" TO.Visible_reply
@@ -82,6 +86,11 @@ let test_autonomous_yield_boundary_contract () =
     ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
     }
   in
+  let blocking_approval : Masc.Keeper_agent_run.autonomous_yield_request =
+    { reason = Masc.Keeper_agent_run.Blocking_approval_waiting
+    ; boundary = Masc.Keeper_agent_run.Yield_immediately
+    }
+  in
   check bool "chat may yield before first provider dispatch" true
     (F.autonomous_yield_allowed_at_turn
        ~start_turn
@@ -102,8 +111,19 @@ let test_autonomous_yield_boundary_contract () =
        ~start_turn
        ~turn:(start_turn + 1)
        durable_stimulus);
+  check bool "preexisting blocking approval prevents provider turn 1" true
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:start_turn
+       blocking_approval);
+  check bool "in-flight blocking approval stops before provider turn 2" true
+    (F.autonomous_yield_allowed_at_turn
+       ~start_turn
+       ~turn:(start_turn + 1)
+       blocking_approval);
   match
     F.stop_reason_of_autonomous_yield
+      ~start_turn
       ~turn:(start_turn + 1)
       durable_stimulus
   with
@@ -113,7 +133,8 @@ let test_autonomous_yield_boundary_contract () =
   | Runtime_agent.Completed
   | Runtime_agent.TurnBudgetExhausted _
   | Runtime_agent.MutationBoundaryReached _
-  | Runtime_agent.Yielded_to_chat_waiting _ ->
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_blocking_approval _ ->
     fail "durable request mapped to the wrong stop reason"
 
 let payload fields = Some (`Assoc fields)

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -222,6 +222,7 @@ let test_threaded_stimulus_decision_renders_wake_reason () =
      scheduler decision knows the trigger, the legacy recompute cannot. *)
   let decision =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
       ~meta base_observation
   in
@@ -240,6 +241,7 @@ let test_hitl_resolution_steers_continuation () =
      keeper_surface_post instead of only proceeding on its own state. *)
   let decision =
     WO.keeper_cycle_decision
+      ~base_path:""
       ~event_queue_triggers:[ WO.Hitl_resolved_stimulus ]
       ~meta base_observation
   in


### PR DESCRIPTION
## Summary

This Draft closes the post-merge P1 gaps found in the 48-hour MASC/OAS audit:

- makes Blocking HITL decisions durable, single-owner, workspace-scoped, and retry-idempotent
- persists exact typed continue/repository-registration gates across restart and rejects stale approvals without overwriting newer `Dead` or operator state
- blocks queued chat, direct chat, and in-flight provider turns at the same Blocking boundary
- makes nonblocking approval resolution durable before acknowledgement
- serializes keeper meta CAS with a cross-domain per-path lock, preserving typed control state during heartbeat/bootstrap/identity repair
- restores corrupt repository-registration records through a dedicated operator recovery gate
- aligns dashboard/SSE/governance projections with workspace authority

## Product impact

- User-visible change: keepers stop at one durable operator-decision boundary instead of resuming, duplicating work, or losing a gate after restart/race. Dashboard and SSE approval views are isolated to the active workspace.

## Root cause evidence

The post-rebase supervisor regression reproduced two writes of the same `meta_version=5`: a typed partial-commit gate was persisted, then a stale identity repair overwrote it with another version 5. The process-local lock depended on global Eio guard registration, while POSIX `lockf` does not serialize threads in the same process. The new lock regression and meta CAS test prove exactly one same-version writer wins even when the Eio guard is disabled.

## Evidence

- `test_file_lock_eio`: 4/4
- `test_keeper_meta_cas_retry`: 8/8
- `test_keeper_repo_claim_hitl`: 15/15
- `test_keeper_approval_queue`: 29/29
- `test_keeper_supervisor`: 90/90
- `test_keeper_latched_reason`: 8/8
- `test_keeper_latched_reason_wiring`: 12/12
- `test_keeper_turn_admission`: all checks passed
- `test_keeper_tool_execute_retry_deterministic_close`: 40/40
- queued-chat, governance, HITL summary, heartbeat, reactive-wake, containment, connector, and failed-task focused executables passed
- `bash scripts/check-variants.sh`: PASS
- `git diff --check`: clean

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/3
provenance: operator_proxy
stages:
  - name: reproduce_same_version_overwrite
    provenance: operator_proxy
    evidence: "supervisor regression emitted two meta_version=5 writes; the stale identity write erased the typed gate"
  - name: focused_regression_suite
    provenance: operator_proxy
    evidence: "FileLock 4/4, CAS 8/8, repository HITL 15/15, approval queue 29/29, supervisor 90/90"
  - name: current_main_rebase_validation
    provenance: operator_proxy
    evidence: "rebased onto origin/main 2aee03b53b and reran the six core focused executables"
```

## GOAL LOOP ACT checklist

- [x] Observe — captured the same-version overwrite and stale typed-gate failure
- [x] Orient — mapped to the 48-hour post-merge P1 audit and exact HITL/keeper boundaries
- [x] Decide — P1 because stale writers could erase an operator-owned gate and duplicate side effects
- [x] Act — replaced the unsafe lock boundary and made gate decisions durable and typed
- [x] Verify — focused race, restart, stale-approval, Dead-tombstone, queued-chat, and provider-boundary tests pass
- [x] Loop — remaining work is CI and review cleanup on this Draft; no separate source follow-up is currently known

## Review evidence

Fresh-context GLM review was run over the approval/CAS/FileLock and execution/supervisor paths. Reported candidates were checked against current code and the focused race tests; no confirmed current-head blocker remained. Local Ollama review was attempted first but returned zero bytes and timed out, so it was not counted as review evidence.

## Linked issue

- Relates to the post-merge audit of #23956, #23963, #23974, #23976, #23977, and #23989.

## Variant addition checklist

- [x] **OCaml** — typed HITL/yield/latched variants and exhaustive matches updated
- [ ] **TypeScript** — N/A: no corresponding dashboard union variant was added or renamed
- [x] **TLA+ spec** — approval resolution ownership/state domain updated
- [x] **Event / JSON schema** — typed latched-reason and resolution payload codecs updated
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` passed locally

## Merge guard

This remains Draft and `do-not-merge` until required GitHub checks are green and review comments are resolved.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/hitl-postmerge-p1-20260710` → `main` · 1 commit(s) · synced 2026-07-11T03:31:42Z

| sha | subject | date |
|---|---|---|
| `d96089932` | fix(keeper): make HITL gates durable and exact | 2026-07-11 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->