### PR TITLE
feat(dashboard): nav-rail attention badges + kill unmounted parallel navs (#65)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -38,7 +38,7 @@ import { startErrorCleanup, stopErrorCleanup } from './components/common/error-n
 import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
 import { isPrimaryDashboardSurface } from './config/navigation'
-import { governanceData } from './components/governance-signals'
+import { navBadges, markBoardMentionsSeenNow } from './nav-badges'
 import type { TabId } from './types'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
@@ -65,7 +65,6 @@ import {
 import { TopBarV2 } from './components/v2/top-bar-v2'
 import { NavRailV2 } from './components/v2/nav-rail-v2'
 import { loadTools, toolsData, toolsLoading } from './components/tools/tool-state'
-import { scheduledPendingApprovalCount } from './components/tools/scheduled-automation-panel'
 
 // Sidebar collapsed state persists across reloads (kept for compatibility with
 // downstream consumers / tests). The v2 rail is a fixed 58px icon rail, so this
@@ -191,7 +190,7 @@ export function App() {
     })
 
     // Governance/HITL approvals feed the always-visible nav-rail approvals
-    // badge and topbar attention indicator (see approvalsBadge below), so the
+    // badge and topbar attention indicator (nav-badges.ts navBadges), so the
     // governance resource must refresh globally. Keep boot on the read-only
     // refresh module instead of governance-actions: first paint should not load
     // toast/action write handlers just to count pending approvals.
@@ -247,6 +246,10 @@ export function App() {
       console.warn('[dashboard] subscribeDashboardRoute failed', err)
     })
     refreshCurrentRoute({ recordVisit: true })
+    // Board-mentions nav-rail badge: mark currently-known for-me mentions as
+    // seen when the operator visits the board surface (mirrors the
+    // per-keeper advanceKeeperLastSeen "mark read on visit" pattern).
+    if (route.value.tab === 'board') markBoardMentionsSeenNow()
   }, [route.value.tab, route.value.params.section, route.value.params.view, route.value.params.q])
 
   const dock = useCopilotDock()
@@ -278,9 +281,6 @@ export function App() {
     document.documentElement.setAttribute('data-volt', tweaksVolt.value)
     document.documentElement.setAttribute('data-theme', tweaksTheme.value === 'paper' ? 'paper' : '')
   }, [tweaksVolt.value, tweaksTheme.value])
-
-  const approvalsBadge = governanceData.value?.approval_queue?.length ?? 0
-  const scheduleBadge = scheduledPendingApprovalCount(toolsData.value?.scheduled_automation ?? null)
 
   // Body grid columns. Desktop: nav rail (58px) + single content column. Mobile:
   // a single 1fr column — the nav becomes a fixed bottom tab bar (.v2-nav.is-mnav),
@@ -324,7 +324,7 @@ export function App() {
 
       <div class="v2-stage">
         <div class="v2-body" style=${{ gridTemplateColumns: cols }}>
-          ${compactChromeMode ? null : html`<${NavRailV2} badges=${{ approvals: approvalsBadge, schedule: scheduleBadge }} mobile=${isMobile} />`}
+          ${compactChromeMode ? null : html`<${NavRailV2} badges=${navBadges.value} mobile=${isMobile} />`}
           <main
             id="main-content"
             tabindex=${-1}

--- a/dashboard/src/board-mentions-last-seen.test.ts
+++ b/dashboard/src/board-mentions-last-seen.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  _clearBoardMentionsLastSeenForTests,
+  advanceBoardMentionsLastSeen,
+  boardMentionsLastSeenMs,
+  hydrateBoardMentionsLastSeen,
+  markBoardMentionsSeen,
+  unseenMentionCount,
+  type MentionTimestampRow,
+} from './board-mentions-last-seen'
+
+const STORAGE_KEY = 'masc_board_mentions_last_seen_v1'
+
+function row(timestampMs: number | null): MentionTimestampRow {
+  return { timestampMs }
+}
+
+describe('board mentions last-seen cursor', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    _clearBoardMentionsLastSeenForTests()
+  })
+
+  afterEach(() => {
+    _clearBoardMentionsLastSeenForTests()
+    window.localStorage.clear()
+  })
+
+  it('advances monotonically and persists to localStorage', () => {
+    advanceBoardMentionsLastSeen(1000)
+    expect(boardMentionsLastSeenMs.value).toBe(1000)
+
+    // A backward advance is a no-op — the operator cannot "un-see" a mention.
+    advanceBoardMentionsLastSeen(500)
+    expect(boardMentionsLastSeenMs.value).toBe(1000)
+
+    // A forward advance moves the cursor and rewrites storage.
+    advanceBoardMentionsLastSeen(2000)
+    expect(boardMentionsLastSeenMs.value).toBe(2000)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('2000')
+  })
+
+  it('ignores non-finite / non-positive advances', () => {
+    advanceBoardMentionsLastSeen(Number.NaN)
+    advanceBoardMentionsLastSeen(Number.POSITIVE_INFINITY)
+    advanceBoardMentionsLastSeen(0)
+    advanceBoardMentionsLastSeen(-5)
+    expect(boardMentionsLastSeenMs.value).toBe(0)
+  })
+
+  it('hydrates from localStorage and drops malformed values on read', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'not-a-number')
+    expect(hydrateBoardMentionsLastSeen()).toBe(0)
+
+    window.localStorage.setItem(STORAGE_KEY, '1234')
+    expect(hydrateBoardMentionsLastSeen()).toBe(1234)
+    expect(boardMentionsLastSeenMs.value).toBe(1234)
+  })
+
+  it('clears the signal and storage for tests', () => {
+    advanceBoardMentionsLastSeen(1000)
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+    _clearBoardMentionsLastSeenForTests()
+    expect(boardMentionsLastSeenMs.value).toBe(0)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('counts for-me rows newer than the cursor, ignoring null timestamps', () => {
+    advanceBoardMentionsLastSeen(1000)
+    const rows = [row(500), row(null), row(1500), row(2000)]
+    expect(unseenMentionCount(rows)).toBe(2)
+  })
+
+  it('marks seen by advancing the cursor to the newest known row', () => {
+    const rows = [row(500), row(1500), row(null), row(2000)]
+    expect(unseenMentionCount(rows)).toBe(3)
+    markBoardMentionsSeen(rows)
+    expect(boardMentionsLastSeenMs.value).toBe(2000)
+    expect(unseenMentionCount(rows)).toBe(0)
+  })
+
+  it('marking seen with no rows is a no-op (never regresses the cursor)', () => {
+    advanceBoardMentionsLastSeen(1000)
+    markBoardMentionsSeen([])
+    expect(boardMentionsLastSeenMs.value).toBe(1000)
+  })
+})

