### PR TITLE
fix(dashboard): restore IDE metadata and v2 layout

### DIFF
--- a/dashboard/design-system/headless-core/keeper-line-ownership.ts
+++ b/dashboard/design-system/headless-core/keeper-line-ownership.ts
@@ -9,7 +9,7 @@
 
 import { kSlot, type AgentColorSlot } from './agent-presence'
 
-export type KeeperEditKind = 'edit' | 'create' | 'refactor' | 'revert'
+export type KeeperEditKind = 'edit' | 'create' | 'refactor' | 'revert' | 'observed'
 
 export interface KeeperEdit {
   readonly file_path: string

--- a/dashboard/src/components/ide/code-document-store.test.ts
+++ b/dashboard/src/components/ide/code-document-store.test.ts
@@ -83,4 +83,64 @@ describe('createCodeDocumentStore', () => {
       repoId: 'masc',
     })
   })
+
+  it('notifies metadata subscribers as region loading settles', async () => {
+    fetchIdeRegionsMock.mockResolvedValueOnce([])
+    const store = createCodeDocumentStore({
+      file_path: 'a.ts',
+      language: 'typescript',
+      content: 'export {}',
+    })
+    let calls = 0
+    const unsubscribe = store.subscribeRegions(() => {
+      calls += 1
+    })
+
+    await store.loadRegions('a.ts')
+
+    unsubscribe()
+    expect(calls).toBeGreaterThan(0)
+    expect(store.regionsLoading()).toBe(false)
+    expect(store.regionsState()).toBe('ready')
+  })
+
+  it('clears region metadata when a different file becomes active', async () => {
+    fetchIdeRegionsMock.mockResolvedValueOnce([{
+      file_path: 'a.ts',
+      line_start: 1,
+      line_end: 1,
+      keeper_id: 'sangsu',
+      source_type: 'tool_call',
+      source_tool_name: 'tool_edit_file',
+      source_turn: 1,
+      source_note: null,
+      timestamp_ms: 1,
+    }])
+    const store = createCodeDocumentStore({
+      file_path: 'a.ts',
+      language: 'typescript',
+      content: 'export {}',
+    })
+
+    await store.loadRegions('a.ts')
+    expect(store.regions()).toHaveLength(1)
+
+    store.load({ file_path: 'b.ts', language: 'typescript', content: 'export {}' })
+    expect(store.regions()).toEqual([])
+    expect(store.regionsState()).toBe('idle')
+  })
+
+  it('exposes region fetch failure instead of presenting an empty result as ready', async () => {
+    fetchIdeRegionsMock.mockRejectedValueOnce(new Error('regions offline'))
+    const store = createCodeDocumentStore({
+      file_path: 'a.ts',
+      language: 'typescript',
+      content: 'export {}',
+    })
+
+    await expect(store.loadRegions('a.ts')).rejects.toThrow('regions offline')
+
+    expect(store.regionsState()).toBe('error')
+    expect(store.regionsLoading()).toBe(false)
+  })
 })

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -18,6 +18,8 @@ export interface CodeDocumentSnapshot extends CodeDocumentSource {
   readonly lines: ReadonlyArray<CodeDocumentLine>
 }
 
