### PR TITLE
feat(memory): add typed explicit-root MemoryOS I/O

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -200,24 +200,6 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
-let write_all_fd ~path fd content =
-  let rec loop offset =
-    if offset < String.length content
-    then
-      match
-        Unix.write_substring
-          fd
-          content
-          offset
-          (String.length content - offset)
-      with
-      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
-      | 0 -> raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
-      | wrote -> loop (offset + wrote)
-  in
-  loop 0
-;;
-
 let append_file_durable_unix (path : string) (content : string) : unit =
   let mu = get_append_path_mutex path in
   Stdlib.Mutex.lock mu;
@@ -232,7 +214,22 @@ let append_file_durable_unix (path : string) (content : string) : unit =
       in
       let write_result =
         try
-          write_all_fd ~path fd content;
+          let rec write_all offset =
+            if offset < String.length content
+            then
+              match
+                Unix.write_substring
+                  fd
+                  content
+                  offset
+                  (String.length content - offset)
+              with
+              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
+              | 0 ->
+                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+              | wrote -> write_all (offset + wrote)
+          in
+          write_all 0;
           Unix.fsync fd;
           Ok ()
         with

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -200,6 +200,24 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let write_all_fd ~path fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring
+          fd
+          content
+          offset
+          (String.length content - offset)
+      with
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+      | 0 -> raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+      | wrote -> loop (offset + wrote)
+  in
+  loop 0
+;;
+
 let append_file_durable_unix (path : string) (content : string) : unit =
   let mu = get_append_path_mutex path in
   Stdlib.Mutex.lock mu;
@@ -214,22 +232,7 @@ let append_file_durable_unix (path : string) (content : string) : unit =
       in
       let write_result =
         try
-          let rec write_all offset =
-            if offset < String.length content
-            then
-              match
-                Unix.write_substring
-                  fd
-                  content
-                  offset
-                  (String.length content - offset)
-              with
-              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
-              | 0 ->
-                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
-              | wrote -> write_all (offset + wrote)
-          in
-          write_all 0;
+          write_all_fd ~path fd content;
           Unix.fsync fd;
           Ok ()
         with

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -665,7 +665,7 @@ let extract_and_append_with_provider_classified
        the truth anchor recall's recency ranking reads. The judgment (window
        join + metric) lives here at the write boundary; the fold itself stays
        a pure function of the decision. *)
-    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun () ->
+    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun bundle ->
       match
         try
           let window = Keeper_memory_os_io.fact_recall_window in
@@ -684,10 +684,17 @@ let extract_and_append_with_provider_classified
             Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
           in
           let (_ : Keeper_memory_os_io.fact_merge_stats) =
