### PR TITLE
refactor(keeper): centralize replay prefix persistence contract

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -124,30 +124,17 @@ let emit_wire_capture_response_suppressed_metrics ~keeper_name reasons =
     reasons
 ;;
 
-let rec messages_prefix_equal expected actual =
-  match expected, actual with
-  | [], _ -> true
-  | expected_msg :: expected_rest, actual_msg :: actual_rest ->
-    expected_msg = actual_msg && messages_prefix_equal expected_rest actual_rest
-  | _ :: _, [] -> false
-;;
-
-let rec drop_prefix prefix messages =
-  match prefix, messages with
-  | [], rest -> rest
-  | _ :: prefix_rest, _ :: message_rest -> drop_prefix prefix_rest message_rest
-  | _ :: _, [] -> []
-;;
-
 let prune_current_turn_replay
       ~(history_messages : Agent_sdk.Types.message list)
       ~(pre_turn_working_context : Yojson.Safe.t option)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
-  if
-    messages_prefix_equal history_messages checkpoint.Agent_sdk.Checkpoint.messages
-    && List.length checkpoint.Agent_sdk.Checkpoint.messages > List.length history_messages
-  then
+  match
+    Keeper_replay_prefix.split
+      ~prefix:history_messages
+      checkpoint.Agent_sdk.Checkpoint.messages
+  with
+  | Ok (_current_turn_message :: _) ->
     let messages =
       Keeper_context_core.repair_broken_tool_call_pairs history_messages
     in
@@ -156,7 +143,7 @@ let prune_current_turn_replay
         Agent_sdk.Checkpoint.messages
       ; working_context = pre_turn_working_context
       }
-  else None
+  | Ok [] | Error _ -> None
 ;;
 
 let canonical_success_replay_checkpoint
@@ -165,12 +152,13 @@ let canonical_success_replay_checkpoint
       ~(response_text : string)
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
-  if messages_prefix_equal history_messages checkpoint.Agent_sdk.Checkpoint.messages
-  then
-    let dropped_current_turn_replay =
-      List.length checkpoint.Agent_sdk.Checkpoint.messages
-      > List.length history_messages
-    in
+  match
+    Keeper_replay_prefix.split
+      ~prefix:history_messages
+      checkpoint.Agent_sdk.Checkpoint.messages
+  with
+  | Ok current_suffix ->
+    let dropped_current_turn_replay = current_suffix <> [] in
     let checkpoint =
       if String.trim response_text = ""
       then
@@ -181,9 +169,6 @@ let canonical_success_replay_checkpoint
         }
       else
         let messages =
-          let current_suffix =
-            drop_prefix history_messages checkpoint.Agent_sdk.Checkpoint.messages
-          in
           if
             List.exists
               (fun (msg : Agent_sdk.Types.message) ->
@@ -211,7 +196,7 @@ let canonical_success_replay_checkpoint
       , if dropped_current_turn_replay
         then Some Canonical_success_replay
         else None )
-  else
+  | Error _ ->
     Error
       "refusing to save checkpoint: canonical replay persistence requires \
        checkpoint messages to match pre-turn history prefix"

