### PR TITLE
fix(slack): add capabilities field to status_json so dashboard shows bind/unbind actions

### DIFF
--- a/lib/gate/channel_gate_connector_capability.ml
+++ b/lib/gate/channel_gate_connector_capability.ml
@@ -1,0 +1,17 @@
+type t =
+  | Runtime_status
+  | Bindings
+  | Audit
+
+let to_wire = function
+  | Runtime_status -> "runtime_status"
+  | Bindings -> "bindings"
+  | Audit -> "audit"
+;;
+
+let all = [ Runtime_status; Bindings; Audit ]
+let to_yojson capabilities =
+  `List (List.map (fun capability -> `String (to_wire capability)) capabilities)
+;;
+
+let all_json = to_yojson all

--- a/lib/gate/channel_gate_connector_capability.mli
+++ b/lib/gate/channel_gate_connector_capability.mli
@@ -1,0 +1,14 @@
+(** Closed connector capabilities advertised to dashboard consumers. *)
+
+type t =
+  | Runtime_status
+  | Bindings
+  | Audit
+
+val to_wire : t -> string
+val all : t list
+(** Capabilities exposed by the connector dashboard contract. *)
+
+val to_yojson : t list -> Yojson.Safe.t
+val all_json : Yojson.Safe.t
+(** Canonical projection of {!all}; shared by every connector descriptor. *)

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -330,7 +330,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("connector_id", `String connector_id);
       ("display_name", `String display_name);
       ("channel", `String channel);
-      ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]);
+      ("capabilities", Channel_gate_connector_capability.all_json);
       ("status", `String (string_member status "status"));
       ("available", `Bool (bool_member status "available"));
       ("connected", `Bool (bool_member status "connected"));

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -212,7 +212,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("connector_id", `String connector_id);
       ("display_name", `String display_name);
       ("channel", `String channel);
-      ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]);
+      ("capabilities", Channel_gate_connector_capability.all_json);
       ("status", `String (string_member status "status"));
       ("available", `Bool (bool_member status "available"));
       ("connected", `Bool (bool_member status "connected"));

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -259,9 +259,7 @@ module Make (Config : Config) = struct
         ("connector_id", `String connector_id);
         ("display_name", `String display_name);
         ("channel", `String channel);
-        ( "capabilities",
-          `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]
-        );
+        ("capabilities", Channel_gate_connector_capability.all_json);
         ("status", `String (string_member status "status"));
         ("available", `Bool (bool_member status "available"));
         ("connected", `Bool (bool_member status "connected"));

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -147,7 +147,7 @@ let status_json ?(audit_limit = 10) () =
   let configured_binding_json = List.map binding_json configured_bindings in
   `Assoc
     [ ("channel", `String channel)
-    ; ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ])
+    ; ("capabilities", Channel_gate_connector_capability.all_json)
     ; ("available", `Bool available)
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -147,6 +147,7 @@ let status_json ?(audit_limit = 10) () =
   let configured_binding_json = List.map binding_json configured_bindings in
   `Assoc
     [ ("channel", `String channel)
+    ; ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ])
     ; ("available", `Bool available)
     ; ("connected", `Bool connected)
     ; ("stale", `Bool stale)

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -8,6 +8,7 @@
   channel_gate
   channel_gate_binding_store
   channel_gate_connector
+  channel_gate_connector_capability
   channel_gate_discord_names
   channel_gate_discord_state
   channel_gate_imessage_state

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -78,6 +78,15 @@ let test_gate_time_parser_accepts_python_utc_isoformat () =
     (Option.is_none
        (Gate_time_util.parse_iso8601_opt "2026-06-06T00:00:00+09:00"))
 
+let test_connector_capability_wire_contract () =
+  check
+    (list string)
+    "closed capability order and wire values"
+    [ "runtime_status"; "bindings"; "audit" ]
+    (List.map
+       Channel_gate_connector_capability.to_wire
+       Channel_gate_connector_capability.all)
+
 let test_slack_bind_persists_binding_and_audit () =
   with_temp_dir @@ fun dir ->
   with_sidecar_paths "slack" dir (fun () ->
@@ -195,6 +204,11 @@ let test_slack_connector_json_carries_identity () =
       (json |> U.member "connector_id" |> U.to_string);
     check string "display name" "Slack"
       (json |> U.member "display_name" |> U.to_string);
+    check
+      (testable Yojson.Safe.pp Yojson.Safe.equal)
+      "connector capabilities use the canonical projection"
+      Channel_gate_connector_capability.all_json
+      (json |> U.member "capabilities");
     (* The endpoint passes [~gate_status_json]; identity must survive the
        merge, since it is the tile-matching key. *)
     let merged =
@@ -223,6 +237,8 @@ let () =
         [
           test_case "gate time parses python UTC isoformat" `Quick
             test_gate_time_parser_accepts_python_utc_isoformat;
+          test_case "connector capability wire contract" `Quick
+            test_connector_capability_wire_contract;
           test_case "slack bind persists binding and audit" `Quick
             test_slack_bind_persists_binding_and_audit;
           test_case "slack binding read errors are typed" `Quick


### PR DESCRIPTION
## 요약

- Slack connector descriptor에 dashboard bind/unbind용 capability를 복구했어용.
- `runtime_status`/`bindings`/`audit` wire를 closed `Channel_gate_connector_capability.t` 한 곳에서 소유하게 했어용.
- Discord/iMessage/sidecar/Slack의 중복 JSON literal을 canonical projection으로 교체했어용.
- capability wire 계약과 Slack descriptor 투영 회귀 테스트를 추가했어용.

## 경계

Connector capability와 JSON projection은 `masc_gate` 내부 SSOT가 소유해용. Dashboard는 관측된 capability만 사용하고 connector 이름으로 기능을 추측하지 않아용.

## 검증

- touched ML/MLI parser PASS
- `ocamlformat --check` PASS
- `git diff --check` PASS
- test coverage gate PASS
- OCaml structure, enum/string, stringly-boundary, SSOT ratchet PASS
- 전체 Dune build/test는 저장소 정책대로 PR CI에 위임했어용.

## 근거

- [근거] 기존 main에서 동일 capability JSON literal이 Discord/iMessage/sidecar 세 곳에 중복되어 있었고 Slack이 네 번째가 될 상태였어용 — `rg runtime_status lib/gate` — 확인 2026-07-11 15:18 KST — 신뢰도 High
- [근거] Dashboard는 `bindings` capability가 있을 때만 binding action을 노출해용 — `dashboard/src/pages/connector-status.ts` — 확인 2026-07-11 15:18 KST — 신뢰도 High