--- a/dashboard/src/board-mentions-last-seen.ts
+++ b/dashboard/src/board-mentions-last-seen.ts
@@ -1,0 +1,104 @@
+import { signal } from '@preact/signals'
+
+// Minimal structural dependency (not the full MentionInboxRow from
+// mention-inbox.ts) — this module only ever reads the timestamp, so it
+// depends on exactly that, not the row's message/mentionTargets/isForMe
+// fields. Any `MentionInboxModel['forMe']` row is assignable here.
+export interface MentionTimestampRow {
+  readonly timestampMs: number | null
+}
+
+// Board "mentions for me" unread cursor — single global watermark (unlike
+// keeper-last-seen.ts's per-keeper map: there is exactly one operator-facing
+// mention inbox, not one per surface). Storage/normalize conventions cloned
+// from keeper-last-seen.ts (try/catch storage() wrapper, drop malformed
+// values on read, monotonic forward-only advance, a _clear...ForTests reset).
+//
+// Unit is unix milliseconds, not seconds: MentionInboxRow.timestampMs (the
+// only thing this cursor is ever compared against) is already `Date.parse`
+// milliseconds, and unlike keeper-last-seen.ts there is no server-echoed
+// since_unix contract to match — so no seconds conversion is introduced.
+
+const STORAGE_KEY = 'masc_board_mentions_last_seen_v1'
+
+function storage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function readStored(): number {
+  const store = storage()
+  if (!store) return 0
+  try {
+    const raw = store.getItem(STORAGE_KEY)
+    if (!raw) return 0
+    const parsed = Number(raw)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  } catch {
+    return 0
+  }
+}
+
+function writeStored(value: number): void {
+  const store = storage()
+  if (!store) return
+  try {
+    if (value <= 0) {
+      store.removeItem(STORAGE_KEY)
+    } else {
+      store.setItem(STORAGE_KEY, String(value))
+    }
+  } catch {
+    // Best-effort persistence only; the in-memory signal remains authoritative
+    // for this session even if localStorage is unavailable (private mode, quota).
+  }
+}
+
+export const boardMentionsLastSeenMs = signal<number>(0)
+
+/** Re-read the persisted cursor into the signal. Called once at module load;
+ *  exposed so a cross-tab storage event (or a test) can re-hydrate on demand. */
+export function hydrateBoardMentionsLastSeen(): number {
+  const value = readStored()
+  boardMentionsLastSeenMs.value = value
+  return value
+}
+
+hydrateBoardMentionsLastSeen()
+
+// Monotonic forward-only advance: the operator cannot "un-see" a mention, so
+// the cursor never moves backwards. Writes to storage only when it actually
+// advances.
+export function advanceBoardMentionsLastSeen(unixMs: number): void {
+  if (!Number.isFinite(unixMs) || unixMs <= 0) return
+  if (boardMentionsLastSeenMs.value >= unixMs) return
+  boardMentionsLastSeenMs.value = unixMs
+  writeStored(unixMs)
+}
+
+/** Count of for-me mention rows newer than the last-seen cursor. `forMe` is
+ *  `buildMentionInboxModel(...).forMe` — the exact rows the board's own
+ *  MentionInboxPanel already renders, so this introduces no new data source. */
+export function unseenMentionCount(forMe: readonly MentionTimestampRow[]): number {
+  const cursor = boardMentionsLastSeenMs.value
+  return forMe.filter(row => row.timestampMs !== null && row.timestampMs > cursor).length
+}
+
+/** Advance the cursor to the newest for-me mention currently known. Call on
+ *  board-route visit (app.ts) — mirrors keeper-last-seen.ts's
+ *  newestConversationEntryUnix + advance pairing. */
+export function markBoardMentionsSeen(forMe: readonly MentionTimestampRow[]): void {
+  let newest = 0
+  for (const row of forMe) {
+    if (row.timestampMs !== null && row.timestampMs > newest) newest = row.timestampMs
+  }
+  if (newest > 0) advanceBoardMentionsLastSeen(newest)
+}
+
+export function _clearBoardMentionsLastSeenForTests(): void {
+  boardMentionsLastSeenMs.value = 0
+  writeStored(0)
+}

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { ConnectionStatus, DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, shouldRenderSurfaceLead, SideRail, summarizeAttentionPreview } from './dashboard-shell'
+import { ConnectionStatus, DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, shouldRenderSurfaceLead } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardWsConnected, dashboardWsLastError, dashboardWsReady, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
@@ -144,38 +144,6 @@ describe('isKeeperDetailDashboardRoute', () => {
       params: { section: 'agents' },
       postId: null,
     })).toBe(false)
-  })
-})
-
-describe('summarizeAttentionPreview', () => {
-  it('includes grounded evidence in attention tooltip lines', () => {
-    expect(summarizeAttentionPreview([
-      {
-        summary: 'Adversarial review failed',
-        kind: 'review_rejected',
-        grounded_verdict: {
-          verdict: 'FAIL',
-          reason: 'bad branch',
-          evidence: [
-            { path: 'lib/foo.ml', line: 12, quote: 'let bad = true' },
-          ],
-        },
-      },
-    ])).toEqual([
-      'Adversarial review failed | lib/foo.ml:12 let bad = true',
-    ])
-  })
-
-  it('falls back to evidence_preview when no grounded verdict exists', () => {
-    expect(summarizeAttentionPreview([
-      {
-        summary: 'Needs inspection',
-        kind: 'runtime_blocked',
-        evidence_preview: ['runtime_blocker_state=blocked'],
-      },
-    ])).toEqual([
-      'Needs inspection | runtime_blocker_state=blocked',
-    ])
   })
 })
 
@@ -1021,69 +989,6 @@ describe('dashboardHealthChips', () => {
     })
     expect(cdal?.detail).toContain('stale=3')
     expect(cdal?.detail).toContain('current_missing_task_scope=5')
-  })
-})
-
-describe('SideRail v2 chrome', () => {
-  let container: HTMLDivElement
-
-  beforeEach(() => {
-    container = document.createElement('div')
-    document.body.appendChild(container)
-    route.value = {
-      tab: 'workspace',
-      params: { section: 'work' },
-      postId: null,
-    }
-  })
-
-  afterEach(() => {
-    render(null, container)
-    container.remove()
-  })
-
-  it('renders v2 structural classes and highlights the active surface', () => {
-    render(h(SideRail, { collapsed: false, onToggle: () => {} }), container)
-
-    expect(container.querySelector('.nav-brand')).not.toBeNull()
-    expect(container.querySelector('.nav-sec')).not.toBeNull()
-    expect(container.querySelector('.nav-link.active')).not.toBeNull()
-    expect(container.querySelector('.nav-link.active')?.textContent).toContain('Work')
-    expect(container.querySelector('.nav-link.active')?.textContent).not.toContain('Settings')
-
-    // Multiple surfaces render sublists (any surface with 2+ sections), so
-    // anchor on the globally-unique active sublink instead of the first list.
-    const sublist = container.querySelector('.nav-sublist')
-    expect(sublist).not.toBeNull()
-    const activeSublink = container.querySelector('.nav-sublink.active')
-    expect(activeSublink).not.toBeNull()
-    expect(activeSublink?.textContent).toContain('Work')
-    expect(container.querySelector('.nav-footer .nav-footer-settings')?.textContent).toContain('Settings')
-  })
-
-  it('moves Settings to the rail footer and highlights it there', () => {
-    route.value = {
-      tab: 'settings',
-      params: {},
-      postId: null,
-    }
-
-    render(h(SideRail, { collapsed: false, onToggle: () => {} }), container)
-
-    expect(container.querySelector('.nav-group .nav-link.active')).toBeNull()
-    const settings = container.querySelector('.nav-footer .nav-footer-settings')
-    expect(settings).not.toBeNull()
-    expect(settings?.className).toContain('active')
-    expect(settings?.textContent).toContain('Settings')
-  })
-
-  it('renders collapsed icon-only links with v2 classes', () => {
-    render(h(SideRail, { collapsed: true, onToggle: () => {} }), container)
-
-    const links = container.querySelectorAll('.nav-link-collapsed')
-    expect(links.length).toBeGreaterThan(0)
-    expect(container.querySelector('.nav-link-collapsed.active')).not.toBeNull()
-    expect(container.querySelector('.nav-footer .nav-footer-settings')).not.toBeNull()
   })
 })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect, useMemo } from 'preact/hooks'
-import type { GroundedVerdict, RouteState, TabId } from '../types'
+import type { RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import {
   fetchDashboardRuntimeProbe,
@@ -14,7 +14,6 @@ import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsLastError, dashboardWsReady, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
 import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution, tasksByStatus } from '../store'
-import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruth, namespaceTruthInitializing } from '../namespace-truth-store'
 import {
   configuredCountSourceLabel,
@@ -27,14 +26,10 @@ import { ErrorBoundary } from './common/error-boundary'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState } from './common/feedback-state'
 import {
-  DASHBOARD_SURFACES,
   DASHBOARD_NAV_ITEMS,
-  PRIMARY_DASHBOARD_SURFACES,
   currentSectionForRoute,
-  visibleSectionItemsForTab,
 } from '../config/navigation'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
-import { ChevronRight, ChevronLeft } from 'lucide-preact'
 import { ExternalLink } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
 import { CopyIdButton } from './common/copy-id-button'
@@ -43,8 +38,6 @@ import { unacknowledgedCount } from './common/error-notification-state'
 import { ErrorPanel } from './common/error-panel'
 import { Bell } from 'lucide-preact'
 import { ringFocusClasses } from './common/ring'
