### PR TITLE
fix(fs): type descriptor-owned mutation progress

### DIFF
--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -1,73 +1,5 @@
 (* See [atomic_write.mli] for the contract. *)
 
-(* Durable atomic write: tmp → fsync(tmp) → rename → fsync(parent dir).
-   Without the fsync pair, a crash between the rename and the kernel's
-   dirty-page flush can leave the target truncated or zero-length —
-   observed on backlog.json after an abrupt shutdown (2026-04-18). *)
-let fsync_path path =
-  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      try Unix.close fd with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Stdlib.Printf.eprintf
-          "[fs_compat] fsync_path close failed: %s\n%!"
-          (Printexc.to_string exn))
-    (fun () ->
-      try Unix.fsync fd with
-      | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
-           is still durable to the extent the underlying FS offers. *)
-        ())
-;;
-
-(* #10205 finding 2: keep the atomic-tmp filename shape in one place
-   so the writer ([save_file_atomic]) and the orphan-sweep matcher
-   ([is_atomic_orphan_name]) cannot drift independently. A
-   prefix/suffix change on one side without the other would cause
-   the sweep to either miss live orphans or scoop unrelated tmp
-   files. *)
-let atomic_tmp_prefix = ".atomic_"
-let atomic_tmp_suffix = ".tmp"
-
-let save_file_atomic
-  ~(save_file : string -> string -> unit)
-  (path : string)
-  (content : string)
-  : (unit, string) Result.t
-  =
-  let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
-  in
-  try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
-    Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    raise e
-  | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
-;;
-
-let is_atomic_orphan_name name =
-  let n = String.length name in
-  let p = String.length atomic_tmp_prefix in
-  let s = String.length atomic_tmp_suffix in
-  n >= p + s
-  && String.starts_with name ~prefix:atomic_tmp_prefix
-  && String.ends_with ~suffix:atomic_tmp_suffix name
-;;
-
 let cleanup_atomic_orphans
   ~(mkdir_p_unix : string -> unit)
   ~(base_path : string)
@@ -112,7 +44,7 @@ let cleanup_atomic_orphans
   in
   let scan_dir dir entries =
     Array.iter
-      (fun name -> if is_atomic_orphan_name name then handle_file dir name)
+      (fun name -> if Durable_mutation.is_temporary_name name then handle_file dir name)
       entries
   in
   let read_dir_entries dir =

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -9,32 +9,12 @@
 
     Crash recovery is provided by [cleanup_atomic_orphans], a
     boot-time sweep for [.atomic_*.tmp] files left behind when the
-    owning process was SIGKILL'd or [Filename.temp_file] itself
-    raised ENFILE/EMFILE before the with-handler could register.
+    owning process was SIGKILL'd after the descriptor-owned writer
+    created its exclusive temporary entry.
 
