### PR TITLE
fix(ide): unify layout CSS, purge decorative layer chips, explicit empty states (#49 #51 #52)

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -58,6 +58,41 @@ describe('IdeActivityPanel', () => {
     expect(container.textContent).toContain('no keeper activity')
   })
 
+  it('shows a no-scope message instead of "no recent activity" when neither repoId nor keeperLane is set', async () => {
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, {}), container)
+
+    await waitFor(() => {
+      const notice = container.querySelector('[data-testid="ide-activity-no-scope"]')
+      expect(notice?.textContent).toBe('관측 스코프(저장소/keeper)가 선택되지 않았습니다')
+    })
+    expect(container.textContent).not.toContain('no recent activity')
+  })
+
+  it('shows "no recent activity" (not the no-scope message) when a scoped fetch genuinely finds nothing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({ ok: true, data: { events: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { repoId: 'masc' }), container)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('no recent activity')
+    })
+    expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).toBeNull()
+  })
+
   it('treats a null active file as no active file', () => {
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: null }), container)
@@ -598,7 +633,10 @@ describe('IdeActivityPanel', () => {
     await waitFor(() => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('offline 1 failed')
     })
-    expect(container.textContent).toContain('no recent activity')
+    // No repoId/keeperLane was passed: the empty list explains the missing
+    // scope rather than claiming "no recent activity" (which would imply
+    // a real, merely-empty fetch happened).
+    expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
   })
 
   it('degrades the refresh tone when the keeper lane fetch fails', async () => {

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -93,6 +93,112 @@ describe('IdeActivityPanel', () => {
     expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).toBeNull()
   })
 
+  it('hides the previous repository snapshot immediately when scope is cleared', async () => {
+    let activityCalls = 0
+    let resolveUnscopedGraph: ((response: Response) => void) | null = null
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            events: [{
+              type: 'turn',
+              keeper_id: 'repo-a-keeper',
+              turn_id: 'turn-repo-a',
+              phase: 'completed',
+              timestamp_ms: 100,
+            }],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      activityCalls += 1
+      if (activityCalls === 1) {
+        return new Response(JSON.stringify({ events: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Promise<Response>(resolve => {
+        resolveUnscopedGraph = resolve
+      })
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { repoId: 'repo-a' }), container)
+    await waitFor(() => expect(container.textContent).toContain('turn-repo-a'))
+
+    render(h(IdeActivityPanel, {}), container)
+    expect(container.textContent).not.toContain('turn-repo-a')
+    expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
+
+    await waitFor(() => expect(resolveUnscopedGraph).not.toBeNull())
+    resolveUnscopedGraph!(new Response(JSON.stringify({ events: [] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    await waitFor(() => {
+      expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('loaded')
+    })
+  })
+
+  it('does not expose repository A events while repository B is loading', async () => {
+    let resolveRepoB: ((response: Response) => void) | null = null
+    vi.stubGlobal('fetch', vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/activity/events')) {
+        return new Response(JSON.stringify({ events: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      if (url.includes('repo_id=repo-a')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            events: [{
+              type: 'turn',
+              keeper_id: 'repo-a-keeper',
+              turn_id: 'turn-repo-a',
+              phase: 'completed',
+              timestamp_ms: 100,
+            }],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('repo_id=repo-b')) {
+        return new Promise<Response>(resolve => {
+          resolveRepoB = resolve
+        })
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    }))
+
+    const container = document.createElement('div')
+    render(h(IdeActivityPanel, { repoId: 'repo-a' }), container)
+    await waitFor(() => expect(container.textContent).toContain('turn-repo-a'))
+
+    render(h(IdeActivityPanel, { repoId: 'repo-b' }), container)
+    expect(container.textContent).not.toContain('turn-repo-a')
+    await waitFor(() => expect(resolveRepoB).not.toBeNull())
+
+    resolveRepoB!(new Response(JSON.stringify({
+      ok: true,
+      data: {
+        events: [{
+          type: 'turn',
+          keeper_id: 'repo-b-keeper',
+          turn_id: 'turn-repo-b',
+          phase: 'completed',
+          timestamp_ms: 200,
+        }],
+      },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+    await waitFor(() => expect(container.textContent).toContain('turn-repo-b'))
+    expect(container.textContent).not.toContain('turn-repo-a')
+  })
+
   it('treats a null active file as no active file', () => {
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: null }), container)

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -69,10 +69,21 @@ interface ApiActivityResponse {
   readonly latest_seq?: number
 }
 
-interface ActivityFetchResult {
+interface GraphFetchResult {
   readonly events: ReadonlyArray<RunActivityEvent>
   readonly workspaceId: string
   readonly ok: boolean
+}
+
+interface ActivityFetchResult extends GraphFetchResult {
+  /**
+   * Whether the IDE-bridge portion of the feed (repo/keeper-lane scoped
+   * observations) was actually queried. False when neither repoId nor
+   * keeperLane is set — distinct from a real fetch that came back empty,
+   * so the render can tell "nothing to observe here" apart from "no
+   * scope selected" instead of collapsing both into one empty state.
+   */
+  readonly scoped: boolean
 }
 
 type ActivityRefreshTone = 'loading' | 'live' | 'stale' | 'offline'
@@ -209,16 +220,17 @@ async function fetchActivityEvents(
   const graph = await fetchActivityGraphEvents()
   const bridge = await fetchIdeBridgeRunActivityEvents(graph.workspaceId, repoId, keeperLane)
   return {
-    ...graph,
+    workspaceId: graph.workspaceId,
     // A bridge fetch failure must degrade the refresh tone instead of
     // rendering an empty-but-"live" feed: an operator cannot distinguish
     // "no keeper activity" from "the activity source is broken" otherwise.
     ok: graph.ok && bridge.ok,
     events: mergeRunActivityEvents(graph.events, bridge.events),
+    scoped: bridge.scoped,
   }
 }
 
-async function fetchActivityGraphEvents(): Promise<ActivityFetchResult> {
+async function fetchActivityGraphEvents(): Promise<GraphFetchResult> {
   try {
     const data = await get<ApiActivityResponse>('/api/v1/activity/events?limit=50')
     const rawEvents = data.events
@@ -236,6 +248,7 @@ async function fetchActivityGraphEvents(): Promise<ActivityFetchResult> {
 interface BridgeFetchResult {
   readonly events: ReadonlyArray<RunActivityEvent>
   readonly ok: boolean
+  readonly scoped: boolean
 }
 
 /**
@@ -257,7 +270,12 @@ async function fetchIdeBridgeRunActivityEvents(
   if (lane) {
     sources.push(fetchIdeEvents({ limit: 50, scope: { kind: 'keeper_lane', keeperId: lane } }))
   }
-  if (sources.length === 0) return { events: EMPTY_ACTIVITY, ok: true }
+  // Neither scope is set: there is nothing to query, not a request that
+  // happened to find zero events. `ok: true` here would previously read
+  // identically to a genuine empty-but-healthy fetch — `scoped: false`
+  // is the caller's signal to render "no scope selected" instead of
+  // "no recent activity".
+  if (sources.length === 0) return { events: EMPTY_ACTIVITY, ok: true, scoped: false }
   const settled = await Promise.allSettled(sources)
   const events: RunActivityEvent[] = []
   let ok = true
@@ -270,7 +288,7 @@ async function fetchIdeBridgeRunActivityEvents(
       ok = false
     }
   }
-  return { events, ok }
+  return { events, ok, scoped: true }
 }
 
 function mergeRunActivityEvents(
@@ -477,6 +495,13 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
     return store
   }, [])
   const [refreshState, setRefreshState] = useState<ActivityRefreshState>(INITIAL_REFRESH_STATE)
+  // Lazy-initialized from props so the first render (before the async
+  // fetch resolves) already reflects whether a scope is selected, instead
+  // of flashing "no recent activity" for a scoped panel that just hasn't
+  // loaded yet.
+  const [bridgeScoped, setBridgeScoped] = useState(
+    () => Boolean(repoId?.trim()) || Boolean(keeperLane?.trim()),
+  )
   const emittedTraceIds = useRef<ReadonlySet<string>>(new Set())
   const refreshMs = normalizedPollMs(pollMs)
 
@@ -490,8 +515,9 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
         lastAttemptMs: attemptMs,
         tone: prev.lastOkMs === null && prev.failedCount === 0 ? 'loading' : prev.tone,
       }))
-      const { events, workspaceId, ok } = await fetchActivityEvents(repoId, keeperLane)
+      const { events, workspaceId, ok, scoped } = await fetchActivityEvents(repoId, keeperLane)
       if (cancelled) return
+      setBridgeScoped(scoped)
       if (ok) {
         store.reset(workspaceId)
         store.seed(events)
@@ -577,7 +603,9 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
         class="ide-rail-list ide-activity-list"
       >
         ${events.length === 0
-          ? html`<li class="ide-rail-empty">no recent activity</li>`
+          ? bridgeScoped
+            ? html`<li class="ide-rail-empty">no recent activity</li>`
+            : html`<li class="ide-rail-empty" data-testid="ide-activity-no-scope">관측 스코프(저장소/keeper)가 선택되지 않았습니다</li>`
           : events.map(item => html`<${ActivityRow} item=${item} presence=${presence} overlay=${overlay} />`)}
       </ol>
     </div>

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -75,16 +75,7 @@ interface GraphFetchResult {
   readonly ok: boolean
 }
 
-interface ActivityFetchResult extends GraphFetchResult {
-  /**
-   * Whether the IDE-bridge portion of the feed (repo/keeper-lane scoped
-   * observations) was actually queried. False when neither repoId nor
-   * keeperLane is set — distinct from a real fetch that came back empty,
-   * so the render can tell "nothing to observe here" apart from "no
-   * scope selected" instead of collapsing both into one empty state.
-   */
-  readonly scoped: boolean
-}
+type ActivityFetchResult = GraphFetchResult
 
 type ActivityRefreshTone = 'loading' | 'live' | 'stale' | 'offline'
 
@@ -96,6 +87,7 @@ interface ActivityRefreshState {
 }
 
 const EMPTY_ACTIVITY: ReadonlyArray<RunActivityEvent> = []
+const EMPTY_KEEPERS: ReadonlyArray<string> = []
 const EMPTY_ANNOTATIONS: ReadonlyArray<IdeAnnotation> = []
 const EMPTY_DIFF_ROWS: ReadonlyArray<UnifiedDiffRow> = []
 const EMPTY_DIAGNOSTICS: ReadonlyArray<LspDiagnosticAnchor> = []
@@ -226,7 +218,6 @@ async function fetchActivityEvents(
     // "no keeper activity" from "the activity source is broken" otherwise.
     ok: graph.ok && bridge.ok,
     events: mergeRunActivityEvents(graph.events, bridge.events),
-    scoped: bridge.scoped,
   }
 }
 
@@ -248,7 +239,6 @@ async function fetchActivityGraphEvents(): Promise<GraphFetchResult> {
 interface BridgeFetchResult {
   readonly events: ReadonlyArray<RunActivityEvent>
   readonly ok: boolean
-  readonly scoped: boolean
 }
 
 /**
@@ -271,11 +261,9 @@ async function fetchIdeBridgeRunActivityEvents(
     sources.push(fetchIdeEvents({ limit: 50, scope: { kind: 'keeper_lane', keeperId: lane } }))
   }
   // Neither scope is set: there is nothing to query, not a request that
-  // happened to find zero events. `ok: true` here would previously read
-  // identically to a genuine empty-but-healthy fetch — `scoped: false`
-  // is the caller's signal to render "no scope selected" instead of
-  // "no recent activity".
-  if (sources.length === 0) return { events: EMPTY_ACTIVITY, ok: true, scoped: false }
+  // happened to find zero events. The caller derives the visible no-scope
+  // state from the current props, before any asynchronous response arrives.
+  if (sources.length === 0) return { events: EMPTY_ACTIVITY, ok: true }
   const settled = await Promise.allSettled(sources)
   const events: RunActivityEvent[] = []
   let ok = true
@@ -288,7 +276,7 @@ async function fetchIdeBridgeRunActivityEvents(
       ok = false
     }
   }
-  return { events, ok, scoped: true }
+  return { events, ok }
 }
 
 function mergeRunActivityEvents(
@@ -479,6 +467,14 @@ function normalizedPollMs(value: number | undefined): number | null {
   return Math.floor(value)
 }
 
+function activityScopeKey(repoId?: string | null, keeperLane?: string | null): string {
+  return JSON.stringify([repoId?.trim() || null, keeperLane?.trim() || null])
+}
+
+function hasActivityBridgeScope(repoId?: string | null, keeperLane?: string | null): boolean {
+  return Boolean(repoId?.trim()) || Boolean(keeperLane?.trim())
+}
+
 export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   const {
     activeFile: rawActiveFile = '',
@@ -495,15 +491,18 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
     return store
   }, [])
   const [refreshState, setRefreshState] = useState<ActivityRefreshState>(INITIAL_REFRESH_STATE)
-  // Lazy-initialized from props so the first render (before the async
-  // fetch resolves) already reflects whether a scope is selected, instead
-  // of flashing "no recent activity" for a scoped panel that just hasn't
-  // loaded yet.
-  const [bridgeScoped, setBridgeScoped] = useState(
-    () => Boolean(repoId?.trim()) || Boolean(keeperLane?.trim()),
-  )
+  const requestedScopeKey = activityScopeKey(repoId, keeperLane)
+  const bridgeScoped = hasActivityBridgeScope(repoId, keeperLane)
+  const [loadedScopeKey, setLoadedScopeKey] = useState<string | null>(null)
+  const loadedScopeKeyRef = useRef<string | null>(null)
   const emittedTraceIds = useRef<ReadonlySet<string>>(new Set())
   const refreshMs = normalizedPollMs(pollMs)
+
+  useEffect(() => {
+    if (loadedScopeKeyRef.current !== requestedScopeKey) {
+      setRefreshState(INITIAL_REFRESH_STATE)
+    }
+  }, [requestedScopeKey])
 
   useEffect(() => {
     let cancelled = false
@@ -515,12 +514,13 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
         lastAttemptMs: attemptMs,
         tone: prev.lastOkMs === null && prev.failedCount === 0 ? 'loading' : prev.tone,
       }))
-      const { events, workspaceId, ok, scoped } = await fetchActivityEvents(repoId, keeperLane)
+      const { events, workspaceId, ok } = await fetchActivityEvents(repoId, keeperLane)
       if (cancelled) return
-      setBridgeScoped(scoped)
       if (ok) {
         store.reset(workspaceId)
         store.seed(events)
+        loadedScopeKeyRef.current = requestedScopeKey
+        setLoadedScopeKey(requestedScopeKey)
         setRefreshState({
           tone: 'live',
           lastOkMs: Date.now(),
@@ -528,9 +528,10 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
           failedCount: 0,
         })
       } else {
+        const sameScopeSnapshot = loadedScopeKeyRef.current === requestedScopeKey
         setRefreshState(prev => ({
-          tone: prev.lastOkMs === null ? 'offline' : 'stale',
-          lastOkMs: prev.lastOkMs,
+          tone: sameScopeSnapshot && prev.lastOkMs !== null ? 'stale' : 'offline',
+          lastOkMs: sameScopeSnapshot ? prev.lastOkMs : null,
           lastAttemptMs: attemptMs,
           failedCount: prev.failedCount + 1,
         }))
@@ -542,7 +543,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
       cancelled = true
       if (timer !== null) clearTimeout(timer)
     }
-  }, [store, refreshMs, repoId, keeperLane])
+  }, [store, refreshMs, repoId, keeperLane, requestedScopeKey])
 
   useStoreSubscription(store.subscribe)
   useSignalValue(globalPresenceSnapshot)
@@ -550,8 +551,9 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   useSignalValue(ideConversationThreadSnapshot)
   useSignalValue(lspDiagnosticSnapshot)
 
-  const events = store.events()
-  const keepers = store.knownKeepers()
+  const snapshotMatchesScope = loadedScopeKey === requestedScopeKey
+  const events = snapshotMatchesScope ? store.events() : EMPTY_ACTIVITY
+  const keepers = snapshotMatchesScope ? store.knownKeepers() : EMPTY_KEEPERS
   const presence = globalPresenceSnapshot.value
   const overlay = cursorOverlaySignal.value
   const threadSnapshot = ideConversationThreadSnapshot.value

--- a/dashboard/src/components/ide/ide-editor-blame.ts
+++ b/dashboard/src/components/ide/ide-editor-blame.ts
@@ -1,20 +1,21 @@
 import { html } from 'htm/preact'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
+import { assertExhaustive } from '../../lib/exhaustive'
 import { KeeperBadge } from '../keeper-badge'
 import type { LineOwnership } from './keeper-line-ownership-store'
 
-const IDE_LAYER_ORDER = ['time', 'parallel', 'tools', 'approve', 'notes', 'runtime', 'keeper-trace', 'explode'] as const
+// 'tools' / 'approve' / 'runtime' / 'explode' were removed (masc#24069 #49):
+// layerSummary() returned hardcoded literals ('0 anchored' / '0 approval' /
+// '0 hits') with no backing data source, and 'explode' had no render branch
+// anywhere despite its toolbar tooltip promising a per-keeper ghost view.
+const IDE_LAYER_ORDER = ['time', 'parallel', 'notes', 'keeper-trace'] as const
 export type IdeLayerKind = (typeof IDE_LAYER_ORDER)[number]
 
 const LAYER_LABEL: Record<IdeLayerKind, string> = {
   time: 'Time',
   parallel: 'Parallel',
-  tools: 'Tools',
-  approve: 'Approve',
   notes: 'Notes',
-  runtime: 'Runtime',
   'keeper-trace': 'Trace',
-  explode: 'EXPLODE',
 }
 
 export function editorGridRows(hasLayerSummary: boolean, findOpen: boolean): string {
@@ -93,8 +94,8 @@ export function LayerOverlaySummary(
             padding: '1px var(--sp-2)',
             border: '1px solid var(--color-border-default)',
             borderRadius: 'var(--r-2)',
-            background: kind === 'explode' ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',
-            color: kind === 'explode' ? 'var(--color-accent-fg)' : 'var(--color-fg-secondary)',
+            background: 'var(--color-bg-elevated)',
+            color: 'var(--color-fg-secondary)',
             whiteSpace: 'nowrap',
           }}
         >
@@ -139,13 +140,11 @@ function layerLabel(kind: IdeLayerKind): string {
 }
 
 function layerSummary(kind: IdeLayerKind, latestEdit: number | null, keepers: ReadonlyArray<string>, annotationCount: number = 0): string {
-  if (kind === 'time') return latestEdit === null ? 'no edits' : `latest ${formatTime(latestEdit)}`
-  if (kind === 'parallel') return `${keepers.length} keepers`
-  if (kind === 'tools') return '0 anchored'
-  if (kind === 'approve') return '0 approval'
-  if (kind === 'notes') return annotationCount === 1 ? '1 note' : `${annotationCount} notes`
-  if (kind === 'runtime') return '0 hits'
-  if (kind === 'keeper-trace') return 'stitched trace'
-  if (kind === 'explode') return 'exclusive ghost view'
-  return ''
+  switch (kind) {
+    case 'time': return latestEdit === null ? 'no edits' : `latest ${formatTime(latestEdit)}`
+    case 'parallel': return `${keepers.length} keepers`
+    case 'notes': return annotationCount === 1 ? '1 note' : `${annotationCount} notes`
+    case 'keeper-trace': return 'stitched trace'
+    default: return assertExhaustive(kind, 'IdeLayerKind')
+  }
 }

--- a/dashboard/src/components/ide/ide-memory-panel.test.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.test.ts
@@ -42,7 +42,7 @@ describe('IdeMemoryPanel', () => {
   })
 
   it('renders v2 IDE marker classes for the panel, rows, and action button', async () => {
-    render(h(IdeMemoryPanel, { keeperName: 'sangsu' }), container)
+    render(h(IdeMemoryPanel, { keeperName: 'sangsu', repoId: 'masc' }), container)
 
     await waitFor(() => {
       expect(container.querySelector('.ide-memory-panel.v2-ide-panel')).not.toBeNull()
@@ -84,5 +84,33 @@ describe('IdeMemoryPanel', () => {
     expect(String(url)).toContain('keeper_id=sangsu')
     expect(String(url)).toContain('canonical_url=https%3A%2F%2Fgithub.com%2Fjeong-sik%2Fmasc.git')
     expect(String(url)).not.toContain('repo_id=')
+  })
+
+  it('renders an explicit no-repo-selected state and never calls the API without a scope', async () => {
+    render(h(IdeMemoryPanel, { keeperName: 'sangsu' }), container)
+
+    await waitFor(() => {
+      const notice = container.querySelector('[data-testid="ide-memory-panel-no-scope"]')
+      expect(notice?.textContent).toBe('저장소를 선택하면 메모리를 조회합니다')
+    })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(container.querySelector('.ide-memory-panel__error')).toBeNull()
+  })
+
+  it('shows the typed API error message instead of a bare status code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ error: 'repo_index_unavailable', message: 'Repository index is rebuilding' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    render(h(IdeMemoryPanel, { keeperName: 'sangsu', repoId: 'masc' }), container)
+
+    await waitFor(() => {
+      const errorNode = container.querySelector('[data-testid="ide-memory-panel-error"]')
+      expect(errorNode?.textContent).toContain('Repository index is rebuilding')
+    })
+    expect(container.querySelector('[data-testid="ide-memory-panel-error"]')?.textContent).not.toBe('HTTP 503')
   })
 })

--- a/dashboard/src/components/ide/ide-memory-panel.ts
+++ b/dashboard/src/components/ide/ide-memory-panel.ts
@@ -3,6 +3,7 @@ import { useEffect, useState, useCallback } from 'preact/hooks'
 import { MemoryLens } from '../memory/memory-lens'
 import type { MemoryLensProps } from '../memory/memory-lens'
 import { appendIdeScopeParams, type IdeScope } from '../../api/ide'
+import { extractApiError, get } from '../../api/core'
 
 interface MemoryEntry {
   readonly id: string
@@ -150,7 +151,21 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Mirrors api/ide.ts's resolveIdeScope: the server requires exactly one
+  // of repo_id / canonical_url / keeper_lane. Without one it fails closed
+  // with 400 missing_ide_scope — checking here first means the panel never
+  // makes that doomed request and never surfaces its bare status code.
+  const hasScope = Boolean(scope) || Boolean(repoId?.trim()) || Boolean(canonicalUrl?.trim())
+
   const fetchMemory = useCallback(async () => {
+    if (!hasScope) {
+      setEntries([])
+      setTotal(0)
+      setContract(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
     setLoading(true)
     setError(null)
     try {
@@ -158,18 +173,16 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
       if (keeperName) params.set('keeper_id', keeperName)
       appendIdeScopeParams(params, { scope, repoId, canonicalUrl })
       params.set('limit', '50')
-      const res = await fetch(`/api/v1/ide/memory?${params}`)
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data: MemoryResponse = await res.json()
+      const data = await get<MemoryResponse>(`/api/v1/ide/memory?${params}`)
       setEntries(data.entries)
       setTotal(data.total)
       setContract(data.contract ?? null)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load')
+      setError(extractApiError(e, 'Failed to load memory entries').message)
     } finally {
       setLoading(false)
     }
-  }, [keeperName, scope, repoId, canonicalUrl])
+  }, [hasScope, keeperName, scope, repoId, canonicalUrl])
 
   useEffect(() => {
     fetchMemory()
@@ -193,19 +206,21 @@ export function IdeMemoryPanel({ keeperName, scope, repoId, canonicalUrl }: IdeM
           <button
             class="ide-memory-panel__refresh v2-ide-action"
             onClick=${fetchMemory}
-            disabled=${loading}
+            disabled=${loading || !hasScope}
             title="Refresh memory entries"
           >↻</button>
           <span class="ide-memory-panel__count">${total}</span>
         </span>
       </div>
-      ${loading
-        ? html`<div class="ide-memory-panel__loading">Loading...</div>`
-        : error
-          ? html`<div class="ide-memory-panel__error">${error}</div>`
-          : entries.length === 0
-            ? html`<div class="ide-memory-panel__empty">No memory entries</div>`
-            : html`
+      ${!hasScope
+        ? html`<div class="ide-memory-panel__empty" data-testid="ide-memory-panel-no-scope">저장소를 선택하면 메모리를 조회합니다</div>`
+        : loading
+          ? html`<div class="ide-memory-panel__loading">Loading...</div>`
+          : error
+            ? html`<div class="ide-memory-panel__error" data-testid="ide-memory-panel-error">${error}</div>`
+            : entries.length === 0
+              ? html`<div class="ide-memory-panel__empty">No memory entries</div>`
+              : html`
               <div class="ide-memory-panel__list">
                 ${entries.map(
                   (entry) => html`

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -184,7 +184,7 @@ describe('IdeShell', () => {
   it('hydrates layer buttons from the route layers param', () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'source', layers: 'time,approve' },
+      params: { section: 'ide-shell', view: 'source', layers: 'time,notes' },
       postId: null,
     }
 
@@ -196,12 +196,74 @@ describe('IdeShell', () => {
     expect(container.querySelector('[data-testid="ide-readiness-notice"]')?.textContent)
       .toBe('experimental')
     expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Tools').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('false')
     expect(container.textContent).toContain('PERSISTENCE MAP')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Time')
-    expect(container.textContent).toContain('Approve')
+    expect(container.textContent).toContain('Notes')
+  })
+
+  it('disables time/parallel layer buttons outside the BLAME view with an explanatory tooltip', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source', layers: 'time,parallel' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const timeBtn = buttonByText(container, 'Time')
+    const parallelBtn = buttonByText(container, 'Parallel')
+    expect(timeBtn.disabled).toBe(true)
+    expect(parallelBtn.disabled).toBe(true)
+    expect(timeBtn.getAttribute('title')).toContain('BLAME 뷰에서만')
+    expect(parallelBtn.getAttribute('title')).toContain('BLAME 뷰에서만')
+    // Deep-linked active state survives the gate — disabled communicates
+    // "can't toggle here", not "silently cleared".
+    expect(timeBtn.getAttribute('aria-pressed')).toBe('true')
+    expect(parallelBtn.getAttribute('aria-pressed')).toBe('true')
+    // Trace/Notes are not view-gated.
+    expect(buttonByText(container, 'Trace').disabled).toBe(false)
+    expect(buttonByText(container, 'Notes').disabled).toBe(false)
+  })
+
+  it('enables time/parallel layer buttons in the BLAME view', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'blame' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    expect(buttonByText(container, 'Time').disabled).toBe(false)
+    expect(buttonByText(container, 'Parallel').disabled).toBe(false)
+  })
+
+  it('removed the decorative tools/approve/runtime/explode layer chips', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    // Scope to the layers group: the context route-group chips legitimately
+    // render a 'Runtime' button, so a container-wide text probe would match
+    // the wrong feature and mask a layer-chip regression.
+    const layers = container.querySelector('[data-testid="ide-toolbar-layers"]')
+    expect(layers).not.toBeNull()
+    const layerLabels = Array.from(layers!.querySelectorAll('button'))
+      .map(button => button.textContent?.trim())
+    expect(layerLabels).not.toContain('Tools')
+    expect(layerLabels).not.toContain('Approve')
+    expect(layerLabels).not.toContain('Runtime')
+    expect(layerLabels).not.toContain('EXPLODE')
+    expect(layerLabels).toEqual(
+      expect.arrayContaining(['Time', 'Parallel', 'Notes', 'Trace']),
+    )
   })
 
   it('renders repository git status without the dirty-count stub', async () => {
@@ -314,7 +376,7 @@ describe('IdeShell', () => {
   it('derives compact operational statusbar chips from IDE route context', () => {
     const model = deriveIdeStatusbarModel({
       activeView: 'split-diff',
-      activeLayers: new Set(['keeper-trace', 'approve']),
+      activeLayers: new Set(['keeper-trace', 'notes']),
       activeFilePath: 'dashboard/src/components/ide/ide-shell.ts',
       findOpen: true,
       terminalOpen: true,
@@ -708,19 +770,19 @@ describe('IdeShell', () => {
   it('persists layer toggles back to the route', () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'split-diff', layers: 'time,approve' },
+      params: { section: 'ide-shell', view: 'split-diff', layers: 'notes' },
       postId: null,
     }
 
     render(h(IdeShell, {}), container)
     expect(container.querySelector('[aria-label="Split diff preview"]')).not.toBeNull()
-    fireEvent.click(buttonByText(container, 'Tools'))
+    fireEvent.click(buttonByText(container, 'Trace'))
 
     expect(route.value.params.view).toBe('split-diff')
-    expect(route.value.params.layers).toBe('approve,time,tools')
+    expect(route.value.params.layers).toBe('keeper-trace,notes')
 
-    fireEvent.click(buttonByText(container, 'EXPLODE'))
-    expect(route.value.params.layers).toBe('explode')
+    fireEvent.click(buttonByText(container, 'Notes'))
+    expect(route.value.params.layers).toBe('keeper-trace')
   })
 
   it('turns focus=review into a unified review workspace with review layers', () => {
@@ -735,24 +797,22 @@ describe('IdeShell', () => {
     expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
     expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Runtime').getAttribute('aria-pressed')).toBe('false')
+    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('false')
   })
 
   it('lets explicit review-focus layers override the default review bundle', () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'unified', focus: 'review', layers: 'runtime' },
+      params: { section: 'ide-shell', view: 'unified', focus: 'review', layers: 'parallel' },
       postId: null,
     }
 
     render(h(IdeShell, {}), container)
 
     expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
-    expect(buttonByText(container, 'Runtime').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
-    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
   })
 
@@ -765,13 +825,11 @@ describe('IdeShell', () => {
 
     render(h(IdeShell, {}), container)
     fireEvent.click(buttonByText(container, 'Trace'))
-    fireEvent.click(buttonByText(container, 'Approve'))
     fireEvent.click(buttonByText(container, 'Notes'))
 
     expect(route.value.params.layers).toBe('none')
     expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
-    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
   })
 
@@ -786,7 +844,6 @@ describe('IdeShell', () => {
 
     expect(container.querySelector('[data-testid="ide-review-focus"]')).toBeNull()
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
-    expect(buttonByText(container, 'Approve').getAttribute('aria-pressed')).toBe('false')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
   })
 
@@ -831,12 +888,12 @@ describe('IdeShell', () => {
 
     render(h(IdeShell, {}), container)
     const input = ideCommandInput(container)
-    input.value = 'runtime'
+    input.value = 'parallel'
     fireEvent.input(input)
     await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull())
     fireEvent.keyDown(input, { key: 'Enter' })
 
-    expect(route.value.params.layers).toBe('runtime')
+    expect(route.value.params.layers).toBe('parallel')
   })
 
   it('runs the rails command from the IDE command bar', async () => {
@@ -892,27 +949,6 @@ describe('IdeShell', () => {
     expect(container.querySelector('[data-testid="ide-find-panel"]')).not.toBeNull()
   })
 
-  it('renders the Runtime layer button and toggles it via URL', () => {
-    route.value = {
-      tab: 'code',
-      params: { section: 'ide-shell', view: 'source' },
-      postId: null,
-    }
-
-    render(h(IdeShell, {}), container)
-
-    const btn = buttonByText(container, 'Runtime')
-    expect(btn.getAttribute('aria-pressed')).toBe('false')
-
-    fireEvent.click(btn)
-    expect(route.value.params.layers).toBe('runtime')
-    expect(btn.getAttribute('aria-pressed')).toBe('true')
-
-    fireEvent.click(btn)
-    expect(route.value.params.layers).toBeUndefined()
-    expect(btn.getAttribute('aria-pressed')).toBe('false')
-  })
-
   it('preserves keeper context and chat while keeping the terminal drawer present', () => {
     route.value = {
       tab: 'code',
@@ -945,6 +981,36 @@ describe('IdeShell', () => {
       .toContain('waiting for Execute output')
     expect(container.querySelector('[data-testid="ide-interject-fab"]')).not.toBeNull()
   })
+
+  it('keeps default right rail context diagnostics bounded above the primary conversation rail', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const rail = container.querySelector('[data-testid="ide-right-rail"]')
+    const contextStack = container.querySelector('[data-testid="ide-right-context-stack"]')
+    const primaryRail = container.querySelector('[data-testid="ide-primary-conversation-rail"]')
+    expect(rail).not.toBeNull()
+    expect(contextStack).not.toBeNull()
+    expect(primaryRail).not.toBeNull()
+    expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
+    // rail tab labels renamed by #24081 ('Run Activity' → '활동', 'Keeper
+    // Cursors' → '커서'); the diagnostics-bounding assertions are unchanged.
+    expect(buttonByText(container, '활동').getAttribute('title'))
+      .toBe('Workspace and keeper activity linked to the active file and repository')
+    expect(buttonByText(container, '커서').getAttribute('title'))
+      .toBe('Live keeper file focus and cursor stream status')
+    expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
+      .toContain('Dashboard event transport')
+    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
+  })
+
 
   it('switches the IDE right rail tabs and renders cursor stream focus', async () => {
     route.value = {
@@ -1126,18 +1192,18 @@ describe('IdeShell', () => {
     expect(getLocalStorageItem(IDE_TREE_WIDTH_STORAGE_KEY)).toBe(String(IDE_TREE_WIDTH_MAX))
   })
 
-  it('hydrates runtime layer button from the ?layers=runtime URL param', () => {
+  it('hydrates the trace layer button from the ?layers=keeper-trace URL param', () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'source', layers: 'runtime' },
+      params: { section: 'ide-shell', view: 'source', layers: 'keeper-trace' },
       postId: null,
     }
 
     render(h(IdeShell, {}), container)
 
-    expect(buttonByText(container, 'Runtime').getAttribute('aria-pressed')).toBe('true')
+    expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
     expect(container.textContent).toContain('Active overlays')
-    expect(container.textContent).toContain('Runtime')
+    expect(container.textContent).toContain('Trace')
   })
 
   it('mounts the OverlayKeeperTrace overlay when the keeper-trace layer is toggled on', () => {

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -181,7 +181,7 @@ describe('IdeShell', () => {
     )
   })
 
-  it('hydrates layer buttons from the route layers param', () => {
+  it('hydrates only view-compatible layers from the route layers param', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source', layers: 'time,notes' },
@@ -195,16 +195,16 @@ describe('IdeShell', () => {
     expect(container.querySelector('.v2-ide-toolbar')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-readiness-notice"]')?.textContent)
       .toBe('experimental')
-    expect(buttonByText(container, 'Time').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('false')
+    const layerButtons = container.querySelectorAll('[data-testid="ide-toolbar-layers"] button')
+    expect(Array.from(layerButtons).some(button => button.textContent === 'Time')).toBe(false)
+    expect(Array.from(layerButtons).some(button => button.textContent === 'Parallel')).toBe(false)
     expect(container.textContent).toContain('PERSISTENCE MAP')
     expect(container.textContent).toContain('Active overlays')
-    expect(container.textContent).toContain('Time')
     expect(container.textContent).toContain('Notes')
   })
 
-  it('disables time/parallel layer buttons outside the BLAME view with an explanatory tooltip', () => {
+  it('removes BLAME-only layers and command actions outside the BLAME view', async () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source', layers: 'time,parallel' },
@@ -213,19 +213,18 @@ describe('IdeShell', () => {
 
     render(h(IdeShell, {}), container)
 
-    const timeBtn = buttonByText(container, 'Time')
-    const parallelBtn = buttonByText(container, 'Parallel')
-    expect(timeBtn.disabled).toBe(true)
-    expect(parallelBtn.disabled).toBe(true)
-    expect(timeBtn.getAttribute('title')).toContain('BLAME 뷰에서만')
-    expect(parallelBtn.getAttribute('title')).toContain('BLAME 뷰에서만')
-    // Deep-linked active state survives the gate — disabled communicates
-    // "can't toggle here", not "silently cleared".
-    expect(timeBtn.getAttribute('aria-pressed')).toBe('true')
-    expect(parallelBtn.getAttribute('aria-pressed')).toBe('true')
-    // Trace/Notes are not view-gated.
+    const layers = container.querySelector('[data-testid="ide-toolbar-layers"]')
+    expect(layers?.textContent).not.toContain('Time')
+    expect(layers?.textContent).not.toContain('Parallel')
     expect(buttonByText(container, 'Trace').disabled).toBe(false)
     expect(buttonByText(container, 'Notes').disabled).toBe(false)
+
+    const input = ideCommandInput(container)
+    input.value = 'parallel'
+    fireEvent.input(input)
+    await waitFor(() => expect(input.getAttribute('aria-expanded')).toBe('true'))
+    const options = Array.from(container.querySelectorAll('[role="option"]'))
+    expect(options.some(option => option.textContent?.includes('Parallel'))).toBe(false)
   })
 
   it('enables time/parallel layer buttons in the BLAME view', () => {
@@ -239,6 +238,22 @@ describe('IdeShell', () => {
 
     expect(buttonByText(container, 'Time').disabled).toBe(false)
     expect(buttonByText(container, 'Parallel').disabled).toBe(false)
+  })
+
+  it('drops BLAME-only layers from the route when leaving BLAME', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'blame', layers: 'time,parallel,notes' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+    fireEvent.click(buttonByText(container, 'SOURCE'))
+
+    expect(route.value.params.view).toBe('source')
+    expect(route.value.params.layers).toBe('notes')
+    expect(container.querySelector('[data-testid="ide-toolbar-layers"]')?.textContent)
+      .not.toContain('Time')
   })
 
   it('removed the decorative tools/approve/runtime/explode layer chips', () => {
@@ -261,8 +276,10 @@ describe('IdeShell', () => {
     expect(layerLabels).not.toContain('Approve')
     expect(layerLabels).not.toContain('Runtime')
     expect(layerLabels).not.toContain('EXPLODE')
+    expect(layerLabels).not.toContain('Time')
+    expect(layerLabels).not.toContain('Parallel')
     expect(layerLabels).toEqual(
-      expect.arrayContaining(['Time', 'Parallel', 'Notes', 'Trace']),
+      expect.arrayContaining(['Notes', 'Trace']),
     )
   })
 
@@ -798,10 +815,11 @@ describe('IdeShell', () => {
     expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
-    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('false')
+    expect(container.querySelector('[data-testid="ide-toolbar-layers"]')?.textContent)
+      .not.toContain('Parallel')
   })
 
-  it('lets explicit review-focus layers override the default review bundle', () => {
+  it('filters view-incompatible explicit review-focus layers', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'unified', focus: 'review', layers: 'parallel' },
@@ -811,7 +829,8 @@ describe('IdeShell', () => {
     render(h(IdeShell, {}), container)
 
     expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
-    expect(buttonByText(container, 'Parallel').getAttribute('aria-pressed')).toBe('true')
+    expect(container.querySelector('[data-testid="ide-toolbar-layers"]')?.textContent)
+      .not.toContain('Parallel')
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('false')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('false')
   })
@@ -882,7 +901,7 @@ describe('IdeShell', () => {
   it('runs layer commands from the IDE command bar', async () => {
     route.value = {
       tab: 'code',
-      params: { section: 'ide-shell', view: 'source' },
+      params: { section: 'ide-shell', view: 'blame' },
       postId: null,
     }
 

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -25,6 +25,7 @@ import {
   IDE_LAYER_LABELS,
   REVIEW_FOCUS_LAYERS,
   IdeToolbar,
+  availableLayersForView,
 } from './ide-toolbar'
 import { IdeBreadcrumb } from './ide-breadcrumb'
 import { IdeReviewFocusStrip } from './ide-review-focus-strip'
@@ -1033,7 +1034,10 @@ export function IdeShell() {
   const [activeView, setActiveView] = useState<ViewTab>(() => viewFromRoute(route.value.params.view))
   const lspStatus = useSignalValue(lspStatusSnapshot)
   const reviewFocusActive = activeFocus === 'review' && activeView === 'unified'
-  const activeLayers = layersFromRoute(route.value.params.layers, reviewFocusActive ? activeFocus : null)
+  const activeLayers = availableLayersForView(
+    layersFromRoute(route.value.params.layers, reviewFocusActive ? activeFocus : null),
+    activeView,
+  )
   const terminalOpen = route.value.params.terminal === 'open'
   // The reference IDE keeps the drawer in the shell at all times. A route can
   // still opt out explicitly, while only `terminal=open` starts live output.
@@ -1069,7 +1073,15 @@ export function IdeShell() {
 
   const handleViewChange = (next: ViewTab) => {
     setActiveView(next)
-    const nextParams: Record<string, string> = { ...route.value.params, section: 'ide-shell', view: next }
+    const leavingImplicitReview =
+      next !== 'unified'
+      && focusFromRoute(route.value.params.focus) === 'review'
+      && !route.value.params.layers?.trim()
+    const compatibleLayers = availableLayersForView(
+      leavingImplicitReview ? new Set() : activeLayers,
+      next,
+    )
+    const nextParams = paramsWithLayers(route.value.params, next, compatibleLayers)
     if (next !== 'unified' && focusFromRoute(nextParams.focus) === 'review') {
       delete nextParams.focus
       if (nextParams.layers?.trim().toLowerCase() === EMPTY_LAYER_PARAM) delete nextParams.layers

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -99,13 +99,9 @@ export const IDE_TREE_WIDTH_MIN = 180
 export const IDE_TREE_WIDTH_MAX = 360
 const STATUSBAR_LAYER_PRIORITY: ReadonlyArray<string> = [
   'keeper-trace',
-  'approve',
   'notes',
-  'runtime',
   'time',
   'parallel',
-  'tools',
-  'explode',
 ]
 const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
   source: 'SOURCE',
@@ -1323,7 +1319,7 @@ export function IdeShell() {
               class="ide-plane-conversation ide-v2-rail v2-ide-panel"
               data-testid="ide-right-rail"
             >
-              <div class="ide-v2-rail-tabs ide-rail-tabs" role="tablist" aria-label="IDE right rail">
+              <div class="ide-v2-rail-tabs" role="tablist" aria-label="IDE right rail">
                 ${IDE_RIGHT_RAIL_TABS.map(tab => html`
                   <button
                     key=${tab.id}
@@ -1332,7 +1328,7 @@ export function IdeShell() {
                     aria-selected=${rightRailTab === tab.id ? 'true' : 'false'}
                     aria-label=${tab.title}
                     title=${tab.title}
-                    class=${`ide-v2-rail-tab ide-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
+                    class=${`ide-v2-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
                     onClick=${() => setRightRailTab(tab.id)}
                   >${tab.label}</button>
                 `)}

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -35,24 +35,32 @@ const TOOLBAR_BUTTON_BASE =
 
 const VIEW_TAB_BASE = 'ide-v2-view'
 
+// 'tools' / 'approve' / 'runtime' / 'explode' were removed (masc#24069 #49):
+// they rendered as toggleable chips but had no backing data source or render
+// branch — see ide-editor-blame.ts's IDE_LAYER_ORDER comment for detail. The
+// 'keeper-trace' entry's `conflictsWith: ['runtime']` (RFC-0028 §10) is
+// dropped with 'runtime': there is nothing left for it to conflict with.
 export const IDE_LAYERS: ReadonlyArray<OverlayLayer> = [
   { kind: 'time', label: 'Time', description: '변경 timestamp gradient' },
   { kind: 'parallel', label: 'Parallel', description: '동시 keeper 작업 표시' },
-  { kind: 'tools', label: 'Tools', description: 'MCP tool 호출' },
-  { kind: 'approve', label: 'Approve', description: 'APPROVE thread 마커' },
   { kind: 'notes', label: 'Notes', description: 'NOTE/SUGGEST 마커' },
-  { kind: 'runtime', label: 'Runtime', description: 'provider/model/cost/latency gutter chip' },
   {
     kind: 'keeper-trace',
     label: 'Trace',
     description: '3-source stitched gutter chip (anchored-thread / runtime-hop / decision-log)',
-    conflictsWith: ['runtime'],
   },
-  { kind: 'explode', label: 'EXPLODE', description: 'per-keeper ghost copies', mutuallyExclusive: true },
 ]
 
 export const IDE_LAYER_LABELS = new Map(IDE_LAYERS.map(layer => [layer.kind, layer.label]))
-export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'approve', 'notes'] as const
+export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'notes'] as const
+
+// 'time' / 'parallel' read per-line git-blame ownership data
+// (ide-data-workspace-store.ts fetchGitBlame) that is only populated when
+// the editor is showing the BLAME view. Toggling either in another view
+// previously activated a layer with no data to render — a silent no-op.
+// Gated here so the toolbar disables the affordance instead.
+const VIEW_GATED_LAYER_KINDS: ReadonlySet<string> = new Set(['time', 'parallel'])
+const VIEW_GATE_TOOLTIP = 'BLAME 뷰에서만 사용할 수 있습니다 (git blame ownership 데이터 필요)'
 
 interface IdeToolbarProps {
   readonly activeView: ViewTab
@@ -237,12 +245,15 @@ export function IdeToolbar({
         class="ide-toolbar-layers flex min-w-0 items-center gap-1.5 overflow-x-auto pb-0.5 font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
       >
         <span class="shrink-0">LAYERS</span>
-        ${IDE_LAYERS.map(layer => html`
+        ${IDE_LAYERS.map(layer => {
+          const viewGated = VIEW_GATED_LAYER_KINDS.has(layer.kind) && activeView !== 'blame'
+          return html`
           <button
             type="button"
             aria-pressed=${isActive(layer.kind) ? 'true' : 'false'}
+            disabled=${viewGated}
             onClick=${() => handleLayerToggle(layer.kind)}
-            title=${layer.description}
+            title=${viewGated ? `${layer.description} — ${VIEW_GATE_TOOLTIP}` : layer.description}
             class=${TOOLBAR_BUTTON_BASE}
             style=${{
               background: isActive(layer.kind)
@@ -253,13 +264,12 @@ export function IdeToolbar({
                 : 'var(--color-fg-secondary)',
               border: '1px solid',
               borderColor: isActive(layer.kind)
-                ? layer.mutuallyExclusive
-                  ? 'var(--color-status-warn)'
-                  : 'var(--color-accent-fg)'
+                ? 'var(--color-accent-fg)'
                 : 'var(--color-border-default)',
             }}
           >${layer.label}</button>
-        `)}
+        `
+        })}
         ${active.size > 0
           ? html`<span class="shrink-0 text-[var(--color-fg-disabled)]">${active.size} active</span>`
           : null}

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -60,7 +60,17 @@ export const REVIEW_FOCUS_LAYERS = ['keeper-trace', 'notes'] as const
 // previously activated a layer with no data to render — a silent no-op.
 // Gated here so the toolbar disables the affordance instead.
 const VIEW_GATED_LAYER_KINDS: ReadonlySet<string> = new Set(['time', 'parallel'])
-const VIEW_GATE_TOOLTIP = 'BLAME 뷰에서만 사용할 수 있습니다 (git blame ownership 데이터 필요)'
+
+export function layerAvailableInView(kind: string, view: ViewTab): boolean {
+  return !VIEW_GATED_LAYER_KINDS.has(kind) || view === 'blame'
+}
+
+export function availableLayersForView(
+  layers: ReadonlySet<string>,
+  view: ViewTab,
+): ReadonlySet<string> {
+  return new Set(Array.from(layers).filter(kind => layerAvailableInView(kind, view)))
+}
 
 interface IdeToolbarProps {
   readonly activeView: ViewTab
@@ -118,6 +128,7 @@ export function IdeToolbar({
   }, [])
   const { active, isActive } = useLayeredOverlay(controller)
   const [contextFocus, setContextFocus] = useState(ideContextFocus.value)
+  const availableLayers = IDE_LAYERS.filter(layer => layerAvailableInView(layer.kind, activeView))
 
   useEffect(() => {
     controller.setActive(activeLayers)
@@ -140,7 +151,7 @@ export function IdeToolbar({
       keywords: `${tab.id} ${tab.label} editor mode`,
       handler: () => onViewChange(tab.id),
     })),
-    ...IDE_LAYERS.map(layer => ({
+    ...availableLayers.map(layer => ({
       id: `layer-${layer.kind}`,
       title: `${isActive(layer.kind) ? 'Hide' : 'Show'} ${layer.label} layer`,
       keywords: `toggle ${layer.kind} ${layer.description}`,
@@ -245,15 +256,12 @@ export function IdeToolbar({
         class="ide-toolbar-layers flex min-w-0 items-center gap-1.5 overflow-x-auto pb-0.5 font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
       >
         <span class="shrink-0">LAYERS</span>
-        ${IDE_LAYERS.map(layer => {
-          const viewGated = VIEW_GATED_LAYER_KINDS.has(layer.kind) && activeView !== 'blame'
-          return html`
+        ${availableLayers.map(layer => html`
           <button
             type="button"
             aria-pressed=${isActive(layer.kind) ? 'true' : 'false'}
-            disabled=${viewGated}
             onClick=${() => handleLayerToggle(layer.kind)}
-            title=${viewGated ? `${layer.description} — ${VIEW_GATE_TOOLTIP}` : layer.description}
+            title=${layer.description}
             class=${TOOLBAR_BUTTON_BASE}
             style=${{
               background: isActive(layer.kind)
@@ -268,10 +276,9 @@ export function IdeToolbar({
                 : 'var(--color-border-default)',
             }}
           >${layer.label}</button>
-        `
-        })}
-        ${active.size > 0
-          ? html`<span class="shrink-0 text-[var(--color-fg-disabled)]">${active.size} active</span>`
+        `)}
+        ${availableLayers.some(layer => active.has(layer.kind))
+          ? html`<span class="shrink-0 text-[var(--color-fg-disabled)]">${availableLayers.filter(layer => active.has(layer.kind)).length} active</span>`
           : null}
       </div>
     </div>

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -35,10 +35,11 @@ import { routeLinkLabels } from './ide-context-route-helpers'
  * keeps the bucket-by-line shape; consumers (editor gutter, sidebar
  * keeper rail) decide where to mount the chips.
  *
- * Conflict avoidance (RFC §10): the `keeper-trace` IDE_LAYERS entry
- * declares `conflictsWith: ['runtime']` so activating either layer drops
- * the other automatically — see `layered-overlay.ts`. PR-β does not
- * orchestrate with runtime-overlay directly; the layer registry handles it.
+ * Conflict avoidance (RFC §10): the `keeper-trace` IDE_LAYERS entry used to
+ * declare `conflictsWith: ['runtime']` so activating either layer dropped
+ * the other automatically (see `layered-overlay.ts`). The 'runtime' layer
+ * was removed (masc#24069 #49 — decorative chip, no backing overlay), so
+ * this entry no longer needs a conflict declaration.
  */
 
 export const TRACE_CHIP_CAP = 3

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -589,27 +589,6 @@
   box-shadow: inset 2px 0 0 var(--color-accent-fg);
 }
 
-.ide-plane-grid {
-  display: grid;
-  grid-template-columns: minmax(200px, 248px) minmax(420px, 1fr) minmax(320px, 420px);
-  grid-template-rows: minmax(0, 1fr) minmax(180px, 32%);
-  height: 100%;
-  min-height: 0;
-  min-width: 0;
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.ide-plane-tree {
-  grid-column: 1;
-  grid-row: 1 / span 2;
-  position: relative;
-  z-index: var(--z-base);
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-}
-
 .ide-explorer {
   display: flex;
   flex-direction: column;
@@ -717,44 +696,6 @@
   white-space: nowrap;
 }
 
-.ide-plane-editor {
-  grid-column: 2;
-  grid-row: 1 / span 2;
-  position: relative;
-  z-index: var(--z-base);
-  display: grid;
-  grid-template-rows: minmax(0, 1fr);
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-  border-right: 1px solid var(--color-border-default);
-}
-
-.ide-plane-conversation {
-  grid-column: 3;
-  grid-row: 1;
-  position: relative;
-  z-index: var(--z-base);
-  display: grid;
-  grid-template-rows: minmax(0, 42%) minmax(0, 1fr);
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.ide-plane-activity {
-  grid-column: 3;
-  grid-row: 2;
-  position: relative;
-  z-index: var(--z-base);
-  min-width: 0;
-  min-height: 0;
-  overflow: hidden;
-  border-top: 1px solid var(--color-border-divider);
-  isolation: isolate;
-}
-
 .ide-plane-context-stack,
 .ide-plane-primary-rail {
   min-width: 0;
@@ -778,21 +719,6 @@
 
 .ide-plane-primary-rail > .ide-rail-panel {
   min-height: 0;
-}
-
-.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-grid {
-  grid-template-columns: minmax(200px, 260px) minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr);
-}
-
-.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-tree {
-  grid-row: 1;
-}
-
-.ide-plane-shell[data-rails-collapsed="true"] .ide-plane-editor {
-  grid-column: 2;
-  grid-row: 1;
-  border-right: 0;
 }
 
 .ide-branch-context {
@@ -2486,46 +2412,6 @@ button.ide-persistence-focus:focus-visible {
     min-width: 0;
     overflow: hidden;
   }
-
-  .ide-plane-grid {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(10rem, 18rem) minmax(26rem, 1fr) minmax(12rem, 18rem) minmax(10rem, 16rem);
-    overflow: auto;
-  }
-
-  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-grid {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(10rem, 18rem) minmax(26rem, 1fr);
-  }
-
-  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-tree,
-  .ide-plane-shell[data-rails-collapsed="true"] .ide-plane-editor {
-    grid-column: 1;
-    grid-row: auto;
-  }
-
-  .ide-plane-tree,
-  .ide-plane-editor,
-  .ide-plane-conversation,
-  .ide-plane-activity {
-    grid-column: 1;
-    grid-row: auto;
-  }
-
-  .ide-plane-tree,
-  .ide-plane-conversation,
-  .ide-plane-activity {
-    overflow: hidden;
-  }
-
-  .ide-plane-conversation {
-    max-height: none;
-    overflow: hidden;
-  }
-
-  .ide-plane-editor {
-    overflow: hidden;
-  }
 }
 
 @media (max-width: 640px) {
@@ -2535,38 +2421,6 @@ button.ide-persistence-focus:focus-visible {
     height: auto;
     min-height: 100%;
     overflow: visible;
-  }
-
-  .ide-plane-grid {
-    grid-template-rows:
-      24rem
-      36rem
-      34rem
-      20rem;
-    height: auto;
-    overflow: visible;
-  }
-
-  .ide-plane-tree {
-    height: 24rem;
-    min-height: 24rem;
-  }
-
-  .ide-plane-editor {
-    height: 36rem;
-    min-height: 36rem;
-  }
-
-  .ide-plane-conversation {
-    height: 34rem;
-    min-height: 34rem;
-    overflow: auto;
-  }
-
-  .ide-plane-activity {
-    height: 20rem;
-    min-height: 20rem;
-    overflow: auto;
   }
 
   .ide-explorer-scroll {

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -392,20 +392,12 @@
 .ide-v2-rail-tabs {
   flex: none;
   display: flex;
-  flex-wrap: wrap;
-  gap: 2px;
-  padding: 10px 10px 0;
-  border-bottom: 1px solid var(--border-soft);
-}
-
-.ide-v2-surface .ide-v2-rail-tabs.ide-rail-tabs {
-  display: flex;
-  flex: none;
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: flex-end;
-  height: auto;
-  min-height: 0;
+  gap: 2px;
+  padding: 10px 10px 0;
+  border-bottom: 1px solid var(--border-soft);
 }
 
 .ide-v2-rail-tab {
@@ -422,7 +414,7 @@
   border-bottom: 2px solid transparent;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
 }
 
 .ide-v2-rail-tab.on {
@@ -432,11 +424,6 @@
 
 .ide-v2-rail-tab[aria-selected="true"] {
   color: var(--volt-strong);
-}
-
-.ide-v2-surface .ide-v2-rail-tabs.ide-rail-tabs > .ide-v2-rail-tab {
-  flex: 1 1 0;
-  height: auto;
 }
 
 .ide-v2-rail-scroll {

--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -690,9 +690,12 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 
 /* activity rail */
 .ide-rail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; min-width: 0; }
-.ide-rail-tabs { flex: none; display: flex; gap: 2px; padding: 9px 10px 0; border-bottom: 1px solid var(--border-soft); }
-.ide-rail-tab { font-family: var(--font-ui); font-size: var(--fs-11); padding: 6px 11px; border: 0; background: none; color: var(--text-dim); cursor: pointer; border-bottom: 2px solid transparent; }
-.ide-rail-tab.on { color: var(--volt-strong); border-bottom-color: var(--volt); }
+/* .ide-rail-tabs / .ide-rail-tab were a duplicate of ide-v2.css's
+   .ide-v2-rail-tabs / .ide-v2-rail-tab (same DOM nodes carry both class
+   pairs). This file loads after ide-v2.css (main.ts import order), so at
+   equal specificity these rules silently won and overrode ide-v2.css's
+   font-size/padding, causing the IDE right-rail tab labels to wrap.
+   Removed here so ide-v2.css is the single owner; see ide-v2.css:381-405. */
 .ide-rail-scroll { flex: 1; overflow-y: auto; padding: 11px 12px; display: flex; flex-direction: column; gap: 9px; }
 .ide-ev { display: grid; grid-template-columns: 24px 1fr; gap: 8px; padding: 8px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
 .ide-ev .ico { width: 22px; height: 22px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: var(--fs-10); background: var(--bg-deep); border: 1px solid var(--border-main); color: var(--text-dim); }

--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -690,12 +690,7 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 
 /* activity rail */
 .ide-rail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; min-width: 0; }
-/* .ide-rail-tabs / .ide-rail-tab were a duplicate of ide-v2.css's
-   .ide-v2-rail-tabs / .ide-v2-rail-tab (same DOM nodes carry both class
-   pairs). This file loads after ide-v2.css (main.ts import order), so at
-   equal specificity these rules silently won and overrode ide-v2.css's
-   font-size/padding, causing the IDE right-rail tab labels to wrap.
-   Removed here so ide-v2.css is the single owner; see ide-v2.css:381-405. */
+/* Right-rail tab layout is owned solely by ide-v2.css. */
 .ide-rail-scroll { flex: 1; overflow-y: auto; padding: 11px 12px; display: flex; flex-direction: column; gap: 9px; }
 .ide-ev { display: grid; grid-template-columns: 24px 1fr; gap: 8px; padding: 8px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
 .ide-ev .ico { width: 22px; height: 22px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: var(--fs-10); background: var(--bg-deep); border: 1px solid var(--border-main); color: var(--text-dim); }

--- a/dashboard/src/styles/v2-ide.css
+++ b/dashboard/src/styles/v2-ide.css
@@ -64,6 +64,12 @@
   background: var(--color-brass-soft);
 }
 
+.v2-ide-action:disabled,
+.v2-ide-toolbar .v2-ide-action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* ── Rows (lists, tables) ─────────────────────────────────────────────────── */
 
 .v2-ide-row,


### PR DESCRIPTION
## 목적

캠페인 #49/#51/#52의 IDE 죽은 UI·레이아웃·빈 상태를 최신 v2 경계에서 정리합니다.

## 변경

- 구식 2행 IDE grid 및 1100/640px 고정-height 레이아웃을 삭제합니다.
- 오른쪽 rail tab CSS를 `ide-v2.css` 한 곳으로 통합하고 nowrap/ellipsis 계약을 둡니다.
- backing data/render branch가 없는 tools/approve/runtime/explode layer를 삭제합니다.
- Time/Parallel은 실제 blame 데이터가 있는 BLAME view에만 존재합니다. SOURCE/SPLIT/UNIFIED에서는 버튼·command action·route active state를 모두 제거하고 BLAME 이탈 시 URL에서도 숙청합니다.
- Memory는 repo scope 없이 요청하지 않고 명시적 no-scope를 렌더합니다.
- Activity는 normalized repo/lane scope key와 loaded key를 분리해 A scope 이벤트를 B scope 로딩·실패 중 표시하지 않습니다. stale snapshot은 같은 scope에서만 유지합니다.

## 적대 리뷰 수리

- disabled 버튼을 우회하던 command palette 경로 제거
- direct `view=source&layers=time` silent-active 제거
- BLAME → SOURCE 전환 시 Time/Parallel route state 제거
- repo A → no-scope 및 repo A → delayed repo B 전환 회귀 테스트 추가
- #24081 이후 도달 불가한 legacy rail selector/comment 삭제

## 검증

- `pnpm typecheck` PASS
- focused Vitest: ide-shell + ide-activity-panel 66/66 PASS
- `git diff --check` PASS
- targeted ESLint: 0 errors, 다만 현 config가 4개 TS 파일을 ignore하여 lint 증거로 과대계상하지 않음
- local Dune은 실행하지 않았습니다.

Refs #24069, #23925 items 49/51/52.