-import { SurfaceIcon } from './surface-icon'
-import { governanceData } from './governance-signals'
 import { Breadcrumb, type BreadcrumbItem } from './common/breadcrumb'
 import { RouteLink } from './common/route-link'
 import {
@@ -975,74 +968,6 @@ export function BuildIdentityBadge() {
   `
 }
 
-
-
-/** Pure: gather the top-N attention-item summaries as tooltip lines so
-    hovering the bottom-left health dot answers "what are the N
-    things?" without a click. Reference UIs: Datadog monitor rollup
-    tooltip, Vercel deployment status footer, Gmail "2 unread" with
-    sender preview — all reveal the contributing items on hover so the
-    operator decides whether to navigate. Exposed for tests. */
-type AttentionPreviewInput = {
-  summary?: string | null
-  kind?: string | null
-  evidence_preview?: readonly string[] | null
-  grounded_verdict?: GroundedVerdict | null
-}
-
-function clipAttentionLine(raw: string, max: number): string {
-  return raw.length > max ? `${raw.slice(0, Math.max(0, max - 3))}...` : raw
-}
-
-function firstGroundedEvidencePreview(verdict?: GroundedVerdict | null): string | null {
-  const ref = verdict?.evidence.find(item => item.path.trim() !== '' && item.quote.trim() !== '')
-  if (!ref) return null
-  const location = typeof ref.line === 'number' ? `${ref.path}:${ref.line}` : ref.path
-  return `${location} ${ref.quote.trim()}`
-}
-
-export function summarizeAttentionPreview(
-  items: ReadonlyArray<AttentionPreviewInput>,
-  max = 3,
-): string[] {
-  // Two-pass: first filter to valid (non-empty summary or kind), then
-  // cap. This separates "skipped for noise" from "truncated for max"
-  // so the tail count only reflects genuinely pending items that
-  // didn't fit — never padding from null/empty rows.
-  const valid: string[] = []
-  for (const item of items) {
-    if (!item) continue
-    const summary = item.summary?.trim()
-    const kind = item.kind?.trim()
-    const base = (summary && summary !== '') ? summary : (kind && kind !== '' ? kind : '')
-    if (base === '') continue
-    const groundedEvidence = firstGroundedEvidencePreview(item.grounded_verdict)
-    const previewEvidence =
-      groundedEvidence
-      ?? item.evidence_preview?.map(value => value.trim()).find(value => value !== '')
-      ?? null
-    const raw = previewEvidence
-      ? `${clipAttentionLine(base, 45)} | ${clipAttentionLine(previewEvidence, 60)}`
-      : base
-    valid.push(clipAttentionLine(raw, previewEvidence ? 110 : 60))
-  }
-  if (valid.length <= max) return valid
-  return [...valid.slice(0, max), `... +${valid.length - max} more`]
-}
-
-/** Pure: compose the full title-attribute string for the health
-    indicator — label on the first line, attention previews indented
-    under it. Newlines render in native title tooltips on all major
-    browsers, so no HTML escaping or markup is needed. */
-function composeHealthIndicatorTitle(
-  label: string,
-  attentionLines: ReadonlyArray<string>,
-): string {
-  if (attentionLines.length === 0) return label
-  const indented = attentionLines.map(line => `  · ${line}`)
-  return [label, ...indented].join('\n')
-}
-
 function dashboardRouteBoundaryKey(routeState: RouteState): string {
   const params = routeState.params
   const parts = [
@@ -1062,202 +987,6 @@ function dashboardRouteBoundaryKey(routeState: RouteState): string {
   }
 
   return parts.filter(Boolean).join(':')
-}
-
-function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
-  const wsOnly = dashboardWsOnlyEnabled()
-  const live = wsOnly
-    ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
-    : connected.value
-  const snap = missionSnapshot.value
-  const sessions = snap?.sessions ?? []
-  let blockers = 0
-  for (let i = 0; i < sessions.length; i++) {
-    if (sessions[i]?.blocker_summary) blockers++
-  }
-  const attentionQueue = snap?.attention_queue ?? []
-  const attentionCount = attentionQueue.length
-
-  let dotClass: string
-  let label: string
-
-  if (!live) {
-    dotClass = 'bg-[var(--color-status-err)]'
-    label = 'Transport offline'
-  } else if (!snap) {
-    dotClass = 'bg-[var(--color-fg-muted)]'
-    label = missionLoading.value ? 'Mission loading' : 'Mission idle'
-  } else if (blockers > 0 || attentionCount > 0) {
-    dotClass = 'bg-[var(--color-status-warn)]'
-    const total = blockers + attentionCount
-    label = `Mission attention ${total}`
-  } else {
-    dotClass = 'bg-[var(--color-status-ok)]'
-    label = 'Mission healthy'
-  }
-
-  const attentionLines = attentionCount > 0 ? summarizeAttentionPreview(attentionQueue) : []
-  const titleText = composeHealthIndicatorTitle(label, attentionLines)
-
-  const dot = html`<span class="block size-2 shrink-0 rounded-[var(--r-0)] ${dotClass} shadow-1"></span>`
-
-  if (collapsed) {
-    return html`<div class="v2-shell-panel flex justify-center" title=${titleText} role="img" aria-label=${label}>${dot}</div>`
-  }
-
-  return html`
-    <div class="v2-shell-panel flex items-center gap-2 px-1" role="status" aria-label=${label} title=${titleText}>
-      ${dot}
-      <span class="text-[var(--color-fg-muted)] truncate">${label}</span>
-    </div>
-  `
-}
-
-export function SideRail({
-  collapsed,
-  onToggle,
-  primaryOnly = true,
-}: {
-  collapsed?: boolean
-  onToggle?: () => void
-  primaryOnly?: boolean
-}) {
-  const currentTab = route.value.tab
-  const currentSection = currentSectionForRoute(route.value)
-  // Open keeper-approval count for the Approvals nav badge. Same signal the
-  // Approvals/Command surfaces read, so the badge tracks resolutions live.
-  const openApprovals = governanceData.value?.approval_queue?.length ?? 0
-  const settingsSurface = DASHBOARD_SURFACES.find(surface => surface.id === 'settings')
-  const visibleSurfaces = primaryOnly
-    ? PRIMARY_DASHBOARD_SURFACES.filter(surface => surface.id !== 'settings')
-    : DASHBOARD_SURFACES.filter(surface => surface.hidden !== true && surface.id !== 'settings')
-  const settingsActive = currentTab === 'settings'
-
-  return html`
-    <nav class="v2-shell-surface flex flex-col h-full" aria-label="Dashboard navigation">
-      <div class="nav-brand v2-shell-toolbar flex ${collapsed ? 'flex-col items-center gap-1.5' : 'items-center justify-between'} border-b border-[var(--color-border-default)] px-2 pt-2 pb-2">
-        ${collapsed
-          ? html`
-            <!-- Collapsed brand = the keeper-v2 prototype's .nav-home logo box
-                 (v2.css:242): 38x38 volt-filled square, "M" monogram, glow. -->
-            <div class="nav-home" aria-hidden="true">M</div>
-          `
-          : html`
-            <div class="px-1 leading-none">
-              <div class="nb-title font-mono text-[var(--fs-9)] font-bold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-disabled)]">MASC</div>
-              <div class="nb-sub mt-1 font-mono text-[var(--fs-11)] font-semibold uppercase tracking-[0.14em] text-[var(--color-fg-secondary)]">Cockpit</div>
-            </div>
-          `}
-        <button type="button"
-          class=${`v2-shell-action nav-collapse flex size-6 items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
-          aria-label=${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          onClick=${onToggle}
-          title=${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        >
-          ${collapsed ? html`<${ChevronRight} size=${14} />` : html`<${ChevronLeft} size=${14} />`}
-        </button>
-      </div>
-
-      <div class="flex-1 overflow-y-auto px-2 py-2">
-        ${!collapsed ? html`
-          <div class="nav-sec px-1 pb-1.5 font-mono text-[var(--fs-9)] font-bold uppercase tracking-[0.2em] text-[var(--color-fg-disabled)]">Surfaces</div>
-        ` : null}
-        <div class="flex flex-col gap-1">
-          ${visibleSurfaces.map(surface => {
-            const isSurfaceActive = surface.id === currentTab
-            const sections = visibleSectionItemsForTab(surface.id)
-
-            if (collapsed) {
-              return html`
-                <${RouteLink}
-                  tab=${surface.defaultTab}
-                  params=${surface.defaultParams}
-                  class="v2-shell-row nav-link-collapsed flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
-                  title=${surface.label}
-                  aria-label=${surface.label}
-                  ariaCurrent=${isSurfaceActive ? 'page' : undefined}
-                >
-                  <span class="nav-icon ${surface.id === 'approvals' && openApprovals > 0 ? 'relative' : ''}" aria-hidden="true">
-                    <${SurfaceIcon} icon=${surface.icon} size=${15} />
-                    ${surface.id === 'approvals' && openApprovals > 0 ? html`<span class="ap-nav-dot"></span>` : null}
-                  </span>
-                  <span class="sr-only">${surface.label}${surface.id === 'approvals' && openApprovals > 0 ? ` (${openApprovals} 대기)` : ''}</span>
-                <//>
-              `
-            }
-
-            return html`
-              <div class="nav-group v2-shell-panel flex flex-col gap-0.5 border-t border-[var(--color-border-divider)] pt-1 first:border-t-0 first:pt-0">
-                <${RouteLink}
-                  tab=${surface.defaultTab}
-                  params=${surface.defaultParams}
-                  class="v2-shell-row nav-link flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSurfaceActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}"
-                  ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
-                >
-                  <span class="nav-icon flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] ${isSurfaceActive ? 'bg-[var(--select-10)] text-[var(--select)]' : 'bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'}" aria-hidden="true">
-                    <${SurfaceIcon} icon=${surface.icon} size=${13} />
-                  </span>
-                  <div class="nav-label flex-1 min-w-0">
-                    <div class="truncate font-mono text-[var(--fs-11)] font-semibold uppercase leading-4 tracking-[var(--track-caps)] ${isSurfaceActive ? 'text-[var(--select)]' : ''}">${surface.label}</div>
-                  </div>
-                  ${surface.id === 'approvals' && openApprovals > 0
-                    ? html`<span class="ap-nav-badge" data-testid="approvals-nav-badge" title=${`${openApprovals}건 승인 대기`}>${openApprovals}</span>`
-                    : null}
-                <//>
-
-                ${sections.length > 1 ? html`
-                  <div class="nav-sublist v2-shell-detail ml-2.5 flex flex-col gap-px border-l border-[var(--color-border-divider)] pl-2.5" role="list">
-                    ${sections.map(item => {
-                      const isSectionActive = isSurfaceActive && currentSection?.id === item.id
-                      return html`
-                        <div role="listitem">
-                          <${RouteLink}
-                            tab=${surface.id}
-                            params=${item.params}
-                            class="v2-shell-row nav-sublink block w-full rounded-[var(--r-0)] border px-2 py-0.5 text-left font-mono text-[var(--fs-10)] uppercase leading-5 tracking-[var(--track-sub)] cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${isSectionActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-primary)]'}"
-                            ariaCurrent=${isSectionActive ? 'page' : undefined}
-                          >
-                            <div class="truncate">${item.label}</div>
-                          <//>
-                        </div>
-                      `
-                    })}
-                  </div>
-                ` : null}
-              </div>
-            `
-          })}
-        </div>
-      </div>
-
-      <div class="nav-footer v2-shell-panel flex shrink-0 flex-col gap-2 border-t border-[var(--color-border-default)] px-2 py-2">
-        ${settingsSurface ? html`
-          <${RouteLink}
-            tab=${settingsSurface.defaultTab}
-            params=${settingsSurface.defaultParams}
-            class=${collapsed
-              ? `v2-shell-row nav-link-collapsed nav-footer-settings flex h-7 w-full items-center justify-center rounded-[var(--r-0)] border cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${settingsActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--select)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}`
-              : `v2-shell-row nav-link nav-footer-settings flex min-h-7 w-full items-center gap-1.5 rounded-[var(--r-0)] border px-1.5 py-1 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-[var(--t-med)] ${settingsActive ? 'active border-[var(--select-20)] bg-[var(--select-10)] !text-[var(--color-fg-secondary)] shadow-[inset_2px_0_0_var(--select)]' : 'border-transparent bg-transparent !text-[var(--color-fg-muted)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:!text-[var(--color-fg-secondary)]'}`}
-            ariaCurrent=${settingsActive ? 'page' : undefined}
-            title=${settingsSurface.label}
-            aria-label=${settingsSurface.label}
-          >
-            <span class="nav-icon ${collapsed ? '' : 'flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)]'} ${settingsActive ? 'bg-[var(--select-10)] text-[var(--select)]' : collapsed ? '' : 'bg-[var(--color-bg-surface)] text-[var(--color-fg-muted)]'}" aria-hidden="true">
-              <${SurfaceIcon} icon=${settingsSurface.icon} size=${collapsed ? 15 : 13} />
-            </span>
-            ${collapsed
-              ? html`<span class="sr-only">${settingsSurface.label}</span>`
-              : html`
-                  <div class="nav-label flex-1 min-w-0">
-                    <div class="truncate font-mono text-[var(--fs-11)] font-semibold uppercase leading-4 tracking-[var(--track-caps)] ${settingsActive ? 'text-[var(--select)]' : ''}">${settingsSurface.label}</div>
-                  </div>
-                `}
-          <//>
-        ` : null}
-        <${HealthIndicator} collapsed=${collapsed} />
-      </div>
-    </nav>
-  `
 }
 
 function TabContent() {

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -43,6 +43,14 @@ export async function loadTools() {
   await toolsResource.load(signal => fetchDashboardTools({ signal }))
 }
 
+/** Test-only: set toolsData without a real fetch. toolsResource is a private
+ *  module-level singleton (unlike governanceResource, which is exported), so
+ *  consumers of toolsData (e.g. nav-badges.ts) need this hook to unit-test
+ *  the schedule-badge derivation deterministically. */
+export function _setToolsDataForTests(data: DashboardToolsResponse | null): void {
+  toolsResource.reset(data)
+}
+
 export function hasSurface(item: DashboardToolInventoryItem, surface: string): boolean {
   return (item.surfaces ?? []).includes(surface)
 }

--- a/dashboard/src/components/v2/nav-rail-v2.test.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.test.ts
@@ -12,10 +12,35 @@ vi.mock('../../router', () => ({
   route: mocks.route,
 }))
 
-import { NavRailV2 } from './nav-rail-v2'
+import { NavRailV2, type NavBadges } from './nav-rail-v2'
 
 function scheduleNavItem(container: HTMLElement): Element | undefined {
   return Array.from(container.querySelectorAll('.nav-item')).find(el => el.textContent?.includes('예약'))
+}
+
+function navItem(container: HTMLElement, label: string): Element | undefined {
+  return Array.from(container.querySelectorAll('.nav-item')).find(el => el.textContent?.includes(label))
+}
+
+// Every RailBadgeTab present with an explicit value — the type is a closed
+// Record, so a real caller (nav-badges.ts) can never omit a key; tests
+// exercise the same full-record contract rather than the old partial shape.
+function badges(overrides: Partial<NavBadges> = {}): NavBadges {
+  return {
+    overview: 0,
+    keepers: 0,
+    monitoring: 0,
+    workspace: 0,
+    approvals: 0,
+    schedule: 0,
+    board: 0,
+    fusion: 0,
+    logs: 0,
+    code: 0,
+    connectors: 0,
+    settings: 0,
+    ...overrides,
+  }
 }
 
 describe('NavRailV2 schedule badge', () => {
@@ -34,7 +59,7 @@ describe('NavRailV2 schedule badge', () => {
   })
 
   it('renders the pending-schedule count on the schedule nav item', () => {
-    render(html`<${NavRailV2} badges=${{ approvals: 0, schedule: 3 }} />`, container)
+    render(html`<${NavRailV2} badges=${badges({ schedule: 3 })} />`, container)
 
     const item = scheduleNavItem(container)
     expect(item).toBeTruthy()
@@ -42,7 +67,7 @@ describe('NavRailV2 schedule badge', () => {
   })
 
   it('omits the schedule badge when there are no pending schedules', () => {
-    render(html`<${NavRailV2} badges=${{ approvals: 0, schedule: 0 }} />`, container)
+    render(html`<${NavRailV2} badges=${badges({ schedule: 0 })} />`, container)
 
     expect(scheduleNavItem(container)?.querySelector('.nav-badge')).toBeNull()
   })
@@ -68,5 +93,66 @@ describe('NavRailV2 schedule badge', () => {
       'spacer',
       '설정',
     ])
+  })
+})
+
+describe('NavRailV2 badge record contract', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.navigate.mockClear()
+    mocks.route.value = { tab: 'overview', params: {} }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders a count badge on every non-zero tab, including the footer 설정 button', () => {
+    render(
+      html`<${NavRailV2} badges=${badges({ keepers: 2, workspace: 5, board: 1, connectors: 3, settings: 7 })} />`,
+      container,
+    )
+
+    expect(navItem(container, 'Keepers')?.querySelector('.nav-badge')?.textContent).toBe('2')
+    expect(navItem(container, '작업')?.querySelector('.nav-badge')?.textContent).toBe('5')
+    expect(navItem(container, '보드')?.querySelector('.nav-badge')?.textContent).toBe('1')
+    expect(navItem(container, '커넥터')?.querySelector('.nav-badge')?.textContent).toBe('3')
+    expect(navItem(container, '설정')?.querySelector('.nav-badge')?.textContent).toBe('7')
+  })
+
+  it('renders nothing for tabs whose badge is an explicit zero', () => {
+    render(html`<${NavRailV2} badges=${badges({ keepers: 4 })} />`, container)
+
+    // overview/monitoring/fusion/logs/code/settings are explicit zeros in the
+    // typed record (nav-badges.ts) — the rail must render the same "nothing"
+    // as an absent badges prop, not a visible "0".
+    for (const label of ['개요', 'Monitor', 'Fusion', '로그', 'IDE', '설정']) {
+      expect(navItem(container, label)?.querySelector('.nav-badge')).toBeNull()
+    }
+    expect(navItem(container, 'Keepers')?.querySelector('.nav-badge')?.textContent).toBe('4')
+  })
+
+  it('treats an absent badges prop the same as an all-zero record', () => {
+    render(html`<${NavRailV2} />`, container)
+
+    expect(container.querySelectorAll('.nav-badge').length).toBe(0)
+  })
+
+  it('adds sr-only count text alongside the visible badge', () => {
+    render(html`<${NavRailV2} badges=${badges({ approvals: 9 })} />`, container)
+
+    const approvalsItem = navItem(container, '승인')
+    expect(approvalsItem?.querySelector('.sr-only')?.textContent).toBe(' (9건)')
+  })
+
+  it('sums hidden-tab badges into the mobile 더보기 tile', () => {
+    render(html`<${NavRailV2} mobile=${true} badges=${badges({ board: 2, connectors: 3 })} />`, container)
+
+    const more = Array.from(container.querySelectorAll('.nav-item')).find(el => el.textContent?.includes('더보기'))
+    expect(more?.querySelector('.nav-badge')?.textContent).toBe('5')
   })
 })

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -21,7 +21,13 @@ type NavEntry = SurfaceEntry | 'sep'
 // Groups mirror the 2026-07 standalone export's rail DOM: 개요 |
 // Keepers · Monitor | 작업 · 승인 · 예약 | 보드 · Fusion · 로그 |
 // IDE · 커넥터 (설정 stays in the footer slot below the spacer).
