### PR TITLE
fix(board): mention highlight + close silent-drop branches in wake fan-out (#60)

### DIFF
--- a/dashboard/src/components/board/mention-inbox.ts
+++ b/dashboard/src/components/board/mention-inbox.ts
@@ -7,6 +7,7 @@ import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
 import { currentDashboardActorName } from '../../lib/dashboard-session-actor'
+import { MENTION_RE } from '../../lib/mention-utils'
 import { messages, shellAuthSummary } from '../../store'
 import type { DashboardShellAuthSummary, Message } from '../../types'
 import { navigateBoard } from './board-route'
@@ -23,8 +24,6 @@ export interface MentionInboxModel {
   forMe: MentionInboxRow[]
   others: MentionInboxRow[]
 }
-
-const MENTION_RE = /(^|[^A-Za-z0-9._-])@([A-Za-z0-9._-]{1,64})/g
 
 function normalizeTarget(value: string | null | undefined): string | null {
   const normalized = value?.trim().replace(/^@+/, '').toLowerCase()

--- a/dashboard/src/components/common/markdown-renderer.test.ts
+++ b/dashboard/src/components/common/markdown-renderer.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { MarkdownContent, renderMarkdown } from './markdown-renderer'
+import { MarkdownContent, highlightMentions, renderMarkdown } from './markdown-renderer'
 import { renderMermaidSvg } from './mermaid-graph'
+import { keepers } from '../../store'
 
 // Mock the shared mermaid render path: markdown-renderer delegates to it for
 // ```mermaid fences. Real mermaid is dynamically imported and unavailable here.
@@ -186,5 +187,68 @@ describe('MarkdownContent mermaid fences', () => {
     expect(container.querySelector('code.language-mermaid')).not.toBeNull()
 
     warnSpy.mockRestore()
+  })
+})
+
+describe('highlightMentions', () => {
+  it('wraps a mention matching a known name in a mention span', () => {
+    const out = highlightMentions('<p>hi @albini look</p>', new Set(['albini']))
+    expect(out).toContain('<span class="mention">@albini</span>')
+  })
+
+  it('leaves an @word not in the known-name set as plain text', () => {
+    const out = highlightMentions('<p>send to user@example</p>', new Set(['albini']))
+    expect(out).not.toContain('class="mention"')
+  })
+
+  it('matches case-insensitively against the known-name set', () => {
+    const out = highlightMentions('<p>PING @ALBINI now</p>', new Set(['albini']))
+    expect(out).toContain('<span class="mention">@ALBINI</span>')
+  })
+
+  it('does not highlight a mention-shaped token inside a code block', () => {
+    const out = highlightMentions('<pre><code>@albini</code></pre>', new Set(['albini']))
+    expect(out).not.toContain('class="mention"')
+    expect(out).toContain('@albini')
+  })
+
+  it('does not highlight inside inline code', () => {
+    const out = highlightMentions('<p>use <code>@albini</code> as a flag</p>', new Set(['albini']))
+    expect(out).not.toContain('class="mention"')
+  })
+
+  it('returns the input unchanged when there is no known-name set', () => {
+    const html = '<p>@albini</p>'
+    expect(highlightMentions(html, new Set())).toBe(html)
+  })
+})
+
+describe('MarkdownContent mention highlighting', () => {
+  afterEach(() => {
+    keepers.value = []
+  })
+
+  it('highlights a mention of a keeper in the live roster', () => {
+    keepers.value = [{ name: 'albini' } as (typeof keepers.value)[number]]
+    const container = document.createElement('div')
+    render(h(MarkdownContent, { text: 'hey @albini take a look' }), container)
+    const mention = container.querySelector('.mention')
+    expect(mention).not.toBeNull()
+    expect(mention?.textContent).toBe('@albini')
+  })
+
+  it('does not highlight an @word for a keeper not in the roster', () => {
+    keepers.value = [{ name: 'someone-else' } as (typeof keepers.value)[number]]
+    const container = document.createElement('div')
+    render(h(MarkdownContent, { text: 'hey @albini take a look' }), container)
+    expect(container.querySelector('.mention')).toBeNull()
+  })
+
+  it('does not highlight a mention-shaped token inside a fenced code block', () => {
+    keepers.value = [{ name: 'albini' } as (typeof keepers.value)[number]]
+    const container = document.createElement('div')
+    render(h(MarkdownContent, { text: '```\n@albini\n```' }), container)
+    expect(container.querySelector('.mention')).toBeNull()
+    expect(container.querySelector('code')?.textContent).toContain('@albini')
   })
 })

--- a/dashboard/src/components/common/markdown-renderer.ts
+++ b/dashboard/src/components/common/markdown-renderer.ts
@@ -12,6 +12,8 @@ import { highlightCodeHtml } from './shiki-highlighter'
 import { renderMermaidSvg } from './mermaid-graph'
 import { sanitizeHtml } from '../../lib/dompurify'
 import { memoizeLru } from '../../lib/lru-cache'
+import { MENTION_RE } from '../../lib/mention-utils'
+import { keepers } from '../../store'
 
 // ── Marked instance (GFM tables + line-break support) ────────
 const md = new Marked({ gfm: true, breaks: true })