--- a/lib/keeper/keeper_replay_prefix.ml
+++ b/lib/keeper/keeper_replay_prefix.ml
@@ -1,0 +1,67 @@
+type prefix_mismatch =
+  | Prefix_longer_than_messages
+  | Prefix_message_mismatch
+
+type restore_error =
+  | Projected_checkpoint_prefix_mismatch of
+      { canonical_mismatch : prefix_mismatch
+      ; dispatch_mismatch : prefix_mismatch
+      }
+
+type projection =
+  | Unchanged
+  | Media_degraded of
+      { canonical_prefix : Agent_sdk.Types.message list
+      ; dispatch_prefix : Agent_sdk.Types.message list
+      }
+
+let unchanged = Unchanged
+
+let media_degraded ~canonical_prefix ~dispatch_prefix =
+  Media_degraded { canonical_prefix; dispatch_prefix }
+;;
+
+let rec split ~(prefix : Agent_sdk.Types.message list) messages =
+  match prefix, messages with
+  | [], suffix -> Ok suffix
+  | _ :: _, [] -> Error Prefix_longer_than_messages
+  | expected :: prefix_rest, actual :: message_rest ->
+    if expected = actual
+    then split ~prefix:prefix_rest message_rest
+    else Error Prefix_message_mismatch
+;;
+
+let restore_messages projection checkpoint_messages =
+  match projection with
+  | Unchanged -> Ok checkpoint_messages
+  | Media_degraded { canonical_prefix; dispatch_prefix } ->
+    (match split ~prefix:canonical_prefix checkpoint_messages with
+     | Ok _already_canonical_suffix -> Ok checkpoint_messages
+     | Error canonical_mismatch ->
+       (match split ~prefix:dispatch_prefix checkpoint_messages with
+        | Ok current_turn_suffix -> Ok (canonical_prefix @ current_turn_suffix)
+        | Error dispatch_mismatch ->
+          Error
+            (Projected_checkpoint_prefix_mismatch
+               { canonical_mismatch; dispatch_mismatch })))
+;;
+
+let restore_checkpoint projection (checkpoint : Agent_sdk.Checkpoint.t) =
+  match restore_messages projection checkpoint.messages with
+  | Error error -> Error error
+  | Ok messages -> Ok { checkpoint with messages }
+;;
+
+let prefix_mismatch_to_string = function
+  | Prefix_longer_than_messages -> "prefix_longer_than_messages"
+  | Prefix_message_mismatch -> "prefix_message_mismatch"
+;;
+
+let restore_error_to_string = function
+  | Projected_checkpoint_prefix_mismatch
+      { canonical_mismatch; dispatch_mismatch } ->
+    Printf.sprintf
+      "media-degraded checkpoint preserves neither canonical nor typed dispatch history prefix (canonical=%s, dispatch=%s)"
+      (prefix_mismatch_to_string canonical_mismatch)
+      (prefix_mismatch_to_string dispatch_mismatch)
+;;

--- a/lib/keeper/keeper_replay_prefix.ml
+++ b/lib/keeper/keeper_replay_prefix.ml
@@ -17,6 +17,8 @@ type projection =
 
 let unchanged = Unchanged
 
+(* TEL-OK: pure typed projection constructor; provider dispatch and checkpoint
+   persistence callers own telemetry at their action boundaries. *)
 let media_degraded ~canonical_prefix ~dispatch_prefix =
   Media_degraded { canonical_prefix; dispatch_prefix }
 ;;

--- a/lib/keeper/keeper_replay_prefix.mli
+++ b/lib/keeper/keeper_replay_prefix.mli
@@ -1,0 +1,45 @@
+(** Typed replay-prefix contract shared by dispatch, provider retry inspection,
+    and checkpoint persistence.
+
+    A media-degraded provider receives a projected dispatch prefix, while the
+    durable checkpoint must retain the canonical pre-turn prefix.  This pure
+    module is the single authority for splitting and restoring those prefixes. *)
+
+type prefix_mismatch =
+  | Prefix_longer_than_messages
+  | Prefix_message_mismatch
+
+type restore_error
+type projection
+
+(** No dispatch projection was applied. *)
+val unchanged : projection
+
+(** Record the exact canonical and projected prefixes used for a
+    media-degraded dispatch. *)
+val media_degraded :
+  canonical_prefix:Agent_sdk.Types.message list ->
+  dispatch_prefix:Agent_sdk.Types.message list ->
+  projection
+
+(** Split [messages] after an exact structural [prefix]. *)
+val split :
+  prefix:Agent_sdk.Types.message list ->
+  Agent_sdk.Types.message list ->
+  (Agent_sdk.Types.message list, prefix_mismatch) result
+
+(** Restore a projected provider checkpoint to its canonical replay prefix.
+    An unchanged projection is returned verbatim.  A media-degraded projection
+    accepts either an already-canonical checkpoint or the exact dispatch prefix
+    and fails explicitly for every other checkpoint. *)
+val restore_messages :
+  projection ->
+  Agent_sdk.Types.message list ->
+  (Agent_sdk.Types.message list, restore_error) result
+
+val restore_checkpoint :
+  projection ->
+  Agent_sdk.Checkpoint.t ->
+  (Agent_sdk.Checkpoint.t, restore_error) result
+
+val restore_error_to_string : restore_error -> string

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -746,12 +746,12 @@ let run_named
             }
           in
           let provider_attempt_started_at = Mtime_clock.now () in
