### PR TITLE
fix(board): rebuild contributor quality on Wilson score, retire Trending (#58)

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -539,14 +539,11 @@ describe('fetchBoard', () => {
           report_count: 2,
           moderation_status: 'flagged',
           contributor_quality: {
-            source: 'agent_reputation',
-            completion_rate: 0.8,
-            response_rate: 0.6,
-            board_posts: 3,
-            board_comments: 5,
-            accountability_score: 0.9,
-            autonomy_level: 'elevated',
-            thompson_confidence: 0.7,
+            source: 'board_votes',
+            score: 0.9,
+            ups: 18,
+            downs: 2,
+            evidence_state: 'measured',
           },
           reactions: [
             {
@@ -601,14 +598,11 @@ describe('fetchBoard', () => {
       report_count: 2,
       moderation_status: 'flagged',
       contributor_quality: {
-        source: 'agent_reputation',
-        completion_rate: 0.8,
-        response_rate: 0.6,
-        board_posts: 3,
-        board_comments: 5,
-        accountability_score: 0.9,
-        autonomy_level: 'elevated',
-        thompson_confidence: 0.7,
+        source: 'board_votes',
+        score: 0.9,
+        ups: 18,
+        downs: 2,
+        evidence_state: 'measured',
       },
       claim_evidence: {
         state: 'artifact_missing',
@@ -754,20 +748,19 @@ describe('fetchBoard', () => {
     expect(result.posts[0]?.origin).toBeNull()
   })
 
-  it('keeps contributor_quality when only band and autonomy_level are present', async () => {
+  it('keeps contributor_quality when only evidence_state is present', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         posts: [
           {
-            id: 'post-band-only',
+            id: 'post-evidence-only',
             author: 'analyst',
-            title: 'Band only',
+            title: 'Evidence only',
             body: 'contributor_quality has no numeric fields',
             created_at: 1_713_000_000,
             updated_at: 1_713_000_000,
             contributor_quality: {
-              band: 'strong',
-              autonomy_level: 'elevated',
+              evidence_state: 'default',
             },
           },
         ],
@@ -781,8 +774,7 @@ describe('fetchBoard', () => {
     const result = await fetchBoard()
 
     expect(result.posts[0]?.contributor_quality).toEqual({
-      band: 'strong',
-      autonomy_level: 'elevated',
+      evidence_state: 'default',
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -103,19 +103,6 @@ function normalizeBoardActorSource(raw: unknown): BoardActorIdentity['source'] {
   }
 }
 
-function normalizeBoardContributorBand(raw: unknown): BoardContributorQuality['band'] {
-  const band = asString(raw, '').trim().toLowerCase()
-  switch (band) {
-    case 'low':
-    case 'watch':
-    case 'strong':
-    case 'excellent':
-      return band
-    default:
-      return undefined
-  }
-}
-
 function normalizeBoardKarmaTargetKind(raw: unknown): BoardKarmaLedgerEvent['target_kind'] | null {
   const kind = asString(raw, '').trim().toLowerCase()
   return kind === 'post' || kind === 'comment' ? kind : null
@@ -481,15 +468,9 @@ function normalizeBoardModerationStatus(raw: unknown): BoardModerationStatus {
 function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality | null {
   if (!isRecord(raw)) return null
   const score = asNumber(raw.score)
-  const completionRate = asNumber(raw.completion_rate)
-  const responseRate = asNumber(raw.response_rate)
-  const boardPosts = asNumber(raw.board_posts)
-  const boardComments = asNumber(raw.board_comments)
-  const accountabilityScore = asNumber(raw.accountability_score)
-  const thompsonConfidence = asNumber(raw.thompson_confidence)
+  const ups = asNumber(raw.ups)
+  const downs = asNumber(raw.downs)
   const source = asString(raw.source, '').trim() || undefined
-  const band = normalizeBoardContributorBand(raw.band)
-  const autonomyLevel = asString(raw.autonomy_level, '').trim() || undefined
   const rawEvidenceState = asString(raw.evidence_state, '').trim()
   const evidenceState = rawEvidenceState === 'measured' || rawEvidenceState === 'default'
     ? rawEvidenceState
@@ -497,28 +478,16 @@ function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality
 
   if (
     score === undefined
-    && completionRate === undefined
-    && responseRate === undefined
-    && boardPosts === undefined
-    && boardComments === undefined
-    && accountabilityScore === undefined
-    && thompsonConfidence === undefined
+    && ups === undefined
+    && downs === undefined
     && source === undefined
-    && band === undefined
-    && autonomyLevel === undefined
     && evidenceState === undefined
   ) return null
   return {
     score,
-    band,
+    ups,
+    downs,
     source,
-    completion_rate: completionRate,
-    response_rate: responseRate,
-    board_posts: boardPosts,
-    board_comments: boardComments,
-    accountability_score: accountabilityScore,
-    autonomy_level: autonomyLevel,
-    thompson_confidence: thompsonConfidence,
     evidence_state: evidenceState,
   }
 }

--- a/dashboard/src/components/board/board-state.ts
+++ b/dashboard/src/components/board/board-state.ts
@@ -55,7 +55,7 @@ export type { BoardComment, BoardPost, BoardSortMode }
 export const SORT_MODES: { id: BoardSortMode; label: string }[] = [
   { id: 'recent', label: '최신순' },
   { id: 'hot', label: '인기순' },
-  { id: 'trending', label: '급상승' },
+  { id: 'best', label: '베스트' },
   { id: 'updated', label: '최근 갱신' },
   { id: 'discussed', label: '댓글 많은 순' },
 ]

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -610,9 +610,11 @@ describe('BoardSurface Component', () => {
         body: 'content',
         author: 'ani1999',
         contributor_quality: {
-          accountability_score: 0.72,
-          source: 'agent_reputation',
-          board_posts: 1,
+          score: 0.72,
+          ups: 14,
+          downs: 2,
+          source: 'board_votes',
+          evidence_state: 'measured',
         },
       }),
     ]
@@ -622,7 +624,11 @@ describe('BoardSurface Component', () => {
     expect(screen.getByLabelText(/기여자 품질 72점/)).toHaveTextContent('품질 72')
   })
 
-  it('hides default contributor quality priors on post cards', () => {
+  // board-quality-wilson (#58): with no vote evidence (evidence_state
+  // "default"), the badge must not show a fabricated score even when
+  // the backend still sends score: 1 (there is none to send in practice,
+  // but the FE gate must not trust a numeric field over evidence_state).
+  it('hides contributor quality without vote evidence', () => {
     boardPosts.value = [
       makePost({
         id: 'post-quality-prior',
@@ -630,14 +636,10 @@ describe('BoardSurface Component', () => {
         body: 'content',
         author: 'ani1999',
         contributor_quality: {
-          accountability_score: 1,
-          source: 'agent_reputation',
-          board_posts: 0,
-          board_comments: 0,
-          completion_rate: 0,
-          response_rate: 0,
-          autonomy_level: 'standard',
-          thompson_confidence: 0.5,
+          score: 1,
+          ups: 0,
+          downs: 0,
+          source: 'board_votes',
           evidence_state: 'default',
         },
       }),
@@ -656,8 +658,10 @@ describe('BoardSurface Component', () => {
         body: 'content',
         author: 'ani1999',
         contributor_quality: {
-          accountability_score: 1,
-          source: 'agent_reputation',
+          score: 1,
+          ups: 3,
+          downs: 0,
+          source: 'board_votes',
           evidence_state: 'measured',
         },
       }),

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -50,6 +50,7 @@ import {
   boardClaimEvidenceTitle,
   contributorQualityBadgeClass,
   contributorQualityPercent,
+  contributorQualityTooltip,
   navigateToAuthor,
   stripInlineMarkdown,
   dedupeLeadingHeading,
@@ -370,9 +371,7 @@ function PostCard({ post }: { post: BoardPost }) {
   const voteScoreAria = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
   const isMod = post.moderation_status && post.moderation_status !== 'none' && post.moderation_status !== 'approved'
   const qualityPercent = contributorQualityPercent(post.contributor_quality)
-  const qualityTitle = qualityPercent === null
-    ? undefined
-    : `기여자 품질 ${qualityPercent}점`
+  const qualityTitle = contributorQualityTooltip(post.contributor_quality)
   const claimEvidenceLabel = boardClaimEvidenceLabel(post.claim_evidence)
   const claimEvidenceTitle = boardClaimEvidenceTitle(post.claim_evidence)
   const selected = selectedBoardPostId.value === post.id
@@ -456,7 +455,7 @@ function PostCard({ post }: { post: BoardPost }) {
         ${post.pinned ? html`<span class="bd-badge pin" title="고정된 게시글">고정</span>` : null}
         ${isMod ? html`<span class="bd-badge mod">모더레이션 대기</span>` : null}
         ${post.flair ? html`<span class="bd-badge">flair:${post.flair}</span>` : null}
-        ${qualityPercent !== null ? html`<span class="bd-badge ${contributorQualityBadgeClass(post.contributor_quality)}" aria-label=${qualityTitle} title=${qualityTitle}>품질 ${qualityPercent}</span>` : null}
+        ${qualityPercent !== null ? html`<span class="bd-badge ${contributorQualityBadgeClass()}" aria-label=${qualityTitle} title=${qualityTitle}>품질 ${qualityPercent}</span>` : null}
         ${claimEvidenceLabel !== null ? html`
           <span
             class=${`bd-badge ${boardClaimEvidenceBadgeClass(post.claim_evidence)}`}

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -539,8 +539,10 @@ describe('PostDetail', () => {
       moderation_status: 'approved',
       contributor_quality: {
         score: 0.91,
-        band: 'excellent',
-        source: 'agent_reputation',
+        ups: 20,
+        downs: 1,
+        source: 'board_votes',
+        evidence_state: 'measured',
       },
       comments: [],
     } as any
@@ -551,7 +553,7 @@ describe('PostDetail', () => {
     expect(screen.getByText(/Direct board post without automation provenance/)).toBeInTheDocument()
     expect(screen.getByText('직접')).toBeInTheDocument()
     expect(screen.getByLabelText('게시글 moderation 승인됨 1건')).toHaveTextContent('승인됨 1')
-    expect(screen.getByLabelText('기여자 품질 91점 · 우수')).toHaveTextContent('품질 91')
+    expect(screen.getByLabelText('기여자 품질 91점 (Wilson lower bound) · 👍20 👎1')).toHaveTextContent('품질 91')
   })
 
   it('renders contributor quality when it is the only detail badge', () => {
@@ -569,15 +571,17 @@ describe('PostDetail', () => {
       moderation_status: 'none',
       contributor_quality: {
         score: 0.42,
-        band: 'watch',
-        source: 'agent_reputation',
+        ups: 5,
+        downs: 5,
+        source: 'board_votes',
+        evidence_state: 'measured',
       },
       comments: [],
     } as any
 
     render(h(PostDetail, { post }))
 
-    expect(screen.getByLabelText('기여자 품질 42점 · 관찰')).toHaveTextContent('품질 42')
+    expect(screen.getByLabelText('기여자 품질 42점 (Wilson lower bound) · 👍5 👎5')).toHaveTextContent('품질 42')
   })
 
   it('renders claim evidence when it is the only detail badge', () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -26,8 +26,8 @@ import {
   boardClaimEvidenceLabel,
   boardClaimEvidenceTitle,
   contributorQualityBadgeClass,
-  contributorQualityBandLabel,
   contributorQualityPercent,
+  contributorQualityTooltip,
   navigateToAuthor,
 } from '../../lib/board-utils'
 import {
@@ -551,10 +551,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
   const qualityPercent = contributorQualityPercent(post.contributor_quality)
-  const qualityBand = contributorQualityBandLabel(post.contributor_quality)
-  const qualityTitle = qualityPercent === null
-    ? undefined
-    : `기여자 품질 ${qualityPercent}점 · ${qualityBand}`
+  const qualityTitle = contributorQualityTooltip(post.contributor_quality)
   const claimEvidenceLabel = boardClaimEvidenceLabel(post.claim_evidence)
   const claimEvidenceTitle = boardClaimEvidenceTitle(post.claim_evidence)
   const upvoteActive = post.current_vote === 'up'
@@ -642,7 +639,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
                     <span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
                     ${qualityPercent !== null ? html`
                       <span
-                        class=${`inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${contributorQualityBadgeClass(post.contributor_quality)}`}
+                        class=${`inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-2xs font-medium border ${contributorQualityBadgeClass()}`}
                         aria-label=${qualityTitle}
                         title=${qualityTitle}
                       >품질 ${qualityPercent}</span>

--- a/dashboard/src/lib/board-utils.test.ts
+++ b/dashboard/src/lib/board-utils.test.ts
@@ -5,9 +5,9 @@ import {
   boardPostPermalink,
   boardPostTrackbackMarkdown,
   boardPostXShareUrl,
-  contributorQualityBandLabel,
   contributorQualityBadgeClass,
   contributorQualityPercent,
+  contributorQualityTooltip,
   dedupeLeadingHeading,
   stripInlineMarkdown,
 } from './board-utils'
@@ -118,42 +118,45 @@ describe('board post sharing helpers', () => {
 })
 
 describe('contributor quality helpers', () => {
-  it('uses accountability_score when legacy score is absent and evidence exists', () => {
+  it('reads score from the Wilson-based board_votes projection when evidence is measured', () => {
     const quality = {
-      source: 'agent_reputation',
-      completion_rate: 0.8,
-      response_rate: 0.6,
-      board_posts: 1,
-      accountability_score: 0.9,
+      score: 0.72,
+      ups: 14,
+      downs: 2,
+      source: 'board_votes',
+      evidence_state: 'measured' as const,
     }
 
-    expect(contributorQualityPercent(quality)).toBe(90)
-    expect(contributorQualityBandLabel(quality)).toBe('품질')
-    expect(contributorQualityBadgeClass(quality)).toContain('color-bg-muted')
+    expect(contributorQualityPercent(quality)).toBe(72)
+    expect(contributorQualityBadgeClass()).toContain('color-bg-muted')
+    expect(contributorQualityTooltip(quality)).toBe('기여자 품질 72점 (Wilson lower bound) · 👍14 👎2')
   })
 
-  it('does not render default reputation priors as a numeric quality score', () => {
+  // board-quality-wilson (#58): evidence_state is the only gate now — no
+  // fallback heuristic re-derives "has evidence" from unrelated fields.
+  it('hides the score when evidence_state is not measured, even if score is present', () => {
     expect(contributorQualityPercent({
-      source: 'agent_reputation',
-      completion_rate: 0,
-      response_rate: 0,
-      board_posts: 0,
-      board_comments: 0,
-      accountability_score: 1,
-      autonomy_level: 'standard',
-      thompson_confidence: 0.5,
+      score: 1,
+      ups: 0,
+      downs: 0,
+      source: 'board_votes',
+      evidence_state: 'default',
     })).toBeNull()
   })
 
-  it('uses backend-supplied quality band without inventing thresholds', () => {
-    const quality = {
-      accountability_score: 0.4,
-      board_comments: 2,
-      band: 'strong' as const,
-    }
-    expect(contributorQualityPercent(quality)).toBe(40)
-    expect(contributorQualityBandLabel(quality)).toBe('강함')
-    expect(contributorQualityBadgeClass(quality)).toContain('ok-10')
+  it('hides the score when evidence_state is absent entirely', () => {
+    expect(contributorQualityPercent({ score: 0.5 })).toBeNull()
+  })
+
+  it('renders a measured score of 100 without a band', () => {
+    const quality = { score: 1, ups: 3, downs: 0, source: 'board_votes', evidence_state: 'measured' as const }
+    expect(contributorQualityPercent(quality)).toBe(100)
+    expect(contributorQualityTooltip(quality)).toBe('기여자 품질 100점 (Wilson lower bound) · 👍3 👎0')
+  })
+
+  it('defaults the tooltip vote counts to 0 when ups/downs are missing', () => {
+    const quality = { score: 0.42, source: 'board_votes', evidence_state: 'measured' as const }
+    expect(contributorQualityTooltip(quality)).toBe('기여자 품질 42점 (Wilson lower bound) · 👍0 👎0')
   })
 })
 

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -172,37 +172,26 @@ export function boardActorTitle(
 
 export function contributorQualityPercent(quality?: BoardContributorQuality | null): number | null {
   if (!contributorQualityHasEvidence(quality)) return null
-  const score = contributorQualityDisplayScore(quality)
-  return score === null ? null : clampPct(Math.round(score * 100))
+  const score = quality?.score
+  return score === undefined || !Number.isFinite(score) ? null : clampPct(Math.round(score * 100))
 }
 
-export function contributorQualityBandLabel(quality?: BoardContributorQuality | null): string {
-  switch (contributorQualityDisplayBand(quality)) {
-    case 'excellent':
-      return '우수'
-    case 'strong':
-      return '강함'
-    case 'watch':
-      return '관찰'
-    case 'low':
-      return '낮음'
-    default:
-      return '품질'
-  }
+// board-quality-wilson (#58): band is gone (dead code — no backend site
+// ever emitted it), so the badge no longer color-codes by quality tier.
+// The tooltip carries the evidence (ups/downs) instead of a band label.
+const CONTRIBUTOR_QUALITY_BADGE_CLASS =
+  'bg-[var(--color-bg-muted)] text-[var(--color-fg-muted)] border-[var(--color-border-divider)]'
+
+export function contributorQualityBadgeClass(): string {
+  return CONTRIBUTOR_QUALITY_BADGE_CLASS
 }
 
-export function contributorQualityBadgeClass(quality?: BoardContributorQuality | null): string {
-  switch (contributorQualityDisplayBand(quality)) {
-    case 'excellent':
-    case 'strong':
-      return 'bg-[var(--ok-10)] text-[var(--ok-fg)] border-[var(--ok-20)]'
-    case 'watch':
-      return 'bg-[var(--warn-10)] text-[var(--warn-bright)] border-[var(--warn-20)]'
-    case 'low':
-      return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
-    default:
-      return 'bg-[var(--color-bg-muted)] text-[var(--color-fg-muted)] border-[var(--color-border-divider)]'
-  }
+export function contributorQualityTooltip(quality?: BoardContributorQuality | null): string | undefined {
+  const percent = contributorQualityPercent(quality)
+  if (percent === null) return undefined
+  const ups = quality?.ups ?? 0
+  const downs = quality?.downs ?? 0
+  return `기여자 품질 ${percent}점 (Wilson lower bound) · 👍${ups} 👎${downs}`
 }
 
 export function boardClaimEvidenceLabel(evidence?: BoardClaimEvidenceProjection | null): string | null {
@@ -248,45 +237,14 @@ export function boardClaimEvidenceTitle(evidence?: BoardClaimEvidenceProjection 
   ].join(' · ')
 }
 
-function contributorQualityDisplayScore(
-  quality?: BoardContributorQuality | null,
-): number | null {
-  if (!quality) return null
-  const legacyScore = quality.score
-  if (legacyScore !== undefined && Number.isFinite(legacyScore)) return legacyScore
-  const accountabilityScore = quality.accountability_score
-  if (accountabilityScore !== undefined && Number.isFinite(accountabilityScore)) {
-    return accountabilityScore
-  }
-  return null
-}
-
-function contributorQualityDisplayBand(
-  quality?: BoardContributorQuality | null,
-): BoardContributorQuality['band'] | null {
-  if (quality?.band) return quality.band
-  return null
-}
-
+// board-quality-wilson (#58): evidence is gated on the backend's own
+// evidence_state alone. The old heuristic here re-derived "has evidence"
+// client-side from six unrelated reputation fields (each with its own
+// hardcoded default), duplicating a decision the backend already makes
+// authoritatively from vote counts. Trust evidence_state; do not
+// reconstruct it from parallel signals.
 function contributorQualityHasEvidence(quality?: BoardContributorQuality | null): boolean {
-  if (!quality) return false
-  if (quality.evidence_state !== undefined) {
-    return quality.evidence_state === 'measured'
-  }
-  if (quality.band) return true
-  if (quality.score !== undefined && Number.isFinite(quality.score)) return true
-  if ((quality.board_posts ?? 0) > 0) return true
-  if ((quality.board_comments ?? 0) > 0) return true
-  if ((quality.completion_rate ?? 0) > 0) return true
-  if ((quality.response_rate ?? 0) > 0) return true
-
-  const DEFAULT_ACCOUNTABILITY_SCORE = 1.0
-  const DEFAULT_THOMPSON_CONFIDENCE = 0.5
-  const DEFAULT_AUTONOMY_LEVEL = 'standard'
-
-  if (quality.accountability_score !== undefined && quality.accountability_score < DEFAULT_ACCOUNTABILITY_SCORE) return true
-  if (quality.thompson_confidence !== undefined && quality.thompson_confidence !== DEFAULT_THOMPSON_CONFIDENCE) return true
-  return quality.autonomy_level !== undefined && quality.autonomy_level !== DEFAULT_AUTONOMY_LEVEL
+  return quality?.evidence_state === 'measured'
 }
 
 /** Navigate to keeper detail if author is a keeper, otherwise agent profile. */

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -136,17 +136,18 @@ type BoardPostMeta = Record<string, unknown> & {
 export type BoardVoteDirection = 'up' | 'down'
 export type BoardModerationStatus = 'none' | 'flagged' | 'approved' | 'removed' | 'hidden' | 'warned'
 
+// board-quality-wilson (#58): score is Board_sort.wilson_lower_bound(ups,
+// downs) over peer votes received by the author — see
+// docs/spec/11-board.md §9a.7. `band` is gone (was dead code: no backend
+// site ever emitted it). completion_rate/response_rate/accountability_score/
+// autonomy_level/thompson_confidence stay on the agent-reputation surface,
+// not this board projection (they answered "did this agent skip
+// commitments", unrelated to peer-vote quality).
 export interface BoardContributorQuality {
   score?: number
-  band?: 'low' | 'watch' | 'strong' | 'excellent'
+  ups?: number
+  downs?: number
   source?: string
-  completion_rate?: number
-  response_rate?: number
-  board_posts?: number
-  board_comments?: number
-  accountability_score?: number
-  autonomy_level?: string
-  thompson_confidence?: number
   evidence_state?: 'default' | 'measured'
 }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -300,7 +300,7 @@ export interface JournalEntry {
 
 // --- Sort modes ---
 
-export type BoardSortMode = 'hot' | 'trending' | 'recent' | 'updated' | 'discussed'
+export type BoardSortMode = 'hot' | 'best' | 'recent' | 'updated' | 'discussed'
 
 // --- Route state ---
 

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -166,13 +166,27 @@ PostgreSQL Board backend는 runtime contract가 아니다. Bootstrap은 filesyst
 
 | 정렬 | 계산 방식 | 설명 |
 |------|--------------------------|------|
-| Hot | (votes_up - votes_down) DESC, created_at DESC | 기본. net peer vote순 |
-| Trending | (votes_up - votes_down) / age^0.5 DESC | net peer vote / sqrt(age). reply_count는 별도 engagement signal로 랭킹 점수에 합산하지 않는다. age = max(1.0, hours since creation) |
+| Hot | `sign(net) * log10(max(1, abs(net))) + (created_at - epoch) / 45000` DESC, created_at DESC tiebreak | 기본. net = votes_up - votes_down. Reddit `hot()` 공식 (하단 참조) |
+| Best | Wilson score interval lower bound(votes_up, votes_down) DESC, created_at DESC tiebreak | 신뢰구간 기반 순위. 표본 수가 적으면 비율이 같아도 낮게 평가된다 |
 | Recent | created_at DESC | 생성 시간순 |
 | Updated | updated_at DESC | 마지막 활동순 (vote, comment 포함) |
 | Discussed | reply_count DESC, created_at DESC | 댓글 수순 |
 
-Hot/Trending 공식은 `Board_sort` 모듈(`lib/board/board_sort.ml`)에 단일 SSOT로 정의되며, `Board_core.list_posts`(캐시 기본 정렬)와 `Board_dispatch.sort_posts_in_memory`(HTTP/MCP 정렬) 양쪽이 공유한다. 과거 Trending이 `(net + reply_count * 2) / age^0.5`로 net vote와 reply를 합산했으나, 이는 downvote 과반 비난글(net 음수)이 댓글 수로 호평글을 제치는 부스트를 유발해 net-vote only로 정정했다(board-karma-v2 S2). reply_count는 표시 전용 engagement signal이다.
+Hot/Best 공식은 `Board_sort` 모듈(`lib/board/board_sort.ml`)에 단일 SSOT로 정의되며, `Board_core.list_posts`(캐시 기본 정렬)와 `Board_dispatch.sort_posts_in_memory`(HTTP/MCP 정렬) 양쪽이 공유한다. reply_count는 표시 전용 engagement signal이며 어느 랭킹 점수에도 합산되지 않는다.
+
+board-quality-wilson (#58, 2026-07-11): 과거 Trending(`net vote / sqrt(age hours)`, decay는 있으나 신뢰구간 가중치 없음)을 폐지했다. Trending의 유일한 차별점(시간 감쇠)을 Hot이 흡수했고(아래 Hot 공식), 표본 신뢰도가 필요한 유스케이스는 Best(Wilson lower bound)로 대체했다. `sort_order_of_string_opt`는 `"trending"`을 `"best"`의 별칭으로 받지 않는다 — 별칭 허용은 net-vote+decay와 confidence-weighted-ratio라는 의미 변화를 호출자에게 숨기게 된다.
+
+**Hot** — Reddit의 `hot()` 알고리즘(reddit-archive/reddit `r2/r2/lib/db/_sorts.pyx`)을 그대로 이식했다. `log10` 항은 득표 차이가 커질수록 순위에 미치는 영향을 줄이고(10표 vs 11표는 거의 안 움직이지만 1표 vs 11표는 크게 움직인다), 선형 시간 항은 45000초(12.5시간)마다 한 자릿수(order of magnitude) 득표 차이에 해당하는 감쇠를 적용한다. `epoch`는 결과 비교(상대 순서)에만 쓰이므로 어떤 고정값을 골라도 순위는 동일하다 — 출처 추적을 위해 Reddit 원본 epoch(2005-12-08T07:46:43Z)를 그대로 사용한다.
+
+**Best** — Evan Miller, "How Not To Sort By Average Rating" (2009, https://www.evanmiller.org/how-not-to-sort-by-average-rating.html)의 Wilson score interval 하한 공식이다. Reddit의 `_confidence()` 정렬(같은 파일)이 동일 공식과 z=1.96을 그대로 사용한다.
+
+```
+n = ups + downs
+p̂ = ups / n
+lower_bound = (p̂ + z²/2n − z·sqrt((p̂(1−p̂) + z²/4n) / n)) / (1 + z²/n)
+```
+
+`n = 0`이면 `0.0`을 반환한다 — "증거 없음"과 "확신 있게 낮음"을 구분하는 것은 호출자의 책임이다(§9a.7의 `evidence_state` 참조). 표본이 적으면 비율이 100%여도 하한이 낮게 잡혀, 1표 만점 게시물이 99표 중 98표(비율 98%)를 받은 게시물을 앞지르지 못한다.
 
 ---
 
@@ -342,30 +356,40 @@ change storage, sorting, karma ledger replay, or moderation state.
 ### 9a.7 Contributor Quality Projection
 
 Board post read paths may include `contributor_quality`, a compact
-projection of the existing `Agent_reputation` score for the post author.
-It is request-time derived data and does not create new board storage.
+peer-vote-evidence score for the post author. It is request-time derived
+data and does not create new board storage.
 
 ```json
 {
   "contributor_quality": {
     "score": 0.72,
-    "band": "strong",
-    "source": "agent_reputation",
-    "completion_rate": 0.8,
-    "response_rate": 0.6,
-    "board_posts": 3,
-    "board_comments": 5,
-    "accountability_score": 0.9,
-    "autonomy_level": "elevated",
-    "thompson_confidence": 0.7
+    "ups": 14,
+    "downs": 2,
+    "evidence_state": "measured",
+    "source": "board_votes"
   }
 }
 ```
 
-`band` is a UI hint derived from `score`: `excellent` (>= 0.85),
-`strong` (>= 0.65), `watch` (>= 0.35), otherwise `low`. This projection
-is advisory only; sorting, moderation, karma ledger replay, and author
-permissions remain unchanged.
+`score` is `Board_sort.wilson_lower_bound ~ups ~downs` (§5 Best) over
+peer votes *received* by the author across their posts and comments —
+self-votes excluded, same recipient/voter check as the karma ledger
+(§9a.1). `ups`/`downs` are the raw evidence counts the score was
+computed from. `score` is **absent** (not `0.0`, not `null`) when
+`ups + downs = 0`; `evidence_state` is `"default"` in that case and
+`"measured"` otherwise — the dashboard badge does not render without
+`evidence_state = "measured"` (no fallback to any other field).
+
+board-quality-wilson (#58, 2026-07-11): this replaced a prior contract
+that sourced `score`/`band` from `Reputation.agent_reputation`'s
+`accountability_score` (a task-evidence penalty unrelated to peer
+votes) and never actually emitted `score`/`band` from the backend — the
+dashboard silently fell back to `accountability_score` under a "quality"
+label. `band` is deleted entirely (was dead code: no backend site ever
+emitted it, so the four color-coded UI bands were unreachable); the
+badge shows the numeric score and the tooltip shows `ups`/`downs`
+instead. This projection remains advisory only; sorting, moderation,
+karma ledger replay, and author permissions are unaffected.
 
 
 ## 10. MCP Tool Surface

--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -23,7 +23,7 @@ module Float = Stdlib.Float
     @since 0.6.0
 *)
 
-type sort_order = Hot | Trending | Recent | Updated | Discussed
+type sort_order = Hot | Best | Recent | Updated | Discussed
 
 (** Issue #8449: SSOT helpers for [sort_order]. Three call sites used to
     own private parsers and a separate Variant in [Board_tool]; this PR
@@ -31,12 +31,21 @@ type sort_order = Hot | Trending | Recent | Updated | Discussed
     from the Variant. PR B will collapse the duplicate Variant; PR C
     will route [server_utils] through these parsers.
 
+    board-quality-wilson (#58): [Trending] retired in favor of [Best]
+    (Wilson score interval lower bound over votes — see
+    [Board_sort.wilson_lower_bound]); the old Hot picked up Trending's
+    time-decay role (see [Board_sort.hot_score]). [sort_order_of_string_opt]
+    intentionally does NOT accept "trending" as an alias for "best" — a
+    silent alias would hide the semantic change (net vote+decay vs.
+    confidence-weighted ratio) from any caller still passing the old
+    string.
+
     All constructors are nullary so [List.map] works. *)
-let all_sort_orders = [ Hot; Trending; Recent; Updated; Discussed ]
+let all_sort_orders = [ Hot; Best; Recent; Updated; Discussed ]
 
 let sort_order_to_string = function
   | Hot -> "hot"
-  | Trending -> "trending"
+  | Best -> "best"
   | Recent -> "recent"
   | Updated -> "updated"
   | Discussed -> "discussed"
@@ -47,7 +56,7 @@ let valid_sort_order_strings = List.map sort_order_to_string all_sort_orders
 let sort_order_of_string_opt s =
   match String.lowercase_ascii (String.trim s) with
   | "hot" -> Some Hot
-  | "trending" -> Some Trending
+  | "best" -> Some Best
   | "recent" -> Some Recent
   | "updated" -> Some Updated
   | "discussed" -> Some Discussed
@@ -310,7 +319,7 @@ let backend () =
 
 let sort_posts_in_memory ~sort_by (posts : Board.post list) =
   (* Ranking formulas live in [Board_sort] (single source of truth) so the
-     Hot/Trending definitions cannot drift between this in-memory sort and
+     Hot/Best definitions cannot drift between this in-memory sort and
      [Board_core.list_posts]'s cached default sort. See [Board_sort]. *)
   match sort_by with
   | Hot -> List.sort Board_sort.hot_compare posts
@@ -320,8 +329,7 @@ let sort_posts_in_memory ~sort_by (posts : Board.post list) =
   | Updated ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
         Stdlib.Float.compare b.updated_at a.updated_at) posts
-  | Trending ->
-      List.sort (Board_sort.trending_compare ~now:(Time_compat.now ())) posts
+  | Best -> List.sort Board_sort.best_compare posts
   | Discussed ->
       List.sort (fun (a : Board.post) (b : Board.post) ->
         let cmp = Stdlib.Int.compare b.reply_count a.reply_count in
@@ -458,7 +466,7 @@ let list_posts ?(visibility_filter = None) ?hearth ?author_filter ?exclude_autho
         ||
         match sort_by with
         | Hot -> false
-        | Trending | Recent | Updated | Discussed -> true
+        | Best | Recent | Updated | Discussed -> true
       in
       let fetch_limit =
         if needs_full_scan then Board.Limits.max_posts else max limit 500

--- a/lib/board/board_dispatch.mli
+++ b/lib/board/board_dispatch.mli
@@ -21,7 +21,7 @@
 
 (** {1 Sort orders} *)
 
-type sort_order = Hot | Trending | Recent | Updated | Discussed
+type sort_order = Hot | Best | Recent | Updated | Discussed
 
 val sort_order_to_string : sort_order -> string
 

--- a/lib/board/board_sort.ml
+++ b/lib/board/board_sort.ml
@@ -6,17 +6,26 @@
     one site no longer silently drifts the other.
 
     Ranking semantics:
-    - Hot ranks on net peer vote ({!net_vote} = votes_up - votes_down),
-      DESC, with created_at DESC tiebreak.
-    - Trending ranks on net peer vote only, decayed by sqrt(age in hours).
-      Reply count is a separate engagement signal and is NOT summed into
-      the ranking score. The previous formula ((net + reply_count * 2) /
-      sqrt(age)) boosted downvote-heavy controversial posts above cleanly
-      upvoted posts — e.g. net -98 with 80 replies outranked net +40 with
-      0 replies at the same age. See [docs/spec/11-board.md] §5 and the
-      board-karma-v2 plan.
+    - Hot ranks on a time-decayed log-vote score ({!hot_score}), DESC,
+      with created_at DESC tiebreak. Formula and constants: see
+      {!hot_score}.
+    - Best ranks on the Wilson score interval lower bound
+      ({!wilson_lower_bound}) over (votes_up, votes_down) — the
+      confidence-adjusted upvote ratio, so a post with few votes does
+      not outrank one with many votes at the same ratio. See
+      {!wilson_lower_bound}.
+    - Recent/Updated/Discussed remain simple field comparators owned by
+      {!Board_dispatch.sort_posts_in_memory}; they need no shared
+      formula.
 
-    @since board-karma-v2 (S2) *)
+    board-quality-wilson (item #58): replaced the former Trending sort
+    (net vote / sqrt(age hours), no confidence weighting) with the
+    decayed Hot below — Trending's only distinguishing feature (time
+    decay) is now Hot's default behavior, so keeping both was two
+    parallel projections of "recency-weighted votes". See
+    [docs/spec/11-board.md] §5.
+
+    @since board-karma-v2 (S2); reworked board-quality-wilson (#58) *)
 
 (** Net peer vote: upvotes minus downvotes.
 
@@ -25,30 +34,83 @@
     definition. *)
 let net_vote (p : Board_types.post) : int = p.votes_up - p.votes_down
 
+(** Reddit "hot" epoch reference point (2005-12-08T07:46:43Z — Reddit's
+    own reference implementation's epoch). [hot_score] only feeds
+    relative comparisons, so any fixed epoch produces identical
+    ordering; kept at the published value for traceability to the
+    source formula below, not because the specific date matters. *)
+let hot_epoch_seconds = 1_134_028_003.0
+
+(** Seconds-per-decade-of-votes decay divisor from Reddit's published
+    hot-ranking formula (reddit-archive/reddit
+    r2/r2/lib/db/_sorts.pyx, function [hot]): every 45000 seconds
+    (12.5 hours) of age costs a post the ranking equivalent of one
+    order-of-magnitude change in net vote count ([log10]). *)
+let hot_decay_seconds = 45_000.0
+
+(** Hot ranking score for a single post: [sign(net) * log10(max(1,
+    |net|)) + (created_at - epoch) / hot_decay_seconds] — Reddit's
+    "hot" formula (reddit-archive/reddit r2/r2/lib/db/_sorts.pyx,
+    function [hot]). The log term makes vote-count differences matter
+    less as they grow (10 vs 11 net votes barely moves the score; 1 vs
+    11 does); the linear time term lets newer posts at a lower vote
+    count still overtake older heavily-voted ones, which is the decay
+    the old Trending formula had and raw-net-vote Hot did not. *)
+let hot_score (p : Board_types.post) : float =
+  let net = Stdlib.float_of_int (net_vote p) in
+  let sign = if net > 0.0 then 1.0 else if net < 0.0 then -1.0 else 0.0 in
+  let order = Stdlib.log10 (Stdlib.Float.max 1.0 (Stdlib.Float.abs net)) in
+  (sign *. order) +. ((p.created_at -. hot_epoch_seconds) /. hot_decay_seconds)
+
 (** Hot ordering comparator.
 
-    [compare a b]: net vote DESC, then created_at DESC (newer first).
-    Suitable as the argument to [List.sort]. *)
+    [compare a b]: {!hot_score} DESC, then created_at DESC (newer
+    first). Suitable as the argument to [List.sort]. *)
 let hot_compare (a : Board_types.post) (b : Board_types.post) : int =
-  let cmp = Stdlib.Int.compare (net_vote b) (net_vote a) in
+  let cmp = Stdlib.Float.compare (hot_score b) (hot_score a) in
   if cmp <> 0 then cmp
   else Stdlib.Float.compare b.created_at a.created_at
 
-(** Trending score for a single post: net vote / sqrt(age in hours).
+(** z-value for a 95% confidence normal approximation to the Binomial
+    proportion, per Evan Miller, "How Not To Sort By Average Rating"
+    (2009,
+    https://www.evanmiller.org/how-not-to-sort-by-average-rating.html) —
+    the derivation Reddit's own "best" sort
+    (reddit-archive/reddit r2/r2/lib/db/_sorts.pyx, function
+    [_confidence]) implements verbatim, including this constant. *)
+let wilson_z = 1.96
 
-    Age is floored at 1.0 hour so that sub-hour posts do not acquire a
-    sub-1 divisor spike. [now] is the evaluation timestamp (wall clock). *)
-let trending_score ~now (p : Board_types.post) : float =
-  let age_hours =
-    Stdlib.Float.max 1.0 ((now -. p.created_at) /. Masc_time_constants.hour)
+(** Wilson score interval lower bound for a Bernoulli proportion
+    estimated from [ups] successes out of [ups + downs] trials.
+
+    Formula: [(p̂ + z²/2n - z * sqrt((p̂(1-p̂) + z²/4n) / n)) / (1 +
+    z²/n)] where [p̂ = ups / n], [n = ups + downs], [z = wilson_z].
+    This is the closed-form lower bound derived in Evan Miller's "How
+    Not To Sort By Average Rating" (see {!wilson_z}); it is the reason
+    a post with 1 upvote / 0 downvotes does not outrank one with 99
+    upvotes / 1 downvote — the raw ratio (1.0 vs 0.99) says the
+    opposite, but the interval width at n=1 makes the bound near 0.
+
+    Returns [0.0] when [ups + downs = 0] (no evidence). Callers that
+    need to distinguish "no votes cast" from "confidently rated near
+    zero" must check [ups + downs = 0] themselves — this function
+    only computes the bound. *)
+let wilson_lower_bound ~ups ~downs : float =
+  let n = Stdlib.float_of_int (ups + downs) in
+  if n <= 0.0 then 0.0
+  else
+    let phat = Stdlib.float_of_int ups /. n in
+    let z2 = wilson_z *. wilson_z in
+    ((phat +. (z2 /. (2.0 *. n)))
+     -. (wilson_z *. Stdlib.sqrt (((phat *. (1.0 -. phat)) +. (z2 /. (4.0 *. n))) /. n)))
+    /. (1.0 +. (z2 /. n))
+
+(** Best ordering comparator: {!wilson_lower_bound} over a post's own
+    (votes_up, votes_down) DESC, then created_at DESC. *)
+let best_compare (a : Board_types.post) (b : Board_types.post) : int =
+  let score (p : Board_types.post) =
+    wilson_lower_bound ~ups:p.votes_up ~downs:p.votes_down
   in
-  Stdlib.Float.of_int (net_vote p) /. Stdlib.sqrt age_hours
-
-(** Trending ordering comparator. [compare a b]: trending score DESC, then
-    created_at DESC (newer first) — matches [hot_compare]'s tiebreak so
-    posts with an identical score have a deterministic, not [List.sort]-
-    implementation-dependent, order. *)
-let trending_compare ~now (a : Board_types.post) (b : Board_types.post) : int =
-  let cmp = Stdlib.Float.compare (trending_score ~now b) (trending_score ~now a) in
+  let cmp = Stdlib.Float.compare (score b) (score a) in
   if cmp <> 0 then cmp
   else Stdlib.Float.compare b.created_at a.created_at

--- a/lib/board/board_sort.mli
+++ b/lib/board/board_sort.mli
@@ -1,17 +1,38 @@
 (** Board_sort — single source of truth for board post ranking formulas.
 
-    See {!Board_sort} for the rationale (Hot-sort deduplication, Trending
-    net-vote-only semantics). *)
+    See {!Board_sort} for the rationale (Hot/Best formulas, why
+    Trending was folded into the new decayed Hot). *)
 
 val net_vote : Board_types.post -> int
 (** [net_vote p] is [p.votes_up - p.votes_down]. Negative for
     downvote-heavy posts. *)
 
+val hot_epoch_seconds : float
+(** Fixed reference point for {!hot_score}'s decay term. Any fixed
+    epoch yields identical ordering; see {!Board_sort} for why this
+    specific value was chosen (traceability, not correctness). *)
+
+val hot_decay_seconds : float
+(** Seconds of age equivalent to one order-of-magnitude change in net
+    vote count in {!hot_score}. See {!Board_sort} for the source
+    formula. *)
+
+val hot_score : Board_types.post -> float
+(** Time-decayed log-vote hot ranking score. See {!Board_sort} for the
+    formula and citation. *)
+
 val hot_compare : Board_types.post -> Board_types.post -> int
-(** Hot ordering comparator: net vote DESC, then created_at DESC. *)
+(** Hot ordering comparator: {!hot_score} DESC, then created_at DESC. *)
 
-val trending_score : now:float -> Board_types.post -> float
-(** Trending score: net vote / sqrt(age in hours), age floored at 1h. *)
+val wilson_z : float
+(** z-value for the 95% confidence Wilson score interval used by
+    {!wilson_lower_bound}. See {!Board_sort} for citation. *)
 
-val trending_compare : now:float -> Board_types.post -> Board_types.post -> int
-(** Trending ordering comparator: trending score DESC. *)
+val wilson_lower_bound : ups:int -> downs:int -> float
+(** Wilson score interval lower bound over [ups] successes in
+    [ups + downs] trials. [0.0] when [ups + downs = 0] — see
+    {!Board_sort} for the full formula and citation. *)
+
+val best_compare : Board_types.post -> Board_types.post -> int
+(** Best ordering comparator: {!wilson_lower_bound} over
+    (votes_up, votes_down) DESC, then created_at DESC. *)

--- a/lib/board_sort.ml
+++ b/lib/board_sort.ml
@@ -1,0 +1,1 @@
+include Masc_board_handlers.Board_sort

--- a/lib/board_sort.mli
+++ b/lib/board_sort.mli
@@ -1,0 +1,3 @@
+include module type of struct
+  include Masc_board_handlers.Board_sort
+end

--- a/lib/board_tool_adapter/board_tool.mli
+++ b/lib/board_tool_adapter/board_tool.mli
@@ -71,7 +71,7 @@ val detect_truncated_markdown_with_reason :
 
 type sort_order = Board_dispatch.sort_order =
   | Hot
-  | Trending
+  | Best
   | Recent
   | Updated
   | Discussed

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -366,7 +366,7 @@ let detect_truncated_markdown_with_reason (text : string) : truncation_signal op
     automatically updates the user-facing list. *)
 type sort_order = Board_dispatch.sort_order =
   | Hot
-  | Trending
+  | Best
   | Recent
   | Updated
   | Discussed

--- a/lib/board_tool_adapter/board_tool_format.mli
+++ b/lib/board_tool_adapter/board_tool_format.mli
@@ -11,7 +11,7 @@ type truncation_signal =
 
 type sort_order = Board_dispatch.sort_order =
   | Hot
-  | Trending
+  | Best
   | Recent
   | Updated
   | Discussed

--- a/lib/board_tool_adapter/board_tool_post.ml
+++ b/lib/board_tool_adapter/board_tool_post.ml
@@ -409,7 +409,7 @@ let handle_post_list_uncached ~tool_name ~start_time args : Tool_result.result =
       let sort_label =
         match sort_by with
         | Board_tool_format.Hot -> "Hot"
-        | Board_tool_format.Trending -> "Trending"
+        | Board_tool_format.Best -> "Best"
         | Board_tool_format.Recent -> "Recent"
         | Board_tool_format.Updated -> "Recently Updated"
         | Board_tool_format.Discussed -> "Most Discussed"

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -280,6 +280,8 @@ let build_board_vote_totals ~votes_path ~posts_path ~comments_path :
   index_authors (load_jsonl_safe comments_path);
   let by_author : (string, int * int) Hashtbl.t = Hashtbl.create 256 in
   let bump recipient select =
+    (* DET-OK: accumulator zero-init — an absent table entry means "no votes
+       counted yet for this author", not an unknown/unparsed input. *)
     let prev = Hashtbl.find_opt by_author recipient |> Option.value ~default:(0, 0) in
     Hashtbl.replace by_author recipient (select prev)
   in
@@ -324,6 +326,9 @@ let board_vote_totals_table board_dir : (string, int * int) Hashtbl.t =
     self-votes. [(0, 0)] when the author has never received a peer vote —
     callers use that to mean "no evidence" (see {!Board_sort.wilson_lower_bound}). *)
 let votes_received_in_dir ~(board_dir : string) ~(agent_name : string) : int * int =
+  (* DET-OK: (0, 0) is the documented no-evidence value for an author with no
+     received peer votes (contract above) — not a permissive unknown-input
+     default; callers surface it as an explicit absent badge state. *)
   Hashtbl.find_opt (board_vote_totals_table board_dir) agent_name
   |> Option.value ~default:(0, 0)
 

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -240,6 +240,97 @@ let count_board_activity (config : Workspace.config) ~(agent_name : string)
     : int * int =
   count_board_activity_in_dir ~board_dir:(Workspace.masc_dir config) ~agent_name
 
+(** {1 Board Vote Counting}
+
+    board-quality-wilson (#58): peer votes received by an author,
+    aggregated from board_votes.jsonl joined against board_posts.jsonl /
+    board_comments.jsonl for author identity. This is the evidence input
+    to the board contributor-quality score (see
+    {!Board_sort.wilson_lower_bound} in [server_utils.ml]) — a signal
+    distinct from {!count_board_activity} (posts/comments the agent
+    authored) and unrelated to {!accountability_metrics} (a
+    task-evidence penalty). Mirrors {!board_activity_table}'s
+    mtime-gated projection pattern rather than reading the live
+    [Board.store] actor, for the same reason: this module already reads
+    board JSONL directly and has no dependency on board actor
+    initialization order. *)
+
+(** Self-votes are excluded exactly like
+    {!Board_votes.karma_event_of_vote}'s recipient/voter equality check
+    — an author cannot inflate or deflate their own Wilson evidence by
+    voting on their own post/comment. Unlike karma (which only counts
+    [Up]), both directions count here: the Wilson bound needs the full
+    (ups, downs) trial count, not just the reputation-earning subset. *)
+let board_vote_totals_cache :
+    (string, int * int) Hashtbl.t Jsonl_mtime_projection.t =
+  Jsonl_mtime_projection.create ()
+
+let build_board_vote_totals ~votes_path ~posts_path ~comments_path :
+    (string, int * int) Hashtbl.t =
+  let author_of_id : (string, string) Hashtbl.t = Hashtbl.create 256 in
+  let index_authors rows =
+    List.iter
+      (fun json ->
+        let id = Safe_ops.json_string ~default:"" "id" json in
+        let author = Safe_ops.json_string ~default:"" "author" json in
+        if id <> "" && author <> "" then Hashtbl.replace author_of_id id author)
+      rows
+  in
+  index_authors (load_jsonl_safe posts_path);
+  index_authors (load_jsonl_safe comments_path);
+  let by_author : (string, int * int) Hashtbl.t = Hashtbl.create 256 in
+  let bump recipient select =
+    let prev = Hashtbl.find_opt by_author recipient |> Option.value ~default:(0, 0) in
+    Hashtbl.replace by_author recipient (select prev)
+  in
+  List.iter
+    (fun json ->
+      (* [target] is the full "kind:id:voter" vote-log key (see
+         [Board_votes.parse_vote_key]); [voter] is also persisted as
+         its own field ([Board_votes.vote_log_jsonl]) — read that
+         directly instead of re-deriving it from [target]. Only [id]
+         needs extracting from [target] here. *)
+      let target = Safe_ops.json_string ~default:"" "target" json in
+      let voter = Safe_ops.json_string ~default:"" "voter" json in
+      let direction = Safe_ops.json_string ~default:"" "direction" json in
+      match String.index_opt target ':' with
+      | None -> ()
+      | Some i1 ->
+        let rest = String.sub target (i1 + 1) (String.length target - i1 - 1) in
+        let id = match String.index_opt rest ':' with
+          | Some i2 -> String.sub rest 0 i2
+          | None -> rest
+        in
+        (match Hashtbl.find_opt author_of_id id with
+         | None -> ()
+         | Some recipient when String.equal recipient voter -> ()
+         | Some recipient ->
+           (match direction with
+            | "up" -> bump recipient (fun (ups, downs) -> (ups + 1, downs))
+            | "down" -> bump recipient (fun (ups, downs) -> (ups, downs + 1))
+            | _ -> ())))
+    (load_jsonl_safe votes_path);
+  by_author
+
+let board_vote_totals_table board_dir : (string, int * int) Hashtbl.t =
+  let votes_path = Filename.concat board_dir "board_votes.jsonl" in
+  let posts_path = Filename.concat board_dir "board_posts.jsonl" in
+  let comments_path = Filename.concat board_dir "board_comments.jsonl" in
+  Jsonl_mtime_projection.get board_vote_totals_cache ~key:board_dir
+    ~sources:[ votes_path; posts_path; comments_path ]
+    ~build:(fun () -> build_board_vote_totals ~votes_path ~posts_path ~comments_path)
+
+(** [(ups, downs)] received by [agent_name] under [board_dir], excluding
+    self-votes. [(0, 0)] when the author has never received a peer vote —
+    callers use that to mean "no evidence" (see {!Board_sort.wilson_lower_bound}). *)
+let votes_received_in_dir ~(board_dir : string) ~(agent_name : string) : int * int =
+  Hashtbl.find_opt (board_vote_totals_table board_dir) agent_name
+  |> Option.value ~default:(0, 0)
+
+(** [(ups, downs)] received by [agent_name], excluding self-votes. *)
+let votes_received (config : Workspace.config) ~(agent_name : string) : int * int =
+  votes_received_in_dir ~board_dir:(Workspace.masc_dir config) ~agent_name
+
 (** {1 Mention Counting} *)
 
 let count_mention_activity (config : Workspace.config) ~(agent_name : string)

--- a/lib/reputation.mli
+++ b/lib/reputation.mli
@@ -85,6 +85,23 @@ val count_board_activity_in_dir :
     Exposed for tests; the per-render board dashboard reaches this through
     {!compute_reputation}. *)
 
+val votes_received_in_dir :
+  board_dir:string -> agent_name:string -> int * int
+(** [(ups, downs)] peer votes received by [agent_name] under [board_dir],
+    aggregated from board_votes.jsonl joined against board_posts.jsonl /
+    board_comments.jsonl for author identity, through the same
+    mtime-gated projection style as {!count_board_activity_in_dir}.
+    Self-votes are excluded (matches {!Board_votes.karma_event_of_vote}'s
+    recipient/voter equality check), but unlike karma both [Up] and
+    [Down] are counted — this feeds the board contributor-quality Wilson
+    score (see [Board_sort.wilson_lower_bound]), which needs the full
+    trial count, not just the reputation-earning subset. [(0, 0)] means
+    "no peer vote evidence", not "confidently zero". Exposed for tests. *)
+
+val votes_received : Workspace.config -> agent_name:string -> int * int
+(** [(ups, downs)] received by [agent_name]; resolves [board_dir] from
+    [config] and delegates to {!votes_received_in_dir}. *)
+
 val reputation_to_json : agent_reputation -> Yojson.Safe.t
 (** Alias for {!agent_reputation_to_yojson}. *)
 

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -231,20 +231,31 @@ let board_moderation_fields ~include_moderation ~target_kind ~target_id =
       ("moderation_status", `String summary.Board_moderation.moderation_status);
     ]
 
-let board_contributor_quality_json
-    (rep : Reputation.agent_reputation) : Yojson.Safe.t =
+(* board-quality-wilson (#58): contributor_quality on a board post/comment
+   is a peer-vote-evidence score, not a repackaging of the unrelated
+   task-accountability penalty (Reputation.agent_reputation.accountability_score
+   answers "did this agent skip commitments", not "do peers rate this
+   agent's contributions well"). score = Board_sort.wilson_lower_bound
+   over (ups, downs) received — see docs/spec/11-board.md §9a.7 for the
+   contract and lib/board/board_sort.ml for the formula + citation.
+   evidence_state is derived from vote evidence alone (ups + downs > 0),
+   independent of Reputation.agent_reputation.evidence_state, which is
+   "measured" for ANY agent activity (tasks, mentions, v2 ledger, ...)
+   and would defeat the point: an agent active elsewhere but never
+   board-voted-on must still show no badge. *)
+let board_contributor_quality_json ~(ups : int) ~(downs : int) : Yojson.Safe.t =
+  let has_evidence = ups + downs > 0 in
   `Assoc
-    [
-      ("source", `String "agent_reputation");
-      ("completion_rate", `Float rep.completion_rate);
-      ("response_rate", `Float rep.response_rate);
-      ("board_posts", `Int rep.board_posts);
-      ("board_comments", `Int rep.board_comments);
-      ("accountability_score", `Float rep.accountability_score);
-      ("autonomy_level", `String rep.autonomy_level);
-      ("thompson_confidence", `Float rep.thompson_confidence);
-      ("evidence_state", `String rep.evidence_state);
-    ]
+    ([
+       ("source", `String "board_votes");
+       ("ups", `Int ups);
+       ("downs", `Int downs);
+       ("evidence_state", `String (if has_evidence then "measured" else "default"));
+     ]
+     @
+     if has_evidence then
+       [ ("score", `Float (Board_sort.wilson_lower_bound ~ups ~downs)) ]
+     else [])
 
 let board_contributor_quality_lookup ?config () =
   match config with
@@ -257,11 +268,10 @@ let board_contributor_quality_lookup ?config () =
         | None ->
             let value =
               try
-                let rep =
-                  Reputation.compute_reputation config
-                    ~agent_name:author
+                let ups, downs =
+                  Reputation.votes_received config ~agent_name:author
                 in
-                Some (board_contributor_quality_json rep)
+                Some (board_contributor_quality_json ~ups ~downs)
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->

--- a/lib/server_utils.mli
+++ b/lib/server_utils.mli
@@ -169,15 +169,18 @@ val board_reactions_lookup :
   Board.reaction_target_type * string ->
   Board.reaction_summary list
 
-val board_contributor_quality_json :
-  Reputation.agent_reputation -> Yojson.Safe.t
-(** [board_contributor_quality_json rep] projects the existing agent
-    reputation record into the compact board contributor-quality contract. *)
+val board_contributor_quality_json : ups:int -> downs:int -> Yojson.Safe.t
+(** [board_contributor_quality_json ~ups ~downs] emits the board
+    contributor-quality contract [{score?, ups, downs, evidence_state,
+    source}] — [score] is {!Board_sort.wilson_lower_bound} over
+    [(ups, downs)], present only when [ups + downs > 0].  See
+    docs/spec/11-board.md §9a.7. *)
 
 val board_contributor_quality_lookup :
   ?config:Workspace.config -> unit -> string -> Yojson.Safe.t option
 (** [board_contributor_quality_lookup ?config ()] returns a request-local
-    memoized lookup by author.  Without [config], it returns [None]. *)
+    memoized lookup by author, backed by {!Reputation.votes_received}.
+    Without [config], it returns [None]. *)
 
 val board_claim_evidence_lookup : unit -> string -> Yojson.Safe.t option
 (** [board_claim_evidence_lookup ()] snapshots the board-claim sidecar once and

--- a/lib/tool_surface/tool_shard_types_enum_mirrors.ml
+++ b/lib/tool_surface/tool_shard_types_enum_mirrors.ml
@@ -45,5 +45,5 @@ let writable_memory_kind_enum_strings =
 ;;
 
 let fs_write_mode_enum_strings = [ "overwrite"; "append"; "patch" ]
-let sort_order_enum_strings = [ "hot"; "trending"; "recent"; "updated"; "discussed" ]
+let sort_order_enum_strings = [ "hot"; "best"; "recent"; "updated"; "discussed" ]
 let vote_direction_enum_strings = [ "up"; "down" ]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -466,10 +466,10 @@ let test_list_posts_negative_limit_returns_empty () =
 let test_list_posts_with_sort () =
   let posts_hot = Board_dispatch.list_posts ~sort_by:Board_dispatch.Hot ~limit:5 () in
   let posts_recent = Board_dispatch.list_posts ~sort_by:Board_dispatch.Recent ~limit:5 () in
-  let posts_trending = Board_dispatch.list_posts ~sort_by:Board_dispatch.Trending ~limit:5 () in
+  let posts_best = Board_dispatch.list_posts ~sort_by:Board_dispatch.Best ~limit:5 () in
   let posts_updated = Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:5 () in
   let posts_discussed = Board_dispatch.list_posts ~sort_by:Board_dispatch.Discussed ~limit:5 () in
-  let counts = List.map List.length [posts_hot; posts_recent; posts_trending; posts_updated; posts_discussed] in
+  let counts = List.map List.length [posts_hot; posts_recent; posts_best; posts_updated; posts_discussed] in
   let all_same = List.for_all (fun c -> c = List.hd counts) counts in
   Alcotest.(check bool) "all sort orders return same count" true all_same
 
@@ -487,13 +487,25 @@ let test_recent_sort_bypasses_hot_cutoff () =
     | Ok _ -> ()
     | Error e -> Alcotest.fail (Board.show_board_error e)
   in
+  (* board-quality-wilson (#58): Hot ranks on
+     Board_sort.hot_score = sign(net) * log10(max(1,|net|)) + decay, so a
+     net-vote gap of 1 (log10(1) = 0) is noise the decay term can (and,
+     for a same-instant fixture, does) cancel out entirely — that is the
+     intended behavior of Reddit's hot() formula, not a bug. Each filler
+     post needs a full order of magnitude of net vote (10 distinct
+     upvotes) to stay decisively ahead of a same-instant net-0 post; 1
+     vote each (the pre-#58 fixture) would make every post here tie the
+     brand-new cold post on hot_score, defeating this test's purpose. *)
+  let net_votes_per_hot_post = 10 in
   for i = 1 to 101 do
     let hot_post =
       create_post_exn ~author:(Printf.sprintf "hot-author-%03d" i)
         ~content:(Printf.sprintf "hot post %03d" i)
     in
-    vote_up_exn ~post_id:(Board.Post_id.to_string hot_post.id)
-      ~voter:(Printf.sprintf "hot-voter-%03d" i)
+    for j = 1 to net_votes_per_hot_post do
+      vote_up_exn ~post_id:(Board.Post_id.to_string hot_post.id)
+        ~voter:(Printf.sprintf "hot-voter-%03d-%02d" i j)
+    done
   done;
   let cold_post =
     create_post_exn ~author:"recent-cold-author"

--- a/test/test_board_sort.ml
+++ b/test/test_board_sort.ml
@@ -1,4 +1,4 @@
-(** Unit tests for Board_sort — the extracted Hot/Trending ranking SSOT. *)
+(** Unit tests for Board_sort — the extracted Hot/Best ranking SSOT. *)
 
 open Masc
 module Board_sort = Masc_board_handlers.Board_sort
@@ -37,58 +37,126 @@ let make_post ~id ~created_at ~votes_up ~votes_down ~reply_count () : Board.post
   ; origin = None
   }
 
-(* Regression for the pre-Board_sort formula ((net + reply_count * 2) /
-   sqrt(age)), which let a heavily-downvoted, high-reply post outrank a
-   cleanly upvoted, low-reply post of the same age (e.g. net -98 with 80
-   replies beat net +40 with 0 replies). Trending must rank on net vote
-   only. *)
-let test_trending_ranks_net_vote_not_reply_count () =
-  let now = 1_000_000.0 in
-  let hour = Masc_time_constants.hour in
-  let downvoted_high_reply =
-    make_post ~id:"p-downvoted" ~created_at:(now -. hour) ~votes_up:1 ~votes_down:99
+(* Hot's time-decay term (see Board_sort.hot_score) is what let the old
+   Trending sort surface newer, lower-vote posts ahead of older,
+   higher-vote ones — a raw net-vote Hot (pre-#58) could not do this.
+   Post B has 1/10th the net vote of Post A but is one full decay window
+   (hot_decay_seconds) newer, which exactly cancels the log10(10) = 1.0
+   vote-order gap, so B ties A on score and then wins the tiebreak. *)
+let test_hot_score_decays_newer_lower_vote_ties_older_higher_vote () =
+  let older =
+    make_post ~id:"p-older" ~created_at:Board_sort.hot_epoch_seconds
+      ~votes_up:10 ~votes_down:0 ~reply_count:0 ()
+  in
+  let newer =
+    make_post ~id:"p-newer"
+      ~created_at:(Board_sort.hot_epoch_seconds +. Board_sort.hot_decay_seconds)
+      ~votes_up:1 ~votes_down:0 ~reply_count:0 ()
+  in
+  Alcotest.(check bool)
+    "fixture actually ties on hot_score (else this isn't testing decay)"
+    true
+    (Stdlib.Float.equal (Board_sort.hot_score older) (Board_sort.hot_score newer));
+  let sorted = List.sort Board_sort.hot_compare [ older; newer ] in
+  Alcotest.(check string)
+    "newer, lower-vote post wins the tie via decay + created_at tiebreak"
+    "p-newer"
+    (Board.Post_id.to_string (List.hd sorted).id)
+
+let test_hot_score_downvote_heavy_ranks_below_upvoted () =
+  let now = Board_sort.hot_epoch_seconds +. (100.0 *. Board_sort.hot_decay_seconds) in
+  let downvoted = make_post ~id:"p-downvoted" ~created_at:now ~votes_up:1 ~votes_down:99
       ~reply_count:80 ()
   in
-  let upvoted_low_reply =
-    make_post ~id:"p-upvoted" ~created_at:(now -. hour) ~votes_up:40 ~votes_down:0
+  let upvoted = make_post ~id:"p-upvoted" ~created_at:now ~votes_up:40 ~votes_down:0
       ~reply_count:0 ()
   in
-  let sorted =
-    List.sort (Board_sort.trending_compare ~now) [ downvoted_high_reply; upvoted_low_reply ]
-  in
+  let sorted = List.sort Board_sort.hot_compare [ downvoted; upvoted ] in
   Alcotest.(check string)
-    "upvoted low-reply post ranks first despite fewer replies"
+    "upvoted post ranks first regardless of reply count"
     "p-upvoted"
     (Board.Post_id.to_string (List.hd sorted).id)
 
-let test_trending_tiebreaks_on_created_at_desc () =
-  let now = 1_000_000.0 in
-  let hour = Masc_time_constants.hour in
-  (* net_vote / sqrt(age_hours) ties at 5.0 for both (10/sqrt(4) = 5/sqrt(1) = 5.0)
-     despite different ages and net votes; only created_at should distinguish
-     the order. *)
-  let older = make_post ~id:"p-older" ~created_at:(now -. (4.0 *. hour)) ~votes_up:10
-      ~votes_down:0 ~reply_count:0 ()
+let test_wilson_lower_bound_zero_votes_is_zero () =
+  Alcotest.(check (float 0.0)) "n=0 -> 0.0" 0.0
+    (Board_sort.wilson_lower_bound ~ups:0 ~downs:0)
+
+let test_wilson_lower_bound_all_upvotes_below_one () =
+  (* n=1, ups=1: the interval lower bound must stay well below the raw
+     ratio (1.0) — that gap is the entire point of using Wilson instead
+     of a raw ratio for a single data point. *)
+  let lb = Board_sort.wilson_lower_bound ~ups:1 ~downs:0 in
+  Alcotest.(check bool) "single upvote scores far below 1.0" true (lb < 0.5)
+
+let test_wilson_lower_bound_larger_n_same_ratio_scores_higher () =
+  (* Same 90% upvote ratio at two sample sizes: the larger sample must
+     score higher because its confidence interval is tighter — this is
+     the exact failure mode Wilson corrects that a raw ratio (or a naive
+     Beta posterior mean, see Reputation.thompson_confidence_for_agent)
+     cannot: a single upvote would tie a 9/1 split under a raw-ratio
+     comparison. *)
+  let small_n = Board_sort.wilson_lower_bound ~ups:9 ~downs:1 in
+  let large_n = Board_sort.wilson_lower_bound ~ups:90 ~downs:10 in
+  Alcotest.(check bool) "n=100 at 90% scores higher than n=10 at 90%" true
+    (large_n > small_n)
+
+let test_best_compare_ranks_confidence_not_raw_net_vote () =
+  (* Raw net vote (votes_up - votes_down) favors 1 upvote / 0 downvotes
+     (net +1) over 98 upvotes / 2 downvotes (net +96) only if net vote
+     itself were the metric being compared here — it isn't the point of
+     this fixture. Pick a pair where net vote and Wilson bound actually
+     disagree: 1 upvote/0 downvotes (net +1, ratio 100%, n=1) vs.
+     49 upvotes/51 downvotes (net -2, ratio ~49%, n=100). Net vote ranks
+     the first higher (+1 > -2); Wilson must rank the second higher
+     because its huge sample size pins the bound near the true ~49%
+     ratio, which safely clears the single-vote post's low-n bound. *)
+  let now = Board_sort.hot_epoch_seconds in
+  let single_upvote = make_post ~id:"p-single" ~created_at:now ~votes_up:1 ~votes_down:0
+      ~reply_count:0 ()
   in
-  let newer = make_post ~id:"p-newer" ~created_at:(now -. hour) ~votes_up:5 ~votes_down:0
+  let large_sample = make_post ~id:"p-large" ~created_at:now ~votes_up:49 ~votes_down:51
+      ~reply_count:0 ()
+  in
+  Alcotest.(check bool) "net vote would (wrongly) favor the single upvote" true
+    (Board_sort.net_vote single_upvote > Board_sort.net_vote large_sample);
+  let sorted = List.sort Board_sort.best_compare [ single_upvote; large_sample ] in
+  Alcotest.(check string)
+    "Best ranks the large, evenly-split sample above the single upvote"
+    "p-large"
+    (Board.Post_id.to_string (List.hd sorted).id)
+
+let test_best_compare_tiebreaks_on_created_at_desc () =
+  let older = make_post ~id:"p-older" ~created_at:1_000_000.0 ~votes_up:5 ~votes_down:0
+      ~reply_count:0 ()
+  in
+  let newer = make_post ~id:"p-newer" ~created_at:1_000_100.0 ~votes_up:5 ~votes_down:0
       ~reply_count:3 ()
   in
-  Alcotest.(check bool)
-    "fixture actually ties on trending_score (else this isn't testing the tiebreak)"
-    true
-    (Board_sort.trending_score ~now older = Board_sort.trending_score ~now newer);
-  let sorted = List.sort (Board_sort.trending_compare ~now) [ older; newer ] in
-  Alcotest.(check string)
-    "newer post wins the tiebreak"
+  let sorted = List.sort Board_sort.best_compare [ older; newer ] in
+  Alcotest.(check string) "newer post wins the tiebreak on identical votes"
     "p-newer"
     (Board.Post_id.to_string (List.hd sorted).id)
 
 let () =
   Alcotest.run "Board_sort"
-    [ ( "trending"
-      , [ Alcotest.test_case "ranks net vote, not reply count" `Quick
-            test_trending_ranks_net_vote_not_reply_count
+    [ ( "hot"
+      , [ Alcotest.test_case "decay lets a newer, lower-vote post tie an older, higher-vote one" `Quick
+            test_hot_score_decays_newer_lower_vote_ties_older_higher_vote
+        ; Alcotest.test_case "downvote-heavy high-reply post still ranks below upvoted" `Quick
+            test_hot_score_downvote_heavy_ranks_below_upvoted
+        ] )
+    ; ( "wilson_lower_bound"
+      , [ Alcotest.test_case "n=0 returns 0.0" `Quick
+            test_wilson_lower_bound_zero_votes_is_zero
+        ; Alcotest.test_case "single upvote scores far below the raw 1.0 ratio" `Quick
+            test_wilson_lower_bound_all_upvotes_below_one
+        ; Alcotest.test_case "larger n at the same ratio scores higher" `Quick
+            test_wilson_lower_bound_larger_n_same_ratio_scores_higher
+        ] )
+    ; ( "best"
+      , [ Alcotest.test_case "ranks confidence-weighted ratio, not raw net vote" `Quick
+            test_best_compare_ranks_confidence_not_raw_net_vote
         ; Alcotest.test_case "tiebreaks on created_at desc" `Quick
-            test_trending_tiebreaks_on_created_at_desc
+            test_best_compare_tiebreaks_on_created_at_desc
         ] )
     ]

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -62,7 +62,7 @@ let test_sort_order_witness_in_enum () =
       Alcotest.failf "sort_order_to_string %S not in valid_sort_order_strings" actual
   in
   witness D.Hot;
-  witness D.Trending;
+  witness D.Best;
   witness D.Recent;
   witness D.Updated;
   witness D.Discussed;
@@ -78,6 +78,11 @@ let test_sort_order_legacy_aliases_rejected () =
   rejected "new rejected" "new";
   rejected "active rejected" "active";
   rejected "comments rejected" "comments";
+  (* board-quality-wilson (#58): "trending" is a retired sort name, not an
+     alias for "best" — a silent alias would hide the semantic change
+     (net-vote+decay vs. confidence-weighted ratio) from any caller still
+     passing the old string. *)
+  rejected "trending rejected (retired, not an alias for best)" "trending";
   rejected "garbage rejected" "definitely-not-an-order"
 
 let test_permanent_post () =

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -181,7 +181,7 @@ let test_sort_order_of_string () =
     | Error e -> Alcotest.failf "%s: expected Ok, got Error: %s" name e
   in
   check "hot" Board_tool.Hot "hot";
-  check "trending" Board_tool.Trending "trending";
+  check "best" Board_tool.Best "best";
   check "recent" Board_tool.Recent "recent";
   check "updated" Board_tool.Updated "updated";
   check "discussed" Board_tool.Discussed "discussed";
@@ -508,20 +508,8 @@ let test_board_dashboard_json_embeds_contributor_quality () =
     | Ok post -> post
     | Error e -> Alcotest.fail (Board.show_board_error e)
   in
-  let rep =
-    {
-      (Reputation.default_reputation ~agent_name:"quality-author") with
-      completion_rate = 0.8;
-      response_rate = 0.6;
-      board_posts = 3;
-      board_comments = 5;
-      accountability_score = 0.9;
-      autonomy_level = "elevated";
-      thompson_confidence = 0.7;
-    }
-  in
   let contributor_quality =
-    Server_utils.board_contributor_quality_json rep
+    Server_utils.board_contributor_quality_json ~ups:14 ~downs:2
   in
   let post_json =
     Server_utils.board_post_dashboard_json ~contributor_quality
@@ -532,10 +520,28 @@ let test_board_dashboard_json_embeds_contributor_quality () =
     | `Assoc _ as quality -> quality
     | _ -> Alcotest.fail "expected contributor_quality object"
   in
-  Alcotest.(check string) "quality source" "agent_reputation"
+  Alcotest.(check string) "quality source" "board_votes"
     (json_member_string quality "source");
-  Alcotest.(check int) "quality board posts" 3
-    (json_member_int quality "board_posts")
+  Alcotest.(check int) "quality ups" 14
+    (json_member_int quality "ups");
+  Alcotest.(check int) "quality downs" 2
+    (json_member_int quality "downs");
+  Alcotest.(check string) "quality evidence_state" "measured"
+    (json_member_string quality "evidence_state")
+
+let test_board_contributor_quality_absent_without_evidence () =
+  (* Zero votes must show as "no evidence" (evidence_state = "default",
+     score field absent), not a fabricated numeric quality — this is the
+     honest-disappearance contract from item #58's fix design. *)
+  with_eio @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let quality = Server_utils.board_contributor_quality_json ~ups:0 ~downs:0 in
+  Alcotest.(check string) "no-evidence state" "default"
+    (json_member_string quality "evidence_state");
+  Alcotest.(check bool) "score field absent without evidence" true
+    (match Yojson.Safe.Util.member "score" quality with
+     | `Null -> true
+     | _ -> false)
 
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
@@ -1344,7 +1350,7 @@ let test_post_list_sort_orders () =
   cleanup ();
   ignore (dispatch "masc_board_post"
     (make_args [("content", `String "sort test"); ("author", `String "a")]));
-  let sorts = ["hot"; "trending"; "recent"; "updated"; "discussed"] in
+  let sorts = ["hot"; "best"; "recent"; "updated"; "discussed"] in
   List.iter (fun s ->
     let ok, body = dispatch "masc_board_list"
       (make_args [("sort_by", `String s)]) in
@@ -1362,7 +1368,7 @@ let test_post_list_invalid_sort_rejected () =
     (make_args [("sort", `String "invalid_xyz")]) in
   Alcotest.(check bool) "invalid sort rejected" false ok;
   Alcotest.(check bool) "error mentions valid sorts" true
-    (contains_substring body "invalid sort. Valid: hot, trending, recent, updated, discussed")
+    (contains_substring body "invalid sort. Valid: hot, best, recent, updated, discussed")
 
 let test_post_list_filter_combinations () =
   with_eio @@ fun env ->
@@ -2616,6 +2622,8 @@ let () =
             `Quick test_board_dashboard_json_hides_unvoted_scores_when_blind;
           Alcotest.test_case "board dashboard json embeds contributor quality"
             `Quick test_board_dashboard_json_embeds_contributor_quality;
+          Alcotest.test_case "board contributor quality absent without vote evidence"
+            `Quick test_board_contributor_quality_absent_without_evidence;
           Alcotest.test_case "MCP runtime board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "MCP runtime board post author accepts matching alias"


### PR DESCRIPTION
## 목적 (캠페인 #58)

Board "품질" 배지의 불투명 휴리스틱 해체. 진단(wf_e047f03f CONFIRMED): 백엔드는 score/band 없이 raw 필드만 방출하고, FE가 **accountability_score(페널티 휴리스틱)를 품질로 위장 표시**. 스펙(11-board.md)이 약속한 composite score는 미구현이었다.

## 공식 (문서화 완료 — 코드 doc comment + spec §5/§9a.7)

- **Hot** (기존 raw net-vote 비교자 대체): `sign(net)·log10(max(1,|net|)) + age/45000` — Reddit 원공식 (reddit-archive r2 `_sorts.pyx` 인용). 12.5h 나이 = 투표 한 자릿수.
- **Best** (신규, Trending 대체): Wilson score lower bound, z=1.96 — Evan Miller "How Not To Sort By Average Rating", Reddit `_confidence()` 동일 공식. n=0 → 0.0.
- **Contributor quality**: 받은 peer 투표에 대한 `wilson_lower_bound(ups, downs)` — 신규 `Reputation.votes_received` projection(mtime-gated JSONL, 기존 board_activity_table 패턴, 자기투표 제외). `evidence_state:"measured"`는 `ups+downs > 0`일 때만 — 증거 없으면 배지 정직 소멸.
- 매직넘버 0: z값 등 named constant + 근거 주석.

## 삭제 (rg 증명)

- `Trending` sort 전체 은퇴 (dispatch/sort/adapter/enum mirror) — `"trending"`은 alias 없이 `None` (회귀 테스트로 고정, 조용한 별칭 금지).
- `band`: wire에서 한 번도 방출된 적 없는 사문 계약 — 백엔드~FE 전체 삭제.
- board projection의 accountability_score 위장 fallback + FE의 "has evidence" 재파생 휴리스틱(하드코딩 기본값 3개 포함) 삭제 — 일반 agent-reputation 표면은 무접촉.

## 검증

- OCaml @check + ocamlformat 클린 (19파일, 오케스트레이터 재검증 포함, 최신 main rebase 후).
- test_board_sort 재작성 7/7 (Wilson known-values: n=0→0, 동비율 큰 n 우위 — raw ratio가 못 갖는 속성), test_board_dispatch 77/77, test_board_ttl 17/17 (trending 거부 케이스), coverage 112/112.
- Dashboard tsc 클린 + **전체 스위트 8,713 green** (에이전트).
- 픽스처 1건 수정: 구식 fixture가 net=+1 필러를 썼는데 Reddit 실공식에선 log10(1)=0으로 정당한 동점 — net=+10으로 교정 (워크어라운드 아닌 올바른 픽스처).

## 후속 (별도 이슈)

`tool_shard_types_enum_mirrors.ml`의 sort_order 미러가 손관리 + 주석이 인용하는 sync 테스트(test_types.ml)가 실존하지 않음 — drift 위험, 분리 추적.

진단: workflow wf_e047f03f (캠페인 원장 masc#23925).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