@@ -116,11 +118,103 @@ function renderMarkdownUncached(text: string): string {
 const MARKDOWN_CACHE_MAX = 256
 export const renderMarkdown = memoizeLru(renderMarkdownUncached, { max: MARKDOWN_CACHE_MAX })
 
+// ── Mention highlighting ──────────────────────────────────────
+// A separate post-process over the sanitized HTML, not baked into
+// `renderMarkdown`: which names are "known" changes with the live keeper
+// roster, but `renderMarkdown`'s cache is keyed by source text alone.
+// Baking roster membership into that cache would either go stale (a keeper
+// that leaves stops highlighting in already-cached posts) or force
+// text+roster as the cache key (defeats the point of caching by text — the
+// roster changes far more often than any given post is re-rendered).
+// Operating on the DOM (not marked's tokenizer) also gets code/pre
+// exclusion for free: walking the tree and skipping `<code>`/`<pre>`
+// descendants is exactly what "don't highlight inside code" means,
+// without needing marked's inline-extension dispatch order (which does not
+// reserve '@' as a token boundary and would need the built-in text
+// tokenizer's stop-char set widened to ever see it).
+function isInsideCodeOrPre(node: Node, root: Node): boolean {
+  let el: Node | null = node.parentNode
+  while (el && el !== root) {
+    if (el.nodeName === 'CODE' || el.nodeName === 'PRE') return true
+    el = el.parentNode
+  }
+  return false
+}
+
+function collectHighlightableTextNodes(root: Node): Text[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  const nodes: Text[] = []
+  let current = walker.nextNode()
+  while (current) {
+    if (!isInsideCodeOrPre(current, root)) nodes.push(current as Text)
+    current = walker.nextNode()
+  }
+  return nodes
+}
+
+function highlightMentionsInTextNode(node: Text, knownNames: ReadonlySet<string>): void {
+  const value = node.nodeValue ?? ''
+  if (!value.includes('@')) return
+
+  const fragment = document.createDocumentFragment()
+  let lastIndex = 0
+  let matchedAny = false
+
+  for (const match of value.matchAll(MENTION_RE)) {
+    const [, boundary = '', name] = match
+    if (name === undefined || !knownNames.has(name.toLowerCase())) continue
+    const start = (match.index ?? 0) + boundary.length
+    const end = start + 1 + name.length // '@' + name
+    fragment.appendChild(document.createTextNode(value.slice(lastIndex, start)))
+    const span = document.createElement('span')
+    span.className = 'mention'
+    span.textContent = `@${name}`
+    fragment.appendChild(span)
+    lastIndex = end
+    matchedAny = true
+  }
+
+  if (!matchedAny) return
+  fragment.appendChild(document.createTextNode(value.slice(lastIndex)))
+  node.replaceWith(fragment)
+}
+
+/** Wrap `@name` runs matching a known keeper/agent name in
+ * `<span class="mention">`. Skips text inside `<code>`/`<pre>` so a
+ * mention-shaped token in a code block stays literal. Names not in
+ * `knownNames` (emails, typos, unrelated `@word`s) are left as plain text —
+ * only addresses that resolve to a real roster entry get highlighted.
+ * Exported for testing. */
+export function highlightMentions(html: string, knownNames: ReadonlySet<string>): string {
+  if (knownNames.size === 0 || !html.includes('@')) return html
+  const container = document.createElement('div')
+  container.innerHTML = html
+  for (const node of collectHighlightableTextNodes(container)) {
+    highlightMentionsInTextNode(node, knownNames)
+  }
+  return container.innerHTML
+}
+
 // ── Component ────────────────────────────────────────────────
 export function MarkdownContent({ text, class: className }: { text: string; class?: string }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const htmlStr = useMemo(() => renderMarkdown(text), [text])
   const classes = ['markdown-content', className].filter(Boolean).join(' ')
+
+  // Roster-name join (not `keepers.value` itself) as the memo key: the
+  // roster signal gets a new array reference on every poll tick even when
+  // the name set is unchanged, which would otherwise re-run mention
+  // highlighting (and the effects below, since they depend on the
+  // highlighted HTML) on a cadence unrelated to any actual content change.
+  const rosterKey = keepers.value.map(keeper => keeper.name.toLowerCase()).join('\0')
+  const knownNames = useMemo(
+    () => new Set(rosterKey ? rosterKey.split('\0') : []),
+    [rosterKey],
+  )
+  const highlighted = useMemo(
+    () => highlightMentions(htmlStr, knownNames),
+    [htmlStr, knownNames],
+  )
 
   // Post-render: replace mermaid code blocks with rendered SVG
   useEffect(() => {
@@ -156,7 +250,7 @@ export function MarkdownContent({ text, class: className }: { text: string; clas
       }
     })()
     return () => { cancelled = true }
-  }, [htmlStr])
+  }, [highlighted])
 
   // Post-render: highlight code blocks with shiki
   useEffect(() => {
@@ -204,9 +298,9 @@ export function MarkdownContent({ text, class: className }: { text: string; clas
         }
       }
     })()
-    
-    return () => { cancelled = true }
-  }, [htmlStr])
 
