### PR TITLE
fix(fs): make descriptor-backed locks cancellation-safe

### DIFF
--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -44,6 +44,11 @@ type stat =
   ; link_count : int64
   }
 
+type directory_identity =
+  { device : int64
+  ; inode : int64
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -64,6 +69,12 @@ external open_read_fd
   -> string
   -> Unix.file_descr
   = "masc_anchored_open_read"
+
+external open_write_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_write"
 
 external create_exclusive_fd
   :  Unix.file_descr
@@ -142,6 +153,37 @@ let combine_close ~operation fd f =
 let with_open_root path f =
   let fd = open_root_fd path in
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
+;;
+
+let identity fd =
+  let metadata = Unix.fstat fd in
+  if metadata.Unix.st_kind <> Unix.S_DIR
+  then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
+  { device = Int64.of_int metadata.Unix.st_dev
+  ; inode = Int64.of_int metadata.Unix.st_ino
+  }
+;;
+
+let with_lock_file dir ~name ~perm f =
+  let name_value = segment_value name in
+  let created, fd =
+    match create_exclusive_fd dir name_value perm with
+    | fd -> true, fd
+    | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+      false, open_write_fd dir name_value
+  in
+  combine_close ~operation:"anchored lock-file transaction" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then
+      raise
+        (Unix.Unix_error
+           (Unix.EINVAL, "anchored_lock_file", name_value));
+    if created
+    then (
+      Unix.fsync fd;
+      Unix.fsync dir);
+    f fd)
 ;;
 
 let with_open_dir parent name f =
@@ -285,7 +327,7 @@ let stat dir name =
     (stat_at_raw dir (segment_value name))
 ;;
 
-let same_identity left right =
+let same_identity (left : stat) (right : stat) =
   Int64.equal left.device right.device && Int64.equal left.inode right.inode
 ;;
 

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -1,0 +1,309 @@
+type t = Unix.file_descr
+
+type kind =
+  | Regular_file
+  | Directory
+  | Symbolic_link
+  | Other
+
+type stat =
+  { kind : kind
+  ; size : int64
+  ; device : int64
+  ; inode : int64
+  ; link_count : int64
+  }
+
+external open_root_fd : string -> Unix.file_descr = "masc_anchored_open_root"
+
+external open_dir_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_dir"
+
+external open_read_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_read"
+
+external create_exclusive_fd
+  :  Unix.file_descr
+  -> string
+  -> int
+  -> Unix.file_descr
+  = "masc_anchored_create_exclusive"
+
+external mkdir_at : Unix.file_descr -> string -> int -> unit = "masc_anchored_mkdir"
+external unlink_at : Unix.file_descr -> string -> unit = "masc_anchored_unlink"
+
+external rename_at
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  -> string
+  -> unit
+  = "masc_anchored_rename"
+
+external link_at
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  -> string
+  -> unit
+  = "masc_anchored_link"
+
+external stat_at_raw
+  :  Unix.file_descr
+  -> string
+  -> (int * int64 * int64 * int64 * int64) option
+  = "masc_anchored_stat"
+
+external read_dir_raw : Unix.file_descr -> string list = "masc_anchored_readdir"
+
+let is_single_segment value =
+  (not (String.equal value ""))
+  && not (String.equal value ".")
+  && not (String.equal value "..")
+  && String.equal (Filename.basename value) value
+;;
+
+let require_segment ~operation value =
+  if not (is_single_segment value)
+  then invalid_arg (Printf.sprintf "%s: expected one path segment: %S" operation value)
+;;
+
+let combine_close ~operation fd f =
+  let outcome =
+    try Ok (f ()) with
+    | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  let close_outcome =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  match outcome, close_outcome with
+  | Ok value, Ok () -> value
+  | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+  | Ok _, Error close_error -> raise close_error
+  | Error (primary, _), Error close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "%s failed (%s); descriptor close also failed (%s)"
+            operation
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let with_open_root path f =
+  let fd = open_root_fd path in
+  combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
+;;
+
+let with_open_dir parent name f =
+  require_segment ~operation:"with_open_dir" name;
+  let fd = open_dir_fd parent name in
+  combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
+;;
+
+let fsync fd = Unix.fsync fd
+
+let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+  require_segment ~operation:"with_ensure_dir" name;
+  let created =
+    match open_dir_fd parent name with
+    | fd -> false, fd
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+      (match mkdir_at parent name perm with
+       | () -> ()
+       | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      let fd = open_dir_fd parent name in
+      true, fd
+  in
+  let was_created, fd = created in
+  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
+    if was_created then fsync parent;
+    if enforce_perm
+    then (
+      Unix.fchmod fd perm;
+      fsync fd)
+    else if was_created
+    then fsync fd;
+    f fd)
+;;
+
+let kind_of_int = function
+  | 0 -> Regular_file
+  | 1 -> Directory
+  | 2 -> Symbolic_link
+  | 3 -> Other
+  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
+;;
+
+let stat dir name =
+  require_segment ~operation:"stat" name;
+  Option.map
+    (fun (kind, size, device, inode, link_count) ->
+       { kind = kind_of_int kind; size; device; inode; link_count })
+    (stat_at_raw dir name)
+;;
+
+let same_identity left right =
+  Int64.equal left.device right.device && Int64.equal left.inode right.inode
+;;
+
+let read_file dir name =
+  require_segment ~operation:"read_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored read" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
+    let buffer = Bytes.create 65536 in
+    let content = Buffer.create (min metadata.Unix.st_size 65536) in
+    let rec loop () =
+      match Unix.read fd buffer 0 (Bytes.length buffer) with
+      | 0 -> Buffer.contents content
+      | count ->
+        Buffer.add_subbytes content buffer 0 count;
+        loop ()
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+    in
+    loop ())
+;;
+
+let write_all fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring fd content offset (String.length content - offset)
+      with
+      | 0 -> raise (Unix.Unix_error (Unix.EIO, "anchored_write", ""))
+      | count -> loop (offset + count)
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+  in
+  loop 0
+;;
+
+let temp_counter = Atomic.make 0
+
+let rec create_temporary dir =
+  let sequence = Atomic.fetch_and_add temp_counter 1 in
+  let name = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
+  match create_exclusive_fd dir name 0o600 with
+  | fd -> name, fd
+  | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary dir
+;;
+
+let unlink_if_exists dir name =
+  require_segment ~operation:"unlink_if_exists" name;
+  match unlink_at dir name with
+  | () -> true
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+;;
+
+let save_file_atomic dir ~name ~perm content =
+  require_segment ~operation:"save_file_atomic" name;
+  let temp_name, fd = create_temporary dir in
+  let cleanup () =
+    match unlink_if_exists dir temp_name with
+    | true | false -> Ok ()
+    | exception exn -> Error exn
+  in
+  let write_outcome =
+    try
+      write_all fd content;
+      Unix.fchmod fd perm;
+      Unix.fsync fd;
+      Ok ()
+    with
+    | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  let close_outcome =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  let primary =
+    match write_outcome, close_outcome with
+    | Ok (), Ok () -> Ok ()
+    | Error (exn, _), Ok () | Ok (), Error exn -> Error exn
+    | Error (write_error, _), Error close_error ->
+      Error
+        (Failure
+           (Printf.sprintf
+              "anchored atomic write failed (%s); close also failed (%s)"
+              (Printexc.to_string write_error)
+              (Printexc.to_string close_error)))
+  in
+  match primary with
+  | Error exn ->
+    (match exn with
+     | Eio.Cancel.Cancelled _ ->
+       (match cleanup () with
+        | Ok () -> ()
+        | Error cleanup_error ->
+          Printf.eprintf
+            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
+            temp_name
+            (Printexc.to_string cleanup_error));
+       raise exn
+     | _ ->
+       let detail =
+         match cleanup () with
+         | Ok () -> Printexc.to_string exn
+         | Error cleanup_error ->
+           Printf.sprintf
+             "%s; temporary cleanup failed: %s"
+             (Printexc.to_string exn)
+             (Printexc.to_string cleanup_error)
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
+  | Ok () ->
+    (match rename_at dir temp_name dir name with
+     | () ->
+       (match fsync dir with
+        | () -> Ok ()
+        | exception exn ->
+          Error
+            (Printf.sprintf
+               "save_file_atomic %s committed but directory fsync failed: %s"
+               name
+               (Printexc.to_string exn)))
+     | exception exn ->
+       let detail =
+         match cleanup () with
+         | Ok () -> Printexc.to_string exn
+         | Error cleanup_error ->
+           Printf.sprintf
+             "%s; temporary cleanup failed: %s"
+             (Printexc.to_string exn)
+             (Printexc.to_string cleanup_error)
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
+;;
+
+let rename ~src_dir ~src ~dst_dir ~dst =
+  require_segment ~operation:"rename source" src;
+  require_segment ~operation:"rename destination" dst;
+  rename_at src_dir src dst_dir dst;
+  fsync dst_dir;
+  if src_dir != dst_dir then fsync src_dir
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  require_segment ~operation:"link source" src;
+  require_segment ~operation:"link destination" dst;
+  link_at src_dir src dst_dir dst;
+  fsync dst_dir
+;;
+
+let read_dir dir = read_dir_raw dir |> List.sort String.compare

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -374,7 +374,7 @@ let atomic_replace dir ~name ~perm content =
             dir
             (segment_value name)
         with
-        | exception Eio.Cancel.Cancelled _ as exn ->
+        | exception (Eio.Cancel.Cancelled _ as exn) ->
           let cleanup_error = cleanup_temp dir temp_name in
           (match cleanup_error with
            | None -> ()
@@ -397,7 +397,7 @@ let atomic_replace dir ~name ~perm content =
 let unlink_if_exists dir name =
   match unlink_at dir (segment_value name) with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->
@@ -414,7 +414,7 @@ let rename ~src_dir ~src ~dst_dir ~dst =
       dst_dir
       (segment_value dst)
   with
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->
@@ -434,7 +434,7 @@ let link_no_replace ~src_dir ~src ~dst_dir ~dst =
       dst_dir
       (segment_value dst)
   with
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -157,6 +157,22 @@ let same_identity left right =
   Int64.equal left.device right.device && Int64.equal left.inode right.inode
 ;;
 
+let kind_of_unix = function
+  | Unix.S_REG -> Regular_file
+  | Unix.S_DIR -> Directory
+  | Unix.S_LNK -> Symbolic_link
+  | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO | Unix.S_SOCK -> Other
+;;
+
+let stat_of_unix (metadata : Unix.stats) =
+  { kind = kind_of_unix metadata.st_kind
+  ; size = Int64.of_int metadata.st_size
+  ; device = Int64.of_int metadata.st_dev
+  ; inode = Int64.of_int metadata.st_ino
+  ; link_count = Int64.of_int metadata.st_nlink
+  }
+;;
+
 let read_file dir name =
   require_segment ~operation:"read_file" name;
   let fd = open_read_fd dir name in
@@ -175,6 +191,28 @@ let read_file dir name =
       | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
     in
     loop ())
+;;
+
+let fsync_file dir name =
+  require_segment ~operation:"fsync_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored file fsync" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name));
+    Unix.fsync fd;
+    stat_of_unix metadata)
+;;
+
+let chmod_file dir name perm =
+  require_segment ~operation:"chmod_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored file chmod" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name));
+    Unix.fchmod fd perm;
+    Unix.fsync fd)
 ;;
 
 let write_all fd content =
@@ -204,7 +242,9 @@ let rec create_temporary dir =
 let unlink_if_exists dir name =
   require_segment ~operation:"unlink_if_exists" name;
   match unlink_at dir name with
-  | () -> true
+  | () ->
+    fsync dir;
+    true
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
 ;;
 

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -463,10 +463,10 @@ let write_all fd content =
 let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
-  (* NDT-OK: PID and process-local sequence only mint an exclusive temporary
-     entry name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no
-     policy, ordering, or replay decision depends on the generated spelling. *)
   let sequence = Atomic.fetch_and_add temp_counter 1 in
+  (* PID and process-local sequence only mint an exclusive temporary entry
+     name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no policy,
+     ordering, or replay decision depends on the generated spelling. NDT-OK. *)
   let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
   let name =
     match Segment.of_string raw with

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -44,12 +44,10 @@ type stat =
   ; link_count : int64
   }
 
-type directory_identity =
-  { device : int64
-  ; inode : int64
+type lock_file =
+  { descriptor : Unix.file_descr
+  ; metadata : stat
   }
-
-type lock_file
 
 exception Descriptor_cleanup_failed of
   { operation : string
@@ -177,18 +175,6 @@ let with_open_root path f =
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
 ;;
 
-let identity fd =
-  let metadata = stat_of_raw (fstat_raw fd) in
-  if metadata.kind <> Directory
-  then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
-  { device = metadata.device; inode = metadata.inode }
-;;
-
-type lock_file =
-  { descriptor : Unix.file_descr
-  ; metadata : stat
-  }
-
 let open_lock_file dir ~name ~perm =
   let name_value = segment_value name in
   let created, fd =
@@ -227,7 +213,7 @@ let open_lock_file dir ~name ~perm =
 let lock_file_descriptor file = file.descriptor
 
 let lock_file_identity file =
-  { device = file.metadata.device; inode = file.metadata.inode }
+  file.metadata.device, file.metadata.inode
 ;;
 
 let close_lock_file file = Unix.close file.descriptor
@@ -254,12 +240,12 @@ let close_after_primary ~operation fd primary backtrace =
   | () -> Printexc.raise_with_backtrace primary backtrace
   | exception close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "%s failed (%s); descriptor close also failed (%s)"
-            operation
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation
+         ; primary
+         ; primary_backtrace = backtrace
+         ; close_error
+         })
 ;;
 
 let open_ensured_child parent ~name ~perm ~enforce_perm =
@@ -303,15 +289,17 @@ let close_parent_before_descending ~parent ~child =
   match Unix.close parent with
   | () -> child
   | exception parent_close_error ->
+    let primary_backtrace = Printexc.get_raw_backtrace () in
     (match Unix.close child with
      | () -> raise parent_close_error
      | exception child_close_error ->
        raise
-         (Failure
-            (Printf.sprintf
-               "ancestor close failed (%s); child close also failed (%s)"
-               (Printexc.to_string parent_close_error)
-               (Printexc.to_string child_close_error))))
+         (Descriptor_cleanup_failed
+            { operation = "anchored ancestor close"
+            ; primary = parent_close_error
+            ; primary_backtrace
+            ; close_error = child_close_error
+            }))
 ;;
 
 let with_ensure_path ~root steps f =
@@ -359,19 +347,8 @@ let with_open_path_opt ~root steps f =
   walk (open_root_fd root) steps
 ;;
 
-let kind_of_int = function
-  | 0 -> Regular_file
-  | 1 -> Directory
-  | 2 -> Symbolic_link
-  | 3 -> Other
-  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
-;;
-
 let stat dir name =
-  Option.map
-    (fun (kind, size, device, inode, link_count) ->
-       { kind = kind_of_int kind; size; device; inode; link_count })
-    (stat_at_raw dir (segment_value name))
+  Option.map stat_of_raw (stat_at_raw dir (segment_value name))
 ;;
 
 let same_identity (left : stat) (right : stat) =
@@ -529,11 +506,12 @@ let atomic_replace dir ~name ~perm content =
       | Ok (), Error exn -> Error (exn, Printexc.get_raw_backtrace ())
       | Error (write_error, backtrace), Error close_error ->
         Error
-          ( Failure
-              (Printf.sprintf
-                 "anchored atomic write failed (%s); close also failed (%s)"
-                 (Printexc.to_string write_error)
-                 (Printexc.to_string close_error))
+          ( Descriptor_cleanup_failed
+              { operation = "anchored atomic write"
+              ; primary = write_error
+              ; primary_backtrace = backtrace
+              ; close_error
+              }
           , backtrace )
     in
     (match before_commit with
@@ -643,13 +621,14 @@ let combine_closedir handle f =
   | Ok value, Ok () -> value
   | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
   | Ok _, Error close_error -> raise close_error
-  | Error (primary, _), Error close_error ->
+  | Error (primary, primary_backtrace), Error close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "anchored readdir failed (%s); closedir also failed (%s)"
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation = "anchored readdir"
+         ; primary
+         ; primary_backtrace
+         ; close_error
+         })
 ;;
 
 let read_dir dir =
@@ -657,6 +636,7 @@ let read_dir dir =
   let handle =
     try fdopendir duplicate with
     | exn ->
+      let primary_backtrace = Printexc.get_raw_backtrace () in
       let close_error =
         try
           Unix.close duplicate;
@@ -668,11 +648,12 @@ let read_dir dir =
        | None -> raise exn
        | Some close_error ->
          raise
-           (Failure
-              (Printf.sprintf
-                 "fdopendir failed (%s); duplicate close also failed (%s)"
-                 (Printexc.to_string exn)
-                 (Printexc.to_string close_error))))
+           (Descriptor_cleanup_failed
+              { operation = "anchored fdopendir"
+              ; primary = exn
+              ; primary_backtrace
+              ; close_error
+              }))
   in
   combine_closedir handle (fun () ->
     let rec loop acc =

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -160,7 +160,20 @@ let with_open_dir_opt parent name f =
 
 let fsync fd = Unix.fsync fd
 
-let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+let close_after_primary ~operation fd primary backtrace =
+  match Unix.close fd with
+  | () -> Printexc.raise_with_backtrace primary backtrace
+  | exception close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "%s failed (%s); descriptor close also failed (%s)"
+            operation
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let open_ensured_child parent ~name ~perm ~enforce_perm =
   let name_value = segment_value name in
   let needs_publish, fd =
     match open_dir_fd parent name_value with
@@ -171,11 +184,90 @@ let with_ensure_dir parent ~name ~perm ~enforce_perm f =
        | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       true, open_dir_fd parent name_value
   in
-  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
+  (try
     if enforce_perm then Unix.fchmod fd perm;
     if needs_publish || enforce_perm then fsync fd;
     if needs_publish then fsync parent;
+    fd
+   with
+   | exn ->
+     close_after_primary
+       ~operation:"anchored ensured-directory acquisition"
+       fd
+       exn
+       (Printexc.get_raw_backtrace ()))
+;;
+
+let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+  let fd = open_ensured_child parent ~name ~perm ~enforce_perm in
+  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
     f fd)
+;;
+
+type ensure_step =
+  { name : Segment.t
+  ; perm : int
+  ; enforce_perm : bool
+  }
+
+let close_parent_before_descending ~parent ~child =
+  match Unix.close parent with
+  | () -> child
+  | exception parent_close_error ->
+    (match Unix.close child with
+     | () -> raise parent_close_error
+     | exception child_close_error ->
+       raise
+         (Failure
+            (Printf.sprintf
+               "ancestor close failed (%s); child close also failed (%s)"
+               (Printexc.to_string parent_close_error)
+               (Printexc.to_string child_close_error))))
+;;
+
+let with_ensure_path ~root steps f =
+  let rec walk current = function
+    | [] ->
+      combine_close ~operation:"anchored ensured-path transaction" current
+        (fun () -> f current)
+    | { name; perm; enforce_perm } :: rest ->
+      let next =
+        try open_ensured_child current ~name ~perm ~enforce_perm with
+        | exn ->
+          close_after_primary
+            ~operation:"anchored ensured-path acquisition"
+            current
+            exn
+            (Printexc.get_raw_backtrace ())
+      in
+      walk (close_parent_before_descending ~parent:current ~child:next) rest
+  in
+  walk (open_root_fd root) steps
+;;
+
+let with_open_path_opt ~root steps f =
+  let rec walk current = function
+    | [] ->
+      Some
+        (combine_close ~operation:"anchored existing-path transaction" current
+           (fun () -> f current))
+    | name :: rest ->
+      (match open_dir_fd current (segment_value name) with
+       | next ->
+         walk
+           (close_parent_before_descending ~parent:current ~child:next)
+           rest
+       | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+         combine_close ~operation:"anchored missing-path close" current
+           (fun () -> None)
+       | exception exn ->
+         close_after_primary
+           ~operation:"anchored existing-path acquisition"
+           current
+           exn
+           (Printexc.get_raw_backtrace ()))
+  in
+  walk (open_root_fd root) steps
 ;;
 
 let kind_of_int = function

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -49,6 +49,15 @@ type directory_identity =
   ; inode : int64
   }
 
+type lock_file
+
+exception Descriptor_cleanup_failed of
+  { operation : string
+  ; primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -108,6 +117,11 @@ external stat_at_raw
   -> (int * int64 * int64 * int64 * int64) option
   = "masc_anchored_stat"
 
+external fstat_raw
+  :  Unix.file_descr
+  -> int * int64 * int64 * int64 * int64
+  = "masc_anchored_fstat"
+
 external fdopendir : Unix.file_descr -> Unix.dir_handle = "masc_anchored_fdopendir"
 
 let segment_value = Segment.to_string
@@ -122,6 +136,18 @@ let mutation_error_to_string = function
       (Printexc.to_string cleanup_error)
   | Committed_not_durable cause ->
     Printf.sprintf "committed but not durable: %s" (Printexc.to_string cause)
+;;
+
+let kind_of_int = function
+  | 0 -> Regular_file
+  | 1 -> Directory
+  | 2 -> Symbolic_link
+  | 3 -> Other
+  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
+;;
+
+let stat_of_raw (kind, size, device, inode, link_count) =
+  { kind = kind_of_int kind; size; device; inode; link_count }
 ;;
 
 let combine_close ~operation fd f =
@@ -140,14 +166,10 @@ let combine_close ~operation fd f =
   | Ok value, Ok () -> value
   | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
   | Ok _, Error close_error -> raise close_error
-  | Error (primary, _), Error close_error ->
+  | Error (primary, primary_backtrace), Error close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "%s failed (%s); descriptor close also failed (%s)"
-            operation
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation; primary; primary_backtrace; close_error })
 ;;
 
 let with_open_root path f =
@@ -156,15 +178,18 @@ let with_open_root path f =
 ;;
 
 let identity fd =