-          let result, checkpoint_after, _success_sample =
+          let provider_result, checkpoint_after, _success_sample =
             Keeper_turn_driver_try_provider.run_try_provider
               try_provider_ctx ?resume_checkpoint ?per_provider_timeout_s candidate
           in
           let result =
-            match result with
+            match provider_result with
             | Error _ as error -> error
             | Ok run_result ->
               (match run_result.Runtime_agent.checkpoint with
@@ -779,7 +779,11 @@ let run_named
             in
             Int64.to_float ns /. 1_000_000.
           in
-          (match result with
+          (* Binding health describes the provider attempt, not MASC-local
+             checkpoint projection.  A fail-closed replay-prefix error must
+             fail the turn without falsely degrading a provider that returned
+             successfully. *)
+          (match provider_result with
            | Ok _ ->
              record_candidate_health_success
                ~keeper_name

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -70,31 +70,6 @@ let media_degrade_manifest_decision ~(runtime_id : string)
         ("media_dropped_counts", `String summary);
       ])
 
-let rec strip_matching_message_prefix prefix messages =
-  match prefix, messages with
-  | [], suffix -> Some suffix
-  | expected :: prefix_rest, actual :: message_rest when expected = actual ->
-    strip_matching_message_prefix prefix_rest message_rest
-  | _ :: _, [] | _ :: _, _ :: _ -> None
-
-type replay_prefix_projection =
-  | Replay_prefix_unchanged
-  | Replay_prefix_media_degraded
-
-let restore_canonical_replay_prefix
-    ~(canonical_prefix : Agent_sdk.Types.message list)
-    ~(dispatch_prefix : Agent_sdk.Types.message list)
-    ~(checkpoint_messages : Agent_sdk.Types.message list)
-    : (Agent_sdk.Types.message list, string) result =
-  match strip_matching_message_prefix canonical_prefix checkpoint_messages with
-  | Some _already_canonical_suffix -> Ok checkpoint_messages
-  | None ->
-    (match strip_matching_message_prefix dispatch_prefix checkpoint_messages with
-     | Some current_turn_suffix -> Ok (canonical_prefix @ current_turn_suffix)
-     | None ->
-       Error
-         "media-degraded checkpoint preserves neither canonical nor typed dispatch history prefix")
-
 type context_window_rebudget =
   { requested_context_window : int option
   ; final_runtime_context_window : int
@@ -602,7 +577,7 @@ let run_named
        | None ->
          (* Nothing strippable (e.g. only ToolResult-nested media): keep the
             inputs unchanged so the loud capability floor still applies. *)
-         goal_blocks, initial_messages, oas_checkpoint, Replay_prefix_unchanged
+         goal_blocks, initial_messages, oas_checkpoint, Keeper_replay_prefix.unchanged
        | Some note ->
          Log.Keeper.warn
            "%s: RFC-0265 media degrade on %s — dropped %s, continuing text-only"
@@ -616,17 +591,19 @@ let run_named
          let goal_with_note =
            stripped_goal @ [ Agent_sdk.Types.text_block note ]
          in
+         let dispatch_prefix =
+           match stripped_checkpoint with
+           | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
+           | None -> stripped_initial
+         in
          ( Some goal_with_note
          , stripped_initial
          , stripped_checkpoint
-         , Replay_prefix_media_degraded ))
+         , Keeper_replay_prefix.media_degraded
+             ~canonical_prefix:canonical_replay_prefix
+             ~dispatch_prefix ))
     | Runtime_agent.No_reroute_needed | Runtime_agent.Reroute _ ->
-      goal_blocks, initial_messages, oas_checkpoint, Replay_prefix_unchanged
-  in
-  let dispatch_replay_prefix =
-    match oas_checkpoint with
-    | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
-    | None -> initial_messages
+      goal_blocks, initial_messages, oas_checkpoint, Keeper_replay_prefix.unchanged
   in
   let transport_resolved =
     match transport with
@@ -777,22 +754,23 @@ let run_named
             match result with
             | Error _ as error -> error
             | Ok run_result ->
-              (match replay_prefix_projection, run_result.Runtime_agent.checkpoint with
-               | Replay_prefix_unchanged, _ | Replay_prefix_media_degraded, None ->
-                 Ok run_result
-               | Replay_prefix_media_degraded, Some checkpoint ->
+              (match run_result.Runtime_agent.checkpoint with
+               | None -> Ok run_result
+               | Some checkpoint ->
                  (match
-                    restore_canonical_replay_prefix
-                      ~canonical_prefix:canonical_replay_prefix
-                      ~dispatch_prefix:dispatch_replay_prefix
-                      ~checkpoint_messages:checkpoint.Agent_sdk.Checkpoint.messages
+                    Keeper_replay_prefix.restore_checkpoint
+                      replay_prefix_projection
+                      checkpoint
                   with
-                  | Ok messages ->
+                  | Ok checkpoint ->
                     Ok
                       { run_result with
-                        Runtime_agent.checkpoint = Some { checkpoint with messages }
+                        Runtime_agent.checkpoint = Some checkpoint
                       }
-                  | Error detail -> Error (Agent_sdk.Error.Internal detail)))
+                  | Error error ->
+                    Error
+                       (Agent_sdk.Error.Internal
+                          (Keeper_replay_prefix.restore_error_to_string error))))
           in
           let latency_ms =
             let ns =
@@ -845,7 +823,6 @@ module For_testing = struct
   let lane_modality_reroute_decision = lane_modality_reroute_decision
   let dedupe_runtimes_preserve_order = dedupe_runtimes_preserve_order
 	  let media_degrade_manifest_decision = media_degrade_manifest_decision
-	  let restore_canonical_replay_prefix = restore_canonical_replay_prefix
 	  let attempt_inference_policy = attempt_inference_policy
 	  let attempt_runtime_candidates = attempt_runtime_candidates
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -70,6 +70,40 @@ let media_degrade_manifest_decision ~(runtime_id : string)
         ("media_dropped_counts", `String summary);
       ])
 
+type provider_run_result =
+  (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+
+type provider_attempt_outcomes =
+  { provider_result : provider_run_result
+  ; turn_result : provider_run_result
+  }
+
+let project_provider_attempt_result ~replay_prefix_projection provider_result =
+  let turn_result =
+    match provider_result with
+    | Error _ as error -> error
+    | Ok run_result ->
+      (match run_result.Runtime_agent.checkpoint with
+       | None -> Ok run_result
+       | Some checkpoint ->
+         (match
+            Keeper_replay_prefix.restore_checkpoint
+              replay_prefix_projection
+              checkpoint
+          with
+          | Ok checkpoint ->
+            Ok
+              { run_result with
+                Runtime_agent.checkpoint = Some checkpoint
+              }
+          | Error error ->
+            Error
+              (Agent_sdk.Error.Internal
+                 (Keeper_replay_prefix.restore_error_to_string error))))
+  in
+  { provider_result; turn_result }
+;;
+
 type context_window_rebudget =
   { requested_context_window : int option
   ; final_runtime_context_window : int
@@ -750,27 +784,10 @@ let run_named
             Keeper_turn_driver_try_provider.run_try_provider
               try_provider_ctx ?resume_checkpoint ?per_provider_timeout_s candidate
           in
-          let result =
-            match provider_result with
-            | Error _ as error -> error
-            | Ok run_result ->
-              (match run_result.Runtime_agent.checkpoint with
-               | None -> Ok run_result
-               | Some checkpoint ->
-                 (match
-                    Keeper_replay_prefix.restore_checkpoint
-                      replay_prefix_projection
-                      checkpoint
-                  with
-                  | Ok checkpoint ->
-                    Ok
-                      { run_result with
-                        Runtime_agent.checkpoint = Some checkpoint
-                      }
-                  | Error error ->
-                    Error
-                       (Agent_sdk.Error.Internal
-                          (Keeper_replay_prefix.restore_error_to_string error))))
+          let outcomes =
+            project_provider_attempt_result
+              ~replay_prefix_projection
+              provider_result
           in
           let latency_ms =
             let ns =
@@ -783,7 +800,7 @@ let run_named
              checkpoint projection.  A fail-closed replay-prefix error must
              fail the turn without falsely degrading a provider that returned
              successfully. *)
-          (match provider_result with
+          (match outcomes.provider_result with
            | Ok _ ->
              record_candidate_health_success
                ~keeper_name
@@ -795,11 +812,16 @@ let run_named
                 record_candidate_health_rejected ~keeper_name candidate ~reason
               | Some _ | None ->
                 record_candidate_health_error ~keeper_name candidate err));
-          result, checkpoint_after))
+          outcomes.turn_result, checkpoint_after))
     attempt_runtimes
 
 
 module For_testing = struct