-            File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
-              Keeper_memory_os_io.merge_and_cap_facts
+            Keeper_memory_os_io.with_facts_lock_in_bundle
+              ?clock
+              bundle
+              ~on_timeout:(fun timeout ->
+                raise
+                  (Failure
+                     (Keeper_memory_os_io.lock_timeout_to_string timeout)))
+              (fun lock ->
+              Keeper_memory_os_io.merge_and_cap_facts_in_lock
+                lock
                 ~now
-                ~keeper_id
                 ~merge
                 ~incoming:episode.Keeper_memory_os_types.claims
                 ~keep:window
@@ -703,21 +710,21 @@ let extract_and_append_with_provider_classified
           Error message
       with
       | Ok () ->
-        Keeper_memory_os_io.append_episode ~keeper_id episode;
-        Keeper_memory_os_io.append_event ~keeper_id episode;
+        Keeper_memory_os_io.append_episode_in_bundle bundle episode;
+        Keeper_memory_os_io.append_event_in_bundle bundle episode;
         (* RFC-0272 (defect D): bound the append-only episode log under the same
            bundle lock that serialized the writes above, so a re-extraction cannot
            grow events.jsonl / episodes/ without limit. Hysteresis-gated: the trim
            is a no-op until the high-water, so this is off the per-turn hot path. *)
         ignore
-          (Keeper_memory_os_io.cap_events
-             ~keeper_id
+          (Keeper_memory_os_io.cap_events_in_bundle
+             bundle
              ~keep:Keeper_memory_os_io.event_recall_window
              ~trigger:Keeper_memory_os_io.event_store_max
             : int);
         ignore
-          (Keeper_memory_os_io.cap_episode_files
-             ~keeper_id
+          (Keeper_memory_os_io.cap_episode_files_in_bundle
+             bundle
              ~keep:Keeper_memory_os_io.episode_file_window
              ~trigger:Keeper_memory_os_io.episode_file_store_max
             : int);

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -68,7 +68,9 @@ let with_facts_lock ?clock ~keeper_id f =
   Io.with_facts_lock
     ?clock
     ~keeper_id
-    ~on_timeout:(fun msg -> Transport_failed ("consolidation " ^ msg))
+    ~on_timeout:(fun timeout ->
+      Transport_failed
+        ("consolidation " ^ Io.lock_timeout_to_string timeout))
     f
 ;;
 
@@ -121,15 +123,15 @@ let messages_for_consolidation facts =
 ;;
 
 let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~after () =
-  with_facts_lock ?clock ~keeper_id (fun () ->
-    match Io.read_facts_all_strict ~keeper_id with
+  with_facts_lock ?clock ~keeper_id (fun lock ->
+    match Io.read_facts_all_strict_in_lock lock with
     | Error msg ->
       Unparseable ("consolidation fact store changed before rewrite: " ^ msg)
     | Ok current ->
       if not (Io.same_fact_snapshot facts current)
       then Snapshot_changed { before; current = List.length current }
       else (
-        Io.rewrite_facts_atomically ~keeper_id survivors;
+        Io.rewrite_facts_in_lock lock survivors;
         Consolidated { before; after }))
 ;;
 

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -118,84 +118,68 @@ let dedup_by_claim items =
    value is not a number GC can threshold. Forgetting is the librarian's
    delete-on-contradiction judgment plus this structural TTL, not a low score. *)
 let run_gc_with_store
-      ~facts_path
       ~read_facts_all_strict
       ~rewrite_facts_atomically
       ?(dry_run = false)
-      ~keeper_id
       ~now
       ()
   =
-  (* Serialize the whole read-modify-rewrite on the same per-keeper facts lock the
-     librarian write path (Keeper_librarian_runtime, wrapping merge_and_cap_facts)
-     and the consolidation runtime already hold on facts_path. Without it, a
-     librarian merge that commits between GC's read and GC's rewrite is silently
-     overwritten — a lost update that permanently drops a freshly persisted fact.
-     The lock spans both the read and the rewrite, so no concurrent writer can
-     interleave; because the read-modify-rewrite is entirely inside the lock there
-     is no unlocked gap to guard with a snapshot CAS (unlike
-     Keeper_memory_os_consolidation_runtime, whose LLM call runs between its read
-     and rewrite and so re-validates the snapshot under the lock). No clock is
-     threaded: lock-retry sleeps run on a systhread (off the keeper hot path, GC
-     is a 600s maintenance sweep, so cooperative yielding buys nothing), and
-     File_lock_eio already offloads the blocking flock so the Eio domain is not
-     stalled. Must run inside an Eio context (the maintenance fiber and tests
-     both are). *)
-  File_lock_eio.with_lock facts_path (fun () ->
-    (* Read strictly: a malformed JSONL row aborts the sweep rather than being
-       silently dropped by the lenient decoder and then erased by the rewrite
-       below. Every other destructive rewrite path already refuses to overwrite a
-       store it cannot fully parse — cap_facts / merge_and_cap_facts via
-       read_facts_for_rewrite, the consolidator and consolidation runtime via
-       read_facts_all_strict. GC was the lone path that turned one corrupt line
-       into permanent deletion of the surrounding facts (it read via the lenient
-       read_facts_all). Preserve over delete: leave a corrupt store untouched and
-       let the raised error surface so an operator can repair it. *)
-    match read_facts_all_strict () with
-    | Error message ->
-      raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
-    | Ok facts ->
-      let indexed = List.mapi (fun index fact -> { index; fact }) facts in
-      let live, expired =
-        List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
-      in
-      let ttl_expired_ephemeral, ttl_expired_non_ephemeral, ttl_expired_by_category =
-        expired_category_counts expired
-      in
-      let deduped = dedup_by_claim live in
-      let survivors = List.map (fun item -> item.fact) deduped in
-      if not dry_run then rewrite_facts_atomically survivors;
-      { total_input = List.length facts
-      ; ttl_expired = List.length expired
-      ; ttl_expired_ephemeral
-      ; ttl_expired_non_ephemeral
-      ; ttl_expired_by_category
-      ; dedup_removed = List.length live - List.length deduped
-      ; written = List.length survivors
-      ; dry_run
-      })
+  (* The caller holds the descriptor-anchored facts capability across this
+     strict read-modify-rewrite. A malformed row aborts before rewrite, so GC
+     never turns decoder tolerance into permanent data loss. *)
+  match read_facts_all_strict () with
+  | Error message ->
+    raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
+  | Ok facts ->
+    let indexed = List.mapi (fun index fact -> { index; fact }) facts in
+    let live, expired =
+      List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
+    in
+    let ttl_expired_ephemeral, ttl_expired_non_ephemeral, ttl_expired_by_category =
+      expired_category_counts expired
+    in
+    let deduped = dedup_by_claim live in
+    let survivors = List.map (fun item -> item.fact) deduped in
+    if not dry_run then rewrite_facts_atomically survivors;
+    { total_input = List.length facts
+    ; ttl_expired = List.length expired
+    ; ttl_expired_ephemeral
+    ; ttl_expired_non_ephemeral
+    ; ttl_expired_by_category
+    ; dedup_removed = List.length live - List.length deduped
+    ; written = List.length survivors
+    ; dry_run
+    }
 ;;
 
 let run_gc ?dry_run ~keeper_id ~now () =
-  run_gc_with_store
-    ~facts_path:(Io.facts_path ~keeper_id)
-    ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict ~keeper_id)
-    ~rewrite_facts_atomically:(fun facts -> Io.rewrite_facts_atomically ~keeper_id facts)
-    ?dry_run
+  Io.with_facts_lock
     ~keeper_id
-    ~now
-    ()
+    ~on_timeout:Io.raise_lock_timeout
+    (fun lock ->
+      run_gc_with_store
+        ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict_in_lock lock)
+        ~rewrite_facts_atomically:(Io.rewrite_facts_in_lock lock)
+        ?dry_run
+        ~now
+        ())
 ;;
 
 let run_gc_for_keepers_dir ~keepers_dir ?dry_run ~keeper_id ~now () =
-  run_gc_with_store
-    ~facts_path:(Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~read_facts_all_strict:(fun () ->
-      Io.read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~rewrite_facts_atomically:(fun facts ->
-      Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts)
-    ?dry_run
-    ~keeper_id
-    ~now
-    ()
+  let keeper_name =
+    match Keeper_id.Keeper_name.of_string keeper_id with
+    | Ok keeper_name -> keeper_name
+    | Error detail -> invalid_arg detail
+  in
+  Io.with_facts_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:keeper_name
+    ~on_timeout:Io.raise_lock_timeout
+    (fun lock ->
+      run_gc_with_store
+        ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict_in_lock lock)
+        ~rewrite_facts_atomically:(Io.rewrite_facts_in_lock lock)
+        ?dry_run
+        ~now
+        ())
 ;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -139,14 +139,12 @@ let with_descriptor_lock ?clock root name f =
   let diagnostic_path =
     Filename.concat root.path (Anchored.Segment.to_string name)
   in
-  File_lock_eio.with_lock_file
+  File_lock_eio.with_anchored_file_lock
     ?clock
     ~path:diagnostic_path
-    ~open_file:(fun () ->
-      Anchored.open_lock_file root.handle ~name ~perm:0o644)
-    ~descriptor:Anchored.lock_file_descriptor
-    ~identity:Anchored.lock_file_identity
-    ~close_file:Anchored.close_lock_file
+    ~directory:root.handle
+    ~name
+    ~perm:0o644
     f
 ;;
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,12 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let ensure_configured_keepers_dir () =
+  let path = keepers_dir () in
+  ensure_dir path;
+  path
+;;
+
 let keeper_name_exn raw =
   match Keeper_id.Keeper_name.of_string raw with
   | Ok keeper_name -> keeper_name
@@ -38,6 +44,70 @@ let keeper_name_exn raw =
 ;;
 
 let keeper_name_string = Keeper_id.Keeper_name.to_string
+
+let trace_id_exn raw =
+  match Keeper_id.Trace_id.of_string raw with
+  | Ok trace_id -> trace_id
+  | Error detail -> invalid_arg detail
+;;
+
+let trace_id_string = Keeper_id.Trace_id.to_string
+
+let lstat_if_present path =
+  try Some (Unix.lstat path) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+;;
+
+let require_real_directory path =
+  match lstat_if_present path with
+  | Some stat when stat.Unix.st_kind = Unix.S_DIR -> ()
+  | Some _ ->
+    invalid_arg (Printf.sprintf "expected a real directory, found another file kind: %s" path)
+  | None -> invalid_arg (Printf.sprintf "required directory does not exist: %s" path)
+;;
+
+let require_regular_file_or_missing path =
+  match lstat_if_present path with
+  | None -> ()
+  | Some stat when stat.Unix.st_kind = Unix.S_REG -> ()
+  | Some _ ->
+    invalid_arg
+      (Printf.sprintf "expected a regular file or missing path: %s" path)
+;;
+
+let fsync_directory_exn path =
+  match Fs_compat.fsync_directory path with
+  | Ok () -> ()
+  | Error detail -> raise (Sys_error detail)
+;;
+
+let ensure_real_child_directory ~parent ~child_name =
+  require_real_directory parent;
+  let child = Filename.concat parent child_name in
+  let created =
+    match lstat_if_present child with
+    | Some stat when stat.Unix.st_kind = Unix.S_DIR -> false
+    | Some _ ->
+      invalid_arg
+        (Printf.sprintf
+           "expected a real directory, found another file kind: %s"
+           child)
+    | None ->
+      (try
+         Unix.mkdir child 0o755;
+         true
+       with
+       | Unix.Unix_error (Unix.EEXIST, _, _) -> false)
+  in
+  require_real_directory parent;
+  require_real_directory child;
+  if created then fsync_directory_exn parent;
+  child
+;;
+
+let validate_lock_target base_path =
+  require_regular_file_or_missing (base_path ^ ".lock")
+;;
 
 module For_testing = struct
   let with_keepers_dir path f =
@@ -126,33 +196,79 @@ let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
 ;;
 
 let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  File_lock_eio.with_lock
-    ?clock
-    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    f
+  require_real_directory keepers_dir;
+  let lock_base =
+    episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id
+  in
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
   with_episode_bundle_lock_for_keepers_dir
     ?clock
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     f
 ;;
 
+let facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  facts_path_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:(keeper_name_string keeper_id)
+;;
+
+let with_facts_lock_unhandled_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  require_real_directory keepers_dir;
+  let lock_base = facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing lock_base;
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
+;;
+
+let with_facts_lock_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      ~on_timeout
+      f
+  =
+  try
+    with_facts_lock_unhandled_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      f
+  with
+  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
+    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+;;
+
+let with_facts_lock ?clock ~keeper_id ~on_timeout f =
+  with_facts_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~on_timeout
+    f
+;;
+
+let episodes_directory_name = "episodes"
+
 let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
-  let d =
-    Filename.concat
-      keepers_dir
-      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  let keeper_dir =
+    ensure_real_child_directory
+      ~parent:keepers_dir
+      ~child_name:(keeper_name_string keeper_id)
   in
-  ensure_dir d;
-  d
+  ensure_real_child_directory
+    ~parent:keeper_dir
+    ~child_name:episodes_directory_name
 ;;
 
 let episodes_dir ~keeper_id =
   episodes_dir_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -167,9 +283,10 @@ let tool_result_path ~keeper_id ~tool_call_id =
 ;;
 
 let episode_path ~keeper_id ~trace_id ~generation =
+  let trace_id = trace_id_exn trace_id in
   Filename.concat
     (episodes_dir ~keeper_id)
-    (Printf.sprintf "%s-g%04d.json" trace_id generation)
+    (Printf.sprintf "%s-g%04d.json" (trace_id_string trace_id) generation)
 ;;
 
 (* Raised when a durable atomic write fails. Distinct from [Failure] so the
@@ -211,15 +328,23 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
+let write_file_atomically_in_real_directory path content =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> raise (Atomic_write_failed msg)
+;;
+
 let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   Filename.concat
     (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
-    (Printf.sprintf "%s.generation" trace_id)
+    (Printf.sprintf "%s.generation" (trace_id_string trace_id))
 ;;
 
 let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
-  let prefix = Printf.sprintf "%s-g" trace_id in
+  let prefix = Printf.sprintf "%s-g" (trace_id_string trace_id) in
   Sys.readdir dir
   |> Array.to_list
   |> List.filter_map (fun name ->
@@ -232,15 +357,16 @@ let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id 
 ;;
 
 let read_generation_counter path =
-  if not (Sys.file_exists path)
-  then None
-  else (
+  require_regular_file_or_missing path;
+  match lstat_if_present path with
+  | None -> None
+  | Some _ ->
     let ic = open_in_bin path in
     Fun.protect
       ~finally:(fun () -> close_in_noerr ic)
       (fun () ->
-         let len = in_channel_length ic in
-         really_input_string ic len |> String.trim |> int_of_string_opt))
+        let len = in_channel_length ic in
+        really_input_string ic len |> String.trim |> int_of_string_opt)
 ;;
 
 (** Compute the next generation number for a trace's episode files.
@@ -259,6 +385,8 @@ let next_generation_with_floor_for_keepers_dir
   let counter_path =
     generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
   in
+  require_regular_file_or_missing counter_path;
+  validate_lock_target counter_path;
   File_lock_eio.with_lock counter_path (fun () ->
     let next_from_files =
       max_generation_from_files_for_keepers_dir
@@ -273,23 +401,30 @@ let next_generation_with_floor_for_keepers_dir
       | None -> 0
     in
     let generation = max floor (max next_from_files next_from_counter) in
-    write_file_atomically counter_path (Printf.sprintf "%d\n" (generation + 1));
+    write_file_atomically_in_real_directory
+      counter_path
+      (Printf.sprintf "%d\n" (generation + 1));
     generation)
 ;;
 
 let next_generation_with_floor ~floor ~keeper_id ~trace_id =
   next_generation_with_floor_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~floor
     ~keeper_id:(keeper_name_exn keeper_id)
-    ~trace_id
+    ~trace_id:(trace_id_exn trace_id)
 ;;
 
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
+let unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
@@ -298,7 +433,7 @@ let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
       (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
-         episode.trace_id
+         (trace_id_string trace_id)
          episode.generation
          created_ms)
   in
@@ -324,12 +459,22 @@ let append_json path json =
   append_line path (Yojson.Safe.to_string json)
 ;;
 
+let append_json_no_follow path json =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  Fs_compat.append_file_durable_no_follow
+    path
+    (Yojson.Safe.to_string json ^ "\n")
+;;
+
 let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
 let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  append_json
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  require_real_directory keepers_dir;
+  append_json_no_follow
     (events_path_for_keepers_dir
        ~keepers_dir
        ~keeper_id:(keeper_name_string keeper_id))
@@ -338,40 +483,53 @@ let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
 
 let append_event ~keeper_id episode =
   append_event_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  let trace_id = trace_id_exn episode.trace_id in
+  let path =
+    unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  in
+  write_file_atomically_in_real_directory
+    path
+    (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
   append_episode_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
   with_episode_bundle_lock ~keeper_id (fun () ->
-    File_lock_eio.with_lock (facts_path ~keeper_id) (fun () ->
-      List.iter (append_fact ~keeper_id) episode.claims);
+    with_facts_lock_unhandled_for_keepers_dir
+      ~keepers_dir:(ensure_configured_keepers_dir ())
+      ~keeper_id:(keeper_name_exn keeper_id)
+      (fun () -> List.iter (append_fact ~keeper_id) episode.claims);
     append_episode ~keeper_id episode;
     append_event ~keeper_id episode)
 ;;
 
 let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_real_directory keepers_dir;
+  require_regular_file_or_missing path;
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
     |> String.concat "\n"
   in
   let content = if String.equal content "" then "" else content ^ "\n" in
-  write_file_atomically path content
+  write_file_atomically_in_real_directory path content
 ;;
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
@@ -382,7 +540,10 @@ let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
 ;;
 
 let rewrite_facts_atomically ~keeper_id facts =
-  rewrite_facts_atomically_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id facts
+  rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
+    facts
 ;;
 
 (* ---------- Facts snapshot CAS (optimistic concurrency) ---------- *)
@@ -407,19 +568,6 @@ let rec same_fact_snapshot left right =
   | l :: ls, r :: rs ->
     String.equal (fact_fingerprint l) (fact_fingerprint r) && same_fact_snapshot ls rs
   | [], _ :: _ | _ :: _, [] -> false
-;;
-
-(* Run [f] holding the per-keeper facts lock. On lock-acquisition timeout (another
-   writer holds the flock past the retry budget) [on_timeout msg] decides the
-   caller's result rather than letting [Flock_timeout] escape — callers that want a
-   typed skip/no-op outcome pass it here instead of catching the exception
-   themselves. Non-timeout body exceptions propagate after the lock finalizer runs.
-   Keep [on_timeout] total and non-raising so timeout remains a typed outcome, not
-   a second failure path. *)
-let with_facts_lock ?clock ~keeper_id ~on_timeout f =
-  try File_lock_eio.with_lock ?clock (facts_path ~keeper_id) f with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
 ;;
 
 let save_tool_result ~keeper_id ~tool_call_id json =
@@ -534,17 +682,18 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_lines_all (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  |> List.filter_map (parse_json_line fact_of_json)
-;;
-
-let read_facts_all ~keeper_id =
-  read_facts_all_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+let validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  require_real_directory keepers_dir;
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing path;
+  path
+;;
+
+let read_facts_all_at_path path =
+  read_lines_all path |> List.filter_map (parse_json_line fact_of_json)
+;;
+
+let read_facts_all_strict_at_path path =
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
@@ -554,18 +703,38 @@ let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
   loop 1 [] (read_lines_all path)
 ;;
 
-let read_facts_all_strict ~keeper_id =
-  read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
-  read_lines_tail (facts_path_for_keepers_dir ~keepers_dir ~keeper_id) ~n
+let read_facts_tail_at_path path ~n =
+  read_lines_tail path ~n
   |> List.filter_map (parse_json_line fact_of_json)
   |> take_last n
 ;;
 
+let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all ~keeper_id =
+  read_facts_all_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_strict_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all_strict ~keeper_id =
+  read_facts_all_strict_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
+  read_facts_tail_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~n
+;;
+
 let read_facts_tail ~keeper_id ~n =
-  read_facts_tail_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id ~n
+  read_facts_tail_at_path (facts_path ~keeper_id) ~n
 ;;
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
@@ -628,7 +797,7 @@ let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
 
 let read_facts_for_rewrite ~keeper_id =
   read_facts_for_rewrite_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -773,7 +942,7 @@ let merge_and_cap_facts
       ~rank
   =
   merge_and_cap_facts_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~now
     ~keeper_id:(keeper_name_exn keeper_id)
     ~merge
@@ -847,11 +1016,13 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
 let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  require_real_directory keepers_dir;
   let path =
     events_path_for_keepers_dir
       ~keepers_dir
       ~keeper_id:(keeper_name_string keeper_id)
   in
+  require_regular_file_or_missing path;
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -867,13 +1038,13 @@ let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
       | [] -> ""
       | _ -> String.concat "\n" kept ^ "\n"
     in
-    write_file_atomically path content;
+    write_file_atomically_in_real_directory path content;
     List.length all - List.length kept
 ;;
 
 let cap_events ~keeper_id ~keep ~trigger =
   cap_events_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger
@@ -919,7 +1090,7 @@ let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
 
 let cap_episode_files ~keeper_id ~keep ~trigger =
   cap_episode_files_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -53,60 +53,101 @@ let trace_id_exn raw =
 
 let trace_id_string = Keeper_id.Trace_id.to_string
 
-let lstat_if_present path =
-  try Some (Unix.lstat path) with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+module Anchored = Fs_compat.Anchored_dir
+
+type root =
+  { handle : Anchored.t
+  ; path : string
+  }
+
+type keeper_scope =
+  { root : root
+  ; keeper_id : Keeper_id.Keeper_name.t
+  ; keeper_name : string
+  }
+
+type episode_bundle = Episode_bundle of keeper_scope
+type facts_lock = Facts_lock of keeper_scope
+
+type lock_timeout =
+  { caller : string
+  ; path : string
+  ; attempts : int
+  }
+
+let lock_timeout_to_string timeout =
+  Printf.sprintf
+    "lock timeout: caller=%s path=%s attempts=%d"
+    timeout.caller
+    timeout.path
+    timeout.attempts
 ;;
 
-let require_real_directory path =
-  match lstat_if_present path with
-  | Some stat when stat.Unix.st_kind = Unix.S_DIR -> ()
-  | Some _ ->
-    invalid_arg (Printf.sprintf "expected a real directory, found another file kind: %s" path)
-  | None -> invalid_arg (Printf.sprintf "required directory does not exist: %s" path)
+let raise_lock_timeout timeout =
+  raise
+    (File_lock_eio.Flock_timeout
+       { caller = timeout.caller
+       ; path = timeout.path
+       ; attempts = timeout.attempts
+       })
 ;;
 
-let require_regular_file_or_missing path =
-  match lstat_if_present path with
-  | None -> ()
-  | Some stat when stat.Unix.st_kind = Unix.S_REG -> ()
-  | Some _ ->
+let segment_exn ~context raw =
+  match Anchored.Segment.of_string raw with
+  | Ok segment -> segment
+  | Error error ->
     invalid_arg
-      (Printf.sprintf "expected a regular file or missing path: %s" path)
+      (Printf.sprintf
+         "%s %S is not one filesystem segment: %s"
+         context
+         raw
+         (Anchored.Segment.error_to_string error))
 ;;
 
-let fsync_directory_exn path =
-  match Fs_compat.fsync_directory path with
-  | Ok () -> ()
-  | Error detail -> raise (Sys_error detail)
+let with_root path f =
+  Anchored.with_open_root path @@ fun handle ->
+  f { handle; path }
 ;;
 
-let ensure_real_child_directory ~parent ~child_name =
-  require_real_directory parent;
-  let child = Filename.concat parent child_name in
-  let created =
-    match lstat_if_present child with
-    | Some stat when stat.Unix.st_kind = Unix.S_DIR -> false
-    | Some _ ->
-      invalid_arg
-        (Printf.sprintf
-           "expected a real directory, found another file kind: %s"
-           child)
-    | None ->
-      (try
-         Unix.mkdir child 0o755;
-         true
-       with
-       | Unix.Unix_error (Unix.EEXIST, _, _) -> false)
+let scope root keeper_id =
+  { root; keeper_id; keeper_name = keeper_name_string keeper_id }
+;;
+
+let facts_suffix = ".facts.jsonl"
+let events_suffix = ".events.jsonl"
+let lock_suffix = ".lock"
+let episode_bundle_lock_suffix = ".episode-bundle.lock"
+
+let keeper_artifact_name ~suffix keeper_id =
+  segment_exn
+    ~context:"keeper memory artifact"
+    (keeper_name_string keeper_id ^ suffix)
+;;
+
+let facts_name keeper_id = keeper_artifact_name ~suffix:facts_suffix keeper_id
+let events_name keeper_id = keeper_artifact_name ~suffix:events_suffix keeper_id
+
+let facts_lock_name keeper_id =
+  keeper_artifact_name ~suffix:(facts_suffix ^ lock_suffix) keeper_id
+;;
+
+let episode_bundle_lock_name keeper_id =
+  keeper_artifact_name ~suffix:episode_bundle_lock_suffix keeper_id
+;;
+
+let with_descriptor_lock ?clock root name f =
+  let diagnostic_path =
+    Filename.concat root.path (Anchored.Segment.to_string name)
   in
-  require_real_directory parent;
-  require_real_directory child;
-  if created then fsync_directory_exn parent;
-  child
-;;
-
-let validate_lock_target base_path =
-  require_regular_file_or_missing (base_path ^ ".lock")
+  File_lock_eio.with_lock_file
+    ?clock
+    ~path:diagnostic_path
+    ~open_file:(fun () ->
+      Anchored.open_lock_file root.handle ~name ~perm:0o644)
+    ~descriptor:Anchored.lock_file_descriptor
+    ~identity:Anchored.lock_file_identity
+    ~close_file:Anchored.close_lock_file
+    f
 ;;
 
 module For_testing = struct
@@ -121,7 +162,7 @@ module For_testing = struct
 end
 
 let facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".facts.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ facts_suffix)
 ;;
 
 let facts_path ~keeper_id =
@@ -135,17 +176,22 @@ let facts_path ~keeper_id =
    sweep's output is never folded back in as a source keeper. Sorted for
    deterministic sweep order. *)
 let list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir =
-  let dir = keepers_dir in
-  if not (Sys.file_exists dir && Sys.is_directory dir)
-  then []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter_map (fun name ->
-      match Filename.chop_suffix_opt ~suffix:".facts.jsonl" name with
-      | Some id when not (String.equal id shared_store_id) -> Some id
-      | Some _ | None -> None)
-    |> List.sort String.compare
+  match
+    with_root keepers_dir (fun root ->
+      Anchored.read_dir root.handle
+      |> List.filter_map (fun entry ->
+        let name = Anchored.Segment.to_string entry in
+        match Filename.chop_suffix_opt ~suffix:facts_suffix name with
+        | Some id when String.equal id shared_store_id -> None
+        | Some id ->
+          (match Keeper_id.Keeper_name.of_string id with
+           | Ok keeper_id -> Some (keeper_name_string keeper_id)
+           | Error detail -> invalid_arg detail)
+        | None -> None)
+      |> List.sort String.compare)
+  with
+  | ids -> ids
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> []
 ;;
 
 let list_fact_store_keeper_ids () =
@@ -158,7 +204,7 @@ let list_fact_store_keeper_ids_for_base_path ~base_path =
 ;;
 
 let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ events_suffix)
 ;;
 
 type legacy_memory_file =
@@ -189,19 +235,14 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat
-    keepers_dir
-    (keeper_name_string keeper_id ^ ".episode-bundle")
-;;
-
 let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  require_real_directory keepers_dir;
-  let lock_base =
-    episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id
-  in
-  validate_lock_target lock_base;
-  File_lock_eio.with_lock ?clock lock_base f
+  with_root keepers_dir @@ fun root ->
+  let keeper = scope root keeper_id in
+  with_descriptor_lock
+    ?clock
+    root
+    (episode_bundle_lock_name keeper_id)
+    (fun () -> f (Episode_bundle keeper))
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
@@ -212,18 +253,20 @@ let with_episode_bundle_lock ?clock ~keeper_id f =
     f
 ;;
 
-let facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  facts_path_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id:(keeper_name_string keeper_id)
+let with_facts_lock_scope ?clock keeper f =
+  with_descriptor_lock
+    ?clock
+    keeper.root
+    (facts_lock_name keeper.keeper_id)
+    (fun () -> f (Facts_lock keeper))
 ;;
 
-let with_facts_lock_unhandled_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  require_real_directory keepers_dir;
-  let lock_base = facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_regular_file_or_missing lock_base;
-  validate_lock_target lock_base;
-  File_lock_eio.with_lock ?clock lock_base f
+let with_facts_lock_scope_or_timeout ?clock keeper ~on_timeout f =
+  try
+    with_facts_lock_scope ?clock keeper f
+  with
+  | File_lock_eio.Flock_timeout { caller; path; attempts } ->
+    on_timeout { caller; path; attempts }
 ;;
 
 let with_facts_lock_for_keepers_dir
@@ -233,15 +276,16 @@ let with_facts_lock_for_keepers_dir
       ~on_timeout
       f
   =
-  try
-    with_facts_lock_unhandled_for_keepers_dir
-      ?clock
-      ~keepers_dir
-      ~keeper_id
-      f
-  with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+  with_root keepers_dir @@ fun root ->
+  with_facts_lock_scope_or_timeout
+    ?clock
+    (scope root keeper_id)
+    ~on_timeout
+    f
+;;
+
+let with_facts_lock_in_bundle ?clock (Episode_bundle keeper) ~on_timeout f =
+  with_facts_lock_scope_or_timeout ?clock keeper ~on_timeout f
 ;;
 
 let with_facts_lock ?clock ~keeper_id ~on_timeout f =
@@ -255,15 +299,57 @@ let with_facts_lock ?clock ~keeper_id ~on_timeout f =
 
 let episodes_directory_name = "episodes"
 
-let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
-  let keeper_dir =
-    ensure_real_child_directory
-      ~parent:keepers_dir
-      ~child_name:(keeper_name_string keeper_id)
+let with_episodes_directory keeper f =
+  let keeper_name =
+    segment_exn ~context:"keeper directory" keeper.keeper_name
   in
-  ensure_real_child_directory
-    ~parent:keeper_dir
-    ~child_name:episodes_directory_name
+  let episodes_name =
+    segment_exn ~context:"episodes directory" episodes_directory_name
+  in
+  Anchored.with_ensure_dir
+    keeper.root.handle
+    ~name:keeper_name
+    ~perm:0o755
+    ~enforce_perm:false
+  @@ fun keeper_dir ->
+  Anchored.with_ensure_dir
+    keeper_dir
+    ~name:episodes_name
+    ~perm:0o755
+    ~enforce_perm:false
+    (fun handle ->
+      let path =
+        Filename.concat
+          keeper.root.path
+          (Filename.concat keeper.keeper_name episodes_directory_name)
+      in
+      f { handle; path })
+;;
+
+let with_existing_episodes_directory keeper f =
+  let keeper_name =
+    segment_exn ~context:"keeper directory" keeper.keeper_name
+  in
+  let episodes_name =
+    segment_exn ~context:"episodes directory" episodes_directory_name
+  in
+  match
+    Anchored.with_open_dir_opt keeper.root.handle keeper_name (fun keeper_dir ->
+      Anchored.with_open_dir_opt keeper_dir episodes_name (fun handle ->
+        let path =
+          Filename.concat
+            keeper.root.path
+            (Filename.concat keeper.keeper_name episodes_directory_name)
+        in
+        f { handle; path }))
+  with
+  | None | Some None -> None
+  | Some (Some value) -> Some value
+;;
+
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  with_root keepers_dir @@ fun root ->
+  with_episodes_directory (scope root keeper_id) (fun episodes -> episodes.path)
 ;;
 
 let episodes_dir ~keeper_id =
@@ -328,45 +414,64 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let write_file_atomically_in_real_directory path content =
-  require_real_directory (Filename.dirname path);
-  require_regular_file_or_missing path;
-  match Fs_compat.save_file_atomic path content with
+let atomic_replace directory name content =
+  match Anchored.atomic_replace directory.handle ~name ~perm:0o644 content with
   | Ok () -> ()
-  | Error msg -> raise (Atomic_write_failed msg)
+  | Error error ->
+    let path =
+      Filename.concat directory.path (Anchored.Segment.to_string name)
+    in
+    raise
+      (Atomic_write_failed
+         (Printf.sprintf
+            "%s: %s"
+            path
+            (Anchored.mutation_error_to_string error)))
 ;;
 
-let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
-  Filename.concat
-    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+let generation_counter_name trace_id =
+  segment_exn
+    ~context:"episode generation counter"
     (Printf.sprintf "%s.generation" (trace_id_string trace_id))
 ;;
 
-let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
-  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
+let generation_lock_name trace_id =
+  segment_exn
+    ~context:"episode generation lock"
+    (Printf.sprintf "%s.generation.lock" (trace_id_string trace_id))
+;;
+
+let leading_decimal value =
+  let rec end_index index =
+    if index >= String.length value
+    then index
+    else
+      match value.[index] with
+      | '0' .. '9' -> end_index (index + 1)
+      | _ -> index
+  in
+  match end_index 0 with
+  | 0 -> None
+  | length -> int_of_string_opt (String.sub value 0 length)
+;;
+
+let max_generation_from_files episodes trace_id =
   let prefix = Printf.sprintf "%s-g" (trace_id_string trace_id) in
-  Sys.readdir dir
-  |> Array.to_list
+  Anchored.read_dir episodes.handle
   |> List.filter_map (fun name ->
+    let name = Anchored.Segment.to_string name in
     if String.starts_with ~prefix name then
       let plen = String.length prefix in
       let rest = String.sub name plen (String.length name - plen) in
-      if String.length rest >= 4 then int_of_string_opt (String.sub rest 0 4) else None
+      leading_decimal rest
     else None)
   |> List.fold_left max (-1)
 ;;
 
-let read_generation_counter path =
-  require_regular_file_or_missing path;
-  match lstat_if_present path with
+let read_generation_counter episodes name =
+  match Anchored.read_file_opt episodes.handle name with
   | None -> None
-  | Some _ ->
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let len = in_channel_length ic in
-        really_input_string ic len |> String.trim |> int_of_string_opt)
+  | Some content -> String.trim content |> int_of_string_opt
 ;;
 
 (** Compute the next generation number for a trace's episode files.
@@ -382,29 +487,23 @@ let next_generation_with_floor_for_keepers_dir
       ~keeper_id
       ~trace_id
   =
-  let counter_path =
-    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  with_root keepers_dir @@ fun root ->
+  with_episodes_directory (scope root keeper_id) @@ fun episodes ->
+  let counter_name = generation_counter_name trace_id in
+  with_descriptor_lock episodes (generation_lock_name trace_id)
+  @@ fun () ->
+  let next_from_files = max_generation_from_files episodes trace_id + 1 in
+  let next_from_counter =
+    match read_generation_counter episodes counter_name with
+    | Some next -> next
+    | None -> 0
   in
-  require_regular_file_or_missing counter_path;
-  validate_lock_target counter_path;
-  File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files =
-      max_generation_from_files_for_keepers_dir
-        ~keepers_dir
-        ~keeper_id
-        ~trace_id
-      + 1
-    in
-    let next_from_counter =
-      match read_generation_counter counter_path with
-      | Some next -> next
-      | None -> 0
-    in
-    let generation = max floor (max next_from_files next_from_counter) in
-    write_file_atomically_in_real_directory
-      counter_path
-      (Printf.sprintf "%d\n" (generation + 1));
-    generation)
+  let generation = max floor (max next_from_files next_from_counter) in
+  atomic_replace
+    episodes
+    counter_name
+    (Printf.sprintf "%d\n" (generation + 1));
+  generation
 ;;
 
 let next_generation_with_floor ~floor ~keeper_id ~trace_id =
@@ -419,117 +518,135 @@ let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id
-      ~trace_id
-      episode
-  =
+let unique_episode_name episodes ~trace_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
-    Filename.concat
-      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
-      (Printf.sprintf
-         "%s-g%04d-t%013Ld"
-         (trace_id_string trace_id)
-         episode.generation
-         created_ms)
+    Printf.sprintf
+      "%s-g%04d-t%013Ld"
+      (trace_id_string trace_id)
+      episode.generation
+      created_ms
   in
   let rec loop suffix =
-    let path =
+    let raw =
       if suffix = 0
       then base ^ ".json"
       else Printf.sprintf "%s-%04d.json" base suffix
     in
-    if Sys.file_exists path then loop (suffix + 1) else path
+    let name = segment_exn ~context:"episode artifact" raw in
+    match Anchored.stat episodes.handle name with
+    | Some _ -> loop (suffix + 1)
+    | None -> name
   in
   loop 0
 ;;
 
-(* ---------- Append helpers ---------- *)
-
-let append_line path line =
-  ensure_dir (Filename.dirname path);
-  Fs_compat.append_file_durable path (line ^ "\n")
-;;
-
-let append_json path json =
-  append_line path (Yojson.Safe.to_string json)
-;;
-
-let append_json_no_follow path json =
-  require_real_directory (Filename.dirname path);
-  require_regular_file_or_missing path;
-  Fs_compat.append_file_durable_no_follow
-    path
-    (Yojson.Safe.to_string json ^ "\n")
+let append_json_anchored directory name json =
+  let current =
+    match Anchored.read_file_opt directory.handle name with
+    | Some content -> content
+    | None -> ""
+  in
+  atomic_replace
+    directory
+    name
+    (current ^ Yojson.Safe.to_string json ^ "\n")
 ;;
 
 let append_fact ~keeper_id fact =
-  append_json (facts_path ~keeper_id) (fact_to_json fact)
+  with_facts_lock
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+    (fun (Facts_lock keeper) ->
+      append_json_anchored keeper.root (facts_name keeper.keeper_id) (fact_to_json fact))
+;;
+
+let append_event_in_bundle (Episode_bundle keeper) episode =
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  append_json_anchored
+    keeper.root
+    (events_name keeper.keeper_id)
+    (episode_to_json episode)
+;;
+
+let append_episode_in_bundle (Episode_bundle keeper) episode =
+  let trace_id = trace_id_exn episode.trace_id in
+  with_episodes_directory keeper @@ fun episodes ->
+  let name = unique_episode_name episodes ~trace_id episode in
+  atomic_replace
+    episodes
+    name
+    (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
   ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
-  require_real_directory keepers_dir;
-  append_json_no_follow
-    (events_path_for_keepers_dir
-       ~keepers_dir
-       ~keeper_id:(keeper_name_string keeper_id))
-    (episode_to_json episode)
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> append_event_in_bundle bundle episode)
 ;;
 
 let append_event ~keeper_id episode =
+  let keeper_id = keeper_name_exn keeper_id in
   append_event_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     episode
 ;;
 
 let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  let trace_id = trace_id_exn episode.trace_id in
-  let path =
-    unique_episode_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id
-      ~trace_id
-      episode
-  in
-  write_file_atomically_in_real_directory
-    path
-    (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> append_episode_in_bundle bundle episode)
 ;;
 
 let append_episode ~keeper_id episode =
+  let keeper_id = keeper_name_exn keeper_id in
   append_episode_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     episode
 ;;
 
-let append_episode_bundle ~keeper_id episode =
-  with_episode_bundle_lock ~keeper_id (fun () ->
-    with_facts_lock_unhandled_for_keepers_dir
-      ~keepers_dir:(ensure_configured_keepers_dir ())
-      ~keeper_id:(keeper_name_exn keeper_id)
-      (fun () -> List.iter (append_fact ~keeper_id) episode.claims);
-    append_episode ~keeper_id episode;
-    append_event ~keeper_id episode)
-;;
-
-let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
-  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_real_directory keepers_dir;
-  require_regular_file_or_missing path;
+let facts_content facts =
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
     |> String.concat "\n"
   in
-  let content = if String.equal content "" then "" else content ^ "\n" in
-  write_file_atomically_in_real_directory path content
+  if String.equal content "" then "" else content ^ "\n"
+;;
+
+let rewrite_facts_in_lock (Facts_lock keeper) facts =
+  atomic_replace keeper.root (facts_name keeper.keeper_id) (facts_content facts)
+;;
+
+let append_episode_bundle ~keeper_id episode =
+  with_episode_bundle_lock ~keeper_id (fun bundle ->
+    with_facts_lock_in_bundle
+      bundle
+      ~on_timeout:raise_lock_timeout
+      (fun (Facts_lock keeper) ->
+        List.iter
+          (fun fact ->
+            append_json_anchored
+              keeper.root
+              (facts_name keeper.keeper_id)
+              (fact_to_json fact))
+          episode.claims);
+    append_episode_in_bundle bundle episode;
+    append_event_in_bundle bundle episode)
+;;
+
+let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  rewrite_facts_in_lock (Facts_lock (scope root keeper_id)) facts
 ;;
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
@@ -591,12 +708,6 @@ let load_tool_result ~keeper_id ~tool_call_id =
 
 (* ---------- Tail reads ---------- *)
 
-let count_newlines s =
-  let count = ref 0 in
-  String.iter (fun ch -> if Char.equal ch '\n' then incr count) s;
-  !count
-;;
-
 let split_lines s =
   let len = String.length s in
   let rec loop start i acc =
@@ -621,40 +732,6 @@ let split_lines s =
       loop start (i + 1) acc
   in
   loop 0 0 []
-;;
-
-let read_lines_tail path ~n =
-  if n <= 0 || not (Sys.file_exists path)
-  then []
-  else (
-    let ic = open_in_bin path in
-    let rec loop pos chunks newline_count =
-      if pos <= 0 || newline_count > n
-      then chunks
-      else (
-        let chunk_len = min 8192 pos in
-        let next_pos = pos - chunk_len in
-        seek_in ic next_pos;
-        let chunk = really_input_string ic chunk_len in
-        loop next_pos (chunk :: chunks) (newline_count + count_newlines chunk))
-    in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let len = in_channel_length ic in
-         loop len [] 0 |> String.concat "" |> split_lines))
-;;
-
-let read_lines_all path =
-  if not (Sys.file_exists path)
-  then []
-  else (
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let len = in_channel_length ic in
-         really_input_string ic len |> split_lines))
 ;;
 
 let take_last n xs =
@@ -682,59 +759,71 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  require_real_directory keepers_dir;
-  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_regular_file_or_missing path;
-  path
+let read_lines_all_anchored directory name =
+  match Anchored.read_file_opt directory.handle name with
+  | None -> []
+  | Some content -> split_lines content
 ;;
 
-let read_facts_all_at_path path =
-  read_lines_all path |> List.filter_map (parse_json_line fact_of_json)
+let read_facts_all_for_scope keeper =
+  read_lines_all_anchored keeper.root (facts_name keeper.keeper_id)
+  |> List.filter_map (parse_json_line fact_of_json)
 ;;
 
-let read_facts_all_strict_at_path path =
+let read_facts_all_strict_for_scope keeper =
+  let path =
+    facts_path_for_keepers_dir
+      ~keepers_dir:keeper.root.path
+      ~keeper_id:keeper.keeper_name
+  in
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
       let* fact = parse_fact_json_line_strict ~path ~line_number line in
       loop (line_number + 1) (fact :: acc) rest
   in
-  loop 1 [] (read_lines_all path)
+  loop 1 [] (read_lines_all_anchored keeper.root (facts_name keeper.keeper_id))
 ;;
 
-let read_facts_tail_at_path path ~n =
-  read_lines_tail path ~n
-  |> List.filter_map (parse_json_line fact_of_json)
-  |> take_last n
+let read_facts_all_strict_in_lock (Facts_lock keeper) =
+  read_facts_all_strict_for_scope keeper
 ;;
 
 let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_facts_all_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_for_scope (scope root keeper_id)
 ;;
 
 let read_facts_all ~keeper_id =
-  read_facts_all_at_path (facts_path ~keeper_id)
+  read_facts_all_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
 ;;
 
 let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_facts_all_strict_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_strict_for_scope (scope root keeper_id)
 ;;
 
 let read_facts_all_strict ~keeper_id =
-  read_facts_all_strict_at_path (facts_path ~keeper_id)
+  read_facts_all_strict_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
 ;;
 
 let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
-  read_facts_tail_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~n
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_for_scope (scope root keeper_id) |> take_last n
 ;;
 
 let read_facts_tail ~keeper_id ~n =
-  read_facts_tail_at_path (facts_path ~keeper_id) ~n
+  read_facts_tail_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
+    ~n
 ;;
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
@@ -777,28 +866,19 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
+let read_facts_for_rewrite_in_lock (Facts_lock keeper) =
   (* RFC-0302 (#22823) phase-2b: [keepers_dir] is resolved by the caller before
      this boundary. Offload the blocking full read + strict parse of the fact
      store off the main Eio scheduler. This is the per-write read on the
      librarian hot path ([merge_and_cap_facts]) and [cap_facts]. Callers hold a
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
-     reads only the explicit root and [keeper_id], and the Fs_compat rewrite that
-     follows stays on main. *)
+     reads only the retained root capability and typed keeper name. *)
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir
-        ~keepers_dir
-        ~keeper_id:(keeper_name_string keeper_id))
+      read_facts_all_strict_for_scope keeper)
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
-;;
-
-let read_facts_for_rewrite ~keeper_id =
-  read_facts_for_rewrite_for_keepers_dir
-    ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -808,8 +888,11 @@ let read_facts_for_rewrite ~keeper_id =
    rewrite happens only once every ([trigger] - [keep]) appended facts. Returns
    the number of facts dropped. *)
 let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