-    The [save_file] and [mkdir_p_unix] primitives are injected so
-    this module stays free of [Fs_compat]'s Eio bridge — same
-    cycle-free placement pattern as [Mkdir_memo] and [Fd_cache]. *)
-
-(** [save_file_atomic ~save_file path content] writes [content] to
-    a temp file in [path]'s directory, fsyncs the tmp, renames it
-    over [path], and best-effort fsyncs the parent directory.
-
-    Returns [Ok ()] on success or [Error msg] when the write or
-    rename fails (the tmp is cleaned up). Re-raises
-    [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
-    must not be swallowed (RFC-0143). *)
-val save_file_atomic
-  :  save_file:(string -> string -> unit)
-  -> string
-  -> string
-  -> (unit, string) Result.t
-
-(** [true] iff [name] matches the [.atomic_*.tmp] shape produced
-    by {!save_file_atomic}. Exposed so a periodic sweep can match
-    the same filename pattern without re-deriving the prefix and
-    suffix — #10205 finding 2. *)
-val is_atomic_orphan_name : string -> bool
+    The writer SSOT is {!Durable_mutation}; this module owns only the
+    legacy boot-time recovery traversal until #24083 replaces it with
+    schema-owned roots. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,7 +3,10 @@
 (library
  (name fs_compat)
  (public_name masc.fs_compat)
- (modules fs_compat mkdir_memo fd_cache atomic_write)
+ (modules fs_compat mkdir_memo fd_cache atomic_write durable_mutation)
+ (foreign_stubs
+  (language c)
+  (names durable_mutation_stubs))
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/fs_compat/durable_mutation.ml
+++ b/lib/fs_compat/durable_mutation.ml
@@ -1,0 +1,276 @@
+module Segment = struct
+  type t = string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  let of_string = function
+    | "" -> Error Empty
+    | "." -> Error Dot
+    | ".." -> Error Dot_dot
+    | value when String.contains value '/' -> Error Contains_separator
+    | value when String.contains value '\000' -> Error Contains_nul
+    | value -> Ok value
+  ;;
+
+  let to_string value = value
+end
+
+type diagnostic_stage =
+  | Temporary_close
+  | Temporary_cleanup
+  | Parent_close
+  | Observer
+
+type diagnostic =
+  { stage : diagnostic_stage
+  ; cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a progress =
+  | Not_committed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Committed_not_durable of
+      { value : 'a
+      ; cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Durable of 'a
+
+type 'a report =
+  { progress : 'a progress
+  ; diagnostics : diagnostic list
+  }
+
+type observation =
+  | Observed
+  | Observer_failed of diagnostic
+
+external open_parent : string -> Unix.file_descr = "masc_durable_mutation_open_parent"
+
+external create_exclusive
+  :  Unix.file_descr
+  -> string
+  -> int
+  -> Unix.file_descr
+  = "masc_durable_mutation_create_exclusive"
+
+external rename_entry
+  :  Unix.file_descr
+  -> string
+  -> string
+  -> unit
+  = "masc_durable_mutation_rename"
+
+external unlink_entry
+  :  Unix.file_descr
+  -> string
+  -> unit
+  = "masc_durable_mutation_unlink"
+
+let diagnostic stage cause backtrace = { stage; cause; backtrace }
+
+let diagnostic_stage_to_string = function
+  | Temporary_close -> "temporary close"
+  | Temporary_cleanup -> "temporary cleanup"
+  | Parent_close -> "parent close"
+  | Observer -> "observer"
+;;
+
+let diagnostic_to_string diagnostic =
+  Printf.sprintf
+    "%s: %s"
+    (diagnostic_stage_to_string diagnostic.stage)
+    (Printexc.to_string diagnostic.cause)
+;;
+
+let temporary_prefix = ".atomic_"
+let temporary_suffix = ".tmp"
+
+let is_temporary_name name =
+  let name_length = String.length name in
+  let prefix_length = String.length temporary_prefix in
+  let suffix_length = String.length temporary_suffix in
+  name_length >= prefix_length + suffix_length
+  && String.starts_with name ~prefix:temporary_prefix
+  && String.ends_with name ~suffix:temporary_suffix
+;;
+
+let run_state_machine ~prepare ~commit ~publish ~cleanup =
+  let not_committed cause backtrace =
+    { progress = Not_committed { cause; backtrace }; diagnostics = cleanup () }
+  in
+  match prepare () with
+  | exception cause -> not_committed cause (Printexc.get_raw_backtrace ())
+  | () ->
+    (match commit () with
+     | exception cause -> not_committed cause (Printexc.get_raw_backtrace ())
+     | () ->
+       (match publish () with
+        | () -> { progress = Durable (); diagnostics = [] }
+        | exception cause ->
+          { progress =
+              Committed_not_durable
+                { value = (); cause; backtrace = Printexc.get_raw_backtrace () }
+          ; diagnostics = []
+          }))
+;;
+
+module For_testing = struct
+  let run_state_machine = run_state_machine
+end
+
+type temporary_owner =
+  | Not_created
+  | Open of Unix.file_descr
+  | Released
+
+let temp_counter = Atomic.make 0
+
+let rec create_temporary parent =
+  let sequence = Atomic.fetch_and_add temp_counter 1 in
+  (* NDT-OK: the process ID only mints an O_EXCL entry name. No policy, replay,
+     ordering, or identity decision depends on its value. *)
+  let process_id = Unix.getpid () in
+  let raw =
+    Printf.sprintf
+      "%s%x_%x%s"
+      temporary_prefix
+      process_id
+      sequence
+      temporary_suffix
+  in
+  match create_exclusive parent raw 0o600 with
+  | descriptor -> raw, descriptor
+  | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary parent
+;;
+
+let write_all descriptor content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring
+          descriptor
+          content
+          offset
+          (String.length content - offset)
+      with
+      | 0 -> raise (Unix.Unix_error (Unix.EIO, "durable_mutation_write", ""))
+      | count -> loop (offset + count)
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+  in
+  loop 0
+;;
+
+let close_once owner stage =
+  match !owner with
+  | Not_created | Released -> []
+  | Open descriptor ->
+    owner := Released;
+    (match Unix.close descriptor with
+     | () -> []
+     | exception cause ->
+       [ diagnostic stage cause (Printexc.get_raw_backtrace ()) ])
+;;
+
+let cleanup_temporary parent temp_name owner =
+  let close_diagnostics = close_once owner Temporary_close in
+  match !temp_name with
+  | None -> close_diagnostics
+  | Some name ->
+    temp_name := None;
+    (match unlink_entry parent name with
+     | () ->
+       (match Unix.fsync parent with
+        | () -> close_diagnostics
+        | exception cause ->
+          close_diagnostics
+          @ [ diagnostic
+                Temporary_cleanup
+                cause
+                (Printexc.get_raw_backtrace ())
+            ])
+     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> close_diagnostics
+     | exception cause ->
+       close_diagnostics
+       @ [ diagnostic
+             Temporary_cleanup
+             cause
+             (Printexc.get_raw_backtrace ())
+         ])
+;;
+
+let atomic_replace_at parent ~name ~perm content =
+  let temp_name = ref None in
+  let owner = ref Not_created in
+  let prepare () =
+    let name, descriptor = create_temporary parent in
+    temp_name := Some name;
+    owner := Open descriptor;
+    write_all descriptor content;
+    Unix.fchmod descriptor perm;
+    Unix.fsync descriptor;
+    match close_once owner Temporary_close with
+    | [] -> ()
+    | { cause; backtrace; _ } :: _ ->
+      Printexc.raise_with_backtrace cause backtrace
+  in
+  let commit () =
+    match !temp_name with
+    | None -> invalid_arg "durable mutation temporary entry is not prepared"
+    | Some temporary ->
+      rename_entry parent temporary (Segment.to_string name);
+      temp_name := None
+  in
+  run_state_machine
+    ~prepare
+    ~commit
+    ~publish:(fun () -> Unix.fsync parent)
+    ~cleanup:(fun () -> cleanup_temporary parent temp_name owner)
+;;
+
+let add_parent_close report parent =
+  match Unix.close parent with
+  | () -> report
+  | exception cause ->
+    { report with
+      diagnostics =
+        report.diagnostics
+        @ [ diagnostic Parent_close cause (Printexc.get_raw_backtrace ()) ]
+    }
+;;
+
+let atomic_replace_blocking ~parent ~name ~perm content =
+  match open_parent parent with
+  | exception cause ->
+    { progress =
+        Not_committed { cause; backtrace = Printexc.get_raw_backtrace () }
+    ; diagnostics = []
+    }
+  | parent_descriptor ->
+    let report = atomic_replace_at parent_descriptor ~name ~perm content in
+    add_parent_close report parent_descriptor
+;;
+
+let atomic_replace_eio ~parent ~name ~perm content =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"durable-mutation" (fun () ->
+      atomic_replace_blocking ~parent ~name ~perm content))
+;;
+
+let observe observer report =
+  match observer report with
+  | () -> Observed
+  | exception (Eio.Cancel.Cancelled _ as cause) -> raise cause
+  | exception cause ->
+    Observer_failed
+      (diagnostic Observer cause (Printexc.get_raw_backtrace ()))
+;;

--- a/lib/fs_compat/durable_mutation.mli
+++ b/lib/fs_compat/durable_mutation.mli
@@ -1,0 +1,90 @@
+(** Descriptor-owned durable filesystem mutations.
+
+    A mutation has one closed progress state. Once the final directory entry
+    operation succeeds, later failures can only produce
+    {!Committed_not_durable}; they can never be reported as retry-safe.
+
+    The blocking and Eio entry points are intentionally separate. The Eio
+    entry point protects the complete system-thread operation from
+    cancellation, so a caller always receives the committed state. *)
+
+module Segment : sig
+  type t = private string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+end
+
+type diagnostic_stage =
+  | Temporary_close
+  | Temporary_cleanup
+  | Parent_close
+  | Observer
+
+type diagnostic =
+  { stage : diagnostic_stage
+  ; cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+val diagnostic_to_string : diagnostic -> string
+
+type 'a progress =
+  | Not_committed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Committed_not_durable of
+      { value : 'a
+      ; cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Durable of 'a
+
+type 'a report =
+  { progress : 'a progress
+  ; diagnostics : diagnostic list
+  }
+
+type observation =
+  | Observed
+  | Observer_failed of diagnostic
+
+val is_temporary_name : string -> bool
+(** [true] exactly for names minted by this mutation core. Recovery delegates
+    to this predicate instead of duplicating the writer's naming contract. *)
+
+val atomic_replace_blocking :
+  parent:string -> name:Segment.t -> perm:int -> string -> unit report
+(** Open [parent] once as a directory capability, create and fsync an exclusive
+    temporary file relative to it, rename that entry over [name], and fsync the
+    same parent descriptor. The descriptor has one owner and one close path. *)
+
+val atomic_replace_eio :
+  parent:string -> name:Segment.t -> perm:int -> string -> unit report
+(** Eio-safe counterpart of {!atomic_replace_blocking}. The whole blocking
+    state machine runs in a protected system-thread call. There is no runtime
+    detection or same-domain fallback. *)
+
+val observe : ('a report -> unit) -> 'a report -> observation
+(** Invoke an observer without allowing observer failure to replace or mutate
+    the authoritative mutation report. Non-cancellation failure is returned
+    explicitly; Eio cancellation remains a control signal and is re-raised. *)
+
+module For_testing : sig
+  val run_state_machine :
+    prepare:(unit -> unit) ->
+    commit:(unit -> unit) ->
+    publish:(unit -> unit) ->
+    cleanup:(unit -> diagnostic list) ->
+    unit report
+  (** Deterministic seam for phase-transition and cancellation tests. Production
+      mutations use this same state machine. *)
+end

--- a/lib/fs_compat/durable_mutation_stubs.c
+++ b/lib/fs_compat/durable_mutation_stubs.c
@@ -1,0 +1,113 @@
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
+#error "durable mutation requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#endif
+
+static int parent_fd(value descriptor)
+{
+  return Int_val(descriptor);
+}
+
+static void free_preserving_errno(void *pointer)
+{
+  int saved_errno = errno;
+  caml_stat_free(pointer);
+  errno = saved_errno;
+}
+
+CAMLprim value masc_durable_mutation_open_parent(value path)
+{
+  CAMLparam1(path);
+  char *copied_path;
+  int descriptor;
+
+  caml_unix_check_path(path, "durable_mutation_open_parent");
+  copied_path = caml_stat_strdup(String_val(path));
+  caml_enter_blocking_section();
+  descriptor = open(copied_path,
+                    O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_path);
+  if (descriptor == -1) uerror("durable_mutation_open_parent", path);
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value masc_durable_mutation_create_exclusive(value parent,
+                                                       value name,
+                                                       value mode)
+{
+  CAMLparam1(name);
+  char *copied_name;
+  int descriptor;
+
+  caml_unix_check_path(name, "durable_mutation_create_exclusive");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  descriptor = openat(parent_fd(parent), copied_name,
+                      O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                      Int_val(mode));
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_name);
+  if (descriptor == -1) uerror("durable_mutation_create_exclusive", name);
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value masc_durable_mutation_rename(value parent,
+                                            value old_name,
+                                            value new_name)
+{
+  CAMLparam2(old_name, new_name);
+  size_t old_length;
+  size_t new_length;
+  char *allocation;
+  char *old_copy;
+  char *new_copy;
+  int result;
+
+  caml_unix_check_path(old_name, "durable_mutation_rename_old");
+  caml_unix_check_path(new_name, "durable_mutation_rename_new");
+  old_length = caml_string_length(old_name);
+  new_length = caml_string_length(new_name);
+  allocation = caml_stat_alloc(old_length + new_length + 2);
+  old_copy = allocation;
+  new_copy = allocation + old_length + 1;
+  memcpy(old_copy, String_val(old_name), old_length);
+  old_copy[old_length] = '\0';
+  memcpy(new_copy, String_val(new_name), new_length);
+  new_copy[new_length] = '\0';
+  caml_enter_blocking_section();
+  result = renameat(parent_fd(parent), old_copy,
+                    parent_fd(parent), new_copy);
+  caml_leave_blocking_section();
+  free_preserving_errno(allocation);
+  if (result == -1) uerror("durable_mutation_rename", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_durable_mutation_unlink(value parent, value name)
+{
+  CAMLparam1(name);
+  char *copied_name;
+  int result;
+
+  caml_unix_check_path(name, "durable_mutation_unlink");
+  copied_name = caml_stat_strdup(String_val(name));
+  caml_enter_blocking_section();
+  result = unlinkat(parent_fd(parent), copied_name, 0);
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_name);
+  if (result == -1) uerror("durable_mutation_unlink", name);
+  CAMLreturn(Val_unit);
+}

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -13,6 +13,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+module Durable_mutation = Durable_mutation
+
 (** Global fs — WORM Atomic (write-once at startup, read from any domain).
     Using Atomic.t is required for OCaml 5 multi-domain safety:
     Executor_pool workers run on a separate domain and read this value. *)
@@ -238,10 +240,52 @@ let save_file (path : string) (content : string) : unit =
 ;;
 
 let save_file_atomic path content =
-  Atomic_write.save_file_atomic ~save_file path content
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  let parent = Filename.dirname path in
+  match Durable_mutation.Segment.of_string (Filename.basename path) with
+  | Error _ -> Error (Printf.sprintf "save_file_atomic %s: invalid final segment" path)
+  | Ok name ->
+    let report =
+      Durable_mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        content
+    in
+    let diagnostic_suffix =
+      match report.diagnostics with
+      | [] -> ""
+      | diagnostics ->
+        "; diagnostics: "
+        ^ String.concat
+            "; "
+            (List.map Durable_mutation.diagnostic_to_string diagnostics)
+    in
+    (match report.progress, report.diagnostics with
+     | Durable_mutation.Durable (), [] -> Ok ()
+     | Durable_mutation.Durable (), _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: durable%s"
+            path
+            diagnostic_suffix)
+     | Durable_mutation.Not_committed { cause; _ }, _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: not committed: %s%s"
+            path
+            (Printexc.to_string cause)
+            diagnostic_suffix)
+     | Durable_mutation.Committed_not_durable { cause; _ }, _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: committed but not durable: %s%s"
+            path
+            (Printexc.to_string cause)
+            diagnostic_suffix))
 ;;
 
-let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
+let is_atomic_orphan_name = Durable_mutation.is_temporary_name
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
   Atomic_write.cleanup_atomic_orphans ~mkdir_p_unix ~base_path ?recovered_subdir ()

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -10,6 +10,10 @@
     [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
 exception Test_isolation_breach of string
 
+(** Typed descriptor-owned durable mutation core. The path API below is a
+    compatibility adapter until its callers are migrated under #24084. *)
+module Durable_mutation : module type of Durable_mutation
+
 (** Set global Eio filesystem. Call at server startup. *)
 val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 
@@ -35,19 +39,20 @@ val load_file_opt : string -> string option
 val save_file : string -> string -> unit
 
 (** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. *)
+    Returns [Error msg] on I/O failure instead of raising. Until #24084 migrates
+    callers, the message names whether the mutation was not committed, committed
+    but not durable, or durable with a descriptor-cleanup diagnostic. Callers
+    must not infer retry safety by matching this text. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
-(** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
-    by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
-    {!save_file_atomic}.  Exposed for tests and for a potential
-    periodic sweep. *)
+(** [true] iff [name] matches the [.atomic_*.tmp] pattern minted by
+    {!Durable_mutation}. Exposed for recovery and tests. *)
 val is_atomic_orphan_name : string -> bool
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
-    owning process was SIGKILL'd, or [Filename.temp_file] itself
-    raised ENFILE/EMFILE before the cleanup was registered).
+    owning process was SIGKILL'd after its exclusive temporary entry
+    was created).
 
     Scans [base_path] and its immediate subdirectories (skipping
     [recovered_subdir] and anything that isn't a directory).

--- a/test/dune
+++ b/test/dune
@@ -2789,3 +2789,5 @@
  (deps
   (source_tree ../lib)
   (source_tree ../bin)))
+
+(include stanzas/test_durable_mutation_state_machine.inc)

--- a/test/stanzas/test_durable_mutation_state_machine.inc
+++ b/test/stanzas/test_durable_mutation_state_machine.inc
@@ -1,0 +1,5 @@
+(test
+ (name test_durable_mutation_state_machine)
+ (modules test_durable_mutation_state_machine)
+ (modes native)
+ (libraries fs_compat eio eio_main alcotest unix))

--- a/test/test_durable_mutation_state_machine.ml
+++ b/test/test_durable_mutation_state_machine.ml
@@ -1,0 +1,253 @@
+open Alcotest
+
+module Mutation = Fs_compat.Durable_mutation
+
+let segment value =
+  match Mutation.Segment.of_string value with
+  | Ok value -> value
+  | Error _ -> failf "invalid test segment: %S" value
+;;
+
+let progress_testable =
+  testable
+    (fun formatter -> function
+       | `Not_committed -> Format.pp_print_string formatter "Not_committed"
+       | `Committed_not_durable ->
+         Format.pp_print_string formatter "Committed_not_durable"
+       | `Durable -> Format.pp_print_string formatter "Durable")
+    ( = )
+;;
+
+let check_progress expected report =
+  let actual =
+    match report.Mutation.progress with
+    | Mutation.Not_committed _ -> `Not_committed
+    | Mutation.Committed_not_durable _ -> `Committed_not_durable
+    | Mutation.Durable () -> `Durable
+  in
+  check progress_testable "mutation progress" expected actual
+;;
+
+let test_segment_boundary () =
+  List.iter
+    (fun value ->
+      check bool value true (Result.is_error (Mutation.Segment.of_string value)))
+    [ ""; "."; ".."; "a/b"; "a\000b" ];
+  check bool "plain child accepted" true
+    (Result.is_ok (Mutation.Segment.of_string "state.json"))
+;;
+
+let test_prepare_failure_is_not_committed () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:(fun () -> raise Exit)
+      ~commit:(fun () -> fail "commit must not run")
+      ~publish:(fun () -> fail "publish must not run")
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Not_committed report;
+  check int "cleanup once" 1 !cleanup_calls
+;;
+
+let test_commit_failure_is_not_committed () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:(fun () -> raise Exit)
+      ~publish:(fun () -> fail "publish must not run")
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Not_committed report;
+  check int "cleanup once" 1 !cleanup_calls
+;;
+
+let test_cancellation_after_commit_preserves_committed_state () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:(fun () ->
+        raise (Eio.Cancel.Cancelled (Failure "cancel after rename")))
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Committed_not_durable report;
+  check int "committed entry is never cleaned up" 0 !cleanup_calls
+;;
+
+let test_observer_failure_is_separate () =
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:ignore
+      ~cleanup:(fun () -> [])
+  in
+  match Mutation.observe (fun _ -> raise Exit) report with
+  | Mutation.Observed -> fail "observer failure was not reported"
+  | Mutation.Observer_failed diagnostic ->
+    check bool "observer diagnostic" true
+      (diagnostic.Mutation.stage = Mutation.Observer);
+    check_progress `Durable report
+;;
+
+let test_observer_cancellation_propagates () =
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:ignore
+      ~cleanup:(fun () -> [])
+  in
+  match
+    Mutation.observe
+      (fun _ -> raise (Eio.Cancel.Cancelled (Failure "observer cancelled")))
+      report
+  with
+  | exception Eio.Cancel.Cancelled _ -> ()
+  | Mutation.Observed | Mutation.Observer_failed _ ->
+    fail "observer swallowed Eio cancellation"
+;;
+
+let with_temp_dir f =
+  let path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "durable_mutation_%d_%08x"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      Array.iter
+        (fun name -> Sys.remove (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    (fun () -> f path)
+;;
+
+let read_file path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+;;
+
+let test_real_blocking_replace () =
+  with_temp_dir (fun parent ->
+    let name = segment "state.json" in
+    let path = Filename.concat parent "state.json" in
+    let first =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        "first"
+    in
+    check_progress `Durable first;
+    let second =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        "second"
+    in
+    check_progress `Durable second;
+    check string "replacement visible" "second" (read_file path);
+    check int "no temporary residue" 1 (Array.length (Sys.readdir parent)))
+;;
+
+let test_parent_symlink_is_rejected () =
+  with_temp_dir (fun root ->
+    let real_parent = Filename.concat root "real" in
+    let linked_parent = Filename.concat root "linked" in
+    Unix.mkdir real_parent 0o700;
+    Unix.symlink real_parent linked_parent;
+    let report =
+      Mutation.atomic_replace_blocking
+        ~parent:linked_parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "blocked"
+    in
+    check_progress `Not_committed report;
+    check bool "real directory untouched" false
+      (Sys.file_exists (Filename.concat real_parent "state.json"));
+    Unix.unlink linked_parent;
+    Unix.rmdir real_parent)
+;;
+
+let test_final_symlink_is_replaced_not_followed () =
+  with_temp_dir (fun parent ->
+    let outside = Filename.concat parent "outside.json" in
+    let target = Filename.concat parent "state.json" in
+    let channel = open_out_bin outside in
+    output_string channel "outside";
+    close_out channel;
+    Unix.symlink outside target;
+    let report =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "inside"
+    in
+    check_progress `Durable report;
+    check string "outside inode untouched" "outside" (read_file outside);
+    check string "target entry replaced" "inside" (read_file target))
+;;
+
+let test_eio_boundary_returns_report () =
+  with_temp_dir (fun parent ->
+    Eio_main.run @@ fun _env ->
+    let report =
+      Mutation.atomic_replace_eio
+        ~parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "eio"
+    in
+    check_progress `Durable report)
+;;
+
+let () =
+  run
+    "durable-mutation-state-machine"
+    [ ( "contract"
+      , [ test_case "segment boundary" `Quick test_segment_boundary
+        ; test_case
+            "prepare failure is not committed"
+            `Quick
+            test_prepare_failure_is_not_committed
+        ; test_case
+            "commit failure is not committed"
+            `Quick
+            test_commit_failure_is_not_committed
+        ; test_case
+            "cancellation after commit preserves state"
+            `Quick
+            test_cancellation_after_commit_preserves_committed_state
+        ; test_case
+            "observer failure is separate"
+            `Quick
+            test_observer_failure_is_separate
+        ; test_case
+            "observer cancellation propagates"
+            `Quick
+            test_observer_cancellation_propagates
+        ; test_case "blocking replace" `Quick test_real_blocking_replace
+        ; test_case
+            "parent symlink rejected"
+            `Quick
+            test_parent_symlink_is_rejected
+        ; test_case
+            "final symlink replaced"
+            `Quick
+            test_final_symlink_is_replaced_not_followed
+        ; test_case "Eio boundary" `Quick test_eio_boundary_returns_report
+        ] )
+    ]


### PR DESCRIPTION
## What changed

- Added one descriptor-owned durable mutation state machine with closed outcomes: `Not_committed`, `Committed_not_durable`, and `Durable`.
- Anchored atomic replacement to one opened parent directory descriptor. Temporary create, final `renameat`, cleanup, and parent `fsync` no longer regain authority from a string path after acquisition.
- Split blocking and Eio APIs explicitly. The Eio path uses `Eio.Cancel.protect` around one `run_in_systhread` call, with no runtime detection or same-domain fallback.
- Reported temporary/parent descriptor cleanup and observer failures separately from mutation progress.
- Routed the existing `Fs_compat.save_file_atomic` compatibility API through the same writer core and made orphan-name matching consume the writer SSOT. The broad recovery traversal remains unchanged for #24083; caller outcome migration remains #24084.

## Root cause

The previous writer used string-path operations across prepare, rename, and directory sync, treated post-rename directory-sync failure as success, and exposed no closed state that distinguished retry-safe failure from a visible-but-not-durable commit. A cancellation or observer failure after the final rename could therefore erase the authoritative commit state at the caller boundary.

## Validation

- `scripts/dune-local.sh build test/test_durable_mutation_state_machine.exe test/test_fs_compat.exe test/test_fs_atomic_orphan_sweep_10130.exe`
- Native `test_durable_mutation_state_machine`: 10/10
- Native `test_fs_compat`: 13/13
- Native `test_fs_atomic_orphan_sweep_10130`: 8/8
- `ocamlformat --check` on touched ML/MLI
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/check-ssot.sh`
- `git diff --check`

Addresses #24082.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/fs-typed-mutation-24082` → `main` · 1 commit(s) · synced 2026-07-11T06:09:58Z

| sha | subject | date |
|---|---|---|
| `21b173cc1` | fix(fs): type descriptor-owned mutation progress | 2026-07-11 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->