### PR TITLE
fix(keeper): prepare retained shutdown before stop

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -34,10 +34,11 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
-    stop_keepalive ~base_path:config.base_path requested_name;
     match read_meta_resolved config requested_name with
     | Error e -> tool_result_error e
-    | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
+    | Ok None ->
+      stop_keepalive ~base_path:config.base_path requested_name;
+      tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
       (match
          Atomic.get remove_pending_confirms_by_target_callback config
@@ -54,54 +55,60 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
         "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
          remove_meta=%b remove_session=%b"
         name pending_confirms_removed remove_meta remove_session;
-      (if remove_meta then
-         ( Safe_ops.remove_file_logged ~context:"keeper_down"
-             (keeper_meta_path config name);
-           Keeper_registry.unregister ~base_path:config.base_path name;
-           (* Tier K4c teardown — when the keeper is fully removed
-              (remove_meta=true), drop its tool-emission accumulator
-              from the registry so its slot is reclaimable. The
-              retain-paused branch (else) deliberately keeps the
-              accumulator alive so a future resume can drain any
-              pending items captured before pause. *)
-           Keeper_tool_emission_hook.drop_keeper_accumulator name )
-       else
-         let retained =
-           {
-             m with
-             updated_at = now_iso ();
-             paused = true;
-             (* keeper_down (remove_meta=false) is an operator-initiated
-                retain-paused shutdown; record it as an operator pause so the
-                status bridge can name it. Observability only — the
-                Operator_pause dispatch below is unchanged. *)
-             latched_reason =
-               Some
-                 (Keeper_latched_reason.Operator_paused
-                    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down });
-           }
-         in
-         ((match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.caller_wins config retained
-           with
-           | Ok () -> ()
-           | Error err ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string WriteMetaFailures)
-                 ~labels:[("keeper", name);
-                          ("phase",
-                           if Keeper_meta_store.is_version_conflict_error err
-                           then "keeper_down_cas_race"
-                           else "keeper_down")]
-                 ();
-               if Keeper_meta_store.is_version_conflict_error err then
-                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
-               else
-                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
-          Keeper_registry.update_meta ~base_path:config.base_path name retained;
-          Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
-            Keeper_state_machine.Operator_pause));
+      let prepare_shutdown =
+        if remove_meta then Ok ()
+        else
+          let retained =
+            {
+              m with
+              updated_at = now_iso ();
+              paused = true;
+              (* [keeper_down] is a retained shutdown, not a pause followed by
+                 a second lifecycle command.  Persist the next-boot intent
+                 before stopping the live registry entry; the stop transition
+                 itself owns the transient FSM teardown. *)
+              latched_reason =
+                Some
+                  (Keeper_latched_reason.Operator_paused
+                     { operator_actor = Keeper_latched_reason.operator_actor_keeper_down });
+            }
+          in
+          match
+            write_meta_with_merge
+              ~merge:Keeper_meta_merge.caller_wins config retained
+          with
+          | Ok () ->
+            Keeper_registry.update_meta ~base_path:config.base_path name retained;
+            Ok ()
+          | Error err ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string WriteMetaFailures)
+              ~labels:
+                [ "keeper", name
+                ; ( "phase"
+                  , if Keeper_meta_store.is_version_conflict_error err
+                    then "keeper_down_cas_race"
+                    else "keeper_down" )
+                ]
+              ();
+            Error (Printf.sprintf "keeper_down failed to persist paused state: %s" err)
+      in
+      (match prepare_shutdown with
+       | Error msg -> tool_result_error msg
+       | Ok () ->
+      (* No irreversible lifecycle mutation occurs before pending-confirm and
+         retained-meta preparation have succeeded. *)
+      stop_keepalive ~base_path:config.base_path name;
+      (if remove_meta then (
+         Safe_ops.remove_file_logged ~context:"keeper_down"
+           (keeper_meta_path config name);
+         Keeper_registry.unregister ~base_path:config.base_path name;
+         (* Tier K4c teardown — when the keeper is fully removed
+            (remove_meta=true), drop its tool-emission accumulator
+            from the registry so its slot is reclaimable. The
+            retain-paused branch deliberately keeps the accumulator alive so
+            a future resume can drain items captured before shutdown. *)
+         Keeper_tool_emission_hook.drop_keeper_accumulator name));
       if remove_session then (
         let rec rm_rf path =
           if Fs_compat.file_exists path then begin
@@ -129,7 +136,7 @@ let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
         ("remove_session", `Bool remove_session);
         ("pending_confirms_removed", `Int pending_confirms_removed);
       ] in
-      tool_result_ok (Yojson.Safe.to_string json))
+      tool_result_ok (Yojson.Safe.to_string json)))
 
 let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
 

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -4,9 +4,9 @@
 
 type tool_result = Keeper_types_profile.tool_result
 
