### PR TITLE
fix(runtime)!: keep max_tokens optional end-to-end

### DIFF
--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -206,7 +206,7 @@ let build_agent
          match max_tokens with
          | None -> Ok base_config
          | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
-           Ok { base_config with max_tokens = n }
+           Ok { base_config with max_tokens = Some n }
          | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
        in
        (match base_config with

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -203,8 +203,9 @@ end
     @param temperature Subsystem temperature fallback; a selected runtime model
            declaration takes precedence. When omitted,
            [Keeper_config.keeper_unified_temperature] is the fallback.
-    @param max_tokens Maximum output tokens override; when omitted, resolved
-           from [Runtime_inference] with a 8192 fallback
+    @param max_tokens Explicit output-token request override. [None] (the
+           default) sends no [max_tokens] field on the request — masc#24067 /
+           oas#2517: the keeper lane never synthesizes one
     @param is_retry When [true], replays the current user message into the
            working context without persisting it again, so transient retry
            attempts do not duplicate the user entry in session history *)
@@ -362,27 +363,9 @@ let run_turn
   let requested_max_tokens = max_tokens in
   let meta = ctx.meta in
   let temperature = ctx.temperature in
-  let max_output_ceiling =
-    None
-  in
-  let max_tokens, pre_dispatch_max_tokens_error =
-    match
-      Runtime_inference.validate_max_tokens_within_ceiling
-        ~runtime_id
-        ~provider_ceiling:max_output_ceiling
-        ctx.max_tokens
-    with
-    | Ok max_tokens -> max_tokens, None
-    | Error internal_error ->
-      let detail =
-        Option.value
-          ~default:(Keeper_internal_error.kind_of_masc_internal_error internal_error)
-          (Keeper_internal_error.summary_of_masc_internal_error internal_error)
-      in
-      Log.Keeper.error "%s: %s" meta.name detail;
-      ( ctx.max_tokens,
-        Some (Keeper_internal_error.sdk_error_of_masc_internal_error internal_error) )
-  in
+  (* Carry explicit caller/profile intent only. OAS owns model ceiling
+     validation and envelope-specific clamp/fallback policy. *)
+  let max_tokens = ctx.max_tokens in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in
   let session = ctx.session in
@@ -700,11 +683,7 @@ let run_turn
          ~max_context
          ~pre_dispatch_compacted;
        (* Section 3: Dispatch — call Keeper_turn_driver.run_named / Agent.run. *)
-       let pre_dispatch_error =
-         match pre_dispatch_checkpoint_error with
-         | Some err -> Some err
-         | None -> pre_dispatch_max_tokens_error
-       in
+       let pre_dispatch_error = pre_dispatch_checkpoint_error in
        let turn_result =
          match pre_dispatch_error with
          | Some err -> Error err
@@ -816,7 +795,7 @@ let run_turn
                     ?stream_idle_timeout_s
                     ~body_timeout_s:timeout_s
                     ~temperature
-                    ~max_tokens
+                    ?max_tokens
                     ~max_tokens_for_runtime
                     ~accept:
                       Keeper_tool_response.response_has_text_or_tool_progress
@@ -1102,10 +1081,7 @@ let run_turn
           ~sampling:
             { temperature = Some temperature
             ; top_p = Runtime.top_p_of_runtime_id runtime_id_string
-            ; max_tokens =
-                (match pre_dispatch_max_tokens_error with
-                 | None -> Some max_tokens
-                 | Some _ -> None)
+            ; max_tokens
             ; thinking_budget = tctx.thinking_budget
             ; enable_thinking = tctx.thinking_enabled
             }

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -137,7 +137,9 @@ val per_provider_timeout_for_turn
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature Subsystem temperature fallback; a selected runtime model
            declaration takes precedence
-    @param max_tokens Maximum output tokens override
+    @param max_tokens Explicit output-token request override. [None] (the
+           default) sends no [max_tokens] field on the request — masc#24067 /
+           oas#2517: the keeper lane never synthesizes one
     @param on_event Optional event callback
     @param trajectory_acc Optional trajectory accumulator for recording
     @param tool_overlay Optional mutable tool overlay for dynamic tools

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -61,7 +61,6 @@ let is_transient_internal_runner_error (err : Agent_sdk.Error.sdk_error) : bool 
       | Keeper_turn_driver.Admission_queue_rejected _
       | Keeper_turn_driver.Provider_timeout _
       | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _
       | Keeper_turn_driver.Internal_bridge_exception _
       | Keeper_turn_driver.Internal_contract_rejected _ )
@@ -283,7 +282,6 @@ let is_auto_recoverable_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Provider_timeout _)
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
@@ -302,7 +300,6 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Provider_timeout _)
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
@@ -333,7 +330,6 @@ let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool 
       | Keeper_turn_driver.Admission_queue_timeout _
       | Keeper_turn_driver.Turn_timeout _
       | Keeper_turn_driver.Provider_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
@@ -484,7 +480,6 @@ let degraded_retry_after_recoverable_error
     | Some
         (Keeper_turn_driver.Runtime_exhausted _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
-    | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _)
     (* RFC-0159 Phase A: opaque internal failures have no
        local-recovery retry mapping. *)
@@ -530,7 +525,6 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.Accept_rejected _) ->
         accept_rejection_degraded_retry_reason err
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
-    | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _)
     (* RFC-0159 Phase A: typed [Internal_*] variants are not runtime-rotation
        reasons; they expose previously-opaque raw exception payloads.  *)
@@ -763,7 +757,6 @@ let is_completion_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
       | Keeper_turn_driver.Admission_queue_rejected _
       | Keeper_turn_driver.Turn_timeout _
       | Keeper_turn_driver.Provider_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
@@ -930,7 +923,6 @@ let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures should not trigger the
      keeper-cycle-failed WARN by themselves; the surrounding handler
@@ -1008,7 +1000,6 @@ let is_runtime_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures are not runtime exhaustion. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)

--- a/lib/keeper/keeper_error_classify_post_commit.ml
+++ b/lib/keeper/keeper_error_classify_post_commit.ml
@@ -47,7 +47,6 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Provider_timeout _)
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   (* RFC-0159 Phase A: opaque internal failures are unambiguous failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
@@ -67,7 +66,6 @@ let ambiguous_side_effect_error_tools (err : Agent_sdk.Error.sdk_error) =
       | Keeper_turn_driver.Admission_queue_timeout _
       | Keeper_turn_driver.Turn_timeout _
       | Keeper_turn_driver.Provider_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
       | Keeper_turn_driver.Internal_contract_rejected _ )

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -192,15 +192,18 @@ let publish_runtime_execution_built
     ~temperature
     ~generation
   =
-  let payload = `Assoc [
-    ("keeper_name", `String keeper_name);
-    ("runtime_id", `String runtime_id);
-    ("max_tokens", `Int max_tokens);
-    ("max_context", `Int max_context);
-    ("max_context_resolution", `String (string_of_int effective_budget));
-    ("temperature", `Float temperature);
-    ("generation", `Int generation);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
+  let payload =
+    `Assoc
+      ([ ("keeper_name", `String keeper_name)
+       ; ("runtime_id", `String runtime_id)
+       ]
+       @ Runtime_max_tokens.telemetry_fields max_tokens
+       @ [ ("max_context", `Int max_context)
+         ; ("max_context_resolution", `String (string_of_int effective_budget))
+         ; ("temperature", `Float temperature)
+         ; ("generation", `Int generation)
+         ; ("timestamp", `Float (Time_compat.now ()))
+         ])
+  in
   masc_publish
     (Agent_sdk.Event_bus.mk_event (Custom ("telemetry_event", payload)))

--- a/lib/keeper/keeper_event_publisher.mli
+++ b/lib/keeper/keeper_event_publisher.mli
@@ -130,10 +130,13 @@ val publish_audit_event :
 
     Shape: [{id, ts, actor, kind, target?, summary, severity, payload?}]. *)
 
+(** [max_tokens] is always represented on the wire as an integer or [null].
+    The payload also carries [max_tokens_source]: [explicit_override] for
+    [Some _], [omitted] for [None]. *)
 val publish_runtime_execution_built :
   keeper_name:string ->
   runtime_id:string ->
-  max_tokens:int ->
+  max_tokens:int option ->
   max_context:int ->
   effective_budget:int ->
   temperature:float ->

--- a/lib/keeper/keeper_provider_runtime_boundary.ml
+++ b/lib/keeper/keeper_provider_runtime_boundary.ml
@@ -101,7 +101,6 @@ let classify_masc_internal_error = function
       | Keeper_internal_error.Admission_queue_timeout _
       | Keeper_internal_error.Admission_queue_rejected _
       | Keeper_internal_error.Turn_timeout _