-  let metadata = Unix.fstat fd in
-  if metadata.Unix.st_kind <> Unix.S_DIR
+  let metadata = stat_of_raw (fstat_raw fd) in
+  if metadata.kind <> Directory
   then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
-  { device = Int64.of_int metadata.Unix.st_dev
-  ; inode = Int64.of_int metadata.Unix.st_ino
-  }
+  { device = metadata.device; inode = metadata.inode }
 ;;
 
-let with_lock_file dir ~name ~perm f =
+type lock_file =
+  { descriptor : Unix.file_descr
+  ; metadata : stat
+  }
+
+let open_lock_file dir ~name ~perm =
   let name_value = segment_value name in
   let created, fd =
     match create_exclusive_fd dir name_value perm with
@@ -172,9 +197,9 @@ let with_lock_file dir ~name ~perm f =
     | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
       false, open_write_fd dir name_value
   in
-  combine_close ~operation:"anchored lock-file transaction" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
+  try
+    let metadata = stat_of_raw (fstat_raw fd) in
+    if metadata.kind <> Regular_file
     then
       raise
         (Unix.Unix_error
@@ -183,7 +208,29 @@ let with_lock_file dir ~name ~perm f =
     then (
       Unix.fsync fd;
       Unix.fsync dir);
-    f fd)
+    { descriptor = fd; metadata }
+  with
+  | exn ->
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    (match Unix.close fd with
+     | () -> Printexc.raise_with_backtrace exn primary_backtrace
+     | exception close_error ->
+       raise
+         (Descriptor_cleanup_failed
+            { operation = "anchored lock-file acquisition"
+            ; primary = exn
+            ; primary_backtrace
+            ; close_error
+            }))
+;;
+
+let lock_file_descriptor file = file.descriptor
+
+let lock_file_identity file =
+  { device = file.metadata.device; inode = file.metadata.inode }
+;;
+
+let close_lock_file file = Unix.close file.descriptor
 ;;
 
 let with_open_dir parent name f =
@@ -421,6 +468,9 @@ let write_all fd content =
 let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
+  (* NDT-OK: PID and process-local sequence only mint an exclusive temporary
+     entry name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no
+     policy, ordering, or replay decision depends on the generated spelling. *)
   let sequence = Atomic.fetch_and_add temp_counter 1 in
   let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
   let name =

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -148,6 +148,11 @@ let stat_of_raw (kind, size, device, inode, link_count) =
   { kind = kind_of_int kind; size; device; inode; link_count }
 ;;
 
+let run_blocking f =
+  try Eio_unix.run_in_systhread f with
+  | Effect.Unhandled _ -> f ()
+;;
+
 let combine_close ~operation fd f =
   let outcome =
     try Ok (f ()) with
@@ -155,7 +160,7 @@ let combine_close ~operation fd f =
   in
   let close_outcome =
     try
-      Unix.close fd;
+      run_blocking (fun () -> Unix.close fd);
       Ok ()
     with
     | exn -> Error exn
@@ -171,43 +176,44 @@ let combine_close ~operation fd f =
 ;;
 
 let with_open_root path f =
-  let fd = open_root_fd path in
+  let fd = run_blocking (fun () -> open_root_fd path) in
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
 ;;
 
 let open_lock_file dir ~name ~perm =
-  let name_value = segment_value name in
-  let created, fd =
-    match create_exclusive_fd dir name_value perm with
-    | fd -> true, fd
-    | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
-      false, open_write_fd dir name_value
-  in
-  try
-    let metadata = stat_of_raw (fstat_raw fd) in
-    if metadata.kind <> Regular_file
-    then
-      raise
-        (Unix.Unix_error
-           (Unix.EINVAL, "anchored_lock_file", name_value));
-    if created
-    then (
-      Unix.fsync fd;
-      Unix.fsync dir);
-    { descriptor = fd; metadata }
-  with
-  | exn ->
-    let primary_backtrace = Printexc.get_raw_backtrace () in
-    (match Unix.close fd with
-     | () -> Printexc.raise_with_backtrace exn primary_backtrace
-     | exception close_error ->
-       raise
-         (Descriptor_cleanup_failed
-            { operation = "anchored lock-file acquisition"
-            ; primary = exn
-            ; primary_backtrace
-            ; close_error
-            }))
+  run_blocking (fun () ->
+    let name_value = segment_value name in
+    let created, fd =
+      match create_exclusive_fd dir name_value perm with
+      | fd -> true, fd
+      | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+        false, open_write_fd dir name_value
+    in
+    try
+      let metadata = stat_of_raw (fstat_raw fd) in
+      if metadata.kind <> Regular_file
+      then
+        raise
+          (Unix.Unix_error
+             (Unix.EINVAL, "anchored_lock_file", name_value));
+      if created
+      then (
+        Unix.fsync fd;
+        Unix.fsync dir);
+      { descriptor = fd; metadata }
+    with
+    | exn ->
+      let primary_backtrace = Printexc.get_raw_backtrace () in
+      (match Unix.close fd with
+       | () -> Printexc.raise_with_backtrace exn primary_backtrace
+       | exception close_error ->
+         raise
+           (Descriptor_cleanup_failed
+              { operation = "anchored lock-file acquisition"
+              ; primary = exn
+              ; primary_backtrace
+              ; close_error
+              })))
 ;;
 
 let lock_file_descriptor file = file.descriptor
@@ -216,16 +222,17 @@ let lock_file_identity file =
   file.metadata.device, file.metadata.inode
 ;;
 
-let close_lock_file file = Unix.close file.descriptor
+let close_lock_file file =
+  run_blocking (fun () -> Unix.close file.descriptor)
 ;;
 
 let with_open_dir parent name f =
-  let fd = open_dir_fd parent (segment_value name) in
+  let fd = run_blocking (fun () -> open_dir_fd parent (segment_value name)) in
   combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
 ;;
 
 let with_open_dir_opt parent name f =
-  match open_dir_fd parent (segment_value name) with
+  match run_blocking (fun () -> open_dir_fd parent (segment_value name)) with
   | fd ->
     Some
       (combine_close ~operation:"anchored optional-directory transaction" fd
@@ -233,10 +240,10 @@ let with_open_dir_opt parent name f =
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
-let fsync fd = Unix.fsync fd
+let fsync fd = run_blocking (fun () -> Unix.fsync fd)
 
 let close_after_primary ~operation fd primary backtrace =
-  match Unix.close fd with
+  match run_blocking (fun () -> Unix.close fd) with
   | () -> Printexc.raise_with_backtrace primary backtrace
   | exception close_error ->
     raise
@@ -274,7 +281,10 @@ let open_ensured_child parent ~name ~perm ~enforce_perm =
 ;;
 
 let with_ensure_dir parent ~name ~perm ~enforce_perm f =
-  let fd = open_ensured_child parent ~name ~perm ~enforce_perm in
+  let fd =
+    run_blocking (fun () ->
+      open_ensured_child parent ~name ~perm ~enforce_perm)
+  in
   combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
     f fd)
 ;;
@@ -286,11 +296,11 @@ type ensure_step =
   }
 
 let close_parent_before_descending ~parent ~child =
-  match Unix.close parent with
+  match run_blocking (fun () -> Unix.close parent) with
   | () -> child
   | exception parent_close_error ->
     let primary_backtrace = Printexc.get_raw_backtrace () in
-    (match Unix.close child with
+    (match run_blocking (fun () -> Unix.close child) with
      | () -> raise parent_close_error
      | exception child_close_error ->
        raise
@@ -309,7 +319,10 @@ let with_ensure_path ~root steps f =
         (fun () -> f current)
     | { name; perm; enforce_perm } :: rest ->
       let next =
-        try open_ensured_child current ~name ~perm ~enforce_perm with
+        try
+          run_blocking (fun () ->
+            open_ensured_child current ~name ~perm ~enforce_perm)
+        with
         | exn ->
           close_after_primary
             ~operation:"anchored ensured-path acquisition"
@@ -319,7 +332,7 @@ let with_ensure_path ~root steps f =
       in
       walk (close_parent_before_descending ~parent:current ~child:next) rest
   in
-  walk (open_root_fd root) steps
+  walk (run_blocking (fun () -> open_root_fd root)) steps
 ;;
 
 let with_open_path_opt ~root steps f =
@@ -329,7 +342,9 @@ let with_open_path_opt ~root steps f =
         (combine_close ~operation:"anchored existing-path transaction" current
            (fun () -> f current))
     | name :: rest ->
-      (match open_dir_fd current (segment_value name) with
+      (match
+         run_blocking (fun () -> open_dir_fd current (segment_value name))
+       with
        | next ->
          walk
            (close_parent_before_descending ~parent:current ~child:next)
@@ -344,11 +359,12 @@ let with_open_path_opt ~root steps f =
            exn
            (Printexc.get_raw_backtrace ()))
   in
-  walk (open_root_fd root) steps
+  walk (run_blocking (fun () -> open_root_fd root)) steps
 ;;
 
 let stat dir name =
-  Option.map stat_of_raw (stat_at_raw dir (segment_value name))
+  run_blocking (fun () ->
+    Option.map stat_of_raw (stat_at_raw dir (segment_value name)))
 ;;
 
 let same_identity (left : stat) (right : stat) =
@@ -390,11 +406,11 @@ let read_from_fd ~name fd =
 
 let read_file_opt dir name =
   let name_value = segment_value name in
-  match open_read_fd dir name_value with
+  match run_blocking (fun () -> open_read_fd dir name_value) with
   | fd ->
     Some
       (combine_close ~operation:"anchored read" fd (fun () ->
-         read_from_fd ~name:name_value fd))
+         run_blocking (fun () -> read_from_fd ~name:name_value fd)))
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
@@ -408,24 +424,26 @@ let read_file dir name =
 
 let fsync_file dir name =
   let name_value = segment_value name in
-  let fd = open_read_fd dir name_value in
+  let fd = run_blocking (fun () -> open_read_fd dir name_value) in
   combine_close ~operation:"anchored file fsync" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
-    Unix.fsync fd;
-    stat_of_unix metadata)
+    run_blocking (fun () ->
+      let metadata = Unix.fstat fd in
+      if metadata.Unix.st_kind <> Unix.S_REG
+      then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
+      Unix.fsync fd;
+      stat_of_unix metadata))
 ;;
 
 let chmod_file dir name perm =
   let name_value = segment_value name in
-  let fd = open_read_fd dir name_value in
+  let fd = run_blocking (fun () -> open_read_fd dir name_value) in
   combine_close ~operation:"anchored file chmod" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
-    Unix.fchmod fd perm;
-    Unix.fsync fd)
+    run_blocking (fun () ->
+      let metadata = Unix.fstat fd in
+      if metadata.Unix.st_kind <> Unix.S_REG
+      then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
+      Unix.fchmod fd perm;
+      Unix.fsync fd))
 ;;
 
 let write_all fd content =
@@ -474,7 +492,7 @@ let cleanup_temp dir name =
   | exn -> Some exn
 ;;
 
-let atomic_replace dir ~name ~perm content =
+let atomic_replace_blocking dir ~name ~perm content =
   let temp_result =
     try Ok (create_temporary dir) with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -556,7 +574,11 @@ let atomic_replace dir ~name ~perm content =
            | exception cause -> Error (Committed_not_durable cause))))
 ;;
 
-let unlink_if_exists dir name =
+let atomic_replace dir ~name ~perm content =
+  run_blocking (fun () -> atomic_replace_blocking dir ~name ~perm content)
+;;
+
+let unlink_if_exists_blocking dir name =
   match unlink_at dir (segment_value name) with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
@@ -568,7 +590,11 @@ let unlink_if_exists dir name =
      | exception cause -> Error (Committed_not_durable cause))
 ;;
 
-let rename ~src_dir ~src ~dst_dir ~dst =
+let unlink_if_exists dir name =
+  run_blocking (fun () -> unlink_if_exists_blocking dir name)
+;;
+
+let rename_blocking ~src_dir ~src ~dst_dir ~dst =
   match
     rename_at
       src_dir
@@ -588,7 +614,11 @@ let rename ~src_dir ~src ~dst_dir ~dst =
      | cause -> Error (Committed_not_durable cause))
 ;;
 
-let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+let rename ~src_dir ~src ~dst_dir ~dst =
+  run_blocking (fun () -> rename_blocking ~src_dir ~src ~dst_dir ~dst)
+;;
+
+let link_no_replace_blocking ~src_dir ~src ~dst_dir ~dst =
   match
     link_at
       src_dir
@@ -603,6 +633,10 @@ let link_no_replace ~src_dir ~src ~dst_dir ~dst =
     (match fsync dst_dir with
      | () -> Ok ()
      | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  run_blocking (fun () -> link_no_replace_blocking ~src_dir ~src ~dst_dir ~dst)
 ;;
 
 let combine_closedir handle f =
@@ -631,7 +665,7 @@ let combine_closedir handle f =
          })
 ;;
 
-let read_dir dir =
+let read_dir_blocking dir =
   let duplicate = Unix.dup ~cloexec:true dir in
   let handle =
     try fdopendir duplicate with
@@ -675,3 +709,6 @@ let read_dir dir =
           acc
     in
     loop [])
+;;
+
+let read_dir dir = run_blocking (fun () -> read_dir_blocking dir)

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -1,5 +1,35 @@
 type t = Unix.file_descr
 
+module Segment = struct
+  type t = string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  let of_string = function
+    | "" -> Error Empty
+    | "." -> Error Dot
+    | ".." -> Error Dot_dot
+    | value when String.contains value '/' -> Error Contains_separator
+    | value when String.contains value '\000' -> Error Contains_nul
+    | value -> Ok value
+  ;;
+
+  let to_string value = value
+
+  let error_to_string = function
+    | Empty -> "path segment is empty"
+    | Dot -> "path segment is dot"
+    | Dot_dot -> "path segment is dot-dot"
+    | Contains_separator -> "path segment contains a separator"
+    | Contains_nul -> "path segment contains NUL"
+  ;;
+end
+
 type kind =
   | Regular_file
   | Directory
@@ -13,6 +43,13 @@ type stat =
   ; inode : int64
   ; link_count : int64
   }
+
+type mutation_error =
+  | Not_committed of
+      { cause : exn
+      ; cleanup_error : exn option
+      }
+  | Committed_not_durable of exn
 
 external open_root_fd : string -> Unix.file_descr = "masc_anchored_open_root"
 
@@ -60,18 +97,20 @@ external stat_at_raw
   -> (int * int64 * int64 * int64 * int64) option
   = "masc_anchored_stat"
 
-external read_dir_raw : Unix.file_descr -> string list = "masc_anchored_readdir"
+external fdopendir : Unix.file_descr -> Unix.dir_handle = "masc_anchored_fdopendir"
 
-let is_single_segment value =
-  (not (String.equal value ""))
-  && not (String.equal value ".")
-  && not (String.equal value "..")
-  && String.equal (Filename.basename value) value
-;;
+let segment_value = Segment.to_string
 
-let require_segment ~operation value =
-  if not (is_single_segment value)
-  then invalid_arg (Printf.sprintf "%s: expected one path segment: %S" operation value)
+let mutation_error_to_string = function
+  | Not_committed { cause; cleanup_error = None } ->
+    Printf.sprintf "not committed: %s" (Printexc.to_string cause)
+  | Not_committed { cause; cleanup_error = Some cleanup_error } ->
+    Printf.sprintf
+      "not committed: %s; cleanup failed: %s"
+      (Printexc.to_string cause)
+      (Printexc.to_string cleanup_error)
+  | Committed_not_durable cause ->
+    Printf.sprintf "committed but not durable: %s" (Printexc.to_string cause)
 ;;
 
 let combine_close ~operation fd f =
@@ -106,34 +145,36 @@ let with_open_root path f =
 ;;
 
 let with_open_dir parent name f =
-  require_segment ~operation:"with_open_dir" name;
-  let fd = open_dir_fd parent name in
+  let fd = open_dir_fd parent (segment_value name) in
   combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
+;;
+
+let with_open_dir_opt parent name f =
+  match open_dir_fd parent (segment_value name) with
+  | fd ->
+    Some
+      (combine_close ~operation:"anchored optional-directory transaction" fd
+         (fun () -> f fd))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
 let fsync fd = Unix.fsync fd
 
 let with_ensure_dir parent ~name ~perm ~enforce_perm f =
-  require_segment ~operation:"with_ensure_dir" name;
-  let created =
-    match open_dir_fd parent name with
+  let name_value = segment_value name in
+  let needs_publish, fd =
+    match open_dir_fd parent name_value with
     | fd -> false, fd
     | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-      (match mkdir_at parent name perm with
+      (match mkdir_at parent name_value perm with
        | () -> ()
        | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-      let fd = open_dir_fd parent name in
-      true, fd
+      true, open_dir_fd parent name_value
   in
-  let was_created, fd = created in
   combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
-    if was_created then fsync parent;
-    if enforce_perm
-    then (
-      Unix.fchmod fd perm;
-      fsync fd)
-    else if was_created
-    then fsync fd;
+    if enforce_perm then Unix.fchmod fd perm;
+    if needs_publish || enforce_perm then fsync fd;
+    if needs_publish then fsync parent;
     f fd)
 ;;
 
@@ -146,11 +187,10 @@ let kind_of_int = function
 ;;
 
 let stat dir name =
-  require_segment ~operation:"stat" name;
   Option.map
     (fun (kind, size, device, inode, link_count) ->
        { kind = kind_of_int kind; size; device; inode; link_count })
-    (stat_at_raw dir name)
+    (stat_at_raw dir (segment_value name))
 ;;
 
 let same_identity left right =
@@ -173,44 +213,59 @@ let stat_of_unix (metadata : Unix.stats) =
   }
 ;;
 
+let read_from_fd ~name fd =
+  let metadata = Unix.fstat fd in
+  if metadata.Unix.st_kind <> Unix.S_REG
+  then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
+  let buffer = Bytes.create 65536 in
+  let content = Buffer.create (min metadata.Unix.st_size 65536) in
+  let rec loop () =
+    match Unix.read fd buffer 0 (Bytes.length buffer) with
+    | 0 -> Buffer.contents content
+    | count ->
+      Buffer.add_subbytes content buffer 0 count;
+      loop ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ()
+;;
+
+let read_file_opt dir name =
+  let name_value = segment_value name in
+  match open_read_fd dir name_value with
+  | fd ->
+    Some
+      (combine_close ~operation:"anchored read" fd (fun () ->
+         read_from_fd ~name:name_value fd))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
+;;
+
 let read_file dir name =
-  require_segment ~operation:"read_file" name;
-  let fd = open_read_fd dir name in
-  combine_close ~operation:"anchored read" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
-    let buffer = Bytes.create 65536 in
-    let content = Buffer.create (min metadata.Unix.st_size 65536) in
-    let rec loop () =
-      match Unix.read fd buffer 0 (Bytes.length buffer) with
-      | 0 -> Buffer.contents content
-      | count ->
-        Buffer.add_subbytes content buffer 0 count;
-        loop ()
-      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
-    in
-    loop ())
+  match read_file_opt dir name with
+  | Some content -> content
+  | None ->
+    raise
+      (Unix.Unix_error (Unix.ENOENT, "anchored_read", segment_value name))
 ;;
 
 let fsync_file dir name =
-  require_segment ~operation:"fsync_file" name;
-  let fd = open_read_fd dir name in
+  let name_value = segment_value name in
+  let fd = open_read_fd dir name_value in
   combine_close ~operation:"anchored file fsync" fd (fun () ->
     let metadata = Unix.fstat fd in
     if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name));
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
     Unix.fsync fd;
     stat_of_unix metadata)
 ;;
 
 let chmod_file dir name perm =
-  require_segment ~operation:"chmod_file" name;
-  let fd = open_read_fd dir name in
+  let name_value = segment_value name in
+  let fd = open_read_fd dir name_value in
   combine_close ~operation:"anchored file chmod" fd (fun () ->
     let metadata = Unix.fstat fd in
     if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name));
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
     Unix.fchmod fd perm;
     Unix.fsync fd)
 ;;
@@ -233,117 +288,225 @@ let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
   let sequence = Atomic.fetch_and_add temp_counter 1 in
-  let name = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
-  match create_exclusive_fd dir name 0o600 with
+  let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
+  let name =
+    match Segment.of_string raw with
+    | Ok name -> name
+    | Error error ->
+      invalid_arg
+        (Printf.sprintf
+           "generated invalid atomic filename: %s"
+           (Segment.error_to_string error))
+  in
+  match create_exclusive_fd dir (segment_value name) 0o600 with
   | fd -> name, fd
   | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary dir
 ;;
 
-let unlink_if_exists dir name =
-  require_segment ~operation:"unlink_if_exists" name;
-  match unlink_at dir name with
-  | () ->
+let cleanup_temp dir name =
+  try
+    unlink_at dir (segment_value name);
     fsync dir;
-    true
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+    None
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+  | exn -> Some exn
 ;;
 
-let save_file_atomic dir ~name ~perm content =
-  require_segment ~operation:"save_file_atomic" name;
-  let temp_name, fd = create_temporary dir in
-  let cleanup () =
-    match unlink_if_exists dir temp_name with
-    | true | false -> Ok ()
-    | exception exn -> Error exn
+let atomic_replace dir ~name ~perm content =
+  let temp_result =
+    try Ok (create_temporary dir) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error exn
   in