-  let path = facts_path ~keeper_id in
-  let all = read_facts_for_rewrite ~keeper_id in
+  with_facts_lock
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+  @@ fun (Facts_lock _ as lock) ->
+  let all = read_facts_for_rewrite_in_lock lock in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows before the trigger gate
      and before ranking, so an under-cap store does not retain expired rows on
      disk until the off-by-default GC sweep. Facts with no effective horizon
@@ -827,14 +910,7 @@ let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
         |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
         |> take_first keep
     in
-    let content =
-      match kept with
-      | [] -> ""
-      | _ ->
-        (kept |> List.map (fun f -> Yojson.Safe.to_string (fact_to_json f)) |> String.concat "\n")
-        ^ "\n"
-    in
-    write_file_atomically path content;
+    rewrite_facts_in_lock lock kept;
     List.length all - List.length kept)
 ;;
 
@@ -889,19 +965,16 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts_for_keepers_dir
-      ~keepers_dir
+let merge_and_cap_facts_in_lock
+      (Facts_lock _ as lock)
       ~now
-      ~keeper_id
       ~merge
       ~incoming
       ~keep
       ~trigger
       ~rank
   =
-  let existing =
-    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
-  in
+  let existing = read_facts_for_rewrite_in_lock lock in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -925,11 +998,33 @@ let merge_and_cap_facts_for_keepers_dir
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id:(keeper_name_string keeper_id)
-      kept;
+    rewrite_facts_in_lock lock kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  with_facts_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+    (fun lock ->
+      merge_and_cap_facts_in_lock
+        lock
+        ~now
+        ~merge
+        ~incoming
+        ~keep
+        ~trigger
+        ~rank)
 ;;
 
 let merge_and_cap_facts
