### PR TITLE
feat(memory): add durable per-keeper job store

### DIFF
--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -134,6 +134,7 @@ type recovery_report =
 type claim_report =
   { leases : lease list
   ; cleanup_errors : error list
+  ; blocked : error option
   }
 
 let io_operation_to_string = function
@@ -1455,76 +1456,88 @@ let claim_all ~base_path ~keeper_name ~now =
       |> List.map (fun (path, envelope) -> path, envelope.job)
       |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
     in
+    let process_item path job =
+      let receipt_path = receipt_path ~base_path job in
+      let* receipt_exists = file_exists receipt_path in
+      if receipt_exists
+      then
+        let* receipt = read_receipt receipt_path in
+        if not (receipt_identity_matches_job receipt.identity job)
+        then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+        else
+          Ok
+            (`Skipped
+              (cleanup_paths
+                 [ path
+                 ; awaiting_path ~base_path job
+                 ; inflight_path ~base_path job
+                 ; operation_stage_path
+                     ~base_path
+                     ~keeper_name:job.keeper_name
+                     ~operation_id:job.id
+                 ]))
+      else
+        let lease = { job; started_at = now } in
+        let destination = inflight_path ~base_path job in
+        let* inflight_exists = file_exists destination in
+        if inflight_exists
+        then
+          let* inflight = read_envelope destination in
+          let* () =
+            ensure_queue_coordinates
+              ~expected_keeper_name:keeper_name
+              ~path:destination
+              inflight
+          in
+          let* () = ensure_same_job ~expected:job ~path:destination inflight in
+          let* () =
+            ensure_expected_state
+              ~expected:Expect_inflight
+              ~path:destination
+              inflight
+          in
+          Error
+            (Pending_already_inflight
+               { job_id = job.id
+               ; pending_path = path
+               ; inflight_path = destination
+               })
+        else
+          let* () =
+            save_json
+              destination
+              (envelope_to_json
+                 { job
+                 ; state = Inflight { started_at = lease.started_at }
+                 })
+          in
+          Ok (`Claimed (lease, cleanup_paths [ path ]))
+    in
     let rec claim leases cleanup_errors = function
       | [] ->
         Ok
           { leases = List.rev leases
           ; cleanup_errors = List.rev cleanup_errors
+          ; blocked = None
           }
       | (path, job) :: rest ->
-        let receipt_path = receipt_path ~base_path job in
-        let* receipt_exists = file_exists receipt_path in
-        if receipt_exists
-        then
-          let* receipt = read_receipt receipt_path in
-          if not (receipt_identity_matches_job receipt.identity job)
-          then Error (Identity_conflict { job_id = job.id; path = receipt_path })
-          else
-            let item_cleanup_errors =
-              cleanup_paths
-                [ path
-                ; awaiting_path ~base_path job
-                ; inflight_path ~base_path job
-                ; operation_stage_path
-                    ~base_path
-                    ~keeper_name:job.keeper_name
-                    ~operation_id:job.id
-                ]
-            in
-            claim
-              leases
-              (List.rev_append item_cleanup_errors cleanup_errors)
-              rest
-        else
-          let lease = { job; started_at = now } in
-          let destination = inflight_path ~base_path job in
-          let* inflight_exists = file_exists destination in
-          if inflight_exists
-          then
-            let* inflight = read_envelope destination in
-            let* () =
-              ensure_queue_coordinates
-                ~expected_keeper_name:keeper_name
-                ~path:destination
-                inflight
-            in
-            let* () = ensure_same_job ~expected:job ~path:destination inflight in
-            let* () =
-              ensure_expected_state
-                ~expected:Expect_inflight
-                ~path:destination
-                inflight
-            in
-            Error
-              (Pending_already_inflight
-                 { job_id = job.id
-                 ; pending_path = path
-                 ; inflight_path = destination
-                 })
-          else
-            let* () =
-              save_json
-                destination
-                (envelope_to_json
-                   { job
-                   ; state = Inflight { started_at = lease.started_at }
-                   })
-            in
-            let item_cleanup_errors = cleanup_paths [ path ] in
-            claim
-              (lease :: leases)
-              (List.rev_append item_cleanup_errors cleanup_errors)
-              rest
+        (match process_item path job with
+         | Error error ->
+           Ok
+             { leases = List.rev leases
+             ; cleanup_errors = List.rev cleanup_errors
+             ; blocked = Some error
+             }
+         | Ok (`Skipped item_cleanup_errors) ->
+           claim
+             leases
+             (List.rev_append item_cleanup_errors cleanup_errors)
+             rest
+         | Ok (`Claimed (lease, item_cleanup_errors)) ->
+           claim
+             (lease :: leases)
+             (List.rev_append item_cleanup_errors cleanup_errors)
+             rest)
     in
     claim [] [] ordered
 ;;

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -325,27 +325,37 @@ let sync_directory path =
   | Error detail -> Error (Io_error { operation = Sync; path; detail })
 ;;
 
+let not_real_directory_error path =
+  Io_error
+    { operation = Inspect
+    ; path
+    ; detail = "memory job store path is not a real directory"
+    }
+;;
+
+let require_existing_real_directory path =
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  if stat.Unix.st_kind = Unix.S_DIR
+  then Ok ()
+  else Error (not_real_directory_error path)
+;;
+
 let ensure_real_directory ~owned path =
   let* before = inspect_path path in
-  let* () =
+  let* created =
     match before with
-    | Some _ -> Ok ()
+    | Some _ -> Ok false
     | None ->
-      protect_io Ensure_directory path (fun () ->
-        Fs_compat.mkdir_p_durable_unix path)
+      let mode = if owned then private_directory_mode else 0o755 in
+      let* () =
+        protect_io Ensure_directory path (fun () ->
+          try Unix.mkdir path mode with
+          | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+      in
+      Ok true
   in
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  let* () =
-    if stat.Unix.st_kind = Unix.S_DIR
-    then Ok ()
-    else
-      Error
-        (Io_error
-           { operation = Inspect
-           ; path
-           ; detail = "memory job store path is not a real directory"
-           })
-  in
+  let* () = require_existing_real_directory path in
+  let* () = if created then sync_directory (Filename.dirname path) else Ok () in
   if not owned
   then Ok ()
   else
@@ -356,10 +366,60 @@ let ensure_real_directory ~owned path =
     sync_directory path
 ;;
 
+let managed_root_directories ~base_path =
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
+  [ masc_dir; Common.keepers_runtime_dir_of_base ~base_path ]
+;;
+
+let keeper_ancestor_directories ~base_path ~keeper_name =
+  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
+  [ Filename.concat keepers_root keeper_name
+  ; keeper_jobs_dir ~base_path ~keeper_name
+  ]
+;;
+
+let validate_real_directory_chain paths =
+  let rec loop = function
+    | [] -> Ok true
+    | path :: rest ->
+      let* stat = inspect_path path in
+      (match stat with
+       | None -> Ok false
+       | Some stat when stat.Unix.st_kind = Unix.S_DIR -> loop rest
+       | Some _ -> Error (not_real_directory_error path))
+  in
+  loop paths
+;;
+
+let require_real_directory_chain paths =
+  let rec loop = function
+    | [] -> Ok ()
+    | path :: rest ->
+      let* () = require_existing_real_directory path in
+      loop rest
+  in
+  loop paths
+;;
+
+let validate_managed_root_if_present ~base_path =
+  validate_real_directory_chain
+    (base_path :: managed_root_directories ~base_path)
+;;
+
+let validate_keeper_ancestors_if_present ~base_path ~keeper_name =
+  validate_real_directory_chain
+    (base_path
+     :: (managed_root_directories ~base_path
+         @ keeper_ancestor_directories ~base_path ~keeper_name))
+;;
+
 let ensure_store_dirs ~base_path ~keeper_name =
   let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
   let keeper_dir = Filename.concat keepers_root keeper_name in
-  let parent_dirs = [ keepers_root; keeper_dir ] in
+  let* () = require_existing_real_directory base_path in
+  let parent_dirs =
+    managed_root_directories ~base_path @ [ keeper_dir ]
+  in
   let owned_dirs =
     [ keeper_jobs_dir ~base_path ~keeper_name
     ; pending_dir ~base_path ~keeper_name
@@ -376,7 +436,9 @@ let ensure_store_dirs ~base_path ~keeper_name =
       loop ~owned rest
   in
   let* () = loop ~owned:false parent_dirs in
-  loop ~owned:true owned_dirs
+  let* () = loop ~owned:true owned_dirs in
+  require_real_directory_chain
+    (base_path :: (parent_dirs @ owned_dirs))
 ;;
 
 let valid_job_id id =
@@ -1328,6 +1390,7 @@ let activate ~base_path (job : job) =
 ;;
 
 let abort_awaiting ~base_path (job : job) =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
   let path = awaiting_path ~base_path job in
   let* exists = file_exists path in
   if not exists
@@ -1443,6 +1506,7 @@ let claim_all ~base_path ~keeper_name ~now =
   else if (not (Float.is_finite now)) || now < 0.0
   then Error (Invalid_claim_time now)
   else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
     let dir = pending_dir ~base_path ~keeper_name in
     let* paths = list_json_paths dir in
     let* envelopes =
@@ -1624,31 +1688,37 @@ let backlog_count ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
-    let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
-    let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
-    let* awaiting_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_awaiting
-        awaiting
+    let* ancestors_exist =
+      validate_keeper_ancestors_if_present ~base_path ~keeper_name
     in
-    let* pending_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_pending
-        pending
-    in
-    let* inflight_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_inflight
-        inflight
-    in
-    Ok
-      (List.length awaiting_envelopes
-       + List.length pending_envelopes
-       + List.length inflight_envelopes)
+    if not ancestors_exist
+    then Ok 0
+    else
+      let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+      let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
+      let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
+      let* awaiting_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_awaiting
+          awaiting
+      in
+      let* pending_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_pending
+          pending
+      in
+      let* inflight_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_inflight
+          inflight
+      in
+      Ok
+        (List.length awaiting_envelopes
+         + List.length pending_envelopes
+         + List.length inflight_envelopes)
 ;;
 
 let directory_exists path =
@@ -1673,7 +1743,7 @@ let directory_exists path =
 
 let discover_keeper_names ~base_path =
   let root = Common.keepers_runtime_dir_of_base ~base_path in
-  let* root_exists = directory_exists root in
+  let* root_exists = validate_managed_root_if_present ~base_path in
   if not root_exists
   then Ok ([], [])
   else

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -1103,7 +1103,7 @@ let reconcile_atomic_orphans_in_dir dir =
     loop entries
 ;;
 
-let job_equal left right =
+let job_equal (left : job) (right : job) =
   String.equal left.id right.id
   && String.equal left.keeper_name right.keeper_name
   && String.equal left.trace_id right.trace_id

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -606,7 +606,7 @@ let receipt_identity_of_job (job : job) =
   }
 ;;
 
-let make_terminal_receipt lease ~ended_at ~outcome ~detail =
+let make_terminal_receipt (lease : lease) ~ended_at ~outcome ~detail =
   let started_at = lease.started_at in
   if
     (not (Float.is_finite started_at))

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -306,9 +306,155 @@ let operation_stage_path ~base_path ~keeper_name ~operation_id =
   path_for_id (operations_dir ~base_path ~keeper_name) operation_id
 ;;
 
-let inspect_path path =
-  try Ok (Some (Unix.lstat path)) with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+module Anchored = Fs_compat.Anchored_dir
+
+type anchored_directory =
+  { handle : Anchored.t
+  ; path : string
+  }
+
+type store_directories =
+  { jobs : anchored_directory
+  ; awaiting : anchored_directory
+  ; pending : anchored_directory
+  ; inflight : anchored_directory
+  ; receipts : anchored_directory
+  ; operations : anchored_directory
+  }
+
+type artifact =
+  { directory : anchored_directory
+  ; name : Anchored.Segment.t
+  ; path : string
+  }
+
+let child_name ~parent path =
+  if String.equal (Filename.dirname path) parent
+  then
+    let raw = Filename.basename path in
+    (match Anchored.Segment.of_string raw with
+     | Ok segment -> Ok segment
+     | Error error ->
+       Error
+         (Io_error
+            { operation = Inspect
+            ; path
+            ; detail = Anchored.Segment.error_to_string error
+            }))
+  else
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail =
+             Printf.sprintf
+               "memory job path is not a direct child of its SSOT parent %s"
+               parent
+         })
+;;
+
+let with_directory ~owned parent path f =
+  let* name = child_name ~parent:parent.path path in
+  let permission = if owned then private_directory_mode else 0o755 in
+  try
+    Anchored.with_ensure_dir
+      parent.handle
+      ~name
+      ~perm:permission
+      ~enforce_perm:owned
+      (fun handle -> f { handle; path })
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Ensure_directory
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let with_ensured_store ~base_path ~keeper_name f =
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_path = Filename.concat keepers_path keeper_name in
+  let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+  let awaiting_path = awaiting_dir ~base_path ~keeper_name in
+  let pending_path = pending_dir ~base_path ~keeper_name in
+  let inflight_path = inflight_dir ~base_path ~keeper_name in
+  let receipts_path = receipts_dir ~base_path ~keeper_name in
+  let operations_path = operations_dir ~base_path ~keeper_name in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* keeper_name_segment = child_name ~parent:keepers_path keeper_path in
+  let* jobs_name = child_name ~parent:keeper_path jobs_path in
+  let steps : Anchored.ensure_step list =
+    [ { name = masc_name; perm = 0o755; enforce_perm = false }
+    ; { name = keepers_name; perm = 0o755; enforce_perm = false }
+    ; { name = keeper_name_segment; perm = 0o755; enforce_perm = false }
+    ; { name = jobs_name
+      ; perm = private_directory_mode
+      ; enforce_perm = true
+      }
+    ]
+  in
+  try
+    Anchored.with_ensure_path ~root:base_path steps @@ fun handle ->
+    let jobs = { handle; path = jobs_path } in
+    with_directory ~owned:true jobs awaiting_path @@ fun awaiting ->
+    with_directory ~owned:true jobs pending_path @@ fun pending ->
+    with_directory ~owned:true jobs inflight_path @@ fun inflight ->
+    with_directory ~owned:true jobs receipts_path @@ fun receipts ->
+    with_directory ~owned:true jobs operations_path @@ fun operations ->
+    f { jobs; awaiting; pending; inflight; receipts; operations }
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Ensure_directory
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+type 'a presence =
+  | Missing
+  | Present of 'a
+
+type existing_jobs = { jobs : anchored_directory }
+
+let with_existing_directory parent path f =
+  let* name = child_name ~parent:parent.path path in
+  try
+    match
+      Anchored.with_open_dir_opt parent.handle name (fun handle ->
+        f { handle; path })
+    with
+    | None -> Ok Missing
+    | Some result -> result
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Error
@@ -319,126 +465,101 @@ let inspect_path path =
          })
 ;;
 