-  let write_outcome =
-    try
-      write_all fd content;
-      Unix.fchmod fd perm;
-      Unix.fsync fd;
-      Ok ()
-    with
+  match temp_result with
+  | Error cause -> Error (Not_committed { cause; cleanup_error = None })
+  | Ok (temp_name, fd) ->
+    let write_outcome =
+      try
+        write_all fd content;
+        Unix.fchmod fd perm;
+        Unix.fsync fd;
+        Ok ()
+      with
+      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+    in
+    let close_outcome =
+      try
+        Unix.close fd;
+        Ok ()
+      with
+      | exn -> Error exn
+    in
+    let before_commit =
+      match write_outcome, close_outcome with
+      | Ok (), Ok () -> Ok ()
+      | Error (exn, backtrace), Ok () -> Error (exn, backtrace)
+      | Ok (), Error exn -> Error (exn, Printexc.get_raw_backtrace ())
+      | Error (write_error, backtrace), Error close_error ->
+        Error
+          ( Failure
+              (Printf.sprintf
+                 "anchored atomic write failed (%s); close also failed (%s)"
+                 (Printexc.to_string write_error)
+                 (Printexc.to_string close_error))
+          , backtrace )
+    in
+    (match before_commit with
+     | Error ((Eio.Cancel.Cancelled _ as cause), backtrace) ->
+       (match cleanup_temp dir temp_name with
+        | None -> ()
+        | Some cleanup_error ->
+          Printf.eprintf
+            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
+            (segment_value temp_name)
+            (Printexc.to_string cleanup_error));
+       Printexc.raise_with_backtrace cause backtrace
+     | Error (cause, _) ->
+       Error
+         (Not_committed
+            { cause; cleanup_error = cleanup_temp dir temp_name })
+     | Ok () ->
+       (match
+          rename_at
+            dir
+            (segment_value temp_name)
+            dir
+            (segment_value name)
+        with
+        | exception Eio.Cancel.Cancelled _ as exn ->
+          let cleanup_error = cleanup_temp dir temp_name in
+          (match cleanup_error with
+           | None -> ()
+           | Some error ->
+             Printf.eprintf
+               "[fs_compat] cancelled anchored-rename cleanup failed name=%s: %s\n%!"
+               (segment_value temp_name)
+               (Printexc.to_string error));
+          raise exn
+        | exception cause ->
+          Error
+            (Not_committed
+               { cause; cleanup_error = cleanup_temp dir temp_name })
+        | () ->
+          (match fsync dir with
+           | () -> Ok ()
+           | exception cause -> Error (Committed_not_durable cause))))
+;;
+
+let unlink_if_exists dir name =
+  match unlink_at dir (segment_value name) with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (match fsync dir with
+     | () -> Ok `Removed
+     | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let rename ~src_dir ~src ~dst_dir ~dst =
+  match
+    rename_at
+      src_dir
+      (segment_value src)
+      dst_dir
+      (segment_value dst)
+  with
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (try
+       fsync dst_dir;
+       if src_dir != dst_dir then fsync src_dir;
+       Ok ()
+     with
+     | cause -> Error (Committed_not_durable cause))
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  match
+    link_at
+      src_dir
+      (segment_value src)
+      dst_dir
+      (segment_value dst)
+  with
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (match fsync dst_dir with
+     | () -> Ok ()
+     | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let combine_closedir handle f =
+  let outcome =
+    try Ok (f ()) with
     | exn -> Error (exn, Printexc.get_raw_backtrace ())
   in
   let close_outcome =
     try
-      Unix.close fd;
+      Unix.closedir handle;
       Ok ()
     with
     | exn -> Error exn
   in
-  let primary =
-    match write_outcome, close_outcome with
-    | Ok (), Ok () -> Ok ()
-    | Error (exn, _), Ok () | Ok (), Error exn -> Error exn
-    | Error (write_error, _), Error close_error ->
-      Error
-        (Failure
-           (Printf.sprintf
-              "anchored atomic write failed (%s); close also failed (%s)"
-              (Printexc.to_string write_error)
-              (Printexc.to_string close_error)))
+  match outcome, close_outcome with
+  | Ok value, Ok () -> value
+  | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+  | Ok _, Error close_error -> raise close_error
+  | Error (primary, _), Error close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "anchored readdir failed (%s); closedir also failed (%s)"
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let read_dir dir =
+  let duplicate = Unix.dup ~cloexec:true dir in
+  let handle =
+    try fdopendir duplicate with
+    | exn ->
+      let close_error =
+        try
+          Unix.close duplicate;
+          None
+        with
+        | close_error -> Some close_error
+      in
+      (match close_error with
+       | None -> raise exn
+       | Some close_error ->
+         raise
+           (Failure
+              (Printf.sprintf
+                 "fdopendir failed (%s); duplicate close also failed (%s)"
+                 (Printexc.to_string exn)
+                 (Printexc.to_string close_error))))
   in
-  match primary with
-  | Error exn ->
-    (match exn with
-     | Eio.Cancel.Cancelled _ ->
-       (match cleanup () with
-        | Ok () -> ()
-        | Error cleanup_error ->
-          Printf.eprintf
-            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
-            temp_name
-            (Printexc.to_string cleanup_error));
-       raise exn
-     | _ ->
-       let detail =
-         match cleanup () with
-         | Ok () -> Printexc.to_string exn
-         | Error cleanup_error ->
-           Printf.sprintf
-             "%s; temporary cleanup failed: %s"
-             (Printexc.to_string exn)
-             (Printexc.to_string cleanup_error)
-       in
-       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
-  | Ok () ->
-    (match rename_at dir temp_name dir name with
-     | () ->
-       (match fsync dir with
-        | () -> Ok ()
-        | exception exn ->
-          Error
-            (Printf.sprintf
-               "save_file_atomic %s committed but directory fsync failed: %s"
-               name
-               (Printexc.to_string exn)))
-     | exception exn ->
-       let detail =
-         match cleanup () with
-         | Ok () -> Printexc.to_string exn
-         | Error cleanup_error ->
-           Printf.sprintf
-             "%s; temporary cleanup failed: %s"
-             (Printexc.to_string exn)
-             (Printexc.to_string cleanup_error)
-       in
-       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
-;;
-
-let rename ~src_dir ~src ~dst_dir ~dst =
-  require_segment ~operation:"rename source" src;
-  require_segment ~operation:"rename destination" dst;
-  rename_at src_dir src dst_dir dst;
-  fsync dst_dir;
-  if src_dir != dst_dir then fsync src_dir
-;;
-
-let link_no_replace ~src_dir ~src ~dst_dir ~dst =
-  require_segment ~operation:"link source" src;
-  require_segment ~operation:"link destination" dst;
-  link_at src_dir src dst_dir dst;
-  fsync dst_dir
-;;
-
-let read_dir dir = read_dir_raw dir |> List.sort String.compare
+  combine_closedir handle (fun () ->
+    let rec loop acc =
+      match Unix.readdir handle with
+      | "." | ".." -> loop acc
+      | raw ->
+        (match Segment.of_string raw with
+         | Ok segment -> loop (segment :: acc)
+         | Error error ->
+           raise
+             (Failure
+                (Printf.sprintf
+                   "filesystem returned invalid directory entry: %s"
+                   (Segment.error_to_string error))))
+      | exception End_of_file ->
+        List.sort
+          (fun left right ->
+             String.compare (segment_value left) (segment_value right))
+          acc
+    in
+    loop [])

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -37,9 +37,13 @@ type stat =
   ; link_count : int64
   }
 
-type directory_identity =
-  { device : int64
-  ; inode : int64
+type lock_file
+
+exception Descriptor_cleanup_failed of
+  { operation : string
+  ; primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
   }
 
 type mutation_error =
@@ -55,17 +59,16 @@ val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
 
-val identity : t -> directory_identity
-(** Stable identity of the opened directory capability. Unlike a path spelling,
-    this remains unchanged if the directory is renamed while it is open. *)
-
-val with_lock_file :
-  t -> name:Segment.t -> perm:int -> (Unix.file_descr -> 'a) -> 'a
+val open_lock_file : t -> name:Segment.t -> perm:int -> lock_file
 (** Open or create one regular lock file relative to the directory capability,
-    without following a final symlink. A newly-created lock file and directory
-    entry are fsynced before the callback. The descriptor remains open for the
-    callback and is closed on every exit; closing releases any POSIX record lock
-    acquired by the callback. *)
+    without following a final symlink. A newly-created file and directory entry
+    are fsynced before this returns. The returned artifact must be closed with
+    {!close_lock_file}; {!File_lock_eio.with_lock_file} owns that lifecycle for
+    ordinary lock users. *)
+
+val lock_file_descriptor : lock_file -> Unix.file_descr
+val lock_file_identity : lock_file -> int64 * int64
+val close_lock_file : lock_file -> unit
 
 val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -42,13 +42,22 @@ val stat : t -> string -> stat option
 val read_file : t -> string -> string
 (** Read one existing regular file without following a final symlink. *)
 
+val fsync_file : t -> string -> stat
+(** Fsync one existing regular file and return the identity of the opened file.
+    The final entry is opened with [O_NOFOLLOW]. *)
+
+val chmod_file : t -> string -> int -> unit
+(** Apply permissions to one existing regular file through its opened file
+    descriptor, without following a final symlink. *)
+
 val save_file_atomic :
   t -> name:string -> perm:int -> string -> (unit, string) result
 (** Write through an exclusive temporary file in [t], fsync it, rename it over
     [name], and fsync [t]. No path component is reopened by name outside [t]. *)
 
 val unlink_if_exists : t -> string -> bool
-(** Remove one non-directory child entry. Returns [false] only for ENOENT. *)
+(** Remove and durably publish removal of one non-directory child entry.
+    Returns [false] only for ENOENT. *)
 
 val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
 (** Atomically move one child entry between two directory capabilities. *)

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -64,7 +64,7 @@ val open_lock_file : t -> name:Segment.t -> perm:int -> lock_file
 (** Open or create one regular lock file relative to the directory capability,
     without following a final symlink. A newly-created file and directory entry
     are fsynced before this returns. The returned artifact must be closed with
-    {!close_lock_file}; {!File_lock_eio.with_lock_file} owns that lifecycle for
+    {!close_lock_file}; {!File_lock_eio.with_anchored_file_lock} owns that lifecycle for
     ordinary lock users. *)
 
 val lock_file_descriptor : lock_file -> Unix.file_descr

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -8,6 +8,21 @@
 
 type t
 
+module Segment : sig
+  type t = private string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+  val error_to_string : error -> string
+end
+
 type kind =
   | Regular_file
   | Directory
@@ -22,51 +37,79 @@ type stat =
   ; link_count : int64
   }
 
+type mutation_error =
+  | Not_committed of
+      { cause : exn
+      ; cleanup_error : exn option
+      }
+  | Committed_not_durable of exn
+
+val mutation_error_to_string : mutation_error -> string
+
 val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
 
-val with_open_dir : t -> string -> (t -> 'a) -> 'a
+val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)
 
+val with_open_dir_opt : t -> Segment.t -> (t -> 'a) -> 'a option
+(** Open one child directory using the open operation itself as the existence
+    test. [None] means ENOENT; symlinks and all other failures are raised. *)
+
 val with_ensure_dir :
-  t -> name:string -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
+  t -> name:Segment.t -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
 (** Open one child directory, creating and durably publishing it when absent.
-    [name] must be one path segment. When [enforce_perm] is true, the opened
-    directory is [fchmod]ed and fsynced before the callback. *)
+    When [enforce_perm] is true, the opened directory is [fchmod]ed. Creation is
+    committed as [mkdirat -> openat -> fchmod -> fsync(child) -> fsync(parent)]. *)
 
-val stat : t -> string -> stat option
+val stat : t -> Segment.t -> stat option
 (** Inspect one child entry without following a symlink. [None] means ENOENT;
-    every other error is raised. *)
+    every other error is raised. This is a diagnostic snapshot, not authority
+    for a later path-based operation. *)
 
-val read_file : t -> string -> string
+val read_file : t -> Segment.t -> string
 (** Read one existing regular file without following a final symlink. *)
 
-val fsync_file : t -> string -> stat
+val read_file_opt : t -> Segment.t -> string option
+(** Read a regular file using [openat] itself as the existence test. *)
+
+val fsync_file : t -> Segment.t -> stat
 (** Fsync one existing regular file and return the identity of the opened file.
     The final entry is opened with [O_NOFOLLOW]. *)
 
-val chmod_file : t -> string -> int -> unit
+val chmod_file : t -> Segment.t -> int -> unit
 (** Apply permissions to one existing regular file through its opened file
     descriptor, without following a final symlink. *)
 
-val save_file_atomic :
-  t -> name:string -> perm:int -> string -> (unit, string) result
-(** Write through an exclusive temporary file in [t], fsync it, rename it over
-    [name], and fsync [t]. No path component is reopened by name outside [t]. *)
+val atomic_replace :
+  t -> name:Segment.t -> perm:int -> string -> (unit, mutation_error) result
+(** Write through an exclusive temporary file, fsync it, rename it over [name],
+    and fsync the directory. A visible rename followed by failed directory fsync
+    is reported as {!Committed_not_durable}, never as an untyped failure. *)
 
-val unlink_if_exists : t -> string -> bool
-(** Remove and durably publish removal of one non-directory child entry.
-    Returns [false] only for ENOENT. *)
+val unlink_if_exists :
+  t -> Segment.t -> ([ `Missing | `Removed ], mutation_error) result
+(** Remove and durably publish removal of one non-directory child entry. *)
 
-val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+val rename :
+  src_dir:t ->
+  src:Segment.t ->
+  dst_dir:t ->
+  dst:Segment.t ->
+  (unit, mutation_error) result
 (** Atomically move one child entry between two directory capabilities. *)
 
-val link_no_replace : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
-(** Create a hard link without replacing [dst]. The source symlink, if any, is
-    linked as a symlink rather than followed. *)
+val link_no_replace :
+  src_dir:t ->
+  src:Segment.t ->
+  dst_dir:t ->
+  dst:Segment.t ->
+  (unit, mutation_error) result
+(** Create and durably publish a hard link without replacing [dst]. The source
+    symlink, if any, is linked as a symlink rather than followed. *)
 
-val read_dir : t -> string list
+val read_dir : t -> Segment.t list
 (** Return child names, excluding [.] and [..], in lexical order. *)
 
 val fsync : t -> unit

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -3,8 +3,9 @@
     Every descendant lookup is relative to an already-open directory file
     descriptor. Path components are never re-resolved from an absolute string,
     so replacing a managed ancestor with a symlink cannot redirect an active
-    transaction outside its root capability. These calls are blocking and must
-    run in a system thread when invoked from Eio. *)
+    transaction outside its root capability. Filesystem syscalls are dispatched
+    to a system thread when an Eio runtime is active; callbacks continue on the
+    caller's fiber and must not be invoked from a system-thread-only body. *)
 
 type t
 

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -1,0 +1,67 @@
+(** Descriptor-anchored blocking filesystem operations.
+
+    Every descendant lookup is relative to an already-open directory file
+    descriptor. Path components are never re-resolved from an absolute string,
+    so replacing a managed ancestor with a symlink cannot redirect an active
+    transaction outside its root capability. These calls are blocking and must
+    run in a system thread when invoked from Eio. *)
+
+type t
+
+type kind =
+  | Regular_file
+  | Directory
+  | Symbolic_link
+  | Other
+
+type stat =
+  { kind : kind
+  ; size : int64
+  ; device : int64
+  ; inode : int64
+  ; link_count : int64
+  }
+
+val with_open_root : string -> (t -> 'a) -> 'a
+(** Open an existing real directory without following a final symlink and close
+    the capability after the callback. Close failures are never discarded. *)
+
+val with_open_dir : t -> string -> (t -> 'a) -> 'a
+(** Open one existing child directory without following symlinks. *)
+
+val with_ensure_dir :
+  t -> name:string -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
+(** Open one child directory, creating and durably publishing it when absent.
+    [name] must be one path segment. When [enforce_perm] is true, the opened
+    directory is [fchmod]ed and fsynced before the callback. *)
+
+val stat : t -> string -> stat option
+(** Inspect one child entry without following a symlink. [None] means ENOENT;
+    every other error is raised. *)
+
+val read_file : t -> string -> string
+(** Read one existing regular file without following a final symlink. *)
+
+val save_file_atomic :
+  t -> name:string -> perm:int -> string -> (unit, string) result
+(** Write through an exclusive temporary file in [t], fsync it, rename it over
+    [name], and fsync [t]. No path component is reopened by name outside [t]. *)
+
+val unlink_if_exists : t -> string -> bool
+(** Remove one non-directory child entry. Returns [false] only for ENOENT. *)
+
+val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+(** Atomically move one child entry between two directory capabilities. *)
+
+val link_no_replace : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+(** Create a hard link without replacing [dst]. The source symlink, if any, is
+    linked as a symlink rather than followed. *)
+
+val read_dir : t -> string list
+(** Return child names, excluding [.] and [..], in lexical order. *)
+
+val fsync : t -> unit
+(** Durably publish prior directory-entry changes. Unsupported operations are
+    raised explicitly. *)
+
+val same_identity : stat -> stat -> bool

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -63,6 +63,23 @@ val with_ensure_dir :
     When [enforce_perm] is true, the opened directory is [fchmod]ed. Creation is
     committed as [mkdirat -> openat -> fchmod -> fsync(child) -> fsync(parent)]. *)
 
+type ensure_step =
+  { name : Segment.t
+  ; perm : int
+  ; enforce_perm : bool
+  }
+
+val with_ensure_path :
+  root:string -> ensure_step list -> (t -> 'a) -> 'a
+(** Open [root], walk [steps] one descriptor-relative component at a time, and
+    retain only the leaf descriptor for the callback. Missing components are
+    created with the same durability contract as {!with_ensure_dir}. *)
+
+val with_open_path_opt :
+  root:string -> Segment.t list -> (t -> 'a) -> 'a option
+(** Read-only counterpart of {!with_ensure_path}. [None] means a component was
+    absent. Ancestor descriptors are closed before the callback. *)
+
 val stat : t -> Segment.t -> stat option
 (** Inspect one child entry without following a symlink. [None] means ENOENT;
     every other error is raised. This is a diagnostic snapshot, not authority

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -37,6 +37,11 @@ type stat =
   ; link_count : int64
   }
 
+type directory_identity =
+  { device : int64
+  ; inode : int64
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -49,6 +54,18 @@ val mutation_error_to_string : mutation_error -> string
 val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
+
+val identity : t -> directory_identity
+(** Stable identity of the opened directory capability. Unlike a path spelling,
+    this remains unchanged if the directory is renamed while it is open. *)
+
+val with_lock_file :
+  t -> name:Segment.t -> perm:int -> (Unix.file_descr -> 'a) -> 'a
+(** Open or create one regular lock file relative to the directory capability,
+    without following a final symlink. A newly-created lock file and directory
+    entry are fsynced before the callback. The descriptor remains open for the
+    callback and is closed on every exit; closing releases any POSIX record lock
+    acquired by the callback. *)
 
 val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -1,0 +1,191 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#endif
+
+#if !defined(AT_SYMLINK_NOFOLLOW)
+#error "descriptor-anchored filesystem requires AT_SYMLINK_NOFOLLOW"
+#endif
+
+static int anchored_fd(value descriptor)
+{
+  return Int_val(descriptor);
+}
+
+CAMLprim value masc_anchored_open_root(value path)
+{
+  CAMLparam1(path);
+  int fd = open(String_val(path), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_root", path);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_open_dir(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_dir", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_open_read(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_read", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
+{
+  CAMLparam3(directory, name, mode);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                  Int_val(mode));
+  if (fd == -1) uerror("anchored_create_exclusive", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_mkdir(value directory, value name, value mode)
+{
+  CAMLparam3(directory, name, mode);
+  if (mkdirat(anchored_fd(directory), String_val(name), Int_val(mode)) == -1)
+    uerror("anchored_mkdir", name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_unlink(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  if (unlinkat(anchored_fd(directory), String_val(name), 0) == -1)
+    uerror("anchored_unlink", name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_rename(value old_directory, value old_name,
+                                    value new_directory, value new_name)
+{
+  CAMLparam4(old_directory, old_name, new_directory, new_name);
+  if (renameat(anchored_fd(old_directory), String_val(old_name),
+               anchored_fd(new_directory), String_val(new_name)) == -1)
+    uerror("anchored_rename", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_link(value old_directory, value old_name,
+                                  value new_directory, value new_name)
+{
+  CAMLparam4(old_directory, old_name, new_directory, new_name);
+  if (linkat(anchored_fd(old_directory), String_val(old_name),
+             anchored_fd(new_directory), String_val(new_name), 0) == -1)
+    uerror("anchored_link", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_stat(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  CAMLlocal3(result, tuple, number);
+  struct stat metadata;
+
+  if (fstatat(anchored_fd(directory), String_val(name), &metadata,
+              AT_SYMLINK_NOFOLLOW) == -1) {
+    if (errno == ENOENT) CAMLreturn(Val_int(0));
+    uerror("anchored_stat", name);
+  }
+
+  int kind = 3;
+  if (S_ISREG(metadata.st_mode)) kind = 0;
+  else if (S_ISDIR(metadata.st_mode)) kind = 1;
+  else if (S_ISLNK(metadata.st_mode)) kind = 2;
+
+  tuple = caml_alloc(5, 0);
+  Store_field(tuple, 0, Val_int(kind));
+  number = caml_copy_int64((int64_t) metadata.st_size);
+  Store_field(tuple, 1, number);
+  number = caml_copy_int64((int64_t) metadata.st_dev);
+  Store_field(tuple, 2, number);
+  number = caml_copy_int64((int64_t) metadata.st_ino);
+  Store_field(tuple, 3, number);
+  number = caml_copy_int64((int64_t) metadata.st_nlink);
+  Store_field(tuple, 4, number);
+
+  result = caml_alloc(1, 0);
+  Store_field(result, 0, tuple);
+  CAMLreturn(result);
+}
+
+CAMLprim value masc_anchored_readdir(value directory)
+{
+  CAMLparam1(directory);
+  CAMLlocal3(entries, cell, name);
+
+  int duplicate = dup(anchored_fd(directory));
+  if (duplicate == -1) uerror("anchored_readdir_dup", Nothing);
+
+  DIR *handle = fdopendir(duplicate);
+  if (handle == NULL) {
+    int saved_errno = errno;
+    int close_result = close(duplicate);
+    int close_errno = errno;
+    if (close_result == -1) {
+      char detail[160];
+      snprintf(detail, sizeof(detail),
+               "anchored_readdir_open errno=%d; duplicate close errno=%d",
+               saved_errno, close_errno);
+      caml_failwith(detail);
+    }
+    errno = saved_errno;
+    uerror("anchored_readdir_open", Nothing);
+  }
+
+  entries = Val_emptylist;
+  errno = 0;
+  for (;;) {
+    struct dirent *entry = readdir(handle);
+    if (entry == NULL) break;
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      continue;
+    name = caml_copy_string(entry->d_name);
+    cell = caml_alloc(2, 0);
+    Store_field(cell, 0, name);
+    Store_field(cell, 1, entries);
+    entries = cell;
+    errno = 0;
+  }
+
+  int read_errno = errno;
+  int close_result = closedir(handle);
+  int close_errno = errno;
+  if (read_errno != 0 && close_result == -1) {
+    char detail[160];
+    snprintf(detail, sizeof(detail),
+             "anchored_readdir errno=%d; closedir errno=%d",
+             read_errno, close_errno);
+    caml_failwith(detail);
+  }
+  if (close_result == -1) read_errno = close_errno;
+  if (read_errno != 0) {
+    errno = read_errno;
+    uerror("anchored_readdir", Nothing);
+  }
+
+  CAMLreturn(entries);
+}

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -1,14 +1,13 @@
 #include <caml/alloc.h>
-#include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/signals.h>
 #include <caml/unixsupport.h>
 
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -27,86 +26,180 @@ static int anchored_fd(value descriptor)
   return Int_val(descriptor);
 }
 
+static void stat_free_preserving_errno(void *pointer)
+{
+  int saved_errno = errno;
+  caml_stat_free(pointer);
+  errno = saved_errno;
+}
+
 CAMLprim value masc_anchored_open_root(value path)
 {
   CAMLparam1(path);
-  int fd = open(String_val(path), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  char *copied_path;
+  int fd;
+
+  caml_unix_check_path(path, "anchored_open_root");
+  copied_path = caml_stat_strdup(String_val(path));
+  caml_enter_blocking_section();
+  fd = open(copied_path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_path);
   if (fd == -1) uerror("anchored_open_root", path);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_open_dir(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_dir");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_dir", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_open_read(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_read");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_read", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
 {
-  CAMLparam3(directory, name, mode);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
-                  Int_val(mode));
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_create_exclusive");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+              Int_val(mode));
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_create_exclusive", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_mkdir(value directory, value name, value mode)
 {
-  CAMLparam3(directory, name, mode);
-  if (mkdirat(anchored_fd(directory), String_val(name), Int_val(mode)) == -1)
-    uerror("anchored_mkdir", name);
+  CAMLparam1(name);
+  char *copied_name;
+  int result;
+
+  caml_unix_check_path(name, "anchored_mkdir");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  result = mkdirat(anchored_fd(directory), copied_name, Int_val(mode));
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (result == -1) uerror("anchored_mkdir", name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_unlink(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  if (unlinkat(anchored_fd(directory), String_val(name), 0) == -1)
-    uerror("anchored_unlink", name);
+  CAMLparam1(name);
+  char *copied_name;
+  int result;
+
+  caml_unix_check_path(name, "anchored_unlink");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  result = unlinkat(anchored_fd(directory), copied_name, 0);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (result == -1) uerror("anchored_unlink", name);
   CAMLreturn(Val_unit);
+}
+
+static char *copy_two_paths(value first, value second, char **second_copy)
+{
+  size_t first_length = caml_string_length(first);
+  size_t second_length = caml_string_length(second);
+  char *allocation = caml_stat_alloc(first_length + second_length + 2);
+  *second_copy = allocation + first_length + 1;
+  memcpy(allocation, String_val(first), first_length + 1);
+  memcpy(*second_copy, String_val(second), second_length + 1);
+  return allocation;
 }
 
 CAMLprim value masc_anchored_rename(value old_directory, value old_name,
                                     value new_directory, value new_name)
 {
-  CAMLparam4(old_directory, old_name, new_directory, new_name);
-  if (renameat(anchored_fd(old_directory), String_val(old_name),
-               anchored_fd(new_directory), String_val(new_name)) == -1)
-    uerror("anchored_rename", old_name);
+  CAMLparam2(old_name, new_name);
+  char *old_copy;
+  char *new_copy;
+  int result;
+
+  caml_unix_check_path(old_name, "anchored_rename_old");
+  caml_unix_check_path(new_name, "anchored_rename_new");
+  old_copy = copy_two_paths(old_name, new_name, &new_copy);
+  caml_enter_blocking_section();
+  result = renameat(anchored_fd(old_directory), old_copy,
+                    anchored_fd(new_directory), new_copy);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(old_copy);
+  if (result == -1) uerror("anchored_rename", old_name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_link(value old_directory, value old_name,
                                   value new_directory, value new_name)
 {
-  CAMLparam4(old_directory, old_name, new_directory, new_name);
-  if (linkat(anchored_fd(old_directory), String_val(old_name),
-             anchored_fd(new_directory), String_val(new_name), 0) == -1)
-    uerror("anchored_link", old_name);
+  CAMLparam2(old_name, new_name);
+  char *old_copy;
+  char *new_copy;
+  int result;
+
+  caml_unix_check_path(old_name, "anchored_link_old");
+  caml_unix_check_path(new_name, "anchored_link_new");
+  old_copy = copy_two_paths(old_name, new_name, &new_copy);
+  caml_enter_blocking_section();
+  result = linkat(anchored_fd(old_directory), old_copy,
+                  anchored_fd(new_directory), new_copy, 0);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(old_copy);
+  if (result == -1) uerror("anchored_link", old_name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_stat(value directory, value name)
 {
-  CAMLparam2(directory, name);
+  CAMLparam1(name);
   CAMLlocal3(result, tuple, number);
+  char *copied_name;
   struct stat metadata;
+  int stat_result;
 
-  if (fstatat(anchored_fd(directory), String_val(name), &metadata,
-              AT_SYMLINK_NOFOLLOW) == -1) {
+  caml_unix_check_path(name, "anchored_stat");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (stat_result == -1) {
     if (errno == ENOENT) CAMLreturn(Val_int(0));
     uerror("anchored_stat", name);
   }
@@ -132,60 +225,16 @@ CAMLprim value masc_anchored_stat(value directory, value name)
   CAMLreturn(result);
 }
 
-CAMLprim value masc_anchored_readdir(value directory)
+CAMLprim value masc_anchored_fdopendir(value descriptor)
 {
-  CAMLparam1(directory);
-  CAMLlocal3(entries, cell, name);
+  CAMLparam0();
+  CAMLlocal1(result);
+  DIR *directory;
 
-  int duplicate = dup(anchored_fd(directory));
-  if (duplicate == -1) uerror("anchored_readdir_dup", Nothing);
-
-  DIR *handle = fdopendir(duplicate);
-  if (handle == NULL) {
-    int saved_errno = errno;
-    int close_result = close(duplicate);
-    int close_errno = errno;
-    if (close_result == -1) {
-      char detail[160];
-      snprintf(detail, sizeof(detail),
-               "anchored_readdir_open errno=%d; duplicate close errno=%d",
-               saved_errno, close_errno);
-      caml_failwith(detail);
-    }
-    errno = saved_errno;
-    uerror("anchored_readdir_open", Nothing);
-  }
-
-  entries = Val_emptylist;
-  errno = 0;
-  for (;;) {
-    struct dirent *entry = readdir(handle);
-    if (entry == NULL) break;
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-      continue;
-    name = caml_copy_string(entry->d_name);
-    cell = caml_alloc(2, 0);
-    Store_field(cell, 0, name);
-    Store_field(cell, 1, entries);
-    entries = cell;
-    errno = 0;
-  }
-
-  int read_errno = errno;
-  int close_result = closedir(handle);
-  int close_errno = errno;
-  if (read_errno != 0 && close_result == -1) {
-    char detail[160];
-    snprintf(detail, sizeof(detail),
-             "anchored_readdir errno=%d; closedir errno=%d",
-             read_errno, close_errno);
-    caml_failwith(detail);
-  }
-  if (close_result == -1) read_errno = close_errno;
-  if (read_errno != 0) {
-    errno = read_errno;
-    uerror("anchored_readdir", Nothing);
-  }
-
-  CAMLreturn(entries);
+  result = caml_alloc_small(1, Abstract_tag);
+  DIR_Val(result) = NULL;
+  directory = fdopendir(anchored_fd(descriptor));
+  if (directory == NULL) uerror("anchored_fdopendir", Nothing);
+  DIR_Val(result) = directory;
+  CAMLreturn(result);
 }

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -13,8 +13,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
-#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, and O_NOCTTY"
 #endif
 
 #if !defined(AT_SYMLINK_NOFOLLOW)
@@ -88,12 +88,21 @@ CAMLprim value masc_anchored_open_write(value directory, value name)
   CAMLparam1(name);
   char *copied_name;
   int fd;
+  struct stat metadata;
+  int stat_result;
 
   caml_unix_check_path(name, "anchored_open_write");
   copied_name = caml_stat_strdup(String_val(name));
   caml_enter_blocking_section();
-  fd = openat(anchored_fd(directory), copied_name,
-              O_WRONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  if (stat_result == 0 && !S_ISREG(metadata.st_mode)) {
+    errno = S_ISLNK(metadata.st_mode) ? ELOOP : EINVAL;
+    fd = -1;
+  } else {
+    fd = openat(anchored_fd(directory), copied_name,
+                O_WRONLY | O_NONBLOCK | O_NOCTTY | O_NOFOLLOW | O_CLOEXEC);
+  }
   caml_leave_blocking_section();
   stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_write", name);
@@ -240,6 +249,36 @@ CAMLprim value masc_anchored_stat(value directory, value name)
   result = caml_alloc(1, 0);
   Store_field(result, 0, tuple);
   CAMLreturn(result);
+}
+
+CAMLprim value masc_anchored_fstat(value descriptor)
+{
+  CAMLparam0();
+  CAMLlocal2(tuple, number);
+  struct stat metadata;
+  int stat_result;
+  int kind = 3;
+
+  caml_enter_blocking_section();
+  stat_result = fstat(anchored_fd(descriptor), &metadata);
+  caml_leave_blocking_section();
+  if (stat_result == -1) uerror("anchored_fstat", Nothing);
+
+  if (S_ISREG(metadata.st_mode)) kind = 0;
+  else if (S_ISDIR(metadata.st_mode)) kind = 1;
+  else if (S_ISLNK(metadata.st_mode)) kind = 2;
+
+  tuple = caml_alloc(5, 0);
+  Store_field(tuple, 0, Val_int(kind));
+  number = caml_copy_int64((int64_t) metadata.st_size);
+  Store_field(tuple, 1, number);
+  number = caml_copy_int64((int64_t) metadata.st_dev);
+  Store_field(tuple, 2, number);
+  number = caml_copy_int64((int64_t) metadata.st_ino);
+  Store_field(tuple, 3, number);
+  number = caml_copy_int64((int64_t) metadata.st_nlink);
+  Store_field(tuple, 4, number);
+  CAMLreturn(tuple);
 }
 
 CAMLprim value masc_anchored_fdopendir(value descriptor)

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -83,6 +83,23 @@ CAMLprim value masc_anchored_open_read(value directory, value name)
   CAMLreturn(Val_int(fd));
 }
 
+CAMLprim value masc_anchored_open_write(value directory, value name)
+{
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_write");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_WRONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (fd == -1) uerror("anchored_open_write", name);
+  CAMLreturn(Val_int(fd));
+}
+
 CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
 {
   CAMLparam1(name);

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -13,8 +13,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY)
-#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, and O_NOCTTY"
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY) || !defined(O_NONBLOCK)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, O_NOCTTY, and O_NONBLOCK"
 #endif
 
 #if !defined(AT_SYMLINK_NOFOLLOW)
@@ -71,12 +71,21 @@ CAMLprim value masc_anchored_open_read(value directory, value name)
   CAMLparam1(name);
   char *copied_name;
   int fd;
+  struct stat metadata;
+  int stat_result;
 
   caml_unix_check_path(name, "anchored_open_read");
   copied_name = caml_stat_strdup(String_val(name));
   caml_enter_blocking_section();
-  fd = openat(anchored_fd(directory), copied_name,
-              O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  if (stat_result == 0 && !S_ISREG(metadata.st_mode)) {
+    errno = S_ISLNK(metadata.st_mode) ? ELOOP : EINVAL;
+    fd = -1;
+  } else {
+    fd = openat(anchored_fd(directory), copied_name,
+                O_RDONLY | O_NONBLOCK | O_NOCTTY | O_NOFOLLOW | O_CLOEXEC);
+  }
   caml_leave_blocking_section();
   stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_read", name);

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -22,6 +22,15 @@ let fsync_path path =
         ())
 ;;
 
+let fsync_directory path =
+  try
+    fsync_path path;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "fsync directory %s: %s" path (Printexc.to_string exn))
+;;
+
 (* #10205 finding 2: keep the atomic-tmp filename shape in one place
    so the writer ([save_file_atomic]) and the orphan-sweep matcher
    ([is_atomic_orphan_name]) cannot drift independently. A
@@ -38,25 +47,57 @@ let save_file_atomic
   : (unit, string) Result.t
   =
   let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
-  in
-  try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
-    Ok ()
+  match
+    try
+      Ok
+        (Stdlib.Filename.temp_file
+           ~temp_dir:dir
+           atomic_tmp_prefix
+           atomic_tmp_suffix)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error exn
   with
-  | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    raise e
-  | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+  | Error exn ->
+    Error
+      (Printf.sprintf
+         "save_file_atomic %s: temp creation failed: %s"
+         path
+         (Printexc.to_string exn))
+  | Ok tmp ->
+    let cleanup_tmp () =
+      try
+        Unix.unlink tmp;
+        Ok ()
+      with
+      | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+      | exn -> Error (Printexc.to_string exn)
+    in
+    (try
+       save_file tmp content;
+       fsync_path tmp;
+       Stdlib.Sys.rename tmp path;
+       fsync_path dir;
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn ->
+       (match cleanup_tmp () with
+        | Ok () -> ()
+        | Error detail ->
+          Stdlib.Printf.eprintf
+            "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+            tmp
+            detail);
+       raise exn
+     | exn ->
+       let primary = Printexc.to_string exn in
+       let detail =
+         match cleanup_tmp () with
+         | Ok () -> primary
+         | Error cleanup ->
+           Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" path detail))
 ;;
 
 let is_atomic_orphan_name name =
@@ -66,6 +107,51 @@ let is_atomic_orphan_name name =
   n >= p + s
   && String.starts_with name ~prefix:atomic_tmp_prefix
   && String.ends_with ~suffix:atomic_tmp_suffix name
+;;
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~path ~recovered_dir =
+  let name = Stdlib.Filename.basename path in
+  if not (is_atomic_orphan_name name)
+  then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
+  else
+    try
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind <> Unix.S_REG
+      then Error (Printf.sprintf "atomic-write orphan is not a regular file: %s" path)
+      else if stat.Unix.st_size = 0
+      then (
+        Stdlib.Sys.remove path;
+        fsync_path (Stdlib.Filename.dirname path);
+        Ok Deleted_zero_length)
+      else (
+        let recovered_stat = Unix.lstat recovered_dir in
+        if recovered_stat.Unix.st_kind <> Unix.S_DIR
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery path is not a real directory: %s"
+               recovered_dir)
+        else
+        let destination = Stdlib.Filename.concat recovered_dir name in
+        if Stdlib.Sys.file_exists destination
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery destination already exists: %s"
+               destination)
+        else (
+          Stdlib.Sys.rename path destination;
+          fsync_path (Stdlib.Filename.dirname path);
+          if not (String.equal recovered_dir (Stdlib.Filename.dirname path))
+          then fsync_path recovered_dir;
+          Ok (Preserved_nonempty destination)))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
 ;;
 
 let cleanup_atomic_orphans
@@ -83,32 +169,51 @@ let cleanup_atomic_orphans
      [mkdir_p_unix] is recursive, idempotent (handles [EEXIST] precisely
      instead of swallowing every [Unix_error]), and correct when
      [base_path] itself does not exist yet (boot-time race). *)
-  let ensure_recovered_dir () =
-    try mkdir_p_unix recovered_dir with
-    | Unix.Unix_error _ -> ()
+  let report_error detail =
+    Stdlib.Printf.eprintf "[fs_compat] atomic orphan sweep: %s\n%!" detail
+  in
+  let ensure_recovered_dir path =
+    try
+      mkdir_p_unix path;
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind = Unix.S_DIR
+      then (
+        fsync_path (Stdlib.Filename.dirname path);
+        Ok ())
+      else
+        Error
+          (Printf.sprintf
+             "recovered path is not a real directory: %s"
+             path)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Printf.sprintf
+           "cannot create recovered directory %s: %s"
+           path
+           (Printexc.to_string exn))
   in
   let handle_file dir name =
     let path = Stdlib.Filename.concat dir name in
-    match Unix.stat path with
-    | exception Unix.Unix_error _ -> ()
-    | stat when stat.Unix.st_size = 0 ->
-      (try
-         Stdlib.Sys.remove path;
-         incr deleted
-       with
-       | Sys_error _ -> ())
-    | _stat ->
-      ensure_recovered_dir ();
-      let target =
-        Stdlib.Filename.concat
-          recovered_dir
-          (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
-      in
-      (try
-         Stdlib.Sys.rename path target;
-         incr preserved
-       with
-       | Sys_error _ | Unix.Unix_error _ -> ())
+    let bucket =
+      if String.equal dir base_path then "root" else Stdlib.Filename.basename dir
+    in
+    let file_recovered_dir = Stdlib.Filename.concat recovered_dir bucket in
+    match ensure_recovered_dir recovered_dir with
+    | Error detail -> report_error detail
+    | Ok () ->
+      (match ensure_recovered_dir file_recovered_dir with
+       | Error detail -> report_error detail
+       | Ok () ->
+         (match
+            recover_atomic_orphan
+              ~path
+              ~recovered_dir:file_recovered_dir
+          with
+          | Ok Deleted_zero_length -> incr deleted
+          | Ok (Preserved_nonempty _) -> incr preserved
+          | Error detail -> report_error detail))
   in
   let scan_dir dir entries =
     Array.iter
@@ -117,7 +222,9 @@ let cleanup_atomic_orphans
   in
   let read_dir_entries dir =
     match Stdlib.Sys.readdir dir with
-    | exception Sys_error _ -> [||]
+    | exception Sys_error detail ->
+      report_error (Printf.sprintf "cannot list %s: %s" dir detail);
+      [||]
     | entries -> entries
   in
   (* #10205 finding 4: previous body called [Stdlib.Sys.readdir base_path]
@@ -132,8 +239,15 @@ let cleanup_atomic_orphans
       then ()
       else (
         let sub = Stdlib.Filename.concat base_path name in
-        match Unix.stat sub with
-        | exception Unix.Unix_error _ -> ()
+        match Unix.lstat sub with
+        | exception Unix.Unix_error (error, operation, argument) ->
+          report_error
+            (Printf.sprintf
+               "cannot inspect %s: %s (%s %s)"
+               sub
+               (Unix.error_message error)
+               operation
+               argument)
         | stat when stat.Unix.st_kind = Unix.S_DIR ->
           scan_dir sub (read_dir_entries sub)
         | _ -> ()))

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -128,6 +128,7 @@ let recover_atomic_orphan ~path ~recovered_dir =
         fsync_path (Stdlib.Filename.dirname path);
         Ok Deleted_zero_length)
       else (
+        fsync_path path;
         let recovered_stat = Unix.lstat recovered_dir in
         if recovered_stat.Unix.st_kind <> Unix.S_DIR
         then

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -113,10 +113,16 @@ type atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
-let recover_atomic_orphan ~path ~recovered_dir =
+let recover_atomic_orphan ~path ~recovered_root ~bucket =
   let name = Stdlib.Filename.basename path in
   if not (is_atomic_orphan_name name)
   then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
+  else if
+    String.equal bucket ""
+    || String.equal bucket "."
+    || String.equal bucket ".."
+    || not (String.equal (Stdlib.Filename.basename bucket) bucket)
+  then Error (Printf.sprintf "invalid atomic-write recovery bucket: %S" bucket)
   else
     try
       let stat = Unix.lstat path in
@@ -129,6 +135,15 @@ let recover_atomic_orphan ~path ~recovered_dir =
         Ok Deleted_zero_length)
       else (
         fsync_path path;
+        let recovered_root_stat = Unix.lstat recovered_root in
+        if recovered_root_stat.Unix.st_kind <> Unix.S_DIR
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery root is not a real directory: %s"
+               recovered_root)
+        else
+        let recovered_dir = Stdlib.Filename.concat recovered_root bucket in
         let recovered_stat = Unix.lstat recovered_dir in
         if recovered_stat.Unix.st_kind <> Unix.S_DIR
         then
@@ -138,18 +153,43 @@ let recover_atomic_orphan ~path ~recovered_dir =
                recovered_dir)
         else
         let destination = Stdlib.Filename.concat recovered_dir name in
-        if Stdlib.Sys.file_exists destination
+        if String.equal destination path
         then
           Error
             (Printf.sprintf
-               "atomic-write recovery destination already exists: %s"
+               "atomic-write recovery destination equals source: %s"
                destination)
-        else (
-          Stdlib.Sys.rename path destination;
-          fsync_path (Stdlib.Filename.dirname path);
-          if not (String.equal recovered_dir (Stdlib.Filename.dirname path))
-          then fsync_path recovered_dir;
-          Ok (Preserved_nonempty destination)))
+        else
+          let source_dir = Stdlib.Filename.dirname path in
+          let finish_existing_link destination_stat =
+            if
+              stat.Unix.st_dev = destination_stat.Unix.st_dev
+              && stat.Unix.st_ino = destination_stat.Unix.st_ino
+            then (
+              fsync_path recovered_dir;
+              Unix.unlink path;
+              fsync_path source_dir;
+              Ok (Preserved_nonempty destination))
+            else
+              Error
+                (Printf.sprintf
+                   "atomic-write recovery destination already exists: %s"
+                   destination)
+          in
+          (match Unix.lstat destination with
+           | destination_stat -> finish_existing_link destination_stat
+           | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+             (match Unix.link path destination with
+              | () ->
+                fsync_path recovered_dir;
+                Unix.unlink path;
+                fsync_path source_dir;
+                Ok (Preserved_nonempty destination)
+              | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+                Error
+                  (Printf.sprintf
+                     "atomic-write recovery destination concurrently appeared: %s"
+                     destination))))
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
@@ -210,7 +250,8 @@ let cleanup_atomic_orphans
          (match
             recover_atomic_orphan
               ~path
-              ~recovered_dir:file_recovered_dir
+              ~recovered_root:recovered_dir
+              ~bucket
           with
           | Ok Deleted_zero_length -> incr deleted
           | Ok (Preserved_nonempty _) -> incr preserved

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -4,27 +4,71 @@
    Without the fsync pair, a crash between the rename and the kernel's
    dirty-page flush can leave the target truncated or zero-length —
    observed on backlog.json after an abrupt shutdown (2026-04-18). *)
-let fsync_path path =
-  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      try Unix.close fd with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Stdlib.Printf.eprintf
-          "[fs_compat] fsync_path close failed: %s\n%!"
-          (Printexc.to_string exn))
-    (fun () ->
-      try Unix.fsync fd with
-      | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
-           is still durable to the extent the underlying FS offers. *)
-        ())
+type fsync_target =
+  | Regular_file
+  | Directory
+
+let same_file_identity left right =
+  left.Unix.st_dev = right.Unix.st_dev
+  && left.Unix.st_ino = right.Unix.st_ino
+;;
+
+let expected_kind = function
+  | Regular_file -> Unix.S_REG
+  | Directory -> Unix.S_DIR
+;;
+
+let fsync_operation = function
+  | Regular_file -> "fsync_regular_file"
+  | Directory -> "fsync_directory"
+;;
+
+let fsync_path ?expected ~target path =
+  let operation = fsync_operation target in
+  let fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  let sync_result =
+    try
+      let actual = Unix.fstat fd in
+      if actual.Unix.st_kind <> expected_kind target
+      then
+        raise
+          (Unix.Unix_error
+             ((match target with
+               | Regular_file -> Unix.EINVAL
+               | Directory -> Unix.ENOTDIR),
+              operation,
+              path));
+      (match expected with
+       | Some expected when not (same_file_identity expected actual) ->
+         raise (Unix.Unix_error (Unix.EAGAIN, operation, path))
+       | Some _ | None -> ());
+      Unix.fsync fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  let close_result =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  match sync_result, close_result with
+  | Ok (), Ok () -> ()
+  | Error exn, Ok () | Ok (), Error exn -> raise exn
+  | Error primary, Error close_error ->
+    Stdlib.Printf.eprintf
+      "[fs_compat] %s close also failed path=%s: %s\n%!"
+      operation
+      path
+      (Printexc.to_string close_error);
+    raise primary
 ;;
 
 let fsync_directory path =
   try
-    fsync_path path;
+    fsync_path ~target:Directory path;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -40,17 +84,13 @@ let fsync_directory path =
 let atomic_tmp_prefix = ".atomic_"
 let atomic_tmp_suffix = ".tmp"
 
-let save_file_atomic
-  ~(save_file : string -> string -> unit)
-  (path : string)
-  (content : string)
-  : (unit, string) Result.t
-  =
+let save_file_atomic (path : string) (content : string) : (unit, string) Result.t =
   let dir = Stdlib.Filename.dirname path in
   match
     try
       Ok
-        (Stdlib.Filename.temp_file
+        (Stdlib.Filename.open_temp_file
+           ~mode:[ Open_binary ]
            ~temp_dir:dir
            atomic_tmp_prefix
            atomic_tmp_suffix)
@@ -64,40 +104,101 @@ let save_file_atomic
          "save_file_atomic %s: temp creation failed: %s"
          path
          (Printexc.to_string exn))
-  | Ok tmp ->
-    let cleanup_tmp () =
-      try
-        Unix.unlink tmp;
-        Ok ()
-      with
-      | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
-      | exn -> Error (Printexc.to_string exn)
-    in
-    (try
-       save_file tmp content;
-       fsync_path tmp;
-       Stdlib.Sys.rename tmp path;
-       fsync_path dir;
-       Ok ()
+  | Ok (tmp, output) ->
+    (match
+       try Ok (Unix.fstat (Unix.descr_of_out_channel output)) with
+       | exn -> Error exn
      with
-     | Eio.Cancel.Cancelled _ as exn ->
-       (match cleanup_tmp () with
-        | Ok () -> ()
-        | Error detail ->
+     | Error inspect_error ->
+       (try Stdlib.close_out output with
+        | close_error ->
           Stdlib.Printf.eprintf
-            "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+            "[fs_compat] atomic-write close also failed path=%s: %s\n%!"
             tmp
-            detail);
-       raise exn
-     | exn ->
-       let primary = Printexc.to_string exn in
-       let detail =
-         match cleanup_tmp () with
-         | Ok () -> primary
-         | Error cleanup ->
-           Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+            (Printexc.to_string close_error));
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: cannot inspect atomically-opened temp %s: %s; temp retained"
+            path
+            tmp
+            (Printexc.to_string inspect_error))
+     | Ok temp_identity ->
+       let cleanup_tmp () =
+         try
+           let actual = Unix.lstat tmp in
+           if
+             actual.Unix.st_kind = Unix.S_REG
+             && same_file_identity temp_identity actual
+           then (
+             Unix.unlink tmp;
+             Ok ())
+           else
+             Error
+               (Printf.sprintf
+                  "refusing to unlink replaced atomic-write temp path: %s"
+                  tmp)
+         with
+         | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+         | exn -> Error (Printexc.to_string exn)
        in
-       Error (Printf.sprintf "save_file_atomic %s: %s" path detail))
+       let write_result =
+         match
+           try
+             Stdlib.output_string output content;
+             Ok ()
+           with
+           | exn -> Error exn
+         with
+         | Ok () ->
+           (try
+              Stdlib.close_out output;
+              Ok ()
+            with
+            | exn -> Error exn)
+         | Error primary ->
+           (try Stdlib.close_out output with
+            | close_error ->
+              Stdlib.Printf.eprintf
+                "[fs_compat] atomic-write close also failed path=%s: %s\n%!"
+                tmp
+                (Printexc.to_string close_error));
+           Error primary
+       in
+       (try
+          (match write_result with
+           | Ok () -> ()
+           | Error exn -> raise exn);
+          fsync_path ~expected:temp_identity ~target:Regular_file tmp;
+          let temp_after_sync = Unix.lstat tmp in
+          if
+            temp_after_sync.Unix.st_kind <> Unix.S_REG
+            || not (same_file_identity temp_identity temp_after_sync)
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.EAGAIN, "save_file_atomic", tmp));
+          Stdlib.Sys.rename tmp path;
+          fsync_path ~target:Directory dir;
+          Ok ()
+        with
+        | Eio.Cancel.Cancelled _ as exn ->
+          (match cleanup_tmp () with
+           | Ok () -> ()
+           | Error detail ->
+             Stdlib.Printf.eprintf
+               "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+               tmp
+               detail);
+          raise exn
+        | exn ->
+          let primary = Printexc.to_string exn in
+          let detail =
+            match cleanup_tmp () with
+            | Ok () -> primary
+            | Error cleanup ->
+              Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+          in
+          Error (Printf.sprintf "save_file_atomic %s: %s" path detail)))
 ;;
 
 let is_atomic_orphan_name name =
@@ -133,11 +234,28 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
       then Error (Printf.sprintf "atomic-write orphan is not a regular file: %s" path)
       else if stat.Unix.st_size = 0
       then (
+        fsync_path ~expected:stat ~target:Regular_file path;
+        let source_before_unlink = Unix.lstat path in
+        if
+          source_before_unlink.Unix.st_kind <> Unix.S_REG
+          || not (same_file_identity stat source_before_unlink)
+        then
+          raise
+            (Unix.Unix_error
+               (Unix.EAGAIN, "recover_atomic_orphan", path));
         Stdlib.Sys.remove path;
-        fsync_path (Stdlib.Filename.dirname path);
+        fsync_path ~target:Directory (Stdlib.Filename.dirname path);
         Ok Deleted_zero_length)
       else (
-        fsync_path path;
+        fsync_path ~expected:stat ~target:Regular_file path;
+        let source_after_sync = Unix.lstat path in
+        if
+          source_after_sync.Unix.st_kind <> Unix.S_REG
+          || not (same_file_identity stat source_after_sync)
+        then
+          raise
+            (Unix.Unix_error
+               (Unix.EAGAIN, "recover_atomic_orphan", path));
         let recovered_root_stat = Unix.lstat recovered_root in
         if recovered_root_stat.Unix.st_kind <> Unix.S_DIR
         then
@@ -166,13 +284,23 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
           let source_dir = Stdlib.Filename.dirname path in
           let finish_existing_link destination_stat =
             if
-              stat.Unix.st_dev = destination_stat.Unix.st_dev
-              && stat.Unix.st_ino = destination_stat.Unix.st_ino
+              destination_stat.Unix.st_kind = Unix.S_REG
+              && same_file_identity stat destination_stat
             then (
-              fsync_path recovered_dir;
-              Unix.unlink path;
-              fsync_path source_dir;
-              Ok (Preserved_nonempty destination))
+              let source_before_unlink = Unix.lstat path in
+              if
+                source_before_unlink.Unix.st_kind <> Unix.S_REG
+                || not (same_file_identity stat source_before_unlink)
+              then
+                Error
+                  (Printf.sprintf
+                     "atomic-write recovery source changed before unlink: %s"
+                     path)
+              else (
+                fsync_path ~target:Directory recovered_dir;
+                Unix.unlink path;
+                fsync_path ~target:Directory source_dir;
+                Ok (Preserved_nonempty destination)))
             else
               Error
                 (Printf.sprintf
@@ -182,12 +310,10 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
           (match Unix.lstat destination with
            | destination_stat -> finish_existing_link destination_stat
            | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-             (match Unix.link path destination with
+             (match Unix.link ~follow:false path destination with
               | () ->
-                fsync_path recovered_dir;
-                Unix.unlink path;
-                fsync_path source_dir;
-                Ok (Preserved_nonempty destination)
+                let destination_stat = Unix.lstat destination in
+                finish_existing_link destination_stat
               | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
                 Error
                   (Printf.sprintf
@@ -228,7 +354,7 @@ let cleanup_atomic_orphans
       let stat = Unix.lstat path in
       if stat.Unix.st_kind = Unix.S_DIR
       then (
-        fsync_path (Stdlib.Filename.dirname path);
+        fsync_path ~target:Directory (Stdlib.Filename.dirname path);
         Ok ())
       else
         Error

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -113,15 +113,18 @@ type atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
+let is_single_path_segment value =
+  (not (String.equal value ""))
+  && not (String.equal value ".")
+  && not (String.equal value "..")
+  && String.equal (Stdlib.Filename.basename value) value
+;;
+
 let recover_atomic_orphan ~path ~recovered_root ~bucket =
   let name = Stdlib.Filename.basename path in
   if not (is_atomic_orphan_name name)
   then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
-  else if
-    String.equal bucket ""
-    || String.equal bucket "."
-    || String.equal bucket ".."
-    || not (String.equal (Stdlib.Filename.basename bucket) bucket)
+  else if not (is_single_path_segment bucket)
   then Error (Printf.sprintf "invalid atomic-write recovery bucket: %S" bucket)
   else
     try
@@ -202,6 +205,12 @@ let cleanup_atomic_orphans
   ()
   : int * int
   =
+  if not (is_single_path_segment recovered_subdir)
+  then
+    invalid_arg
+      (Printf.sprintf
+         "cleanup_atomic_orphans: recovered_subdir must be one path segment: %S"
+         recovered_subdir);
   let recovered_dir = Stdlib.Filename.concat base_path recovered_subdir in
   let deleted = ref 0 in
   let preserved = ref 0 in

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -69,7 +69,9 @@ val recover_atomic_orphan
 
     Returns [(deleted, preserved)]:
     - [deleted]: zero-byte orphans removed.
-    - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+    - [preserved]: non-zero orphans moved to [recovered_subdir].
+
+    @raise Invalid_argument when [recovered_subdir] is not one path segment. *)
 val cleanup_atomic_orphans
   :  mkdir_p_unix:(string -> unit)
   -> base_path:string

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -50,8 +50,8 @@ val recover_atomic_orphan
   -> recovered_dir:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan. Zero-length files are
-    deleted; non-empty files are moved without overwrite into the existing real
-    [recovered_dir] for forensic review. *)
+    deleted; non-empty files are fsynced and moved without overwrite into the
+    existing real [recovered_dir] for forensic review. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -47,11 +47,14 @@ type atomic_orphan_recovery =
 
 val recover_atomic_orphan
   :  path:string
-  -> recovered_dir:string
+  -> recovered_root:string
+  -> bucket:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan. Zero-length files are
-    deleted; non-empty files are fsynced and moved without overwrite into the
-    existing real [recovered_dir] for forensic review. *)
+    deleted; non-empty files are fsynced and linked without overwrite into the
+    existing real [recovered_root]/[bucket], then unlinked from the source. Both
+    path components must be real directories and [bucket] must be one segment.
+    A crash after linking is completed idempotently by inode identity. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -12,28 +12,29 @@
     owning process was SIGKILL'd or [Filename.temp_file] itself
     raised ENFILE/EMFILE before the with-handler could register.
 
-    The [save_file] and [mkdir_p_unix] primitives are injected so
-    this module stays free of [Fs_compat]'s Eio bridge — same
-    cycle-free placement pattern as [Mkdir_memo] and [Fd_cache]. *)
+    The implementation is blocking Unix I/O. Eio callers must offload the
+    complete transaction rather than mixing Eio path writes with Unix fsync
+    and rename operations. *)
 
-(** [save_file_atomic ~save_file path content] writes [content] to
-    a temp file in [path]'s directory, fsyncs the tmp, renames it
-    over [path], and best-effort fsyncs the parent directory.
+(** [save_file_atomic path content] atomically opens a temp file in [path]'s
+    directory, writes [content], verifies its file identity, fsyncs it, renames it
+    over [path], and fsyncs the parent directory. A failed or unsupported
+    durability operation is returned as [Error]; it is never treated as a
+    successful commit.
 
     Returns [Ok ()] on success or [Error msg] when the write or
     rename fails (the tmp is cleaned up). Re-raises
     [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
     must not be swallowed (RFC-0143). *)
 val save_file_atomic
-  :  save_file:(string -> string -> unit)
-  -> string
+  :  string
   -> string
   -> (unit, string) Result.t
 
 val fsync_directory : string -> (unit, string) result
-(** Durably publish prior directory-entry changes. Unsupported-filesystem
-    [EINVAL]/[EOPNOTSUPP] is treated as success by the underlying portability
-    boundary; every other failure is returned explicitly. *)
+(** Durably publish prior directory-entry changes. [path] must resolve to a
+    directory. Unsupported filesystem operations and close failures are
+    returned explicitly. *)
 
 (** [true] iff [name] matches the [.atomic_*.tmp] shape produced
     by {!save_file_atomic}. Exposed so a periodic sweep can match

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -30,11 +30,28 @@ val save_file_atomic
   -> string
   -> (unit, string) Result.t
 
+val fsync_directory : string -> (unit, string) result
+(** Durably publish prior directory-entry changes. Unsupported-filesystem
+    [EINVAL]/[EOPNOTSUPP] is treated as success by the underlying portability
+    boundary; every other failure is returned explicitly. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] shape produced
     by {!save_file_atomic}. Exposed so a periodic sweep can match
     the same filename pattern without re-deriving the prefix and
     suffix — #10205 finding 2. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan. Zero-length files are
+    deleted; non-empty files are moved without overwrite into the existing real
+    [recovered_dir] for forensic review. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 
@@ -42,8 +59,8 @@ val is_atomic_orphan_name : string -> bool
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted (they lost the rename race
       but never held data).
-    - Non-zero orphans are MOVED to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are MOVED into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,7 +3,10 @@
 (library
  (name fs_compat)
  (public_name masc.fs_compat)
- (modules fs_compat mkdir_memo fd_cache atomic_write)
+ (modules fs_compat mkdir_memo fd_cache atomic_write anchored_fs)
+ (foreign_stubs
+  (language c)
+  (names anchored_fs_stubs))
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -318,10 +318,11 @@ type atomic_orphan_recovery = Atomic_write.atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
-let recover_atomic_orphan ~path ~recovered_dir =
+let recover_atomic_orphan ~path ~recovered_root ~bucket =
   Atomic_write.recover_atomic_orphan
     ~path
-    ~recovered_dir
+    ~recovered_root
+    ~bucket
 ;;
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
@@ -344,7 +345,9 @@ let append_file (path : string) (content : string) : unit =
 let append_file_durable path content =
   test_exec_home_guard ~op:"append_file_durable" path;
   match Atomic.get global_fs with
-  | Some _ -> Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content)
+  | Some _ ->
+    (try Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content) with
+     | Stdlib.Effect.Unhandled _ -> append_file_durable_unix path content)
   | None -> append_file_durable_unix path content
 ;;
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1,3 +1,5 @@
+module Anchored_dir = Anchored_fs
+
 (** Filesystem Compatibility Layer - Eio-native I/O with fallback
 
     Provides a unified filesystem API for gradual migration from
@@ -205,11 +207,13 @@ let append_file_durable_unix (path : string) (content : string) : unit =
     ~finally:(fun () -> Stdlib.Mutex.unlock mu)
     (fun () ->
       let fd =
-        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+        Unix.openfile
+          path
+          [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
+          0o644
       in
-      Stdlib.Fun.protect
-        ~finally:(fun () -> Unix.close fd)
-        (fun () ->
+      let write_result =
+        try
           let rec write_all offset =
             if offset < String.length content
             then
@@ -226,7 +230,27 @@ let append_file_durable_unix (path : string) (content : string) : unit =
               | wrote -> write_all (offset + wrote)
           in
           write_all 0;
-          Unix.fsync fd);
+          Unix.fsync fd;
+          Ok ()
+        with
+        | exn -> Error exn
+      in
+      let close_result =
+        try
+          Unix.close fd;
+          Ok ()
+        with
+        | exn -> Error exn
+      in
+      (match write_result, close_result with
+       | Ok (), Ok () -> ()
+       | Error exn, Ok () | Ok (), Error exn -> raise exn
+       | Error primary, Error close_error ->
+         Stdlib.Printf.eprintf
+           "[fs_compat] durable append close also failed path=%s: %s\n%!"
+           path
+           (Printexc.to_string close_error);
+         raise primary);
       match Atomic_write.fsync_directory (Filename.dirname path) with
       | Ok () -> ()
       | Error detail -> raise (Sys_error detail))
@@ -248,32 +272,36 @@ let mkdir_p_unix (path : string) : unit =
 
 let mkdir_p_durable_unix path =
   test_exec_home_guard ~op:"mkdir_p_durable_unix" path;
-  let rec missing_directories current acc =
+  let rec ensure_directory current =
     if
       String.equal current ""
       || String.equal current "."
       || String.equal current "/"
-    then acc
+    then ()
     else
-      match Unix.stat current with
-      | stat when stat.Unix.st_kind = Unix.S_DIR -> acc
+      match Unix.lstat current with
+      | stat when stat.Unix.st_kind = Unix.S_DIR -> ()
       | _ ->
         raise
           (Unix.Unix_error
              (Unix.ENOTDIR, "mkdir_p_durable_unix", current))
       | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-        missing_directories
-          (Filename.dirname current)
-          (current :: acc)
+        let parent = Filename.dirname current in
+        ensure_directory parent;
+        (match Unix.mkdir current 0o755 with
+         | () -> ()
+         | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+        (match Unix.lstat current with
+         | stat when stat.Unix.st_kind = Unix.S_DIR -> ()
+         | _ ->
+           raise
+             (Unix.Unix_error
+                (Unix.ENOTDIR, "mkdir_p_durable_unix", current)));
+        (match Atomic_write.fsync_directory parent with
+         | Ok () -> ()
+         | Error detail -> raise (Sys_error detail))
   in
-  let created = missing_directories path [] in
-  mkdir_p_unix path;
-  List.iter
-    (fun created_dir ->
-       match Atomic_write.fsync_directory (Filename.dirname created_dir) with
-       | Ok () -> ()
-       | Error detail -> raise (Sys_error detail))
-    created
+  ensure_directory path
 ;;
 
 (** Load entire file contents as string.
@@ -302,12 +330,17 @@ let save_file (path : string) (content : string) : unit =
 ;;
 
 let save_file_atomic path content =
-  Atomic_write.save_file_atomic ~save_file path content
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  match Atomic.get global_fs with
+  | Some _ ->
+    (try Eio_unix.run_in_systhread (fun () -> Atomic_write.save_file_atomic path content) with
+     | Stdlib.Effect.Unhandled _ -> Atomic_write.save_file_atomic path content)
+  | None -> Atomic_write.save_file_atomic path content
 ;;
 
 let save_file_atomic_unix path content =
   test_exec_home_guard ~op:"save_file_atomic_unix" path;
-  Atomic_write.save_file_atomic ~save_file:save_file_unix path content
+  Atomic_write.save_file_atomic path content
 ;;
 
 let fsync_directory path = Atomic_write.fsync_directory path

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -198,6 +198,40 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let append_file_durable_unix (path : string) (content : string) : unit =
+  let mu = get_append_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let fd =
+        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+      in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+          let rec write_all offset =
+            if offset < String.length content
+            then
+              match
+                Unix.write_substring
+                  fd
+                  content
+                  offset
+                  (String.length content - offset)
+              with
+              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
+              | 0 ->
+                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+              | wrote -> write_all (offset + wrote)
+          in
+          write_all 0;
+          Unix.fsync fd);
+      match Atomic_write.fsync_directory (Filename.dirname path) with
+      | Ok () -> ()
+      | Error detail -> raise (Sys_error detail))
+;;
+
 let mkdir_p_unix (path : string) : unit =
   let rec ensure_dir (p : string) : unit =
     if String.equal p "" || String.equal p "." || String.equal p "/"
@@ -210,6 +244,36 @@ let mkdir_p_unix (path : string) : unit =
       | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   in
   ensure_dir path
+;;
+
+let mkdir_p_durable_unix path =
+  test_exec_home_guard ~op:"mkdir_p_durable_unix" path;
+  let rec missing_directories current acc =
+    if
+      String.equal current ""
+      || String.equal current "."
+      || String.equal current "/"
+    then acc
+    else
+      match Unix.stat current with
+      | stat when stat.Unix.st_kind = Unix.S_DIR -> acc
+      | _ ->
+        raise
+          (Unix.Unix_error
+             (Unix.ENOTDIR, "mkdir_p_durable_unix", current))
+      | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+        missing_directories
+          (Filename.dirname current)
+          (current :: acc)
+  in
+  let created = missing_directories path [] in
+  mkdir_p_unix path;
+  List.iter
+    (fun created_dir ->
+       match Atomic_write.fsync_directory (Filename.dirname created_dir) with
+       | Ok () -> ()
+       | Error detail -> raise (Sys_error detail))
+    created
 ;;
 
 (** Load entire file contents as string.
@@ -241,7 +305,24 @@ let save_file_atomic path content =
   Atomic_write.save_file_atomic ~save_file path content
 ;;
 
+let save_file_atomic_unix path content =
+  test_exec_home_guard ~op:"save_file_atomic_unix" path;
+  Atomic_write.save_file_atomic ~save_file:save_file_unix path content
+;;
+
+let fsync_directory path = Atomic_write.fsync_directory path
+
 let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
+
+type atomic_orphan_recovery = Atomic_write.atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~path ~recovered_dir =
+  Atomic_write.recover_atomic_orphan
+    ~path
+    ~recovered_dir
+;;
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
   Atomic_write.cleanup_atomic_orphans ~mkdir_p_unix ~base_path ?recovered_subdir ()
@@ -258,6 +339,13 @@ let append_file (path : string) (content : string) : unit =
     (fun fs ->
        let eio_path = Eio.Path.(fs / path) in
        Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
+;;
+
+let append_file_durable path content =
+  test_exec_home_guard ~op:"append_file_durable" path;
+  match Atomic.get global_fs with
+  | Some _ -> Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content)
+  | None -> append_file_durable_unix path content
 ;;
 
 (** Check if file exists.

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -3,6 +3,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+module Anchored_dir : module type of Anchored_fs
+
 (** #9921: raised by mutating [Fs_compat] entry points
     ([append_file], [save_file], [mkdir_p]) when the target path falls
     under [HOME] and the process is a test executable. Defense in depth
@@ -38,8 +40,9 @@ val load_file_opt : string -> string option
 (** Save string to file (overwrite). *)
 val save_file : string -> string -> unit
 
-(** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. *)
+(** Write content to path via temp file + rename. When the Eio runtime is
+    registered, the complete blocking Unix transaction is offloaded to a
+    system thread. Returns [Error msg] on I/O failure instead of raising. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
 val save_file_atomic_unix : string -> string -> (unit, string) result
@@ -48,8 +51,8 @@ val save_file_atomic_unix : string -> string -> (unit, string) result
     via [Eio_unix.run_in_systhread]); never call it directly from an Eio fiber. *)
 
 val fsync_directory : string -> (unit, string) result
-(** Durably publish directory-entry changes without hiding unsupported I/O
-    failures. *)
+(** Durably publish directory-entry changes. Rejects non-directories and
+    returns unsupported I/O and close failures explicitly. *)
 
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
@@ -137,8 +140,9 @@ val mkdir_p : string -> unit
 
 val mkdir_p_durable_unix : string -> unit
 (** Blocking recursive directory creation followed by parent-directory fsync
-    for every newly-created path segment. Callers running in Eio must offload
-    the complete transaction to a system thread. *)
+    for every path segment observed missing. A symlink or non-directory found
+    at the target or while walking the missing suffix is rejected. Callers
+    running in Eio must offload the complete transaction to a system thread. *)
 
 (** [mkdir_p_memoized path] is [mkdir_p] but skips the stat/mkdir
     syscalls on every call after the first for the same [path].

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -38,11 +38,32 @@ val save_file : string -> string -> unit
     Returns [Error msg] on I/O failure instead of raising. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
+val save_file_atomic_unix : string -> string -> (unit, string) result
+(** Blocking Unix implementation of {!save_file_atomic}. This is for durable
+    stores whose entire transaction is run outside an Eio domain (for example
+    via [Eio_unix.run_in_systhread]); never call it directly from an Eio fiber. *)
+
+val fsync_directory : string -> (unit, string) result
+(** Durably publish directory-entry changes without hiding unsupported I/O
+    failures. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
     {!save_file_atomic}.  Exposed for tests and for a potential
     periodic sweep. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan using the same policy as
+    {!cleanup_atomic_orphans}, while preserving failures as typed results. The
+    recovery directory must already exist and must be a real directory. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
@@ -52,8 +73,8 @@ val is_atomic_orphan_name : string -> bool
     Scans [base_path] and its immediate subdirectories (skipping
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted.
-    - Non-zero orphans are moved to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are moved into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 
@@ -68,6 +89,11 @@ val cleanup_atomic_orphans
 
 (** Append string to file. *)
 val append_file : string -> string -> unit
+
+(** Append the complete byte string under the per-path append lock and fsync the
+    file before returning. Runtime calls execute the blocking fd operations in
+    a system thread. *)
+val append_file_durable : string -> string -> unit
 
 (** Check if file exists. *)
 val file_exists : string -> bool
@@ -101,6 +127,11 @@ val realpath : string -> string
 
 (** Create directory recursively. *)
 val mkdir_p : string -> unit
+
+val mkdir_p_durable_unix : string -> unit
+(** Blocking recursive directory creation followed by parent-directory fsync
+    for every newly-created path segment. Callers running in Eio must offload
+    the complete transaction to a system thread. *)
 
 (** [mkdir_p_memoized path] is [mkdir_p] but skips the stat/mkdir
     syscalls on every call after the first for the same [path].

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -63,11 +63,12 @@ type atomic_orphan_recovery =
 
 val recover_atomic_orphan
   :  path:string
-  -> recovered_dir:string
+  -> recovered_root:string
+  -> bucket:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan using the same policy as
-    {!cleanup_atomic_orphans}, while preserving failures as typed results. The
-    recovery directory must already exist and must be a real directory. *)
+    {!cleanup_atomic_orphans}, while preserving failures as typed results. Root
+    and bucket directories must already exist as real directories. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -85,7 +85,9 @@ val recover_atomic_orphan
 
     Returns [(deleted, preserved)]:
     - [deleted]: zero-byte orphans removed.
-    - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+    - [preserved]: non-zero orphans moved to [recovered_subdir].
+
+    @raise Invalid_argument when [recovered_subdir] is not one path segment. *)
 val cleanup_atomic_orphans
   :  base_path:string
   -> ?recovered_subdir:string

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -25,6 +25,10 @@ val has_fs : unit -> bool
 (** Load entire file as string. *)
 val load_file : string -> string
 
+val load_file_unix : string -> string
+(** Blocking Unix implementation of {!load_file}. This is for transactions
+    already offloaded from an Eio domain. *)
+
 (** Load entire file as string, or [None] when the file is missing.
     Option-returning sibling of {!load_file} (which raises on a missing
     path). Other I/O failures of an existing file propagate as

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -19,6 +19,7 @@
  (libraries
   masc_core
   masc_log
+  fs_compat
   time_compat
   masc_cancel_safe
   eio

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -13,6 +13,33 @@
 
 module SMap = Set_util.StringMap
 
+module Key = struct
+  type t =
+    { directory_device : int64
+    ; directory_inode : int64
+    ; entry : string
+    }
+
+  let directory_entry ~directory_device ~directory_inode ~entry =
+    { directory_device; directory_inode; entry }
+  ;;
+
+  let equal left right =
+    Int64.equal left.directory_device right.directory_device
+    && Int64.equal left.directory_inode right.directory_inode
+    && String.equal left.entry right.entry
+  ;;
+
+  let registry_key key =
+    Printf.sprintf
+      "descriptor:%Lx:%Lx:%d:%s"
+      key.directory_device
+      key.directory_inode
+      (String.length key.entry)
+      key.entry
+  ;;
+end
+
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
 (** Observability hook fired after each [acquire_flock_retry*] attempt
@@ -178,9 +205,15 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
     that do not honor the non-blocking contract reliably. Retry sleep yields
     to the Eio scheduler when a clock is available and otherwise sleeps in a
     systhread so the calling fiber does not block the domain. *)
-let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
-    ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
-  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+let acquire_flock_on_fd_cooperative
+      ?clock
+      ~fd
+      ~lock_path
+      ?(max_attempts = 200)
+      ?(sleep_sec = 0.01)
+      ~caller
+      ()
+  =
   let started_at = Time_compat.now () in
   let rec acquire attempts =
     if attempts <= 0 then begin
@@ -210,7 +243,21 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
         acquire (attempts - 1)
       end
   in
-  try acquire max_attempts
+  acquire max_attempts
+;;
+
+let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
+    ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
+  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+  try
+    acquire_flock_on_fd_cooperative
+      ?clock
+      ~fd
+      ~lock_path
+      ~max_attempts
+      ~sleep_sec
+      ~caller
+      ()
   with exn ->
     run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
     raise exn
@@ -250,6 +297,23 @@ let with_lock ?clock path f =
       f
   in
   with_mutex path (fun () -> run_with_flock ())
+
+(** Descriptor-relative counterpart of [with_lock]. [with_file] must keep the
+    supplied descriptor open for its callback and close it before returning.
+    The cooperative mutex encloses [with_file], so the POSIX lock is released by
+    close before another same-process fiber can enter the critical section. *)
+let with_lock_file ?clock ~key ~path ~with_file f =
+  with_mutex (Key.registry_key key) (fun () ->
+    with_file (fun fd ->
+      ignore
+        (acquire_flock_on_fd_cooperative
+           ?clock
+           ~fd
+           ~lock_path:path
+           ~caller:"File_lock_eio"
+           ()
+         : Unix.file_descr);
+      f ()))
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -21,6 +21,11 @@ exception Lock_file_cleanup_failed of
   ; close_error : exn
   }
 
+exception Flock_release_failed of
+  { unlock_error : exn option
+  ; close_error : exn option
+  }
+
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store counter + histogram so
@@ -81,7 +86,7 @@ let rec atomic_update_with_result atomic f =
 type lock_entry = {
   mu : Eio.Mutex.t;
   pre_eio_mu : Stdlib.Mutex.t;
-  mutable last_used : float;
+  last_used : float Atomic.t;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
@@ -108,30 +113,29 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
   )
 
-(** Get or create a lock entry for the given file path.
+(** Get or create a process-local lock entry for the given file identity.
     Increments [active] to prevent prune_stale_entries from removing
-    in-use entries (see TLA+ FileLockStarvation spec).
-    Falls back to direct Hashtbl access when no Eio context is available
-    (e.g. in unit tests that don't use Eio_main.run). *)
+    in-use entries (see TLA+ FileLockStarvation spec). *)
 let get_entry path =
   prune_stale_entries ();
   let entry =
     atomic_update_with_result table (fun state ->
       match SMap.find_opt path state.entries with
       | Some entry ->
-        entry.last_used <- Time_compat.now ();
+        Atomic.set entry.last_used (Time_compat.now ());
         (state, entry)
       | None ->
         let entry =
           { mu = Eio.Mutex.create ()
           ; pre_eio_mu = Stdlib.Mutex.create ()
-          ; last_used = Time_compat.now ()
+          ; last_used = Atomic.make (Time_compat.now ())
           ; active = Atomic.make 0
           }
         in
@@ -144,17 +148,43 @@ let get_entry path =
 let release_entry entry =
   ignore (Atomic.fetch_and_add entry.active (-1))
 
-let with_cooperative_entry entry f =
+let protect_from_cancel f =
+  if Eio_guard.is_ready () then Eio.Cancel.protect f else f ()
+;;
+
+let require_eio_context () =
   if Eio_guard.is_ready ()
   then
-    try Eio.Mutex.use_ro entry.mu f with
+    try Eio.Cancel.protect (fun () -> ()) with
     | Effect.Unhandled _ as exn ->
       raise
         (Failure
            (Printf.sprintf
               "File_lock_eio requires an Eio fiber after runtime startup: %s"
               (Printexc.to_string exn)))
-  else Stdlib.Mutex.protect entry.pre_eio_mu f
+;;
+
+let with_eio_entry entry f =
+  (* A pre-Eio caller holds [pre_eio_mu] for its full critical section.
+     Taking and immediately releasing it here is a transition barrier: once
+     [Eio_guard.enable] is visible, no later pre-Eio caller can enter without
+     rechecking the guard while holding the same mutex. Normal Eio operation
+     sees an uncontended constant-time gate and waits only on [entry.mu]. *)
+  require_eio_context ();
+  Stdlib.Mutex.protect entry.pre_eio_mu (fun () -> ());
+  Eio.Mutex.use_ro entry.mu f
+;;
+
+let rec with_cooperative_entry entry f =
+  if Eio_guard.is_ready ()
+  then with_eio_entry entry f
+  else
+    match
+      Stdlib.Mutex.protect entry.pre_eio_mu (fun () ->
+        if Eio_guard.is_ready () then None else Some (f ()))
+    with
+    | Some value -> value
+    | None -> with_cooperative_entry entry f
 ;;
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
@@ -195,8 +225,13 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
   in
   try acquire max_attempts
   with exn ->
-    (try Unix.close fd with Unix.Unix_error _ -> ());
-    raise exn
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    (match Unix.close fd with
+     | () -> Printexc.raise_with_backtrace exn primary_backtrace
+     | exception close_error ->
+       raise
+         (Lock_file_cleanup_failed
+            { primary = exn; primary_backtrace; close_error }))
 
 (** Fiber-friendly wrapper around [acquire_flock_retry].
     Opening/closing the descriptor uses a systhread, and the F_TLOCK attempt
@@ -247,7 +282,11 @@ let acquire_flock_on_fd_cooperative
 
 let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
     ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
-  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+  require_eio_context ();
+  let fd =
+    protect_from_cancel (fun () ->
+      run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm))
+  in
   try
     acquire_flock_on_fd_cooperative
       ?clock
@@ -258,8 +297,14 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
       ~caller
       ()
   with exn ->
-    run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
-    raise exn
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    protect_from_cancel (fun () ->
+      match run_blocking_lock_op (fun () -> Unix.close fd) with
+      | () -> Printexc.raise_with_backtrace exn primary_backtrace
+      | exception close_error ->
+        raise
+          (Lock_file_cleanup_failed
+             { primary = exn; primary_backtrace; close_error }))
 
 let acquire_flock_fd ?clock lock_path =
   acquire_flock_retry_cooperative ?clock ~lock_path
@@ -268,8 +313,19 @@ let acquire_flock_fd ?clock lock_path =
 
 let release_flock_fd fd =
   run_blocking_lock_op (fun () ->
-      (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
-      Unix.close fd)
+      let unlock_error =
+        match Unix.lockf fd Unix.F_ULOCK 0 with
+        | () -> None
+        | exception exn -> Some exn
+      in
+      let close_error =
+        match Unix.close fd with
+        | () -> None
+        | exception exn -> Some exn
+      in
+      match unlock_error, close_error with
+      | None, None -> ()
+      | _ -> raise (Flock_release_failed { unlock_error; close_error }))
 
 (** Run [f] while holding only the cooperative per-path mutex.
     Use this for in-memory backends that need single-process fiber
@@ -288,11 +344,13 @@ let with_lock ?clock path f =
   let run_with_flock () =
     let lock_path = path ^ ".lock" in
     let dir = Filename.dirname lock_path in
-    if not (Sys.file_exists dir) then
-      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    run_blocking_lock_op (fun () ->
+      if not (Sys.file_exists dir) then
+        (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()));
     let fd = acquire_flock_fd ?clock lock_path in
     Common.protect ~module_name:"file_lock_eio" ~finally_label:"finalizer"
-      ~finally:(fun () -> release_flock_fd fd)
+      ~finally:(fun () ->
+        protect_from_cancel (fun () -> release_flock_fd fd))
       f
   in
   with_mutex path (fun () -> run_with_flock ())
@@ -301,22 +359,34 @@ let file_registry_key ~device ~inode =
   Printf.sprintf "descriptor-inode:%Lx:%Lx" device inode
 ;;
 
-let with_lock_file
+type close_state =
+  | Open
+  | Close_attempted
+  | Closed
+
+let with_anchored_file_lock
       ?clock
       ~path
-      ~open_file
-      ~descriptor
-      ~identity
-      ~close_file
+      ~directory
+      ~name
+      ~perm
       f
   =
-  let file = run_blocking_lock_op open_file in
-  let closed = ref false in
+  require_eio_context ();
+  let module Dir = Fs_compat.Anchored_dir in
+  let file =
+    protect_from_cancel (fun () ->
+      Dir.open_lock_file directory ~name ~perm)
+  in
+  let close_state = ref Open in
   let close_once () =
-    if not !closed
-    then (
-      closed := true;
-      run_blocking_lock_op (fun () -> close_file file))
+    match !close_state with
+    | Closed | Close_attempted -> ()
+    | Open ->
+      close_state := Close_attempted;
+      protect_from_cancel (fun () ->
+        Dir.close_lock_file file;
+        close_state := Closed)
   in
   let finish outcome =
     let close_outcome =
@@ -335,32 +405,35 @@ let with_lock_file
         (Lock_file_cleanup_failed
            { primary; primary_backtrace; close_error })
   in
-  let device, inode = identity file in
-  let entry = get_entry (file_registry_key ~device ~inode) in
-  let run () =
-    let outcome =
-      try
-        ignore
-          (acquire_flock_on_fd_cooperative
-             ?clock
-             ~fd:(descriptor file)
-             ~lock_path:path
-             ~caller:"File_lock_eio"
-             ()
-           : Unix.file_descr);
-        Ok (f ())
-      with
-      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  let run_scoped () =
+    let device, inode = Dir.lock_file_identity file in
+    let entry = get_entry (file_registry_key ~device ~inode) in
+    let run () =
+      let outcome =
+        try
+          ignore
+            (acquire_flock_on_fd_cooperative
+               ?clock
+               ~fd:(Dir.lock_file_descriptor file)
+               ~lock_path:path
+               ~caller:"File_lock_eio"
+               ()
+             : Unix.file_descr);
+          Ok (f ())
+        with
+        | exn -> Error (exn, Printexc.get_raw_backtrace ())
+      in
+      finish outcome
     in
-    finish outcome
-  in
-  try
     Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
       ~finally:(fun () -> release_entry entry)
       (fun () -> with_cooperative_entry entry run)
+  in
+  try
+    run_scoped ()
   with
   | exn ->
-    if !closed
+    if !close_state <> Open
     then raise exn
     else finish (Error (exn, Printexc.get_raw_backtrace ()))
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -13,34 +13,13 @@
 
 module SMap = Set_util.StringMap
 
-module Key = struct
-  type t =
-    { directory_device : int64
-    ; directory_inode : int64
-    ; entry : string
-    }
-
-  let directory_entry ~directory_device ~directory_inode ~entry =
-    { directory_device; directory_inode; entry }
-  ;;
-
-  let equal left right =
-    Int64.equal left.directory_device right.directory_device
-    && Int64.equal left.directory_inode right.directory_inode
-    && String.equal left.entry right.entry
-  ;;
-
-  let registry_key key =
-    Printf.sprintf
-      "descriptor:%Lx:%Lx:%d:%s"
-      key.directory_device
-      key.directory_inode
-      (String.length key.entry)
-      key.entry
-  ;;
-end
-
 exception Flock_timeout of { caller : string; path : string; attempts : int }
+
+exception Lock_file_cleanup_failed of
+  { primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
 
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
@@ -101,6 +80,7 @@ let rec atomic_update_with_result atomic f =
 
 type lock_entry = {
   mu : Eio.Mutex.t;
+  pre_eio_mu : Stdlib.Mutex.t;
   mutable last_used : float;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
@@ -148,7 +128,13 @@ let get_entry path =
         entry.last_used <- Time_compat.now ();
         (state, entry)
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
+        let entry =
+          { mu = Eio.Mutex.create ()
+          ; pre_eio_mu = Stdlib.Mutex.create ()
+          ; last_used = Time_compat.now ()
+          ; active = Atomic.make 0
+          }
+        in
         let entries = SMap.add path entry state.entries in
         (publish_entries state entries, entry))
   in
@@ -157,6 +143,19 @@ let get_entry path =
 
 let release_entry entry =
   ignore (Atomic.fetch_and_add entry.active (-1))
+
+let with_cooperative_entry entry f =
+  if Eio_guard.is_ready ()
+  then
+    try Eio.Mutex.use_ro entry.mu f with
+    | Effect.Unhandled _ as exn ->
+      raise
+        (Failure
+           (Printf.sprintf
+              "File_lock_eio requires an Eio fiber after runtime startup: %s"
+              (Printexc.to_string exn)))
+  else Stdlib.Mutex.protect entry.pre_eio_mu f
+;;
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 
@@ -279,7 +278,7 @@ let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () -> with_cooperative_entry entry f)
 
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
@@ -298,22 +297,72 @@ let with_lock ?clock path f =
   in
   with_mutex path (fun () -> run_with_flock ())
 
-(** Descriptor-relative counterpart of [with_lock]. [with_file] must keep the
-    supplied descriptor open for its callback and close it before returning.
-    The cooperative mutex encloses [with_file], so the POSIX lock is released by
-    close before another same-process fiber can enter the critical section. *)
-let with_lock_file ?clock ~key ~path ~with_file f =
-  with_mutex (Key.registry_key key) (fun () ->
-    with_file (fun fd ->
-      ignore
-        (acquire_flock_on_fd_cooperative
-           ?clock
-           ~fd
-           ~lock_path:path
-           ~caller:"File_lock_eio"
-           ()
-         : Unix.file_descr);
-      f ()))
+let file_registry_key ~device ~inode =
+  Printf.sprintf "descriptor-inode:%Lx:%Lx" device inode
+;;
+
+let with_lock_file
+      ?clock
+      ~path
+      ~open_file
+      ~descriptor
+      ~identity
+      ~close_file
+      f
+  =
+  let file = run_blocking_lock_op open_file in
+  let closed = ref false in
+  let close_once () =
+    if not !closed
+    then (
+      closed := true;
+      run_blocking_lock_op (fun () -> close_file file))
+  in
+  let finish outcome =
+    let close_outcome =
+      try
+        close_once ();
+        Ok ()
+      with
+      | exn -> Error exn
+    in
+    match outcome, close_outcome with
+    | Ok value, Ok () -> value
+    | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+    | Ok _, Error close_error -> raise close_error
+    | Error (primary, primary_backtrace), Error close_error ->
+      raise
+        (Lock_file_cleanup_failed
+           { primary; primary_backtrace; close_error })
+  in
+  let device, inode = identity file in
+  let entry = get_entry (file_registry_key ~device ~inode) in
+  let run () =
+    let outcome =
+      try
+        ignore
+          (acquire_flock_on_fd_cooperative
+             ?clock
+             ~fd:(descriptor file)
+             ~lock_path:path
+             ~caller:"File_lock_eio"
+             ()
+           : Unix.file_descr);
+        Ok (f ())
+      with
+      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+    in
+    finish outcome
+  in
+  try
+    Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
+      ~finally:(fun () -> release_entry entry)
+      (fun () -> with_cooperative_entry entry run)
+  with
+  | exn ->
+    if !closed
+    then raise exn
+    else finish (Error (exn, Printexc.get_raw_backtrace ()))
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -29,6 +29,12 @@ val stale_lock_seconds : float
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+exception Lock_file_cleanup_failed of
+  { primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -71,17 +77,6 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
-module Key : sig
-  type t
-
-  val directory_entry :
-    directory_device:int64 -> directory_inode:int64 -> entry:string -> t
-  (** Same-process lock identity for one entry in an already-open directory.
-      It is independent of the path spelling used to reach that directory. *)
-
-  val equal : t -> t -> bool
-end
-
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
     single-process fiber serialisation but have no filesystem
@@ -100,15 +95,18 @@ val with_lock :
 
 val with_lock_file :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> key:Key.t
   -> path:string
-  -> with_file:((Unix.file_descr -> 'a) -> 'a)
+  -> open_file:(unit -> 'resource)
+  -> descriptor:('resource -> Unix.file_descr)
+  -> identity:('resource -> int64 * int64)
+  -> close_file:('resource -> unit)
   -> (unit -> 'a)
   -> 'a
-(** Descriptor-relative counterpart of {!with_lock}. [with_file] opens the lock
-    artifact without path re-resolution, keeps its descriptor open for the
-    supplied callback, and closes it before returning. [key] provides canonical
-    same-process serialization; [path] is diagnostic only. *)
+(** Descriptor-relative counterpart of {!with_lock}. The caller provides a
+    blocking-only [open_file]/[close_file] pair; opening and close run in a
+    system thread under Eio. Same-process serialization is derived from the
+    opened regular file's actual [(device, inode)], so path and hard-link aliases
+    cannot select different cooperative mutexes. [path] is diagnostic only. *)
 
 (** {1 Observability hook} *)
 

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -35,6 +35,14 @@ exception Lock_file_cleanup_failed of
   ; close_error : exn
   }
 
+exception Flock_release_failed of
+  { unlock_error : exn option
+  ; close_error : exn option
+  }
+(** Unlock and close both ran but at least one failed. Neither failure is
+    discarded; [close_error = Some _] means the descriptor's final state is
+    unknown and must not be retried. *)
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -72,41 +80,50 @@ val acquire_flock_fd :
   string ->
   Unix.file_descr
 
-(** [release_flock_fd fd] unlocks (best-effort) and closes [fd]. *)
+(** [release_flock_fd fd] unlocks and closes [fd]. Failures from either step
+    are reported as {!Flock_release_failed}; close is attempted even if unlock
+    failed. *)
 val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
-    single-process fiber serialisation but have no filesystem
-    artifact to flock. *)
+    single-process fiber serialisation but have no filesystem artifact to
+    flock. Before Eio starts, it uses a transition gate; an Eio caller drains
+    that gate before acquiring the cooperative mutex, so the two modes never
+    overlap for one key. *)
 val with_mutex : string -> (unit -> 'a) -> 'a
 
 (** [with_lock ?clock path f] runs [f] while holding both the
     cooperative Eio.Mutex and an OS-level flock on [path ^ ".lock"].
     The flock uses non-blocking F_TLOCK retries — max 200 attempts,
-    ~2s total with default sleeps. *)
+    ~2s total with default sleeps. A pre-Eio caller and a later Eio caller use
+    the same transition gate before the latter acquires its cooperative mutex.
+    *)
 val with_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   string ->
   (unit -> 'a) ->
   'a
 
-val with_lock_file :
+val with_anchored_file_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> path:string
-  -> open_file:(unit -> 'resource)
-  -> descriptor:('resource -> Unix.file_descr)
-  -> identity:('resource -> int64 * int64)
-  -> close_file:('resource -> unit)
+  -> directory:Fs_compat.Anchored_dir.t
+  -> name:Fs_compat.Anchored_dir.Segment.t
+  -> perm:int
   -> (unit -> 'a)
   -> 'a
-(** Descriptor-relative counterpart of {!with_lock}. The caller provides a
-    blocking-only [open_file]/[close_file] pair; opening and close run in a
-    system thread under Eio. Same-process serialization is derived from the
-    opened regular file's actual [(device, inode)], so path and hard-link aliases
-    cannot select different cooperative mutexes. [path] is diagnostic only. *)
+(** Descriptor-relative lock scoped to an anchored directory capability. It
+    opens, identifies, locks, and closes one regular lock artifact as a single
+    ownership unit. Same-process serialization is derived from that opened
+    file's actual [(device, inode)], so hard-link aliases cannot select
+    different cooperative mutexes. [path] is diagnostic only.
+
+    The lock artifact closes in a cancellation-protected cleanup scope. If the
+    close syscall reports an error, its descriptor is never retried because a
+    retry could close a reused descriptor. *)
 
 (** {1 Observability hook} *)
 

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -71,6 +71,17 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
+module Key : sig
+  type t
+
+  val directory_entry :
+    directory_device:int64 -> directory_inode:int64 -> entry:string -> t
+  (** Same-process lock identity for one entry in an already-open directory.
+      It is independent of the path spelling used to reach that directory. *)
+
+  val equal : t -> t -> bool
+end
+
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
     single-process fiber serialisation but have no filesystem
@@ -86,6 +97,18 @@ val with_lock :
   string ->
   (unit -> 'a) ->
   'a
+
+val with_lock_file :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> key:Key.t
+  -> path:string
+  -> with_file:((Unix.file_descr -> 'a) -> 'a)
+  -> (unit -> 'a)
+  -> 'a
+(** Descriptor-relative counterpart of {!with_lock}. [with_file] opens the lock
+    artifact without path re-resolution, keeps its descriptor open for the
+    supplied callback, and closes it before returning. [key] provides canonical
+    same-process serialization; [path] is diagnostic only. *)
 
 (** {1 Observability hook} *)
 

--- a/test/stanzas/test_fs_atomic_orphan_sweep_10130.inc
+++ b/test/stanzas/test_fs_atomic_orphan_sweep_10130.inc
@@ -1,4 +1,4 @@
 (test
  (name test_fs_atomic_orphan_sweep_10130)
  (modules test_fs_atomic_orphan_sweep_10130)
- (libraries fs_compat alcotest unix))
+ (libraries fs_compat alcotest eio eio_main unix))

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -59,44 +59,77 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
-let test_descriptor_lock_identity_ignores_path_alias () =
+let with_descriptor_lock directory ~segment ~path f =
+  let module Dir = Fs_compat.Anchored_dir in
+  File_lock_eio.with_lock_file
+    ~path
+    ~open_file:(fun () ->
+      Dir.open_lock_file directory ~name:segment ~perm:0o600)
+    ~descriptor:Dir.lock_file_descriptor
+    ~identity:Dir.lock_file_identity
+    ~close_file:Dir.close_lock_file
+    f
+;;
+
+let test_descriptor_lock_hard_link_alias_serializes_and_recovers () =
   with_temp_path @@ fun path ->
   Unix.mkdir path 0o700;
-  let lock_path = Filename.concat path "state.lock" in
+  let primary_path = Filename.concat path "state.lock" in
+  let alias_path = Filename.concat path "alias.lock" in
   Fun.protect
-    ~finally:(fun () -> cleanup_if_exists lock_path)
+    ~finally:(fun () ->
+      cleanup_if_exists alias_path;
+      cleanup_if_exists primary_path)
     (fun () ->
-      let alias = Filename.concat path Filename.current_dir_name in
       let module Dir = Fs_compat.Anchored_dir in
-      let segment =
+      let primary =
         match Dir.Segment.of_string "state.lock" with
         | Ok segment -> segment
         | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
       in
-      Dir.with_open_root path @@ fun first ->
-      Dir.with_open_root alias @@ fun second ->
-      let first_identity = Dir.identity first in
-      let second_identity = Dir.identity second in
-      let key (identity : Dir.directory_identity) =
-        File_lock_eio.Key.directory_entry
-          ~directory_device:identity.device
-          ~directory_inode:identity.inode
-          ~entry:(Dir.Segment.to_string segment)
+      let alias =
+        match Dir.Segment.of_string "alias.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
       in
-      let first_key = key first_identity in
-      let second_key = key second_identity in
-      check bool
-        "directory aliases share one typed lock key"
-        true
-        (File_lock_eio.Key.equal first_key second_key);
-      let calls = ref 0 in
-      File_lock_eio.with_lock_file
-        ~key:first_key
-        ~path:lock_path
-        ~with_file:(fun callback ->
-          Dir.with_lock_file first ~name:segment ~perm:0o600 callback)
-        (fun () -> incr calls);
-      check int "descriptor lock body called once" 1 !calls)
+      Dir.with_open_root path @@ fun first ->
+      let bootstrap = Dir.open_lock_file first ~name:primary ~perm:0o600 in
+      Dir.close_lock_file bootstrap;
+      Unix.link primary_path alias_path;
+      Eio_main.run @@ fun _env ->
+      Eio_guard.enable ();
+      Fun.protect
+        ~finally:Eio_guard.disable
+        (fun () ->
+          Eio.Switch.run @@ fun sw ->
+          let first_entered, resolve_first_entered = Eio.Promise.create () in
+          let release_first, resolve_release_first = Eio.Promise.create () in
+          let second_attempted, resolve_second_attempted = Eio.Promise.create () in
+          let second_entered, resolve_second_entered = Eio.Promise.create () in
+          Eio.Fiber.fork ~sw (fun () ->
+            with_descriptor_lock first ~segment:primary ~path:primary_path (fun () ->
+              Eio.Promise.resolve resolve_first_entered ();
+              Eio.Promise.await release_first));
+          Eio.Promise.await first_entered;
+          Eio.Fiber.fork ~sw (fun () ->
+            Eio.Promise.resolve resolve_second_attempted ();
+            with_descriptor_lock first ~segment:alias ~path:alias_path (fun () ->
+              Eio.Promise.resolve resolve_second_entered ()));
+          Eio.Promise.await second_attempted;
+          Eio.Fiber.yield ();
+          Alcotest.(check bool)
+            "hard-link alias body waits for the first holder"
+            true
+            (Option.is_none (Eio.Promise.peek second_entered));
+          Eio.Promise.resolve resolve_release_first ();
+          Eio.Promise.await second_entered;
+          (match
+             with_descriptor_lock first ~segment:primary ~path:primary_path (fun () ->
+               failwith "body failure")
+           with
+           | exception Failure "body failure" -> ()
+           | () -> Alcotest.fail "expected body failure");
+          with_descriptor_lock first ~segment:alias ~path:alias_path (fun () -> ())))
 
 let () =
   run "file_lock_eio"
@@ -108,8 +141,8 @@ let () =
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
           test_case
-            "descriptor identity ignores path aliases"
+            "hard-link alias serializes and recovers after failure"
             `Quick
-            test_descriptor_lock_identity_ignores_path_alias;
+            test_descriptor_lock_hard_link_alias_serializes_and_recovers;
         ] );
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -59,6 +59,45 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_descriptor_lock_identity_ignores_path_alias () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let lock_path = Filename.concat path "state.lock" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_if_exists lock_path)
+    (fun () ->
+      let alias = Filename.concat path Filename.current_dir_name in
+      let module Dir = Fs_compat.Anchored_dir in
+      let segment =
+        match Dir.Segment.of_string "state.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun first ->
+      Dir.with_open_root alias @@ fun second ->
+      let first_identity = Dir.identity first in
+      let second_identity = Dir.identity second in
+      let key (identity : Dir.directory_identity) =
+        File_lock_eio.Key.directory_entry
+          ~directory_device:identity.device
+          ~directory_inode:identity.inode
+          ~entry:(Dir.Segment.to_string segment)
+      in
+      let first_key = key first_identity in
+      let second_key = key second_identity in
+      check bool
+        "directory aliases share one typed lock key"
+        true
+        (File_lock_eio.Key.equal first_key second_key);
+      let calls = ref 0 in
+      File_lock_eio.with_lock_file
+        ~key:first_key
+        ~path:lock_path
+        ~with_file:(fun callback ->
+          Dir.with_lock_file first ~name:segment ~perm:0o600 callback)
+        (fun () -> incr calls);
+      check int "descriptor lock body called once" 1 !calls)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +107,9 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case
+            "descriptor identity ignores path aliases"
+            `Quick
+            test_descriptor_lock_identity_ignores_path_alias;
         ] );
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -25,8 +25,8 @@ let test_with_lock_without_eio () =
   let calls = ref 0 in
   let result =
     File_lock_eio.with_lock path (fun () ->
-        incr calls;
-        "ok")
+      incr calls;
+      "ok")
   in
   check string "result" "ok" result;
   check int "single call" 1 !calls;
@@ -60,14 +60,11 @@ let test_with_lock_inside_eio () =
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
 let with_descriptor_lock directory ~segment ~path f =
-  let module Dir = Fs_compat.Anchored_dir in
-  File_lock_eio.with_lock_file
+  File_lock_eio.with_anchored_file_lock
     ~path
-    ~open_file:(fun () ->
-      Dir.open_lock_file directory ~name:segment ~perm:0o600)
-    ~descriptor:Dir.lock_file_descriptor
-    ~identity:Dir.lock_file_identity
-    ~close_file:Dir.close_lock_file
+    ~directory
+    ~name:segment
+    ~perm:0o600
     f
 ;;
 
@@ -131,6 +128,76 @@ let test_descriptor_lock_hard_link_alias_serializes_and_recovers () =
            | () -> Alcotest.fail "expected body failure");
           with_descriptor_lock first ~segment:alias ~path:alias_path (fun () -> ())))
 
+let test_descriptor_lock_cancellation_closes_before_reacquire () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let lock_path = Filename.concat path "state.lock" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_if_exists lock_path)
+    (fun () ->
+      let module Dir = Fs_compat.Anchored_dir in
+      let segment =
+        match Dir.Segment.of_string "state.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun root ->
+      Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      Fun.protect
+        ~finally:Eio_guard.disable
+        (fun () ->
+          let entered, resolve_entered = Eio.Promise.create () in
+          let completed =
+            Eio.Fiber.first
+              (fun () ->
+                with_descriptor_lock root ~segment ~path:lock_path (fun () ->
+                  Eio.Promise.resolve resolve_entered ();
+                  Eio.Time.sleep (Eio.Stdenv.clock env) 60.0))
+              (fun () -> Eio.Promise.await entered)
+          in
+          check unit "cancelling peer completed" () completed;
+          with_descriptor_lock root ~segment ~path:lock_path (fun () -> ())))
+
+let test_anchored_lock_and_read_reject_nonregular_entries () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let fifo_path = Filename.concat path "state.fifo" in
+  let target_path = Filename.concat path "target" in
+  let link_path = Filename.concat path "state.link" in
+  Unix.mkfifo fifo_path 0o600;
+  let output = open_out_bin target_path in
+  output_string output "target";
+  close_out output;
+  Unix.symlink "target" link_path;
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_if_exists link_path;
+      cleanup_if_exists target_path;
+      cleanup_if_exists fifo_path)
+    (fun () ->
+      let module Dir = Fs_compat.Anchored_dir in
+      let fifo =
+        match Dir.Segment.of_string "state.fifo" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      let link =
+        match Dir.Segment.of_string "state.link" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun root ->
+      (match Dir.read_file root fifo with
+       | exception Unix.Unix_error (Unix.EINVAL, _, _) -> ()
+       | _ -> Alcotest.fail "FIFO was accepted as an anchored readable file");
+      (match Dir.open_lock_file root ~name:fifo ~perm:0o600 with
+       | exception Unix.Unix_error (Unix.EINVAL, _, _) -> ()
+       | _ -> Alcotest.fail "FIFO was accepted as an anchored lock file");
+      match Dir.open_lock_file root ~name:link ~perm:0o600 with
+      | exception Unix.Unix_error (Unix.ELOOP, _, _) -> ()
+      | _ -> Alcotest.fail "symlink was accepted as an anchored lock file")
+
 let () =
   run "file_lock_eio"
     [
@@ -144,5 +211,13 @@ let () =
             "hard-link alias serializes and recovers after failure"
             `Quick
             test_descriptor_lock_hard_link_alias_serializes_and_recovers;