-const SURFACES: readonly NavEntry[] = [
+//
+// `as const satisfies` (rather than a `: readonly NavEntry[]` annotation)
+// keeps each entry's `tab` field a literal instead of widening it to `TabId`,
+// so RailBadgeTab below is exactly the tabs this rail renders — add a surface
+// here and the nav-badges.ts `satisfies NavBadges` check immediately demands
+// an explicit badge decision for it (0 allowed, but stated).
+const SURFACES = [
   { tab: 'overview', label: '개요', icon: 'grid' },
   'sep',
   { tab: 'keepers', label: 'Keepers', icon: 'users' },
@@ -37,15 +43,25 @@ const SURFACES: readonly NavEntry[] = [
   'sep',
   { tab: 'code', label: 'IDE', icon: 'code' },
   { tab: 'connectors', label: '커넥터', icon: 'plug' },
-]
+] as const satisfies readonly NavEntry[]
 
-export interface NavBadges {
-  readonly approvals?: number
-  readonly schedule?: number
-}
+// Each literal member of the const tuple, minus the 'sep' separators — the
+// precise per-position type (e.g. `{ tab: "connectors"; ... }`), not the
+// widened nominal SurfaceEntry interface. A predicate asserting `is
+// SurfaceEntry` here would fail: SurfaceEntry's `tab: TabId` is broader than
+// any single tuple position's literal tab, so it isn't assignable to the
+// exact union TypeScript infers for `(typeof SURFACES)[number]`.
+type SurfaceTupleEntry = Exclude<(typeof SURFACES)[number], 'sep'>
+
+/** Every tab the rail can show a badge on: the SURFACES entries plus the
+ *  footer-slotted 설정 button. Kept as a closed record (not `Partial`) so
+ *  adding a rail tab is a compile error until nav-badges.ts states its count. */
+export type RailBadgeTab = SurfaceTupleEntry['tab'] | 'settings'
+
+export type NavBadges = Readonly<Record<RailBadgeTab, number>>
 
 const SURFACE_LABEL: Readonly<Record<string, string>> = Object.fromEntries(
-  SURFACES.filter((e): e is SurfaceEntry => e !== 'sep').map((e) => [e.tab, e.label]),
+  SURFACES.filter((e): e is SurfaceTupleEntry => e !== 'sep').map((e) => [e.tab, e.label]),
 )
 
 /** Crumb label for a tab (prototype SURFACE_LABEL); settings + unknowns fall back. */
@@ -57,31 +73,30 @@ export function surfaceLabel(tab: TabId): string {
 // (home / agents / work / approvals) gets first-class tabs; the rest live behind
 // a 더보기 sheet so no tab drops below the 44px hit target (prototype shell.jsx).
 const MOBILE_PRIMARY: readonly TabId[] = ['overview', 'workspace', 'keepers', 'approvals']
-const SURFACE_ENTRIES: readonly SurfaceEntry[] = SURFACES.filter((e): e is SurfaceEntry => e !== 'sep')
+const SURFACE_ENTRIES: readonly SurfaceTupleEntry[] = SURFACES.filter((e): e is SurfaceTupleEntry => e !== 'sep')
 
 export function NavRailV2({ badges, mobile = false }: { badges?: NavBadges; mobile?: boolean }) {
   const active = route.value.tab
-  const badgeFor = (tab: TabId): number | undefined => {
-    if (tab === 'approvals') return badges?.approvals || undefined
-    if (tab === 'schedule') return badges?.schedule || undefined
-    return undefined
-  }
+  // 0/absent both render nothing — `|| undefined` treats the typed record's
+  // explicit zeros (overview/monitoring/fusion/logs/code/settings — see
+  // nav-badges.ts) the same as an omitted `badges` prop (tests, storybook).
+  const badgeFor = (tab: RailBadgeTab): number | undefined => badges?.[tab] || undefined
 
   const [moreOpen, setMoreOpen] = useState(false)
   useEffect(() => { setMoreOpen(false) }, [active])
 
   if (mobile) {
-    const byTab = new Map(SURFACE_ENTRIES.map((e) => [e.tab, e]))
-    const primary = MOBILE_PRIMARY.map((t) => byTab.get(t)).filter((e): e is SurfaceEntry => !!e)
+    const byTab = new Map<TabId, SurfaceTupleEntry>(SURFACE_ENTRIES.map((e) => [e.tab, e]))
+    const primary = MOBILE_PRIMARY.map((t) => byTab.get(t)).filter((e): e is SurfaceTupleEntry => !!e)
     const hidden = SURFACE_ENTRIES.filter((e) => !MOBILE_PRIMARY.includes(e.tab))
     const moreActive = !MOBILE_PRIMARY.includes(active)
     const hiddenBadge = hidden.reduce((n, e) => n + (badgeFor(e.tab) ?? 0), 0)
-    const Tab = (e: SurfaceEntry) => {
+    const Tab = (e: SurfaceTupleEntry) => {
       const badge = badgeFor(e.tab)
       return html`
         <button key=${e.tab} class=${`nav-item ${active === e.tab ? 'on' : ''}`} onClick=${() => navigate(e.tab)} title=${e.label}>
           ${ICONS[e.icon]}<span class="nlbl">${e.label}</span>
-          ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+          ${badge ? html`<span class="nav-badge">${badge}</span><span class="sr-only">${` (${badge}건)`}</span>` : null}
         </button>
       `
     }
@@ -106,13 +121,14 @@ export function NavRailV2({ badges, mobile = false }: { badges?: NavBadges; mobi
                       <button key=${e.tab} class=${`mnav-tile ${active === e.tab ? 'on' : ''}`} onClick=${() => { navigate(e.tab); setMoreOpen(false) }}>
                         <span class="mnav-ic">${ICONS[e.icon]}</span>
                         <span class="mnav-lbl">${e.label}</span>
-                        ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+                        ${badge ? html`<span class="nav-badge">${badge}</span><span class="sr-only">${` (${badge}건)`}</span>` : null}
                       </button>
                     `
                   })}
                   <button class=${`mnav-tile ${active === 'settings' ? 'on' : ''}`} onClick=${() => { navigate('settings'); setMoreOpen(false) }}>
                     <span class="mnav-ic">${ICONS.gear}</span>
                     <span class="mnav-lbl">설정</span>
+                    ${badgeFor('settings') ? html`<span class="nav-badge">${badgeFor('settings')}</span>` : null}
                   </button>
                 </div>
               </div>
@@ -141,19 +157,25 @@ export function NavRailV2({ badges, mobile = false }: { badges?: NavBadges; mobi
                   title=${entry.label}
                 >
                   ${ICONS[entry.icon]}<span class="nlbl">${entry.label}</span>
-                  ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+                  ${badge ? html`<span class="nav-badge">${badge}</span><span class="sr-only">${` (${badge}건)`}</span>` : null}
                 </button>
               `
             })(),
       )}
       <div class="nav-spacer"></div>
-      <button
-        class=${`nav-item ${active === 'settings' ? 'on' : ''}`}
-        title="설정"
-        onClick=${() => navigate('settings')}
-      >
-        ${ICONS.gear}<span class="nlbl">설정</span>
-      </button>
+      ${(() => {
+        const settingsBadge = badgeFor('settings')
+        return html`
+          <button
+            class=${`nav-item ${active === 'settings' ? 'on' : ''}`}
+            title="설정"
+            onClick=${() => navigate('settings')}
+          >
+            ${ICONS.gear}<span class="nlbl">설정</span>
+            ${settingsBadge ? html`<span class="nav-badge">${settingsBadge}</span><span class="sr-only">${` (${settingsBadge}건)`}</span>` : null}
+          </button>
+        `
+      })()}
     </nav>
   `
 }

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -7,9 +7,8 @@
 import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { navigate, route } from '../../router'
-import { executionLoaded, keepers, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
+import { executionLoaded, keepers, shellCounts, shellRuntimeResolution } from '../../store'
 import { activeKeeperName } from '../../keeper-state'
-import { governanceData } from '../governance-signals'
 import { toolsData } from '../tools/tool-state'
 import { scheduledPendingApprovalCount } from '../tools/scheduled-automation-panel'
 import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
@@ -26,8 +25,7 @@ import { ConnectionStatus, ErrorCounterBadge, BuildIdentityBadge } from '../dash
 import { AuthStatus } from '../auth-status'
 import { EmergencyStopControl } from '../emergency-stop-control'
 import { TransportBeacon } from '../transport-beacon'
-
-const DEAD_PHASES = new Set(['Overflowed', 'Crashed', 'Dead', 'Zombie'])
+import { attentionBreakdown } from '../../nav-badges'
 
 interface AttentionAgg {
   approvals: number
@@ -37,13 +35,18 @@ interface AttentionAgg {
   total: number
 }
 
+// Sourced from nav-badges.ts's shared attentionBreakdown — the nav rail's
+// combined `keepers` badge (needsAttentionKeepers + deadKeepers) and this
+// dropdown's two separate drill-down rows are one derivation, two views.
 function computeAttention(): AttentionAgg {
-  const ks = keepers.value
-  const approvals = governanceData.value?.approval_queue?.length ?? 0
-  const attKeepers = ks.filter((k) => k.needs_attention === true).length
-  const dead = ks.filter((k) => !!k.lifecycle_phase && DEAD_PHASES.has(k.lifecycle_phase)).length
-  const stale = staleKeepers.value.size
-  return { approvals, keepers: attKeepers, dead, stale, total: approvals + attKeepers + dead + stale }
+  const a = attentionBreakdown.value
+  return {
+    approvals: a.approvals,
+    keepers: a.needsAttentionKeepers,
+    dead: a.deadKeepers,
+    stale: a.staleKeepers,
+    total: a.approvals + a.needsAttentionKeepers + a.deadKeepers + a.staleKeepers,
+  }
 }
 
 function AttentionIndicatorV2() {

--- a/dashboard/src/nav-badges.test.ts
+++ b/dashboard/src/nav-badges.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { keeperHeartbeats, keepers, messages, shellAuthSummary, tasks } from './store'
+import { governanceResource } from './components/governance-signals'
+import { _setToolsDataForTests } from './components/tools/tool-state'
+import { _clearBoardMentionsLastSeenForTests } from './board-mentions-last-seen'
+import { attentionBreakdown, navBadges } from './nav-badges'
+import { HEARTBEAT_STALE_MS } from './config/constants'
+import type { Keeper, KeeperApprovalQueueItem, Message, Task } from './types'
+
+function keeper(overrides: Partial<Keeper> & { name: string }): Keeper {
+  return { status: 'idle', ...overrides } as Keeper
+}
+
+function task(overrides: Partial<Task> & { id: string; status: string }): Task {
+  return { ...overrides } as Task
+}
+
+function message(overrides: Partial<Message> & { content: string }): Message {
+  return { from: 'keeper', ...overrides }
+}
+
+describe('nav-badges attentionBreakdown / navBadges', () => {
+  beforeEach(() => {
+    keepers.value = []
+    keeperHeartbeats.value = new Map()
+    tasks.value = []
+    messages.value = []
+    shellAuthSummary.value = {
+      enabled: true,
+      require_token: false,
+      default_role: null,
+      token_present: true,
+      token_valid: true,
+      token_agent: 'dashboard',
+      requested_agent: null,
+      effective_agent: 'dashboard',
+      effective_role: 'admin',
+      auth_error_code: null,
+      auth_error_detail: null,
+      can_keeper_msg: true,
+      keeper_msg_error: null,
+    }
+    governanceResource.reset(null)
+    _setToolsDataForTests(null)
+    _clearBoardMentionsLastSeenForTests()
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    keepers.value = []
+    keeperHeartbeats.value = new Map()
+    tasks.value = []
+    messages.value = []
+    shellAuthSummary.value = null
+    governanceResource.reset(null)
+    _setToolsDataForTests(null)
+    _clearBoardMentionsLastSeenForTests()
+    window.localStorage.clear()
+  })
+
+  it('is all zero with no live sources', () => {
+    expect(attentionBreakdown.value).toEqual({
+      approvals: 0,
+      needsAttentionKeepers: 0,
+      deadKeepers: 0,
+      staleKeepers: 0,
+      boardMentionsForMe: 0,
+      awaitingVerification: 0,
+      schedulePending: 0,
+    })
+    expect(navBadges.value).toEqual({
+      overview: 0,
+      keepers: 0,
+      monitoring: 0,
+      workspace: 0,
+      approvals: 0,
+      schedule: 0,
+      board: 0,
+      fusion: 0,
+      logs: 0,
+      code: 0,
+      connectors: 0,
+      settings: 0,
+    })
+  })
+
+  it('approvals badge counts governanceData.approval_queue', () => {
+    governanceResource.reset({
+      approval_queue: [{}, {}, {}] as KeeperApprovalQueueItem[],
+    })
+    expect(attentionBreakdown.value.approvals).toBe(3)
+    expect(navBadges.value.approvals).toBe(3)
+  })
+
+  it('keepers badge combines needs_attention and dead-phase keepers', () => {
+    keepers.value = [
+      keeper({ name: 'a', needs_attention: true }),
+      keeper({ name: 'b', lifecycle_phase: 'Dead' }),
+      keeper({ name: 'c', lifecycle_phase: 'Overflowed' }),
+      keeper({ name: 'd' }),
+    ]
+    expect(attentionBreakdown.value.needsAttentionKeepers).toBe(1)
+    expect(attentionBreakdown.value.deadKeepers).toBe(2)
+    // The rail's single 'keepers' badge sums both — the top-bar dropdown keeps
+    // them as separate drill-down rows (see top-bar-v2.ts's own AttentionAgg).
+    expect(navBadges.value.keepers).toBe(3)
+  })
+
+  it('connectors badge sources from staleKeepers (heartbeat staleness)', () => {
+    keepers.value = [keeper({ name: 'stale-one' }), keeper({ name: 'fresh-one' })]
+    keeperHeartbeats.value = new Map([
+      ['stale-one', Date.now() - (HEARTBEAT_STALE_MS + 1_000)],
+      ['fresh-one', Date.now()],
+    ])
+    expect(attentionBreakdown.value.staleKeepers).toBe(1)
+    expect(navBadges.value.connectors).toBe(1)
+  })
+
+  it('workspace badge counts awaiting-verification tasks', () => {
+    tasks.value = [
+      task({ id: '1', status: 'awaiting_verification' }),
+      task({ id: '2', status: 'in_progress' }),
+      task({ id: '3', status: 'awaiting_verification' }),
+    ]
+    expect(attentionBreakdown.value.awaitingVerification).toBe(2)
+    expect(navBadges.value.workspace).toBe(2)
+  })
+
+  it('schedule badge sources from the scheduled-automation pending count', () => {
+    _setToolsDataForTests({
+      scheduled_automation: { counts: { pending: 4 }, requests: [] },
+    } as never)
+    expect(attentionBreakdown.value.schedulePending).toBe(4)
+    expect(navBadges.value.schedule).toBe(4)
+  })
+
+  it('board badge counts unseen for-me mentions and clears once seen', () => {
+    messages.value = [
+      message({ id: 'm1', content: '@dashboard please check this', timestamp: '2026-07-01T00:00:00Z' }),
+      message({ id: 'm2', content: '@someone-else not for me', timestamp: '2026-07-01T00:00:01Z' }),
+    ]
+    expect(attentionBreakdown.value.boardMentionsForMe).toBe(1)
+    expect(navBadges.value.board).toBe(1)
+  })
+
+  it('explicit-zero tabs never derive a count from any source', () => {
+    // Populate every underlying signal at once; overview/monitoring/fusion/
+    // logs/code/settings must stay 0 regardless (documented "no live source"
+    // decisions in nav-badges.ts).
+    keepers.value = [keeper({ name: 'a', needs_attention: true })]
+    tasks.value = [task({ id: '1', status: 'awaiting_verification' })]
+    governanceResource.reset({ approval_queue: [{}] as KeeperApprovalQueueItem[] })
+    _setToolsDataForTests({ scheduled_automation: { counts: { pending: 1 }, requests: [] } } as never)
+
+    const b = navBadges.value
+    expect(b.overview).toBe(0)
+    expect(b.monitoring).toBe(0)
+    expect(b.fusion).toBe(0)
+    expect(b.logs).toBe(0)
+    expect(b.code).toBe(0)
+    expect(b.settings).toBe(0)
+  })
+})

--- a/dashboard/src/nav-badges.ts
+++ b/dashboard/src/nav-badges.ts
@@ -1,0 +1,93 @@
+// Single derivation for "what needs the operator's attention" — computed
+// once, consumed by both the nav rail (per-tab badge counts, NavRailV2) and
+// the top-bar attention dropdown (drill-down rows, AttentionIndicatorV2).
+// Before this module the same underlying signals (governanceData, keepers,
+// staleKeepers) were re-derived independently in nav-rail-v2 (a 2-key closed
+// record) and top-bar-v2 (computeAttention) — see the #65 nav-badge audit
+// brief. Extending either surface now means adding a field here once.
+//
+// Every rail tab must have a decision (0 allowed, but stated): the
+// `satisfies NavBadges` check below is exhaustive over RailBadgeTab, so
+// adding a surface to nav-rail-v2.ts's SURFACES is a compile error here until
+// this module states what that tab's badge count is.
+
+import { computed, type ReadonlySignal } from '@preact/signals'
+import { keepers, messages, shellAuthSummary, staleKeepers, tasksByStatus } from './store'
+import { governanceData } from './components/governance-signals'
+import { toolsData } from './components/tools/tool-state'
+import { scheduledPendingApprovalCount } from './components/tools/scheduled-automation-panel'
+import { buildMentionInboxModel, mentionTargetCandidates } from './components/board/mention-inbox'
+import { currentDashboardActorName } from './lib/dashboard-session-actor'
+import { markBoardMentionsSeen, unseenMentionCount } from './board-mentions-last-seen'
+import type { NavBadges } from './components/v2/nav-rail-v2'
+
+// Keeper lifecycle phases treated as "needs operator intervention" — moved
+// here from top-bar-v2.ts (single definition; top-bar re-imports it).
+export const DEAD_KEEPER_PHASES = new Set(['Overflowed', 'Crashed', 'Dead', 'Zombie'])
+
+export interface AttentionBreakdown {
+  approvals: number
+  needsAttentionKeepers: number
+  deadKeepers: number
+  staleKeepers: number
+  boardMentionsForMe: number
+  awaitingVerification: number
+  schedulePending: number
+}
+
+// KNOWN LIMITATION (documented, not silently propagated — see PR body /
+// #65 audit): `staleKeepers` is keeper *heartbeat* staleness
+// (store.ts HEARTBEAT_STALE_MS), not connector-*gate* staleness
+// (GateConnectorInfo.stale in connector-status.ts, which is only fetched
+// when the Connectors surface itself mounts — not a route-independent
+// signal). The pre-existing top-bar-v2 attention dropdown has labeled this
+// count "stale 게이트" and routed it to the connectors tab since it was
+// introduced; this module preserves that exact mapping (no new backend
+// aggregation) rather than inventing a fix here. Flagged as a follow-up.
+export const attentionBreakdown: ReadonlySignal<AttentionBreakdown> = computed(() => {
+  const ks = keepers.value
+  const targets = mentionTargetCandidates(shellAuthSummary.value, currentDashboardActorName())
+  const mentionModel = buildMentionInboxModel(messages.value, targets)
+  return {
+    approvals: governanceData.value?.approval_queue?.length ?? 0,
+    needsAttentionKeepers: ks.filter(k => k.needs_attention === true).length,
+    deadKeepers: ks.filter(k => !!k.lifecycle_phase && DEAD_KEEPER_PHASES.has(k.lifecycle_phase)).length,
+    staleKeepers: staleKeepers.value.size,
+    boardMentionsForMe: unseenMentionCount(mentionModel.forMe),
+    awaitingVerification: tasksByStatus.value.awaitingVerification.length,
+    schedulePending: scheduledPendingApprovalCount(toolsData.value?.scheduled_automation ?? null),
+  }
+})
+
+// Explicit zeros, decided (brief #65 "Kill or keep"): overview and settings
+// have no attention semantics; monitoring's fleet detail already lives in the
+// health strip; fusion runs are informational, not attention; logs already
+// has its own dedicated top-bar ErrorCounterBadge (a second projection of
+// unacknowledgedCount here would violate SSOT); code/IDE has no live source.
+export const navBadges: ReadonlySignal<NavBadges> = computed(() => {
+  const a = attentionBreakdown.value
+  return {
+    overview: 0,
+    keepers: a.needsAttentionKeepers + a.deadKeepers,
+    monitoring: 0,
+    workspace: a.awaitingVerification,
+    approvals: a.approvals,
+    schedule: a.schedulePending,
+    board: a.boardMentionsForMe,
+    fusion: 0,
+    logs: 0,
+    code: 0,
+    connectors: a.staleKeepers,
+    settings: 0,
+  } satisfies NavBadges
+})
+
+/** Advance the board-mentions cursor to the newest currently-known for-me
+ *  mention. Call on board-route visit (app.ts) — the same "mark read on
+ *  visit" shape as advanceKeeperLastSeen, just app-root-driven instead of
+ *  panel-mount-driven since the board surface itself is out of scope here. */
+export function markBoardMentionsSeenNow(): void {
+  const targets = mentionTargetCandidates(shellAuthSummary.value, currentDashboardActorName())
+  const model = buildMentionInboxModel(messages.value, targets)
+  markBoardMentionsSeen(model.forMe)
+}

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -291,7 +291,13 @@ describe('setupSSEReaction reconnect hydration', () => {
     cleanup()
   })
 
-  it('does not refresh hidden heavy surfaces for keeper lifecycle events on overview', async () => {
+  it('still fires the route-independent nav-badge refresh for keeper lifecycle events on overview, but not the operator refresh', async () => {
+    // RFC brief #65: keeper-lifecycle events additionally schedule an
+    // UNGATED light refreshExecution() (nav-badges.ts keepers/workspace
+    // badges must not freeze off the keepers/monitoring/workspace-planning
+    // routes) — this is on top of, not instead of, the pre-existing
+    // route-gated `{force:true}` refresh below. Only the operator refresh
+    // stays strictly route-scoped.
     const { sseStore, sse } = await loadSseStore()
     const refreshOperator = vi.fn()
     sseStore.registerOperatorRefresh(refreshOperator)
@@ -307,13 +313,14 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshExecution).not.toHaveBeenCalled()
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).not.toHaveBeenCalledWith({ force: true })
     expect(refreshOperator).not.toHaveBeenCalled()
 
     cleanup()
   })
 
-  it('routes execution SSE refreshes only when the current route needs execution data', async () => {
+  it('routes execution SSE refreshes with both the route-scoped force refresh and the ungated nav-badge refresh', async () => {
     const { sseStore, sse } = await loadSseStore()
     route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
     const cleanup = sseStore.setupSSEReaction()
@@ -327,7 +334,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledTimes(2)
     expect(refreshExecution).toHaveBeenCalledWith({ force: true })
 
     cleanup()
@@ -346,7 +353,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledTimes(2)
     expect(refreshExecution).toHaveBeenCalledWith({ force: true })
 
     cleanup()
@@ -364,7 +371,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledTimes(2)
     expect(refreshExecution).toHaveBeenCalledWith({ force: true })
   })
 
@@ -383,7 +390,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(refreshExecution).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps operator lifecycle refreshes scoped to the command route', async () => {
+  it('keeps the route-scoped force refresh off the command route, but still fires the ungated nav-badge refresh', async () => {
     const { sseStore, sse } = await loadSseStore()
     const refreshOperator = vi.fn()
     sseStore.registerOperatorRefresh(refreshOperator)
@@ -399,7 +406,8 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshOperator).toHaveBeenCalledTimes(1)
-    expect(refreshExecution).not.toHaveBeenCalled()
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).not.toHaveBeenCalledWith({ force: true })
 
     cleanup()
   })

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -265,8 +265,33 @@ const KEEPER_LIFECYCLE_EVENTS = new Set([
   'keeper_phase_changed',
 ])
 
+// Board content events that may carry an @mention of the operator. The
+// nav-rail board badge (nav-badges.ts) derives its count from the `messages`
+// signal, populated by the 'execution' refresh target — but that target is
+// route-gated (routeWantsExecution: keepers / workspace-planning /
+// monitoring journey|agents|cognition / fleet-health-comparison only), so a
+// post landing off those routes would freeze the badge. Set membership is
+// unprefixed; callers normalize via normalizeMascEventType before checking.
+const BOARD_MENTION_REFRESH_EVENTS = new Set([
+  'post_created', 'board_post', 'comment_added', 'board_comment',
+])
+
 function normalizeMascEventType(type: string): string {
   return type.startsWith('masc/') ? type.slice('masc/'.length) : type
+}
+
+// Route-independent (ungated) light execution refresh — mirrors the
+// governance approval-event refresh below (scheduleRefresh called directly,
+// not through scheduleTargetRefresh's routeWantsRefreshTarget gate) so the
+// nav-rail badges that read the execution slice (keepers needs_attention/
+// dead-phase count, workspace awaiting-verification count, board mentions)
+// stay live on every route instead of only where routeWantsExecution already
+// allows a refresh. Debounced under its own key so it never cancels/replaces
+// the route-gated 'execution' refresh scheduled elsewhere in this file — at
+// worst both fire and refreshExecution's own FetchScheduler cooldown/inflight
+// guard (store.ts) coalesces the duplicate call.
+function scheduleNavBadgeExecutionRefresh(): void {
+  scheduleRefresh('nav-badge-execution', () => { void refreshExecution() })
 }
 
 /** Hydrate project-snapshot signals directly from SSE payload — zero HTTP fetch. */
@@ -417,6 +442,15 @@ async function hydrateAfterReconnect(): Promise<void> {
   // the active surface, so an approval that arrived (or resolved) during the
   // gap must be re-fetched on reconnect, not only on the governance surface.
   handleGovernance()
+  // Same reasoning for the nav-rail schedule badge (nav-badges.ts): the
+  // scheduled-automation projection is otherwise only loaded at app boot and
+  // on schedule-surface visits (app.ts), so a pending-approval change during
+  // a disconnect gap would freeze the badge until the next such visit.
+  void import('./components/tools/tool-state')
+    .then(({ loadTools }) => loadTools())
+    .catch(err =>
+      console.warn('[SSE] reconnect scheduled-automation reload failed', err instanceof Error ? err.message : err),
+    )
   // Recover keeper_chat_appended events that fell outside the server replay
   // buffer while disconnected. The live stream cannot re-deliver them, so the
   // open conversation panel must re-fetch its transcript. Route and periodic
@@ -546,6 +580,14 @@ export function routeServerPushEvent(event: SSEEvent): void {
 
   if (KEEPER_LIFECYCLE_EVENTS.has(normalizeMascEventType(routedType))) {
     handleKeeperLifecycle(event)
+    scheduleNavBadgeExecutionRefresh()
+  }
+
+  // board_post/comment_added etc. fall through to here (post_created's own
+  // mention-refresh trigger lives in hydrateServerPushEvent above, since a
+  // 'recent'-sort board short-circuits before reaching this function).
+  if (BOARD_MENTION_REFRESH_EVENTS.has(normalizeMascEventType(routedType))) {
+    scheduleNavBadgeExecutionRefresh()
   }
 
   if (IDE_WORKSPACE_REFRESH_EVENTS.has(normalizeMascEventType(routedType))) {
@@ -649,8 +691,16 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
     return true
   }
 
-  if (event.type === 'post_created' && handleBoardPostCreated(event)) {
-    return true
+  if (event.type === 'post_created') {
+    // The board-mentions nav badge cares about every post regardless of the
+    // board surface's own sort-mode/dedup gate below — handleBoardPostCreated
+    // only prepends into the board list for 'recent' sort, and returning
+    // early here (post processed) would otherwise skip
+    // routeServerPushEvent's BOARD_MENTION_REFRESH_EVENTS trigger entirely.
+    scheduleNavBadgeExecutionRefresh()
+    if (handleBoardPostCreated(event)) {
+      return true
+    }
   }
 
   return false

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -126,10 +126,6 @@
 /* Fetch error banner (live surface). */
 .ap-error { font-size: var(--fs-12); color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-bad) 7%, transparent); padding: 10px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; }
 
-/* Nav-rail count badge / dot for the approvals surface (open-approval count). */
-.ap-nav-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 6px; border-radius: var(--radius-pill); font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; line-height: 1; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 38%, transparent); }
-.ap-nav-dot { position: absolute; top: 3px; right: 3px; width: 6px; height: 6px; border-radius: 50%; background: var(--status-bad); box-shadow: 0 0 0 2px var(--bg-panel); }
-
 @media (max-width: 980px) {
   .ap-workspace { grid-template-columns: 1fr; }
   .ap-detail-panel { position: static; }


### PR DESCRIPTION
## 목적 (캠페인 #65)

좌측 네비의 상태 무표정 문제. 진단(wf_e047f03f CONFIRMED): NavRailV2는 approvals/schedule 배지를 이미 보유 — 결함은 `NavBadges` 계약이 2키로 hard-closed된 것과, 미마운트 평행 nav(SideRail/HealthIndicator)의 침묵 부패.

## 배선표 (탭 → 소스 → 형태)

| 탭 | 소스 | 형태 |
|---|---|---|
| approvals | governanceData.approval_queue.length | count (기존) |
| schedule | scheduledPendingApprovalCount | count (기존) |
| keepers | needs_attention + dead-phase 카운트 | count (신규) |
| workspace | awaitingVerification.length (health-strip과 동일 소스) | count (신규) |
| board | 미확인 나를-향한 멘션 (last-seen 커서 + mention inbox 모델) | count (신규) |
| connectors | staleKeepers.size | count (신규, 아래 한계 참조) |
| 나머지 6탭 | 명시적 0 + 코드 주석에 사유 문서화 | 없음 |

없는 소스는 배지 미추가(날조 0). exhaustive `RailBadgeTab` 계약으로 승격 — 탭 추가 시 컴파일 강제.

## 삭제 (rg 잔존참조 0 증명)

`SideRail`/`HealthIndicator` 미마운트 평행 nav 일체 (dashboard-shell.ts 순삭 366줄) + 고아 CSS. 에이전트가 sed 범위 실수로 살아있는 함수(dashboardRouteBoundaryKey) 1개를 쓸어낸 것을 자가 발견·복원(tsc 확인).

## sse-store 확장 (브리프 이탈, 근거 수용)

배지가 라이브이려면 route-gated 'execution' refresh만으로는 off-route에서 동결 — 별도 debounce 키의 ungated 경량 refresh 트리거 추가(기존 governance 이벤트 refresh와 동형, FetchScheduler cooldown이 중복 흡수). 재연결 hydration에 schedule 배지 소스 재적재 포함. 기존 route-gated 계약을 인코딩한 테스트 단언 5건 갱신.

## 알려진 한계 (수정 아닌 보존 + 문서화)

`staleKeepers`는 keeper heartbeat 신선도(120s)인데 top-bar가 도입 시점(03d5feaf25)부터 "stale 게이트"로 오라벨 — 기존 시맨틱을 보존하고 코드에 명시 표기. 후속 이슈로 분리 예정.

## 검증

tsc + lint 클린, 스코프 스위트 134/134 (에이전트) + 97/97 (오케스트레이터 재검증, rebase 후).

진단: workflow wf_e047f03f (캠페인 원장 masc#23925).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
