### PR TITLE
DIAG (do-not-merge): executor_pool 34 base_path resolution probe

### DIFF
--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1359,9 +1359,28 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
         (Filename.concat keepers_dir "base.toml")
         "[keeper]\nautoboot_enabled = true\n";
       Config_dir_resolver.reset ();
+      let read_trim p =
+        if Sys.file_exists p
+        then String.trim (In_channel.with_open_bin p In_channel.input_all)
+        else "<none>"
+      in
+      let resolved_kdir =
+        Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+      in
+      Printf.eprintf
+        "[EP34] test_keepers_dir=%s\n[EP34] resolved_kdir=%s\n[EP34] same=%b\n\
+         [EP34] base@test=%s\n[EP34] base@resolved=%s\n[EP34] resolved_entries=[%s]\n%!"
+        keepers_dir resolved_kdir (String.equal keepers_dir resolved_kdir)
+        (read_trim (Filename.concat keepers_dir "base.toml"))
+        (read_trim (Filename.concat resolved_kdir "base.toml"))
+        (if Sys.file_exists resolved_kdir
+         then String.concat ";" (Array.to_list (Sys.readdir resolved_kdir))
+         else "<missing>");
       let json =
         Server_dashboard_http_core.dashboard_shell_http_json ~light:true config
       in
+      Printf.eprintf "[EP34] configured_keepers=%d\n%!"
+        (json |> member "configured_keepers" |> to_int);
       Alcotest.(check int)
         "configured_keepers includes explicit autoboot base keeper"
         3


### PR DESCRIPTION
일회성 CI 진단. executor_pool 34(configured_keepers 2 vs 3)의 런타임 원인 관측용. count 경로 전 함수가 uncached임을 정적으로 증명했으므로 Received=2는 런타임 전용. ~base_path 해석 keepers_dir이 테스트 write dir과 일치하는지 + read 시점 autoboot 내용을 [EP34] 로그로 확인. **관측 후 close**.