+          test_case
+            "cancellation closes descriptor lock before re-acquire"
+            `Quick
+            test_descriptor_lock_cancellation_closes_before_reacquire;
+          test_case
+            "anchored lock and read reject FIFO and symlink entries"
+            `Quick
+            test_anchored_lock_and_read_reject_nonregular_entries;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -238,22 +238,12 @@ let test_blocking_durable_primitives () =
   (match Fs_compat.save_file_atomic_unix target "second" with
    | Ok () -> ()
    | Error detail -> Alcotest.failf "blocking atomic overwrite failed: %s" detail);
-  let ic = open_in_bin target in
-  let content =
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () -> really_input_string ic (in_channel_length ic))
-  in
+  let content = Fs_compat.load_file_unix target in
   Alcotest.(check string) "blocking atomic content" "second" content;
   let append_target = Filename.concat nested "events.jsonl" in
   Fs_compat.append_file_durable append_target "one\n";
   Fs_compat.append_file_durable append_target "two\n";
-  let append_ic = open_in_bin append_target in
-  let appended =
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr append_ic)
-      (fun () -> really_input_string append_ic (in_channel_length append_ic))
-  in
+  let appended = Fs_compat.load_file_unix append_target in
   Alcotest.(check string) "durable append content" "one\ntwo\n" appended;
   let missing_parent_target =
     Filename.concat base_path "missing-parent/state.json"

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -490,6 +490,28 @@ let test_anchored_root_rejects_symlink () =
   | exception Unix.Unix_error _ -> ()
   | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
 
