### PR TITLE
fix(keeper): canonical success wire for Completed stop_reason (#24073 point 5)

### DIFF
--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -315,7 +315,13 @@ type t =
   }
 
 let stop_reason_to_string = function
-  | Runtime_agent.Completed -> "completed"
+  (* Canonical success wire via the same [Keeper_turn_disposition.to_wire] SSOT
+     the budget case below uses (#24073 point 5). The prior raw "completed"
+     literal was unknown to [Keeper_turn_disposition.of_wire] (only "success"
+     maps to [Success]), so a genuinely completed turn decoded to [Unknown] and
+     displayed severity=bad. Legacy receipts persisted "completed" are still
+     accepted on read by [terminal_reason_is_success]. *)
+  | Runtime_agent.Completed -> Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
     (* Single SSOT for the budget-exhausted wire grammar: serialise through
        [Keeper_turn_disposition.to_wire] so this producer and the dashboard /

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -275,7 +275,11 @@ let append_decision_record
               in
                 let stop_reason_str =
                   match r.stop_reason with
-                  | Runtime_agent.Completed -> "completed"
+                  (* Canonical success wire via SSOT [to_wire], consistent with
+                     the receipt producer and the budget case below (#24073
+                     point 5). Raw "completed" decoded to [Unknown]/bad. *)
+                  | Runtime_agent.Completed ->
+                      Keeper_turn_disposition.(to_wire Success)
                   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
                       (* Detail-less wire form via the single SSOT [to_wire]:
                          [Runtime_agent.TurnBudgetExhausted] carries only

--- a/test/dune
+++ b/test/dune
@@ -119,6 +119,7 @@
   test_institution_ids
   test_keeper_turn_disposition
   test_keeper_execution_receipt_budget_wire
+  test_keeper_execution_receipt_completed_wire
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report
@@ -483,6 +484,7 @@
   test_institution_ids
   test_keeper_turn_disposition
   test_keeper_execution_receipt_budget_wire
+  test_keeper_execution_receipt_completed_wire
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report

--- a/test/test_keeper_execution_receipt_completed_wire.ml
+++ b/test/test_keeper_execution_receipt_completed_wire.ml
@@ -1,0 +1,55 @@
+(* Producer↔wire↔consumer contract for the Completed disposition (#24073 point 5).
+
+   The receipt producer [Keeper_execution_receipt_types.stop_reason_to_string]
+   used to emit the raw literal ["completed"] for [Runtime_agent.Completed]. The
+   dashboard / runtime-trust consumer [Keeper_turn_disposition.of_wire] only maps
+   ["success"] to [Success]; ["completed"] fell through to [Unknown], so a
+   genuinely completed turn displayed severity=bad (observed on a paused keeper's
+   stale terminal_reason). The fix routes the producer through the single
+   [Keeper_turn_disposition.to_wire] SSOT (= "success"), exactly as the adjacent
+   [TurnBudgetExhausted] case already does. Mirrors
+   test_keeper_execution_receipt_budget_wire. Non-vacuous: reverting the producer
+   to the raw "completed" literal turns assertions 1 and 2 red. *)
+
+module D = Masc.Keeper_turn_disposition
+module Receipt = Masc.Keeper_execution_receipt_types
+
+let failures = ref []
+let check name cond = if not cond then failures := name :: !failures
+
+let () =
+  let wire = Receipt.stop_reason_to_string Runtime_agent.Completed in
+  (* 1. Producer emits the canonical success wire (the SSOT grammar). *)
+  check
+    (Printf.sprintf "producer emits canonical success wire (got %S)" wire)
+    (String.equal wire "success");
+  (* 2. Producer output round-trips through the consumer to the typed value the
+     dashboard reads. *)
+  (match D.of_wire wire with
+   | D.Success -> ()
+   | other ->
+     check
+       (Printf.sprintf
+          "consumer classifies producer output as Success (got %s)"
+          (D.to_wire other))
+       false);
+  (* 3. The legacy raw "completed" is intentionally NOT tolerated by of_wire:
+     receipts persisted before this fix read as Unknown and self-heal on the
+     keeper's next turn (same migration stance as the budget-wire fix — a
+     completed-tolerant of_wire path is the rejected decoder-alias workaround). *)
+  (match D.of_wire "completed" with
+   | D.Unknown _ -> ()
+   | other ->
+     check
+       (Printf.sprintf
+          "legacy 'completed' should read Unknown, not %s — alias reintroduced"
+          (D.to_wire other))
+       false);
+  match !failures with
+  | [] -> print_endline "test_keeper_execution_receipt_completed_wire: OK"
+  | xs ->
+    List.iter (fun n -> print_endline ("FAIL: " ^ n)) (List.rev xs);
+    failwith
+      (Printf.sprintf "%d completed-wire contract assertion(s) failed"
+         (List.length xs))
+;;


### PR DESCRIPTION
#24073 point 5의 자족적 slice. `Runtime_agent.Completed`를 wire로 직렬화하는 disposition-path producer 2곳(receipt `stop_reason_to_string`:318, `keeper_unified_metrics_decision`:278)이 raw "completed"를 emit했는데, `Keeper_turn_disposition.of_wire`는 "success"만 Success로 매핑 → "completed"는 Unknown/bad. 인접 TurnBudgetExhausted case가 이미 쓰는 SSOT `to_wire`로 통일(= "success").

- **완전성**: `Runtime_agent.Completed → disposition wire` producer는 이 2곳이 전부. 세 번째 "completed"(`keeper_unified_turn_success:443 outcome_str`)는 `Log.Keeper.info` 로그 문자열이지 disposition wire가 아니라 별개 concern(N-of-M 아님).
- **legacy**: 기존 persisted "completed"는 다음 turn에 self-heal(budget-wire 선례와 동일 stance). **of_wire decoder alias는 추가 안 함**(#24073에서 리뷰어가 거부한 워크어라운드).
- **테스트**: `test_keeper_execution_receipt_completed_wire`가 producer="success" + of_wire→Success + legacy "completed"→Unknown(self-heal)을 pin. budget-wire 테스트 미러, non-vacuous.
- **범위 밖**: per-keeper queue-ownership 코어는 #24073 본체.

Refs #24073.