### PR TITLE
fix(keeper): isolate authorization-refused providers

### DIFF
--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -415,10 +415,12 @@ let network_error_kind_is_terminal
 
 let sdk_error_is_terminal_provider_runtime_failure
     (err : Agent_sdk.Error.sdk_error) : bool =
-  let direct_typed_network =
+  let direct_typed_terminal =
     match err with
-    | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
-    | Agent_sdk.Error.Provider (Llm_provider.Error.NotFound _) ->
+    | Agent_sdk.Error.Api
+        (Llm_provider.Retry.AuthError _ | Llm_provider.Retry.NotFound _)
+    | Agent_sdk.Error.Provider
+        (Llm_provider.Error.AuthError _ | Llm_provider.Error.NotFound _) ->
         true
     | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError { kind; _ }) ->
         network_error_kind_is_terminal kind
@@ -440,7 +442,7 @@ let sdk_error_is_terminal_provider_runtime_failure
         message_looks_like_terminal_provider_runtime_failure message
     | _ -> false
   in
-  direct_typed_network
+  direct_typed_terminal
   || direct_api_message
   || message_looks_like_terminal_provider_runtime_failure
        (Agent_sdk.Error.to_string err)

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -310,6 +310,71 @@ let test_payment_required_is_hard_quota () =
   | None -> Alcotest.fail "expected hard_quota recoverable reason"
 ;;
 
+let test_authorization_errors_are_terminal_provider_failures () =
+  let api_error =
+    SdkE.Api
+      (Retry.AuthError
+         { message = "provider refused the current account entitlement" })
+  in
+  let provider_error =
+    SdkE.Provider
+      (Llm_provider.Error.AuthError
+         { provider = "authorization-test"
+         ; detail = "provider refused the current account entitlement"
+         })
+  in
+  List.iter
+    (fun (label, err) ->
+       Alcotest.(check bool)
+         (label ^ " is terminal")
+         true
+         (KTD.sdk_error_is_terminal_provider_runtime_failure err);
+       match EC.recoverable_runtime_failure_reason err with
+       | Some EC.Auth_error -> ()
+       | Some reason ->
+         Alcotest.failf
+           "%s expected auth_error, got %s"
+           label
+           (EC.degraded_retry_reason_to_string reason)
+       | None -> Alcotest.failf "%s expected auth_error recovery route" label)
+    [ "api", api_error; "provider", provider_error ];
+  let candidate =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"authorization-terminal-test"
+      ~base_url:"https://authorization-terminal.example/v1"
+      ()
+    |> RC.of_provider_config ~max_concurrent:None
+  in
+  let keeper_name = "authorization-terminal-cooldown-test" in
+  let provider_key =
+    match RC.health_keys candidate with
+    | [ key ] -> keeper_name ^ "@" ^ key
+    | keys ->
+      Alcotest.failf
+        "expected one health key, got [%s]"
+        (String.concat "; " keys)
+  in
+  KTD.For_testing.record_candidate_health_error ~keeper_name candidate api_error;
+  let info =
+    match BH.provider_info BH.global ~provider_key with
+    | Some info -> info
+    | None -> Alcotest.failf "expected provider info for %s" provider_key
+  in
+  Alcotest.(check bool)
+    "authorization refusal opens immediate cooldown"
+    true
+    info.in_cooldown;
+  Alcotest.(check int)
+    "authorization refusal counted as terminal failure"
+    1
+    (BH.recent_outcome_count
+       BH.global
+       ~provider_key
+       ~outcome:BH.Outcome_terminal_failure
+       ~window_s:BH.window_sec)
+;;
+
 (* Regression: a transient Overloaded (529/CapacityExhausted) whose prose
    coincidentally contains a hard-quota indicator must NOT be classified as hard
    quota. The typed variant already says transient; the message scan previously
@@ -1223,6 +1288,10 @@ let () =
             "payment required is classified as hard quota"
             `Quick
             test_payment_required_is_hard_quota
+        ; Alcotest.test_case
+            "authorization refusals are terminal provider failures"
+            `Quick
+            test_authorization_errors_are_terminal_provider_failures
         ; Alcotest.test_case
             "transient overload with quota prose is not hard quota"
             `Quick


### PR DESCRIPTION
## 현재 상태

`blocked-on-oas`예용. 현재 원격 head `824444f4a23b641ff4506c7f047ec052e3cc91e9`는 OAS 0.211의 `AuthError`만 소비하므로 새 403 계약을 아직 보존하지 못해용.

## 필요한 순서

1. OAS #2520의 `AuthorizationError`가 main/release에 도달해야 해용.
2. MASC의 OAS pin을 main에서 도달 가능한 exact SHA와 실제 최소 버전으로 갱신해야 해용.
3. MASC가 API/provider 403을 별도 authorization 타입·wire·fallback 이유로 소비하고 Keeper별 provider lane만 cooldown해야 해용.
4. exact-head CI가 green이어야 해용.

## 경계

MASC가 OAS의 typed error를 소비해용. OAS는 MASC를 알지 않아용. PR branch의 미병합 SHA를 영구 pin하지 않아용.

## 예정 검증

- 403 상태 보존 및 401 credential hint 비주입
- API/provider typed conversion
- authorization terminal wire/event/fallback 분리
- 동일 Keeper lane cooldown 및 다른 Keeper lane 비영향
- parser/ocamlformat/determinism/enum/silent-failure/OAS-boundary/SSOT ratchet
- 전체 Dune build/test는 PR CI에서 수행해용.

## 근거

- [근거] OAS #2520 exact head `a1df5686bc2dfc17eac02878e917a5303a33c7bb` CI green, 아직 Draft/Open — `gh pr view 2520` — 확인 2026-07-11 15:08 KST — 신뢰도 High
- [근거] RFC 9110 HTTP 403 인가 거부 의미: https://www.rfc-editor.org/rfc/rfc9110.html — 확인 2026-07-11 14:56 KST — 신뢰도 High
- [근거] Kimi Code 공식 401/403 오류 구분: https://www.kimi.com/code/docs/en/kimi-code/error-reference.html — 확인 2026-07-11 14:56 KST — 신뢰도 High