+let test_anchored_lock_file_rejects_symlink () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let outside = Filename.concat base_path "outside.lock" in
+  let link = Filename.concat base_path "managed.lock" in
+  Fs_compat.save_file_unix outside "sentinel";
+  Unix.symlink outside link;
+  Dir.with_open_root base_path @@ fun root ->
+  (match
+     Dir.with_lock_file
+       root
+       ~name:(anchored_segment "managed.lock")
+       ~perm:0o600
+       (fun _ -> ())
+   with
+   | exception Unix.Unix_error _ -> ()
+   | () -> Alcotest.fail "symlinked lock file was accepted");
+  Alcotest.(check string)
+    "symlink target unchanged"
+    "sentinel"
+    (Fs_compat.load_file_unix outside)
+
 let test_anchored_segments_reject_ambiguous_names () =
   let module Segment = Fs_compat.Anchored_dir.Segment in
   List.iter
@@ -545,6 +567,8 @@ let () =
             test_anchored_capability_survives_path_substitution;
           Alcotest.test_case "symlinked root rejected" `Quick
             test_anchored_root_rejects_symlink;
+          Alcotest.test_case "symlinked lock file rejected" `Quick
+            test_anchored_lock_file_rejects_symlink;
           Alcotest.test_case "ambiguous segments rejected" `Quick
             test_anchored_segments_reject_ambiguous_names;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -499,11 +499,10 @@ let test_anchored_lock_file_rejects_symlink () =
   Unix.symlink outside link;
   Dir.with_open_root base_path @@ fun root ->
   (match
-     Dir.with_lock_file
+     Dir.open_lock_file
        root
        ~name:(anchored_segment "managed.lock")
        ~perm:0o600
-       (fun _ -> ())
    with
    | exception Unix.Unix_error _ -> ()
    | () -> Alcotest.fail "symlinked lock file was accepted");
@@ -511,6 +510,21 @@ let test_anchored_lock_file_rejects_symlink () =
     "symlink target unchanged"
     "sentinel"
     (Fs_compat.load_file_unix outside)
+
+let test_anchored_lock_file_rejects_fifo () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let fifo = Filename.concat base_path "managed.lock" in
+  Unix.mkfifo fifo 0o600;
+  Dir.with_open_root base_path @@ fun root ->
+  match
+    Dir.open_lock_file
+      root
+      ~name:(anchored_segment "managed.lock")
+      ~perm:0o600
+  with
+  | exception Unix.Unix_error _ -> ()
+  | _ -> Alcotest.fail "FIFO lock artifact was accepted"
 
 let test_anchored_segments_reject_ambiguous_names () =
   let module Segment = Fs_compat.Anchored_dir.Segment in
@@ -569,6 +583,8 @@ let () =
             test_anchored_root_rejects_symlink;
           Alcotest.test_case "symlinked lock file rejected" `Quick
             test_anchored_lock_file_rejects_symlink;