@@ -952,20 +1047,20 @@ let merge_and_cap_facts
     ~rank
 ;;
 
-let read_events_tail ~keeper_id ~n =
-  read_lines_tail (events_path ~keeper_id) ~n
+let read_events_tail_for_scope keeper ~n =
+  read_lines_all_anchored keeper.root (events_name keeper.keeper_id)
   |> List.filter_map (parse_json_line episode_of_json)
   |> take_last n
 ;;
 
-let read_episode_file path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-       let len = in_channel_length ic in
-       let buf = really_input_string ic len in
-       parse_json_line episode_of_json buf)
+let read_events_tail ~keeper_id ~n =
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root (ensure_configured_keepers_dir ()) @@ fun root ->
+  read_events_tail_for_scope (scope root keeper_id) ~n
+;;
+
+let parse_episode_content content =
+  parse_json_line episode_of_json content
 ;;
 
 let compare_episode_recency a b =
@@ -983,24 +1078,39 @@ let compare_episode_recency a b =
       else String.compare a.episode_summary b.episode_summary))
 ;;
 
-let read_episode_files_tail ~keeper_id ~n =
-  let dir = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
-  if n <= 0 || not (Sys.file_exists dir && Sys.is_directory dir)
+let episode_files episodes =
+  Anchored.read_dir episodes.handle
+  |> List.filter (fun name ->
+    Filename.check_suffix (Anchored.Segment.to_string name) ".json")
+  |> List.filter_map (fun name ->
+    Anchored.read_file episodes.handle name
+    |> parse_episode_content
+    |> Option.map (fun episode -> name, episode))
+;;
+
+let read_episode_files_tail_for_scope keeper ~n =
+  if n <= 0
   then []
