### PR TITLE
fix(ide): close remaining keeper v2 parity gaps

### DIFF
--- a/dashboard/src/components/ide/execute-output-drawer.test.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.test.ts
@@ -165,6 +165,28 @@ describe('ExecuteOutputDrawer event mapping', () => {
     expect(mounted.querySelector('[data-status-chip-tone="neutral"]')?.textContent).toContain('idle')
   })
 
+  it('collapses and restores the compact execution drawer without starting a stream', async () => {
+    mounted = document.createElement('div')
+    render(h(ExecuteOutputDrawer, {
+      keeperName: 'sangsu',
+      streamEnabled: false,
+      compact: true,
+    }), mounted)
+
+    await waitFor(() => expect(mounted?.textContent).toContain('waiting for an active Execute output task'))
+    const toggle = mounted.querySelector<HTMLButtonElement>('.execute-output-drawer-toggle')
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(mounted.querySelector('[data-testid="execute-output-terminal"]')).not.toBeNull()
+
+    fireEvent.click(toggle!)
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false')
+    expect(mounted.querySelector('[data-testid="execute-output-terminal"]')).toBeNull()
+
+    fireEvent.click(toggle!)
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(mounted.querySelector('[data-testid="execute-output-terminal"]')).not.toBeNull()
+  })
+
   it('renders streaming summary chips for stdout, stderr, and dropped bytes', async () => {
     let resolveFetch: (value: Response) => void = () => undefined
     const fetchPromise = new Promise<Response>(resolve => {

--- a/dashboard/src/components/ide/execute-output-drawer.ts
+++ b/dashboard/src/components/ide/execute-output-drawer.ts
@@ -31,6 +31,8 @@ interface ExecuteOutputDrawerProps {
   /** Render the persistent IDE drawer without opening a live stream until the
       operator explicitly requests terminal execution for the current route. */
   readonly streamEnabled?: boolean
+  /** Match the keeper-v2 IDE drawer geometry while preserving live output. */
+  readonly compact?: boolean
 }
 
 type ExecuteOutputStatus = 'idle' | 'streaming' | 'closed' | 'error'
@@ -244,12 +246,14 @@ function ExecuteOutputSummaryStrip({
 export function ExecuteOutputDrawer({
   keeperName,
   streamEnabled = true,
+  compact = false,
 }: ExecuteOutputDrawerProps) {
   const keeper = keeperName.trim()
   const [lines, setLines] = useState<OutputLine[]>([])
   const [status, setStatus] = useState<ExecuteOutputStatus>('idle')
   const [taskId, setTaskId] = useState<string | null>(null)
   const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
+  const [expanded, setExpanded] = useState(true)
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const terminalLines = useMemo(() => lines.map(toTerminalLine), [lines])
   const summary = useMemo(() => summarizeOutputLines(lines), [lines])
@@ -322,7 +326,7 @@ export function ExecuteOutputDrawer({
 
   return html`
     <aside
-      class="execute-output-drawer v2-ide-panel border-t border-solid border-[var(--color-border-divider)] bg-[var(--color-bg-page)]"
+      class=${`execute-output-drawer v2-ide-panel border-t border-solid border-[var(--color-border-divider)] bg-[var(--color-bg-page)] ${compact ? 'is-compact' : ''} ${expanded ? 'is-expanded' : 'is-collapsed'}`}
       data-testid="execute-output-drawer"
       data-keeper=${keeper}
       aria-label="Execute output drawer"
@@ -330,7 +334,18 @@ export function ExecuteOutputDrawer({
       <div
         class="execute-output-drawer-header v2-ide-toolbar flex min-w-0 flex-wrap items-center gap-2 border-b border-solid border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 font-mono text-2xs"
       >
-        <span class="text-[var(--color-fg-secondary)]">TERMINAL</span>
+        ${compact ? html`
+          <button
+            type="button"
+            class="execute-output-drawer-toggle"
+            aria-expanded=${expanded ? 'true' : 'false'}
+            title=${expanded ? '실행 출력 접기' : '실행 출력 펼치기'}
+            onClick=${() => setExpanded(current => !current)}
+          >
+            <span class="execute-output-drawer-chevron" aria-hidden="true">▾</span>
+            <span>실행 출력</span>
+          </button>
+        ` : html`<span class="text-[var(--color-fg-secondary)]">TERMINAL</span>`}
         <span class="text-[var(--color-fg-muted)]">${keeper || 'none'}</span>
         ${taskId
           ? html`<span class="truncate text-[var(--color-fg-disabled)]">${taskId}</span>`
@@ -341,15 +356,17 @@ export function ExecuteOutputDrawer({
           <${ExecuteOutputSummaryStrip} summary=${summary} status=${status} />
         </div>
       </div>
-      <${Terminal}
-        lines=${terminalLines}
-        prompt=${status === 'streaming' ? `${keeper || '(no keeper)'}:$ ` : ''}
-        testId="execute-output-terminal"
-        ariaLabel="Execute output terminal"
-        emptyText="waiting for Execute output"
-        className="h-[260px] overflow-auto bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs leading-relaxed"
-        viewportRef=${viewportRef}
-      />
+      ${expanded ? html`
+        <${Terminal}
+          lines=${terminalLines}
+          prompt=${status === 'streaming' ? `${keeper || '(no keeper)'}:$ ` : ''}
+          testId="execute-output-terminal"
+          ariaLabel="Execute output terminal"
+          emptyText="waiting for Execute output"
+          className="h-[260px] overflow-auto bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs leading-relaxed"
+          viewportRef=${viewportRef}
+        />
+      ` : null}
     </aside>
   `
 }

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -166,6 +166,7 @@ export interface IdeActivityPanelProps {
   readonly annotations?: ReadonlyArray<IdeAnnotation>
   readonly diffRows?: ReadonlyArray<UnifiedDiffRow>
   readonly pollMs?: number
+  readonly compact?: boolean
   readonly children?: unknown
 }
 
@@ -483,6 +484,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
     annotations = EMPTY_ANNOTATIONS,
     diffRows = EMPTY_DIFF_ROWS,
     pollMs = 0,
+    compact = false,
   } = props
   const activeFile = rawActiveFile ?? ''
   const store = useMemo(() => {
@@ -495,6 +497,7 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
   const bridgeScoped = hasActivityBridgeScope(repoId, keeperLane)
   const [loadedScopeKey, setLoadedScopeKey] = useState<string | null>(null)
   const loadedScopeKeyRef = useRef<string | null>(null)
+  const [compactInsightsOpen, setCompactInsightsOpen] = useState(false)
   const emittedTraceIds = useRef<ReadonlySet<string>>(new Set())
   const refreshMs = normalizedPollMs(pollMs)
 
@@ -570,37 +573,73 @@ export function IdeActivityPanel(props: IdeActivityPanelProps = {}) {
 
   return html`
     <div
-      class="ide-rail-panel ide-activity-panel"
+      class=${`ide-rail-panel ide-activity-panel ${compact ? 'is-compact' : ''}`}
       role="region"
       aria-label="EVENT TIMELINE"
     >
-      <div
-        class="ide-rail-head"
-      >
-        <span>EVENT TIMELINE</span>
-        <span class="ide-activity-head-meta">
-          <span>${events.length} events · ${keepers.length} keepers</span>
-          <span
-            class="ide-activity-refresh-status"
-            data-state=${refreshState.tone}
-            role="status"
-            aria-label=${`Activity refresh ${activityRefreshLabel(refreshState, refreshMs)}`}
-            title=${activityRefreshTitle(refreshState, refreshMs)}
-          >
-            ${activityRefreshLabel(refreshState, refreshMs)}
+      ${compact ? null : html`
+        <div
+          class="ide-rail-head"
+        >
+          <span>EVENT TIMELINE</span>
+          <span class="ide-activity-head-meta">
+            <span>${events.length} events · ${keepers.length} keepers</span>
+            <span
+              class="ide-activity-refresh-status"
+              data-state=${refreshState.tone}
+              role="status"
+              aria-label=${`Activity refresh ${activityRefreshLabel(refreshState, refreshMs)}`}
+              title=${activityRefreshTitle(refreshState, refreshMs)}
+            >
+              ${activityRefreshLabel(refreshState, refreshMs)}
+            </span>
           </span>
-        </span>
-      </div>
-      <${RunProgressStrip} summary=${progress} />
-      <${IdeContextLens}
-        filePath=${activeFile}
-        annotations=${annotations}
-        diffRows=${diffRows}
-        events=${events}
-        threads=${threads}
-        diagnostics=${diagnostics}
-        overlay=${overlay}
-      />
+        </div>
+        <${RunProgressStrip} summary=${progress} />
+        <${IdeContextLens}
+          filePath=${activeFile}
+          annotations=${annotations}
+          diffRows=${diffRows}
+          events=${events}
+          threads=${threads}
+          diagnostics=${diagnostics}
+          overlay=${overlay}
+        />
+      `}
+      ${compact ? html`
+        <div
+          class="ide-activity-compact-status"
+          data-state=${refreshState.tone}
+          role="status"
+          aria-label=${`Activity refresh ${activityRefreshLabel(refreshState, refreshMs)}`}
+          title=${activityRefreshTitle(refreshState, refreshMs)}
+        >
+          <span>${events.length} events · ${keepers.length} keepers</span>
+          <span>${activityRefreshLabel(refreshState, refreshMs)}</span>
+        </div>
+        <div class="ide-activity-compact-insights">
+          <button
+            type="button"
+            aria-expanded=${compactInsightsOpen ? 'true' : 'false'}
+            onClick=${() => setCompactInsightsOpen(current => !current)}
+          >
+            Observation context
+            <span>${progress.linkedEvents}/${progress.totalEvents} linked</span>
+          </button>
+          ${compactInsightsOpen ? html`
+            <${RunProgressStrip} summary=${progress} />
+            <${IdeContextLens}
+              filePath=${activeFile}
+              annotations=${annotations}
+              diffRows=${diffRows}
+              events=${events}
+              threads=${threads}
+              diagnostics=${diagnostics}
+              overlay=${overlay}
+            />
+          ` : null}
+        </div>
+      ` : null}
       <ol
         class="ide-rail-list ide-activity-list"
       >

--- a/dashboard/src/components/ide/ide-annotation-composer.test.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.test.ts
@@ -1,8 +1,12 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { useState } from 'preact/hooks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { IdeAnnotationComposer } from './ide-annotation-composer'
+import {
+  IdeAnnotationComposer,
+  type IdeAnnotationComposerDraft,
+} from './ide-annotation-composer'
 import { ideEditorSelection } from './ide-editor-selection'
 
 vi.mock('../../api/ide', async importOriginal => {
@@ -48,6 +52,25 @@ function composer({
       subscribeActiveRepositoryId=${() => () => {}}
       refresh=${refresh}
     />
+  `
+}
+
+function SharedComposerPair() {
+  const [draft, setDraft] = useState<IdeAnnotationComposerDraft | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const props = {
+    documentStore: documentStoreFixture('lib/foo.ml'),
+    activeRepositoryId: () => 'masc',
+    subscribeActiveRepositoryId: () => () => {},
+    refresh: () => {},
+    draft,
+    onDraftChange: setDraft,
+    submitting,
+    onSubmittingChange: setSubmitting,
+  }
+  return html`
+    <div data-slot="rail"><${IdeAnnotationComposer} ...${props} /></div>
+    <div data-slot="mobile"><${IdeAnnotationComposer} ...${props} /></div>
   `
 }
 
@@ -122,6 +145,41 @@ describe('IdeAnnotationComposer', () => {
     const submit = el.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')
     expect(submit?.disabled).toBe(true)
     expect(el.textContent ?? '').toContain('내용을 입력하세요')
+  })
+
+  it('shares one controlled draft between desktop and responsive placements', async () => {
+    const el = mount(html`<${SharedComposerPair} />`)
+    const rail = el.querySelector<HTMLElement>('[data-slot="rail"]')!
+    await open(rail)
+
+    const railContent = rail.querySelector<HTMLTextAreaElement>('[data-testid="ide-annotation-content"]')!
+    railContent.value = '리사이즈 후에도 유지'
+    railContent.dispatchEvent(new Event('input', { bubbles: true }))
+    await tick()
+
+    const mobileContent = el.querySelector<HTMLTextAreaElement>(
+      '[data-slot="mobile"] [data-testid="ide-annotation-content"]',
+    )
+    expect(mobileContent?.value).toBe('리사이즈 후에도 유지')
+  })
+
+  it('shares submission state so a resize cannot issue a duplicate annotation', async () => {
+    createIdeAnnotationMock.mockReturnValue(new Promise(() => {}))
+    const el = mount(html`<${SharedComposerPair} />`)
+    const rail = el.querySelector<HTMLElement>('[data-slot="rail"]')!
+    await open(rail)
+
+    const content = rail.querySelector<HTMLTextAreaElement>('[data-testid="ide-annotation-content"]')!
+    content.value = '중복 저장 방지'
+    content.dispatchEvent(new Event('input', { bubbles: true }))
+    await tick()
+    rail.querySelector<HTMLButtonElement>('[data-testid="ide-annotation-submit"]')?.click()
+    await tick()
+
+    expect(createIdeAnnotationMock).toHaveBeenCalledOnce()
+    expect(el.querySelector<HTMLButtonElement>(
+      '[data-slot="mobile"] [data-testid="ide-annotation-submit"]',
+    )?.disabled).toBe(true)
   })
 
   it.each(['1.9', '1e3', '12abc', '-3', ''])(

--- a/dashboard/src/components/ide/ide-annotation-composer.ts
+++ b/dashboard/src/components/ide/ide-annotation-composer.ts
@@ -28,14 +28,14 @@ const ANNOTATION_KINDS: readonly AnnotationKind[] = [
   'Bookmark',
 ]
 
-interface ComposerDraft {
+export interface IdeAnnotationComposerDraft {
   readonly kind: AnnotationKind
   readonly lineStart: string
   readonly lineEnd: string
   readonly content: string
 }
 
-function draftFromSelection(filePath: string): ComposerDraft {
+function draftFromSelection(filePath: string): IdeAnnotationComposerDraft {
   const selection = ideEditorSelection.value
   const matches = selection !== null && selection.filePath === filePath
   const lineStart = matches ? selection.lineStart : 1
@@ -60,7 +60,7 @@ function parseLine(raw: string): number | null {
   return value
 }
 
-function draftProblem(draft: ComposerDraft): string | null {
+function draftProblem(draft: IdeAnnotationComposerDraft): string | null {
   const lineStart = parseLine(draft.lineStart)
   const lineEnd = parseLine(draft.lineEnd)
   if (lineStart === null) return 'line_start는 1 이상의 정수여야 합니다'
@@ -75,6 +75,10 @@ export function IdeAnnotationComposer({
   activeRepositoryId,
   subscribeActiveRepositoryId,
   refresh,
+  draft: controlledDraft,
+  onDraftChange,
+  submitting: controlledSubmitting,
+  onSubmittingChange,
 }: {
   documentStore: {
     document: () => { readonly file_path: string | null }
@@ -83,13 +87,21 @@ export function IdeAnnotationComposer({
   activeRepositoryId: () => string | null
   subscribeActiveRepositoryId: (listener: () => void) => () => void
   refresh: () => void
+  draft?: IdeAnnotationComposerDraft | null
+  onDraftChange?: (draft: IdeAnnotationComposerDraft | null) => void
+  submitting?: boolean
+  onSubmittingChange?: (submitting: boolean) => void
 }): VNode | null {
   useStoreSubscription(documentStore.subscribe)
   useStoreSubscription(subscribeActiveRepositoryId)
   useSignalValue(ideEditorSelection)
 
-  const [draft, setDraft] = useState<ComposerDraft | null>(null)
-  const [submitting, setSubmitting] = useState(false)
+  const [localDraft, setLocalDraft] = useState<IdeAnnotationComposerDraft | null>(null)
+  const [localSubmitting, setLocalSubmitting] = useState(false)
+  const draft = onDraftChange ? controlledDraft ?? null : localDraft
+  const setDraft = onDraftChange ?? setLocalDraft
+  const submitting = onSubmittingChange ? controlledSubmitting ?? false : localSubmitting
+  const setSubmitting = onSubmittingChange ?? setLocalSubmitting
 
   const filePath = documentStore.document().file_path
   if (filePath === null) return null
@@ -115,8 +127,9 @@ export function IdeAnnotationComposer({
   }
 
   const problem = draftProblem(draft)
-  const update = (patch: Partial<ComposerDraft>) =>
-    setDraft(current => (current === null ? current : { ...current, ...patch }))
+  const update = (patch: Partial<IdeAnnotationComposerDraft>) => {
+    if (draft !== null) setDraft({ ...draft, ...patch })
+  }
 
   const submit = async () => {
     if (problem !== null || repoId === null || submitting) return

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../sse-store', () => ({
 import {
   clearWorkspaceFetchIssue,
   createIdeDataWorkspaceStore,
+  firstObservedChangedFilePath,
   replaceWorkspaceFetchIssue,
   retainCurrentWorkspaceFetchIssues,
   sameWorkspaceTreeIdentity,
@@ -72,6 +73,26 @@ function seedWorkspaceApiMocks(): void {
   workspaceApiMocks.fetchGitDiff.mockResolvedValue([])
   ideApiMocks.fetchIdeAnnotations.mockResolvedValue([])
 }
+
+describe('firstObservedChangedFilePath', () => {
+  it('keeps the server-observed hidden changed path ahead of an unchanged visible file', () => {
+    expect(firstObservedChangedFilePath([
+      { path: '.github/workflows/ci.yml', hasChildren: false, diff: '+1' },
+      { path: 'README.md', hasChildren: false, diff: null },
+    ])).toBe('.github/workflows/ci.yml')
+  })
+
+  it('does not turn empty values, keeper ownership, or an arbitrary file into focus', () => {
+    const nodes = [
+      { path: '', hasChildren: false, diff: '+1', keeperId: null },
+      { path: '.github/workflows/ci.yml', hasChildren: false, diff: '', keeperId: 'keeper-a' },
+      { path: 'README.md', hasChildren: false, diff: null, keeperId: 'keeper-b' },
+      { path: 'lib', hasChildren: true, diff: '+2', keeperId: null },
+    ]
+
+    expect(firstObservedChangedFilePath(nodes)).toBeNull()
+  })
+})
 
 describe('selectPreferredIdeRepositoryId', () => {
   // ── Current selection persistence ────────────────────────────

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -102,11 +102,19 @@ export interface WorkspaceFetchIssueContext {
 
 type WorkspaceFetchIssueScope = Pick<WorkspaceFetchIssueContext, 'filePath' | 'keeper' | 'repoId'>
 
-function firstFilePath(
-  nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>,
+export function firstObservedChangedFilePath(
+  nodes: ReadonlyArray<{
+    readonly path: string
+    readonly hasChildren: boolean
+    readonly diff: string | null
+  }>,
 ): string | null {
-  const firstFile = nodes.find(node => !node.hasChildren)
-  return firstFile?.path ?? null
+  return nodes.find(node =>
+    !node.hasChildren
+    && node.path.trim().length > 0
+    && node.diff !== null
+    && node.diff.trim().length > 0,
+  )?.path ?? null
 }
 
 export function workspaceTreeIdentity(
@@ -393,7 +401,10 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       repoId,
     })
 
-    // Load file tree (independent of active file — needed to suggest first file)
+    // Load the file tree independently of the active file. When no explicit
+    // operator/route focus exists, the server-ordered changed-file observation
+    // is the only automatic focus contract. Do not infer focus from dot-path
+    // visibility, keeper ownership, or an arbitrary tree leaf.
     fetchWorkspaceTree(2, opts).then(({ nodes, source, basePath }) => {
       if (signal.aborted) return
       clearIssue('tree', { keeper: keeperParam ?? null, repoId })
@@ -422,9 +433,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
         }
       }
 
-      const hasCurrentFile =
-        filePath !== null && nodes.some(node => node.path === filePath && !node.hasChildren)
-      const nextFile = hasCurrentFile ? null : firstFilePath(nodes)
+      const nextFile = filePath === null ? firstObservedChangedFilePath(nodes) : null
       if (nextFile && nextFile !== activeIdeFile.value) {
         activeIdeFile.value = nextFile
       }

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -144,7 +144,7 @@ function presenceHeader(snap: KeeperPresenceSnapshot) {
   `
 }
 
-export function IdePresenceStrip() {
+export function IdePresenceStrip({ compact = false }: { readonly compact?: boolean } = {}) {
   const presenceStore = useMemo(() => createKeeperPresenceStore(LOADING_SNAPSHOT), [])
 
   useEffect(() => {
@@ -169,6 +169,46 @@ export function IdePresenceStrip() {
 
   const current = presenceStore.snapshot()
   const entries = presenceStore.entries()
+
+  if (compact) {
+    const compactStateLabel = current.kind === 'live'
+      ? `Presence live: ${current.runtime_id}`
+      : current.kind === 'disconnected'
+        ? `Presence disconnected: ${current.reason}`
+        : 'Presence loading'
+    return html`
+      <div
+        class="ide-presence-strip ide-v2-presence-compact v2-ide-panel"
+        role="status"
+        aria-label="Live workspace keeper presence"
+        data-state=${current.kind}
+      >
+        <span class="lbl">Presence</span>
+        <span
+          class="ide-v2-presence-state"
+          data-state=${current.kind}
+          aria-label=${compactStateLabel}
+          title=${compactStateLabel}
+        >${current.kind === 'live' ? '●' : '○'}</span>
+        <ul>
+          ${entries.map(entry => html`
+            <li
+              key=${entry.keeper_id}
+              title=${`${entry.keeper_id} · ${entry.role} · ${entry.workspace_label}`}
+              aria-label=${`${entry.keeper_id} ${entry.status} in ${entry.workspace_label}`}
+            >
+              <${KeeperBadge}
+                id=${entry.keeper_id}
+                variant="sigil"
+                size="sm"
+                beat=${entry.status === 'active'}
+              />
+            </li>
+          `)}
+        </ul>
+      </div>
+    `
+  }
 
   return html`
     <div

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -48,6 +48,7 @@ import { activeIdeFile, ideContextFocus } from './ide-state'
 import { resetIdeDataWorkspaceStoreForTest } from './ide-workspace-singleton'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { EMPTY_LSP_STATUS_SNAPSHOT, lspStatusSnapshot } from './ide-lsp-client'
+import { DEFAULT_MOBILE_BREAKPOINT } from '../../hooks/use-is-mobile'
 
 function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll('button'))
@@ -194,12 +195,12 @@ describe('IdeShell', () => {
     expect(container.querySelectorAll('.v2-ide-panel').length).toBeGreaterThanOrEqual(3)
     expect(container.querySelector('.v2-ide-toolbar')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-readiness-notice"]')?.textContent)
-      .toBe('experimental')
+      .toContain('실험 · 미검증')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
     const layerButtons = container.querySelectorAll('[data-testid="ide-toolbar-layers"] button')
     expect(Array.from(layerButtons).some(button => button.textContent === 'Time')).toBe(false)
     expect(Array.from(layerButtons).some(button => button.textContent === 'Parallel')).toBe(false)
-    expect(container.textContent).toContain('PERSISTENCE MAP')
+    expect(container.textContent).toContain('Work Context')
     expect(container.textContent).toContain('Active overlays')
     expect(container.textContent).toContain('Notes')
   })
@@ -968,7 +969,7 @@ describe('IdeShell', () => {
     expect(container.querySelector('[data-testid="ide-find-panel"]')).not.toBeNull()
   })
 
-  it('preserves keeper context and chat while keeping the terminal drawer present', () => {
+  it('starts on the reference activity rail and keeps work context available without a fourth tab', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
@@ -980,9 +981,19 @@ describe('IdeShell', () => {
     const rail = container.querySelector('[data-testid="ide-right-rail"]')
     expect(rail).not.toBeNull()
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
-    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
-    expect(buttonByText(container, 'Work Context').getAttribute('title'))
-      .toBe('Keeper work, persistence, memory, and chat scoped to the active IDE context')
+    expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelectorAll('.ide-v2-rail-tab')).toHaveLength(3)
+    expect(container.querySelector('.ide-activity-compact-status')?.getAttribute('role')).toBe('status')
+    expect(container.querySelector('.ide-v2-presence-state')?.getAttribute('aria-label')).toBeTruthy()
+    expect(container.querySelector('.ide-v2-connection-dot')?.getAttribute('aria-label')).toBeTruthy()
+    const observationToggle = container.querySelector<HTMLButtonElement>(
+      '.ide-activity-compact-insights > button',
+    )
+    expect(observationToggle?.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(observationToggle!)
+    expect(container.querySelector('.ide-run-progress')).not.toBeNull()
+    expect(container.querySelector('.ide-context-lens')?.textContent).toContain('CONTEXT LENS')
     expect(buttonByText(container, '활동').getAttribute('title'))
       .toBe('Workspace and keeper activity linked to the active file and repository')
     expect(buttonByText(container, '어노테이션').getAttribute('title'))
@@ -991,17 +1002,19 @@ describe('IdeShell', () => {
       .toBe('Live keeper file focus and cursor stream status')
     expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
       .toContain('Dashboard event transport')
+    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
+    fireEvent.click(buttonByText(container, 'Work Context'))
     expect(container.querySelector('[data-testid="ide-right-context-stack"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-primary-conversation-rail"]')).not.toBeNull()
-    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
     expect(container.querySelector('[data-testid="execute-output-drawer"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="execute-output-drawer"]')?.textContent)
-      .toContain('waiting for Execute output')
+      .toContain('waiting for an active Execute output task')
     expect(container.querySelector('[data-testid="ide-interject-fab"]')).not.toBeNull()
   })
 
-  it('keeps default right rail context diagnostics bounded above the primary conversation rail', () => {
+  it('keeps disclosed work context diagnostics bounded above the primary conversation rail', () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source' },
@@ -1009,6 +1022,7 @@ describe('IdeShell', () => {
     }
 
     render(h(IdeShell, {}), container)
+    fireEvent.click(buttonByText(container, 'Work Context'))
 
     const rail = container.querySelector('[data-testid="ide-right-rail"]')
     const contextStack = container.querySelector('[data-testid="ide-right-context-stack"]')
@@ -1017,16 +1031,14 @@ describe('IdeShell', () => {
     expect(contextStack).not.toBeNull()
     expect(primaryRail).not.toBeNull()
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
-    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
-    // rail tab labels renamed by #24081 ('Run Activity' → '활동', 'Keeper
-    // Cursors' → '커서'); the diagnostics-bounding assertions are unchanged.
+    expect(buttonByText(container, 'Work Context').getAttribute('aria-expanded')).toBe('true')
     expect(buttonByText(container, '활동').getAttribute('title'))
       .toBe('Workspace and keeper activity linked to the active file and repository')
     expect(buttonByText(container, '커서').getAttribute('title'))
       .toBe('Live keeper file focus and cursor stream status')
     expect(container.querySelector('[data-testid="ide-dashboard-connection"]')?.getAttribute('title'))
       .toContain('Dashboard event transport')
-    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
     expect(container.querySelector('[data-testid="ide-cursor-rail"]')).toBeNull()
   })
 
@@ -1079,9 +1091,9 @@ describe('IdeShell', () => {
       },
     }
 
-    expect(buttonByText(container, 'Work Context').getAttribute('aria-selected')).toBe('true')
-    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).not.toBeNull()
-    expect(container.querySelector('.ide-plane-activity')).toBeNull()
+    expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
+    expect(container.querySelector('[data-testid="ide-right-context-stack"]')).toBeNull()
+    expect(container.querySelector('.ide-plane-activity')).not.toBeNull()
 
     fireEvent.click(buttonByText(container, '활동'))
     expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
@@ -1151,6 +1163,58 @@ describe('IdeShell', () => {
     expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-rails-collapsed')).toBe('true')
     fireEvent.click(buttonByText(container, 'Rails'))
     expect(route.value.params.rails).toBeUndefined()
+  })
+
+  it('toggles the file tree from the reference chrome and persists the route param', () => {
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    render(h(IdeShell, {}), container)
+
+    const treeButton = container.querySelector<HTMLButtonElement>('[data-testid="ide-tree-toggle"]')
+    expect(treeButton?.getAttribute('aria-pressed')).toBe('false')
+    expect(container.querySelector('.ide-plane-tree')).not.toBeNull()
+
+    fireEvent.click(treeButton!)
+    expect(route.value.params.tree).toBe('hidden')
+    expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-tree-collapsed')).toBe('true')
+    expect(container.querySelector('.ide-plane-tree')).toBeNull()
+
+    fireEvent.click(container.querySelector<HTMLButtonElement>('[data-testid="ide-tree-toggle"]')!)
+    expect(route.value.params.tree).toBeUndefined()
+    expect(container.querySelector('.ide-plane-tree')).not.toBeNull()
+  })
+
+  it('does not mount the polling rail on mobile and keeps annotation creation in the editor', () => {
+    const originalWidth = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: DEFAULT_MOBILE_BREAKPOINT,
+    })
+    route.value = {
+      tab: 'code',
+      params: { section: 'ide-shell', view: 'source' },
+      postId: null,
+    }
+
+    try {
+      render(h(IdeShell, {}), container)
+
+      expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-rails-collapsed')).toBe('true')
+      expect(container.querySelector('.ide-plane-shell')?.getAttribute('data-mobile-viewport')).toBe('true')
+      expect(container.querySelector('[data-testid="ide-right-rail"]')).toBeNull()
+      expect(container.querySelector('.ide-activity-panel')).toBeNull()
+      expect(vi.mocked(fetch).mock.calls.some(([input]) =>
+        String(input).includes('/api/v1/activity/events'),
+      )).toBe(false)
+      expect(container.querySelector('.ide-v2-responsive-annotation-composer [data-testid="ide-annotation-composer-closed"]'))
+        .not.toBeNull()
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth })
+    }
   })
 
   it('normalizes persisted IDE tree widths to the supported range', () => {

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -12,7 +12,10 @@ import { getIdeDataWorkspaceStore } from './ide-workspace-singleton'
 import { parsePositiveLineString } from '../common/normalize'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
-import { IdeAnnotationComposer } from './ide-annotation-composer'
+import {
+  IdeAnnotationComposer,
+  type IdeAnnotationComposerDraft,
+} from './ide-annotation-composer'
 import { IdeConversationRail } from './ide-conversation-rail'
 import { IdeActivityPanel } from './ide-activity-panel'
 import { IdeAnnotationRail } from './ide-annotation-rail'
@@ -62,10 +65,11 @@ import {
   serializeActive,
 } from '../../../design-system/headless-core/layered-overlay'
 import { viewFromRoute } from './ide-view-route'
+import { useIsMobile } from '../../hooks/use-is-mobile'
 
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'
-type IdeRightRailTab = 'context' | 'activity' | 'annotations' | 'cursors'
+type IdeRightRailTab = 'activity' | 'annotations' | 'cursors'
 type IdeStatusbarChipTone = 'brass' | 'ghost' | 'info' | 'ok' | 'warn'
 type IdeConnectionTone = 'ok' | 'warn'
 
@@ -111,11 +115,6 @@ const STATUSBAR_VIEW_LABELS: Readonly<Record<ViewTab, string>> = {
   blame: 'BLAME',
 }
 const IDE_RIGHT_RAIL_TABS: ReadonlyArray<IdeRightRailTabDescriptor> = [
-  {
-    id: 'context',
-    label: 'Work Context',
-    title: 'Keeper work, persistence, memory, and chat scoped to the active IDE context',
-  },
   {
     id: 'activity',
     label: '활동',
@@ -893,6 +892,7 @@ export function IdeShell() {
   // navigation instead of being disposed and refetched. Do NOT dispose on
   // unmount — the store is intentionally shared across all IdeShell mounts.
   const workspaceStore = useMemo(() => getIdeDataWorkspaceStore(), [])
+  const isMobileViewport = useIsMobile()
 
   const annotations = useSubscribedSnapshot(
     workspaceStore.annotations,
@@ -1045,7 +1045,12 @@ export function IdeShell() {
   const findOpen = route.value.params.find === 'open'
   const terminalKeeper = keeperFromRoute()
   const railsCollapsed = route.value.params.rails === 'hidden'
-  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('context')
+  const effectiveRailsCollapsed = railsCollapsed || isMobileViewport
+  const treeCollapsed = route.value.params.tree === 'hidden'
+  const [rightRailTab, setRightRailTab] = useState<IdeRightRailTab>('activity')
+  const [workContextOpen, setWorkContextOpen] = useState(false)
+  const [annotationDraft, setAnnotationDraft] = useState<IdeAnnotationComposerDraft | null>(null)
+  const [annotationSubmitting, setAnnotationSubmitting] = useState(false)
   const [treeWidth, setTreeWidth] = useState<number>(readStoredIdeTreeWidth)
   const statusbar = deriveIdeStatusbarModel({
     activeView,
@@ -1054,7 +1059,7 @@ export function IdeShell() {
     contextFocus,
     findOpen,
     terminalOpen,
-    railsCollapsed,
+    railsCollapsed: effectiveRailsCollapsed,
     reviewFocusActive,
     routeParams: route.value.params,
     repositories,
@@ -1082,6 +1087,7 @@ export function IdeShell() {
       next,
     )
     const nextParams = paramsWithLayers(route.value.params, next, compatibleLayers)
+    delete nextParams.find
     if (next !== 'unified' && focusFromRoute(nextParams.focus) === 'review') {
       delete nextParams.focus
       if (nextParams.layers?.trim().toLowerCase() === EMPTY_LAYER_PARAM) delete nextParams.layers
@@ -1095,6 +1101,17 @@ export function IdeShell() {
 
   const handleRailsToggle = () => {
     navigate('code', paramsWithRails(route.value.params, activeView, !railsCollapsed))
+  }
+
+  const handleTreeToggle = () => {
+    const nextParams: Record<string, string> = {
+      ...route.value.params,
+      section: 'ide-shell',
+      view: activeView,
+    }
+    if (treeCollapsed) delete nextParams.tree
+    else nextParams.tree = 'hidden'
+    navigate('code', nextParams)
   }
 
   const handleTerminalOpen = () => {
@@ -1210,53 +1227,25 @@ export function IdeShell() {
       role="region"
       aria-label="Code IDE shell"
       data-terminal-open=${terminalVisible ? 'true' : 'false'}
-      data-rails-collapsed=${railsCollapsed ? 'true' : 'false'}
+      data-mobile-viewport=${isMobileViewport ? 'true' : 'false'}
+      data-rails-collapsed=${effectiveRailsCollapsed ? 'true' : 'false'}
+      data-tree-collapsed=${treeCollapsed ? 'true' : 'false'}
       data-tree-width=${String(treeWidth)}
     >
       <div class="ide-v2-top">
-        <header
-          class="ide-plane-statusbar"
-          aria-label="IDE operational status"
-          data-testid="ide-statusbar"
-        >
-          <span class="ide-plane-statusbar-title">MASC IDE</span>
-          <span
-            class="chip sm is-warn"
-            data-testid="ide-readiness-notice"
-            title="IDE shell is observational; LSP, overlay, and shell flows are not a verified execution boundary."
-          >experimental</span>
-          <span>·</span>
-          <span
-            class="chip sm is-brass"
-            style=${{ flexShrink: 0 }}
-            data-testid="ide-statusbar-workspace"
-            title=${statusbar.workspaceBasePath
-              ? `base_path: ${statusbar.workspaceBasePath} (set MASC_BASE_PATH to change)`
-              : undefined}
-          >${statusbar.workspaceLabel}</span>
-          <${IdeRepoOrigin}
-            repositories=${repositories}
-            activeRepositoryId=${activeRepositoryId}
-          />
-          <div
-            class="ide-plane-statusbar-meta"
-            aria-label="IDE operational context"
-          >
-            ${statusbar.chips.map(chip => html`
-              <span
-                key=${chip.id}
-                class=${`chip sm is-${chip.tone}`}
-                title=${chip.title}
-                data-testid=${`ide-statusbar-chip-${chip.id}`}
-              >${chip.label}</span>
-            `)}
-          </div>
-          <${IdePresenceStrip} />
-          <${IdeDashboardConnectionChip}
-            label=${statusbar.connectionLabel}
-            tone=${statusbar.connectionTone}
-          />
-        </header>
+        <button
+          type="button"
+          class="ide-v2-action ide-v2-tree-toggle"
+          aria-pressed=${treeCollapsed ? 'true' : 'false'}
+          aria-label=${treeCollapsed ? '파일 트리 펼치기' : '파일 트리 접기'}
+          title=${treeCollapsed ? '파일 트리 펼치기' : '파일 트리 접기'}
+          data-testid="ide-tree-toggle"
+          onClick=${handleTreeToggle}
+        >${treeCollapsed ? '⊞' : '⊟'}</button>
+        <${IdeRepoOrigin}
+          repositories=${repositories}
+          activeRepositoryId=${activeRepositoryId}
+        />
         <${IdeToolbar}
           activeView=${activeView}
           activeLayers=${activeLayers}
@@ -1266,49 +1255,113 @@ export function IdeShell() {
           onRailsToggle=${handleRailsToggle}
           onTerminalOpen=${handleTerminalOpen}
           onFindOpen=${handleFindOpen}
+          onFindClose=${handleFindClose}
+          findOpen=${findOpen}
+          compact=${true}
         />
+        <span class="spacer" />
+        <details
+          class="ide-v2-operational-status"
+          data-testid="ide-statusbar"
+          aria-label="IDE operational status"
+        >
+          <summary
+            class="chip sm is-warn"
+            data-testid="ide-readiness-notice"
+            title="IDE shell is observational; LSP, overlay, and shell flows are not a verified execution boundary."
+          >
+            <span
+              class="ide-v2-connection-dot"
+              data-state=${statusbar.connectionTone}
+              aria-label=${statusbar.connectionLabel}
+            >●</span>
+            실험 · 미검증
+          </summary>
+          <div
+            class="ide-v2-operational-status-popover"
+            aria-label="IDE operational status"
+          >
+            <span
+              class="chip sm is-brass"
+              data-testid="ide-statusbar-workspace"
+              title=${statusbar.workspaceBasePath
+                ? `base_path: ${statusbar.workspaceBasePath} (set MASC_BASE_PATH to change)`
+                : undefined}
+            >${statusbar.workspaceLabel}</span>
+            ${statusbar.chips.map(chip => html`
+              <span
+                key=${chip.id}
+                class=${`chip sm is-${chip.tone}`}
+                title=${chip.title}
+                data-testid=${`ide-statusbar-chip-${chip.id}`}
+              >${chip.label}</span>
+            `)}
+            <${IdeDashboardConnectionChip}
+              label=${statusbar.connectionLabel}
+              tone=${statusbar.connectionTone}
+            />
+          </div>
+        </details>
+        <${IdePresenceStrip} compact=${true} />
+        <button
+          type="button"
+          class="ide-v2-action ide-v2-rail-toggle"
+          aria-pressed=${railsCollapsed ? 'true' : 'false'}
+          aria-label=${railsCollapsed ? '활동 레일 펼치기' : '활동 레일 접기'}
+          title=${railsCollapsed ? '활동 레일 펼치기' : '활동 레일 접기'}
+          data-testid="ide-rail-toggle"
+          onClick=${handleRailsToggle}
+        >${railsCollapsed ? '⊢' : '⊣'}</button>
       </div>
-      ${reviewFocusActive
-        ? html`<${IdeReviewFocusStrip} activeLayers=${activeLayers} />`
-        : html`<${IdeBreadcrumb} />`}
       <div
-        class="ide-plane-grid ide-v2-body ${railsCollapsed ? 'no-rail' : ''}"
+        class="ide-plane-grid ide-v2-body ${treeCollapsed ? 'no-tree' : ''} ${railsCollapsed ? 'no-rail' : ''}"
         role="presentation"
         style=${`--ide-tree-width: ${treeWidth}px;`}
       >
-        <div class="ide-plane-tree ide-v2-tree v2-ide-panel">
-          <${IdeExplorer}
-            fileTreeStore=${workspaceStore.fileTreeStore}
-            workspaceSource=${workspaceStore.workspaceSource}
-            subscribeWorkspaceSource=${workspaceStore.subscribeWorkspaceSource}
-            repositories=${workspaceStore.repositories}
-            activeRepositoryId=${workspaceStore.activeRepositoryId}
-            onRepositoryChange=${workspaceStore.setActiveRepositoryId}
-            onRepositoryScan=${workspaceStore.scanRepositories}
-            subscribeRepositories=${workspaceStore.subscribeRepositories}
-          />
-          <button
-            type="button"
-            class="ide-v2-tree-resize"
-            aria-label="Resize file tree"
-            aria-orientation="vertical"
-            aria-valuemin=${IDE_TREE_WIDTH_MIN}
-            aria-valuemax=${IDE_TREE_WIDTH_MAX}
-            aria-valuenow=${treeWidth}
-            data-testid="ide-tree-resize"
-            onPointerDown=${handleTreeResizePointerDown}
-            onKeyDown=${handleTreeResizeKeyDown}
-          />
-        </div>
+        ${treeCollapsed ? null : html`
+          <div class="ide-plane-tree ide-v2-tree v2-ide-panel">
+            <${IdeExplorer}
+              fileTreeStore=${workspaceStore.fileTreeStore}
+              workspaceSource=${workspaceStore.workspaceSource}
+              subscribeWorkspaceSource=${workspaceStore.subscribeWorkspaceSource}
+              repositories=${workspaceStore.repositories}
+              activeRepositoryId=${workspaceStore.activeRepositoryId}
+              onRepositoryChange=${workspaceStore.setActiveRepositoryId}
+              onRepositoryScan=${workspaceStore.scanRepositories}
+              subscribeRepositories=${workspaceStore.subscribeRepositories}
+            />
+            <button
+              type="button"
+              class="ide-v2-tree-resize"
+              aria-label="Resize file tree"
+              aria-orientation="vertical"
+              aria-valuemin=${IDE_TREE_WIDTH_MIN}
+              aria-valuemax=${IDE_TREE_WIDTH_MAX}
+              aria-valuenow=${treeWidth}
+              data-testid="ide-tree-resize"
+              onPointerDown=${handleTreeResizePointerDown}
+              onKeyDown=${handleTreeResizeKeyDown}
+            />
+          </div>
+        `}
         <div
           class="ide-plane-editor ide-v2-editor v2-ide-panel"
         >
-          <${IdeAnnotationComposer}
-            documentStore=${workspaceStore.documentStore}
-            activeRepositoryId=${workspaceStore.activeRepositoryId}
-            subscribeActiveRepositoryId=${workspaceStore.subscribeActiveRepositoryId}
-            refresh=${workspaceStore.refresh}
-          />
+          ${reviewFocusActive
+            ? html`<${IdeReviewFocusStrip} activeLayers=${activeLayers} />`
+            : html`<${IdeBreadcrumb} />`}
+          <div class="ide-v2-responsive-annotation-composer">
+            <${IdeAnnotationComposer}
+              documentStore=${workspaceStore.documentStore}
+              activeRepositoryId=${workspaceStore.activeRepositoryId}
+              subscribeActiveRepositoryId=${workspaceStore.subscribeActiveRepositoryId}
+              refresh=${workspaceStore.refresh}
+              draft=${annotationDraft}
+              onDraftChange=${setAnnotationDraft}
+              submitting=${annotationSubmitting}
+              onSubmittingChange=${setAnnotationSubmitting}
+            />
+          </div>
           <${IdeEditor}
             activeView=${activeView}
             activeLayers=${activeLayers}
@@ -1323,8 +1376,15 @@ export function IdeShell() {
             onAnnotationDelete=${handleAnnotationDelete}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
+          ${terminalVisible
+            ? html`<${ExecuteOutputDrawer}
+                keeperName=${terminalKeeper}
+                streamEnabled=${terminalOpen}
+                compact=${true}
+              />`
+            : null}
         </div>
-        ${railsCollapsed
+        ${effectiveRailsCollapsed
           ? null
           : html`
             <div
@@ -1346,22 +1406,6 @@ export function IdeShell() {
                 `)}
               </div>
               <div class="ide-v2-rail-scroll">
-                ${rightRailTab === 'context' ? html`
-                  <div
-                    class="ide-plane-context-stack"
-                    data-testid="ide-right-context-stack"
-                  >
-                    <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
-                    <${IdePersistencePanel} keeperName=${terminalKeeper} />
-                    <${IdeMemoryPanel} keeperName=${terminalKeeper} repoId=${activeRepositoryId} />
-                  </div>
-                  <div
-                    class="ide-plane-primary-rail"
-                    data-testid="ide-primary-conversation-rail"
-                  >
-                    <${IdeConversationRail} />
-                  </div>
-                ` : null}
                 ${rightRailTab === 'activity' ? html`
                   <div class="ide-plane-activity" style=${{ minHeight: 0 }}>
                     <${IdeActivityPanel}
@@ -1371,11 +1415,39 @@ export function IdeShell() {
                       annotations=${annotations}
                       diffRows=${diffRows}
                       pollMs=${IDE_ACTIVITY_POLL_MS}
+                      compact=${true}
                     />
+                    <div class="ide-v2-work-context">
+                      <button
+                        type="button"
+                        aria-expanded=${workContextOpen ? 'true' : 'false'}
+                        onClick=${() => setWorkContextOpen(current => !current)}
+                      >Work Context</button>
+                      ${workContextOpen ? html`
+                        <div class="ide-plane-context-stack" data-testid="ide-right-context-stack">
+                          <${IdeKeeperWorkPanel} keeperName=${terminalKeeper} />
+                          <${IdePersistencePanel} keeperName=${terminalKeeper} />
+                          <${IdeMemoryPanel} keeperName=${terminalKeeper} repoId=${activeRepositoryId} />
+                        </div>
+                        <div class="ide-plane-primary-rail" data-testid="ide-primary-conversation-rail">
+                          <${IdeConversationRail} />
+                        </div>
+                      ` : null}
+                    </div>
                   </div>
                 ` : null}
                 ${rightRailTab === 'annotations' ? html`
                   <div class="ide-plane-annotations" style=${{ minHeight: 0 }}>
+                    <${IdeAnnotationComposer}
+                      documentStore=${workspaceStore.documentStore}
+                      activeRepositoryId=${workspaceStore.activeRepositoryId}
+                      subscribeActiveRepositoryId=${workspaceStore.subscribeActiveRepositoryId}
+                      refresh=${workspaceStore.refresh}
+                      draft=${annotationDraft}
+                      onDraftChange=${setAnnotationDraft}
+                      submitting=${annotationSubmitting}
+                      onSubmittingChange=${setAnnotationSubmitting}
+                    />
                     <${IdeAnnotationRail} annotations=${annotations} />
                   </div>
                 ` : null}
@@ -1384,9 +1456,6 @@ export function IdeShell() {
             </div>
           `}
       </div>
-      ${terminalVisible
-        ? html`<${ExecuteOutputDrawer} keeperName=${terminalKeeper} streamEnabled=${terminalOpen} />`
-        : null}
       <${IdeInterject} keeperName=${terminalKeeper} compact=${terminalVisible} />
     </section>
   `

--- a/dashboard/src/components/ide/ide-toolbar.test.ts
+++ b/dashboard/src/components/ide/ide-toolbar.test.ts
@@ -167,6 +167,44 @@ describe('IdeToolbar', () => {
     expect(railsButton?.classList.contains('v2-ide-action')).toBe(true)
   })
 
+  it('exposes the reference search tab in compact chrome', () => {
+    container = document.createElement('div')
+    const onFindOpen = vi.fn()
+    const onFindClose = vi.fn()
+
+    render(h(IdeToolbar, {
+      activeView: 'source',
+      activeLayers: new Set<string>(),
+      onViewChange: vi.fn(),
+      onLayersChange: vi.fn(),
+      compact: true,
+      findOpen: false,
+      onFindOpen,
+      onFindClose,
+    }), container)
+
+    const search = container.querySelector<HTMLButtonElement>('[data-view="find"]')
+    expect(container.querySelector('[data-compact="true"]')).not.toBeNull()
+    expect(search?.textContent).toBe('검색')
+    expect(search?.getAttribute('aria-selected')).toBe('false')
+    fireEvent.click(search!)
+    expect(onFindOpen).toHaveBeenCalledOnce()
+
+    render(h(IdeToolbar, {
+      activeView: 'source',
+      activeLayers: new Set<string>(),
+      onViewChange: vi.fn(),
+      onLayersChange: vi.fn(),
+      compact: true,
+      findOpen: true,
+      onFindOpen,
+      onFindClose,
+    }), container)
+    expect(container.querySelectorAll('[role="tab"][aria-selected="true"]')).toHaveLength(1)
+    expect(container.querySelector('[data-view="find"]')?.getAttribute('aria-selected')).toBe('true')
+    expect(container.querySelector('[aria-label="Advanced IDE controls"]')).not.toBeNull()
+  })
+
   it('groups focused context links by operational surface', () => {
     const groups = deriveToolbarContextRouteGroups({
       file_path: 'lib/runtime.ml',

--- a/dashboard/src/components/ide/ide-toolbar.ts
+++ b/dashboard/src/components/ide/ide-toolbar.ts
@@ -81,6 +81,9 @@ interface IdeToolbarProps {
   readonly onRailsToggle?: () => void
   readonly onTerminalOpen?: () => void
   readonly onFindOpen?: () => void
+  readonly onFindClose?: () => void
+  readonly findOpen?: boolean
+  readonly compact?: boolean
 }
 
 export type ToolbarContextRouteGroupId = 'code' | 'planning' | 'board' | 'repo' | 'runtime' | 'other'
@@ -120,6 +123,9 @@ export function IdeToolbar({
   onRailsToggle,
   onTerminalOpen,
   onFindOpen,
+  onFindClose,
+  findOpen = false,
+  compact = false,
 }: IdeToolbarProps) {
   const controller = useMemo(() => {
     const next = createLayeredOverlay(IDE_LAYERS)
@@ -191,6 +197,7 @@ export function IdeToolbar({
       data-testid="ide-toolbar"
       class="ide-toolbar v2-ide-toolbar"
       data-has-rails=${onRailsToggle ? 'true' : 'false'}
+      data-compact=${compact ? 'true' : 'false'}
     >
       <div
         class="ide-toolbar-tabs flex min-w-0 gap-1.5 overflow-x-auto pb-0.5"
@@ -202,13 +209,65 @@ export function IdeToolbar({
           <button
             type="button"
             role="tab"
-            aria-selected=${tab.id === activeView ? 'true' : 'false'}
-            tabIndex=${tab.id === activeView ? 0 : -1}
+            aria-selected=${!findOpen && tab.id === activeView ? 'true' : 'false'}
+            tabIndex=${!findOpen && tab.id === activeView ? 0 : -1}
             onClick=${() => onViewChange(tab.id)}
+            data-view=${tab.id}
             class=${`${TOOLBAR_BUTTON_BASE} ${VIEW_TAB_BASE}`}
           >${tab.label}</button>
         `)}
+        ${compact && onFindOpen ? html`
+          <button
+            type="button"
+            role="tab"
+            aria-selected=${findOpen ? 'true' : 'false'}
+            tabIndex=${findOpen ? 0 : -1}
+            onClick=${findOpen && onFindClose ? onFindClose : onFindOpen}
+            data-view="find"
+            class=${`${TOOLBAR_BUTTON_BASE} ${VIEW_TAB_BASE}`}
+          >검색</button>
+        ` : null}
       </div>
+      ${compact ? html`
+        <details class="ide-toolbar-advanced">
+          <summary
+            class="ide-v2-action"
+            aria-label="Advanced IDE controls"
+            title="Advanced IDE controls"
+          >⋯</summary>
+          <div class="ide-toolbar-advanced-popover">
+            <div class="ide-toolbar-advanced-views" aria-label="Advanced view modes">
+              ${VIEW_TABS.filter(tab => tab.id === 'unified' || tab.id === 'blame').map(tab => html`
+                <button
+                  type="button"
+                  aria-pressed=${tab.id === activeView && !findOpen ? 'true' : 'false'}
+                  onClick=${() => onViewChange(tab.id)}
+                  class=${TOOLBAR_BUTTON_BASE}
+                >${tab.label}</button>
+              `)}
+            </div>
+            <${CommandBar}
+              actions=${commandActions}
+              placeholder="Run IDE command..."
+              testId="ide-compact-command-bar"
+              className="min-w-0"
+              inputClassName="h-7 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 font-mono text-2xs text-[var(--color-fg-primary)] outline-none transition-colors placeholder:text-[var(--color-fg-disabled)] focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)]"
+            />
+            <div class="ide-toolbar-advanced-layers" aria-label="Layers (multi-select)">
+              <span>LAYERS</span>
+              ${availableLayers.map(layer => html`
+                <button
+                  type="button"
+                  aria-pressed=${isActive(layer.kind) ? 'true' : 'false'}
+                  onClick=${() => handleLayerToggle(layer.kind)}
+                  title=${layer.description}
+                  class=${TOOLBAR_BUTTON_BASE}
+                >${layer.label}</button>
+              `)}
+            </div>
+          </div>
+        </details>
+      ` : null}
       <div class="ide-toolbar-command-cluster">
         <${CommandBar}
           actions=${commandActions}

--- a/dashboard/src/styles/ide-v2-responsive.test.ts
+++ b/dashboard/src/styles/ide-v2-responsive.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_MOBILE_BREAKPOINT } from '../hooks/use-is-mobile'
+
+const css = readFileSync(resolve(__dirname, 'ide-v2.css'), 'utf-8')
+const MOBILE_SHELL = '.ide-plane-shell[data-mobile-viewport="true"]'
+const DESKTOP_SHELL = '.ide-plane-shell[data-mobile-viewport="false"]'
+
+function declarations(selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  parse(css).walkRules(rule => {
+    if (!rule.selectors.includes(selector)) return
+    rule.walkDecls(declaration => {
+      declarations[declaration.prop] = declaration.value.trim()
+    })
+  })
+  return declarations
+}
+
+function mediaDeclarations(selector: string, maxWidth: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  parse(css).walkAtRules('media', atRule => {
+    if (!atRule.params.includes(`max-width: ${maxWidth}`)) return
+    atRule.walkRules(rule => {
+      if (!rule.selectors.includes(selector)) return
+      rule.walkDecls(declaration => {
+        declarations[declaration.prop] = declaration.value.trim()
+      })
+    })
+  })
+  return declarations
+}
+
+describe('keeper-v2 IDE responsive contract', () => {
+  it('drops the tree before mobile so the editor keeps a usable width', () => {
+    expect(mediaDeclarations(
+      `${DESKTOP_SHELL}[data-rails-collapsed="false"] .ide-v2-body.ide-plane-grid`,
+      '1180px',
+    )['grid-template-columns']).toBe('minmax(0, 1fr) minmax(270px, 320px)')
+    expect(mediaDeclarations(`${DESKTOP_SHELL} .ide-v2-tree`, '1180px').display).toBe('none')
+    expect(mediaDeclarations(`${DESKTOP_SHELL} .ide-v2-tree-toggle`, '1180px').display).toBe('none')
+  })
+
+  it('uses the typed viewport state instead of a second CSS breakpoint SSOT', () => {
+    expect(css).not.toContain(`max-width: ${DEFAULT_MOBILE_BREAKPOINT}px`)
+    expect(declarations(`${MOBILE_SHELL} .ide-v2-body.ide-plane-grid`)['grid-template-columns'])
+      .toBe('minmax(0, 1fr)')
+  })
+
+  it('keeps annotation creation available when the right rail is not mounted', () => {
+    expect(declarations(`${MOBILE_SHELL} .ide-v2-responsive-annotation-composer`).display)
+      .toBe('block')
+  })
+
+  it('hides controls for panes that mobile layout cannot render', () => {
+    expect(declarations(`${MOBILE_SHELL} .ide-v2-tree-toggle`).display).toBe('none')
+    expect(declarations(`${MOBILE_SHELL} .ide-v2-rail-toggle`).display).toBe('none')
+  })
+})

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -23,6 +23,16 @@
   color: var(--text-primary);
 }
 
+/* The keeper-v2 IDE is an immersive surface: the shell health strip and the
+   generic content inset duplicate IDE-local chrome and shrink all three panes. */
+.v2-app[data-surface="code"] > .v2-health-strip {
+  display: none;
+}
+
+.v2-app[data-surface="code"] .v2-surface-host > .h-full {
+  padding: 0 !important;
+}
+
 .ide-v2-surface > .ide-interject-bar {
   flex: none;
   position: relative;
@@ -45,6 +55,145 @@
   padding: 0 14px;
   border-bottom: 1px solid var(--border-main);
   background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+}
+
+.ide-v2-top > .ide-repo {
+  flex: 0 1 auto;
+  min-width: 12rem;
+  max-width: 34rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ide-v2-top > .ide-toolbar[data-compact="true"] {
+  flex: none;
+  width: auto;
+}
+
+.ide-v2-top > .ide-toolbar[data-compact="true"] .ide-toolbar-command-cluster,
+.ide-v2-top > .ide-toolbar[data-compact="true"] .ide-toolbar-layers,
+.ide-v2-top > .ide-toolbar[data-compact="true"] [data-view="unified"],
+.ide-v2-top > .ide-toolbar[data-compact="true"] [data-view="blame"],
+.ide-v2-top > .ide-toolbar[data-compact="true"] > .v2-ide-action {
+  display: none !important;
+}
+
+.ide-toolbar-advanced {
+  position: relative;
+  flex: none;
+}
+
+.ide-toolbar-advanced > summary {
+  display: inline-flex;
+  list-style: none;
+}
+
+.ide-toolbar-advanced > summary::-webkit-details-marker {
+  display: none;
+}
+
+.ide-toolbar-advanced-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: calc(var(--z-base) + 9);
+  display: grid;
+  width: min(42rem, 75vw);
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.42);
+}
+
+.ide-toolbar-advanced-views,
+.ide-toolbar-advanced-layers {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.ide-toolbar-advanced-layers > span {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  letter-spacing: 0.12em;
+}
+
+.ide-v2-operational-status {
+  position: relative;
+  flex: none;
+}
+
+.ide-v2-operational-status > summary {
+  cursor: pointer;
+  list-style: none;
+  white-space: nowrap;
+}
+
+.ide-v2-operational-status > summary::-webkit-details-marker {
+  display: none;
+}
+
+.ide-v2-operational-status-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: calc(var(--z-base) + 8);
+  display: flex;
+  width: min(32rem, 75vw);
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-panel);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.42);
+}
+
+.ide-v2-presence-compact {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-dim);
+}
+
+.ide-v2-presence-compact .lbl {
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.ide-v2-presence-compact ul {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  list-style: none;
+}
+
+.ide-v2-presence-compact li {
+  display: inline-flex;
+  flex: none;
+}
+
+.ide-v2-presence-state[data-state="live"],
+.ide-v2-connection-dot[data-state="ok"] {
+  color: var(--status-ok);
+}
+
+.ide-v2-presence-state:not([data-state="live"]),
+.ide-v2-connection-dot[data-state="warn"] {
+  color: var(--status-warn);
 }
 
 .ide-v2-top .ide-plane-statusbar,
@@ -176,6 +325,14 @@
   grid-template-rows: minmax(0, 1fr);
 }
 
+.ide-plane-shell[data-tree-collapsed="true"] .ide-v2-body.ide-plane-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(270px, 320px);
+}
+
+.ide-plane-shell[data-tree-collapsed="true"][data-rails-collapsed="true"] .ide-v2-body.ide-plane-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .ide-plane-shell[data-rails-collapsed="true"] .ide-v2-body.ide-plane-grid {
   grid-template-columns: var(--ide-tree-width, 230px) minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr);
@@ -189,6 +346,16 @@
 .ide-v2-body.ide-plane-grid .ide-plane-editor {
   grid-column: 2;
   grid-row: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.ide-plane-shell[data-tree-collapsed="true"] .ide-v2-body.ide-plane-grid .ide-plane-editor {
+  grid-column: 1;
+}
+
+.ide-plane-shell[data-tree-collapsed="true"] .ide-v2-body.ide-plane-grid .ide-plane-conversation {
+  grid-column: 2;
 }
 
 .ide-v2-body.ide-plane-grid .ide-plane-conversation {
@@ -323,6 +490,11 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+}
+
+.ide-v2-responsive-annotation-composer {
+  display: none;
+  flex: none;
 }
 
 /* Breadcrumb */
@@ -465,6 +637,118 @@
   padding: 12px 12px;
   flex: 1;
   min-height: 0;
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact {
+  min-height: 100%;
+}
+
+.ide-activity-compact-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+}
+
+.ide-activity-compact-status[data-state="offline"],
+.ide-activity-compact-status[data-state="stale"] {
+  color: var(--status-warn);
+}
+
+.ide-activity-compact-insights {
+  margin-bottom: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+}
+
+.ide-activity-compact-insights > button {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.ide-activity-compact-insights > .ide-run-progress,
+.ide-activity-compact-insights > .ide-context-lens {
+  border-top: 1px solid var(--border-soft);
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-list {
+  gap: 9px;
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-row {
+  position: relative;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 9px;
+  min-height: 70px;
+  padding: 10px;
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-time {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: var(--fs-9);
+  color: var(--text-dim);
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-dot {
+  grid-column: 1;
+  align-self: start;
+  width: 24px;
+  height: 24px;
+  margin-top: 0;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--ide-activity-dot) 18%, var(--bg-deep));
+  box-shadow: inset 0 0 0 6px var(--bg-deep);
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-row > div {
+  grid-column: 2;
+  padding-right: 34px;
+  overflow-wrap: anywhere;
+}
+
+.ide-v2-rail .ide-activity-panel.is-compact .ide-activity-row > div > span:first-child {
+  flex-wrap: wrap;
+}
+
+.ide-v2-work-context {
+  margin: 0 12px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+}
+
+.ide-v2-work-context > button {
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: var(--fs-9);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: left;
+  cursor: pointer;
 }
 
 .ide-v2-rail .ide-plane-annotations {
@@ -730,23 +1014,50 @@
 /* The live drawer retains the existing stream contract, while this v2 shell
    gives it the compact, always-present execution-output geometry of the
    reference IDE. */
-.ide-v2-surface > .execute-output-drawer {
+.ide-v2-editor > .execute-output-drawer {
   flex: none;
-  max-height: 208px;
+  max-height: 200px;
+  min-height: 30px;
   border-top: 1px solid var(--border-main);
   background: var(--bg-well);
 }
 
-.ide-v2-surface > .execute-output-drawer .execute-output-drawer-header {
+.ide-v2-editor > .execute-output-drawer .execute-output-drawer-header {
   min-height: 30px;
   padding: 5px 14px;
   border-bottom-color: var(--border-soft);
   background: var(--bg-sunken);
 }
 
-.ide-v2-surface > .execute-output-drawer [data-terminal] {
-  height: 168px !important;
+.ide-v2-editor > .execute-output-drawer [data-terminal] {
+  height: auto !important;
+  min-height: 48px;
+  max-height: 168px;
   background: var(--bg-well) !important;
+}
+
+.ide-v2-editor > .execute-output-drawer.is-collapsed {
+  max-height: 30px;
+}
+
+.execute-output-drawer-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-mid);
+  font: inherit;
+  cursor: pointer;
+}
+
+.execute-output-drawer-chevron {
+  transition: transform 0.18s;
+}
+
+.execute-output-drawer.is-collapsed .execute-output-drawer-chevron {
+  transform: rotate(-90deg);
 }
 
 .ide-interject-fab {
@@ -860,37 +1171,65 @@
 
 /* ── Responsive ────────────────────────────────────────────────────────────── */
 
-@media (max-width: 1280px) {
-  .ide-v2-body,
-  .ide-v2-body.ide-plane-grid {
-    grid-template-columns: var(--ide-tree-width, 230px) minmax(0, 1fr);
+@media (max-width: 1180px) {
+  .ide-plane-shell[data-mobile-viewport="false"][data-rails-collapsed="false"] .ide-v2-body.ide-plane-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(270px, 320px) !important;
   }
 
-  .ide-v2-rail,
-  .ide-v2-body.ide-plane-grid .ide-plane-conversation {
+  .ide-plane-shell[data-mobile-viewport="false"][data-rails-collapsed="true"] .ide-v2-body.ide-plane-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .ide-plane-shell[data-mobile-viewport="false"] .ide-v2-tree,
+  .ide-plane-shell[data-mobile-viewport="false"] .ide-v2-body.ide-plane-grid .ide-plane-tree {
+    display: none;
+  }
+
+  .ide-plane-shell[data-mobile-viewport="false"] .ide-v2-body.ide-plane-grid .ide-plane-editor,
+  .ide-plane-shell[data-mobile-viewport="false"][data-tree-collapsed="true"] .ide-v2-body.ide-plane-grid .ide-plane-editor {
+    grid-column: 1;
+  }
+
+  .ide-plane-shell[data-mobile-viewport="false"] .ide-v2-body.ide-plane-grid .ide-plane-conversation,
+  .ide-plane-shell[data-mobile-viewport="false"][data-tree-collapsed="true"] .ide-v2-body.ide-plane-grid .ide-plane-conversation {
+    grid-column: 2;
+  }
+
+  .ide-plane-shell[data-mobile-viewport="false"] .ide-v2-tree-toggle {
     display: none;
   }
 }
 
-@media (max-width: 900px) {
-  .ide-v2-top {
-    height: auto;
-    min-height: 42px;
-    flex-wrap: wrap;
-    padding: 6px 10px;
-  }
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-top {
+  height: auto;
+  min-height: 42px;
+  flex-wrap: wrap;
+  padding: 6px 10px;
+}
 
-  .ide-v2-top .ide-toolbar-command-cluster {
-    display: none;
-  }
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-top .ide-toolbar-command-cluster {
+  display: none;
+}
 
-  .ide-v2-body,
-  .ide-v2-body.ide-plane-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-body,
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-body.ide-plane-grid {
+  grid-template-columns: minmax(0, 1fr) !important;
+}
 
-  .ide-v2-tree,
-  .ide-v2-body.ide-plane-grid .ide-plane-tree {
-    display: none;
-  }
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-tree,
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-body.ide-plane-grid .ide-plane-tree {
+  display: none;
+}
+
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-body.ide-plane-grid .ide-plane-editor {
+  grid-column: 1;
+}
+
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-responsive-annotation-composer {
+  display: block;
+}
+
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-tree-toggle,
+.ide-plane-shell[data-mobile-viewport="true"] .ide-v2-rail-toggle {
+  display: none;
 }


### PR DESCRIPTION
## What changed

- align the IDE shell with the keeper v2 reference geometry: 42px toolbar, 230px explorer, flexible editor, and 320px activity rail
- move breadcrumbs and execute output into the editor column and expose Source, Split Diff, Search, and advanced view controls
- render real activity, degraded/offline state, Run Progress, and Context Lens metadata without prototype fixtures
- preserve an explicit active file; when none exists, select only the first server-ordered file carrying a non-empty changed-file observation
- keep hidden changed paths such as `.github/workflows/ci.yml` eligible and never infer focus from path visibility, keeper ownership, or an arbitrary leaf
- preserve annotation drafts and submission state across responsive placements while preventing duplicate submits
- make `useIsMobile` the sole mobile threshold owner and project its typed state into CSS through `data-mobile-viewport`
- unmount the activity rail on mobile so a CSS-hidden rail cannot continue polling, while retaining annotation access
- preserve current-main view-compatible layer gating and activity scope isolation

## Why

The implemented IDE had diverged from the keeper v2 reference in both layout and metadata wiring. Initial editor focus mixed several UI guesses, and responsive behavior duplicated the same threshold in TypeScript and CSS. Those splits could select unrelated files or leave an invisible polling rail alive after one threshold drifted.

## Impact

Operators get the intended dense IDE layout together with live repository and keeper metadata. Initial focus is either explicit or derived from one observable changed-file contract. Responsive layout and component lifetime now share one state source.

## Validation

Current head `e97eb4e9ed7621a014b7ec6c54f6e38c55e40b6d`, rebased on `main@572c0833deaca18181903e911a9b5b73232f3ecd`:

- `pnpm typecheck`
- focused Vitest: `ide-data-workspace-store.test.ts`, `ide-shell.test.ts`, `ide-v2-responsive.test.ts` — 3 files / 71 tests
- `git diff --check origin/main...HEAD`
- no local Dune build (CI is the Dune authority)