+          Alcotest.test_case "FIFO lock file rejected" `Quick
+            test_anchored_lock_file_rejects_fifo;
           Alcotest.test_case "ambiguous segments rejected" `Quick
             test_anchored_segments_reject_ambiguous_names;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -9,7 +9,8 @@
    [Fs_compat.cleanup_atomic_orphans] is a boot-time sweep:
    - zero-byte orphans are deleted;
    - non-zero orphans are MOVED (not deleted) to
-     [<base_path>/.recovered/] so operators can forensically
+     a source-directory bucket below [<base_path>/.recovered/] so operators can
+     forensically
      inspect data-loss events.
 
    These tests pin that contract so a future refactor can't
@@ -96,8 +97,9 @@ let test_nonzero_orphan_preserved_in_recovered () =
   Alcotest.(check int) "1 preserved" 1 preserved;
   Alcotest.(check bool) "original removed" false
     (Sys.file_exists orphan);
-  let recovered_dir = Filename.concat base_path ".recovered" in
-  Alcotest.(check bool) ".recovered/ created" true
+  let recovered_root = Filename.concat base_path ".recovered" in
+  let recovered_dir = Filename.concat recovered_root "root" in
+  Alcotest.(check bool) ".recovered/root created" true
     (Sys.file_exists recovered_dir);
   let entries = Sys.readdir recovered_dir in
   Alcotest.(check int) "1 file in .recovered/" 1 (Array.length entries);
