### PR TITLE
fix(auth): gate dashboard dev-token by exact request Host

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -453,20 +453,121 @@ let host_port_scheme_of_origin origin =
       origin (Printexc.to_string exn);
     None
 
+type request_host_rejection =
+  | Missing_request_host
+  | Malformed_request_host
+  | Non_loopback_request_host of string
+
+type admitted_request_host =
+  { host : string
+  ; port : int option
+  }
+
+let ascii_is_digit c = c >= '0' && c <= '9'
+
+let ascii_is_hex_digit c =
+  ascii_is_digit c
+  || (c >= 'a' && c <= 'f')
+  || (c >= 'A' && c <= 'F')
+;;
+
+let reg_name_char_is_allowed c =
+  ascii_is_digit c
+  || (c >= 'a' && c <= 'z')
+  || (c >= 'A' && c <= 'Z')
+  || String.contains "-._~!$&'()*+,;=" c
+;;
+
+let reg_name_is_valid host =
+  let length = String.length host in
+  let rec consume index =
+    if index = length
+    then true
+    else if Char.equal host.[index] '%'
+    then
+      index + 2 < length
+      && ascii_is_hex_digit host.[index + 1]
+      && ascii_is_hex_digit host.[index + 2]
+      && consume (index + 3)
+    else reg_name_char_is_allowed host.[index] && consume (index + 1)
+  in
+  length > 0 && consume 0
+;;
+
+let parse_request_host_port_suffix suffix =
+  if String.equal suffix ""
+  then Ok None
+  else if not (Char.equal suffix.[0] ':')
+  then Error ()
+  else
+    let raw_port = String.sub suffix 1 (String.length suffix - 1) in
+    if String.equal raw_port "" || not (String.for_all ascii_is_digit raw_port)
+    then Error ()
+    else
+      match int_of_string_opt raw_port with
+      | Some port when port <= 65_535 -> Ok (Some port)
+      | Some _ | None -> Error ()
+;;
+
+let parse_request_host_header raw =
+  let authority = String.trim raw in
+  if String.equal authority ""
+  then None
+  else if Char.equal authority.[0] '['
+  then
+    match String.index_opt authority ']' with
+    | None | Some 1 -> None
+    | Some closing_bracket ->
+      let host = String.sub authority 1 (closing_bracket - 1) in
+      let suffix_start = closing_bracket + 1 in
+      let suffix =
+        String.sub authority suffix_start (String.length authority - suffix_start)
+      in
+      (match Ipaddr.V6.of_string host, parse_request_host_port_suffix suffix with
+       | Ok _, Ok port -> Some { host = String.lowercase_ascii host; port }
+       | Error _, _ | _, Error () -> None)
+  else
+    let colon_count =
+      String.fold_left
+        (fun count char -> if Char.equal char ':' then count + 1 else count)
+        0
+        authority
+    in
+    if colon_count > 1
+    then None
+    else
+      let host, suffix =
+        match String.index_opt authority ':' with
+        | None -> authority, ""
+        | Some separator ->
+          ( String.sub authority 0 separator
+          , String.sub authority separator (String.length authority - separator) )
+      in
+      if not (reg_name_is_valid host)
+      then None
+      else
+        match parse_request_host_port_suffix suffix with
+        | Ok port -> Some { host = String.lowercase_ascii host; port }
+        | Error () -> None
+;;
+
+let admit_loopback_request_host request =
+  match Httpun.Headers.get request.Httpun.Request.headers "host" with
+  | None -> Error Missing_request_host
+  | Some raw ->
+    (match parse_request_host_header raw with
+     | None -> Error Malformed_request_host
+     | Some ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
+     | Some { host; _ } -> Error (Non_loopback_request_host host))
+;;
+
 let host_port_of_request request =
   match Httpun.Headers.get request.Httpun.Request.headers "host" with
   | None -> None
