### PR TITLE
fix(runtime): harden durable keeper filesystem and MemoryOS boundaries

### DIFF
--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -44,6 +44,11 @@ type stat =
   ; link_count : int64
   }
 
+type directory_identity =
+  { device : int64
+  ; inode : int64
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -64,6 +69,12 @@ external open_read_fd
   -> string
   -> Unix.file_descr
   = "masc_anchored_open_read"
+
+external open_write_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_write"
 
 external create_exclusive_fd
   :  Unix.file_descr
@@ -142,6 +153,37 @@ let combine_close ~operation fd f =
 let with_open_root path f =
   let fd = open_root_fd path in
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
+;;
+
+let identity fd =
+  let metadata = Unix.fstat fd in
+  if metadata.Unix.st_kind <> Unix.S_DIR
+  then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
+  { device = Int64.of_int metadata.Unix.st_dev
+  ; inode = Int64.of_int metadata.Unix.st_ino
+  }
+;;
+
+let with_lock_file dir ~name ~perm f =
+  let name_value = segment_value name in
+  let created, fd =
+    match create_exclusive_fd dir name_value perm with
+    | fd -> true, fd
+    | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+      false, open_write_fd dir name_value
+  in
+  combine_close ~operation:"anchored lock-file transaction" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then
+      raise
+        (Unix.Unix_error
+           (Unix.EINVAL, "anchored_lock_file", name_value));
+    if created
+    then (
+      Unix.fsync fd;
+      Unix.fsync dir);
+    f fd)
 ;;
 
 let with_open_dir parent name f =
@@ -285,7 +327,7 @@ let stat dir name =
     (stat_at_raw dir (segment_value name))
 ;;
 
-let same_identity left right =
+let same_identity (left : stat) (right : stat) =
   Int64.equal left.device right.device && Int64.equal left.inode right.inode
 ;;
 

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -1,0 +1,309 @@
+type t = Unix.file_descr
+
+type kind =
+  | Regular_file
+  | Directory
+  | Symbolic_link
+  | Other
+
+type stat =
+  { kind : kind
+  ; size : int64
+  ; device : int64
+  ; inode : int64
+  ; link_count : int64
+  }
+
+external open_root_fd : string -> Unix.file_descr = "masc_anchored_open_root"
+
+external open_dir_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_dir"
+
+external open_read_fd
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  = "masc_anchored_open_read"
+
+external create_exclusive_fd
+  :  Unix.file_descr
+  -> string
+  -> int
+  -> Unix.file_descr
+  = "masc_anchored_create_exclusive"
+
+external mkdir_at : Unix.file_descr -> string -> int -> unit = "masc_anchored_mkdir"
+external unlink_at : Unix.file_descr -> string -> unit = "masc_anchored_unlink"
+
+external rename_at
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  -> string
+  -> unit
+  = "masc_anchored_rename"
+
+external link_at
+  :  Unix.file_descr
+  -> string
+  -> Unix.file_descr
+  -> string
+  -> unit
+  = "masc_anchored_link"
+
+external stat_at_raw
+  :  Unix.file_descr
+  -> string
+  -> (int * int64 * int64 * int64 * int64) option
+  = "masc_anchored_stat"
+
+external read_dir_raw : Unix.file_descr -> string list = "masc_anchored_readdir"
+
+let is_single_segment value =
+  (not (String.equal value ""))
+  && not (String.equal value ".")
+  && not (String.equal value "..")
+  && String.equal (Filename.basename value) value
+;;
+
+let require_segment ~operation value =
+  if not (is_single_segment value)
+  then invalid_arg (Printf.sprintf "%s: expected one path segment: %S" operation value)
+;;
+
+let combine_close ~operation fd f =
+  let outcome =
+    try Ok (f ()) with
+    | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  let close_outcome =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  match outcome, close_outcome with
+  | Ok value, Ok () -> value
+  | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+  | Ok _, Error close_error -> raise close_error
+  | Error (primary, _), Error close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "%s failed (%s); descriptor close also failed (%s)"
+            operation
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let with_open_root path f =
+  let fd = open_root_fd path in
+  combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
+;;
+
+let with_open_dir parent name f =
+  require_segment ~operation:"with_open_dir" name;
+  let fd = open_dir_fd parent name in
+  combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
+;;
+
+let fsync fd = Unix.fsync fd
+
+let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+  require_segment ~operation:"with_ensure_dir" name;
+  let created =
+    match open_dir_fd parent name with
+    | fd -> false, fd
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+      (match mkdir_at parent name perm with
+       | () -> ()
+       | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+      let fd = open_dir_fd parent name in
+      true, fd
+  in
+  let was_created, fd = created in
+  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
+    if was_created then fsync parent;
+    if enforce_perm
+    then (
+      Unix.fchmod fd perm;
+      fsync fd)
+    else if was_created
+    then fsync fd;
+    f fd)
+;;
+
+let kind_of_int = function
+  | 0 -> Regular_file
+  | 1 -> Directory
+  | 2 -> Symbolic_link
+  | 3 -> Other
+  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
+;;
+
+let stat dir name =
+  require_segment ~operation:"stat" name;
+  Option.map
+    (fun (kind, size, device, inode, link_count) ->
+       { kind = kind_of_int kind; size; device; inode; link_count })
+    (stat_at_raw dir name)
+;;
+
+let same_identity left right =
+  Int64.equal left.device right.device && Int64.equal left.inode right.inode
+;;
+
+let read_file dir name =
+  require_segment ~operation:"read_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored read" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
+    let buffer = Bytes.create 65536 in
+    let content = Buffer.create (min metadata.Unix.st_size 65536) in
+    let rec loop () =
+      match Unix.read fd buffer 0 (Bytes.length buffer) with
+      | 0 -> Buffer.contents content
+      | count ->
+        Buffer.add_subbytes content buffer 0 count;
+        loop ()
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+    in
+    loop ())
+;;
+
+let write_all fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring fd content offset (String.length content - offset)
+      with
+      | 0 -> raise (Unix.Unix_error (Unix.EIO, "anchored_write", ""))
+      | count -> loop (offset + count)
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+  in
+  loop 0
+;;
+
+let temp_counter = Atomic.make 0
+
+let rec create_temporary dir =
+  let sequence = Atomic.fetch_and_add temp_counter 1 in
+  let name = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
+  match create_exclusive_fd dir name 0o600 with
+  | fd -> name, fd
+  | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary dir
+;;
+
+let unlink_if_exists dir name =
+  require_segment ~operation:"unlink_if_exists" name;
+  match unlink_at dir name with
+  | () -> true
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+;;
+
+let save_file_atomic dir ~name ~perm content =
+  require_segment ~operation:"save_file_atomic" name;
+  let temp_name, fd = create_temporary dir in
+  let cleanup () =
+    match unlink_if_exists dir temp_name with
+    | true | false -> Ok ()
+    | exception exn -> Error exn
+  in
+  let write_outcome =
+    try
+      write_all fd content;
+      Unix.fchmod fd perm;
+      Unix.fsync fd;
+      Ok ()
+    with
+    | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  in
+  let close_outcome =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  let primary =
+    match write_outcome, close_outcome with
+    | Ok (), Ok () -> Ok ()
+    | Error (exn, _), Ok () | Ok (), Error exn -> Error exn
+    | Error (write_error, _), Error close_error ->
+      Error
+        (Failure
+           (Printf.sprintf
+              "anchored atomic write failed (%s); close also failed (%s)"
+              (Printexc.to_string write_error)
+              (Printexc.to_string close_error)))
+  in
+  match primary with
+  | Error exn ->
+    (match exn with
+     | Eio.Cancel.Cancelled _ ->
+       (match cleanup () with
+        | Ok () -> ()
+        | Error cleanup_error ->
+          Printf.eprintf
+            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
+            temp_name
+            (Printexc.to_string cleanup_error));
+       raise exn
+     | _ ->
+       let detail =
+         match cleanup () with
+         | Ok () -> Printexc.to_string exn
+         | Error cleanup_error ->
+           Printf.sprintf
+             "%s; temporary cleanup failed: %s"
+             (Printexc.to_string exn)
+             (Printexc.to_string cleanup_error)
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
+  | Ok () ->
+    (match rename_at dir temp_name dir name with
+     | () ->
+       (match fsync dir with
+        | () -> Ok ()
+        | exception exn ->
+          Error
+            (Printf.sprintf
+               "save_file_atomic %s committed but directory fsync failed: %s"
+               name
+               (Printexc.to_string exn)))
+     | exception exn ->
+       let detail =
+         match cleanup () with
+         | Ok () -> Printexc.to_string exn
+         | Error cleanup_error ->
+           Printf.sprintf
+             "%s; temporary cleanup failed: %s"
+             (Printexc.to_string exn)
+             (Printexc.to_string cleanup_error)
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
+;;
+
+let rename ~src_dir ~src ~dst_dir ~dst =
+  require_segment ~operation:"rename source" src;
+  require_segment ~operation:"rename destination" dst;
+  rename_at src_dir src dst_dir dst;
+  fsync dst_dir;
+  if src_dir != dst_dir then fsync src_dir
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  require_segment ~operation:"link source" src;
+  require_segment ~operation:"link destination" dst;
+  link_at src_dir src dst_dir dst;
+  fsync dst_dir
+;;
+
+let read_dir dir = read_dir_raw dir |> List.sort String.compare

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -374,7 +374,7 @@ let atomic_replace dir ~name ~perm content =
             dir
             (segment_value name)
         with
-        | exception Eio.Cancel.Cancelled _ as exn ->
+        | exception (Eio.Cancel.Cancelled _ as exn) ->
           let cleanup_error = cleanup_temp dir temp_name in
           (match cleanup_error with
            | None -> ()
@@ -397,7 +397,7 @@ let atomic_replace dir ~name ~perm content =
 let unlink_if_exists dir name =
   match unlink_at dir (segment_value name) with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->
@@ -414,7 +414,7 @@ let rename ~src_dir ~src ~dst_dir ~dst =
       dst_dir
       (segment_value dst)
   with
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->
@@ -434,7 +434,7 @@ let link_no_replace ~src_dir ~src ~dst_dir ~dst =
       dst_dir
       (segment_value dst)
   with
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception cause ->
     Error (Not_committed { cause; cleanup_error = None })
   | () ->

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -157,6 +157,22 @@ let same_identity left right =
   Int64.equal left.device right.device && Int64.equal left.inode right.inode
 ;;
 
+let kind_of_unix = function
+  | Unix.S_REG -> Regular_file
+  | Unix.S_DIR -> Directory
+  | Unix.S_LNK -> Symbolic_link
+  | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO | Unix.S_SOCK -> Other
+;;
+
+let stat_of_unix (metadata : Unix.stats) =
+  { kind = kind_of_unix metadata.st_kind
+  ; size = Int64.of_int metadata.st_size
+  ; device = Int64.of_int metadata.st_dev
+  ; inode = Int64.of_int metadata.st_ino
+  ; link_count = Int64.of_int metadata.st_nlink
+  }
+;;
+
 let read_file dir name =
   require_segment ~operation:"read_file" name;
   let fd = open_read_fd dir name in
@@ -175,6 +191,28 @@ let read_file dir name =
       | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
     in
     loop ())
+;;
+
+let fsync_file dir name =
+  require_segment ~operation:"fsync_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored file fsync" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name));
+    Unix.fsync fd;
+    stat_of_unix metadata)
+;;
+
+let chmod_file dir name perm =
+  require_segment ~operation:"chmod_file" name;
+  let fd = open_read_fd dir name in
+  combine_close ~operation:"anchored file chmod" fd (fun () ->
+    let metadata = Unix.fstat fd in
+    if metadata.Unix.st_kind <> Unix.S_REG
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name));
+    Unix.fchmod fd perm;
+    Unix.fsync fd)
 ;;
 
 let write_all fd content =
@@ -204,7 +242,9 @@ let rec create_temporary dir =
 let unlink_if_exists dir name =
   require_segment ~operation:"unlink_if_exists" name;
   match unlink_at dir name with
-  | () -> true
+  | () ->
+    fsync dir;
+    true
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
 ;;
 

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -463,10 +463,10 @@ let write_all fd content =
 let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
-  (* NDT-OK: PID and process-local sequence only mint an exclusive temporary
-     entry name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no
-     policy, ordering, or replay decision depends on the generated spelling. *)
   let sequence = Atomic.fetch_and_add temp_counter 1 in
+  (* PID and process-local sequence only mint an exclusive temporary entry
+     name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no policy,
+     ordering, or replay decision depends on the generated spelling. NDT-OK. *)
   let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
   let name =
     match Segment.of_string raw with

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -44,12 +44,10 @@ type stat =
   ; link_count : int64
   }
 
-type directory_identity =
-  { device : int64
-  ; inode : int64
+type lock_file =
+  { descriptor : Unix.file_descr
+  ; metadata : stat
   }
-
-type lock_file
 
 exception Descriptor_cleanup_failed of
   { operation : string
@@ -177,18 +175,6 @@ let with_open_root path f =
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
 ;;
 
-let identity fd =
-  let metadata = stat_of_raw (fstat_raw fd) in
-  if metadata.kind <> Directory
-  then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
-  { device = metadata.device; inode = metadata.inode }
-;;
-
-type lock_file =
-  { descriptor : Unix.file_descr
-  ; metadata : stat
-  }
-
 let open_lock_file dir ~name ~perm =
   let name_value = segment_value name in
   let created, fd =
@@ -227,7 +213,7 @@ let open_lock_file dir ~name ~perm =
 let lock_file_descriptor file = file.descriptor
 
 let lock_file_identity file =
-  { device = file.metadata.device; inode = file.metadata.inode }
+  file.metadata.device, file.metadata.inode
 ;;
 
 let close_lock_file file = Unix.close file.descriptor
@@ -254,12 +240,12 @@ let close_after_primary ~operation fd primary backtrace =
   | () -> Printexc.raise_with_backtrace primary backtrace
   | exception close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "%s failed (%s); descriptor close also failed (%s)"
-            operation
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation
+         ; primary
+         ; primary_backtrace = backtrace
+         ; close_error
+         })
 ;;
 
 let open_ensured_child parent ~name ~perm ~enforce_perm =
@@ -303,15 +289,17 @@ let close_parent_before_descending ~parent ~child =
   match Unix.close parent with
   | () -> child
   | exception parent_close_error ->
+    let primary_backtrace = Printexc.get_raw_backtrace () in
     (match Unix.close child with
      | () -> raise parent_close_error
      | exception child_close_error ->
        raise
-         (Failure
-            (Printf.sprintf
-               "ancestor close failed (%s); child close also failed (%s)"
-               (Printexc.to_string parent_close_error)
-               (Printexc.to_string child_close_error))))
+         (Descriptor_cleanup_failed
+            { operation = "anchored ancestor close"
+            ; primary = parent_close_error
+            ; primary_backtrace
+            ; close_error = child_close_error
+            }))
 ;;
 
 let with_ensure_path ~root steps f =
@@ -359,19 +347,8 @@ let with_open_path_opt ~root steps f =
   walk (open_root_fd root) steps
 ;;
 
-let kind_of_int = function
-  | 0 -> Regular_file
-  | 1 -> Directory
-  | 2 -> Symbolic_link
-  | 3 -> Other
-  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
-;;
-
 let stat dir name =
-  Option.map
-    (fun (kind, size, device, inode, link_count) ->
-       { kind = kind_of_int kind; size; device; inode; link_count })
-    (stat_at_raw dir (segment_value name))
+  Option.map stat_of_raw (stat_at_raw dir (segment_value name))
 ;;
 
 let same_identity (left : stat) (right : stat) =
@@ -529,11 +506,12 @@ let atomic_replace dir ~name ~perm content =
       | Ok (), Error exn -> Error (exn, Printexc.get_raw_backtrace ())
       | Error (write_error, backtrace), Error close_error ->
         Error
-          ( Failure
-              (Printf.sprintf
-                 "anchored atomic write failed (%s); close also failed (%s)"
-                 (Printexc.to_string write_error)
-                 (Printexc.to_string close_error))
+          ( Descriptor_cleanup_failed
+              { operation = "anchored atomic write"
+              ; primary = write_error
+              ; primary_backtrace = backtrace
+              ; close_error
+              }
           , backtrace )
     in
     (match before_commit with
@@ -643,13 +621,14 @@ let combine_closedir handle f =
   | Ok value, Ok () -> value
   | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
   | Ok _, Error close_error -> raise close_error
-  | Error (primary, _), Error close_error ->
+  | Error (primary, primary_backtrace), Error close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "anchored readdir failed (%s); closedir also failed (%s)"
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation = "anchored readdir"
+         ; primary
+         ; primary_backtrace
+         ; close_error
+         })
 ;;
 
 let read_dir dir =
@@ -657,6 +636,7 @@ let read_dir dir =
   let handle =
     try fdopendir duplicate with
     | exn ->
+      let primary_backtrace = Printexc.get_raw_backtrace () in
       let close_error =
         try
           Unix.close duplicate;
@@ -668,11 +648,12 @@ let read_dir dir =
        | None -> raise exn
        | Some close_error ->
          raise
-           (Failure
-              (Printf.sprintf
-                 "fdopendir failed (%s); duplicate close also failed (%s)"
-                 (Printexc.to_string exn)
-                 (Printexc.to_string close_error))))
+           (Descriptor_cleanup_failed
+              { operation = "anchored fdopendir"
+              ; primary = exn
+              ; primary_backtrace
+              ; close_error
+              }))
   in
   combine_closedir handle (fun () ->
     let rec loop acc =

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -160,7 +160,20 @@ let with_open_dir_opt parent name f =
 
 let fsync fd = Unix.fsync fd
 
-let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+let close_after_primary ~operation fd primary backtrace =
+  match Unix.close fd with
+  | () -> Printexc.raise_with_backtrace primary backtrace
+  | exception close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "%s failed (%s); descriptor close also failed (%s)"
+            operation
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let open_ensured_child parent ~name ~perm ~enforce_perm =
   let name_value = segment_value name in
   let needs_publish, fd =
     match open_dir_fd parent name_value with
@@ -171,11 +184,90 @@ let with_ensure_dir parent ~name ~perm ~enforce_perm f =
        | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       true, open_dir_fd parent name_value
   in
-  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
+  (try
     if enforce_perm then Unix.fchmod fd perm;
     if needs_publish || enforce_perm then fsync fd;
     if needs_publish then fsync parent;
+    fd
+   with
+   | exn ->
+     close_after_primary
+       ~operation:"anchored ensured-directory acquisition"
+       fd
+       exn
+       (Printexc.get_raw_backtrace ()))
+;;
+
+let with_ensure_dir parent ~name ~perm ~enforce_perm f =
+  let fd = open_ensured_child parent ~name ~perm ~enforce_perm in
+  combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
     f fd)
+;;
+
+type ensure_step =
+  { name : Segment.t
+  ; perm : int
+  ; enforce_perm : bool
+  }
+
+let close_parent_before_descending ~parent ~child =
+  match Unix.close parent with
+  | () -> child
+  | exception parent_close_error ->
+    (match Unix.close child with
+     | () -> raise parent_close_error
+     | exception child_close_error ->
+       raise
+         (Failure
+            (Printf.sprintf
+               "ancestor close failed (%s); child close also failed (%s)"
+               (Printexc.to_string parent_close_error)
+               (Printexc.to_string child_close_error))))
+;;
+
+let with_ensure_path ~root steps f =
+  let rec walk current = function
+    | [] ->
+      combine_close ~operation:"anchored ensured-path transaction" current
+        (fun () -> f current)
+    | { name; perm; enforce_perm } :: rest ->
+      let next =
+        try open_ensured_child current ~name ~perm ~enforce_perm with
+        | exn ->
+          close_after_primary
+            ~operation:"anchored ensured-path acquisition"
+            current
+            exn
+            (Printexc.get_raw_backtrace ())
+      in
+      walk (close_parent_before_descending ~parent:current ~child:next) rest
+  in
+  walk (open_root_fd root) steps
+;;
+
+let with_open_path_opt ~root steps f =
+  let rec walk current = function
+    | [] ->
+      Some
+        (combine_close ~operation:"anchored existing-path transaction" current
+           (fun () -> f current))
+    | name :: rest ->
+      (match open_dir_fd current (segment_value name) with
+       | next ->
+         walk
+           (close_parent_before_descending ~parent:current ~child:next)
+           rest
+       | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+         combine_close ~operation:"anchored missing-path close" current
+           (fun () -> None)
+       | exception exn ->
+         close_after_primary
+           ~operation:"anchored existing-path acquisition"
+           current
+           exn
+           (Printexc.get_raw_backtrace ()))
+  in
+  walk (open_root_fd root) steps
 ;;
 
 let kind_of_int = function

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -49,6 +49,15 @@ type directory_identity =
   ; inode : int64
   }
 
+type lock_file
+
+exception Descriptor_cleanup_failed of
+  { operation : string
+  ; primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -108,6 +117,11 @@ external stat_at_raw
   -> (int * int64 * int64 * int64 * int64) option
   = "masc_anchored_stat"
 
+external fstat_raw
+  :  Unix.file_descr
+  -> int * int64 * int64 * int64 * int64
+  = "masc_anchored_fstat"
+
 external fdopendir : Unix.file_descr -> Unix.dir_handle = "masc_anchored_fdopendir"
 
 let segment_value = Segment.to_string
@@ -122,6 +136,18 @@ let mutation_error_to_string = function
       (Printexc.to_string cleanup_error)
   | Committed_not_durable cause ->
     Printf.sprintf "committed but not durable: %s" (Printexc.to_string cause)
+;;
+
+let kind_of_int = function
+  | 0 -> Regular_file
+  | 1 -> Directory
+  | 2 -> Symbolic_link
+  | 3 -> Other
+  | value -> invalid_arg (Printf.sprintf "anchored stat returned invalid kind: %d" value)
+;;
+
+let stat_of_raw (kind, size, device, inode, link_count) =
+  { kind = kind_of_int kind; size; device; inode; link_count }
 ;;
 
 let combine_close ~operation fd f =
@@ -140,14 +166,10 @@ let combine_close ~operation fd f =
   | Ok value, Ok () -> value
   | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
   | Ok _, Error close_error -> raise close_error
-  | Error (primary, _), Error close_error ->
+  | Error (primary, primary_backtrace), Error close_error ->
     raise
-      (Failure
-         (Printf.sprintf
-            "%s failed (%s); descriptor close also failed (%s)"
-            operation
-            (Printexc.to_string primary)
-            (Printexc.to_string close_error)))
+      (Descriptor_cleanup_failed
+         { operation; primary; primary_backtrace; close_error })
 ;;
 
 let with_open_root path f =
@@ -156,15 +178,18 @@ let with_open_root path f =
 ;;
 
 let identity fd =
-  let metadata = Unix.fstat fd in
-  if metadata.Unix.st_kind <> Unix.S_DIR
+  let metadata = stat_of_raw (fstat_raw fd) in
+  if metadata.kind <> Directory
   then raise (Unix.Unix_error (Unix.ENOTDIR, "anchored_identity", ""));
-  { device = Int64.of_int metadata.Unix.st_dev
-  ; inode = Int64.of_int metadata.Unix.st_ino
-  }
+  { device = metadata.device; inode = metadata.inode }
 ;;
 
-let with_lock_file dir ~name ~perm f =
+type lock_file =
+  { descriptor : Unix.file_descr
+  ; metadata : stat
+  }
+
+let open_lock_file dir ~name ~perm =
   let name_value = segment_value name in
   let created, fd =
     match create_exclusive_fd dir name_value perm with
@@ -172,9 +197,9 @@ let with_lock_file dir ~name ~perm f =
     | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
       false, open_write_fd dir name_value
   in
-  combine_close ~operation:"anchored lock-file transaction" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
+  try
+    let metadata = stat_of_raw (fstat_raw fd) in
+    if metadata.kind <> Regular_file
     then
       raise
         (Unix.Unix_error
@@ -183,7 +208,29 @@ let with_lock_file dir ~name ~perm f =
     then (
       Unix.fsync fd;
       Unix.fsync dir);
-    f fd)
+    { descriptor = fd; metadata }
+  with
+  | exn ->
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    (match Unix.close fd with
+     | () -> Printexc.raise_with_backtrace exn primary_backtrace
+     | exception close_error ->
+       raise
+         (Descriptor_cleanup_failed
+            { operation = "anchored lock-file acquisition"
+            ; primary = exn
+            ; primary_backtrace
+            ; close_error
+            }))
+;;
+
+let lock_file_descriptor file = file.descriptor
+
+let lock_file_identity file =
+  { device = file.metadata.device; inode = file.metadata.inode }
+;;
+
+let close_lock_file file = Unix.close file.descriptor
 ;;
 
 let with_open_dir parent name f =
@@ -421,6 +468,9 @@ let write_all fd content =
 let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
+  (* NDT-OK: PID and process-local sequence only mint an exclusive temporary
+     entry name. Correctness comes from [O_EXCL] and retries on [EEXIST]; no
+     policy, ordering, or replay decision depends on the generated spelling. *)
   let sequence = Atomic.fetch_and_add temp_counter 1 in
   let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
   let name =

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -148,6 +148,11 @@ let stat_of_raw (kind, size, device, inode, link_count) =
   { kind = kind_of_int kind; size; device; inode; link_count }
 ;;
 
+let run_blocking f =
+  try Eio_unix.run_in_systhread f with
+  | Effect.Unhandled _ -> f ()
+;;
+
 let combine_close ~operation fd f =
   let outcome =
     try Ok (f ()) with
@@ -155,7 +160,7 @@ let combine_close ~operation fd f =
   in
   let close_outcome =
     try
-      Unix.close fd;
+      run_blocking (fun () -> Unix.close fd);
       Ok ()
     with
     | exn -> Error exn
@@ -171,43 +176,44 @@ let combine_close ~operation fd f =
 ;;
 
 let with_open_root path f =
-  let fd = open_root_fd path in
+  let fd = run_blocking (fun () -> open_root_fd path) in
   combine_close ~operation:"anchored root transaction" fd (fun () -> f fd)
 ;;
 
 let open_lock_file dir ~name ~perm =
-  let name_value = segment_value name in
-  let created, fd =
-    match create_exclusive_fd dir name_value perm with
-    | fd -> true, fd
-    | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
-      false, open_write_fd dir name_value
-  in
-  try
-    let metadata = stat_of_raw (fstat_raw fd) in
-    if metadata.kind <> Regular_file
-    then
-      raise
-        (Unix.Unix_error
-           (Unix.EINVAL, "anchored_lock_file", name_value));
-    if created
-    then (
-      Unix.fsync fd;
-      Unix.fsync dir);
-    { descriptor = fd; metadata }
-  with
-  | exn ->
-    let primary_backtrace = Printexc.get_raw_backtrace () in
-    (match Unix.close fd with
-     | () -> Printexc.raise_with_backtrace exn primary_backtrace
-     | exception close_error ->
-       raise
-         (Descriptor_cleanup_failed
-            { operation = "anchored lock-file acquisition"
-            ; primary = exn
-            ; primary_backtrace
-            ; close_error
-            }))
+  run_blocking (fun () ->
+    let name_value = segment_value name in
+    let created, fd =
+      match create_exclusive_fd dir name_value perm with
+      | fd -> true, fd
+      | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+        false, open_write_fd dir name_value
+    in
+    try
+      let metadata = stat_of_raw (fstat_raw fd) in
+      if metadata.kind <> Regular_file
+      then
+        raise
+          (Unix.Unix_error
+             (Unix.EINVAL, "anchored_lock_file", name_value));
+      if created
+      then (
+        Unix.fsync fd;
+        Unix.fsync dir);
+      { descriptor = fd; metadata }
+    with
+    | exn ->
+      let primary_backtrace = Printexc.get_raw_backtrace () in
+      (match Unix.close fd with
+       | () -> Printexc.raise_with_backtrace exn primary_backtrace
+       | exception close_error ->
+         raise
+           (Descriptor_cleanup_failed
+              { operation = "anchored lock-file acquisition"
+              ; primary = exn
+              ; primary_backtrace
+              ; close_error
+              })))
 ;;
 
 let lock_file_descriptor file = file.descriptor
@@ -216,16 +222,17 @@ let lock_file_identity file =
   file.metadata.device, file.metadata.inode
 ;;
 
-let close_lock_file file = Unix.close file.descriptor
+let close_lock_file file =
+  run_blocking (fun () -> Unix.close file.descriptor)
 ;;
 
 let with_open_dir parent name f =
-  let fd = open_dir_fd parent (segment_value name) in
+  let fd = run_blocking (fun () -> open_dir_fd parent (segment_value name)) in
   combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
 ;;
 
 let with_open_dir_opt parent name f =
-  match open_dir_fd parent (segment_value name) with
+  match run_blocking (fun () -> open_dir_fd parent (segment_value name)) with
   | fd ->
     Some
       (combine_close ~operation:"anchored optional-directory transaction" fd
@@ -233,10 +240,10 @@ let with_open_dir_opt parent name f =
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
-let fsync fd = Unix.fsync fd
+let fsync fd = run_blocking (fun () -> Unix.fsync fd)
 
 let close_after_primary ~operation fd primary backtrace =
-  match Unix.close fd with
+  match run_blocking (fun () -> Unix.close fd) with
   | () -> Printexc.raise_with_backtrace primary backtrace
   | exception close_error ->
     raise
@@ -274,7 +281,10 @@ let open_ensured_child parent ~name ~perm ~enforce_perm =
 ;;
 
 let with_ensure_dir parent ~name ~perm ~enforce_perm f =
-  let fd = open_ensured_child parent ~name ~perm ~enforce_perm in
+  let fd =
+    run_blocking (fun () ->
+      open_ensured_child parent ~name ~perm ~enforce_perm)
+  in
   combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
     f fd)
 ;;
@@ -286,11 +296,11 @@ type ensure_step =
   }
 
 let close_parent_before_descending ~parent ~child =
-  match Unix.close parent with
+  match run_blocking (fun () -> Unix.close parent) with
   | () -> child
   | exception parent_close_error ->
     let primary_backtrace = Printexc.get_raw_backtrace () in
-    (match Unix.close child with
+    (match run_blocking (fun () -> Unix.close child) with
      | () -> raise parent_close_error
      | exception child_close_error ->
        raise
@@ -309,7 +319,10 @@ let with_ensure_path ~root steps f =
         (fun () -> f current)
     | { name; perm; enforce_perm } :: rest ->
       let next =
-        try open_ensured_child current ~name ~perm ~enforce_perm with
+        try
+          run_blocking (fun () ->
+            open_ensured_child current ~name ~perm ~enforce_perm)
+        with
         | exn ->
           close_after_primary
             ~operation:"anchored ensured-path acquisition"
@@ -319,7 +332,7 @@ let with_ensure_path ~root steps f =
       in
       walk (close_parent_before_descending ~parent:current ~child:next) rest
   in
-  walk (open_root_fd root) steps
+  walk (run_blocking (fun () -> open_root_fd root)) steps
 ;;
 
 let with_open_path_opt ~root steps f =
@@ -329,7 +342,9 @@ let with_open_path_opt ~root steps f =
         (combine_close ~operation:"anchored existing-path transaction" current
            (fun () -> f current))
     | name :: rest ->
-      (match open_dir_fd current (segment_value name) with
+      (match
+         run_blocking (fun () -> open_dir_fd current (segment_value name))
+       with
        | next ->
          walk
            (close_parent_before_descending ~parent:current ~child:next)
@@ -344,11 +359,12 @@ let with_open_path_opt ~root steps f =
            exn
            (Printexc.get_raw_backtrace ()))
   in
-  walk (open_root_fd root) steps
+  walk (run_blocking (fun () -> open_root_fd root)) steps
 ;;
 
 let stat dir name =
-  Option.map stat_of_raw (stat_at_raw dir (segment_value name))
+  run_blocking (fun () ->
+    Option.map stat_of_raw (stat_at_raw dir (segment_value name)))
 ;;
 
 let same_identity (left : stat) (right : stat) =
@@ -390,11 +406,11 @@ let read_from_fd ~name fd =
 
 let read_file_opt dir name =
   let name_value = segment_value name in
-  match open_read_fd dir name_value with
+  match run_blocking (fun () -> open_read_fd dir name_value) with
   | fd ->
     Some
       (combine_close ~operation:"anchored read" fd (fun () ->
-         read_from_fd ~name:name_value fd))
+         run_blocking (fun () -> read_from_fd ~name:name_value fd)))
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
@@ -408,24 +424,26 @@ let read_file dir name =
 
 let fsync_file dir name =
   let name_value = segment_value name in
-  let fd = open_read_fd dir name_value in
+  let fd = run_blocking (fun () -> open_read_fd dir name_value) in
   combine_close ~operation:"anchored file fsync" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
-    Unix.fsync fd;
-    stat_of_unix metadata)
+    run_blocking (fun () ->
+      let metadata = Unix.fstat fd in
+      if metadata.Unix.st_kind <> Unix.S_REG
+      then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
+      Unix.fsync fd;
+      stat_of_unix metadata))
 ;;
 
 let chmod_file dir name perm =
   let name_value = segment_value name in
-  let fd = open_read_fd dir name_value in
+  let fd = run_blocking (fun () -> open_read_fd dir name_value) in
   combine_close ~operation:"anchored file chmod" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
-    Unix.fchmod fd perm;
-    Unix.fsync fd)
+    run_blocking (fun () ->
+      let metadata = Unix.fstat fd in
+      if metadata.Unix.st_kind <> Unix.S_REG
+      then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
+      Unix.fchmod fd perm;
+      Unix.fsync fd))
 ;;
 
 let write_all fd content =
@@ -474,7 +492,7 @@ let cleanup_temp dir name =
   | exn -> Some exn
 ;;
 
-let atomic_replace dir ~name ~perm content =
+let atomic_replace_blocking dir ~name ~perm content =
   let temp_result =
     try Ok (create_temporary dir) with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -556,7 +574,11 @@ let atomic_replace dir ~name ~perm content =
            | exception cause -> Error (Committed_not_durable cause))))
 ;;
 
-let unlink_if_exists dir name =
+let atomic_replace dir ~name ~perm content =
+  run_blocking (fun () -> atomic_replace_blocking dir ~name ~perm content)
+;;
+
+let unlink_if_exists_blocking dir name =
   match unlink_at dir (segment_value name) with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
@@ -568,7 +590,11 @@ let unlink_if_exists dir name =
      | exception cause -> Error (Committed_not_durable cause))
 ;;
 
-let rename ~src_dir ~src ~dst_dir ~dst =
+let unlink_if_exists dir name =
+  run_blocking (fun () -> unlink_if_exists_blocking dir name)
+;;
+
+let rename_blocking ~src_dir ~src ~dst_dir ~dst =
   match
     rename_at
       src_dir
@@ -588,7 +614,11 @@ let rename ~src_dir ~src ~dst_dir ~dst =
      | cause -> Error (Committed_not_durable cause))
 ;;
 
-let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+let rename ~src_dir ~src ~dst_dir ~dst =
+  run_blocking (fun () -> rename_blocking ~src_dir ~src ~dst_dir ~dst)
+;;
+
+let link_no_replace_blocking ~src_dir ~src ~dst_dir ~dst =
   match
     link_at
       src_dir
@@ -603,6 +633,10 @@ let link_no_replace ~src_dir ~src ~dst_dir ~dst =
     (match fsync dst_dir with
      | () -> Ok ()
      | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  run_blocking (fun () -> link_no_replace_blocking ~src_dir ~src ~dst_dir ~dst)
 ;;
 
 let combine_closedir handle f =
@@ -631,7 +665,7 @@ let combine_closedir handle f =
          })
 ;;
 
-let read_dir dir =
+let read_dir_blocking dir =
   let duplicate = Unix.dup ~cloexec:true dir in
   let handle =
     try fdopendir duplicate with
@@ -675,3 +709,6 @@ let read_dir dir =
           acc
     in
     loop [])
+;;
+
+let read_dir dir = run_blocking (fun () -> read_dir_blocking dir)

--- a/lib/fs_compat/anchored_fs.ml
+++ b/lib/fs_compat/anchored_fs.ml
@@ -1,5 +1,35 @@
 type t = Unix.file_descr
 
+module Segment = struct
+  type t = string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  let of_string = function
+    | "" -> Error Empty
+    | "." -> Error Dot
+    | ".." -> Error Dot_dot
+    | value when String.contains value '/' -> Error Contains_separator
+    | value when String.contains value '\000' -> Error Contains_nul
+    | value -> Ok value
+  ;;
+
+  let to_string value = value
+
+  let error_to_string = function
+    | Empty -> "path segment is empty"
+    | Dot -> "path segment is dot"
+    | Dot_dot -> "path segment is dot-dot"
+    | Contains_separator -> "path segment contains a separator"
+    | Contains_nul -> "path segment contains NUL"
+  ;;
+end
+
 type kind =
   | Regular_file
   | Directory
@@ -13,6 +43,13 @@ type stat =
   ; inode : int64
   ; link_count : int64
   }
+
+type mutation_error =
+  | Not_committed of
+      { cause : exn
+      ; cleanup_error : exn option
+      }
+  | Committed_not_durable of exn
 
 external open_root_fd : string -> Unix.file_descr = "masc_anchored_open_root"
 
@@ -60,18 +97,20 @@ external stat_at_raw
   -> (int * int64 * int64 * int64 * int64) option
   = "masc_anchored_stat"
 
-external read_dir_raw : Unix.file_descr -> string list = "masc_anchored_readdir"
+external fdopendir : Unix.file_descr -> Unix.dir_handle = "masc_anchored_fdopendir"
 
-let is_single_segment value =
-  (not (String.equal value ""))
-  && not (String.equal value ".")
-  && not (String.equal value "..")
-  && String.equal (Filename.basename value) value
-;;
+let segment_value = Segment.to_string
 
-let require_segment ~operation value =
-  if not (is_single_segment value)
-  then invalid_arg (Printf.sprintf "%s: expected one path segment: %S" operation value)
+let mutation_error_to_string = function
+  | Not_committed { cause; cleanup_error = None } ->
+    Printf.sprintf "not committed: %s" (Printexc.to_string cause)
+  | Not_committed { cause; cleanup_error = Some cleanup_error } ->
+    Printf.sprintf
+      "not committed: %s; cleanup failed: %s"
+      (Printexc.to_string cause)
+      (Printexc.to_string cleanup_error)
+  | Committed_not_durable cause ->
+    Printf.sprintf "committed but not durable: %s" (Printexc.to_string cause)
 ;;
 
 let combine_close ~operation fd f =
@@ -106,34 +145,36 @@ let with_open_root path f =
 ;;
 
 let with_open_dir parent name f =
-  require_segment ~operation:"with_open_dir" name;
-  let fd = open_dir_fd parent name in
+  let fd = open_dir_fd parent (segment_value name) in
   combine_close ~operation:"anchored directory transaction" fd (fun () -> f fd)
+;;
+
+let with_open_dir_opt parent name f =
+  match open_dir_fd parent (segment_value name) with
+  | fd ->
+    Some
+      (combine_close ~operation:"anchored optional-directory transaction" fd
+         (fun () -> f fd))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
 ;;
 
 let fsync fd = Unix.fsync fd
 
 let with_ensure_dir parent ~name ~perm ~enforce_perm f =
-  require_segment ~operation:"with_ensure_dir" name;
-  let created =
-    match open_dir_fd parent name with
+  let name_value = segment_value name in
+  let needs_publish, fd =
+    match open_dir_fd parent name_value with
     | fd -> false, fd
     | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-      (match mkdir_at parent name perm with
+      (match mkdir_at parent name_value perm with
        | () -> ()
        | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
-      let fd = open_dir_fd parent name in
-      true, fd
+      true, open_dir_fd parent name_value
   in
-  let was_created, fd = created in
   combine_close ~operation:"anchored ensured-directory transaction" fd (fun () ->
-    if was_created then fsync parent;
-    if enforce_perm
-    then (
-      Unix.fchmod fd perm;
-      fsync fd)
-    else if was_created
-    then fsync fd;
+    if enforce_perm then Unix.fchmod fd perm;
+    if needs_publish || enforce_perm then fsync fd;
+    if needs_publish then fsync parent;
     f fd)
 ;;
 
@@ -146,11 +187,10 @@ let kind_of_int = function
 ;;
 
 let stat dir name =
-  require_segment ~operation:"stat" name;
   Option.map
     (fun (kind, size, device, inode, link_count) ->
        { kind = kind_of_int kind; size; device; inode; link_count })
-    (stat_at_raw dir name)
+    (stat_at_raw dir (segment_value name))
 ;;
 
 let same_identity left right =
@@ -173,44 +213,59 @@ let stat_of_unix (metadata : Unix.stats) =
   }
 ;;
 
+let read_from_fd ~name fd =
+  let metadata = Unix.fstat fd in
+  if metadata.Unix.st_kind <> Unix.S_REG
+  then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
+  let buffer = Bytes.create 65536 in
+  let content = Buffer.create (min metadata.Unix.st_size 65536) in
+  let rec loop () =
+    match Unix.read fd buffer 0 (Bytes.length buffer) with
+    | 0 -> Buffer.contents content
+    | count ->
+      Buffer.add_subbytes content buffer 0 count;
+      loop ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ()
+;;
+
+let read_file_opt dir name =
+  let name_value = segment_value name in
+  match open_read_fd dir name_value with
+  | fd ->
+    Some
+      (combine_close ~operation:"anchored read" fd (fun () ->
+         read_from_fd ~name:name_value fd))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> None
+;;
+
 let read_file dir name =
-  require_segment ~operation:"read_file" name;
-  let fd = open_read_fd dir name in
-  combine_close ~operation:"anchored read" fd (fun () ->
-    let metadata = Unix.fstat fd in
-    if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_read", name));
-    let buffer = Bytes.create 65536 in
-    let content = Buffer.create (min metadata.Unix.st_size 65536) in
-    let rec loop () =
-      match Unix.read fd buffer 0 (Bytes.length buffer) with
-      | 0 -> Buffer.contents content
-      | count ->
-        Buffer.add_subbytes content buffer 0 count;
-        loop ()
-      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
-    in
-    loop ())
+  match read_file_opt dir name with
+  | Some content -> content
+  | None ->
+    raise
+      (Unix.Unix_error (Unix.ENOENT, "anchored_read", segment_value name))
 ;;
 
 let fsync_file dir name =
-  require_segment ~operation:"fsync_file" name;
-  let fd = open_read_fd dir name in
+  let name_value = segment_value name in
+  let fd = open_read_fd dir name_value in
   combine_close ~operation:"anchored file fsync" fd (fun () ->
     let metadata = Unix.fstat fd in
     if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name));
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_fsync_file", name_value));
     Unix.fsync fd;
     stat_of_unix metadata)
 ;;
 
 let chmod_file dir name perm =
-  require_segment ~operation:"chmod_file" name;
-  let fd = open_read_fd dir name in
+  let name_value = segment_value name in
+  let fd = open_read_fd dir name_value in
   combine_close ~operation:"anchored file chmod" fd (fun () ->
     let metadata = Unix.fstat fd in
     if metadata.Unix.st_kind <> Unix.S_REG
-    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name));
+    then raise (Unix.Unix_error (Unix.EINVAL, "anchored_chmod_file", name_value));
     Unix.fchmod fd perm;
     Unix.fsync fd)
 ;;
@@ -233,117 +288,225 @@ let temp_counter = Atomic.make 0
 
 let rec create_temporary dir =
   let sequence = Atomic.fetch_and_add temp_counter 1 in
-  let name = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
-  match create_exclusive_fd dir name 0o600 with
+  let raw = Printf.sprintf ".atomic_%x_%x.tmp" (Unix.getpid ()) sequence in
+  let name =
+    match Segment.of_string raw with
+    | Ok name -> name
+    | Error error ->
+      invalid_arg
+        (Printf.sprintf
+           "generated invalid atomic filename: %s"
+           (Segment.error_to_string error))
+  in
+  match create_exclusive_fd dir (segment_value name) 0o600 with
   | fd -> name, fd
   | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary dir
 ;;
 
-let unlink_if_exists dir name =
-  require_segment ~operation:"unlink_if_exists" name;
-  match unlink_at dir name with
-  | () ->
+let cleanup_temp dir name =
+  try
+    unlink_at dir (segment_value name);
     fsync dir;
-    true
-  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+    None
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+  | exn -> Some exn
 ;;
 
-let save_file_atomic dir ~name ~perm content =
-  require_segment ~operation:"save_file_atomic" name;
-  let temp_name, fd = create_temporary dir in
-  let cleanup () =
-    match unlink_if_exists dir temp_name with
-    | true | false -> Ok ()
-    | exception exn -> Error exn
+let atomic_replace dir ~name ~perm content =
+  let temp_result =
+    try Ok (create_temporary dir) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error exn
   in
-  let write_outcome =
-    try
-      write_all fd content;
-      Unix.fchmod fd perm;
-      Unix.fsync fd;
-      Ok ()
-    with
+  match temp_result with
+  | Error cause -> Error (Not_committed { cause; cleanup_error = None })
+  | Ok (temp_name, fd) ->
+    let write_outcome =
+      try
+        write_all fd content;
+        Unix.fchmod fd perm;
+        Unix.fsync fd;
+        Ok ()
+      with
+      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+    in
+    let close_outcome =
+      try
+        Unix.close fd;
+        Ok ()
+      with
+      | exn -> Error exn
+    in
+    let before_commit =
+      match write_outcome, close_outcome with
+      | Ok (), Ok () -> Ok ()
+      | Error (exn, backtrace), Ok () -> Error (exn, backtrace)
+      | Ok (), Error exn -> Error (exn, Printexc.get_raw_backtrace ())
+      | Error (write_error, backtrace), Error close_error ->
+        Error
+          ( Failure
+              (Printf.sprintf
+                 "anchored atomic write failed (%s); close also failed (%s)"
+                 (Printexc.to_string write_error)
+                 (Printexc.to_string close_error))
+          , backtrace )
+    in
+    (match before_commit with
+     | Error ((Eio.Cancel.Cancelled _ as cause), backtrace) ->
+       (match cleanup_temp dir temp_name with
+        | None -> ()
+        | Some cleanup_error ->
+          Printf.eprintf
+            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
+            (segment_value temp_name)
+            (Printexc.to_string cleanup_error));
+       Printexc.raise_with_backtrace cause backtrace
+     | Error (cause, _) ->
+       Error
+         (Not_committed
+            { cause; cleanup_error = cleanup_temp dir temp_name })
+     | Ok () ->
+       (match
+          rename_at
+            dir
+            (segment_value temp_name)
+            dir
+            (segment_value name)
+        with
+        | exception Eio.Cancel.Cancelled _ as exn ->
+          let cleanup_error = cleanup_temp dir temp_name in
+          (match cleanup_error with
+           | None -> ()
+           | Some error ->
+             Printf.eprintf
+               "[fs_compat] cancelled anchored-rename cleanup failed name=%s: %s\n%!"
+               (segment_value temp_name)
+               (Printexc.to_string error));
+          raise exn
+        | exception cause ->
+          Error
+            (Not_committed
+               { cause; cleanup_error = cleanup_temp dir temp_name })
+        | () ->
+          (match fsync dir with
+           | () -> Ok ()
+           | exception cause -> Error (Committed_not_durable cause))))
+;;
+
+let unlink_if_exists dir name =
+  match unlink_at dir (segment_value name) with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok `Missing
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (match fsync dir with
+     | () -> Ok `Removed
+     | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let rename ~src_dir ~src ~dst_dir ~dst =
+  match
+    rename_at
+      src_dir
+      (segment_value src)
+      dst_dir
+      (segment_value dst)
+  with
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (try
+       fsync dst_dir;
+       if src_dir != dst_dir then fsync src_dir;
+       Ok ()
+     with
+     | cause -> Error (Committed_not_durable cause))
+;;
+
+let link_no_replace ~src_dir ~src ~dst_dir ~dst =
+  match
+    link_at
+      src_dir
+      (segment_value src)
+      dst_dir
+      (segment_value dst)
+  with
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception cause ->
+    Error (Not_committed { cause; cleanup_error = None })
+  | () ->
+    (match fsync dst_dir with
+     | () -> Ok ()
+     | exception cause -> Error (Committed_not_durable cause))
+;;
+
+let combine_closedir handle f =
+  let outcome =
+    try Ok (f ()) with
     | exn -> Error (exn, Printexc.get_raw_backtrace ())
   in
   let close_outcome =
     try
-      Unix.close fd;
+      Unix.closedir handle;
       Ok ()
     with
     | exn -> Error exn
   in
-  let primary =
-    match write_outcome, close_outcome with
-    | Ok (), Ok () -> Ok ()
-    | Error (exn, _), Ok () | Ok (), Error exn -> Error exn
-    | Error (write_error, _), Error close_error ->
-      Error
-        (Failure
-           (Printf.sprintf
-              "anchored atomic write failed (%s); close also failed (%s)"
-              (Printexc.to_string write_error)
-              (Printexc.to_string close_error)))
+  match outcome, close_outcome with
+  | Ok value, Ok () -> value
+  | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+  | Ok _, Error close_error -> raise close_error
+  | Error (primary, _), Error close_error ->
+    raise
+      (Failure
+         (Printf.sprintf
+            "anchored readdir failed (%s); closedir also failed (%s)"
+            (Printexc.to_string primary)
+            (Printexc.to_string close_error)))
+;;
+
+let read_dir dir =
+  let duplicate = Unix.dup ~cloexec:true dir in
+  let handle =
+    try fdopendir duplicate with
+    | exn ->
+      let close_error =
+        try
+          Unix.close duplicate;
+          None
+        with
+        | close_error -> Some close_error
+      in
+      (match close_error with
+       | None -> raise exn
+       | Some close_error ->
+         raise
+           (Failure
+              (Printf.sprintf
+                 "fdopendir failed (%s); duplicate close also failed (%s)"
+                 (Printexc.to_string exn)
+                 (Printexc.to_string close_error))))
   in
-  match primary with
-  | Error exn ->
-    (match exn with
-     | Eio.Cancel.Cancelled _ ->
-       (match cleanup () with
-        | Ok () -> ()
-        | Error cleanup_error ->
-          Printf.eprintf
-            "[fs_compat] cancelled anchored-write cleanup failed name=%s: %s\n%!"
-            temp_name
-            (Printexc.to_string cleanup_error));
-       raise exn
-     | _ ->
-       let detail =
-         match cleanup () with
-         | Ok () -> Printexc.to_string exn
-         | Error cleanup_error ->
-           Printf.sprintf
-             "%s; temporary cleanup failed: %s"
-             (Printexc.to_string exn)
-             (Printexc.to_string cleanup_error)
-       in
-       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
-  | Ok () ->
-    (match rename_at dir temp_name dir name with
-     | () ->
-       (match fsync dir with
-        | () -> Ok ()
-        | exception exn ->
-          Error
-            (Printf.sprintf
-               "save_file_atomic %s committed but directory fsync failed: %s"
-               name
-               (Printexc.to_string exn)))
-     | exception exn ->
-       let detail =
-         match cleanup () with
-         | Ok () -> Printexc.to_string exn
-         | Error cleanup_error ->
-           Printf.sprintf
-             "%s; temporary cleanup failed: %s"
-             (Printexc.to_string exn)
-             (Printexc.to_string cleanup_error)
-       in
-       Error (Printf.sprintf "save_file_atomic %s: %s" name detail))
-;;
-
-let rename ~src_dir ~src ~dst_dir ~dst =
-  require_segment ~operation:"rename source" src;
-  require_segment ~operation:"rename destination" dst;
-  rename_at src_dir src dst_dir dst;
-  fsync dst_dir;
-  if src_dir != dst_dir then fsync src_dir
-;;
-
-let link_no_replace ~src_dir ~src ~dst_dir ~dst =
-  require_segment ~operation:"link source" src;
-  require_segment ~operation:"link destination" dst;
-  link_at src_dir src dst_dir dst;
-  fsync dst_dir
-;;
-
-let read_dir dir = read_dir_raw dir |> List.sort String.compare
+  combine_closedir handle (fun () ->
+    let rec loop acc =
+      match Unix.readdir handle with
+      | "." | ".." -> loop acc
+      | raw ->
+        (match Segment.of_string raw with
+         | Ok segment -> loop (segment :: acc)
+         | Error error ->
+           raise
+             (Failure
+                (Printf.sprintf
+                   "filesystem returned invalid directory entry: %s"
+                   (Segment.error_to_string error))))
+      | exception End_of_file ->
+        List.sort
+          (fun left right ->
+             String.compare (segment_value left) (segment_value right))
+          acc
+    in
+    loop [])

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -37,9 +37,13 @@ type stat =
   ; link_count : int64
   }
 
-type directory_identity =
-  { device : int64
-  ; inode : int64
+type lock_file
+
+exception Descriptor_cleanup_failed of
+  { operation : string
+  ; primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
   }
 
 type mutation_error =
@@ -55,17 +59,16 @@ val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
 
-val identity : t -> directory_identity
-(** Stable identity of the opened directory capability. Unlike a path spelling,
-    this remains unchanged if the directory is renamed while it is open. *)
-
-val with_lock_file :
-  t -> name:Segment.t -> perm:int -> (Unix.file_descr -> 'a) -> 'a
+val open_lock_file : t -> name:Segment.t -> perm:int -> lock_file
 (** Open or create one regular lock file relative to the directory capability,
-    without following a final symlink. A newly-created lock file and directory
-    entry are fsynced before the callback. The descriptor remains open for the
-    callback and is closed on every exit; closing releases any POSIX record lock
-    acquired by the callback. *)
+    without following a final symlink. A newly-created file and directory entry
+    are fsynced before this returns. The returned artifact must be closed with
+    {!close_lock_file}; {!File_lock_eio.with_lock_file} owns that lifecycle for
+    ordinary lock users. *)
+
+val lock_file_descriptor : lock_file -> Unix.file_descr
+val lock_file_identity : lock_file -> int64 * int64
+val close_lock_file : lock_file -> unit
 
 val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -42,13 +42,22 @@ val stat : t -> string -> stat option
 val read_file : t -> string -> string
 (** Read one existing regular file without following a final symlink. *)
 
+val fsync_file : t -> string -> stat
+(** Fsync one existing regular file and return the identity of the opened file.
+    The final entry is opened with [O_NOFOLLOW]. *)
+
+val chmod_file : t -> string -> int -> unit
+(** Apply permissions to one existing regular file through its opened file
+    descriptor, without following a final symlink. *)
+
 val save_file_atomic :
   t -> name:string -> perm:int -> string -> (unit, string) result
 (** Write through an exclusive temporary file in [t], fsync it, rename it over
     [name], and fsync [t]. No path component is reopened by name outside [t]. *)
 
 val unlink_if_exists : t -> string -> bool
-(** Remove one non-directory child entry. Returns [false] only for ENOENT. *)
+(** Remove and durably publish removal of one non-directory child entry.
+    Returns [false] only for ENOENT. *)
 
 val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
 (** Atomically move one child entry between two directory capabilities. *)

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -64,7 +64,7 @@ val open_lock_file : t -> name:Segment.t -> perm:int -> lock_file
 (** Open or create one regular lock file relative to the directory capability,
     without following a final symlink. A newly-created file and directory entry
     are fsynced before this returns. The returned artifact must be closed with
-    {!close_lock_file}; {!File_lock_eio.with_lock_file} owns that lifecycle for
+    {!close_lock_file}; {!File_lock_eio.with_anchored_file_lock} owns that lifecycle for
     ordinary lock users. *)
 
 val lock_file_descriptor : lock_file -> Unix.file_descr

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -8,6 +8,21 @@
 
 type t
 
+module Segment : sig
+  type t = private string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+  val error_to_string : error -> string
+end
+
 type kind =
   | Regular_file
   | Directory
@@ -22,51 +37,79 @@ type stat =
   ; link_count : int64
   }
 
+type mutation_error =
+  | Not_committed of
+      { cause : exn
+      ; cleanup_error : exn option
+      }
+  | Committed_not_durable of exn
+
+val mutation_error_to_string : mutation_error -> string
+
 val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
 
-val with_open_dir : t -> string -> (t -> 'a) -> 'a
+val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)
 
+val with_open_dir_opt : t -> Segment.t -> (t -> 'a) -> 'a option
+(** Open one child directory using the open operation itself as the existence
+    test. [None] means ENOENT; symlinks and all other failures are raised. *)
+
 val with_ensure_dir :
-  t -> name:string -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
+  t -> name:Segment.t -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
 (** Open one child directory, creating and durably publishing it when absent.
-    [name] must be one path segment. When [enforce_perm] is true, the opened
-    directory is [fchmod]ed and fsynced before the callback. *)
+    When [enforce_perm] is true, the opened directory is [fchmod]ed. Creation is
+    committed as [mkdirat -> openat -> fchmod -> fsync(child) -> fsync(parent)]. *)
 
-val stat : t -> string -> stat option
+val stat : t -> Segment.t -> stat option
 (** Inspect one child entry without following a symlink. [None] means ENOENT;
-    every other error is raised. *)
+    every other error is raised. This is a diagnostic snapshot, not authority
+    for a later path-based operation. *)
 
-val read_file : t -> string -> string
+val read_file : t -> Segment.t -> string
 (** Read one existing regular file without following a final symlink. *)
 
-val fsync_file : t -> string -> stat
+val read_file_opt : t -> Segment.t -> string option
+(** Read a regular file using [openat] itself as the existence test. *)
+
+val fsync_file : t -> Segment.t -> stat
 (** Fsync one existing regular file and return the identity of the opened file.
     The final entry is opened with [O_NOFOLLOW]. *)
 
-val chmod_file : t -> string -> int -> unit
+val chmod_file : t -> Segment.t -> int -> unit
 (** Apply permissions to one existing regular file through its opened file
     descriptor, without following a final symlink. *)
 
-val save_file_atomic :
-  t -> name:string -> perm:int -> string -> (unit, string) result
-(** Write through an exclusive temporary file in [t], fsync it, rename it over
-    [name], and fsync [t]. No path component is reopened by name outside [t]. *)
+val atomic_replace :
+  t -> name:Segment.t -> perm:int -> string -> (unit, mutation_error) result
+(** Write through an exclusive temporary file, fsync it, rename it over [name],
+    and fsync the directory. A visible rename followed by failed directory fsync
+    is reported as {!Committed_not_durable}, never as an untyped failure. *)
 
-val unlink_if_exists : t -> string -> bool
-(** Remove and durably publish removal of one non-directory child entry.
-    Returns [false] only for ENOENT. *)
+val unlink_if_exists :
+  t -> Segment.t -> ([ `Missing | `Removed ], mutation_error) result
+(** Remove and durably publish removal of one non-directory child entry. *)
 
-val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+val rename :
+  src_dir:t ->
+  src:Segment.t ->
+  dst_dir:t ->
+  dst:Segment.t ->
+  (unit, mutation_error) result
 (** Atomically move one child entry between two directory capabilities. *)
 
-val link_no_replace : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
-(** Create a hard link without replacing [dst]. The source symlink, if any, is
-    linked as a symlink rather than followed. *)
+val link_no_replace :
+  src_dir:t ->
+  src:Segment.t ->
+  dst_dir:t ->
+  dst:Segment.t ->
+  (unit, mutation_error) result
+(** Create and durably publish a hard link without replacing [dst]. The source
+    symlink, if any, is linked as a symlink rather than followed. *)
 
-val read_dir : t -> string list
+val read_dir : t -> Segment.t list
 (** Return child names, excluding [.] and [..], in lexical order. *)
 
 val fsync : t -> unit

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -3,8 +3,9 @@
     Every descendant lookup is relative to an already-open directory file
     descriptor. Path components are never re-resolved from an absolute string,
     so replacing a managed ancestor with a symlink cannot redirect an active
-    transaction outside its root capability. These calls are blocking and must
-    run in a system thread when invoked from Eio. *)
+    transaction outside its root capability. Filesystem syscalls are dispatched
+    to a system thread when an Eio runtime is active; callbacks continue on the
+    caller's fiber and must not be invoked from a system-thread-only body. *)
 
 type t
 

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -1,0 +1,67 @@
+(** Descriptor-anchored blocking filesystem operations.
+
+    Every descendant lookup is relative to an already-open directory file
+    descriptor. Path components are never re-resolved from an absolute string,
+    so replacing a managed ancestor with a symlink cannot redirect an active
+    transaction outside its root capability. These calls are blocking and must
+    run in a system thread when invoked from Eio. *)
+
+type t
+
+type kind =
+  | Regular_file
+  | Directory
+  | Symbolic_link
+  | Other
+
+type stat =
+  { kind : kind
+  ; size : int64
+  ; device : int64
+  ; inode : int64
+  ; link_count : int64
+  }
+
+val with_open_root : string -> (t -> 'a) -> 'a
+(** Open an existing real directory without following a final symlink and close
+    the capability after the callback. Close failures are never discarded. *)
+
+val with_open_dir : t -> string -> (t -> 'a) -> 'a
+(** Open one existing child directory without following symlinks. *)
+
+val with_ensure_dir :
+  t -> name:string -> perm:int -> enforce_perm:bool -> (t -> 'a) -> 'a
+(** Open one child directory, creating and durably publishing it when absent.
+    [name] must be one path segment. When [enforce_perm] is true, the opened
+    directory is [fchmod]ed and fsynced before the callback. *)
+
+val stat : t -> string -> stat option
+(** Inspect one child entry without following a symlink. [None] means ENOENT;
+    every other error is raised. *)
+
+val read_file : t -> string -> string
+(** Read one existing regular file without following a final symlink. *)
+
+val save_file_atomic :
+  t -> name:string -> perm:int -> string -> (unit, string) result
+(** Write through an exclusive temporary file in [t], fsync it, rename it over
+    [name], and fsync [t]. No path component is reopened by name outside [t]. *)
+
+val unlink_if_exists : t -> string -> bool
+(** Remove one non-directory child entry. Returns [false] only for ENOENT. *)
+
+val rename : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+(** Atomically move one child entry between two directory capabilities. *)
+
+val link_no_replace : src_dir:t -> src:string -> dst_dir:t -> dst:string -> unit
+(** Create a hard link without replacing [dst]. The source symlink, if any, is
+    linked as a symlink rather than followed. *)
+
+val read_dir : t -> string list
+(** Return child names, excluding [.] and [..], in lexical order. *)
+
+val fsync : t -> unit
+(** Durably publish prior directory-entry changes. Unsupported operations are
+    raised explicitly. *)
+
+val same_identity : stat -> stat -> bool

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -63,6 +63,23 @@ val with_ensure_dir :
     When [enforce_perm] is true, the opened directory is [fchmod]ed. Creation is
     committed as [mkdirat -> openat -> fchmod -> fsync(child) -> fsync(parent)]. *)
 
+type ensure_step =
+  { name : Segment.t
+  ; perm : int
+  ; enforce_perm : bool
+  }
+
+val with_ensure_path :
+  root:string -> ensure_step list -> (t -> 'a) -> 'a
+(** Open [root], walk [steps] one descriptor-relative component at a time, and
+    retain only the leaf descriptor for the callback. Missing components are
+    created with the same durability contract as {!with_ensure_dir}. *)
+
+val with_open_path_opt :
+  root:string -> Segment.t list -> (t -> 'a) -> 'a option
+(** Read-only counterpart of {!with_ensure_path}. [None] means a component was
+    absent. Ancestor descriptors are closed before the callback. *)
+
 val stat : t -> Segment.t -> stat option
 (** Inspect one child entry without following a symlink. [None] means ENOENT;
     every other error is raised. This is a diagnostic snapshot, not authority

--- a/lib/fs_compat/anchored_fs.mli
+++ b/lib/fs_compat/anchored_fs.mli
@@ -37,6 +37,11 @@ type stat =
   ; link_count : int64
   }
 
+type directory_identity =
+  { device : int64
+  ; inode : int64
+  }
+
 type mutation_error =
   | Not_committed of
       { cause : exn
@@ -49,6 +54,18 @@ val mutation_error_to_string : mutation_error -> string
 val with_open_root : string -> (t -> 'a) -> 'a
 (** Open an existing real directory without following a final symlink and close
     the capability after the callback. Close failures are never discarded. *)
+
+val identity : t -> directory_identity
+(** Stable identity of the opened directory capability. Unlike a path spelling,
+    this remains unchanged if the directory is renamed while it is open. *)
+
+val with_lock_file :
+  t -> name:Segment.t -> perm:int -> (Unix.file_descr -> 'a) -> 'a
+(** Open or create one regular lock file relative to the directory capability,
+    without following a final symlink. A newly-created lock file and directory
+    entry are fsynced before the callback. The descriptor remains open for the
+    callback and is closed on every exit; closing releases any POSIX record lock
+    acquired by the callback. *)
 
 val with_open_dir : t -> Segment.t -> (t -> 'a) -> 'a
 (** Open one existing child directory without following symlinks. *)

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -1,0 +1,191 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/unixsupport.h>
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#endif
+
+#if !defined(AT_SYMLINK_NOFOLLOW)
+#error "descriptor-anchored filesystem requires AT_SYMLINK_NOFOLLOW"
+#endif
+
+static int anchored_fd(value descriptor)
+{
+  return Int_val(descriptor);
+}
+
+CAMLprim value masc_anchored_open_root(value path)
+{
+  CAMLparam1(path);
+  int fd = open(String_val(path), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_root", path);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_open_dir(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_dir", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_open_read(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd == -1) uerror("anchored_open_read", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
+{
+  CAMLparam3(directory, name, mode);
+  int fd = openat(anchored_fd(directory), String_val(name),
+                  O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                  Int_val(mode));
+  if (fd == -1) uerror("anchored_create_exclusive", name);
+  CAMLreturn(Val_int(fd));
+}
+
+CAMLprim value masc_anchored_mkdir(value directory, value name, value mode)
+{
+  CAMLparam3(directory, name, mode);
+  if (mkdirat(anchored_fd(directory), String_val(name), Int_val(mode)) == -1)
+    uerror("anchored_mkdir", name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_unlink(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  if (unlinkat(anchored_fd(directory), String_val(name), 0) == -1)
+    uerror("anchored_unlink", name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_rename(value old_directory, value old_name,
+                                    value new_directory, value new_name)
+{
+  CAMLparam4(old_directory, old_name, new_directory, new_name);
+  if (renameat(anchored_fd(old_directory), String_val(old_name),
+               anchored_fd(new_directory), String_val(new_name)) == -1)
+    uerror("anchored_rename", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_link(value old_directory, value old_name,
+                                  value new_directory, value new_name)
+{
+  CAMLparam4(old_directory, old_name, new_directory, new_name);
+  if (linkat(anchored_fd(old_directory), String_val(old_name),
+             anchored_fd(new_directory), String_val(new_name), 0) == -1)
+    uerror("anchored_link", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_anchored_stat(value directory, value name)
+{
+  CAMLparam2(directory, name);
+  CAMLlocal3(result, tuple, number);
+  struct stat metadata;
+
+  if (fstatat(anchored_fd(directory), String_val(name), &metadata,
+              AT_SYMLINK_NOFOLLOW) == -1) {
+    if (errno == ENOENT) CAMLreturn(Val_int(0));
+    uerror("anchored_stat", name);
+  }
+
+  int kind = 3;
+  if (S_ISREG(metadata.st_mode)) kind = 0;
+  else if (S_ISDIR(metadata.st_mode)) kind = 1;
+  else if (S_ISLNK(metadata.st_mode)) kind = 2;
+
+  tuple = caml_alloc(5, 0);
+  Store_field(tuple, 0, Val_int(kind));
+  number = caml_copy_int64((int64_t) metadata.st_size);
+  Store_field(tuple, 1, number);
+  number = caml_copy_int64((int64_t) metadata.st_dev);
+  Store_field(tuple, 2, number);
+  number = caml_copy_int64((int64_t) metadata.st_ino);
+  Store_field(tuple, 3, number);
+  number = caml_copy_int64((int64_t) metadata.st_nlink);
+  Store_field(tuple, 4, number);
+
+  result = caml_alloc(1, 0);
+  Store_field(result, 0, tuple);
+  CAMLreturn(result);
+}
+
+CAMLprim value masc_anchored_readdir(value directory)
+{
+  CAMLparam1(directory);
+  CAMLlocal3(entries, cell, name);
+
+  int duplicate = dup(anchored_fd(directory));
+  if (duplicate == -1) uerror("anchored_readdir_dup", Nothing);
+
+  DIR *handle = fdopendir(duplicate);
+  if (handle == NULL) {
+    int saved_errno = errno;
+    int close_result = close(duplicate);
+    int close_errno = errno;
+    if (close_result == -1) {
+      char detail[160];
+      snprintf(detail, sizeof(detail),
+               "anchored_readdir_open errno=%d; duplicate close errno=%d",
+               saved_errno, close_errno);
+      caml_failwith(detail);
+    }
+    errno = saved_errno;
+    uerror("anchored_readdir_open", Nothing);
+  }
+
+  entries = Val_emptylist;
+  errno = 0;
+  for (;;) {
+    struct dirent *entry = readdir(handle);
+    if (entry == NULL) break;
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+      continue;
+    name = caml_copy_string(entry->d_name);
+    cell = caml_alloc(2, 0);
+    Store_field(cell, 0, name);
+    Store_field(cell, 1, entries);
+    entries = cell;
+    errno = 0;
+  }
+
+  int read_errno = errno;
+  int close_result = closedir(handle);
+  int close_errno = errno;
+  if (read_errno != 0 && close_result == -1) {
+    char detail[160];
+    snprintf(detail, sizeof(detail),
+             "anchored_readdir errno=%d; closedir errno=%d",
+             read_errno, close_errno);
+    caml_failwith(detail);
+  }
+  if (close_result == -1) read_errno = close_errno;
+  if (read_errno != 0) {
+    errno = read_errno;
+    uerror("anchored_readdir", Nothing);
+  }
+
+  CAMLreturn(entries);
+}

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -1,14 +1,13 @@
 #include <caml/alloc.h>
-#include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/signals.h>
 #include <caml/unixsupport.h>
 
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -27,86 +26,180 @@ static int anchored_fd(value descriptor)
   return Int_val(descriptor);
 }
 
+static void stat_free_preserving_errno(void *pointer)
+{
+  int saved_errno = errno;
+  caml_stat_free(pointer);
+  errno = saved_errno;
+}
+
 CAMLprim value masc_anchored_open_root(value path)
 {
   CAMLparam1(path);
-  int fd = open(String_val(path), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  char *copied_path;
+  int fd;
+
+  caml_unix_check_path(path, "anchored_open_root");
+  copied_path = caml_stat_strdup(String_val(path));
+  caml_enter_blocking_section();
+  fd = open(copied_path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_path);
   if (fd == -1) uerror("anchored_open_root", path);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_open_dir(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_dir");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_dir", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_open_read(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_read");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_read", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
 {
-  CAMLparam3(directory, name, mode);
-  int fd = openat(anchored_fd(directory), String_val(name),
-                  O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
-                  Int_val(mode));
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_create_exclusive");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+              Int_val(mode));
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_create_exclusive", name);
   CAMLreturn(Val_int(fd));
 }
 
 CAMLprim value masc_anchored_mkdir(value directory, value name, value mode)
 {
-  CAMLparam3(directory, name, mode);
-  if (mkdirat(anchored_fd(directory), String_val(name), Int_val(mode)) == -1)
-    uerror("anchored_mkdir", name);
+  CAMLparam1(name);
+  char *copied_name;
+  int result;
+
+  caml_unix_check_path(name, "anchored_mkdir");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  result = mkdirat(anchored_fd(directory), copied_name, Int_val(mode));
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (result == -1) uerror("anchored_mkdir", name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_unlink(value directory, value name)
 {
-  CAMLparam2(directory, name);
-  if (unlinkat(anchored_fd(directory), String_val(name), 0) == -1)
-    uerror("anchored_unlink", name);
+  CAMLparam1(name);
+  char *copied_name;
+  int result;
+
+  caml_unix_check_path(name, "anchored_unlink");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  result = unlinkat(anchored_fd(directory), copied_name, 0);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (result == -1) uerror("anchored_unlink", name);
   CAMLreturn(Val_unit);
+}
+
+static char *copy_two_paths(value first, value second, char **second_copy)
+{
+  size_t first_length = caml_string_length(first);
+  size_t second_length = caml_string_length(second);
+  char *allocation = caml_stat_alloc(first_length + second_length + 2);
+  *second_copy = allocation + first_length + 1;
+  memcpy(allocation, String_val(first), first_length + 1);
+  memcpy(*second_copy, String_val(second), second_length + 1);
+  return allocation;
 }
 
 CAMLprim value masc_anchored_rename(value old_directory, value old_name,
                                     value new_directory, value new_name)
 {
-  CAMLparam4(old_directory, old_name, new_directory, new_name);
-  if (renameat(anchored_fd(old_directory), String_val(old_name),
-               anchored_fd(new_directory), String_val(new_name)) == -1)
-    uerror("anchored_rename", old_name);
+  CAMLparam2(old_name, new_name);
+  char *old_copy;
+  char *new_copy;
+  int result;
+
+  caml_unix_check_path(old_name, "anchored_rename_old");
+  caml_unix_check_path(new_name, "anchored_rename_new");
+  old_copy = copy_two_paths(old_name, new_name, &new_copy);
+  caml_enter_blocking_section();
+  result = renameat(anchored_fd(old_directory), old_copy,
+                    anchored_fd(new_directory), new_copy);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(old_copy);
+  if (result == -1) uerror("anchored_rename", old_name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_link(value old_directory, value old_name,
                                   value new_directory, value new_name)
 {
-  CAMLparam4(old_directory, old_name, new_directory, new_name);
-  if (linkat(anchored_fd(old_directory), String_val(old_name),
-             anchored_fd(new_directory), String_val(new_name), 0) == -1)
-    uerror("anchored_link", old_name);
+  CAMLparam2(old_name, new_name);
+  char *old_copy;
+  char *new_copy;
+  int result;
+
+  caml_unix_check_path(old_name, "anchored_link_old");
+  caml_unix_check_path(new_name, "anchored_link_new");
+  old_copy = copy_two_paths(old_name, new_name, &new_copy);
+  caml_enter_blocking_section();
+  result = linkat(anchored_fd(old_directory), old_copy,
+                  anchored_fd(new_directory), new_copy, 0);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(old_copy);
+  if (result == -1) uerror("anchored_link", old_name);
   CAMLreturn(Val_unit);
 }
 
 CAMLprim value masc_anchored_stat(value directory, value name)
 {
-  CAMLparam2(directory, name);
+  CAMLparam1(name);
   CAMLlocal3(result, tuple, number);
+  char *copied_name;
   struct stat metadata;
+  int stat_result;
 
-  if (fstatat(anchored_fd(directory), String_val(name), &metadata,
-              AT_SYMLINK_NOFOLLOW) == -1) {
+  caml_unix_check_path(name, "anchored_stat");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (stat_result == -1) {
     if (errno == ENOENT) CAMLreturn(Val_int(0));
     uerror("anchored_stat", name);
   }
@@ -132,60 +225,16 @@ CAMLprim value masc_anchored_stat(value directory, value name)
   CAMLreturn(result);
 }
 
-CAMLprim value masc_anchored_readdir(value directory)
+CAMLprim value masc_anchored_fdopendir(value descriptor)
 {
-  CAMLparam1(directory);
-  CAMLlocal3(entries, cell, name);
+  CAMLparam0();
+  CAMLlocal1(result);
+  DIR *directory;
 
-  int duplicate = dup(anchored_fd(directory));
-  if (duplicate == -1) uerror("anchored_readdir_dup", Nothing);
-
-  DIR *handle = fdopendir(duplicate);
-  if (handle == NULL) {
-    int saved_errno = errno;
-    int close_result = close(duplicate);
-    int close_errno = errno;
-    if (close_result == -1) {
-      char detail[160];
-      snprintf(detail, sizeof(detail),
-               "anchored_readdir_open errno=%d; duplicate close errno=%d",
-               saved_errno, close_errno);
-      caml_failwith(detail);
-    }
-    errno = saved_errno;
-    uerror("anchored_readdir_open", Nothing);
-  }
-
-  entries = Val_emptylist;
-  errno = 0;
-  for (;;) {
-    struct dirent *entry = readdir(handle);
-    if (entry == NULL) break;
-    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-      continue;
-    name = caml_copy_string(entry->d_name);
-    cell = caml_alloc(2, 0);
-    Store_field(cell, 0, name);
-    Store_field(cell, 1, entries);
-    entries = cell;
-    errno = 0;
-  }
-
-  int read_errno = errno;
-  int close_result = closedir(handle);
-  int close_errno = errno;
-  if (read_errno != 0 && close_result == -1) {
-    char detail[160];
-    snprintf(detail, sizeof(detail),
-             "anchored_readdir errno=%d; closedir errno=%d",
-             read_errno, close_errno);
-    caml_failwith(detail);
-  }
-  if (close_result == -1) read_errno = close_errno;
-  if (read_errno != 0) {
-    errno = read_errno;
-    uerror("anchored_readdir", Nothing);
-  }
-
-  CAMLreturn(entries);
+  result = caml_alloc_small(1, Abstract_tag);
+  DIR_Val(result) = NULL;
+  directory = fdopendir(anchored_fd(descriptor));
+  if (directory == NULL) uerror("anchored_fdopendir", Nothing);
+  DIR_Val(result) = directory;
+  CAMLreturn(result);
 }

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -13,8 +13,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
-#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, and O_NOCTTY"
 #endif
 
 #if !defined(AT_SYMLINK_NOFOLLOW)
@@ -88,12 +88,21 @@ CAMLprim value masc_anchored_open_write(value directory, value name)
   CAMLparam1(name);
   char *copied_name;
   int fd;
+  struct stat metadata;
+  int stat_result;
 
   caml_unix_check_path(name, "anchored_open_write");
   copied_name = caml_stat_strdup(String_val(name));
   caml_enter_blocking_section();
-  fd = openat(anchored_fd(directory), copied_name,
-              O_WRONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  if (stat_result == 0 && !S_ISREG(metadata.st_mode)) {
+    errno = S_ISLNK(metadata.st_mode) ? ELOOP : EINVAL;
+    fd = -1;
+  } else {
+    fd = openat(anchored_fd(directory), copied_name,
+                O_WRONLY | O_NONBLOCK | O_NOCTTY | O_NOFOLLOW | O_CLOEXEC);
+  }
   caml_leave_blocking_section();
   stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_write", name);
@@ -240,6 +249,36 @@ CAMLprim value masc_anchored_stat(value directory, value name)
   result = caml_alloc(1, 0);
   Store_field(result, 0, tuple);
   CAMLreturn(result);
+}
+
+CAMLprim value masc_anchored_fstat(value descriptor)
+{
+  CAMLparam0();
+  CAMLlocal2(tuple, number);
+  struct stat metadata;
+  int stat_result;
+  int kind = 3;
+
+  caml_enter_blocking_section();
+  stat_result = fstat(anchored_fd(descriptor), &metadata);
+  caml_leave_blocking_section();
+  if (stat_result == -1) uerror("anchored_fstat", Nothing);
+
+  if (S_ISREG(metadata.st_mode)) kind = 0;
+  else if (S_ISDIR(metadata.st_mode)) kind = 1;
+  else if (S_ISLNK(metadata.st_mode)) kind = 2;
+
+  tuple = caml_alloc(5, 0);
+  Store_field(tuple, 0, Val_int(kind));
+  number = caml_copy_int64((int64_t) metadata.st_size);
+  Store_field(tuple, 1, number);
+  number = caml_copy_int64((int64_t) metadata.st_dev);
+  Store_field(tuple, 2, number);
+  number = caml_copy_int64((int64_t) metadata.st_ino);
+  Store_field(tuple, 3, number);
+  number = caml_copy_int64((int64_t) metadata.st_nlink);
+  Store_field(tuple, 4, number);
+  CAMLreturn(tuple);
 }
 
 CAMLprim value masc_anchored_fdopendir(value descriptor)

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -83,6 +83,23 @@ CAMLprim value masc_anchored_open_read(value directory, value name)
   CAMLreturn(Val_int(fd));
 }
 
+CAMLprim value masc_anchored_open_write(value directory, value name)
+{
+  CAMLparam1(name);
+  char *copied_name;
+  int fd;
+
+  caml_unix_check_path(name, "anchored_open_write");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  fd = openat(anchored_fd(directory), copied_name,
+              O_WRONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  stat_free_preserving_errno(copied_name);
+  if (fd == -1) uerror("anchored_open_write", name);
+  CAMLreturn(Val_int(fd));
+}
+
 CAMLprim value masc_anchored_create_exclusive(value directory, value name, value mode)
 {
   CAMLparam1(name);

--- a/lib/fs_compat/anchored_fs_stubs.c
+++ b/lib/fs_compat/anchored_fs_stubs.c
@@ -13,8 +13,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY)
-#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, and O_NOCTTY"
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW) || !defined(O_NOCTTY) || !defined(O_NONBLOCK)
+#error "descriptor-anchored filesystem requires O_CLOEXEC, O_DIRECTORY, O_NOFOLLOW, O_NOCTTY, and O_NONBLOCK"
 #endif
 
 #if !defined(AT_SYMLINK_NOFOLLOW)
@@ -71,12 +71,21 @@ CAMLprim value masc_anchored_open_read(value directory, value name)
   CAMLparam1(name);
   char *copied_name;
   int fd;
+  struct stat metadata;
+  int stat_result;
 
   caml_unix_check_path(name, "anchored_open_read");
   copied_name = caml_stat_strdup(String_val(name));
   caml_enter_blocking_section();
-  fd = openat(anchored_fd(directory), copied_name,
-              O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+  stat_result = fstatat(anchored_fd(directory), copied_name, &metadata,
+                        AT_SYMLINK_NOFOLLOW);
+  if (stat_result == 0 && !S_ISREG(metadata.st_mode)) {
+    errno = S_ISLNK(metadata.st_mode) ? ELOOP : EINVAL;
+    fd = -1;
+  } else {
+    fd = openat(anchored_fd(directory), copied_name,
+                O_RDONLY | O_NONBLOCK | O_NOCTTY | O_NOFOLLOW | O_CLOEXEC);
+  }
   caml_leave_blocking_section();
   stat_free_preserving_errno(copied_name);
   if (fd == -1) uerror("anchored_open_read", name);

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -22,6 +22,15 @@ let fsync_path path =
         ())
 ;;
 
+let fsync_directory path =
+  try
+    fsync_path path;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "fsync directory %s: %s" path (Printexc.to_string exn))
+;;
+
 (* #10205 finding 2: keep the atomic-tmp filename shape in one place
    so the writer ([save_file_atomic]) and the orphan-sweep matcher
    ([is_atomic_orphan_name]) cannot drift independently. A
@@ -38,25 +47,57 @@ let save_file_atomic
   : (unit, string) Result.t
   =
   let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
-  in
-  try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
-    Ok ()
+  match
+    try
+      Ok
+        (Stdlib.Filename.temp_file
+           ~temp_dir:dir
+           atomic_tmp_prefix
+           atomic_tmp_suffix)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error exn
   with
-  | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    raise e
-  | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+  | Error exn ->
+    Error
+      (Printf.sprintf
+         "save_file_atomic %s: temp creation failed: %s"
+         path
+         (Printexc.to_string exn))
+  | Ok tmp ->
+    let cleanup_tmp () =
+      try
+        Unix.unlink tmp;
+        Ok ()
+      with
+      | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+      | exn -> Error (Printexc.to_string exn)
+    in
+    (try
+       save_file tmp content;
+       fsync_path tmp;
+       Stdlib.Sys.rename tmp path;
+       fsync_path dir;
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn ->
+       (match cleanup_tmp () with
+        | Ok () -> ()
+        | Error detail ->
+          Stdlib.Printf.eprintf
+            "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+            tmp
+            detail);
+       raise exn
+     | exn ->
+       let primary = Printexc.to_string exn in
+       let detail =
+         match cleanup_tmp () with
+         | Ok () -> primary
+         | Error cleanup ->
+           Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+       in
+       Error (Printf.sprintf "save_file_atomic %s: %s" path detail))
 ;;
 
 let is_atomic_orphan_name name =
@@ -66,6 +107,51 @@ let is_atomic_orphan_name name =
   n >= p + s
   && String.starts_with name ~prefix:atomic_tmp_prefix
   && String.ends_with ~suffix:atomic_tmp_suffix name
+;;
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~path ~recovered_dir =
+  let name = Stdlib.Filename.basename path in
+  if not (is_atomic_orphan_name name)
+  then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
+  else
+    try
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind <> Unix.S_REG
+      then Error (Printf.sprintf "atomic-write orphan is not a regular file: %s" path)
+      else if stat.Unix.st_size = 0
+      then (
+        Stdlib.Sys.remove path;
+        fsync_path (Stdlib.Filename.dirname path);
+        Ok Deleted_zero_length)
+      else (
+        let recovered_stat = Unix.lstat recovered_dir in
+        if recovered_stat.Unix.st_kind <> Unix.S_DIR
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery path is not a real directory: %s"
+               recovered_dir)
+        else
+        let destination = Stdlib.Filename.concat recovered_dir name in
+        if Stdlib.Sys.file_exists destination
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery destination already exists: %s"
+               destination)
+        else (
+          Stdlib.Sys.rename path destination;
+          fsync_path (Stdlib.Filename.dirname path);
+          if not (String.equal recovered_dir (Stdlib.Filename.dirname path))
+          then fsync_path recovered_dir;
+          Ok (Preserved_nonempty destination)))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
 ;;
 
 let cleanup_atomic_orphans
@@ -83,32 +169,51 @@ let cleanup_atomic_orphans
      [mkdir_p_unix] is recursive, idempotent (handles [EEXIST] precisely
      instead of swallowing every [Unix_error]), and correct when
      [base_path] itself does not exist yet (boot-time race). *)
-  let ensure_recovered_dir () =
-    try mkdir_p_unix recovered_dir with
-    | Unix.Unix_error _ -> ()
+  let report_error detail =
+    Stdlib.Printf.eprintf "[fs_compat] atomic orphan sweep: %s\n%!" detail
+  in
+  let ensure_recovered_dir path =
+    try
+      mkdir_p_unix path;
+      let stat = Unix.lstat path in
+      if stat.Unix.st_kind = Unix.S_DIR
+      then (
+        fsync_path (Stdlib.Filename.dirname path);
+        Ok ())
+      else
+        Error
+          (Printf.sprintf
+             "recovered path is not a real directory: %s"
+             path)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Printf.sprintf
+           "cannot create recovered directory %s: %s"
+           path
+           (Printexc.to_string exn))
   in
   let handle_file dir name =
     let path = Stdlib.Filename.concat dir name in
-    match Unix.stat path with
-    | exception Unix.Unix_error _ -> ()
-    | stat when stat.Unix.st_size = 0 ->
-      (try
-         Stdlib.Sys.remove path;
-         incr deleted
-       with
-       | Sys_error _ -> ())
-    | _stat ->
-      ensure_recovered_dir ();
-      let target =
-        Stdlib.Filename.concat
-          recovered_dir
-          (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
-      in
-      (try
-         Stdlib.Sys.rename path target;
-         incr preserved
-       with
-       | Sys_error _ | Unix.Unix_error _ -> ())
+    let bucket =
+      if String.equal dir base_path then "root" else Stdlib.Filename.basename dir
+    in
+    let file_recovered_dir = Stdlib.Filename.concat recovered_dir bucket in
+    match ensure_recovered_dir recovered_dir with
+    | Error detail -> report_error detail
+    | Ok () ->
+      (match ensure_recovered_dir file_recovered_dir with
+       | Error detail -> report_error detail
+       | Ok () ->
+         (match
+            recover_atomic_orphan
+              ~path
+              ~recovered_dir:file_recovered_dir
+          with
+          | Ok Deleted_zero_length -> incr deleted
+          | Ok (Preserved_nonempty _) -> incr preserved
+          | Error detail -> report_error detail))
   in
   let scan_dir dir entries =
     Array.iter
@@ -117,7 +222,9 @@ let cleanup_atomic_orphans
   in
   let read_dir_entries dir =
     match Stdlib.Sys.readdir dir with
-    | exception Sys_error _ -> [||]
+    | exception Sys_error detail ->
+      report_error (Printf.sprintf "cannot list %s: %s" dir detail);
+      [||]
     | entries -> entries
   in
   (* #10205 finding 4: previous body called [Stdlib.Sys.readdir base_path]
@@ -132,8 +239,15 @@ let cleanup_atomic_orphans
       then ()
       else (
         let sub = Stdlib.Filename.concat base_path name in
-        match Unix.stat sub with
-        | exception Unix.Unix_error _ -> ()
+        match Unix.lstat sub with
+        | exception Unix.Unix_error (error, operation, argument) ->
+          report_error
+            (Printf.sprintf
+               "cannot inspect %s: %s (%s %s)"
+               sub
+               (Unix.error_message error)
+               operation
+               argument)
         | stat when stat.Unix.st_kind = Unix.S_DIR ->
           scan_dir sub (read_dir_entries sub)
         | _ -> ()))

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -128,6 +128,7 @@ let recover_atomic_orphan ~path ~recovered_dir =
         fsync_path (Stdlib.Filename.dirname path);
         Ok Deleted_zero_length)
       else (
+        fsync_path path;
         let recovered_stat = Unix.lstat recovered_dir in
         if recovered_stat.Unix.st_kind <> Unix.S_DIR
         then

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -113,10 +113,16 @@ type atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
-let recover_atomic_orphan ~path ~recovered_dir =
+let recover_atomic_orphan ~path ~recovered_root ~bucket =
   let name = Stdlib.Filename.basename path in
   if not (is_atomic_orphan_name name)
   then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
+  else if
+    String.equal bucket ""
+    || String.equal bucket "."
+    || String.equal bucket ".."
+    || not (String.equal (Stdlib.Filename.basename bucket) bucket)
+  then Error (Printf.sprintf "invalid atomic-write recovery bucket: %S" bucket)
   else
     try
       let stat = Unix.lstat path in
@@ -129,6 +135,15 @@ let recover_atomic_orphan ~path ~recovered_dir =
         Ok Deleted_zero_length)
       else (
         fsync_path path;
+        let recovered_root_stat = Unix.lstat recovered_root in
+        if recovered_root_stat.Unix.st_kind <> Unix.S_DIR
+        then
+          Error
+            (Printf.sprintf
+               "atomic-write recovery root is not a real directory: %s"
+               recovered_root)
+        else
+        let recovered_dir = Stdlib.Filename.concat recovered_root bucket in
         let recovered_stat = Unix.lstat recovered_dir in
         if recovered_stat.Unix.st_kind <> Unix.S_DIR
         then
@@ -138,18 +153,43 @@ let recover_atomic_orphan ~path ~recovered_dir =
                recovered_dir)
         else
         let destination = Stdlib.Filename.concat recovered_dir name in
-        if Stdlib.Sys.file_exists destination
+        if String.equal destination path
         then
           Error
             (Printf.sprintf
-               "atomic-write recovery destination already exists: %s"
+               "atomic-write recovery destination equals source: %s"
                destination)
-        else (
-          Stdlib.Sys.rename path destination;
-          fsync_path (Stdlib.Filename.dirname path);
-          if not (String.equal recovered_dir (Stdlib.Filename.dirname path))
-          then fsync_path recovered_dir;
-          Ok (Preserved_nonempty destination)))
+        else
+          let source_dir = Stdlib.Filename.dirname path in
+          let finish_existing_link destination_stat =
+            if
+              stat.Unix.st_dev = destination_stat.Unix.st_dev
+              && stat.Unix.st_ino = destination_stat.Unix.st_ino
+            then (
+              fsync_path recovered_dir;
+              Unix.unlink path;
+              fsync_path source_dir;
+              Ok (Preserved_nonempty destination))
+            else
+              Error
+                (Printf.sprintf
+                   "atomic-write recovery destination already exists: %s"
+                   destination)
+          in
+          (match Unix.lstat destination with
+           | destination_stat -> finish_existing_link destination_stat
+           | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+             (match Unix.link path destination with
+              | () ->
+                fsync_path recovered_dir;
+                Unix.unlink path;
+                fsync_path source_dir;
+                Ok (Preserved_nonempty destination)
+              | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
+                Error
+                  (Printf.sprintf
+                     "atomic-write recovery destination concurrently appeared: %s"
+                     destination))))
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Printf.sprintf "%s: %s" path (Printexc.to_string exn))
@@ -210,7 +250,8 @@ let cleanup_atomic_orphans
          (match
             recover_atomic_orphan
               ~path
-              ~recovered_dir:file_recovered_dir
+              ~recovered_root:recovered_dir
+              ~bucket
           with
           | Ok Deleted_zero_length -> incr deleted
           | Ok (Preserved_nonempty _) -> incr preserved

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -4,27 +4,71 @@
    Without the fsync pair, a crash between the rename and the kernel's
    dirty-page flush can leave the target truncated or zero-length —
    observed on backlog.json after an abrupt shutdown (2026-04-18). *)
-let fsync_path path =
-  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      try Unix.close fd with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Stdlib.Printf.eprintf
-          "[fs_compat] fsync_path close failed: %s\n%!"
-          (Printexc.to_string exn))
-    (fun () ->
-      try Unix.fsync fd with
-      | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
-           is still durable to the extent the underlying FS offers. *)
-        ())
+type fsync_target =
+  | Regular_file
+  | Directory
+
+let same_file_identity left right =
+  left.Unix.st_dev = right.Unix.st_dev
+  && left.Unix.st_ino = right.Unix.st_ino
+;;
+
+let expected_kind = function
+  | Regular_file -> Unix.S_REG
+  | Directory -> Unix.S_DIR
+;;
+
+let fsync_operation = function
+  | Regular_file -> "fsync_regular_file"
+  | Directory -> "fsync_directory"
+;;
+
+let fsync_path ?expected ~target path =
+  let operation = fsync_operation target in
+  let fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  let sync_result =
+    try
+      let actual = Unix.fstat fd in
+      if actual.Unix.st_kind <> expected_kind target
+      then
+        raise
+          (Unix.Unix_error
+             ((match target with
+               | Regular_file -> Unix.EINVAL
+               | Directory -> Unix.ENOTDIR),
+              operation,
+              path));
+      (match expected with
+       | Some expected when not (same_file_identity expected actual) ->
+         raise (Unix.Unix_error (Unix.EAGAIN, operation, path))
+       | Some _ | None -> ());
+      Unix.fsync fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  let close_result =
+    try
+      Unix.close fd;
+      Ok ()
+    with
+    | exn -> Error exn
+  in
+  match sync_result, close_result with
+  | Ok (), Ok () -> ()
+  | Error exn, Ok () | Ok (), Error exn -> raise exn
+  | Error primary, Error close_error ->
+    Stdlib.Printf.eprintf
+      "[fs_compat] %s close also failed path=%s: %s\n%!"
+      operation
+      path
+      (Printexc.to_string close_error);
+    raise primary
 ;;
 
 let fsync_directory path =
   try
-    fsync_path path;
+    fsync_path ~target:Directory path;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -40,17 +84,13 @@ let fsync_directory path =
 let atomic_tmp_prefix = ".atomic_"
 let atomic_tmp_suffix = ".tmp"
 
-let save_file_atomic
-  ~(save_file : string -> string -> unit)
-  (path : string)
-  (content : string)
-  : (unit, string) Result.t
-  =
+let save_file_atomic (path : string) (content : string) : (unit, string) Result.t =
   let dir = Stdlib.Filename.dirname path in
   match
     try
       Ok
-        (Stdlib.Filename.temp_file
+        (Stdlib.Filename.open_temp_file
+           ~mode:[ Open_binary ]
            ~temp_dir:dir
            atomic_tmp_prefix
            atomic_tmp_suffix)
@@ -64,40 +104,101 @@ let save_file_atomic
          "save_file_atomic %s: temp creation failed: %s"
          path
          (Printexc.to_string exn))
-  | Ok tmp ->
-    let cleanup_tmp () =
-      try
-        Unix.unlink tmp;
-        Ok ()
-      with
-      | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
-      | exn -> Error (Printexc.to_string exn)
-    in
-    (try
-       save_file tmp content;
-       fsync_path tmp;
-       Stdlib.Sys.rename tmp path;
-       fsync_path dir;
-       Ok ()
+  | Ok (tmp, output) ->
+    (match
+       try Ok (Unix.fstat (Unix.descr_of_out_channel output)) with
+       | exn -> Error exn
      with
-     | Eio.Cancel.Cancelled _ as exn ->
-       (match cleanup_tmp () with
-        | Ok () -> ()
-        | Error detail ->
+     | Error inspect_error ->
+       (try Stdlib.close_out output with
+        | close_error ->
           Stdlib.Printf.eprintf
-            "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+            "[fs_compat] atomic-write close also failed path=%s: %s\n%!"
             tmp
-            detail);
-       raise exn
-     | exn ->
-       let primary = Printexc.to_string exn in
-       let detail =
-         match cleanup_tmp () with
-         | Ok () -> primary
-         | Error cleanup ->
-           Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+            (Printexc.to_string close_error));
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: cannot inspect atomically-opened temp %s: %s; temp retained"
+            path
+            tmp
+            (Printexc.to_string inspect_error))
+     | Ok temp_identity ->
+       let cleanup_tmp () =
+         try
+           let actual = Unix.lstat tmp in
+           if
+             actual.Unix.st_kind = Unix.S_REG
+             && same_file_identity temp_identity actual
+           then (
+             Unix.unlink tmp;
+             Ok ())
+           else
+             Error
+               (Printf.sprintf
+                  "refusing to unlink replaced atomic-write temp path: %s"
+                  tmp)
+         with
+         | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+         | exn -> Error (Printexc.to_string exn)
        in
-       Error (Printf.sprintf "save_file_atomic %s: %s" path detail))
+       let write_result =
+         match
+           try
+             Stdlib.output_string output content;
+             Ok ()
+           with
+           | exn -> Error exn
+         with
+         | Ok () ->
+           (try
+              Stdlib.close_out output;
+              Ok ()
+            with
+            | exn -> Error exn)
+         | Error primary ->
+           (try Stdlib.close_out output with
+            | close_error ->
+              Stdlib.Printf.eprintf
+                "[fs_compat] atomic-write close also failed path=%s: %s\n%!"
+                tmp
+                (Printexc.to_string close_error));
+           Error primary
+       in
+       (try
+          (match write_result with
+           | Ok () -> ()
+           | Error exn -> raise exn);
+          fsync_path ~expected:temp_identity ~target:Regular_file tmp;
+          let temp_after_sync = Unix.lstat tmp in
+          if
+            temp_after_sync.Unix.st_kind <> Unix.S_REG
+            || not (same_file_identity temp_identity temp_after_sync)
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.EAGAIN, "save_file_atomic", tmp));
+          Stdlib.Sys.rename tmp path;
+          fsync_path ~target:Directory dir;
+          Ok ()
+        with
+        | Eio.Cancel.Cancelled _ as exn ->
+          (match cleanup_tmp () with
+           | Ok () -> ()
+           | Error detail ->
+             Stdlib.Printf.eprintf
+               "[fs_compat] cancelled atomic-write cleanup failed path=%s: %s\n%!"
+               tmp
+               detail);
+          raise exn
+        | exn ->
+          let primary = Printexc.to_string exn in
+          let detail =
+            match cleanup_tmp () with
+            | Ok () -> primary
+            | Error cleanup ->
+              Printf.sprintf "%s; temp cleanup failed: %s" primary cleanup
+          in
+          Error (Printf.sprintf "save_file_atomic %s: %s" path detail)))
 ;;
 
 let is_atomic_orphan_name name =
@@ -133,11 +234,28 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
       then Error (Printf.sprintf "atomic-write orphan is not a regular file: %s" path)
       else if stat.Unix.st_size = 0
       then (
+        fsync_path ~expected:stat ~target:Regular_file path;
+        let source_before_unlink = Unix.lstat path in
+        if
+          source_before_unlink.Unix.st_kind <> Unix.S_REG
+          || not (same_file_identity stat source_before_unlink)
+        then
+          raise
+            (Unix.Unix_error
+               (Unix.EAGAIN, "recover_atomic_orphan", path));
         Stdlib.Sys.remove path;
-        fsync_path (Stdlib.Filename.dirname path);
+        fsync_path ~target:Directory (Stdlib.Filename.dirname path);
         Ok Deleted_zero_length)
       else (
-        fsync_path path;
+        fsync_path ~expected:stat ~target:Regular_file path;
+        let source_after_sync = Unix.lstat path in
+        if
+          source_after_sync.Unix.st_kind <> Unix.S_REG
+          || not (same_file_identity stat source_after_sync)
+        then
+          raise
+            (Unix.Unix_error
+               (Unix.EAGAIN, "recover_atomic_orphan", path));
         let recovered_root_stat = Unix.lstat recovered_root in
         if recovered_root_stat.Unix.st_kind <> Unix.S_DIR
         then
@@ -166,13 +284,23 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
           let source_dir = Stdlib.Filename.dirname path in
           let finish_existing_link destination_stat =
             if
-              stat.Unix.st_dev = destination_stat.Unix.st_dev
-              && stat.Unix.st_ino = destination_stat.Unix.st_ino
+              destination_stat.Unix.st_kind = Unix.S_REG
+              && same_file_identity stat destination_stat
             then (
-              fsync_path recovered_dir;
-              Unix.unlink path;
-              fsync_path source_dir;
-              Ok (Preserved_nonempty destination))
+              let source_before_unlink = Unix.lstat path in
+              if
+                source_before_unlink.Unix.st_kind <> Unix.S_REG
+                || not (same_file_identity stat source_before_unlink)
+              then
+                Error
+                  (Printf.sprintf
+                     "atomic-write recovery source changed before unlink: %s"
+                     path)
+              else (
+                fsync_path ~target:Directory recovered_dir;
+                Unix.unlink path;
+                fsync_path ~target:Directory source_dir;
+                Ok (Preserved_nonempty destination)))
             else
               Error
                 (Printf.sprintf
@@ -182,12 +310,10 @@ let recover_atomic_orphan ~path ~recovered_root ~bucket =
           (match Unix.lstat destination with
            | destination_stat -> finish_existing_link destination_stat
            | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-             (match Unix.link path destination with
+             (match Unix.link ~follow:false path destination with
               | () ->
-                fsync_path recovered_dir;
-                Unix.unlink path;
-                fsync_path source_dir;
-                Ok (Preserved_nonempty destination)
+                let destination_stat = Unix.lstat destination in
+                finish_existing_link destination_stat
               | exception Unix.Unix_error (Unix.EEXIST, _, _) ->
                 Error
                   (Printf.sprintf
@@ -228,7 +354,7 @@ let cleanup_atomic_orphans
       let stat = Unix.lstat path in
       if stat.Unix.st_kind = Unix.S_DIR
       then (
-        fsync_path (Stdlib.Filename.dirname path);
+        fsync_path ~target:Directory (Stdlib.Filename.dirname path);
         Ok ())
       else
         Error

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -113,15 +113,18 @@ type atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
+let is_single_path_segment value =
+  (not (String.equal value ""))
+  && not (String.equal value ".")
+  && not (String.equal value "..")
+  && String.equal (Stdlib.Filename.basename value) value
+;;
+
 let recover_atomic_orphan ~path ~recovered_root ~bucket =
   let name = Stdlib.Filename.basename path in
   if not (is_atomic_orphan_name name)
   then Error (Printf.sprintf "not an atomic-write orphan: %s" path)
-  else if
-    String.equal bucket ""
-    || String.equal bucket "."
-    || String.equal bucket ".."
-    || not (String.equal (Stdlib.Filename.basename bucket) bucket)
+  else if not (is_single_path_segment bucket)
   then Error (Printf.sprintf "invalid atomic-write recovery bucket: %S" bucket)
   else
     try
@@ -202,6 +205,12 @@ let cleanup_atomic_orphans
   ()
   : int * int
   =
+  if not (is_single_path_segment recovered_subdir)
+  then
+    invalid_arg
+      (Printf.sprintf
+         "cleanup_atomic_orphans: recovered_subdir must be one path segment: %S"
+         recovered_subdir);
   let recovered_dir = Stdlib.Filename.concat base_path recovered_subdir in
   let deleted = ref 0 in
   let preserved = ref 0 in

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -69,7 +69,9 @@ val recover_atomic_orphan
 
     Returns [(deleted, preserved)]:
     - [deleted]: zero-byte orphans removed.
-    - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+    - [preserved]: non-zero orphans moved to [recovered_subdir].
+
+    @raise Invalid_argument when [recovered_subdir] is not one path segment. *)
 val cleanup_atomic_orphans
   :  mkdir_p_unix:(string -> unit)
   -> base_path:string

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -50,8 +50,8 @@ val recover_atomic_orphan
   -> recovered_dir:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan. Zero-length files are
-    deleted; non-empty files are moved without overwrite into the existing real
-    [recovered_dir] for forensic review. *)
+    deleted; non-empty files are fsynced and moved without overwrite into the
+    existing real [recovered_dir] for forensic review. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -47,11 +47,14 @@ type atomic_orphan_recovery =
 
 val recover_atomic_orphan
   :  path:string
-  -> recovered_dir:string
+  -> recovered_root:string
+  -> bucket:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan. Zero-length files are
-    deleted; non-empty files are fsynced and moved without overwrite into the
-    existing real [recovered_dir] for forensic review. *)
+    deleted; non-empty files are fsynced and linked without overwrite into the
+    existing real [recovered_root]/[bucket], then unlinked from the source. Both
+    path components must be real directories and [bucket] must be one segment.
+    A crash after linking is completed idempotently by inode identity. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -12,28 +12,29 @@
     owning process was SIGKILL'd or [Filename.temp_file] itself
     raised ENFILE/EMFILE before the with-handler could register.
 
-    The [save_file] and [mkdir_p_unix] primitives are injected so
-    this module stays free of [Fs_compat]'s Eio bridge — same
-    cycle-free placement pattern as [Mkdir_memo] and [Fd_cache]. *)
+    The implementation is blocking Unix I/O. Eio callers must offload the
+    complete transaction rather than mixing Eio path writes with Unix fsync
+    and rename operations. *)
 
-(** [save_file_atomic ~save_file path content] writes [content] to
-    a temp file in [path]'s directory, fsyncs the tmp, renames it
-    over [path], and best-effort fsyncs the parent directory.
+(** [save_file_atomic path content] atomically opens a temp file in [path]'s
+    directory, writes [content], verifies its file identity, fsyncs it, renames it
+    over [path], and fsyncs the parent directory. A failed or unsupported
+    durability operation is returned as [Error]; it is never treated as a
+    successful commit.
 
     Returns [Ok ()] on success or [Error msg] when the write or
     rename fails (the tmp is cleaned up). Re-raises
     [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
     must not be swallowed (RFC-0143). *)
 val save_file_atomic
-  :  save_file:(string -> string -> unit)
-  -> string
+  :  string
   -> string
   -> (unit, string) Result.t
 
 val fsync_directory : string -> (unit, string) result
-(** Durably publish prior directory-entry changes. Unsupported-filesystem
-    [EINVAL]/[EOPNOTSUPP] is treated as success by the underlying portability
-    boundary; every other failure is returned explicitly. *)
+(** Durably publish prior directory-entry changes. [path] must resolve to a
+    directory. Unsupported filesystem operations and close failures are
+    returned explicitly. *)
 
 (** [true] iff [name] matches the [.atomic_*.tmp] shape produced
     by {!save_file_atomic}. Exposed so a periodic sweep can match

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -30,11 +30,28 @@ val save_file_atomic
   -> string
   -> (unit, string) Result.t
 
+val fsync_directory : string -> (unit, string) result
+(** Durably publish prior directory-entry changes. Unsupported-filesystem
+    [EINVAL]/[EOPNOTSUPP] is treated as success by the underlying portability
+    boundary; every other failure is returned explicitly. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] shape produced
     by {!save_file_atomic}. Exposed so a periodic sweep can match
     the same filename pattern without re-deriving the prefix and
     suffix — #10205 finding 2. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan. Zero-length files are
+    deleted; non-empty files are moved without overwrite into the existing real
+    [recovered_dir] for forensic review. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 
@@ -42,8 +59,8 @@ val is_atomic_orphan_name : string -> bool
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted (they lost the rename race
       but never held data).
-    - Non-zero orphans are MOVED to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are MOVED into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,7 +3,10 @@
 (library
  (name fs_compat)
  (public_name masc.fs_compat)
- (modules fs_compat mkdir_memo fd_cache atomic_write)
+ (modules fs_compat mkdir_memo fd_cache atomic_write anchored_fs)
+ (foreign_stubs
+  (language c)
+  (names anchored_fs_stubs))
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -318,10 +318,11 @@ type atomic_orphan_recovery = Atomic_write.atomic_orphan_recovery =
   | Deleted_zero_length
   | Preserved_nonempty of string
 
-let recover_atomic_orphan ~path ~recovered_dir =
+let recover_atomic_orphan ~path ~recovered_root ~bucket =
   Atomic_write.recover_atomic_orphan
     ~path
-    ~recovered_dir
+    ~recovered_root
+    ~bucket
 ;;
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
@@ -344,7 +345,9 @@ let append_file (path : string) (content : string) : unit =
 let append_file_durable path content =
   test_exec_home_guard ~op:"append_file_durable" path;
   match Atomic.get global_fs with
-  | Some _ -> Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content)
+  | Some _ ->
+    (try Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content) with
+     | Stdlib.Effect.Unhandled _ -> append_file_durable_unix path content)
   | None -> append_file_durable_unix path content
 ;;
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -200,24 +200,6 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
-let write_all_fd ~path fd content =
-  let rec loop offset =
-    if offset < String.length content
-    then
-      match
-        Unix.write_substring
-          fd
-          content
-          offset
-          (String.length content - offset)
-      with
-      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
-      | 0 -> raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
-      | wrote -> loop (offset + wrote)
-  in
-  loop 0
-;;
-
 let append_file_durable_unix (path : string) (content : string) : unit =
   let mu = get_append_path_mutex path in
   Stdlib.Mutex.lock mu;
@@ -232,7 +214,22 @@ let append_file_durable_unix (path : string) (content : string) : unit =
       in
       let write_result =
         try
-          write_all_fd ~path fd content;
+          let rec write_all offset =
+            if offset < String.length content
+            then
+              match
+                Unix.write_substring
+                  fd
+                  content
+                  offset
+                  (String.length content - offset)
+              with
+              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
+              | 0 ->
+                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+              | wrote -> write_all (offset + wrote)
+          in
+          write_all 0;
           Unix.fsync fd;
           Ok ()
         with

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1,3 +1,5 @@
+module Anchored_dir = Anchored_fs
+
 (** Filesystem Compatibility Layer - Eio-native I/O with fallback
 
     Provides a unified filesystem API for gradual migration from
@@ -205,11 +207,13 @@ let append_file_durable_unix (path : string) (content : string) : unit =
     ~finally:(fun () -> Stdlib.Mutex.unlock mu)
     (fun () ->
       let fd =
-        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+        Unix.openfile
+          path
+          [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
+          0o644
       in
-      Stdlib.Fun.protect
-        ~finally:(fun () -> Unix.close fd)
-        (fun () ->
+      let write_result =
+        try
           let rec write_all offset =
             if offset < String.length content
             then
@@ -226,7 +230,27 @@ let append_file_durable_unix (path : string) (content : string) : unit =
               | wrote -> write_all (offset + wrote)
           in
           write_all 0;
-          Unix.fsync fd);
+          Unix.fsync fd;
+          Ok ()
+        with
+        | exn -> Error exn
+      in
+      let close_result =
+        try
+          Unix.close fd;
+          Ok ()
+        with
+        | exn -> Error exn
+      in
+      (match write_result, close_result with
+       | Ok (), Ok () -> ()
+       | Error exn, Ok () | Ok (), Error exn -> raise exn
+       | Error primary, Error close_error ->
+         Stdlib.Printf.eprintf
+           "[fs_compat] durable append close also failed path=%s: %s\n%!"
+           path
+           (Printexc.to_string close_error);
+         raise primary);
       match Atomic_write.fsync_directory (Filename.dirname path) with
       | Ok () -> ()
       | Error detail -> raise (Sys_error detail))
@@ -248,32 +272,36 @@ let mkdir_p_unix (path : string) : unit =
 
 let mkdir_p_durable_unix path =
   test_exec_home_guard ~op:"mkdir_p_durable_unix" path;
-  let rec missing_directories current acc =
+  let rec ensure_directory current =
     if
       String.equal current ""
       || String.equal current "."
       || String.equal current "/"
-    then acc
+    then ()
     else
-      match Unix.stat current with
-      | stat when stat.Unix.st_kind = Unix.S_DIR -> acc
+      match Unix.lstat current with
+      | stat when stat.Unix.st_kind = Unix.S_DIR -> ()
       | _ ->
         raise
           (Unix.Unix_error
              (Unix.ENOTDIR, "mkdir_p_durable_unix", current))
       | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
-        missing_directories
-          (Filename.dirname current)
-          (current :: acc)
+        let parent = Filename.dirname current in
+        ensure_directory parent;
+        (match Unix.mkdir current 0o755 with
+         | () -> ()
+         | exception Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+        (match Unix.lstat current with
+         | stat when stat.Unix.st_kind = Unix.S_DIR -> ()
+         | _ ->
+           raise
+             (Unix.Unix_error
+                (Unix.ENOTDIR, "mkdir_p_durable_unix", current)));
+        (match Atomic_write.fsync_directory parent with
+         | Ok () -> ()
+         | Error detail -> raise (Sys_error detail))
   in
-  let created = missing_directories path [] in
-  mkdir_p_unix path;
-  List.iter
-    (fun created_dir ->
-       match Atomic_write.fsync_directory (Filename.dirname created_dir) with
-       | Ok () -> ()
-       | Error detail -> raise (Sys_error detail))
-    created
+  ensure_directory path
 ;;
 
 (** Load entire file contents as string.
@@ -302,12 +330,17 @@ let save_file (path : string) (content : string) : unit =
 ;;
 
 let save_file_atomic path content =
-  Atomic_write.save_file_atomic ~save_file path content
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  match Atomic.get global_fs with
+  | Some _ ->
+    (try Eio_unix.run_in_systhread (fun () -> Atomic_write.save_file_atomic path content) with
+     | Stdlib.Effect.Unhandled _ -> Atomic_write.save_file_atomic path content)
+  | None -> Atomic_write.save_file_atomic path content
 ;;
 
 let save_file_atomic_unix path content =
   test_exec_home_guard ~op:"save_file_atomic_unix" path;
-  Atomic_write.save_file_atomic ~save_file:save_file_unix path content
+  Atomic_write.save_file_atomic path content
 ;;
 
 let fsync_directory path = Atomic_write.fsync_directory path

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -200,6 +200,24 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let write_all_fd ~path fd content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring
+          fd
+          content
+          offset
+          (String.length content - offset)
+      with
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+      | 0 -> raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+      | wrote -> loop (offset + wrote)
+  in
+  loop 0
+;;
+
 let append_file_durable_unix (path : string) (content : string) : unit =
   let mu = get_append_path_mutex path in
   Stdlib.Mutex.lock mu;
@@ -214,22 +232,7 @@ let append_file_durable_unix (path : string) (content : string) : unit =
       in
       let write_result =
         try
-          let rec write_all offset =
-            if offset < String.length content
-            then
-              match
-                Unix.write_substring
-                  fd
-                  content
-                  offset
-                  (String.length content - offset)
-              with
-              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
-              | 0 ->
-                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
-              | wrote -> write_all (offset + wrote)
-          in
-          write_all 0;
+          write_all_fd ~path fd content;
           Unix.fsync fd;
           Ok ()
         with

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -198,6 +198,40 @@ let append_file_unix (path : string) (content : string) : unit =
         (fun () -> Stdlib.output_string oc content))
 ;;
 
+let append_file_durable_unix (path : string) (content : string) : unit =
+  let mu = get_append_path_mutex path in
+  Stdlib.Mutex.lock mu;
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
+    (fun () ->
+      let fd =
+        Unix.openfile path [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND ] 0o644
+      in
+      Stdlib.Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+          let rec write_all offset =
+            if offset < String.length content
+            then
+              match
+                Unix.write_substring
+                  fd
+                  content
+                  offset
+                  (String.length content - offset)
+              with
+              | exception Unix.Unix_error (Unix.EINTR, _, _) -> write_all offset
+              | 0 ->
+                raise (Sys_error (Printf.sprintf "%s: zero-byte append" path))
+              | wrote -> write_all (offset + wrote)
+          in
+          write_all 0;
+          Unix.fsync fd);
+      match Atomic_write.fsync_directory (Filename.dirname path) with
+      | Ok () -> ()
+      | Error detail -> raise (Sys_error detail))
+;;
+
 let mkdir_p_unix (path : string) : unit =
   let rec ensure_dir (p : string) : unit =
     if String.equal p "" || String.equal p "." || String.equal p "/"
@@ -210,6 +244,36 @@ let mkdir_p_unix (path : string) : unit =
       | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   in
   ensure_dir path
+;;
+
+let mkdir_p_durable_unix path =
+  test_exec_home_guard ~op:"mkdir_p_durable_unix" path;
+  let rec missing_directories current acc =
+    if
+      String.equal current ""
+      || String.equal current "."
+      || String.equal current "/"
+    then acc
+    else
+      match Unix.stat current with
+      | stat when stat.Unix.st_kind = Unix.S_DIR -> acc
+      | _ ->
+        raise
+          (Unix.Unix_error
+             (Unix.ENOTDIR, "mkdir_p_durable_unix", current))
+      | exception Unix.Unix_error (Unix.ENOENT, _, _) ->
+        missing_directories
+          (Filename.dirname current)
+          (current :: acc)
+  in
+  let created = missing_directories path [] in
+  mkdir_p_unix path;
+  List.iter
+    (fun created_dir ->
+       match Atomic_write.fsync_directory (Filename.dirname created_dir) with
+       | Ok () -> ()
+       | Error detail -> raise (Sys_error detail))
+    created
 ;;
 
 (** Load entire file contents as string.
@@ -241,7 +305,24 @@ let save_file_atomic path content =
   Atomic_write.save_file_atomic ~save_file path content
 ;;
 
+let save_file_atomic_unix path content =
+  test_exec_home_guard ~op:"save_file_atomic_unix" path;
+  Atomic_write.save_file_atomic ~save_file:save_file_unix path content
+;;
+
+let fsync_directory path = Atomic_write.fsync_directory path
+
 let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
+
+type atomic_orphan_recovery = Atomic_write.atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+let recover_atomic_orphan ~path ~recovered_dir =
+  Atomic_write.recover_atomic_orphan
+    ~path
+    ~recovered_dir
+;;
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
   Atomic_write.cleanup_atomic_orphans ~mkdir_p_unix ~base_path ?recovered_subdir ()
@@ -258,6 +339,13 @@ let append_file (path : string) (content : string) : unit =
     (fun fs ->
        let eio_path = Eio.Path.(fs / path) in
        Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
+;;
+
+let append_file_durable path content =
+  test_exec_home_guard ~op:"append_file_durable" path;
+  match Atomic.get global_fs with
+  | Some _ -> Eio_unix.run_in_systhread (fun () -> append_file_durable_unix path content)
+  | None -> append_file_durable_unix path content
 ;;
 
 (** Check if file exists.

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -3,6 +3,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+module Anchored_dir : module type of Anchored_fs
+
 (** #9921: raised by mutating [Fs_compat] entry points
     ([append_file], [save_file], [mkdir_p]) when the target path falls
     under [HOME] and the process is a test executable. Defense in depth
@@ -38,8 +40,9 @@ val load_file_opt : string -> string option
 (** Save string to file (overwrite). *)
 val save_file : string -> string -> unit
 
-(** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. *)
+(** Write content to path via temp file + rename. When the Eio runtime is
+    registered, the complete blocking Unix transaction is offloaded to a
+    system thread. Returns [Error msg] on I/O failure instead of raising. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
 val save_file_atomic_unix : string -> string -> (unit, string) result
@@ -48,8 +51,8 @@ val save_file_atomic_unix : string -> string -> (unit, string) result
     via [Eio_unix.run_in_systhread]); never call it directly from an Eio fiber. *)
 
 val fsync_directory : string -> (unit, string) result
-(** Durably publish directory-entry changes without hiding unsupported I/O
-    failures. *)
+(** Durably publish directory-entry changes. Rejects non-directories and
+    returns unsupported I/O and close failures explicitly. *)
 
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
@@ -137,8 +140,9 @@ val mkdir_p : string -> unit
 
 val mkdir_p_durable_unix : string -> unit
 (** Blocking recursive directory creation followed by parent-directory fsync
-    for every newly-created path segment. Callers running in Eio must offload
-    the complete transaction to a system thread. *)
+    for every path segment observed missing. A symlink or non-directory found
+    at the target or while walking the missing suffix is rejected. Callers
+    running in Eio must offload the complete transaction to a system thread. *)
 
 (** [mkdir_p_memoized path] is [mkdir_p] but skips the stat/mkdir
     syscalls on every call after the first for the same [path].

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -38,11 +38,32 @@ val save_file : string -> string -> unit
     Returns [Error msg] on I/O failure instead of raising. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
+val save_file_atomic_unix : string -> string -> (unit, string) result
+(** Blocking Unix implementation of {!save_file_atomic}. This is for durable
+    stores whose entire transaction is run outside an Eio domain (for example
+    via [Eio_unix.run_in_systhread]); never call it directly from an Eio fiber. *)
+
+val fsync_directory : string -> (unit, string) result
+(** Durably publish directory-entry changes without hiding unsupported I/O
+    failures. *)
+
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
     {!save_file_atomic}.  Exposed for tests and for a potential
     periodic sweep. *)
 val is_atomic_orphan_name : string -> bool
+
+type atomic_orphan_recovery =
+  | Deleted_zero_length
+  | Preserved_nonempty of string
+
+val recover_atomic_orphan
+  :  path:string
+  -> recovered_dir:string
+  -> (atomic_orphan_recovery, string) result
+(** Reconcile one recognized atomic-write orphan using the same policy as
+    {!cleanup_atomic_orphans}, while preserving failures as typed results. The
+    recovery directory must already exist and must be a real directory. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
@@ -52,8 +73,8 @@ val is_atomic_orphan_name : string -> bool
     Scans [base_path] and its immediate subdirectories (skipping
     [recovered_subdir] and anything that isn't a directory).
     - Zero-byte orphans are deleted.
-    - Non-zero orphans are moved to
-      [<base_path>/<recovered_subdir>/<original-name>.<ts-ms>]
+    - Non-zero orphans are moved into a source-directory bucket under
+      [<base_path>/<recovered_subdir>]
       so operators can forensically inspect data-loss events
       instead of having them silently cleaned up.
 
@@ -68,6 +89,11 @@ val cleanup_atomic_orphans
 
 (** Append string to file. *)
 val append_file : string -> string -> unit
+
+(** Append the complete byte string under the per-path append lock and fsync the
+    file before returning. Runtime calls execute the blocking fd operations in
+    a system thread. *)
+val append_file_durable : string -> string -> unit
 
 (** Check if file exists. *)
 val file_exists : string -> bool
@@ -101,6 +127,11 @@ val realpath : string -> string
 
 (** Create directory recursively. *)
 val mkdir_p : string -> unit
+
+val mkdir_p_durable_unix : string -> unit
+(** Blocking recursive directory creation followed by parent-directory fsync
+    for every newly-created path segment. Callers running in Eio must offload
+    the complete transaction to a system thread. *)
 
 (** [mkdir_p_memoized path] is [mkdir_p] but skips the stat/mkdir
     syscalls on every call after the first for the same [path].

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -63,11 +63,12 @@ type atomic_orphan_recovery =
 
 val recover_atomic_orphan
   :  path:string
-  -> recovered_dir:string
+  -> recovered_root:string
+  -> bucket:string
   -> (atomic_orphan_recovery, string) result
 (** Reconcile one recognized atomic-write orphan using the same policy as
-    {!cleanup_atomic_orphans}, while preserving failures as typed results. The
-    recovery directory must already exist and must be a real directory. *)
+    {!cleanup_atomic_orphans}, while preserving failures as typed results. Root
+    and bucket directories must already exist as real directories. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -85,7 +85,9 @@ val recover_atomic_orphan
 
     Returns [(deleted, preserved)]:
     - [deleted]: zero-byte orphans removed.
-    - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+    - [preserved]: non-zero orphans moved to [recovered_subdir].
+
+    @raise Invalid_argument when [recovered_subdir] is not one path segment. *)
 val cleanup_atomic_orphans
   :  base_path:string
   -> ?recovered_subdir:string

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -25,6 +25,10 @@ val has_fs : unit -> bool
 (** Load entire file as string. *)
 val load_file : string -> string
 
+val load_file_unix : string -> string
+(** Blocking Unix implementation of {!load_file}. This is for transactions
+    already offloaded from an Eio domain. *)
+
 (** Load entire file as string, or [None] when the file is missing.
     Option-returning sibling of {!load_file} (which raises on a missing
     path). Other I/O failures of an existing file propagate as

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -665,7 +665,7 @@ let extract_and_append_with_provider_classified
        the truth anchor recall's recency ranking reads. The judgment (window
        join + metric) lives here at the write boundary; the fold itself stays
        a pure function of the decision. *)
-    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun () ->
+    Keeper_memory_os_io.with_episode_bundle_lock ?clock ~keeper_id (fun bundle ->
       match
         try
           let window = Keeper_memory_os_io.fact_recall_window in
@@ -684,10 +684,17 @@ let extract_and_append_with_provider_classified
             Keeper_memory_os_policy.reobserve_fact ~now ~provenance ~existing ~incoming
           in
           let (_ : Keeper_memory_os_io.fact_merge_stats) =
-            File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
-              Keeper_memory_os_io.merge_and_cap_facts
+            Keeper_memory_os_io.with_facts_lock_in_bundle
+              ?clock
+              bundle
+              ~on_timeout:(fun timeout ->
+                raise
+                  (Failure
+                     (Keeper_memory_os_io.lock_timeout_to_string timeout)))
+              (fun lock ->
+              Keeper_memory_os_io.merge_and_cap_facts_in_lock
+                lock
                 ~now
-                ~keeper_id
                 ~merge
                 ~incoming:episode.Keeper_memory_os_types.claims
                 ~keep:window
@@ -703,21 +710,21 @@ let extract_and_append_with_provider_classified
           Error message
       with
       | Ok () ->
-        Keeper_memory_os_io.append_episode ~keeper_id episode;
-        Keeper_memory_os_io.append_event ~keeper_id episode;
+        Keeper_memory_os_io.append_episode_in_bundle bundle episode;
+        Keeper_memory_os_io.append_event_in_bundle bundle episode;
         (* RFC-0272 (defect D): bound the append-only episode log under the same
            bundle lock that serialized the writes above, so a re-extraction cannot
            grow events.jsonl / episodes/ without limit. Hysteresis-gated: the trim
            is a no-op until the high-water, so this is off the per-turn hot path. *)
         ignore
-          (Keeper_memory_os_io.cap_events
-             ~keeper_id
+          (Keeper_memory_os_io.cap_events_in_bundle
+             bundle
              ~keep:Keeper_memory_os_io.event_recall_window
              ~trigger:Keeper_memory_os_io.event_store_max
             : int);
         ignore
-          (Keeper_memory_os_io.cap_episode_files
-             ~keeper_id
+          (Keeper_memory_os_io.cap_episode_files_in_bundle
+             bundle
              ~keep:Keeper_memory_os_io.episode_file_window
              ~trigger:Keeper_memory_os_io.episode_file_store_max
             : int);

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -134,6 +134,7 @@ type recovery_report =
 type claim_report =
   { leases : lease list
   ; cleanup_errors : error list
+  ; blocked : error option
   }
 
 let io_operation_to_string = function
@@ -1455,76 +1456,88 @@ let claim_all ~base_path ~keeper_name ~now =
       |> List.map (fun (path, envelope) -> path, envelope.job)
       |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
     in
+    let process_item path job =
+      let receipt_path = receipt_path ~base_path job in
+      let* receipt_exists = file_exists receipt_path in
+      if receipt_exists
+      then
+        let* receipt = read_receipt receipt_path in
+        if not (receipt_identity_matches_job receipt.identity job)
+        then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+        else
+          Ok
+            (`Skipped
+              (cleanup_paths
+                 [ path
+                 ; awaiting_path ~base_path job
+                 ; inflight_path ~base_path job
+                 ; operation_stage_path
+                     ~base_path
+                     ~keeper_name:job.keeper_name
+                     ~operation_id:job.id
+                 ]))
+      else
+        let lease = { job; started_at = now } in
+        let destination = inflight_path ~base_path job in
+        let* inflight_exists = file_exists destination in
+        if inflight_exists
+        then
+          let* inflight = read_envelope destination in
+          let* () =
+            ensure_queue_coordinates
+              ~expected_keeper_name:keeper_name
+              ~path:destination
+              inflight
+          in
+          let* () = ensure_same_job ~expected:job ~path:destination inflight in
+          let* () =
+            ensure_expected_state
+              ~expected:Expect_inflight
+              ~path:destination
+              inflight
+          in
+          Error
+            (Pending_already_inflight
+               { job_id = job.id
+               ; pending_path = path
+               ; inflight_path = destination
+               })
+        else
+          let* () =
+            save_json
+              destination
+              (envelope_to_json
+                 { job
+                 ; state = Inflight { started_at = lease.started_at }
+                 })
+          in
+          Ok (`Claimed (lease, cleanup_paths [ path ]))
+    in
     let rec claim leases cleanup_errors = function
       | [] ->
         Ok
           { leases = List.rev leases
           ; cleanup_errors = List.rev cleanup_errors
+          ; blocked = None
           }
       | (path, job) :: rest ->
-        let receipt_path = receipt_path ~base_path job in
-        let* receipt_exists = file_exists receipt_path in
-        if receipt_exists
-        then
-          let* receipt = read_receipt receipt_path in
-          if not (receipt_identity_matches_job receipt.identity job)
-          then Error (Identity_conflict { job_id = job.id; path = receipt_path })
-          else
-            let item_cleanup_errors =
-              cleanup_paths
-                [ path
-                ; awaiting_path ~base_path job
-                ; inflight_path ~base_path job
-                ; operation_stage_path
-                    ~base_path
-                    ~keeper_name:job.keeper_name
-                    ~operation_id:job.id
-                ]
-            in
-            claim
-              leases
-              (List.rev_append item_cleanup_errors cleanup_errors)
-              rest
-        else
-          let lease = { job; started_at = now } in
-          let destination = inflight_path ~base_path job in
-          let* inflight_exists = file_exists destination in
-          if inflight_exists
-          then
-            let* inflight = read_envelope destination in
-            let* () =
-              ensure_queue_coordinates
-                ~expected_keeper_name:keeper_name
-                ~path:destination
-                inflight
-            in
-            let* () = ensure_same_job ~expected:job ~path:destination inflight in
-            let* () =
-              ensure_expected_state
-                ~expected:Expect_inflight
-                ~path:destination
-                inflight
-            in
-            Error
-              (Pending_already_inflight
-                 { job_id = job.id
-                 ; pending_path = path
-                 ; inflight_path = destination
-                 })
-          else
-            let* () =
-              save_json
-                destination
-                (envelope_to_json
-                   { job
-                   ; state = Inflight { started_at = lease.started_at }
-                   })
-            in
-            let item_cleanup_errors = cleanup_paths [ path ] in
-            claim
-              (lease :: leases)
-              (List.rev_append item_cleanup_errors cleanup_errors)
-              rest
+        (match process_item path job with
+         | Error error ->
+           Ok
+             { leases = List.rev leases
+             ; cleanup_errors = List.rev cleanup_errors
+             ; blocked = Some error
+             }
+         | Ok (`Skipped item_cleanup_errors) ->
+           claim
+             leases
+             (List.rev_append item_cleanup_errors cleanup_errors)
+             rest
+         | Ok (`Claimed (lease, item_cleanup_errors)) ->
+           claim
+             (lease :: leases)
+             (List.rev_append item_cleanup_errors cleanup_errors)
+             rest)
     in
     claim [] [] ordered
 ;;

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -325,27 +325,37 @@ let sync_directory path =
   | Error detail -> Error (Io_error { operation = Sync; path; detail })
 ;;
 
+let not_real_directory_error path =
+  Io_error
+    { operation = Inspect
+    ; path
+    ; detail = "memory job store path is not a real directory"
+    }
+;;
+
+let require_existing_real_directory path =
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  if stat.Unix.st_kind = Unix.S_DIR
+  then Ok ()
+  else Error (not_real_directory_error path)
+;;
+
 let ensure_real_directory ~owned path =
   let* before = inspect_path path in
-  let* () =
+  let* created =
     match before with
-    | Some _ -> Ok ()
+    | Some _ -> Ok false
     | None ->
-      protect_io Ensure_directory path (fun () ->
-        Fs_compat.mkdir_p_durable_unix path)
+      let mode = if owned then private_directory_mode else 0o755 in
+      let* () =
+        protect_io Ensure_directory path (fun () ->
+          try Unix.mkdir path mode with
+          | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+      in
+      Ok true
   in
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  let* () =
-    if stat.Unix.st_kind = Unix.S_DIR
-    then Ok ()
-    else
-      Error
-        (Io_error
-           { operation = Inspect
-           ; path
-           ; detail = "memory job store path is not a real directory"
-           })
-  in
+  let* () = require_existing_real_directory path in
+  let* () = if created then sync_directory (Filename.dirname path) else Ok () in
   if not owned
   then Ok ()
   else
@@ -356,10 +366,60 @@ let ensure_real_directory ~owned path =
     sync_directory path
 ;;
 
+let managed_root_directories ~base_path =
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
+  [ masc_dir; Common.keepers_runtime_dir_of_base ~base_path ]
+;;
+
+let keeper_ancestor_directories ~base_path ~keeper_name =
+  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
+  [ Filename.concat keepers_root keeper_name
+  ; keeper_jobs_dir ~base_path ~keeper_name
+  ]
+;;
+
+let validate_real_directory_chain paths =
+  let rec loop = function
+    | [] -> Ok true
+    | path :: rest ->
+      let* stat = inspect_path path in
+      (match stat with
+       | None -> Ok false
+       | Some stat when stat.Unix.st_kind = Unix.S_DIR -> loop rest
+       | Some _ -> Error (not_real_directory_error path))
+  in
+  loop paths
+;;
+
+let require_real_directory_chain paths =
+  let rec loop = function
+    | [] -> Ok ()
+    | path :: rest ->
+      let* () = require_existing_real_directory path in
+      loop rest
+  in
+  loop paths
+;;
+
+let validate_managed_root_if_present ~base_path =
+  validate_real_directory_chain
+    (base_path :: managed_root_directories ~base_path)
+;;
+
+let validate_keeper_ancestors_if_present ~base_path ~keeper_name =
+  validate_real_directory_chain
+    (base_path
+     :: (managed_root_directories ~base_path
+         @ keeper_ancestor_directories ~base_path ~keeper_name))
+;;
+
 let ensure_store_dirs ~base_path ~keeper_name =
   let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
   let keeper_dir = Filename.concat keepers_root keeper_name in
-  let parent_dirs = [ keepers_root; keeper_dir ] in
+  let* () = require_existing_real_directory base_path in
+  let parent_dirs =
+    managed_root_directories ~base_path @ [ keeper_dir ]
+  in
   let owned_dirs =
     [ keeper_jobs_dir ~base_path ~keeper_name
     ; pending_dir ~base_path ~keeper_name
@@ -376,7 +436,9 @@ let ensure_store_dirs ~base_path ~keeper_name =
       loop ~owned rest
   in
   let* () = loop ~owned:false parent_dirs in
-  loop ~owned:true owned_dirs
+  let* () = loop ~owned:true owned_dirs in
+  require_real_directory_chain
+    (base_path :: (parent_dirs @ owned_dirs))
 ;;
 
 let valid_job_id id =
@@ -1328,6 +1390,7 @@ let activate ~base_path (job : job) =
 ;;
 
 let abort_awaiting ~base_path (job : job) =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
   let path = awaiting_path ~base_path job in
   let* exists = file_exists path in
   if not exists
@@ -1443,6 +1506,7 @@ let claim_all ~base_path ~keeper_name ~now =
   else if (not (Float.is_finite now)) || now < 0.0
   then Error (Invalid_claim_time now)
   else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
     let dir = pending_dir ~base_path ~keeper_name in
     let* paths = list_json_paths dir in
     let* envelopes =
@@ -1624,31 +1688,37 @@ let backlog_count ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
-    let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
-    let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
-    let* awaiting_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_awaiting
-        awaiting
+    let* ancestors_exist =
+      validate_keeper_ancestors_if_present ~base_path ~keeper_name
     in
-    let* pending_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_pending
-        pending
-    in
-    let* inflight_envelopes =
-      load_envelopes
-        ~expected_keeper_name:keeper_name
-        ~expected_state:Expect_inflight
-        inflight
-    in
-    Ok
-      (List.length awaiting_envelopes
-       + List.length pending_envelopes
-       + List.length inflight_envelopes)
+    if not ancestors_exist
+    then Ok 0
+    else
+      let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+      let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
+      let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
+      let* awaiting_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_awaiting
+          awaiting
+      in
+      let* pending_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_pending
+          pending
+      in
+      let* inflight_envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state:Expect_inflight
+          inflight
+      in
+      Ok
+        (List.length awaiting_envelopes
+         + List.length pending_envelopes
+         + List.length inflight_envelopes)
 ;;
 
 let directory_exists path =
@@ -1673,7 +1743,7 @@ let directory_exists path =
 
 let discover_keeper_names ~base_path =
   let root = Common.keepers_runtime_dir_of_base ~base_path in
-  let* root_exists = directory_exists root in
+  let* root_exists = validate_managed_root_if_present ~base_path in
   if not root_exists
   then Ok ([], [])
   else

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -1103,7 +1103,7 @@ let reconcile_atomic_orphans_in_dir dir =
     loop entries
 ;;
 
-let job_equal left right =
+let job_equal (left : job) (right : job) =
   String.equal left.id right.id
   && String.equal left.keeper_name right.keeper_name
   && String.equal left.trace_id right.trace_id

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -606,7 +606,7 @@ let receipt_identity_of_job (job : job) =
   }
 ;;
 
-let make_terminal_receipt lease ~ended_at ~outcome ~detail =
+let make_terminal_receipt (lease : lease) ~ended_at ~outcome ~detail =
   let started_at = lease.started_at in
   if
     (not (Float.is_finite started_at))

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -306,9 +306,155 @@ let operation_stage_path ~base_path ~keeper_name ~operation_id =
   path_for_id (operations_dir ~base_path ~keeper_name) operation_id
 ;;
 
-let inspect_path path =
-  try Ok (Some (Unix.lstat path)) with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+module Anchored = Fs_compat.Anchored_dir
+
+type anchored_directory =
+  { handle : Anchored.t
+  ; path : string
+  }
+
+type store_directories =
+  { jobs : anchored_directory
+  ; awaiting : anchored_directory
+  ; pending : anchored_directory
+  ; inflight : anchored_directory
+  ; receipts : anchored_directory
+  ; operations : anchored_directory
+  }
+
+type artifact =
+  { directory : anchored_directory
+  ; name : Anchored.Segment.t
+  ; path : string
+  }
+
+let child_name ~parent path =
+  if String.equal (Filename.dirname path) parent
+  then
+    let raw = Filename.basename path in
+    (match Anchored.Segment.of_string raw with
+     | Ok segment -> Ok segment
+     | Error error ->
+       Error
+         (Io_error
+            { operation = Inspect
+            ; path
+            ; detail = Anchored.Segment.error_to_string error
+            }))
+  else
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail =
+             Printf.sprintf
+               "memory job path is not a direct child of its SSOT parent %s"
+               parent
+         })
+;;
+
+let with_directory ~owned parent path f =
+  let* name = child_name ~parent:parent.path path in
+  let permission = if owned then private_directory_mode else 0o755 in
+  try
+    Anchored.with_ensure_dir
+      parent.handle
+      ~name
+      ~perm:permission
+      ~enforce_perm:owned
+      (fun handle -> f { handle; path })
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Ensure_directory
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let with_ensured_store ~base_path ~keeper_name f =
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_path = Filename.concat keepers_path keeper_name in
+  let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+  let awaiting_path = awaiting_dir ~base_path ~keeper_name in
+  let pending_path = pending_dir ~base_path ~keeper_name in
+  let inflight_path = inflight_dir ~base_path ~keeper_name in
+  let receipts_path = receipts_dir ~base_path ~keeper_name in
+  let operations_path = operations_dir ~base_path ~keeper_name in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* keeper_name_segment = child_name ~parent:keepers_path keeper_path in
+  let* jobs_name = child_name ~parent:keeper_path jobs_path in
+  let steps : Anchored.ensure_step list =
+    [ { name = masc_name; perm = 0o755; enforce_perm = false }
+    ; { name = keepers_name; perm = 0o755; enforce_perm = false }
+    ; { name = keeper_name_segment; perm = 0o755; enforce_perm = false }
+    ; { name = jobs_name
+      ; perm = private_directory_mode
+      ; enforce_perm = true
+      }
+    ]
+  in
+  try
+    Anchored.with_ensure_path ~root:base_path steps @@ fun handle ->
+    let jobs = { handle; path = jobs_path } in
+    with_directory ~owned:true jobs awaiting_path @@ fun awaiting ->
+    with_directory ~owned:true jobs pending_path @@ fun pending ->
+    with_directory ~owned:true jobs inflight_path @@ fun inflight ->
+    with_directory ~owned:true jobs receipts_path @@ fun receipts ->
+    with_directory ~owned:true jobs operations_path @@ fun operations ->
+    f { jobs; awaiting; pending; inflight; receipts; operations }
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Ensure_directory
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+type 'a presence =
+  | Missing
+  | Present of 'a
+
+type existing_jobs = { jobs : anchored_directory }
+
+let with_existing_directory parent path f =
+  let* name = child_name ~parent:parent.path path in
+  try
+    match
+      Anchored.with_open_dir_opt parent.handle name (fun handle ->
+        f { handle; path })
+    with
+    | None -> Ok Missing
+    | Some result -> result
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     Error
@@ -319,126 +465,101 @@ let inspect_path path =
          })
 ;;
 
-let sync_directory path =
-  match Fs_compat.fsync_directory path with
-  | Ok () -> Ok ()
-  | Error detail -> Error (Io_error { operation = Sync; path; detail })
-;;
-
-let not_real_directory_error path =
-  Io_error
-    { operation = Inspect
-    ; path
-    ; detail = "memory job store path is not a real directory"
-    }
-;;
-
-let require_existing_real_directory path =
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  if stat.Unix.st_kind = Unix.S_DIR
-  then Ok ()
-  else Error (not_real_directory_error path)
-;;
-
-let ensure_real_directory ~owned path =
-  let* before = inspect_path path in
-  let* created =
-    match before with
-    | Some _ -> Ok false
-    | None ->
-      let mode = if owned then private_directory_mode else 0o755 in
-      let* () =
-        protect_io Ensure_directory path (fun () ->
-          try Unix.mkdir path mode with
-          | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-      in
-      Ok true
+let with_optional_directory parent path f =
+  let* presence =
+    with_existing_directory parent path (fun directory ->
+      let* value = f directory in
+      Ok (Present value))
   in
-  let* () = require_existing_real_directory path in
-  let* () = if created then sync_directory (Filename.dirname path) else Ok () in
-  if not owned
-  then Ok ()
-  else
-    let* () =
-      protect_io Set_permissions path (fun () ->
-        Unix.chmod path private_directory_mode)
-    in
-    sync_directory path
+  match presence with
+  | Missing -> Ok None
+  | Present value -> Ok (Some value)
 ;;
 
-let managed_root_directories ~base_path =
-  let masc_dir = Common.masc_dir_from_base_path ~base_path in
-  [ masc_dir; Common.keepers_runtime_dir_of_base ~base_path ]
+let with_existing_jobs ~base_path ~keeper_name f =
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_path = Filename.concat keepers_path keeper_name in
+  let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* keeper_name_segment = child_name ~parent:keepers_path keeper_path in
+  let* jobs_name = child_name ~parent:keeper_path jobs_path in
+  try
+    match
+      Anchored.with_open_path_opt
+        ~root:base_path
+        [ masc_name; keepers_name; keeper_name_segment; jobs_name ]
+        (fun handle ->
+           let* value = f { jobs = { handle; path = jobs_path } } in
+           Ok (Present value))
+    with
+    | None -> Ok Missing
+    | Some result -> result
+  with
+  | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = jobs_path
+         ; detail = Printexc.to_string exn
+         })
 ;;
 
-let keeper_ancestor_directories ~base_path ~keeper_name =
-  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
-  [ Filename.concat keepers_root keeper_name
-  ; keeper_jobs_dir ~base_path ~keeper_name
-  ]
+let artifact_from_segment directory name =
+  let raw_name = Anchored.Segment.to_string name in
+  { directory
+  ; name
+  ; path = Filename.concat directory.path raw_name
+  }
 ;;
 
-let validate_real_directory_chain paths =
-  let rec loop = function
-    | [] -> Ok true
-    | path :: rest ->
-      let* stat = inspect_path path in
-      (match stat with
-       | None -> Ok false
-       | Some stat when stat.Unix.st_kind = Unix.S_DIR -> loop rest
-       | Some _ -> Error (not_real_directory_error path))
+let artifact directory raw_name =
+  let name =
+    match Anchored.Segment.of_string raw_name with
+    | Ok segment -> segment
+    | Error error ->
+      invalid_arg
+        (Printf.sprintf
+           "invalid memory job artifact name %S: %s"
+           raw_name
+           (Anchored.Segment.error_to_string error))
   in
-  loop paths
+  artifact_from_segment directory name
 ;;
 
-let require_real_directory_chain paths =
-  let rec loop = function
-    | [] -> Ok ()
-    | path :: rest ->
-      let* () = require_existing_real_directory path in
-      loop rest
-  in
-  loop paths
+let artifact_for_id directory id = artifact directory (id ^ json_suffix)
+
+let awaiting_artifact store (job : job) =
+  artifact_for_id store.awaiting job.id
 ;;
 
-let validate_managed_root_if_present ~base_path =
-  validate_real_directory_chain
-    (base_path :: managed_root_directories ~base_path)
+let pending_artifact store (job : job) =
+  artifact_for_id store.pending job.id
 ;;
 
-let validate_keeper_ancestors_if_present ~base_path ~keeper_name =
-  validate_real_directory_chain
-    (base_path
-     :: (managed_root_directories ~base_path
-         @ keeper_ancestor_directories ~base_path ~keeper_name))
+let inflight_artifact store (job : job) =
+  artifact_for_id store.inflight job.id
 ;;
 
-let ensure_store_dirs ~base_path ~keeper_name =
-  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
-  let keeper_dir = Filename.concat keepers_root keeper_name in
-  let* () = require_existing_real_directory base_path in
-  let parent_dirs =
-    managed_root_directories ~base_path @ [ keeper_dir ]
-  in
-  let owned_dirs =
-    [ keeper_jobs_dir ~base_path ~keeper_name
-    ; pending_dir ~base_path ~keeper_name
-    ; awaiting_dir ~base_path ~keeper_name
-    ; inflight_dir ~base_path ~keeper_name
-    ; receipts_dir ~base_path ~keeper_name
-    ; operations_dir ~base_path ~keeper_name
-    ]
-  in
-  let rec loop ~owned = function
-    | [] -> Ok ()
-    | dir :: rest ->
-      let* () = ensure_real_directory ~owned dir in
-      loop ~owned rest
-  in
-  let* () = loop ~owned:false parent_dirs in
-  let* () = loop ~owned:true owned_dirs in
-  require_real_directory_chain
-    (base_path :: (parent_dirs @ owned_dirs))
+let receipt_artifact store (job : job) =
+  artifact_for_id store.receipts job.id
+;;
+
+let receipt_artifact_for_identity store (identity : receipt_identity) =
+  artifact_for_id store.receipts identity.id
+;;
+
+let operation_artifact store operation_id =
+  artifact_for_id store.operations operation_id
 ;;
 
 let valid_job_id id =
@@ -918,189 +1039,315 @@ let receipt_of_json json =
   | _ -> Error "memory job receipt must be a JSON object"
 ;;
 
-let read_json path =
-  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
-  if stat.Unix.st_kind <> Unix.S_REG
-  then
+let inspect_artifact item =
+  protect_io Inspect item.path (fun () ->
+    Anchored.stat item.directory.handle item.name)
+;;
+
+let read_json_opt item =
+  let content =
+    try Ok (Anchored.read_file_opt item.directory.handle item.name) with
+    | Unix.Unix_error ((Unix.ELOOP | Unix.EISDIR), _, _) as exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = item.path
+           ; detail = Printexc.to_string exn
+           })
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Io_error
+           { operation = Read
+           ; path = item.path
+           ; detail = Printexc.to_string exn
+           })
+  in
+  let* content = content in
+  match content with
+  | None -> Ok None
+  | Some content ->
+    (match Safe_ops.parse_json_safe ~context:item.path content with
+     | Ok json -> Ok (Some json)
+     | Error detail ->
+       Error (Io_error { operation = Read; path = item.path; detail }))
+;;
+
+let read_json item =
+  let* json = read_json_opt item in
+  match json with
+  | Some json -> Ok json
+  | None ->
     Error
       (Io_error
-         { operation = Inspect
-         ; path
-         ; detail = "memory job artifact is not a regular file"
+         { operation = Read
+         ; path = item.path
+         ; detail = "memory job artifact does not exist"
          })
-  else
-    match
-      try
-        Fs_compat.load_file_unix path
-        |> Safe_ops.parse_json_safe ~context:path
-      with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn -> Error (Printexc.to_string exn)
-    with
-    | Ok json -> Ok json
-    | Error detail -> Error (Io_error { operation = Read; path; detail })
 ;;
 
-let read_envelope path =
-  let* json = read_json path in
+let read_envelope item =
+  let* json = read_json item in
   envelope_of_json json
-  |> Result.map_error (fun detail -> Decode_error { path; detail })
+  |> Result.map_error (fun detail -> Decode_error { path = item.path; detail })
 ;;
 
-let read_receipt path =
-  let* json = read_json path in
+let read_envelope_opt item =
+  let* json = read_json_opt item in
+  match json with
+  | None -> Ok None
+  | Some json ->
+    envelope_of_json json
+    |> Result.map Option.some
+    |> Result.map_error (fun detail ->
+      Decode_error { path = item.path; detail })
+;;
+
+let read_receipt item =
+  let* json = read_json item in
   receipt_of_json json
-  |> Result.map_error (fun detail -> Decode_error { path; detail })
+  |> Result.map_error (fun detail -> Decode_error { path = item.path; detail })
 ;;
 
-let save_json path json =
+let read_receipt_opt item =
+  let* json = read_json_opt item in
+  match json with
+  | None -> Ok None
+  | Some json ->
+    receipt_of_json json
+    |> Result.map Option.some
+    |> Result.map_error (fun detail ->
+      Decode_error { path = item.path; detail })
+;;
+
+let save_json item json =
   match
-    Fs_compat.save_file_atomic_unix
-      path
+    Anchored.atomic_replace
+      item.directory.handle
+      ~name:item.name
+      ~perm:private_file_mode
       (Yojson.Safe.pretty_to_string json)
   with
-  | Ok () ->
-    protect_io Set_permissions path (fun () -> Unix.chmod path private_file_mode)
-  | Error detail -> Error (Io_error { operation = Write; path; detail })
-;;
-
-let file_exists path =
-  try
-    ignore (Unix.lstat path);
-    Ok true
-  with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
+  | Ok () -> Ok ()
+  | Error error ->
     Error
       (Io_error
-         { operation = Inspect
-         ; path
-         ; detail = Printexc.to_string exn
+         { operation = Write
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
          })
 ;;
 
-let remove_if_exists path =
-  let* exists = file_exists path in
-  if not exists
-  then Ok ()
-  else protect_io Remove path (fun () -> Sys.remove path)
+let remove_if_exists item =
+  match Anchored.unlink_if_exists item.directory.handle item.name with
+  | Ok (`Missing | `Removed) -> Ok ()
+  | Error error ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
+         })
 ;;
 
-let cleanup_paths paths =
+let remove_required item =
+  match Anchored.unlink_if_exists item.directory.handle item.name with
+  | Ok `Removed -> Ok ()
+  | Ok `Missing ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = "required memory job artifact disappeared before unlink"
+         })
+  | Error error ->
+    Error
+      (Io_error
+         { operation = Remove
+         ; path = item.path
+         ; detail = Anchored.mutation_error_to_string error
+         })
+;;
+
+let cleanup_artifacts items =
   List.fold_left
-    (fun errors path ->
-       match remove_if_exists path with
+    (fun errors item ->
+       match remove_if_exists item with
        | Ok () -> errors
        | Error error -> error :: errors)
     []
-    paths
+    items
   |> List.rev
 ;;
 
-let reconcile_atomic_orphan dir name =
-  let path = Filename.concat dir name in
-  let recovered_root =
-    Filename.concat
-      (Filename.dirname dir)
-      recovered_atomic_writes_dirname
-  in
-  let bucket = Filename.basename dir in
-  let recovered_dir =
-    Filename.concat
-      recovered_root
-      bucket
-  in
-  let* () = ensure_real_directory ~owned:true recovered_root in
-  let* () = ensure_real_directory ~owned:true recovered_dir in
-  match Fs_compat.recover_atomic_orphan ~path ~recovered_root ~bucket with
-  | Error detail -> Error (Io_error { operation = Inspect; path; detail })
-  | Ok Fs_compat.Deleted_zero_length ->
-    Log.Keeper.warn "memory job queue removed zero-length atomic orphan path=%s" path;
+let require_same_regular_identity ~source ~destination expected = function
+  | Some ({ Anchored.kind = Regular_file; _ } as actual)
+    when Anchored.same_identity expected actual -> Ok ()
+  | Some _ ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = destination
+         ; detail =
+             Printf.sprintf
+               "atomic orphan destination conflicts with source %s"
+               source
+         })
+  | None ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = destination
+         ; detail = "atomic orphan destination disappeared"
+         })
+;;
+
+let reconcile_atomic_orphan ~jobs directory name =
+  let source = artifact_from_segment directory name in
+  let* inspected = inspect_artifact source in
+  match inspected with
+  | None ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = source.path
+         ; detail = "atomic orphan disappeared during reconciliation"
+         })
+  | Some { Anchored.kind = Regular_file; size = 0L; _ } ->
+    let* () = remove_required source in
+    Log.Keeper.warn
+      "memory job queue removed zero-length atomic orphan path=%s"
+      source.path;
     Ok ()
-  | Ok (Fs_compat.Preserved_nonempty destination) ->
-    (match
-       protect_io Set_permissions recovered_dir (fun () ->
-         Unix.chmod recovered_dir private_directory_mode)
-     with
-     | Error _ as error -> error
-     | Ok () ->
-       let* () =
-         protect_io Set_permissions destination (fun () ->
-           Unix.chmod destination private_file_mode)
-       in
-       Log.Keeper.error
-         "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
-         path
-         destination;
-       Ok ())
-;;
-
-let list_json_paths dir =
-  let* exists = file_exists dir in
-  if not exists
-  then Ok []
-  else
-    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+  | Some ({ Anchored.kind = Regular_file; _ } as source_identity) ->
+    let* synced_identity =
+      protect_io Sync source.path (fun () ->
+        Anchored.fsync_file directory.handle name)
+    in
     let* () =
-      if stat.Unix.st_kind = Unix.S_DIR
+      if Anchored.same_identity source_identity synced_identity
       then Ok ()
       else
         Error
           (Io_error
              { operation = Inspect
-             ; path = dir
-             ; detail = "memory job queue path is not a real directory"
+             ; path = source.path
+             ; detail = "atomic orphan changed while it was being synced"
              })
     in
-    let* entries =
-      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    let bucket_name = Filename.basename directory.path in
+    let recovered_path =
+      Filename.concat jobs.path recovered_atomic_writes_dirname
     in
-    let rec validate acc = function
-      | [] -> Ok (List.sort String.compare acc)
-      | name :: rest ->
-        let path = Filename.concat dir name in
-        if Filename.check_suffix name json_suffix
-        then validate (path :: acc) rest
-        else if Fs_compat.is_atomic_orphan_name name
-        then
-          let* () = reconcile_atomic_orphan dir name in
-          validate acc rest
-        else Error (Unexpected_queue_entry path)
+    with_directory ~owned:true jobs recovered_path @@ fun recovered ->
+    let bucket_path = Filename.concat recovered.path bucket_name in
+    with_directory ~owned:true recovered bucket_path @@ fun bucket ->
+    let destination = artifact_from_segment bucket name in
+    let* destination_before = inspect_artifact destination in
+    let* () =
+      match destination_before with
+      | Some _ ->
+        require_same_regular_identity
+          ~source:source.path
+          ~destination:destination.path
+          synced_identity
+          destination_before
+      | None ->
+        let link_result =
+          match
+            Anchored.link_no_replace
+              ~src_dir:directory.handle
+              ~src:name
+              ~dst_dir:bucket.handle
+              ~dst:name
+          with
+          | Ok () -> Ok ()
+          | Error
+              (Anchored.Not_committed
+                 { cause = Unix.Unix_error (Unix.EEXIST, _, _)
+                 ; cleanup_error = None
+                 }) -> Ok ()
+          | Error error ->
+            Error
+              (Io_error
+                 { operation = Write
+                 ; path = destination.path
+                 ; detail = Anchored.mutation_error_to_string error
+                 })
+        in
+        let* () = link_result in
+        let* destination_after = inspect_artifact destination in
+        require_same_regular_identity
+          ~source:source.path
+          ~destination:destination.path
+          synced_identity
+          destination_after
     in
-    validate [] entries
+    let* source_before_unlink = inspect_artifact source in
+    let* () =
+      require_same_regular_identity
+        ~source:source.path
+        ~destination:source.path
+        synced_identity
+        source_before_unlink
+    in
+    let* () = remove_required source in
+    let* () =
+      protect_io Set_permissions destination.path (fun () ->
+        Anchored.chmod_file bucket.handle name private_file_mode)
+    in
+    Log.Keeper.error
+      "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
+      source.path
+      destination.path;
+    Ok ()
+  | Some _ ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path = source.path
+         ; detail = "atomic orphan is not a regular file"
+         })
 ;;
 
-let reconcile_atomic_orphans_in_dir dir =
-  let* exists = file_exists dir in
-  if not exists
-  then Ok ()
-  else
-    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
-    let* () =
-      if stat.Unix.st_kind = Unix.S_DIR
-      then Ok ()
-      else
-        Error
-          (Io_error
-             { operation = Inspect
-             ; path = dir
-             ; detail = "memory job queue path is not a real directory"
-             })
-    in
-    let* entries =
-      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
-    in
-    let rec loop = function
-      | [] -> Ok ()
-      | name :: rest ->
-        if Fs_compat.is_atomic_orphan_name name
-        then
-          let* () = reconcile_atomic_orphan dir name in
-          loop rest
-        else loop rest
-    in
-    loop entries
+let list_json_artifacts ~jobs directory =
+  let* entries =
+    protect_io List_directory directory.path (fun () ->
+      Anchored.read_dir directory.handle)
+  in
+  let rec validate acc = function
+    | [] -> Ok (List.rev acc)
+    | name :: rest ->
+      let raw_name = Anchored.Segment.to_string name in
+      let item = artifact_from_segment directory name in
+      if Filename.check_suffix raw_name json_suffix
+      then validate (item :: acc) rest
+      else if Fs_compat.is_atomic_orphan_name raw_name
+      then
+        let* () = reconcile_atomic_orphan ~jobs directory name in
+        validate acc rest
+      else Error (Unexpected_queue_entry item.path)
+  in
+  validate [] entries
+;;
+
+let reconcile_atomic_orphans_in_dir ~jobs directory =
+  let* entries =
+    protect_io List_directory directory.path (fun () ->
+      Anchored.read_dir directory.handle)
+  in
+  let rec loop = function
+    | [] -> Ok ()
+    | name :: rest ->
+      if
+        Fs_compat.is_atomic_orphan_name
+          (Anchored.Segment.to_string name)
+      then
+        let* () = reconcile_atomic_orphan ~jobs directory name in
+        loop rest
+      else loop rest
+  in
+  loop entries
 ;;
 
 let job_equal (left : job) (right : job) =
@@ -1176,41 +1423,38 @@ let ensure_queue_coordinates ~expected_keeper_name ~path envelope =
   else Ok ()
 ;;
 
-let classify_existing_envelope ~expected_job ~expected_state ~path outcome =
-  let* exists = file_exists path in
-  if not exists
-  then Ok None
-  else
-    let* envelope = read_envelope path in
+let classify_existing_envelope ~expected_job ~expected_state ~item outcome =
+  let* envelope = read_envelope_opt item in
+  match envelope with
+  | None -> Ok None
+  | Some envelope ->
     let* () =
       ensure_queue_coordinates
         ~expected_keeper_name:expected_job.keeper_name
-        ~path
+        ~path:item.path
         envelope
     in
-    let* () = ensure_same_job ~expected:expected_job ~path envelope in
-    let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+    let* () = ensure_same_job ~expected:expected_job ~path:item.path envelope in
+    let* () =
+      ensure_expected_state ~expected:expected_state ~path:item.path envelope
+    in
     Ok (Some outcome)
 ;;
 
 let stage_awaiting_turn_commit ~base_path job =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let receipt_path = receipt_path ~base_path job in
-  let* receipt_exists = file_exists receipt_path in
-  if receipt_exists
-  then
-    let* receipt = read_receipt receipt_path in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let receipt_item = receipt_artifact store job in
+  let* existing_receipt = read_receipt_opt receipt_item in
+  match existing_receipt with
+  | Some receipt ->
     if receipt_identity_matches_retry receipt.identity job
     then
       let cleanup_errors =
-        cleanup_paths
-          [ awaiting_path ~base_path job
-          ; pending_path ~base_path job
-          ; inflight_path ~base_path job
-          ; operation_stage_path
-              ~base_path
-              ~keeper_name:job.keeper_name
-              ~operation_id:job.id
+        cleanup_artifacts
+          [ awaiting_artifact store job
+          ; pending_artifact store job
+          ; inflight_artifact store job
+          ; operation_artifact store job.id
           ]
       in
       List.iter
@@ -1221,16 +1465,18 @@ let stage_awaiting_turn_commit ~base_path job =
              (error_to_string error))
         cleanup_errors;
       Ok Already_completed
-    else Error (Identity_conflict { job_id = job.id; path = receipt_path })
-  else
-    let awaiting_path = awaiting_path ~base_path job in
-    let pending_path = pending_path ~base_path job in
-    let inflight_path = inflight_path ~base_path job in
+    else
+      Error
+        (Identity_conflict { job_id = job.id; path = receipt_item.path })
+  | None ->
+    let awaiting_item = awaiting_artifact store job in
+    let pending_item = pending_artifact store job in
+    let inflight_item = inflight_artifact store job in
     let* awaiting =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_awaiting
-        ~path:awaiting_path
+        ~item:awaiting_item
         Already_awaiting
     in
     match awaiting with
@@ -1240,7 +1486,7 @@ let stage_awaiting_turn_commit ~base_path job =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_pending
-        ~path:pending_path
+        ~item:pending_item
         Already_pending
     in
     match pending with
@@ -1250,14 +1496,14 @@ let stage_awaiting_turn_commit ~base_path job =
         classify_existing_envelope
           ~expected_job:job
           ~expected_state:Expect_inflight
-          ~path:inflight_path
+          ~item:inflight_item
           Already_inflight
       in
       (match inflight with
        | Some outcome -> Ok outcome
        | None ->
          let envelope = { job; state = Awaiting_turn_commit } in
-         let* () = save_json awaiting_path (envelope_to_json envelope) in
+         let* () = save_json awaiting_item (envelope_to_json envelope) in
          Ok Staged_awaiting_turn_commit)
 ;;
 
@@ -1278,103 +1524,108 @@ let compare_job_order left right =
         if by_enqueued <> 0 then by_enqueued else String.compare left.id right.id
 ;;
 
-let load_envelopes ~expected_keeper_name ~expected_state paths =
+let load_envelopes ~expected_keeper_name ~expected_state items =
   let rec loop acc = function
     | [] -> Ok (List.rev acc)
-    | path :: rest ->
-      let* envelope = read_envelope path in
+    | item :: rest ->
+      let* envelope = read_envelope item in
       let* () =
-        ensure_queue_coordinates ~expected_keeper_name ~path envelope
+        ensure_queue_coordinates
+          ~expected_keeper_name
+          ~path:item.path
+          envelope
       in
-      let* () = ensure_expected_state ~expected:expected_state ~path envelope in
-      loop ((path, envelope) :: acc) rest
+      let* () =
+        ensure_expected_state
+          ~expected:expected_state
+          ~path:item.path
+          envelope
+      in
+      loop ((item, envelope) :: acc) rest
   in
-  loop [] paths
+  loop [] items
 ;;
 
 let list_awaiting ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
-    let* paths = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
+    let* items = list_json_artifacts ~jobs:store.jobs store.awaiting in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_awaiting
-        paths
+        items
     in
     Ok (List.map (fun (_, envelope) -> envelope.job) envelopes)
 ;;
 
 let activate ~base_path (job : job) =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let awaiting = awaiting_path ~base_path job in
-  let pending = pending_path ~base_path job in
-  let inflight = inflight_path ~base_path job in
-  let receipt = receipt_path ~base_path job in
-  let operation =
-    operation_stage_path
-      ~base_path
-      ~keeper_name:job.keeper_name
-      ~operation_id:job.id
-  in
-  let* receipt_exists = file_exists receipt in
-  if receipt_exists
-  then
-    let* terminal = read_receipt receipt in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let awaiting = awaiting_artifact store job in
+  let pending = pending_artifact store job in
+  let inflight = inflight_artifact store job in
+  let receipt = receipt_artifact store job in
+  let operation = operation_artifact store job.id in
+  let* terminal = read_receipt_opt receipt in
+  match terminal with
+  | Some terminal ->
     if not (receipt_identity_matches_retry terminal.identity job)
-    then Error (Identity_conflict { job_id = job.id; path = receipt })
+    then Error (Identity_conflict { job_id = job.id; path = receipt.path })
     else
-      let cleanup_errors = cleanup_paths [ awaiting; pending; inflight; operation ] in
+      let cleanup_errors =
+        cleanup_artifacts [ awaiting; pending; inflight; operation ]
+      in
       Ok (Activation_already_completed, { cleanup_errors })
-  else
+  | None ->
     let* pending_state =
       classify_existing_envelope
         ~expected_job:job
         ~expected_state:Expect_pending
-        ~path:pending
+        ~item:pending
         Activation_already_pending
     in
     (match pending_state with
      | Some activation ->
-       let cleanup_errors = cleanup_paths [ awaiting ] in
+       let cleanup_errors = cleanup_artifacts [ awaiting ] in
        Ok (activation, { cleanup_errors })
      | None ->
        let* inflight_state =
          classify_existing_envelope
            ~expected_job:job
            ~expected_state:Expect_inflight
-           ~path:inflight
+           ~item:inflight
            Activation_already_inflight
        in
        (match inflight_state with
         | Some activation ->
-          let cleanup_errors = cleanup_paths [ awaiting ] in
+          let cleanup_errors = cleanup_artifacts [ awaiting ] in
           Ok (activation, { cleanup_errors })
         | None ->
-          let* awaiting_exists = file_exists awaiting in
-          if not awaiting_exists
-          then
+          let* awaiting_envelope = read_envelope_opt awaiting in
+          (match awaiting_envelope with
+           | None ->
             Error
               (Decode_error
-                 { path = awaiting
+                 { path = awaiting.path
                  ; detail =
                      "cannot activate a memory job without its awaiting-turn-commit envelope"
                  })
-          else
-            let* envelope = read_envelope awaiting in
+           | Some envelope ->
             let* () =
               ensure_queue_coordinates
                 ~expected_keeper_name:job.keeper_name
-                ~path:awaiting
+                ~path:awaiting.path
                 envelope
             in
-            let* () = ensure_same_job ~expected:job ~path:awaiting envelope in
+            let* () =
+              ensure_same_job ~expected:job ~path:awaiting.path envelope
+            in
             let* () =
               ensure_expected_state
                 ~expected:Expect_awaiting
-                ~path:awaiting
+                ~path:awaiting.path
                 envelope
             in
             let* () =
@@ -1385,113 +1636,108 @@ let activate ~base_path (job : job) =
                    ; state = Pending
                    })
             in
-            let cleanup_errors = cleanup_paths [ awaiting ] in
-            Ok (Activated, { cleanup_errors })))
+            let cleanup_errors = cleanup_artifacts [ awaiting ] in
+            Ok (Activated, { cleanup_errors }))))
 ;;
 
 let abort_awaiting ~base_path (job : job) =
-  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
-  let path = awaiting_path ~base_path job in
-  let* exists = file_exists path in
-  if not exists
-  then Ok ()
-  else
-    let* envelope = read_envelope path in
+  with_ensured_store ~base_path ~keeper_name:job.keeper_name @@ fun store ->
+  let item = awaiting_artifact store job in
+  let* envelope = read_envelope_opt item in
+  match envelope with
+  | None -> Ok ()
+  | Some envelope ->
     let* () =
       ensure_queue_coordinates
         ~expected_keeper_name:job.keeper_name
-        ~path
+        ~path:item.path
         envelope
     in
-    let* () = ensure_same_job ~expected:job ~path envelope in
+    let* () = ensure_same_job ~expected:job ~path:item.path envelope in
     let* () =
-      ensure_expected_state ~expected:Expect_awaiting ~path envelope
+      ensure_expected_state ~expected:Expect_awaiting ~path:item.path envelope
     in
-    remove_if_exists path
+    remove_if_exists item
 ;;
 
-let recover_one ~base_path (inflight_path, envelope) =
+let recover_one store (inflight_item, envelope) =
   match envelope.state with
   | Awaiting_turn_commit | Pending ->
     Error
       (Decode_error
-         { path = inflight_path
+         { path = inflight_item.path
          ; detail = "inflight directory contains a pending envelope"
          })
   | Inflight { started_at } ->
     let job = envelope.job in
-    let receipt_path = receipt_path ~base_path job in
-    let* receipt_exists = file_exists receipt_path in
-    if receipt_exists
-    then
-      let* receipt = read_receipt receipt_path in
+    let receipt_item = receipt_artifact store job in
+    let* receipt = read_receipt_opt receipt_item in
+    (match receipt with
+     | Some receipt ->
       if not (receipt_identity_matches_job receipt.identity job)
-      then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+      then
+        Error
+          (Identity_conflict { job_id = job.id; path = receipt_item.path })
       else if not (Float.equal receipt.started_at started_at)
       then
         Error
           (Inflight_lease_conflict
              { job_id = job.id
-             ; path = inflight_path
+             ; path = inflight_item.path
              ; expected_started_at = receipt.started_at
              ; actual_started_at = started_at
              })
       else
         let cleanup_errors =
-          cleanup_paths
-            [ operation_stage_path
-                ~base_path
-                ~keeper_name:job.keeper_name
-                ~operation_id:job.id
-            ; awaiting_path ~base_path job
-            ; pending_path ~base_path job
-            ; inflight_path
+          cleanup_artifacts
+            [ operation_artifact store job.id
+            ; awaiting_artifact store job
+            ; pending_artifact store job
+            ; inflight_item
             ]
         in
         Ok (false, cleanup_errors)
-    else
-      let pending_path = pending_path ~base_path job in
-      let* pending_exists = file_exists pending_path in
+     | None ->
+      let pending_item = pending_artifact store job in
+      let* pending = read_envelope_opt pending_item in
       let* () =
-        if pending_exists
-        then
-          let* pending = read_envelope pending_path in
-          let* () = ensure_same_job ~expected:job ~path:pending_path pending in
+        match pending with
+        | Some pending ->
+          let* () =
+            ensure_same_job ~expected:job ~path:pending_item.path pending
+          in
           ensure_expected_state
             ~expected:Expect_pending
-            ~path:pending_path
+            ~path:pending_item.path
             pending
-        else save_json pending_path (envelope_to_json { job; state = Pending })
+        | None -> save_json pending_item (envelope_to_json { job; state = Pending })
       in
-      let cleanup_errors = cleanup_paths [ inflight_path ] in
-      Ok (true, cleanup_errors)
+      let cleanup_errors = cleanup_artifacts [ inflight_item ] in
+      Ok (true, cleanup_errors))
 ;;
 
 let recover_inflight ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
     let* () =
-      reconcile_atomic_orphans_in_dir
-        (receipts_dir ~base_path ~keeper_name)
+      reconcile_atomic_orphans_in_dir ~jobs:store.jobs store.receipts
     in
     let* () =
-      reconcile_atomic_orphans_in_dir
-        (operations_dir ~base_path ~keeper_name)
+      reconcile_atomic_orphans_in_dir ~jobs:store.jobs store.operations
     in
-    let dir = inflight_dir ~base_path ~keeper_name in
-    let* paths = list_json_paths dir in
+    let* items = list_json_artifacts ~jobs:store.jobs store.inflight in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_inflight
-        paths
+        items
     in
     let rec loop replayed cleanup_errors = function
       | [] -> Ok { replayed; cleanup_errors = List.rev cleanup_errors }
       | item :: rest ->
-        let* did_recover, item_cleanup_errors = recover_one ~base_path item in
+        let* did_recover, item_cleanup_errors = recover_one store item in
         loop
           (if did_recover then replayed + 1 else replayed)
           (List.rev_append item_cleanup_errors cleanup_errors)
@@ -1506,67 +1752,65 @@ let claim_all ~base_path ~keeper_name ~now =
   else if (not (Float.is_finite now)) || now < 0.0
   then Error (Invalid_claim_time now)
   else
-    let* () = ensure_store_dirs ~base_path ~keeper_name in
-    let dir = pending_dir ~base_path ~keeper_name in
-    let* paths = list_json_paths dir in
+    with_ensured_store ~base_path ~keeper_name @@ fun store ->
+    let* items = list_json_artifacts ~jobs:store.jobs store.pending in
     let* envelopes =
       load_envelopes
         ~expected_keeper_name:keeper_name
         ~expected_state:Expect_pending
-        paths
+        items
     in
     let ordered =
       envelopes
-      |> List.map (fun (path, envelope) -> path, envelope.job)
+      |> List.map (fun (item, envelope) -> item, envelope.job)
       |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
     in
-    let process_item path job =
-      let receipt_path = receipt_path ~base_path job in
-      let* receipt_exists = file_exists receipt_path in
-      if receipt_exists
-      then
-        let* receipt = read_receipt receipt_path in
+    let process_item item job =
+      let receipt_item = receipt_artifact store job in
+      let* receipt = read_receipt_opt receipt_item in
+      match receipt with
+      | Some receipt ->
         if not (receipt_identity_matches_job receipt.identity job)
-        then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+        then
+          Error
+            (Identity_conflict { job_id = job.id; path = receipt_item.path })
         else
           Ok
             (`Skipped
-              (cleanup_paths
-                 [ path
-                 ; awaiting_path ~base_path job
-                 ; inflight_path ~base_path job
-                 ; operation_stage_path
-                     ~base_path
-                     ~keeper_name:job.keeper_name
-                     ~operation_id:job.id
+              (cleanup_artifacts
+                 [ item
+                 ; awaiting_artifact store job
+                 ; inflight_artifact store job
+                 ; operation_artifact store job.id
                  ]))
-      else
+      | None ->
         let lease = { job; started_at = now } in
-        let destination = inflight_path ~base_path job in
-        let* inflight_exists = file_exists destination in
-        if inflight_exists
-        then
-          let* inflight = read_envelope destination in
+        let destination = inflight_artifact store job in
+        let* inflight = read_envelope_opt destination in
+        (match inflight with
+         | Some inflight ->
           let* () =
             ensure_queue_coordinates
               ~expected_keeper_name:keeper_name
-              ~path:destination
+              ~path:destination.path
               inflight
           in
-          let* () = ensure_same_job ~expected:job ~path:destination inflight in
+          let* () =
+            ensure_same_job ~expected:job ~path:destination.path inflight
+          in
           let* () =
             ensure_expected_state
               ~expected:Expect_inflight
-              ~path:destination
+              ~path:destination.path
               inflight
           in
           Error
             (Pending_already_inflight
                { job_id = job.id
-               ; pending_path = path
-               ; inflight_path = destination
+               ; pending_path = item.path
+               ; inflight_path = destination.path
                })
-        else
+         | None ->
           let* () =
             save_json
               destination
@@ -1575,7 +1819,7 @@ let claim_all ~base_path ~keeper_name ~now =
                  ; state = Inflight { started_at = lease.started_at }
                  })
           in
-          Ok (`Claimed (lease, cleanup_paths [ path ]))
+          Ok (`Claimed (lease, cleanup_artifacts [ item ])))
     in
     let rec claim leases cleanup_errors = function
       | [] ->
@@ -1584,8 +1828,8 @@ let claim_all ~base_path ~keeper_name ~now =
           ; cleanup_errors = List.rev cleanup_errors
           ; blocked = None
           }
-      | (path, job) :: rest ->
-        (match process_item path job with
+      | (item, job) :: rest ->
+        (match process_item item job with
          | Error error ->
            Ok
              { leases = List.rev leases
@@ -1608,34 +1852,16 @@ let claim_all ~base_path ~keeper_name ~now =
 
 let finish ~base_path (receipt : terminal_receipt) =
   let identity = receipt.identity in
-  let* () = ensure_store_dirs ~base_path ~keeper_name:identity.keeper_name in
-  let path = receipt_path_for_identity ~base_path identity in
-  let operation =
-    operation_stage_path
-      ~base_path
-      ~keeper_name:identity.keeper_name
-      ~operation_id:identity.id
-  in
-  let awaiting =
-    path_for_id
-      (awaiting_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let pending =
-    path_for_id
-      (pending_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let inflight =
-    path_for_id
-      (inflight_dir ~base_path ~keeper_name:identity.keeper_name)
-      identity.id
-  in
-  let* exists = file_exists path in
+  with_ensured_store ~base_path ~keeper_name:identity.keeper_name @@ fun store ->
+  let receipt_item = receipt_artifact_for_identity store identity in
+  let operation = operation_artifact store identity.id in
+  let awaiting = artifact_for_id store.awaiting identity.id in
+  let pending = artifact_for_id store.pending identity.id in
+  let inflight = artifact_for_id store.inflight identity.id in
+  let* existing_receipt = read_receipt_opt receipt_item in
   let* () =
-    if exists
-    then
-      let* current = read_receipt path in
+    match existing_receipt with
+    | Some current ->
       if receipt_identity_equal current.identity identity
          && current.outcome = receipt.outcome
          && Float.equal current.started_at receipt.started_at
@@ -1644,29 +1870,40 @@ let finish ~base_path (receipt : terminal_receipt) =
               (payload_sha256 current.detail)
               (payload_sha256 receipt.detail)
       then Ok ()
-      else Error (Identity_conflict { job_id = identity.id; path })
-    else
-      let* inflight_exists = file_exists inflight in
-      if not inflight_exists
-      then Error (Missing_inflight_lease { job_id = identity.id; path = inflight })
       else
-        let* envelope = read_envelope inflight in
+        Error
+          (Identity_conflict { job_id = identity.id; path = receipt_item.path })
+    | None ->
+      let* inflight_envelope = read_envelope_opt inflight in
+      (match inflight_envelope with
+       | None ->
+        Error
+          (Missing_inflight_lease
+             { job_id = identity.id; path = inflight.path })
+       | Some envelope ->
         let* () =
           ensure_queue_coordinates
             ~expected_keeper_name:identity.keeper_name
-            ~path:inflight
+            ~path:inflight.path
             envelope
         in
-        let* () = ensure_expected_state ~expected:Expect_inflight ~path:inflight envelope in
+        let* () =
+          ensure_expected_state
+            ~expected:Expect_inflight
+            ~path:inflight.path
+            envelope
+        in
         if not (receipt_identity_matches_job identity envelope.job)
-        then Error (Identity_conflict { job_id = identity.id; path = inflight })
+        then
+          Error
+            (Identity_conflict { job_id = identity.id; path = inflight.path })
         else
           (match envelope.state with
            | Awaiting_turn_commit | Pending ->
              Error
                (Missing_inflight_lease
                   { job_id = identity.id
-                  ; path = inflight
+                  ; path = inflight.path
                   })
            | Inflight { started_at } ->
              if not (Float.equal started_at receipt.started_at)
@@ -1674,110 +1911,160 @@ let finish ~base_path (receipt : terminal_receipt) =
                Error
                  (Inflight_lease_conflict
                     { job_id = identity.id
-                    ; path = inflight
+                    ; path = inflight.path
                     ; expected_started_at = receipt.started_at
                     ; actual_started_at = started_at
                     })
-             else save_json path (receipt_to_json receipt))
+             else save_json receipt_item (receipt_to_json receipt)))
   in
-  let cleanup_errors = cleanup_paths [ operation; awaiting; pending; inflight ] in
+  let cleanup_errors =
+    cleanup_artifacts [ operation; awaiting; pending; inflight ]
+  in
   Ok { cleanup_errors }
+;;
+
+let count_queue_in_jobs ~keeper_name ~jobs ~path ~expected_state =
+  let* count =
+    with_optional_directory jobs path (fun directory ->
+      let* items = list_json_artifacts ~jobs directory in
+      let* envelopes =
+        load_envelopes
+          ~expected_keeper_name:keeper_name
+          ~expected_state
+          items
+      in
+      Ok (List.length envelopes))
+  in
+  Ok (Option.value count ~default:0)
+;;
+
+let count_backlog_in_jobs ~base_path ~keeper_name jobs =
+  let* awaiting =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(awaiting_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_awaiting
+  in
+  let* pending =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(pending_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_pending
+  in
+  let* inflight =
+    count_queue_in_jobs
+      ~keeper_name
+      ~jobs
+      ~path:(inflight_dir ~base_path ~keeper_name)
+      ~expected_state:Expect_inflight
+  in
+  Ok (awaiting + pending + inflight)
 ;;
 
 let backlog_count ~base_path ~keeper_name =
   if not (keeper_name_is_valid keeper_name)
   then Error (Invalid_keeper_name keeper_name)
   else
-    let* ancestors_exist =
-      validate_keeper_ancestors_if_present ~base_path ~keeper_name
+    let* presence =
+      with_existing_jobs ~base_path ~keeper_name @@ fun store ->
+      count_backlog_in_jobs ~base_path ~keeper_name store.jobs
     in
-    if not ancestors_exist
-    then Ok 0
-    else
-      let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
-      let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
-      let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
-      let* awaiting_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_awaiting
-          awaiting
-      in
-      let* pending_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_pending
-          pending
-      in
-      let* inflight_envelopes =
-        load_envelopes
-          ~expected_keeper_name:keeper_name
-          ~expected_state:Expect_inflight
-          inflight
-      in
-      Ok
-        (List.length awaiting_envelopes
-         + List.length pending_envelopes
-         + List.length inflight_envelopes)
-;;
-
-let directory_exists path =
-  let* exists = file_exists path in
-  if not exists
-  then Ok false
-  else
-    let* is_directory =
-      protect_io Inspect path (fun () ->
-        (Unix.lstat path).Unix.st_kind = Unix.S_DIR)
-    in
-    if is_directory
-    then Ok true
-    else
-      Error
-        (Io_error
-           { operation = Inspect
-           ; path
-           ; detail = "expected a directory but found a non-directory entry"
-           })
+    (match presence with
+     | Missing -> Ok 0
+     | Present count -> Ok count)
 ;;
 
 let discover_keeper_names ~base_path =
-  let root = Common.keepers_runtime_dir_of_base ~base_path in
-  let* root_exists = validate_managed_root_if_present ~base_path in
-  if not root_exists
-  then Ok ([], [])
-  else
-    let* entries =
-      protect_io List_directory root (fun () -> Sys.readdir root |> Array.to_list)
-    in
-    let rec loop keepers errors = function
-      | [] ->
-        Ok
-          ( List.sort_uniq String.compare keepers
-          , List.rev errors )
-      | keeper_name :: rest ->
-        if not (keeper_name_is_valid keeper_name)
-        then loop keepers (Invalid_keeper_name keeper_name :: errors) rest
-        else
-          let keeper_dir = Filename.concat root keeper_name in
-          let jobs_dir = keeper_jobs_dir ~base_path ~keeper_name in
-          (match directory_exists keeper_dir with
-           | Error error -> loop keepers (error :: errors) rest
-           | Ok false -> loop keepers errors rest
-           | Ok true ->
-             (match directory_exists jobs_dir with
-              | Error error -> loop keepers (error :: errors) rest
-              | Ok false -> loop keepers errors rest
-              | Ok true ->
-                (match backlog_count ~base_path ~keeper_name with
-                 | Error error -> loop keepers (error :: errors) rest
-                 | Ok count ->
+  let masc_path = Common.masc_dir_from_base_path ~base_path in
+  let keepers_path = Common.keepers_runtime_dir_of_base ~base_path in
+  let* masc_name = child_name ~parent:base_path masc_path in
+  let* keepers_name = child_name ~parent:masc_path keepers_path in
+  let* presence =
+    try
+      match
+        Anchored.with_open_path_opt
+          ~root:base_path
+          [ masc_name; keepers_name ]
+          (fun handle ->
+             let keepers_directory = { handle; path = keepers_path } in
+             let* entries =
+               protect_io List_directory keepers_path (fun () ->
+                 Anchored.read_dir keepers_directory.handle)
+             in
+             let rec loop keepers errors = function
+               | [] ->
+                 Ok
+                   (Present
+                      ( List.sort_uniq String.compare keepers
+                      , List.rev errors ))
+               | keeper_segment :: rest ->
+                 let keeper_name =
+                   Anchored.Segment.to_string keeper_segment
+                 in
+                 if not (keeper_name_is_valid keeper_name)
+                 then
                    loop
-                     (if count > 0 then keeper_name :: keepers else keepers)
-                     errors
-                     rest)))
-    in
-    loop [] [] entries
+                     keepers
+                     (Invalid_keeper_name keeper_name :: errors)
+                     rest
+                 else
+                   let keeper_path =
+                     Filename.concat keepers_path keeper_name
+                   in
+                   let jobs_path = keeper_jobs_dir ~base_path ~keeper_name in
+                   let count_result =
+                     with_optional_directory
+                       keepers_directory
+                       keeper_path
+                       (fun keeper_directory ->
+                          let* jobs_presence =
+                            with_optional_directory
+                              keeper_directory
+                              jobs_path
+                              (count_backlog_in_jobs
+                                 ~base_path
+                                 ~keeper_name)
+                          in
+                          Ok (Option.value jobs_presence ~default:0))
+                   in
+                   (match count_result with
+                    | Error error ->
+                      loop keepers (error :: errors) rest
+                    | Ok None -> loop keepers errors rest
+                    | Ok (Some count) ->
+                      loop
+                        (if count > 0
+                         then keeper_name :: keepers
+                         else keepers)
+                        errors
+                        rest)
+             in
+             loop [] [] entries)
+      with
+      | None -> Ok Missing
+      | Some result -> result
+    with
+    | Unix.Unix_error ((Unix.ELOOP | Unix.ENOTDIR), _, _) as exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = keepers_path
+           ; detail = Printexc.to_string exn
+           })
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path = keepers_path
+           ; detail = Printexc.to_string exn
+           })
+  in
+  match presence with
+  | Missing -> Ok ([], [])
+  | Present result -> Ok result
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_job_store.ml
+++ b/lib/keeper/keeper_memory_job_store.ml
@@ -1,0 +1,1706 @@
+(** Durable per-keeper post-turn memory jobs. *)
+
+let job_schema = "masc.keeper_memory_job.v1"
+let envelope_schema = "masc.keeper_memory_job_envelope.v1"
+let receipt_schema = "masc.keeper_memory_job_receipt.v2"
+let jobs_dirname = "memory-jobs"
+let awaiting_dirname = "awaiting-turn-commit"
+let pending_dirname = "pending"
+let inflight_dirname = "inflight"
+let receipts_dirname = "receipts"
+let operations_dirname = "operations"
+let recovered_atomic_writes_dirname = "recovered-atomic-writes"
+let json_suffix = ".json"
+let private_directory_mode = 0o700
+let private_file_mode = 0o600
+
+type job =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease =
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity =
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt =
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Sync
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_claim_time of float
+  | Invalid_json_value of string
+  | Invalid_terminal_timestamps of
+      { started_at : float
+      ; ended_at : float
+      }
+  | Invalid_job_id of string
+  | Missing_inflight_lease of
+      { job_id : string
+      ; path : string
+      }
+  | Inflight_lease_conflict of
+      { job_id : string
+      ; path : string
+      ; expected_started_at : float
+      ; actual_started_at : float
+      }
+  | Pending_already_inflight of
+      { job_id : string
+      ; pending_path : string
+      ; inflight_path : string
+      }
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+let io_operation_to_string = function
+  | Ensure_directory -> "ensure_directory"
+  | Set_permissions -> "set_permissions"
+  | Sync -> "sync"
+  | Inspect -> "inspect"
+  | List_directory -> "list_directory"
+  | Read -> "read"
+  | Write -> "write"
+  | Remove -> "remove"
+;;
+
+let error_to_string = function
+  | Invalid_keeper_name name ->
+    Printf.sprintf "invalid keeper name: %S" name
+  | Invalid_trace_id detail -> detail
+  | Invalid_turn_identity { generation; turn; oas_turn_count } ->
+    Printf.sprintf
+      "invalid memory job turn identity generation=%d turn=%d oas_turn_count=%d"
+      generation
+      turn
+      oas_turn_count
+  | Invalid_enqueue_time value ->
+    Printf.sprintf "invalid memory job enqueue time: %g" value
+  | Invalid_claim_time value ->
+    Printf.sprintf "invalid memory job claim time: %g" value
+  | Invalid_json_value detail ->
+    Printf.sprintf "invalid memory job JSON value: %s" detail
+  | Invalid_terminal_timestamps { started_at; ended_at } ->
+    Printf.sprintf
+      "invalid memory job terminal timestamps started_at=%g ended_at=%g"
+      started_at
+      ended_at
+  | Invalid_job_id id -> Printf.sprintf "invalid memory job id: %S" id
+  | Missing_inflight_lease { job_id; path } ->
+    Printf.sprintf
+      "memory job completion has no inflight lease id=%s path=%s"
+      job_id
+      path
+  | Inflight_lease_conflict
+      { job_id
+      ; path
+      ; expected_started_at
+      ; actual_started_at
+      } ->
+    Printf.sprintf
+      "memory job inflight lease mismatch id=%s path=%s expected_started_at=%g actual_started_at=%g"
+      job_id
+      path
+      expected_started_at
+      actual_started_at
+  | Pending_already_inflight { job_id; pending_path; inflight_path } ->
+    Printf.sprintf
+      "memory job pending claim already has an inflight lease id=%s pending=%s inflight=%s"
+      job_id
+      pending_path
+      inflight_path
+  | Unexpected_queue_entry path ->
+    Printf.sprintf "unexpected entry in memory job queue: %s" path
+  | Decode_error { path; detail } ->
+    Printf.sprintf "memory job decode failed path=%s: %s" path detail
+  | Identity_conflict { job_id; path } ->
+    Printf.sprintf
+      "memory job identity conflict id=%s path=%s"
+      job_id
+      path
+  | Io_error { operation; path; detail } ->
+    Printf.sprintf
+      "memory job %s failed path=%s: %s"
+      (io_operation_to_string operation)
+      path
+      detail
+;;
+
+let ( let* ) = Result.bind
+
+let keeper_name_is_valid keeper_name =
+  Result.is_ok (Keeper_id.Keeper_name.of_string keeper_name)
+;;
+
+let protect_io operation path f =
+  try Ok (f ()) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let keeper_jobs_dir ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       keeper_name)
+    jobs_dirname
+;;
+
+let pending_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) pending_dirname
+;;
+
+let awaiting_dir ~base_path ~keeper_name =
+  Filename.concat
+    (keeper_jobs_dir ~base_path ~keeper_name)
+    awaiting_dirname
+;;
+
+let inflight_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) inflight_dirname
+;;
+
+let receipts_dir ~base_path ~keeper_name =
+  Filename.concat (keeper_jobs_dir ~base_path ~keeper_name) receipts_dirname
+;;
+
+let operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat keepers_dir keeper_name)
+       jobs_dirname)
+    operations_dirname
+;;
+
+let operations_dir ~base_path ~keeper_name =
+  operation_stages_dir_for_keepers_dir
+    ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
+    ~keeper_name
+;;
+
+let path_for_id dir id = Filename.concat dir (id ^ json_suffix)
+
+let pending_path ~base_path (job : job) =
+  path_for_id (pending_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let awaiting_path ~base_path (job : job) =
+  path_for_id (awaiting_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let inflight_path ~base_path (job : job) =
+  path_for_id (inflight_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path ~base_path (job : job) =
+  path_for_id (receipts_dir ~base_path ~keeper_name:job.keeper_name) job.id
+;;
+
+let receipt_path_for_identity ~base_path (identity : receipt_identity) =
+  path_for_id
+    (receipts_dir ~base_path ~keeper_name:identity.keeper_name)
+    identity.id
+;;
+
+let operation_stage_path_for_keepers_dir_unchecked
+      ~keepers_dir
+      ~keeper_name
+      ~operation_id
+  =
+  path_for_id
+    (operation_stages_dir_for_keepers_dir ~keepers_dir ~keeper_name)
+    operation_id
+;;
+
+let operation_stage_path ~base_path ~keeper_name ~operation_id =
+  path_for_id (operations_dir ~base_path ~keeper_name) operation_id
+;;
+
+let inspect_path path =
+  try Ok (Some (Unix.lstat path)) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let sync_directory path =
+  match Fs_compat.fsync_directory path with
+  | Ok () -> Ok ()
+  | Error detail -> Error (Io_error { operation = Sync; path; detail })
+;;
+
+let ensure_real_directory ~owned path =
+  let* before = inspect_path path in
+  let* () =
+    match before with
+    | Some _ -> Ok ()
+    | None ->
+      protect_io Ensure_directory path (fun () ->
+        Fs_compat.mkdir_p_durable_unix path)
+  in
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  let* () =
+    if stat.Unix.st_kind = Unix.S_DIR
+    then Ok ()
+    else
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path
+           ; detail = "memory job store path is not a real directory"
+           })
+  in
+  if not owned
+  then Ok ()
+  else
+    let* () =
+      protect_io Set_permissions path (fun () ->
+        Unix.chmod path private_directory_mode)
+    in
+    sync_directory path
+;;
+
+let ensure_store_dirs ~base_path ~keeper_name =
+  let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
+  let keeper_dir = Filename.concat keepers_root keeper_name in
+  let parent_dirs = [ keepers_root; keeper_dir ] in
+  let owned_dirs =
+    [ keeper_jobs_dir ~base_path ~keeper_name
+    ; pending_dir ~base_path ~keeper_name
+    ; awaiting_dir ~base_path ~keeper_name
+    ; inflight_dir ~base_path ~keeper_name
+    ; receipts_dir ~base_path ~keeper_name
+    ; operations_dir ~base_path ~keeper_name
+    ]
+  in
+  let rec loop ~owned = function
+    | [] -> Ok ()
+    | dir :: rest ->
+      let* () = ensure_real_directory ~owned dir in
+      loop ~owned rest
+  in
+  let* () = loop ~owned:false parent_dirs in
+  loop ~owned:true owned_dirs
+;;
+
+let valid_job_id id =
+  String.length id = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       id
+;;
+
+let is_valid_job_id = valid_job_id
+
+let rec validate_json_value = function
+  | `Float value when not (Float.is_finite value) ->
+    Error (Invalid_json_value "floating-point values must be finite")
+  | `Assoc fields ->
+    let names = List.map fst fields |> List.sort String.compare in
+    let rec reject_duplicate_names = function
+      | left :: (right :: _) when String.equal left right ->
+        Error
+          (Invalid_json_value
+             (Printf.sprintf "duplicate object field %S" left))
+      | _ :: rest -> reject_duplicate_names rest
+      | [] -> Ok ()
+    in
+    let* () = reject_duplicate_names names in
+    let rec validate_fields = function
+      | [] -> Ok ()
+      | (_, value) :: rest ->
+        let* () = validate_json_value value in
+        validate_fields rest
+    in
+    validate_fields fields
+  | `List values ->
+    let rec validate_values = function
+      | [] -> Ok ()
+      | value :: rest ->
+        let* () = validate_json_value value in
+        validate_values rest
+    in
+    validate_values values
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _ -> Ok ()
+;;
+
+let validate_json_value_for_decode json =
+  validate_json_value json |> Result.map_error error_to_string
+;;
+
+let operation_stage_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_name
+      ~operation_id
+  =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ -> Error (Invalid_keeper_name keeper_name)
+  | Ok keeper_name ->
+    if not (valid_job_id operation_id)
+    then Error (Invalid_job_id operation_id)
+    else
+      Ok
+        (operation_stage_path_for_keepers_dir_unchecked
+           ~keepers_dir
+           ~keeper_name:(Keeper_id.Keeper_name.to_string keeper_name)
+           ~operation_id)
+;;
+
+let job_identity_string ~keeper_name ~trace_id ~generation ~turn ~oas_turn_count =
+  String.concat
+    "\000"
+    [ keeper_name
+    ; trace_id
+    ; string_of_int generation
+    ; string_of_int turn
+    ; string_of_int oas_turn_count
+    ]
+;;
+
+let make_job
+      ~keeper_name
+      ~trace_id
+      ~generation
+      ~turn
+      ~oas_turn_count
+      ~enqueued_at
+      ~payload
+  =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ -> Error (Invalid_keeper_name keeper_name)
+  | Ok keeper_name_t ->
+    (match Keeper_id.Trace_id.of_string trace_id with
+     | Error detail -> Error (Invalid_trace_id detail)
+     | Ok trace_id_t ->
+       if generation < 0 || turn < 0 || oas_turn_count < 0
+       then Error (Invalid_turn_identity { generation; turn; oas_turn_count })
+       else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+       then Error (Invalid_enqueue_time enqueued_at)
+       else
+         let* () = validate_json_value payload in
+         let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_t in
+         let trace_id = Keeper_id.Trace_id.to_string trace_id_t in
+         let id =
+           job_identity_string
+             ~keeper_name
+             ~trace_id
+             ~generation
+             ~turn
+             ~oas_turn_count
+           |> Digestif.SHA256.digest_string
+           |> Digestif.SHA256.to_hex
+         in
+         Ok
+           { id
+           ; keeper_name
+           ; trace_id
+           ; generation
+           ; turn
+           ; oas_turn_count
+           ; enqueued_at
+           ; payload
+           })
+;;
+
+let job_to_json (job : job) =
+  `Assoc
+    [ "schema", `String job_schema
+    ; "id", `String job.id
+    ; "keeper_name", `String job.keeper_name
+    ; "trace_id", `String job.trace_id
+    ; "generation", `Int job.generation
+    ; "turn", `Int job.turn
+    ; "oas_turn_count", `Int job.oas_turn_count
+    ; "enqueued_at", `Float job.enqueued_at
+    ; "payload", job.payload
+    ]
+;;
+
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (key, value) -> key, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _) as json ->
+    json
+;;
+
+let payload_sha256 payload =
+  canonical_json payload
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let receipt_identity_of_job (job : job) =
+  { id = job.id
+  ; keeper_name = job.keeper_name
+  ; trace_id = job.trace_id
+  ; generation = job.generation
+  ; turn = job.turn
+  ; oas_turn_count = job.oas_turn_count
+  ; enqueued_at = job.enqueued_at
+  ; payload_sha256 = payload_sha256 job.payload
+  }
+;;
+
+let make_terminal_receipt lease ~ended_at ~outcome ~detail =
+  let started_at = lease.started_at in
+  if
+    (not (Float.is_finite started_at))
+    || started_at < 0.0
+    || not (Float.is_finite ended_at)
+    || ended_at < started_at
+  then
+    Error
+      (Invalid_terminal_timestamps
+         { started_at
+         ; ended_at
+         })
+  else
+    let* () = validate_json_value detail in
+    Ok
+      { identity = receipt_identity_of_job lease.job
+      ; started_at
+      ; ended_at
+      ; outcome
+      ; detail
+      }
+;;
+
+let receipt_identity_matches_retry identity (job : job) =
+  String.equal identity.id job.id
+  && String.equal identity.keeper_name job.keeper_name
+  && String.equal identity.trace_id job.trace_id
+  && identity.generation = job.generation
+  && identity.turn = job.turn
+  && identity.oas_turn_count = job.oas_turn_count
+  && String.equal identity.payload_sha256 (payload_sha256 job.payload)
+;;
+
+let receipt_identity_matches_job identity (job : job) =
+  receipt_identity_matches_retry identity job
+  && Float.equal identity.enqueued_at job.enqueued_at
+;;
+
+let receipt_identity_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && Float.equal left.enqueued_at right.enqueued_at
+  && String.equal left.payload_sha256 right.payload_sha256
+;;
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be a string" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let int_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (Printf.sprintf "field %s must be an int" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float value) -> Ok value
+  | Some (`Int value) -> Ok (float_of_int value)
+  | Some _ -> Error (Printf.sprintf "field %s must be a number" name)
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let json_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing field %s" name)
+;;
+
+let job_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema job_schema)
+    then Error (Printf.sprintf "unsupported memory job schema: %s" schema)
+    else
+      let* id = string_field "id" fields in
+      let* keeper_name = string_field "keeper_name" fields in
+      let* trace_id = string_field "trace_id" fields in
+      let* generation = int_field "generation" fields in
+      let* turn = int_field "turn" fields in
+      let* oas_turn_count = int_field "oas_turn_count" fields in
+      let* enqueued_at = float_field "enqueued_at" fields in
+      let* payload = json_field "payload" fields in
+      let* () =
+        validate_json_value payload
+        |> Result.map_error error_to_string
+      in
+      if not (valid_job_id id)
+      then Error (Printf.sprintf "invalid memory job id: %S" id)
+      else
+        let* keeper_name =
+          Keeper_id.Keeper_name.of_string keeper_name
+        in
+        let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+        if generation < 0 || turn < 0 || oas_turn_count < 0
+        then Error "turn identity values must be non-negative"
+        else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+        then Error "enqueued_at must be finite and non-negative"
+        else
+          let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+          let trace_id = Keeper_id.Trace_id.to_string trace_id in
+          let expected_id =
+            job_identity_string
+              ~keeper_name
+              ~trace_id
+              ~generation
+              ~turn
+              ~oas_turn_count
+            |> Digestif.SHA256.digest_string
+            |> Digestif.SHA256.to_hex
+          in
+          if not (String.equal id expected_id)
+          then Error "memory job id does not match its typed turn identity"
+          else
+            Ok
+              { id
+              ; keeper_name
+              ; trace_id
+              ; generation
+              ; turn
+              ; oas_turn_count
+              ; enqueued_at
+              ; payload
+              }
+  | _ -> Error "memory job must be a JSON object"
+;;
+
+type persisted_state =
+  | Awaiting_turn_commit
+  | Pending
+  | Inflight of { started_at : float }
+
+type envelope =
+  { job : job
+  ; state : persisted_state
+  }
+
+let state_to_json = function
+  | Awaiting_turn_commit ->
+    `Assoc [ "kind", `String "awaiting_turn_commit" ]
+  | Pending -> `Assoc [ "kind", `String "pending" ]
+  | Inflight { started_at } ->
+    `Assoc
+      [ "kind", `String "inflight"
+      ; "started_at", `Float started_at
+      ]
+;;
+
+let envelope_to_json envelope =
+  `Assoc
+    [ "schema", `String envelope_schema
+    ; "job", job_to_json envelope.job
+    ; "state", state_to_json envelope.state
+    ]
+;;
+
+let state_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "awaiting_turn_commit" -> Ok Awaiting_turn_commit
+     | "pending" -> Ok Pending
+     | "inflight" ->
+       let* started_at = float_field "started_at" fields in
+       if (not (Float.is_finite started_at)) || started_at < 0.0
+       then Error "inflight started_at must be finite and non-negative"
+       else Ok (Inflight { started_at })
+     | other -> Error (Printf.sprintf "unknown memory job state: %s" other))
+  | _ -> Error "memory job state must be an object"
+;;
+
+let envelope_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema envelope_schema)
+    then Error (Printf.sprintf "unsupported memory job envelope schema: %s" schema)
+    else
+      let* job_json = json_field "job" fields in
+      let* state_json = json_field "state" fields in
+      let* job = job_of_json job_json in
+      let* state = state_of_json state_json in
+      Ok { job; state }
+  | _ -> Error "memory job envelope must be a JSON object"
+;;
+
+let terminal_outcome_to_string = function
+  | Succeeded -> "succeeded"
+  | Failed -> "failed"
+;;
+
+let terminal_outcome_of_string = function
+  | "succeeded" -> Ok Succeeded
+  | "failed" -> Ok Failed
+  | value -> Error (Printf.sprintf "unknown terminal outcome: %s" value)
+;;
+
+let receipt_identity_to_json identity =
+  `Assoc
+    [ "id", `String identity.id
+    ; "keeper_name", `String identity.keeper_name
+    ; "trace_id", `String identity.trace_id
+    ; "generation", `Int identity.generation
+    ; "turn", `Int identity.turn
+    ; "oas_turn_count", `Int identity.oas_turn_count
+    ; "enqueued_at", `Float identity.enqueued_at
+    ; "payload_sha256", `String identity.payload_sha256
+    ]
+;;
+
+let receipt_identity_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* id = string_field "id" fields in
+    let* keeper_name = string_field "keeper_name" fields in
+    let* trace_id = string_field "trace_id" fields in
+    let* generation = int_field "generation" fields in
+    let* turn = int_field "turn" fields in
+    let* oas_turn_count = int_field "oas_turn_count" fields in
+    let* enqueued_at = float_field "enqueued_at" fields in
+    let* payload_sha256 = string_field "payload_sha256" fields in
+    let* keeper_name = Keeper_id.Keeper_name.of_string keeper_name in
+    let* trace_id = Keeper_id.Trace_id.of_string trace_id in
+    let keeper_name = Keeper_id.Keeper_name.to_string keeper_name in
+    let trace_id = Keeper_id.Trace_id.to_string trace_id in
+    let expected_id =
+      job_identity_string
+        ~keeper_name
+        ~trace_id
+        ~generation
+        ~turn
+        ~oas_turn_count
+      |> Digestif.SHA256.digest_string
+      |> Digestif.SHA256.to_hex
+    in
+    if generation < 0 || turn < 0 || oas_turn_count < 0
+    then Error "receipt turn identity values must be non-negative"
+    else if (not (Float.is_finite enqueued_at)) || enqueued_at < 0.0
+    then Error "receipt enqueued_at must be finite and non-negative"
+    else if not (valid_job_id id) || not (String.equal id expected_id)
+    then Error "receipt id does not match its typed turn identity"
+    else if not (valid_job_id payload_sha256)
+    then Error "receipt payload_sha256 must be a lowercase SHA-256 digest"
+    else
+      Ok
+        { id
+        ; keeper_name
+        ; trace_id
+        ; generation
+        ; turn
+        ; oas_turn_count
+        ; enqueued_at
+        ; payload_sha256
+        }
+  | _ -> Error "receipt job identity must be a JSON object"
+;;
+
+let receipt_to_json (receipt : terminal_receipt) =
+  `Assoc
+    [ "schema", `String receipt_schema
+    ; "job_identity", receipt_identity_to_json receipt.identity
+    ; "started_at", `Float receipt.started_at
+    ; "ended_at", `Float receipt.ended_at
+    ; "outcome", `String (terminal_outcome_to_string receipt.outcome)
+    ; "detail", receipt.detail
+    ]
+;;
+
+let receipt_of_json json =
+  let* () = validate_json_value_for_decode json in
+  match json with
+  | `Assoc fields ->
+    let* schema = string_field "schema" fields in
+    if not (String.equal schema receipt_schema)
+    then Error (Printf.sprintf "unsupported memory job receipt schema: %s" schema)
+    else
+      let* identity_json = json_field "job_identity" fields in
+      let* identity = receipt_identity_of_json identity_json in
+      let* started_at = float_field "started_at" fields in
+      let* ended_at = float_field "ended_at" fields in
+      let* outcome_string = string_field "outcome" fields in
+      let* outcome = terminal_outcome_of_string outcome_string in
+      let* detail = json_field "detail" fields in
+      let* () =
+        validate_json_value detail
+        |> Result.map_error error_to_string
+      in
+      if
+        (not (Float.is_finite started_at))
+        || started_at < 0.0
+        || not (Float.is_finite ended_at)
+        || ended_at < started_at
+      then Error "receipt timestamps must be finite, non-negative, and ordered"
+      else Ok { identity; started_at; ended_at; outcome; detail }
+  | _ -> Error "memory job receipt must be a JSON object"
+;;
+
+let read_json path =
+  let* stat = protect_io Inspect path (fun () -> Unix.lstat path) in
+  if stat.Unix.st_kind <> Unix.S_REG
+  then
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = "memory job artifact is not a regular file"
+         })
+  else
+    match
+      try
+        Fs_compat.load_file_unix path
+        |> Safe_ops.parse_json_safe ~context:path
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Printexc.to_string exn)
+    with
+    | Ok json -> Ok json
+    | Error detail -> Error (Io_error { operation = Read; path; detail })
+;;
+
+let read_envelope path =
+  let* json = read_json path in
+  envelope_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let read_receipt path =
+  let* json = read_json path in
+  receipt_of_json json
+  |> Result.map_error (fun detail -> Decode_error { path; detail })
+;;
+
+let save_json path json =
+  match
+    Fs_compat.save_file_atomic_unix
+      path
+      (Yojson.Safe.pretty_to_string json)
+  with
+  | Ok () ->
+    protect_io Set_permissions path (fun () -> Unix.chmod path private_file_mode)
+  | Error detail -> Error (Io_error { operation = Write; path; detail })
+;;
+
+let file_exists path =
+  try
+    ignore (Unix.lstat path);
+    Ok true
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Io_error
+         { operation = Inspect
+         ; path
+         ; detail = Printexc.to_string exn
+         })
+;;
+
+let remove_if_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else protect_io Remove path (fun () -> Sys.remove path)
+;;
+
+let cleanup_paths paths =
+  List.fold_left
+    (fun errors path ->
+       match remove_if_exists path with
+       | Ok () -> errors
+       | Error error -> error :: errors)
+    []
+    paths
+  |> List.rev
+;;
+
+let reconcile_atomic_orphan dir name =
+  let path = Filename.concat dir name in
+  let recovered_root =
+    Filename.concat
+      (Filename.dirname dir)
+      recovered_atomic_writes_dirname
+  in
+  let bucket = Filename.basename dir in
+  let recovered_dir =
+    Filename.concat
+      recovered_root
+      bucket
+  in
+  let* () = ensure_real_directory ~owned:true recovered_root in
+  let* () = ensure_real_directory ~owned:true recovered_dir in
+  match Fs_compat.recover_atomic_orphan ~path ~recovered_root ~bucket with
+  | Error detail -> Error (Io_error { operation = Inspect; path; detail })
+  | Ok Fs_compat.Deleted_zero_length ->
+    Log.Keeper.warn "memory job queue removed zero-length atomic orphan path=%s" path;
+    Ok ()
+  | Ok (Fs_compat.Preserved_nonempty destination) ->
+    (match
+       protect_io Set_permissions recovered_dir (fun () ->
+         Unix.chmod recovered_dir private_directory_mode)
+     with
+     | Error _ as error -> error
+     | Ok () ->
+       let* () =
+         protect_io Set_permissions destination (fun () ->
+           Unix.chmod destination private_file_mode)
+       in
+       Log.Keeper.error
+         "memory job queue preserved non-empty atomic orphan source=%s destination=%s"
+         path
+         destination;
+       Ok ())
+;;
+
+let list_json_paths dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok []
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec validate acc = function
+      | [] -> Ok (List.sort String.compare acc)
+      | name :: rest ->
+        let path = Filename.concat dir name in
+        if Filename.check_suffix name json_suffix
+        then validate (path :: acc) rest
+        else if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          validate acc rest
+        else Error (Unexpected_queue_entry path)
+    in
+    validate [] entries
+;;
+
+let reconcile_atomic_orphans_in_dir dir =
+  let* exists = file_exists dir in
+  if not exists
+  then Ok ()
+  else
+    let* stat = protect_io Inspect dir (fun () -> Unix.lstat dir) in
+    let* () =
+      if stat.Unix.st_kind = Unix.S_DIR
+      then Ok ()
+      else
+        Error
+          (Io_error
+             { operation = Inspect
+             ; path = dir
+             ; detail = "memory job queue path is not a real directory"
+             })
+    in
+    let* entries =
+      protect_io List_directory dir (fun () -> Sys.readdir dir |> Array.to_list)
+    in
+    let rec loop = function
+      | [] -> Ok ()
+      | name :: rest ->
+        if Fs_compat.is_atomic_orphan_name name
+        then
+          let* () = reconcile_atomic_orphan dir name in
+          loop rest
+        else loop rest
+    in
+    loop entries
+;;
+
+let job_equal left right =
+  String.equal left.id right.id
+  && String.equal left.keeper_name right.keeper_name
+  && String.equal left.trace_id right.trace_id
+  && left.generation = right.generation
+  && left.turn = right.turn
+  && left.oas_turn_count = right.oas_turn_count
+  && String.equal (payload_sha256 left.payload) (payload_sha256 right.payload)
+;;
+
+let ensure_same_job ~expected ~path envelope =
+  if job_equal expected envelope.job
+  then Ok ()
+  else Error (Identity_conflict { job_id = expected.id; path })
+;;
+
+type expected_envelope_state =
+  | Expect_awaiting
+  | Expect_pending
+  | Expect_inflight
+
+let ensure_expected_state ~expected ~path envelope =
+  match expected, envelope.state with
+  | Expect_awaiting, Awaiting_turn_commit
+  | Expect_pending, Pending
+  | Expect_inflight, Inflight _ -> Ok ()
+  | Expect_awaiting, (Pending | Inflight _)
+  | Expect_pending, (Awaiting_turn_commit | Inflight _)
+  | Expect_inflight, (Awaiting_turn_commit | Pending) ->
+    let expected_label =
+      match expected with
+      | Expect_awaiting -> "awaiting-turn-commit"
+      | Expect_pending -> "pending"
+      | Expect_inflight -> "inflight"
+    in
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "%s directory contains an envelope with a different state"
+               expected_label
+         })
+;;
+
+let ensure_queue_coordinates ~expected_keeper_name ~path envelope =
+  let expected_name = envelope.job.id ^ json_suffix in
+  let actual_name = Filename.basename path in
+  if not (String.equal envelope.job.keeper_name expected_keeper_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue keeper coordinate mismatch expected=%s actual=%s"
+               expected_keeper_name
+               envelope.job.keeper_name
+         })
+  else if not (String.equal actual_name expected_name)
+  then
+    Error
+      (Decode_error
+         { path
+         ; detail =
+             Printf.sprintf
+               "queue filename coordinate mismatch expected=%s actual=%s"
+               expected_name
+               actual_name
+         })
+  else Ok ()
+;;
+
+let classify_existing_envelope ~expected_job ~expected_state ~path outcome =
+  let* exists = file_exists path in
+  if not exists
+  then Ok None
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:expected_job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:expected_job ~path envelope in
+    let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+    Ok (Some outcome)
+;;
+
+let stage_awaiting_turn_commit ~base_path job =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let receipt_path = receipt_path ~base_path job in
+  let* receipt_exists = file_exists receipt_path in
+  if receipt_exists
+  then
+    let* receipt = read_receipt receipt_path in
+    if receipt_identity_matches_retry receipt.identity job
+    then
+      let cleanup_errors =
+        cleanup_paths
+          [ awaiting_path ~base_path job
+          ; pending_path ~base_path job
+          ; inflight_path ~base_path job
+          ; operation_stage_path
+              ~base_path
+              ~keeper_name:job.keeper_name
+              ~operation_id:job.id
+          ]
+      in
+      List.iter
+        (fun error ->
+           Log.Keeper.error ~keeper_name:job.keeper_name
+             "memory job completed-state cleanup debt job_id=%s: %s"
+             job.id
+             (error_to_string error))
+        cleanup_errors;
+      Ok Already_completed
+    else Error (Identity_conflict { job_id = job.id; path = receipt_path })
+  else
+    let awaiting_path = awaiting_path ~base_path job in
+    let pending_path = pending_path ~base_path job in
+    let inflight_path = inflight_path ~base_path job in
+    let* awaiting =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_awaiting
+        ~path:awaiting_path
+        Already_awaiting
+    in
+    match awaiting with
+    | Some outcome -> Ok outcome
+    | None ->
+    let* pending =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending_path
+        Already_pending
+    in
+    match pending with
+    | Some outcome -> Ok outcome
+    | None ->
+      let* inflight =
+        classify_existing_envelope
+          ~expected_job:job
+          ~expected_state:Expect_inflight
+          ~path:inflight_path
+          Already_inflight
+      in
+      (match inflight with
+       | Some outcome -> Ok outcome
+       | None ->
+         let envelope = { job; state = Awaiting_turn_commit } in
+         let* () = save_json awaiting_path (envelope_to_json envelope) in
+         Ok Staged_awaiting_turn_commit)
+;;
+
+let compare_job_order left right =
+  let by_turn = Int.compare left.turn right.turn in
+  if by_turn <> 0
+  then by_turn
+  else
+    let by_generation = Int.compare left.generation right.generation in
+    if by_generation <> 0
+    then by_generation
+    else
+      let by_oas_turn = Int.compare left.oas_turn_count right.oas_turn_count in
+      if by_oas_turn <> 0
+      then by_oas_turn
+      else
+        let by_enqueued = Float.compare left.enqueued_at right.enqueued_at in
+        if by_enqueued <> 0 then by_enqueued else String.compare left.id right.id
+;;
+
+let load_envelopes ~expected_keeper_name ~expected_state paths =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | path :: rest ->
+      let* envelope = read_envelope path in
+      let* () =
+        ensure_queue_coordinates ~expected_keeper_name ~path envelope
+      in
+      let* () = ensure_expected_state ~expected:expected_state ~path envelope in
+      loop ((path, envelope) :: acc) rest
+  in
+  loop [] paths
+;;
+
+let list_awaiting ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* paths = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        paths
+    in
+    Ok (List.map (fun (_, envelope) -> envelope.job) envelopes)
+;;
+
+let activate ~base_path (job : job) =
+  let* () = ensure_store_dirs ~base_path ~keeper_name:job.keeper_name in
+  let awaiting = awaiting_path ~base_path job in
+  let pending = pending_path ~base_path job in
+  let inflight = inflight_path ~base_path job in
+  let receipt = receipt_path ~base_path job in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:job.keeper_name
+      ~operation_id:job.id
+  in
+  let* receipt_exists = file_exists receipt in
+  if receipt_exists
+  then
+    let* terminal = read_receipt receipt in
+    if not (receipt_identity_matches_retry terminal.identity job)
+    then Error (Identity_conflict { job_id = job.id; path = receipt })
+    else
+      let cleanup_errors = cleanup_paths [ awaiting; pending; inflight; operation ] in
+      Ok (Activation_already_completed, { cleanup_errors })
+  else
+    let* pending_state =
+      classify_existing_envelope
+        ~expected_job:job
+        ~expected_state:Expect_pending
+        ~path:pending
+        Activation_already_pending
+    in
+    (match pending_state with
+     | Some activation ->
+       let cleanup_errors = cleanup_paths [ awaiting ] in
+       Ok (activation, { cleanup_errors })
+     | None ->
+       let* inflight_state =
+         classify_existing_envelope
+           ~expected_job:job
+           ~expected_state:Expect_inflight
+           ~path:inflight
+           Activation_already_inflight
+       in
+       (match inflight_state with
+        | Some activation ->
+          let cleanup_errors = cleanup_paths [ awaiting ] in
+          Ok (activation, { cleanup_errors })
+        | None ->
+          let* awaiting_exists = file_exists awaiting in
+          if not awaiting_exists
+          then
+            Error
+              (Decode_error
+                 { path = awaiting
+                 ; detail =
+                     "cannot activate a memory job without its awaiting-turn-commit envelope"
+                 })
+          else
+            let* envelope = read_envelope awaiting in
+            let* () =
+              ensure_queue_coordinates
+                ~expected_keeper_name:job.keeper_name
+                ~path:awaiting
+                envelope
+            in
+            let* () = ensure_same_job ~expected:job ~path:awaiting envelope in
+            let* () =
+              ensure_expected_state
+                ~expected:Expect_awaiting
+                ~path:awaiting
+                envelope
+            in
+            let* () =
+              save_json
+                pending
+                (envelope_to_json
+                   { job = envelope.job
+                   ; state = Pending
+                   })
+            in
+            let cleanup_errors = cleanup_paths [ awaiting ] in
+            Ok (Activated, { cleanup_errors })))
+;;
+
+let abort_awaiting ~base_path (job : job) =
+  let path = awaiting_path ~base_path job in
+  let* exists = file_exists path in
+  if not exists
+  then Ok ()
+  else
+    let* envelope = read_envelope path in
+    let* () =
+      ensure_queue_coordinates
+        ~expected_keeper_name:job.keeper_name
+        ~path
+        envelope
+    in
+    let* () = ensure_same_job ~expected:job ~path envelope in
+    let* () =
+      ensure_expected_state ~expected:Expect_awaiting ~path envelope
+    in
+    remove_if_exists path
+;;
+
+let recover_one ~base_path (inflight_path, envelope) =
+  match envelope.state with
+  | Awaiting_turn_commit | Pending ->
+    Error
+      (Decode_error
+         { path = inflight_path
+         ; detail = "inflight directory contains a pending envelope"
+         })
+  | Inflight { started_at } ->
+    let job = envelope.job in
+    let receipt_path = receipt_path ~base_path job in
+    let* receipt_exists = file_exists receipt_path in
+    if receipt_exists
+    then
+      let* receipt = read_receipt receipt_path in
+      if not (receipt_identity_matches_job receipt.identity job)
+      then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+      else if not (Float.equal receipt.started_at started_at)
+      then
+        Error
+          (Inflight_lease_conflict
+             { job_id = job.id
+             ; path = inflight_path
+             ; expected_started_at = receipt.started_at
+             ; actual_started_at = started_at
+             })
+      else
+        let cleanup_errors =
+          cleanup_paths
+            [ operation_stage_path
+                ~base_path
+                ~keeper_name:job.keeper_name
+                ~operation_id:job.id
+            ; awaiting_path ~base_path job
+            ; pending_path ~base_path job
+            ; inflight_path
+            ]
+        in
+        Ok (false, cleanup_errors)
+    else
+      let pending_path = pending_path ~base_path job in
+      let* pending_exists = file_exists pending_path in
+      let* () =
+        if pending_exists
+        then
+          let* pending = read_envelope pending_path in
+          let* () = ensure_same_job ~expected:job ~path:pending_path pending in
+          ensure_expected_state
+            ~expected:Expect_pending
+            ~path:pending_path
+            pending
+        else save_json pending_path (envelope_to_json { job; state = Pending })
+      in
+      let cleanup_errors = cleanup_paths [ inflight_path ] in
+      Ok (true, cleanup_errors)
+;;
+
+let recover_inflight ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* () = ensure_store_dirs ~base_path ~keeper_name in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (receipts_dir ~base_path ~keeper_name)
+    in
+    let* () =
+      reconcile_atomic_orphans_in_dir
+        (operations_dir ~base_path ~keeper_name)
+    in
+    let dir = inflight_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        paths
+    in
+    let rec loop replayed cleanup_errors = function
+      | [] -> Ok { replayed; cleanup_errors = List.rev cleanup_errors }
+      | item :: rest ->
+        let* did_recover, item_cleanup_errors = recover_one ~base_path item in
+        loop
+          (if did_recover then replayed + 1 else replayed)
+          (List.rev_append item_cleanup_errors cleanup_errors)
+          rest
+    in
+    loop 0 [] envelopes
+;;
+
+let claim_all ~base_path ~keeper_name ~now =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else if (not (Float.is_finite now)) || now < 0.0
+  then Error (Invalid_claim_time now)
+  else
+    let dir = pending_dir ~base_path ~keeper_name in
+    let* paths = list_json_paths dir in
+    let* envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        paths
+    in
+    let ordered =
+      envelopes
+      |> List.map (fun (path, envelope) -> path, envelope.job)
+      |> List.sort (fun (_, left) (_, right) -> compare_job_order left right)
+    in
+    let rec claim leases cleanup_errors = function
+      | [] ->
+        Ok
+          { leases = List.rev leases
+          ; cleanup_errors = List.rev cleanup_errors
+          }
+      | (path, job) :: rest ->
+        let receipt_path = receipt_path ~base_path job in
+        let* receipt_exists = file_exists receipt_path in
+        if receipt_exists
+        then
+          let* receipt = read_receipt receipt_path in
+          if not (receipt_identity_matches_job receipt.identity job)
+          then Error (Identity_conflict { job_id = job.id; path = receipt_path })
+          else
+            let item_cleanup_errors =
+              cleanup_paths
+                [ path
+                ; awaiting_path ~base_path job
+                ; inflight_path ~base_path job
+                ; operation_stage_path
+                    ~base_path
+                    ~keeper_name:job.keeper_name
+                    ~operation_id:job.id
+                ]
+            in
+            claim
+              leases
+              (List.rev_append item_cleanup_errors cleanup_errors)
+              rest
+        else
+          let lease = { job; started_at = now } in
+          let destination = inflight_path ~base_path job in
+          let* inflight_exists = file_exists destination in
+          if inflight_exists
+          then
+            let* inflight = read_envelope destination in
+            let* () =
+              ensure_queue_coordinates
+                ~expected_keeper_name:keeper_name
+                ~path:destination
+                inflight
+            in
+            let* () = ensure_same_job ~expected:job ~path:destination inflight in
+            let* () =
+              ensure_expected_state
+                ~expected:Expect_inflight
+                ~path:destination
+                inflight
+            in
+            Error
+              (Pending_already_inflight
+                 { job_id = job.id
+                 ; pending_path = path
+                 ; inflight_path = destination
+                 })
+          else
+            let* () =
+              save_json
+                destination
+                (envelope_to_json
+                   { job
+                   ; state = Inflight { started_at = lease.started_at }
+                   })
+            in
+            let item_cleanup_errors = cleanup_paths [ path ] in
+            claim
+              (lease :: leases)
+              (List.rev_append item_cleanup_errors cleanup_errors)
+              rest
+    in
+    claim [] [] ordered
+;;
+
+let finish ~base_path (receipt : terminal_receipt) =
+  let identity = receipt.identity in
+  let* () = ensure_store_dirs ~base_path ~keeper_name:identity.keeper_name in
+  let path = receipt_path_for_identity ~base_path identity in
+  let operation =
+    operation_stage_path
+      ~base_path
+      ~keeper_name:identity.keeper_name
+      ~operation_id:identity.id
+  in
+  let awaiting =
+    path_for_id
+      (awaiting_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let pending =
+    path_for_id
+      (pending_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let inflight =
+    path_for_id
+      (inflight_dir ~base_path ~keeper_name:identity.keeper_name)
+      identity.id
+  in
+  let* exists = file_exists path in
+  let* () =
+    if exists
+    then
+      let* current = read_receipt path in
+      if receipt_identity_equal current.identity identity
+         && current.outcome = receipt.outcome
+         && Float.equal current.started_at receipt.started_at
+         && Float.equal current.ended_at receipt.ended_at
+         && String.equal
+              (payload_sha256 current.detail)
+              (payload_sha256 receipt.detail)
+      then Ok ()
+      else Error (Identity_conflict { job_id = identity.id; path })
+    else
+      let* inflight_exists = file_exists inflight in
+      if not inflight_exists
+      then Error (Missing_inflight_lease { job_id = identity.id; path = inflight })
+      else
+        let* envelope = read_envelope inflight in
+        let* () =
+          ensure_queue_coordinates
+            ~expected_keeper_name:identity.keeper_name
+            ~path:inflight
+            envelope
+        in
+        let* () = ensure_expected_state ~expected:Expect_inflight ~path:inflight envelope in
+        if not (receipt_identity_matches_job identity envelope.job)
+        then Error (Identity_conflict { job_id = identity.id; path = inflight })
+        else
+          (match envelope.state with
+           | Awaiting_turn_commit | Pending ->
+             Error
+               (Missing_inflight_lease
+                  { job_id = identity.id
+                  ; path = inflight
+                  })
+           | Inflight { started_at } ->
+             if not (Float.equal started_at receipt.started_at)
+             then
+               Error
+                 (Inflight_lease_conflict
+                    { job_id = identity.id
+                    ; path = inflight
+                    ; expected_started_at = receipt.started_at
+                    ; actual_started_at = started_at
+                    })
+             else save_json path (receipt_to_json receipt))
+  in
+  let cleanup_errors = cleanup_paths [ operation; awaiting; pending; inflight ] in
+  Ok { cleanup_errors }
+;;
+
+let backlog_count ~base_path ~keeper_name =
+  if not (keeper_name_is_valid keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    let* awaiting = list_json_paths (awaiting_dir ~base_path ~keeper_name) in
+    let* pending = list_json_paths (pending_dir ~base_path ~keeper_name) in
+    let* inflight = list_json_paths (inflight_dir ~base_path ~keeper_name) in
+    let* awaiting_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_awaiting
+        awaiting
+    in
+    let* pending_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_pending
+        pending
+    in
+    let* inflight_envelopes =
+      load_envelopes
+        ~expected_keeper_name:keeper_name
+        ~expected_state:Expect_inflight
+        inflight
+    in
+    Ok
+      (List.length awaiting_envelopes
+       + List.length pending_envelopes
+       + List.length inflight_envelopes)
+;;
+
+let directory_exists path =
+  let* exists = file_exists path in
+  if not exists
+  then Ok false
+  else
+    let* is_directory =
+      protect_io Inspect path (fun () ->
+        (Unix.lstat path).Unix.st_kind = Unix.S_DIR)
+    in
+    if is_directory
+    then Ok true
+    else
+      Error
+        (Io_error
+           { operation = Inspect
+           ; path
+           ; detail = "expected a directory but found a non-directory entry"
+           })
+;;
+
+let discover_keeper_names ~base_path =
+  let root = Common.keepers_runtime_dir_of_base ~base_path in
+  let* root_exists = directory_exists root in
+  if not root_exists
+  then Ok ([], [])
+  else
+    let* entries =
+      protect_io List_directory root (fun () -> Sys.readdir root |> Array.to_list)
+    in
+    let rec loop keepers errors = function
+      | [] ->
+        Ok
+          ( List.sort_uniq String.compare keepers
+          , List.rev errors )
+      | keeper_name :: rest ->
+        if not (keeper_name_is_valid keeper_name)
+        then loop keepers (Invalid_keeper_name keeper_name :: errors) rest
+        else
+          let keeper_dir = Filename.concat root keeper_name in
+          let jobs_dir = keeper_jobs_dir ~base_path ~keeper_name in
+          (match directory_exists keeper_dir with
+           | Error error -> loop keepers (error :: errors) rest
+           | Ok false -> loop keepers errors rest
+           | Ok true ->
+             (match directory_exists jobs_dir with
+              | Error error -> loop keepers (error :: errors) rest
+              | Ok false -> loop keepers errors rest
+              | Ok true ->
+                (match backlog_count ~base_path ~keeper_name with
+                 | Error error -> loop keepers (error :: errors) rest
+                 | Ok count ->
+                   loop
+                     (if count > 0 then keeper_name :: keepers else keepers)
+                     errors
+                     rest)))
+    in
+    loop [] [] entries
+;;
+
+module For_testing = struct
+  let awaiting_dir = awaiting_dir
+  let pending_dir = pending_dir
+  let inflight_dir = inflight_dir
+  let receipts_dir = receipts_dir
+  let receipt_path = receipt_path
+end

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,6 +1,9 @@
 (** Durable per-keeper post-turn memory jobs.
 
-    The store is rooted exclusively from [base_path]. A job moves through
+    The store is rooted exclusively from [base_path], which must be an existing
+    real directory. Every managed descendant component from the MASC directory
+    through the per-keeper queues is created one segment at a time and checked
+    with [lstat]; symlink and non-directory components fail explicitly. A job moves through
     [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
     execution receipt gates the first transition; the terminal memory receipt
     gates acknowledgement. Recovery requeues only inflight jobs that have no

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -130,6 +130,7 @@ type recovery_report =
 type claim_report =
   { leases : lease list
   ; cleanup_errors : error list
+  ; blocked : error option
   }
 
 val error_to_string : error -> string
@@ -187,7 +188,9 @@ val recover_inflight :
 val claim_all :
   base_path:string -> keeper_name:string -> now:float -> (claim_report, error) result
 (** Claim the current pending batch with one validated scan and one sort. The
-    returned leases preserve the keeper's linear turn order. *)
+    returned leases preserve the keeper's linear turn order. A transition error
+    after earlier claims is returned in [blocked] alongside those leases, so no
+    inflight work loses its owner. Pre-scan failures still return [Error]. *)
 
 val finish :
   base_path:string -> terminal_receipt -> (cleanup_report, error) result

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,0 +1,224 @@
+(** Durable per-keeper post-turn memory jobs.
+
+    The store is rooted exclusively from [base_path]. A job moves through
+    [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
+    execution receipt gates the first transition; the terminal memory receipt
+    gates acknowledgement. Recovery requeues only inflight jobs that have no
+    terminal memory receipt.
+    Operations are blocking Unix transactions. Eio callers must run the whole
+    transaction outside the scheduler domain and serialize access for one
+    keeper; files are still written atomically so process crashes cannot expose
+    partial JSON. *)
+
+type job = private
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload : Yojson.Safe.t
+  }
+
+type lease = private
+  { job : job
+  ; started_at : float
+  }
+
+type admission =
+  | Staged_awaiting_turn_commit
+  | Already_awaiting
+  | Already_pending
+  | Already_inflight
+  | Already_completed
+
+type activation =
+  | Activated
+  | Activation_already_pending
+  | Activation_already_inflight
+  | Activation_already_completed
+
+type terminal_outcome =
+  | Succeeded
+  | Failed
+
+type receipt_identity = private
+  { id : string
+  ; keeper_name : string
+  ; trace_id : string
+  ; generation : int
+  ; turn : int
+  ; oas_turn_count : int
+  ; enqueued_at : float
+  ; payload_sha256 : string
+  }
+
+type terminal_receipt = private
+  { identity : receipt_identity
+  ; started_at : float
+  ; ended_at : float
+  ; outcome : terminal_outcome
+  ; detail : Yojson.Safe.t
+  }
+
+type io_operation =
+  | Ensure_directory
+  | Set_permissions
+  | Sync
+  | Inspect
+  | List_directory
+  | Read
+  | Write
+  | Remove
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_turn_identity of
+      { generation : int
+      ; turn : int
+      ; oas_turn_count : int
+      }
+  | Invalid_enqueue_time of float
+  | Invalid_claim_time of float
+  | Invalid_json_value of string
+  | Invalid_terminal_timestamps of
+      { started_at : float
+      ; ended_at : float
+      }
+  | Invalid_job_id of string
+  | Missing_inflight_lease of
+      { job_id : string
+      ; path : string
+      }
+  | Inflight_lease_conflict of
+      { job_id : string
+      ; path : string
+      ; expected_started_at : float
+      ; actual_started_at : float
+      }
+  | Pending_already_inflight of
+      { job_id : string
+      ; pending_path : string
+      ; inflight_path : string
+      }
+  | Unexpected_queue_entry of string
+  | Decode_error of
+      { path : string
+      ; detail : string
+      }
+  | Identity_conflict of
+      { job_id : string
+      ; path : string
+      }
+  | Io_error of
+      { operation : io_operation
+      ; path : string
+      ; detail : string
+      }
+
+type cleanup_report =
+  { cleanup_errors : error list
+  }
+
+type recovery_report =
+  { replayed : int
+  ; cleanup_errors : error list
+  }
+
+type claim_report =
+  { leases : lease list
+  ; cleanup_errors : error list
+  }
+
+val error_to_string : error -> string
+val is_valid_job_id : string -> bool
+
+val make_job :
+  keeper_name:string ->
+  trace_id:string ->
+  generation:int ->
+  turn:int ->
+  oas_turn_count:int ->
+  enqueued_at:float ->
+  payload:Yojson.Safe.t ->
+  (job, error) result
+(** Construct a job with a deterministic full SHA-256 id over its typed turn
+    identity. Re-admitting the same turn is therefore idempotent. *)
+
+val job_to_json : job -> Yojson.Safe.t
+val job_of_json : Yojson.Safe.t -> (job, string) result
+val receipt_identity_of_job : job -> receipt_identity
+val make_terminal_receipt :
+  lease ->
+  ended_at:float ->
+  outcome:terminal_outcome ->
+  detail:Yojson.Safe.t ->
+  (terminal_receipt, error) result
+(** Build completion evidence from the opaque lease returned by {!claim_all}.
+    A staged or pending job cannot mint terminal authority. *)
+val receipt_to_json : terminal_receipt -> Yojson.Safe.t
+val receipt_of_json : Yojson.Safe.t -> (terminal_receipt, string) result
+
+val stage_awaiting_turn_commit :
+  base_path:string -> job -> (admission, error) result
+(** Persist the job in a non-runnable outbox before returning. It cannot be
+    claimed until {!activate} runs after the owning execution receipt commits. *)
+
+val list_awaiting :
+  base_path:string -> keeper_name:string -> (job list, error) result
+
+val activate :
+  base_path:string -> job -> (activation * cleanup_report, error) result
+(** Durably move an awaiting job into [pending]. Writing [pending] is the
+    activation commit; failure to remove the old awaiting envelope is reported
+    as cleanup debt and cannot block the runnable lane. *)
+
+val abort_awaiting : base_path:string -> job -> (unit, error) result
+(** Remove a non-runnable job when its owning execution receipt failed. *)
+
+val recover_inflight :
+  base_path:string -> keeper_name:string -> (recovery_report, error) result
+(** Move every receipt-less inflight job back to pending. Inflight jobs with a
+    terminal receipt are acknowledged without replay. Cleanup failures are
+    returned as debt and never stop recovery of later jobs. *)
+
+val claim_all :
+  base_path:string -> keeper_name:string -> now:float -> (claim_report, error) result
+(** Claim the current pending batch with one validated scan and one sort. The
+    returned leases preserve the keeper's linear turn order. *)
+
+val finish :
+  base_path:string -> terminal_receipt -> (cleanup_report, error) result
+(** Atomically persist the terminal receipt before acknowledging queue/stage
+    files. The first commit requires the matching inflight lease and timestamp;
+    repeating [finish] for an already-committed identical receipt is idempotent.
+    Post-commit cleanup errors are returned as debt, not as commit failure. *)
+
+val backlog_count :
+  base_path:string -> keeper_name:string -> (int, error) result
+
+val discover_keeper_names :
+  base_path:string -> (string list * error list, error) result
+(** Discover keeper directories with awaiting, pending, or inflight memory jobs. A
+    keeper-local malformed queue is returned in the error list without
+    suppressing healthy keepers; an outer [Error] means the keepers root itself
+    could not be inspected. *)
+
+val operation_stage_path_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_name:string ->
+  operation_id:string ->
+  (string, error) result
+(** SSOT path for a provider result staged until its memory-job terminal receipt
+    is durable. Both keeper and operation coordinates are validated before the
+    path is returned. *)
+
+module For_testing : sig
+  val awaiting_dir : base_path:string -> keeper_name:string -> string
+  val pending_dir : base_path:string -> keeper_name:string -> string
+  val inflight_dir : base_path:string -> keeper_name:string -> string
+  val receipts_dir : base_path:string -> keeper_name:string -> string
+  val receipt_path : base_path:string -> job -> string
+end

--- a/lib/keeper/keeper_memory_job_store.mli
+++ b/lib/keeper/keeper_memory_job_store.mli
@@ -1,9 +1,13 @@
 (** Durable per-keeper post-turn memory jobs.
 
     The store is rooted exclusively from [base_path], which must be an existing
-    real directory. Every managed descendant component from the MASC directory
-    through the per-keeper queues is created one segment at a time and checked
-    with [lstat]; symlink and non-directory components fail explicitly. A job moves through
+    trusted real directory supplied by the BasePath SSOT. Every managed
+    descendant is a typed single segment opened relative to a directory file
+    descriptor with [O_NOFOLLOW]; symlink and non-directory components fail
+    explicitly. Ancestor descriptors are closed while walking, and queue
+    transactions retain only the [memory-jobs] leaf plus the queue descriptors
+    needed by that transaction. Diagnostic absolute paths are never syscall
+    authority. A job moves through
     [awaiting-turn-commit -> pending -> inflight -> terminal receipt]. The
     execution receipt gates the first transition; the terminal memory receipt
     gates acknowledgement. Recovery requeues only inflight jobs that have no

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -68,7 +68,9 @@ let with_facts_lock ?clock ~keeper_id f =
   Io.with_facts_lock
     ?clock
     ~keeper_id
-    ~on_timeout:(fun msg -> Transport_failed ("consolidation " ^ msg))
+    ~on_timeout:(fun timeout ->
+      Transport_failed
+        ("consolidation " ^ Io.lock_timeout_to_string timeout))
     f
 ;;
 
@@ -121,15 +123,15 @@ let messages_for_consolidation facts =
 ;;
 
 let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~after () =
-  with_facts_lock ?clock ~keeper_id (fun () ->
-    match Io.read_facts_all_strict ~keeper_id with
+  with_facts_lock ?clock ~keeper_id (fun lock ->
+    match Io.read_facts_all_strict_in_lock lock with
     | Error msg ->
       Unparseable ("consolidation fact store changed before rewrite: " ^ msg)
     | Ok current ->
       if not (Io.same_fact_snapshot facts current)
       then Snapshot_changed { before; current = List.length current }
       else (
-        Io.rewrite_facts_atomically ~keeper_id survivors;
+        Io.rewrite_facts_in_lock lock survivors;
         Consolidated { before; after }))
 ;;
 

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -118,84 +118,68 @@ let dedup_by_claim items =
    value is not a number GC can threshold. Forgetting is the librarian's
    delete-on-contradiction judgment plus this structural TTL, not a low score. *)
 let run_gc_with_store
-      ~facts_path
       ~read_facts_all_strict
       ~rewrite_facts_atomically
       ?(dry_run = false)
-      ~keeper_id
       ~now
       ()
   =
-  (* Serialize the whole read-modify-rewrite on the same per-keeper facts lock the
-     librarian write path (Keeper_librarian_runtime, wrapping merge_and_cap_facts)
-     and the consolidation runtime already hold on facts_path. Without it, a
-     librarian merge that commits between GC's read and GC's rewrite is silently
-     overwritten — a lost update that permanently drops a freshly persisted fact.
-     The lock spans both the read and the rewrite, so no concurrent writer can
-     interleave; because the read-modify-rewrite is entirely inside the lock there
-     is no unlocked gap to guard with a snapshot CAS (unlike
-     Keeper_memory_os_consolidation_runtime, whose LLM call runs between its read
-     and rewrite and so re-validates the snapshot under the lock). No clock is
-     threaded: lock-retry sleeps run on a systhread (off the keeper hot path, GC
-     is a 600s maintenance sweep, so cooperative yielding buys nothing), and
-     File_lock_eio already offloads the blocking flock so the Eio domain is not
-     stalled. Must run inside an Eio context (the maintenance fiber and tests
-     both are). *)
-  File_lock_eio.with_lock facts_path (fun () ->
-    (* Read strictly: a malformed JSONL row aborts the sweep rather than being
-       silently dropped by the lenient decoder and then erased by the rewrite
-       below. Every other destructive rewrite path already refuses to overwrite a
-       store it cannot fully parse — cap_facts / merge_and_cap_facts via
-       read_facts_for_rewrite, the consolidator and consolidation runtime via
-       read_facts_all_strict. GC was the lone path that turned one corrupt line
-       into permanent deletion of the surrounding facts (it read via the lenient
-       read_facts_all). Preserve over delete: leave a corrupt store untouched and
-       let the raised error surface so an operator can repair it. *)
-    match read_facts_all_strict () with
-    | Error message ->
-      raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
-    | Ok facts ->
-      let indexed = List.mapi (fun index fact -> { index; fact }) facts in
-      let live, expired =
-        List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
-      in
-      let ttl_expired_ephemeral, ttl_expired_non_ephemeral, ttl_expired_by_category =
-        expired_category_counts expired
-      in
-      let deduped = dedup_by_claim live in
-      let survivors = List.map (fun item -> item.fact) deduped in
-      if not dry_run then rewrite_facts_atomically survivors;
-      { total_input = List.length facts
-      ; ttl_expired = List.length expired
-      ; ttl_expired_ephemeral
-      ; ttl_expired_non_ephemeral
-      ; ttl_expired_by_category
-      ; dedup_removed = List.length live - List.length deduped
-      ; written = List.length survivors
-      ; dry_run
-      })
+  (* The caller holds the descriptor-anchored facts capability across this
+     strict read-modify-rewrite. A malformed row aborts before rewrite, so GC
+     never turns decoder tolerance into permanent data loss. *)
+  match read_facts_all_strict () with
+  | Error message ->
+    raise (Fact_store_corrupt ("memory os gc fact store read failed: " ^ message))
+  | Ok facts ->
+    let indexed = List.mapi (fun index fact -> { index; fact }) facts in
+    let live, expired =
+      List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
+    in
+    let ttl_expired_ephemeral, ttl_expired_non_ephemeral, ttl_expired_by_category =
+      expired_category_counts expired
+    in
+    let deduped = dedup_by_claim live in
+    let survivors = List.map (fun item -> item.fact) deduped in
+    if not dry_run then rewrite_facts_atomically survivors;
+    { total_input = List.length facts
+    ; ttl_expired = List.length expired
+    ; ttl_expired_ephemeral
+    ; ttl_expired_non_ephemeral
+    ; ttl_expired_by_category
+    ; dedup_removed = List.length live - List.length deduped
+    ; written = List.length survivors
+    ; dry_run
+    }
 ;;
 
 let run_gc ?dry_run ~keeper_id ~now () =
-  run_gc_with_store
-    ~facts_path:(Io.facts_path ~keeper_id)
-    ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict ~keeper_id)
-    ~rewrite_facts_atomically:(fun facts -> Io.rewrite_facts_atomically ~keeper_id facts)
-    ?dry_run
+  Io.with_facts_lock
     ~keeper_id
-    ~now
-    ()
+    ~on_timeout:Io.raise_lock_timeout
+    (fun lock ->
+      run_gc_with_store
+        ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict_in_lock lock)
+        ~rewrite_facts_atomically:(Io.rewrite_facts_in_lock lock)
+        ?dry_run
+        ~now
+        ())
 ;;
 
 let run_gc_for_keepers_dir ~keepers_dir ?dry_run ~keeper_id ~now () =
-  run_gc_with_store
-    ~facts_path:(Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~read_facts_all_strict:(fun () ->
-      Io.read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~rewrite_facts_atomically:(fun facts ->
-      Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts)
-    ?dry_run
-    ~keeper_id
-    ~now
-    ()
+  let keeper_name =
+    match Keeper_id.Keeper_name.of_string keeper_id with
+    | Ok keeper_name -> keeper_name
+    | Error detail -> invalid_arg detail
+  in
+  Io.with_facts_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:keeper_name
+    ~on_timeout:Io.raise_lock_timeout
+    (fun lock ->
+      run_gc_with_store
+        ~read_facts_all_strict:(fun () -> Io.read_facts_all_strict_in_lock lock)
+        ~rewrite_facts_atomically:(Io.rewrite_facts_in_lock lock)
+        ?dry_run
+        ~now
+        ())
 ;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -139,14 +139,12 @@ let with_descriptor_lock ?clock root name f =
   let diagnostic_path =
     Filename.concat root.path (Anchored.Segment.to_string name)
   in
-  File_lock_eio.with_lock_file
+  File_lock_eio.with_anchored_file_lock
     ?clock
     ~path:diagnostic_path
-    ~open_file:(fun () ->
-      Anchored.open_lock_file root.handle ~name ~perm:0o644)
-    ~descriptor:Anchored.lock_file_descriptor
-    ~identity:Anchored.lock_file_identity
-    ~close_file:Anchored.close_lock_file
+    ~directory:root.handle
+    ~name
+    ~perm:0o644
     f
 ;;
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,12 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let ensure_configured_keepers_dir () =
+  let path = keepers_dir () in
+  ensure_dir path;
+  path
+;;
+
 let keeper_name_exn raw =
   match Keeper_id.Keeper_name.of_string raw with
   | Ok keeper_name -> keeper_name
@@ -38,6 +44,70 @@ let keeper_name_exn raw =
 ;;
 
 let keeper_name_string = Keeper_id.Keeper_name.to_string
+
+let trace_id_exn raw =
+  match Keeper_id.Trace_id.of_string raw with
+  | Ok trace_id -> trace_id
+  | Error detail -> invalid_arg detail
+;;
+
+let trace_id_string = Keeper_id.Trace_id.to_string
+
+let lstat_if_present path =
+  try Some (Unix.lstat path) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+;;
+
+let require_real_directory path =
+  match lstat_if_present path with
+  | Some stat when stat.Unix.st_kind = Unix.S_DIR -> ()
+  | Some _ ->
+    invalid_arg (Printf.sprintf "expected a real directory, found another file kind: %s" path)
+  | None -> invalid_arg (Printf.sprintf "required directory does not exist: %s" path)
+;;
+
+let require_regular_file_or_missing path =
+  match lstat_if_present path with
+  | None -> ()
+  | Some stat when stat.Unix.st_kind = Unix.S_REG -> ()
+  | Some _ ->
+    invalid_arg
+      (Printf.sprintf "expected a regular file or missing path: %s" path)
+;;
+
+let fsync_directory_exn path =
+  match Fs_compat.fsync_directory path with
+  | Ok () -> ()
+  | Error detail -> raise (Sys_error detail)
+;;
+
+let ensure_real_child_directory ~parent ~child_name =
+  require_real_directory parent;
+  let child = Filename.concat parent child_name in
+  let created =
+    match lstat_if_present child with
+    | Some stat when stat.Unix.st_kind = Unix.S_DIR -> false
+    | Some _ ->
+      invalid_arg
+        (Printf.sprintf
+           "expected a real directory, found another file kind: %s"
+           child)
+    | None ->
+      (try
+         Unix.mkdir child 0o755;
+         true
+       with
+       | Unix.Unix_error (Unix.EEXIST, _, _) -> false)
+  in
+  require_real_directory parent;
+  require_real_directory child;
+  if created then fsync_directory_exn parent;
+  child
+;;
+
+let validate_lock_target base_path =
+  require_regular_file_or_missing (base_path ^ ".lock")
+;;
 
 module For_testing = struct
   let with_keepers_dir path f =
@@ -126,33 +196,79 @@ let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
 ;;
 
 let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  File_lock_eio.with_lock
-    ?clock
-    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    f
+  require_real_directory keepers_dir;
+  let lock_base =
+    episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id
+  in
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
   with_episode_bundle_lock_for_keepers_dir
     ?clock
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     f
 ;;
 
+let facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  facts_path_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:(keeper_name_string keeper_id)
+;;
+
+let with_facts_lock_unhandled_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  require_real_directory keepers_dir;
+  let lock_base = facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing lock_base;
+  validate_lock_target lock_base;
+  File_lock_eio.with_lock ?clock lock_base f
+;;
+
+let with_facts_lock_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      ~on_timeout
+      f
+  =
+  try
+    with_facts_lock_unhandled_for_keepers_dir
+      ?clock
+      ~keepers_dir
+      ~keeper_id
+      f
+  with
+  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
+    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+;;
+
+let with_facts_lock ?clock ~keeper_id ~on_timeout f =
+  with_facts_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~on_timeout
+    f
+;;
+
+let episodes_directory_name = "episodes"
+
 let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
-  let d =
-    Filename.concat
-      keepers_dir
-      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  let keeper_dir =
+    ensure_real_child_directory
+      ~parent:keepers_dir
+      ~child_name:(keeper_name_string keeper_id)
   in
-  ensure_dir d;
-  d
+  ensure_real_child_directory
+    ~parent:keeper_dir
+    ~child_name:episodes_directory_name
 ;;
 
 let episodes_dir ~keeper_id =
   episodes_dir_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -167,9 +283,10 @@ let tool_result_path ~keeper_id ~tool_call_id =
 ;;
 
 let episode_path ~keeper_id ~trace_id ~generation =
+  let trace_id = trace_id_exn trace_id in
   Filename.concat
     (episodes_dir ~keeper_id)
-    (Printf.sprintf "%s-g%04d.json" trace_id generation)
+    (Printf.sprintf "%s-g%04d.json" (trace_id_string trace_id) generation)
 ;;
 
 (* Raised when a durable atomic write fails. Distinct from [Failure] so the
@@ -211,15 +328,23 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
+let write_file_atomically_in_real_directory path content =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> raise (Atomic_write_failed msg)
+;;
+
 let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   Filename.concat
     (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
-    (Printf.sprintf "%s.generation" trace_id)
+    (Printf.sprintf "%s.generation" (trace_id_string trace_id))
 ;;
 
 let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
   let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
-  let prefix = Printf.sprintf "%s-g" trace_id in
+  let prefix = Printf.sprintf "%s-g" (trace_id_string trace_id) in
   Sys.readdir dir
   |> Array.to_list
   |> List.filter_map (fun name ->
@@ -232,15 +357,16 @@ let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id 
 ;;
 
 let read_generation_counter path =
-  if not (Sys.file_exists path)
-  then None
-  else (
+  require_regular_file_or_missing path;
+  match lstat_if_present path with
+  | None -> None
+  | Some _ ->
     let ic = open_in_bin path in
     Fun.protect
       ~finally:(fun () -> close_in_noerr ic)
       (fun () ->
-         let len = in_channel_length ic in
-         really_input_string ic len |> String.trim |> int_of_string_opt))
+        let len = in_channel_length ic in
+        really_input_string ic len |> String.trim |> int_of_string_opt)
 ;;
 
 (** Compute the next generation number for a trace's episode files.
@@ -259,6 +385,8 @@ let next_generation_with_floor_for_keepers_dir
   let counter_path =
     generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
   in
+  require_regular_file_or_missing counter_path;
+  validate_lock_target counter_path;
   File_lock_eio.with_lock counter_path (fun () ->
     let next_from_files =
       max_generation_from_files_for_keepers_dir
@@ -273,23 +401,30 @@ let next_generation_with_floor_for_keepers_dir
       | None -> 0
     in
     let generation = max floor (max next_from_files next_from_counter) in
-    write_file_atomically counter_path (Printf.sprintf "%d\n" (generation + 1));
+    write_file_atomically_in_real_directory
+      counter_path
+      (Printf.sprintf "%d\n" (generation + 1));
     generation)
 ;;
 
 let next_generation_with_floor ~floor ~keeper_id ~trace_id =
   next_generation_with_floor_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~floor
     ~keeper_id:(keeper_name_exn keeper_id)
-    ~trace_id
+    ~trace_id:(trace_id_exn trace_id)
 ;;
 
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
+let unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
@@ -298,7 +433,7 @@ let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
       (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
-         episode.trace_id
+         (trace_id_string trace_id)
          episode.generation
          created_ms)
   in
@@ -324,12 +459,22 @@ let append_json path json =
   append_line path (Yojson.Safe.to_string json)
 ;;
 
+let append_json_no_follow path json =
+  require_real_directory (Filename.dirname path);
+  require_regular_file_or_missing path;
+  Fs_compat.append_file_durable_no_follow
+    path
+    (Yojson.Safe.to_string json ^ "\n")
+;;
+
 let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
 let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  append_json
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  require_real_directory keepers_dir;
+  append_json_no_follow
     (events_path_for_keepers_dir
        ~keepers_dir
        ~keeper_id:(keeper_name_string keeper_id))
@@ -338,40 +483,53 @@ let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
 
 let append_event ~keeper_id episode =
   append_event_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  let trace_id = trace_id_exn episode.trace_id in
+  let path =
+    unique_episode_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id
+      ~trace_id
+      episode
+  in
+  write_file_atomically_in_real_directory
+    path
+    (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
   append_episode_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
   with_episode_bundle_lock ~keeper_id (fun () ->
-    File_lock_eio.with_lock (facts_path ~keeper_id) (fun () ->
-      List.iter (append_fact ~keeper_id) episode.claims);
+    with_facts_lock_unhandled_for_keepers_dir
+      ~keepers_dir:(ensure_configured_keepers_dir ())
+      ~keeper_id:(keeper_name_exn keeper_id)
+      (fun () -> List.iter (append_fact ~keeper_id) episode.claims);
     append_episode ~keeper_id episode;
     append_event ~keeper_id episode)
 ;;
 
 let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_real_directory keepers_dir;
+  require_regular_file_or_missing path;
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
     |> String.concat "\n"
   in
   let content = if String.equal content "" then "" else content ^ "\n" in
-  write_file_atomically path content
+  write_file_atomically_in_real_directory path content
 ;;
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
@@ -382,7 +540,10 @@ let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
 ;;
 
 let rewrite_facts_atomically ~keeper_id facts =
-  rewrite_facts_atomically_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id facts
+  rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
+    facts
 ;;
 
 (* ---------- Facts snapshot CAS (optimistic concurrency) ---------- *)
@@ -407,19 +568,6 @@ let rec same_fact_snapshot left right =
   | l :: ls, r :: rs ->
     String.equal (fact_fingerprint l) (fact_fingerprint r) && same_fact_snapshot ls rs
   | [], _ :: _ | _ :: _, [] -> false
-;;
-
-(* Run [f] holding the per-keeper facts lock. On lock-acquisition timeout (another
-   writer holds the flock past the retry budget) [on_timeout msg] decides the
-   caller's result rather than letting [Flock_timeout] escape — callers that want a
-   typed skip/no-op outcome pass it here instead of catching the exception
-   themselves. Non-timeout body exceptions propagate after the lock finalizer runs.
-   Keep [on_timeout] total and non-raising so timeout remains a typed outcome, not
-   a second failure path. *)
-let with_facts_lock ?clock ~keeper_id ~on_timeout f =
-  try File_lock_eio.with_lock ?clock (facts_path ~keeper_id) f with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
 ;;
 
 let save_tool_result ~keeper_id ~tool_call_id json =
@@ -534,17 +682,18 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_lines_all (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  |> List.filter_map (parse_json_line fact_of_json)
-;;
-
-let read_facts_all ~keeper_id =
-  read_facts_all_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+let validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  require_real_directory keepers_dir;
   let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  require_regular_file_or_missing path;
+  path
+;;
+
+let read_facts_all_at_path path =
+  read_lines_all path |> List.filter_map (parse_json_line fact_of_json)
+;;
+
+let read_facts_all_strict_at_path path =
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
@@ -554,18 +703,38 @@ let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
   loop 1 [] (read_lines_all path)
 ;;
 
-let read_facts_all_strict ~keeper_id =
-  read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
-;;
-
-let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
-  read_lines_tail (facts_path_for_keepers_dir ~keepers_dir ~keeper_id) ~n
+let read_facts_tail_at_path path ~n =
+  read_lines_tail path ~n
   |> List.filter_map (parse_json_line fact_of_json)
   |> take_last n
 ;;
 
+let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all ~keeper_id =
+  read_facts_all_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
+  read_facts_all_strict_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+;;
+
+let read_facts_all_strict ~keeper_id =
+  read_facts_all_strict_at_path (facts_path ~keeper_id)
+;;
+
+let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
+  read_facts_tail_at_path
+    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    ~n
+;;
+
 let read_facts_tail ~keeper_id ~n =
-  read_facts_tail_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id ~n
+  read_facts_tail_at_path (facts_path ~keeper_id) ~n
 ;;
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
@@ -628,7 +797,7 @@ let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
 
 let read_facts_for_rewrite ~keeper_id =
   read_facts_for_rewrite_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
@@ -773,7 +942,7 @@ let merge_and_cap_facts
       ~rank
   =
   merge_and_cap_facts_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~now
     ~keeper_id:(keeper_name_exn keeper_id)
     ~merge
@@ -847,11 +1016,13 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
 let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  require_real_directory keepers_dir;
   let path =
     events_path_for_keepers_dir
       ~keepers_dir
       ~keeper_id:(keeper_name_string keeper_id)
   in
+  require_regular_file_or_missing path;
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -867,13 +1038,13 @@ let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
       | [] -> ""
       | _ -> String.concat "\n" kept ^ "\n"
     in
-    write_file_atomically path content;
+    write_file_atomically_in_real_directory path content;
     List.length all - List.length kept
 ;;
 
 let cap_events ~keeper_id ~keep ~trigger =
   cap_events_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger
@@ -919,7 +1090,7 @@ let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
 
 let cap_episode_files ~keeper_id ~keep ~trigger =
   cap_episode_files_for_keepers_dir
-    ~keepers_dir:(keepers_dir ())
+    ~keepers_dir:(ensure_configured_keepers_dir ())
     ~keeper_id:(keeper_name_exn keeper_id)
     ~keep
     ~trigger

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -53,60 +53,101 @@ let trace_id_exn raw =
 
 let trace_id_string = Keeper_id.Trace_id.to_string
 
-let lstat_if_present path =
-  try Some (Unix.lstat path) with
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> None
+module Anchored = Fs_compat.Anchored_dir
+
+type root =
+  { handle : Anchored.t
+  ; path : string
+  }
+
+type keeper_scope =
+  { root : root
+  ; keeper_id : Keeper_id.Keeper_name.t
+  ; keeper_name : string
+  }
+
+type episode_bundle = Episode_bundle of keeper_scope
+type facts_lock = Facts_lock of keeper_scope
+
+type lock_timeout =
+  { caller : string
+  ; path : string
+  ; attempts : int
+  }
+
+let lock_timeout_to_string timeout =
+  Printf.sprintf
+    "lock timeout: caller=%s path=%s attempts=%d"
+    timeout.caller
+    timeout.path
+    timeout.attempts
 ;;
 
-let require_real_directory path =
-  match lstat_if_present path with
-  | Some stat when stat.Unix.st_kind = Unix.S_DIR -> ()
-  | Some _ ->
-    invalid_arg (Printf.sprintf "expected a real directory, found another file kind: %s" path)
-  | None -> invalid_arg (Printf.sprintf "required directory does not exist: %s" path)
+let raise_lock_timeout timeout =
+  raise
+    (File_lock_eio.Flock_timeout
+       { caller = timeout.caller
+       ; path = timeout.path
+       ; attempts = timeout.attempts
+       })
 ;;
 
-let require_regular_file_or_missing path =
-  match lstat_if_present path with
-  | None -> ()
-  | Some stat when stat.Unix.st_kind = Unix.S_REG -> ()
-  | Some _ ->
+let segment_exn ~context raw =
+  match Anchored.Segment.of_string raw with
+  | Ok segment -> segment
+  | Error error ->
     invalid_arg
-      (Printf.sprintf "expected a regular file or missing path: %s" path)
+      (Printf.sprintf
+         "%s %S is not one filesystem segment: %s"
+         context
+         raw
+         (Anchored.Segment.error_to_string error))
 ;;
 
-let fsync_directory_exn path =
-  match Fs_compat.fsync_directory path with
-  | Ok () -> ()
-  | Error detail -> raise (Sys_error detail)
+let with_root path f =
+  Anchored.with_open_root path @@ fun handle ->
+  f { handle; path }
 ;;
 
-let ensure_real_child_directory ~parent ~child_name =
-  require_real_directory parent;
-  let child = Filename.concat parent child_name in
-  let created =
-    match lstat_if_present child with
-    | Some stat when stat.Unix.st_kind = Unix.S_DIR -> false
-    | Some _ ->
-      invalid_arg
-        (Printf.sprintf
-           "expected a real directory, found another file kind: %s"
-           child)
-    | None ->
-      (try
-         Unix.mkdir child 0o755;
-         true
-       with
-       | Unix.Unix_error (Unix.EEXIST, _, _) -> false)
+let scope root keeper_id =
+  { root; keeper_id; keeper_name = keeper_name_string keeper_id }
+;;
+
+let facts_suffix = ".facts.jsonl"
+let events_suffix = ".events.jsonl"
+let lock_suffix = ".lock"
+let episode_bundle_lock_suffix = ".episode-bundle.lock"
+
+let keeper_artifact_name ~suffix keeper_id =
+  segment_exn
+    ~context:"keeper memory artifact"
+    (keeper_name_string keeper_id ^ suffix)
+;;
+
+let facts_name keeper_id = keeper_artifact_name ~suffix:facts_suffix keeper_id
+let events_name keeper_id = keeper_artifact_name ~suffix:events_suffix keeper_id
+
+let facts_lock_name keeper_id =
+  keeper_artifact_name ~suffix:(facts_suffix ^ lock_suffix) keeper_id
+;;
+
+let episode_bundle_lock_name keeper_id =
+  keeper_artifact_name ~suffix:episode_bundle_lock_suffix keeper_id
+;;
+
+let with_descriptor_lock ?clock root name f =
+  let diagnostic_path =
+    Filename.concat root.path (Anchored.Segment.to_string name)
   in
-  require_real_directory parent;
-  require_real_directory child;
-  if created then fsync_directory_exn parent;
-  child
-;;
-
-let validate_lock_target base_path =
-  require_regular_file_or_missing (base_path ^ ".lock")
+  File_lock_eio.with_lock_file
+    ?clock
+    ~path:diagnostic_path
+    ~open_file:(fun () ->
+      Anchored.open_lock_file root.handle ~name ~perm:0o644)
+    ~descriptor:Anchored.lock_file_descriptor
+    ~identity:Anchored.lock_file_identity
+    ~close_file:Anchored.close_lock_file
+    f
 ;;
 
 module For_testing = struct
@@ -121,7 +162,7 @@ module For_testing = struct
 end
 
 let facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".facts.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ facts_suffix)
 ;;
 
 let facts_path ~keeper_id =
@@ -135,17 +176,22 @@ let facts_path ~keeper_id =
    sweep's output is never folded back in as a source keeper. Sorted for
    deterministic sweep order. *)
 let list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir =
-  let dir = keepers_dir in
-  if not (Sys.file_exists dir && Sys.is_directory dir)
-  then []
-  else
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter_map (fun name ->
-      match Filename.chop_suffix_opt ~suffix:".facts.jsonl" name with
-      | Some id when not (String.equal id shared_store_id) -> Some id
-      | Some _ | None -> None)
-    |> List.sort String.compare
+  match
+    with_root keepers_dir (fun root ->
+      Anchored.read_dir root.handle
+      |> List.filter_map (fun entry ->
+        let name = Anchored.Segment.to_string entry in
+        match Filename.chop_suffix_opt ~suffix:facts_suffix name with
+        | Some id when String.equal id shared_store_id -> None
+        | Some id ->
+          (match Keeper_id.Keeper_name.of_string id with
+           | Ok keeper_id -> Some (keeper_name_string keeper_id)
+           | Error detail -> invalid_arg detail)
+        | None -> None)
+      |> List.sort String.compare)
+  with
+  | ids -> ids
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> []
 ;;
 
 let list_fact_store_keeper_ids () =
@@ -158,7 +204,7 @@ let list_fact_store_keeper_ids_for_base_path ~base_path =
 ;;
 
 let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
+  Filename.concat keepers_dir (keeper_id ^ events_suffix)
 ;;
 
 type legacy_memory_file =
@@ -189,19 +235,14 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  Filename.concat
-    keepers_dir
-    (keeper_name_string keeper_id ^ ".episode-bundle")
-;;
-
 let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  require_real_directory keepers_dir;
-  let lock_base =
-    episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id
-  in
-  validate_lock_target lock_base;
-  File_lock_eio.with_lock ?clock lock_base f
+  with_root keepers_dir @@ fun root ->
+  let keeper = scope root keeper_id in
+  with_descriptor_lock
+    ?clock
+    root
+    (episode_bundle_lock_name keeper_id)
+    (fun () -> f (Episode_bundle keeper))
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
@@ -212,18 +253,20 @@ let with_episode_bundle_lock ?clock ~keeper_id f =
     f
 ;;
 
-let facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  facts_path_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id:(keeper_name_string keeper_id)
+let with_facts_lock_scope ?clock keeper f =
+  with_descriptor_lock
+    ?clock
+    keeper.root
+    (facts_lock_name keeper.keeper_id)
+    (fun () -> f (Facts_lock keeper))
 ;;
 
-let with_facts_lock_unhandled_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
-  require_real_directory keepers_dir;
-  let lock_base = facts_lock_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_regular_file_or_missing lock_base;
-  validate_lock_target lock_base;
-  File_lock_eio.with_lock ?clock lock_base f
+let with_facts_lock_scope_or_timeout ?clock keeper ~on_timeout f =
+  try
+    with_facts_lock_scope ?clock keeper f
+  with
+  | File_lock_eio.Flock_timeout { caller; path; attempts } ->
+    on_timeout { caller; path; attempts }
 ;;
 
 let with_facts_lock_for_keepers_dir
@@ -233,15 +276,16 @@ let with_facts_lock_for_keepers_dir
       ~on_timeout
       f
   =
-  try
-    with_facts_lock_unhandled_for_keepers_dir
-      ?clock
-      ~keepers_dir
-      ~keeper_id
-      f
-  with
-  | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-    on_timeout (Printf.sprintf "lock timeout: %s after %d attempts" path attempts)
+  with_root keepers_dir @@ fun root ->
+  with_facts_lock_scope_or_timeout
+    ?clock
+    (scope root keeper_id)
+    ~on_timeout
+    f
+;;
+
+let with_facts_lock_in_bundle ?clock (Episode_bundle keeper) ~on_timeout f =
+  with_facts_lock_scope_or_timeout ?clock keeper ~on_timeout f
 ;;
 
 let with_facts_lock ?clock ~keeper_id ~on_timeout f =
@@ -255,15 +299,57 @@ let with_facts_lock ?clock ~keeper_id ~on_timeout f =
 
 let episodes_directory_name = "episodes"
 
-let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
-  let keeper_dir =
-    ensure_real_child_directory
-      ~parent:keepers_dir
-      ~child_name:(keeper_name_string keeper_id)
+let with_episodes_directory keeper f =
+  let keeper_name =
+    segment_exn ~context:"keeper directory" keeper.keeper_name
   in
-  ensure_real_child_directory
-    ~parent:keeper_dir
-    ~child_name:episodes_directory_name
+  let episodes_name =
+    segment_exn ~context:"episodes directory" episodes_directory_name
+  in
+  Anchored.with_ensure_dir
+    keeper.root.handle
+    ~name:keeper_name
+    ~perm:0o755
+    ~enforce_perm:false
+  @@ fun keeper_dir ->
+  Anchored.with_ensure_dir
+    keeper_dir
+    ~name:episodes_name
+    ~perm:0o755
+    ~enforce_perm:false
+    (fun handle ->
+      let path =
+        Filename.concat
+          keeper.root.path
+          (Filename.concat keeper.keeper_name episodes_directory_name)
+      in
+      f { handle; path })
+;;
+
+let with_existing_episodes_directory keeper f =
+  let keeper_name =
+    segment_exn ~context:"keeper directory" keeper.keeper_name
+  in
+  let episodes_name =
+    segment_exn ~context:"episodes directory" episodes_directory_name
+  in
+  match
+    Anchored.with_open_dir_opt keeper.root.handle keeper_name (fun keeper_dir ->
+      Anchored.with_open_dir_opt keeper_dir episodes_name (fun handle ->
+        let path =
+          Filename.concat
+            keeper.root.path
+            (Filename.concat keeper.keeper_name episodes_directory_name)
+        in
+        f { handle; path }))
+  with
+  | None | Some None -> None
+  | Some (Some value) -> Some value
+;;
+
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  with_root keepers_dir @@ fun root ->
+  with_episodes_directory (scope root keeper_id) (fun episodes -> episodes.path)
 ;;
 
 let episodes_dir ~keeper_id =
@@ -328,45 +414,64 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let write_file_atomically_in_real_directory path content =
-  require_real_directory (Filename.dirname path);
-  require_regular_file_or_missing path;
-  match Fs_compat.save_file_atomic path content with
+let atomic_replace directory name content =
+  match Anchored.atomic_replace directory.handle ~name ~perm:0o644 content with
   | Ok () -> ()
-  | Error msg -> raise (Atomic_write_failed msg)
+  | Error error ->
+    let path =
+      Filename.concat directory.path (Anchored.Segment.to_string name)
+    in
+    raise
+      (Atomic_write_failed
+         (Printf.sprintf
+            "%s: %s"
+            path
+            (Anchored.mutation_error_to_string error)))
 ;;
 
-let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
-  Filename.concat
-    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+let generation_counter_name trace_id =
+  segment_exn
+    ~context:"episode generation counter"
     (Printf.sprintf "%s.generation" (trace_id_string trace_id))
 ;;
 
-let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
-  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
+let generation_lock_name trace_id =
+  segment_exn
+    ~context:"episode generation lock"
+    (Printf.sprintf "%s.generation.lock" (trace_id_string trace_id))
+;;
+
+let leading_decimal value =
+  let rec end_index index =
+    if index >= String.length value
+    then index
+    else
+      match value.[index] with
+      | '0' .. '9' -> end_index (index + 1)
+      | _ -> index
+  in
+  match end_index 0 with
+  | 0 -> None
+  | length -> int_of_string_opt (String.sub value 0 length)
+;;
+
+let max_generation_from_files episodes trace_id =
   let prefix = Printf.sprintf "%s-g" (trace_id_string trace_id) in
-  Sys.readdir dir
-  |> Array.to_list
+  Anchored.read_dir episodes.handle
   |> List.filter_map (fun name ->
+    let name = Anchored.Segment.to_string name in
     if String.starts_with ~prefix name then
       let plen = String.length prefix in
       let rest = String.sub name plen (String.length name - plen) in
-      if String.length rest >= 4 then int_of_string_opt (String.sub rest 0 4) else None
+      leading_decimal rest
     else None)
   |> List.fold_left max (-1)
 ;;
 
-let read_generation_counter path =
-  require_regular_file_or_missing path;
-  match lstat_if_present path with
+let read_generation_counter episodes name =
+  match Anchored.read_file_opt episodes.handle name with
   | None -> None
-  | Some _ ->
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let len = in_channel_length ic in
-        really_input_string ic len |> String.trim |> int_of_string_opt)
+  | Some content -> String.trim content |> int_of_string_opt
 ;;
 
 (** Compute the next generation number for a trace's episode files.
@@ -382,29 +487,23 @@ let next_generation_with_floor_for_keepers_dir
       ~keeper_id
       ~trace_id
   =
-  let counter_path =
-    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  with_root keepers_dir @@ fun root ->
+  with_episodes_directory (scope root keeper_id) @@ fun episodes ->
+  let counter_name = generation_counter_name trace_id in
+  with_descriptor_lock episodes (generation_lock_name trace_id)
+  @@ fun () ->
+  let next_from_files = max_generation_from_files episodes trace_id + 1 in
+  let next_from_counter =
+    match read_generation_counter episodes counter_name with
+    | Some next -> next
+    | None -> 0
   in
-  require_regular_file_or_missing counter_path;
-  validate_lock_target counter_path;
-  File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files =
-      max_generation_from_files_for_keepers_dir
-        ~keepers_dir
-        ~keeper_id
-        ~trace_id
-      + 1
-    in
-    let next_from_counter =
-      match read_generation_counter counter_path with
-      | Some next -> next
-      | None -> 0
-    in
-    let generation = max floor (max next_from_files next_from_counter) in
-    write_file_atomically_in_real_directory
-      counter_path
-      (Printf.sprintf "%d\n" (generation + 1));
-    generation)
+  let generation = max floor (max next_from_files next_from_counter) in
+  atomic_replace
+    episodes
+    counter_name
+    (Printf.sprintf "%d\n" (generation + 1));
+  generation
 ;;
 
 let next_generation_with_floor ~floor ~keeper_id ~trace_id =
@@ -419,117 +518,135 @@ let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id
-      ~trace_id
-      episode
-  =
+let unique_episode_name episodes ~trace_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
-    Filename.concat
-      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
-      (Printf.sprintf
-         "%s-g%04d-t%013Ld"
-         (trace_id_string trace_id)
-         episode.generation
-         created_ms)
+    Printf.sprintf
+      "%s-g%04d-t%013Ld"
+      (trace_id_string trace_id)
+      episode.generation
+      created_ms
   in
   let rec loop suffix =
-    let path =
+    let raw =
       if suffix = 0
       then base ^ ".json"
       else Printf.sprintf "%s-%04d.json" base suffix
     in
-    if Sys.file_exists path then loop (suffix + 1) else path
+    let name = segment_exn ~context:"episode artifact" raw in
+    match Anchored.stat episodes.handle name with
+    | Some _ -> loop (suffix + 1)
+    | None -> name
   in
   loop 0
 ;;
 
-(* ---------- Append helpers ---------- *)
-
-let append_line path line =
-  ensure_dir (Filename.dirname path);
-  Fs_compat.append_file_durable path (line ^ "\n")
-;;
-
-let append_json path json =
-  append_line path (Yojson.Safe.to_string json)
-;;
-
-let append_json_no_follow path json =
-  require_real_directory (Filename.dirname path);
-  require_regular_file_or_missing path;
-  Fs_compat.append_file_durable_no_follow
-    path
-    (Yojson.Safe.to_string json ^ "\n")
+let append_json_anchored directory name json =
+  let current =
+    match Anchored.read_file_opt directory.handle name with
+    | Some content -> content
+    | None -> ""
+  in
+  atomic_replace
+    directory
+    name
+    (current ^ Yojson.Safe.to_string json ^ "\n")
 ;;
 
 let append_fact ~keeper_id fact =
-  append_json (facts_path ~keeper_id) (fact_to_json fact)
+  with_facts_lock
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+    (fun (Facts_lock keeper) ->
+      append_json_anchored keeper.root (facts_name keeper.keeper_id) (fact_to_json fact))
+;;
+
+let append_event_in_bundle (Episode_bundle keeper) episode =
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  append_json_anchored
+    keeper.root
+    (events_name keeper.keeper_id)
+    (episode_to_json episode)
+;;
+
+let append_episode_in_bundle (Episode_bundle keeper) episode =
+  let trace_id = trace_id_exn episode.trace_id in
+  with_episodes_directory keeper @@ fun episodes ->
+  let name = unique_episode_name episodes ~trace_id episode in
+  atomic_replace
+    episodes
+    name
+    (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
   ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
-  require_real_directory keepers_dir;
-  append_json_no_follow
-    (events_path_for_keepers_dir
-       ~keepers_dir
-       ~keeper_id:(keeper_name_string keeper_id))
-    (episode_to_json episode)
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> append_event_in_bundle bundle episode)
 ;;
 
 let append_event ~keeper_id episode =
+  let keeper_id = keeper_name_exn keeper_id in
   append_event_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     episode
 ;;
 
 let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
-  let trace_id = trace_id_exn episode.trace_id in
-  let path =
-    unique_episode_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id
-      ~trace_id
-      episode
-  in
-  write_file_atomically_in_real_directory
-    path
-    (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  ignore (trace_id_exn episode.trace_id : Keeper_id.Trace_id.t);
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> append_episode_in_bundle bundle episode)
 ;;
 
 let append_episode ~keeper_id episode =
+  let keeper_id = keeper_name_exn keeper_id in
   append_episode_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     episode
 ;;
 
-let append_episode_bundle ~keeper_id episode =
-  with_episode_bundle_lock ~keeper_id (fun () ->
-    with_facts_lock_unhandled_for_keepers_dir
-      ~keepers_dir:(ensure_configured_keepers_dir ())
-      ~keeper_id:(keeper_name_exn keeper_id)
-      (fun () -> List.iter (append_fact ~keeper_id) episode.claims);
-    append_episode ~keeper_id episode;
-    append_event ~keeper_id episode)
-;;
-
-let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
-  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_real_directory keepers_dir;
-  require_regular_file_or_missing path;
+let facts_content facts =
   let content =
     facts
     |> List.map (fun fact -> fact_to_json fact |> Yojson.Safe.to_string)
     |> String.concat "\n"
   in
-  let content = if String.equal content "" then "" else content ^ "\n" in
-  write_file_atomically_in_real_directory path content
+  if String.equal content "" then "" else content ^ "\n"
+;;
+
+let rewrite_facts_in_lock (Facts_lock keeper) facts =
+  atomic_replace keeper.root (facts_name keeper.keeper_id) (facts_content facts)
+;;
+
+let append_episode_bundle ~keeper_id episode =
+  with_episode_bundle_lock ~keeper_id (fun bundle ->
+    with_facts_lock_in_bundle
+      bundle
+      ~on_timeout:raise_lock_timeout
+      (fun (Facts_lock keeper) ->
+        List.iter
+          (fun fact ->
+            append_json_anchored
+              keeper.root
+              (facts_name keeper.keeper_id)
+              (fact_to_json fact))
+          episode.claims);
+    append_episode_in_bundle bundle episode;
+    append_event_in_bundle bundle episode)
+;;
+
+let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  rewrite_facts_in_lock (Facts_lock (scope root keeper_id)) facts
 ;;
 
 let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
@@ -591,12 +708,6 @@ let load_tool_result ~keeper_id ~tool_call_id =
 
 (* ---------- Tail reads ---------- *)
 
-let count_newlines s =
-  let count = ref 0 in
-  String.iter (fun ch -> if Char.equal ch '\n' then incr count) s;
-  !count
-;;
-
 let split_lines s =
   let len = String.length s in
   let rec loop start i acc =
@@ -621,40 +732,6 @@ let split_lines s =
       loop start (i + 1) acc
   in
   loop 0 0 []
-;;
-
-let read_lines_tail path ~n =
-  if n <= 0 || not (Sys.file_exists path)
-  then []
-  else (
-    let ic = open_in_bin path in
-    let rec loop pos chunks newline_count =
-      if pos <= 0 || newline_count > n
-      then chunks
-      else (
-        let chunk_len = min 8192 pos in
-        let next_pos = pos - chunk_len in
-        seek_in ic next_pos;
-        let chunk = really_input_string ic chunk_len in
-        loop next_pos (chunk :: chunks) (newline_count + count_newlines chunk))
-    in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let len = in_channel_length ic in
-         loop len [] 0 |> String.concat "" |> split_lines))
-;;
-
-let read_lines_all path =
-  if not (Sys.file_exists path)
-  then []
-  else (
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let len = in_channel_length ic in
-         really_input_string ic len |> split_lines))
 ;;
 
 let take_last n xs =
@@ -682,59 +759,71 @@ let parse_fact_json_line_strict ~path ~line_number line =
     Error (Printf.sprintf "%s:%d: invalid fact JSON: %s" path line_number message)
 ;;
 
-let validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id =
-  require_real_directory keepers_dir;
-  let path = facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  require_regular_file_or_missing path;
-  path
+let read_lines_all_anchored directory name =
+  match Anchored.read_file_opt directory.handle name with
+  | None -> []
+  | Some content -> split_lines content
 ;;
 
-let read_facts_all_at_path path =
-  read_lines_all path |> List.filter_map (parse_json_line fact_of_json)
+let read_facts_all_for_scope keeper =
+  read_lines_all_anchored keeper.root (facts_name keeper.keeper_id)
+  |> List.filter_map (parse_json_line fact_of_json)
 ;;
 
-let read_facts_all_strict_at_path path =
+let read_facts_all_strict_for_scope keeper =
+  let path =
+    facts_path_for_keepers_dir
+      ~keepers_dir:keeper.root.path
+      ~keeper_id:keeper.keeper_name
+  in
   let rec loop line_number acc = function
     | [] -> Ok (List.rev acc)
     | line :: rest ->
       let* fact = parse_fact_json_line_strict ~path ~line_number line in
       loop (line_number + 1) (fact :: acc) rest
   in
-  loop 1 [] (read_lines_all path)
+  loop 1 [] (read_lines_all_anchored keeper.root (facts_name keeper.keeper_id))
 ;;
 
-let read_facts_tail_at_path path ~n =
-  read_lines_tail path ~n
-  |> List.filter_map (parse_json_line fact_of_json)
-  |> take_last n
+let read_facts_all_strict_in_lock (Facts_lock keeper) =
+  read_facts_all_strict_for_scope keeper
 ;;
 
 let read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_facts_all_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_for_scope (scope root keeper_id)
 ;;
 
 let read_facts_all ~keeper_id =
-  read_facts_all_at_path (facts_path ~keeper_id)
+  read_facts_all_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
 ;;
 
 let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
-  read_facts_all_strict_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_strict_for_scope (scope root keeper_id)
 ;;
 
 let read_facts_all_strict ~keeper_id =
-  read_facts_all_strict_at_path (facts_path ~keeper_id)
+  read_facts_all_strict_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
 ;;
 
 let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
-  read_facts_tail_at_path
-    (validated_facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-    ~n
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root keepers_dir @@ fun root ->
+  read_facts_all_for_scope (scope root keeper_id) |> take_last n
 ;;
 
 let read_facts_tail ~keeper_id ~n =
-  read_facts_tail_at_path (facts_path ~keeper_id) ~n
+  read_facts_tail_for_keepers_dir
+    ~keepers_dir:(ensure_configured_keepers_dir ())
+    ~keeper_id
+    ~n
 ;;
 
 let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
@@ -777,28 +866,19 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
+let read_facts_for_rewrite_in_lock (Facts_lock keeper) =
   (* RFC-0302 (#22823) phase-2b: [keepers_dir] is resolved by the caller before
      this boundary. Offload the blocking full read + strict parse of the fact
      store off the main Eio scheduler. This is the per-write read on the
      librarian hot path ([merge_and_cap_facts]) and [cap_facts]. Callers hold a
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
-     reads only the explicit root and [keeper_id], and the Fs_compat rewrite that
-     follows stays on main. *)
+     reads only the retained root capability and typed keeper name. *)
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir
-        ~keepers_dir
-        ~keeper_id:(keeper_name_string keeper_id))
+      read_facts_all_strict_for_scope keeper)
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
-;;
-
-let read_facts_for_rewrite ~keeper_id =
-  read_facts_for_rewrite_for_keepers_dir
-    ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -808,8 +888,11 @@ let read_facts_for_rewrite ~keeper_id =
    rewrite happens only once every ([trigger] - [keep]) appended facts. Returns
    the number of facts dropped. *)
 let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
-  let path = facts_path ~keeper_id in
-  let all = read_facts_for_rewrite ~keeper_id in
+  with_facts_lock
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+  @@ fun (Facts_lock _ as lock) ->
+  let all = read_facts_for_rewrite_in_lock lock in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows before the trigger gate
      and before ranking, so an under-cap store does not retain expired rows on
      disk until the off-by-default GC sweep. Facts with no effective horizon
@@ -827,14 +910,7 @@ let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
         |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
         |> take_first keep
     in
-    let content =
-      match kept with
-      | [] -> ""
-      | _ ->
-        (kept |> List.map (fun f -> Yojson.Safe.to_string (fact_to_json f)) |> String.concat "\n")
-        ^ "\n"
-    in
-    write_file_atomically path content;
+    rewrite_facts_in_lock lock kept;
     List.length all - List.length kept)
 ;;
 
@@ -889,19 +965,16 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts_for_keepers_dir
-      ~keepers_dir
+let merge_and_cap_facts_in_lock
+      (Facts_lock _ as lock)
       ~now
-      ~keeper_id
       ~merge
       ~incoming
       ~keep
       ~trigger
       ~rank
   =
-  let existing =
-    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
-  in
+  let existing = read_facts_for_rewrite_in_lock lock in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -925,11 +998,33 @@ let merge_and_cap_facts_for_keepers_dir
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id:(keeper_name_string keeper_id)
-      kept;
+    rewrite_facts_in_lock lock kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  with_facts_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    ~on_timeout:raise_lock_timeout
+    (fun lock ->
+      merge_and_cap_facts_in_lock
+        lock
+        ~now
+        ~merge
+        ~incoming
+        ~keep
+        ~trigger
+        ~rank)
 ;;
 
 let merge_and_cap_facts
@@ -952,20 +1047,20 @@ let merge_and_cap_facts
     ~rank
 ;;
 
-let read_events_tail ~keeper_id ~n =
-  read_lines_tail (events_path ~keeper_id) ~n
+let read_events_tail_for_scope keeper ~n =
+  read_lines_all_anchored keeper.root (events_name keeper.keeper_id)
   |> List.filter_map (parse_json_line episode_of_json)
   |> take_last n
 ;;
 
-let read_episode_file path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-       let len = in_channel_length ic in
-       let buf = really_input_string ic len in
-       parse_json_line episode_of_json buf)
+let read_events_tail ~keeper_id ~n =
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root (ensure_configured_keepers_dir ()) @@ fun root ->
+  read_events_tail_for_scope (scope root keeper_id) ~n
+;;
+
+let parse_episode_content content =
+  parse_json_line episode_of_json content
 ;;
 
 let compare_episode_recency a b =
@@ -983,24 +1078,39 @@ let compare_episode_recency a b =
       else String.compare a.episode_summary b.episode_summary))
 ;;
 
-let read_episode_files_tail ~keeper_id ~n =
-  let dir = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
-  if n <= 0 || not (Sys.file_exists dir && Sys.is_directory dir)
+let episode_files episodes =
+  Anchored.read_dir episodes.handle
+  |> List.filter (fun name ->
+    Filename.check_suffix (Anchored.Segment.to_string name) ".json")
+  |> List.filter_map (fun name ->
+    Anchored.read_file episodes.handle name
+    |> parse_episode_content
+    |> Option.map (fun episode -> name, episode))
+;;
+
+let read_episode_files_tail_for_scope keeper ~n =
+  if n <= 0
   then []
-  else (
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.filter (fun name -> Filename.check_suffix name ".json")
-    |> List.map (fun name -> Filename.concat dir name)
-    |> List.filter Sys.file_exists
-    |> List.filter_map read_episode_file
-    |> List.sort compare_episode_recency
-    |> take_last n)
+  else
+    match
+      with_existing_episodes_directory keeper (fun episodes ->
+        episode_files episodes
+        |> List.map snd
+        |> List.sort compare_episode_recency
+        |> take_last n)
+    with
+    | None -> []
+    | Some episodes -> episodes
 ;;
 
 let read_episodes_tail ~keeper_id ~n =
-  let events = read_events_tail ~keeper_id ~n in
-  if events = [] then read_episode_files_tail ~keeper_id ~n else events
+  let keeper_id = keeper_name_exn keeper_id in
+  with_root (ensure_configured_keepers_dir ()) @@ fun root ->
+  let keeper = scope root keeper_id in
+  let events = read_events_tail_for_scope keeper ~n in
+  if events = []
+  then read_episode_files_tail_for_scope keeper ~n
+  else events
 ;;
 
 (* RFC-0272 (defect D): the hysteresis decision shared by the episode-log caps.
@@ -1015,20 +1125,16 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
-  require_real_directory keepers_dir;
-  let path =
-    events_path_for_keepers_dir
-      ~keepers_dir
-      ~keeper_id:(keeper_name_string keeper_id)
-  in
-  require_regular_file_or_missing path;
+let cap_events_in_bundle (Episode_bundle keeper) ~keep ~trigger =
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
-     does not starve the main Eio scheduler when a pool is installed (inline
-     fallback in tests / before the pool is set up). [path] is resolved on main;
-     the atomic rewrite below (write_file_atomically -> Fs_compat, an Eio.Path.save)
-     stays on main. The closure reads only [path] and no shared mutable state. *)
-  let all = Domain_pool_ref.submit_io_or_inline (fun () -> read_lines_all path) in
+     does not starve the main Eio scheduler when a pool is installed. The
+     closure retains the opened root capability, so an ancestor substitution
+     cannot redirect the read. *)
+  let name = events_name keeper.keeper_id in
+  let all =
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      read_lines_all_anchored keeper.root name)
+  in
   match trim_target ~count:(List.length all) ~keep ~trigger with
   | None -> 0
   | Some keep_n ->
@@ -1038,14 +1144,22 @@ let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
       | [] -> ""
       | _ -> String.concat "\n" kept ^ "\n"
     in
-    write_file_atomically_in_real_directory path content;
+    atomic_replace keeper.root name content;
     List.length all - List.length kept
 ;;
 
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> cap_events_in_bundle bundle ~keep ~trigger)
+;;
+
 let cap_events ~keeper_id ~keep ~trigger =
+  let keeper_id = keeper_name_exn keeper_id in
   cap_events_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     ~keep
     ~trigger
 ;;
@@ -1054,44 +1168,66 @@ let cap_events ~keeper_id ~keep ~trigger =
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
    parseable files are counted and ordered — an unparseable file has no recency
-   to rank, so it is left untouched rather than blindly deleted. Unlink is
-   best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
-   fine, and no lock is taken here that could deadlock with the bundle lock the
-   caller already holds. Returns the number unlinked. *)
-let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+   to rank, so it is left untouched rather than blindly deleted. Each unlink is
+   descriptor-relative and durably published; an I/O failure is surfaced rather
+   than treated as a successful trim. The caller already holds the bundle lock,
+   so no second lock is acquired. Returns the number unlinked. *)
+let cap_episode_files_in_bundle (Episode_bundle keeper) ~keep ~trigger =
   (* RFC-0302 (#22823): resolve and create [episodes_dir] from the explicit root
      on the main domain, then offload the blocking readdir + per-file episode read
      + best-effort unlink scan to the shared domain pool. The closure captures
      only immutable [dir]/[keep]/[trigger]; no mutable OCaml state is shared, so
      it is domain-safe. The caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
-  Domain_pool_ref.submit_io_or_inline (fun () ->
-    let parsed =
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
-      |> List.map (fun name -> Filename.concat dir name)
-      |> List.filter Sys.file_exists
-      |> List.filter_map (fun p ->
-        match read_episode_file p with
-        | Some ep -> Some (p, ep)
-        | None -> None)
-    in
-    match trim_target ~count:(List.length parsed) ~keep ~trigger with
-    | None -> 0
-    | Some keep_n ->
-      let sorted = List.sort (fun (_, a) (_, b) -> compare_episode_recency a b) parsed in
-      let n_drop = List.length sorted - keep_n in
-      let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
-      List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
-      List.length to_drop)
+  match
+    with_existing_episodes_directory keeper (fun episodes ->
+      let parsed =
+        Domain_pool_ref.submit_io_or_inline (fun () -> episode_files episodes)
+      in
+      match trim_target ~count:(List.length parsed) ~keep ~trigger with
+      | None -> 0
+      | Some keep_n ->
+        let sorted =
+          List.sort
+            (fun (_, left) (_, right) ->
+               compare_episode_recency left right)
+            parsed
+        in
+        let n_drop = List.length sorted - keep_n in
+        sorted
+        |> List.filteri (fun index _ -> index < n_drop)
+        |> List.fold_left
+             (fun removed (name, _) ->
+                match Anchored.unlink_if_exists episodes.handle name with
+                | Ok `Removed -> removed + 1
+                | Ok `Missing -> removed
+                | Error error ->
+                  raise
+                    (Atomic_write_failed
+                       (Printf.sprintf
+                          "%s: %s"
+                          (Filename.concat
+                             episodes.path
+                             (Anchored.Segment.to_string name))
+                          (Anchored.mutation_error_to_string error))))
+             0)
+  with
+  | None -> 0
+  | Some removed -> removed
+;;
+
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  with_episode_bundle_lock_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id
+    (fun bundle -> cap_episode_files_in_bundle bundle ~keep ~trigger)
 ;;
 
 let cap_episode_files ~keeper_id ~keep ~trigger =
+  let keeper_id = keeper_name_exn keeper_id in
   cap_episode_files_for_keepers_dir
     ~keepers_dir:(ensure_configured_keepers_dir ())
-    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keeper_id
     ~keep
     ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -31,6 +31,14 @@ let keepers_dir () =
   | None -> Config_dir_resolver.keepers_dir ()
 ;;
 
+let keeper_name_exn raw =
+  match Keeper_id.Keeper_name.of_string raw with
+  | Ok keeper_name -> keeper_name
+  | Error detail -> invalid_arg detail
+;;
+
+let keeper_name_string = Keeper_id.Keeper_name.to_string
+
 module For_testing = struct
   let with_keepers_dir path f =
     ensure_dir path;
@@ -111,18 +119,41 @@ let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
 
-let episode_bundle_lock_path ~keeper_id =
-  Filename.concat (keepers_dir ()) (keeper_id ^ ".episode-bundle")
+let episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id =
+  Filename.concat
+    keepers_dir
+    (keeper_name_string keeper_id ^ ".episode-bundle")
+;;
+
+let with_episode_bundle_lock_for_keepers_dir ?clock ~keepers_dir ~keeper_id f =
+  File_lock_eio.with_lock
+    ?clock
+    (episode_bundle_lock_path_for_keepers_dir ~keepers_dir ~keeper_id)
+    f
 ;;
 
 let with_episode_bundle_lock ?clock ~keeper_id f =
-  File_lock_eio.with_lock ?clock (episode_bundle_lock_path ~keeper_id) f
+  with_episode_bundle_lock_for_keepers_dir
+    ?clock
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    f
+;;
+
+let episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id =
+  let d =
+    Filename.concat
+      keepers_dir
+      (Filename.concat (keeper_name_string keeper_id) "episodes")
+  in
+  ensure_dir d;
+  d
 ;;
 
 let episodes_dir ~keeper_id =
-  let d = Filename.concat (keepers_dir ()) (Filename.concat keeper_id "episodes") in
-  ensure_dir d;
-  d
+  episodes_dir_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 let tool_results_dir ~keeper_id =
@@ -180,12 +211,14 @@ let write_file_atomically path content =
   | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
-let generation_counter_path ~keeper_id ~trace_id =
-  Filename.concat (episodes_dir ~keeper_id) (Printf.sprintf "%s.generation" trace_id)
+let generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  Filename.concat
+    (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
+    (Printf.sprintf "%s.generation" trace_id)
 ;;
 
-let max_generation_from_files ~keeper_id ~trace_id =
-  let dir = episodes_dir ~keeper_id in
+let max_generation_from_files_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id =
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   let prefix = Printf.sprintf "%s-g" trace_id in
   Sys.readdir dir
   |> Array.to_list
@@ -217,10 +250,23 @@ let read_generation_counter path =
     lock. The counter intentionally allows gaps when extraction later fails;
     uniqueness is more important than contiguous numbering across fibers or
     processes. *)
-let next_generation_with_floor ~floor ~keeper_id ~trace_id =
-  let counter_path = generation_counter_path ~keeper_id ~trace_id in
+let next_generation_with_floor_for_keepers_dir
+      ~keepers_dir
+      ~floor
+      ~keeper_id
+      ~trace_id
+  =
+  let counter_path =
+    generation_counter_path_for_keepers_dir ~keepers_dir ~keeper_id ~trace_id
+  in
   File_lock_eio.with_lock counter_path (fun () ->
-    let next_from_files = max_generation_from_files ~keeper_id ~trace_id + 1 in
+    let next_from_files =
+      max_generation_from_files_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id
+        ~trace_id
+      + 1
+    in
     let next_from_counter =
       match read_generation_counter counter_path with
       | Some next -> next
@@ -231,17 +277,25 @@ let next_generation_with_floor ~floor ~keeper_id ~trace_id =
     generation)
 ;;
 
+let next_generation_with_floor ~floor ~keeper_id ~trace_id =
+  next_generation_with_floor_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~floor
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~trace_id
+;;
+
 let next_generation ~keeper_id ~trace_id =
   next_generation_with_floor ~floor:0 ~keeper_id ~trace_id
 ;;
 
-let unique_episode_path ~keeper_id episode =
+let unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode =
   let created_ms =
     episode.created_at *. 1000.0 |> Float.max 0.0 |> Int64.of_float
   in
   let base =
     Filename.concat
-      (episodes_dir ~keeper_id)
+      (episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id)
       (Printf.sprintf
          "%s-g%04d-t%013Ld"
          episode.trace_id
@@ -263,8 +317,7 @@ let unique_episode_path ~keeper_id episode =
 
 let append_line path line =
   ensure_dir (Filename.dirname path);
-  let oc = open_out_gen [ Open_append; Open_creat; Open_text ] 0o644 path in
-  with_out_channel oc ~f:(fun oc -> output_string oc (line ^ "\n"))
+  Fs_compat.append_file_durable path (line ^ "\n")
 ;;
 
 let append_json path json =
@@ -275,13 +328,31 @@ let append_fact ~keeper_id fact =
   append_json (facts_path ~keeper_id) (fact_to_json fact)
 ;;
 
+let append_event_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  append_json
+    (events_path_for_keepers_dir
+       ~keepers_dir
+       ~keeper_id:(keeper_name_string keeper_id))
+    (episode_to_json episode)
+;;
+
 let append_event ~keeper_id episode =
-  append_json (events_path ~keeper_id) (episode_to_json episode)
+  append_event_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
+;;
+
+let append_episode_for_keepers_dir ~keepers_dir ~keeper_id episode =
+  let path = unique_episode_path_for_keepers_dir ~keepers_dir ~keeper_id episode in
+  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
 ;;
 
 let append_episode ~keeper_id episode =
-  let path = unique_episode_path ~keeper_id episode in
-  write_file_atomically path (Yojson.Safe.pretty_to_string (episode_to_json episode))
+  append_episode_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    episode
 ;;
 
 let append_episode_bundle ~keeper_id episode =
@@ -537,24 +608,28 @@ let read_all_facts ~keeper_id =
   read_facts_all ~keeper_id
 ;;
 
-let read_facts_for_rewrite ~keeper_id =
-  (* RFC-0302 (#22823) phase-2b: resolve keepers_dir on the main domain (it touches
-     the Config_dir_resolver plain-ref memo), then offload the blocking full read +
-     strict parse of the fact store off the main Eio scheduler. This is the
-     per-write read on the librarian hot path (merge_and_cap_facts) and cap_facts.
-     Byte-equivalent to [read_facts_all_strict ~keeper_id] (which is exactly
-     [read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ())]) — only
-     the resolution is hoisted to main and the read is offloaded. Callers hold a
+let read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id =
+  (* RFC-0302 (#22823) phase-2b: [keepers_dir] is resolved by the caller before
+     this boundary. Offload the blocking full read + strict parse of the fact
+     store off the main Eio scheduler. This is the per-write read on the
+     librarian hot path ([merge_and_cap_facts]) and [cap_facts]. Callers hold a
      File_lock_eio flock on main across this (inline-in-tests) submit; the closure
-     reads only [keepers]/[keeper_id] and no shared mutable state, and the
-     Fs_compat rewrite that follows stays on main. *)
-  let keepers = keepers_dir () in
+     reads only the explicit root and [keeper_id], and the Fs_compat rewrite that
+     follows stays on main. *)
   match
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      read_facts_all_strict_for_keepers_dir ~keepers_dir:keepers ~keeper_id)
+      read_facts_all_strict_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id:(keeper_name_string keeper_id))
   with
   | Ok facts -> facts
   | Error message -> invalid_arg message
+;;
+
+let read_facts_for_rewrite ~keeper_id =
+  read_facts_for_rewrite_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
 ;;
 
 (* RFC-0239 Q4 (supersedes RFC-0238 Capped_by_score): bound the append-only
@@ -645,8 +720,19 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
-  let existing = read_facts_for_rewrite ~keeper_id in
+let merge_and_cap_facts_for_keepers_dir
+      ~keepers_dir
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  let existing =
+    read_facts_for_rewrite_for_keepers_dir ~keepers_dir ~keeper_id
+  in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
   (* RFC-0259 §3.6 (P5): drop effective-horizon-expired rows on the same boundary the
      GC sweep uses, before the trigger gate and ranking, so an under-cap store
@@ -670,8 +756,31 @@ let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
         in
         kept, total - List.length kept)
     in
-    rewrite_facts_atomically ~keeper_id kept;
+    rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+      kept;
     { merged; appended; dropped = rank_dropped + List.length expired })
+;;
+
+let merge_and_cap_facts
+      ~now
+      ~keeper_id
+      ~merge
+      ~incoming
+      ~keep
+      ~trigger
+      ~rank
+  =
+  merge_and_cap_facts_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~now
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~merge
+    ~incoming
+    ~keep
+    ~trigger
+    ~rank
 ;;
 
 let read_events_tail ~keeper_id ~n =
@@ -737,8 +846,12 @@ let trim_target ~count ~keep ~trigger = if count <= trigger then None else Some 
    [read_lines_tail] has: a line [episode_of_json] cannot parse is tail-trimmed
    like any other, never silently dropped mid-file. Returns the number dropped
    (diagnostic; the rewrite is the mechanism). *)
-let cap_events ~keeper_id ~keep ~trigger =
-  let path = events_path ~keeper_id in
+let cap_events_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  let path =
+    events_path_for_keepers_dir
+      ~keepers_dir
+      ~keeper_id:(keeper_name_string keeper_id)
+  in
   (* RFC-0302 (#22823): submit the blocking full read to the domain pool so it
      does not starve the main Eio scheduler when a pool is installed (inline
      fallback in tests / before the pool is set up). [path] is resolved on main;
@@ -758,6 +871,14 @@ let cap_events ~keeper_id ~keep ~trigger =
     List.length all - List.length kept
 ;;
 
+let cap_events ~keeper_id ~keep ~trigger =
+  cap_events_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
+;;
+
 (* RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
    parseable-file count exceeds [trigger], keep the [keep] most-recent files by
    [compare_episode_recency] (the order recall uses) and unlink the rest. Only
@@ -766,16 +887,14 @@ let cap_events ~keeper_id ~keep ~trigger =
    best-effort / [Sys_error]-tolerant: a concurrent reader holding a file is
    fine, and no lock is taken here that could deadlock with the bundle lock the
    caller already holds. Returns the number unlinked. *)
-let cap_episode_files ~keeper_id ~keep ~trigger =
-  (* RFC-0302 (#22823): resolve [episodes_dir] on the main domain (it touches the
-     Config_dir_resolver plain-ref memo + mkdir), then offload the blocking
-     readdir + per-file episode read + best-effort unlink scan to the shared
-     domain pool so the scan does not starve the main Eio scheduler. The offloaded
-     closure reads only the resolved [dir] string and does no Eio/lock/shared-
-     mutable work (Sys.remove is a filesystem unlink, not OCaml shared state), so
-     it is domain-safe; the caller's bundle flock stays held on main across the
+let cap_episode_files_for_keepers_dir ~keepers_dir ~keeper_id ~keep ~trigger =
+  (* RFC-0302 (#22823): resolve and create [episodes_dir] from the explicit root
+     on the main domain, then offload the blocking readdir + per-file episode read
+     + best-effort unlink scan to the shared domain pool. The closure captures
+     only immutable [dir]/[keep]/[trigger]; no mutable OCaml state is shared, so
+     it is domain-safe. The caller's bundle flock stays held on main across the
      (inline-fallback in tests) submit. *)
-  let dir = episodes_dir ~keeper_id in
+  let dir = episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id in
   Domain_pool_ref.submit_io_or_inline (fun () ->
     let parsed =
       Sys.readdir dir
@@ -796,4 +915,12 @@ let cap_episode_files ~keeper_id ~keep ~trigger =
       let to_drop = sorted |> List.filteri (fun i _ -> i < n_drop) |> List.map fst in
       List.iter (fun p -> try Sys.remove p with Sys_error _ -> ()) to_drop;
       List.length to_drop)
+;;
+
+let cap_episode_files ~keeper_id ~keep ~trigger =
+  cap_episode_files_for_keepers_dir
+    ~keepers_dir:(keepers_dir ())
+    ~keeper_id:(keeper_name_exn keeper_id)
+    ~keep
+    ~trigger
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -61,6 +61,20 @@ val next_generation_with_floor_for_keepers_dir :
 
 (** {1 Atomic writes} *)
 
+type episode_bundle
+type facts_lock
+(** Scoped capabilities retained while the corresponding descriptor-anchored
+    lock is held. Values must not escape their callback. *)
+
+type lock_timeout =
+  { caller : string
+  ; path : string
+  ; attempts : int
+  }
+
+val lock_timeout_to_string : lock_timeout -> string
+val raise_lock_timeout : lock_timeout -> 'a
+
 (** Run [f] against the channel then close it, releasing the descriptor on every
     exit path — including when [close_out]'s flush raises, which OCaml's
     [close_out] leaves the fd open on. The body's exception propagates (so
@@ -75,6 +89,8 @@ val append_event_for_keepers_dir :
 val append_episode : keeper_id:string -> episode -> unit
 val append_episode_for_keepers_dir :
   keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
+val append_event_in_bundle : episode_bundle -> episode -> unit
+val append_episode_in_bundle : episode_bundle -> episode -> unit
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
@@ -84,14 +100,14 @@ val append_episode_for_keepers_dir :
 val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keeper_id:string ->
-  (unit -> 'a) ->
+  (episode_bundle -> 'a) ->
   'a
 
 val with_episode_bundle_lock_for_keepers_dir :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keepers_dir:string ->
   keeper_id:Keeper_id.Keeper_name.t ->
-  (unit -> 'a) ->
+  (episode_bundle -> 'a) ->
   'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
@@ -115,7 +131,7 @@ val fact_fingerprint : fact -> string
 val same_fact_snapshot : fact list -> fact list -> bool
 
 (** [with_facts_lock ?clock ~keeper_id ~on_timeout f] runs [f] holding the
-    per-keeper facts lock. On flock-acquisition timeout, [on_timeout msg] produces
+    per-keeper facts lock. On flock-acquisition timeout, [on_timeout timeout] produces
     the result instead of raising {!File_lock_eio.Flock_timeout}, so callers can
     return a typed skip/no-op for a contended cycle. Non-timeout exceptions from
     [f] propagate after the lock finalizer runs. Keep [on_timeout] total and
@@ -123,8 +139,8 @@ val same_fact_snapshot : fact list -> fact list -> bool
 val with_facts_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> keeper_id:string
-  -> on_timeout:(string -> 'a)
-  -> (unit -> 'a)
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
   -> 'a
 
 (** Explicit-root form of {!with_facts_lock}. [keeper_id] is already validated,
@@ -135,9 +151,21 @@ val with_facts_lock_for_keepers_dir :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> keepers_dir:string
   -> keeper_id:Keeper_id.Keeper_name.t
-  -> on_timeout:(string -> 'a)
-  -> (unit -> 'a)
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
   -> 'a
+
+val with_facts_lock_in_bundle :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> episode_bundle
+  -> on_timeout:(lock_timeout -> 'a)
+  -> (facts_lock -> 'a)
+  -> 'a
+(** Acquire the facts lock from an existing bundle capability, retaining the
+    same opened keepers directory across both locks. *)
+
+val read_facts_all_strict_in_lock : facts_lock -> (fact list, string) result
+val rewrite_facts_in_lock : facts_lock -> fact list -> unit
 
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
@@ -193,10 +221,13 @@ val cap_events_for_keepers_dir :
   trigger:int ->
   int
 
+val cap_events_in_bundle : episode_bundle -> keep:int -> trigger:int -> int
+
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
-    recency and best-effort unlink the rest; otherwise no-op. Unparseable files
-    are left untouched. Returns the number unlinked. *)
+    recency and durably unlink the rest; otherwise no-op. Unparseable files are
+    left untouched. Every unlink failure is surfaced. Returns the number
+    unlinked. *)
 val cap_episode_files :
   keeper_id:string -> keep:int -> trigger:int -> int
 val cap_episode_files_for_keepers_dir :
@@ -205,6 +236,9 @@ val cap_episode_files_for_keepers_dir :
   keep:int ->
   trigger:int ->
   int
+
+val cap_episode_files_in_bundle :
+  episode_bundle -> keep:int -> trigger:int -> int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -252,13 +286,21 @@ val merge_and_cap_facts :
   -> rank:(fact -> float)
   -> fact_merge_stats
 
-(** The explicit-root merge is a read-modify-rewrite operation. Its caller must
-    hold {!with_facts_lock_for_keepers_dir}; if an episode bundle is also being
-    published, the caller must hold the bundle lock before the facts lock. *)
+(** The explicit-root merge acquires its own descriptor-anchored facts lock. *)
 val merge_and_cap_facts_for_keepers_dir :
   keepers_dir:string
   -> now:float
   -> keeper_id:Keeper_id.Keeper_name.t
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_in_lock :
+  facts_lock
+  -> now:float
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -34,6 +34,8 @@ val current_path_for_legacy_memory_filename :
     to the current store path under [keepers_dir], when the filename is a
     supported legacy memory artifact. *)
 val episodes_dir : keeper_id:string -> string
+val episodes_dir_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string
 val episode_path : keeper_id:string -> trace_id:string -> generation:int -> string
@@ -47,7 +49,15 @@ val next_generation : keeper_id:string -> trace_id:string -> int
 
 (** Like {!next_generation}, but preserves a caller-provided generation lower
     bound while still advancing the counter past it. *)
-val next_generation_with_floor : floor:int -> keeper_id:string -> trace_id:string -> int
+val next_generation_with_floor :
+  floor:int -> keeper_id:string -> trace_id:string -> int
+
+val next_generation_with_floor_for_keepers_dir :
+  keepers_dir:string ->
+  floor:int ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  trace_id:string ->
+  int
 
 (** {1 Atomic writes} *)
 
@@ -60,13 +70,27 @@ val with_out_channel : out_channel -> f:(out_channel -> unit) -> unit
 
 val append_fact : keeper_id:string -> fact -> unit
 val append_event : keeper_id:string -> episode -> unit
+val append_event_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 val append_episode : keeper_id:string -> episode -> unit
+val append_episode_for_keepers_dir :
+  keepers_dir:string -> keeper_id:Keeper_id.Keeper_name.t -> episode -> unit
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
     lock, then publish [events_path] last as the reader-visible commit marker. *)
 val with_episode_bundle_lock :
-  ?clock:float Eio.Time.clock_ty Eio.Resource.t -> keeper_id:string -> (unit -> 'a) -> 'a
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keeper_id:string ->
+  (unit -> 'a) ->
+  'a
+
+val with_episode_bundle_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  (unit -> 'a) ->
+  'a
 
 val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
@@ -147,12 +171,25 @@ val trim_target : count:int -> keep:int -> trigger:int -> int option
     malformed-line tolerant) and atomically rewrite; otherwise no-op. Returns the
     number of lines dropped. *)
 val cap_events : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_events_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** RFC-0272 (defect D): bound the [episodes/] directory by file count. When the
     parseable-file count exceeds [trigger], keep the [keep] most-recent files by
     recency and best-effort unlink the rest; otherwise no-op. Unparseable files
     are left untouched. Returns the number unlinked. *)
-val cap_episode_files : keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files :
+  keeper_id:string -> keep:int -> trigger:int -> int
+val cap_episode_files_for_keepers_dir :
+  keepers_dir:string ->
+  keeper_id:Keeper_id.Keeper_name.t ->
+  keep:int ->
+  trigger:int ->
+  int
 
 (** Read and parse every fact in the store (unbounded; used by retention). *)
 val read_all_facts : keeper_id:string -> fact list
@@ -193,6 +230,17 @@ type fact_merge_stats =
 val merge_and_cap_facts :
   now:float
   -> keeper_id:string
+  -> merge:(existing:fact -> incoming:fact -> fact)
+  -> incoming:fact list
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> fact_merge_stats
+
+val merge_and_cap_facts_for_keepers_dir :
+  keepers_dir:string
+  -> now:float
+  -> keeper_id:Keeper_id.Keeper_name.t
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -56,7 +56,7 @@ val next_generation_with_floor_for_keepers_dir :
   keepers_dir:string ->
   floor:int ->
   keeper_id:Keeper_id.Keeper_name.t ->
-  trace_id:string ->
+  trace_id:Keeper_id.Trace_id.t ->
   int
 
 (** {1 Atomic writes} *)
@@ -78,7 +78,9 @@ val append_episode_for_keepers_dir :
 
 (** Serialize a cross-file episode bundle write for one keeper. Callers that
     write facts plus episode/event artifacts should take this before the facts
-    lock, then publish [events_path] last as the reader-visible commit marker. *)
+    lock, then publish [events_path] last as the reader-visible commit marker.
+    The global lock order is bundle lock, then facts lock; reversing it can
+    deadlock another writer. *)
 val with_episode_bundle_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   keeper_id:string ->
@@ -124,6 +126,19 @@ val with_facts_lock :
   -> on_timeout:(string -> 'a)
   -> (unit -> 'a)
   -> 'a
+
+(** Explicit-root form of {!with_facts_lock}. [keeper_id] is already validated,
+    [keepers_dir] must be an existing real directory, and symlink/non-regular
+    fact and lock targets are rejected. When both locks are needed, acquire
+    {!with_episode_bundle_lock_for_keepers_dir} first and this lock second. *)
+val with_facts_lock_for_keepers_dir :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keepers_dir:string
+  -> keeper_id:Keeper_id.Keeper_name.t
+  -> on_timeout:(string -> 'a)
+  -> (unit -> 'a)
+  -> 'a
+
 val save_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t -> unit
 val load_tool_result : keeper_id:string -> tool_call_id:string -> Yojson.Safe.t option
 
@@ -237,6 +252,9 @@ val merge_and_cap_facts :
   -> rank:(fact -> float)
   -> fact_merge_stats
 
+(** The explicit-root merge is a read-modify-rewrite operation. Its caller must
+    hold {!with_facts_lock_for_keepers_dir}; if an episode bundle is also being
+    published, the caller must hold the bundle lock before the facts lock. *)
 val merge_and_cap_facts_for_keepers_dir :
   keepers_dir:string
   -> now:float

--- a/lib/keeper_registry/keeper_id.ml
+++ b/lib/keeper_registry/keeper_id.ml
@@ -1,8 +1,16 @@
+(* Bounded preview for identifier validation errors. These values originate from
+   external requests/config/JSON, so emitting the full invalid value can amplify
+   logs. *)
+let preview_id s =
+  if String.length s <= 32 then s
+  else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+;;
+
 module Keeper_name = struct
   type t = string
   let is_valid s =
     let len = String.length s in
-    len > 0 && len <= 64 &&
+    s <> "." && s <> ".." && len > 0 && len <= 64 &&
     let rec check i =
       if i = len then true
       else
@@ -14,20 +22,24 @@ module Keeper_name = struct
 
   let of_string s =
     if is_valid s then Ok s
-    else Error (Printf.sprintf "Invalid keeper_name format: '%s'" s)
+    else
+      let reason =
+        if String.equal s "." then "reserved name '.'"
+        else if String.equal s ".." then "reserved name '..'"
+        else if String.length s = 0 then "empty string"
+        else if String.length s > 64
+        then Printf.sprintf "length %d exceeds 64" (String.length s)
+        else "contains characters outside [A-Za-z0-9_-]"
+      in
+      Error
+        (Printf.sprintf
+           "Invalid keeper_name %S: %s"
+           (preview_id s)
+           reason)
 
   let to_string s = s
   let equal = String.equal
 end
-
-(* Bounded preview for id validation error messages — these ids
-   originate from external requests / config / JSON; full dump risks
-   log spam on bad input. 32 bytes matches the pattern from iter#83
-   [decode_global_id] (#16903) and iter#84 [Ids.Trace_id]. *)
-let preview_id s =
-  if String.length s <= 32 then s
-  else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
-;;
 
 module Trace_id = struct
   type t = string

--- a/lib/keeper_registry/keeper_id.ml
+++ b/lib/keeper_registry/keeper_id.ml
@@ -8,17 +8,14 @@ let preview_id s =
 
 module Keeper_name = struct
   type t = string
+
   let is_valid s =
     let len = String.length s in
-    s <> "." && s <> ".." && len > 0 && len <= 64 &&
-    let rec check i =
-      if i = len then true
-      else
-        let c = s.[i] in
-        match c with
-        | 'a'..'z' | 'A'..'Z' | '0'..'9' | '-' | '_' -> check (i + 1)
-        | _ -> false
-    in check 0
+    (not (String.equal s "."))
+    && not (String.equal s "..")
+    && len <= 64
+    && Safe_identifier.is_portable_name s
+  ;;
 
   let of_string s =
     if is_valid s then Ok s
@@ -29,13 +26,14 @@ module Keeper_name = struct
         else if String.length s = 0 then "empty string"
         else if String.length s > 64
         then Printf.sprintf "length %d exceeds 64" (String.length s)
-        else "contains characters outside [A-Za-z0-9_-]"
+        else Safe_identifier.portable_name_error ~field:"keeper_name"
       in
       Error
         (Printf.sprintf
            "Invalid keeper_name %S: %s"
            (preview_id s)
            reason)
+  ;;
 
   let to_string s = s
   let equal = String.equal
@@ -57,7 +55,7 @@ module Trace_id = struct
         else if String.length s = 0 then "empty string"
         else if String.length s > 64
         then Printf.sprintf "length %d exceeds 64" (String.length s)
-        else "contains characters outside [A-Za-z0-9_-]"
+        else Safe_identifier.portable_name_error ~field:"trace_id"
       in
       Error (Printf.sprintf "Invalid trace_id %S: %s" (preview_id s) reason))
   let to_string s = s

--- a/lib/keeper_registry/keeper_id.mli
+++ b/lib/keeper_registry/keeper_id.mli
@@ -2,6 +2,8 @@
     Implements "Parse, Don't Validate" by making IDs abstract or private. *)
 
 module Keeper_name : sig
+  (** One portable path segment. The reserved filesystem segments [.] and [..]
+      are rejected before a Keeper name can become a filesystem coordinate. *)
   type t = private string
   val of_string : string -> (t, string) result
   val to_string : t -> string

--- a/lib/process/dune
+++ b/lib/process/dune
@@ -19,6 +19,7 @@
  (libraries
   masc_core
   masc_log
+  fs_compat
   time_compat
   masc_cancel_safe
   eio

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -13,6 +13,33 @@
 
 module SMap = Set_util.StringMap
 
+module Key = struct
+  type t =
+    { directory_device : int64
+    ; directory_inode : int64
+    ; entry : string
+    }
+
+  let directory_entry ~directory_device ~directory_inode ~entry =
+    { directory_device; directory_inode; entry }
+  ;;
+
+  let equal left right =
+    Int64.equal left.directory_device right.directory_device
+    && Int64.equal left.directory_inode right.directory_inode
+    && String.equal left.entry right.entry
+  ;;
+
+  let registry_key key =
+    Printf.sprintf
+      "descriptor:%Lx:%Lx:%d:%s"
+      key.directory_device
+      key.directory_inode
+      (String.length key.entry)
+      key.entry
+  ;;
+end
+
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
 (** Observability hook fired after each [acquire_flock_retry*] attempt
@@ -178,9 +205,15 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
     that do not honor the non-blocking contract reliably. Retry sleep yields
     to the Eio scheduler when a clock is available and otherwise sleeps in a
     systhread so the calling fiber does not block the domain. *)
-let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
-    ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
-  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+let acquire_flock_on_fd_cooperative
+      ?clock
+      ~fd
+      ~lock_path
+      ?(max_attempts = 200)
+      ?(sleep_sec = 0.01)
+      ~caller
+      ()
+  =
   let started_at = Time_compat.now () in
   let rec acquire attempts =
     if attempts <= 0 then begin
@@ -210,7 +243,21 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
         acquire (attempts - 1)
       end
   in
-  try acquire max_attempts
+  acquire max_attempts
+;;
+
+let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
+    ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
+  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+  try
+    acquire_flock_on_fd_cooperative
+      ?clock
+      ~fd
+      ~lock_path
+      ~max_attempts
+      ~sleep_sec
+      ~caller
+      ()
   with exn ->
     run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
     raise exn
@@ -250,6 +297,23 @@ let with_lock ?clock path f =
       f
   in
   with_mutex path (fun () -> run_with_flock ())
+
+(** Descriptor-relative counterpart of [with_lock]. [with_file] must keep the
+    supplied descriptor open for its callback and close it before returning.
+    The cooperative mutex encloses [with_file], so the POSIX lock is released by
+    close before another same-process fiber can enter the critical section. *)
+let with_lock_file ?clock ~key ~path ~with_file f =
+  with_mutex (Key.registry_key key) (fun () ->
+    with_file (fun fd ->
+      ignore
+        (acquire_flock_on_fd_cooperative
+           ?clock
+           ~fd
+           ~lock_path:path
+           ~caller:"File_lock_eio"
+           ()
+         : Unix.file_descr);
+      f ()))
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -21,6 +21,11 @@ exception Lock_file_cleanup_failed of
   ; close_error : exn
   }
 
+exception Flock_release_failed of
+  { unlock_error : exn option
+  ; close_error : exn option
+  }
+
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store counter + histogram so
@@ -81,7 +86,7 @@ let rec atomic_update_with_result atomic f =
 type lock_entry = {
   mu : Eio.Mutex.t;
   pre_eio_mu : Stdlib.Mutex.t;
-  mutable last_used : float;
+  last_used : float Atomic.t;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
@@ -108,30 +113,29 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
   )
 
-(** Get or create a lock entry for the given file path.
+(** Get or create a process-local lock entry for the given file identity.
     Increments [active] to prevent prune_stale_entries from removing
-    in-use entries (see TLA+ FileLockStarvation spec).
-    Falls back to direct Hashtbl access when no Eio context is available
-    (e.g. in unit tests that don't use Eio_main.run). *)
+    in-use entries (see TLA+ FileLockStarvation spec). *)
 let get_entry path =
   prune_stale_entries ();
   let entry =
     atomic_update_with_result table (fun state ->
       match SMap.find_opt path state.entries with
       | Some entry ->
-        entry.last_used <- Time_compat.now ();
+        Atomic.set entry.last_used (Time_compat.now ());
         (state, entry)
       | None ->
         let entry =
           { mu = Eio.Mutex.create ()
           ; pre_eio_mu = Stdlib.Mutex.create ()
-          ; last_used = Time_compat.now ()
+          ; last_used = Atomic.make (Time_compat.now ())
           ; active = Atomic.make 0
           }
         in
@@ -144,17 +148,43 @@ let get_entry path =
 let release_entry entry =
   ignore (Atomic.fetch_and_add entry.active (-1))
 
-let with_cooperative_entry entry f =
+let protect_from_cancel f =
+  if Eio_guard.is_ready () then Eio.Cancel.protect f else f ()
+;;
+
+let require_eio_context () =
   if Eio_guard.is_ready ()
   then
-    try Eio.Mutex.use_ro entry.mu f with
+    try Eio.Cancel.protect (fun () -> ()) with
     | Effect.Unhandled _ as exn ->
       raise
         (Failure
            (Printf.sprintf
               "File_lock_eio requires an Eio fiber after runtime startup: %s"
               (Printexc.to_string exn)))
-  else Stdlib.Mutex.protect entry.pre_eio_mu f
+;;
+
+let with_eio_entry entry f =
+  (* A pre-Eio caller holds [pre_eio_mu] for its full critical section.
+     Taking and immediately releasing it here is a transition barrier: once
+     [Eio_guard.enable] is visible, no later pre-Eio caller can enter without
+     rechecking the guard while holding the same mutex. Normal Eio operation
+     sees an uncontended constant-time gate and waits only on [entry.mu]. *)
+  require_eio_context ();
+  Stdlib.Mutex.protect entry.pre_eio_mu (fun () -> ());
+  Eio.Mutex.use_ro entry.mu f
+;;
+
+let rec with_cooperative_entry entry f =
+  if Eio_guard.is_ready ()
+  then with_eio_entry entry f
+  else
+    match
+      Stdlib.Mutex.protect entry.pre_eio_mu (fun () ->
+        if Eio_guard.is_ready () then None else Some (f ()))
+    with
+    | Some value -> value
+    | None -> with_cooperative_entry entry f
 ;;
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
@@ -195,8 +225,13 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
   in
   try acquire max_attempts
   with exn ->
-    (try Unix.close fd with Unix.Unix_error _ -> ());
-    raise exn
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    (match Unix.close fd with
+     | () -> Printexc.raise_with_backtrace exn primary_backtrace
+     | exception close_error ->
+       raise
+         (Lock_file_cleanup_failed
+            { primary = exn; primary_backtrace; close_error }))
 
 (** Fiber-friendly wrapper around [acquire_flock_retry].
     Opening/closing the descriptor uses a systhread, and the F_TLOCK attempt
@@ -247,7 +282,11 @@ let acquire_flock_on_fd_cooperative
 
 let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
     ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
-  let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+  require_eio_context ();
+  let fd =
+    protect_from_cancel (fun () ->
+      run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm))
+  in
   try
     acquire_flock_on_fd_cooperative
       ?clock
@@ -258,8 +297,14 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
       ~caller
       ()
   with exn ->
-    run_blocking_lock_op (fun () -> try Unix.close fd with Unix.Unix_error _ -> ());
-    raise exn
+    let primary_backtrace = Printexc.get_raw_backtrace () in
+    protect_from_cancel (fun () ->
+      match run_blocking_lock_op (fun () -> Unix.close fd) with
+      | () -> Printexc.raise_with_backtrace exn primary_backtrace
+      | exception close_error ->
+        raise
+          (Lock_file_cleanup_failed
+             { primary = exn; primary_backtrace; close_error }))
 
 let acquire_flock_fd ?clock lock_path =
   acquire_flock_retry_cooperative ?clock ~lock_path
@@ -268,8 +313,19 @@ let acquire_flock_fd ?clock lock_path =
 
 let release_flock_fd fd =
   run_blocking_lock_op (fun () ->
-      (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
-      Unix.close fd)
+      let unlock_error =
+        match Unix.lockf fd Unix.F_ULOCK 0 with
+        | () -> None
+        | exception exn -> Some exn
+      in
+      let close_error =
+        match Unix.close fd with
+        | () -> None
+        | exception exn -> Some exn
+      in
+      match unlock_error, close_error with
+      | None, None -> ()
+      | _ -> raise (Flock_release_failed { unlock_error; close_error }))
 
 (** Run [f] while holding only the cooperative per-path mutex.
     Use this for in-memory backends that need single-process fiber
@@ -288,11 +344,13 @@ let with_lock ?clock path f =
   let run_with_flock () =
     let lock_path = path ^ ".lock" in
     let dir = Filename.dirname lock_path in
-    if not (Sys.file_exists dir) then
-      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    run_blocking_lock_op (fun () ->
+      if not (Sys.file_exists dir) then
+        (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()));
     let fd = acquire_flock_fd ?clock lock_path in
     Common.protect ~module_name:"file_lock_eio" ~finally_label:"finalizer"
-      ~finally:(fun () -> release_flock_fd fd)
+      ~finally:(fun () ->
+        protect_from_cancel (fun () -> release_flock_fd fd))
       f
   in
   with_mutex path (fun () -> run_with_flock ())
@@ -301,22 +359,34 @@ let file_registry_key ~device ~inode =
   Printf.sprintf "descriptor-inode:%Lx:%Lx" device inode
 ;;
 
-let with_lock_file
+type close_state =
+  | Open
+  | Close_attempted
+  | Closed
+
+let with_anchored_file_lock
       ?clock
       ~path
-      ~open_file
-      ~descriptor
-      ~identity
-      ~close_file
+      ~directory
+      ~name
+      ~perm
       f
   =
-  let file = run_blocking_lock_op open_file in
-  let closed = ref false in
+  require_eio_context ();
+  let module Dir = Fs_compat.Anchored_dir in
+  let file =
+    protect_from_cancel (fun () ->
+      Dir.open_lock_file directory ~name ~perm)
+  in
+  let close_state = ref Open in
   let close_once () =
-    if not !closed
-    then (
-      closed := true;
-      run_blocking_lock_op (fun () -> close_file file))
+    match !close_state with
+    | Closed | Close_attempted -> ()
+    | Open ->
+      close_state := Close_attempted;
+      protect_from_cancel (fun () ->
+        Dir.close_lock_file file;
+        close_state := Closed)
   in
   let finish outcome =
     let close_outcome =
@@ -335,32 +405,35 @@ let with_lock_file
         (Lock_file_cleanup_failed
            { primary; primary_backtrace; close_error })
   in
-  let device, inode = identity file in
-  let entry = get_entry (file_registry_key ~device ~inode) in
-  let run () =
-    let outcome =
-      try
-        ignore
-          (acquire_flock_on_fd_cooperative
-             ?clock
-             ~fd:(descriptor file)
-             ~lock_path:path
-             ~caller:"File_lock_eio"
-             ()
-           : Unix.file_descr);
-        Ok (f ())
-      with
-      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+  let run_scoped () =
+    let device, inode = Dir.lock_file_identity file in
+    let entry = get_entry (file_registry_key ~device ~inode) in
+    let run () =
+      let outcome =
+        try
+          ignore
+            (acquire_flock_on_fd_cooperative
+               ?clock
+               ~fd:(Dir.lock_file_descriptor file)
+               ~lock_path:path
+               ~caller:"File_lock_eio"
+               ()
+             : Unix.file_descr);
+          Ok (f ())
+        with
+        | exn -> Error (exn, Printexc.get_raw_backtrace ())
+      in
+      finish outcome
     in
-    finish outcome
-  in
-  try
     Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
       ~finally:(fun () -> release_entry entry)
       (fun () -> with_cooperative_entry entry run)
+  in
+  try
+    run_scoped ()
   with
   | exn ->
-    if !closed
+    if !close_state <> Open
     then raise exn
     else finish (Error (exn, Printexc.get_raw_backtrace ()))
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -13,34 +13,13 @@
 
 module SMap = Set_util.StringMap
 
-module Key = struct
-  type t =
-    { directory_device : int64
-    ; directory_inode : int64
-    ; entry : string
-    }
-
-  let directory_entry ~directory_device ~directory_inode ~entry =
-    { directory_device; directory_inode; entry }
-  ;;
-
-  let equal left right =
-    Int64.equal left.directory_device right.directory_device
-    && Int64.equal left.directory_inode right.directory_inode
-    && String.equal left.entry right.entry
-  ;;
-
-  let registry_key key =
-    Printf.sprintf
-      "descriptor:%Lx:%Lx:%d:%s"
-      key.directory_device
-      key.directory_inode
-      (String.length key.entry)
-      key.entry
-  ;;
-end
-
 exception Flock_timeout of { caller : string; path : string; attempts : int }
+
+exception Lock_file_cleanup_failed of
+  { primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
 
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
@@ -101,6 +80,7 @@ let rec atomic_update_with_result atomic f =
 
 type lock_entry = {
   mu : Eio.Mutex.t;
+  pre_eio_mu : Stdlib.Mutex.t;
   mutable last_used : float;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
@@ -148,7 +128,13 @@ let get_entry path =
         entry.last_used <- Time_compat.now ();
         (state, entry)
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
+        let entry =
+          { mu = Eio.Mutex.create ()
+          ; pre_eio_mu = Stdlib.Mutex.create ()
+          ; last_used = Time_compat.now ()
+          ; active = Atomic.make 0
+          }
+        in
         let entries = SMap.add path entry state.entries in
         (publish_entries state entries, entry))
   in
@@ -157,6 +143,19 @@ let get_entry path =
 
 let release_entry entry =
   ignore (Atomic.fetch_and_add entry.active (-1))
+
+let with_cooperative_entry entry f =
+  if Eio_guard.is_ready ()
+  then
+    try Eio.Mutex.use_ro entry.mu f with
+    | Effect.Unhandled _ as exn ->
+      raise
+        (Failure
+           (Printf.sprintf
+              "File_lock_eio requires an Eio fiber after runtime startup: %s"
+              (Printexc.to_string exn)))
+  else Stdlib.Mutex.protect entry.pre_eio_mu f
+;;
 
 let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 
@@ -279,7 +278,7 @@ let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () -> with_cooperative_entry entry f)
 
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
@@ -298,22 +297,72 @@ let with_lock ?clock path f =
   in
   with_mutex path (fun () -> run_with_flock ())
 
-(** Descriptor-relative counterpart of [with_lock]. [with_file] must keep the
-    supplied descriptor open for its callback and close it before returning.
-    The cooperative mutex encloses [with_file], so the POSIX lock is released by
-    close before another same-process fiber can enter the critical section. *)
-let with_lock_file ?clock ~key ~path ~with_file f =
-  with_mutex (Key.registry_key key) (fun () ->
-    with_file (fun fd ->
-      ignore
-        (acquire_flock_on_fd_cooperative
-           ?clock
-           ~fd
-           ~lock_path:path
-           ~caller:"File_lock_eio"
-           ()
-         : Unix.file_descr);
-      f ()))
+let file_registry_key ~device ~inode =
+  Printf.sprintf "descriptor-inode:%Lx:%Lx" device inode
+;;
+
+let with_lock_file
+      ?clock
+      ~path
+      ~open_file
+      ~descriptor
+      ~identity
+      ~close_file
+      f
+  =
+  let file = run_blocking_lock_op open_file in
+  let closed = ref false in
+  let close_once () =
+    if not !closed
+    then (
+      closed := true;
+      run_blocking_lock_op (fun () -> close_file file))
+  in
+  let finish outcome =
+    let close_outcome =
+      try
+        close_once ();
+        Ok ()
+      with
+      | exn -> Error exn
+    in
+    match outcome, close_outcome with
+    | Ok value, Ok () -> value
+    | Error (exn, backtrace), Ok () -> Printexc.raise_with_backtrace exn backtrace
+    | Ok _, Error close_error -> raise close_error
+    | Error (primary, primary_backtrace), Error close_error ->
+      raise
+        (Lock_file_cleanup_failed
+           { primary; primary_backtrace; close_error })
+  in
+  let device, inode = identity file in
+  let entry = get_entry (file_registry_key ~device ~inode) in
+  let run () =
+    let outcome =
+      try
+        ignore
+          (acquire_flock_on_fd_cooperative
+             ?clock
+             ~fd:(descriptor file)
+             ~lock_path:path
+             ~caller:"File_lock_eio"
+             ()
+           : Unix.file_descr);
+        Ok (f ())
+      with
+      | exn -> Error (exn, Printexc.get_raw_backtrace ())
+    in
+    finish outcome
+  in
+  try
+    Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
+      ~finally:(fun () -> release_entry entry)
+      (fun () -> with_cooperative_entry entry run)
+  with
+  | exn ->
+    if !closed
+    then raise exn
+    else finish (Error (exn, Printexc.get_raw_backtrace ()))
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -29,6 +29,12 @@ val stale_lock_seconds : float
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+exception Lock_file_cleanup_failed of
+  { primary : exn
+  ; primary_backtrace : Printexc.raw_backtrace
+  ; close_error : exn
+  }
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -71,17 +77,6 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
-module Key : sig
-  type t
-
-  val directory_entry :
-    directory_device:int64 -> directory_inode:int64 -> entry:string -> t
-  (** Same-process lock identity for one entry in an already-open directory.
-      It is independent of the path spelling used to reach that directory. *)
-
-  val equal : t -> t -> bool
-end
-
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
     single-process fiber serialisation but have no filesystem
@@ -100,15 +95,18 @@ val with_lock :
 
 val with_lock_file :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> key:Key.t
   -> path:string
-  -> with_file:((Unix.file_descr -> 'a) -> 'a)
+  -> open_file:(unit -> 'resource)
+  -> descriptor:('resource -> Unix.file_descr)
+  -> identity:('resource -> int64 * int64)
+  -> close_file:('resource -> unit)
   -> (unit -> 'a)
   -> 'a
-(** Descriptor-relative counterpart of {!with_lock}. [with_file] opens the lock
-    artifact without path re-resolution, keeps its descriptor open for the
-    supplied callback, and closes it before returning. [key] provides canonical
-    same-process serialization; [path] is diagnostic only. *)
+(** Descriptor-relative counterpart of {!with_lock}. The caller provides a
+    blocking-only [open_file]/[close_file] pair; opening and close run in a
+    system thread under Eio. Same-process serialization is derived from the
+    opened regular file's actual [(device, inode)], so path and hard-link aliases
+    cannot select different cooperative mutexes. [path] is diagnostic only. *)
 
 (** {1 Observability hook} *)
 

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -35,6 +35,14 @@ exception Lock_file_cleanup_failed of
   ; close_error : exn
   }
 
+exception Flock_release_failed of
+  { unlock_error : exn option
+  ; close_error : exn option
+  }
+(** Unlock and close both ran but at least one failed. Neither failure is
+    discarded; [close_error = Some _] means the descriptor's final state is
+    unknown and must not be retried. *)
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -72,41 +80,50 @@ val acquire_flock_fd :
   string ->
   Unix.file_descr
 
-(** [release_flock_fd fd] unlocks (best-effort) and closes [fd]. *)
+(** [release_flock_fd fd] unlocks and closes [fd]. Failures from either step
+    are reported as {!Flock_release_failed}; close is attempted even if unlock
+    failed. *)
 val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
-    single-process fiber serialisation but have no filesystem
-    artifact to flock. *)
+    single-process fiber serialisation but have no filesystem artifact to
+    flock. Before Eio starts, it uses a transition gate; an Eio caller drains
+    that gate before acquiring the cooperative mutex, so the two modes never
+    overlap for one key. *)
 val with_mutex : string -> (unit -> 'a) -> 'a
 
 (** [with_lock ?clock path f] runs [f] while holding both the
     cooperative Eio.Mutex and an OS-level flock on [path ^ ".lock"].
     The flock uses non-blocking F_TLOCK retries — max 200 attempts,
-    ~2s total with default sleeps. *)
+    ~2s total with default sleeps. A pre-Eio caller and a later Eio caller use
+    the same transition gate before the latter acquires its cooperative mutex.
+    *)
 val with_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   string ->
   (unit -> 'a) ->
   'a
 
-val with_lock_file :
+val with_anchored_file_lock :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> path:string
-  -> open_file:(unit -> 'resource)
-  -> descriptor:('resource -> Unix.file_descr)
-  -> identity:('resource -> int64 * int64)
-  -> close_file:('resource -> unit)
+  -> directory:Fs_compat.Anchored_dir.t
+  -> name:Fs_compat.Anchored_dir.Segment.t
+  -> perm:int
   -> (unit -> 'a)
   -> 'a
-(** Descriptor-relative counterpart of {!with_lock}. The caller provides a
-    blocking-only [open_file]/[close_file] pair; opening and close run in a
-    system thread under Eio. Same-process serialization is derived from the
-    opened regular file's actual [(device, inode)], so path and hard-link aliases
-    cannot select different cooperative mutexes. [path] is diagnostic only. *)
+(** Descriptor-relative lock scoped to an anchored directory capability. It
+    opens, identifies, locks, and closes one regular lock artifact as a single
+    ownership unit. Same-process serialization is derived from that opened
+    file's actual [(device, inode)], so hard-link aliases cannot select
+    different cooperative mutexes. [path] is diagnostic only.
+
+    The lock artifact closes in a cancellation-protected cleanup scope. If the
+    close syscall reports an error, its descriptor is never retried because a
+    retry could close a reused descriptor. *)
 
 (** {1 Observability hook} *)
 

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -71,6 +71,17 @@ val release_flock_fd : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
 
+module Key : sig
+  type t
+
+  val directory_entry :
+    directory_device:int64 -> directory_inode:int64 -> entry:string -> t
+  (** Same-process lock identity for one entry in an already-open directory.
+      It is independent of the path spelling used to reach that directory. *)
+
+  val equal : t -> t -> bool
+end
+
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need
     single-process fiber serialisation but have no filesystem
@@ -86,6 +97,18 @@ val with_lock :
   string ->
   (unit -> 'a) ->
   'a
+
+val with_lock_file :
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> key:Key.t
+  -> path:string
+  -> with_file:((Unix.file_descr -> 'a) -> 'a)
+  -> (unit -> 'a)
+  -> 'a
+(** Descriptor-relative counterpart of {!with_lock}. [with_file] opens the lock
+    artifact without path re-resolution, keeps its descriptor open for the
+    supplied callback, and closes it before returning. [key] provides canonical
+    same-process serialization; [path] is diagnostic only. *)
 
 (** {1 Observability hook} *)
 

--- a/test/dune
+++ b/test/dune
@@ -42,6 +42,7 @@
   test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
+  test_keeper_memory_job_store
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_keeper_verification_audit
@@ -403,6 +404,7 @@
   test_keeper_memory_os_recall_echo
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
+  test_keeper_memory_job_store
   test_keeper_memory_lane
   test_env_keeper_scrub
   test_keeper_reactive_wake_backlog_gate

--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,7 @@
   test_connector_reactive_wake_throttle
   test_keeper_bank_longterm_inject_flag
   test_keeper_memory_job_store
+  test_keeper_memory_os_explicit_root
   test_keeper_memory_lane
   test_keeper_reactive_wake_backlog_gate
   test_keeper_verification_audit

--- a/test/stanzas/test_fs_atomic_orphan_sweep_10130.inc
+++ b/test/stanzas/test_fs_atomic_orphan_sweep_10130.inc
@@ -1,4 +1,4 @@
 (test
  (name test_fs_atomic_orphan_sweep_10130)
  (modules test_fs_atomic_orphan_sweep_10130)
- (libraries fs_compat alcotest unix))
+ (libraries fs_compat alcotest eio eio_main unix))

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -1,5 +1,7 @@
 open Alcotest
 
+exception Body_failure
+
 let cleanup_if_exists path =
   if Sys.file_exists path then
     if Sys.is_directory path then
@@ -122,9 +124,9 @@ let test_descriptor_lock_hard_link_alias_serializes_and_recovers () =
           Eio.Promise.await second_entered;
           (match
              with_descriptor_lock first ~segment:primary ~path:primary_path (fun () ->
-               failwith "body failure")
+               raise Body_failure)
            with
-           | exception Failure "body failure" -> ()
+           | exception Body_failure -> ()
            | () -> Alcotest.fail "expected body failure");
           with_descriptor_lock first ~segment:alias ~path:alias_path (fun () -> ())))
 

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -59,44 +59,77 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
-let test_descriptor_lock_identity_ignores_path_alias () =
+let with_descriptor_lock directory ~segment ~path f =
+  let module Dir = Fs_compat.Anchored_dir in
+  File_lock_eio.with_lock_file
+    ~path
+    ~open_file:(fun () ->
+      Dir.open_lock_file directory ~name:segment ~perm:0o600)
+    ~descriptor:Dir.lock_file_descriptor
+    ~identity:Dir.lock_file_identity
+    ~close_file:Dir.close_lock_file
+    f
+;;
+
+let test_descriptor_lock_hard_link_alias_serializes_and_recovers () =
   with_temp_path @@ fun path ->
   Unix.mkdir path 0o700;
-  let lock_path = Filename.concat path "state.lock" in
+  let primary_path = Filename.concat path "state.lock" in
+  let alias_path = Filename.concat path "alias.lock" in
   Fun.protect
-    ~finally:(fun () -> cleanup_if_exists lock_path)
+    ~finally:(fun () ->
+      cleanup_if_exists alias_path;
+      cleanup_if_exists primary_path)
     (fun () ->
-      let alias = Filename.concat path Filename.current_dir_name in
       let module Dir = Fs_compat.Anchored_dir in
-      let segment =
+      let primary =
         match Dir.Segment.of_string "state.lock" with
         | Ok segment -> segment
         | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
       in
-      Dir.with_open_root path @@ fun first ->
-      Dir.with_open_root alias @@ fun second ->
-      let first_identity = Dir.identity first in
-      let second_identity = Dir.identity second in
-      let key (identity : Dir.directory_identity) =
-        File_lock_eio.Key.directory_entry
-          ~directory_device:identity.device
-          ~directory_inode:identity.inode
-          ~entry:(Dir.Segment.to_string segment)
+      let alias =
+        match Dir.Segment.of_string "alias.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
       in
-      let first_key = key first_identity in
-      let second_key = key second_identity in
-      check bool
-        "directory aliases share one typed lock key"
-        true
-        (File_lock_eio.Key.equal first_key second_key);
-      let calls = ref 0 in
-      File_lock_eio.with_lock_file
-        ~key:first_key
-        ~path:lock_path
-        ~with_file:(fun callback ->
-          Dir.with_lock_file first ~name:segment ~perm:0o600 callback)
-        (fun () -> incr calls);
-      check int "descriptor lock body called once" 1 !calls)
+      Dir.with_open_root path @@ fun first ->
+      let bootstrap = Dir.open_lock_file first ~name:primary ~perm:0o600 in
+      Dir.close_lock_file bootstrap;
+      Unix.link primary_path alias_path;
+      Eio_main.run @@ fun _env ->
+      Eio_guard.enable ();
+      Fun.protect
+        ~finally:Eio_guard.disable
+        (fun () ->
+          Eio.Switch.run @@ fun sw ->
+          let first_entered, resolve_first_entered = Eio.Promise.create () in
+          let release_first, resolve_release_first = Eio.Promise.create () in
+          let second_attempted, resolve_second_attempted = Eio.Promise.create () in
+          let second_entered, resolve_second_entered = Eio.Promise.create () in
+          Eio.Fiber.fork ~sw (fun () ->
+            with_descriptor_lock first ~segment:primary ~path:primary_path (fun () ->
+              Eio.Promise.resolve resolve_first_entered ();
+              Eio.Promise.await release_first));
+          Eio.Promise.await first_entered;
+          Eio.Fiber.fork ~sw (fun () ->
+            Eio.Promise.resolve resolve_second_attempted ();
+            with_descriptor_lock first ~segment:alias ~path:alias_path (fun () ->
+              Eio.Promise.resolve resolve_second_entered ()));
+          Eio.Promise.await second_attempted;
+          Eio.Fiber.yield ();
+          Alcotest.(check bool)
+            "hard-link alias body waits for the first holder"
+            true
+            (Option.is_none (Eio.Promise.peek second_entered));
+          Eio.Promise.resolve resolve_release_first ();
+          Eio.Promise.await second_entered;
+          (match
+             with_descriptor_lock first ~segment:primary ~path:primary_path (fun () ->
+               failwith "body failure")
+           with
+           | exception Failure "body failure" -> ()
+           | () -> Alcotest.fail "expected body failure");
+          with_descriptor_lock first ~segment:alias ~path:alias_path (fun () -> ())))
 
 let () =
   run "file_lock_eio"
@@ -108,8 +141,8 @@ let () =
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
           test_case
-            "descriptor identity ignores path aliases"
+            "hard-link alias serializes and recovers after failure"
             `Quick
-            test_descriptor_lock_identity_ignores_path_alias;
+            test_descriptor_lock_hard_link_alias_serializes_and_recovers;
         ] );
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -59,6 +59,45 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_descriptor_lock_identity_ignores_path_alias () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let lock_path = Filename.concat path "state.lock" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_if_exists lock_path)
+    (fun () ->
+      let alias = Filename.concat path Filename.current_dir_name in
+      let module Dir = Fs_compat.Anchored_dir in
+      let segment =
+        match Dir.Segment.of_string "state.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun first ->
+      Dir.with_open_root alias @@ fun second ->
+      let first_identity = Dir.identity first in
+      let second_identity = Dir.identity second in
+      let key (identity : Dir.directory_identity) =
+        File_lock_eio.Key.directory_entry
+          ~directory_device:identity.device
+          ~directory_inode:identity.inode
+          ~entry:(Dir.Segment.to_string segment)
+      in
+      let first_key = key first_identity in
+      let second_key = key second_identity in
+      check bool
+        "directory aliases share one typed lock key"
+        true
+        (File_lock_eio.Key.equal first_key second_key);
+      let calls = ref 0 in
+      File_lock_eio.with_lock_file
+        ~key:first_key
+        ~path:lock_path
+        ~with_file:(fun callback ->
+          Dir.with_lock_file first ~name:segment ~perm:0o600 callback)
+        (fun () -> incr calls);
+      check int "descriptor lock body called once" 1 !calls)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +107,9 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case
+            "descriptor identity ignores path aliases"
+            `Quick
+            test_descriptor_lock_identity_ignores_path_alias;
         ] );
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -25,8 +25,8 @@ let test_with_lock_without_eio () =
   let calls = ref 0 in
   let result =
     File_lock_eio.with_lock path (fun () ->
-        incr calls;
-        "ok")
+      incr calls;
+      "ok")
   in
   check string "result" "ok" result;
   check int "single call" 1 !calls;
@@ -60,14 +60,11 @@ let test_with_lock_inside_eio () =
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
 let with_descriptor_lock directory ~segment ~path f =
-  let module Dir = Fs_compat.Anchored_dir in
-  File_lock_eio.with_lock_file
+  File_lock_eio.with_anchored_file_lock
     ~path
-    ~open_file:(fun () ->
-      Dir.open_lock_file directory ~name:segment ~perm:0o600)
-    ~descriptor:Dir.lock_file_descriptor
-    ~identity:Dir.lock_file_identity
-    ~close_file:Dir.close_lock_file
+    ~directory
+    ~name:segment
+    ~perm:0o600
     f
 ;;
 
@@ -131,6 +128,76 @@ let test_descriptor_lock_hard_link_alias_serializes_and_recovers () =
            | () -> Alcotest.fail "expected body failure");
           with_descriptor_lock first ~segment:alias ~path:alias_path (fun () -> ())))
 
+let test_descriptor_lock_cancellation_closes_before_reacquire () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let lock_path = Filename.concat path "state.lock" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_if_exists lock_path)
+    (fun () ->
+      let module Dir = Fs_compat.Anchored_dir in
+      let segment =
+        match Dir.Segment.of_string "state.lock" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun root ->
+      Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      Fun.protect
+        ~finally:Eio_guard.disable
+        (fun () ->
+          let entered, resolve_entered = Eio.Promise.create () in
+          let completed =
+            Eio.Fiber.first
+              (fun () ->
+                with_descriptor_lock root ~segment ~path:lock_path (fun () ->
+                  Eio.Promise.resolve resolve_entered ();
+                  Eio.Time.sleep (Eio.Stdenv.clock env) 60.0))
+              (fun () -> Eio.Promise.await entered)
+          in
+          check unit "cancelling peer completed" () completed;
+          with_descriptor_lock root ~segment ~path:lock_path (fun () -> ())))
+
+let test_anchored_lock_and_read_reject_nonregular_entries () =
+  with_temp_path @@ fun path ->
+  Unix.mkdir path 0o700;
+  let fifo_path = Filename.concat path "state.fifo" in
+  let target_path = Filename.concat path "target" in
+  let link_path = Filename.concat path "state.link" in
+  Unix.mkfifo fifo_path 0o600;
+  let output = open_out_bin target_path in
+  output_string output "target";
+  close_out output;
+  Unix.symlink "target" link_path;
+  Fun.protect
+    ~finally:(fun () ->
+      cleanup_if_exists link_path;
+      cleanup_if_exists target_path;
+      cleanup_if_exists fifo_path)
+    (fun () ->
+      let module Dir = Fs_compat.Anchored_dir in
+      let fifo =
+        match Dir.Segment.of_string "state.fifo" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      let link =
+        match Dir.Segment.of_string "state.link" with
+        | Ok segment -> segment
+        | Error error -> Alcotest.fail (Dir.Segment.error_to_string error)
+      in
+      Dir.with_open_root path @@ fun root ->
+      (match Dir.read_file root fifo with
+       | exception Unix.Unix_error (Unix.EINVAL, _, _) -> ()
+       | _ -> Alcotest.fail "FIFO was accepted as an anchored readable file");
+      (match Dir.open_lock_file root ~name:fifo ~perm:0o600 with
+       | exception Unix.Unix_error (Unix.EINVAL, _, _) -> ()
+       | _ -> Alcotest.fail "FIFO was accepted as an anchored lock file");
+      match Dir.open_lock_file root ~name:link ~perm:0o600 with
+      | exception Unix.Unix_error (Unix.ELOOP, _, _) -> ()
+      | _ -> Alcotest.fail "symlink was accepted as an anchored lock file")
+
 let () =
   run "file_lock_eio"
     [
@@ -144,5 +211,13 @@ let () =
             "hard-link alias serializes and recovers after failure"
             `Quick
             test_descriptor_lock_hard_link_alias_serializes_and_recovers;
+          test_case
+            "cancellation closes descriptor lock before re-acquire"
+            `Quick
+            test_descriptor_lock_cancellation_closes_before_reacquire;
+          test_case
+            "anchored lock and read reject FIFO and symlink entries"
+            `Quick
+            test_anchored_lock_and_read_reject_nonregular_entries;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -238,22 +238,12 @@ let test_blocking_durable_primitives () =
   (match Fs_compat.save_file_atomic_unix target "second" with
    | Ok () -> ()
    | Error detail -> Alcotest.failf "blocking atomic overwrite failed: %s" detail);
-  let ic = open_in_bin target in
-  let content =
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () -> really_input_string ic (in_channel_length ic))
-  in
+  let content = Fs_compat.load_file_unix target in
   Alcotest.(check string) "blocking atomic content" "second" content;
   let append_target = Filename.concat nested "events.jsonl" in
   Fs_compat.append_file_durable append_target "one\n";
   Fs_compat.append_file_durable append_target "two\n";
-  let append_ic = open_in_bin append_target in
-  let appended =
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr append_ic)
-      (fun () -> really_input_string append_ic (in_channel_length append_ic))
-  in
+  let appended = Fs_compat.load_file_unix append_target in
   Alcotest.(check string) "durable append content" "one\ntwo\n" appended;
   let missing_parent_target =
     Filename.concat base_path "missing-parent/state.json"

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -490,6 +490,28 @@ let test_anchored_root_rejects_symlink () =
   | exception Unix.Unix_error _ -> ()
   | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
 
+let test_anchored_lock_file_rejects_symlink () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let outside = Filename.concat base_path "outside.lock" in
+  let link = Filename.concat base_path "managed.lock" in
+  Fs_compat.save_file_unix outside "sentinel";
+  Unix.symlink outside link;
+  Dir.with_open_root base_path @@ fun root ->
+  (match
+     Dir.with_lock_file
+       root
+       ~name:(anchored_segment "managed.lock")
+       ~perm:0o600
+       (fun _ -> ())
+   with
+   | exception Unix.Unix_error _ -> ()
+   | () -> Alcotest.fail "symlinked lock file was accepted");
+  Alcotest.(check string)
+    "symlink target unchanged"
+    "sentinel"
+    (Fs_compat.load_file_unix outside)
+
 let test_anchored_segments_reject_ambiguous_names () =
   let module Segment = Fs_compat.Anchored_dir.Segment in
   List.iter
@@ -545,6 +567,8 @@ let () =
             test_anchored_capability_survives_path_substitution;
           Alcotest.test_case "symlinked root rejected" `Quick
             test_anchored_root_rejects_symlink;
+          Alcotest.test_case "symlinked lock file rejected" `Quick
+            test_anchored_lock_file_rejects_symlink;
           Alcotest.test_case "ambiguous segments rejected" `Quick
             test_anchored_segments_reject_ambiguous_names;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -499,11 +499,10 @@ let test_anchored_lock_file_rejects_symlink () =
   Unix.symlink outside link;
   Dir.with_open_root base_path @@ fun root ->
   (match
-     Dir.with_lock_file
+     Dir.open_lock_file
        root
        ~name:(anchored_segment "managed.lock")
        ~perm:0o600
-       (fun _ -> ())
    with
    | exception Unix.Unix_error _ -> ()
    | () -> Alcotest.fail "symlinked lock file was accepted");
@@ -511,6 +510,21 @@ let test_anchored_lock_file_rejects_symlink () =
     "symlink target unchanged"
     "sentinel"
     (Fs_compat.load_file_unix outside)
+
+let test_anchored_lock_file_rejects_fifo () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let fifo = Filename.concat base_path "managed.lock" in
+  Unix.mkfifo fifo 0o600;
+  Dir.with_open_root base_path @@ fun root ->
+  match
+    Dir.open_lock_file
+      root
+      ~name:(anchored_segment "managed.lock")
+      ~perm:0o600
+  with
+  | exception Unix.Unix_error _ -> ()
+  | _ -> Alcotest.fail "FIFO lock artifact was accepted"
 
 let test_anchored_segments_reject_ambiguous_names () =
   let module Segment = Fs_compat.Anchored_dir.Segment in
@@ -569,6 +583,8 @@ let () =
             test_anchored_root_rejects_symlink;
           Alcotest.test_case "symlinked lock file rejected" `Quick
             test_anchored_lock_file_rejects_symlink;
+          Alcotest.test_case "FIFO lock file rejected" `Quick
+            test_anchored_lock_file_rejects_fifo;
           Alcotest.test_case "ambiguous segments rejected" `Quick
             test_anchored_segments_reject_ambiguous_names;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -9,7 +9,8 @@
    [Fs_compat.cleanup_atomic_orphans] is a boot-time sweep:
    - zero-byte orphans are deleted;
    - non-zero orphans are MOVED (not deleted) to
-     [<base_path>/.recovered/] so operators can forensically
+     a source-directory bucket below [<base_path>/.recovered/] so operators can
+     forensically
      inspect data-loss events.
 
    These tests pin that contract so a future refactor can't
@@ -96,8 +97,9 @@ let test_nonzero_orphan_preserved_in_recovered () =
   Alcotest.(check int) "1 preserved" 1 preserved;
   Alcotest.(check bool) "original removed" false
     (Sys.file_exists orphan);
-  let recovered_dir = Filename.concat base_path ".recovered" in
-  Alcotest.(check bool) ".recovered/ created" true
+  let recovered_root = Filename.concat base_path ".recovered" in
+  let recovered_dir = Filename.concat recovered_root "root" in
+  Alcotest.(check bool) ".recovered/root created" true
     (Sys.file_exists recovered_dir);
   let entries = Sys.readdir recovered_dir in
   Alcotest.(check int) "1 file in .recovered/" 1 (Array.length entries);
@@ -189,6 +191,77 @@ let test_recovered_dir_skipped_on_rescan () =
   Alcotest.(check bool) ".recovered/ seed file untouched" true
     (Sys.file_exists (Filename.concat recovered ".atomic_seed.tmp"))
 
+let test_direct_recovery_rejects_symlinked_destination () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let target = Filename.concat base_path "outside" in
+  let recovered = Filename.concat base_path "recovered" in
+  write_file ~path:orphan ~content:"forensic payload";
+  Unix.mkdir target 0o755;
+  Unix.symlink target recovered;
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "symlinked recovery destination was accepted");
+  Alcotest.(check bool) "orphan retained" true (Sys.file_exists orphan);
+  Alcotest.(check int)
+    "symlink target untouched"
+    0
+    (Array.length (Sys.readdir target))
+
+let test_direct_recovery_preserves_without_overwrite () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let recovered = Filename.concat base_path "recovered" in
+  Unix.mkdir recovered 0o755;
+  write_file ~path:orphan ~content:"first";
+  let destination = Filename.concat recovered ".atomic_data.tmp" in
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Ok (Fs_compat.Preserved_nonempty actual) ->
+     Alcotest.(check string) "recovery destination" destination actual
+   | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "nonempty orphan deleted"
+   | Error detail -> Alcotest.failf "direct recovery failed: %s" detail);
+  write_file ~path:orphan ~content:"second";
+  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "existing forensic evidence was overwritten");
+  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan)
+
+let test_blocking_durable_primitives () =
+  with_temp_base @@ fun base_path ->
+  let nested = Filename.concat base_path "one/two/three" in
+  Fs_compat.mkdir_p_durable_unix nested;
+  Alcotest.(check bool) "durable directory tree created" true (Sys.is_directory nested);
+  let target = Filename.concat nested "state.json" in
+  (match Fs_compat.save_file_atomic_unix target "first" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "blocking atomic write failed: %s" detail);
+  (match Fs_compat.save_file_atomic_unix target "second" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "blocking atomic overwrite failed: %s" detail);
+  let ic = open_in_bin target in
+  let content =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> really_input_string ic (in_channel_length ic))
+  in
+  Alcotest.(check string) "blocking atomic content" "second" content;
+  let append_target = Filename.concat nested "events.jsonl" in
+  Fs_compat.append_file_durable append_target "one\n";
+  Fs_compat.append_file_durable append_target "two\n";
+  let append_ic = open_in_bin append_target in
+  let appended =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr append_ic)
+      (fun () -> really_input_string append_ic (in_channel_length append_ic))
+  in
+  Alcotest.(check string) "durable append content" "one\ntwo\n" appended;
+  let missing_parent_target =
+    Filename.concat base_path "missing-parent/state.json"
+  in
+  (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
+   | Error _ -> ()
+   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
     [
@@ -211,5 +284,12 @@ let () =
             test_mixed_batch;
           Alcotest.test_case ".recovered/ skipped on rescan" `Quick
             test_recovered_dir_skipped_on_rescan;
+          Alcotest.test_case "symlinked recovery rejected" `Quick
+            test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "direct recovery does not overwrite" `Quick
+            test_direct_recovery_preserves_without_overwrite;
         ] );
+      ( "durable-primitives",
+        [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
+            test_blocking_durable_primitives ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -213,6 +213,37 @@ let test_direct_recovery_rejects_symlinked_destination () =
     0
     (Array.length (Sys.readdir target))
 
+let test_cleanup_rejects_recovery_escape () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  write_file ~path:orphan ~content:"forensic payload";
+  (match
+     Fs_compat.cleanup_atomic_orphans
+       ~base_path
+       ~recovered_subdir:"../outside"
+       ()
+   with
+   | exception Invalid_argument _ -> ()
+   | _ -> Alcotest.fail "recovery traversal was accepted");
+  Alcotest.(check bool) "traversal source retained" true (Sys.file_exists orphan)
+
+let test_cleanup_rejects_symlinked_recovery_root () =
+  with_temp_base @@ fun base_path ->
+  let orphan = Filename.concat base_path ".atomic_data.tmp" in
+  let target = Filename.concat base_path "outside" in
+  let recovered = Filename.concat base_path ".recovered" in
+  write_file ~path:orphan ~content:"forensic payload";
+  Unix.mkdir target 0o755;
+  Unix.symlink target recovered;
+  let deleted, preserved = Fs_compat.cleanup_atomic_orphans ~base_path () in
+  Alcotest.(check int) "no deletion through symlink" 0 deleted;
+  Alcotest.(check int) "no preservation through symlink" 0 preserved;
+  Alcotest.(check bool) "symlink source retained" true (Sys.file_exists orphan);
+  Alcotest.(check int)
+    "symlink root target untouched"
+    0
+    (Array.length (Sys.readdir target))
+
 let test_direct_recovery_preserves_without_overwrite () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
@@ -322,6 +353,10 @@ let () =
             test_recovered_dir_skipped_on_rescan;
           Alcotest.test_case "symlinked recovery rejected" `Quick
             test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "recovery traversal rejected" `Quick
+            test_cleanup_rejects_recovery_escape;
+          Alcotest.test_case "symlinked recovery root rejected" `Quick
+            test_cleanup_rejects_symlinked_recovery_root;
           Alcotest.test_case "direct recovery does not overwrite" `Quick
             test_direct_recovery_preserves_without_overwrite;
         ] );

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -199,7 +199,12 @@ let test_direct_recovery_rejects_symlinked_destination () =
   write_file ~path:orphan ~content:"forensic payload";
   Unix.mkdir target 0o755;
   Unix.symlink target recovered;
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root:recovered
+       ~bucket:"root"
+   with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "symlinked recovery destination was accepted");
   Alcotest.(check bool) "orphan retained" true (Sys.file_exists orphan);
@@ -211,20 +216,48 @@ let test_direct_recovery_rejects_symlinked_destination () =
 let test_direct_recovery_preserves_without_overwrite () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
-  let recovered = Filename.concat base_path "recovered" in
+  let recovered_root = Filename.concat base_path "recovered" in
+  let recovered = Filename.concat recovered_root "root" in
+  Unix.mkdir recovered_root 0o755;
   Unix.mkdir recovered 0o755;
   write_file ~path:orphan ~content:"first";
   let destination = Filename.concat recovered ".atomic_data.tmp" in
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
    | Ok (Fs_compat.Preserved_nonempty actual) ->
      Alcotest.(check string) "recovery destination" destination actual
    | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "nonempty orphan deleted"
    | Error detail -> Alcotest.failf "direct recovery failed: %s" detail);
   write_file ~path:orphan ~content:"second";
-  (match Fs_compat.recover_atomic_orphan ~path:orphan ~recovered_dir:recovered with
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "existing forensic evidence was overwritten");
-  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan)
+  Alcotest.(check bool) "second orphan retained" true (Sys.file_exists orphan);
+  Unix.unlink destination;
+  Unix.link orphan destination;
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
+   | Ok (Fs_compat.Preserved_nonempty actual) ->
+     Alcotest.(check string) "interrupted recovery destination" destination actual
+   | Ok Fs_compat.Deleted_zero_length -> Alcotest.fail "linked orphan deleted"
+   | Error detail -> Alcotest.failf "linked recovery failed: %s" detail);
+  Alcotest.(check bool)
+    "interrupted source acknowledged"
+    false
+    (Sys.file_exists orphan)
 
 let test_blocking_durable_primitives () =
   with_temp_base @@ fun base_path ->
@@ -251,6 +284,19 @@ let test_blocking_durable_primitives () =
   (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
    | Error _ -> ()
    | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+
+let test_durable_append_falls_back_outside_eio () =
+  with_temp_base @@ fun base_path ->
+  Fun.protect
+    ~finally:Fs_compat.clear_fs
+    (fun () ->
+       Eio_main.run (fun env -> Fs_compat.set_fs (Eio.Stdenv.fs env));
+       let path = Filename.concat base_path "outside-eio.jsonl" in
+       Fs_compat.append_file_durable path "row\n";
+       Alcotest.(check string)
+         "fallback durable append"
+         "row\n"
+         (Fs_compat.load_file_unix path))
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -281,5 +327,8 @@ let () =
         ] );
       ( "durable-primitives",
         [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
-            test_blocking_durable_primitives ] );
+            test_blocking_durable_primitives;
+          Alcotest.test_case "durable append outside Eio runtime" `Quick
+            test_durable_append_falls_back_outside_eio;
+        ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -375,41 +375,81 @@ let test_durable_append_falls_back_outside_eio () =
          "row\n"
          (Fs_compat.load_file_unix path))
 
+let anchored_segment raw =
+  match Fs_compat.Anchored_dir.Segment.of_string raw with
+  | Ok segment -> segment
+  | Error error ->
+    Alcotest.failf
+      "invalid anchored test segment %S: %s"
+      raw
+      (Fs_compat.Anchored_dir.Segment.error_to_string error)
+;;
+
+let require_anchored_mutation label = function
+  | Ok value -> value
+  | Error error ->
+    Alcotest.failf
+      "%s: %s"
+      label
+      (Fs_compat.Anchored_dir.mutation_error_to_string error)
+;;
+
 let test_anchored_directory_primitives () =
   with_temp_base @@ fun base_path ->
   let module Dir = Fs_compat.Anchored_dir in
   Dir.with_open_root base_path @@ fun root ->
   Dir.with_ensure_dir
     root
-    ~name:"managed"
+    ~name:(anchored_segment "managed")
     ~perm:0o700
     ~enforce_perm:true
   @@ fun managed ->
-  (match Dir.save_file_atomic managed ~name:"state.json" ~perm:0o600 "one" with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "anchored atomic write failed: %s" detail);
-  Alcotest.(check string) "anchored read" "one" (Dir.read_file managed "state.json");
-  (match Dir.stat managed "state.json" with
+  require_anchored_mutation
+    "anchored atomic write"
+    (Dir.atomic_replace
+       managed
+       ~name:(anchored_segment "state.json")
+       ~perm:0o600
+       "one");
+  Alcotest.(check string)
+    "anchored read"
+    "one"
+    (Dir.read_file managed (anchored_segment "state.json"));
+  (match Dir.stat managed (anchored_segment "state.json") with
    | Some { kind = Dir.Regular_file; _ } -> ()
    | Some _ -> Alcotest.fail "anchored stat returned the wrong file kind"
    | None -> Alcotest.fail "anchored stat lost a committed file");
-  Dir.rename
-    ~src_dir:managed
-    ~src:"state.json"
-    ~dst_dir:managed
-    ~dst:"renamed.json";
+  require_anchored_mutation
+    "anchored rename"
+    (Dir.rename
+       ~src_dir:managed
+       ~src:(anchored_segment "state.json")
+       ~dst_dir:managed
+       ~dst:(anchored_segment "renamed.json"));
   Alcotest.(check bool)
     "source removed by rename"
     false
-    (Option.is_some (Dir.stat managed "state.json"));
+    (Option.is_some (Dir.stat managed (anchored_segment "state.json")));
   Alcotest.(check bool)
     "renamed file removed"
     true
-    (Dir.unlink_if_exists managed "renamed.json");
+    (match
+       require_anchored_mutation
+         "anchored unlink"
+         (Dir.unlink_if_exists managed (anchored_segment "renamed.json"))
+     with
+     | `Removed -> true
+     | `Missing -> false);
   Alcotest.(check bool)
     "missing unlink is explicit false"
     false
-    (Dir.unlink_if_exists managed "renamed.json")
+    (match
+       require_anchored_mutation
+         "anchored missing unlink"
+         (Dir.unlink_if_exists managed (anchored_segment "renamed.json"))
+     with
+     | `Removed -> true
+     | `Missing -> false)
 
 let test_anchored_capability_survives_path_substitution () =
   with_temp_base @@ fun base_path ->
@@ -420,12 +460,16 @@ let test_anchored_capability_survives_path_substitution () =
   Unix.mkdir managed_path 0o700;
   Unix.mkdir outside_path 0o700;
   Dir.with_open_root base_path @@ fun root ->
-  Dir.with_open_dir root "managed" @@ fun managed ->
+  Dir.with_open_dir root (anchored_segment "managed") @@ fun managed ->
   Unix.rename managed_path detached_path;
   Unix.symlink outside_path managed_path;
-  (match Dir.save_file_atomic managed ~name:"proof.json" ~perm:0o600 "anchored" with
-   | Ok () -> ()
-   | Error detail -> Alcotest.failf "anchored write after substitution: %s" detail);
+  require_anchored_mutation
+    "anchored write after substitution"
+    (Dir.atomic_replace
+       managed
+       ~name:(anchored_segment "proof.json")
+       ~perm:0o600
+       "anchored");
   Alcotest.(check bool)
     "replacement symlink target untouched"
     false
@@ -445,6 +489,15 @@ let test_anchored_root_rejects_symlink () =
   match Dir.with_open_root alias (fun _ -> ()) with
   | exception Unix.Unix_error _ -> ()
   | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
+
+let test_anchored_segments_reject_ambiguous_names () =
+  let module Segment = Fs_compat.Anchored_dir.Segment in
+  List.iter
+    (fun raw ->
+       match Segment.of_string raw with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.failf "ambiguous anchored segment accepted: %S" raw)
+    [ ""; "."; ".."; "a/b"; "nul\000suffix" ]
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -492,5 +545,7 @@ let () =
             test_anchored_capability_survives_path_substitution;
           Alcotest.test_case "symlinked root rejected" `Quick
             test_anchored_root_rejects_symlink;
+          Alcotest.test_case "ambiguous segments rejected" `Quick
+            test_anchored_segments_reject_ambiguous_names;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -213,6 +213,30 @@ let test_direct_recovery_rejects_symlinked_destination () =
     0
     (Array.length (Sys.readdir target))
 
+let test_direct_recovery_rejects_symlinked_source () =
+  with_temp_base @@ fun base_path ->
+  let target = Filename.concat base_path "target" in
+  let orphan = Filename.concat base_path ".atomic_symlink.tmp" in
+  let recovered_root = Filename.concat base_path "recovered" in
+  let recovered = Filename.concat recovered_root "root" in
+  write_file ~path:target ~content:"must remain outside recovery";
+  Unix.mkdir recovered_root 0o755;
+  Unix.mkdir recovered 0o755;
+  Unix.symlink target orphan;
+  (match
+     Fs_compat.recover_atomic_orphan
+       ~path:orphan
+       ~recovered_root
+       ~bucket:"root"
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "symlinked orphan source was accepted");
+  Alcotest.(check bool) "source symlink retained" true (Sys.file_exists orphan);
+  Alcotest.(check string)
+    "symlink target retained"
+    "must remain outside recovery"
+    (Fs_compat.load_file_unix target)
+
 let test_cleanup_rejects_recovery_escape () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data.tmp" in
@@ -314,7 +338,29 @@ let test_blocking_durable_primitives () =
   in
   (match Fs_compat.save_file_atomic_unix missing_parent_target "value" with
    | Error _ -> ()
-   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded")
+   | Ok () -> Alcotest.fail "write with missing parent unexpectedly succeeded");
+  (match Fs_compat.fsync_directory target with
+   | Error _ -> ()
+   | Ok () -> Alcotest.fail "regular file accepted as directory fsync target")
+
+let test_durable_mkdir_rejects_non_directories () =
+  with_temp_base @@ fun base_path ->
+  let file = Filename.concat base_path "file" in
+  let target = Filename.concat base_path "target" in
+  let symlink = Filename.concat base_path "symlink" in
+  write_file ~path:file ~content:"not a directory";
+  Unix.mkdir target 0o755;
+  Unix.symlink target symlink;
+  (match Fs_compat.mkdir_p_durable_unix file with
+   | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> ()
+   | _ -> Alcotest.fail "regular file accepted as durable directory");
+  (match Fs_compat.mkdir_p_durable_unix (Filename.concat symlink "child") with
+   | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> ()
+   | _ -> Alcotest.fail "symlinked ancestor accepted as durable directory");
+  Alcotest.(check int)
+    "symlink target unchanged"
+    0
+    (Array.length (Sys.readdir target))
 
 let test_durable_append_falls_back_outside_eio () =
   with_temp_base @@ fun base_path ->
@@ -328,6 +374,77 @@ let test_durable_append_falls_back_outside_eio () =
          "fallback durable append"
          "row\n"
          (Fs_compat.load_file_unix path))
+
+let test_anchored_directory_primitives () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  Dir.with_open_root base_path @@ fun root ->
+  Dir.with_ensure_dir
+    root
+    ~name:"managed"
+    ~perm:0o700
+    ~enforce_perm:true
+  @@ fun managed ->
+  (match Dir.save_file_atomic managed ~name:"state.json" ~perm:0o600 "one" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "anchored atomic write failed: %s" detail);
+  Alcotest.(check string) "anchored read" "one" (Dir.read_file managed "state.json");
+  (match Dir.stat managed "state.json" with
+   | Some { kind = Dir.Regular_file; _ } -> ()
+   | Some _ -> Alcotest.fail "anchored stat returned the wrong file kind"
+   | None -> Alcotest.fail "anchored stat lost a committed file");
+  Dir.rename
+    ~src_dir:managed
+    ~src:"state.json"
+    ~dst_dir:managed
+    ~dst:"renamed.json";
+  Alcotest.(check bool)
+    "source removed by rename"
+    false
+    (Option.is_some (Dir.stat managed "state.json"));
+  Alcotest.(check bool)
+    "renamed file removed"
+    true
+    (Dir.unlink_if_exists managed "renamed.json");
+  Alcotest.(check bool)
+    "missing unlink is explicit false"
+    false
+    (Dir.unlink_if_exists managed "renamed.json")
+
+let test_anchored_capability_survives_path_substitution () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let managed_path = Filename.concat base_path "managed" in
+  let detached_path = Filename.concat base_path "detached" in
+  let outside_path = Filename.concat base_path "outside" in
+  Unix.mkdir managed_path 0o700;
+  Unix.mkdir outside_path 0o700;
+  Dir.with_open_root base_path @@ fun root ->
+  Dir.with_open_dir root "managed" @@ fun managed ->
+  Unix.rename managed_path detached_path;
+  Unix.symlink outside_path managed_path;
+  (match Dir.save_file_atomic managed ~name:"proof.json" ~perm:0o600 "anchored" with
+   | Ok () -> ()
+   | Error detail -> Alcotest.failf "anchored write after substitution: %s" detail);
+  Alcotest.(check bool)
+    "replacement symlink target untouched"
+    false
+    (Sys.file_exists (Filename.concat outside_path "proof.json"));
+  Alcotest.(check string)
+    "open descriptor retained original directory"
+    "anchored"
+    (Fs_compat.load_file_unix (Filename.concat detached_path "proof.json"))
+
+let test_anchored_root_rejects_symlink () =
+  with_temp_base @@ fun base_path ->
+  let module Dir = Fs_compat.Anchored_dir in
+  let target = Filename.concat base_path "target" in
+  let alias = Filename.concat base_path "alias" in
+  Unix.mkdir target 0o700;
+  Unix.symlink target alias;
+  match Dir.with_open_root alias (fun _ -> ()) with
+  | exception Unix.Unix_error _ -> ()
+  | () -> Alcotest.fail "symlinked root was accepted as an anchored capability"
 
 let () =
   Alcotest.run "fs_atomic_orphan_sweep_10130"
@@ -353,6 +470,8 @@ let () =
             test_recovered_dir_skipped_on_rescan;
           Alcotest.test_case "symlinked recovery rejected" `Quick
             test_direct_recovery_rejects_symlinked_destination;
+          Alcotest.test_case "symlinked source rejected" `Quick
+            test_direct_recovery_rejects_symlinked_source;
           Alcotest.test_case "recovery traversal rejected" `Quick
             test_cleanup_rejects_recovery_escape;
           Alcotest.test_case "symlinked recovery root rejected" `Quick
@@ -363,7 +482,15 @@ let () =
       ( "durable-primitives",
         [ Alcotest.test_case "blocking durable filesystem boundaries" `Quick
             test_blocking_durable_primitives;
+          Alcotest.test_case "durable mkdir rejects non-directories" `Quick
+            test_durable_mkdir_rejects_non_directories;
           Alcotest.test_case "durable append outside Eio runtime" `Quick
             test_durable_append_falls_back_outside_eio;
+          Alcotest.test_case "descriptor anchored operations" `Quick
+            test_anchored_directory_primitives;
+          Alcotest.test_case "ancestor substitution stays confined" `Quick
+            test_anchored_capability_survives_path_substitution;
+          Alcotest.test_case "symlinked root rejected" `Quick
+            test_anchored_root_rejects_symlink;
         ] );
     ]

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -495,7 +495,7 @@ let test_anchored_lock_file_rejects_symlink () =
   let module Dir = Fs_compat.Anchored_dir in
   let outside = Filename.concat base_path "outside.lock" in
   let link = Filename.concat base_path "managed.lock" in
-  Fs_compat.save_file_unix outside "sentinel";
+  Fs_compat.save_file outside "sentinel";
   Unix.symlink outside link;
   Dir.with_open_root base_path @@ fun root ->
   (match

--- a/test/test_keeper_id.ml
+++ b/test/test_keeper_id.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Uid = Keeper_id.Uid
+module Keeper_name = Keeper_id.Keeper_name
 
 let test_generate_format () =
   let uid = Uid.generate () in
@@ -53,6 +54,20 @@ let test_equal () =
   check bool "different UIDs not equal" false (Uid.equal a b);
   check bool "same UID equal" true (Uid.equal a a)
 
+let test_keeper_name_portable_contract () =
+  List.iter
+    (fun input ->
+       match Keeper_name.of_string input with
+       | Ok parsed -> check string "portable name" input (Keeper_name.to_string parsed)
+       | Error error -> failf "portable keeper name %S rejected: %s" input error)
+    [ "keeper"; "dot.name"; "under_score"; "dash-name" ];
+  List.iter
+    (fun input ->
+       match Keeper_name.of_string input with
+       | Error _ -> ()
+       | Ok _ -> failf "unsafe keeper name %S accepted" input)
+    [ ""; "."; ".."; "slash/name"; "nul\000suffix" ]
+
 let () =
   run "Keeper ID"
     [
@@ -63,5 +78,11 @@ let () =
           test_case "of_string valid" `Quick test_of_string_valid;
           test_case "of_string invalid" `Quick test_of_string_invalid;
           test_case "equal" `Quick test_equal;
+        ] );
+      ( "Keeper name",
+        [ test_case
+            "portable path-segment contract"
+            `Quick
+            test_keeper_name_portable_contract
         ] );
     ]

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -629,6 +629,27 @@ let test_discovery_isolates_malformed_keeper () =
 ;;
 
 let test_typed_boundaries_reject_invalid_values () =
+  List.iter
+    (fun keeper_name ->
+       match
+         Store.make_job
+           ~keeper_name
+           ~trace_id:"trace-k1"
+           ~generation:1
+           ~turn:1
+           ~oas_turn_count:1
+           ~enqueued_at:1.0
+           ~payload:`Null
+       with
+       | Error (Store.Invalid_keeper_name _) -> ()
+       | Error error ->
+         Alcotest.failf
+           "wrong keeper-name error for %S: %s"
+           keeper_name
+           (Store.error_to_string error)
+       | Ok _ ->
+         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name)
+    [ "."; ".." ];
   (match
      Store.make_job
        ~keeper_name:"k1"

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -39,7 +39,7 @@ let terminal_receipt
       ?(ended_at = 3.0)
       ?(outcome = Store.Succeeded)
       ?(detail = `Assoc [ "status", `String "ok" ])
-      lease
+      (lease : Store.lease)
   =
   match
     Store.make_terminal_receipt
@@ -53,14 +53,14 @@ let terminal_receipt
     Alcotest.failf "receipt construction failed: %s" (Store.error_to_string error)
 ;;
 
-let stage ~base_path job =
+let stage ~base_path (job : Store.job) =
   match Store.stage_awaiting_turn_commit ~base_path job with
   | Ok admission -> admission
   | Error error ->
     Alcotest.failf "stage failed: %s" (Store.error_to_string error)
 ;;
 
-let activate ~base_path job =
+let activate ~base_path (job : Store.job) =
   match Store.activate ~base_path job with
   | Ok (activation, report) ->
     Alcotest.(check int)
@@ -88,7 +88,7 @@ let check_backlog ~base_path ~keeper_name expected =
     Alcotest.failf "backlog failed: %s" (Store.error_to_string error)
 ;;
 
-let awaiting_path ~base_path job =
+let awaiting_path ~base_path (job : Store.job) =
   Filename.concat
     (Store.For_testing.awaiting_dir
        ~base_path
@@ -96,7 +96,7 @@ let awaiting_path ~base_path job =
     (job.id ^ ".json")
 ;;
 
-let pending_path ~base_path job =
+let pending_path ~base_path (job : Store.job) =
   Filename.concat
     (Store.For_testing.pending_dir
        ~base_path
@@ -147,7 +147,7 @@ let rec json_contains_string needle = function
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null -> false
 ;;
 
-let operation_path ~base_path job =
+let operation_path ~base_path (job : Store.job) =
   match
     Store.operation_stage_path_for_keepers_dir
       ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
@@ -159,7 +159,7 @@ let operation_path ~base_path job =
     Alcotest.failf "operation path failed: %s" (Store.error_to_string error)
 ;;
 
-let finish ~base_path receipt =
+let finish ~base_path (receipt : Store.terminal_receipt) =
   match Store.finish ~base_path receipt with
   | Ok report -> report
   | Error error ->

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -483,6 +483,23 @@ let test_wrong_state_and_coordinate_are_rejected () =
 ;;
 
 let test_symlinked_store_boundaries_are_rejected () =
+  with_temp_dir "memory-job-masc-parent-symlink" (fun base_path ->
+    with_temp_dir "memory-job-external-masc" (fun external_masc ->
+      let job = make_job 1 in
+      Unix.symlink
+        external_masc
+        (Masc.Common.masc_dir_from_base_path ~base_path);
+      (match Store.stage_awaiting_turn_commit ~base_path job with
+       | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+       | Error error ->
+         Alcotest.failf
+           "wrong intermediate-parent error: %s"
+           (Store.error_to_string error)
+       | Ok _ -> Alcotest.fail "symlinked .masc parent was accepted");
+      Alcotest.(check int)
+        "intermediate target untouched"
+        0
+        (Array.length (Sys.readdir external_masc))));
   with_temp_dir "memory-job-root-symlink" (fun base_path ->
     let job = make_job 1 in
     let jobs_root =
@@ -631,7 +648,7 @@ let test_discovery_isolates_malformed_keeper () =
 let test_typed_boundaries_reject_invalid_values () =
   List.iter
     (fun keeper_name ->
-       match
+       (match
          Store.make_job
            ~keeper_name
            ~trace_id:"trace-k1"
@@ -648,7 +665,23 @@ let test_typed_boundaries_reject_invalid_values () =
            keeper_name
            (Store.error_to_string error)
        | Ok _ ->
-         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name)
+         Alcotest.failf "reserved keeper path segment %S was accepted" keeper_name);
+       (match
+          Store.operation_stage_path_for_keepers_dir
+            ~keepers_dir:"/unused"
+            ~keeper_name
+            ~operation_id:(String.make 64 'a')
+        with
+        | Error (Store.Invalid_keeper_name _) -> ()
+        | Error error ->
+          Alcotest.failf
+            "wrong operation-stage keeper error for %S: %s"
+            keeper_name
+            (Store.error_to_string error)
+        | Ok _ ->
+          Alcotest.failf
+            "operation stage accepted reserved keeper segment %S"
+            keeper_name))
     [ "."; ".." ];
   (match
      Store.make_job

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -74,7 +74,9 @@ let activate ~base_path job =
 
 let claim ~base_path ~keeper_name ~now =
   match Store.claim_all ~base_path ~keeper_name ~now with
-  | Ok report -> report
+  | Ok ({ blocked = None; _ } as report) -> report
+  | Ok { blocked = Some error; _ } ->
+    Alcotest.failf "claim blocked: %s" (Store.error_to_string error)
   | Error error ->
     Alcotest.failf "claim failed: %s" (Store.error_to_string error)
 ;;
@@ -280,12 +282,54 @@ let test_claim_does_not_overwrite_existing_lease () =
     in
     write_json pending pending_envelope;
     (match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
-     | Error (Store.Pending_already_inflight _) -> ()
+     | Ok
+         { leases = []
+         ; blocked = Some (Store.Pending_already_inflight _)
+         ; _
+         } -> ()
      | Error error ->
        Alcotest.failf "wrong duplicate claim error: %s" (Store.error_to_string error)
      | Ok _ -> Alcotest.fail "existing inflight lease was overwritten");
     let receipt = terminal_receipt first_lease in
     ignore (finish ~base_path receipt);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_partial_claims_remain_owned_when_later_job_blocks () =
+  with_temp_dir "memory-job-partial-claim" (fun base_path ->
+    let first = make_job ~oas_turn_count:1 ~enqueued_at:1.0 1 in
+    let second = make_job ~oas_turn_count:2 ~enqueued_at:2.0 2 in
+    ignore (stage ~base_path second);
+    ignore (activate ~base_path second);
+    let second_pending = pending_path ~base_path second in
+    let second_envelope = read_json second_pending in
+    let second_lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected second job lease"
+    in
+    write_json second_pending second_envelope;
+    ignore (stage ~base_path first);
+    ignore (activate ~base_path first);
+    let report =
+      match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
+      | Ok report -> report
+      | Error error ->
+        Alcotest.failf "partial claim failed: %s" (Store.error_to_string error)
+    in
+    Alcotest.(check (list int))
+      "earlier lease returned"
+      [ 1 ]
+      (List.map (fun lease -> lease.Store.job.turn) report.leases);
+    (match report.blocked with
+     | Some (Store.Pending_already_inflight _) -> ()
+     | Some error ->
+       Alcotest.failf "wrong partial blocker: %s" (Store.error_to_string error)
+     | None -> Alcotest.fail "later inflight collision was not surfaced");
+    List.iter
+      (fun lease -> ignore (finish ~base_path (terminal_receipt lease)))
+      report.leases;
+    ignore (finish ~base_path (terminal_receipt second_lease));
     check_backlog ~base_path ~keeper_name:"k1" 0)
 ;;
 
@@ -688,6 +732,10 @@ let () =
             "claim preserves existing inflight lease"
             `Quick
             test_claim_does_not_overwrite_existing_lease
+        ; Alcotest.test_case
+            "partial claims remain owned"
+            `Quick
+            test_partial_claims_remain_owned_when_later_job_blocks
         ; Alcotest.test_case
             "receipt-backed inflight is not replayed"
             `Quick

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -602,7 +602,7 @@ let test_discovery_isolates_malformed_keeper () =
       Filename.concat
         (Filename.concat
            (Common.keepers_runtime_dir_of_base ~base_path)
-           "bad.name")
+           "bad name")
         "memory-jobs"
     in
     Fs_compat.mkdir_p malformed;
@@ -643,6 +643,31 @@ let test_discovery_isolates_malformed_keeper () =
         Alcotest.failf
           "symlink discovery failed: %s"
           (Store.error_to_string error)))
+;;
+
+let test_dotted_keeper_name_uses_typed_store_boundary () =
+  with_temp_dir "memory-job-dotted-keeper" (fun base_path ->
+    let keeper_name = "dot.name" in
+    let job = make_job ~keeper_name ~trace_id:"trace.dot" 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one dotted-keeper lease"
+    in
+    let receipt = terminal_receipt lease in
+    (match Store.finish ~base_path receipt with
+     | Ok { cleanup_errors = [] } -> ()
+     | Ok report ->
+       Alcotest.failf
+         "dotted-keeper finish left cleanup debt: %d"
+         (List.length report.cleanup_errors)
+     | Error error ->
+       Alcotest.failf
+         "dotted-keeper finish failed: %s"
+         (Store.error_to_string error));
+    check_backlog ~base_path ~keeper_name 0)
 ;;
 
 let test_typed_boundaries_reject_invalid_values () =
@@ -828,6 +853,10 @@ let () =
             "typed boundaries reject invalid values"
             `Quick
             test_typed_boundaries_reject_invalid_values
+        ; Alcotest.test_case
+            "dotted keeper name follows portable SSOT"
+            `Quick
+            test_dotted_keeper_name_uses_typed_store_boundary
         ; Alcotest.test_case
             "receipt identity omits payload"
             `Quick

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -1,0 +1,735 @@
+(** Durable per-Keeper memory-job store regression tests. *)
+
+module Store = Masc.Keeper_memory_job_store
+
+let with_temp_dir label f =
+  let path = Filename.temp_file ("masc-" ^ label ^ "-") "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree path)
+    (fun () -> f path)
+;;
+
+let make_job
+      ?(keeper_name = "k1")
+      ?(trace_id = "trace-k1")
+      ?(generation = 1)
+      ?(oas_turn_count = 1)
+      ?(enqueued_at = 1.0)
+      ?(payload = `Assoc [ "value", `Int 1 ])
+      turn
+  =
+  match
+    Store.make_job
+      ~keeper_name
+      ~trace_id
+      ~generation
+      ~turn
+      ~oas_turn_count
+      ~enqueued_at
+      ~payload
+  with
+  | Ok job -> job
+  | Error error ->
+    Alcotest.failf "job construction failed: %s" (Store.error_to_string error)
+;;
+
+let terminal_receipt
+      ?(ended_at = 3.0)
+      ?(outcome = Store.Succeeded)
+      ?(detail = `Assoc [ "status", `String "ok" ])
+      lease
+  =
+  match
+    Store.make_terminal_receipt
+      lease
+      ~ended_at
+      ~outcome
+      ~detail
+  with
+  | Ok receipt -> receipt
+  | Error error ->
+    Alcotest.failf "receipt construction failed: %s" (Store.error_to_string error)
+;;
+
+let stage ~base_path job =
+  match Store.stage_awaiting_turn_commit ~base_path job with
+  | Ok admission -> admission
+  | Error error ->
+    Alcotest.failf "stage failed: %s" (Store.error_to_string error)
+;;
+
+let activate ~base_path job =
+  match Store.activate ~base_path job with
+  | Ok (activation, report) ->
+    Alcotest.(check int)
+      "activation cleanup debt"
+      0
+      (List.length report.cleanup_errors);
+    activation
+  | Error error ->
+    Alcotest.failf "activation failed: %s" (Store.error_to_string error)
+;;
+
+let claim ~base_path ~keeper_name ~now =
+  match Store.claim_all ~base_path ~keeper_name ~now with
+  | Ok report -> report
+  | Error error ->
+    Alcotest.failf "claim failed: %s" (Store.error_to_string error)
+;;
+
+let check_backlog ~base_path ~keeper_name expected =
+  match Store.backlog_count ~base_path ~keeper_name with
+  | Ok actual -> Alcotest.(check int) "durable backlog" expected actual
+  | Error error ->
+    Alcotest.failf "backlog failed: %s" (Store.error_to_string error)
+;;
+
+let awaiting_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.awaiting_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let pending_path ~base_path job =
+  Filename.concat
+    (Store.For_testing.pending_dir
+       ~base_path
+       ~keeper_name:job.Store.keeper_name)
+    (job.id ^ ".json")
+;;
+
+let write_text path content =
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let write_json path json =
+  match
+    Fs_compat.save_file_atomic_unix
+      path
+      (Yojson.Safe.pretty_to_string json)
+  with
+  | Ok () -> ()
+  | Error detail -> Alcotest.failf "write failed path=%s: %s" path detail
+;;
+
+let read_json path =
+  match Safe_ops.read_json_file_safe path with
+  | Ok json -> json
+  | Error detail -> Alcotest.failf "read failed path=%s: %s" path detail
+;;
+
+let replace_assoc_field name value = function
+  | `Assoc fields ->
+    `Assoc
+      ((name, value)
+       :: List.filter
+            (fun (field, _) -> not (String.equal field name))
+            fields)
+  | _ -> Alcotest.fail "expected JSON object"
+;;
+
+let rec json_contains_string needle = function
+  | `String value -> String.equal value needle
+  | `Assoc fields ->
+    List.exists
+      (fun (_, value) -> json_contains_string needle value)
+      fields
+  | `List values -> List.exists (json_contains_string needle) values
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `Null -> false
+;;
+
+let operation_path ~base_path job =
+  match
+    Store.operation_stage_path_for_keepers_dir
+      ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+      ~keeper_name:job.Store.keeper_name
+      ~operation_id:job.id
+  with
+  | Ok path -> path
+  | Error error ->
+    Alcotest.failf "operation path failed: %s" (Store.error_to_string error)
+;;
+
+let finish ~base_path receipt =
+  match Store.finish ~base_path receipt with
+  | Ok report -> report
+  | Error error ->
+    Alcotest.failf "finish failed: %s" (Store.error_to_string error)
+;;
+
+let test_retry_preserves_first_durable_envelope () =
+  with_temp_dir "memory-job-canonical" (fun base_path ->
+    let first =
+      make_job
+        ~enqueued_at:1.0
+        ~payload:(`Assoc [ "alpha", `Int 1; "beta", `Int 2 ])
+        1
+    in
+    let retry =
+      make_job
+        ~enqueued_at:99.0
+        ~payload:(`Assoc [ "beta", `Int 2; "alpha", `Int 1 ])
+        1
+    in
+    Alcotest.(check bool)
+      "first stage"
+      true
+      (stage ~base_path first = Store.Staged_awaiting_turn_commit);
+    Alcotest.(check bool)
+      "semantic duplicate"
+      true
+      (stage ~base_path retry = Store.Already_awaiting);
+    Alcotest.(check bool)
+      "activate retry"
+      true
+      (activate ~base_path retry = Store.Activated);
+    let report = claim ~base_path ~keeper_name:"k1" ~now:2.0 in
+    let lease =
+      match report.leases with
+      | [ lease ] -> lease
+      | leases ->
+        Alcotest.failf "expected one lease, got %d" (List.length leases)
+    in
+    Alcotest.(check (float 0.0))
+      "first enqueue timestamp wins"
+      first.enqueued_at
+      lease.job.enqueued_at;
+    Alcotest.(check bool)
+      "first payload representation wins"
+      true
+      (Yojson.Safe.equal first.payload lease.job.payload);
+    let conflict =
+      make_job ~payload:(`Assoc [ "alpha", `Int 9 ]) 1
+    in
+    (match Store.stage_awaiting_turn_commit ~base_path conflict with
+     | Error (Store.Identity_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong conflict: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "conflicting payload was accepted");
+    let receipt = terminal_receipt lease in
+    ignore (finish ~base_path receipt);
+    let conflicting_receipt = terminal_receipt ~ended_at:4.0 lease in
+    (match Store.finish ~base_path conflicting_receipt with
+     | Error (Store.Identity_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong terminal conflict: %s"
+         (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "conflicting terminal timestamps were accepted");
+    check_backlog ~base_path ~keeper_name:"k1" 0;
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    Alcotest.(check int)
+      "queue directory mode"
+      0o700
+      ((Unix.stat awaiting_dir).Unix.st_perm land 0o777);
+    Alcotest.(check int)
+      "receipt mode"
+      0o600
+      ((Unix.stat (Store.For_testing.receipt_path ~base_path first)).Unix.st_perm
+       land 0o777))
+;;
+
+let test_ordered_claim_and_terminal_cleanup () =
+  with_temp_dir "memory-job-order" (fun base_path ->
+    let second = make_job ~oas_turn_count:2 ~enqueued_at:2.0 2 in
+    let first = make_job ~oas_turn_count:1 ~enqueued_at:1.0 1 in
+    List.iter
+      (fun job ->
+         ignore (stage ~base_path job);
+         ignore (activate ~base_path job))
+      [ second; first ];
+    let report = claim ~base_path ~keeper_name:"k1" ~now:3.0 in
+    Alcotest.(check (list int))
+      "linear turn order"
+      [ 1; 2 ]
+      (List.map (fun lease -> lease.Store.job.turn) report.leases);
+    Alcotest.(check int)
+      "claim cleanup debt"
+      0
+      (List.length report.cleanup_errors);
+    List.iter
+      (fun lease ->
+         ignore
+           (finish
+              ~base_path
+              (terminal_receipt lease)))
+      report.leases;
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_claim_does_not_overwrite_existing_lease () =
+  with_temp_dir "memory-job-double-claim" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let pending = pending_path ~base_path job in
+    let pending_envelope = read_json pending in
+    let first_lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    write_json pending pending_envelope;
+    (match Store.claim_all ~base_path ~keeper_name:"k1" ~now:3.0 with
+     | Error (Store.Pending_already_inflight _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong duplicate claim error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "existing inflight lease was overwritten");
+    let receipt = terminal_receipt first_lease in
+    ignore (finish ~base_path receipt);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_receipt_backed_inflight_is_not_replayed () =
+  with_temp_dir "memory-job-receipt-recovery" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let operation = operation_path ~base_path job in
+    Fs_compat.mkdir_p_durable_unix (Filename.dirname operation);
+    write_text operation "staged provider result";
+    let receipt = terminal_receipt lease in
+    write_json
+      (Store.For_testing.receipt_path ~base_path job)
+      (Store.receipt_to_json receipt);
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Ok report ->
+       Alcotest.(check int) "receipt prevents replay" 0 report.replayed;
+       Alcotest.(check int)
+         "recovery cleanup debt"
+         0
+         (List.length report.cleanup_errors)
+     | Error error ->
+       Alcotest.failf "recovery failed: %s" (Store.error_to_string error));
+    Alcotest.(check bool)
+      "provider stage acknowledged"
+      false
+      (Sys.file_exists operation);
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_recovery_rejects_mismatched_lease_receipt () =
+  with_temp_dir "memory-job-receipt-lease" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let mismatched =
+      Store.receipt_to_json (terminal_receipt lease)
+      |> replace_assoc_field "started_at" (`Float 9.0)
+    in
+    write_json (Store.For_testing.receipt_path ~base_path job) mismatched;
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Error (Store.Inflight_lease_conflict _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong lease mismatch: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "mismatched terminal lease was accepted");
+    check_backlog ~base_path ~keeper_name:"k1" 1)
+;;
+
+let test_terminal_cleanup_debt_is_explicit () =
+  with_temp_dir "memory-job-cleanup-debt" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let operation = operation_path ~base_path job in
+    Fs_compat.mkdir_p_durable_unix operation;
+    let report =
+      finish
+        ~base_path
+        (terminal_receipt lease)
+    in
+    Alcotest.(check bool)
+      "cleanup debt returned"
+      true
+      (report.cleanup_errors <> []);
+    Alcotest.(check bool)
+      "terminal receipt committed first"
+      true
+      (Sys.file_exists (Store.For_testing.receipt_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:"k1" 0)
+;;
+
+let test_stale_completion_cannot_ack_requeued_work () =
+  with_temp_dir "memory-job-stale-completion" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let receipt = terminal_receipt lease in
+    (match Store.recover_inflight ~base_path ~keeper_name:"k1" with
+     | Ok report -> Alcotest.(check int) "one job requeued" 1 report.replayed
+     | Error error ->
+       Alcotest.failf "recovery failed: %s" (Store.error_to_string error));
+    (match Store.finish ~base_path receipt with
+     | Error (Store.Missing_inflight_lease _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong stale completion error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "stale completion acknowledged requeued work");
+    Alcotest.(check bool)
+      "terminal receipt absent"
+      false
+      (Sys.file_exists (Store.For_testing.receipt_path ~base_path job));
+    check_backlog ~base_path ~keeper_name:"k1" 1)
+;;
+
+let test_wrong_state_and_coordinate_are_rejected () =
+  with_temp_dir "memory-job-coordinates" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let pending = pending_path ~base_path job in
+    let envelope =
+      read_json pending
+      |> replace_assoc_field
+           "state"
+           (`Assoc
+              [ "kind", `String "inflight"
+              ; "started_at", `Float 1.0
+              ])
+    in
+    write_json pending envelope;
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Decode_error _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong state error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "pending directory accepted inflight state"));
+  with_temp_dir "memory-job-filename" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let source = awaiting_path ~base_path job in
+    let destination =
+      Filename.concat
+        (Filename.dirname source)
+        (String.make 64 'a' ^ ".json")
+    in
+    Sys.rename source destination;
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Decode_error _) -> ()
+     | Error error ->
+       Alcotest.failf "wrong coordinate error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "mismatched filename was accepted"))
+;;
+
+let test_symlinked_store_boundaries_are_rejected () =
+  with_temp_dir "memory-job-root-symlink" (fun base_path ->
+    let job = make_job 1 in
+    let jobs_root =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+      |> Filename.dirname
+    in
+    let target = Filename.concat base_path "outside-jobs" in
+    Unix.mkdir target 0o700;
+    Fs_compat.mkdir_p (Filename.dirname jobs_root);
+    Unix.symlink target jobs_root;
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong root error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked memory-jobs root was accepted");
+    Alcotest.(check int)
+      "root target untouched"
+      0
+      (Array.length (Sys.readdir target)));
+  with_temp_dir "memory-job-keeper-symlink" (fun base_path ->
+    let job = make_job 1 in
+    let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+    let keeper_dir = Filename.concat keepers_root "k1" in
+    let target = Filename.concat base_path "outside-keeper" in
+    Fs_compat.mkdir_p keepers_root;
+    Unix.mkdir target 0o700;
+    Unix.symlink target keeper_dir;
+    (match Store.stage_awaiting_turn_commit ~base_path job with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong keeper error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked keeper directory was accepted");
+    Alcotest.(check int)
+      "keeper target untouched"
+      0
+      (Array.length (Sys.readdir target)));
+  with_temp_dir "memory-job-recovery-symlink" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let awaiting_dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    let recovered_root =
+      Filename.concat
+        (Filename.dirname awaiting_dir)
+        "recovered-atomic-writes"
+    in
+    let target = Filename.concat base_path "outside-recovery" in
+    Unix.mkdir target 0o700;
+    Unix.symlink target recovered_root;
+    let orphan = Filename.concat awaiting_dir ".atomic_data.tmp" in
+    write_text orphan "forensic payload";
+    (match Store.backlog_count ~base_path ~keeper_name:"k1" with
+     | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
+     | Error error ->
+       Alcotest.failf "wrong recovery error: %s" (Store.error_to_string error)
+     | Ok _ -> Alcotest.fail "symlinked recovery root was accepted");
+    Alcotest.(check bool) "orphan remains in queue" true (Sys.file_exists orphan);
+    Alcotest.(check int)
+      "recovery target untouched"
+      0
+      (Array.length (Sys.readdir target)))
+;;
+
+let test_atomic_orphans_are_reconciled_without_loss () =
+  with_temp_dir "memory-job-orphans" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let dir =
+      Store.For_testing.awaiting_dir ~base_path ~keeper_name:"k1"
+    in
+    let empty = Filename.concat dir ".atomic_empty.tmp" in
+    let nonempty = Filename.concat dir ".atomic_data.tmp" in
+    write_text empty "";
+    write_text nonempty "forensic payload";
+    check_backlog ~base_path ~keeper_name:"k1" 1;
+    Alcotest.(check bool) "empty orphan removed" false (Sys.file_exists empty);
+    Alcotest.(check bool)
+      "nonempty orphan moved"
+      false
+      (Sys.file_exists nonempty);
+    let recovered =
+      Filename.concat
+        (Filename.concat
+           (Filename.dirname dir)
+           "recovered-atomic-writes/awaiting-turn-commit")
+        ".atomic_data.tmp"
+    in
+    Alcotest.(check bool)
+      "nonempty orphan preserved"
+      true
+      (Sys.file_exists recovered))
+;;
+
+let test_discovery_isolates_malformed_keeper () =
+  with_temp_dir "memory-job-discovery" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    let malformed =
+      Filename.concat
+        (Filename.concat
+           (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+           "bad.name")
+        "memory-jobs"
+    in
+    Fs_compat.mkdir_p malformed;
+    match Store.discover_keeper_names ~base_path with
+    | Ok (keepers, errors) ->
+      Alcotest.(check (list string)) "healthy keeper" [ "k1" ] keepers;
+      Alcotest.(check int) "malformed keeper isolated" 1 (List.length errors)
+    | Error error ->
+      Alcotest.failf "discovery failed: %s" (Store.error_to_string error));
+  with_temp_dir "memory-job-discovery-root" (fun base_path ->
+    with_temp_dir "memory-job-discovery-external" (fun external_base ->
+      let external_job =
+        make_job
+          ~keeper_name:"k2"
+          ~trace_id:"trace-k2"
+          1
+      in
+      ignore (stage ~base_path:external_base external_job);
+      let external_keeper =
+        Filename.concat
+          (Masc.Common.keepers_runtime_dir_of_base ~base_path:external_base)
+          "k2"
+      in
+      let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+      Fs_compat.mkdir_p keepers_root;
+      Unix.symlink external_keeper (Filename.concat keepers_root "k2");
+      match Store.discover_keeper_names ~base_path with
+      | Ok (keepers, errors) ->
+        Alcotest.(check (list string))
+          "external keeper not discovered"
+          []
+          keepers;
+        Alcotest.(check int)
+          "symlinked keeper isolated"
+          1
+          (List.length errors)
+      | Error error ->
+        Alcotest.failf
+          "symlink discovery failed: %s"
+          (Store.error_to_string error)))
+;;
+
+let test_typed_boundaries_reject_invalid_values () =
+  (match
+     Store.make_job
+       ~keeper_name:"k1"
+       ~trace_id:"trace-k1"
+       ~generation:1
+       ~turn:1
+       ~oas_turn_count:1
+       ~enqueued_at:1.0
+       ~payload:(`Float Float.nan)
+   with
+   | Error (Store.Invalid_json_value _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong payload error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "non-finite payload was accepted");
+  with_temp_dir "memory-job-invalid-receipt" (fun base_path ->
+    let job = make_job 1 in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    match
+      Store.make_terminal_receipt
+        lease
+        ~ended_at:1.0
+        ~outcome:Store.Succeeded
+        ~detail:`Null
+    with
+    | Error (Store.Invalid_terminal_timestamps _) -> ()
+    | Error error ->
+      Alcotest.failf "wrong timestamp error: %s" (Store.error_to_string error)
+    | Ok _ -> Alcotest.fail "reversed terminal timestamps were accepted");
+  (match Store.claim_all ~base_path:"/unused" ~keeper_name:"k1" ~now:Float.nan with
+   | Error (Store.Invalid_claim_time _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong claim-time error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "non-finite claim time was accepted");
+  (match
+     Store.operation_stage_path_for_keepers_dir
+       ~keepers_dir:"/unused"
+       ~keeper_name:"k1"
+       ~operation_id:"../escape"
+   with
+   | Error (Store.Invalid_job_id _) -> ()
+   | Error error ->
+     Alcotest.failf "wrong operation-id error: %s" (Store.error_to_string error)
+   | Ok _ -> Alcotest.fail "invalid operation id produced a path");
+  let job = make_job 1 in
+  let duplicate_id_json =
+    match Store.job_to_json job with
+    | `Assoc fields -> `Assoc (("id", `String job.id) :: fields)
+    | _ -> Alcotest.fail "job JSON must be an object"
+  in
+  (match Store.job_of_json duplicate_id_json with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "duplicate control field was accepted")
+;;
+
+let test_receipt_identity_omits_payload () =
+  with_temp_dir "memory-job-receipt-projection" (fun base_path ->
+    let secret = "secret-checkpoint-payload" in
+    let job =
+      make_job ~payload:(`Assoc [ "secret", `String secret ]) 1
+    in
+    ignore (stage ~base_path job);
+    ignore (activate ~base_path job);
+    let lease =
+      match (claim ~base_path ~keeper_name:"k1" ~now:2.0).leases with
+      | [ lease ] -> lease
+      | _ -> Alcotest.fail "expected one lease"
+    in
+    let json = Store.receipt_to_json (terminal_receipt lease) in
+    Alcotest.(check bool)
+      "receipt does not retain payload"
+      false
+      (json_contains_string secret json);
+    match json with
+    | `Assoc fields ->
+      Alcotest.(check bool)
+        "receipt has no job object"
+        false
+        (List.mem_assoc "job" fields)
+    | _ -> Alcotest.fail "receipt must be an object")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_job_store"
+    [ ( "durability"
+      , [ Alcotest.test_case
+            "retry preserves first durable envelope"
+            `Quick
+            test_retry_preserves_first_durable_envelope
+        ; Alcotest.test_case
+            "ordered claim and terminal cleanup"
+            `Quick
+            test_ordered_claim_and_terminal_cleanup
+        ; Alcotest.test_case
+            "claim preserves existing inflight lease"
+            `Quick
+            test_claim_does_not_overwrite_existing_lease
+        ; Alcotest.test_case
+            "receipt-backed inflight is not replayed"
+            `Quick
+            test_receipt_backed_inflight_is_not_replayed
+        ; Alcotest.test_case
+            "mismatched lease receipt is rejected"
+            `Quick
+            test_recovery_rejects_mismatched_lease_receipt
+        ; Alcotest.test_case
+            "terminal cleanup debt is explicit"
+            `Quick
+            test_terminal_cleanup_debt_is_explicit
+        ; Alcotest.test_case
+            "stale completion cannot acknowledge requeued work"
+            `Quick
+            test_stale_completion_cannot_ack_requeued_work
+        ; Alcotest.test_case
+            "atomic orphans reconcile without loss"
+            `Quick
+            test_atomic_orphans_are_reconciled_without_loss
+        ] )
+    ; ( "validation"
+      , [ Alcotest.test_case
+            "wrong state and coordinates are rejected"
+            `Quick
+            test_wrong_state_and_coordinate_are_rejected
+        ; Alcotest.test_case
+            "symlinked store boundaries are rejected"
+            `Quick
+            test_symlinked_store_boundaries_are_rejected
+        ; Alcotest.test_case
+            "discovery isolates malformed keeper"
+            `Quick
+            test_discovery_isolates_malformed_keeper
+        ; Alcotest.test_case
+            "typed boundaries reject invalid values"
+            `Quick
+            test_typed_boundaries_reject_invalid_values
+        ; Alcotest.test_case
+            "receipt identity omits payload"
+            `Quick
+            test_receipt_identity_omits_payload
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_job_store.ml
+++ b/test/test_keeper_memory_job_store.ml
@@ -150,7 +150,7 @@ let rec json_contains_string needle = function
 let operation_path ~base_path job =
   match
     Store.operation_stage_path_for_keepers_dir
-      ~keepers_dir:(Masc.Common.keepers_runtime_dir_of_base ~base_path)
+      ~keepers_dir:(Common.keepers_runtime_dir_of_base ~base_path)
       ~keeper_name:job.Store.keeper_name
       ~operation_id:job.id
   with
@@ -488,7 +488,7 @@ let test_symlinked_store_boundaries_are_rejected () =
       let job = make_job 1 in
       Unix.symlink
         external_masc
-        (Masc.Common.masc_dir_from_base_path ~base_path);
+        (Common.masc_dir_from_base_path ~base_path);
       (match Store.stage_awaiting_turn_commit ~base_path job with
        | Error (Store.Io_error { operation = Store.Inspect; _ }) -> ()
        | Error error ->
@@ -521,7 +521,7 @@ let test_symlinked_store_boundaries_are_rejected () =
       (Array.length (Sys.readdir target)));
   with_temp_dir "memory-job-keeper-symlink" (fun base_path ->
     let job = make_job 1 in
-    let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+    let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
     let keeper_dir = Filename.concat keepers_root "k1" in
     let target = Filename.concat base_path "outside-keeper" in
     Fs_compat.mkdir_p keepers_root;
@@ -601,7 +601,7 @@ let test_discovery_isolates_malformed_keeper () =
     let malformed =
       Filename.concat
         (Filename.concat
-           (Masc.Common.keepers_runtime_dir_of_base ~base_path)
+           (Common.keepers_runtime_dir_of_base ~base_path)
            "bad.name")
         "memory-jobs"
     in
@@ -623,10 +623,10 @@ let test_discovery_isolates_malformed_keeper () =
       ignore (stage ~base_path:external_base external_job);
       let external_keeper =
         Filename.concat
-          (Masc.Common.keepers_runtime_dir_of_base ~base_path:external_base)
+          (Common.keepers_runtime_dir_of_base ~base_path:external_base)
           "k2"
       in
-      let keepers_root = Masc.Common.keepers_runtime_dir_of_base ~base_path in
+      let keepers_root = Common.keepers_runtime_dir_of_base ~base_path in
       Fs_compat.mkdir_p keepers_root;
       Unix.symlink external_keeper (Filename.concat keepers_root "k2");
       match Store.discover_keeper_names ~base_path with

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2205,10 +2205,11 @@ let test_with_facts_lock_propagates_body_failure () =
          Memory_io.with_facts_lock
            ~clock
            ~keeper_id
-           ~on_timeout:(fun msg ->
+           ~on_timeout:(fun timeout ->
              Alcotest.fail
-               ("body Failure was misclassified as a lock timeout: " ^ msg))
-           (fun () -> failwith "body exploded")
+               ("body Failure was misclassified as a lock timeout: "
+                ^ Memory_io.lock_timeout_to_string timeout))
+           (fun _lock -> failwith "body exploded")
        with
        | _ -> Alcotest.fail "expected body Failure to propagate"
        | exception Failure msg when String.equal msg "body exploded" -> ()
@@ -2218,8 +2219,11 @@ let test_with_facts_lock_propagates_body_failure () =
         Memory_io.with_facts_lock
           ~clock
           ~keeper_id
-          ~on_timeout:(fun msg -> Alcotest.fail ("lock was not released: " ^ msg))
-          (fun () -> "reacquired")
+          ~on_timeout:(fun timeout ->
+            Alcotest.fail
+              ("lock was not released: "
+               ^ Memory_io.lock_timeout_to_string timeout))
+          (fun _lock -> "reacquired")
       in
       Alcotest.(check string) "lock reacquired after body exception" "reacquired" reacquired))
 ;;
@@ -2234,8 +2238,8 @@ let test_with_facts_lock_timeout_uses_on_timeout () =
           Memory_io.with_facts_lock
             ~clock
             ~keeper_id
-            ~on_timeout:(fun msg -> msg)
-            (fun () -> "unexpected body result")
+            ~on_timeout:Memory_io.lock_timeout_to_string
+            (fun _lock -> "unexpected body result")
         in
         Alcotest.(check bool)
           "timeout used on_timeout"
@@ -2245,8 +2249,11 @@ let test_with_facts_lock_timeout_uses_on_timeout () =
         Memory_io.with_facts_lock
           ~clock
           ~keeper_id
-          ~on_timeout:(fun msg -> Alcotest.fail ("lock was not released: " ^ msg))
-          (fun () -> "reacquired")
+          ~on_timeout:(fun timeout ->
+            Alcotest.fail
+              ("lock was not released: "
+               ^ Memory_io.lock_timeout_to_string timeout))
+          (fun _lock -> "reacquired")
       in
       Alcotest.(check string) "lock reacquired after timeout" "reacquired" reacquired))
 ;;

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -59,6 +59,12 @@ let expect_invalid_argument label f =
   | exception Invalid_argument _ -> ()
 ;;
 
+let expect_filesystem_rejection label f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected filesystem rejection" label
+  | exception Unix.Unix_error _ -> ()
+;;
+
 let test_explicit_root_isolates_append_and_generation () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
@@ -77,15 +83,9 @@ let test_explicit_root_isolates_append_and_generation () =
     Memory_io.with_episode_bundle_lock_for_keepers_dir
       ~keepers_dir:first
       ~keeper_id
-      (fun () ->
-         Memory_io.append_episode_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           first_episode;
-         Memory_io.append_event_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           first_episode);
+      (fun bundle ->
+         Memory_io.append_episode_in_bundle bundle first_episode;
+         Memory_io.append_event_in_bundle bundle first_episode);
     Alcotest.(check bool)
       "first root receives event"
       true
@@ -115,6 +115,24 @@ let test_explicit_root_isolates_append_and_generation () =
     Alcotest.(check int)
       "first generation advances"
       5
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:0
+         ~keeper_id
+         ~trace_id);
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun bundle ->
+         Memory_io.append_episode_in_bundle
+           bundle
+           (episode
+              ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+              ~generation:10_000
+              ~created_at:2_000.0));
+    Alcotest.(check int)
+      "generation scan keeps every decimal digit"
+      10_001
       (Memory_io.next_generation_with_floor_for_keepers_dir
          ~keepers_dir:first
          ~floor:0
@@ -152,16 +170,13 @@ let test_explicit_root_scopes_merge_and_retention () =
       Memory_io.with_facts_lock_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
-        ~on_timeout:Alcotest.fail
-        (fun () ->
-          Memory_io.rewrite_facts_atomically_for_keepers_dir
-            ~keepers_dir:first
-            ~keeper_id:keeper_id_string
-            [ existing ];
-          Memory_io.merge_and_cap_facts_for_keepers_dir
-            ~keepers_dir:first
+        ~on_timeout:(fun timeout ->
+          Alcotest.fail (Memory_io.lock_timeout_to_string timeout))
+        (fun lock ->
+          Memory_io.rewrite_facts_in_lock lock [ existing ];
+          Memory_io.merge_and_cap_facts_in_lock
+            lock
             ~now:3.0
-            ~keeper_id
             ~merge:(fun ~existing:_ ~incoming -> incoming)
             ~incoming:[ incoming ]
             ~keep:2
@@ -182,7 +197,7 @@ let test_explicit_root_scopes_merge_and_retention () =
       Memory_io.with_episode_bundle_lock_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
-        (fun () ->
+        (fun bundle ->
           List.iter
             (fun generation ->
               let persisted =
@@ -191,23 +206,15 @@ let test_explicit_root_scopes_merge_and_retention () =
                   ~generation
                   ~created_at:(10.0 +. float_of_int generation)
               in
-              Memory_io.append_episode_for_keepers_dir
-                ~keepers_dir:first
-                ~keeper_id
-                persisted;
-              Memory_io.append_event_for_keepers_dir
-                ~keepers_dir:first
-                ~keeper_id
-                persisted)
+              Memory_io.append_episode_in_bundle bundle persisted;
+              Memory_io.append_event_in_bundle bundle persisted)
             [ 0; 1; 2 ];
-          ( Memory_io.cap_events_for_keepers_dir
-              ~keepers_dir:first
-              ~keeper_id
+          ( Memory_io.cap_events_in_bundle
+              bundle
               ~keep:1
               ~trigger:2
-          , Memory_io.cap_episode_files_for_keepers_dir
-              ~keepers_dir:first
-              ~keeper_id
+          , Memory_io.cap_episode_files_in_bundle
+              bundle
               ~keep:1
               ~trigger:2 ))
     in
@@ -251,6 +258,71 @@ let test_invalid_episode_trace_is_rejected_before_io () =
          (Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id))))
 ;;
 
+let test_invalid_facts_keeper_is_rejected_before_io () =
+  with_temp_roots (fun ~first ~second:_ ->
+    expect_invalid_argument "invalid facts keeper" (fun () ->
+      Memory_io.rewrite_facts_atomically_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id:"../escape"
+        []);
+    Alcotest.(check (list string))
+      "invalid keeper creates no artifact"
+      []
+      (Sys.readdir first |> Array.to_list))
+;;
+
+let test_bundle_capability_survives_root_substitution () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "substitution-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let detached = Filename.concat (Filename.dirname first) "detached-first" in
+    let persisted =
+      episode
+        ~trace_id:"substitution-trace"
+        ~generation:0
+        ~created_at:1.0
+    in
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun bundle ->
+        Unix.rename first detached;
+        Unix.symlink second first;
+        Memory_io.append_event_in_bundle bundle persisted);
+    Alcotest.(check string)
+      "retained descriptor receives event"
+      (Yojson.Safe.to_string (Types.episode_to_json persisted) ^ "\n")
+      (Fs_compat.load_file
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:detached
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check bool)
+      "replacement target stays untouched"
+      false
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:second
+            ~keeper_id:keeper_id_string));
+    Sys.remove first;
+    Unix.rename detached first)
+;;
+
+let test_dotted_keeper_uses_ambient_api () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id = "keeper.alpha" in
+    let persisted =
+      episode ~trace_id:"dotted-trace" ~generation:0 ~created_at:1.0
+    in
+    Memory_io.For_testing.with_keepers_dir first (fun () ->
+      Memory_io.append_event ~keeper_id persisted;
+      Alcotest.(check int)
+        "dotted keeper event is readable"
+        1
+        (List.length (Memory_io.read_events_tail ~keeper_id ~n:1))))
+;;
+
 let test_symlinked_episodes_directory_is_rejected () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
@@ -266,7 +338,7 @@ let test_symlinked_episodes_directory_is_rejected () =
     let trace_id =
       Keeper_id.Trace_id.of_string "symlink-episodes-trace" |> Result.get_ok
     in
-    expect_invalid_argument "symlinked episodes directory" (fun () ->
+    expect_filesystem_rejection "symlinked episodes directory" (fun () ->
       Memory_io.append_episode_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
@@ -296,7 +368,7 @@ let test_symlinked_events_file_is_rejected () =
     let trace_id =
       Keeper_id.Trace_id.of_string "symlink-events-trace" |> Result.get_ok
     in
-    expect_invalid_argument "symlinked events file" (fun () ->
+    expect_filesystem_rejection "symlinked events file" (fun () ->
       Memory_io.append_event_for_keepers_dir
         ~keepers_dir:first
         ~keeper_id
@@ -326,6 +398,18 @@ let () =
             "invalid episode trace is rejected before I/O"
             `Quick
             test_invalid_episode_trace_is_rejected_before_io
+        ; Alcotest.test_case
+            "invalid facts keeper is rejected before I/O"
+            `Quick
+            test_invalid_facts_keeper_is_rejected_before_io
+        ; Alcotest.test_case
+            "bundle capability survives root substitution"
+            `Quick
+            test_bundle_capability_survives_root_substitution
+        ; Alcotest.test_case
+            "dotted keeper uses ambient API"
+            `Quick
+            test_dotted_keeper_uses_ambient_api
         ; Alcotest.test_case
             "symlinked episodes directory is rejected"
             `Quick

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -53,23 +53,36 @@ let episode_file_count ~keepers_dir ~keeper_id =
   |> List.length
 ;;
 
+let expect_invalid_argument label f =
+  match f () with
+  | () -> Alcotest.failf "%s: expected Invalid_argument" label
+  | exception Invalid_argument _ -> ()
+;;
+
 let test_explicit_root_isolates_append_and_generation () =
   with_temp_roots (fun ~first ~second ->
     let keeper_id =
       Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-root-trace" in
-    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-root-trace" |> Result.get_ok
+    in
+    let first_episode =
+      episode
+        ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+        ~generation:0
+        ~created_at:1_000.0
+    in
     Memory_io.with_episode_bundle_lock_for_keepers_dir
       ~keepers_dir:first
       ~keeper_id
       (fun () ->
-         Memory_io.append_event_for_keepers_dir
+         Memory_io.append_episode_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode;
-         Memory_io.append_episode_for_keepers_dir
+         Memory_io.append_event_for_keepers_dir
            ~keepers_dir:first
            ~keeper_id
            first_episode);
@@ -124,23 +137,36 @@ let test_explicit_root_scopes_merge_and_retention () =
       |> Result.get_ok
     in
     let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
-    let trace_id = "explicit-retention-trace" in
-    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
-    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
-    Memory_io.rewrite_facts_atomically_for_keepers_dir
-      ~keepers_dir:first
-      ~keeper_id:keeper_id_string
-      [ existing ];
+    let trace_id =
+      Keeper_id.Trace_id.of_string "explicit-retention-trace"
+      |> Result.get_ok
+    in
+    let trace_id_string = Keeper_id.Trace_id.to_string trace_id in
+    let existing =
+      fact ~claim:"existing" ~trace_id:trace_id_string ~turn:0 ~observed_at:1.0
+    in
+    let incoming =
+      fact ~claim:"incoming" ~trace_id:trace_id_string ~turn:1 ~observed_at:2.0
+    in
     let stats =
-      Memory_io.merge_and_cap_facts_for_keepers_dir
+      Memory_io.with_facts_lock_for_keepers_dir
         ~keepers_dir:first
-        ~now:3.0
         ~keeper_id
-        ~merge:(fun ~existing:_ ~incoming -> incoming)
-        ~incoming:[ incoming ]
-        ~keep:2
-        ~trigger:2
-        ~rank:(fun persisted -> persisted.Types.first_seen)
+        ~on_timeout:Alcotest.fail
+        (fun () ->
+          Memory_io.rewrite_facts_atomically_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string
+            [ existing ];
+          Memory_io.merge_and_cap_facts_for_keepers_dir
+            ~keepers_dir:first
+            ~now:3.0
+            ~keeper_id
+            ~merge:(fun ~existing:_ ~incoming -> incoming)
+            ~incoming:[ incoming ]
+            ~keep:2
+            ~trigger:2
+            ~rank:(fun persisted -> persisted.Types.first_seen))
     in
     Alcotest.(check int) "one fact appended" 1 stats.appended;
     Alcotest.(check int) "no fact merged" 0 stats.merged;
@@ -152,31 +178,43 @@ let test_explicit_root_scopes_merge_and_retention () =
      with
      | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
      | Error detail -> Alcotest.fail detail);
-    List.iter
-      (fun generation ->
-         Memory_io.append_event_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation));
-         Memory_io.append_episode_for_keepers_dir
-           ~keepers_dir:first
-           ~keeper_id
-           (episode
-              ~trace_id
-              ~generation
-              ~created_at:(10.0 +. float_of_int generation)))
-      [ 0; 1; 2 ];
+    let event_dropped, episode_dropped =
+      Memory_io.with_episode_bundle_lock_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (fun () ->
+          List.iter
+            (fun generation ->
+              let persisted =
+                episode
+                  ~trace_id:trace_id_string
+                  ~generation
+                  ~created_at:(10.0 +. float_of_int generation)
+              in
+              Memory_io.append_episode_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted;
+              Memory_io.append_event_for_keepers_dir
+                ~keepers_dir:first
+                ~keeper_id
+                persisted)
+            [ 0; 1; 2 ];
+          ( Memory_io.cap_events_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2
+          , Memory_io.cap_episode_files_for_keepers_dir
+              ~keepers_dir:first
+              ~keeper_id
+              ~keep:1
+              ~trigger:2 ))
+    in
     Alcotest.(check int)
       "event cap reports removed rows"
       2
-      (Memory_io.cap_events_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      event_dropped;
     Alcotest.(check int)
       "event cap retains one row"
       1
@@ -188,15 +226,88 @@ let test_explicit_root_scopes_merge_and_retention () =
     Alcotest.(check int)
       "episode cap reports removed files"
       2
-      (Memory_io.cap_episode_files_for_keepers_dir
-         ~keepers_dir:first
-         ~keeper_id
-         ~keep:1
-         ~trigger:2);
+      episode_dropped;
     Alcotest.(check int)
       "episode cap retains one file"
       1
       (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let test_invalid_episode_trace_is_rejected_before_io () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "invalid-trace-keeper" |> Result.get_ok
+    in
+    let invalid_episode = episode ~trace_id:"../escape" ~generation:0 ~created_at:1.0 in
+    expect_invalid_argument "invalid episode trace" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        invalid_episode);
+    Alcotest.(check bool)
+      "invalid trace creates no keeper directory"
+      false
+      (Sys.file_exists
+         (Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id))))
+;;
+
+let test_symlinked_episodes_directory_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-episodes-keeper" |> Result.get_ok
+    in
+    let keeper_dir =
+      Filename.concat first (Keeper_id.Keeper_name.to_string keeper_id)
+    in
+    Unix.mkdir keeper_dir 0o700;
+    let outside = Filename.concat second "outside-episodes" in
+    Unix.mkdir outside 0o700;
+    Unix.symlink outside (Filename.concat keeper_dir "episodes");
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-episodes-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked episodes directory" (fun () ->
+      Memory_io.append_episode_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check (list string))
+      "outside directory remains empty"
+      []
+      (Sys.readdir outside |> Array.to_list))
+;;
+
+let test_symlinked_events_file_is_rejected () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "symlink-events-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let outside = Filename.concat second "outside-events.jsonl" in
+    Fs_compat.save_file outside "sentinel\n";
+    Unix.symlink
+      outside
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string);
+    let trace_id =
+      Keeper_id.Trace_id.of_string "symlink-events-trace" |> Result.get_ok
+    in
+    expect_invalid_argument "symlinked events file" (fun () ->
+      Memory_io.append_event_for_keepers_dir
+        ~keepers_dir:first
+        ~keeper_id
+        (episode
+           ~trace_id:(Keeper_id.Trace_id.to_string trace_id)
+           ~generation:0
+           ~created_at:1.0));
+    Alcotest.(check string)
+      "outside file remains unchanged"
+      "sentinel\n"
+      (Fs_compat.load_file outside))
 ;;
 
 let () =
@@ -211,6 +322,18 @@ let () =
             "merge and retention are root-scoped"
             `Quick
             test_explicit_root_scopes_merge_and_retention
+        ; Alcotest.test_case
+            "invalid episode trace is rejected before I/O"
+            `Quick
+            test_invalid_episode_trace_is_rejected_before_io
+        ; Alcotest.test_case
+            "symlinked episodes directory is rejected"
+            `Quick
+            test_symlinked_episodes_directory_is_rejected
+        ; Alcotest.test_case
+            "symlinked events file is rejected"
+            `Quick
+            test_symlinked_events_file_is_rejected
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,5 +1,5 @@
-module Types = Keeper_memory_os_types
-module Memory_io = Keeper_memory_os_io
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
 
 let with_temp_roots f =
   let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in

--- a/test/test_keeper_memory_os_explicit_root.ml
+++ b/test/test_keeper_memory_os_explicit_root.ml
@@ -1,0 +1,216 @@
+module Types = Keeper_memory_os_types
+module Memory_io = Keeper_memory_os_io
+
+let with_temp_roots f =
+  let root = Filename.temp_file "keeper-memory-explicit-root-" ".tmp" in
+  Sys.remove root;
+  Unix.mkdir root 0o700;
+  let first = Filename.concat root "first" in
+  let second = Filename.concat root "second" in
+  Unix.mkdir first 0o700;
+  Unix.mkdir second 0o700;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree root)
+    (fun () -> f ~first ~second)
+;;
+
+let fact ~claim ~trace_id ~turn ~observed_at =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = Some Types.Durable_knowledge
+  ; source = { Types.trace_id; turn; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen = observed_at
+  ; valid_until = None
+  ; last_verified_at = Some observed_at
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let episode ~trace_id ~generation ~created_at =
+  { Types.trace_id
+  ; generation
+  ; episode_summary = Printf.sprintf "episode-%d" generation
+  ; claims = []
+  ; open_items = []
+  ; constraints = []
+  ; preserved_tool_refs = []
+  ; source_turn_range = Some (generation, generation)
+  ; created_at
+  ; valid_until = None
+  ; terminal_marker = None
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let episode_file_count ~keepers_dir ~keeper_id =
+  Memory_io.episodes_dir_for_keepers_dir ~keepers_dir ~keeper_id
+  |> Sys.readdir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".json")
+  |> List.length
+;;
+
+let test_explicit_root_isolates_append_and_generation () =
+  with_temp_roots (fun ~first ~second ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-root-keeper" |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-root-trace" in
+    let first_episode = episode ~trace_id ~generation:0 ~created_at:1_000.0 in
+    Memory_io.with_episode_bundle_lock_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id
+      (fun () ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode;
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           first_episode);
+    Alcotest.(check bool)
+      "first root receives event"
+      true
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:first
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check bool)
+      "second root remains untouched"
+      false
+      (Sys.file_exists
+         (Memory_io.events_path_for_keepers_dir
+            ~keepers_dir:second
+            ~keeper_id:keeper_id_string));
+    Alcotest.(check int)
+      "episode written only to explicit root"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id);
+    Alcotest.(check int)
+      "first generation starts at floor"
+      4
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:4
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "first generation advances"
+      5
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:first
+         ~floor:0
+         ~keeper_id
+         ~trace_id);
+    Alcotest.(check int)
+      "second root has an independent counter"
+      0
+      (Memory_io.next_generation_with_floor_for_keepers_dir
+         ~keepers_dir:second
+         ~floor:0
+         ~keeper_id
+         ~trace_id))
+;;
+
+let test_explicit_root_scopes_merge_and_retention () =
+  with_temp_roots (fun ~first ~second:_ ->
+    let keeper_id =
+      Keeper_id.Keeper_name.of_string "explicit-retention-keeper"
+      |> Result.get_ok
+    in
+    let keeper_id_string = Keeper_id.Keeper_name.to_string keeper_id in
+    let trace_id = "explicit-retention-trace" in
+    let existing = fact ~claim:"existing" ~trace_id ~turn:0 ~observed_at:1.0 in
+    let incoming = fact ~claim:"incoming" ~trace_id ~turn:1 ~observed_at:2.0 in
+    Memory_io.rewrite_facts_atomically_for_keepers_dir
+      ~keepers_dir:first
+      ~keeper_id:keeper_id_string
+      [ existing ];
+    let stats =
+      Memory_io.merge_and_cap_facts_for_keepers_dir
+        ~keepers_dir:first
+        ~now:3.0
+        ~keeper_id
+        ~merge:(fun ~existing:_ ~incoming -> incoming)
+        ~incoming:[ incoming ]
+        ~keep:2
+        ~trigger:2
+        ~rank:(fun persisted -> persisted.Types.first_seen)
+    in
+    Alcotest.(check int) "one fact appended" 1 stats.appended;
+    Alcotest.(check int) "no fact merged" 0 stats.merged;
+    Alcotest.(check int) "no fact dropped" 0 stats.dropped;
+    (match
+       Memory_io.read_facts_all_strict_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+     with
+     | Ok persisted -> Alcotest.(check int) "two facts persisted" 2 (List.length persisted)
+     | Error detail -> Alcotest.fail detail);
+    List.iter
+      (fun generation ->
+         Memory_io.append_event_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation));
+         Memory_io.append_episode_for_keepers_dir
+           ~keepers_dir:first
+           ~keeper_id
+           (episode
+              ~trace_id
+              ~generation
+              ~created_at:(10.0 +. float_of_int generation)))
+      [ 0; 1; 2 ];
+    Alcotest.(check int)
+      "event cap reports removed rows"
+      2
+      (Memory_io.cap_events_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "event cap retains one row"
+      1
+      (Memory_io.events_path_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id:keeper_id_string
+       |> Fs_compat.load_jsonl
+       |> List.length);
+    Alcotest.(check int)
+      "episode cap reports removed files"
+      2
+      (Memory_io.cap_episode_files_for_keepers_dir
+         ~keepers_dir:first
+         ~keeper_id
+         ~keep:1
+         ~trigger:2);
+    Alcotest.(check int)
+      "episode cap retains one file"
+      1
+      (episode_file_count ~keepers_dir:first ~keeper_id))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os_explicit_root"
+    [ ( "explicit-root"
+      , [ Alcotest.test_case
+            "append and generation are root-scoped"
+            `Quick
+            test_explicit_root_isolates_append_and_generation
+        ; Alcotest.test_case
+            "merge and retention are root-scoped"
+            `Quick
+            test_explicit_root_scopes_merge_and_retention
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add descriptor-anchored, cancellation-safe durable filesystem primitives
- add a typed per-keeper durable memory job store with explicit recovery semantics
- move MemoryOS persistence to explicit-root anchored capabilities

## Runtime bugs addressed
- lock ownership keyed by path aliases instead of opened inode identity
- cancellation/exception paths that could poison lock state or leak descriptors
- non-atomic and symlink-sensitive durable keeper persistence boundaries
- implicit global MemoryOS root selection and silent partial state transitions

## Validation
- ocamlformat on changed OCaml sources
- OCaml parser checks and C syntax checks performed locally
- determinism contract guard passed locally
- full Dune build/test intentionally delegated to GitHub CI per repository policy

## Boundary
MASC-only runtime and persistence work. OAS remains unaware of MASC.