### PR TITLE
fix(keeper): serialize meta CAS with typed conflicts

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -21,7 +21,28 @@ let runtime_meta_write_sync_hook config meta =
 let register_runtime_meta_write_sync f =
   Atomic.set runtime_meta_write_sync_hook_atomic f
 
-let version_conflict_re = Re.Pcre.re "meta version conflict" |> Re.compile
+type write_error =
+  | Version_conflict of
+      { keeper_name : string
+      ; expected_version : int
+      ; actual : Keeper_meta_contract.keeper_meta
+      }
+  | Storage_error of string
+
+let write_error_to_string = function
+  | Version_conflict { keeper_name; expected_version; actual } ->
+    Printf.sprintf
+      "meta version conflict for %s: expected %d, disk has %d"
+      keeper_name
+      expected_version
+      actual.meta_version
+  | Storage_error msg -> msg
+;;
+
+let meta_cas_key config keeper_name =
+  Keeper_types_profile.keeper_meta_path config keeper_name
+  |> fun path -> File_lock_eio.Key.of_path (path ^ ".cas")
+;;
 
 let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string) result =
   if not (Fs_compat.file_exists path)
@@ -308,35 +329,46 @@ let persist_meta config path persisted =
    counters are a monotone invariant (RFC-0225 §3.2, RFC-0237); a caller that
    lost the race must resolve the conflict through [write_meta_with_merge],
    never overwrite the disk snapshot. *)
-let write_meta config (m : Keeper_meta_contract.keeper_meta) : (unit, string) result =
+let write_meta_result_with
+      with_lock
+      config
+      (m : Keeper_meta_contract.keeper_meta)
+  : (unit, write_error) result
+  =
   let path = keeper_meta_path config m.name in
-  match read_meta_file_path path with
-  | Ok (Some existing) ->
-    if existing.meta_version <> m.meta_version
-    then
+  with_lock (meta_cas_key config m.name) (fun () ->
+    match read_meta_file_path path with
+    | Ok (Some existing) ->
+      if existing.meta_version <> m.meta_version
+      then
+        Error
+          (Version_conflict
+             { keeper_name = m.name
+             ; expected_version = m.meta_version
+             ; actual = existing
+             })
+      else (
+        let persisted = { m with meta_version = m.meta_version + 1 } in
+        Result.map_error (fun msg -> Storage_error msg) (persist_meta config path persisted))
+    | Ok None ->
+      let persisted = { m with meta_version = 1 } in
+      Result.map_error (fun msg -> Storage_error msg) (persist_meta config path persisted)
+    | Error msg ->
       Error
-        (Printf.sprintf
-           "meta version conflict for %s: expected %d, disk has %d"
-           m.name
-           m.meta_version
-           existing.meta_version)
-    else (
-      let persisted = { m with meta_version = m.meta_version + 1 } in
-      persist_meta config path persisted)
-  | Ok None ->
-    (* No existing file: initial write. *)
-    let persisted = { m with meta_version = 1 } in
-    persist_meta config path persisted
-  | Error msg ->
-    Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)
+        (Storage_error
+           (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)))
 ;;
 
-let is_version_conflict_error msg =
-  try
-    ignore (Re.exec version_conflict_re msg);
-    true
-  with
-  | Not_found -> false
+let write_meta_result config m =
+  write_meta_result_with File_lock_eio.with_lock_eio config m
+;;
+
+let write_meta_blocking_result config m =
+  write_meta_result_with File_lock_eio.with_lock_blocking config m
+;;
+
+let write_meta config m =
+  Result.map_error write_error_to_string (write_meta_result config m)
 ;;
 
 (* ── Boot-time canonicalization ─────────────────────────── *)
@@ -411,22 +443,19 @@ let migrate_retired_keeper_meta_keys config =
 (* #9769 root fix: CAS retry with explicit field ownership. The
    turn-failure/cycle path uses [Keeper_meta_merge.heartbeat_fields_from_disk]
    now only carries the disk meta_version forward. *)
-let write_meta_with_merge
+let write_meta_with_merge_result
       ?(max_retries = 3)
       ~(merge : latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta)
       config
       (m : Keeper_meta_contract.keeper_meta)
-  : (unit, string) result
+  : (unit, write_error) result
   =
-  let path = keeper_meta_path config m.name in
   let rec attempt n (caller : Keeper_meta_contract.keeper_meta) =
-    match write_meta config caller with
+    match write_meta_result config caller with
     | Ok () -> Ok ()