-  return html`<div ref=${containerRef} class=${classes} dangerouslySetInnerHTML=${{ __html: htmlStr }}></div>`
+    return () => { cancelled = true }
+  }, [highlighted])
+
+  return html`<div ref=${containerRef} class=${classes} dangerouslySetInnerHTML=${{ __html: highlighted }}></div>`
 }

--- a/dashboard/src/lib/mention-utils.ts
+++ b/dashboard/src/lib/mention-utils.ts
@@ -1,6 +1,16 @@
 // Shared mention utilities — SSOT for keeper mention UI logic.
 // Used by composer-v2.ts and quick-intervene.ts.
 
+// Boundary-aware @token grammar: the char before '@' is either the start of
+// the string or not part of the name-char class, so "email@example.com"
+// does not tokenize as a mention of "example". Char class mirrors the
+// backend's board-signal mention matcher (lib/keeper/keeper_lane_mentions.ml
+// via keeper_world_observation_board_signal.ml) so a post that highlights a
+// mention and a post that wakes a keeper agree on what counts as an
+// address. SSOT for extraction (extractMentionTargets) and rendering
+// (markdown-renderer.ts's mention highlight) — do not duplicate this regex.
+export const MENTION_RE = /(^|[^A-Za-z0-9._-])@([A-Za-z0-9._-]{1,64})/g
+
 export interface OnlineKeeper {
   name: string
   status?: string

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -66,6 +66,8 @@
   & table { margin: 8px 0; }
 
   & img { max-width: 100%; height: auto; border-radius: var(--r-2); margin: 4px 0; }
+
+  & .mention { color: var(--brass-1); font-weight: var(--fw-semi); }
 }
 
 /* ── Mermaid rendered output ──────────────────────────────── */

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -307,6 +307,22 @@ let trim_nonempty value =
   let v = String.trim value in
   if v = "" then None else Some v
 
+(* Normalize an operator-facing mention target: trim whitespace, strip any
+   leading '@' characters (targets are sometimes configured pre-prefixed,
+   e.g. "@albini", or even doubly so), lowercase for case-insensitive
+   matching. [None] for a target that normalizes to empty — an all-'@'/
+   whitespace target has no representable identity (parse, don't validate:
+   a target stored with its '@' intact used to build a never-matching
+   "@@name" search needle downstream). *)
+let normalize_mention_target value =
+  let trimmed = String.trim value in
+  let len = String.length trimmed in
+  let rec skip_at i = if i < len && trimmed.[i] = '@' then skip_at (i + 1) else i in
+  let start = skip_at 0 in
+  let stripped = String.sub trimmed start (len - start) in
+  let normalized = String.lowercase_ascii stripped in
+  if normalized = "" then None else Some normalized
+
 let trim_to_option value =
   let v = String.trim value in
   if v = "" then None else Some v

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -125,6 +125,16 @@ val trim_nonempty : string -> string option
 (** [trim_nonempty s] trims whitespace and returns [Some s] if non-empty,
     [None] otherwise. SSOT for the per-module [trim_nonempty] helpers. *)
 
+val normalize_mention_target : string -> string option
+(** [normalize_mention_target target] trims whitespace, strips any leading
+    ['@'] characters, and lowercases the result for case-insensitive
+    matching. [None] when the target normalizes to empty. SSOT for
+    normalizing keeper board-mention targets at both write time
+    ([Keeper_turn_up_args.resolve_mention_targets]) and read time
+    ([Keeper_world_observation_board_signal.match_signal]) so a target
+    stored pre-prefixed with ['@'] cannot desync from the '@'-free names
+    the board-signal matcher extracts from post text. *)
+
 val trim_to_option : string -> string option
 (** [trim_to_option s] is an alias for [trim_nonempty]. Both are identical;
     [trim_to_option] is kept for migration compatibility. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -612,6 +612,42 @@ let board_signal_wake_keeper
     Ok ())
 ;;
 
+(** Routing outcome for a single board-signal candidate, given its phase and
+    whether an explicit mention is entitled to auto-resume a paused keeper.
+    Every (phase, wake_reason) pair reaching {!board_signal_wake_lane} comes
+    through {!board_signal_entry_is_wakeup_candidate}'s Running/Paused
+    filter; other phases are defensively [Excluded].
+
+    RFC-0334 W1: a deterministic address ([Explicit_mention]) is never
+    dropped — a paused keeper without operator-granted auto-resume still
+    gets the stimulus in its mailbox ([Mailbox_only]) for whenever it next
+    resumes, instead of the stimulus vanishing with no wake and no queue
+    entry. Non-explicit followups (thread-reply / reaction) on a paused
+    keeper stay [Excluded]: pause is an operator opt-out from implicit wake,
+    not from addressed mentions. *)
+type board_signal_wake_lane =
+  | Immediate of Board_wake.wake_reason
+  | Mailbox_only of Board_wake.wake_reason
+  | Excluded
+
+let board_signal_wake_lane
+      ~(phase : Keeper_state_machine.phase)
+      ~(auto_resume_allowed : bool)
+      (wake_reason : Board_wake.wake_reason option)
+  : board_signal_wake_lane
+  =
+  match phase, wake_reason with
+  | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention
+    when auto_resume_allowed ->
+    Immediate Board_wake.Explicit_mention
+  | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention ->
+    Mailbox_only Board_wake.Explicit_mention
+  | Keeper_state_machine.Paused, _ -> Excluded
+  | Keeper_state_machine.Running, Some reason -> Immediate reason
+  | Keeper_state_machine.Running, None -> Excluded
+  | _, _ -> Excluded
+;;
+
 let wakeup_relevant_keeper_for_board_signal
       ~(config : Workspace.config)
       (signal : Board_dispatch.board_signal)
