### PR TITLE
fix(dashboard): wire Overview panels to live sources, delete dead prototype sections (#43)

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -1,42 +1,58 @@
 import { h } from 'preact'
-import { cleanup, render } from '@testing-library/preact'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Gate connectors have no global boot-time fetch (unlike governance/tools,
+// which app.ts loads at app-mount and this test file never mounts), so
+// Overview's own useEffect calls fetchGateConnectors directly. Mock it here so
+// (a) the blocked-fetch guard in vitest-setup.ts never fires and (b) the
+// "live payload" tests below can control what it resolves to. Default: an
+// empty-but-successful connector list, harmless for every test that does not
+// care about connector content.
+const { mockFetchGateConnectors } = vi.hoisted(() => ({
+  mockFetchGateConnectors: vi.fn().mockResolvedValue({
+    connectors: [],
+    total: 0,
+    active_count: 0,
+    discord_trigger_policy: 'unknown',
+    generated_at: '2026-01-01T00:00:00Z',
+  }),
+}))
+vi.mock('../../api/gate', () => ({
+  fetchGateConnectors: mockFetchGateConnectors,
+}))
+
+// toolsData/toolsError back the 예약 승인 KPI + 예약·자동화 card. The
+// underlying resource in tool-state.ts is not exported (by design — every
+// other consumer reads the computed signal, not the resource), so the module
+// is mocked with a plain mutable `{ value }` stand-in tests can set directly
+// before render, mirroring components/keeper-shared.test.ts's convention.
+const { mockedToolsData } = vi.hoisted(() => ({
+  mockedToolsData: { value: null as unknown },
+}))
+vi.mock('../tools/tool-state', () => ({
+  toolsData: mockedToolsData,
+  toolsError: { value: null },
+}))
+
 import {
-  computeFunnelCounts,
-  formatTargetRatio,
-  pickActiveSession,
-  progressPct,
-  pickActiveKeepers,
-  severityToneClass,
-  deriveAgentAlerts,
-  deriveTaskAlerts,
-  deriveFleetTickerEvents,
   deriveKeeperAttentionReason,
   pickAttentionKeepers,
   computeOverviewStats,
   computeOverviewDigest,
   buildOverviewTelemetrySnapshot,
-  keeperRuntimeLabel,
   OVERVIEW_TELEMETRY_BAR_COUNT,
   OVERVIEW_TELEMETRY_EVENTS_PER_BUCKET,
   OVERVIEW_TELEMETRY_EVENT_SAMPLE_LIMIT,
-  type FunnelCounts,
   Overview,
 } from './overview'
 import type { FusionRunRecord, TelemetryEntry, TelemetrySourceSummary } from '../../api/dashboard'
-import { keepers } from '../../store'
-import type { Goal } from '../../types/core'
-
-// bar-seg ratio helper (mirrors FunnelCard inline logic)
-function segPct(counts: FunnelCounts, key: 'created' | 'inProgress' | 'awaiting' | 'completed'): number {
-  const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
-  return total > 0 ? (counts[key] / total) * 100 : 0
-}
-import type { Agent, Task, Keeper, Message, BoardPost } from '../../types/core'
-import type {
-  DashboardMissionResponse,
-  DashboardMissionSessionCard,
-} from '../../types/dashboard-mission'
+import type { DashboardScheduledAutomation, DashboardScheduledAutomationRequest } from '../../api'
+import { keepers, goals, boardTotal } from '../../store'
+import type { Keeper, Goal } from '../../types/core'
+import { governanceResource } from '../governance-signals'
+import type { DashboardGovernanceResponse, KeeperApprovalQueueItem } from '../../types'
+import type { GateConnectorInfo, GateConnectorsData } from '../../api/gate'
 
 const FIXED_NOW = new Date(2026, 3, 18, 10, 0, 0, 0).getTime()
 
@@ -52,469 +68,9 @@ function localIsoAt(
   return d.toISOString()
 }
 
-function makeSession(partial: Partial<DashboardMissionSessionCard>): DashboardMissionSessionCard {
-  return {
-    session_id: 's-1',
-    goal: 'default goal',
-    member_names: [],
-    related_attention_count: 0,
-    member_previews: [],
-    operation_badges: [],
-    keeper_refs: [],
-    ...partial,
-  }
-}
-
-function makeTask(partial: Partial<Task>): Task {
-  return { id: 't-1', title: 't', ...partial }
-}
-
 function makeKeeper(partial: Partial<Keeper>): Keeper {
   return { name: 'k', status: 'active', ...partial }
 }
-
-function makeMessage(partial: Partial<Message>): Message {
-  return { id: 'm-1', content: 'message', ...partial }
-}
-
-function makeBoardPost(partial: Partial<BoardPost>): BoardPost {
-  return {
-    id: 'p-1',
-    author: 'keeper',
-    title: 'post',
-    body: 'body',
-    content: 'content',
-    tags: [],
-    votes: 0,
-    comment_count: 0,
-    created_at: localIsoAt(1),
-    updated_at: localIsoAt(1),
-    ...partial,
-  }
-}
-
-describe('computeFunnelCounts', () => {
-  it('counts today-created tasks regardless of status', () => {
-    const tasks = [
-      makeTask({ id: 'a', created_at: localIsoAt(1), status: 'todo' }),
-      makeTask({ id: 'b', created_at: localIsoAt(9, 59), status: 'in_progress' }),
-      makeTask({ id: 'c', created_at: localIsoAt(23, 59, 59, -1), status: 'todo' }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    expect(counts.created).toBe(2)
-  })
-
-  it('groups claimed + in_progress as inProgress', () => {
-    const tasks = [
-      makeTask({ id: 'a', status: 'claimed' }),
-      makeTask({ id: 'b', status: 'in_progress' }),
-      makeTask({ id: 'c', status: 'todo' }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    expect(counts.inProgress).toBe(2)
-  })
-
-  it('separates awaiting_verification from other statuses', () => {
-    const tasks = [
-      makeTask({ id: 'a', status: 'awaiting_verification' }),
-      makeTask({ id: 'b', status: 'done', completed_at: localIsoAt(5) }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    expect(counts.awaiting).toBe(1)
-    expect(counts.completed).toBe(1)
-  })
-
-  it('counts only today-completed done tasks', () => {
-    const tasks = [
-      makeTask({ id: 'a', status: 'done', completed_at: localIsoAt(5) }),
-      makeTask({ id: 'b', status: 'done', completed_at: localIsoAt(23, 0, 0, -1) }),
-      makeTask({ id: 'c', status: 'done' }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    expect(counts.completed).toBe(1)
-  })
-
-  it('takes target from active session required_count when positive', () => {
-    const active = makeSession({ required_count: 12 })
-    const counts = computeFunnelCounts([], active, FIXED_NOW)
-    expect(counts.target).toBe(12)
-  })
-
-  it('returns null target when required_count is 0 or missing', () => {
-    expect(computeFunnelCounts([], makeSession({ required_count: 0 }), FIXED_NOW).target).toBeNull()
-    expect(computeFunnelCounts([], makeSession({}), FIXED_NOW).target).toBeNull()
-    expect(computeFunnelCounts([], null, FIXED_NOW).target).toBeNull()
-  })
-
-  it('ignores invalid ISO timestamps', () => {
-    const tasks = [
-      makeTask({ id: 'a', created_at: 'not-a-date', status: 'todo' }),
-      makeTask({ id: 'b', created_at: '', status: 'done', completed_at: 'nope' }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    expect(counts.created).toBe(0)
-    expect(counts.completed).toBe(0)
-  })
-
-  it('bar-seg ratio sums to ~100% across all funnel stages', () => {
-    const tasks = [
-      makeTask({ id: 'a', created_at: localIsoAt(1), status: 'in_progress' }),
-      makeTask({ id: 'b', created_at: localIsoAt(2), status: 'awaiting_verification' }),
-      makeTask({ id: 'c', created_at: localIsoAt(3), status: 'done', completed_at: localIsoAt(4) }),
-    ]
-    const counts = computeFunnelCounts(tasks, null, FIXED_NOW)
-    const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
-    const pcts = [counts.inProgress, counts.awaiting, counts.completed, counts.created]
-      .map(n => total > 0 ? (n / total) * 100 : 0)
-    const sum = pcts.reduce((a, b) => a + b, 0)
-    expect(Math.round(sum)).toBe(100)
-  })
-
-  it('bar-seg ratio returns 0 when funnel is empty', () => {
-    const counts = computeFunnelCounts([], null, FIXED_NOW)
-    expect(segPct(counts, 'created')).toBe(0)
-    expect(segPct(counts, 'completed')).toBe(0)
-  })
-})
-
-describe('formatTargetRatio', () => {
-  const base: FunnelCounts = {
-    created: 0,
-    inProgress: 0,
-    awaiting: 0,
-    completed: 0,
-    target: null,
-  }
-
-  it('returns just the completed count when target is null', () => {
-    expect(formatTargetRatio({ ...base, completed: 3 })).toBe('3')
-  })
-
-  it('formats ratio as n/m (p%)', () => {
-    expect(formatTargetRatio({ ...base, completed: 4, target: 10 })).toBe('4/10 (40%)')
-  })
-
-  it('caps percentage at 100 when completed exceeds target', () => {
-    expect(formatTargetRatio({ ...base, completed: 20, target: 5 })).toBe('20/5 (100%)')
-  })
-})
-
-describe('pickActiveSession', () => {
-  it('returns null for null snapshot', () => {
-    expect(pickActiveSession(null)).toBeNull()
-  })
-
-  it('returns null for empty sessions', () => {
-    const snap = { sessions: [] } as unknown as DashboardMissionResponse
-    expect(pickActiveSession(snap)).toBeNull()
-  })
-
-  it('prefers first session with active/running/busy status', () => {
-    const a = makeSession({ session_id: 'a', status: 'paused' })
-    const b = makeSession({ session_id: 'b', status: 'running' })
-    const c = makeSession({ session_id: 'c', status: 'active' })
-    const snap = { sessions: [a, b, c] } as unknown as DashboardMissionResponse
-    expect(pickActiveSession(snap)?.session_id).toBe('b')
-  })
-
-  it('falls back to first session when none are active', () => {
-    const a = makeSession({ session_id: 'a', status: 'paused' })
-    const b = makeSession({ session_id: 'b', status: 'paused' })
-    const snap = { sessions: [a, b] } as unknown as DashboardMissionResponse
-    expect(pickActiveSession(snap)?.session_id).toBe('a')
-  })
-})
-
-describe('progressPct', () => {
-  it('returns null when no active session', () => {
-    expect(progressPct(null)).toBeNull()
-  })
-
-  it('returns null when required_count is missing or zero', () => {
-    expect(progressPct(makeSession({}))).toBeNull()
-    expect(progressPct(makeSession({ required_count: 0 }))).toBeNull()
-  })
-
-  it('computes seen/required rounded-[var(--r-1)] percentage', () => {
-    expect(progressPct(makeSession({ required_count: 10, seen_count: 3 }))).toBe(30)
-    expect(progressPct(makeSession({ required_count: 4, seen_count: 1 }))).toBe(25)
-  })
-
-  it('falls back to active_count when seen_count is missing', () => {
-    expect(progressPct(makeSession({ required_count: 10, active_count: 4 }))).toBe(40)
-  })
-
-  it('caps percentage at 100', () => {
-    expect(progressPct(makeSession({ required_count: 3, seen_count: 10 }))).toBe(100)
-  })
-})
-
-describe('pickActiveKeepers', () => {
-  it('returns empty when no keepers', () => {
-    expect(pickActiveKeepers([])).toEqual([])
-  })
-
-  it('sorts by latest heartbeat descending', () => {
-    const keepers: Keeper[] = [
-      makeKeeper({ name: 'old', last_heartbeat: '2026-04-18T08:00:00+09:00' }),
-      makeKeeper({ name: 'new', last_heartbeat: '2026-04-18T09:59:00+09:00' }),
-      makeKeeper({ name: 'middle', last_heartbeat: '2026-04-18T09:00:00+09:00' }),
-    ]
-    const picked = pickActiveKeepers(keepers, 3)
-    expect(picked.map(k => k.name)).toEqual(['new', 'middle', 'old'])
-  })
-
-  it('deprioritizes paused keepers even with recent heartbeat', () => {
-    const keepers: Keeper[] = [
-      makeKeeper({
-        name: 'paused-recent',
-        paused: true,
-        last_heartbeat: '2026-04-18T09:59:00+09:00',
-      }),
-      makeKeeper({ name: 'active-older', last_heartbeat: '2026-04-18T08:00:00+09:00' }),
-    ]
-    const picked = pickActiveKeepers(keepers, 2)
-    expect(picked[0]?.name).toBe('active-older')
-  })
-
-  it('deprioritizes phase-paused keepers even when the paused flag is absent', () => {
-    const keepers: Keeper[] = [
-      makeKeeper({
-        name: 'phase-paused-recent',
-        status: 'offline',
-        phase: 'Paused',
-        pipeline_stage: 'paused',
-        last_heartbeat: '2026-04-18T09:59:00+09:00',
-      }),
-      makeKeeper({ name: 'active-older', status: 'busy', last_heartbeat: '2026-04-18T08:00:00+09:00' }),
-    ]
-    const picked = pickActiveKeepers(keepers, 2)
-    expect(picked[0]?.name).toBe('active-older')
-  })
-
-  it('respects max parameter', () => {
-    const keepers: Keeper[] = Array.from({ length: 5 }, (_, i) =>
-      makeKeeper({ name: `k${i}`, last_heartbeat: `2026-04-18T0${i}:00:00+09:00` }),
-    )
-    expect(pickActiveKeepers(keepers, 2)).toHaveLength(2)
-  })
-})
-
-describe('deriveFleetTickerEvents', () => {
-  it('combines recent task, message, board, and keeper events in newest-first order', () => {
-    const events = deriveFleetTickerEvents({
-      taskList: [makeTask({ id: 'task-old', title: 'Old task', updated_at: localIsoAt(1), status: 'in_progress' })],
-      messageList: [makeMessage({ id: 'msg-new', from: 'sangsu', content: 'new message', timestamp: localIsoAt(4) })],
-      boardPostList: [makeBoardPost({ id: 'post-mid', title: 'Board post', updated_at: localIsoAt(3), created_at: localIsoAt(2) })],
-      keeperList: [makeKeeper({ name: 'keeper-mid', last_heartbeat: localIsoAt(2), status: 'active' })],
-    })
-
-    expect(events.map(event => event.id)).toEqual([
-      'message:msg-new',
-      'board:post-mid',
-      'keeper:keeper-mid',
-      'task:task-old',
-    ])
-  })
-
-  it('drops events without valid timestamps or readable text', () => {
-    const events = deriveFleetTickerEvents({
-      taskList: [makeTask({ id: 'bad-task', title: 'Bad', updated_at: 'not-a-date' })],
-      messageList: [makeMessage({ id: 'blank-message', content: '   ', timestamp: localIsoAt(4) })],
-      boardPostList: [makeBoardPost({ id: 'blank-post', title: '', body: '', content: '', updated_at: localIsoAt(3) })],
-      keeperList: [makeKeeper({ name: 'no-heartbeat' })],
-    })
-
-    expect(events).toEqual([])
-  })
-
-  it('uses trimmed board content fallback when title or author is whitespace', () => {
-    const events = deriveFleetTickerEvents({
-      taskList: [],
-      messageList: [],
-      boardPostList: [
-        makeBoardPost({
-          id: 'post-whitespace-title',
-          author: '   ',
-          title: '   ',
-          content: '  usable content  ',
-          body: 'body fallback',
-          updated_at: localIsoAt(3),
-        }),
-      ],
-      keeperList: [],
-    })
-
-    expect(events).toHaveLength(1)
-    expect(events[0]?.id).toBe('board:post-whitespace-title')
-    expect(events[0]?.actor).toBe('board')
-    expect(events[0]?.text).toBe('usable content')
-  })
-
-  it('limits output and maps operational tones', () => {
-    const events = deriveFleetTickerEvents({
-      max: 2,
-      taskList: [
-        makeTask({ id: 'done', title: 'Done task', updated_at: localIsoAt(4), status: 'done' }),
-        makeTask({ id: 'verify', title: 'Verify task', updated_at: localIsoAt(3), status: 'awaiting_verification' }),
-        makeTask({ id: 'cancelled', title: 'Cancelled task', updated_at: localIsoAt(2), status: 'cancelled' }),
-      ],
-      messageList: [],
-      boardPostList: [],
-      keeperList: [],
-    })
-
-    expect(events).toHaveLength(2)
-    expect(events.map(event => event.id)).toEqual(['task:done', 'task:verify'])
-    expect(events.map(event => event.tone)).toEqual(['ok', 'warn'])
-  })
-
-  it('uses keeper pause truth for heartbeat ticker text and tone', () => {
-    const events = deriveFleetTickerEvents({
-      taskList: [],
-      messageList: [],
-      boardPostList: [],
-      keeperList: [
-        makeKeeper({
-          name: 'sangsu',
-          status: 'offline',
-          phase: 'Paused',
-          pipeline_stage: 'paused',
-          last_heartbeat: localIsoAt(4),
-          agent: { exists: true, status: 'busy' },
-        }),
-      ],
-    })
-
-    expect(events).toHaveLength(1)
-    expect(events[0]?.text).toBe('Paused')
-    expect(events[0]?.tone).toBe('warn')
-  })
-})
-
-describe('severityToneClass', () => {
-  it.each<[string | null | undefined, string]>([
-    ['critical', 'text-destructive'],
-    ['HIGH', 'text-destructive'],
-    ['warn', 'text-warning'],
-    ['medium', 'text-warning'],
-    ['info', 'text-text-tertiary'],
-    ['', 'text-text-tertiary'],
-    [null, 'text-text-tertiary'],
-    [undefined, 'text-text-tertiary'],
-  ])('maps severity %s to expected tone', (input, expected) => {
-    expect(severityToneClass(input)).toBe(expected)
-  })
-})
-
-// ─── Alert Panel helpers ──────────────────────────────────────────────────────
-
-function makeAgent(partial: Partial<Agent> = {}): Agent {
-  return { name: 'agent-1', current_task: null, ...partial }
-}
-
-describe('deriveAgentAlerts', () => {
-  it('returns empty array when no agents', () => {
-    expect(deriveAgentAlerts([])).toEqual([])
-  })
-
-  it('returns empty array when all agents are healthy', () => {
-    const agents: Agent[] = [
-      makeAgent({ name: 'a1', status: 'active' }),
-      makeAgent({ name: 'a2', status: 'busy' }),
-      makeAgent({ name: 'a3', status: 'idle' }),
-    ]
-    expect(deriveAgentAlerts(agents)).toHaveLength(0)
-  })
-
-  it('returns critical alert for offline agent', () => {
-    const alerts = deriveAgentAlerts([makeAgent({ name: 'a1', status: 'offline' })])
-    expect(alerts).toHaveLength(1)
-    expect(alerts[0]!.severity).toBe('critical')
-    expect(alerts[0]!.name).toBe('a1')
-    expect(alerts[0]!.reason).toBe('Offline')
-  })
-
-  it('returns critical alert for inactive agent', () => {
-    const alerts = deriveAgentAlerts([makeAgent({ name: 'a1', status: 'inactive' })])
-    expect(alerts).toHaveLength(1)
-    expect(alerts[0]!.severity).toBe('critical')
-    expect(alerts[0]!.reason).toBe('Inactive')
-  })
-
-  it('uses koreanName as display when available', () => {
-    const alerts = deriveAgentAlerts([makeAgent({ name: 'a1', status: 'offline', koreanName: '수호자' })])
-    expect(alerts[0]!.display).toBe('수호자')
-  })
-
-  it('falls back to name when koreanName is empty', () => {
-    const alerts = deriveAgentAlerts([makeAgent({ name: 'a1', status: 'offline', koreanName: '' })])
-    expect(alerts[0]!.display).toBe('a1')
-  })
-
-  it('returns multiple alerts for multiple failing agents', () => {
-    const agents: Agent[] = [
-      makeAgent({ name: 'a1', status: 'offline' }),
-      makeAgent({ name: 'a2', status: 'inactive' }),
-      makeAgent({ name: 'a3', status: 'active' }),
-    ]
-    expect(deriveAgentAlerts(agents)).toHaveLength(2)
-  })
-})
-
-describe('deriveTaskAlerts', () => {
-  const NOW = new Date('2026-04-18T12:00:00Z').getTime()
-  const STALE_UPDATED = new Date('2026-04-18T11:00:00Z').toISOString() // 60 min ago → stale
-  const FRESH_UPDATED = new Date('2026-04-18T11:55:00Z').toISOString() // 5 min ago → not stale
-
-  it('returns empty array when no tasks', () => {
-    expect(deriveTaskAlerts([], NOW)).toEqual([])
-  })
-
-  it('returns empty array when no awaiting_verification tasks', () => {
-    const tasks: Task[] = [makeTask({ status: 'in_progress' }), makeTask({ status: 'done' })]
-    expect(deriveTaskAlerts(tasks, NOW)).toHaveLength(0)
-  })
-
-  it('returns warn alert for stale awaiting_verification task', () => {
-    const tasks: Task[] = [makeTask({ id: 't1', status: 'awaiting_verification', updated_at: STALE_UPDATED })]
-    const alerts = deriveTaskAlerts(tasks, NOW)
-    expect(alerts).toHaveLength(1)
-    expect(alerts[0]!.severity).toBe('warn')
-    expect(alerts[0]!.status).toBe('awaiting_verification')
-  })
-
-  it('does not alert for recently updated awaiting_verification task', () => {
-    const tasks: Task[] = [makeTask({ id: 't1', status: 'awaiting_verification', updated_at: FRESH_UPDATED })]
-    expect(deriveTaskAlerts(tasks, NOW)).toHaveLength(0)
-  })
-
-  it('treats missing updated_at as stale', () => {
-    const tasks: Task[] = [makeTask({ id: 't1', status: 'awaiting_verification' })]
-    const alerts = deriveTaskAlerts(tasks, NOW)
-    expect(alerts).toHaveLength(1)
-  })
-
-  it('treats invalid updated_at as stale', () => {
-    const tasks: Task[] = [
-      makeTask({ id: 't1', status: 'awaiting_verification', updated_at: 'not-a-date' }),
-    ]
-    const alerts = deriveTaskAlerts(tasks, NOW)
-    expect(alerts).toHaveLength(1)
-  })
-
-  it('returns task id and title in alert', () => {
-    const tasks: Task[] = [makeTask({ id: 't99', title: 'Fix bug', status: 'awaiting_verification', updated_at: STALE_UPDATED })]
-    const alerts = deriveTaskAlerts(tasks, NOW)
-    expect(alerts[0]!.id).toBe('t99')
-    expect(alerts[0]!.title).toBe('Fix bug')
-  })
-
-  it('returns assignee in alert when present', () => {
-    const tasks: Task[] = [makeTask({ id: 't1', status: 'awaiting_verification', updated_at: STALE_UPDATED, assignee: 'agent-x' })]
-    expect(deriveTaskAlerts(tasks, NOW)[0]!.assignee).toBe('agent-x')
-  })
-})
 
 describe('deriveKeeperAttentionReason', () => {
   it('returns default warn reason when keeper has no attention signal', () => {
@@ -601,67 +157,23 @@ describe('pickAttentionKeepers', () => {
 
 describe('computeOverviewStats', () => {
   it('returns zeroed stats when empty', () => {
-    expect(computeOverviewStats([], [])).toEqual({
+    expect(computeOverviewStats([])).toEqual({
       run: 0,
       att: 0,
       hot: 0,
-      avgCtx: 0,
-      tasks: 0,
-      traces: 0,
       total: 0,
     })
   })
 
   it('counts running keepers and context pressure', () => {
     const keepers = [
-      makeKeeper({ name: 'a', status: 'active', context_ratio: 0.9, total_turns: 10 }),
-      makeKeeper({ name: 'b', status: 'offline', context_ratio: 0.5, total_turns: 5 }),
+      makeKeeper({ name: 'a', status: 'active', context_ratio: 0.9 }),
+      makeKeeper({ name: 'b', status: 'offline', context_ratio: 0.5 }),
     ]
-    const stats = computeOverviewStats(keepers, [])
+    const stats = computeOverviewStats(keepers)
     expect(stats.run).toBe(1)
     expect(stats.total).toBe(2)
     expect(stats.hot).toBe(1)
-    expect(stats.traces).toBe(15)
-  })
-
-  it('counts tasks assigned to keepers', () => {
-    const keepers = [makeKeeper({ name: 'a' })]
-    const taskList = [
-      makeTask({ id: 't1', assignee: 'a' }),
-      makeTask({ id: 't2', assignee: 'a' }),
-      makeTask({ id: 't3', assignee: 'other' }),
-    ]
-    expect(computeOverviewStats(keepers, taskList).tasks).toBe(2)
-  })
-
-  it('computes average context of running keepers', () => {
-    const keepers = [
-      makeKeeper({ name: 'a', status: 'active', context_ratio: 0.8 }),
-      makeKeeper({ name: 'b', status: 'active', context_ratio: 0.6 }),
-    ]
-    expect(computeOverviewStats(keepers, []).avgCtx).toBe(70)
-  })
-})
-
-describe('keeperRuntimeLabel', () => {
-  it('uses the shared runtime display priority', () => {
-    expect(keeperRuntimeLabel(makeKeeper({
-      runtime_canonical: 'oas.primary',
-      selected_runtime_canonical: 'oas.secondary',
-      runtime_id: 'legacy.runtime',
-    }))).toBe('oas.primary')
-  })
-
-  it('does not expose raw keeper model fields as runtime labels', () => {
-    expect(keeperRuntimeLabel(makeKeeper({
-      active_model_label: 'deepseek-v4-flash',
-      active_model: 'claude-sonnet-4',
-      model: 'fallback',
-    }))).toBe('')
-  })
-
-  it('returns an empty string when no runtime field is present', () => {
-    expect(keeperRuntimeLabel(makeKeeper({}))).toBe('')
   })
 })
 
@@ -825,6 +337,16 @@ function makeFusionRun(partial: Partial<FusionRunRecord>): FusionRunRecord {
   }
 }
 
+function queueItem(overrides: Partial<KeeperApprovalQueueItem> = {}): KeeperApprovalQueueItem {
+  return {
+    id: 'q-1',
+    keeper_name: 'sangsu',
+    tool_name: 'fs_write',
+    risk_level: 'low',
+    ...overrides,
+  }
+}
+
 describe('computeOverviewDigest', () => {
   it('returns zeroed digest with no data', () => {
     const digest = computeOverviewDigest([], [], [])
@@ -832,63 +354,62 @@ describe('computeOverviewDigest', () => {
     expect(digest.approvalsCritical).toBe(false)
     expect(digest.topGoals).toEqual([])
     expect(digest.topGoalLabel).toBeNull()
+    expect(digest.topGoalPriority).toBeNull()
     expect(digest.fusionRunning).toBe(0)
     expect(digest.fusionDone).toBe(0)
     expect(digest.fusionTotal).toBe(0)
     expect(digest.fusionLatest).toBeNull()
   })
 
-  it('counts operator-awaiting keepers as open approvals', () => {
-    const digest = computeOverviewDigest(
-      [
-        makeKeeper({ name: 'gate', runtime_blocker_continue_gate: true }),
-        makeKeeper({ name: 'op', runtime_blocker_class: 'awaiting_operator' }),
-        makeKeeper({ name: 'fine' }),
-      ],
-      [],
-      [],
-    )
+  it('counts the governance approval queue as open approvals', () => {
+    const digest = computeOverviewDigest([], [], [queueItem({ id: 'a' }), queueItem({ id: 'b' })])
     expect(digest.openApprovals).toBe(2)
     expect(digest.approvalsCritical).toBe(false)
   })
 
-  it('flags approvals critical when a keeper is in a bad runtime state', () => {
-    const digest = computeOverviewDigest(
-      [makeKeeper({ name: 'dead', lifecycle_phase: 'Dead', runtime_blocker_class: 'exception' })],
-      [],
-      [],
-    )
+  it('flags approvals critical when any queued item sits in the bad risk band', () => {
+    const digest = computeOverviewDigest([], [], [queueItem({ id: 'a', risk_level: 'critical' })])
     expect(digest.approvalsCritical).toBe(true)
   })
 
-  it('orders top goals by priority and labels the leader by due date', () => {
+  it('orders top ACTIVE goals by priority and labels the leader by title', () => {
     const digest = computeOverviewDigest(
-      [],
       [
         makeGoal({ id: 'low', priority: 2 }),
-        makeGoal({ id: 'lead', priority: 9, due_date: '2026-07-01' }),
+        makeGoal({ id: 'lead', priority: 9, title: '핵심 목표' }),
         makeGoal({ id: 'mid', priority: 5 }),
       ],
       [],
+      [],
     )
     expect(digest.topGoals.map(g => g.id)).toEqual(['lead', 'mid', 'low'])
-    expect(digest.topGoalLabel).toBe('2026-07-01')
+    expect(digest.topGoalLabel).toBe('핵심 목표')
+    expect(digest.topGoalPriority).toBe(9)
   })
 
-  it('falls back to priority label when the leader has no due date', () => {
-    const digest = computeOverviewDigest([], [makeGoal({ id: 'lead', priority: 8, due_date: null })], [])
-    expect(digest.topGoalLabel).toBe('P8')
+  it('excludes dropped/done goals from the top-goal slot even at higher priority', () => {
+    const digest = computeOverviewDigest(
+      [
+        makeGoal({ id: 'dropped-high', priority: 9, status: 'dropped', title: '취소된 목표' }),
+        makeGoal({ id: 'active-lead', priority: 7, status: 'active', title: '활성 목표' }),
+      ],
+      [],
+      [],
+    )
+    expect(digest.topGoals.map(g => g.id)).toEqual(['active-lead'])
+    expect(digest.topGoalLabel).toBe('활성 목표')
+    expect(digest.topGoalPriority).toBe(7)
   })
 
   it('summarizes fusion runs by status and picks the newest as latest', () => {
     const digest = computeOverviewDigest(
-      [],
       [],
       [
         makeFusionRun({ runId: 'older', status: 'completed', startedAt: 100 }),
         makeFusionRun({ runId: 'newest', status: 'running', startedAt: 300 }),
         makeFusionRun({ runId: 'mid', status: 'running', startedAt: 200 }),
       ],
+      [],
     )
     expect(digest.fusionRunning).toBe(2)
     expect(digest.fusionDone).toBe(1)
@@ -1012,5 +533,150 @@ describe('Overview prototype surface', () => {
     } finally {
       keepers.value = previousKeepers
     }
+  })
+})
+
+// ─── KPI/domain card wiring from live payloads (masc campaign #43) ────────────
+//
+// governanceData/goals/boardTotal are real store signals — Overview's own
+// render tree never fetches them (app.ts does, at boot, outside this test),
+// so tests seed the signal directly. Gate connectors are the one signal
+// Overview itself fetches (see loadOverviewConnectors), so that case mocks
+// fetchGateConnectors and drives the real effect via waitFor instead.
+
+function gateConnector(overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo {
+  return {
+    connector_id: 'discord',
+    display_name: 'Discord',
+    connected: true,
+    available: true,
+    ...overrides,
+  } as GateConnectorInfo
+}
+
+function gateConnectorsData(connectors: GateConnectorInfo[]): GateConnectorsData {
+  return {
+    connectors,
+    total: connectors.length,
+    active_count: connectors.filter(c => c.connected).length,
+    discord_trigger_policy: 'mention',
+    generated_at: '2026-07-11T00:00:00Z',
+  }
+}
+
+function scheduledRequest(overrides: Partial<DashboardScheduledAutomationRequest> = {}): DashboardScheduledAutomationRequest {
+  return {
+    schedule_id: 's-1',
+    status: 'pending_approval',
+    risk_class: 'low',
+    approval_required: true,
+    source: 'keeper',
+    ...overrides,
+  }
+}
+
+function scheduledAutomation(requests: DashboardScheduledAutomationRequest[]): DashboardScheduledAutomation {
+  return {
+    request_count: requests.length,
+    request_limit: 100,
+    truncated: false,
+    counts: {},
+    fsm: { state: 'idle', active_count: 0, terminal_count: 0 },
+    requests,
+  }
+}
+
+function governanceResponse(approvalQueue: KeeperApprovalQueueItem[]): DashboardGovernanceResponse {
+  return { approval_queue: approvalQueue }
+}
+
+describe('Overview KPI + domain card wiring (live payloads)', () => {
+  afterEach(() => {
+    cleanup()
+    governanceResource.reset(null)
+    keepers.value = []
+    goals.value = []
+    boardTotal.value = null
+    mockedToolsData.value = null
+    mockFetchGateConnectors.mockClear()
+  })
+
+  it('renders 열린 승인 KPI + 승인 큐 card from governanceData.approval_queue, not keeper blocker flags', () => {
+    governanceResource.state.value = {
+      data: governanceResponse([
+        queueItem({ id: 'a', risk_level: 'low' }),
+        queueItem({ id: 'b', risk_level: 'critical' }),
+      ]),
+      loading: false,
+      error: null,
+    }
+    // A keeper in a critical runtime state must NOT move this KPI any more —
+    // it is no longer a keeper-blocker projection (the bug this PR fixes).
+    keepers.value = [makeKeeper({ name: 'dead', lifecycle_phase: 'Dead', runtime_blocker_class: 'exception' })]
+
+    const { container } = render(h(Overview, null))
+
+    const kpi = container.querySelector('[data-testid="kpi-approvals"] .ov-kpi-v')
+    expect(kpi?.firstChild?.textContent).toBe('2')
+    expect(kpi?.classList.contains('bad')).toBe(true)
+    const card = container.querySelector('[data-testid="domain-approvals"] .ov-dcount')
+    expect(card?.textContent).toBe('2')
+  })
+
+  it('renders 최우선 목표 KPI as the top ACTIVE goal title + priority, excluding dropped goals', () => {
+    goals.value = [
+      makeGoal({ id: 'dropped', priority: 9, status: 'dropped', title: '취소된 목표' }),
+      makeGoal({ id: 'lead', priority: 7, status: 'active', title: '핵심 목표' }),
+    ]
+
+    const { container } = render(h(Overview, null))
+
+    const kpi = container.querySelector('[data-testid="kpi-top-goal"] .ov-kpi-v')
+    expect(kpi?.firstChild?.textContent).toBe('핵심 목표')
+    expect(kpi?.querySelector('small')?.textContent).toBe('P7')
+  })
+
+  it('renders 보드 domain card from the boardTotal store signal, not the client post array length', () => {
+    boardTotal.value = 42
+
+    const { container } = render(h(Overview, null))
+
+    const card = container.querySelector('[data-testid="domain-board"] .ov-stat-row .v')
+    expect(card?.textContent).toBe('42')
+  })
+
+  it('renders 활성 커넥터 KPI + 커넥터 domain card from the live gate connectors payload', async () => {
+    mockFetchGateConnectors.mockResolvedValueOnce(gateConnectorsData([
+      gateConnector({ connector_id: 'discord', display_name: 'Discord', connected: true }),
+      gateConnector({ connector_id: 'slack', display_name: 'Slack', connected: false }),
+    ]))
+
+    const { container } = render(h(Overview, null))
+
+    await waitFor(() => {
+      const kpi = container.querySelector('[data-testid="kpi-connectors"] .ov-kpi-v')
+      expect(kpi?.firstChild?.textContent).toBe('1')
+    })
+    const card = container.querySelector('[data-testid="domain-connectors"]')
+    expect(card?.querySelectorAll('.ov-mini-row')).toHaveLength(2)
+    expect(card?.textContent).toContain('Discord')
+    expect(card?.textContent).toContain('Slack')
+  })
+
+  it('renders 예약 승인 KPI + 예약·자동화 card from the scheduled-automation projection', () => {
+    mockedToolsData.value = {
+      scheduled_automation: scheduledAutomation([
+        scheduledRequest({ schedule_id: 's-1', status: 'pending_approval' }),
+        scheduledRequest({ schedule_id: 's-2', status: 'scheduled' }),
+      ]),
+    }
+
+    const { container } = render(h(Overview, null))
+
+    const kpi = container.querySelector('[data-testid="kpi-schedule"] .ov-kpi-v')
+    expect(kpi?.firstChild?.textContent).toBe('1')
+    const card = container.querySelector('[data-testid="domain-schedule"]')
+    expect(card?.textContent).toContain('승인 대기 1건')
+    expect(card?.textContent).toContain('2')
   })
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1,38 +1,31 @@
 // MASC Dashboard — Overview (slim home)
 //
-// "What's the party doing today?" in one glance, no scroll.
-// 5 sections, top-to-bottom (V2):
-//   0. Alert Panel     — failing agents and stalled tasks, actionable alerts first
-//   1. (Removed: Highlight moved to Lab)
-//   2. Funnel          — 5 task-count cells (new/active/verify/done/target)
-//   3. Mission party   — one active session (goal, members, progress bar, blocker)
-//   4. Keeper strip    — top three keepers by recent heartbeat
+// "What's the party doing today?" in one glance, no scroll. Rendered sections,
+// top-to-bottom:
+//   - Header       — namespace, keeper count, operator, live clock
+//   - KPI strip    — running / attention / open approvals / top goal /
+//                    active connectors / pending schedule approvals / fusion runs
+//   - Attention    — keepers flagged for operator attention with reason + action
+//   - Telemetry    — deterministic 28-bar trace histogram
+//   - Domain cards — work/approvals/schedule/fusion/board/connectors/fleet summary
 //
-// Keeper-v2 port additions:
-//   - Header surface  — namespace, keeper count, operator, live clock
-//   - KPI strip       — running / attention / context pressure / avg ctx / tasks / traces
-//   - Attention queue — keepers flagged for operator attention with reason + action
-//   - Telemetry bars  — deterministic 28-bar trace histogram
-//   - Keeper fleet    — full keeper grid with status, runtime, context meter
+// Every KPI/card reads its owning domain's projection directly (governance
+// approval queue, gate connectors, scheduled-automation, fusion runs, board
+// total) rather than a parallel derivation — see computeOverviewDigest and the
+// per-panel resources below.
 
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { AgentAvatar } from './agent-avatar'
-import { tasks, keepers, boardPosts, goals, fusionRuns } from '../../store'
-import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
+import { keepers, boardTotal, goals, fusionRuns } from '../../store'
+import type { Keeper, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type { FusionRunRecord } from '../../api/dashboard'
-import { SYSTEM_ACTOR_NAME } from '../../types/core'
-import type {
-  DashboardMissionResponse,
-  DashboardMissionSessionCard,
-} from '../../types/dashboard-mission'
+import type { KeeperApprovalQueueItem } from '../../types/governance'
 import { useNowSecondsTicker } from '../../lib/now-signal'
-import { keeperDisplayRuntime, keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
-import { isKeeperPaused } from '../../lib/keeper-predicates'
+import { keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
 import { attentionReasonLabel, nextHumanActionLabel } from '../../lib/keeper-attention-labels'
-import { isAgentOffline } from '../../lib/agent-status'
 import { keeperRowLooksRunning } from '../../runtime-counts'
-import { createAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
+import { createAsyncResource, createManagedAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
 import { navigate } from '../../router'
 import type { TabId } from '../../types/sse'
 import {
@@ -44,6 +37,12 @@ import {
 import {
   OVERVIEW_TELEMETRY_EVENTS_PER_BUCKET,
 } from '../../config/constants'
+import { fetchGateConnectors, type GateConnectorsData } from '../../api/gate'
+import { governanceData } from '../governance-signals'
+import { keeperApprovalRiskVisualBand } from '../../lib/governance-risk-level'
+import { toolsData, toolsError } from '../tools/tool-state'
+import { scheduledPendingApprovalCount } from '../tools/scheduled-automation-panel'
+import type { DashboardScheduledAutomation } from '../../api'
 
 // ─── Attention / Keeper v2 helpers ───────────────────────────────────────────
 
@@ -138,56 +137,40 @@ export interface OverviewStats {
   run: number
   att: number
   hot: number
-  avgCtx: number
-  tasks: number
-  traces: number
   total: number
 }
 
-function keeperTraceCount(keeper: Keeper): number {
-  return keeper.total_turns ?? keeper.turn_count ?? keeper.autonomous_turn_count ?? 0
-}
-
-export function keeperRuntimeLabel(keeper: Keeper): string {
-  return keeperDisplayRuntime(keeper)?.value ?? ''
-}
-
-export function computeOverviewStats(keeperList: readonly Keeper[], taskList: readonly Task[]): OverviewStats {
+export function computeOverviewStats(keeperList: readonly Keeper[]): OverviewStats {
   const total = keeperList.length
   const run = keeperList.filter(keeperRowLooksRunning).length
   const att = pickAttentionKeepers(keeperList).length
   const hot = keeperList.filter(k => (k.context_ratio ?? 0) >= 0.85).length
-  const traces = keeperList.reduce((sum, k) => sum + keeperTraceCount(k), 0)
-
-  const keeperNames = new Set(keeperList.map(k => k.name.toLowerCase()))
-  const tasks = taskList.filter(t => t.assignee && keeperNames.has(t.assignee.toLowerCase())).length
-
-  const liveCtx = keeperList.filter(k => keeperRowLooksRunning(k) && typeof k.context_ratio === 'number')
-  const avgCtx = liveCtx.length
-    ? Math.round(liveCtx.reduce((sum, k) => sum + (k.context_ratio ?? 0), 0) / liveCtx.length * 100)
-    : 0
-
-  return { run, att, hot, avgCtx, tasks, traces, total }
+  return { run, att, hot, total }
 }
 
 // ─── Cross-surface digest (overview.jsx:71-92) ───────────────────────────────
 //
-// The prototype reads window.GOALS / APPROVALS / CONNECTORS / FUSION_RUNS etc.
-// from a mock. The live v2 dashboard exposes goals + fusion runs as signals, and
-// surfaces operator-awaiting keepers as the approval queue. Connectors and the
-// scheduled-automation queue have no live store on this surface yet, so their KPI
-// values render as "—" (em dash) rather than inventing data — see CLAUDE.md
-// "Unknown → Permissive Default": absence is shown as unknown, not as 0.
+// Every field reads its owning domain's live projection — the same source its
+// dedicated surface renders from — rather than a parallel derivation:
+//   - openApprovals/approvalsCritical: governanceData.approval_queue (the HITL
+//     queue the Approvals surface itself renders). Earlier this counted
+//     keeper runtime_blocker flags instead, an SSOT-violating projection that
+//     disagreed with the real queue.
+//   - topGoals/topGoalLabel: the `goals` store signal, filtered to active
+//     goals so dropped/done goals cannot occupy the "최우선 목표" slot.
+//   - fusion*: the `fusionRuns` store signal.
 
 export interface OverviewDigest {
-  /** Keepers blocked awaiting an operator decision (the approval queue). */
+  /** Pending HITL approvals — governanceData.approval_queue.length. */
   openApprovals: number
-  /** Whether any awaiting-operator keeper is in a critical (bad) state. */
+  /** True when any pending approval sits in the critical/bad risk band. */
   approvalsCritical: boolean
-  /** Top goals by priority (highest first), up to 3. */
+  /** Top ACTIVE goals by priority (highest first), up to 3. */
   topGoals: Goal[]
-  /** Most urgent goal label for the "최우선 목표" KPI, or null when none. */
+  /** Title of the top-priority active goal, or null when none is active. */
   topGoalLabel: string | null
+  /** Priority of the top-priority active goal (for the KPI's `sub` line). */
+  topGoalPriority: number | null
   /** Fusion runs currently executing. */
   fusionRunning: number
   /** Completed fusion runs (status === 'completed'). */
@@ -206,33 +189,33 @@ function goalPriorityClass(priority: number): 'high' | 'normal' | 'low' {
 }
 
 export function computeOverviewDigest(
-  keeperList: readonly Keeper[],
   goalList: readonly Goal[],
   fusionList: readonly FusionRunRecord[],
+  approvalQueue: readonly KeeperApprovalQueueItem[],
 ): OverviewDigest {
-  const awaiting = keeperList.filter(
-    k => k.runtime_blocker_continue_gate === true || hasOperatorAttentionBlocker(k.runtime_blocker_class),
-  )
-  const approvalsCritical = keeperList.some(
-    k => hasCriticalAttentionBlocker(k.runtime_blocker_class)
-      || k.lifecycle_phase === 'Dead'
-      || k.lifecycle_phase === 'Crashed',
+  const approvalsCritical = approvalQueue.some(
+    item => keeperApprovalRiskVisualBand(item.risk_level) === 'bad',
   )
 
-  // Highest priority first; ties keep input order (stable sort).
-  const topGoals = [...goalList].sort((a, b) => b.priority - a.priority).slice(0, 3)
+  // Active only — dropped/done goals must not occupy the "최우선 목표" slot or
+  // the 작업·목표 domain card's top-3. Highest priority first; ties keep input
+  // order (stable sort).
+  const activeGoals = goalList.filter(g => g.status === 'active')
+  const topGoals = [...activeGoals].sort((a, b) => b.priority - a.priority).slice(0, 3)
   const lead = topGoals[0] ?? null
-  const topGoalLabel = lead ? (lead.due_date ?? `P${lead.priority}`) : null
+  const topGoalLabel = lead ? lead.title : null
+  const topGoalPriority = lead ? lead.priority : null
 
   const fusionRunning = fusionList.filter(r => r.status === 'running').length
   const fusionDone = fusionList.filter(r => r.status === 'completed').length
   const fusionLatest = [...fusionList].sort((a, b) => b.startedAt - a.startedAt)[0] ?? null
 
   return {
-    openApprovals: awaiting.length,
+    openApprovals: approvalQueue.length,
     approvalsCritical,
     topGoals,
     topGoalLabel,
+    topGoalPriority,
     fusionRunning,
     fusionDone,
     fusionTotal: fusionList.length,
@@ -332,315 +315,6 @@ export function buildOverviewTelemetrySnapshot({
   }
 }
 
-// ─── Alert Panel ─────────────────────────────────────────────────────────────
-
-export interface AgentAlert {
-  name: string
-  display: string
-  reason: string
-  severity: 'critical' | 'warn'
-}
-
-export interface TaskAlert {
-  id: string
-  title: string
-  status: string
-  assignee: string | null
-  severity: 'critical' | 'warn'
-  task: Task
-}
-
-/** Derive a list of failing / offline agent alerts from the live agent list. */
-export function deriveAgentAlerts(agentList: readonly Agent[]): AgentAlert[] {
-  return agentList
-    .filter(a => isAgentOffline(a))
-    .map(a => ({
-      name: a.name,
-      display: a.koreanName && a.koreanName !== '' ? a.koreanName : a.name,
-      reason: a.status === 'offline' ? 'Offline' : 'Inactive',
-      severity: 'critical',
-    }))
-}
-
-/** Derive a list of stalled tasks or tasks needing attention. */
-export function deriveTaskAlerts(taskList: readonly Task[], nowMs: number): TaskAlert[] {
-  const STALL_THRESHOLD_MS = 10 * 60 * 1000
-  const alerts: TaskAlert[] = []
-  for (const t of taskList) {
-    if (t.status !== 'awaiting_verification') continue
-    const updated = parseIsoMs(t.updated_at)
-    if (updated !== null && nowMs - updated <= STALL_THRESHOLD_MS) continue
-    alerts.push({
-      id: t.id,
-      title: t.title,
-      status: 'awaiting_verification',
-      assignee: t.assignee ?? null,
-      severity: 'warn',
-      task: t,
-    })
-  }
-  return alerts
-}
-
-export function severityToneClass(severity?: string | null): string {
-  switch ((severity ?? '').toLowerCase()) {
-    case 'critical':
-    case 'high':
-      return 'text-destructive'
-    case 'warn':
-    case 'medium':
-      return 'text-warning'
-    default:
-      return 'text-text-tertiary'
-  }
-}
-
-// ─── Fleet ticker ───────────────────────────────────────────────────────────
-
-export type FleetTickerKind = 'task' | 'message' | 'board' | 'keeper'
-
-export interface FleetTickerEvent {
-  id: string
-  timestamp: string
-  timestampMs: number
-  actor: string
-  label: string
-  text: string
-  kind: FleetTickerKind
-  tone: 'ok' | 'warn' | 'err' | 'info' | 'idle'
-}
-
-function trimTickerText(text: string, max = 96): string {
-  const normalized = text.replace(/\s+/g, ' ').trim()
-  if (normalized.length <= max) return normalized
-  return `${normalized.slice(0, max - 3)}...`
-}
-
-function firstNonEmptyTrimmed(...values: Array<string | null | undefined>): string | null {
-  for (const value of values) {
-    if (typeof value !== 'string') continue
-    const trimmed = value.trim()
-    if (trimmed !== '') return trimmed
-  }
-  return null
-}
-
-function taskTickerTone(status?: Task['status']): FleetTickerEvent['tone'] {
-  switch (status) {
-    case 'done':
-      return 'ok'
-    case 'awaiting_verification':
-      return 'warn'
-    case 'cancelled':
-      return 'err'
-    case 'claimed':
-    case 'in_progress':
-      return 'info'
-    default:
-      return 'idle'
-  }
-}
-
-function keeperTickerTone(status?: string | null): FleetTickerEvent['tone'] {
-  switch ((status ?? '').toLowerCase()) {
-    case 'active':
-    case 'live':
-      return 'ok'
-    case 'busy':
-    case 'executing':
-      return 'info'
-    case 'offline':
-    case 'dead':
-    case 'stopped':
-    case 'unbooted':
-      return 'err'
-    case 'paused':
-    case 'inactive':
-      return 'warn'
-    default:
-      return 'idle'
-  }
-}
-
-function pushTickerEvent(out: FleetTickerEvent[], event: Omit<FleetTickerEvent, 'timestampMs'>) {
-  const timestampMs = parseIsoMs(event.timestamp)
-  if (timestampMs === null) return
-  const text = trimTickerText(event.text)
-  if (text === '') return
-  out.push({ ...event, timestampMs, text })
-}
-
-// Human-readable keeper status, used in the fleet ticker event text.
-function keeperStatusLabel(status?: string | null): string {
-  switch ((status ?? '').toLowerCase()) {
-    case 'active': case 'live': return 'Active'
-    case 'busy': case 'executing': return 'Busy'
-    case 'paused': return 'Paused'
-    case 'offline': return 'Offline'
-    case 'dead': return 'Dead'
-    case 'stopped': return 'Stopped'
-    case 'unbooted': return 'Unbooted'
-    default: return status ?? 'Unknown'
-  }
-}
-
-export function deriveFleetTickerEvents({
-  taskList,
-  messageList,
-  boardPostList,
-  keeperList,
-  max = 6,
-}: {
-  taskList: readonly Task[]
-  messageList: readonly Message[]
-  boardPostList: readonly BoardPost[]
-  keeperList: readonly Keeper[]
-  max?: number
-}): FleetTickerEvent[] {
-  const events: FleetTickerEvent[] = []
-  for (const task of taskList) {
-    const timestamp = task.updated_at ?? task.completed_at ?? task.created_at
-    if (!timestamp) continue
-    pushTickerEvent(events, {
-      id: `task:${task.id}`,
-      timestamp,
-      actor: task.assignee ?? 'unassigned',
-      label: task.status ?? '(unknown status)',
-      text: task.title,
-      kind: 'task',
-      tone: taskTickerTone(task.status),
-    })
-  }
-  for (const message of messageList) {
-    if (!message.timestamp) continue
-    pushTickerEvent(events, {
-      id: `message:${message.id ?? message.seq ?? message.timestamp}`,
-      timestamp: message.timestamp,
-      actor: message.from ?? SYSTEM_ACTOR_NAME,
-      label: message.type ?? '(unknown type)',
-      text: message.content,
-      kind: 'message',
-      tone: 'info',
-    })
-  }
-  for (const post of boardPostList) {
-    pushTickerEvent(events, {
-      id: `board:${post.id}`,
-      timestamp: post.updated_at || post.created_at,
-      actor: firstNonEmptyTrimmed(post.author) ?? 'board',
-      label: post.post_kind ?? '(unknown post_kind)',
-      text: firstNonEmptyTrimmed(post.title, post.content, post.body) ?? '',
-      kind: 'board',
-      tone: post.post_kind === 'system' ? 'warn' : 'info',
-    })
-  }
-  for (const keeper of keeperList) {
-    if (!keeper.last_heartbeat) continue
-    const displayStatus = keeperDisplayStatus(keeper)
-    pushTickerEvent(events, {
-      id: `keeper:${keeper.name}`,
-      timestamp: keeper.last_heartbeat,
-      actor: keeper.koreanName && keeper.koreanName !== '' ? keeper.koreanName : keeper.name,
-      label: 'heartbeat',
-      text: keeperStatusLabel(displayStatus),
-      kind: 'keeper',
-      tone: keeperTickerTone(displayStatus),
-    })
-  }
-  return events
-    .sort((a, b) => b.timestampMs - a.timestampMs)
-    .slice(0, Math.max(0, max))
-}
-
-// ─── Funnel ──────────────────────────────────────────────────────────────────
-
-export interface FunnelCounts {
-  created: number
-  inProgress: number
-  awaiting: number
-  completed: number
-  target: number | null
-}
-
-export function computeFunnelCounts(taskList: readonly Task[], active: DashboardMissionSessionCard | null, nowMs = Date.now()): FunnelCounts {
-  const todayMs = startOfTodayMs(nowMs)
-  let created = 0
-  let inProgress = 0
-  let awaiting = 0
-  let completed = 0
-  for (const t of taskList) {
-    const createdMs = parseIsoMs(t.created_at)
-    if (createdMs !== null && createdMs >= todayMs) created += 1
-    switch (t.status) {
-      case 'claimed':
-      case 'in_progress':
-        inProgress += 1
-        break
-      case 'awaiting_verification':
-        awaiting += 1
-        break
-      case 'done': {
-        const completedMs = parseIsoMs(t.completed_at)
-        if (completedMs !== null && completedMs >= todayMs) completed += 1
-        break
-      }
-    }
-  }
-  const target =
-    typeof active?.required_count === 'number' && active.required_count > 0
-      ? active.required_count
-      : null
-  return { created, inProgress, awaiting, completed, target }
-}
-
-function startOfTodayMs(nowMs: number): number {
-  const d = new Date(nowMs)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
-
-function parseIsoMs(iso: string | null | undefined): number | null {
-  if (iso === null || iso === undefined || iso === '') return null
-  const ms = Date.parse(iso)
-  return Number.isFinite(ms) ? ms : null
-}
-
-export function formatTargetRatio(counts: FunnelCounts): string {
-  if (counts.target === null) return String(counts.completed)
-  const pct = Math.min(100, Math.round((counts.completed / counts.target) * 100))
-  return `${counts.completed}/${counts.target} (${pct}%)`
-}
-
-// ─── Mission Party ────────────────────────────────────────────────────────────
-
-export function progressPct(session: DashboardMissionSessionCard | null): number | null {
-  if (!session) return null
-  const req = session.required_count ?? 0
-  if (req <= 0) return null
-  const cur = session.seen_count ?? session.active_count ?? 0
-  return Math.min(100, Math.round((cur / req) * 100))
-}
-
-// ─── Keeper Strip ────────────────────────────────────────────────────────────
-
-export function pickActiveKeepers(keeperList: readonly Keeper[], max = 3): Keeper[] {
-  return [...keeperList]
-    .sort((a, b) => {
-      const tsA = parseIsoMs(a.last_heartbeat) ?? 0
-      const tsB = parseIsoMs(b.last_heartbeat) ?? 0
-      const pausedA = isKeeperPaused(a) ? -1e15 : 0
-      const pausedB = isKeeperPaused(b) ? -1e15 : 0
-      return tsB + pausedB - (tsA + pausedA)
-    })
-    .slice(0, max)
-}
-
-export function pickActiveSession(snap: DashboardMissionResponse | null): DashboardMissionSessionCard | null {
-  if (snap === null) return null
-  const running = snap.sessions.find(s => s.status === 'running' || s.status === 'active' || s.status === 'busy')
-  return running ?? snap.sessions[0] ?? null
-}
-
 // ─── Surface Readiness Summary ───────────────────────────────────────────────
 
 const overviewTelemetryResource: AsyncResource<OverviewTelemetrySnapshot> = createAsyncResource()
@@ -664,6 +338,18 @@ function loadOverviewTelemetry(nowMs = Date.now()): Promise<void> {
       truncated: telemetry.truncated ?? false,
     })
   })
+}
+
+// ─── Gate connectors (활성 커넥터 KPI + 커넥터 domain card) ───────────────────────
+//
+// Managed (stale-while-revalidate): the previously loaded connector list stays
+// visible while a periodic refetch is in flight, matching the governance/tools
+// resources this surface also reads from.
+
+const overviewConnectorsResource = createManagedAsyncResource<GateConnectorsData>()
+
+function loadOverviewConnectors(): Promise<GateConnectorsData | undefined> {
+  return overviewConnectorsResource.load(signal => fetchGateConnectors(signal))
 }
 
 // ─── Keeper-v2 overview surfaces ─────────────────────────────────────────────
@@ -733,15 +419,25 @@ function OverviewKpi({
 
 // Cross-surface KPI row — overview.jsx:106-114. Seven cells, each a deep link into
 // its surface. Labels and `sub` separators are copied verbatim from the prototype.
-function OverviewKpiStrip({ stats, digest }: { stats: OverviewStats; digest: OverviewDigest }) {
+function OverviewKpiStrip({
+  stats,
+  digest,
+  connectorsData,
+  scheduledPending,
+}: {
+  stats: OverviewStats
+  digest: OverviewDigest
+  connectorsData: GateConnectorsData | null
+  scheduledPending: number
+}) {
   return html`
     <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
       <${OverviewKpi} label="실행 중 keeper" value=${String(stats.run)} sub=${` / ${stats.total}`} tone="ok" testId="kpi-run" onClick=${() => navigate('monitoring')} />
       <${OverviewKpi} label="주의 필요" value=${String(stats.att)} tone=${stats.att > 0 ? 'bad' : undefined} testId="kpi-att" onClick=${() => navigate('monitoring')} />
       <${OverviewKpi} label="열린 승인" value=${String(digest.openApprovals)} tone=${digest.approvalsCritical ? 'bad' : digest.openApprovals > 0 ? 'warn' : undefined} testId="kpi-approvals" onClick=${() => navigate('approvals')} />
-      <${OverviewKpi} label="최우선 목표" value=${digest.topGoalLabel ?? '—'} tone="volt" testId="kpi-top-goal" onClick=${() => navigate('workspace', { section: 'work' })} />
-      <${OverviewKpi} label="활성 커넥터" value="—" testId="kpi-connectors" onClick=${() => navigate('connectors')} />
-      <${OverviewKpi} label="예약 승인" value="—" testId="kpi-schedule" onClick=${() => navigate('schedule')} />
+      <${OverviewKpi} label="최우선 목표" value=${digest.topGoalLabel ?? '—'} sub=${digest.topGoalPriority !== null ? `P${digest.topGoalPriority}` : undefined} tone="volt" testId="kpi-top-goal" onClick=${() => navigate('workspace', { section: 'work' })} />
+      <${OverviewKpi} label="활성 커넥터" value=${connectorsData ? String(connectorsData.active_count) : '—'} sub=${connectorsData ? ` / ${connectorsData.connectors.length}` : undefined} testId="kpi-connectors" onClick=${() => navigate('connectors')} />
+      <${OverviewKpi} label="예약 승인" value=${String(scheduledPending)} tone=${scheduledPending > 0 ? 'warn' : undefined} testId="kpi-schedule" onClick=${() => navigate('schedule')} />
       <${OverviewKpi} label="진행 심의" value=${String(digest.fusionRunning)} sub=${digest.fusionDone > 0 ? ` · 완료 ${digest.fusionDone}` : undefined} tone=${digest.fusionRunning > 0 ? 'volt' : undefined} testId="kpi-fusion" onClick=${() => navigate('fusion')} />
     </section>
   `
@@ -922,9 +618,19 @@ function DomainCard({
 function OverviewDomainSection({
   stats,
   digest,
+  connectorsData,
+  connectorsError,
+  automation,
+  automationError,
+  scheduledPending,
 }: {
   stats: OverviewStats
   digest: OverviewDigest
+  connectorsData: GateConnectorsData | null
+  connectorsError: string | null
+  automation: DashboardScheduledAutomation | null
+  automationError: string | null
+  scheduledPending: number
 }) {
   return html`
     <h2 class="ov-section-h v2-overview-section-h" data-testid="overview-domains-header">도메인 현황</h2>
@@ -969,10 +675,18 @@ function OverviewDomainSection({
         </div>
       <//>
 
-      <!-- SCHEDULE · overview.jsx:201-215 (no live schedule store yet) -->
+      <!-- SCHEDULE · overview.jsx:201-215 -->
       <${DomainCard} title="예약 · 자동화" linkLabel="예약" nav=${{ tab: 'schedule' }} testId="domain-schedule">
         <div class="ov-mini-list">
-          <div class="ov-mini-empty ov-empty">예약 데이터 미연결</div>
+          ${automation
+            ? html`
+                <div class="ov-mini-row">
+                  <span class="inline-block size-1.5 rounded-full ${scheduledPending > 0 ? 'bg-warning' : 'bg-ok'}"></span>
+                  <span class="ov-mini-txt">${scheduledPending > 0 ? `승인 대기 ${scheduledPending}건` : '승인 대기 없음'}</span>
+                </div>
+                <div class="ov-stat-row"><span class="k">전체 예약</span><span class="v mono">${(automation.requests ?? []).length}</span></div>
+              `
+            : html`<div class="ov-mini-empty ov-empty">${automationError ? `예약 로드 실패: ${automationError}` : '예약 데이터 로드 중'}</div>`}
         </div>
       <//>
 
@@ -1004,13 +718,29 @@ function OverviewDomainSection({
 
       <!-- BOARD · overview.jsx:233-237 -->
       <${DomainCard} title="보드" linkLabel="보드" nav=${{ tab: 'board' }} testId="domain-board">
-        <div class="ov-stat-row"><span class="k">전체 포스트</span><span class="v mono">${boardPosts.value.length}</span></div>
+        <div class="ov-stat-row"><span class="k">전체 포스트</span><span class="v mono">${boardTotal.value !== null ? boardTotal.value : '—'}</span></div>
       <//>
 
-      <!-- CONNECTORS · overview.jsx:240-249 (no live connector store yet) -->
-      <${DomainCard} title="커넥터" linkLabel="커넥터" nav=${{ tab: 'connectors' }} testId="domain-connectors">
+      <!-- CONNECTORS · overview.jsx:240-249 -->
+      <${DomainCard}
+        title="커넥터"
+        count=${connectorsData ? String(connectorsData.active_count) : undefined}
+        tone=${connectorsData ? (connectorsData.active_count > 0 ? 'ok' : 'warn') : undefined}
+        linkLabel="커넥터"
+        nav=${{ tab: 'connectors' }}
+        testId="domain-connectors"
+      >
         <div class="ov-mini-list">
-          <div class="ov-mini-empty ov-empty">커넥터 데이터 미연결</div>
+          ${connectorsData
+            ? connectorsData.connectors.length > 0
+              ? connectorsData.connectors.map(c => html`
+                  <div class="ov-mini-row" key=${c.connector_id}>
+                    <span class="inline-block size-1.5 rounded-full ${c.connected ? 'bg-ok' : 'bg-warning'}"></span>
+                    <span class="ov-mini-txt">${c.display_name}</span>
+                  </div>
+                `)
+              : html`<div class="ov-mini-empty ov-empty">등록된 커넥터 없음</div>`
+            : html`<div class="ov-mini-empty ov-empty">${connectorsError ? `커넥터 로드 실패: ${connectorsError}` : '커넥터 로드 중'}</div>`}
         </div>
       <//>
 
@@ -1039,27 +769,48 @@ export function Overview() {
     }, 60_000)
     return () => window.clearInterval(interval)
   }, [])
-  const taskList = tasks.value
+  // Gate connectors have no global boot-time fetch (unlike governance/tools
+  // below, which app.ts already loads at startup) — this is the only signal
+  // on this surface that needs its own fetch trigger.
+  useEffect(() => {
+    void loadOverviewConnectors()
+    const interval = window.setInterval(() => {
+      void loadOverviewConnectors()
+    }, 60_000)
+    return () => window.clearInterval(interval)
+  }, [])
   const keeperList = keepers.value
   const goalList = goals.value
   const fusionList = fusionRuns.value
-  const stats = useMemo(() => computeOverviewStats(keeperList, taskList), [keeperList, taskList])
+  const approvalQueue = governanceData.value?.approval_queue ?? []
+  const stats = useMemo(() => computeOverviewStats(keeperList), [keeperList])
   const digest = useMemo(
-    () => computeOverviewDigest(keeperList, goalList, fusionList),
-    [keeperList, goalList, fusionList],
+    () => computeOverviewDigest(goalList, fusionList, approvalQueue),
+    [goalList, fusionList, approvalQueue],
   )
   const telemetry = overviewTelemetryResource.state.value
+  const connectors = overviewConnectorsResource.state.value
+  const automation = toolsData.value?.scheduled_automation ?? null
+  const scheduledPending = scheduledPendingApprovalCount(automation)
 
   return html`
     <main class="ov v2-overview-surface ss-surface text-text-primary" data-testid="overview-surface">
       <div class="ov-scroll v2-overview-scroll">
         <${OverviewHeader} />
-        <${OverviewKpiStrip} stats=${stats} digest=${digest} />
+        <${OverviewKpiStrip} stats=${stats} digest=${digest} connectorsData=${connectors.data} scheduledPending=${scheduledPending} />
         <div class="ov-grid v2-overview-primary-grid" data-testid="overview-primary-grid">
           <${OverviewAttentionPanel} keeperList=${keeperList} />
           <${OverviewTelemetry} telemetry=${telemetry} />
         </div>
-        <${OverviewDomainSection} stats=${stats} digest=${digest} />
+        <${OverviewDomainSection}
+          stats=${stats}
+          digest=${digest}
+          connectorsData=${connectors.data}
+          connectorsError=${connectors.error}
+          automation=${automation}
+          automationError=${toolsError.value}
+          scheduledPending=${scheduledPending}
+        />
       </div>
     </main>
   `

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -46,9 +46,14 @@ vi.mock('./keeper-runtime', () => ({
   refreshActiveKeeperChatHistory: vi.fn(),
 }))
 
+vi.mock('./components/governance-refresh', () => ({
+  refreshGovernance: vi.fn(),
+}))
+
 import { refreshFeatureHealth } from './components/feature-health'
 import { refreshObservatorySurface } from './components/observatory/observatory'
 import { refreshActiveKeeperChatHistory } from './keeper-runtime'
+import { refreshGovernance } from './components/governance-refresh'
 import { refreshServerConfig } from './components/server-config'
 import { refreshSurfaceReadiness } from './components/surface-readiness-panel'
 import { refreshForRoute, refreshPlanForRoute } from './tab-refresh'
@@ -59,11 +64,11 @@ describe('refreshPlanForRoute', () => {
     vi.clearAllMocks()
   })
 
-  it('hydrates overview from project snapshot and mission snapshot', () => {
+  it('hydrates overview from project snapshot, mission snapshot, fusion runs, and governance', () => {
     expect(refreshPlanForRoute({
       tab: 'overview',
       params: {},
-    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution'])
+    })).toEqual(['shell', 'namespaceTruth', 'missionSnapshot', 'execution', 'fusionRuns', 'governance'])
   })
 
   it('hydrates the top-level keepers workspace from live execution state', () => {
@@ -245,6 +250,18 @@ describe('refreshPlanForRoute', () => {
     })
 
     expect(refreshExecution).toHaveBeenCalledWith({ immediate: true })
+  })
+
+  it('refreshes fusion runs and governance on overview navigation', async () => {
+    refreshForRoute({
+      tab: 'overview',
+      params: {},
+    })
+
+    expect(refreshFusionRuns).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(refreshGovernance).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('uses the scheduler-backed execution refresh path on monitoring navigation', () => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -42,6 +42,11 @@ async function refreshActiveKeeperChatSurface(): Promise<void> {
   refreshActiveKeeperChatHistory()
 }
 
+async function refreshGovernanceSurface(): Promise<void> {
+  const { refreshGovernance } = await import('./components/governance-refresh')
+  await refreshGovernance()
+}
+
 type RefreshTask =
   | 'shell'
   | 'namespaceTruth'
@@ -59,6 +64,7 @@ type RefreshTask =
   | 'operatorWorkspaceDigest'
   | 'fusionRuns'
   | 'activeKeeperChat'
+  | 'governance'
 
 // Monitor data ownership is partitioned by section. Two tiers:
 //   Tier 1 — visible lanes (agents / fleet-health / runtime / observatory)
@@ -74,7 +80,12 @@ const HIDDEN_DIAGNOSTIC_FALLBACK_PLAN: readonly RefreshTask[] = ['namespaceTruth
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
     case 'overview':
-      return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution']
+      // 'fusionRuns' and 'governance' feed the KPI strip + domain cards
+      // (진행 심의 / 열린 승인) that the overview surface renders unconditionally.
+      // Without them here those signals only populate after a Fusion/Approvals
+      // tab visit, so the default landing tab showed 0/empty regardless of the
+      // live fleet state (masc campaign #43).
+      return ['shell', 'namespaceTruth', 'missionSnapshot', 'execution', 'fusionRuns', 'governance']
     case 'keepers':
       // 'activeKeeperChat' re-hydrates the open conversation panel's transcript
       // (guard-respecting no-op when already loaded). It matters on SSE
@@ -186,6 +197,7 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
   operatorWorkspaceDigest: () => { void refreshOperatorWorkspaceDigest({ force: true }) },
   fusionRuns: () => { void refreshFusionRuns() },
   activeKeeperChat: () => { void refreshActiveKeeperChatSurface() },
+  governance: () => { void refreshGovernanceSurface() },
 }
 
 // --- Tab visit counter (localStorage-persisted) ---


### PR DESCRIPTION
## 목적 (캠페인 #43)

Overview 대시보드에서 "정보가 제대로 나오는 걸 본 적 없음"의 근본 수리. 진단(wf_e047f03f CONFIRMED): route refresh plan이 shell/namespace/mission/execution만 로드해 fusion/board 신호가 영구 공백 + KPI 2셀·domain 카드 2개가 라이브 endpoint가 있는데도 하드코딩 대시 + 렌더되지 않는 프로토타입 섹션 5개(~280줄).

## 배선 (실데이터)

- refresh plan에 `fusionRuns` + `governance` 태스크 추가 — 기본 랜딩 탭에서 즉시 채워짐
- 열린 승인 KPI/카드: Approvals 표면과 **같은 소스**(`governanceData.approval_queue`)로 교체 (keeper `runtime_blocker_*` 평행 투영 삭제 — critical keeper가 승인 KPI를 움직이던 오배선 회귀 가드 테스트 포함)
- 최우선 목표 KPI: active-status 필터 + `P{priority}` 표기
- 활성 커넥터 KPI/카드: `/api/v1/gate/connectors` stale-while-revalidate 리소스 신설
- 예약 승인: 기존 `scheduledPendingApprovalCount` 소비
- 보드 카드: Overview에서 항상 0이던 `boardPosts.length` → 기존 SSE/WS가 이미 쓰고 있었지만 **소비자가 0이던** `boardTotal` signal

## 삭제 (~280줄, rg 잔존참조 0 증명)

alert 패널/fleet ticker/funnel/mission party/keeper strip 프로토타입 5섹션 + `OverviewStats.tasks/traces/avgCtx`. 동명 함수 2건(keeper-workspace-shared, planning-panel)은 독립 구현임을 확인 후 보존.

## 브리프 이탈 (근거 있는 수정)

브리프의 "shell counts에 server-side board_total 추가" 제안은 전제 오류 — `/api/v1/dashboard/board`의 `total`은 한 페이지 초과 시 null(probe-fetch has_more, `server_dashboard_http.ml:125`). 서버 진짜 카운트(`Board_dispatch.stats()`) 노출은 board-domain 백엔드 변경이라 금지 범위 → 기존 `boardTotal` signal 소비로 대체(무위험, 단 세션 내 board 활동 전까지 "—" 표시 가능). **후속**: 서버측 cheap board count 노출.

## 검증

- tsc(noUnusedLocals 포함) + lint 클린 — 삭제 후 죽은 import 부재의 실증명
- 전체 스위트 8623/8624 (1건은 무관 order-dependent flake — 격리 실행 시 127/127), 변경 스코프 66/66 (오케스트레이터 재검증)
- #23994(standing grants) 조정점: approval_queue에서 `risk_level`/`.length`만 소비 — shape 확장에 내성

진단: workflow wf_e047f03f (캠페인 원장 masc#23925).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