-    | Error msg when n >= max_retries -> Error msg
-    | Error msg when not (is_version_conflict_error msg) -> Error msg
-    | Error _ ->
-      (match read_meta_file_path path with
-       | Ok (Some latest) ->
+    | Error error when n >= max_retries -> Error error
+    | Error (Storage_error _ as error) -> Error error
+    | Error (Version_conflict { actual = latest; _ }) ->
          Otel_metric_store.inc_counter
            Otel_metric_store.metric_write_meta_cas_retry_total
            ~labels:[("keeper", caller.name)]
@@ -439,11 +468,11 @@ let write_meta_with_merge
            caller.meta_version
            latest.meta_version;
          attempt (n + 1) (merge ~latest ~caller)
-       | Ok None ->
-         (* Disk file vanished between attempts; fall back to fresh write. *)
-         attempt (n + 1) { caller with meta_version = 0 }
-       | Error read_msg ->
-         Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
   in
   attempt 0 m
+;;
+
+let write_meta_with_merge ?max_retries ~merge config m =
+  write_meta_with_merge_result ?max_retries ~merge config m
+  |> Result.map_error write_error_to_string
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -15,10 +15,15 @@ val runtime_meta_write_sync_hook :
 val register_runtime_meta_write_sync :
   (Workspace.config -> Keeper_meta_contract.keeper_meta -> unit) -> unit
 
-(** Pre-compiled regex matching the CAS [meta version conflict]
-    error message. Exposed for symmetry — used internally by
-    [is_version_conflict_error]. *)
-val version_conflict_re : Re.re
+type write_error =
+  | Version_conflict of
+      { keeper_name : string
+      ; expected_version : int
+      ; actual : Keeper_meta_contract.keeper_meta
+      }
+  | Storage_error of string
+
+val write_error_to_string : write_error -> string
 
 (** Read a keeper meta JSON file at [path]. Returns [Ok None] when
     the file does not exist; warns on unknown keys; scrubs deprecated
@@ -105,18 +110,30 @@ val read_meta_if_changed :
 val persist_meta :
   Workspace.config -> string -> Keeper_meta_contract.keeper_meta -> (unit, string) result
 
-(** Persist [m] with a CAS bump on [meta_version]: the write is rejected
+(** Persist [m] from an Eio fiber with a CAS bump on [meta_version]: the write is rejected
     if the on-disk version has moved since [m] was read. There is no force
     / bypass path — cumulative usage counters are a monotone invariant
     (RFC-0225 §3.2, RFC-0237), so callers that lost a race must resolve the
-    conflict through {!write_meta_with_merge}, not overwrite the disk. *)
+    conflict through {!write_meta_with_merge}, not overwrite the disk. Domain
+    or systhread callers must use {!write_meta_blocking_result}. *)
 val write_meta :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
 
-(** [true] iff [msg] matches [version_conflict_re]. *)
-val is_version_conflict_error : string -> bool
+val write_meta_result :
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (unit, write_error) result
+(** Eio-fiber CAS writer. Version conflicts are typed and carry the exact disk
+    snapshot observed inside the per-path critical section. *)
+
+val write_meta_blocking_result :
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (unit, write_error) result
+(** Domain/systhread CAS writer using the blocking lock contract. Do not call
+    from an Eio fiber. *)
 
 (** Strip retired top-level keys from persisted keeper meta files —
     fields left behind by schema removals (e.g. the #23929 continuity
@@ -150,3 +167,12 @@ val write_meta_with_merge :
   Workspace.config ->
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
+
+val write_meta_with_merge_result :
+  ?max_retries:int ->
+  merge:(latest:Keeper_meta_contract.keeper_meta -> caller:Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta) ->
+  Workspace.config ->
+  Keeper_meta_contract.keeper_meta ->
+  (unit, write_error) result
+(** Typed form of {!write_meta_with_merge}. An exhausted version race remains
+    [Version_conflict]; storage failures remain [Storage_error]. *)

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -48,7 +48,7 @@ let cleanup_dead_tombstone
              pause, the heartbeat merge would copy the operator reason
              back over [Dead_tombstone] and still return [Ok ()]. *)
         match
-          write_meta_with_merge
+          write_meta_with_merge_result
             ~merge:Keeper_meta_merge.dead_tombstone_cleanup_from_disk
             ctx.config
             { meta with
@@ -64,7 +64,8 @@ let cleanup_dead_tombstone
             }
         with
         | Ok () -> true
-        | Error err when is_version_conflict_error err ->
+        | Error (Version_conflict _ as error) ->
+          let err = write_error_to_string error in
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string WriteMetaFailures)
             ~labels:[ "keeper", entry.name; "phase", "dead_cleanup_cas_race" ]
@@ -74,7 +75,7 @@ let cleanup_dead_tombstone
             entry.name
             err;
           false
-        | Error err ->
+        | Error (Storage_error err) ->
           Otel_metric_store.inc_counter
             Keeper_metrics.(to_string WriteMetaFailures)
             ~labels:[ "keeper", entry.name; "phase", "dead_cleanup" ]

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -50,13 +50,14 @@ let resume_keeper_after_reconcile_gate
      [Keeper_registry.update_meta] applies the resume in-memory —
      a registry/disk split that hides the failure. *)
   (match
-     write_meta_with_merge
+     write_meta_with_merge_result
        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
        ctx.config
        resumed_meta
    with
    | Ok () -> ()
-   | Error err when is_version_conflict_error err ->
+   | Error (Version_conflict _ as error) ->
+     let err = write_error_to_string error in
      Otel_metric_store.inc_counter
        Keeper_metrics.(to_string WriteMetaFailures)
        ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume_cas_race" ]
@@ -65,7 +66,7 @@ let resume_keeper_after_reconcile_gate
        "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
        resumed_meta.name
        err
-   | Error err ->
+   | Error (Storage_error err) ->
      Otel_metric_store.inc_counter
        Keeper_metrics.(to_string WriteMetaFailures)
        ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume" ]

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1187,29 +1187,32 @@ let run_keeper_msg_turn_admitted
                  payload wins at the cycle-owned fields and heartbeat-
                  owned fields are taken from disk. *)
               (match
-                 write_meta_with_merge
+                 write_meta_with_merge_result
                    ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
                    ctx.config updated_meta
                with
                | Ok () -> ()
-               | Error msg ->
+               | Error error ->
+                   let msg = write_error_to_string error in
                    Otel_metric_store.inc_counter
                      Keeper_metrics.(to_string WriteMetaFailures)
                      ~labels:
                        [ ("keeper", updated_meta.name);
                          ("phase",
-                          if is_version_conflict_error msg
-                          then "keeper_msg_turn_cas_race"
-                          else "keeper_msg_turn")
+                          match error with
+                          | Version_conflict _ -> "keeper_msg_turn_cas_race"
+                          | Storage_error _ -> "keeper_msg_turn")
                        ]
                      ();
-                   if is_version_conflict_error msg then
-                     Log.Keeper.warn
-                       "write_meta lost CAS race after retries (keeper_msg turn): %s"
-                       msg
-                   else
-                     Log.Keeper.error
-                       "write_meta failed after keeper_msg turn: %s" msg);
+                   (match error with
+                    | Version_conflict _ ->
+                      Log.Keeper.warn
+                        "write_meta lost CAS race after retries (keeper_msg turn): %s"
+                        msg
+                    | Storage_error _ ->
+                      Log.Keeper.error
+                        "write_meta failed after keeper_msg turn: %s"
+                        msg));
               (try
                  Keeper_unified_metrics.append_metrics_snapshot
                    ~config:ctx.config

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -82,23 +82,26 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
            }
          in
          ((match
-             write_meta_with_merge
+             write_meta_with_merge_result
                ~merge:Keeper_meta_merge.caller_wins config retained
            with
            | Ok () -> ()
-           | Error err ->
+           | Error error ->
+               let err = Keeper_meta_store.write_error_to_string error in
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string WriteMetaFailures)
                  ~labels:[("keeper", name);
                           ("phase",
-                           if Keeper_meta_store.is_version_conflict_error err
-                           then "keeper_down_cas_race"
-                           else "keeper_down")]
+                          match error with
+                          | Keeper_meta_store.Version_conflict _ ->
+                            "keeper_down_cas_race"
+                          | Keeper_meta_store.Storage_error _ -> "keeper_down")]
                  ();