@@ -189,6 +191,77 @@ let test_recovered_dir_skipped_on_rescan () =
   Alcotest.(check bool) ".recovered/ seed file untouched" true
     (Sys.file_exists (Filename.concat recovered ".atomic_seed.tmp"))
 
+let test_direct_recovery_rejects_symlinked_destination () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let target = Filename.concat base_path "outside" in
+  let recovered = Filename.concat base_path "recovered" in
+  write_file ~path:orphan ~content:"forensic payload";
+  Unix.mkdir target 0o755;
+  Unix.symlink target recovered;
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "symlinked recovery destination was accepted");
+  Alcotest.(check bool) "orphan retained" true (Sys.file_exists orphan);
+  Alcotest.(check int)
+    "symlink target untouched"
+    0
+    (Array.length (Sys.readdir target))
+
+let test_direct_recovery_preserves_without_overwrite () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let recovered = Filename.concat base_path "recovered" in
+  Unix.mkdir recovered 0o755;
+  write_file ~path:orphan ~content:"first";
+  let destination = Filename.concat recovered ".atomic_data.tmp" in
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Ok (Fs_compat.Preserved_nonempty actual) ->
+     Alcotest.(check string) "recovery destination" destination actual
+   | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "nonempty orphan deleted"
+   | Error detail -> Alcotest.failf "direct recovery failed: %s" detail);
+  write_file ~path:orphan ~content:"second";
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "existing forensic evidence was overwritten");
+  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan)
+
+let test_blocking_durable_primitives () =
+  with_temp_base @@ fun base_path ->
+  let nested = Filename.concat base_path "one/two/three" in
+  Fs_compat.mkdir_p_durable_unix nested;
+  Alcotest.(check bool) "durable directory tree created" true (Sys.is_directory nested);
+  let target = Filename.concat nested "state.json" in
+  (match Fs_compat.save_file_atomic_unix target "first" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "blocking atomic write failed: %s" detail);
+  (match Fs_compat.save_file_atomic_unix target "second" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "blocking atomic overwrite failed: %s" detail);
+  let ic = open_in_bin target in
+  let content =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  Alcotest.(check string) "blocking atomic content" "second" content;
+  let append_target = Filename.concat nested "events.jsonl" in
+  Fs_compat.append_file_durable append_target "one\n";
+  Fs_compat.append_file_durable append_target "two\n";
+  let append_ic = open_in_bin append_target in
+  let appended =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr append_ic)
+      (fun () -> really_input_string append_ic (in_channel_length append_ic))
+  in
+  Alcotest.(check string) "durable append content" "one\ntwo\n" appended;
+  let missing_parent_target =
+    Filename.concat base_path "missing-parent/state.json"
+  in
+  (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
+   | Error _ -> ()
+   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
     [
@@ -211,5 +284,12 @@ let () =
             test_mixed_batch;
           Alcotest.test_case ".recovered/ skipped on rescan" `Quick
             test_recovered_dir_skipped_on_rescan;
+          Alcotest.test_case "symlinked recovery rejected" `Quick
+            test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "direct recovery does not overwrite" `Quick
+            test_direct_recovery_preserves_without_overwrite;
         ] );
+      ( "durable-primitives",
+        [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
+            test_blocking_durable_primitives ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -213,6 +213,37 @@ let test_direct_recovery_rejects_symlinked_destination () =
     0
     (Array.length (Sys.readdir target))
 
+let test_cleanup_rejects_recovery_escape () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  write_file ~path:orphan ~content:"forensic payload";
+  (match
+     Fs_compat.cleanup_atomic_orphans
+       ~base_path
+       ~recovered_subdir:"../outside"
+       ()
+   with
+   | exception Invalid_argument _ -> ()
+   | _ -> Alcotest.fail "recovery traversal was accepted");
+  Alcotest.(check bool) "traversal source retained" true (Sys.file_exists orphan)
+
+let test_cleanup_rejects_symlinked_recovery_root () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let target = Filename.concat base_path "outside" in
+  let recovered = Filename.concat base_path ".recovered" in
+  write_file ~path:orphan ~content:"forensic payload";
+  Unix.mkdir target 0o755;
+  Unix.symlink target recovered;
+  let deleted, preserved = Fs_compat.cleanup_atomic_orphans ~base_path () in
+  Alcotest.(check int) "no deletion through symlink" 0 deleted;
+  Alcotest.(check int) "no preservation through symlink" 0 preserved;
+  Alcotest.(check bool) "symlink source retained" true (Sys.file_exists orphan);
+  Alcotest.(check int)
+    "symlink root target untouched"
+    0
+    (Array.length (Sys.readdir target))
+
 let test_direct_recovery_preserves_without_overwrite () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
@@ -322,6 +353,10 @@ let () =
             test_recovered_dir_skipped_on_rescan;
           Alcotest.test_case "symlinked recovery rejected" `Quick
             test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "recovery traversal rejected" `Quick
+            test_cleanup_rejects_recovery_escape;
+          Alcotest.test_case "symlinked recovery root rejected" `Quick
+            test_cleanup_rejects_symlinked_recovery_root;
           Alcotest.test_case "direct recovery does not overwrite" `Quick
             test_direct_recovery_preserves_without_overwrite;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -199,7 +199,12 @@ let test_direct_recovery_rejects_symlinked_destination () =
   write_file ~path:orphan ~content:"forensic payload";
   Unix.mkdir target 0o755;
   Unix.symlink target recovered;
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root:recovered
+       ~bucket:"root"
+   with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "symlinked recovery destination was accepted");
   Alcotest.(check bool) "orphan retained" true (Sys.file_exists orphan);
@@ -211,20 +216,48 @@ let test_direct_recovery_rejects_symlinked_destination () =
 let test_direct_recovery_preserves_without_overwrite () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
-  let recovered = Filename.concat base_path "recovered" in
+  let recovered_root = Filename.concat base_path "recovered" in
+  let recovered = Filename.concat recovered_root "root" in
+  Unix.mkdir recovered_root 0o755;
   Unix.mkdir recovered 0o755;
   write_file ~path:orphan ~content:"first";
   let destination = Filename.concat recovered ".atomic_data.tmp" in
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
    | Ok (Fs_compat.Preserved_nonempty actual) ->
      Alcotest.(check string) "recovery destination" destination actual
    | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "nonempty orphan deleted"
    | Error detail -> Alcotest.failf "direct recovery failed: %s" detail);
   write_file ~path:orphan ~content:"second";
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "existing forensic evidence was overwritten");
-  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan)
+  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan);
+  Unix.unlink destination;
+  Unix.link orphan destination;
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
+   | Ok (Fs_compat.Preserved_nonempty actual) ->
+     Alcotest.(check string) "interrupted recovery destination" destination actual
+   | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "linked orphan deleted"
+   | Error detail -> Alcotest.failf "linked recovery failed: %s" detail);
+  Alcotest.(check bool)
+    "interrupted source acknowledged"
+    false
+    (Sys.file_exists orphan)
 
 let test_blocking_durable_primitives () =
   with_temp_base @@ fun base_path ->
@@ -251,6 +284,19 @@ let test_blocking_durable_primitives () =
   (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
    | Error _ -> ()
    | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+
+let test_durable_append_falls_back_outside_eio () =
+  with_temp_base @@ fun base_path ->
+  Fun.protect
+    ~finally:Fs_compat.clear_fs
+    (fun () ->
+       Eio_main.run (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env));
+       let path = Filename.concat base_path "outside-eio.jsonl" in
+       Fs_compat.append_file_durable path "row\n";
+       Alcotest.(check string)
+         "fallback durable append"
+         "row\n"
+         (Fs_compat.load_file_unix path))
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -281,5 +327,8 @@ let () =
         ] );
       ( "durable-primitives",
         [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
-            test_blocking_durable_primitives ] );
+            test_blocking_durable_primitives;
+          Alcotest.test_case "durable append outside Eio runtime" `Quick
+            test_durable_append_falls_back_outside_eio;
+        ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -375,41 +375,81 @@ let test_durable_append_falls_back_outside_eio () =
          "row\n"
          (Fs_compat.load_file_unix path))
 
+let anchored_segment raw =
+  match Fs_compat.Anchored_dir.Segment.of_string raw with
+  | Ok segment -> segment
+  | Error error ->
+    Alcotest.failf
+      "invalid anchored test segment %S: %s"
+      raw
+      (Fs_compat.Anchored_dir.Segment.error_to_string error)
+;;
+
+let require_anchored_mutation label = function
+  | Ok value -> value
+  | Error error ->
+    Alcotest.failf
+      "%s: %s"
+      label
+      (Fs_compat.Anchored_dir.mutation_error_to_string error)
+;;
+
 let test_anchored_directory_primitives () =
   with_temp_base @@ fun base_path ->
   let module Dir = Fs_compat.Anchored_dir in
   Dir.with_open_root base_path @@ fun root ->
   Dir.with_ensure_dir
     root
-    ~name:"managed"
+    ~name:(anchored_segment "managed")
     ~perm:0o700
     ~enforce_perm:true
   @@ fun managed ->
-  (match Dir.save_file_atomic managed ~name:"state.json" ~perm:0o600 "one" with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "anchored atomic write failed: %s" detail);
-  Alcotest.(check string) "anchored read" "one" (Dir.read_file managed "state.json");
-  (match Dir.stat managed "state.json" with
+  require_anchored_mutation
+    "anchored atomic write"
+    (Dir.atomic_replace
+       managed
+       ~name:(anchored_segment "state.json")
+       ~perm:0o600
+       "one");
+  Alcotest.(check string)
+    "anchored read"
+    "one"
+    (Dir.read_file managed (anchored_segment "state.json"));
+  (match Dir.stat managed (anchored_segment "state.json") with
    | Some { kind = Dir.Regular_file; _ } -> ()
    | Some _ -> Alcotest.fail "anchored stat returned the wrong file kind"
    | None -> Alcotest.fail "anchored stat lost a committed file");
-  Dir.rename
-    ~src_dir:managed
-    ~src:"state.json"
-    ~dst_dir:managed
-    ~dst:"renamed.json";
+  require_anchored_mutation
+    "anchored rename"
+    (Dir.rename
+       ~src_dir:managed
+       ~src:(anchored_segment "state.json")
+       ~dst_dir:managed
+       ~dst:(anchored_segment "renamed.json"));
   Alcotest.(check bool)
     "source removed by rename"
     false
-    (Option.is_some (Dir.stat managed "state.json"));
+    (Option.is_some (Dir.stat managed (anchored_segment "state.json")));
   Alcotest.(check bool)
     "renamed file removed"
     true
-    (Dir.unlink_if_exists managed "renamed.json");
+    (match
+       require_anchored_mutation
+         "anchored unlink"
+         (Dir.unlink_if_exists managed (anchored_segment "renamed.json"))
+     with
+     | `Removed -> true
+     | `Missing -> false);
   Alcotest.(check bool)
     "missing unlink is explicit false"
     false
-    (Dir.unlink_if_exists managed "renamed.json")
+    (match
+       require_anchored_mutation
+         "anchored missing unlink"
+         (Dir.unlink_if_exists managed (anchored_segment "renamed.json"))
+     with
+     | `Removed -> true
+     | `Missing -> false)
 
 let test_anchored_capability_survives_path_substitution () =
   with_temp_base @@ fun base_path ->
@@ -420,12 +460,16 @@ let test_anchored_capability_survives_path_substitution () =
   Unix.mkdir managed_path 0o700;
   Unix.mkdir outside_path 0o700;
   Dir.with_open_root base_path @@ fun root ->
-  Dir.with_open_dir root "managed" @@ fun managed ->
+  Dir.with_open_dir root (anchored_segment "managed") @@ fun managed ->
   Unix.rename managed_path detached_path;
   Unix.symlink outside_path managed_path;
-  (match Dir.save_file_atomic managed ~name:"proof.json" ~perm:0o600 "anchored" with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "anchored write after substitution: %s" detail);
+  require_anchored_mutation
+    "anchored write after substitution"
+    (Dir.atomic_replace
+       managed
+       ~name:(anchored_segment "proof.json")
+       ~perm:0o600
+       "anchored");
   Alcotest.(check bool)
     "replacement symlink target untouched"
     false
@@ -445,6 +489,15 @@ let test_anchored_root_rejects_symlink () =
   match Dir.with_open_root alias (fun _ -> ()) with
   | exception Unix.Unix_error _ -> ()
   | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
+
+let test_anchored_segments_reject_ambiguous_names () =
+  let module Segment = Fs_compat.Anchored_dir.Segment in
+  List.iter
+    (fun raw ->
+       match Segment.of_string raw with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.failf "ambiguous anchored segment accepted: %S" raw)
+    [ ""; "."; ".."; "a/b"; "nul\000suffix" ]
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -492,5 +545,7 @@ let () =
             test_anchored_capability_survives_path_substitution;
           Alcotest.test_case "symlinked root rejected" `Quick
             test_anchored_root_rejects_symlink;
+          Alcotest.test_case "ambiguous segments rejected" `Quick
+            test_anchored_segments_reject_ambiguous_names;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -213,6 +213,30 @@ let test_direct_recovery_rejects_symlinked_destination () =
     0
     (Array.length (Sys.readdir target))
 
+let test_direct_recovery_rejects_symlinked_source () =
+  with_temp_base @@ fun base_path ->
+  let target = Filename.concat base_path "target" in
+  let orphan = Filename.concat base_path ".atomic_symlink.tmp" in
+  let recovered_root = Filename.concat base_path "recovered" in
+  let recovered = Filename.concat recovered_root "root" in
+  write_file ~path:target ~content:"must remain outside recovery";
+  Unix.mkdir recovered_root 0o755;
+  Unix.mkdir recovered 0o755;
+  Unix.symlink target orphan;
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "symlinked orphan source was accepted");
+  Alcotest.(check bool) "source symlink retained" true (Sys.file_exists orphan);
+  Alcotest.(check string)
+    "symlink target retained"
+    "must remain outside recovery"
+    (Fs_compat.load_file_unix target)
+
 let test_cleanup_rejects_recovery_escape () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
@@ -314,7 +338,29 @@ let test_blocking_durable_primitives () =
   in
   (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
    | Error _ -> ()
-   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded");
+  (match Fs_compat.fsync_directory target with
+   | Error _ -> ()
+   | Ok () -> Alcotest.fail "regular file accepted as directory fsync target")
+
+let test_durable_mkdir_rejects_non_directories () =
+  with_temp_base @@ fun base_path ->
+  let file = Filename.concat base_path "file" in
+  let target = Filename.concat base_path "target" in
+  let symlink = Filename.concat base_path "symlink" in
+  write_file ~path:file ~content:"not a directory";
+  Unix.mkdir target 0o755;
+  Unix.symlink target symlink;
+  (match Fs_compat.mkdir_p_durable_unix file with
+   | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> ()
+   | _ -> Alcotest.fail "regular file accepted as durable directory");
+  (match Fs_compat.mkdir_p_durable_unix (Filename.concat symlink "child") with
+   | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> ()
+   | _ -> Alcotest.fail "symlinked ancestor accepted as durable directory");
+  Alcotest.(check int)
+    "symlink target unchanged"
+    0
+    (Array.length (Sys.readdir target))
 
 let test_durable_append_falls_back_outside_eio () =
   with_temp_base @@ fun base_path ->
@@ -328,6 +374,77 @@ let test_durable_append_falls_back_outside_eio () =
          "fallback durable append"
          "row\n"
          (Fs_compat.load_file_unix path))
+
+let test_anchored_directory_primitives () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  Dir.with_open_root base_path @@ fun root ->
+  Dir.with_ensure_dir
+    root
+    ~name:"managed"
+    ~perm:0o700
+    ~enforce_perm:true
+  @@ fun managed ->
+  (match Dir.save_file_atomic managed ~name:"state.json" ~perm:0o600 "one" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "anchored atomic write failed: %s" detail);
+  Alcotest.(check string) "anchored read" "one" (Dir.read_file managed "state.json");
+  (match Dir.stat managed "state.json" with
+   | Some { kind = Dir.Regular_file; _ } -> ()
+   | Some _ -> Alcotest.fail "anchored stat returned the wrong file kind"
+   | None -> Alcotest.fail "anchored stat lost a committed file");
+  Dir.rename
+    ~src_dir:managed
+    ~src:"state.json"
+    ~dst_dir:managed
+    ~dst:"renamed.json";
+  Alcotest.(check bool)
+    "source removed by rename"
+    false
+    (Option.is_some (Dir.stat managed "state.json"));
+  Alcotest.(check bool)
+    "renamed file removed"
+    true
+    (Dir.unlink_if_exists managed "renamed.json");
+  Alcotest.(check bool)
+    "missing unlink is explicit false"
+    false
+    (Dir.unlink_if_exists managed "renamed.json")
+
+let test_anchored_capability_survives_path_substitution () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let managed_path = Filename.concat base_path "managed" in
+  let detached_path = Filename.concat base_path "detached" in
+  let outside_path = Filename.concat base_path "outside" in
+  Unix.mkdir managed_path 0o700;
+  Unix.mkdir outside_path 0o700;
+  Dir.with_open_root base_path @@ fun root ->
+  Dir.with_open_dir root "managed" @@ fun managed ->
+  Unix.rename managed_path detached_path;
+  Unix.symlink outside_path managed_path;
+  (match Dir.save_file_atomic managed ~name:"proof.json" ~perm:0o600 "anchored" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "anchored write after substitution: %s" detail);
+  Alcotest.(check bool)
+    "replacement symlink target untouched"
+    false
+    (Sys.file_exists (Filename.concat outside_path "proof.json"));
+  Alcotest.(check string)
+    "open descriptor retained original directory"
+    "anchored"
+    (Fs_compat.load_file_unix (Filename.concat detached_path "proof.json"))
+
+let test_anchored_root_rejects_symlink () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let target = Filename.concat base_path "target" in
+  let alias = Filename.concat base_path "alias" in
+  Unix.mkdir target 0o700;
+  Unix.symlink target alias;
+  match Dir.with_open_root alias (fun _ -> ()) with
+  | exception Unix.Unix_error _ -> ()
+  | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -353,6 +470,8 @@ let () =
             test_recovered_dir_skipped_on_rescan;
           Alcotest.test_case "symlinked recovery rejected" `Quick
             test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "symlinked source rejected" `Quick
+            test_direct_recovery_rejects_symlinked_source;
           Alcotest.test_case "recovery traversal rejected" `Quick
             test_cleanup_rejects_recovery_escape;
           Alcotest.test_case "symlinked recovery root rejected" `Quick
@@ -363,7 +482,15 @@ let () =
       ( "durable-primitives",
         [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
             test_blocking_durable_primitives;
+          Alcotest.test_case "durable mkdir rejects non-directories" `Quick
+            test_durable_mkdir_rejects_non_directories;
           Alcotest.test_case "durable append outside Eio runtime" `Quick
             test_durable_append_falls_back_outside_eio;
+          Alcotest.test_case "descriptor anchored operations" `Quick
+            test_anchored_directory_primitives;
+          Alcotest.test_case "ancestor substitution stays confined" `Quick
+            test_anchored_capability_survives_path_substitution;
+          Alcotest.test_case "symlinked root rejected" `Quick
+            test_anchored_root_rejects_symlink;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -495,7 +495,7 @@ let test_anchored_lock_file_rejects_symlink () =
   let module Dir = Fs_compat.Anchored_dir in
   let outside = Filename.concat base_path "outside.lock" in
   let link = Filename.concat base_path "managed.lock" in
-  Fs_compat.save_file_unix outside "sentinel";
+  Fs_compat.save_file outside "sentinel";
   Unix.symlink outside link;
   Dir.with_open_root base_path @@ fun root ->
   (match


### PR DESCRIPTION
Replaces closed #24088.\n\nThis hardens descriptor-backed file locking around Eio cancellation, pre-Eio to Eio transition serialization, and non-regular file rejection. The public lock API now accepts only an anchored directory capability, so file descriptor identity and lifecycle cannot be mismatched by callbacks.\n\nValidation: ocamlformat, OCaml parser checks, C -fsyntax-only, git diff --check. Full Dune build/test is delegated to CI.