-  else (
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
-    |> List.map (fun name -> Filename.concat dir name)
-    |> List.filter Sys.file_exists
-    |> List.filter_map read_episode_file
-    |> List.sort compare_episode_recency
-    |> take_last n)
+  else
+    match
+      with_existing_episodes_directory keeper (fun episodes ->
+        episode_files episodes
+        |> List.map snd
+        |> List.sort compare_episode_recency
+        |> take_last n)
+    with
+    | None -> []
+    | Some episodes -> episodes
 ;;
 
 let read_episodes_tail ~keeper_id ~n =
-  let events = read_events_tail ~keeper_id ~n in
-  if events = [] then read_episode_files_tail ~keeper_id ~n else events
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root (ensure_configured_keepers_dir ()) @@ fun root ->
+  let keeper = scope root keeper_id in
+  let events = read_events_tail_for_scope keeper ~n in
+  if events = []
+  then read_episode_files_tail_for_scope keeper ~n
+  else events
 ;;
 
 (* RFC-0272 (defect D): the hysteresis decision shared by the episode-log caps.
@@ -1015,20 +1125,16 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
-  require_real_directory keepers_dir;
-  let path =
-    events_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id:(keeper_name_string keeper_id)
-  in
-  require_regular_file_or_missing path;
+let cap_events_in_bundle (Episode_bundle keeper) ~keep ~trigger =
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
-     does not starve the main Eio scheduler when a pool is installed (inline
-     fallback in tests / before the pool is set up). [path] is resolved on main;
-     the atomic rewrite below (write_file_atomically -> Fs_compat, an Eio.Path.save)
-     stays on main. The closure reads only [path] and no shared mutable state. *)
-  let all = Domain_pool_ref.submit_io_or_inline (fun () -> read_lines_all path) in
+     does not starve the main Eio scheduler when a pool is installed. The
+     closure retains the opened root capability, so an ancestor substitution
+     cannot redirect the read. *)
+  let name = events_name keeper.keeper_id in
+  let all =
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      read_lines_all_anchored keeper.root name)
+  in
   match trim_target ~count:(List.length all) ~keep ~trigger with
   | None -> 0
   | Some keep_n ->
@@ -1038,14 +1144,22 @@ let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
       | [] -> ""
       | _ -> String.concat "\n" kept ^ "\n"
     in
-    write_file_atomically_in_real_directory path content;
+    atomic_replace keeper.root name content;
     List.length all - List.length kept
 ;;
 
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> cap_events_in_bundle bundle ~keep ~trigger)
+;;
+
 let cap_events ~keeper_id ~keep ~trigger =
+  let keeper_id = keeper_name_exn keeper_id in
   cap_events_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     ~keep
     ~trigger
 ;;
@@ -1054,44 +1168,66 @@ let cap_events ~keeper_id ~keep ~trigger =
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
    parseable files are counted and ordered — an unparseable file has no recency
-   to rank, so it is left untouched rather than blindly deleted. Unlink is
-   best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
-   fine, and no lock is taken here that could deadlock with the bundle lock the
-   caller already holds. Returns the number unlinked. *)
-let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+   to rank, so it is left untouched rather than blindly deleted. Each unlink is
+   descriptor-relative and durably published; an I/O failure is surfaced rather
+   than treated as a successful trim. The caller already holds the bundle lock,
+   so no second lock is acquired. Returns the number unlinked. *)
+let cap_episode_files_in_bundle (Episode_bundle keeper) ~keep ~trigger =
   (* RFC-0302 (#22823): resolve and create [episodes_dir] from the explicit root
      on the main domain, then offload the blocking readdir + per-file episode read
      + best-effort unlink scan to the shared domain pool. The closure captures
      only immutable [dir]/[keep]/[trigger]; no mutable OCaml state is shared, so
      it is domain-safe. The caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
-  Domain_pool_ref.submit_io_or_inline (fun () ->
-    let parsed =
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
-      |> List.map (fun name -> Filename.concat dir name)
-      |> List.filter Sys.file_exists
-      |> List.filter_map (fun p ->
-        match read_episode_file p with
-        | Some ep -> Some (p, ep)
-        | None -> None)
-    in
-    match trim_target ~count:(List.length parsed) ~keep ~trigger with
-    | None -> 0
-    | Some keep_n ->
-      let sorted = List.sort (fun (_, a) (_, b) -> compare_episode_recency a b) parsed in
-      let n_drop = List.length sorted - keep_n in
-      let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
-      List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
-      List.length to_drop)
+  match
+    with_existing_episodes_directory keeper (fun episodes ->
+      let parsed =
+        Domain_pool_ref.submit_io_or_inline (fun () -> episode_files episodes)
+      in
+      match trim_target ~count:(List.length parsed) ~keep ~trigger with
+      | None -> 0
+      | Some keep_n ->
+        let sorted =
+          List.sort
+            (fun (_, left) (_, right) ->
+               compare_episode_recency left right)
+            parsed
+        in
+        let n_drop = List.length sorted - keep_n in
+        sorted
+        |> List.filteri (fun index _ -> index < n_drop)
+        |> List.fold_left
+             (fun removed (name, _) ->
+                match Anchored.unlink_if_exists episodes.handle name with
+                | Ok `Removed -> removed + 1
+                | Ok `Missing -> removed
+                | Error error ->
+                  raise
+                    (Atomic_write_failed
+                       (Printf.sprintf
+                          "%s: %s"
+                          (Filename.concat
+                             episodes.path
+                             (Anchored.Segment.to_string name))
+                          (Anchored.mutation_error_to_string error))))
+             0)
+  with
+  | None -> 0
+  | Some removed -> removed
+;;
+
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> cap_episode_files_in_bundle bundle ~keep ~trigger)
 ;;
 
 let cap_episode_files ~keeper_id ~keep ~trigger =
+  let keeper_id = keeper_name_exn keeper_id in
   cap_episode_files_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     ~keep
     ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,14 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let keeper_name_exn raw =
+  match Keeper_id.Keeper_name.of_string raw with
+  | Ok keeper_name -> keeper_name
+  | Error detail -> invalid_arg detail
+;;
+
+let keeper_name_string = Keeper_id.Keeper_name.to_string
+
 module For_testing = struct
   let with_keepers_dir path f =
     ensure_dir path;
@@ -111,18 +119,41 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat
+    keepers_dir
+    (keeper_name_string keeper_id ^ ".episode-bundle")
+;;
+
+let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  File_lock_eio.with_lock
+    ?clock
+    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
-  File_lock_eio.with_lock ?clock (episode_bundle_lock_path ~keeper_id) f
+  with_episode_bundle_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    f
+;;
+
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  let d =
+    Filename.concat
+      keepers_dir
+      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  in
+  ensure_dir d;
+  d
 ;;
 
 let episodes_dir ~keeper_id =
-  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
-  ensure_dir d;
-  d
+  episodes_dir_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 let tool_results_dir ~keeper_id =
@@ -180,12 +211,14 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let generation_counter_path ~keeper_id ~trace_id =
-  Filename.concat (episodes_dir ~keeper_id) (Printf.sprintf "%s.generation" trace_id)
+let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  Filename.concat
+    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+    (Printf.sprintf "%s.generation" trace_id)
 ;;
 
-let max_generation_from_files ~keeper_id ~trace_id =
-  let dir = episodes_dir ~keeper_id in
+let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   let prefix = Printf.sprintf "%s-g" trace_id in
   Sys.readdir dir
   |> Array.to_list
@@ -217,10 +250,23 @@ let read_generation_counter path =
     lock. The counter intentionally allows gaps when extraction later fails;
     uniqueness is more important than contiguous numbering across fibers or
     processes. *)