-               if Keeper_meta_store.is_version_conflict_error err then
-                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
-               else
-                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
+               (match error with
+                | Keeper_meta_store.Version_conflict _ ->
+                  Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
+                | Keeper_meta_store.Storage_error _ ->
+                  Log.Keeper.error "keeper_down write_meta failed: %s" err));
           Keeper_registry.update_meta ~base_path:config.base_path name retained;
           Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
             Keeper_state_machine.Operator_pause));

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -893,34 +893,35 @@ let run_keeper_cycle
 dominant source of the observed CAS race exhaustion after
              keeper OAS timeout. *)
                   (match
-                     write_meta_with_merge
+                     write_meta_with_merge_result
                        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
                        config
                        updated_meta
                    with
                    | Ok () -> ()
-                   | Error msg ->
+                   | Error error ->
+                     let msg = write_error_to_string error in
                      Otel_metric_store.inc_counter
                        Keeper_metrics.(to_string WriteMetaFailures)
                        ~labels:
                          [ "keeper", updated_meta.name
                          ; ( "phase"
-                           , if is_version_conflict_error msg
-                             then "turn_failure_cas_race"
-                             else "turn_failure" )
+                           , match error with
+                             | Version_conflict _ -> "turn_failure_cas_race"
+                             | Storage_error _ -> "turn_failure" )
                          ]
                        ();