-(** Handle the [masc_keeper_down] MCP tool call: stop keepalive,
-    optionally remove meta and/or session directory, broadcast
-    Operator_pause to the registry. *)
+(** Handle the [masc_keeper_down] MCP tool call.  A retained shutdown persists
+    its operator-paused next-boot intent before stopping the live registry
+    entry; full removal may also remove meta and/or the session directory. *)
 val handle_keeper_down :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -214,7 +214,18 @@ let test_keeper_down_retain_records_reason () =
            ; "remove_session", `Bool false
            ]
        in
-       let _result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
+       let result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
+       check
+         bool
+         "keeper_down reports success"
+         true
+         (Keeper_types_profile.tool_result_success result);
+       check
+         bool
+         "keeper_down removes the stopped live registry entry"
+         true
+         (Option.is_none
+            (Keeper_registry.get ~base_path:config.base_path keeper_name));
        match Keeper_meta_store.read_meta config keeper_name with
        | Ok (Some persisted) ->
          check bool "keeper_down retain pauses keeper" true persisted.paused;
@@ -225,6 +236,54 @@ let test_keeper_down_retain_records_reason () =
            (latched_reason_wire persisted)
        | Ok None -> fail "expected retained keeper meta on disk"
        | Error err -> failf "read persisted meta: %s" err)
+
+let test_keeper_down_cleanup_failure_keeps_lane_registered () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ();
+      Keeper_registry.clear ();
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "downretain-cleanup-failure" in
+       let meta = make_meta keeper_name in
+       Keeper_registry.clear ();
+       (match Keeper_meta_store.write_meta config meta with
+        | Ok () -> ()
+        | Error err -> failf "seed meta write: %s" err);
+       ignore (Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
+         (fun _config ~target_type:_ ~target_id:_ -> Error "cleanup unavailable");
+       let result =
+         Keeper_turn_lifecycle.handle_keeper_down_config
+           ~config
+           (`Assoc
+              [ "name", `String keeper_name
+              ; "remove_meta", `Bool false
+              ; "remove_session", `Bool false
+              ])
+       in
+       check
+         bool
+         "cleanup failure is explicit"
+         false
+         (Keeper_types_profile.tool_result_success result);
+       check
+         bool
+         "cleanup failure leaves the live registry entry intact"
+         true
+         (Option.is_some
+            (Keeper_registry.get ~base_path:config.base_path keeper_name));
+       match Keeper_meta_store.read_meta config keeper_name with
+       | Ok (Some persisted) ->
+         check bool "cleanup failure does not persist a pause" false persisted.paused
+       | Ok None -> fail "expected original keeper meta on disk"
+       | Error err -> failf "read original meta: %s" err)
 
 (* ── Site 1: dead-tombstone cleanup ─────────────────────────── *)
 
@@ -526,6 +585,8 @@ let () =
             test_grpc_pause_directive_records_reason
         ; test_case "keeper_down retain records keeper_down reason" `Quick
             test_keeper_down_retain_records_reason
+        ; test_case "keeper_down cleanup failure keeps lane registered" `Quick
+            test_keeper_down_cleanup_failure_keeps_lane_registered
         ; test_case "dead-tombstone cleanup records Dead_tombstone reason" `Quick
             test_dead_tombstone_cleanup_records_reason
         ; test_case "dead-tombstone cleanup overwrites existing pause reason" `Quick


### PR DESCRIPTION
## Summary
- run pending-confirm cleanup before any irreversible Keeper stop
- persist retained operator-paused intent before registry teardown
- remove the impossible post-Stopped Operator_pause dispatch
- return an explicit tool error when retained meta persistence fails

## Runtime evidence
The live dashboard shutdown path completed running → draining → stopped and then attempted Operator_pause, producing 10 typed terminal-state rejections on 2026-07-11. Cleanup failures could also occur after stop because stop_keepalive ran at function entry.

## Lane semantics
This changes only the selected Keeper lane. Durable next-boot intent is prepared first; the existing typed stop/drain transition still owns transient FSM teardown.

## Validation
- ocamlformat check
- OCaml parser checks for implementation, interface, and regression test
- determinism contract guard
- full Dune build/test delegated to CI per repository policy