-let next_generation_with_floor ~floor ~keeper_id ~trace_id =
-  let counter_path = generation_counter_path ~keeper_id ~trace_id in
+let next_generation_with_floor_for_keepers_dir
+      ~keepers_dir
+      ~floor
+      ~keeper_id
+      ~trace_id
+  =
+  let counter_path =
+    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  in
   File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files = max_generation_from_files ~keeper_id ~trace_id + 1 in
+    let next_from_files =
+      max_generation_from_files_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+        ~trace_id
+      + 1
+    in
     let next_from_counter =
       match read_generation_counter counter_path with
       | Some next -> next
@@ -231,17 +277,25 @@ let next_generation_with_floor ~floor ~keeper_id ~trace_id =
     generation)
 ;;
 
+let next_generation_with_floor ~floor ~keeper_id ~trace_id =
+  next_generation_with_floor_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~floor
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~trace_id
+;;
+
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path ~keeper_id episode =
+let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
     Filename.concat
-      (episodes_dir ~keeper_id)
+      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
          episode.trace_id
@@ -263,8 +317,7 @@ let unique_episode_path ~keeper_id episode =
 
 let append_line path line =
   ensure_dir (Filename.dirname path);
-  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  with_out_channel oc ~f:(fun oc -> output_string oc (line ^ "\n"))
+  Fs_compat.append_file_durable path (line ^ "\n")
 ;;
 
 let append_json path json =
@@ -275,13 +328,31 @@ let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
+let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  append_json
+    (events_path_for_keepers_dir
+       ~keepers_dir
+       ~keeper_id:(keeper_name_string keeper_id))
+    (episode_to_json episode)
+;;
+
 let append_event ~keeper_id episode =
-  append_json (events_path ~keeper_id) (episode_to_json episode)
+  append_event_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
+;;
+
+let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
+  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
-  let path = unique_episode_path ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  append_episode_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
@@ -537,24 +608,28 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite ~keeper_id =
-  (* RFC-0302 (#22823) phase-2b: resolve keepers_dir on the main domain (it touches
-     the Config_dir_resolver plain-ref memo), then offload the blocking full read +
-     strict parse of the fact store off the main Eio scheduler. This is the
-     per-write read on the librarian hot path (merge_and_cap_facts) and cap_facts.
-     Byte-equivalent to [read_facts_all_strict ~keeper_id] (which is exactly
-     [read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ())]) — only
-     the resolution is hoisted to main and the read is offloaded. Callers hold a
+let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
+  (* RFC-0302 (#22823) phase-2b: [keepers_dir] is resolved by the caller before
+     this boundary. Offload the blocking full read + strict parse of the fact
+     store off the main Eio scheduler. This is the per-write read on the
+     librarian hot path ([merge_and_cap_facts]) and [cap_facts]. Callers hold a
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
-     reads only [keepers]/[keeper_id] and no shared mutable state, and the
-     Fs_compat rewrite that follows stays on main. *)
-  let keepers = keepers_dir () in
+     reads only the explicit root and [keeper_id], and the Fs_compat rewrite that
+     follows stays on main. *)
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir ~keepers_dir:keepers ~keeper_id)
+      read_facts_all_strict_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id:(keeper_name_string keeper_id))
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
+;;
+
+let read_facts_for_rewrite ~keeper_id =
+  read_facts_for_rewrite_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -645,8 +720,19 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
-  let existing = read_facts_for_rewrite ~keeper_id in
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  let existing =
+    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
+  in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -670,8 +756,31 @@ let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically ~keeper_id kept;
+    rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+      kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  merge_and_cap_facts_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~now
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~merge
+    ~incoming
+    ~keep
+    ~trigger
+    ~rank
 ;;
 
 let read_events_tail ~keeper_id ~n =
@@ -737,8 +846,12 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events ~keeper_id ~keep ~trigger =
-  let path = events_path ~keeper_id in
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  let path =
+    events_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+  in
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -758,6 +871,14 @@ let cap_events ~keeper_id ~keep ~trigger =
     List.length all - List.length kept
 ;;
 
+let cap_events ~keeper_id ~keep ~trigger =
+  cap_events_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
+;;
+
 (* RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
@@ -766,16 +887,14 @@ let cap_events ~keeper_id ~keep ~trigger =
    best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
    fine, and no lock is taken here that could deadlock with the bundle lock the
    caller already holds. Returns the number unlinked. *)