-let sync_directory path =
-  match Fs_compat.fsync_directory path with
-  | Ok () -> Ok ()
-  | Error detail -> Error (Io_error { operation = Sync; path; detail })
-;;
-
-let not_real_directory_error path =
-  Io_error
-    { operation = Inspect
-    ; path
-    ; detail = "memory job store path is not a real directory"
-    }
-;;
-
-let require_existing_real_directory path =
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  if stat.Unix.st_kind = Unix.S_DIR
-  then Ok ()
-  else Error (not_real_directory_error path)
-;;
-
-let ensure_real_directory ~owned path =
-  let* before = inspect_path path in
-  let* created =
-    match before with
-    | Some _ -> Ok false
-    | None ->
-      let mode = if owned then private_directory_mode else 0o755 in
-      let* () =
-        protect_io Ensure_directory path (fun () ->
-          try Unix.mkdir path mode with
-          | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-      in
-      Ok true
+let with_optional_directory parent path f =
+  let* presence =
+    with_existing_directory parent path (fun directory ->
+      let* value = f directory in
+      Ok (Present value))
   in
-  let* () = require_existing_real_directory path in
-  let* () = if created then sync_directory (Filename.dirname path) else Ok () in
-  if not owned
-  then Ok ()
-  else
-    let* () =
-      protect_io Set_permissions path (fun () ->
-        Unix.chmod path private_directory_mode)
-    in
-    sync_directory path
+  match presence with
+  | Missing -> Ok None
+  | Present value -> Ok (Some value)
 ;;
 
-let managed_root_directories ~base_path =
-  let masc_dir = Common.masc_dir_from_base_path ~base_path in
-  [ masc_dir; Common.keepers_runtime_dir_of_base ~base_path ]
+let with_existing_jobs ~base_path ~keeper_name f =
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_path = Filename.concat keepers_path keeper_name in
+  let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* keeper_name_segment = child_name ~parent:keepers_path keeper_path in
+  let* jobs_name = child_name ~parent:keeper_path jobs_path in
+  try
+    match
+      Anchored.with_open_path_opt
+        ~root:base_path
+        [ masc_name; keepers_name; keeper_name_segment; jobs_name ]
+        (fun handle ->
+           let* value = f { jobs = { handle; path = jobs_path } } in
+           Ok (Present value))
+    with
+    | None -> Ok Missing
+    | Some result -> result
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
 ;;
 
-let keeper_ancestor_directories ~base_path ~keeper_name =
-  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
-  [ Filename.concat keepers_root keeper_name
-  ; keeper_jobs_dir ~base_path ~keeper_name
-  ]
+let artifact_from_segment directory name =
+  let raw_name = Anchored.Segment.to_string name in
+  { directory
+  ; name
+  ; path = Filename.concat directory.path raw_name
+  }
 ;;
 
-let validate_real_directory_chain paths =
-  let rec loop = function
-    | [] -> Ok true
-    | path :: rest ->
-      let* stat = inspect_path path in
-      (match stat with
-       | None -> Ok false
-       | Some stat when stat.Unix.st_kind = Unix.S_DIR -> loop rest
-       | Some _ -> Error (not_real_directory_error path))
+let artifact directory raw_name =
+  let name =
+    match Anchored.Segment.of_string raw_name with
+    | Ok segment -> segment
+    | Error error ->
+      invalid_arg
+        (Printf.sprintf
+           "invalid memory job artifact name %S: %s"
+           raw_name
+           (Anchored.Segment.error_to_string error))
   in
-  loop paths
+  artifact_from_segment directory name
 ;;
 
-let require_real_directory_chain paths =
-  let rec loop = function
-    | [] -> Ok ()
-    | path :: rest ->
-      let* () = require_existing_real_directory path in
-      loop rest
-  in
-  loop paths
+let artifact_for_id directory id = artifact directory (id ^ json_suffix)
+
+let awaiting_artifact store (job : job) =
+  artifact_for_id store.awaiting job.id
 ;;
 
-let validate_managed_root_if_present ~base_path =
-  validate_real_directory_chain
-    (base_path :: managed_root_directories ~base_path)
+let pending_artifact store (job : job) =
+  artifact_for_id store.pending job.id
 ;;
 
-let validate_keeper_ancestors_if_present ~base_path ~keeper_name =
-  validate_real_directory_chain
-    (base_path
-     :: (managed_root_directories ~base_path
-         @ keeper_ancestor_directories ~base_path ~keeper_name))
+let inflight_artifact store (job : job) =
+  artifact_for_id store.inflight job.id
 ;;
 
-let ensure_store_dirs ~base_path ~keeper_name =
-  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
-  let keeper_dir = Filename.concat keepers_root keeper_name in
-  let* () = require_existing_real_directory base_path in
-  let parent_dirs =
-    managed_root_directories ~base_path @ [ keeper_dir ]
-  in
-  let owned_dirs =
-    [ keeper_jobs_dir ~base_path ~keeper_name
-    ; pending_dir ~base_path ~keeper_name
-    ; awaiting_dir ~base_path ~keeper_name
-    ; inflight_dir ~base_path ~keeper_name
-    ; receipts_dir ~base_path ~keeper_name
-    ; operations_dir ~base_path ~keeper_name
-    ]
-  in
-  let rec loop ~owned = function
-    | [] -> Ok ()
-    | dir :: rest ->
-      let* () = ensure_real_directory ~owned dir in
-      loop ~owned rest
-  in
-  let* () = loop ~owned:false parent_dirs in
-  let* () = loop ~owned:true owned_dirs in
-  require_real_directory_chain
-    (base_path :: (parent_dirs @ owned_dirs))
+let receipt_artifact store (job : job) =
+  artifact_for_id store.receipts job.id
+;;
+
+let receipt_artifact_for_identity store (identity : receipt_identity) =
+  artifact_for_id store.receipts identity.id
+;;
+
+let operation_artifact store operation_id =
+  artifact_for_id store.operations operation_id
 ;;
 
 let valid_job_id id =
@@ -918,189 +1039,315 @@ let receipt_of_json json =
   | _ -> Error "memory job receipt must be a JSON object"
 ;;
 
-let read_json path =
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  if stat.Unix.st_kind <> Unix.S_REG
-  then
+let inspect_artifact item =
+  protect_io Inspect item.path (fun () ->
+    Anchored.stat item.directory.handle item.name)
+;;
+
+let read_json_opt item =
+  let content =
+    try Ok (Anchored.read_file_opt item.directory.handle item.name) with
+    | Unix.Unix_error ((Unix.ELOOP | Unix.EISDIR), _, _) as exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = item.path
+           ; detail = Printexc.to_string exn
+           })
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Io_error
+           { operation = Read
+           ; path = item.path
+           ; detail = Printexc.to_string exn
+           })
+  in
+  let* content = content in
+  match content with
+  | None -> Ok None
+  | Some content ->
+    (match Safe_ops.parse_json_safe ~context:item.path content with
+     | Ok json -> Ok (Some json)
+     | Error detail ->
+       Error (Io_error { operation = Read; path = item.path; detail }))
+;;
+
+let read_json item =
+  let* json = read_json_opt item in
+  match json with
+  | Some json -> Ok json
+  | None ->
     Error
       (Io_error
-         { operation = Inspect
-         ; path
-         ; detail = "memory job artifact is not a regular file"
+         { operation = Read
+         ; path = item.path
+         ; detail = "memory job artifact does not exist"
          })
-  else
-    match
-      try
-        Fs_compat.load_file_unix path
-        |> Safe_ops.parse_json_safe ~context:path
-      with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn -> Error (Printexc.to_string exn)
-    with
-    | Ok json -> Ok json
-    | Error detail -> Error (Io_error { operation = Read; path; detail })
 ;;
 
-let read_envelope path =
-  let* json = read_json path in
+let read_envelope item =
+  let* json = read_json item in
   envelope_of_json json
-  |> Result.map_error (fun detail -> Decode_error { path; detail })
+  |> Result.map_error (fun detail -> Decode_error { path = item.path; detail })
 ;;
 
-let read_receipt path =
-  let* json = read_json path in
+let read_envelope_opt item =
+  let* json = read_json_opt item in
+  match json with
+  | None -> Ok None
+  | Some json ->
+    envelope_of_json json
+    |> Result.map Option.some
+    |> Result.map_error (fun detail ->
+      Decode_error { path = item.path; detail })
+;;
+
+let read_receipt item =
+  let* json = read_json item in
   receipt_of_json json
-  |> Result.map_error (fun detail -> Decode_error { path; detail })
+  |> Result.map_error (fun detail -> Decode_error { path = item.path; detail })
 ;;
 
-let save_json path json =
+let read_receipt_opt item =
+  let* json = read_json_opt item in
+  match json with
+  | None -> Ok None
+  | Some json ->
+    receipt_of_json json
+    |> Result.map Option.some
+    |> Result.map_error (fun detail ->
+      Decode_error { path = item.path; detail })
+;;
+
+let save_json item json =
   match
-    Fs_compat.save_file_atomic_unix
-      path
+    Anchored.atomic_replace
+      item.directory.handle
+      ~name:item.name
+      ~perm:private_file_mode
       (Yojson.Safe.pretty_to_string json)
   with
-  | Ok () ->
-    protect_io Set_permissions path (fun () -> Unix.chmod path private_file_mode)
-  | Error detail -> Error (Io_error { operation = Write; path; detail })
-;;
-
-let file_exists path =
-  try
-    ignore (Unix.lstat path);
-    Ok true
-  with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
+  | Ok () -> Ok ()
+  | Error error ->
     Error
       (Io_error
-         { operation = Inspect
-         ; path
-         ; detail = Printexc.to_string exn
+         { operation = Write
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
          })
 ;;
 
-let remove_if_exists path =
-  let* exists = file_exists path in
-  if not exists
-  then Ok ()
-  else protect_io Remove path (fun () -> Sys.remove path)
+let remove_if_exists item =
+  match Anchored.unlink_if_exists item.directory.handle item.name with
+  | Ok (`Missing | `Removed) -> Ok ()
+  | Error error ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
+         })
 ;;
 
-let cleanup_paths paths =
+let remove_required item =
+  match Anchored.unlink_if_exists item.directory.handle item.name with
+  | Ok `Removed -> Ok ()
+  | Ok `Missing ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = "required memory job artifact disappeared before unlink"
+         })
+  | Error error ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
+         })
+;;
+
+let cleanup_artifacts items =
   List.fold_left
-    (fun errors path ->
-       match remove_if_exists path with
+    (fun errors item ->
+       match remove_if_exists item with
        | Ok () -> errors
        | Error error -> error :: errors)
     []
-    paths
+    items
   |> List.rev
 ;;
 
-let reconcile_atomic_orphan dir name =
-  let path = Filename.concat dir name in
-  let recovered_root =
-    Filename.concat
-      (Filename.dirname dir)
-      recovered_atomic_writes_dirname
-  in
-  let bucket = Filename.basename dir in
-  let recovered_dir =
-    Filename.concat
-      recovered_root
-      bucket
-  in
-  let* () = ensure_real_directory ~owned:true recovered_root in
-  let* () = ensure_real_directory ~owned:true recovered_dir in
-  match Fs_compat.recover_atomic_orphan ~path ~recovered_root ~bucket with
-  | Error detail -> Error (Io_error { operation = Inspect; path; detail })
-  | Ok Fs_compat.Deleted_zero_length ->
-    Log.Keeper.warn "memory job queue removed zero-length atomic orphan path=%s" path;
+let require_same_regular_identity ~source ~destination expected = function
+  | Some ({ Anchored.kind = Regular_file; _ } as actual)
+    when Anchored.same_identity expected actual -> Ok ()
+  | Some _ ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = destination
+         ; detail =
+             Printf.sprintf
+               "atomic orphan destination conflicts with source %s"
+               source
+         })
+  | None ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = destination
+         ; detail = "atomic orphan destination disappeared"
+         })
+;;
+
+let reconcile_atomic_orphan ~jobs directory name =
+  let source = artifact_from_segment directory name in
+  let* inspected = inspect_artifact source in
+  match inspected with
+  | None ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = source.path
+         ; detail = "atomic orphan disappeared during reconciliation"
+         })
+  | Some { Anchored.kind = Regular_file; size = 0L; _ } ->
+    let* () = remove_required source in
+    Log.Keeper.warn
+      "memory job queue removed zero-length atomic orphan path=%s"
+      source.path;
     Ok ()
-  | Ok (Fs_compat.Preserved_nonempty destination) ->
-    (match
-       protect_io Set_permissions recovered_dir (fun () ->
-         Unix.chmod recovered_dir private_directory_mode)
-     with
-     | Error _ as error -> error
-     | Ok () ->
-       let* () =
-         protect_io Set_permissions destination (fun () ->
-           Unix.chmod destination private_file_mode)
-       in
-       Log.Keeper.error
-         "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
-         path
-         destination;
-       Ok ())
-;;
-
-let list_json_paths dir =
-  let* exists = file_exists dir in
-  if not exists
-  then Ok []
-  else
-    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+  | Some ({ Anchored.kind = Regular_file; _ } as source_identity) ->
+    let* synced_identity =
+      protect_io Sync source.path (fun () ->
+        Anchored.fsync_file directory.handle name)
+    in
     let* () =
-      if stat.Unix.st_kind = Unix.S_DIR
+      if Anchored.same_identity source_identity synced_identity
       then Ok ()
       else
         Error
           (Io_error
              { operation = Inspect
-             ; path = dir
-             ; detail = "memory job queue path is not a real directory"
+             ; path = source.path
+             ; detail = "atomic orphan changed while it was being synced"
              })
     in
-    let* entries =
-      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    let bucket_name = Filename.basename directory.path in
+    let recovered_path =
+      Filename.concat jobs.path recovered_atomic_writes_dirname
     in
-    let rec validate acc = function
-      | [] -> Ok (List.sort String.compare acc)
-      | name :: rest ->
-        let path = Filename.concat dir name in
-        if Filename.check_suffix name json_suffix
-        then validate (path :: acc) rest
-        else if Fs_compat.is_atomic_orphan_name name
-        then
-          let* () = reconcile_atomic_orphan dir name in
-          validate acc rest
-        else Error (Unexpected_queue_entry path)
+    with_directory ~owned:true jobs recovered_path @@ fun recovered ->
+    let bucket_path = Filename.concat recovered.path bucket_name in
+    with_directory ~owned:true recovered bucket_path @@ fun bucket ->
+    let destination = artifact_from_segment bucket name in
+    let* destination_before = inspect_artifact destination in
+    let* () =
+      match destination_before with
+      | Some _ ->
+        require_same_regular_identity
+          ~source:source.path
+          ~destination:destination.path
+          synced_identity
+          destination_before
+      | None ->
+        let link_result =
+          match
+            Anchored.link_no_replace
+              ~src_dir:directory.handle
+              ~src:name
+              ~dst_dir:bucket.handle
+              ~dst:name
+          with
+          | Ok () -> Ok ()
+          | Error
+              (Anchored.Not_committed
+                 { cause = Unix.Unix_error (Unix.EEXIST, _, _)
+                 ; cleanup_error = None
+                 }) -> Ok ()
+          | Error error ->
+            Error
+              (Io_error
+                 { operation = Write
+                 ; path = destination.path
+                 ; detail = Anchored.mutation_error_to_string error
+                 })
+        in
+        let* () = link_result in
+        let* destination_after = inspect_artifact destination in
+        require_same_regular_identity
+          ~source:source.path
+          ~destination:destination.path
+          synced_identity
+          destination_after
     in
-    validate [] entries
+    let* source_before_unlink = inspect_artifact source in
+    let* () =
+      require_same_regular_identity
+        ~source:source.path
+        ~destination:source.path
+        synced_identity
+        source_before_unlink
+    in
+    let* () = remove_required source in
+    let* () =
+      protect_io Set_permissions destination.path (fun () ->
+        Anchored.chmod_file bucket.handle name private_file_mode)
+    in
+    Log.Keeper.error
+      "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
+      source.path
+      destination.path;
+    Ok ()
+  | Some _ ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = source.path
+         ; detail = "atomic orphan is not a regular file"
+         })
 ;;
 
-let reconcile_atomic_orphans_in_dir dir =
-  let* exists = file_exists dir in
-  if not exists
-  then Ok ()
-  else
-    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
-    let* () =
-      if stat.Unix.st_kind = Unix.S_DIR
-      then Ok ()
-      else
-        Error
-          (Io_error
-             { operation = Inspect
-             ; path = dir
-             ; detail = "memory job queue path is not a real directory"
-             })
-    in
-    let* entries =
-      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
-    in
-    let rec loop = function
-      | [] -> Ok ()
-      | name :: rest ->
-        if Fs_compat.is_atomic_orphan_name name
-        then
-          let* () = reconcile_atomic_orphan dir name in
-          loop rest
-        else loop rest
-    in
-    loop entries
+let list_json_artifacts ~jobs directory =
+  let* entries =
+    protect_io List_directory directory.path (fun () ->
+      Anchored.read_dir directory.handle)
+  in
+  let rec validate acc = function
+    | [] -> Ok (List.rev acc)
+    | name :: rest ->
+      let raw_name = Anchored.Segment.to_string name in
+      let item = artifact_from_segment directory name in
+      if Filename.check_suffix raw_name json_suffix
+      then validate (item :: acc) rest
+      else if Fs_compat.is_atomic_orphan_name raw_name
+      then
+        let* () = reconcile_atomic_orphan ~jobs directory name in
+        validate acc rest
+      else Error (Unexpected_queue_entry item.path)
+  in
+  validate [] entries
+;;
+
+let reconcile_atomic_orphans_in_dir ~jobs directory =
+  let* entries =
+    protect_io List_directory directory.path (fun () ->
+      Anchored.read_dir directory.handle)
+  in
+  let rec loop = function
+    | [] -> Ok ()
+    | name :: rest ->
+      if
+        Fs_compat.is_atomic_orphan_name
+          (Anchored.Segment.to_string name)
+      then
+        let* () = reconcile_atomic_orphan ~jobs directory name in
+        loop rest
+      else loop rest
+  in
+  loop entries
 ;;
 
 let job_equal (left : job) (right : job) =
@@ -1176,41 +1423,38 @@ let ensure_queue_coordinates ~expected_keeper_name ~path envelope =
   else Ok ()
 ;;
 
-let classify_existing_envelope ~expected_job ~expected_state ~path outcome =
-  let* exists = file_exists path in
-  if not exists
-  then Ok None
-  else
-    let* envelope = read_envelope path in
+let classify_existing_envelope ~expected_job ~expected_state ~item outcome =
+  let* envelope = read_envelope_opt item in
+  match envelope with
+  | None -> Ok None
+  | Some envelope ->
     let* () =
       ensure_queue_coordinates
         ~expected_keeper_name:expected_job.keeper_name
-        ~path
+        ~path:item.path
         envelope
     in
-    let* () = ensure_same_job ~expected:expected_job ~path envelope in
-    let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+    let* () = ensure_same_job ~expected:expected_job ~path:item.path envelope in
+    let* () =
+      ensure_expected_state ~expected:expected_state ~path:item.path envelope
+    in
     Ok (Some outcome)
 ;;
 
 let stage_awaiting_turn_commit ~base_path job =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let receipt_path = receipt_path ~base_path job in
-  let* receipt_exists = file_exists receipt_path in
-  if receipt_exists
-  then
-    let* receipt = read_receipt receipt_path in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let receipt_item = receipt_artifact store job in
+  let* existing_receipt = read_receipt_opt receipt_item in
+  match existing_receipt with
+  | Some receipt ->
     if receipt_identity_matches_retry receipt.identity job
     then
       let cleanup_errors =
-        cleanup_paths
-          [ awaiting_path ~base_path job
-          ; pending_path ~base_path job
-          ; inflight_path ~base_path job
-          ; operation_stage_path
-              ~base_path
-              ~keeper_name:job.keeper_name
-              ~operation_id:job.id
+        cleanup_artifacts
+          [ awaiting_artifact store job
+          ; pending_artifact store job
+          ; inflight_artifact store job
+          ; operation_artifact store job.id
           ]
       in
       List.iter
@@ -1221,16 +1465,18 @@ let stage_awaiting_turn_commit ~base_path job =
              (error_to_string error))
         cleanup_errors;
       Ok Already_completed
-    else Error (Identity_conflict { job_id = job.id; path = receipt_path })
-  else
-    let awaiting_path = awaiting_path ~base_path job in
-    let pending_path = pending_path ~base_path job in
-    let inflight_path = inflight_path ~base_path job in
+    else
+      Error
+        (Identity_conflict { job_id = job.id; path = receipt_item.path })
+  | None ->
+    let awaiting_item = awaiting_artifact store job in
+    let pending_item = pending_artifact store job in
+    let inflight_item = inflight_artifact store job in
     let* awaiting =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_awaiting
-        ~path:awaiting_path
+        ~item:awaiting_item
         Already_awaiting
     in
     match awaiting with
@@ -1240,7 +1486,7 @@ let stage_awaiting_turn_commit ~base_path job =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_pending
-        ~path:pending_path
+        ~item:pending_item
         Already_pending
     in
     match pending with
@@ -1250,14 +1496,14 @@ let stage_awaiting_turn_commit ~base_path job =
         classify_existing_envelope
           ~expected_job:job
           ~expected_state:Expect_inflight