-  | Some host_header -> (
-      try
-        let uri = Uri.of_string ("http://" ^ host_header) in
-        match Uri.host uri with
-        | None -> None
-        | Some host ->
-            Some (String.trim host |> String.lowercase_ascii, Uri.port uri)
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        Log.Auth.debug "host_port_of_request: parse failed for %S: %s"
-          host_header (Printexc.to_string exn);
-        None)
+  | Some host_header ->
+    Option.map
+      (fun { host; port } -> host, port)
+      (parse_request_host_header host_header)
 
 (* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
    can be toggled without restarting the server process. *)

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -166,6 +166,22 @@ val host_port_scheme_of_origin :
   string -> (string * int option * string option) option
 (** Parse an [Origin] header value into [(host, port, scheme)]. *)
 
+type request_host_rejection =
+  | Missing_request_host
+  | Malformed_request_host
+  | Non_loopback_request_host of string
+
+type admitted_request_host =
+  { host : string
+  ; port : int option
+  }
+
+val admit_loopback_request_host :
+  Httpun.Request.t -> (admitted_request_host, request_host_rejection) result
+(** Parse the request [Host] authority and admit exact loopback hosts only.
+    Missing, malformed, and non-loopback authorities remain distinct typed
+    rejections. Credential-bearing endpoints must run this gate before I/O. *)
+
 val host_port_of_request : Httpun.Request.t -> (string * int option) option
 (** Host/port from the request's [Host] header. *)
 

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -6,6 +6,32 @@
 
 let dashboard_dev_actor_name = "dashboard"
 
+type request_error =
+  | Request_host_rejected of Server_auth.request_host_rejection
+  | Token_operation_failed of string
+
+let request_error_code = function
+  | Request_host_rejected Server_auth.Missing_request_host ->
+    "dashboard_dev_token_host_missing"
+  | Request_host_rejected Server_auth.Malformed_request_host ->
+    "dashboard_dev_token_host_malformed"
+  | Request_host_rejected (Server_auth.Non_loopback_request_host _) ->
+    "dashboard_dev_token_host_non_loopback"
+  | Token_operation_failed _ -> "dashboard_dev_token_operation_failed"
+;;
+
+let request_error_to_string = function
+  | Request_host_rejected Server_auth.Missing_request_host ->
+    "dashboard dev-token request is missing the Host header"
+  | Request_host_rejected Server_auth.Malformed_request_host ->
+    "dashboard dev-token request has a malformed Host authority"
+  | Request_host_rejected (Server_auth.Non_loopback_request_host host) ->
+    Printf.sprintf
+      "dashboard dev-token request Host %S is not an exact loopback host"
+      host
+  | Token_operation_failed detail -> detail
+;;
+
 let dashboard_dev_token_path base_path =
   Filename.concat
     (Filename.concat (Common.masc_dir_from_base_path ~base_path) "auth")
@@ -78,3 +104,12 @@ let ensure_dashboard_dev_token base_path : (string, string) result =
   | Error msg -> Error msg
   | Ok (Some raw) -> Ok raw
   | Ok None -> mint_dashboard_dev_token base_path
+
+let ensure_dashboard_dev_token_for_request ~request ~base_path =
+  match Server_auth.admit_loopback_request_host request with
+  | Error rejection -> Error (Request_host_rejected rejection)
+  | Ok _ ->
+    Result.map_error
+      (fun detail -> Token_operation_failed detail)
+      (ensure_dashboard_dev_token base_path)
+;;

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -1,4 +1,16 @@
 (** Dashboard dev-token file and minting helpers for dashboard routes. *)
 
+type request_error =
+  | Request_host_rejected of Server_auth.request_host_rejection
+  | Token_operation_failed of string
+
 val dashboard_dev_token_path : string -> string
+val request_error_code : request_error -> string
+val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result
+
+val ensure_dashboard_dev_token_for_request :
+  request:Httpun.Request.t ->
+  base_path:string ->
+  (string, request_error) result
+(** Admit an exact loopback request Host before token or credential I/O. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -503,15 +503,42 @@ let add_routes ~sw ~clock router =
        else
          with_public_read (fun state req reqd ->
            let base_path = (Mcp_server.workspace_config state).base_path in
-           let raw_result = ensure_dashboard_dev_token base_path in
+           let raw_result =
+             Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token_for_request
+               ~request:req
+               ~base_path
+           in
            begin
              match raw_result with
              | Ok raw ->
                Http.Response.json_value ~request:req
                  (`Assoc [ ("token", `String raw) ]) reqd
-             | Error msg ->
-               Http.Response.json_value ~status:`Internal_server_error
-                 ~request:req (`Assoc [ ("error", `String msg) ]) reqd
+             | Error err ->
+               let status =
+                 match err with
+                 | Server_routes_http_dashboard_dev_token.Request_host_rejected _ ->
+                   `Forbidden
+                 | Server_routes_http_dashboard_dev_token.Token_operation_failed _ ->
+                   `Internal_server_error
+               in
+               let error_code =
+                 Server_routes_http_dashboard_dev_token.request_error_code err
+               in
+               let message =
+                 Server_routes_http_dashboard_dev_token.request_error_to_string err
+               in
+               Log.Auth.error
+                 "dashboard dev-token denied code=%s detail=%s"
+                 error_code
+                 message;
+               Http.Response.json_value
+                 ~status
+                 ~request:req
+                 (`Assoc
+                    [ "error", `String message
+                    ; "error_code", `String error_code
+                    ])
+                 reqd
            end) request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-probe" (fun request reqd ->
        let force = Server_utils.bool_query_param request "force" ~default:false in

--- a/test/dune
+++ b/test/dune
@@ -95,6 +95,7 @@
   test_operator_control_judgment
   test_with_cleanups_on_release
   test_auth_login
+  test_dashboard_dev_token_host_gate
   test_audit_log
   test_console_sink
   test_governance_anomaly
@@ -459,6 +460,7 @@
   test_operator_control_support
   test_with_cleanups_on_release
   test_auth_login
+  test_dashboard_dev_token_host_gate
   test_audit_log
   test_console_sink
   test_governance_anomaly

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,0 +1,98 @@
+open Alcotest
+
+let request ?host () =
+  let headers =
+    match host with
+    | None -> Httpun.Headers.empty
+    | Some value -> Httpun.Headers.of_list [ "host", value ]
+  in
+  Httpun.Request.create ~headers `GET "/api/v1/dashboard/dev-token"
+;;
+
+let check_admitted raw expected_host expected_port =
+  match Server_auth.admit_loopback_request_host (request ~host:raw ()) with
+  | Ok admitted ->
+    check string "host" expected_host admitted.host;
+    check (option int) "port" expected_port admitted.port
+  | Error _ -> failf "expected Host %S to be admitted" raw
+;;
+
+let test_exact_loopback_authorities () =
+  check_admitted "localhost:8935" "localhost" (Some 8935);
+  check_admitted " LOCALHOST:8935 " "localhost" (Some 8935);
+  check_admitted "127.0.0.1" "127.0.0.1" None;
+  check_admitted "[::1]:8935" "::1" (Some 8935);
+  check_admitted "[0:0:0:0:0:0:0:1]" "0:0:0:0:0:0:0:1" None
+;;
+
+let test_malformed_suffixes_are_fully_rejected () =
+  List.iter
+    (fun raw ->
+      match Server_auth.admit_loopback_request_host (request ~host:raw ()) with
+      | Error Server_auth.Malformed_request_host -> ()
+      | _ -> failf "Host %S must be rejected as malformed" raw)
+    [ "localhost:8935<suffix>"
+    ; "localhost:8935/ignored"
+    ; "localhost:8935:80"
+    ; "localhost:"
+    ; "localhost:65536"
+    ; "localhost#fragment"
+    ; "user@localhost:8935"
+    ; "[::1]garbage"
+    ; "[::1]:8935garbage"
+    ]
+;;
+
+let test_host_rejections_are_typed () =
+  (match Server_auth.admit_loopback_request_host (request ()) with
+   | Error Server_auth.Missing_request_host -> ()
+   | _ -> fail "missing Host must have a typed rejection");
+  (match
+     Server_auth.admit_loopback_request_host
+       (request ~host:"localhost/path" ())
+   with
+   | Error Server_auth.Malformed_request_host -> ()
+   | _ -> fail "Host containing a path must be malformed");
+  (match
+     Server_auth.admit_loopback_request_host
+       (request ~host:"attacker.example:8935" ())
+   with
+   | Error (Server_auth.Non_loopback_request_host "attacker.example") -> ()
+   | _ -> fail "non-loopback Host must retain its typed rejection")
+;;
+
+let test_rejection_precedes_token_io () =
+  let base_path = Filename.temp_file "masc-dev-token-host-" ".workspace" in
+  Sys.remove base_path;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists base_path then Unix.rmdir base_path)
+    (fun () ->
+       List.iter
+         (fun raw ->
+           match
+             Server_routes_http_dashboard_dev_token
+             .ensure_dashboard_dev_token_for_request
+               ~request:(request ~host:raw ())
+               ~base_path
+           with
+           | Error
+               (Server_routes_http_dashboard_dev_token.Request_host_rejected _) ->
+             check bool "base path remains absent" false (Sys.file_exists base_path)
+           | _ -> failf "Host %S must fail before token I/O" raw)
+         [ "attacker.example"; "localhost:8935<suffix>" ])
+;;
+
+let () =
+  run
+    "dashboard-dev-token-host-gate"
+    [ ( "host admission"
+      , [ test_case "exact loopback authorities" `Quick test_exact_loopback_authorities
+        ; test_case
+            "malformed suffixes are fully rejected"
+            `Quick
+            test_malformed_suffixes_are_fully_rejected
+        ; test_case "typed rejections" `Quick test_host_rejections_are_typed
+        ; test_case "rejection precedes token I/O" `Quick test_rejection_precedes_token_io
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- request `Host`를 전용 authority parser로 완전 소비하고 exact loopback만 허용합니다.
- bracketed IPv6, reg-name/IPv4, explicit port를 결정적으로 파싱합니다.
- missing/malformed/non-loopback을 typed rejection으로 분리합니다.
- dev-token credential/token I/O보다 앞에 admission을 배치합니다.
- route는 Host rejection을 403 + stable `error_code`로 관측 가능하게 반환합니다.
- 기존 `host_port_of_request`도 같은 parser를 소비해 Host 해석 SSOT를 하나로 유지합니다.

## 적대 리뷰 수리

초기 구현의 `Uri.of_string ("http://" ^ authority)`는 유효 prefix 뒤 malformed suffix를 남길 수 있었습니다. 범용 URI parser와 catch-all을 제거하고 다음을 fail-closed로 고정했습니다.

- path/query/fragment/userinfo 및 trailing garbage
- unbracketed IPv6
- empty/non-numeric/out-of-range port
- incomplete percent escape
- bracketed IPv6 뒤 잘못된 suffix

## Boundary

#24031의 1단계 Host gate만 분리한 독립 보안 슬라이스입니다. 폐기된 #24039의 토큰 rotation/permission/catalog 대개편은 포함하지 않습니다. Worker 권한 전환과 crash-safe rotation은 #24082/#24084 이후 별도 수직 슬라이스로 남깁니다.

## Verification

- `git diff --check` PASS
- touched ML `ocamlformat --check` PASS
- touched ML `ocamlc -stop-after parsing` PASS
- touched ML `ocamldep -modules` PASS
- local Dune은 실행하지 않았으며 exact-head PR CI가 빌드/테스트 권위입니다.

## Test contract

- localhost/127.0.0.1/IPv6 loopback exact admission
- missing/malformed/non-loopback typed rejection
- malformed suffix 완전 거부
- non-loopback 및 malformed request 모두 token/credential I/O 0

Exact head: `c4c070db15`, base: `main@572c0833de`.

Refs #24031.