@@ -626,50 +662,73 @@ let wakeup_relevant_keeper_for_board_signal
     | Board_dispatch.Board_comment_added -> "comment_added"
     | Board_dispatch.Board_reaction_changed _ -> "reaction_changed"
   in
+  (* Visibility for the REPO_WAKE_UP audit finding: a [None] wake_reason
+     means the candidate keeper had no explicit mention match and (for
+     comments) no external reply after its own comment. Without this
+     counter, operators cannot distinguish between a board post that
+     legitimately had no deterministic addressee and one that was silently
+     dropped by a keeper whose mention_targets configuration is too narrow.
+     Fires for every phase the fan-out considers (Running and Paused) — a
+     paused keeper's non-match used to be invisible even though the
+     candidate scan already looked at it. *)
+  let no_wake_counter ~(phase : Keeper_state_machine.phase) (meta : keeper_meta) =
+    let phase_label =
+      match phase with
+      | Keeper_state_machine.Running -> "running"
+      | Keeper_state_machine.Paused -> "paused"
+      | _ -> "other"
+    in
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string BoardSignalNoWakeTotal)
+      ~labels:[
+        ("keeper", meta.name);
+        ("kind", signal_kind_label);
+        ("phase", phase_label);
+      ]
+      ();
+    record_board_attention_candidate ~config ~signal_kind_label ~meta signal
+  in
   (* Yield meter: scanning all running keepers' meta files is CPU-bound
      when many keepers share a domain.  Yield every ~1000 iterations. *)
   let board_ym = Eio_guard.create_yield_meter () in
-  let candidates =
+  let candidates, mailbox_only =
     registry_entries
-    |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-      let result =
-        match read_meta config entry.name with
-        | Ok (Some meta) ->
-          let wake_reason =
-            Keeper_world_observation.board_signal_wake_reason
-              ~meta
-              ~signal
-          in
-          (* Visibility for the REPO_WAKE_UP audit finding: a [None]
-             wake_reason means the running keeper had no explicit mention
-             match and (for comments) no external reply after its own comment.
-             Without this counter, operators cannot distinguish between a
-             board post that legitimately had no deterministic addressee and
-             one that was silently dropped by a keeper whose mention_targets
-             configuration is too narrow. *)
-          (match wake_reason, entry.phase with
-           | None, Keeper_state_machine.Running ->
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string BoardSignalNoWakeTotal)
-               ~labels:[
-                 ("keeper", meta.name);
-                 ("kind", signal_kind_label);
-               ]
-               ();
-             record_board_attention_candidate ~config ~signal_kind_label ~meta signal
-           | None, _ | Some _, _ -> ());
-          (match entry.phase, wake_reason with
-           | Keeper_state_machine.Paused, Some Board_wake.Explicit_mention
-             when paused_meta_allows_board_auto_resume meta ->
-             Some (meta, wake_reason)
-           | Keeper_state_machine.Paused, _ -> None
-           | Keeper_state_machine.Running, _ -> Some (meta, wake_reason)
-           | _ -> None)
-        | _ -> None
-      in
-      Eio_guard.yield_step board_ym;
-      result)
+    |> List.fold_left
+         (fun (candidates_acc, mailbox_acc) (entry : Keeper_registry.registry_entry) ->
+           let candidates_acc, mailbox_acc =
+             match read_effective_meta config entry.name with
+             | Ok (Some meta) ->
+               (* RFC-0334 W3 unify-to-EFFECTIVE (census: issue #23837): read
+                  the profile/persona-overlaid meta, not the raw disk record,
+                  so a persona's [mention_targets] overlay is visible to the
+                  fan-out. The raw read silently made alias/persona mentions
+                  unmatchable. *)
+               let wake_reason =
+                 Keeper_world_observation.board_signal_wake_reason
+                   ~meta
+                   ~signal
+               in
+               (match wake_reason, entry.phase with
+                | None, (Keeper_state_machine.Running | Keeper_state_machine.Paused) ->
+                  no_wake_counter ~phase:entry.phase meta
+                | None, _ | Some _, _ -> ());
+               (match
+                  board_signal_wake_lane
+                    ~phase:entry.phase
+                    ~auto_resume_allowed:(paused_meta_allows_board_auto_resume meta)
+                    wake_reason
+                with
+                | Immediate reason -> (meta, Some reason) :: candidates_acc, mailbox_acc
+                | Mailbox_only reason -> candidates_acc, (meta, reason) :: mailbox_acc
+                | Excluded -> candidates_acc, mailbox_acc)
+             | _ -> candidates_acc, mailbox_acc
+           in
+           Eio_guard.yield_step board_ym;
+           candidates_acc, mailbox_acc)
+         ([], [])
   in
+  let candidates = List.rev candidates in
+  let mailbox_only = List.rev mailbox_only in
   let wake_meta (meta : keeper_meta) reason =
     if
       board_reactive_wakeup_allowed
@@ -692,6 +751,24 @@ let wakeup_relevant_keeper_for_board_signal
           (Board_wake.wake_reason_label reason)
           signal.post_id
           err)