-          ~path:inflight_path
+          ~item:inflight_item
           Already_inflight
       in
       (match inflight with
        | Some outcome -> Ok outcome
        | None ->
          let envelope = { job; state = Awaiting_turn_commit } in
-         let* () = save_json awaiting_path (envelope_to_json envelope) in
+         let* () = save_json awaiting_item (envelope_to_json envelope) in
          Ok Staged_awaiting_turn_commit)
 ;;
 
@@ -1278,103 +1524,108 @@ let compare_job_order left right =
         if by_enqueued <> 0 then by_enqueued else String.compare left.id right.id
 ;;
 
-let load_envelopes ~expected_keeper_name ~expected_state paths =
+let load_envelopes ~expected_keeper_name ~expected_state items =
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
-    | path :: rest ->
-      let* envelope = read_envelope path in
+    | item :: rest ->
+      let* envelope = read_envelope item in
       let* () =
-        ensure_queue_coordinates ~expected_keeper_name ~path envelope
+        ensure_queue_coordinates
+          ~expected_keeper_name
+          ~path:item.path
+          envelope
       in
-      let* () = ensure_expected_state ~expected:expected_state ~path envelope in
-      loop ((path, envelope) :: acc) rest
+      let* () =
+        ensure_expected_state
+          ~expected:expected_state
+          ~path:item.path
+          envelope
+      in
+      loop ((item, envelope) :: acc) rest
   in
-  loop [] paths
+  loop [] items
 ;;
 
 let list_awaiting ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
-    let* paths = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
+    let* items = list_json_artifacts ~jobs:store.jobs store.awaiting in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_awaiting
-        paths
+        items
     in
     Ok (List.map (fun (_, envelope) -> envelope.job) envelopes)
 ;;
 
 let activate ~base_path (job : job) =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let awaiting = awaiting_path ~base_path job in
-  let pending = pending_path ~base_path job in
-  let inflight = inflight_path ~base_path job in
-  let receipt = receipt_path ~base_path job in
-  let operation =
-    operation_stage_path
-      ~base_path
-      ~keeper_name:job.keeper_name
-      ~operation_id:job.id
-  in
-  let* receipt_exists = file_exists receipt in
-  if receipt_exists
-  then
-    let* terminal = read_receipt receipt in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let awaiting = awaiting_artifact store job in
+  let pending = pending_artifact store job in
+  let inflight = inflight_artifact store job in
+  let receipt = receipt_artifact store job in
+  let operation = operation_artifact store job.id in
+  let* terminal = read_receipt_opt receipt in
+  match terminal with
+  | Some terminal ->
     if not (receipt_identity_matches_retry terminal.identity job)
-    then Error (Identity_conflict { job_id = job.id; path = receipt })
+    then Error (Identity_conflict { job_id = job.id; path = receipt.path })
     else
-      let cleanup_errors = cleanup_paths [ awaiting; pending; inflight; operation ] in
+      let cleanup_errors =
+        cleanup_artifacts [ awaiting; pending; inflight; operation ]
+      in
       Ok (Activation_already_completed, { cleanup_errors })
-  else
+  | None ->
     let* pending_state =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_pending
-        ~path:pending
+        ~item:pending
         Activation_already_pending
     in
     (match pending_state with
      | Some activation ->
-       let cleanup_errors = cleanup_paths [ awaiting ] in
+       let cleanup_errors = cleanup_artifacts [ awaiting ] in
        Ok (activation, { cleanup_errors })
      | None ->
        let* inflight_state =
          classify_existing_envelope
            ~expected_job:job
            ~expected_state:Expect_inflight
-           ~path:inflight
+           ~item:inflight
            Activation_already_inflight
        in
        (match inflight_state with
         | Some activation ->
-          let cleanup_errors = cleanup_paths [ awaiting ] in
+          let cleanup_errors = cleanup_artifacts [ awaiting ] in
           Ok (activation, { cleanup_errors })
         | None ->
-          let* awaiting_exists = file_exists awaiting in
-          if not awaiting_exists
-          then
+          let* awaiting_envelope = read_envelope_opt awaiting in
+          (match awaiting_envelope with
+           | None ->
             Error
               (Decode_error
-                 { path = awaiting
+                 { path = awaiting.path
                  ; detail =
                      "cannot activate a memory job without its awaiting-turn-commit envelope"
                  })
-          else
-            let* envelope = read_envelope awaiting in
+           | Some envelope ->
             let* () =
               ensure_queue_coordinates
                 ~expected_keeper_name:job.keeper_name
-                ~path:awaiting
+                ~path:awaiting.path
                 envelope
             in
-            let* () = ensure_same_job ~expected:job ~path:awaiting envelope in
+            let* () =
+              ensure_same_job ~expected:job ~path:awaiting.path envelope
+            in
             let* () =
               ensure_expected_state
                 ~expected:Expect_awaiting
-                ~path:awaiting
+                ~path:awaiting.path
                 envelope
             in
             let* () =
@@ -1385,113 +1636,108 @@ let activate ~base_path (job : job) =
                    ; state = Pending
                    })
             in
-            let cleanup_errors = cleanup_paths [ awaiting ] in
-            Ok (Activated, { cleanup_errors })))
+            let cleanup_errors = cleanup_artifacts [ awaiting ] in
+            Ok (Activated, { cleanup_errors }))))
 ;;
 
 let abort_awaiting ~base_path (job : job) =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let path = awaiting_path ~base_path job in
-  let* exists = file_exists path in
-  if not exists
-  then Ok ()
-  else
-    let* envelope = read_envelope path in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let item = awaiting_artifact store job in
+  let* envelope = read_envelope_opt item in
+  match envelope with
+  | None -> Ok ()
+  | Some envelope ->
     let* () =
       ensure_queue_coordinates
         ~expected_keeper_name:job.keeper_name
-        ~path
+        ~path:item.path
         envelope
     in
-    let* () = ensure_same_job ~expected:job ~path envelope in
+    let* () = ensure_same_job ~expected:job ~path:item.path envelope in
     let* () =
-      ensure_expected_state ~expected:Expect_awaiting ~path envelope
+      ensure_expected_state ~expected:Expect_awaiting ~path:item.path envelope
     in
-    remove_if_exists path
+    remove_if_exists item
 ;;
 