+export type CodeDocumentRegionsState = 'idle' | 'loading' | 'ready' | 'error'
+
 export interface CodeDocumentStore {
   readonly load: (source: unknown) => boolean
   readonly document: () => CodeDocumentSnapshot
@@ -25,6 +27,8 @@ export interface CodeDocumentStore {
   readonly line: (lineNumber: number) => CodeDocumentLine | null
   readonly regions: () => ReadonlyArray<IdeCodeRegion>
   readonly regionsLoading: () => boolean
+  readonly regionsState: () => CodeDocumentRegionsState
+  readonly subscribeRegions: (listener: () => void) => () => void
   readonly loadRegions: (
     filePath: string,
     opts?: { keeper?: string; repoId?: string | null; signal?: AbortSignal },
@@ -47,11 +51,17 @@ export function createCodeDocumentStore(
   const initial = normalizeSource(initialSource, maxLines) ?? EMPTY_DOCUMENT
   const snapshot = signal<CodeDocumentSnapshot>(initial)
   const regionsSignal = signal<ReadonlyArray<IdeCodeRegion>>([])
-  const regionsLoadingSignal = signal<boolean>(false)
+  const regionsStateSignal = signal<CodeDocumentRegionsState>('idle')
+  let regionRequestId = 0
 
   const load = (source: unknown): boolean => {
     const next = normalizeSource(source, maxLines)
     if (!next) return false
+    if (next.file_path !== snapshot.peek().file_path) {
+      regionRequestId += 1
+      regionsSignal.value = []
+      regionsStateSignal.value = 'idle'
+    }
     snapshot.value = next
     return true
   }
@@ -60,13 +70,25 @@ export function createCodeDocumentStore(
     filePath: string,
     opts?: { keeper?: string; repoId?: string | null; signal?: AbortSignal },
   ): Promise<void> => {
-    regionsLoadingSignal.value = true
+    const requestId = regionRequestId + 1
+    regionRequestId = requestId
+    regionsStateSignal.value = 'loading'
     try {
       const fetched = await fetchIdeRegions(filePath, opts ?? {})
-      if (opts?.signal?.aborted) return
+      if (opts?.signal?.aborted || requestId !== regionRequestId) return
       regionsSignal.value = fetched
+      regionsStateSignal.value = 'ready'
+    } catch (error) {
+      if (!opts?.signal?.aborted && requestId === regionRequestId) {
+        regionsStateSignal.value = 'error'
+      }
+      throw error
     } finally {
-      regionsLoadingSignal.value = false
+      // A stale request must never clear the visible loading state of the
+      // newer file/request that superseded it.
+      if (requestId === regionRequestId && opts?.signal?.aborted) {
+        regionsStateSignal.value = 'idle'
+      }
     }
   }
 
@@ -87,7 +109,27 @@ export function createCodeDocumentStore(
     lines: () => snapshot.value.lines,
     line: lineNumber => snapshot.value.lines[lineNumber - 1] ?? null,
     regions: () => regionsSignal.value,
-    regionsLoading: () => regionsLoadingSignal.value,
+    regionsLoading: () => regionsStateSignal.value === 'loading',
+    regionsState: () => regionsStateSignal.value,
+    subscribeRegions: (listener: () => void) => {
+      // Preact Signals notify immediately on subscribe. Wait until both
+      // region-related signals have delivered that initial value, then expose
+      // later loading/data changes as one document-metadata subscription.
+      let initialNotifications = 2
+      const notify = (): void => {
+        if (initialNotifications > 0) {
+          initialNotifications -= 1
+          return
+        }
+        listener()
+      }
+      const unsubscribeRegions = regionsSignal.subscribe(notify)
+      const unsubscribeState = regionsStateSignal.subscribe(notify)
+      return () => {
+        unsubscribeRegions()
+        unsubscribeState()
+      }
+    },
     loadRegions,
     subscribe,
   }
@@ -135,4 +177,3 @@ function normalizeMaxLines(value: number | undefined): number {
   if (isPositiveSafeInteger(value)) return value
   return 5_000
 }
-

--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -28,6 +28,9 @@ interface OutputLine {
 
 interface ExecuteOutputDrawerProps {
   keeperName: string
+  /** Render the persistent IDE drawer without opening a live stream until the
+      operator explicitly requests terminal execution for the current route. */
+  readonly streamEnabled?: boolean
 }
 
 type ExecuteOutputStatus = 'idle' | 'streaming' | 'closed' | 'error'
@@ -238,7 +241,10 @@ function ExecuteOutputSummaryStrip({
   `
 }
 
-export function ExecuteOutputDrawer({ keeperName }: ExecuteOutputDrawerProps) {
+export function ExecuteOutputDrawer({
+  keeperName,
+  streamEnabled = true,
+}: ExecuteOutputDrawerProps) {
   const keeper = keeperName.trim()
   const [lines, setLines] = useState<OutputLine[]>([])
   const [status, setStatus] = useState<ExecuteOutputStatus>('idle')
@@ -263,6 +269,12 @@ export function ExecuteOutputDrawer({ keeperName }: ExecuteOutputDrawerProps) {
   }, [])
 
   useEffect(() => {
+    if (!streamEnabled) {
+      setLines([{ text: 'waiting for an active Execute output task', stream: 'meta' }])
+      setStatus('idle')
+      setTaskId(null)
+      return
+    }
     if (!keeper) {
       setLines([{ text: 'no keeper selected', stream: 'meta' }])
       setStatus('idle')
@@ -294,7 +306,7 @@ export function ExecuteOutputDrawer({ keeperName }: ExecuteOutputDrawerProps) {
     })
 
     return () => controller.abort()
-  }, [keeper])
+  }, [keeper, streamEnabled])
 
   useEffect(() => {
     if (prefersReducedMotion) return

--- a/dashboard/src/components/ide/ide-annotation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-annotation-rail.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
+import { IdeAnnotationRail } from './ide-annotation-rail'
+import { ideContextFocus } from './ide-state'
+
+afterEach(() => {
+  ideContextFocus.value = null
+})
+
+describe('IdeAnnotationRail', () => {
+  it('renders an empty state when the current file has no annotations', () => {
+    const container = document.createElement('div')
+    render(h(IdeAnnotationRail, { annotations: [] }), container)
+
+    expect(container.querySelector('[data-testid="ide-annotation-rail"]')?.textContent)
+      .toContain('no annotations for this file')
+  })
+
+  it('opens a file-addressable annotation context from its card', () => {
+    const container = document.createElement('div')
+    render(h(IdeAnnotationRail, {
+      annotations: [{
+        id: 'ann-1',
+        file_path: 'lib/scheduler/round.ml',
+        line_start: 94,
+        line_end: 94,
+        keeper_id: 'sangsu',
+        kind: 'Decision',
+        content: 'Move compact outside the round lock.',
+        goal_id: 'goal-1',
+        task_id: 'task-1',
+        board_post_id: null,
+        comment_id: null,
+        pr_id: '7741',
+        git_ref: 'main',
+        log_id: null,
+        session_id: null,
+        operation_id: null,
+        worker_run_id: null,
+        created_at_ms: 1,
+        updated_at_ms: 2,
+      }],
+    }), container)
+
+    expect(container.textContent).toContain('Move compact outside the round lock.')
+    expect(container.textContent).toContain('CTX 6')
+
+    fireEvent.click(container.querySelector<HTMLButtonElement>('.ide-annotation-rail-card-main')!)
+    expect(ideContextFocus.value).toMatchObject({
+      file_path: 'lib/scheduler/round.ml',
+      line: 94,
+      surface: 'Decision',
+      keeper_id: 'sangsu',
+    })
+  })
+})

--- a/dashboard/src/components/ide/ide-annotation-rail.ts
+++ b/dashboard/src/components/ide/ide-annotation-rail.ts
@@ -1,0 +1,100 @@
+import { html } from 'htm/preact'
+import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
+import { KeeperBadge } from '../keeper-badge'
+import { focusIdeContextAnchor } from './ide-state'
+import { routeLinksForContext } from './ide-context-lens'
+
+const EMPTY_ANNOTATIONS: ReadonlyArray<IdeAnnotation> = []
+
+const KIND_LABEL: Readonly<Record<IdeAnnotation['kind'], string>> = {
+  Comment: 'comment',
+  Decision: 'decision',
+  Question: 'question',
+  Bookmark: 'bookmark',
+}
+
+/**
+ * Compact, file-addressable annotation view for the IDE rail.  The reference
+ * IDE uses a dedicated annotation tab; keeping it separate from the broader
+ * keeper-work dashboard makes the editor's operational context scannable.
+ */
+export function IdeAnnotationRail({
+  annotations = EMPTY_ANNOTATIONS,
+}: {
+  readonly annotations?: ReadonlyArray<IdeAnnotation>
+}) {
+  return html`
+    <section
+      class="ide-annotation-rail"
+      data-testid="ide-annotation-rail"
+      aria-label="IDE annotations"
+    >
+      ${annotations.length === 0
+        ? html`<div class="ide-rail-empty">no annotations for this file</div>`
+        : html`
+          <ol class="ide-annotation-rail-list">
+            ${annotations.map(annotation => html`<${AnnotationRailCard} annotation=${annotation} />`)}
+          </ol>
+        `}
+    </section>
+  `
+}
+
+function AnnotationRailCard({ annotation }: { readonly annotation: IdeAnnotation }) {
+  const lineLabel = annotation.line_start === annotation.line_end
+    ? `L${annotation.line_start}`
+    : `L${annotation.line_start}-${annotation.line_end}`
+  const routeLinks = routeLinksForContext({
+    filePath: annotation.file_path,
+    line: annotation.line_start,
+    surface: annotation.kind,
+    label: annotation.content,
+    sourceId: `annotation:${annotation.id}`,
+    goalId: annotation.goal_id ?? undefined,
+    taskId: annotation.task_id ?? undefined,
+    boardPostId: annotation.board_post_id ?? undefined,
+    commentId: annotation.comment_id ?? undefined,
+    prId: annotation.pr_id ?? undefined,
+    gitRef: annotation.git_ref ?? undefined,
+    logId: annotation.log_id ?? undefined,
+    sessionId: annotation.session_id ?? undefined,
+    operationId: annotation.operation_id ?? undefined,
+    workerRunId: annotation.worker_run_id ?? undefined,
+    keeperId: annotation.keeper_id,
+  })
+  const focus = (): void => {
+    focusIdeContextAnchor({
+      file_path: annotation.file_path,
+      line: annotation.line_start,
+      surface: annotation.kind,
+      label: annotation.content,
+      source_id: `annotation:${annotation.id}`,
+      keeper_id: annotation.keeper_id,
+      route_links: routeLinks,
+    })
+  }
+
+  return html`
+    <li class="ide-annotation-rail-card">
+      <button
+        type="button"
+        class="ide-annotation-rail-card-main"
+        aria-label=${`Focus ${annotation.kind} annotation at ${annotation.file_path}:${annotation.line_start}`}
+        title=${`${annotation.file_path}:${lineLabel}`}
+        onClick=${focus}
+      >
+        <span class=${`ide-annotation-rail-kind is-${annotation.kind.toLowerCase()}`}>
+          ${KIND_LABEL[annotation.kind]}
+        </span>
+        <span class="ide-annotation-rail-line">${lineLabel}</span>
+        <span class="ide-annotation-rail-content">${annotation.content}</span>
+      </button>
+      <div class="ide-annotation-rail-meta">
+        <${KeeperBadge} id=${annotation.keeper_id} variant="sigil" size="sm" />
+        <span>${annotation.keeper_id}</span>
+        <span class="ide-annotation-rail-path">${annotation.file_path}</span>
+        ${routeLinks.length > 0 ? html`<span class="ide-annotation-rail-context">CTX ${routeLinks.length}</span>` : null}
+      </div>
+    </li>
+  `
+}

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -1,15 +1,47 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+const workspaceApiMocks = vi.hoisted(() => ({
+  fetchWorkspaceTree: vi.fn(),
+  fetchWorkspaceChildren: vi.fn(),
+  fetchWorkspaceFile: vi.fn(),
+  fetchGitBlame: vi.fn(),
+  fetchGitDiff: vi.fn(),
+}))
+const ideApiMocks = vi.hoisted(() => ({
+  fetchIdeAnnotations: vi.fn(),
+  fetchIdeRegions: vi.fn(),
+  ideScopeFromKeeperLane: vi.fn((keeperId: string | undefined) =>
+    keeperId ? { kind: 'keeper_lane' as const, keeperId } : null),
+}))
+
+vi.mock('../../api/repositories', () => ({
+  discoverRepositories: vi.fn().mockResolvedValue([]),
+  fetchRepositoriesList: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('../../api/workspace', () => workspaceApiMocks)
+vi.mock('../../api/ide', () => ideApiMocks)
+vi.mock('../../sse-store', () => ({
+  registerIdeWorkspaceRefresh: vi.fn(() => () => {}),
+}))
+
 import {
   clearWorkspaceFetchIssue,
+  createIdeDataWorkspaceStore,
   replaceWorkspaceFetchIssue,
   retainCurrentWorkspaceFetchIssues,
   sameWorkspaceTreeIdentity,
+  selectInitialIdeFilePath,
   selectPreferredIdeRepositoryId,
   workspaceFetchIssueFromError,
   workspaceTreeIdentity,
 } from './ide-data-workspace-store'
 import { isDiffEditorView, viewFromRoute } from './ide-view-route'
 import type { Repository } from '../../api/repositories'
+import { activeIdeFile } from './ide-state'
+import { activeKeeperName } from '../../keeper-state'
+import { selectedTask } from '../goals/task-detail-selection'
+import { route } from '../../router'
 
 function repo(
   id: string,
@@ -28,6 +60,18 @@ function repo(
     created_at: null,
     updated_at: null,
   }
+}
+
+function seedWorkspaceApiMocks(): void {
+  workspaceApiMocks.fetchWorkspaceTree.mockResolvedValue({
+    nodes: [],
+    source: { kind: 'project' },
+    basePath: null,
+  })
+  workspaceApiMocks.fetchWorkspaceChildren.mockResolvedValue([])
+  workspaceApiMocks.fetchGitBlame.mockResolvedValue([])
+  workspaceApiMocks.fetchGitDiff.mockResolvedValue([])
+  ideApiMocks.fetchIdeAnnotations.mockResolvedValue([])
 }
 
 describe('selectPreferredIdeRepositoryId', () => {
@@ -162,6 +206,79 @@ describe('selectPreferredIdeRepositoryId', () => {
 })
 
 describe('workspace fetch diagnostics', () => {
+  it('does not choose Finder metadata as the default editor file', () => {
+    expect(selectInitialIdeFilePath([
+      { path: '.DS_Store', hasChildren: false },
+      { path: 'lib/scheduler/round.ml', hasChildren: false },
+    ])).toBe('lib/scheduler/round.ml')
+  })
+
+  it('loads regions after the active file commits and projects them to source ownership', async () => {
+    const previousFile = activeIdeFile.value
+    const previousKeeper = activeKeeperName.value
+    const previousTask = selectedTask.value
+    const previousRoute = route.value
+    let resolveFile: (value: { ok: boolean; content: string; language: string }) => void = () => {
+      throw new Error('workspace file request was not started')
+    }
+
+    vi.clearAllMocks()
+    seedWorkspaceApiMocks()
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementationOnce(() => new Promise(resolve => {
+      resolveFile = resolve
+    }))
+    ideApiMocks.fetchIdeRegions.mockResolvedValueOnce([{
+      file_path: 'lib/scheduler/round.ml',
+      line_start: 2,
+      line_end: 3,
+      keeper_id: 'sangsu',
+      source_type: 'tool_call',
+      source_tool_name: 'edit_file',
+      source_turn: 7,
+      source_note: null,
+      timestamp_ms: 1_700_000_000_000,
+    }])
+    activeIdeFile.value = 'lib/scheduler/round.ml'
+    activeKeeperName.value = 'sangsu'
+    selectedTask.value = null
+    route.value = { tab: 'code', params: { view: 'source' }, postId: null }
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(workspaceApiMocks.fetchWorkspaceFile).toHaveBeenCalledOnce()
+      })
+      expect(ideApiMocks.fetchIdeRegions).not.toHaveBeenCalled()
+
+      resolveFile({ ok: true, content: 'let a = 1\nlet b = 2\n', language: 'ocaml' })
+
+      await vi.waitFor(() => {
+        expect(ideApiMocks.fetchIdeRegions).toHaveBeenCalledWith(
+          'lib/scheduler/round.ml',
+          expect.objectContaining({
+            repoId: null,
+            scope: { kind: 'keeper_lane', keeperId: 'sangsu' },
+          }),
+        )
+      })
+      await vi.waitFor(() => {
+        expect(store.ownershipStore.ownership().get(2)).toMatchObject({
+          keeper_id: 'sangsu',
+          last_edit_kind: 'observed',
+        })
+      })
+      expect(store.ownershipStore.ownership().get(3)).toMatchObject({
+        keeper_id: 'sangsu',
+      })
+    } finally {
+      store.dispose()
+      activeIdeFile.value = previousFile
+      activeKeeperName.value = previousKeeper
+      selectedTask.value = previousTask
+      route.value = previousRoute
+    }
+  })
+
   it('materializes failed fetches without stringly fallback coercion', () => {
     const issue = workspaceFetchIssueFromError('diff', new Error('network down'), {
       filePath: 'lib/runtime.ml',

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -31,7 +31,6 @@ import {
   replaceWorkspaceFetchIssue,
   retainCurrentWorkspaceFetchIssues,
   sameWorkspaceTreeIdentity,
-  selectInitialIdeFilePath,
   selectPreferredIdeRepositoryId,
   workspaceFetchIssueFromError,
   workspaceTreeIdentity,
@@ -206,13 +205,6 @@ describe('selectPreferredIdeRepositoryId', () => {
 })
 
 describe('workspace fetch diagnostics', () => {
-  it('does not choose Finder metadata as the default editor file', () => {
-    expect(selectInitialIdeFilePath([
-      { path: '.DS_Store', hasChildren: false },
-      { path: 'lib/scheduler/round.ml', hasChildren: false },
-    ])).toBe('lib/scheduler/round.ml')
-  })
-
   it('loads regions after the active file commits and projects them to source ownership', async () => {
     const previousFile = activeIdeFile.value
     const previousKeeper = activeKeeperName.value

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -102,14 +102,10 @@ export interface WorkspaceFetchIssueContext {
 
 type WorkspaceFetchIssueScope = Pick<WorkspaceFetchIssueContext, 'filePath' | 'keeper' | 'repoId'>
 
-export function selectInitialIdeFilePath(
+function firstFilePath(
   nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>,
 ): string | null {
-  // Finder metadata is a real workspace entry but never a useful first editor
-  // target. Prefer the first editable file while retaining a fallback for the
-  // unusual workspace that contains only metadata files.
-  const firstFile = nodes.find(node => !node.hasChildren && !node.path.endsWith('/.DS_Store') && node.path !== '.DS_Store')
-    ?? nodes.find(node => !node.hasChildren)
+  const firstFile = nodes.find(node => !node.hasChildren)
   return firstFile?.path ?? null
 }
 
@@ -428,7 +424,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
       const hasCurrentFile =
         filePath !== null && nodes.some(node => node.path === filePath && !node.hasChildren)
-      const nextFile = hasCurrentFile ? null : selectInitialIdeFilePath(nodes)
+      const nextFile = hasCurrentFile ? null : firstFilePath(nodes)
       if (nextFile && nextFile !== activeIdeFile.value) {
         activeIdeFile.value = nextFile
       }

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -34,6 +34,7 @@ import {
 } from './file-tree-store'
 import {
   fetchIdeAnnotations,
+  ideScopeFromKeeperLane,
   type IdeAnnotation,
 } from '../../api/ide'
 import { registerIdeWorkspaceRefresh } from '../../sse-store'
@@ -101,8 +102,14 @@ export interface WorkspaceFetchIssueContext {
 
 type WorkspaceFetchIssueScope = Pick<WorkspaceFetchIssueContext, 'filePath' | 'keeper' | 'repoId'>
 
-function firstFilePath(nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>): string | null {
-  const firstFile = nodes.find(node => !node.hasChildren)
+export function selectInitialIdeFilePath(
+  nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>,
+): string | null {
+  // Finder metadata is a real workspace entry but never a useful first editor
+  // target. Prefer the first editable file while retaining a fallback for the
+  // unusual workspace that contains only metadata files.
+  const firstFile = nodes.find(node => !node.hasChildren && !node.path.endsWith('/.DS_Store') && node.path !== '.DS_Store')
+    ?? nodes.find(node => !node.hasChildren)
   return firstFile?.path ?? null
 }
 
@@ -373,6 +380,17 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
     const keeperParam = keeper || undefined
     const opts = { keeper: keeperParam, repoId, signal, includeDiff: true }
+    // IDE observation routes require one explicit scope. Repository scope is
+    // authoritative when configured; otherwise a selected keeper can read its
+    // own orphan observation lane without fabricating a repository identity.
+    const ideOpts = repoId
+      ? { keeper: keeperParam, repoId, signal }
+      : {
+          keeper: keeperParam,
+          repoId,
+          scope: ideScopeFromKeeperLane(keeperParam),
+          signal,
+        }
     workspaceIssuesSignal.value = retainCurrentWorkspaceFetchIssues(currentWorkspaceIssues(), {
       filePath,
       keeper: keeperParam ?? null,
@@ -410,7 +428,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
       const hasCurrentFile =
         filePath !== null && nodes.some(node => node.path === filePath && !node.hasChildren)
-      const nextFile = hasCurrentFile ? null : firstFilePath(nodes)
+      const nextFile = hasCurrentFile ? null : selectInitialIdeFilePath(nodes)
       if (nextFile && nextFile !== activeIdeFile.value) {
         activeIdeFile.value = nextFile
       }
@@ -449,6 +467,35 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           return
         }
         clearIssue('file', { filePath, keeper: keeperParam ?? null, repoId })
+
+        // The document load invalidates metadata for a different file. Start
+        // the region read only after that load has committed; doing both in
+        // parallel let a slower file response mark a valid region response as
+        // stale before it could populate the ownership projection.
+        documentStore.loadRegions(filePath, ideOpts).then(() => {
+          if (signal.aborted || documentStore.document().file_path !== filePath) return
+          for (const region of documentStore.regions()) {
+            ownershipStore.ingest({
+              file_path: region.file_path,
+              line_start: region.line_start,
+              line_end: region.line_end,
+              keeper_id: region.keeper_id,
+              timestamp_ms: region.timestamp_ms,
+              // Regions prove that a keeper operated on this code range, but the
+              // wire contract deliberately does not infer a more specific edit
+              // operation such as create/refactor/revert.
+              kind: 'observed',
+            })
+          }
+          clearIssue('regions', { filePath, keeper: keeperParam ?? null, repoId })
+        }).catch(error => {
+          recordIssue('regions', error, {
+            filePath,
+            keeper: keeperParam ?? null,
+            repoId,
+            fallbackMessage: 'IDE regions fetch failed',
+          })
+        })
       } else {
         recordIssue('file', new Error('workspace file response was not available'), {
           filePath,
@@ -463,19 +510,6 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
         keeper: keeperParam ?? null,
         repoId,
         fallbackMessage: 'workspace file fetch failed',
-      })
-    })
-
-    // Load regions
-    documentStore.loadRegions(filePath, opts).then(() => {
-      if (signal.aborted) return
-      clearIssue('regions', { filePath, keeper: keeperParam ?? null, repoId })
-    }).catch(error => {
-      recordIssue('regions', error, {
-        filePath,
-        keeper: keeperParam ?? null,
-        repoId,
-        fallbackMessage: 'IDE regions fetch failed',
       })
     })
 
@@ -528,7 +562,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     }
 
     // Load annotations
-    fetchIdeAnnotations({ file_path: filePath, goal_id: task?.goal_id ?? undefined, task_id: task?.id ?? undefined }, opts).then(annotations => {
+    fetchIdeAnnotations({ file_path: filePath, goal_id: task?.goal_id ?? undefined, task_id: task?.id ?? undefined }, ideOpts).then(annotations => {
       if (signal.aborted) return
       clearIssue('annotations', { filePath, keeper: keeperParam ?? null, repoId })
       annotationsSignal.value = annotations

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -74,6 +74,40 @@ describe('IdeEditor', () => {
     })
   })
 
+  it('shows observed keeper ownership in Source view, not only Blame view', async () => {
+    const documentStore = createCodeDocumentStore({
+      file_path: 'runtime.ts',
+      language: 'typescript',
+      content: 'const runtime = 1\n',
+    })
+    const ownershipStore = createKeeperLineOwnershipStore('runtime.ts')
+    ownershipStore.ingest({
+      file_path: 'runtime.ts',
+      line_start: 1,
+      line_end: 1,
+      keeper_id: 'sangsu',
+      timestamp_ms: 1,
+      kind: 'observed',
+    })
+
+    render(
+      h(IdeEditor, {
+        documentStore,
+        ownershipStore,
+        diffRows: () => [],
+      }),
+      container,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.cm-blame-gutter')).not.toBeNull()
+      expect(container.querySelector('[data-testid="ide-observation-summary"]')?.textContent)
+        .toContain('metadata pending')
+    })
+    expect(container.querySelector('.ide-codemirror-shell')?.getAttribute('data-view'))
+      .toBe('source-ownership')
+  })
+
   it('finds current-file matches with case and whole-word options', () => {
     const documentStore = createCodeDocumentStore({
       file_path: 'runtime.ts',

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -101,6 +101,7 @@ export function IdeEditor({
   onAnnotationDelete,
 }: IdeEditorProps) {
   useStoreSubscription(documentStore.subscribe)
+  useStoreSubscription(documentStore.subscribeRegions)
   useStoreSubscription(ownershipStore.subscribe)
   useSignalValue(cursorOverlaySignal)
   useSignalValue(globalPresenceSnapshot)
@@ -131,6 +132,8 @@ export function IdeEditor({
   }
   const documentFilePath: string = document.file_path
   const lines = documentStore.lines()
+  const regions = documentStore.regions()
+  const regionsState = documentStore.regionsState()
   const ownership = ownershipStore.ownership()
   const keepers = ownershipStore.knownKeepers()
   const overlay = cursorOverlaySignal.value
@@ -149,6 +152,20 @@ export function IdeEditor({
     traceEvents: replayTraceEvents,
   })
   const gridTemplateRows = editorGridRows(activeLayerKinds.length > 0, findOpen)
+  const observationSummary = regionsState === 'loading'
+    ? 'metadata loading…'
+    : regionsState === 'error'
+      ? 'metadata unavailable'
+      : regionsState === 'idle'
+        ? 'metadata pending'
+        : `${regions.length} observed · ${ownership.size} owned · ${keepers.length} keepers`
+  const observationTitle = regionsState === 'loading'
+    ? 'Loading keeper-authored code-region metadata'
+    : regionsState === 'error'
+      ? 'Keeper code-region metadata could not be loaded; see the workspace diagnostics'
+      : regionsState === 'idle'
+        ? 'Keeper code-region metadata has not been requested for this file yet'
+        : `${regions.length} observed region(s), ${ownership.size} owned line(s), ${keepers.length} keeper(s)`
 
   return html`
     <div
@@ -185,8 +202,12 @@ export function IdeEditor({
         }}>${document.file_path}</span>
         <span style=${{ color: 'var(--color-fg-disabled)', flexShrink: 0 }}>${document.language}</span>
         <span style=${{ color: 'var(--color-accent-fg)', flexShrink: 0 }}>${VIEW_LABEL[activeView]}</span>
-        <span style=${{ marginLeft: 'auto', flexShrink: 0, whiteSpace: 'nowrap' }}>
-          ${lines.length} lines · ownership · ${keepers.length} keepers · ${activeLayerKinds.length} layers
+        <span
+          style=${{ marginLeft: 'auto', flexShrink: 0, whiteSpace: 'nowrap' }}
+          data-testid="ide-observation-summary"
+          title=${observationTitle}
+        >
+          ${lines.length} lines · ${observationSummary} · ${activeLayerKinds.length} layers
         </span>
         <${EditorCurrentFileSignals} signals=${currentFileSignals} />
         ${currentFileFocus ? html`
@@ -266,6 +287,7 @@ export function IdeEditor({
               documentStore=${documentStore}
               ownershipStore=${ownershipStore}
               showBlame=${activeView === 'blame'}
+              showOwnership=${ownership.size > 0}
               keepers=${keepers}
               onKeeperLineSelect=${onKeeperLineSelect}
               contextFocus=${currentFileFocus}
@@ -286,6 +308,7 @@ function CodeMirrorEditor({
   documentStore,
   ownershipStore,
   showBlame,
+  showOwnership,
   keepers,
   onKeeperLineSelect,
   annotations = [],
@@ -297,6 +320,7 @@ function CodeMirrorEditor({
   readonly documentStore: CodeDocumentStore
   readonly ownershipStore: KeeperLineOwnershipStore
   readonly showBlame: boolean
+  readonly showOwnership: boolean
   readonly keepers: ReadonlyArray<string>
   readonly onKeeperLineSelect?: (keeperId: string, line: number) => void
   readonly annotations?: ReadonlyArray<IdeAnnotation>
@@ -348,7 +372,7 @@ function CodeMirrorEditor({
       const lang = await languageExt(mountFilePath)
       if (destroyed) return
 
-      const blameExts = showBlame ? blameExtensions() : []
+      const blameExts = showOwnership ? blameExtensions() : []
       const state = EditorState.create({
         doc: documentStore.document().content,
         extensions: [
@@ -404,7 +428,7 @@ function CodeMirrorEditor({
       })
 
       editorRef.current = view
-      if (showBlame && ownership.size > 0) {
+      if (showOwnership && ownership.size > 0) {
         pushOwnership(view, ownership)
       }
       if (traceActive && traceLines.length > 0) {
@@ -421,7 +445,7 @@ function CodeMirrorEditor({
       editorRef.current = null
       setReady(false)
     }
-  }, [document.file_path, documentStore, ownershipStore, onKeeperLineSelect, showBlame, traceActive])
+  }, [document.file_path, documentStore, ownershipStore, onKeeperLineSelect, showOwnership, traceActive])
 
   // Push document updates. The first file response can arrive before
   // the CM6 instance is ready or before this component subscribes, so
@@ -440,9 +464,9 @@ function CodeMirrorEditor({
   // Push ownership updates
   useEffect(() => {
     const view = editorRef.current
-    if (!view || !ready || !showBlame) return
+    if (!view || !ready || !showOwnership) return
     pushOwnership(view, ownership)
-  }, [ownership, ready, showBlame])
+  }, [ownership, ready, showOwnership])
 
   useEffect(() => {
     const view = editorRef.current
@@ -498,7 +522,10 @@ function CodeMirrorEditor({
   useSignalValue(keeperTraceState)
 
   return html`
-    <div class="ide-codemirror-shell v2-ide-panel" data-view=${showBlame ? 'blame' : 'source'}>
+    <div
+      class="ide-codemirror-shell v2-ide-panel"
+      data-view=${showBlame ? 'blame' : showOwnership ? 'source-ownership' : 'source'}
+    >
       ${showBlame ? BlameTimeline(ownership, keepers) : null}
       <div ref=${containerRef} class="ide-codemirror-host" />
       ${selectedAnn && editorRef.current ? AnnotationPopover({

--- a/dashboard/src/components/ide/ide-interject.test.ts
+++ b/dashboard/src/components/ide/ide-interject.test.ts
@@ -85,6 +85,19 @@ describe('IdeInterject', () => {
     expect(buttons[2]?.getAttribute('aria-label')).toContain('Keeper-scoped pause')
   })
 
+  it('uses a compact chat entry point until the terminal-first shell expands it', async () => {
+    const container = document.createElement('div')
+    await act(async () => {
+      render(h(IdeInterject, { compact: true }), container)
+    })
+
+    expect(container.querySelector('[data-testid="ide-interject-fab"]')?.textContent).toBe('✦ Chat')
+    expect(container.querySelector('input')).toBeNull()
+
+    fireEvent.click(container.querySelector<HTMLButtonElement>('[data-testid="ide-interject-fab"]')!)
+    expect(container.querySelector('input')?.getAttribute('aria-label')).toBe('Interject input')
+  })
+
   it('enables Send after text is entered', async () => {
     const container = document.createElement('div')
     await act(async () => {
@@ -174,4 +187,3 @@ describe('IdeInterject', () => {
     expect(routeHashParams().get('q')).toBe('interject keeper:sangsu mode:reviewing tool:ocamllsp')
   })
 })
-

--- a/dashboard/src/components/ide/ide-interject.ts
+++ b/dashboard/src/components/ide/ide-interject.ts
@@ -31,6 +31,8 @@ async function dispatchInterject(request: InterjectDispatchRequest): Promise<voi
 
 interface IdeInterjectProps {
   readonly keeperName?: string | null
+  /** A terminal-first IDE keeps chat as a floating entry point until opened. */
+  readonly compact?: boolean
 }
 
 function resolveActiveKeeper(keeperName?: string | null): string {
@@ -38,7 +40,11 @@ function resolveActiveKeeper(keeperName?: string | null): string {
   return routeKeeper || activeKeeperName.value
 }
 
-export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({ keeperName = null }) => {
+export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({
+  keeperName = null,
+  compact = false,
+}) => {
+  const [expanded, setExpanded] = useState(false)
   const [interjectStore] = useState(() =>
     createInterjectStore({
       initialActiveKeeper: resolveActiveKeeper(keeperName),
@@ -89,9 +95,21 @@ export const IdeInterject: FunctionComponent<IdeInterjectProps> = ({ keeperName 
     : null
   const contextLinks = interjectContextRouteLinks(keeperId, cursor)
 
+  if (compact && !expanded) {
+    return html`
+      <button
+        type="button"
+        class="ide-interject-fab"
+        data-testid="ide-interject-fab"
+        aria-label="Open keeper chat"
+        onClick=${() => setExpanded(true)}
+      >✦ Chat</button>
+    `
+  }
+
   return html`
     <div
-      class="ide-interject-bar v2-ide-panel"
+      class=${`ide-interject-bar v2-ide-panel ${compact ? 'ide-interject-expanded' : ''}`}
       role="region"
       aria-label="INTERJECT (interject store active keeper wiring)"
       style=${{

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -2,12 +2,14 @@ import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { get } from '../../api/core'
+import { fetchIdePresence } from '../../api/ide'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
   disconnectedSnapshot,
   globalPresenceSnapshot,
   LOADING_SNAPSHOT,
+  normalizeKeeperPresenceSnapshot,
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
@@ -91,18 +93,30 @@ export function unwrapEnvelope<T>(raw: unknown): T | undefined {
 }
 
 async function fetchPresence(): Promise<KeeperPresenceSnapshot> {
-  try {
-    const [agentsRaw, statusRaw] = await Promise.all([
-      get<unknown>('/api/v1/agents?limit=20'),
-      get<unknown>('/api/v1/status'),
-    ])
+  const [idePresence, agentsResponse, statusResponse] = await Promise.allSettled([
+    fetchIdePresence(),
+    get<unknown>('/api/v1/agents?limit=20'),
+    get<unknown>('/api/v1/status'),
+  ])
+
+  // The IDE endpoint is the only source that has the runtime/branch and
+  // keeper-presence contract together. Prefer it when valid; the generic
+  // agents/status pair remains a compatibility fallback for older servers.
+  if (idePresence.status === 'fulfilled') {
+    const snapshot = normalizeKeeperPresenceSnapshot(idePresence.value)
+    if (snapshot !== null) return snapshot
+  }
+
+  if (agentsResponse.status === 'fulfilled' && statusResponse.status === 'fulfilled') {
+    const agentsRaw = agentsResponse.value
+    const statusRaw = statusResponse.value
     const agentsData = unwrapEnvelope<{ agents?: ApiAgent[] }>(agentsRaw)
     const statusData = unwrapEnvelope<ApiStatus>(statusRaw)
     const agents: ApiAgent[] = Array.isArray(agentsData?.agents) ? agentsData.agents : []
     return agentsToPresence(agents, statusData ?? {})
-  } catch {
-    return disconnectedSnapshot('fetch_failed')
   }
+
+  return disconnectedSnapshot('fetch_failed')
 }
 
 function presenceHeader(snap: KeeperPresenceSnapshot) {

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -198,7 +198,7 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
-    expect(container.textContent).toContain('EVENT TIMELINE')
+    expect(container.textContent).toContain('PERSISTENCE MAP')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Approve')
@@ -501,7 +501,6 @@ describe('IdeShell', () => {
     expect(chipLabels).toEqual([
       'SOURCE',
       'lib/runtime.ml',
-      'terminal',
       'PR L42 Runtime review',
       'Task task-runtime',
       'PR #15035',
@@ -914,7 +913,7 @@ describe('IdeShell', () => {
     expect(btn.getAttribute('aria-pressed')).toBe('false')
   })
 
-  it('uses the reference IDE activity rail and persistent terminal by default', () => {
+  it('preserves keeper context and chat while keeping the terminal drawer present', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
@@ -926,7 +925,9 @@ describe('IdeShell', () => {
     const rail = container.querySelector('[data-testid="ide-right-rail"]')
     expect(rail).not.toBeNull()
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
-    expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, 'Work Context').getAttribute('title'))
+      .toBe('Keeper work, persistence, memory, and chat scoped to the active IDE context')
     expect(buttonByText(container, '활동').getAttribute('title'))
       .toBe('Workspace and keeper activity linked to the active file and repository')
     expect(buttonByText(container, '어노테이션').getAttribute('title'))
@@ -935,9 +936,13 @@ describe('IdeShell', () => {
       .toBe('Live keeper file focus and cursor stream status')
     expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
       .toContain('Dashboard event transport')
-    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ide-primary-conversation-rail"]')).not.toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).toBeNull()
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
     expect(container.querySelector('[data-testid="execute-output-drawer"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="execute-output-drawer"]')?.textContent)
+      .toContain('waiting for Execute output')
     expect(container.querySelector('[data-testid="ide-interject-fab"]')).not.toBeNull()
   })
 
@@ -989,8 +994,14 @@ describe('IdeShell', () => {
       },
     }
 
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
+    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).not.toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+
+    fireEvent.click(buttonByText(container, '활동'))
     expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
     expect(container.querySelector('[data-testid="ide-annotation-rail"]')).toBeNull()
 
     fireEvent.click(buttonByText(container, '어노테이션'))

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -107,6 +107,8 @@ const dashboardFetchHandlers: ReadonlyArray<[
   [/\/api\/v1\/git\/diff/, () => jsonResponse({ unified: [] })],
   [/\/api\/v1\/ide\/regions/, () => jsonResponse({ ok: true, data: [] })],
   [/\/api\/v1\/ide\/annotations/, () => jsonResponse({ ok: true, data: [] })],
+  [/\/api\/v1\/activity\/events/, () => jsonResponse({ events: [] })],
+  [/\/api\/v1\/ide\/events/, () => jsonResponse({ ok: true, data: { events: [] } })],
   [/\/state-diagram/, () => jsonResponse({
     keeper: 'sangsu',
     current_phase: 'observe',
@@ -152,8 +154,12 @@ describe('IdeShell', () => {
     vi.stubGlobal('fetch', vi.fn(dashboardFetchMock))
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     render(null, container)
+    // Preact schedules effect disposal after the render call.  Let the
+    // activity rail clear its optional poll timer while the fetch mock is
+    // still installed, before restoring the real global fetch below.
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
     // IdeShell now shares an app-lifetime workspace-store singleton; dispose it
     // between tests (after unmount) so each test starts from a fresh store
     // instead of inheriting the previous test's tree/repo/diff state.
@@ -192,7 +198,7 @@ describe('IdeShell', () => {
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
-    expect(container.textContent).toContain('PERSISTENCE MAP')
+    expect(container.textContent).toContain('EVENT TIMELINE')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Approve')
@@ -908,7 +914,7 @@ describe('IdeShell', () => {
     expect(btn.getAttribute('aria-pressed')).toBe('false')
   })
 
-  it('keeps default right rail context diagnostics bounded above the primary conversation rail', () => {
+  it('uses the reference IDE activity rail and persistent terminal by default', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
@@ -918,21 +924,21 @@ describe('IdeShell', () => {
     render(h(IdeShell, {}), container)
 
     const rail = container.querySelector('[data-testid="ide-right-rail"]')
-    const contextStack = container.querySelector('[data-testid="ide-right-context-stack"]')
-    const primaryRail = container.querySelector('[data-testid="ide-primary-conversation-rail"]')
     expect(rail).not.toBeNull()
-    expect(contextStack).not.toBeNull()
-    expect(primaryRail).not.toBeNull()
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
-    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
-    expect(buttonByText(container, 'Run Activity').getAttribute('title'))
+    expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, '활동').getAttribute('title'))
       .toBe('Workspace and keeper activity linked to the active file and repository')
-    expect(buttonByText(container, 'Keeper Cursors').getAttribute('title'))
+    expect(buttonByText(container, '어노테이션').getAttribute('title'))
+      .toBe('File-addressable comments, decisions, questions, and bookmarks')
+    expect(buttonByText(container, '커서').getAttribute('title'))
       .toBe('Live keeper file focus and cursor stream status')
     expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
       .toContain('Dashboard event transport')
-    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
+    expect(container.querySelector('[data-testid="execute-output-drawer"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ide-interject-fab"]')).not.toBeNull()
   })
 
   it('switches the IDE right rail tabs and renders cursor stream focus', async () => {
@@ -983,15 +989,18 @@ describe('IdeShell', () => {
       },
     }
 
-    fireEvent.click(buttonByText(container, 'Run Activity'))
-    expect(buttonByText(container, 'Run Activity').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
-    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
+    expect(container.querySelector('[data-testid="ide-annotation-rail"]')).toBeNull()
 
-    fireEvent.click(buttonByText(container, 'Keeper Cursors'))
-    expect(buttonByText(container, 'Keeper Cursors').getAttribute('aria-selected')).toBe('true')
+    fireEvent.click(buttonByText(container, '어노테이션'))
+    expect(buttonByText(container, '어노테이션').getAttribute('aria-selected')).toBe('true')
     expect(container.querySelector('.ide-plane-activity')).toBeNull()
-    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
+    expect(container.querySelector('[data-testid="ide-annotation-rail"]')).not.toBeNull()
+
+    fireEvent.click(buttonByText(container, '커서'))
+    expect(buttonByText(container, '커서').getAttribute('aria-selected')).toBe('true')
+    expect(container.querySelector('[data-testid="ide-annotation-rail"]')).toBeNull()
     const cursorRail = container.querySelector('[data-testid="ide-cursor-rail"]')
     expect(cursorRail).not.toBeNull()
     expect(cursorRail?.textContent).toContain('KEEPER CURSORS')

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -13,9 +13,8 @@ import { parsePositiveLineString } from '../common/normalize'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
 import { IdeAnnotationComposer } from './ide-annotation-composer'
-import { IdeConversationRail } from './ide-conversation-rail'
 import { IdeActivityPanel } from './ide-activity-panel'
-import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
+import { IdeAnnotationRail } from './ide-annotation-rail'
 import { IdeInterject } from './ide-interject'
 import { ExecuteOutputDrawer } from './execute-output-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
@@ -29,8 +28,6 @@ import { IdeBreadcrumb } from './ide-breadcrumb'
 import { IdeReviewFocusStrip } from './ide-review-focus-strip'
 import { pinKeeper } from './multi-keeper-pin-store'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
-import { IdePersistencePanel } from './ide-persistence-panel'
-import { IdeMemoryPanel } from './ide-memory-panel'
 import { routeLinksForContext } from './ide-context-lens'
 import {
   connectKeeperCursorStream,
@@ -63,7 +60,7 @@ import { viewFromRoute } from './ide-view-route'
 
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
-type IdeRightRailTab = 'context' | 'activity' | 'cursors'
+type IdeRightRailTab = 'activity' | 'annotations' | 'cursors'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok' | 'warn'
 type IdeConnectionTone = 'ok' | 'warn'
 
@@ -114,18 +111,18 @@ const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
 }
 const IDE_RIGHT_RAIL_TABS: ReadonlyArray<IdeRightRailTabDescriptor> = [
   {
-    id: 'context',
-    label: 'Work Context',
-    title: 'Keeper work, persistence, memory, and chat scoped to the active IDE context',
-  },
-  {
     id: 'activity',
-    label: 'Run Activity',
+    label: '활동',
     title: 'Workspace and keeper activity linked to the active file and repository',
   },
   {
+    id: 'annotations',
+    label: '어노테이션',
+    title: 'File-addressable comments, decisions, questions, and bookmarks',
+  },
+  {
     id: 'cursors',
-    label: 'Keeper Cursors',
+    label: '커서',
     title: 'Live keeper file focus and cursor stream status',
   },
 ]
@@ -1035,10 +1032,13 @@ export function IdeShell() {
   const terminalOpen =
     route.value.params.terminal === 'open'
     || Boolean(route.value.params.keeper?.trim())
+  // The reference IDE keeps the drawer in the shell at all times. A route can
+  // still opt out explicitly, while only `terminal=open` starts live output.
+  const terminalVisible = route.value.params.terminal !== 'hidden'
   const findOpen = route.value.params.find === 'open'
   const terminalKeeper = keeperFromRoute()
   const railsCollapsed = route.value.params.rails === 'hidden'
-  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('context')
+  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('activity')
   const [treeWidth, setTreeWidth] = useState<number>(readStoredIdeTreeWidth)
   const statusbar = deriveIdeStatusbarModel({
     activeView,
@@ -1194,7 +1194,7 @@ export function IdeShell() {
       class="ide-plane-shell ide-v2-surface v2-ide-surface ss-surface bg-surface-page"
       role="region"
       aria-label="Code IDE shell"
-      data-terminal-open=${terminalOpen ? 'true' : 'false'}
+      data-terminal-open=${terminalVisible ? 'true' : 'false'}
       data-rails-collapsed=${railsCollapsed ? 'true' : 'false'}
       data-tree-width=${String(treeWidth)}
     >
@@ -1331,22 +1331,6 @@ export function IdeShell() {
                 `)}
               </div>
               <div class="ide-v2-rail-scroll">
-                ${rightRailTab === 'context' ? html`
-                  <div
-                    class="ide-plane-context-stack"
-                    data-testid="ide-right-context-stack"
-                  >
-                    <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
-                    <${IdePersistencePanel} keeperName=${terminalKeeper} />
-                    <${IdeMemoryPanel} keeperName=${terminalKeeper} repoId=${activeRepositoryId} />
-                  </div>
-                  <div
-                    class="ide-plane-primary-rail"
-                    data-testid="ide-primary-conversation-rail"
-                  >
-                    <${IdeConversationRail} />
-                  </div>
-                ` : null}
                 ${rightRailTab === 'activity' ? html`
                   <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
                     <${IdeActivityPanel}
@@ -1359,15 +1343,20 @@ export function IdeShell() {
                     />
                   </div>
                 ` : null}
+                ${rightRailTab === 'annotations' ? html`
+                  <div class="ide-plane-annotations" style=${{ minHeight: 0 }}>
+                    <${IdeAnnotationRail} annotations=${annotations} />
+                  </div>
+                ` : null}
                 ${rightRailTab === 'cursors' ? html`<${IdeCursorRailPanel} />` : null}
               </div>
             </div>
           `}
       </div>
-      ${terminalOpen
-        ? html`<${ExecuteOutputDrawer} keeperName=${terminalKeeper} />`
+      ${terminalVisible
+        ? html`<${ExecuteOutputDrawer} keeperName=${terminalKeeper} streamEnabled=${terminalOpen} />`
         : null}
-      <${IdeInterject} keeperName=${terminalKeeper} />
+      <${IdeInterject} keeperName=${terminalKeeper} compact=${terminalVisible} />
     </section>
   `
 }

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -13,8 +13,10 @@ import { parsePositiveLineString } from '../common/normalize'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
 import { IdeAnnotationComposer } from './ide-annotation-composer'
+import { IdeConversationRail } from './ide-conversation-rail'
 import { IdeActivityPanel } from './ide-activity-panel'
 import { IdeAnnotationRail } from './ide-annotation-rail'
+import { IdeKeeperWorkPanel } from './ide-keeper-work-panel'
 import { IdeInterject } from './ide-interject'
 import { ExecuteOutputDrawer } from './execute-output-drawer'
 import { IdePresenceStrip } from './ide-presence-strip'
@@ -28,6 +30,8 @@ import { IdeBreadcrumb } from './ide-breadcrumb'
 import { IdeReviewFocusStrip } from './ide-review-focus-strip'
 import { pinKeeper } from './multi-keeper-pin-store'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
+import { IdePersistencePanel } from './ide-persistence-panel'
+import { IdeMemoryPanel } from './ide-memory-panel'
 import { routeLinksForContext } from './ide-context-lens'
 import {
   connectKeeperCursorStream,
@@ -60,7 +64,7 @@ import { viewFromRoute } from './ide-view-route'
 
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
-type IdeRightRailTab = 'activity' | 'annotations' | 'cursors'
+type IdeRightRailTab = 'context' | 'activity' | 'annotations' | 'cursors'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok' | 'warn'
 type IdeConnectionTone = 'ok' | 'warn'
 
@@ -110,6 +114,11 @@ const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
   blame: 'BLAME',
 }
 const IDE_RIGHT_RAIL_TABS: ReadonlyArray<IdeRightRailTabDescriptor> = [
+  {
+    id: 'context',
+    label: 'Work Context',
+    title: 'Keeper work, persistence, memory, and chat scoped to the active IDE context',
+  },
   {
     id: 'activity',
     label: '활동',
@@ -1029,16 +1038,14 @@ export function IdeShell() {
   const lspStatus = useSignalValue(lspStatusSnapshot)
   const reviewFocusActive = activeFocus === 'review' && activeView === 'unified'
   const activeLayers = layersFromRoute(route.value.params.layers, reviewFocusActive ? activeFocus : null)
-  const terminalOpen =
-    route.value.params.terminal === 'open'
-    || Boolean(route.value.params.keeper?.trim())
+  const terminalOpen = route.value.params.terminal === 'open'
   // The reference IDE keeps the drawer in the shell at all times. A route can
   // still opt out explicitly, while only `terminal=open` starts live output.
   const terminalVisible = route.value.params.terminal !== 'hidden'
   const findOpen = route.value.params.find === 'open'
   const terminalKeeper = keeperFromRoute()
   const railsCollapsed = route.value.params.rails === 'hidden'
-  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('activity')
+  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('context')
   const [treeWidth, setTreeWidth] = useState<number>(readStoredIdeTreeWidth)
   const statusbar = deriveIdeStatusbarModel({
     activeView,
@@ -1331,6 +1338,22 @@ export function IdeShell() {
                 `)}
               </div>
               <div class="ide-v2-rail-scroll">
+                ${rightRailTab === 'context' ? html`
+                  <div
+                    class="ide-plane-context-stack"
+                    data-testid="ide-right-context-stack"
+                  >
+                    <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
+                    <${IdePersistencePanel} keeperName=${terminalKeeper} />
+                    <${IdeMemoryPanel} keeperName=${terminalKeeper} repoId=${activeRepositoryId} />
+                  </div>
+                  <div
+                    class="ide-plane-primary-rail"
+                    data-testid="ide-primary-conversation-rail"
+                  >
+                    <${IdeConversationRail} />
+                  </div>
+                ` : null}
                 ${rightRailTab === 'activity' ? html`
                   <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
                     <${IdeActivityPanel}

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -31,7 +31,7 @@ export function disconnectedSnapshot(reason: string): KeeperPresenceSnapshot {
 export const globalPresenceSnapshot = signal<KeeperPresenceSnapshot>(LOADING_SNAPSHOT)
 
 export function updateKeeperPresenceFromSSE(snapshot: unknown): boolean {
-  const normalized = normalizeSnapshot(snapshot)
+  const normalized = normalizeKeeperPresenceSnapshot(snapshot)
   if (normalized === null) return false
   globalPresenceSnapshot.value = normalized
   return true
@@ -86,7 +86,7 @@ export function createKeeperPresenceStore(
       snapshotSignal.value = withSortedEntries(snapshot)
       return true
     }
-    const normalized = normalizeSnapshot(snapshot)
+    const normalized = normalizeKeeperPresenceSnapshot(snapshot)
     if (normalized === null) return false
     snapshotSignal.value = normalized
     return true
@@ -131,7 +131,13 @@ function withSortedEntries(snap: KeeperPresenceSnapshot): KeeperPresenceSnapshot
   return { ...snap, entries: sorted }
 }
 
-function normalizeSnapshot(value: unknown): KeeperPresenceSnapshot | null {
+/**
+ * Parse the server-owned IDE presence payload.  Keeping this normalizer next
+ * to the store makes REST bootstrap and the SSE stream use the same contract
+ * instead of separately guessing which dashboard summary fields imply a
+ * keeper is present.
+ */
+export function normalizeKeeperPresenceSnapshot(value: unknown): KeeperPresenceSnapshot | null {
   if (!isRecord(value)) return null
   if (!hasNonEmptyStringField(value, 'runtime_id')) return null
   if (!Array.isArray(value.entries)) return null

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -12,6 +12,7 @@
 /* ── Surface shell ─────────────────────────────────────────────────────────── */
 
 .ide-v2-surface {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -378,6 +379,16 @@
   overflow: hidden;
 }
 
+/* The legacy IDE used this node as a two-row CSS grid (conversation over
+   activity).  The reference surface has one continuous activity rail, so make
+   the v2 modifier authoritative even when the legacy stylesheet is emitted
+   later by the CSS bundler. */
+.ide-v2-surface .ide-v2-rail.ide-plane-conversation {
+  display: flex;
+  flex-direction: column;
+  grid-template-rows: none;
+}
+
 .ide-v2-rail-tabs {
   flex: none;
   display: flex;
@@ -385,6 +396,16 @@
   gap: 2px;
   padding: 10px 10px 0;
   border-bottom: 1px solid var(--border-soft);
+}
+
+.ide-v2-surface .ide-v2-rail-tabs.ide-rail-tabs {
+  display: flex;
+  flex: none;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: flex-end;
+  height: auto;
+  min-height: 0;
 }
 
 .ide-v2-rail-tab {
@@ -413,6 +434,11 @@
   color: var(--volt-strong);
 }
 
+.ide-v2-surface .ide-v2-rail-tabs.ide-rail-tabs > .ide-v2-rail-tab {
+  flex: 1 1 0;
+  height: auto;
+}
+
 .ide-v2-rail-scroll {
   flex: 1;
   overflow-y: auto;
@@ -422,10 +448,15 @@
   min-height: 0;
 }
 
+.ide-v2-surface .ide-v2-rail-scroll {
+  min-height: 0;
+}
+
 /* Map existing context-stack / conversation / activity panels into the rail. */
 .ide-v2-rail .ide-plane-context-stack,
 .ide-v2-rail .ide-plane-primary-rail,
 .ide-v2-rail .ide-plane-activity,
+.ide-v2-rail .ide-plane-annotations,
 .ide-v2-rail .ide-plane-cursors {
   border: 0;
   background: transparent;
@@ -447,6 +478,143 @@
   padding: 12px 12px;
   flex: 1;
   min-height: 0;
+}
+
+.ide-v2-rail .ide-plane-annotations {
+  padding: 12px;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.ide-v2-rail .ide-activity-list {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+}
+
+/* The reference rail presents recent activity as independently scannable
+   cards, not a single uninterrupted text log. */
+.ide-v2-rail .ide-activity-row {
+  grid-template-columns: 42px 7px minmax(0, 1fr);
+  gap: 8px;
+  padding: 9px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  box-shadow: 0 1px 0 rgb(0 0 0 / 0.22);
+}
+
+.ide-v2-rail .ide-activity-row:hover {
+  border-color: var(--border-main);
+  background: color-mix(in srgb, var(--bg-card) 86%, var(--volt-wash));
+}
+
+.ide-annotation-rail {
+  min-height: 100%;
+}
+
+.ide-annotation-rail-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ide-annotation-rail-card {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-left: 3px solid var(--volt);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 7.25rem;
+}
+
+.ide-annotation-rail-card-main {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  gap: 6px;
+  align-items: start;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ide-annotation-rail-card-main:hover .ide-annotation-rail-content,
+.ide-annotation-rail-card-main:focus-visible .ide-annotation-rail-content {
+  color: var(--volt-strong);
+}
+
+.ide-annotation-rail-card-main:focus-visible {
+  outline: 1px solid var(--volt);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.ide-annotation-rail-kind,
+.ide-annotation-rail-line,
+.ide-annotation-rail-context {
+  padding: 2px 5px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.2;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.ide-annotation-rail-kind {
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+}
+
+.ide-annotation-rail-kind.is-decision { color: var(--color-status-ok); }
+.ide-annotation-rail-kind.is-question { color: var(--color-status-warn); }
+.ide-annotation-rail-kind.is-bookmark { color: var(--text-dim); }
+
+.ide-annotation-rail-line,
+.ide-annotation-rail-context {
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.ide-annotation-rail-content {
+  min-width: 0;
+  color: var(--text-mid);
+  font-size: var(--fs-11);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.ide-annotation-rail-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.ide-annotation-rail-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-annotation-rail-context {
+  margin-left: auto;
+  flex: none;
 }
 
 .ide-v2-rail .ide-plane-cursors {
@@ -570,6 +738,69 @@
   display: flex;
   flex-direction: column;
   max-height: 200px;
+}
+
+/* The live drawer retains the existing stream contract, while this v2 shell
+   gives it the compact, always-present execution-output geometry of the
+   reference IDE. */
+.ide-v2-surface > .execute-output-drawer {
+  flex: none;
+  max-height: 208px;
+  border-top: 1px solid var(--border-main);
+  background: var(--bg-well);
+}
+
+.ide-v2-surface > .execute-output-drawer .execute-output-drawer-header {
+  min-height: 30px;
+  padding: 5px 14px;
+  border-bottom-color: var(--border-soft);
+  background: var(--bg-sunken);
+}
+
+.ide-v2-surface > .execute-output-drawer [data-terminal] {
+  height: 168px !important;
+  background: var(--bg-well) !important;
+}
+
+.ide-interject-fab {
+  position: absolute;
+  right: 18px;
+  bottom: 16px;
+  z-index: calc(var(--z-base) + 2);
+  min-width: 82px;
+  height: 38px;
+  padding: 0 16px;
+  border: 1px solid color-mix(in srgb, var(--volt) 58%, var(--border-main));
+  border-radius: 999px;
+  background: var(--volt);
+  box-shadow: 0 8px 26px color-mix(in srgb, var(--volt) 24%, transparent);
+  color: var(--bg-deep);
+  font-family: var(--font-ui);
+  font-size: var(--fs-11);
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.ide-interject-fab:hover,
+.ide-interject-fab:focus-visible {
+  background: var(--volt-strong);
+  transform: translateY(-1px);
+}
+
+.ide-interject-fab:focus-visible {
+  outline: 2px solid var(--text-bright);
+  outline-offset: 2px;
+}
+
+.ide-v2-surface > .ide-interject-expanded {
+  position: absolute;
+  right: 18px;
+  bottom: 16px;
+  z-index: calc(var(--z-base) + 3);
+  width: min(34rem, calc(100% - 36px));
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  box-shadow: 0 16px 44px rgb(0 0 0 / 0.42);
 }
 
 .ide-v2-drawer.closed {

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -566,7 +566,7 @@
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
-  font-size: 9px;
+  font-size: var(--fs-9);
   line-height: 1.2;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -602,7 +602,7 @@
   min-width: 0;
   color: var(--text-dim);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: var(--fs-10);
 }
 
 .ide-annotation-rail-path {


### PR DESCRIPTION
## Summary

- load keeper-authored IDE regions after the active document commits, then project them into Source-view line ownership
- expose metadata loading/error/ready state and use keeper-lane scope when no repository scope is available
- align the live IDE shell with the keeper-v2 reference: activity/annotation/cursor rail, persistent execute drawer, compact Chat entry, and card-based activity presentation
- add a real annotation rail

## Root cause

The file-content and region requests started concurrently. When the file response committed after the region request, the document store invalidated the otherwise valid region response as stale. Even successful region responses were not projected into the ownership store used by the Source gutter. Separately, the legacy two-row conversation/activity CSS grid overrode the v2 single-rail layout and stretched the right-rail tabs vertically.

## Impact

The IDE now renders real keeper observation metadata in Source view, reports unavailable metadata explicitly instead of presenting a false zero state, and matches the reference IDE's default three-pane layout more closely without adding fabricated activity or terminal data.

## Validation

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1` for 10 IDE-focused files: 125 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `git diff origin/main...HEAD --check`

Build retains the existing Cinzel runtime-font and large-chunk warnings; no new build errors were introduced.


## Adversarial follow-up (`91325f21f6`)

- preserved the existing Keeper Work, Persistence, Memory, and multi-turn Conversation rail as the default Work Context surface
- kept the Execute drawer present while requiring explicit `terminal=open` before starting the output stream
- removed the client-only `.DS_Store` filename heuristic; initial-file classification needs a typed workspace-tree contract
- replaced raw font sizes with design-token SSOT values
- verified 89 focused IDE tests, TypeScript typecheck, ESLint, production build, raw-font ratchet, and `git diff --check`