-                     if is_version_conflict_error msg
-                     then
-                       Log.Keeper.warn
-                         ~keeper_name:updated_meta.name
-                         "write_meta lost CAS race after retries (turn failure path): %s"
-                         msg
-                     else
-                       Log.Keeper.error
-                         ~keeper_name:updated_meta.name
-                         "write_meta failed after unified turn failure: %s"
-                         msg);
+                     (match error with
+                      | Version_conflict _ ->
+                        Log.Keeper.warn
+                          ~keeper_name:updated_meta.name
+                          "write_meta lost CAS race after retries (turn failure path): %s"
+                          msg
+                      | Storage_error _ ->
+                        Log.Keeper.error
+                          ~keeper_name:updated_meta.name
+                          "write_meta failed after unified turn failure: %s"
+                          msg));
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string WriteMetaCycleFailures)
                     ~labels:[ "keeper", meta.name; "site", Keeper_write_meta_cycle_failure_site.(to_label Turn_failure) ]

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -602,21 +602,22 @@ let persist_terminal_turn_meta
     else updated_meta
   in
   (match
-     Keeper_meta_store.write_meta_with_merge
+     Keeper_meta_store.write_meta_with_merge_result
        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
        config
        updated_meta
    with
    | Ok () -> ()
-   | Error msg ->
+   | Error error ->
+     let msg = Keeper_meta_store.write_error_to_string error in
      Otel_metric_store.inc_counter
        Keeper_metrics.(to_string WriteMetaFailures)
        ~labels:
          [ "keeper", updated_meta.name
          ; ( "phase"
-           , if Keeper_meta_store.is_version_conflict_error msg
-             then "keeper_cycle_cas_race"
-             else "keeper_cycle" )
+           , match error with
+             | Keeper_meta_store.Version_conflict _ -> "keeper_cycle_cas_race"
+             | Keeper_meta_store.Storage_error _ -> "keeper_cycle" )
          ]
        ();
      (* #22043: emit inside the [Error] arm so
@@ -632,9 +633,11 @@ let persist_terminal_turn_meta
          ; "site", Keeper_write_meta_cycle_failure_site.(to_label Keeper_cycle)
          ]
        ();