+    else (
+      (* The 60s content-fingerprint debounce ([board_reactive_wakeup_allowed])
+         guards *wakes*, not *delivery* — see the [deferred] loop below for
+         the identical shape. Before this branch existed, a re-posted
+         identical mention within the debounce window vanished entirely:
+         no wake, no mailbox entry, no log line. Queue identity-dedup
+         already collapses genuine repeats on this path, so enqueueing here
+         unconditionally is safe. *)
+      let stimulus = board_signal_stimulus ~reason signal in
+      Keeper_registry_event_queue.enqueue
+        ~base_path:config.base_path
+        meta.name
+        stimulus;
+      Log.Keeper.info
+        "board signal wakeup deferred to mailbox: keeper=%s reason=%s post=%s cause=debounce"
+        meta.name
+        (Board_wake.wake_reason_label reason)
+        signal.post_id)
   in
   let selected, deferred = select_board_wakeup_candidates candidates in
   let yield_meter = Eio_guard.create_yield_meter ~interval:1 () in
@@ -713,6 +790,22 @@ let wakeup_relevant_keeper_for_board_signal
            ~base_path:config.base_path
            meta.name
            stimulus;
+         Eio_guard.yield_step yield_meter);
+  (* Paused keepers whose operator-granted auto-resume is disallowed still
+     get an explicit mention's stimulus in their mailbox: pause suppresses
+     the wake, not the address. They see it whenever they next resume. *)
+  mailbox_only
+  |> List.iter (fun (meta, reason) ->
+         let stimulus = board_signal_stimulus ~reason signal in
+         Keeper_registry_event_queue.enqueue
+           ~base_path:config.base_path
+           meta.name
+           stimulus;
+         Log.Keeper.info
+           "board signal wakeup deferred to mailbox: keeper=%s reason=%s post=%s cause=paused_no_auto_resume"
+           meta.name
+           (Board_wake.wake_reason_label reason)
+           signal.post_id;
          Eio_guard.yield_step yield_meter);
   let deferred_count = List.length deferred in
   if deferred_count > 0 then begin

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -192,6 +192,31 @@ val select_board_wakeup_candidates :
   ('a * Keeper_world_observation_board_signal.wake_reason) list
   * ('a * Keeper_world_observation_board_signal.wake_reason) list
 
+(** Routing outcome for a single board-signal candidate. [Immediate] wakes
+    now; [Mailbox_only] enqueues the stimulus without waking (a paused
+    keeper whose operator-granted auto-resume is disallowed, addressed by
+    an explicit mention); [Excluded] does neither. Exposed for testing. *)
+type board_signal_wake_lane =
+  | Immediate of Keeper_world_observation_board_signal.wake_reason
+  | Mailbox_only of Keeper_world_observation_board_signal.wake_reason
+  | Excluded
+
+(** [board_signal_wake_lane ~phase ~auto_resume_allowed wake_reason] routes
+    a candidate given its phase and whether an explicit mention is entitled
+    to auto-resume it. RFC-0334 W1: a deterministic address
+    ([Explicit_mention]) is never [Excluded] outright — a paused keeper
+    without auto-resume still gets [Mailbox_only] rather than a silent
+    drop. Non-explicit followups on a paused keeper stay [Excluded]: pause
+    is an operator opt-out from implicit wake, not from addressed
+    mentions. Defensively [Excluded] for phases other than Running/Paused
+    (unreachable given {!board_signal_entry_is_wakeup_candidate}'s
+    pre-filter, but total over all 13 phases). *)
+val board_signal_wake_lane :
+  phase:Keeper_state_machine.phase
+  -> auto_resume_allowed:bool
+  -> Keeper_world_observation_board_signal.wake_reason option
+  -> board_signal_wake_lane
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.board_signal -> unit
 

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -281,14 +281,19 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
       instructions_opt;
     }
 
-(** Resolve mention targets with dedup and filtering. *)
+(** Resolve mention targets with dedup and filtering. Normalizes each target
+    (strip leading '@', lowercase, reject empty after stripping) so a target
+    configured as "@name" cannot desync from the '@'-free name the
+    board-signal matcher extracts from post text (RFC-0334 W3 census, issue
+    #23837: a stored leading '@' produced a never-matching "@@name" search
+    needle downstream before this normalization existed). *)
 let resolve_mention_targets ~mention_targets_opt ~fallback_targets ~name =
   let raw =
     match mention_targets_opt with
     | Some targets -> targets
     | None -> if fallback_targets <> [] then fallback_targets else [ name ]
   in
-  raw |> List.filter_map String_util.trim_nonempty |> dedupe_keep_order
+  raw |> List.filter_map String_util.normalize_mention_target |> dedupe_keep_order
 
 let resolve_sandbox_profile ~fallback =
   fallback

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -89,6 +89,24 @@ let text (signal : Board_dispatch.board_signal) =
        ])
 ;;
 