-      | Keeper_internal_error.Max_tokens_ceiling_violation _
       | Keeper_internal_error.Ambiguous_post_commit _
       | Keeper_internal_error.Internal_unhandled_exception _
       | Keeper_internal_error.Internal_bridge_exception _

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -11,7 +11,7 @@ open Keeper_types_profile
 type run_context =
   { meta : keeper_meta
   ; temperature : float
-  ; max_tokens : int
+  ; max_tokens : int option
   ; context_injector : Agent_sdk.Hooks.context_injector
   ; shared_context : Agent_sdk.Context.t
   ; session_dir : string
@@ -71,28 +71,23 @@ let build_base_system_prompt
     ~home_ground:config.base_path
     ()
 
-let max_tokens_fallback ~keeper_name profile_defaults () =
-  match
-    Keeper_types_profile.unified_max_tokens_override_of_oas_env
-      ~keeper_name
-      profile_defaults.oas_env
-  with
-  | Some value -> value
-  | None -> 8192
+(* masc#24067 / oas#2517: no flat int fallback. The only "no explicit
+   override" outcome is [None] — no max_tokens field goes on the request. *)
+let max_tokens_override ~keeper_name profile_defaults =
+  Keeper_types_profile.unified_max_tokens_override_of_oas_env
+    ~keeper_name
+    profile_defaults.oas_env
 
 let resolve_max_tokens_for_runtime_with_profile ~keeper_name ~profile_defaults
-      ?max_tokens ~runtime_id ()
+      ?max_tokens ~runtime_id:_ ()
   =
   match max_tokens with
-  | Some t ->
-    Runtime_inference.cap_max_tokens_to_runtime_ceiling
-      ~runtime_id
-      ~source:"caller_override"
-      t
-  | None ->
-    Runtime_inference.resolve_max_tokens
-      ~runtime_id
-      ~fallback:(max_tokens_fallback ~keeper_name profile_defaults)
+  (* Explicit caller override passes through unchanged; the OAS provider
+     serializer owns validation/clamp against the catalog ceiling
+     (oas#2517). The former [cap_max_tokens_to_runtime_ceiling] here was an
+     identity stub. *)
+  | Some _ as override -> override
+  | None -> max_tokens_override ~keeper_name profile_defaults
 
 let resolve_max_tokens_for_runtime ~keeper_name ~runtime_id ?max_tokens () =
   let profile_defaults =

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -8,7 +8,7 @@ open Keeper_types_profile
 type run_context =
   { meta : keeper_meta
   ; temperature : float
-  ; max_tokens : int
+  ; max_tokens : int option
   ; context_injector : Agent_sdk.Hooks.context_injector
   ; shared_context : Agent_sdk.Context.t
   ; session_dir : string
@@ -41,13 +41,17 @@ val resolve_max_tokens_for_runtime :
   -> runtime_id:string
   -> ?max_tokens:int
   -> unit
-  -> int
-(** Resolve the keeper turn max-token budget for a concrete runtime id.
+  -> int option
+(** Resolve the keeper turn max-token request value for a concrete runtime id.
 
-    [max_tokens] is an explicit caller override and is capped through
-    {!Runtime_inference.cap_max_tokens_to_runtime_ceiling}. When absent, the
-    keeper profile/env fallback is passed through
-    {!Runtime_inference.resolve_max_tokens} for the supplied runtime. *)
+    [Some caller_override] wins when [max_tokens] is an explicit argument
+    and passes through unchanged (the OAS provider serializer owns
+    validation/clamp against the catalog ceiling, oas#2517).
+    Otherwise, an explicit per-keeper profile/env override
+    ([MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS] via
+    {!Keeper_types_profile.unified_max_tokens_override_of_oas_env}) wins.
+    Absent both, the result is [None]: the caller must not synthesize a
+    request value — no [max_tokens] field goes on the request. *)
 
 val prepare_run_context :
      config:Workspace.config

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -43,7 +43,6 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
   | Some (Keeper_turn_driver.Provider_timeout _) -> None
-  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->
     Some
@@ -140,7 +139,6 @@ let runtime_blocker_surface_of_masc_internal_error = function
   | Keeper_turn_driver.Admission_queue_rejected _
   | Keeper_turn_driver.Turn_timeout _
   | Keeper_turn_driver.Provider_timeout _
-  | Keeper_turn_driver.Max_tokens_ceiling_violation _
   | Keeper_turn_driver.Ambiguous_post_commit _
   | Keeper_turn_driver.Internal_unhandled_exception _
   | Keeper_turn_driver.Internal_bridge_exception _

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -300,7 +300,7 @@ type attempt_inference_policy =
   { attempt_temperature : float
   ; attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
-  ; attempt_max_tokens : int
+  ; attempt_max_tokens : int option
   }
 
 let attempt_inference_policy
@@ -349,7 +349,10 @@ let run_named
     ?stream_idle_timeout_s
     ?body_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
-    ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+    (* masc#24067 / oas#2517: no flat-int default. Omitting [?max_tokens]
+       means [None] — no request [max_tokens] field, not a synthesized
+       fallback. *)
+    ?max_tokens
     ?max_tokens_for_runtime
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -117,7 +117,7 @@ val run_named :
   ?body_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_tokens_for_runtime:(runtime_id:string -> int) ->
+  ?max_tokens_for_runtime:(runtime_id:string -> int option) ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
@@ -167,7 +167,7 @@ type attempt_inference_policy =
   { attempt_temperature : float
   ; attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
-  ; attempt_max_tokens : int
+  ; attempt_max_tokens : int option
   }
 
 module For_testing : sig
@@ -243,11 +243,11 @@ module For_testing : sig
     (context_window_rebudget, Agent_sdk.Error.sdk_error) result
 
   val attempt_inference_policy :
-    ?max_tokens_for_runtime:(runtime_id:string -> int) ->
+    ?max_tokens_for_runtime:(runtime_id:string -> int option) ->
     runtime_id:string ->
     fallback_temperature:float ->
     fallback_enable_thinking:bool option ->
-    fallback_max_tokens:int ->
+    fallback_max_tokens:int option ->
     unit ->
     attempt_inference_policy
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -36,7 +36,7 @@ type try_provider_ctx =
   ; execution_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float
-  ; max_tokens : int
+  ; max_tokens : int option
   ; accept : Agent_sdk_response.api_response -> bool
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -19,7 +19,7 @@ type try_provider_ctx =
   ; execution_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float
-  ; max_tokens : int
+  ; max_tokens : int option
   ; accept : Agent_sdk_response.api_response -> bool
   ; guardrails : Agent_sdk.Guardrails.t option
   ; hooks : Agent_sdk.Hooks.hooks option

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -58,7 +58,6 @@ let is_accept_rejected_sdk_error err =
       | Keeper_internal_error.Admission_queue_rejected _
       | Keeper_internal_error.Turn_timeout _
       | Keeper_internal_error.Provider_timeout _
-      | Keeper_internal_error.Max_tokens_ceiling_violation _
       | Keeper_internal_error.Ambiguous_post_commit _
       | Keeper_internal_error.Internal_unhandled_exception _
       | Keeper_internal_error.Internal_bridge_exception _

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -22,7 +22,7 @@ let config_for_label
     ~(model_label : string)
     ~(system_prompt : string)
     ~(tools : Agent_sdk.Tool.t list)
-    ~(max_tokens : int)
+    ~(max_tokens : int option)
     ~(temperature : float)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
@@ -76,7 +76,7 @@ let run_model_by_label
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
-    ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+    ?max_tokens
     ?wait_timeout_sec
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
@@ -181,7 +181,7 @@ let run_named_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ?stream_idle_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
-    ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+    ?max_tokens
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -209,7 +209,7 @@ let run_named_with_masc_tools
   Keeper_turn_driver.run_named ~runtime_id ~goal ~base_path ?priority ~system_prompt ~tools:oas_tools
     ?max_turns
     ~max_idle_turns
-    ~temperature ~max_tokens
+    ~temperature ?max_tokens
     ?stream_idle_timeout_s ?guardrails ?hooks
     ~accept
     ?compact_ratio
@@ -226,7 +226,7 @@ let run_model_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ?stream_idle_timeout_s
     ?(temperature = Runtime_provider_defaults.agent_default_temperature)
-    ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+    ?max_tokens
     ?wait_timeout_sec
     ?guardrails
     ?hooks

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -17,7 +17,7 @@ type runtime_execution = {
   max_context_resolution : Keeper_context_runtime.max_context_resolution;
   max_context : int;
   temperature : float;
-  max_tokens : int;
+  max_tokens : int option;
 }
 
 let next_fail_open_runtime_for_turn =
@@ -75,7 +75,6 @@ let degraded_retry_bypasses_slot_phase_guard
       | Keeper_turn_driver.Admission_queue_timeout _
       | Keeper_turn_driver.Admission_queue_rejected _
       | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
       | Keeper_turn_driver.Ambiguous_post_commit _
       (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
       | Keeper_turn_driver.Internal_unhandled_exception _

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -15,7 +15,7 @@ type runtime_execution = {
   max_context_resolution : max_context_resolution;
   max_context : int;
   temperature : float;
-  max_tokens : int;
+  max_tokens : int option;
 }
 
 val next_fail_open_runtime_for_turn :

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -89,7 +89,6 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
         | Keeper_turn_driver.Accept_rejected _
         | Keeper_turn_driver.Admission_queue_timeout _
         | Keeper_turn_driver.Admission_queue_rejected _
-        | Keeper_turn_driver.Max_tokens_ceiling_violation _
         | Keeper_turn_driver.Ambiguous_post_commit _
         | Keeper_turn_driver.Internal_unhandled_exception _
         | Keeper_turn_driver.Internal_bridge_exception _

--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -17,6 +17,10 @@ let oas_env_key_prefix = "keeper.oas_env."
 
 let keeper_unified_max_tokens_oas_env_key = "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS"
 
+let keeper_unified_max_tokens_toml_key =
+  oas_env_key_prefix ^ keeper_unified_max_tokens_oas_env_key
+;;
+
 let oas_env_key_is_allowed suffix =
   String.starts_with suffix ~prefix:"MASC_KEEPER_OAS_"
   || (String.starts_with suffix ~prefix:"OAS_"
@@ -74,28 +78,52 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
     doc
 ;;
 
-let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
+let validate_unified_max_tokens_toml_value doc =
+  match List.assoc_opt keeper_unified_max_tokens_toml_key doc with
+  | None -> Ok ()
+  | Some (Keeper_toml_loader.Toml_int value) when value > 0 -> Ok ()
+  | Some _ ->
+    Error
+      (Printf.sprintf
+         "%s must be a positive integer TOML value"
+         keeper_unified_max_tokens_toml_key)
+;;
+
+let parse_unified_max_tokens_override_of_oas_env pairs =
   let key = keeper_unified_max_tokens_oas_env_key in
   let raw_opt = List.assoc_opt key pairs in
   match raw_opt with
-  | None -> None
+  | None -> Ok None
   | Some raw ->
     let trimmed = String.trim raw in
     (match int_of_string_opt trimmed with
-     | Some value ->
-       let min_v = 256 in
-       let max_v = 262_144 in
-       Some (max min_v (min max_v value))
+     | Some value when value > 0 -> Ok (Some value)
+     | Some _ ->
+       Error
+         (Printf.sprintf
+            "keeper.oas_env.%s must be a positive integer, got %S"
+            key
+            raw)
      | None ->
+       Error
+         (Printf.sprintf
+            "keeper.oas_env.%s must be a positive integer, got %S"
+            key
+            raw))
+;;
+
+let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
+  match parse_unified_max_tokens_override_of_oas_env pairs with
+  | Ok value -> value
+  | Error detail ->
        let keeper =
          match keeper_name with
          | Some name -> name
          | None -> "(unknown)"
        in
        Log.Keeper.warn
-         "keeper.oas_env: ignoring invalid %s=%S for keeper=%s; expected integer"
-         key
-         raw
-         keeper;
-       None)
+         "keeper.oas_env: invalid max_tokens override for keeper=%s: %s"
+         keeper
+         detail;
+       None
 ;;

--- a/lib/keeper/keeper_types_profile_oas_env.mli
+++ b/lib/keeper/keeper_types_profile_oas_env.mli
@@ -3,8 +3,17 @@
 val string_of_toml_value_for_env : Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc : Keeper_toml_loader.toml_doc -> (string * string) list
+
+val validate_unified_max_tokens_toml_value
+  :  Keeper_toml_loader.toml_doc
+  -> (unit, string) result
+
+val parse_unified_max_tokens_override_of_oas_env
+  :  (string * string) list
+  -> (int option, string) result
 
 val unified_max_tokens_override_of_oas_env
   :  ?keeper_name:string

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -13,6 +13,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let strs key = Keeper_toml_loader.toml_string_list doc (k key) in
   let has key = List.mem_assoc (k key) doc in
   let has_raw key = List.mem_assoc key doc in
+  let oas_env = extract_oas_env_from_doc doc in
   let tool_access_defaults_result =
     let key = k "tool_access" in
     if has_raw key then
@@ -130,6 +131,15 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in
+  let result =
+    Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
+  in
+  let result =
+    Result.bind result (fun () ->
+      Result.map
+        (fun _ -> ())
+        (parse_unified_max_tokens_override_of_oas_env oas_env))
+  in
   Result.map
     (fun tool_access ->
       {
@@ -168,7 +178,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         per_provider_timeout_state;
         per_provider_timeout;
         always_approve = bool_ "always_approve";
-        oas_env = extract_oas_env_from_doc doc;
+        oas_env;
         unknown_toml_keys = [];
       })
     result

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -217,7 +217,7 @@ let run (ctx : ctx)
                  ~runtime_rotation_attempts:
                    (List.rev turn_state.runtime_rotation_attempts)
                  ~temperature:execution.temperature
-                 ~max_tokens:execution.max_tokens
+                 ?max_tokens:execution.max_tokens
                  ~oas_timeout_s
                  ~oas_timeout_is_explicit:false
                  ~trajectory_acc

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -9,18 +9,19 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_runtime
 
-let resolve_unified_max_tokens_fallback
+(* masc#24067 / oas#2517: the keeper lane must not synthesize a request
+   [max_tokens] value. The only override source is the explicit per-keeper
+   env/profile knob; absent that, [None] — no [max_tokens] field goes on the
+   request. *)
+let resolve_unified_max_tokens_override
       ~(meta_name : string)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ()
+  : int option
   =
-  match
-    Keeper_types_profile.unified_max_tokens_override_of_oas_env
-      ~keeper_name:meta_name
-      profile_defaults.oas_env
-  with
-  | Some value -> value
-  | None -> Keeper_config.keeper_unified_max_tokens ()
+  Keeper_types_profile.unified_max_tokens_override_of_oas_env
+    ~keeper_name:meta_name
+    profile_defaults.oas_env
 
 let build_runtime_execution
       ~(meta : keeper_meta)
@@ -76,36 +77,15 @@ let build_runtime_execution
            ~fallback:Keeper_config.keeper_unified_temperature
        in
        let raw_max_tokens =
-         Runtime_inference.resolve_max_tokens
-           ~runtime_id
-           ~fallback:
-             (resolve_unified_max_tokens_fallback
-                ~meta_name:meta.name
-                ~profile_defaults)
+         resolve_unified_max_tokens_override
+           ~meta_name:meta.name
+           ~profile_defaults
+           ()
        in
-       let max_output_ceiling =
-         None
-       in
-       (match
-         Runtime_inference.validate_max_tokens_within_ceiling
-           ~runtime_id
-            ~provider_ceiling:max_output_ceiling
-            raw_max_tokens
-        with
-        | Error err ->
-          let detail =
-            Option.value
-              ~default:(Keeper_internal_error.kind_of_masc_internal_error err)
-              (Keeper_internal_error.summary_of_masc_internal_error err)
-          in
-          log_pre_dispatch_error ~site:"validate_max_tokens_within_ceiling" detail;
-          Error
-            (Keeper_internal_error.sdk_error_of_masc_internal_error err)
-        | Ok max_tokens ->
-          Ok
-            { Keeper_turn_runtime_budget.runtime_id
-            ; max_context_resolution
-            ; max_context
-            ; temperature
-            ; max_tokens
-            }))
+       Ok
+         { Keeper_turn_runtime_budget.runtime_id
+         ; max_context_resolution
+         ; max_context
+         ; temperature
+         ; max_tokens = raw_max_tokens
+         })

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -3,14 +3,17 @@
 
     Owns the runtime-execution builder: runtime-name → keeper-meta
     projection, model-label resolution, API-key + local-discovery
-    readiness checks, context budget resolution, temperature/max-tokens
-    inference, and ceiling validation. Returns a
+    readiness checks, context budget resolution, temperature inference,
+    max-tokens override resolution, and OAS-owned validation handoff. Returns a
     [Keeper_turn_runtime_budget.runtime_execution] record on success,
     or a typed [Agent_sdk.Error.sdk_error] on the first failed check.
 
-    The unified-max-tokens fallback is internal to this module — its
+    The unified-max-tokens override lookup is internal to this module — its
     behavior depends only on [meta_name] + [profile_defaults], so the
-    caller does not need to thread a callback through. *)
+    caller does not need to thread a callback through. Per masc#24067 /
+    oas#2517 there is no flat-int fallback: absent an explicit per-keeper
+    override, [runtime_execution.max_tokens] is [None] and no [max_tokens]
+    field goes on the request. *)
 
 val build_runtime_execution
   :  meta:Keeper_meta_contract.keeper_meta
@@ -25,8 +28,7 @@ val build_runtime_execution
     Failure modes (returned as [Error]):
     - [Keeper_types_support.ensure_api_keys_for_labels] missing required keys.
     - [ensure_local_discovery_ready] local-runtime discovery fail.
-    - [validate_max_tokens_within_ceiling] raw_max_tokens exceeds the
-      provider's [Runtime_runtime.max_output_tokens_ceiling].
 
-    The function is total over its three failure modes plus the [Ok]
+    OAS alone owns provider/model ceiling validation and envelope-specific
+    clamping. The function is total over its two failure modes plus the [Ok]
     case; no exceptions cross the boundary. *)

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -161,7 +161,6 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
       | Keeper_internal_error.Admission_queue_rejected _
       | Keeper_internal_error.Turn_timeout _
       | Keeper_internal_error.Provider_timeout _
-      | Keeper_internal_error.Max_tokens_ceiling_violation _
       | Keeper_internal_error.Ambiguous_post_commit _
       (* RFC-0159 Phase A: typed [Internal_*] variants are not
          runtime-exhaustion reasons; they map to opaque

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -314,12 +314,6 @@ type masc_internal_error =
       min_required_sec : float;
       phase : string;
     }
-  | Max_tokens_ceiling_violation of {
-      runtime_id : string;
-      requested_max_tokens : int;
-      provider_ceiling : int;
-      reason : string;
-    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;
@@ -590,17 +584,6 @@ let masc_internal_error_to_json = function
         ("min_required_sec", `Float min_required_sec);
         ("phase", `String phase);
       ]
-  | Max_tokens_ceiling_violation
-      { runtime_id; requested_max_tokens; provider_ceiling; reason } ->
-    let runtime_id = runtime_id_to_string runtime_id in
-    `Assoc
-      [
-        ("kind", `String "max_tokens_ceiling_violation");
-        ("runtime_id", `String runtime_id);
-        ("requested_max_tokens", `Int requested_max_tokens);
-        ("provider_ceiling", `Int provider_ceiling);
-        ("reason", `String reason);
-      ]
   | Ambiguous_post_commit { is_timeout; tools; original_error } ->
     `Assoc
       [
@@ -738,15 +721,6 @@ let summary_of_masc_internal_error = function
            "Provider timeout exhausted; phase=%s; source=%s; budget=%.1fs; remaining=%s; min_required=%.1fs; estimated_input_tokens=%d; keeper_turn_timeout=%.1fs"
            phase source budget_sec remaining min_required_sec
            estimated_input_tokens keeper_turn_timeout_sec)
-  | Max_tokens_ceiling_violation
-      { runtime_id; requested_max_tokens; provider_ceiling; reason } ->
-    Some
-      (Printf.sprintf
-         "Invalid max_tokens budget for runtime %s; requested_max_tokens=%d; provider_ceiling=%d; reason=%s"
-         (runtime_id_to_string runtime_id)
-         requested_max_tokens
-         provider_ceiling
-         reason)
   | Accept_rejected
       {
         scope;
@@ -856,7 +830,6 @@ let kind_of_masc_internal_error = function
   | Admission_queue_rejected _ -> "admission_queue_rejected"
   | Turn_timeout _ -> "turn_timeout"
   | Provider_timeout _ -> "provider_timeout"
-  | Max_tokens_ceiling_violation _ -> "max_tokens_ceiling_violation"
   | Ambiguous_post_commit _ -> "ambiguous_post_commit"
   | Internal_unhandled_exception _ -> "internal_unhandled_exception"
   | Internal_bridge_exception _ -> "internal_bridge_exception"
@@ -866,8 +839,7 @@ let runtime_id_of_masc_internal_error = function
   | Runtime_exhausted { runtime_id; _ }
   | Capacity_backpressure { runtime_id; _ }
   | Resumable_cli_session { runtime_id; _ }
-  | Admission_queue_timeout { runtime_id; _ }
-  | Max_tokens_ceiling_violation { runtime_id; _ } ->
+  | Admission_queue_timeout { runtime_id; _ } ->
       let runtime_id = runtime_id_to_string runtime_id in
       if String.equal (String.trim runtime_id) "" then "unknown"
       else runtime_id
@@ -938,7 +910,6 @@ let accept_no_progress_retry_kind = function
   | Admission_queue_rejected _
   | Turn_timeout _
   | Provider_timeout _
-  | Max_tokens_ceiling_violation _
   | Ambiguous_post_commit _
   | Internal_unhandled_exception _
   | Internal_bridge_exception _
@@ -1143,24 +1114,6 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                              (string_opt_of_assoc "phase" json);
                        })
               | _ -> None)
-          | _ -> None)
-      | Some (`String "max_tokens_ceiling_violation") -> (
-          match
-            string_opt_of_assoc "runtime_id" json,
-            int_opt_of_assoc "requested_max_tokens" json,
-            int_opt_of_assoc "provider_ceiling" json
-          with
-          | Some runtime_id, Some requested_max_tokens, Some provider_ceiling ->
-            Some
-              (Max_tokens_ceiling_violation
-                 {
-                   runtime_id;
-                   requested_max_tokens;
-                   provider_ceiling;
-                   reason =
-                     Option.value ~default:"unknown"
-                       (string_opt_of_assoc "reason" json);
-                 })
           | _ -> None)
       | Some (`String "ambiguous_post_commit") -> (
           match string_opt_of_assoc "original_error" json with

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -147,12 +147,6 @@ type masc_internal_error =
       min_required_sec : float;
       phase : string;
     }
-  | Max_tokens_ceiling_violation of {
-      runtime_id : string;
-      requested_max_tokens : int;
-      provider_ceiling : int;
-      reason : string;
-    }
   | Ambiguous_post_commit of {
       is_timeout : bool;
       tools : string list;

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -95,7 +95,6 @@ let route_of_masc_internal ~err (internal : Keeper_internal_error.masc_internal_
      | Some `Read_only_no_progress -> rotate No_progress_read_only
      | Some `Thinking_only_no_progress -> rotate No_progress_thinking_only
      | None -> judge ~err Contract_violation)
-  | Keeper_internal_error.Max_tokens_ceiling_violation _ -> judge ~err Contract_violation
   | Keeper_internal_error.Internal_contract_rejected _ -> judge ~err Contract_violation
   | Keeper_internal_error.Ambiguous_post_commit _ -> judge ~err Mutating_ambiguity
   | Keeper_internal_error.Internal_unhandled_exception _

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1207,9 +1207,9 @@ let max_context_of_runtime_id (id : string) : int option =
    [None] when the runtime is unknown or the catalog row leaves it unset.
    Mirrors [max_context_of_runtime_id] but projects the OAS-typed capability
    rather than the runtime.toml [model] record, because max output is owned by
-   the provider/model catalog, not the per-binding runtime config. Consumed by
-   [Runtime_inference.resolve_max_tokens] to size reasoning turns from the
-   model's own ceiling. *)
+   the provider/model catalog, not the per-binding runtime config. This is an
+   observable capability ceiling only. OAS owns request validation and clamp
+   policy; MASC never turns this value into a request default. *)
 let max_output_tokens_of_runtime_id (id : string) : int option =
   match get_runtime_by_id id with
   | Some rt ->

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -315,9 +315,9 @@ val max_context_of_runtime_id : string -> int option
 val max_output_tokens_of_runtime_id : string -> int option
 (** Declared max output tokens (OAS capability catalog) for the model bound to
     runtime [id], or [None] when the id is not configured or the catalog leaves
-    it unset.  Consumed by {!Runtime_inference.resolve_max_tokens} to size a
-    reasoning turn from the model's own output ceiling rather than the flat
-    fallback. *)
+    it unset. This is an observable capability ceiling only; OAS owns request
+    validation and clamp policy, and MASC never turns it into a request
+    default. *)
 
 val thinking_support_of_runtime_id : string -> bool option
 (** [thinking-support] capability of the model bound to runtime [id], or [None]

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -270,20 +270,6 @@ let supports_tool_choice_override_of_model_spec (spec : Runtime_schema.model_spe
   | None -> None
 ;;
 
-let max_output_tokens_of_model_spec (spec : Runtime_schema.model_spec) =
-  match spec.capabilities with
-  | Some capabilities -> capabilities.max_output_tokens
-  | None -> None
-;;
-
-let effective_max_tokens_for_model spec requested =
-  match requested, max_output_tokens_of_model_spec spec with
-  | Some configured, Some capability -> Some (min configured capability)
-  | Some configured, None -> Some configured
-  | None, Some capability -> Some capability
-  | None, None -> None
-;;
-
 (* --- provider × model spec → Provider_config.t ---
 
    v1 drops the [Provider_tool_support.runtime_capabilities_override] that the
@@ -291,10 +277,9 @@ let effective_max_tokens_for_model spec requested =
    now-removed alias layer); [binding_to_provider_config] never consumed it. *)
 let provider_config_from_declared_provider ?keep_alive ?num_ctx
     (provider : Runtime_schema.provider) (spec : Runtime_schema.model_spec)
-    ~(max_tokens : int option) : (Llm_provider.Provider_config.t, string) result =
+    : (Llm_provider.Provider_config.t, string) result =
   let registry_entry = find_registry_entry provider.id in
   let supports_tool_choice_override = supports_tool_choice_override_of_model_spec spec in
-  let max_tokens = effective_max_tokens_for_model spec max_tokens in
   match provider.transport with
   | Http base_url ->
     let base_url = Masc_network_defaults.normalize_loopback_base_url base_url in
@@ -331,7 +316,6 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~request_path
             ?max_context:spec.max_context
             ?supports_tool_choice_override
-            ?max_tokens
             ?top_p:spec.top_p
             ?top_k:spec.top_k
             ?min_p:spec.min_p
@@ -352,7 +336,6 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ~headers:(Option.value ~default:[] provider.headers)
             ?max_context:spec.max_context
             ?supports_tool_choice_override
-            ?max_tokens
             ?top_p:spec.top_p
             ?top_k:spec.top_k
             ?min_p:spec.min_p
@@ -373,16 +356,6 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
   match Runtime_schema.model_of_id cfg binding.model_id with
   | None -> Error (Printf.sprintf "model not found: %s" binding.model_id)
   | Some spec ->
-    let max_tokens =
-      (* Priced bindings historically sized [max_tokens] from the declared
-         [max-context] override. With the override now optional, an absent
-         override yields [None] and OAS resolves the output ceiling from its
-         capability catalog ([effective_max_output_tokens]) instead of
-         inheriting the input window. *)
-      match binding.price_input, binding.price_output with
-      | Some input_cost, Some _ when input_cost > 0.0 -> spec.max_context
-      | _ -> None
-    in
     (match Runtime_schema.provider_of_id cfg binding.provider_id with
      | None -> Error (Printf.sprintf "provider not found: %s" binding.provider_id)
      | Some provider ->
@@ -395,6 +368,5 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
          ?keep_alive:binding.keep_alive
          ?num_ctx:binding.num_ctx
          provider
-         spec
-         ~max_tokens)
+         spec)
 ;;

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -83,7 +83,7 @@ type config =
   stream_idle_timeout_s : float option;
   max_execution_time_s : float option;
   body_timeout_s : float option;
-  max_tokens : int;
+  max_tokens : int option;
   temperature : float;
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;
@@ -920,12 +920,15 @@ let provider_lifecycle_attrs (config : config) =
     ("provider_kind", `String provider_kind);
     ("model_id", `String config.model_id);
     ("provider_model_id", `String provider_cfg.model_id);