+  type nonrec provider_attempt_outcomes = provider_attempt_outcomes
+
+  let project_provider_attempt_result = project_provider_attempt_result
+  let provider_result outcomes = outcomes.provider_result
+  let turn_result outcomes = outcomes.turn_result
   let checkpoint_after_attempt = checkpoint_after_attempt
   let success_selected_model_raw = success_selected_model_raw
   let record_candidate_health_error = record_candidate_health_error

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -171,6 +171,21 @@ type attempt_inference_policy =
   }
 
 module For_testing : sig
+  type provider_attempt_outcomes
+
+  val project_provider_attempt_result :
+    replay_prefix_projection:Keeper_replay_prefix.projection ->
+    (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result ->
+    provider_attempt_outcomes
+
+  val provider_result :
+    provider_attempt_outcomes ->
+    (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+
+  val turn_result :
+    provider_attempt_outcomes ->
+    (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result
+
   val checkpoint_after_attempt :
     ?agent_ref:Agent_sdk.Agent.t option ref ->
     Agent_sdk.Agent.t option ->

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -237,12 +237,6 @@ module For_testing : sig
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
 
-  val restore_canonical_replay_prefix :
-    canonical_prefix:Agent_sdk.Types.message list ->
-    dispatch_prefix:Agent_sdk.Types.message list ->
-    checkpoint_messages:Agent_sdk.Types.message list ->
-    (Agent_sdk.Types.message list, string) result
-
   val resolve_context_window_tokens_after_runtime_selection :
     requested_context_window:int option ->
     final_runtime_context_window:int ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -266,13 +266,6 @@ let last_tool_progress_context_of_messages messages =
       }
 ;;
 
-let rec drop_matching_prefix ~prefix messages =
-  match prefix, messages with
-  | [], rest -> rest
-  | p :: ps, m :: ms when p = m -> drop_matching_prefix ~prefix:ps ms
-  | _ :: _, _ -> messages
-;;
-
 let accept_rejection_context_of_run_result
       ?(initial_messages = [])
       (run_result : Runtime_agent.run_result)
@@ -280,9 +273,17 @@ let accept_rejection_context_of_run_result
   match run_result.checkpoint with
   | None -> None
   | Some checkpoint ->
-    checkpoint.Agent_sdk.Checkpoint.messages
-    |> drop_matching_prefix ~prefix:initial_messages
-    |> last_tool_progress_context_of_messages
+    let messages = checkpoint.Agent_sdk.Checkpoint.messages in
+    let attempt_messages =
+      match Keeper_replay_prefix.split ~prefix:initial_messages messages with
+      | Ok suffix -> suffix
+      | Error _prefix_mismatch ->
+        (* A rejected provider may return a resumed checkpoint whose carrier
+           does not share this attempt's initial prefix.  Preserve the complete
+           typed trace for rejection diagnostics; never drop by list length. *)
+        messages
+    in
+    last_tool_progress_context_of_messages attempt_messages
 ;;
 
 let format_last_tool_progress_context = function

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -137,6 +137,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
   in
+  (* [tool_access_defaults_result] must remain the final bind: its successful
+     payload is consumed by the record-building [Result.map] below. *)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -129,9 +129,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> runtime_assignment_result)
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  let result =
     Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
   in
   let result =
@@ -139,6 +136,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Result.map
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
+  in
+  let result =
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
     (fun tool_access ->

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -5,6 +5,7 @@
 
 module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
 module Receipt = Masc.Keeper_execution_receipt
+module Replay_prefix = Masc.Keeper_replay_prefix
 
 let message role content =
   Agent_sdk.Types.{ role; content; name = None; tool_call_id = None; metadata = [] }
@@ -60,6 +61,20 @@ let has_content predicate messages =
   List.exists
     (fun (msg : Agent_sdk.Types.message) -> List.exists predicate msg.content)
     messages
+;;
+
+let rec remove_tree path =
+  if Sys.is_directory path
+  then (
+    Sys.readdir path
+    |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+    Unix.rmdir path)
+  else Unix.unlink path
+;;
+
+let with_temp_dir f =
+  let dir = Filename.temp_dir "keeper-replay-projection-" "" in
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
 ;;
 
 let test_patch_last_assistant_preserves_typed_reasoning () =
@@ -250,6 +265,65 @@ let test_empty_success_drops_current_turn_replay () =
     (prune_reason_to_string reason)
 ;;
 
+let test_media_degraded_projection_persists_canonical_checkpoint () =
+  let open Agent_sdk.Types in
+  let canonical_history =
+    [ message User
+        [ Text "canonical history"
+        ; image_block ~media_type:"image/png" ~data:"canonical-image" ()
+        ]
+    ]
+  in
+  let dispatch_history = [ message User [ Text "canonical history" ] ] in
+  let current_assistant = message Assistant [ Text "completed" ] in
+  let projection =
+    Replay_prefix.media_degraded
+      ~canonical_prefix:canonical_history
+      ~dispatch_prefix:dispatch_history
+  in
+  let restored_checkpoint =
+    match
+      Replay_prefix.restore_checkpoint
+        projection
+        (checkpoint ~working_context:None (dispatch_history @ [ current_assistant ]))
+    with
+    | Ok checkpoint -> checkpoint
+    | Error error -> Alcotest.fail (Replay_prefix.restore_error_to_string error)
+  in
+  let checkpoint_for_save, _reason =
+    Finalize.checkpoint_for_replay_persistence
+      ~history_messages:canonical_history
+      ~pre_turn_working_context:None
+      ~completion_contract_result:Receipt.Contract_satisfied_execution
+      ~session_id:"media-projection-session"
+      ~response_text:"completed"
+      restored_checkpoint
+    |> expect_ok
+  in
+  with_temp_dir (fun session_dir ->
+    Masc.Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
+    (match
+       Masc.Keeper_checkpoint_store.save_oas_classified
+         ~session_dir
+         checkpoint_for_save
+     with
+     | Ok (Masc.Keeper_checkpoint_store.Saved _) -> ()
+     | Ok (Masc.Keeper_checkpoint_store.Stale_noop _) ->
+       Alcotest.fail "fresh projected checkpoint was classified as stale"
+     | Error detail -> Alcotest.fail ("projected checkpoint save failed: " ^ detail));
+    match
+      Masc.Keeper_checkpoint_store.load_oas
+        ~session_dir
+        ~session_id:"media-projection-session"
+    with
+    | Error _ -> Alcotest.fail "persisted projected checkpoint could not be loaded"
+    | Ok persisted ->
+      Alcotest.(check bool)
+        "durable checkpoint keeps canonical media and current assistant suffix"
+        true
+        (persisted.messages = canonical_history @ [ current_assistant ]))
+;;
+
 let () =
   Alcotest.run
     "keeper replay checkpoint"
@@ -278,6 +352,10 @@ let () =
             "empty success drops current turn"
             `Quick
             test_empty_success_drops_current_turn_replay
+        ; Alcotest.test_case
+            "media-degraded projection persists canonical checkpoint"
+            `Quick
+            test_media_degraded_projection_persists_canonical_checkpoint
         ] )
     ]
 ;;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1360,6 +1360,29 @@ let test_oas_env_rejects_invalid_unified_max_tokens () =
              (contains_substring detail "positive integer")))
     [ "\"not-an-int\""; "\"8192\""; "true"; "1.5"; "0"; "-1" ]
 