-let recover_one ~base_path (inflight_path, envelope) =
+let recover_one store (inflight_item, envelope) =
   match envelope.state with
   | Awaiting_turn_commit | Pending ->
     Error
       (Decode_error
-         { path = inflight_path
+         { path = inflight_item.path
          ; detail = "inflight directory contains a pending envelope"
          })
   | Inflight { started_at } ->
     let job = envelope.job in
-    let receipt_path = receipt_path ~base_path job in
-    let* receipt_exists = file_exists receipt_path in
-    if receipt_exists
-    then
-      let* receipt = read_receipt receipt_path in
+    let receipt_item = receipt_artifact store job in
+    let* receipt = read_receipt_opt receipt_item in
+    (match receipt with
+     | Some receipt ->
       if not (receipt_identity_matches_job receipt.identity job)
-      then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+      then
+        Error
+          (Identity_conflict { job_id = job.id; path = receipt_item.path })
       else if not (Float.equal receipt.started_at started_at)
       then
         Error
           (Inflight_lease_conflict
              { job_id = job.id
-             ; path = inflight_path
+             ; path = inflight_item.path
              ; expected_started_at = receipt.started_at
              ; actual_started_at = started_at
              })
       else
         let cleanup_errors =
-          cleanup_paths
-            [ operation_stage_path
-                ~base_path
-                ~keeper_name:job.keeper_name
-                ~operation_id:job.id
-            ; awaiting_path ~base_path job
-            ; pending_path ~base_path job
-            ; inflight_path
+          cleanup_artifacts
+            [ operation_artifact store job.id
+            ; awaiting_artifact store job
+            ; pending_artifact store job
+            ; inflight_item
             ]
         in
         Ok (false, cleanup_errors)
-    else
-      let pending_path = pending_path ~base_path job in
-      let* pending_exists = file_exists pending_path in
+     | None ->
+      let pending_item = pending_artifact store job in
+      let* pending = read_envelope_opt pending_item in
       let* () =
-        if pending_exists
-        then
-          let* pending = read_envelope pending_path in
-          let* () = ensure_same_job ~expected:job ~path:pending_path pending in
+        match pending with
+        | Some pending ->
+          let* () =
+            ensure_same_job ~expected:job ~path:pending_item.path pending
+          in
           ensure_expected_state
             ~expected:Expect_pending
-            ~path:pending_path
+            ~path:pending_item.path
             pending
-        else save_json pending_path (envelope_to_json { job; state = Pending })
+        | None -> save_json pending_item (envelope_to_json { job; state = Pending })
       in
-      let cleanup_errors = cleanup_paths [ inflight_path ] in
-      Ok (true, cleanup_errors)
+      let cleanup_errors = cleanup_artifacts [ inflight_item ] in
+      Ok (true, cleanup_errors))
 ;;
 
 let recover_inflight ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
     let* () =
-      reconcile_atomic_orphans_in_dir
-        (receipts_dir ~base_path ~keeper_name)
+      reconcile_atomic_orphans_in_dir ~jobs:store.jobs store.receipts
     in
     let* () =
-      reconcile_atomic_orphans_in_dir
-        (operations_dir ~base_path ~keeper_name)
+      reconcile_atomic_orphans_in_dir ~jobs:store.jobs store.operations
     in
-    let dir = inflight_dir ~base_path ~keeper_name in
-    let* paths = list_json_paths dir in
+    let* items = list_json_artifacts ~jobs:store.jobs store.inflight in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_inflight
-        paths
+        items
     in
     let rec loop replayed cleanup_errors = function
       | [] -> Ok { replayed; cleanup_errors = List.rev cleanup_errors }
       | item :: rest ->
-        let* did_recover, item_cleanup_errors = recover_one ~base_path item in
+        let* did_recover, item_cleanup_errors = recover_one store item in
         loop
           (if did_recover then replayed + 1 else replayed)
           (List.rev_append item_cleanup_errors cleanup_errors)
@@ -1506,67 +1752,65 @@ let claim_all ~base_path ~keeper_name ~now =
   else if (not (Float.is_finite now)) || now < 0.0
   then Error (Invalid_claim_time now)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
-    let dir = pending_dir ~base_path ~keeper_name in
-    let* paths = list_json_paths dir in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
+    let* items = list_json_artifacts ~jobs:store.jobs store.pending in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_pending
-        paths
+        items
     in
     let ordered =
       envelopes
-      |> List.map (fun (path, envelope) -> path, envelope.job)
+      |> List.map (fun (item, envelope) -> item, envelope.job)
       |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
     in
-    let process_item path job =
-      let receipt_path = receipt_path ~base_path job in
-      let* receipt_exists = file_exists receipt_path in
-      if receipt_exists
-      then
-        let* receipt = read_receipt receipt_path in
+    let process_item item job =
+      let receipt_item = receipt_artifact store job in
+      let* receipt = read_receipt_opt receipt_item in
+      match receipt with
+      | Some receipt ->
         if not (receipt_identity_matches_job receipt.identity job)
-        then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+        then
+          Error
+            (Identity_conflict { job_id = job.id; path = receipt_item.path })
         else
           Ok
             (`Skipped
-              (cleanup_paths
-                 [ path
-                 ; awaiting_path ~base_path job
-                 ; inflight_path ~base_path job
-                 ; operation_stage_path
-                     ~base_path
-                     ~keeper_name:job.keeper_name
-                     ~operation_id:job.id
+              (cleanup_artifacts
+                 [ item
+                 ; awaiting_artifact store job
+                 ; inflight_artifact store job
+                 ; operation_artifact store job.id
                  ]))
-      else
+      | None ->
         let lease = { job; started_at = now } in
-        let destination = inflight_path ~base_path job in
-        let* inflight_exists = file_exists destination in
-        if inflight_exists
-        then
-          let* inflight = read_envelope destination in
+        let destination = inflight_artifact store job in
+        let* inflight = read_envelope_opt destination in
+        (match inflight with
+         | Some inflight ->
           let* () =
             ensure_queue_coordinates
               ~expected_keeper_name:keeper_name
-              ~path:destination
+              ~path:destination.path
               inflight
           in
-          let* () = ensure_same_job ~expected:job ~path:destination inflight in
+          let* () =
+            ensure_same_job ~expected:job ~path:destination.path inflight
+          in
           let* () =
             ensure_expected_state
               ~expected:Expect_inflight
-              ~path:destination
+              ~path:destination.path
               inflight
           in
           Error
             (Pending_already_inflight
                { job_id = job.id
-               ; pending_path = path
-               ; inflight_path = destination
+               ; pending_path = item.path
+               ; inflight_path = destination.path
                })
-        else
+         | None ->
           let* () =
             save_json
               destination
@@ -1575,7 +1819,7 @@ let claim_all ~base_path ~keeper_name ~now =
                  ; state = Inflight { started_at = lease.started_at }
                  })
           in
-          Ok (`Claimed (lease, cleanup_paths [ path ]))
+          Ok (`Claimed (lease, cleanup_artifacts [ item ])))
     in
     let rec claim leases cleanup_errors = function
       | [] ->
@@ -1584,8 +1828,8 @@ let claim_all ~base_path ~keeper_name ~now =
           ; cleanup_errors = List.rev cleanup_errors
           ; blocked = None
           }
-      | (path, job) :: rest ->
-        (match process_item path job with
+      | (item, job) :: rest ->
+        (match process_item item job with
          | Error error ->
            Ok
              { leases = List.rev leases
@@ -1608,34 +1852,16 @@ let claim_all ~base_path ~keeper_name ~now =
 
 let finish ~base_path (receipt : terminal_receipt) =
   let identity = receipt.identity in
-  let* () = ensure_store_dirs ~base_path ~keeper_name:identity.keeper_name in
-  let path = receipt_path_for_identity ~base_path identity in
-  let operation =
-    operation_stage_path
-      ~base_path
-      ~keeper_name:identity.keeper_name
-      ~operation_id:identity.id
-  in
-  let awaiting =
-    path_for_id
-      (awaiting_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let pending =
-    path_for_id
-      (pending_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let inflight =
-    path_for_id
-      (inflight_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let* exists = file_exists path in
+  with_ensured_store ~base_path ~keeper_name:identity.keeper_name @@ fun store ->
+  let receipt_item = receipt_artifact_for_identity store identity in
+  let operation = operation_artifact store identity.id in
+  let awaiting = artifact_for_id store.awaiting identity.id in
+  let pending = artifact_for_id store.pending identity.id in
+  let inflight = artifact_for_id store.inflight identity.id in
+  let* existing_receipt = read_receipt_opt receipt_item in
   let* () =
-    if exists
-    then
-      let* current = read_receipt path in
+    match existing_receipt with
+    | Some current ->
       if receipt_identity_equal current.identity identity
          && current.outcome = receipt.outcome
          && Float.equal current.started_at receipt.started_at
@@ -1644,29 +1870,40 @@ let finish ~base_path (receipt : terminal_receipt) =
               (payload_sha256 current.detail)
               (payload_sha256 receipt.detail)
       then Ok ()
-      else Error (Identity_conflict { job_id = identity.id; path })
-    else
-      let* inflight_exists = file_exists inflight in
-      if not inflight_exists
-      then Error (Missing_inflight_lease { job_id = identity.id; path = inflight })
       else
-        let* envelope = read_envelope inflight in
+        Error
+          (Identity_conflict { job_id = identity.id; path = receipt_item.path })
+    | None ->
+      let* inflight_envelope = read_envelope_opt inflight in
+      (match inflight_envelope with
+       | None ->
+        Error
+          (Missing_inflight_lease
+             { job_id = identity.id; path = inflight.path })
+       | Some envelope ->
         let* () =
           ensure_queue_coordinates
             ~expected_keeper_name:identity.keeper_name
-            ~path:inflight
+            ~path:inflight.path
             envelope
         in
-        let* () = ensure_expected_state ~expected:Expect_inflight ~path:inflight envelope in
+        let* () =
+          ensure_expected_state
+            ~expected:Expect_inflight
+            ~path:inflight.path
+            envelope
+        in
         if not (receipt_identity_matches_job identity envelope.job)
-        then Error (Identity_conflict { job_id = identity.id; path = inflight })
+        then
+          Error
+            (Identity_conflict { job_id = identity.id; path = inflight.path })
         else
           (match envelope.state with
            | Awaiting_turn_commit | Pending ->
              Error
                (Missing_inflight_lease
                   { job_id = identity.id
-                  ; path = inflight
+                  ; path = inflight.path
                   })
            | Inflight { started_at } ->
              if not (Float.equal started_at receipt.started_at)
@@ -1674,110 +1911,160 @@ let finish ~base_path (receipt : terminal_receipt) =
                Error
                  (Inflight_lease_conflict
                     { job_id = identity.id
-                    ; path = inflight
+                    ; path = inflight.path
                     ; expected_started_at = receipt.started_at
                     ; actual_started_at = started_at
                     })
-             else save_json path (receipt_to_json receipt))
+             else save_json receipt_item (receipt_to_json receipt)))
   in
-  let cleanup_errors = cleanup_paths [ operation; awaiting; pending; inflight ] in
+  let cleanup_errors =
+    cleanup_artifacts [ operation; awaiting; pending; inflight ]
+  in
   Ok { cleanup_errors }
+;;
+
+let count_queue_in_jobs ~keeper_name ~jobs ~path ~expected_state =
+  let* count =
+    with_optional_directory jobs path (fun directory ->
+      let* items = list_json_artifacts ~jobs directory in
+      let* envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state
+          items
+      in
+      Ok (List.length envelopes))
+  in
+  Ok (Option.value count ~default:0)
+;;
+
+let count_backlog_in_jobs ~base_path ~keeper_name jobs =
+  let* awaiting =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(awaiting_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_awaiting
+  in
+  let* pending =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(pending_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_pending
+  in
+  let* inflight =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(inflight_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_inflight
+  in
+  Ok (awaiting + pending + inflight)
 ;;
 
 let backlog_count ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* ancestors_exist =
-      validate_keeper_ancestors_if_present ~base_path ~keeper_name
+    let* presence =
+      with_existing_jobs ~base_path ~keeper_name @@ fun store ->
+      count_backlog_in_jobs ~base_path ~keeper_name store.jobs
     in
-    if not ancestors_exist
-    then Ok 0
-    else
-      let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
-      let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
-      let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
-      let* awaiting_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_awaiting
-          awaiting
-      in
-      let* pending_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_pending
-          pending
-      in
-      let* inflight_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_inflight
-          inflight
-      in
-      Ok
-        (List.length awaiting_envelopes
-         + List.length pending_envelopes
-         + List.length inflight_envelopes)
-;;
-
-let directory_exists path =
-  let* exists = file_exists path in
-  if not exists
-  then Ok false
-  else
-    let* is_directory =
-      protect_io Inspect path (fun () ->
-        (Unix.lstat path).Unix.st_kind = Unix.S_DIR)
-    in
-    if is_directory
-    then Ok true
-    else
-      Error
-        (Io_error
-           { operation = Inspect
-           ; path
-           ; detail = "expected a directory but found a non-directory entry"
-           })
+    (match presence with
+     | Missing -> Ok 0
+     | Present count -> Ok count)
 ;;
 
 let discover_keeper_names ~base_path =
-  let root = Common.keepers_runtime_dir_of_base ~base_path in
-  let* root_exists = validate_managed_root_if_present ~base_path in
-  if not root_exists
-  then Ok ([], [])
-  else
-    let* entries =
-      protect_io List_directory root (fun () -> Sys.readdir root |> Array.to_list)
-    in
-    let rec loop keepers errors = function
-      | [] ->
-        Ok
-          ( List.sort_uniq String.compare keepers
-          , List.rev errors )
-      | keeper_name :: rest ->
-        if not (keeper_name_is_valid keeper_name)
-        then loop keepers (Invalid_keeper_name keeper_name :: errors) rest
-        else
-          let keeper_dir = Filename.concat root keeper_name in
-          let jobs_dir = keeper_jobs_dir ~base_path ~keeper_name in
-          (match directory_exists keeper_dir with
-           | Error error -> loop keepers (error :: errors) rest
-           | Ok false -> loop keepers errors rest
-           | Ok true ->
-             (match directory_exists jobs_dir with
-              | Error error -> loop keepers (error :: errors) rest
-              | Ok false -> loop keepers errors rest
-              | Ok true ->
-                (match backlog_count ~base_path ~keeper_name with
-                 | Error error -> loop keepers (error :: errors) rest
-                 | Ok count ->
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* presence =
+    try
+      match
+        Anchored.with_open_path_opt
+          ~root:base_path
+          [ masc_name; keepers_name ]
+          (fun handle ->
+             let keepers_directory = { handle; path = keepers_path } in
+             let* entries =
+               protect_io List_directory keepers_path (fun () ->
+                 Anchored.read_dir keepers_directory.handle)
+             in
+             let rec loop keepers errors = function
+               | [] ->
+                 Ok
+                   (Present
+                      ( List.sort_uniq String.compare keepers
+                      , List.rev errors ))
+               | keeper_segment :: rest ->
+                 let keeper_name =
+                   Anchored.Segment.to_string keeper_segment
+                 in
+                 if not (keeper_name_is_valid keeper_name)
+                 then
                    loop
-                     (if count > 0 then keeper_name :: keepers else keepers)
-                     errors
-                     rest)))
-    in
-    loop [] [] entries
+                     keepers
+                     (Invalid_keeper_name keeper_name :: errors)
+                     rest
+                 else
+                   let keeper_path =
+                     Filename.concat keepers_path keeper_name
+                   in
+                   let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+                   let count_result =
+                     with_optional_directory
+                       keepers_directory
+                       keeper_path
+                       (fun keeper_directory ->
+                          let* jobs_presence =
+                            with_optional_directory
+                              keeper_directory
+                              jobs_path
+                              (count_backlog_in_jobs
+                                 ~base_path
+                                 ~keeper_name)
+                          in
+                          Ok (Option.value jobs_presence ~default:0))
+                   in
+                   (match count_result with
+                    | Error error ->
+                      loop keepers (error :: errors) rest
+                    | Ok None -> loop keepers errors rest
+                    | Ok (Some count) ->
+                      loop
+                        (if count > 0
+                         then keeper_name :: keepers
+                         else keepers)
+                        errors
+                        rest)
+             in
+             loop [] [] entries)
+      with
+      | None -> Ok Missing
+      | Some result -> result
+    with
+    | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = keepers_path
+           ; detail = Printexc.to_string exn
+           })
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = keepers_path
+           ; detail = Printexc.to_string exn
+           })
+  in
+  match presence with
+  | Missing -> Ok ([], [])
+  | Present result -> Ok result
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -1,0 +1,1706 @@
+(** Durable per-keeper post-turn memory jobs. *)
+
+let job_schema = "masc.keeper_memory_job.v1"
+let envelope_schema = "masc.keeper_memory_job_envelope.v1"
+let receipt_schema = "masc.keeper_memory_job_receipt.v2"
+let jobs_dirname = "memory-jobs"
+let awaiting_dirname = "awaiting-turn-commit"
+let pending_dirname = "pending"
+let inflight_dirname = "inflight"
+let receipts_dirname = "receipts"
+let operations_dirname = "operations"
+let recovered_atomic_writes_dirname = "recovered-atomic-writes"
+let json_suffix = ".json"
+let private_directory_mode = 0o700
+let private_file_mode = 0o600
+
+type job =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease =
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt =
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Sync
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_claim_time of float
+  | Invalid_json_value of string
+  | Invalid_terminal_timestamps of
+      { started_at : float
+      ; ended_at : float
+      }
+  | Invalid_job_id of string
+  | Missing_inflight_lease of
+      { job_id : string
+      ; path : string
+      }
+  | Inflight_lease_conflict of
+      { job_id : string
+      ; path : string
+      ; expected_started_at : float
+      ; actual_started_at : float
+      }
+  | Pending_already_inflight of
+      { job_id : string
+      ; pending_path : string
+      ; inflight_path : string
+      }
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+let io_operation_to_string = function
+  | Ensure_directory -> "ensure_directory"
+  | Set_permissions -> "set_permissions"
+  | Sync -> "sync"
+  | Inspect -> "inspect"
+  | List_directory -> "list_directory"
+  | Read -> "read"
+  | Write -> "write"
+  | Remove -> "remove"
+;;
+
+let error_to_string = function
+  | Invalid_keeper_name name ->
+    Printf.sprintf "invalid keeper name: %S" name
+  | Invalid_trace_id detail -> detail
+  | Invalid_turn_identity { generation; turn; oas_turn_count } ->
+    Printf.sprintf
+      "invalid memory job turn identity generation=%d turn=%d oas_turn_count=%d"
+      generation
+      turn
+      oas_turn_count
+  | Invalid_enqueue_time value ->
+    Printf.sprintf "invalid memory job enqueue time: %g" value
+  | Invalid_claim_time value ->
+    Printf.sprintf "invalid memory job claim time: %g" value
+  | Invalid_json_value detail ->
+    Printf.sprintf "invalid memory job JSON value: %s" detail
+  | Invalid_terminal_timestamps { started_at; ended_at } ->
+    Printf.sprintf
+      "invalid memory job terminal timestamps started_at=%g ended_at=%g"
+      started_at
+      ended_at
+  | Invalid_job_id id -> Printf.sprintf "invalid memory job id: %S" id
+  | Missing_inflight_lease { job_id; path } ->
+    Printf.sprintf
+      "memory job completion has no inflight lease id=%s path=%s"
+      job_id
+      path
+  | Inflight_lease_conflict
+      { job_id
+      ; path
+      ; expected_started_at
+      ; actual_started_at
+      } ->
+    Printf.sprintf
+      "memory job inflight lease mismatch id=%s path=%s expected_started_at=%g actual_started_at=%g"
+      job_id
+      path
+      expected_started_at
+      actual_started_at
+  | Pending_already_inflight { job_id; pending_path; inflight_path } ->
+    Printf.sprintf
+      "memory job pending claim already has an inflight lease id=%s pending=%s inflight=%s"
+      job_id
+      pending_path
+      inflight_path
+  | Unexpected_queue_entry path ->
+    Printf.sprintf "unexpected entry in memory job queue: %s" path
+  | Decode_error { path; detail } ->
+    Printf.sprintf "memory job decode failed path=%s: %s" path detail
+  | Identity_conflict { job_id; path } ->
+    Printf.sprintf
+      "memory job identity conflict id=%s path=%s"
+      job_id
+      path
+  | Io_error { operation; path; detail } ->
+    Printf.sprintf
+      "memory job %s failed path=%s: %s"
+      (io_operation_to_string operation)
+      path
+      detail
+;;
+
+let ( let* ) = Result.bind
+
+let keeper_name_is_valid keeper_name =
+  Result.is_ok (Keeper_id.Keeper_name.of_string keeper_name)
+;;
+
+let protect_io operation path f =
+  try Ok (f ()) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let keeper_jobs_dir ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       keeper_name)
+    jobs_dirname
+;;
+
+let pending_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) pending_dirname
+;;
+
+let awaiting_dir ~base_path ~keeper_name =
+  Filename.concat
+    (keeper_jobs_dir ~base_path ~keeper_name)
+    awaiting_dirname
+;;
+
+let inflight_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) inflight_dirname
+;;
+
+let receipts_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) receipts_dirname
+;;
+
+let operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat keepers_dir keeper_name)
+       jobs_dirname)
+    operations_dirname
+;;
+
+let operations_dir ~base_path ~keeper_name =
+  operation_stages_dir_for_keepers_dir
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
+    ~keeper_name
+;;
+
+let path_for_id dir id = Filename.concat dir (id ^ json_suffix)
+
+let pending_path ~base_path (job : job) =
+  path_for_id (pending_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let awaiting_path ~base_path (job : job) =
+  path_for_id (awaiting_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let inflight_path ~base_path (job : job) =
+  path_for_id (inflight_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path ~base_path (job : job) =
+  path_for_id (receipts_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path_for_identity ~base_path (identity : receipt_identity) =
+  path_for_id
+    (receipts_dir ~base_path ~keeper_name:identity.keeper_name)
+    identity.id
+;;
+
+let operation_stage_path_for_keepers_dir_unchecked
+      ~keepers_dir
+      ~keeper_name
+      ~operation_id
+  =
+  path_for_id
+    (operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name)
+    operation_id
+;;
+
+let operation_stage_path ~base_path ~keeper_name ~operation_id =
+  path_for_id (operations_dir ~base_path ~keeper_name) operation_id
+;;
+
+let inspect_path path =
+  try Ok (Some (Unix.lstat path)) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let sync_directory path =
+  match Fs_compat.fsync_directory path with
+  | Ok () -> Ok ()
+  | Error detail -> Error (Io_error { operation = Sync; path; detail })
+;;
+
+let ensure_real_directory ~owned path =
+  let* before = inspect_path path in
+  let* () =
+    match before with
+    | Some _ -> Ok ()
+    | None ->
+      protect_io Ensure_directory path (fun () ->
+        Fs_compat.mkdir_p_durable_unix path)
+  in
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  let* () =
+    if stat.Unix.st_kind = Unix.S_DIR
+    then Ok ()
+    else
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path
+           ; detail = "memory job store path is not a real directory"
+           })
+  in
+  if not owned
+  then Ok ()
+  else
+    let* () =
+      protect_io Set_permissions path (fun () ->
+        Unix.chmod path private_directory_mode)
+    in
+    sync_directory path
+;;
+
+let ensure_store_dirs ~base_path ~keeper_name =
+  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_dir = Filename.concat keepers_root keeper_name in
+  let parent_dirs = [ keepers_root; keeper_dir ] in
+  let owned_dirs =
+    [ keeper_jobs_dir ~base_path ~keeper_name
+    ; pending_dir ~base_path ~keeper_name
+    ; awaiting_dir ~base_path ~keeper_name
+    ; inflight_dir ~base_path ~keeper_name
+    ; receipts_dir ~base_path ~keeper_name
+    ; operations_dir ~base_path ~keeper_name
+    ]
+  in
+  let rec loop ~owned = function
+    | [] -> Ok ()
+    | dir :: rest ->
+      let* () = ensure_real_directory ~owned dir in
+      loop ~owned rest
+  in
+  let* () = loop ~owned:false parent_dirs in
+  loop ~owned:true owned_dirs
+;;
+
+let valid_job_id id =
+  String.length id = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       id
+;;
+
+let is_valid_job_id = valid_job_id
+
+let rec validate_json_value = function
+  | `Float value when not (Float.is_finite value) ->
+    Error (Invalid_json_value "floating-point values must be finite")
+  | `Assoc fields ->
+    let names = List.map fst fields |> List.sort String.compare in
+    let rec reject_duplicate_names = function
+      | left :: (right :: _) when String.equal left right ->
+        Error
+          (Invalid_json_value
+             (Printf.sprintf "duplicate object field %S" left))
+      | _ :: rest -> reject_duplicate_names rest
+      | [] -> Ok ()
+    in
+    let* () = reject_duplicate_names names in
+    let rec validate_fields = function
+      | [] -> Ok ()
+      | (_, value) :: rest ->
+        let* () = validate_json_value value in
+        validate_fields rest
+    in
+    validate_fields fields
+  | `List values ->
+    let rec validate_values = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () = validate_json_value value in
+        validate_values rest
+    in
+    validate_values values
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ -> Ok ()
+;;
+
+let validate_json_value_for_decode json =
+  validate_json_value json |> Result.map_error error_to_string
+;;
+
+let operation_stage_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_name
+      ~operation_id
+  =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ -> Error (Invalid_keeper_name keeper_name)
+  | Ok keeper_name ->
+    if not (valid_job_id operation_id)
+    then Error (Invalid_job_id operation_id)
+    else
+      Ok
+        (operation_stage_path_for_keepers_dir_unchecked
+           ~keepers_dir
+           ~keeper_name:(Keeper_id.Keeper_name.to_string keeper_name)
+           ~operation_id)
+;;
+
+let job_identity_string ~keeper_name ~trace_id ~generation ~turn ~oas_turn_count =
+  String.concat
+    "\000"
+    [ keeper_name
+    ; trace_id
+    ; string_of_int generation
+    ; string_of_int turn
+    ; string_of_int oas_turn_count
+    ]
+;;
+
+let make_job
+      ~keeper_name
+      ~trace_id
+      ~generation
+      ~turn
+      ~oas_turn_count
+      ~enqueued_at
+      ~payload
+  =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ -> Error (Invalid_keeper_name keeper_name)
+  | Ok keeper_name_t ->
+    (match Keeper_id.Trace_id.of_string trace_id with
+     | Error detail -> Error (Invalid_trace_id detail)
+     | Ok trace_id_t ->
+       if generation < 0 || turn < 0 || oas_turn_count < 0
+       then Error (Invalid_turn_identity { generation; turn; oas_turn_count })
+       else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+       then Error (Invalid_enqueue_time enqueued_at)
+       else
+         let* () = validate_json_value payload in
+         let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_t in
+         let trace_id = Keeper_id.Trace_id.to_string trace_id_t in
+         let id =
+           job_identity_string
+             ~keeper_name
+             ~trace_id
+             ~generation
+             ~turn
+             ~oas_turn_count
+           |> Digestif.SHA256.digest_string
+           |> Digestif.SHA256.to_hex
+         in
+         Ok
+           { id
+           ; keeper_name
+           ; trace_id
+           ; generation
+           ; turn
+           ; oas_turn_count
+           ; enqueued_at
+           ; payload
+           })
+;;
+
+let job_to_json (job : job) =
+  `Assoc
+    [ "schema", `String job_schema
+    ; "id", `String job.id
+    ; "keeper_name", `String job.keeper_name
+    ; "trace_id", `String job.trace_id
+    ; "generation", `Int job.generation
+    ; "turn", `Int job.turn
+    ; "oas_turn_count", `Int job.oas_turn_count
+    ; "enqueued_at", `Float job.enqueued_at
+    ; "payload", job.payload
+    ]
+;;
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (key, value) -> key, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _) as json ->
+    json
+;;
+
+let payload_sha256 payload =
+  canonical_json payload
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let receipt_identity_of_job (job : job) =
+  { id = job.id
+  ; keeper_name = job.keeper_name
+  ; trace_id = job.trace_id
+  ; generation = job.generation
+  ; turn = job.turn
+  ; oas_turn_count = job.oas_turn_count
+  ; enqueued_at = job.enqueued_at
+  ; payload_sha256 = payload_sha256 job.payload
+  }
+;;
+
+let make_terminal_receipt lease ~ended_at ~outcome ~detail =
+  let started_at = lease.started_at in
+  if
+    (not (Float.is_finite started_at))
+    || started_at < 0.0
+    || not (Float.is_finite ended_at)
+    || ended_at < started_at
+  then
+    Error
+      (Invalid_terminal_timestamps
+         { started_at
+         ; ended_at
+         })
+  else
+    let* () = validate_json_value detail in
+    Ok
+      { identity = receipt_identity_of_job lease.job
+      ; started_at
+      ; ended_at
+      ; outcome
+      ; detail
+      }
+;;
+
+let receipt_identity_matches_retry identity (job : job) =
+  String.equal identity.id job.id
+  && String.equal identity.keeper_name job.keeper_name
+  && String.equal identity.trace_id job.trace_id
+  && identity.generation = job.generation
+  && identity.turn = job.turn
+  && identity.oas_turn_count = job.oas_turn_count
+  && String.equal identity.payload_sha256 (payload_sha256 job.payload)
+;;
+
+let receipt_identity_matches_job identity (job : job) =
+  receipt_identity_matches_retry identity job
+  && Float.equal identity.enqueued_at job.enqueued_at
+;;
+
+let receipt_identity_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && Float.equal left.enqueued_at right.enqueued_at
+  && String.equal left.payload_sha256 right.payload_sha256
+;;
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be a string" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let int_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be an int" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some _ -> Error (Printf.sprintf "field %s must be a number" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let json_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let job_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema job_schema)
+    then Error (Printf.sprintf "unsupported memory job schema: %s" schema)
+    else
+      let* id = string_field "id" fields in
+      let* keeper_name = string_field "keeper_name" fields in
+      let* trace_id = string_field "trace_id" fields in
+      let* generation = int_field "generation" fields in
+      let* turn = int_field "turn" fields in
+      let* oas_turn_count = int_field "oas_turn_count" fields in
+      let* enqueued_at = float_field "enqueued_at" fields in
+      let* payload = json_field "payload" fields in
+      let* () =
+        validate_json_value payload
+        |> Result.map_error error_to_string
+      in
+      if not (valid_job_id id)
+      then Error (Printf.sprintf "invalid memory job id: %S" id)
+      else
+        let* keeper_name =
+          Keeper_id.Keeper_name.of_string keeper_name
+        in
+        let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+        if generation < 0 || turn < 0 || oas_turn_count < 0
+        then Error "turn identity values must be non-negative"
+        else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+        then Error "enqueued_at must be finite and non-negative"
+        else
+          let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+          let trace_id = Keeper_id.Trace_id.to_string trace_id in
+          let expected_id =
+            job_identity_string
+              ~keeper_name
+              ~trace_id
+              ~generation
+              ~turn
+              ~oas_turn_count
+            |> Digestif.SHA256.digest_string
+            |> Digestif.SHA256.to_hex
+          in
+          if not (String.equal id expected_id)
+          then Error "memory job id does not match its typed turn identity"
+          else
+            Ok
+              { id
+              ; keeper_name
+              ; trace_id
+              ; generation
+              ; turn
+              ; oas_turn_count
+              ; enqueued_at
+              ; payload
+              }
+  | _ -> Error "memory job must be a JSON object"
+;;
+
+type persisted_state =
+  | Awaiting_turn_commit
+  | Pending
+  | Inflight of { started_at : float }
+
+type envelope =
+  { job : job
+  ; state : persisted_state
+  }
+
+let state_to_json = function
+  | Awaiting_turn_commit ->
+    `Assoc [ "kind", `String "awaiting_turn_commit" ]
+  | Pending -> `Assoc [ "kind", `String "pending" ]
+  | Inflight { started_at } ->
+    `Assoc
+      [ "kind", `String "inflight"
+      ; "started_at", `Float started_at
+      ]
+;;
+
+let envelope_to_json envelope =
+  `Assoc
+    [ "schema", `String envelope_schema
+    ; "job", job_to_json envelope.job
+    ; "state", state_to_json envelope.state
+    ]
+;;
+
+let state_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "awaiting_turn_commit" -> Ok Awaiting_turn_commit
+     | "pending" -> Ok Pending
+     | "inflight" ->
+       let* started_at = float_field "started_at" fields in
+       if (not (Float.is_finite started_at)) || started_at < 0.0
+       then Error "inflight started_at must be finite and non-negative"
+       else Ok (Inflight { started_at })
+     | other -> Error (Printf.sprintf "unknown memory job state: %s" other))
+  | _ -> Error "memory job state must be an object"
+;;
+
+let envelope_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema envelope_schema)
+    then Error (Printf.sprintf "unsupported memory job envelope schema: %s" schema)
+    else
+      let* job_json = json_field "job" fields in
+      let* state_json = json_field "state" fields in
+      let* job = job_of_json job_json in
+      let* state = state_of_json state_json in
+      Ok { job; state }
+  | _ -> Error "memory job envelope must be a JSON object"
+;;
+
+let terminal_outcome_to_string = function
+  | Succeeded -> "succeeded"
+  | Failed -> "failed"
+;;
+
+let terminal_outcome_of_string = function
+  | "succeeded" -> Ok Succeeded
+  | "failed" -> Ok Failed
+  | value -> Error (Printf.sprintf "unknown terminal outcome: %s" value)
+;;
+
+let receipt_identity_to_json identity =
+  `Assoc
+    [ "id", `String identity.id
+    ; "keeper_name", `String identity.keeper_name
+    ; "trace_id", `String identity.trace_id
+    ; "generation", `Int identity.generation
+    ; "turn", `Int identity.turn
+    ; "oas_turn_count", `Int identity.oas_turn_count
+    ; "enqueued_at", `Float identity.enqueued_at
+    ; "payload_sha256", `String identity.payload_sha256
+    ]
+;;
+
+let receipt_identity_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* id = string_field "id" fields in
+    let* keeper_name = string_field "keeper_name" fields in
+    let* trace_id = string_field "trace_id" fields in
+    let* generation = int_field "generation" fields in
+    let* turn = int_field "turn" fields in
+    let* oas_turn_count = int_field "oas_turn_count" fields in
+    let* enqueued_at = float_field "enqueued_at" fields in
+    let* payload_sha256 = string_field "payload_sha256" fields in
+    let* keeper_name = Keeper_id.Keeper_name.of_string keeper_name in
+    let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+    let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+    let trace_id = Keeper_id.Trace_id.to_string trace_id in
+    let expected_id =
+      job_identity_string
+        ~keeper_name
+        ~trace_id
+        ~generation
+        ~turn
+        ~oas_turn_count
+      |> Digestif.SHA256.digest_string
+      |> Digestif.SHA256.to_hex
+    in
+    if generation < 0 || turn < 0 || oas_turn_count < 0
+    then Error "receipt turn identity values must be non-negative"
+    else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+    then Error "receipt enqueued_at must be finite and non-negative"
+    else if not (valid_job_id id) || not (String.equal id expected_id)
+    then Error "receipt id does not match its typed turn identity"
+    else if not (valid_job_id payload_sha256)
+    then Error "receipt payload_sha256 must be a lowercase SHA-256 digest"
+    else
+      Ok
+        { id
+        ; keeper_name
+        ; trace_id
+        ; generation
+        ; turn
+        ; oas_turn_count
+        ; enqueued_at
+        ; payload_sha256
+        }
+  | _ -> Error "receipt job identity must be a JSON object"
+;;
+
+let receipt_to_json (receipt : terminal_receipt) =
+  `Assoc
+    [ "schema", `String receipt_schema
+    ; "job_identity", receipt_identity_to_json receipt.identity
+    ; "started_at", `Float receipt.started_at
+    ; "ended_at", `Float receipt.ended_at
+    ; "outcome", `String (terminal_outcome_to_string receipt.outcome)
+    ; "detail", receipt.detail
+    ]
+;;
+
+let receipt_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema receipt_schema)
+    then Error (Printf.sprintf "unsupported memory job receipt schema: %s" schema)
+    else
+      let* identity_json = json_field "job_identity" fields in
+      let* identity = receipt_identity_of_json identity_json in
+      let* started_at = float_field "started_at" fields in
+      let* ended_at = float_field "ended_at" fields in
+      let* outcome_string = string_field "outcome" fields in
+      let* outcome = terminal_outcome_of_string outcome_string in
+      let* detail = json_field "detail" fields in
+      let* () =
+        validate_json_value detail
+        |> Result.map_error error_to_string
+      in
+      if
+        (not (Float.is_finite started_at))
+        || started_at < 0.0
+        || not (Float.is_finite ended_at)
+        || ended_at < started_at
+      then Error "receipt timestamps must be finite, non-negative, and ordered"
+      else Ok { identity; started_at; ended_at; outcome; detail }
+  | _ -> Error "memory job receipt must be a JSON object"
+;;
+
+let read_json path =
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  if stat.Unix.st_kind <> Unix.S_REG
+  then
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = "memory job artifact is not a regular file"
+         })
+  else
+    match
+      try
+        Fs_compat.load_file_unix path
+        |> Safe_ops.parse_json_safe ~context:path
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Printexc.to_string exn)
+    with
+    | Ok json -> Ok json
+    | Error detail -> Error (Io_error { operation = Read; path; detail })
+;;
+
+let read_envelope path =
+  let* json = read_json path in
+  envelope_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let read_receipt path =
+  let* json = read_json path in
+  receipt_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let save_json path json =
+  match
+    Fs_compat.save_file_atomic_unix
+      path
+      (Yojson.Safe.pretty_to_string json)
+  with
+  | Ok () ->
+    protect_io Set_permissions path (fun () -> Unix.chmod path private_file_mode)
+  | Error detail -> Error (Io_error { operation = Write; path; detail })
+;;
+
+let file_exists path =
+  try
+    ignore (Unix.lstat path);
+    Ok true
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let remove_if_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else protect_io Remove path (fun () -> Sys.remove path)
+;;
+
+let cleanup_paths paths =
+  List.fold_left
+    (fun errors path ->
+       match remove_if_exists path with
+       | Ok () -> errors
+       | Error error -> error :: errors)
+    []
+    paths
+  |> List.rev
+;;
+
+let reconcile_atomic_orphan dir name =
+  let path = Filename.concat dir name in
+  let recovered_root =
+    Filename.concat
+      (Filename.dirname dir)
+      recovered_atomic_writes_dirname
+  in
+  let bucket = Filename.basename dir in
+  let recovered_dir =
+    Filename.concat
+      recovered_root
+      bucket
+  in
+  let* () = ensure_real_directory ~owned:true recovered_root in
+  let* () = ensure_real_directory ~owned:true recovered_dir in
+  match Fs_compat.recover_atomic_orphan ~path ~recovered_root ~bucket with
+  | Error detail -> Error (Io_error { operation = Inspect; path; detail })
+  | Ok Fs_compat.Deleted_zero_length ->
+    Log.Keeper.warn "memory job queue removed zero-length atomic orphan path=%s" path;
+    Ok ()
+  | Ok (Fs_compat.Preserved_nonempty destination) ->
+    (match
+       protect_io Set_permissions recovered_dir (fun () ->
+         Unix.chmod recovered_dir private_directory_mode)
+     with
+     | Error _ as error -> error
+     | Ok () ->
+       let* () =
+         protect_io Set_permissions destination (fun () ->
+           Unix.chmod destination private_file_mode)
+       in
+       Log.Keeper.error
+         "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
+         path
+         destination;
+       Ok ())
+;;
+
+let list_json_paths dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok []
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec validate acc = function
+      | [] -> Ok (List.sort String.compare acc)
+      | name :: rest ->
+        let path = Filename.concat dir name in
+        if Filename.check_suffix name json_suffix
+        then validate (path :: acc) rest
+        else if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          validate acc rest
+        else Error (Unexpected_queue_entry path)
+    in
+    validate [] entries
+;;
+
+let reconcile_atomic_orphans_in_dir dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok ()
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec loop = function
+      | [] -> Ok ()
+      | name :: rest ->
+        if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          loop rest
+        else loop rest
+    in
+    loop entries
+;;
+
+let job_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && String.equal (payload_sha256 left.payload) (payload_sha256 right.payload)
+;;
+
+let ensure_same_job ~expected ~path envelope =
+  if job_equal expected envelope.job
+  then Ok ()
+  else Error (Identity_conflict { job_id = expected.id; path })
+;;
+
+type expected_envelope_state =
+  | Expect_awaiting
+  | Expect_pending
+  | Expect_inflight
+
+let ensure_expected_state ~expected ~path envelope =
+  match expected, envelope.state with
+  | Expect_awaiting, Awaiting_turn_commit
+  | Expect_pending, Pending
+  | Expect_inflight, Inflight _ -> Ok ()
+  | Expect_awaiting, (Pending | Inflight _)
+  | Expect_pending, (Awaiting_turn_commit | Inflight _)
+  | Expect_inflight, (Awaiting_turn_commit | Pending) ->
+    let expected_label =
+      match expected with
+      | Expect_awaiting -> "awaiting-turn-commit"
+      | Expect_pending -> "pending"
+      | Expect_inflight -> "inflight"
+    in
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "%s directory contains an envelope with a different state"
+               expected_label
+         })
+;;
+
+let ensure_queue_coordinates ~expected_keeper_name ~path envelope =
+  let expected_name = envelope.job.id ^ json_suffix in
+  let actual_name = Filename.basename path in
+  if not (String.equal envelope.job.keeper_name expected_keeper_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue keeper coordinate mismatch expected=%s actual=%s"
+               expected_keeper_name
+               envelope.job.keeper_name
+         })
+  else if not (String.equal actual_name expected_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue filename coordinate mismatch expected=%s actual=%s"
+               expected_name
+               actual_name
+         })
+  else Ok ()
+;;
+
+let classify_existing_envelope ~expected_job ~expected_state ~path outcome =
+  let* exists = file_exists path in
+  if not exists
+  then Ok None
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:expected_job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:expected_job ~path envelope in
+    let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+    Ok (Some outcome)
+;;
+
+let stage_awaiting_turn_commit ~base_path job =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let receipt_path = receipt_path ~base_path job in
+  let* receipt_exists = file_exists receipt_path in
+  if receipt_exists
+  then
+    let* receipt = read_receipt receipt_path in
+    if receipt_identity_matches_retry receipt.identity job
+    then
+      let cleanup_errors =
+        cleanup_paths
+          [ awaiting_path ~base_path job
+          ; pending_path ~base_path job
+          ; inflight_path ~base_path job
+          ; operation_stage_path
+              ~base_path
+              ~keeper_name:job.keeper_name
+              ~operation_id:job.id
+          ]
+      in
+      List.iter
+        (fun error ->
+           Log.Keeper.error ~keeper_name:job.keeper_name
+             "memory job completed-state cleanup debt job_id=%s: %s"
+             job.id
+             (error_to_string error))
+        cleanup_errors;
+      Ok Already_completed
+    else Error (Identity_conflict { job_id = job.id; path = receipt_path })
+  else
+    let awaiting_path = awaiting_path ~base_path job in
+    let pending_path = pending_path ~base_path job in
+    let inflight_path = inflight_path ~base_path job in
+    let* awaiting =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_awaiting
+        ~path:awaiting_path
+        Already_awaiting
+    in
+    match awaiting with
+    | Some outcome -> Ok outcome
+    | None ->
+    let* pending =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending_path
+        Already_pending
+    in
+    match pending with
+    | Some outcome -> Ok outcome
+    | None ->
+      let* inflight =
+        classify_existing_envelope
+          ~expected_job:job
+          ~expected_state:Expect_inflight
+          ~path:inflight_path
+          Already_inflight
+      in
+      (match inflight with
+       | Some outcome -> Ok outcome
+       | None ->
+         let envelope = { job; state = Awaiting_turn_commit } in
+         let* () = save_json awaiting_path (envelope_to_json envelope) in
+         Ok Staged_awaiting_turn_commit)
+;;
+
+let compare_job_order left right =
+  let by_turn = Int.compare left.turn right.turn in
+  if by_turn <> 0
+  then by_turn
+  else
+    let by_generation = Int.compare left.generation right.generation in
+    if by_generation <> 0
+    then by_generation
+    else
+      let by_oas_turn = Int.compare left.oas_turn_count right.oas_turn_count in
+      if by_oas_turn <> 0
+      then by_oas_turn
+      else
+        let by_enqueued = Float.compare left.enqueued_at right.enqueued_at in
+        if by_enqueued <> 0 then by_enqueued else String.compare left.id right.id
+;;
+
+let load_envelopes ~expected_keeper_name ~expected_state paths =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | path :: rest ->
+      let* envelope = read_envelope path in
+      let* () =
+        ensure_queue_coordinates ~expected_keeper_name ~path envelope
+      in
+      let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+      loop ((path, envelope) :: acc) rest
+  in
+  loop [] paths
+;;
+
+let list_awaiting ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* paths = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        paths
+    in
+    Ok (List.map (fun (_, envelope) -> envelope.job) envelopes)
+;;
+
+let activate ~base_path (job : job) =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let awaiting = awaiting_path ~base_path job in
+  let pending = pending_path ~base_path job in
+  let inflight = inflight_path ~base_path job in
+  let receipt = receipt_path ~base_path job in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:job.keeper_name
+      ~operation_id:job.id
+  in
+  let* receipt_exists = file_exists receipt in
+  if receipt_exists
+  then
+    let* terminal = read_receipt receipt in
+    if not (receipt_identity_matches_retry terminal.identity job)
+    then Error (Identity_conflict { job_id = job.id; path = receipt })
+    else
+      let cleanup_errors = cleanup_paths [ awaiting; pending; inflight; operation ] in
+      Ok (Activation_already_completed, { cleanup_errors })
+  else
+    let* pending_state =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending
+        Activation_already_pending
+    in
+    (match pending_state with
+     | Some activation ->
+       let cleanup_errors = cleanup_paths [ awaiting ] in
+       Ok (activation, { cleanup_errors })
+     | None ->
+       let* inflight_state =
+         classify_existing_envelope
+           ~expected_job:job
+           ~expected_state:Expect_inflight
+           ~path:inflight
+           Activation_already_inflight
+       in
+       (match inflight_state with
+        | Some activation ->
+          let cleanup_errors = cleanup_paths [ awaiting ] in
+          Ok (activation, { cleanup_errors })
+        | None ->
+          let* awaiting_exists = file_exists awaiting in
+          if not awaiting_exists
+          then
+            Error
+              (Decode_error
+                 { path = awaiting
+                 ; detail =
+                     "cannot activate a memory job without its awaiting-turn-commit envelope"
+                 })
+          else
+            let* envelope = read_envelope awaiting in
+            let* () =
+              ensure_queue_coordinates
+                ~expected_keeper_name:job.keeper_name
+                ~path:awaiting
+                envelope
+            in
+            let* () = ensure_same_job ~expected:job ~path:awaiting envelope in
+            let* () =
+              ensure_expected_state
+                ~expected:Expect_awaiting
+                ~path:awaiting
+                envelope
+            in
+            let* () =
+              save_json
+                pending
+                (envelope_to_json
+                   { job = envelope.job
+                   ; state = Pending
+                   })
+            in
+            let cleanup_errors = cleanup_paths [ awaiting ] in
+            Ok (Activated, { cleanup_errors })))
+;;
+
+let abort_awaiting ~base_path (job : job) =
+  let path = awaiting_path ~base_path job in
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:job ~path envelope in
+    let* () =
+      ensure_expected_state ~expected:Expect_awaiting ~path envelope
+    in
+    remove_if_exists path
+;;
+
+let recover_one ~base_path (inflight_path, envelope) =
+  match envelope.state with
+  | Awaiting_turn_commit | Pending ->
+    Error
+      (Decode_error
+         { path = inflight_path
+         ; detail = "inflight directory contains a pending envelope"
+         })
+  | Inflight { started_at } ->
+    let job = envelope.job in
+    let receipt_path = receipt_path ~base_path job in
+    let* receipt_exists = file_exists receipt_path in
+    if receipt_exists
+    then
+      let* receipt = read_receipt receipt_path in
+      if not (receipt_identity_matches_job receipt.identity job)
+      then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+      else if not (Float.equal receipt.started_at started_at)
+      then
+        Error
+          (Inflight_lease_conflict
+             { job_id = job.id
+             ; path = inflight_path
+             ; expected_started_at = receipt.started_at
+             ; actual_started_at = started_at
+             })
+      else
+        let cleanup_errors =
+          cleanup_paths
+            [ operation_stage_path
+                ~base_path
+                ~keeper_name:job.keeper_name
+                ~operation_id:job.id
+            ; awaiting_path ~base_path job
+            ; pending_path ~base_path job
+            ; inflight_path
+            ]
+        in
+        Ok (false, cleanup_errors)
+    else
+      let pending_path = pending_path ~base_path job in
+      let* pending_exists = file_exists pending_path in
+      let* () =
+        if pending_exists
+        then
+          let* pending = read_envelope pending_path in
+          let* () = ensure_same_job ~expected:job ~path:pending_path pending in
+          ensure_expected_state
+            ~expected:Expect_pending
+            ~path:pending_path
+            pending
+        else save_json pending_path (envelope_to_json { job; state = Pending })
+      in
+      let cleanup_errors = cleanup_paths [ inflight_path ] in
+      Ok (true, cleanup_errors)
+;;
+
+let recover_inflight ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (receipts_dir ~base_path ~keeper_name)
+    in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (operations_dir ~base_path ~keeper_name)
+    in
+    let dir = inflight_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        paths
+    in
+    let rec loop replayed cleanup_errors = function
+      | [] -> Ok { replayed; cleanup_errors = List.rev cleanup_errors }
+      | item :: rest ->
+        let* did_recover, item_cleanup_errors = recover_one ~base_path item in
+        loop
+          (if did_recover then replayed + 1 else replayed)
+          (List.rev_append item_cleanup_errors cleanup_errors)
+          rest
+    in
+    loop 0 [] envelopes
+;;
+
+let claim_all ~base_path ~keeper_name ~now =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else if (not (Float.is_finite now)) || now < 0.0
+  then Error (Invalid_claim_time now)
+  else
+    let dir = pending_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        paths
+    in
+    let ordered =
+      envelopes
+      |> List.map (fun (path, envelope) -> path, envelope.job)
+      |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
+    in
+    let rec claim leases cleanup_errors = function
+      | [] ->
+        Ok
+          { leases = List.rev leases
+          ; cleanup_errors = List.rev cleanup_errors
+          }
+      | (path, job) :: rest ->
+        let receipt_path = receipt_path ~base_path job in
+        let* receipt_exists = file_exists receipt_path in
+        if receipt_exists
+        then
+          let* receipt = read_receipt receipt_path in
+          if not (receipt_identity_matches_job receipt.identity job)
+          then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+          else
+            let item_cleanup_errors =
+              cleanup_paths
+                [ path
+                ; awaiting_path ~base_path job
+                ; inflight_path ~base_path job
+                ; operation_stage_path
+                    ~base_path
+                    ~keeper_name:job.keeper_name
+                    ~operation_id:job.id
+                ]
+            in
+            claim
+              leases
+              (List.rev_append item_cleanup_errors cleanup_errors)
+              rest
+        else
+          let lease = { job; started_at = now } in
+          let destination = inflight_path ~base_path job in
+          let* inflight_exists = file_exists destination in
+          if inflight_exists
+          then
+            let* inflight = read_envelope destination in
+            let* () =
+              ensure_queue_coordinates
+                ~expected_keeper_name:keeper_name
+                ~path:destination
+                inflight
+            in
+            let* () = ensure_same_job ~expected:job ~path:destination inflight in
+            let* () =
+              ensure_expected_state
+                ~expected:Expect_inflight
+                ~path:destination
+                inflight
+            in
+            Error
+              (Pending_already_inflight
+                 { job_id = job.id
+                 ; pending_path = path
+                 ; inflight_path = destination
+                 })
+          else
+            let* () =
+              save_json
+                destination
+                (envelope_to_json
+                   { job
+                   ; state = Inflight { started_at = lease.started_at }
+                   })
+            in
+            let item_cleanup_errors = cleanup_paths [ path ] in
+            claim
+              (lease :: leases)
+              (List.rev_append item_cleanup_errors cleanup_errors)
+              rest
+    in
+    claim [] [] ordered
+;;
+
+let finish ~base_path (receipt : terminal_receipt) =
+  let identity = receipt.identity in
+  let* () = ensure_store_dirs ~base_path ~keeper_name:identity.keeper_name in
+  let path = receipt_path_for_identity ~base_path identity in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:identity.keeper_name
+      ~operation_id:identity.id
+  in
+  let awaiting =
+    path_for_id
+      (awaiting_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let pending =
+    path_for_id
+      (pending_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let inflight =
+    path_for_id
+      (inflight_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let* exists = file_exists path in
+  let* () =
+    if exists
+    then
+      let* current = read_receipt path in
+      if receipt_identity_equal current.identity identity
+         && current.outcome = receipt.outcome
+         && Float.equal current.started_at receipt.started_at
+         && Float.equal current.ended_at receipt.ended_at
+         && String.equal
+              (payload_sha256 current.detail)
+              (payload_sha256 receipt.detail)
+      then Ok ()
+      else Error (Identity_conflict { job_id = identity.id; path })
+    else
+      let* inflight_exists = file_exists inflight in
+      if not inflight_exists
+      then Error (Missing_inflight_lease { job_id = identity.id; path = inflight })
+      else
+        let* envelope = read_envelope inflight in
+        let* () =
+          ensure_queue_coordinates
+            ~expected_keeper_name:identity.keeper_name
+            ~path:inflight
+            envelope
+        in
+        let* () = ensure_expected_state ~expected:Expect_inflight ~path:inflight envelope in
+        if not (receipt_identity_matches_job identity envelope.job)
+        then Error (Identity_conflict { job_id = identity.id; path = inflight })
+        else
+          (match envelope.state with
+           | Awaiting_turn_commit | Pending ->
+             Error
+               (Missing_inflight_lease
+                  { job_id = identity.id
+                  ; path = inflight
+                  })
+           | Inflight { started_at } ->
+             if not (Float.equal started_at receipt.started_at)
+             then
+               Error
+                 (Inflight_lease_conflict
+                    { job_id = identity.id
+                    ; path = inflight
+                    ; expected_started_at = receipt.started_at
+                    ; actual_started_at = started_at
+                    })
+             else save_json path (receipt_to_json receipt))
+  in
+  let cleanup_errors = cleanup_paths [ operation; awaiting; pending; inflight ] in
+  Ok { cleanup_errors }
+;;
+
+let backlog_count ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
+    let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
+    let* awaiting_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        awaiting
+    in
+    let* pending_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        pending
+    in
+    let* inflight_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        inflight
+    in
+    Ok
+      (List.length awaiting_envelopes
+       + List.length pending_envelopes
+       + List.length inflight_envelopes)
+;;
+
+let directory_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok false
+  else
+    let* is_directory =
+      protect_io Inspect path (fun () ->
+        (Unix.lstat path).Unix.st_kind = Unix.S_DIR)
+    in
+    if is_directory
+    then Ok true
+    else
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path
+           ; detail = "expected a directory but found a non-directory entry"
+           })
+;;
+
+let discover_keeper_names ~base_path =
+  let root = Common.keepers_runtime_dir_of_base ~base_path in
+  let* root_exists = directory_exists root in
+  if not root_exists
+  then Ok ([], [])
+  else
+    let* entries =
+      protect_io List_directory root (fun () -> Sys.readdir root |> Array.to_list)
+    in
+    let rec loop keepers errors = function
+      | [] ->
+        Ok
+          ( List.sort_uniq String.compare keepers
+          , List.rev errors )
+      | keeper_name :: rest ->
+        if not (keeper_name_is_valid keeper_name)
+        then loop keepers (Invalid_keeper_name keeper_name :: errors) rest
+        else
+          let keeper_dir = Filename.concat root keeper_name in
+          let jobs_dir = keeper_jobs_dir ~base_path ~keeper_name in
+          (match directory_exists keeper_dir with
+           | Error error -> loop keepers (error :: errors) rest
+           | Ok false -> loop keepers errors rest
+           | Ok true ->
+             (match directory_exists jobs_dir with
+              | Error error -> loop keepers (error :: errors) rest
+              | Ok false -> loop keepers errors rest
+              | Ok true ->
+                (match backlog_count ~base_path ~keeper_name with
+                 | Error error -> loop keepers (error :: errors) rest
+                 | Ok count ->
+                   loop
+                     (if count > 0 then keeper_name :: keepers else keepers)
+                     errors
+                     rest)))
+    in
+    loop [] [] entries
+;;
+
+module For_testing = struct
+  let awaiting_dir = awaiting_dir
+  let pending_dir = pending_dir
+  let inflight_dir = inflight_dir
+  let receipts_dir = receipts_dir
+  let receipt_path = receipt_path
+end

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,6 +1,9 @@
 (** Durable per-keeper post-turn memory jobs.
 
-    The store is rooted exclusively from [base_path]. A job moves through
+    The store is rooted exclusively from [base_path], which must be an existing
+    real directory. Every managed descendant component from the MASC directory
+    through the per-keeper queues is created one segment at a time and checked
+    with [lstat]; symlink and non-directory components fail explicitly. A job moves through
     [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
     execution receipt gates the first transition; the terminal memory receipt
     gates acknowledgement. Recovery requeues only inflight jobs that have no

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -130,6 +130,7 @@ type recovery_report =
 type claim_report =
   { leases : lease list
   ; cleanup_errors : error list
+  ; blocked : error option
   }
 
 val error_to_string : error -> string
@@ -187,7 +188,9 @@ val recover_inflight :
 val claim_all :
   base_path:string -> keeper_name:string -> now:float -> (claim_report, error) result
 (** Claim the current pending batch with one validated scan and one sort. The
-    returned leases preserve the keeper's linear turn order. *)
+    returned leases preserve the keeper's linear turn order. A transition error
+    after earlier claims is returned in [blocked] alongside those leases, so no
+    inflight work loses its owner. Pre-scan failures still return [Error]. *)
 
 val finish :
   base_path:string -> terminal_receipt -> (cleanup_report, error) result

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,0 +1,224 @@
+(** Durable per-keeper post-turn memory jobs.
+
+    The store is rooted exclusively from [base_path]. A job moves through
+    [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
+    execution receipt gates the first transition; the terminal memory receipt
+    gates acknowledgement. Recovery requeues only inflight jobs that have no
+    terminal memory receipt.
+    Operations are blocking Unix transactions. Eio callers must run the whole
+    transaction outside the scheduler domain and serialize access for one
+    keeper; files are still written atomically so process crashes cannot expose
+    partial JSON. *)
+
+type job = private
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease = private
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity = private
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt = private
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Sync
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_claim_time of float
+  | Invalid_json_value of string
+  | Invalid_terminal_timestamps of
+      { started_at : float
+      ; ended_at : float
+      }
+  | Invalid_job_id of string
+  | Missing_inflight_lease of
+      { job_id : string
+      ; path : string
+      }
+  | Inflight_lease_conflict of
+      { job_id : string
+      ; path : string
+      ; expected_started_at : float
+      ; actual_started_at : float
+      }
+  | Pending_already_inflight of
+      { job_id : string
+      ; pending_path : string
+      ; inflight_path : string
+      }
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+val error_to_string : error -> string
+val is_valid_job_id : string -> bool
+
+val make_job :
+  keeper_name:string ->
+  trace_id:string ->
+  generation:int ->
+  turn:int ->
+  oas_turn_count:int ->
+  enqueued_at:float ->
+  payload:Yojson.Safe.t ->
+  (job, error) result
+(** Construct a job with a deterministic full SHA-256 id over its typed turn
+    identity. Re-admitting the same turn is therefore idempotent. *)
+
+val job_to_json : job -> Yojson.Safe.t
+val job_of_json : Yojson.Safe.t -> (job, string) result
+val receipt_identity_of_job : job -> receipt_identity
+val make_terminal_receipt :
+  lease ->
+  ended_at:float ->
+  outcome:terminal_outcome ->
+  detail:Yojson.Safe.t ->
+  (terminal_receipt, error) result
+(** Build completion evidence from the opaque lease returned by {!claim_all}.
+    A staged or pending job cannot mint terminal authority. *)
+val receipt_to_json : terminal_receipt -> Yojson.Safe.t
+val receipt_of_json : Yojson.Safe.t -> (terminal_receipt, string) result
+
+val stage_awaiting_turn_commit :
+  base_path:string -> job -> (admission, error) result
+(** Persist the job in a non-runnable outbox before returning. It cannot be
+    claimed until {!activate} runs after the owning execution receipt commits. *)
+
+val list_awaiting :
+  base_path:string -> keeper_name:string -> (job list, error) result
+
+val activate :
+  base_path:string -> job -> (activation * cleanup_report, error) result
+(** Durably move an awaiting job into [pending]. Writing [pending] is the
+    activation commit; failure to remove the old awaiting envelope is reported
+    as cleanup debt and cannot block the runnable lane. *)
+
+val abort_awaiting : base_path:string -> job -> (unit, error) result
+(** Remove a non-runnable job when its owning execution receipt failed. *)
+
+val recover_inflight :
+  base_path:string -> keeper_name:string -> (recovery_report, error) result
+(** Move every receipt-less inflight job back to pending. Inflight jobs with a
+    terminal receipt are acknowledged without replay. Cleanup failures are
+    returned as debt and never stop recovery of later jobs. *)
+
+val claim_all :
+  base_path:string -> keeper_name:string -> now:float -> (claim_report, error) result
+(** Claim the current pending batch with one validated scan and one sort. The
+    returned leases preserve the keeper's linear turn order. *)
+
+val finish :
+  base_path:string -> terminal_receipt -> (cleanup_report, error) result
+(** Atomically persist the terminal receipt before acknowledging queue/stage
+    files. The first commit requires the matching inflight lease and timestamp;
+    repeating [finish] for an already-committed identical receipt is idempotent.
+    Post-commit cleanup errors are returned as debt, not as commit failure. *)
+
+val backlog_count :
+  base_path:string -> keeper_name:string -> (int, error) result
+
+val discover_keeper_names :
+  base_path:string -> (string list * error list, error) result
+(** Discover keeper directories with awaiting, pending, or inflight memory jobs. A
+    keeper-local malformed queue is returned in the error list without
+    suppressing healthy keepers; an outer [Error] means the keepers root itself
+    could not be inspected. *)
+
+val operation_stage_path_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_name:string ->
+  operation_id:string ->
+  (string, error) result
+(** SSOT path for a provider result staged until its memory-job terminal receipt
+    is durable. Both keeper and operation coordinates are validated before the
+    path is returned. *)
+
+module For_testing : sig
+  val awaiting_dir : base_path:string -> keeper_name:string -> string
+  val pending_dir : base_path:string -> keeper_name:string -> string
+  val inflight_dir : base_path:string -> keeper_name:string -> string
+  val receipts_dir : base_path:string -> keeper_name:string -> string
+  val receipt_path : base_path:string -> job -> string
+end

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,9 +1,13 @@
 (** Durable per-keeper post-turn memory jobs.
 
     The store is rooted exclusively from [base_path], which must be an existing
-    real directory. Every managed descendant component from the MASC directory
-    through the per-keeper queues is created one segment at a time and checked
-    with [lstat]; symlink and non-directory components fail explicitly. A job moves through
+    trusted real directory supplied by the BasePath SSOT. Every managed
+    descendant is a typed single segment opened relative to a directory file
+    descriptor with [O_NOFOLLOW]; symlink and non-directory components fail
+    explicitly. Ancestor descriptors are closed while walking, and queue
+    transactions retain only the [memory-jobs] leaf plus the queue descriptors
+    needed by that transaction. Diagnostic absolute paths are never syscall
+    authority. A job moves through
     [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
     execution receipt gates the first transition; the terminal memory receipt
     gates acknowledgement. Recovery requeues only inflight jobs that have no

--- a/lib/keeper_registry/keeper_id.ml
+++ b/lib/keeper_registry/keeper_id.ml
@@ -1,8 +1,16 @@
+(* Bounded preview for identifier validation errors. These values originate from
+   external requests/config/JSON, so emitting the full invalid value can amplify
+   logs. *)
+let preview_id s =
+  if String.length s <= 32 then s
+  else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+;;
+
 module Keeper_name = struct
   type t = string
   let is_valid s =
     let len = String.length s in
-    len > 0 && len <= 64 &&
+    s <> "." && s <> ".." && len > 0 && len <= 64 &&
     let rec check i =
       if i = len then true
       else
@@ -14,20 +22,24 @@ module Keeper_name = struct
 
   let of_string s =
     if is_valid s then Ok s
-    else Error (Printf.sprintf "Invalid keeper_name format: '%s'" s)
+    else
+      let reason =
+        if String.equal s "." then "reserved name '.'"
+        else if String.equal s ".." then "reserved name '..'"
+        else if String.length s = 0 then "empty string"
+        else if String.length s > 64
+        then Printf.sprintf "length %d exceeds 64" (String.length s)
+        else "contains characters outside [A-Za-z0-9_-]"
+      in
+      Error
+        (Printf.sprintf
+           "Invalid keeper_name %S: %s"
+           (preview_id s)
+           reason)
 
   let to_string s = s
   let equal = String.equal
 end
-
-(* Bounded preview for id validation error messages — these ids
-   originate from external requests / config / JSON; full dump risks
-   log spam on bad input. 32 bytes matches the pattern from iter#83
-   [decode_global_id] (#16903) and iter#84 [Ids.Trace_id]. *)
-let preview_id s =
-  if String.length s <= 32 then s
-  else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
-;;
 
 module Trace_id = struct
   type t = string

--- a/lib/keeper_registry/keeper_id.ml
+++ b/lib/keeper_registry/keeper_id.ml
@@ -8,17 +8,14 @@ let preview_id s =
 
 module Keeper_name = struct
   type t = string
+
   let is_valid s =
     let len = String.length s in
-    s <> "." && s <> ".." && len > 0 && len <= 64 &&
-    let rec check i =
-      if i = len then true
-      else
-        let c = s.[i] in
-        match c with
-        | 'a'..'z' | 'A'..'Z' | '0'..'9' | '-' | '_' -> check (i + 1)
-        | _ -> false
-    in check 0
+    (not (String.equal s "."))
+    && not (String.equal s "..")
+    && len <= 64
+    && Safe_identifier.is_portable_name s
+  ;;
 
   let of_string s =
     if is_valid s then Ok s
@@ -29,13 +26,14 @@ module Keeper_name = struct
         else if String.length s = 0 then "empty string"
         else if String.length s > 64
         then Printf.sprintf "length %d exceeds 64" (String.length s)
-        else "contains characters outside [A-Za-z0-9_-]"
+        else Safe_identifier.portable_name_error ~field:"keeper_name"
       in
       Error
         (Printf.sprintf
            "Invalid keeper_name %S: %s"
            (preview_id s)
            reason)
+  ;;
 
   let to_string s = s
   let equal = String.equal
@@ -57,7 +55,7 @@ module Trace_id = struct
         else if String.length s = 0 then "empty string"
         else if String.length s > 64
         then Printf.sprintf "length %d exceeds 64" (String.length s)
-        else "contains characters outside [A-Za-z0-9_-]"
+        else Safe_identifier.portable_name_error ~field:"trace_id"
       in
       Error (Printf.sprintf "Invalid trace_id %S: %s" (preview_id s) reason))
   let to_string s = s

--- a/lib/keeper_registry/keeper_id.mli
+++ b/lib/keeper_registry/keeper_id.mli
@@ -2,6 +2,8 @@
     Implements "Parse, Don't Validate" by making IDs abstract or private. *)
 
 module Keeper_name : sig
+  (** One portable path segment. The reserved filesystem segments [.] and [..]
+      are rejected before a Keeper name can become a filesystem coordinate. *)
   type t = private string
   val of_string : string -> (t, string) result
   val to_string : t -> string

--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,7 @@
   test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
+  test_keeper_memory_job_store
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_keeper_verification_audit
@@ -392,6 +393,7 @@
   test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
+  test_keeper_memory_job_store
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate

--- a/test/test_keeper_id.ml
+++ b/test/test_keeper_id.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Uid = Keeper_id.Uid
+module Keeper_name = Keeper_id.Keeper_name
 
 let test_generate_format () =
   let uid = Uid.generate () in
@@ -53,6 +54,20 @@ let test_equal () =
   check bool "different UIDs not equal" false (Uid.equal a b);
   check bool "same UID equal" true (Uid.equal a a)
 
+let test_keeper_name_portable_contract () =
+  List.iter
+    (fun input ->
+       match Keeper_name.of_string input with
+       | Ok parsed -> check string "portable name" input (Keeper_name.to_string parsed)
+       | Error error -> failf "portable keeper name %S rejected: %s" input error)
+    [ "keeper"; "dot.name"; "under_score"; "dash-name" ];
+  List.iter
+    (fun input ->
+       match Keeper_name.of_string input with
+       | Error _ -> ()
+       | Ok _ -> failf "unsafe keeper name %S accepted" input)
+    [ ""; "."; ".."; "slash/name"; "nul\000suffix" ]
+
 let () =
   run "Keeper ID"
     [
@@ -63,5 +78,11 @@ let () =
           test_case "of_string valid" `Quick test_of_string_valid;
           test_case "of_string invalid" `Quick test_of_string_invalid;
           test_case "equal" `Quick test_equal;
+        ] );
+      ( "Keeper name",
+        [ test_case
+            "portable path-segment contract"
+            `Quick
+            test_keeper_name_portable_contract
         ] );
     ]

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -629,6 +629,27 @@ let test_discovery_isolates_malformed_keeper () =
 ;;
 
 let test_typed_boundaries_reject_invalid_values () =
+  List.iter
+    (fun keeper_name ->
+       match
+         Store.make_job
+           ~keeper_name
+           ~trace_id:"trace-k1"
+           ~generation:1
+           ~turn:1
+           ~oas_turn_count:1
+           ~enqueued_at:1.0
+           ~payload:`Null
+       with
+       | Error (Store.Invalid_keeper_name _) -> ()
+       | Error error ->
+         Alcotest.failf
+           "wrong keeper-name error for %S: %s"
+           keeper_name
+           (Store.error_to_string error)
+       | Ok _ ->
+         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name)
+    [ "."; ".." ];
   (match
      Store.make_job
        ~keeper_name:"k1"

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -39,7 +39,7 @@ let terminal_receipt
       ?(ended_at = 3.0)
       ?(outcome = Store.Succeeded)
       ?(detail = `Assoc [ "status", `String "ok" ])
-      lease
+      (lease : Store.lease)
   =
   match
     Store.make_terminal_receipt
@@ -53,14 +53,14 @@ let terminal_receipt
     Alcotest.failf "receipt construction failed: %s" (Store.error_to_string error)
 ;;
 
-let stage ~base_path job =
+let stage ~base_path (job : Store.job) =
   match Store.stage_awaiting_turn_commit ~base_path job with
   | Ok admission -> admission
   | Error error ->
     Alcotest.failf "stage failed: %s" (Store.error_to_string error)
 ;;
 
-let activate ~base_path job =
+let activate ~base_path (job : Store.job) =
   match Store.activate ~base_path job with
   | Ok (activation, report) ->
     Alcotest.(check int)
@@ -88,7 +88,7 @@ let check_backlog ~base_path ~keeper_name expected =
     Alcotest.failf "backlog failed: %s" (Store.error_to_string error)
 ;;
 
-let awaiting_path ~base_path job =
+let awaiting_path ~base_path (job : Store.job) =
   Filename.concat
     (Store.For_testing.awaiting_dir
        ~base_path
@@ -96,7 +96,7 @@ let awaiting_path ~base_path job =
     (job.id ^ ".json")
 ;;
 
-let pending_path ~base_path job =
+let pending_path ~base_path (job : Store.job) =
   Filename.concat
     (Store.For_testing.pending_dir
        ~base_path
@@ -147,7 +147,7 @@ let rec json_contains_string needle = function
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null -> false
 ;;
 
-let operation_path ~base_path job =
+let operation_path ~base_path (job : Store.job) =
   match
     Store.operation_stage_path_for_keepers_dir
       ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
@@ -159,7 +159,7 @@ let operation_path ~base_path job =
     Alcotest.failf "operation path failed: %s" (Store.error_to_string error)
 ;;
 
-let finish ~base_path receipt =
+let finish ~base_path (receipt : Store.terminal_receipt) =
   match Store.finish ~base_path receipt with
   | Ok report -> report
   | Error error ->

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -483,6 +483,23 @@ let test_wrong_state_and_coordinate_are_rejected () =
 ;;
 
 let test_symlinked_store_boundaries_are_rejected () =
+  with_temp_dir "memory-job-masc-parent-symlink" (fun base_path ->
+    with_temp_dir "memory-job-external-masc" (fun external_masc ->
+      let job = make_job 1 in
+      Unix.symlink
+        external_masc
+        (Masc.Common.masc_dir_from_base_path ~base_path);
+      (match Store.stage_awaiting_turn_commit ~base_path job with
+       | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+       | Error error ->
+         Alcotest.failf
+           "wrong intermediate-parent error: %s"
+           (Store.error_to_string error)
+       | Ok _ -> Alcotest.fail "symlinked .masc parent was accepted");
+      Alcotest.(check int)
+        "intermediate target untouched"
+        0
+        (Array.length (Sys.readdir external_masc))));
   with_temp_dir "memory-job-root-symlink" (fun base_path ->
     let job = make_job 1 in
     let jobs_root =
@@ -631,7 +648,7 @@ let test_discovery_isolates_malformed_keeper () =
 let test_typed_boundaries_reject_invalid_values () =
   List.iter
     (fun keeper_name ->
-       match
+       (match
          Store.make_job
            ~keeper_name
            ~trace_id:"trace-k1"
@@ -648,7 +665,23 @@ let test_typed_boundaries_reject_invalid_values () =
            keeper_name
            (Store.error_to_string error)
        | Ok _ ->
-         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name)
+         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name);
+       (match
+          Store.operation_stage_path_for_keepers_dir
+            ~keepers_dir:"/unused"
+            ~keeper_name
+            ~operation_id:(String.make 64 'a')
+        with
+        | Error (Store.Invalid_keeper_name _) -> ()
+        | Error error ->
+          Alcotest.failf
+            "wrong operation-stage keeper error for %S: %s"
+            keeper_name
+            (Store.error_to_string error)
+        | Ok _ ->
+          Alcotest.failf
+            "operation stage accepted reserved keeper segment %S"
+            keeper_name))
     [ "."; ".." ];
   (match
      Store.make_job

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -74,7 +74,9 @@ let activate ~base_path job =
 
 let claim ~base_path ~keeper_name ~now =
   match Store.claim_all ~base_path ~keeper_name ~now with
-  | Ok report -> report
+  | Ok ({ blocked = None; _ } as report) -> report
+  | Ok { blocked = Some error; _ } ->
+    Alcotest.failf "claim blocked: %s" (Store.error_to_string error)
   | Error error ->
     Alcotest.failf "claim failed: %s" (Store.error_to_string error)
 ;;
@@ -280,12 +282,54 @@ let test_claim_does_not_overwrite_existing_lease () =
     in
     write_json pending pending_envelope;
     (match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
-     | Error (Store.Pending_already_inflight _) -> ()
+     | Ok
+         { leases = []
+         ; blocked = Some (Store.Pending_already_inflight _)
+         ; _
+         } -> ()
      | Error error ->
        Alcotest.failf "wrong duplicate claim error: %s" (Store.error_to_string error)
      | Ok _ -> Alcotest.fail "existing inflight lease was overwritten");
     let receipt = terminal_receipt first_lease in
     ignore (finish ~base_path receipt);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_partial_claims_remain_owned_when_later_job_blocks () =
+  with_temp_dir "memory-job-partial-claim" (fun base_path ->
+    let first = make_job ~oas_turn_count:1 ~enqueued_at:1.0 1 in
+    let second = make_job ~oas_turn_count:2 ~enqueued_at:2.0 2 in
+    ignore (stage ~base_path second);
+    ignore (activate ~base_path second);
+    let second_pending = pending_path ~base_path second in
+    let second_envelope = read_json second_pending in
+    let second_lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected second job lease"
+    in
+    write_json second_pending second_envelope;
+    ignore (stage ~base_path first);
+    ignore (activate ~base_path first);
+    let report =
+      match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
+      | Ok report -> report
+      | Error error ->
+        Alcotest.failf "partial claim failed: %s" (Store.error_to_string error)
+    in
+    Alcotest.(check (list int))
+      "earlier lease returned"
+      [ 1 ]
+      (List.map (fun lease -> lease.Store.job.turn) report.leases);
+    (match report.blocked with
+     | Some (Store.Pending_already_inflight _) -> ()
+     | Some error ->
+       Alcotest.failf "wrong partial blocker: %s" (Store.error_to_string error)
+     | None -> Alcotest.fail "later inflight collision was not surfaced");
+    List.iter
+      (fun lease -> ignore (finish ~base_path (terminal_receipt lease)))
+      report.leases;
+    ignore (finish ~base_path (terminal_receipt second_lease));
     check_backlog ~base_path ~keeper_name:"k1" 0)
 ;;
 
@@ -688,6 +732,10 @@ let () =
             "claim preserves existing inflight lease"
             `Quick
             test_claim_does_not_overwrite_existing_lease
+        ; Alcotest.test_case
+            "partial claims remain owned"
+            `Quick
+            test_partial_claims_remain_owned_when_later_job_blocks
         ; Alcotest.test_case
             "receipt-backed inflight is not replayed"
             `Quick

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -602,7 +602,7 @@ let test_discovery_isolates_malformed_keeper () =
       Filename.concat
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path)
-           "bad.name")
+           "bad name")
         "memory-jobs"
     in
     Fs_compat.mkdir_p malformed;
@@ -643,6 +643,31 @@ let test_discovery_isolates_malformed_keeper () =
         Alcotest.failf
           "symlink discovery failed: %s"
           (Store.error_to_string error)))
+;;
+
+let test_dotted_keeper_name_uses_typed_store_boundary () =
+  with_temp_dir "memory-job-dotted-keeper" (fun base_path ->
+    let keeper_name = "dot.name" in
+    let job = make_job ~keeper_name ~trace_id:"trace.dot" 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one dotted-keeper lease"
+    in
+    let receipt = terminal_receipt lease in
+    (match Store.finish ~base_path receipt with
+     | Ok { cleanup_errors = [] } -> ()
+     | Ok report ->
+       Alcotest.failf
+         "dotted-keeper finish left cleanup debt: %d"
+         (List.length report.cleanup_errors)
+     | Error error ->
+       Alcotest.failf
+         "dotted-keeper finish failed: %s"
+         (Store.error_to_string error));
+    check_backlog ~base_path ~keeper_name 0)
 ;;
 
 let test_typed_boundaries_reject_invalid_values () =
@@ -828,6 +853,10 @@ let () =
             "typed boundaries reject invalid values"
             `Quick
             test_typed_boundaries_reject_invalid_values
+        ; Alcotest.test_case
+            "dotted keeper name follows portable SSOT"
+            `Quick
+            test_dotted_keeper_name_uses_typed_store_boundary
         ; Alcotest.test_case
             "receipt identity omits payload"
             `Quick

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -1,0 +1,735 @@
+(** Durable per-Keeper memory-job store regression tests. *)
+
+module Store = Masc.Keeper_memory_job_store
+
+let with_temp_dir label f =
+  let path = Filename.temp_file ("masc-" ^ label ^ "-") "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree path)
+    (fun () -> f path)
+;;
+
+let make_job
+      ?(keeper_name = "k1")
+      ?(trace_id = "trace-k1")
+      ?(generation = 1)
+      ?(oas_turn_count = 1)
+      ?(enqueued_at = 1.0)
+      ?(payload = `Assoc [ "value", `Int 1 ])
+      turn
+  =
+  match
+    Store.make_job
+      ~keeper_name
+      ~trace_id
+      ~generation
+      ~turn
+      ~oas_turn_count
+      ~enqueued_at
+      ~payload
+  with
+  | Ok job -> job
+  | Error error ->
+    Alcotest.failf "job construction failed: %s" (Store.error_to_string error)
+;;
+
+let terminal_receipt
+      ?(ended_at = 3.0)
+      ?(outcome = Store.Succeeded)
+      ?(detail = `Assoc [ "status", `String "ok" ])
+      lease
+  =
+  match
+    Store.make_terminal_receipt
+      lease
+      ~ended_at
+      ~outcome
+      ~detail
+  with
+  | Ok receipt -> receipt
+  | Error error ->
+    Alcotest.failf "receipt construction failed: %s" (Store.error_to_string error)
+;;
+
+let stage ~base_path job =
+  match Store.stage_awaiting_turn_commit ~base_path job with
+  | Ok admission -> admission
+  | Error error ->
+    Alcotest.failf "stage failed: %s" (Store.error_to_string error)
+;;
+
+let activate ~base_path job =
+  match Store.activate ~base_path job with
+  | Ok (activation, report) ->
+    Alcotest.(check int)
+      "activation cleanup debt"
+      0
+      (List.length report.cleanup_errors);
+    activation
+  | Error error ->
+    Alcotest.failf "activation failed: %s" (Store.error_to_string error)
+;;
+
+let claim ~base_path ~keeper_name ~now =
+  match Store.claim_all ~base_path ~keeper_name ~now with
+  | Ok report -> report
+  | Error error ->
+    Alcotest.failf "claim failed: %s" (Store.error_to_string error)
+;;
+
+let check_backlog ~base_path ~keeper_name expected =
+  match Store.backlog_count ~base_path ~keeper_name with
+  | Ok actual -> Alcotest.(check int) "durable backlog" expected actual
+  | Error error ->
+    Alcotest.failf "backlog failed: %s" (Store.error_to_string error)
+;;
+
+let awaiting_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.awaiting_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let pending_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.pending_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let write_text path content =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let write_json path json =
+  match
+    Fs_compat.save_file_atomic_unix
+      path
+      (Yojson.Safe.pretty_to_string json)
+  with
+  | Ok () -> ()
+  | Error detail -> Alcotest.failf "write failed path=%s: %s" path detail
+;;
+
+let read_json path =
+  match Safe_ops.read_json_file_safe path with
+  | Ok json -> json
+  | Error detail -> Alcotest.failf "read failed path=%s: %s" path detail
+;;
+
+let replace_assoc_field name value = function
+  | `Assoc fields ->
+    `Assoc
+      ((name, value)
+       :: List.filter
+            (fun (field, _) -> not (String.equal field name))
+            fields)
+  | _ -> Alcotest.fail "expected JSON object"
+;;
+
+let rec json_contains_string needle = function
+  | `String value -> String.equal value needle
+  | `Assoc fields ->
+    List.exists
+      (fun (_, value) -> json_contains_string needle value)
+      fields
+  | `List values -> List.exists (json_contains_string needle) values
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null -> false
+;;
+
+let operation_path ~base_path job =
+  match
+    Store.operation_stage_path_for_keepers_dir
+      ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+      ~keeper_name:job.Store.keeper_name
+      ~operation_id:job.id
+  with
+  | Ok path -> path
+  | Error error ->
+    Alcotest.failf "operation path failed: %s" (Store.error_to_string error)
+;;
+
+let finish ~base_path receipt =
+  match Store.finish ~base_path receipt with
+  | Ok report -> report
+  | Error error ->
+    Alcotest.failf "finish failed: %s" (Store.error_to_string error)
+;;
+
+let test_retry_preserves_first_durable_envelope () =
+  with_temp_dir "memory-job-canonical" (fun base_path ->
+    let first =
+      make_job
+        ~enqueued_at:1.0
+        ~payload:(`Assoc [ "alpha", `Int 1; "beta", `Int 2 ])
+        1
+    in
+    let retry =
+      make_job
+        ~enqueued_at:99.0
+        ~payload:(`Assoc [ "beta", `Int 2; "alpha", `Int 1 ])
+        1
+    in
+    Alcotest.(check bool)
+      "first stage"
+      true
+      (stage ~base_path first = Store.Staged_awaiting_turn_commit);
+    Alcotest.(check bool)
+      "semantic duplicate"
+      true
+      (stage ~base_path retry = Store.Already_awaiting);
+    Alcotest.(check bool)
+      "activate retry"
+      true
+      (activate ~base_path retry = Store.Activated);
+    let report = claim ~base_path ~keeper_name:"k1" ~now:2.0 in
+    let lease =
+      match report.leases with
+      | [ lease ] -> lease
+      | leases ->
+        Alcotest.failf "expected one lease, got %d" (List.length leases)
+    in
+    Alcotest.(check (float 0.0))
+      "first enqueue timestamp wins"
+      first.enqueued_at
+      lease.job.enqueued_at;
+    Alcotest.(check bool)
+      "first payload representation wins"
+      true
+      (Yojson.Safe.equal first.payload lease.job.payload);
+    let conflict =
+      make_job ~payload:(`Assoc [ "alpha", `Int 9 ]) 1
+    in
+    (match Store.stage_awaiting_turn_commit ~base_path conflict with
+     | Error (Store.Identity_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong conflict: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "conflicting payload was accepted");
+    let receipt = terminal_receipt lease in
+    ignore (finish ~base_path receipt);
+    let conflicting_receipt = terminal_receipt ~ended_at:4.0 lease in
+    (match Store.finish ~base_path conflicting_receipt with
+     | Error (Store.Identity_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong terminal conflict: %s"
+         (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "conflicting terminal timestamps were accepted");
+    check_backlog ~base_path ~keeper_name:"k1" 0;
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    Alcotest.(check int)
+      "queue directory mode"
+      0o700
+      ((Unix.stat awaiting_dir).Unix.st_perm land 0o777);
+    Alcotest.(check int)
+      "receipt mode"
+      0o600
+      ((Unix.stat (Store.For_testing.receipt_path ~base_path first)).Unix.st_perm
+       land 0o777))
+;;
+
+let test_ordered_claim_and_terminal_cleanup () =
+  with_temp_dir "memory-job-order" (fun base_path ->
+    let second = make_job ~oas_turn_count:2 ~enqueued_at:2.0 2 in
+    let first = make_job ~oas_turn_count:1 ~enqueued_at:1.0 1 in
+    List.iter
+      (fun job ->
+         ignore (stage ~base_path job);
+         ignore (activate ~base_path job))
+      [ second; first ];
+    let report = claim ~base_path ~keeper_name:"k1" ~now:3.0 in
+    Alcotest.(check (list int))
+      "linear turn order"
+      [ 1; 2 ]
+      (List.map (fun lease -> lease.Store.job.turn) report.leases);
+    Alcotest.(check int)
+      "claim cleanup debt"
+      0
+      (List.length report.cleanup_errors);
+    List.iter
+      (fun lease ->
+         ignore
+           (finish
+              ~base_path
+              (terminal_receipt lease)))
+      report.leases;
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_claim_does_not_overwrite_existing_lease () =
+  with_temp_dir "memory-job-double-claim" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let pending = pending_path ~base_path job in
+    let pending_envelope = read_json pending in
+    let first_lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    write_json pending pending_envelope;
+    (match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
+     | Error (Store.Pending_already_inflight _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong duplicate claim error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "existing inflight lease was overwritten");
+    let receipt = terminal_receipt first_lease in
+    ignore (finish ~base_path receipt);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_receipt_backed_inflight_is_not_replayed () =
+  with_temp_dir "memory-job-receipt-recovery" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let operation = operation_path ~base_path job in
+    Fs_compat.mkdir_p_durable_unix (Filename.dirname operation);
+    write_text operation "staged provider result";
+    let receipt = terminal_receipt lease in
+    write_json
+      (Store.For_testing.receipt_path ~base_path job)
+      (Store.receipt_to_json receipt);
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Ok report ->
+       Alcotest.(check int) "receipt prevents replay" 0 report.replayed;
+       Alcotest.(check int)
+         "recovery cleanup debt"
+         0
+         (List.length report.cleanup_errors)
+     | Error error ->
+       Alcotest.failf "recovery failed: %s" (Store.error_to_string error));
+    Alcotest.(check bool)
+      "provider stage acknowledged"
+      false
+      (Sys.file_exists operation);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_recovery_rejects_mismatched_lease_receipt () =
+  with_temp_dir "memory-job-receipt-lease" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let mismatched =
+      Store.receipt_to_json (terminal_receipt lease)
+      |> replace_assoc_field "started_at" (`Float 9.0)
+    in
+    write_json (Store.For_testing.receipt_path ~base_path job) mismatched;
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Error (Store.Inflight_lease_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong lease mismatch: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "mismatched terminal lease was accepted");
+    check_backlog ~base_path ~keeper_name:"k1" 1)
+;;
+
+let test_terminal_cleanup_debt_is_explicit () =
+  with_temp_dir "memory-job-cleanup-debt" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let operation = operation_path ~base_path job in
+    Fs_compat.mkdir_p_durable_unix operation;
+    let report =
+      finish
+        ~base_path
+        (terminal_receipt lease)
+    in
+    Alcotest.(check bool)
+      "cleanup debt returned"
+      true
+      (report.cleanup_errors <> []);
+    Alcotest.(check bool)
+      "terminal receipt committed first"
+      true
+      (Sys.file_exists (Store.For_testing.receipt_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_stale_completion_cannot_ack_requeued_work () =
+  with_temp_dir "memory-job-stale-completion" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let receipt = terminal_receipt lease in
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Ok report -> Alcotest.(check int) "one job requeued" 1 report.replayed
+     | Error error ->
+       Alcotest.failf "recovery failed: %s" (Store.error_to_string error));
+    (match Store.finish ~base_path receipt with
+     | Error (Store.Missing_inflight_lease _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong stale completion error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "stale completion acknowledged requeued work");
+    Alcotest.(check bool)
+      "terminal receipt absent"
+      false
+      (Sys.file_exists (Store.For_testing.receipt_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:"k1" 1)
+;;
+
+let test_wrong_state_and_coordinate_are_rejected () =
+  with_temp_dir "memory-job-coordinates" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let pending = pending_path ~base_path job in
+    let envelope =
+      read_json pending
+      |> replace_assoc_field
+           "state"
+           (`Assoc
+              [ "kind", `String "inflight"
+              ; "started_at", `Float 1.0
+              ])
+    in
+    write_json pending envelope;
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Decode_error _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong state error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "pending directory accepted inflight state"));
+  with_temp_dir "memory-job-filename" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let source = awaiting_path ~base_path job in
+    let destination =
+      Filename.concat
+        (Filename.dirname source)
+        (String.make 64 'a' ^ ".json")
+    in
+    Sys.rename source destination;
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Decode_error _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong coordinate error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "mismatched filename was accepted"))
+;;
+
+let test_symlinked_store_boundaries_are_rejected () =
+  with_temp_dir "memory-job-root-symlink" (fun base_path ->
+    let job = make_job 1 in
+    let jobs_root =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+      |> Filename.dirname
+    in
+    let target = Filename.concat base_path "outside-jobs" in
+    Unix.mkdir target 0o700;
+    Fs_compat.mkdir_p (Filename.dirname jobs_root);
+    Unix.symlink target jobs_root;
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong root error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked memory-jobs root was accepted");
+    Alcotest.(check int)
+      "root target untouched"
+      0
+      (Array.length (Sys.readdir target)));
+  with_temp_dir "memory-job-keeper-symlink" (fun base_path ->
+    let job = make_job 1 in
+    let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+    let keeper_dir = Filename.concat keepers_root "k1" in
+    let target = Filename.concat base_path "outside-keeper" in
+    Fs_compat.mkdir_p keepers_root;
+    Unix.mkdir target 0o700;
+    Unix.symlink target keeper_dir;
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong keeper error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked keeper directory was accepted");
+    Alcotest.(check int)
+      "keeper target untouched"
+      0
+      (Array.length (Sys.readdir target)));
+  with_temp_dir "memory-job-recovery-symlink" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    let recovered_root =
+      Filename.concat
+        (Filename.dirname awaiting_dir)
+        "recovered-atomic-writes"
+    in
+    let target = Filename.concat base_path "outside-recovery" in
+    Unix.mkdir target 0o700;
+    Unix.symlink target recovered_root;
+    let orphan = Filename.concat awaiting_dir ".atomic_data.tmp" in
+    write_text orphan "forensic payload";
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong recovery error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked recovery root was accepted");
+    Alcotest.(check bool) "orphan remains in queue" true (Sys.file_exists orphan);
+    Alcotest.(check int)
+      "recovery target untouched"
+      0
+      (Array.length (Sys.readdir target)))
+;;
+
+let test_atomic_orphans_are_reconciled_without_loss () =
+  with_temp_dir "memory-job-orphans" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    let empty = Filename.concat dir ".atomic_empty.tmp" in
+    let nonempty = Filename.concat dir ".atomic_data.tmp" in
+    write_text empty "";
+    write_text nonempty "forensic payload";
+    check_backlog ~base_path ~keeper_name:"k1" 1;
+    Alcotest.(check bool) "empty orphan removed" false (Sys.file_exists empty);
+    Alcotest.(check bool)
+      "nonempty orphan moved"
+      false
+      (Sys.file_exists nonempty);
+    let recovered =
+      Filename.concat
+        (Filename.concat
+           (Filename.dirname dir)
+           "recovered-atomic-writes/awaiting-turn-commit")
+        ".atomic_data.tmp"
+    in
+    Alcotest.(check bool)
+      "nonempty orphan preserved"
+      true
+      (Sys.file_exists recovered))
+;;
+
+let test_discovery_isolates_malformed_keeper () =
+  with_temp_dir "memory-job-discovery" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let malformed =
+      Filename.concat
+        (Filename.concat
+           (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+           "bad.name")
+        "memory-jobs"
+    in
+    Fs_compat.mkdir_p malformed;
+    match Store.discover_keeper_names ~base_path with
+    | Ok (keepers, errors) ->
+      Alcotest.(check (list string)) "healthy keeper" [ "k1" ] keepers;
+      Alcotest.(check int) "malformed keeper isolated" 1 (List.length errors)
+    | Error error ->
+      Alcotest.failf "discovery failed: %s" (Store.error_to_string error));
+  with_temp_dir "memory-job-discovery-root" (fun base_path ->
+    with_temp_dir "memory-job-discovery-external" (fun external_base ->
+      let external_job =
+        make_job
+          ~keeper_name:"k2"
+          ~trace_id:"trace-k2"
+          1
+      in
+      ignore (stage ~base_path:external_base external_job);
+      let external_keeper =
+        Filename.concat
+          (Masc.Common.keepers_runtime_dir_of_base ~base_path:external_base)
+          "k2"
+      in
+      let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+      Fs_compat.mkdir_p keepers_root;
+      Unix.symlink external_keeper (Filename.concat keepers_root "k2");
+      match Store.discover_keeper_names ~base_path with
+      | Ok (keepers, errors) ->
+        Alcotest.(check (list string))
+          "external keeper not discovered"
+          []
+          keepers;
+        Alcotest.(check int)
+          "symlinked keeper isolated"
+          1
+          (List.length errors)
+      | Error error ->
+        Alcotest.failf
+          "symlink discovery failed: %s"
+          (Store.error_to_string error)))
+;;
+
+let test_typed_boundaries_reject_invalid_values () =
+  (match
+     Store.make_job
+       ~keeper_name:"k1"
+       ~trace_id:"trace-k1"
+       ~generation:1
+       ~turn:1
+       ~oas_turn_count:1
+       ~enqueued_at:1.0
+       ~payload:(`Float Float.nan)
+   with
+   | Error (Store.Invalid_json_value _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong payload error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "non-finite payload was accepted");
+  with_temp_dir "memory-job-invalid-receipt" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    match
+      Store.make_terminal_receipt
+        lease
+        ~ended_at:1.0
+        ~outcome:Store.Succeeded
+        ~detail:`Null
+    with
+    | Error (Store.Invalid_terminal_timestamps _) -> ()
+    | Error error ->
+      Alcotest.failf "wrong timestamp error: %s" (Store.error_to_string error)
+    | Ok _ -> Alcotest.fail "reversed terminal timestamps were accepted");
+  (match Store.claim_all ~base_path:"/unused" ~keeper_name:"k1" ~now:Float.nan with
+   | Error (Store.Invalid_claim_time _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong claim-time error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "non-finite claim time was accepted");
+  (match
+     Store.operation_stage_path_for_keepers_dir
+       ~keepers_dir:"/unused"
+       ~keeper_name:"k1"
+       ~operation_id:"../escape"
+   with
+   | Error (Store.Invalid_job_id _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong operation-id error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "invalid operation id produced a path");
+  let job = make_job 1 in
+  let duplicate_id_json =
+    match Store.job_to_json job with
+    | `Assoc fields -> `Assoc (("id", `String job.id) :: fields)
+    | _ -> Alcotest.fail "job JSON must be an object"
+  in
+  (match Store.job_of_json duplicate_id_json with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "duplicate control field was accepted")
+;;
+
+let test_receipt_identity_omits_payload () =
+  with_temp_dir "memory-job-receipt-projection" (fun base_path ->
+    let secret = "secret-checkpoint-payload" in
+    let job =
+      make_job ~payload:(`Assoc [ "secret", `String secret ]) 1
+    in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let json = Store.receipt_to_json (terminal_receipt lease) in
+    Alcotest.(check bool)
+      "receipt does not retain payload"
+      false
+      (json_contains_string secret json);
+    match json with
+    | `Assoc fields ->
+      Alcotest.(check bool)
+        "receipt has no job object"
+        false
+        (List.mem_assoc "job" fields)
+    | _ -> Alcotest.fail "receipt must be an object")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_job_store"
+    [ ( "durability"
+      , [ Alcotest.test_case
+            "retry preserves first durable envelope"
+            `Quick
+            test_retry_preserves_first_durable_envelope
+        ; Alcotest.test_case
+            "ordered claim and terminal cleanup"
+            `Quick
+            test_ordered_claim_and_terminal_cleanup
+        ; Alcotest.test_case
+            "claim preserves existing inflight lease"
+            `Quick
+            test_claim_does_not_overwrite_existing_lease
+        ; Alcotest.test_case
+            "receipt-backed inflight is not replayed"
+            `Quick
+            test_receipt_backed_inflight_is_not_replayed
+        ; Alcotest.test_case
+            "mismatched lease receipt is rejected"
+            `Quick
+            test_recovery_rejects_mismatched_lease_receipt
+        ; Alcotest.test_case
+            "terminal cleanup debt is explicit"
+            `Quick
+            test_terminal_cleanup_debt_is_explicit
+        ; Alcotest.test_case
+            "stale completion cannot acknowledge requeued work"
+            `Quick
+            test_stale_completion_cannot_ack_requeued_work
+        ; Alcotest.test_case
+            "atomic orphans reconcile without loss"
+            `Quick
+            test_atomic_orphans_are_reconciled_without_loss
+        ] )
+    ; ( "validation"
+      , [ Alcotest.test_case
+            "wrong state and coordinates are rejected"
+            `Quick
+            test_wrong_state_and_coordinate_are_rejected
+        ; Alcotest.test_case
+            "symlinked store boundaries are rejected"
+            `Quick
+            test_symlinked_store_boundaries_are_rejected
+        ; Alcotest.test_case
+            "discovery isolates malformed keeper"
+            `Quick
+            test_discovery_isolates_malformed_keeper
+        ; Alcotest.test_case
+            "typed boundaries reject invalid values"
+            `Quick
+            test_typed_boundaries_reject_invalid_values
+        ; Alcotest.test_case
+            "receipt identity omits payload"
+            `Quick
+            test_receipt_identity_omits_payload
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -150,7 +150,7 @@ let rec json_contains_string needle = function
 let operation_path ~base_path job =
   match
     Store.operation_stage_path_for_keepers_dir
-      ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+      ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
       ~keeper_name:job.Store.keeper_name
       ~operation_id:job.id
   with
@@ -488,7 +488,7 @@ let test_symlinked_store_boundaries_are_rejected () =
       let job = make_job 1 in
       Unix.symlink
         external_masc
-        (Masc.Common.masc_dir_from_base_path ~base_path);
+        (Common.masc_dir_from_base_path ~base_path);
       (match Store.stage_awaiting_turn_commit ~base_path job with
        | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
        | Error error ->
@@ -521,7 +521,7 @@ let test_symlinked_store_boundaries_are_rejected () =
       (Array.length (Sys.readdir target)));
   with_temp_dir "memory-job-keeper-symlink" (fun base_path ->
     let job = make_job 1 in
-    let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+    let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
     let keeper_dir = Filename.concat keepers_root "k1" in
     let target = Filename.concat base_path "outside-keeper" in
     Fs_compat.mkdir_p keepers_root;
@@ -601,7 +601,7 @@ let test_discovery_isolates_malformed_keeper () =
     let malformed =
       Filename.concat
         (Filename.concat
-           (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+           (Common.keepers_runtime_dir_of_base ~base_path)
            "bad.name")
         "memory-jobs"
     in
@@ -623,10 +623,10 @@ let test_discovery_isolates_malformed_keeper () =
       ignore (stage ~base_path:external_base external_job);
       let external_keeper =
         Filename.concat
-          (Masc.Common.keepers_runtime_dir_of_base ~base_path:external_base)
+          (Common.keepers_runtime_dir_of_base ~base_path:external_base)
           "k2"
       in
-      let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+      let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
       Fs_compat.mkdir_p keepers_root;
       Unix.symlink external_keeper (Filename.concat keepers_root "k2");
       match Store.discover_keeper_names ~base_path with


### PR DESCRIPTION
Replaces closed Draft PR #24043 after the stacked branch was rebased onto the descriptor-capability foundation.\n\nThis layer adds the durable per-keeper job store and keeps all managed descendant I/O anchored to opened directory descriptors. Full OCaml build and tests are delegated to GitHub Actions.