-    ("max_tokens", `Int config.max_tokens);
-
   ]
+  @ Runtime_max_tokens.telemetry_fields config.max_tokens
   @ nonempty_string "base_url" provider_cfg.base_url
   @ nonempty_string "request_path" provider_cfg.request_path
   @ endpoint
+
+module Lifecycle_for_testing = struct
+  let provider_attrs = provider_lifecycle_attrs
+end
 
 (* ================================================================ *)
 (* Internal: checkpoint persistence                                  *)
@@ -1161,11 +1164,9 @@ let run_blocks
   | t ->
     Log.Misc.info "oas_worker %s: transport=%s"
       config.name (Masc_grpc_transport.to_string t));
-  Option.iter (fun bus ->
-    publish_lifecycle bus ~name:config.name ~event:"build" ~detail:goal_detail
-      ~attrs:(provider_lifecycle_attrs config)
-      ()
-  ) config.event_bus;
+  publish_lifecycle ~name:config.name ~event:"build" ~detail:goal_detail
+    ~attrs:(provider_lifecycle_attrs config)
+    ();
   let agent_result = match oas_checkpoint with
     | Some checkpoint ->
       (try resume_from_checkpoint ~sw ~net ~config ~checkpoint
@@ -1179,15 +1180,13 @@ let run_blocks
   in
   match agent_result with
   | Error e ->
-    Option.iter (fun bus ->
-      publish_lifecycle bus ~name:config.name ~event:"build_error"
-        ~detail:(Agent_sdk.Error.to_string e)
-        ~error:(Agent_sdk.Error.to_string e)
-        ~status:"build_error"
-        ~session_id
-        ~attrs:(provider_lifecycle_attrs config)
-        ()
-    ) config.event_bus;
+    publish_lifecycle ~name:config.name ~event:"build_error"
+      ~detail:(Agent_sdk.Error.to_string e)
+      ~error:(Agent_sdk.Error.to_string e)
+      ~status:"build_error"
+      ~session_id
+      ~attrs:(provider_lifecycle_attrs config)
+      ();
     Error e
   | Ok agent ->
   (match agent_ref with Some r -> r := Some agent | None -> ());
@@ -1235,16 +1234,14 @@ let run_blocks
        | None -> ());
       Some ckpt
     in
-    Option.iter (fun bus ->
-      let lifecycle = worker_lifecycle_classification_of_result result in
-      publish_lifecycle bus ~name:config.name ~event:lifecycle.event
-        ~detail:(Printf.sprintf "session=%s" session_id)
-        ?error:lifecycle.error
-        ~session_id
-        ~status:lifecycle.status
-        ~attrs:(provider_lifecycle_attrs config)
-        ()
-    ) config.event_bus;
+    let lifecycle = worker_lifecycle_classification_of_result result in
+    publish_lifecycle ~name:config.name ~event:lifecycle.event
+      ~detail:(Printf.sprintf "session=%s" session_id)
+      ?error:lifecycle.error
+      ~session_id
+      ~status:lifecycle.status
+      ~attrs:(provider_lifecycle_attrs config)
+      ();
     let turns = (Agent_sdk.Agent.state agent).turn_count in
     let trace_ref = Agent_sdk.Agent.last_raw_trace_run agent in
     let close_after_success () =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -67,7 +67,7 @@ type config = Runtime_agent_context.config = {
   stream_idle_timeout_s : float option;
   max_execution_time_s : float option;
   body_timeout_s : float option;
-  max_tokens : int;
+  max_tokens : int option;
   temperature : float;
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;
@@ -404,8 +404,11 @@ end
 
 (** {1 Lifecycle / checkpoint helpers (re-exported)} *)
 
+module Lifecycle_for_testing : sig
+  val provider_attrs : config -> (string * Yojson.Safe.t) list
+end
+
 val publish_lifecycle :
-  Agent_sdk.Event_bus.t ->
   name:string ->
   event:string ->
   detail:string ->

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -56,7 +56,13 @@ type config =
         streams are not killed by total duration; streaming liveness is
         owned by [stream_idle_timeout_s] plus attempt observation. Non-HTTP
         transports ignore it. *)
-  ; max_tokens : int
+  ; max_tokens : int option
+    (** Request-time output token budget. [None] means no [max_tokens] field
+        goes on the request at all — the keeper lane's default (masc#24067 /
+        oas#2517): the OAS capability catalog ceiling is a validation bound,
+        never a synthesized request value. [Some n] is an explicit
+        operator/profile override or a non-keeper caller's deliberate
+        request budget. *)
   ; temperature : float
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
@@ -158,7 +164,7 @@ let default_config
   ; stream_idle_timeout_s = None
   ; max_execution_time_s = None
   ; body_timeout_s = None
-  ; max_tokens = Runtime_provider_defaults.agent_default_max_tokens
+  ; max_tokens = None
   ; temperature = Runtime_provider_defaults.agent_default_temperature
   ; hooks = None
   ; context_reducer = None
@@ -227,7 +233,6 @@ let builder_without_approval
     Agent_sdk.Builder.create ~net ~model:config.model_id
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt config.system_prompt
-    |> Agent_sdk.Builder.with_max_tokens config.max_tokens
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
     |> Agent_sdk.Builder.with_temperature config.temperature
@@ -236,6 +241,14 @@ let builder_without_approval
     |> Agent_sdk.Builder.with_guardrails guardrails
     |> Agent_sdk.Builder.with_missing_approval_callback_policy
          Agent_sdk.Hooks.Reject_without_callback
+  in
+  let builder =
+    (* masc#24067 / oas#2517: [None] means the request carries no
+       [max_tokens] field at all — [Builder.with_max_tokens] is simply not
+       called, rather than filling in a synthesized default. *)
+    match config.max_tokens with
+    | Some max_tokens -> Agent_sdk.Builder.with_max_tokens max_tokens builder
+    | None -> builder
   in
   let builder =
     match config.stream_idle_timeout_s with
@@ -458,7 +471,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
       name = config.name
     ; model = config.model_id
     ; system_prompt = Some config.system_prompt
-    ; max_tokens = Some config.max_tokens
+    ; max_tokens = config.max_tokens
     ; max_turns = max_turns_for_resume
     ; temperature = Some config.temperature
     ; top_p = config.top_p

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -53,7 +53,13 @@ type config = {
           streams are not killed by total duration; streaming liveness is
           owned by [stream_idle_timeout_s] and the attempt liveness
           observer. Non-HTTP transports ignore it. *)
-  max_tokens : int;
+  max_tokens : int option;
+      (** Request-time output token budget. [None] means no [max_tokens]
+          field goes on the request at all — the keeper lane's default
+          (masc#24067 / oas#2517): the OAS capability catalog ceiling is a
+          validation bound, never a synthesized request value. [Some n] is
+          an explicit operator/profile override or a non-keeper caller's
+          deliberate request budget. *)
   temperature : float;
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -6,7 +6,7 @@
    summary policy).
 
    Completes the previously stubbed per-runtime [resolve_temperature] (the
-   [~runtime_id:_] passthrough), symmetric to [resolve_max_tokens]. Required for
+   [~runtime_id:_] passthrough). Required for
    a model that rejects the fleet default value: Kimi K2.7 (kimi-for-coding)
    accepts only temperature = 1.0 and rejects any other at request time
    ("only 1 is allowed for this model"). *)
@@ -15,52 +15,11 @@ let resolve_temperature ~runtime_id ~fallback =
   | Some temperature -> temperature
   | None -> fallback ()
 
-(* Upper bound on a reasoning turn's [max_tokens]. A reasoning model spends part
-   of one response on thinking before emitting the answer; both share the single
-   [max_tokens] budget. The flat keeper fallback (8192) is too small for that
-   combined budget, so thinking alone can exhaust it and the turn truncates
-   mid-thinking (stop_reason=max_tokens, content=[thinking]) with no visible
-   reply. Live fleet trace (2026-06-30, 111 trajectories): 73
-   thinking_only+max_tokens rejections, 60% on runpod_mtp.
-
-   This is a TOTAL-budget bump, not a [thinking.budget_tokens]-style sub-budget
-   reservation: the answer is not carved out of a thinking allotment, the whole
-   turn simply gets more room. 32768 = 4x the 8192 keeper fallback, enough for
-   the observed thinking lengths plus an answer, while bounding a runaway
-   reasoning loop well below provider ceilings (e.g. deepseek 384000).
-
-   This constant is ONLY an upper bound applied on top of a model's declared
-   OAS ceiling; it is never the request value on its own (see [resolve_max_tokens]). *)
-let reasoning_turn_max_tokens = 32_768
-
-(* A reasoning runtime sizes its turn from the model's own declared output
-   ceiling (OAS capability catalog [max_output_tokens], the value SSOT, read via
-   [Runtime.max_output_tokens_of_runtime_id]), bounded above by
-   [reasoning_turn_max_tokens]. A model whose declared ceiling is below the bound
-   keeps its smaller ceiling so the request never exceeds what the provider
-   accepts (the OAS backend would otherwise clamp and warn).
-
-   When the catalog projects NO ceiling for the runtime, fall back to the
-   caller's flat budget rather than inventing [reasoning_turn_max_tokens] as the
-   request value: with no provider ceiling known, requesting 32768 could exceed
-   what the provider accepts and turn a thinking truncation into a max_tokens
-   rejection. The budget increase is gated on an OAS-declared ceiling, so the
-   value's source stays the model catalog (SSOT). Non-reasoning runtimes keep the
-   caller's flat [fallback] unchanged.
-
-   Completes the previously stubbed per-runtime [resolve_max_tokens] (the
-   [~runtime_id:_] passthrough). Raising a specific reasoning model toward the
-   bound is a catalog change (declare a higher [max_output_tokens]); the value
-   lives in the model catalog, not here. *)
-let resolve_max_tokens ~runtime_id ~fallback =
-  match Runtime.thinking_support_of_runtime_id runtime_id with
-  | Some true ->
-    (match Runtime.max_output_tokens_of_runtime_id runtime_id with
-     | Some ceiling -> min ceiling reasoning_turn_max_tokens
-     | None -> fallback ())
-  | Some false | None -> fallback ()
-
-let cap_max_tokens_to_runtime_ceiling ~runtime_id:_ ~source:_ value = value
+(* masc#24067 / oas#2517: MASC must not synthesize a request [max_tokens]
+   value. The former resolver invented one from either a model capability
+   ceiling or a flat fallback. Callers now carry explicit intent as [int
+   option], and OAS alone owns model-capability validation plus
+   envelope-specific clamp/fallback policy. *)
 
 type seed = {
   thinking_budget : int option;
@@ -95,16 +54,3 @@ let for_runtime ~name =
     ~preserve_thinking:(Runtime.preserve_thinking_of_runtime_id name)
     (Runtime.thinking_support_of_runtime_id name)
 ;;
-
-let validate_max_tokens_within_ceiling ~runtime_id ~provider_ceiling value =
-  match provider_ceiling with
-  | None -> Ok value
-  | Some ceiling when value <= ceiling -> Ok value
-  | Some provider_ceiling ->
-    Error
-      (Keeper_internal_error.Max_tokens_ceiling_violation
-         { runtime_id
-         ; requested_max_tokens = value
-         ; provider_ceiling
-         ; reason = "requested max_tokens exceeds provider ceiling"
-         })

--- a/lib/runtime/runtime_inference.mli
+++ b/lib/runtime/runtime_inference.mli
@@ -3,12 +3,6 @@ val resolve_temperature :
 (** Use the runtime.toml model override when present; evaluate [fallback] only
     when that runtime has no temperature override. *)
 
-val resolve_max_tokens :
-  runtime_id:string -> fallback:(unit -> int) -> int
-
-val cap_max_tokens_to_runtime_ceiling :
-  runtime_id:string -> source:string -> int -> int
-
 type seed = {
   thinking_budget : int option;
   thinking_enabled : bool option;
@@ -28,9 +22,3 @@ val for_runtime : name:string -> seed
     [thinking-support], explicit [preserve-thinking], and OAS typed
     preserve-thinking capability of the bound model.  See
     {!seed_of_thinking_support} for the gate semantics. *)
-
-val validate_max_tokens_within_ceiling :
-  runtime_id:string ->
-  provider_ceiling:int option ->
-  int ->
-  (int, Keeper_internal_error.masc_internal_error) result

--- a/lib/runtime/runtime_max_tokens.ml
+++ b/lib/runtime/runtime_max_tokens.ml
@@ -1,0 +1,19 @@
+type source =
+  | Omitted
+  | Explicit_override
+
+let source_of_value = function
+  | None -> Omitted
+  | Some _ -> Explicit_override
+;;
+
+let source_to_string = function
+  | Omitted -> "omitted"
+  | Explicit_override -> "explicit_override"
+;;
+
+let telemetry_fields value =
+  [ "max_tokens", Json_util.int_opt_to_json value
+  ; "max_tokens_source", `String (source_of_value value |> source_to_string)
+  ]
+;;