+(* [Keeper_lane_mentions] is the RFC-0230/0232 boundary mention parser
+   already proven for keeper chat lanes (whitespace-token + edge-trim,
+   minted through {!Keeper_identity.Keeper_id.of_string} so keeper-shaped
+   forms canonicalize to the same id as the bare name; ["@alicex"] and
+   ["email@alice.com"] provably do not mention ["alice"] —
+   test_keeper_mention_scope pins this). Reusing it here instead of a
+   parallel board-local tokenizer keeps one mention grammar for the whole
+   keeper stack rather than growing a fourth (dashboard already carried
+   three independent FE regexes before this same sweep consolidated them
+   into [mention-utils.ts]).
+
+   [Keeper_lane_mentions.target_ids_of]/[Keeper_identity.Keeper_id.of_string]
+   do not strip a leading '@' from a target string — only
+   {!String_util.normalize_mention_target} does that (RFC-0334 W3 census,
+   issue #23837: a target stored pre-prefixed with '@' must not desync from
+   the '@'-free names extracted from post text). Normalize here too, not
+   only at {!Keeper_turn_up_args.resolve_mention_targets}'s write boundary,
+   so keepers whose on-disk meta predates that normalization still match. *)
 let match_signal
       ~(meta : keeper_meta)
       ~(signal : Board_dispatch.board_signal)
@@ -101,12 +119,19 @@ let match_signal
     let targets =
       if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
     in
-    let haystack = String.lowercase_ascii (text signal) in
+    let normalized_targets =
+      targets |> List.filter_map String_util.normalize_mention_target
+    in
+    let mentioned_ids =
+      Keeper_lane_mentions.mention_ids_of_content (text signal)
+    in
     let matched_targets =
-      targets
+      normalized_targets
       |> List.filter (fun target ->
-        let needle = "@" ^ String.lowercase_ascii (String.trim target) in
-        needle <> "@" && String_util.contains_substring haystack needle)
+        match Keeper_identity.Keeper_id.of_string target with
+        | None -> false
+        | Some target_id ->
+          List.exists (Keeper_identity.Keeper_id.equal target_id) mentioned_ids)
     in
     if matched_targets <> []
     then { explicit_mention = true; matched_targets; score = 100 }

--- a/test/dune
+++ b/test/dune
@@ -54,6 +54,7 @@
   test_policy_source_of_status
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_keeper_board_signal_match
   test_keeper_librarian_retry
   test_surface_ref
   test_admission_fd_gate
@@ -416,6 +417,7 @@
   test_policy_source_of_status
   test_keeper_mention_scope
   test_keeper_lane_mentions
+  test_keeper_board_signal_match
   test_keeper_librarian_retry
   test_surface_ref
   test_admission_fd_gate