+let test_oas_env_max_tokens_validation_preserves_tool_access () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+tool_access = ["masc_status", "masc_tasks"]
+[keeper.oas_env]
+MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok defaults ->
+       check (option (list string))
+         "max_tokens validation preserves the successful tool_access payload"
+         (Some [ "masc_status"; "masc_tasks" ])
+         defaults.tool_access;
+       check (option int)
+         "valid unified max_tokens remains available after validation"
+         (Some 8192)
+         (KTP.unified_max_tokens_override_of_oas_env defaults.oas_env))
+
 let test_oas_env_drops_non_oas_prefix () =
   (* Guards against ambient env injection via keeper TOML: arbitrary keys
      outside the audited allowlist are silently dropped. *)
@@ -1752,6 +1775,8 @@ let () =
             test_oas_env_rejects_legacy_unified_max_tokens_alias;
           test_case "rejects invalid unified max tokens" `Quick
             test_oas_env_rejects_invalid_unified_max_tokens;
+          test_case "max tokens validation preserves tool_access" `Quick
+            test_oas_env_max_tokens_validation_preserves_tool_access;
           test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
             test_oas_env_drops_non_oas_prefix;
           test_case "empty when table absent" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -194,6 +194,46 @@ let test_accept_keeps_result () =
     Alcotest.failf "accepted response should pass through: %s"
       (Agent_sdk.Error.to_string err)
 