--- a/lib/runtime/runtime_max_tokens.mli
+++ b/lib/runtime/runtime_max_tokens.mli
@@ -1,0 +1,13 @@
+(** Request-time output-token intent at the MASC -> OAS boundary. *)
+
+type source =
+  | Omitted
+  | Explicit_override
+
+val source_of_value : int option -> source
+val source_to_string : source -> string
+
+val telemetry_fields : int option -> (string * Yojson.Safe.t) list
+(** Stable observability projection. [None] is [omitted], not
+    [provider_default]: optional envelopes omit the field, while required
+    envelopes may apply an OAS-owned catalog fallback. *)

--- a/lib/runtime/runtime_oas_checkpoint.ml
+++ b/lib/runtime/runtime_oas_checkpoint.ml
@@ -3,16 +3,21 @@
     Keeps side-effecting run helpers separate from the main build/resume/run
     orchestration in {!Runtime_agent}. *)
 
-let publish_lifecycle _bus ~name ~event ~detail ?error ?session_id ?status
+let missing_masc_bus_warned = Atomic.make false
+
+let publish_lifecycle ~name ~event ~detail ?error ?session_id ?status
     ?(attrs = []) () =
   match Masc_event_bus.get () with
-  | None -> ()
-  | Some _mb ->
+  | None ->
+      if Atomic.compare_and_set missing_masc_bus_warned false true then
+        Log.Misc.warn
+          "runtime lifecycle event was not published: MASC event bus is not initialized"
+  | Some mb ->
       let optional_string_field key = function
         | Some value when String.trim value <> "" -> [ (key, `String value) ]
         | _ -> []
       in
-      ignore
+      Agent_sdk.Event_bus.publish mb
         (Agent_sdk.Event_bus.mk_event
            (Custom
               ( Printf.sprintf "masc.oas_worker.%s" event

--- a/lib/runtime/runtime_oas_checkpoint.mli
+++ b/lib/runtime/runtime_oas_checkpoint.mli
@@ -11,7 +11,6 @@
     instead of at every call site in {!Runtime_agent}. *)
 
 val publish_lifecycle :
-  Agent_sdk.Event_bus.t ->
   name:string ->
   event:string ->
   detail:string ->
@@ -22,12 +21,8 @@ val publish_lifecycle :
   unit ->
   unit
 (** Publish a [Custom "masc.oas_worker.<event>"] event on the
-    process-wide [Masc_event_bus]. The first argument is
-    accepted but **ignored** — the function looks up the bus via
-    [Masc_event_bus.get ()] internally; the parameter is kept
-    for backwards-compatibility with callers that already thread
-    the bus through, and for symmetry with sibling lifecycle
-    publishers that do consume their bus argument.
+    process-wide [Masc_event_bus]. Missing bootstrap state is surfaced by a
+    one-shot warning instead of silently dropping every lifecycle event.
 
     Optional [error] / [session_id] / [status] fields are
     included in the payload only when [Some] and non-empty

--- a/lib/runtime_model/runtime_model_string.ml
+++ b/lib/runtime_model/runtime_model_string.ml
@@ -21,7 +21,7 @@ let split_provider_model = Runtime_model_id_split.split_provider_model
 (** Build a config for ["custom:model@url"] specs. *)
 let make_custom_config
   ~temperature
-  ~max_tokens
+  ?max_tokens
   ?system_prompt
   ?supports_tool_choice_override
   ?keep_alive
@@ -42,7 +42,7 @@ let make_custom_config
               ~base_url
               ~request_path:Masc_network_defaults.openai_chat_completions_path)
          ~temperature
-         ~max_tokens
+         ?max_tokens
          ?system_prompt
          ?supports_tool_choice_override
          ?keep_alive
@@ -73,7 +73,7 @@ let resolve_effective_api_key_env
 (** Build a {!Llm_provider.Provider_config.t} from a resolved registry entry. *)
 let make_registry_config
   ~temperature
-  ~max_tokens
+  ?max_tokens
   ?system_prompt
   ?(api_key_env_overrides = [])
   ?supports_tool_choice_override
@@ -147,7 +147,7 @@ let make_registry_config
     ~headers
     ~request_path
     ~temperature
-    ~max_tokens
+    ?max_tokens
     ~max_context
     ?system_prompt
     ?supports_tool_choice_override
@@ -163,7 +163,7 @@ let make_registry_config
     never flattened to [OpenAI_compat]. *)
 let parse_model_string
   ?(temperature = Runtime_provider_defaults.agent_default_temperature)
-  ?(max_tokens = Runtime_provider_defaults.agent_default_max_tokens)
+  ?max_tokens
   ?system_prompt
   ?(api_key_env_overrides = [])
   ?supports_tool_choice_override
@@ -177,7 +177,7 @@ let parse_model_string
   | Some ("custom", model_id) ->
     make_custom_config
       ~temperature
-      ~max_tokens
+      ?max_tokens
       ?system_prompt
       ?supports_tool_choice_override
       ?keep_alive
@@ -198,7 +198,7 @@ let parse_model_string
             Some
               (make_registry_config
                  ~temperature
-                 ~max_tokens
+                 ?max_tokens
                  ?system_prompt
                  ~api_key_env_overrides
                  ?supports_tool_choice_override

--- a/lib/runtime_model/runtime_provider_defaults.ml
+++ b/lib/runtime_model/runtime_provider_defaults.ml
@@ -4,10 +4,6 @@ let agent_default_temperature =
   Llm_provider.Constants.Inference_profile.agent_default.temperature
 ;;
 
-let agent_default_max_tokens =
-  Llm_provider.Constants.Inference_profile.agent_default.max_tokens
-;;
-
 let worker_default_temperature =
   Llm_provider.Constants.Inference_profile.worker_default.temperature
 ;;

--- a/lib/runtime_model/runtime_provider_defaults.mli
+++ b/lib/runtime_model/runtime_provider_defaults.mli
@@ -6,8 +6,6 @@
 
 val agent_default_temperature : float
 
-val agent_default_max_tokens : int
-
 val worker_default_temperature : float
 
 val deterministic_temperature : float

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1340,6 +1340,26 @@ MASC_KEEPER_UNIFIED_MAX_TOKENS = 4096
         None
         (KTP.unified_max_tokens_override_of_oas_env d.oas_env)
 
+let test_oas_env_rejects_invalid_unified_max_tokens () =
+  List.iter
+    (fun raw ->
+      let input =
+        Printf.sprintf
+          "[keeper]\npersona_name = \"analyst\"\n[keeper.oas_env]\nMASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = %s\n"
+          raw
+      in
+      match TL.parse_toml input with
+      | Error e -> fail e
+      | Ok doc ->
+        (match KTP.profile_defaults_of_toml doc with
+         | Ok _ -> failf "expected invalid unified max_tokens rejection for %s" raw
+         | Error detail ->
+           check bool "error names unified max_tokens key" true
+             (contains_substring detail "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS");
+           check bool "error requires a positive integer" true
+             (contains_substring detail "positive integer")))
+    [ "\"not-an-int\""; "\"8192\""; "true"; "1.5"; "0"; "-1" ]
+
 let test_oas_env_drops_non_oas_prefix () =
   (* Guards against ambient env injection via keeper TOML: arbitrary keys
      outside the audited allowlist are silently dropped. *)
@@ -1730,6 +1750,8 @@ let () =
             test_oas_env_parses_allowed_keys;
           test_case "rejects legacy unified max tokens alias" `Quick
             test_oas_env_rejects_legacy_unified_max_tokens_alias;
+          test_case "rejects invalid unified max tokens" `Quick
+            test_oas_env_rejects_invalid_unified_max_tokens;
           test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
             test_oas_env_drops_non_oas_prefix;
           test_case "empty when table absent" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1388,7 +1388,7 @@ let test_direct_no_progress_retry_loop_runs_fallback_attempt () =
       ; max_context_resolution = retry_context_resolution
       ; max_context = retry_context_resolution.turn_budget
       ; temperature = 0.0
-      ; max_tokens = 1024
+      ; max_tokens = Some 1024
       }
     in
     let result =

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -357,13 +357,22 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id
         ()
     in
+    (* masc#24067 / oas#2517: [max_tokens_for_runtime] above always resolves
+       through [Keeper_run_context.resolve_max_tokens_for_runtime] with no
+       caller override and an unconfigured "policy-test" keeper profile, so
+       every candidate below gets [None] — including the reasoning candidate,
+       which under the deleted [Runtime_inference.resolve_max_tokens] used to
+       size itself from the OAS catalog ceiling. [fallback_max_tokens] is
+       [None] in all three calls because a resolver is always supplied, so it
+       is never consulted; see [test_max_tokens_for_runtime_omitted_uses_fallback]
+       below for the branch where it is. *)
     let lane_policy =
       Driver.For_testing.attempt_inference_policy
         ~max_tokens_for_runtime
         ~runtime_id:"mixed"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:None
-        ~fallback_max_tokens:8192
+        ~fallback_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -378,9 +387,9 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "lane id has no preserve thinking policy"
       None
       lane_policy.Driver.attempt_preserve_thinking;
-    Alcotest.(check int)
-      "lane id keeps caller max_tokens fallback"
-      8192
+    Alcotest.(check (option int))
+      "lane id: no override configured -> None (masc#24067 / oas#2517)"
+      None
       lane_policy.Driver.attempt_max_tokens;
     let thinking_policy =
       Driver.For_testing.attempt_inference_policy
@@ -388,7 +397,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id:"thinking.reasoning_big"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some false)
-        ~fallback_max_tokens:8192
+        ~fallback_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -403,9 +412,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "thinking candidate preserves thinking when configured"
       (Some true)
       thinking_policy.Driver.attempt_preserve_thinking;
-    Alcotest.(check int)
-      "thinking candidate sizes from catalog ceiling"
-      32768
+    Alcotest.(check (option int))
+      "thinking candidate: no override configured -> None, not the catalog \
+       ceiling (masc#24067 / oas#2517)"
+      None
       thinking_policy.Driver.attempt_max_tokens;
     let non_thinking_policy =
       Driver.For_testing.attempt_inference_policy
@@ -413,7 +423,7 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
         ~runtime_id:"plain.non_reasoning"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some true)
-        ~fallback_max_tokens:8192
+        ~fallback_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -428,10 +438,61 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "non-thinking candidate disables preserve thinking"
       (Some false)
       non_thinking_policy.Driver.attempt_preserve_thinking;
-    Alcotest.(check int)
-      "non-thinking candidate keeps caller max_tokens fallback"
-      8192
+    Alcotest.(check (option int))
+      "non-thinking candidate: no override configured -> None (masc#24067 / \
+       oas#2517)"
+      None
       non_thinking_policy.Driver.attempt_max_tokens)
+
+(* masc#24067 / oas#2517 regression: when the caller supplies no
+   [max_tokens_for_runtime] resolver at all, [attempt_inference_policy] must
+   still honor an explicit [fallback_max_tokens] verbatim — the option
+   contract only forbids *synthesizing* a value, not carrying one the caller
+   deliberately provided. *)
+let test_max_tokens_for_runtime_omitted_uses_fallback () =
+  let policy =
+    Driver.For_testing.attempt_inference_policy
+      ~runtime_id:"mixed"
+      ~fallback_temperature:0.25
+      ~fallback_enable_thinking:None
+      ~fallback_max_tokens:(Some 4096)
+      ()
+  in
+  Alcotest.(check (option int))
+    "no resolver supplied -> caller fallback_max_tokens passes through"
+    (Some 4096)
+    policy.Driver.attempt_max_tokens;
+  let policy_no_fallback =
+    Driver.For_testing.attempt_inference_policy
+      ~runtime_id:"mixed"
+      ~fallback_temperature:0.25
+      ~fallback_enable_thinking:None
+      ~fallback_max_tokens:None
+      ()
+  in
+  Alcotest.(check (option int))
+    "no resolver, no fallback -> None (never synthesized)"
+    None
+    policy_no_fallback.Driver.attempt_max_tokens
+
+let test_explicit_max_tokens_survives_each_failover_candidate () =
+  let max_tokens_for_runtime ~runtime_id:_ = Some 4096 in
+  List.iter
+    (fun runtime_id ->
+      let policy =
+        Driver.For_testing.attempt_inference_policy
+          ~max_tokens_for_runtime
+          ~runtime_id
+          ~fallback_temperature:0.25
+          ~fallback_enable_thinking:None
+          ~fallback_max_tokens:None
+          ()
+      in
+      Alcotest.(check (option int))
+        (runtime_id ^ " preserves explicit max_tokens")
+        (Some 4096)
+        policy.Driver.attempt_max_tokens)
+    [ "primary.test_model"; "fallback.test_model" ]
 
 let test_resolve_assignment_missing () =
   with_runtime_config runtime_toml_with_lane (fun () ->
@@ -934,6 +995,14 @@ let () =
             "attempt inference policy uses attempt runtime"
             `Quick
             test_attempt_inference_policy_uses_attempt_runtime;
+          Alcotest.test_case
+            "max_tokens_for_runtime omitted uses caller fallback (masc#24067)"
+            `Quick
+            test_max_tokens_for_runtime_omitted_uses_fallback;
+          Alcotest.test_case
+            "explicit max_tokens survives every failover candidate (masc#24067)"
+            `Quick
+            test_explicit_max_tokens_survives_each_failover_candidate;
           Alcotest.test_case
             "attempt loop stops on nonretryable failure"
             `Quick

--- a/test/test_oas_worker_exec_checkpoint.ml
+++ b/test/test_oas_worker_exec_checkpoint.ml
@@ -83,6 +83,65 @@ let test_persist_checkpoint_error_on_readonly () =
     (try ignore (Str.search_forward (Str.regexp "s2") err 0); true
      with Not_found -> false)
 
+let custom_payload_fields expected_topic (event : Agent_sdk.Event_bus.event) =
+  match event.payload with
+  | Agent_sdk.Event_bus.Custom (topic, `Assoc fields) ->
+    check string "lifecycle topic" expected_topic topic;
+    fields
+  | Agent_sdk.Event_bus.Custom (topic, _) ->
+    failf "expected object payload for %s" topic
+  | _ -> fail "expected custom lifecycle event"
+
+let test_publish_lifecycle_reaches_masc_bus_with_max_tokens_intent () =
+  Eio_main.run @@ fun _env ->
+  let bus =
+    Agent_sdk.Event_bus.create ~policy:Agent_sdk.Event_bus.Drop_oldest ()
+  in
+  let subscription =
+    Agent_sdk.Event_bus.subscribe ~purpose:"runtime-lifecycle-test" bus
+  in
+  Masc_event_bus.set bus;
+  Fun.protect
+    ~finally:(fun () -> Agent_sdk.Event_bus.unsubscribe bus subscription)
+    (fun () ->
+      CP.publish_lifecycle
+        ~name:"keeper-a"
+        ~event:"build"
+        ~detail:"omitted"
+        ~attrs:(Runtime_max_tokens.telemetry_fields None)
+        ();
+      CP.publish_lifecycle
+        ~name:"keeper-a"
+        ~event:"completed"
+        ~detail:"explicit"
+        ~attrs:(Runtime_max_tokens.telemetry_fields (Some 4096))
+        ();
+      match Agent_sdk.Event_bus.drain subscription with
+      | [ omitted; explicit ] ->
+        let omitted_fields =
+          custom_payload_fields "masc.oas_worker.build" omitted
+        in
+        check (option (of_pp Yojson.Safe.pp)) "omitted value is observable null"
+          (Some `Null)
+          (List.assoc_opt "max_tokens" omitted_fields);
+        check (option string) "omitted source"
+          (Some "omitted")
+          (Option.bind
+             (List.assoc_opt "max_tokens_source" omitted_fields)
+             Yojson.Safe.Util.to_string_option);
+        let explicit_fields =
+          custom_payload_fields "masc.oas_worker.completed" explicit
+        in
+        check (option (of_pp Yojson.Safe.pp)) "explicit value is preserved"
+          (Some (`Int 4096))
+          (List.assoc_opt "max_tokens" explicit_fields);
+        check (option string) "explicit source"
+          (Some "explicit_override")
+          (Option.bind
+             (List.assoc_opt "max_tokens_source" explicit_fields)
+             Yojson.Safe.Util.to_string_option)
+      | events -> failf "expected two lifecycle events, got %d" (List.length events))
+
 let () =
   run "oas_worker_exec_checkpoint"
     [
@@ -91,5 +150,12 @@ let () =
           test_case "Ok on writable dir" `Quick test_persist_checkpoint_ok;
           test_case "Error on read-only dir (IR-3)"
             `Quick test_persist_checkpoint_error_on_readonly;
+        ] );
+      ( "runtime_lifecycle",
+        [
+          test_case
+            "publishes to MASC bus with max_tokens intent"
+            `Quick
+            test_publish_lifecycle_reaches_masc_bus_with_max_tokens_intent;
         ] );
     ]

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1527,92 +1527,43 @@ let test_seed_of_thinking_support_gate_contract () =
     (Runtime_inference.seed_of_thinking_support None).Runtime_inference.thinking_enabled
 ;;
 
-(* ---- reasoning max_tokens resolution: [Runtime_inference.resolve_max_tokens]
-   sizes a reasoning turn from the model's declared output ceiling (OAS catalog),
-   bounded above by the operational [reasoning_turn_max_tokens] (32768). A
-   reasoning runtime with no catalog ceiling keeps the caller fallback (the bound
-   is never the request value on its own); non-reasoning runtimes keep the caller
-   fallback. Regression guard for the thinking_only + stop_reason=max_tokens
-   truncation (live fleet 2026-06-30). ----
+(* ---- masc#24067 / oas#2517: the keeper lane must not synthesize a request
+   [max_tokens] value. [Runtime_inference.resolve_max_tokens] — which sized a
+   reasoning turn from the model's declared OAS output ceiling, and otherwise
+   fell back to a flat keeper default — is deleted: BOTH arms invented a
+   request value the model catalog ceiling was never meant to supply. MASC
+   keeps that ceiling observable but does not reinterpret it as a request;
+   OAS owns envelope-specific validation and clamp policy.
+   [Keeper_run_context.resolve_max_tokens_for_runtime] replaces it
+   with a two-source-only contract: an explicit caller [?max_tokens] argument,
+   or a per-keeper [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS] profile override
+   (exercised separately in test_keeper_toml.ml's oas_env tests). Absent both,
+   [None] — no [max_tokens] field goes on the OAS request, regardless of
+   whether the runtime is a reasoning model with a declared catalog ceiling. ---- *)
 
-   The fallback sentinel (8192) mirrors the keeper path's flat default and is
-   distinct from every reasoning result asserted below, so a test failure
-   pinpoints which branch regressed. *)
-let fallback_sentinel () = 8192
-
-let test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback () =
+let test_resolve_max_tokens_for_runtime_no_override_is_none () =
   with_runtime_thinking (fun () ->
-    (* qwen36-35b-a3b-mtp declares [max_output_tokens = 65536] in the OAS
-       fixture catalog. The reasoning path defers to that OAS-owned ceiling,
-       bounded by the 32768 operational cap — NOT the flat keeper fallback
-       (8192). *)
-    Alcotest.(check int)
-      "reasoning runtime defers to its OAS capability ceiling, clamped by the \
-       operational bound above the 8192 keeper fallback"
-      32768
-      (Runtime_inference.resolve_max_tokens
+    Alcotest.(check (option int))
+      "unconfigured keeper + no caller override sends no max_tokens, even for \
+       a reasoning runtime with a declared catalog ceiling"
+      None
+      (Keeper_run_context.resolve_max_tokens_for_runtime
+         ~keeper_name:"masc24067-unconfigured-keeper"
          ~runtime_id:"ollama_cloud.thinkdefault"
-         ~fallback:fallback_sentinel))
+         ()))
 ;;
 
-let test_resolve_max_tokens_non_reasoning_uses_fallback () =
+let test_resolve_max_tokens_for_runtime_caller_override_is_some () =
   with_runtime_thinking (fun () ->
-    Alcotest.(check int)
-      "non-reasoning runtime keeps the caller fallback unchanged"
-      8192
-      (Runtime_inference.resolve_max_tokens
-         ~runtime_id:"ollama_cloud.nothink"
-         ~fallback:fallback_sentinel))
-;;
-
-let test_resolve_max_tokens_reasoning_small_ceiling_respected () =
-  with_runtime_thinking (fun () ->
-    Alcotest.(check int)
-      "reasoning runtime whose declared ceiling is below the operational bound \
-       keeps its smaller ceiling (never request more than the provider accepts)"
-      4096
-      (Runtime_inference.resolve_max_tokens
-         ~runtime_id:"ollama_cloud.smallout"
-         ~fallback:fallback_sentinel))
-;;
-
-let test_resolve_max_tokens_reasoning_big_ceiling_clamped () =
-  with_runtime_thinking (fun () ->
-    Alcotest.(check int)
-      "reasoning runtime whose declared ceiling exceeds the operational bound is \
-       clamped to the bound (runaway guard)"
-      32768
-      (Runtime_inference.resolve_max_tokens
-         ~runtime_id:"ollama_cloud.bigout"
-         ~fallback:fallback_sentinel))
-;;
-
-let test_resolve_max_tokens_unknown_runtime_uses_fallback () =
-  with_runtime_thinking (fun () ->
-    Alcotest.(check int)
-      "unknown runtime id falls through to the caller fallback (fail-safe)"
-      8192
-      (Runtime_inference.resolve_max_tokens
-         ~runtime_id:"bogus.binding"
-         ~fallback:fallback_sentinel))
-;;
-
-let test_resolve_max_tokens_reasoning_no_capability_falls_back () =
-  with_runtime_thinking (fun () ->
-    (* [ollama_cloud.think]'s model api-name is absent from the OAS catalog, so
-       its capability projection has no max_output_tokens even though
-       runtime.toml marks it thinking-support=true. A reasoning runtime with no
-       declared ceiling must NOT jump to the operational bound — without a known
-       provider ceiling, requesting 32768 could exceed what the provider accepts
-       and turn the thinking truncation into a max_tokens rejection. It keeps the
-       caller fallback (the budget increase is gated on an OAS-declared ceiling). *)
-    Alcotest.(check int)
-      "reasoning runtime with no catalog ceiling keeps the fallback, does not \
-       jump to the operational bound"
-      8192
-      (Runtime_inference.resolve_max_tokens
-         ~runtime_id:"ollama_cloud.think"
-         ~fallback:fallback_sentinel))
+    Alcotest.(check (option int))
+      "explicit caller max_tokens argument passes through as Some, unchanged \
+       by the target runtime's catalog ceiling"
+      (Some 4096)
+      (Keeper_run_context.resolve_max_tokens_for_runtime
+         ~keeper_name:"masc24067-unconfigured-keeper"
+         ~runtime_id:"ollama_cloud.thinkdefault"
+         ~max_tokens:4096
+         ()))
 ;;
 
 let test_max_output_tokens_accessor_projects_catalog () =
@@ -1976,29 +1927,13 @@ let () =
         ] )
     ; ( "reasoning max_tokens resolution"
       , [ Alcotest.test_case
-            "reasoning runtime defers to OAS capability ceiling, not fallback"
+            "no override configured -> None (masc#24067 / oas#2517)"
             `Quick
-            test_resolve_max_tokens_reasoning_defers_to_caps_not_fallback
+            test_resolve_max_tokens_for_runtime_no_override_is_none
         ; Alcotest.test_case
-            "non-reasoning runtime -> caller fallback"
+            "explicit caller override -> Some (masc#24067 / oas#2517)"
             `Quick
-            test_resolve_max_tokens_non_reasoning_uses_fallback
-        ; Alcotest.test_case
-            "reasoning runtime, ceiling below bound -> ceiling respected"
-            `Quick
-            test_resolve_max_tokens_reasoning_small_ceiling_respected
-        ; Alcotest.test_case
-            "reasoning runtime, ceiling above bound -> clamped to bound"
-            `Quick
-            test_resolve_max_tokens_reasoning_big_ceiling_clamped
-        ; Alcotest.test_case
-            "unknown runtime id -> caller fallback"
-            `Quick
-            test_resolve_max_tokens_unknown_runtime_uses_fallback
-        ; Alcotest.test_case
-            "reasoning runtime with no catalog ceiling -> fallback, not bound"
-            `Quick
-            test_resolve_max_tokens_reasoning_no_capability_falls_back
+            test_resolve_max_tokens_for_runtime_caller_override_is_some
         ; Alcotest.test_case
             "max_output_tokens_of_runtime_id projects catalog ceiling"
             `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -695,9 +695,42 @@ let test_runtime_adapter_materializes_deepseek_openai_compat () =
     check string "model_id" "deepseek-v4-pro" provider_cfg.model_id;
     check string "api key" "ds-test-key" (Llm_provider.Secret.header_value provider_cfg.api_key);
     check (option int) "max_context" (Some 1000000) provider_cfg.max_context;
-    check (option int) "max_tokens" (Some 384000) provider_cfg.max_tokens;
+    check (option int) "max_tokens is not synthesized from capability" None
+      provider_cfg.max_tokens;
     check int "Authorization header count" 0
       (normalized_header_count "Authorization" provider_cfg.headers))
+
+let test_runtime_adapter_max_tokens_wire_omission_and_explicit_override () =
+  with_deepseek_env "ds-test-key" (fun () ->
+    let provider_cfg = deepseek_provider_config_or_fail () in
+    let body =
+      Llm_provider.Backend_openai.build_request_assoc
+        ~config:provider_cfg
+        ~messages:[]
+        ()
+    in
+    (match body with
+     | `Assoc fields ->
+       check bool "catalog capability does not become a wire max_tokens field"
+         false
+         (List.mem_assoc "max_tokens" fields)
+     | _ -> fail "expected OpenAI request object");
+    let explicit_cfg =
+      { provider_cfg with Llm_provider.Provider_config.max_tokens = Some 2048 }
+    in
+    let explicit_body =
+      Llm_provider.Backend_openai.build_request_assoc
+        ~config:explicit_cfg
+        ~messages:[]
+        ()
+    in
+    match explicit_body with
+    | `Assoc fields ->
+      check (option (of_pp Yojson.Safe.pp))
+        "explicit override reaches wire unchanged"
+        (Some (`Int 2048))
+        (List.assoc_opt "max_tokens" fields)
+    | _ -> fail "expected explicit OpenAI request object")
 
 let test_runtime_toml_accepts_glm_coding_capability () =
   let cfg = glm_coding_runtime_config_or_fail () in
@@ -724,7 +757,8 @@ let test_runtime_adapter_materializes_glm_coding_provider () =
     check string "model_id" "glm-4.7" provider_cfg.model_id;
     check string "api key uses coding lane" "coding-key" (Llm_provider.Secret.header_value provider_cfg.api_key);
     check (option int) "max_context" (Some 200000) provider_cfg.max_context;
-    check (option int) "max_tokens" (Some 128000) provider_cfg.max_tokens;
+    check (option int) "max_tokens is not synthesized from capability" None
+      provider_cfg.max_tokens;
     check (option bool) "tool choice override" (Some false)
       provider_cfg.supports_tool_choice_override;
     check int "Authorization header count" 0
@@ -1171,6 +1205,64 @@ let test_runtime_agent_context_uses_configured_turn_budget () =
   check int "resume adds fresh per-call turn budget" 31
     prepared.agent_config.max_turns
 
+let test_runtime_agent_context_preserves_max_tokens_intent () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let check_builder_max_tokens expected max_tokens =
+        let config =
+          Runtime_agent.default_config
+            ~name:"oas-runpod_mtp.qwen"
+            ~provider_cfg:(provider_cfg ())
+            ~system_prompt:""
+            ~tools:[]
+        in
+        let config = { config with max_tokens } in
+        let builder =
+          Runtime_agent_context.builder_without_approval
+            ~net:(Eio.Stdenv.net env)
+            ~config
+            ()
+        in
+        match Agent_sdk.Builder.build_safe builder with
+        | Error err -> fail (Agent_sdk.Error.to_string err)
+        | Ok agent ->
+          check (option int) "builder max_tokens intent" expected
+            (Agent_sdk.Agent.state agent).config.max_tokens;
+          Eio.Switch.on_release sw (fun () -> Agent_sdk.Agent.close agent)
+      in
+      check_builder_max_tokens None None;
+      check_builder_max_tokens (Some 2048) (Some 2048)))
+
+let test_runtime_agent_lifecycle_attrs_preserve_max_tokens_intent () =
+  let config =
+    Runtime_agent.default_config
+      ~name:"oas-runpod_mtp.qwen"
+      ~provider_cfg:(provider_cfg ())
+      ~system_prompt:""
+      ~tools:[]
+  in
+  let fields = Runtime_agent.Lifecycle_for_testing.provider_attrs config in
+  check (option (of_pp Yojson.Safe.pp)) "omitted lifecycle value"
+    (Some `Null)
+    (List.assoc_opt "max_tokens" fields);
+  check (option string) "omitted lifecycle source"
+    (Some "omitted")
+    (Option.bind
+       (List.assoc_opt "max_tokens_source" fields)
+       Yojson.Safe.Util.to_string_option);
+  let explicit_fields =
+    Runtime_agent.Lifecycle_for_testing.provider_attrs
+      { config with max_tokens = Some 2048 }
+  in
+  check (option (of_pp Yojson.Safe.pp)) "explicit lifecycle value"
+    (Some (`Int 2048))
+    (List.assoc_opt "max_tokens" explicit_fields);
+  check (option string) "explicit lifecycle source"
+    (Some "explicit_override")
+    (Option.bind
+       (List.assoc_opt "max_tokens_source" explicit_fields)
+       Yojson.Safe.Util.to_string_option)
+
 let test_runtime_agent_context_preserves_provider_sampling_config () =
   let provider_cfg =
     { (provider_cfg ()) with
@@ -1542,6 +1634,10 @@ let () =
             `Quick
             test_runtime_adapter_materializes_deepseek_openai_compat
         ; test_case
+            "runtime max_tokens wire omission and explicit override"
+            `Quick
+            test_runtime_adapter_max_tokens_wire_omission_and_explicit_override
+        ; test_case
             "runtime adapter materializes GLM Coding Plan provider"
             `Quick
             test_runtime_adapter_materializes_glm_coding_provider
@@ -1573,6 +1669,14 @@ let () =
             "runtime agent context uses configured turn budget"
             `Quick
             test_runtime_agent_context_uses_configured_turn_budget
+        ; test_case
+            "runtime agent context preserves max_tokens intent"
+            `Quick
+            test_runtime_agent_context_preserves_max_tokens_intent
+        ; test_case
+            "runtime lifecycle attrs preserve max_tokens intent"
+            `Quick
+            test_runtime_agent_lifecycle_attrs_preserve_max_tokens_intent
         ; test_case
             "runtime agent context preserves provider sampling config"
             `Quick


### PR DESCRIPTION
## 계약

MASC는 더 이상 카탈로그 `max_output_tokens`, `max_context`, 가격 메타데이터, 또는 8192/16384 상수를 request-time `max_tokens`로 합성하지 않습니다.

- 명시적 caller/profile override: `Some n`, OAS까지 값 그대로 전달
- 명시값 없음: `None`; optional OAS envelope는 wire field를 생략
- required envelope의 누락 처리와 모델 ceiling clamp/검증은 OAS의 typed envelope policy가 소유

## 숙청

- `Runtime_inference.resolve_max_tokens`, MASC-side ceiling validator/cap stub 제거
- dead `Max_tokens_ceiling_violation` 타입, JSON codec, 분류/라우팅 분기 전부 제거
- Runtime adapter가 capability/context/price에서 request budget을 발명하던 경로 제거
- `Runtime_provider_defaults.agent_default_max_tokens` 제거
- `?max_tokens:int option` 이중 optional API를 `?max_tokens:int`로 정리
- hardcoded 256..262144 profile clamp 제거

## Fail-loud 및 관측

- `MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS`는 양의 TOML 정수만 허용; 문자열/bool/float/0/음수는 profile load에서 거부
- `Runtime_max_tokens` typed SSOT가 `omitted | explicit_override`와 JSON projection을 단일 소유
- runtime lifecycle publisher가 이벤트를 만들고 버리던 Silent Failure 수정
- ignored legacy bus 인자 및 `config.event_bus` presence gate 제거
- MASC-owned event bus 미초기화는 one-shot WARN, 정상 경로는 실제 publish
- lifecycle/keeper telemetry는 `max_tokens: null|int`와 `max_tokens_source`를 항상 노출

## 회귀 근거

- adapter -> OAS OpenAI wire: 기본은 `max_tokens` key 없음, 명시 `2048`은 exact
- Runtime builder: `None` / `Some 2048` intent 보존
- failover: primary/fallback 모든 후보가 명시 `4096` 보존
- lifecycle bus capture: 실제 event 수신 + omitted/explicit projection 확인
- invalid profile override 여섯 형태 reject
- catalog ceiling은 관측 accessor로만 유지되고 request default가 아님

로컬 정책에 따라 Dune은 실행하지 않았습니다. `git diff --check`, 변경 ML/MLI `ocamlformat --check`, `ocamlc -stop-after parsing`, `ocamldep -modules`는 `7e76730781`에서 통과했습니다. Dune build/test는 exact-head GitHub CI가 권위입니다.

BREAKING CHANGE: Keeper/Runtime `max_tokens` plumbing은 `int option`; dead ceiling error variant와 ignored lifecycle bus 인자를 제거했습니다.

Closes #24067