-let cap_episode_files ~keeper_id ~keep ~trigger =
-  (* RFC-0302 (#22823): resolve [episodes_dir] on the main domain (it touches the
-     Config_dir_resolver plain-ref memo + mkdir), then offload the blocking
-     readdir + per-file episode read + best-effort unlink scan to the shared
-     domain pool so the scan does not starve the main Eio scheduler. The offloaded
-     closure reads only the resolved [dir] string and does no Eio/lock/shared-
-     mutable work (Sys.remove is a filesystem unlink, not OCaml shared state), so
-     it is domain-safe; the caller's bundle flock stays held on main across the
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  (* RFC-0302 (#22823): resolve and create [episodes_dir] from the explicit root
+     on the main domain, then offload the blocking readdir + per-file episode read
+     + best-effort unlink scan to the shared domain pool. The closure captures
+     only immutable [dir]/[keep]/[trigger]; no mutable OCaml state is shared, so
+     it is domain-safe. The caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir ~keeper_id in
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   Domain_pool_ref.submit_io_or_inline (fun () ->
     let parsed =
       Sys.readdir dir
@@ -796,4 +915,12 @@ let cap_episode_files ~keeper_id ~keep ~trigger =
       let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
       List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
       List.length to_drop)
+;;
+
+let cap_episode_files ~keeper_id ~keep ~trigger =
+  cap_episode_files_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -61,6 +61,20 @@ val next_generation_with_floor_for_keepers_dir :
 
 (** {1 Atomic writes} *)
 
+type episode_bundle
+type facts_lock
+(** Scoped capabilities retained while the corresponding descriptor-anchored
+    lock is held. Values must not escape their callback. *)
+
+type lock_timeout =
+  { caller : string
+  ; path : string
+  ; attempts : int
+  }
+
+val lock_timeout_to_string : lock_timeout -> string
+val raise_lock_timeout : lock_timeout -> 'a
+
 (** Run [f] against the channel then close it, releasing the descriptor on every
     exit path — including when [close_out]'s flush raises, which OCaml's
     [close_out] leaves the fd open on. The body's exception propagates (so
@@ -75,6 +89,8 @@ val append_event_for_keepers_dir :
 val append_episode : keeper_id:string -> episode -> unit
 val append_episode_for_keepers_dir :
   keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
+val append_event_in_bundle : episode_bundle -> episode -> unit
+val append_episode_in_bundle : episode_bundle -> episode -> unit
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
@@ -84,14 +100,14 @@ val append_episode_for_keepers_dir :
 val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keeper_id:string ->
-  (unit -> 'a) ->
+  (episode_bundle -> 'a) ->
   'a
 
 val with_episode_bundle_lock_for_keepers_dir :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keepers_dir:string ->
   keeper_id:Keeper_id.Keeper_name.t ->
-  (unit -> 'a) ->
+  (episode_bundle -> 'a) ->
   'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
@@ -115,7 +131,7 @@ val fact_fingerprint : fact -> string
 val same_fact_snapshot : fact list -> fact list -> bool
 
 (** [with_facts_lock ?clock ~keeper_id ~on_timeout f] runs [f] holding the
-    per-keeper facts lock. On flock-acquisition timeout, [on_timeout msg] produces
+    per-keeper facts lock. On flock-acquisition timeout, [on_timeout timeout] produces
     the result instead of raising {!File_lock_eio.Flock_timeout}, so callers can
     return a typed skip/no-op for a contended cycle. Non-timeout exceptions from
     [f] propagate after the lock finalizer runs. Keep [on_timeout] total and
@@ -123,8 +139,8 @@ val same_fact_snapshot : fact list -> fact list -> bool
 val with_facts_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> keeper_id:string
-  -> on_timeout:(string -> 'a)
-  -> (unit -> 'a)
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
   -> 'a
 
 (** Explicit-root form of {!with_facts_lock}. [keeper_id] is already validated,
@@ -135,9 +151,21 @@ val with_facts_lock_for_keepers_dir :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> keepers_dir:string
   -> keeper_id:Keeper_id.Keeper_name.t
-  -> on_timeout:(string -> 'a)
-  -> (unit -> 'a)
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
   -> 'a
+
+val with_facts_lock_in_bundle :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> episode_bundle
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
+  -> 'a
+(** Acquire the facts lock from an existing bundle capability, retaining the
+    same opened keepers directory across both locks. *)
+
+val read_facts_all_strict_in_lock : facts_lock -> (fact list, string) result
+val rewrite_facts_in_lock : facts_lock -> fact list -> unit
 
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
@@ -193,10 +221,13 @@ val cap_events_for_keepers_dir :
   trigger:int ->
   int
 
+val cap_events_in_bundle : episode_bundle -> keep:int -> trigger:int -> int
+
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
-    recency and best-effort unlink the rest; otherwise no-op. Unparseable files
-    are left untouched. Returns the number unlinked. *)
+    recency and durably unlink the rest; otherwise no-op. Unparseable files are
+    left untouched. Every unlink failure is surfaced. Returns the number
+    unlinked. *)
 val cap_episode_files :
   keeper_id:string -> keep:int -> trigger:int -> int
 val cap_episode_files_for_keepers_dir :
@@ -205,6 +236,9 @@ val cap_episode_files_for_keepers_dir :
   keep:int ->
   trigger:int ->
   int
+
+val cap_episode_files_in_bundle :
+  episode_bundle -> keep:int -> trigger:int -> int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -252,13 +286,21 @@ val merge_and_cap_facts :
   -> rank:(fact -> float)
   -> fact_merge_stats
 
-(** The explicit-root merge is a read-modify-rewrite operation. Its caller must
-    hold {!with_facts_lock_for_keepers_dir}; if an episode bundle is also being
-    published, the caller must hold the bundle lock before the facts lock. *)
+(** The explicit-root merge acquires its own descriptor-anchored facts lock. *)
 val merge_and_cap_facts_for_keepers_dir :
   keepers_dir:string
   -> now:float
   -> keeper_id:Keeper_id.Keeper_name.t
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_in_lock :
+  facts_lock
+  -> now:float
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -34,6 +34,8 @@ val current_path_for_legacy_memory_filename :
     to the current store path under [keepers_dir], when the filename is a
     supported legacy memory artifact. *)
 val episodes_dir : keeper_id:string -> string
+val episodes_dir_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
@@ -47,7 +49,15 @@ val next_generation : keeper_id:string -> trace_id:string -> int
 
 (** Like {!next_generation}, but preserves a caller-provided generation lower
     bound while still advancing the counter past it. *)
-val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:string -> int
+val next_generation_with_floor :
+  floor:int -> keeper_id:string -> trace_id:string -> int
+
+val next_generation_with_floor_for_keepers_dir :
+  keepers_dir:string ->
+  floor:int ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  trace_id:string ->
+  int
 
 (** {1 Atomic writes} *)
 
@@ -60,13 +70,27 @@ val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
 
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
+val append_event_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+val append_episode_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
     lock, then publish [events_path] last as the reader-visible commit marker. *)
 val with_episode_bundle_lock :
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keeper_id:string ->
+  (unit -> 'a) ->
+  'a
+
+val with_episode_bundle_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  (unit -> 'a) ->
+  'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
@@ -147,12 +171,25 @@ val trim_target : count:int -> keep:int -> trigger:int -> int option
     malformed-line tolerant) and atomically rewrite; otherwise no-op. Returns the
     number of lines dropped. *)
 val cap_events : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_events_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
     recency and best-effort unlink the rest; otherwise no-op. Unparseable files
     are left untouched. Returns the number unlinked. *)
-val cap_episode_files : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files :
+  keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -193,6 +230,17 @@ type fact_merge_stats =
 val merge_and_cap_facts :
   now:float
   -> keeper_id:string
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_for_keepers_dir :
+  keepers_dir:string
+  -> now:float
+  -> keeper_id:Keeper_id.Keeper_name.t
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -56,7 +56,7 @@ val next_generation_with_floor_for_keepers_dir :
   keepers_dir:string ->
   floor:int ->
   keeper_id:Keeper_id.Keeper_name.t ->
-  trace_id:string ->
+  trace_id:Keeper_id.Trace_id.t ->
   int
 
 (** {1 Atomic writes} *)
@@ -78,7 +78,9 @@ val append_episode_for_keepers_dir :
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
-    lock, then publish [events_path] last as the reader-visible commit marker. *)
+    lock, then publish [events_path] last as the reader-visible commit marker.
+    The global lock order is bundle lock, then facts lock; reversing it can
+    deadlock another writer. *)
 val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keeper_id:string ->
@@ -124,6 +126,19 @@ val with_facts_lock :
   -> on_timeout:(string -> 'a)
   -> (unit -> 'a)
   -> 'a
+
+(** Explicit-root form of {!with_facts_lock}. [keeper_id] is already validated,
+    [keepers_dir] must be an existing real directory, and symlink/non-regular
+    fact and lock targets are rejected. When both locks are needed, acquire
+    {!with_episode_bundle_lock_for_keepers_dir} first and this lock second. *)
+val with_facts_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keepers_dir:string
+  -> keeper_id:Keeper_id.Keeper_name.t
+  -> on_timeout:(string -> 'a)
+  -> (unit -> 'a)
+  -> 'a
+
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
 
@@ -237,6 +252,9 @@ val merge_and_cap_facts :
   -> rank:(fact -> float)
   -> fact_merge_stats
 
+(** The explicit-root merge is a read-modify-rewrite operation. Its caller must
+    hold {!with_facts_lock_for_keepers_dir}; if an episode bundle is also being
+    published, the caller must hold the bundle lock before the facts lock. *)
 val merge_and_cap_facts_for_keepers_dir :
   keepers_dir:string
   -> now:float

--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,7 @@
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_job_store
+  test_keeper_memory_os_explicit_root
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_keeper_verification_audit

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2205,10 +2205,11 @@ let test_with_facts_lock_propagates_body_failure () =
          Memory_io.with_facts_lock
            ~clock
            ~keeper_id
-           ~on_timeout:(fun msg ->
+           ~on_timeout:(fun timeout ->
              Alcotest.fail
-               ("body Failure was misclassified as a lock timeout: " ^ msg))
-           (fun () -> failwith "body exploded")
+               ("body Failure was misclassified as a lock timeout: "
+                ^ Memory_io.lock_timeout_to_string timeout))
+           (fun _lock -> failwith "body exploded")
        with
        | _ -> Alcotest.fail "expected body Failure to propagate"
        | exception Failure msg when String.equal msg "body exploded" -> ()
@@ -2218,8 +2219,11 @@ let test_with_facts_lock_propagates_body_failure () =
         Memory_io.with_facts_lock
           ~clock
           ~keeper_id
-          ~on_timeout:(fun msg -> Alcotest.fail ("lock was not released: " ^ msg))
-          (fun () -> "reacquired")
+          ~on_timeout:(fun timeout ->
+            Alcotest.fail
+              ("lock was not released: "
+               ^ Memory_io.lock_timeout_to_string timeout))
+          (fun _lock -> "reacquired")
       in
       Alcotest.(check string) "lock reacquired after body exception" "reacquired" reacquired))
 ;;
@@ -2234,8 +2238,8 @@ let test_with_facts_lock_timeout_uses_on_timeout () =
           Memory_io.with_facts_lock
             ~clock
             ~keeper_id
-            ~on_timeout:(fun msg -> msg)
-            (fun () -> "unexpected body result")
+            ~on_timeout:Memory_io.lock_timeout_to_string
+            (fun _lock -> "unexpected body result")
         in
         Alcotest.(check bool)
           "timeout used on_timeout"
@@ -2245,8 +2249,11 @@ let test_with_facts_lock_timeout_uses_on_timeout () =
         Memory_io.with_facts_lock
           ~clock
           ~keeper_id
-          ~on_timeout:(fun msg -> Alcotest.fail ("lock was not released: " ^ msg))
-          (fun () -> "reacquired")
+          ~on_timeout:(fun timeout ->
+            Alcotest.fail
+              ("lock was not released: "
+               ^ Memory_io.lock_timeout_to_string timeout))
+          (fun _lock -> "reacquired")
       in
       Alcotest.(check string) "lock reacquired after timeout" "reacquired" reacquired))
 ;;

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -59,6 +59,12 @@ let expect_invalid_argument label f =
   | exception Invalid_argument _ -> ()
 ;;
 
+let expect_filesystem_rejection label f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected filesystem rejection" label
+  | exception Unix.Unix_error _ -> ()
+;;
+
 let test_explicit_root_isolates_append_and_generation () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
@@ -77,15 +83,9 @@ let test_explicit_root_isolates_append_and_generation () =
     Memory_io.with_episode_bundle_lock_for_keepers_dir
       ~keepers_dir:first
       ~keeper_id
-      (fun () ->
-         Memory_io.append_episode_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           first_episode;
-         Memory_io.append_event_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           first_episode);
+      (fun bundle ->
+         Memory_io.append_episode_in_bundle bundle first_episode;
+         Memory_io.append_event_in_bundle bundle first_episode);
     Alcotest.(check bool)
       "first root receives event"
       true
@@ -115,6 +115,24 @@ let test_explicit_root_isolates_append_and_generation () =
     Alcotest.(check int)
       "first generation advances"
       5
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:0
+         ~keeper_id
+         ~trace_id);
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun bundle ->
+         Memory_io.append_episode_in_bundle
+           bundle
+           (episode
+              ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+              ~generation:10_000
+              ~created_at:2_000.0));
+    Alcotest.(check int)
+      "generation scan keeps every decimal digit"
+      10_001
       (Memory_io.next_generation_with_floor_for_keepers_dir
          ~keepers_dir:first
          ~floor:0
@@ -152,16 +170,13 @@ let test_explicit_root_scopes_merge_and_retention () =
       Memory_io.with_facts_lock_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
-        ~on_timeout:Alcotest.fail
-        (fun () ->
-          Memory_io.rewrite_facts_atomically_for_keepers_dir
-            ~keepers_dir:first
-            ~keeper_id:keeper_id_string
-            [ existing ];
-          Memory_io.merge_and_cap_facts_for_keepers_dir
-            ~keepers_dir:first
+        ~on_timeout:(fun timeout ->
+          Alcotest.fail (Memory_io.lock_timeout_to_string timeout))
+        (fun lock ->
+          Memory_io.rewrite_facts_in_lock lock [ existing ];
+          Memory_io.merge_and_cap_facts_in_lock
+            lock
             ~now:3.0
-            ~keeper_id
             ~merge:(fun ~existing:_ ~incoming -> incoming)
             ~incoming:[ incoming ]
             ~keep:2
@@ -182,7 +197,7 @@ let test_explicit_root_scopes_merge_and_retention () =
       Memory_io.with_episode_bundle_lock_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
-        (fun () ->
+        (fun bundle ->
           List.iter
             (fun generation ->
               let persisted =
@@ -191,23 +206,15 @@ let test_explicit_root_scopes_merge_and_retention () =
                   ~generation
                   ~created_at:(10.0 +. float_of_int generation)
               in
-              Memory_io.append_episode_for_keepers_dir
-                ~keepers_dir:first
-                ~keeper_id
-                persisted;
-              Memory_io.append_event_for_keepers_dir
-                ~keepers_dir:first
-                ~keeper_id
-                persisted)
+              Memory_io.append_episode_in_bundle bundle persisted;
+              Memory_io.append_event_in_bundle bundle persisted)
             [ 0; 1; 2 ];
-          ( Memory_io.cap_events_for_keepers_dir
-              ~keepers_dir:first
-              ~keeper_id
+          ( Memory_io.cap_events_in_bundle
+              bundle
               ~keep:1
               ~trigger:2
-          , Memory_io.cap_episode_files_for_keepers_dir
-              ~keepers_dir:first
-              ~keeper_id
+          , Memory_io.cap_episode_files_in_bundle
+              bundle
               ~keep:1
               ~trigger:2 ))
     in
@@ -251,6 +258,71 @@ let test_invalid_episode_trace_is_rejected_before_io () =
          (Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id))))
 ;;
 
+let test_invalid_facts_keeper_is_rejected_before_io () =
+  with_temp_roots (fun ~first ~second:_ ->
+    expect_invalid_argument "invalid facts keeper" (fun () ->
+      Memory_io.rewrite_facts_atomically_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id:"../escape"
+        []);
+    Alcotest.(check (list string))
+      "invalid keeper creates no artifact"
+      []
+      (Sys.readdir first |> Array.to_list))
+;;
+
+let test_bundle_capability_survives_root_substitution () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "substitution-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let detached = Filename.concat (Filename.dirname first) "detached-first" in
+    let persisted =
+      episode
+        ~trace_id:"substitution-trace"
+        ~generation:0
+        ~created_at:1.0
+    in
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun bundle ->
+        Unix.rename first detached;
+        Unix.symlink second first;
+        Memory_io.append_event_in_bundle bundle persisted);
+    Alcotest.(check string)
+      "retained descriptor receives event"
+      (Yojson.Safe.to_string (Types.episode_to_json persisted) ^ "\n")
+      (Fs_compat.load_file
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:detached
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check bool)
+      "replacement target stays untouched"
+      false
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:second
+            ~keeper_id:keeper_id_string));
+    Sys.remove first;
+    Unix.rename detached first)
+;;
+
+let test_dotted_keeper_uses_ambient_api () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id = "keeper.alpha" in
+    let persisted =
+      episode ~trace_id:"dotted-trace" ~generation:0 ~created_at:1.0
+    in
+    Memory_io.For_testing.with_keepers_dir first (fun () ->
+      Memory_io.append_event ~keeper_id persisted;
+      Alcotest.(check int)
+        "dotted keeper event is readable"
+        1
+        (List.length (Memory_io.read_events_tail ~keeper_id ~n:1))))
+;;
+
 let test_symlinked_episodes_directory_is_rejected () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
@@ -266,7 +338,7 @@ let test_symlinked_episodes_directory_is_rejected () =
     let trace_id =
       Keeper_id.Trace_id.of_string "symlink-episodes-trace" |> Result.get_ok
     in
-    expect_invalid_argument "symlinked episodes directory" (fun () ->
+    expect_filesystem_rejection "symlinked episodes directory" (fun () ->
       Memory_io.append_episode_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
@@ -296,7 +368,7 @@ let test_symlinked_events_file_is_rejected () =
     let trace_id =
       Keeper_id.Trace_id.of_string "symlink-events-trace" |> Result.get_ok
     in
-    expect_invalid_argument "symlinked events file" (fun () ->
+    expect_filesystem_rejection "symlinked events file" (fun () ->
       Memory_io.append_event_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
@@ -326,6 +398,18 @@ let () =
             "invalid episode trace is rejected before I/O"
             `Quick
             test_invalid_episode_trace_is_rejected_before_io
+        ; Alcotest.test_case
+            "invalid facts keeper is rejected before I/O"
+            `Quick
+            test_invalid_facts_keeper_is_rejected_before_io
+        ; Alcotest.test_case
+            "bundle capability survives root substitution"
+            `Quick
+            test_bundle_capability_survives_root_substitution
+        ; Alcotest.test_case
+            "dotted keeper uses ambient API"
+            `Quick
+            test_dotted_keeper_uses_ambient_api
         ; Alcotest.test_case
             "symlinked episodes directory is rejected"
             `Quick

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -53,23 +53,36 @@ let episode_file_count ~keepers_dir ~keeper_id =
   |> List.length
 ;;
 
+let expect_invalid_argument label f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected Invalid_argument" label
+  | exception Invalid_argument _ -> ()
+;;
+
 let test_explicit_root_isolates_append_and_generation () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
       Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-root-trace" in
-    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-root-trace" |> Result.get_ok
+    in
+    let first_episode =
+      episode
+        ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+        ~generation:0
+        ~created_at:1_000.0
+    in
     Memory_io.with_episode_bundle_lock_for_keepers_dir
       ~keepers_dir:first
       ~keeper_id
       (fun () ->
-         Memory_io.append_event_for_keepers_dir
+         Memory_io.append_episode_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode;
-         Memory_io.append_episode_for_keepers_dir
+         Memory_io.append_event_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode);
@@ -124,23 +137,36 @@ let test_explicit_root_scopes_merge_and_retention () =
       |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-retention-trace" in
-    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
-    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
-    Memory_io.rewrite_facts_atomically_for_keepers_dir
-      ~keepers_dir:first
-      ~keeper_id:keeper_id_string
-      [ existing ];
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-retention-trace"
+      |> Result.get_ok
+    in
+    let trace_id_string = Keeper_id.Trace_id.to_string trace_id in
+    let existing =
+      fact ~claim:"existing" ~trace_id:trace_id_string ~turn:0 ~observed_at:1.0
+    in
+    let incoming =
+      fact ~claim:"incoming" ~trace_id:trace_id_string ~turn:1 ~observed_at:2.0
+    in
     let stats =
-      Memory_io.merge_and_cap_facts_for_keepers_dir
+      Memory_io.with_facts_lock_for_keepers_dir
         ~keepers_dir:first
-        ~now:3.0
         ~keeper_id
-        ~merge:(fun ~existing:_ ~incoming -> incoming)
-        ~incoming:[ incoming ]
-        ~keep:2
-        ~trigger:2
-        ~rank:(fun persisted -> persisted.Types.first_seen)
+        ~on_timeout:Alcotest.fail
+        (fun () ->
+          Memory_io.rewrite_facts_atomically_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string
+            [ existing ];
+          Memory_io.merge_and_cap_facts_for_keepers_dir
+            ~keepers_dir:first
+            ~now:3.0
+            ~keeper_id
+            ~merge:(fun ~existing:_ ~incoming -> incoming)
+            ~incoming:[ incoming ]
+            ~keep:2
+            ~trigger:2
+            ~rank:(fun persisted -> persisted.Types.first_seen))
     in
     Alcotest.(check int) "one fact appended" 1 stats.appended;
     Alcotest.(check int) "no fact merged" 0 stats.merged;
@@ -152,31 +178,43 @@ let test_explicit_root_scopes_merge_and_retention () =
      with
      | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
      | Error detail -> Alcotest.fail detail);
-    List.iter
-      (fun generation ->
-         Memory_io.append_event_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation));
-         Memory_io.append_episode_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation)))
-      [ 0; 1; 2 ];
+    let event_dropped, episode_dropped =
+      Memory_io.with_episode_bundle_lock_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (fun () ->
+          List.iter
+            (fun generation ->
+              let persisted =
+                episode
+                  ~trace_id:trace_id_string
+                  ~generation
+                  ~created_at:(10.0 +. float_of_int generation)
+              in
+              Memory_io.append_episode_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted;
+              Memory_io.append_event_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted)
+            [ 0; 1; 2 ];
+          ( Memory_io.cap_events_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2
+          , Memory_io.cap_episode_files_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2 ))
+    in
     Alcotest.(check int)
       "event cap reports removed rows"
       2
-      (Memory_io.cap_events_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      event_dropped;
     Alcotest.(check int)
       "event cap retains one row"
       1
@@ -188,15 +226,88 @@ let test_explicit_root_scopes_merge_and_retention () =
     Alcotest.(check int)
       "episode cap reports removed files"
       2
-      (Memory_io.cap_episode_files_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      episode_dropped;
     Alcotest.(check int)
       "episode cap retains one file"
       1
       (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let test_invalid_episode_trace_is_rejected_before_io () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "invalid-trace-keeper" |> Result.get_ok
+    in
+    let invalid_episode = episode ~trace_id:"../escape" ~generation:0 ~created_at:1.0 in
+    expect_invalid_argument "invalid episode trace" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        invalid_episode);
+    Alcotest.(check bool)
+      "invalid trace creates no keeper directory"
+      false
+      (Sys.file_exists
+         (Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id))))
+;;
+
+let test_symlinked_episodes_directory_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-episodes-keeper" |> Result.get_ok
+    in
+    let keeper_dir =
+      Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id)
+    in
+    Unix.mkdir keeper_dir 0o700;
+    let outside = Filename.concat second "outside-episodes" in
+    Unix.mkdir outside 0o700;
+    Unix.symlink outside (Filename.concat keeper_dir "episodes");
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-episodes-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked episodes directory" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check (list string))
+      "outside directory remains empty"
+      []
+      (Sys.readdir outside |> Array.to_list))
+;;
+
+let test_symlinked_events_file_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-events-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let outside = Filename.concat second "outside-events.jsonl" in
+    Fs_compat.save_file outside "sentinel\n";
+    Unix.symlink
+      outside
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string);
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-events-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked events file" (fun () ->
+      Memory_io.append_event_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check string)
+      "outside file remains unchanged"
+      "sentinel\n"
+      (Fs_compat.load_file outside))
 ;;
 
 let () =
@@ -211,6 +322,18 @@ let () =
             "merge and retention are root-scoped"
             `Quick
             test_explicit_root_scopes_merge_and_retention
+        ; Alcotest.test_case
+            "invalid episode trace is rejected before I/O"
+            `Quick
+            test_invalid_episode_trace_is_rejected_before_io
+        ; Alcotest.test_case
+            "symlinked episodes directory is rejected"
+            `Quick
+            test_symlinked_episodes_directory_is_rejected
+        ; Alcotest.test_case
+            "symlinked events file is rejected"
+            `Quick
+            test_symlinked_events_file_is_rejected
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,5 +1,5 @@
-module Types = Keeper_memory_os_types
-module Memory_io = Keeper_memory_os_io
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
 
 let with_temp_roots f =
   let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,0 +1,216 @@
+module Types = Keeper_memory_os_types
+module Memory_io = Keeper_memory_os_io
+
+let with_temp_roots f =
+  let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in
+  Sys.remove root;
+  Unix.mkdir root 0o700;
+  let first = Filename.concat root "first" in
+  let second = Filename.concat root "second" in
+  Unix.mkdir first 0o700;
+  Unix.mkdir second 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree root)
+    (fun () -> f ~first ~second)
+;;
+
+let fact ~claim ~trace_id ~turn ~observed_at =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = Some Types.Durable_knowledge
+  ; source = { Types.trace_id; turn; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen = observed_at
+  ; valid_until = None
+  ; last_verified_at = Some observed_at
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let episode ~trace_id ~generation ~created_at =
+  { Types.trace_id
+  ; generation
+  ; episode_summary = Printf.sprintf "episode-%d" generation
+  ; claims = []
+  ; open_items = []
+  ; constraints = []
+  ; preserved_tool_refs = []
+  ; source_turn_range = Some (generation, generation)
+  ; created_at
+  ; valid_until = None
+  ; terminal_marker = None
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let episode_file_count ~keepers_dir ~keeper_id =
+  Memory_io.episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id
+  |> Sys.readdir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.length
+;;
+
+let test_explicit_root_isolates_append_and_generation () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-root-trace" in
+    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun () ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode;
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode);
+    Alcotest.(check bool)
+      "first root receives event"
+      true
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check bool)
+      "second root remains untouched"
+      false
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:second
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check int)
+      "episode written only to explicit root"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id);
+    Alcotest.(check int)
+      "first generation starts at floor"
+      4
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:4
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "first generation advances"
+      5
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:0
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "second root has an independent counter"
+      0
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:second
+         ~floor:0
+         ~keeper_id
+         ~trace_id))
+;;
+
+let test_explicit_root_scopes_merge_and_retention () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-retention-keeper"
+      |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-retention-trace" in
+    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
+    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
+    Memory_io.rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id:keeper_id_string
+      [ existing ];
+    let stats =
+      Memory_io.merge_and_cap_facts_for_keepers_dir
+        ~keepers_dir:first
+        ~now:3.0
+        ~keeper_id
+        ~merge:(fun ~existing:_ ~incoming -> incoming)
+        ~incoming:[ incoming ]
+        ~keep:2
+        ~trigger:2
+        ~rank:(fun persisted -> persisted.Types.first_seen)
+    in
+    Alcotest.(check int) "one fact appended" 1 stats.appended;
+    Alcotest.(check int) "no fact merged" 0 stats.merged;
+    Alcotest.(check int) "no fact dropped" 0 stats.dropped;
+    (match
+       Memory_io.read_facts_all_strict_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+     with
+     | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
+     | Error detail -> Alcotest.fail detail);
+    List.iter
+      (fun generation ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation));
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation)))
+      [ 0; 1; 2 ];
+    Alcotest.(check int)
+      "event cap reports removed rows"
+      2
+      (Memory_io.cap_events_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "event cap retains one row"
+      1
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+       |> Fs_compat.load_jsonl
+       |> List.length);
+    Alcotest.(check int)
+      "episode cap reports removed files"
+      2
+      (Memory_io.cap_episode_files_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "episode cap retains one file"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os_explicit_root"
+    [ ( "explicit-root"
+      , [ Alcotest.test_case
+            "append and generation are root-scoped"
+            `Quick
+            test_explicit_root_isolates_append_and_generation
+        ; Alcotest.test_case
+            "merge and retention are root-scoped"
+            `Quick
+            test_explicit_root_scopes_merge_and_retention
+        ] )
+    ]
+;;


### PR DESCRIPTION
Replaces #24087 on the rebased durable-memory stack.\n\nBinds MemoryOS scoped locks to the anchored root capability, retaining explicit-root ownership through the compound facts/episode transaction.\n\nValidation: ocamlformat, parser checks, git diff --check; CI is the Dune build authority.