+let test_replay_projection_failure_preserves_provider_success () =
+  let open Agent_sdk.Types in
+  let canonical_prefix =
+    [ message
+        ~role:User
+        [ Text "canonical history"
+        ; image_block ~media_type:"image/png" ~data:"canonical-image" ()
+        ]
+    ]
+  in
+  let dispatch_prefix = [ message ~role:User [ Text "canonical history" ] ] in
+  let drifted_checkpoint =
+    checkpoint_with_messages [ message ~role:User [ Text "unrelated history" ] ]
+  in
+  let outcomes =
+    Masc.Keeper_turn_driver.For_testing.project_provider_attempt_result
+      ~replay_prefix_projection:
+        (Masc.Keeper_replay_prefix.media_degraded
+           ~canonical_prefix
+           ~dispatch_prefix)
+      (Ok (run_result ~checkpoint:drifted_checkpoint ()))
+  in
+  (match Masc.Keeper_turn_driver.For_testing.provider_result outcomes with
+   | Ok _ -> ()
+   | Error error ->
+     Alcotest.failf
+       "provider success source was overwritten: %s"
+       (Agent_sdk.Error.to_string error));
+  match Masc.Keeper_turn_driver.For_testing.turn_result outcomes with
+  | Error (Agent_sdk.Error.Internal detail) ->
+    Alcotest.(check bool)
+      "local replay-prefix drift fails the turn explicitly"
+      true
+      (String.trim detail <> "")
+  | Error error ->
+    Alcotest.failf
+      "expected typed Internal replay-prefix failure, got %s"
+      (Agent_sdk.Error.to_string error)
+  | Ok _ -> Alcotest.fail "replay-prefix drift did not fail closed"
+
 let test_rejects_as_typed_accept_error () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -2376,6 +2416,10 @@ let () =
       , [
           Alcotest.test_case "accepted response passes through" `Quick
             test_accept_keeps_result;
+          Alcotest.test_case
+            "replay projection failure preserves provider success"
+            `Quick
+            test_replay_projection_failure_preserves_provider_success;
           Alcotest.test_case
             "strict tool_choice is relaxed to auto"
             `Quick

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -377,12 +377,13 @@ let test_media_degrade_restores_canonical_replay_prefix () =
     }
   in
   match
-    Masc.Keeper_turn_driver.For_testing.restore_canonical_replay_prefix
-      ~canonical_prefix:canonical_history
-      ~dispatch_prefix:dispatch_history
-      ~checkpoint_messages:(dispatch_history @ [ assistant ])
+    Masc.Keeper_replay_prefix.restore_messages
+      (Masc.Keeper_replay_prefix.media_degraded
+         ~canonical_prefix:canonical_history
+         ~dispatch_prefix:dispatch_history)
+      (dispatch_history @ [ assistant ])
   with
-  | Error error -> fail error
+  | Error error -> fail (Masc.Keeper_replay_prefix.restore_error_to_string error)
   | Ok restored ->
     check int "canonical history plus current suffix" 2 (List.length restored);
     check bool "original media history is restored" true (List.hd restored = List.hd canonical_history);
@@ -395,10 +396,11 @@ let test_media_degrade_rejects_checkpoint_prefix_drift () =
     [ message_with_blocks [ Agent_sdk.Types.Text "unrelated" ] ]
   in
   match
-    Masc.Keeper_turn_driver.For_testing.restore_canonical_replay_prefix
-      ~canonical_prefix:canonical_history
-      ~dispatch_prefix:dispatch_history
-      ~checkpoint_messages:unrelated_checkpoint
+    Masc.Keeper_replay_prefix.restore_messages
+      (Masc.Keeper_replay_prefix.media_degraded
+         ~canonical_prefix:canonical_history
+         ~dispatch_prefix:dispatch_history)
+      unrelated_checkpoint
   with
   | Error _ -> ()
   | Ok _ -> fail "expected dispatch-prefix drift to fail closed"
@@ -420,12 +422,13 @@ let test_media_degrade_preserves_already_canonical_checkpoint () =
     canonical_history @ [ message_with_blocks [ Agent_sdk.Types.Text "suffix" ] ]
   in
   match
-    Masc.Keeper_turn_driver.For_testing.restore_canonical_replay_prefix
-      ~canonical_prefix:canonical_history
-      ~dispatch_prefix:dispatch_history
-      ~checkpoint_messages
+    Masc.Keeper_replay_prefix.restore_messages
+      (Masc.Keeper_replay_prefix.media_degraded
+         ~canonical_prefix:canonical_history
+         ~dispatch_prefix:dispatch_history)
+      checkpoint_messages
   with
-  | Error error -> fail error
+  | Error error -> fail (Masc.Keeper_replay_prefix.restore_error_to_string error)
   | Ok restored ->
     check
       bool


### PR DESCRIPTION
## Summary
- follow-up to #24112 after its original fix landed while this repair was in progress
- replace driver, finalize, and provider-retry prefix walkers with one typed pure Keeper_replay_prefix authority
- represent unchanged versus media-degraded dispatch as an abstract projection
- restore projected checkpoints through typed result errors before persistence
- remove the legacy driver For_testing prefix API

## Invariant
The provider may receive a media-degraded dispatch prefix, but durable replay keeps the canonical pre-turn media. Prefix drift remains fail-closed. No provider-name checks, string classifiers, or list-length prefix surgery are used.

## Integration proof
The regression constructs a media-degraded dispatch checkpoint, restores it through the typed projection, passes it through finalize checkpoint canonicalization, writes it with Keeper_checkpoint_store, reloads it from disk, and proves the canonical image plus current assistant suffix survived.

## Validation
- OCaml 5.4.1 parser checks for all 8 changed ML and MLI files
- ocamlformat 0.29.0 checks for all changed ML and MLI files
- OCaml 5.4.1 ocamldep succeeds
- standalone type inference for the new Agent SDK leaf succeeds
- git diff --check succeeds
- determinism contract guard passes with no new debt
- local Dune was intentionally not run; CI is the build and test authority

## Merge policy
Keep Draft and status:do-not-merge until exact-head CI and review complete.