--- a/test/test_keeper_board_signal_match.ml
+++ b/test/test_keeper_board_signal_match.ml
@@ -1,0 +1,188 @@
+(* test_keeper_board_signal_match.ml — pins two of the #60 board-mention
+   fixes (RFC-0334 W3 census, issue #23837):
+
+   - [Keeper_world_observation_board_signal.match_signal] now reuses the
+     boundary-aware [Keeper_lane_mentions] parser (already proven for
+     keeper chat lanes) instead of an ["@" ^ target] substring search, so
+     (a) a target already stored with a leading '@' no longer builds a
+     never-matching "@@name" needle, and (b) an email-like "user@name"
+     token does not false-match a target named "name".
+   - [Keeper_keepalive_signal.board_signal_wake_lane] routes a paused
+     keeper whose operator-granted auto-resume is disallowed to
+     [Mailbox_only] for an explicit mention, instead of [Excluded]
+     (silently dropped with no wake and no mailbox entry). *)
+
+open Alcotest
+open Masc
+
+module BS = Keeper_world_observation_board_signal
+module KKS = Keeper_keepalive_signal
+
+let signal ?(kind = Board_dispatch.Board_post_created) ?(post_id = "post-1")
+    ?(author = "operator") ?(content = "") ?(title = "") () :
+  Board_dispatch.board_signal =
+  { kind; post_id; author; title; content; hearth = None; updated_at = Some 1.0 }
+
+let meta ~name ?(mention_targets = []) () =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String (name ^ "-agent"))
+      ; ( "mention_targets"
+        , `List (List.map (fun t -> `String t) mention_targets) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok m -> m
+  | Error err -> fail ("meta fixture failed: " ^ err)
+
+(* ── match_signal: boundary-aware extraction ─────────────────────── *)
+
+let test_plain_mention_matches () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"hey @albini look" ())
+  in
+  check bool "explicit mention" true result.explicit_mention
+
+let test_similar_token_not_matched () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"ping @albinix now" ())
+  in
+  check bool "a different token does not match" false result.explicit_mention
+
+let test_email_like_token_not_matched () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m
+      ~signal:(signal ~content:"send to user@albini.example" ())
+  in
+  check bool "email-like token does not match" false result.explicit_mention
+
+let test_case_insensitive () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"PING @ALBINI NOW" ())
+  in
+  check bool "case-insensitive match" true result.explicit_mention
+
+let test_no_mention () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"just chatting here" ())
+  in
+  check bool "no address, no mention" false result.explicit_mention
+
+let test_self_authored_post_never_self_mentions () =
+  let m = meta ~name:"albini" () in
+  let result =
+    BS.match_signal ~meta:m
+      ~signal:(signal ~author:"albini" ~content:"@albini noting this" ())
+  in
+  check bool "self-authored post does not wake itself" false
+    result.explicit_mention
+
+(* RFC-0334 W3 census (#23837): a target already stored pre-prefixed with
+   '@' used to build a never-matching "@@name" needle downstream. *)
+let test_leading_at_configured_target_still_matches () =
+  let m = meta ~name:"albini" ~mention_targets:[ "@albini" ] () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"hey @albini" ())
+  in
+  check bool "leading '@' on a configured target still matches" true
+    result.explicit_mention
+
+let test_persona_mention_target_matches () =
+  let m = meta ~name:"albini" ~mention_targets:[ "@Curator" ] () in
+  let result =
+    BS.match_signal ~meta:m ~signal:(signal ~content:"paging @curator" ())
+  in
+  check bool "persona alias target matches case-insensitively" true
+    result.explicit_mention
+
+(* ── board_signal_wake_lane: routing matrix ──────────────────────── *)
+
+let lane_to_string = function
+  | KKS.Immediate reason -> "immediate:" ^ BS.wake_reason_label reason
+  | KKS.Mailbox_only reason -> "mailbox_only:" ^ BS.wake_reason_label reason
+  | KKS.Excluded -> "excluded"
+
+let check_lane label ~phase ~auto_resume_allowed wake_reason expected =
+  check string label expected
+    (lane_to_string
+       (KKS.board_signal_wake_lane ~phase ~auto_resume_allowed wake_reason))
+
+let test_running_explicit_mention_is_immediate () =
+  check_lane "running + explicit mention"
+    ~phase:Keeper_state_machine.Running ~auto_resume_allowed:false
+    (Some BS.Explicit_mention) "immediate:explicit_mention"
+
+let test_running_no_reason_is_excluded () =
+  check_lane "running + no deterministic address"
+    ~phase:Keeper_state_machine.Running ~auto_resume_allowed:false
+    None "excluded"
+
+let test_paused_explicit_mention_with_auto_resume_is_immediate () =
+  check_lane "paused + explicit mention + auto-resume allowed"
+    ~phase:Keeper_state_machine.Paused ~auto_resume_allowed:true
+    (Some BS.Explicit_mention) "immediate:explicit_mention"
+
+(* This is the #60 fix: previously [Paused, _ -> None] dropped this case
+   with no wake and no mailbox entry. *)
+let test_paused_explicit_mention_without_auto_resume_is_mailbox_only () =
+  check_lane "paused + explicit mention + auto-resume disallowed"
+    ~phase:Keeper_state_machine.Paused ~auto_resume_allowed:false
+    (Some BS.Explicit_mention) "mailbox_only:explicit_mention"
+
+let test_paused_followup_reason_is_excluded () =
+  check_lane "paused + thread-reply followup (no explicit address)"
+    ~phase:Keeper_state_machine.Paused ~auto_resume_allowed:true
+    (Some BS.Thread_reply_after_self_comment) "excluded"
+
+let test_paused_no_reason_is_excluded () =
+  check_lane "paused + no deterministic address"
+    ~phase:Keeper_state_machine.Paused ~auto_resume_allowed:false
+    None "excluded"
+
+let test_other_phase_is_excluded () =
+  check_lane "offline phase defensively excluded"
+    ~phase:Keeper_state_machine.Offline ~auto_resume_allowed:true
+    (Some BS.Explicit_mention) "excluded"
+
+let () =
+  run "keeper_board_signal_match"
+    [ ( "match_signal"
+      , [ test_case "plain mention matches" `Quick test_plain_mention_matches
+        ; test_case "similar token not matched" `Quick
+            test_similar_token_not_matched
+        ; test_case "email-like token not matched" `Quick
+            test_email_like_token_not_matched
+        ; test_case "case-insensitive match" `Quick test_case_insensitive
+        ; test_case "no mention" `Quick test_no_mention
+        ; test_case "self-authored post never self-mentions" `Quick
+            test_self_authored_post_never_self_mentions
+        ; test_case "leading '@' on configured target still matches" `Quick
+            test_leading_at_configured_target_still_matches
+        ; test_case "persona alias target matches" `Quick
+            test_persona_mention_target_matches
+        ] )
+    ; ( "board_signal_wake_lane"
+      , [ test_case "running + explicit mention -> immediate" `Quick
+            test_running_explicit_mention_is_immediate
+        ; test_case "running + no reason -> excluded" `Quick
+            test_running_no_reason_is_excluded
+        ; test_case "paused + explicit mention + auto-resume -> immediate"
+            `Quick test_paused_explicit_mention_with_auto_resume_is_immediate
+        ; test_case
+            "paused + explicit mention + no auto-resume -> mailbox_only"
+            `Quick
+            test_paused_explicit_mention_without_auto_resume_is_mailbox_only
+        ; test_case "paused + followup reason -> excluded" `Quick
+            test_paused_followup_reason_is_excluded
+        ; test_case "paused + no reason -> excluded" `Quick
+            test_paused_no_reason_is_excluded
+        ; test_case "other phase -> excluded" `Quick test_other_phase_is_excluded
+        ] )
+    ]
+;;

--- a/test/test_keeper_turn_up_args.ml
+++ b/test/test_keeper_turn_up_args.ml
@@ -31,6 +31,30 @@ let test_resolve_mention_targets_normalizes_explicit_values () =
        ~fallback_targets:[ "existing" ]
        ~name:"keeper-a")
 
+(* RFC-0334 W3 census (#23837): a target configured pre-prefixed with '@'
+   used to build a never-matching "@@name" search needle in the board-signal
+   matcher. Normalizing here (strip '@', lowercase) at write time closes
+   that gap regardless of how the operator typed the target. *)
+let test_resolve_mention_targets_strips_leading_at_and_lowercases () =
+  check
+    (list string)
+    "leading '@' stripped, case-folded, deduped across variants"
+    [ "albini" ]
+    (Keeper_turn_up_args.resolve_mention_targets
+       ~mention_targets_opt:(Some [ "@Albini"; "@@albini"; " ALBINI " ])
+       ~fallback_targets:[ "existing" ]
+       ~name:"keeper-a")
+
+let test_resolve_mention_targets_normalizes_fallback () =
+  check
+    (list string)
+    "fallback targets are normalized too"
+    [ "sangsu" ]
+    (Keeper_turn_up_args.resolve_mention_targets
+       ~mention_targets_opt:None
+       ~fallback_targets:[ "@Sangsu" ]
+       ~name:"keeper-a")
+
 let () =
   run
     "keeper_turn_up_args"
@@ -47,6 +71,14 @@ let () =
             "explicit mention_targets normalize and dedupe"
             `Quick
             test_resolve_mention_targets_normalizes_explicit_values
+        ; test_case
+            "leading '@' stripped and lowercased"
+            `Quick
+            test_resolve_mention_targets_strips_leading_at_and_lowercases
+        ; test_case
+            "fallback targets normalized"
+            `Quick
+            test_resolve_mention_targets_normalizes_fallback
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적 (캠페인 #60)

보드 멘션 2축 결함의 근본 수리: (a) 멘션해도 하이라이트 없음 — 멘션 토크나이저 자체가 부재(`.mention` CSS만 존재, 생산자 0), (b) 불러도 대답 없음 — fan-out은 wake하지만 silent-drop 분기들이 정당한 wake를 은닉.

## Backend — silent-drop 분기 처분표 (`11fdb8dc`)

| # | 분기 | 처분 |
|---|---|---|
| 1 | RAW meta 읽기 → persona/profile `mention_targets` overlay 불가시 | **FIXED**: `read_effective_meta`로 스왑 (RFC-0334 W3 unify-to-EFFECTIVE 방향, census #23837 인용 주석). W3a/b/c 인메모리 스왑(#23864 별도 트랙)과 무관한 correctness 축만 |
| 2 | 60s fingerprint debounce가 무동작 drop | **FIXED**: mailbox enqueue + `cause=debounce` 기록 |
| 3 | paused keeper의 명시 멘션 침묵 제외 | **FIXED**: closed `board_signal_wake_lane = Immediate \| Mailbox_only \| Excluded` variant — Mailbox_only로 라우팅 |
| 4 | 선행 '@' 타깃이 "@@name" needle 생성(영구 불일치) | **FIXED**: write-time(resolve_mention_targets) + read-time(match_signal) 이중 정규화(기존 데이터 마이그레이션 없이 방어) |
| 5 | word-boundary 없는 substring 매칭 | **FIXED**: 기존 검증된 `Keeper_lane_mentions` boundary 파서(RFC-0230/0232) 재사용 — 4번째 독립 토크나이저 작성 회피 |
| 6 | NoWake 카운터가 Running만 커버 | **FIXED**: Paused에 phase 라벨로 확장 |

## Frontend — 멘션 하이라이트 (`dad75b35`)

- `highlightMentions()`: sanitize 캐시 후 DOM 후처리 (marked 확장이 아닌 이유: marked는 '@'를 inline-dispatch 경계로 예약하지 않아 내장 text 토크나이저가 먼저 삼킴). 라이브 roster 멤버십 게이트(하드코딩 이름 목록 없음), `code`/`pre` 자손 구조적 제외.
- `MENTION_RE`를 mention-utils.ts SSOT로 이동 (inbox 추출기 + 하이라이터 공용).

## 후속 (수정 안 함, 분리)

- CHAT 멘션 경로에 동일 un-stripped-'@' 읽기 갭 존재 (`keeper_world_observation_message_scope.ml:230,249`) — write-time 수리가 전향적으로 커버하나 read-side 방어 부재. 별도 이슈 예정.

## 검증

- OCaml: `dune build @check lib test` 클린(오케스트레이터 재검증 포함), 신규 `test_keeper_board_signal_match` 15/15(경계 케이스+wake_lane 라우팅 매트릭스), 인접 6스위트 92 pass.
- FE: tsc+lint 클린, 스코프 159 tests pass (에이전트) + 65/65 (오케스트레이터 재검증).
- Risk: `resolve_mention_targets` 정규화는 전향적 — 기존 on-disk meta는 read-time 정규화가 커버.

진단: workflow wf_e047f03f (캠페인 원장 masc#23925).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