-     if Keeper_meta_store.is_version_conflict_error msg
-     then Log.Keeper.warn "write_meta lost CAS race after retries (keeper cycle): %s" msg
-     else Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
+     (match error with
+      | Keeper_meta_store.Version_conflict _ ->
+        Log.Keeper.warn "write_meta lost CAS race after retries (keeper cycle): %s" msg
+      | Keeper_meta_store.Storage_error _ ->
+        Log.Keeper.error "write_meta failed after keeper cycle: %s" msg));
   updated_meta
 ;;
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -1,17 +1,40 @@
-(** File_lock_eio — Cooperative per-key locking via Eio.Mutex + flock.
+(** File_lock_eio — Cooperative per-key locking + flock.
 
     Two-layer locking for local filesystem paths:
-    1. Eio.Mutex (cooperative) — prevents blocking the Eio fiber scheduler
+    1. Shared atomic ownership — serializes Eio fibers and Domain callers
     2. Unix.lockf F_TLOCK (non-blocking) — preserves cross-process safety
 
-    The Eio.Mutex serializes fibers within the process so most contention
-    is resolved cooperatively.  The flock is acquired non-blocking after
-    the Eio.Mutex; if another process holds it, we yield and retry.
+    Eio fibers and blocking Domain callers use separate waiting contracts over
+    the same ownership bit. The flock is acquired non-blocking afterwards; if
+    another process holds it, the caller uses its selected waiting contract.
 
     Distributed backend paths (Some key in workspace_utils_ops.ml) are not
     affected — this only replaces the local filesystem lock path. *)
 
 module SMap = Set_util.StringMap
+module Blocking_mutex = Stdlib.Mutex
+module Blocking_condition = Stdlib.Condition
+
+module Key = struct
+  type t = string
+
+  let normalize_absolute path =
+    let absolute =
+      if Filename.is_relative path
+      then Filename.concat (Sys.getcwd ()) path
+      else path
+    in
+    let parent = Filename.dirname absolute in
+    let canonical_parent =
+      try Unix.realpath parent with
+      | Unix.Unix_error _ -> parent
+    in
+    Filename.concat canonical_parent (Filename.basename absolute)
+  ;;
+
+  let of_path path = normalize_absolute path
+  let to_path key = key
+end
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
@@ -63,19 +86,12 @@ let rec atomic_update atomic f =
     atomic_update atomic f
   end
 
-let rec atomic_update_with_result atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then result
-  else begin
-    observe_cas_retry ();
-    atomic_update_with_result atomic f
-  end
-
 type lock_entry = {
-  mu : Eio.Mutex.t;
-  mutable last_used : float;
-  active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
+  held : bool Atomic.t;
+  wait_mu : Blocking_mutex.t;
+  wait_condition : Blocking_condition.t;
+  last_used : float Atomic.t;
+  active : int Atomic.t;
 }
 
 type table_state = {
@@ -101,7 +117,8 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
@@ -114,22 +131,62 @@ let prune_stale_entries () =
     (e.g. in unit tests that don't use Eio_main.run). *)
 let get_entry path =
   prune_stale_entries ();
-  let entry =
-    atomic_update_with_result table (fun state ->
+  let rec acquire_reference () =
+    let state = Atomic.get table in
+    let entry, updated_state =
       match SMap.find_opt path state.entries with
-      | Some entry ->
-        entry.last_used <- Time_compat.now ();
-        (state, entry)
+      | Some entry -> entry, state
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
-        let entries = SMap.add path entry state.entries in
-        (publish_entries state entries, entry))
+        let entry =
+          { held = Atomic.make false
+          ; wait_mu = Blocking_mutex.create ()
+          ; wait_condition = Blocking_condition.create ()
+          ; last_used = Atomic.make (Time_compat.now ())
+          ; active = Atomic.make 0
+          }
+        in
+        entry, publish_entries state (SMap.add path entry state.entries)
+    in
+    Atomic.incr entry.active;
+    if Atomic.compare_and_set table state updated_state
+    then (
+      Atomic.set entry.last_used (Time_compat.now ());
+      entry)
+    else (
+      let _previous_active = Atomic.fetch_and_add entry.active (-1) in
+      observe_cas_retry ();
+      acquire_reference ())
   in
-  Atomic.incr entry.active;
-  entry
+  acquire_reference ()
 
 let release_entry entry =
-  ignore (Atomic.fetch_and_add entry.active (-1))
+  let _previous_active = Atomic.fetch_and_add entry.active (-1) in
+  ()
+
+let rec acquire_entry_eio entry =
+  if Atomic.compare_and_set entry.held false true
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    acquire_entry_eio entry)
+;;
+
+let acquire_entry_blocking entry =
+  Blocking_mutex.lock entry.wait_mu;
+  Fun.protect
+    ~finally:(fun () -> Blocking_mutex.unlock entry.wait_mu)
+    (fun () ->
+       while not (Atomic.compare_and_set entry.held false true) do
+         Blocking_condition.wait entry.wait_condition entry.wait_mu
+       done)
+;;
+
+let release_entry_lock entry =
+  Atomic.set entry.held false;
+  Blocking_mutex.lock entry.wait_mu;
+  Blocking_condition.broadcast entry.wait_condition;
+  Blocking_mutex.unlock entry.wait_mu
+;;
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 
@@ -225,21 +282,37 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
-(** Run [f] while holding only the cooperative per-path mutex.
-    Use this for in-memory backends that need single-process fiber
-    serialization but do not have a real filesystem artifact to flock. *)
-let with_mutex path f =
-  let entry = get_entry path in
+(** Run [f] while holding shared per-path process-local ownership using the
+    caller-selected waiting contract. *)
+let with_entry_lock acquire (key : Key.t) f =
+  let entry = get_entry (Key.to_path key) in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () ->
+       acquire entry;
+       Common.protect
+         ~module_name:"file_lock_eio"
+         ~finally_label:"release_entry_lock"
+         ~finally:(fun () -> release_entry_lock entry)
+         f)
+;;
 
-(** Run [f] while holding both the cooperative Eio.Mutex and an
-    OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
-    retries; sleep/yield stays scheduler-friendly whether or not a clock
-    is provided. Max 200 attempts (~2s with sleeps). *)
-let with_lock ?clock path f =
+let with_mutex_eio key f = with_entry_lock acquire_entry_eio key f
+let with_mutex_blocking key f = with_entry_lock acquire_entry_blocking key f
+
+let with_mutex path f =
+  let key = Key.of_path path in
+  if Eio_guard.is_ready ()
+  then with_mutex_eio key f
+  else with_mutex_blocking key f
+
+(** Run [f] while holding both shared per-path process-local ownership and an
+    OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK retries;
+    sleep/yield stays scheduler-friendly whether or not a clock is provided.
+    Max 200 attempts (~2s with sleeps). *)
+let with_lock_mode with_mutex ?clock (key : Key.t) f =
   let run_with_flock () =
+    let path = Key.to_path key in
     let lock_path = path ^ ".lock" in
     let dir = Filename.dirname lock_path in
     if not (Sys.file_exists dir) then
@@ -249,7 +322,38 @@ let with_lock ?clock path f =
       ~finally:(fun () -> release_flock_fd fd)
       f
   in
-  with_mutex path (fun () -> run_with_flock ())
+  with_mutex key run_with_flock
+;;
+
+let with_lock_eio ?clock key f =
+  with_lock_mode with_mutex_eio ?clock key f
+;;
+
+let with_lock_blocking key f =
+  let path = Key.to_path key in
+  let run_with_flock () =
+    let lock_path = path ^ ".lock" in
+    let dir = Filename.dirname lock_path in
+    if not (Sys.file_exists dir)
+    then (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    let fd =
+      acquire_flock_retry
+        ~lock_path
+        ~mode:[ Unix.O_CREAT; Unix.O_WRONLY ]
+        ~perm:0o644
+        ~caller:"File_lock_eio.blocking"
+        ()
+    in
+    Fun.protect ~finally:(fun () -> release_flock_fd fd) f
+  in
+  with_mutex_blocking key run_with_flock
+;;
+
+let with_lock ?clock path f =
+  let key = Key.of_path path in
+  if Eio_guard.is_ready ()
+  then with_lock_eio ?clock key f
+  else with_lock_blocking key f
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -1,12 +1,11 @@
-(** File_lock_eio — cooperative per-key locking via [Eio.Mutex] + [flock].
+(** File_lock_eio — cooperative per-key locking + [flock].
 
     Two-layer locking for local filesystem paths:
 
-    + {b Eio.Mutex} (cooperative) — prevents blocking the Eio fiber
-      scheduler; serialises fibers within the process so most contention
-      is resolved cooperatively.
+    + {b Shared atomic ownership} — serialises Eio fibers and Domain callers
+      inside one process without mixing their waiting primitives.
     + {b Unix.lockf F_TLOCK} (non-blocking) — preserves cross-process
-      safety; acquired after the Eio.Mutex. If another process holds
+      safety; acquired after process-local ownership. If another process holds
       the flock the caller yields and retries.
 
     Distributed backend paths (non-local keys in
@@ -28,6 +27,13 @@ val stale_lock_seconds : float
     ordinary callers. *)
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
+
+module Key : sig
+  type t
+
+  val of_path : string -> t
+  (** Canonicalize a lock artifact through its existing parent directory. *)
+end
 
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
@@ -71,21 +77,37 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
-(** [with_mutex path f] runs [f] while holding the cooperative
-    per-[path] Eio.Mutex only. Use for in-memory backends that need
-    single-process fiber serialisation but have no filesystem
-    artifact to flock. *)
+(** Compatibility entry point that selects the Eio or blocking waiting
+    contract from the current runtime context. New callers should prefer
+    {!with_mutex_eio} or {!with_mutex_blocking} so their execution contract
+    is explicit. *)
 val with_mutex : string -> (unit -> 'a) -> 'a
 
-(** [with_lock ?clock path f] runs [f] while holding both the
-    cooperative Eio.Mutex and an OS-level flock on [path ^ ".lock"].
-    The flock uses non-blocking F_TLOCK retries — max 200 attempts,
-    ~2s total with default sleeps. *)
+val with_mutex_eio : Key.t -> (unit -> 'a) -> 'a
+(** Eio-fiber waiting contract. Contention yields through the scheduler. *)
+
+val with_mutex_blocking : Key.t -> (unit -> 'a) -> 'a
+(** Domain/systhread waiting contract. Contention waits on a condition variable. *)
+
+(** Compatibility entry point that selects the Eio or blocking waiting
+    contract from the current runtime context, then holds both process-local
+    ownership and an OS-level flock on [path ^ ".lock"]. New callers should
+    prefer {!with_lock_eio} or {!with_lock_blocking}. The flock uses
+    non-blocking F_TLOCK retries — max 200 attempts, ~2s total with default
+    sleeps. *)
 val with_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   string ->
   (unit -> 'a) ->
   'a
+
+val with_lock_eio :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Key.t ->
+  (unit -> 'a) ->
+  'a
+
+val with_lock_blocking : Key.t -> (unit -> 'a) -> 'a
 
 (** {1 Observability hook} *)
 

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -23,8 +23,9 @@ let with_temp_path f =
 let test_with_lock_without_eio () =
   with_temp_path @@ fun path ->
   let calls = ref 0 in
+  let key = File_lock_eio.Key.of_path path in
   let result =
-    File_lock_eio.with_lock path (fun () ->
+    File_lock_eio.with_lock_blocking key (fun () ->
         incr calls;
         "ok")
   in
@@ -50,14 +51,43 @@ let test_with_lock_inside_eio () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let calls = ref 0 in
+  let key = File_lock_eio.Key.of_path path in
   let result =
-    File_lock_eio.with_lock path (fun () ->
+    File_lock_eio.with_lock_eio key (fun () ->
         incr calls;
         "ok")
   in
   check string "result" "ok" result;
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
+
+let test_eio_and_blocking_contracts_share_ownership () =
+  with_temp_path @@ fun path ->
+  Eio_main.run @@ fun env ->
+  let domain_mgr = Eio.Stdenv.domain_mgr env in
+  let key = File_lock_eio.Key.of_path path in
+  let inside = Atomic.make 0 in
+  let max_inside = Atomic.make 0 in
+  let enter with_lock =
+    with_lock key (fun () ->
+        let current = Atomic.fetch_and_add inside 1 + 1 in
+        let rec record_max () =
+          let previous = Atomic.get max_inside in
+          if current > previous
+             && not (Atomic.compare_and_set max_inside previous current)
+          then record_max ()
+        in
+        record_max ();
+        Unix.sleepf 0.005;
+        let _previous = Atomic.fetch_and_add inside (-1) in
+        ())
+  in
+  Eio.Fiber.both
+    (fun () -> enter (fun key f -> File_lock_eio.with_lock_eio key f))
+    (fun () ->
+       Eio.Domain_manager.run domain_mgr (fun () ->
+         enter File_lock_eio.with_lock_blocking));
+  check int "Eio and blocking callers never overlap" 1 (Atomic.get max_inside)
 
 let () =
   run "file_lock_eio"
@@ -68,5 +98,7 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case "Eio and blocking contracts share ownership" `Quick
+            test_eio_and_blocking_contracts_share_ownership;
         ] );
     ]

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -4,8 +4,7 @@
     [Keeper_meta_merge.caller_wins]:
       - succeeds when no concurrent writer interferes
       - succeeds after N attempts when the disk version has advanced
-      - distinguishes version conflicts from real I/O errors via
-        [is_version_conflict_error] *)
+      - distinguishes typed version conflicts from storage errors *)
 
 open Alcotest
 open Masc
@@ -256,6 +255,60 @@ let test_operator_pause_survives_stale_heartbeat_retry () =
     check bool "stale blocker stays cleared" true
       (Option.is_none final.runtime.last_blocker))
 
+let test_concurrent_same_version_writers_have_one_typed_winner () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Workspace.default_config base_dir in
+    ignore (Workspace.init config ~agent_name:(Some "operator"));
+    let initial = make_meta ~name:"concurrent-cas" in
+    (match Keeper_meta_store.write_meta config initial with
+     | Ok () -> ()
+     | Error err -> fail ("seed write failed: " ^ err));
+    let stale =
+      match Keeper_meta_store.read_meta config initial.name with
+      | Ok (Some meta) -> meta
+      | Ok None -> fail "seed meta disappeared"
+      | Error err -> fail ("seed read failed: " ^ err)
+    in
+    let first = { stale with active_goal_ids = [ "first" ] } in
+    let second = { stale with active_goal_ids = [ "second" ] } in
+    let first_result = ref None in
+    let second_result = ref None in
+    Eio.Fiber.both
+      (fun () -> first_result := Some (Keeper_meta_store.write_meta_result config first))
+      (fun () -> second_result := Some (Keeper_meta_store.write_meta_result config second));
+    let results =
+      [ Option.value ~default:(Error (Keeper_meta_store.Storage_error "first missing")) !first_result
+      ; Option.value ~default:(Error (Keeper_meta_store.Storage_error "second missing")) !second_result
+      ]
+    in
+    let successes, conflicts =
+      List.fold_left
+        (fun (successes, conflicts) -> function
+           | Ok () -> successes + 1, conflicts
+           | Error (Keeper_meta_store.Version_conflict _) -> successes, conflicts + 1
+           | Error (Keeper_meta_store.Storage_error err) ->
+             fail ("unexpected storage error: " ^ err))
+        (0, 0)
+        results
+    in
+    check int "exactly one same-version writer commits" 1 successes;
+    check int "the loser receives a typed conflict" 1 conflicts;
+    let persisted =
+      match Keeper_meta_store.read_meta config initial.name with
+      | Ok (Some meta) -> meta
+      | Ok None -> fail "concurrent CAS winner disappeared"
+      | Error err -> fail ("concurrent CAS winner read failed: " ^ err)
+    in
+    check int "winner advances the disk version"
+      (stale.meta_version + 1) persisted.meta_version;
+    check bool "one complete winner payload reaches disk" true
+      (persisted.active_goal_ids = first.active_goal_ids
+       || persisted.active_goal_ids = second.active_goal_ids))
+
 (* RFC-0237: the [write_meta ~force:true] escape hatch is removed, so the
    counter-rewind path the four keeper-internal sites carried
    (keeper_tool_surface / keeper_tool_surface_ops / keeper_keepalive /
@@ -301,23 +354,22 @@ let test_stale_write_conflicts_without_force () =
     in
     (match Keeper_meta_store.write_meta config stale with
      | Ok () -> fail "stale write unexpectedly succeeded (CAS bypass present?)"
-     | Error msg ->
-       check bool "stale write is rejected as a version conflict" true
-         (Keeper_meta_store.is_version_conflict_error msg));
+     | Error _ -> ());
+    (match Keeper_meta_store.write_meta_result config stale with
+     | Error (Keeper_meta_store.Version_conflict { expected_version; actual; _ }) ->
+       check int "typed conflict carries expected version"
+         stale.meta_version expected_version;
+       check int "typed conflict carries exact disk version"
+         (stale.meta_version + 1) actual.meta_version
+     | Error (Keeper_meta_store.Storage_error err) ->
+       fail ("expected typed conflict, got storage error: " ^ err)
+     | Ok () -> fail "typed stale write unexpectedly succeeded");
     let final = match Keeper_meta_store.read_meta config "delta" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
     check int "advanced disk counter survives (no rewind without force)"
       42 final.runtime.usage.total_turns)
-
-let test_is_version_conflict_error_classifies () =
-  let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in
-  let other_msg = "failed to write meta /tmp/x: Permission denied" in
-  check bool "classifies version conflict" true
-    (Keeper_meta_store.is_version_conflict_error conflict_msg);
-  check bool "rejects unrelated error" false
-    (Keeper_meta_store.is_version_conflict_error other_msg)
 
 let () =
   run "Keeper_types CAS retry (#9764/#9733/#9769)"
@@ -332,12 +384,9 @@ let () =
             `Quick test_monotonic_usage_counters_on_cas_retry;
           test_case "operator pause survives stale heartbeat retry"
             `Quick test_operator_pause_survives_stale_heartbeat_retry;
+          test_case "concurrent same-version writers have one typed winner"
+            `Quick test_concurrent_same_version_writers_have_one_typed_winner;
           test_case "stale write conflicts without force (RFC-0237 escape hatch closed)"
             `Quick test_stale_write_conflicts_without_force;
-        ] );
-      ( "is_version_conflict_error",
-        [
-          test_case "classifies conflict vs I/O error" `Quick
-            test_is_version_conflict_error_classifies;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Serialize keeper-meta CAS by canonical per-path ownership shared by Eio fibers and blocking Domain callers.
- Replace message-regex conflict classification with a typed `Version_conflict | Storage_error` result.
- Keep string formatting only at logging/compatibility boundaries and retry from the exact disk snapshot observed inside the critical section.

## Product impact

- User-visible change: concurrent writers for one keeper meta file can no longer both commit the same `meta_version`; different BasePath/meta paths remain isolated.
- No API, dashboard, provider, or HITL behavior is added in this slice.

## Evidence

- `scripts/dune-local.sh exec ./test/test_file_lock_eio.exe` — PASS, 4/4, including shared Eio/Domain ownership.
- `scripts/dune-local.sh exec ./test/test_keeper_meta_cas_retry.exe` — PASS, 6/6, including exactly one winner, one typed conflict, and persisted winner payload/version.
- `scripts/dune-local.sh exec ./test/test_keeper_supervisor.exe` — PASS, 88/88.
- `scripts/dune-local.sh exec ./test/test_heartbeat_integration.exe` — PASS, 30/30.
- `scripts/dune-local.sh exec ./test/test_keeper_latched_reason_wiring.exe` — PASS, 12/12.
- `scripts/dune-local.sh exec ./test/test_keeper_pause_silent_failure_source.exe` — PASS, 15/15.
- `bash scripts/check-variants.sh` — PASS.
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD` — PASS, no new sites.
- Prohibited-pattern search for the removed conflict regex/string classifier and the rejected 0.5ms polling loop — 0 matches.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/6
provenance: operator_proxy
stages:
  - name: focused-lock-tests
    provenance: operator_proxy
  - name: focused-cas-tests
    provenance: operator_proxy
  - name: supervisor-regression
    provenance: operator_proxy
  - name: heartbeat-regression
    provenance: operator_proxy
  - name: source-wiring-regressions
    provenance: operator_proxy
  - name: static-guards
    provenance: operator_proxy
```

## GOAL LOOP ACT checklist

- [x] Observe — #24060 review identified string-matched CAS control flow, split lock ownership, and hardcoded polling.
- [x] Orient — this is rebuild slice 1 from #24062, intentionally excluding HITL and repository registration.
- [x] Decide — P1 because same-version writers can lose updates; per-path typed CAS is the smallest independent fix.
- [x] Act — one typed lock/CAS carrier plus six existing error-classification call sites; rollback is this single commit.
- [x] Verify — focused concurrency and keeper regression suites pass locally; CI remains authoritative.
- [x] Loop — #24017 has landed; durable Blocking HITL and repository registration remain later independent slices in #24062.

## Review evidence

- Cross-model reviewer: `glm-4.5-direct`, 2026-07-11T03:59:32Z, `origin/main...a03289d18b` precursor diff.
- Rejected unsupported findings: it claimed a retry re-read that the diff removes; called log-boundary formatting control-flow loss despite typed pattern matches; and reported missing condition recheck despite the `while` predicate.
- Accepted P3: strengthened the concurrent-writer test to prove the complete winner payload and incremented version reach disk; amended commit `a03289d18b`.
- Maintainer review and GitHub CI are still required; PR remains Draft with `status:do-not-merge` until those gates are green.

## Linked issue

- Relates #24062
- Later-slice prerequisite satisfied: #24017 landed as `c6e6d9d40f`; this PR still contains no HITL changes.

## Variant addition checklist

- [x] **OCaml** — `write_error` added in `.ml`/`.mli`; all touched control flow matches `Version_conflict` and `Storage_error` exhaustively.
- [ ] **TypeScript** — N/A: internal OCaml storage result, not a dashboard union.
- [ ] **TLA+ spec** — N/A: no protocol/domain literal changed.
- [ ] **Event / JSON schema** — N/A: no serialized enum or event value changed.
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/keeper-meta-cas-typed-20260711` → `main` · 1 commit(s) · synced 2026-07-11T04:33:00Z

| sha | subject | date |
|---|---|---|
| `a03289d18` | fix(keeper): serialize meta CAS with typed conflicts | 2026-07-11 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->