### PR TITLE
fix(keeper): close descriptor model projection

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -158,6 +158,31 @@ let masc_cleanup_zombies_spec : tool_spec =
   }
 ;;
 
+let masc_pause_spec : tool_spec =
+  { name = "masc_pause"
+  ; description =
+      "Pause the workspace until an operator resumes it. Existing state is preserved."
+  ; parameters =
+      [ { p_name = "reason"
+        ; p_type = T_string { enum = None; default = Some "Manual pause" }
+        ; p_description = "Operator-visible reason for pausing the workspace"
+        ; p_required = false
+        }
+      ]
+  ; additional_properties = false
+  ; behavior_contract = []
+  }
+;;
+
+let masc_resume_spec : tool_spec =
+  { name = "masc_resume"
+  ; description = "Resume a workspace that was paused by an operator."
+  ; parameters = []
+  ; additional_properties = false
+  ; behavior_contract = []
+  }
+;;
+
 (* === PR-2: plan group (8 tools) === *)
 
 let masc_plan_init_spec : tool_spec =
@@ -395,6 +420,8 @@ let phase6_specs : tool_spec list =
   ; masc_gc_spec
   ; masc_tool_stats_spec
   ; masc_cleanup_zombies_spec
+  ; masc_pause_spec
+  ; masc_resume_spec
     (* PR-2: plan group *)
   ; masc_plan_init_spec
   ; masc_plan_update_spec

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -113,31 +113,26 @@ let handle_tool name args : Tool_result.result =
 let tool_spec_read_only =
   Tool_name.Board_name.all
   |> List.filter (fun board_name ->
-    not (Tool_name.Board_name.is_resource_write board_name))
+    (Board_tool_registry.operation_policy board_name).readonly)
   |> List.map Tool_name.Board_name.to_string
 ;;
 
-let destructive_board_tool_names =
-  let open Tool_name.Board_name in
-  [ to_string Board_delete; to_string Board_cleanup ]
-;;
-
-let is_destructive_board_tool name = List.mem name destructive_board_tool_names
-
 let register () =
   let handler ~name ~args = Some (handle_tool name args) in
-  let make_spec (s : Masc_domain.tool_schema) =
-    let ro = List.mem s.name tool_spec_read_only in
+  let make_spec board_name =
+    let s = Board_tool_registry.schema_for_board_name board_name in
+    let policy = Board_tool_registry.operation_policy board_name in
     Tool_spec.create
       ~name:s.name
       ~description:s.description
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
       ~handler_binding:(Shared handler)
-      ~is_read_only:ro
-      ~is_idempotent:ro
-      ~is_destructive:(is_destructive_board_tool s.name)
+      ~is_read_only:policy.readonly
+      ~is_idempotent:policy.idempotent
+      ~is_destructive:policy.destructive
+      ~visibility:policy.visibility
       ()
   in
-  Tool_spec.register_all (List.map make_spec Board_tool_registry.tools)
+  Tool_spec.register_all (List.map make_spec Tool_name.Board_name.all)
 ;;

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -111,16 +111,10 @@ let handle_tool name args : Tool_result.result =
 ;;
 
 let tool_spec_read_only =
-  [ "masc_board_list"
-  ; "masc_board_sub_board_list"
-  ; "masc_board_sub_board_get"
-  ; "masc_board_post_get"
-  ; "masc_board_stats"
-  ; "masc_board_search"
-  ; "masc_board_profile"
-  ; "masc_board_hearths"
-  ; "masc_board_curation_read"
-  ]
+  Tool_name.Board_name.all
+  |> List.filter (fun board_name ->
+    not (Tool_name.Board_name.is_resource_write board_name))
+  |> List.map Tool_name.Board_name.to_string
 ;;
 
 let destructive_board_tool_names =

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -177,6 +177,47 @@ let board_tool_curation_submit : Masc_domain.tool_schema =
   }
 ;;
 
+(** {1 Typed operation projection} *)
+type operation_policy =
+  { visibility : Tool_catalog.visibility
+  ; readonly : bool
+  ; idempotent : bool
+  ; destructive : bool
+  }
+
+let operation_policy board_name =
+  let readonly = not (Tool_name.Board_name.is_resource_write board_name) in
+  let destructive =
+    match board_name with
+    | Tool_name.Board_name.Board_delete
+    | Tool_name.Board_name.Board_cleanup -> true
+    | Tool_name.Board_name.Board_comment
+    | Tool_name.Board_name.Board_comment_vote
+    | Tool_name.Board_name.Board_curation_read
+    | Tool_name.Board_name.Board_curation_submit
+    | Tool_name.Board_name.Board_hearths
+    | Tool_name.Board_name.Board_list
+    | Tool_name.Board_name.Board_post
+    | Tool_name.Board_name.Board_post_get
+    | Tool_name.Board_name.Board_post_update
+    | Tool_name.Board_name.Board_profile
+    | Tool_name.Board_name.Board_reaction
+    | Tool_name.Board_name.Board_search
+    | Tool_name.Board_name.Board_stats
+    | Tool_name.Board_name.Board_sub_board_create
+    | Tool_name.Board_name.Board_sub_board_delete
+    | Tool_name.Board_name.Board_sub_board_get
+    | Tool_name.Board_name.Board_sub_board_list
+    | Tool_name.Board_name.Board_sub_board_update
+    | Tool_name.Board_name.Board_vote -> false
+  in
+  { visibility = Tool_catalog.Default
+  ; readonly
+  ; idempotent = readonly
+  ; destructive
+  }
+;;
+
 (** {1 Typed schema projection} *)
 let schema_for_board_name = function
   | Tool_name.Board_name.Board_post -> Board_tool_schemas.tool_post_create

--- a/lib/board_tool_adapter/board_tool_registry.mli
+++ b/lib/board_tool_adapter/board_tool_registry.mli
@@ -2,6 +2,17 @@
 
 val tools : Masc_domain.tool_schema list
 
+type operation_policy =
+  { visibility : Tool_catalog.visibility
+  ; readonly : bool
+  ; idempotent : bool
+  ; destructive : bool
+  }
+
+val operation_policy : Tool_name.Board_name.t -> operation_policy
+(** Immutable registration policy shared by Board [Tool_spec] and Keeper
+    descriptor projection. *)
+
 val schema_for_board_name : Tool_name.Board_name.t -> Masc_domain.tool_schema
 (** Exhaustive typed projection to the advertised [masc_board_*] schema. *)
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -254,7 +254,6 @@ let tool_search_alias_entries =
   ; "masc_status", "상태 현황 방 룸 요약"
   ; "masc_dashboard", "대시보드 현황 대시 보드 개요"
   ; "masc_plan_clear_task", "계획 태스크 제거 해제 클리어"
-  ; "masc_agent_fitness", "에이전트 평가 점수 피트니스"
   ; "masc_web_search", "웹 검색 인터넷 온라인 구글"
   ; "masc_web_fetch", "웹 페이지 가져오기 읽기 URL 페치"
 

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -77,7 +77,7 @@ let tools_for_affordance = function
   | Task_claim ->
     [ "keeper_task_claim" ]
   | Task_audit ->
-    [ "keeper_tasks_audit"; "keeper_tasks_list"; "masc_tasks" ]
+    [ "keeper_tasks_audit"; "keeper_tasks_list" ]
   | Task_verify ->
     (* RFC-0323 G-4: a verify turn clears pending_verification via
        masc_transition action=approve/reject. keeper_task_done is excluded —
@@ -90,7 +90,7 @@ let tools_for_affordance = function
    task/world state (and thus clear the signal that surfaced it)?  Exhaustive
    match over the closed [turn_affordance] sum, so adding a new affordance
    forces a decision here at compile time.  [Task_audit] is the sole
-   advisory-only affordance: its tools (keeper_tasks_audit/list, masc_tasks)
+   advisory-only affordance: its tools (keeper_tasks_audit/list)
    are read-only, so a keeper woken by a [Task_audit]-only signal cannot clear
    that signal — driving a proactive turn on it produces an unbounded no-op
    livelock (the failed_task incident, 2026-06-21..24).
@@ -250,7 +250,6 @@ let tool_search_alias_entries =
   ; "masc_keeper_list", "키퍼 목록 현황"
   ; "masc_keeper_msg", "키퍼 메시지 전달 대화"
   ; "masc_keeper_status", "키퍼 상태 확인"
-  ; "masc_tasks", "태스크 목록 할일 작업"
   ; "masc_add_task", "태스크 추가 등록 생성"
   ; "masc_status", "상태 현황 방 룸 요약"
   ; "masc_dashboard", "대시보드 현황 대시 보드 개요"

--- a/lib/keeper/keeper_run_tools_search.ml
+++ b/lib/keeper/keeper_run_tools_search.ml
@@ -5,16 +5,19 @@ type tool_search_hit_partition =
   }
 
 let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
-  (* PR #14574 review #1/#7: only expose a public alias (e.g. "Execute") when
+  (* Only expose a descriptor's model projection (e.g. "Execute") when
      its routed internal handler is actually in the
-     incoming active surface. Adding all [public_names ()]
-     unconditionally let [keeper_tool_search] return aliases even when
+     incoming active surface. Adding compatibility aliases
+     unconditionally let [keeper_tool_search] return names even when
      their backing tool was not permitted for the turn, which would invite
      the model to attempt unregistered tool calls. *)
-  let aliases_with_allowed_route =
-    Keeper_tool_descriptor_resolution.public_names_for_allowed_internal_names allowed
+  let projected_names_with_allowed_route =
+    Keeper_tool_descriptor.public_descriptors
+    |> List.filter (fun (descriptor : Keeper_tool_descriptor.t) ->
+      List.mem descriptor.internal_name allowed)
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
   in
-  let allowed = allowed @ aliases_with_allowed_route in
+  let allowed = allowed @ projected_names_with_allowed_route in
   let allowed_set =
     let tbl = Hashtbl.create (List.length allowed) in
     List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -321,8 +321,10 @@ let prepare_agent_setup
      keeper tool_access has explicitly excluded — the descriptor would dispatch to
      a registered-but-disallowed tool. See PR #14574 review. *)
   let descriptor_public_names =
-    Keeper_tool_descriptor_resolution.public_names_for_allowed_internal_names
-      policy_allowed_tool_names
+    Keeper_tool_descriptor.public_descriptors
+    |> List.filter (fun (descriptor : Keeper_tool_descriptor.t) ->
+      List.mem descriptor.internal_name policy_allowed_tool_names)
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
   in
   (* Now strip the descriptor internal names from the LLM-visible surface,
      after [descriptor_public_names] has been computed. *)
@@ -364,7 +366,8 @@ let prepare_agent_setup
     ()
   in
   let allowed_public_name_for_internal internal_name =
-    Keeper_tool_descriptor_resolution.public_names_for_internal internal_name
+    Keeper_tool_descriptor.public_descriptors_for_internal internal_name
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
     |> List.find_opt (fun public_name ->
       Keeper_tool_policy.StringSet.mem public_name universe_set
       && Keeper_tool_policy.StringSet.mem public_name policy_allowed_tool_set)

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -116,7 +116,11 @@ let dispatch
     | Mod_run ->
       Tool_run.dispatch { Tool_run.config; agent_name = Some agent_name } ~name ~args
     | Mod_agent -> Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
-    | Mod_state -> Tool_workspace.dispatch { Tool_workspace.config; agent_name } ~name ~args
+    | Mod_state ->
+      Tool_workspace.dispatch_for_keeper
+        { Tool_workspace.config; agent_name }
+        ~name
+        ~args
     | Mod_control ->
       if name = "masc_pause_status"
       then Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args
@@ -146,7 +150,7 @@ let dispatch
       Some (if success then ok message else err message)
     (* ── Tier B: Eio-dependent ─────────────────────────────────── *)
     | Mod_task ->
-      Task.Tool.dispatch
+      Task.Tool.dispatch_for_keeper
         { Task.Tool.config; agent_name; sw = Eio_context.get_switch_opt () }
         ~name
         ~args

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -62,7 +62,10 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
   | Tool_masc_keeper_dispatch
-  | Tool_masc_surface_audit -> true
+  | Tool_masc_surface_audit
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch -> true
   | Tool_execute
   | Tool_search_files
   | Tool_read_file

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1328,15 +1328,24 @@ let board_descriptor name description ~readonly =
 let masc_board_descriptor board_name =
   let schema = Board_tool_registry.schema_for_board_name board_name in
   let name = Tool_name.Board_name.to_string board_name in
-  let readonly = not (Tool_name.Board_name.is_resource_write board_name) in
+  let operation_policy = Board_tool_registry.operation_policy board_name in
+  let readonly = operation_policy.readonly in
   let effect_domain =
     if readonly then Tool_catalog.Read_only else Tool_catalog.Masc_workspace
   in
-  let visibility, keeper_model_projection =
+  let visibility =
     match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-    | Keeper_tool_name.Direct_masc -> Tool_catalog.Default, Internal_name
+    | Keeper_tool_name.Direct_masc ->
+      Tool_catalog.effective_registered_visibility
+        ~name
+        ~declared:operation_policy.visibility
     | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
-      Tool_catalog.Hidden, Dispatch_only
+      Tool_catalog.Hidden
+  in
+  let keeper_model_projection =
+    match visibility with
+    | Tool_catalog.Default -> Internal_name
+    | Tool_catalog.Hidden -> Dispatch_only
   in
   let policy =
     policy

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -914,6 +914,10 @@ let find_voice_schema_opt name =
   find_schema_input_opt Tool_shard_types.voice_tools name
 ;;
 
+let find_misc_schema_opt name =
+  find_schema_input_opt Tool_schemas_misc.schemas name
+;;
+
 let find_base_schema_opt name =
   match find_schema_input_opt Tool_shard_types.base_tools name with
   | Some _ as schema -> schema
@@ -972,8 +976,11 @@ let find_masc_schema_opt name =
 let find_cluster_schema_opt name =
   (* Priority preserves the historical hidden keeper namespace ownership:
      keeper taskboard wrappers first, then typed board wrappers, voice,
-     then public masc_* aggregates. The namespaces are expected to be
-     disjoint; this order is not a conflict resolver. *)
+     the generated misc/control registry, then public masc_* aggregates.
+     The namespaces are expected to be disjoint; this order is not a conflict
+     resolver. [masc_pause]/[masc_resume] deliberately stay out of Config's
+     public schema list, so their canonical Tool_schemas_misc definitions must
+     be read directly rather than replaced by a permissive placeholder. *)
   match find_taskboard_schema_opt name with
   | Some _ as schema -> schema
   | None ->
@@ -982,7 +989,10 @@ let find_cluster_schema_opt name =
      | None ->
        (match find_voice_schema_opt name with
         | Some _ as schema -> schema
-        | None -> find_masc_schema_opt name))
+        | None ->
+          (match find_misc_schema_opt name with
+           | Some _ as schema -> schema
+           | None -> find_masc_schema_opt name)))
 ;;
 
 let base_schema_input name =
@@ -1249,6 +1259,11 @@ let cluster_policy ?(polling_read = false) ~readonly ~inline_safe ~maintenance_o
 let cluster_descriptor_with_schema_source ?(polling_read = false)
       ~keeper_model_projection ~input_schema_source ~input_schema ~id ~name
       ~description ~handler ~readonly ~inline_safe ~maintenance_only () =
+  let keeper_model_projection =
+    if Tool_catalog_surfaces.is_system_internal_hidden name
+    then Dispatch_only
+    else keeper_model_projection
+  in
   let policy =
     cluster_policy ~polling_read ~readonly ~inline_safe ~maintenance_only ()
   in
@@ -1496,14 +1511,14 @@ let masc_misc_descriptor id name description ~readonly =
 
 let masc_control_descriptor id name description ~readonly =
   cluster_descriptor
-    ~keeper_model_projection:Internal_name
+    ~keeper_model_projection:Dispatch_only
     ~id:("masc.control." ^ id)
     ~name
     ~description
     ~handler:Tool_masc_control_dispatch
     ~readonly
     ~inline_safe:false
-    ~maintenance_only:false
+    ~maintenance_only:true
     ()
 ;;
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1518,7 +1518,7 @@ let masc_control_descriptor id name description ~readonly =
     ~handler:Tool_masc_control_dispatch
     ~readonly
     ~inline_safe:false
-    ~maintenance_only:true
+    ~maintenance_only:false
     ()
 ;;
 
@@ -2144,6 +2144,11 @@ let keeper_candidate_names descriptor =
   | (Descriptor_owned | Canonical_registry), Internal_name ->
     [ descriptor.internal_name ]
   | (Descriptor_owned | Canonical_registry), Dispatch_only -> []
+;;
+
+let registered_names descriptor =
+  descriptor.internal_name :: descriptor.public_name :: descriptor.public_aliases
+  |> List.sort_uniq String.compare
 ;;
 
 let model_visible_descriptors () =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1313,15 +1313,13 @@ let board_descriptor name description ~readonly =
 let masc_board_descriptor board_name =
   let schema = Board_tool_registry.schema_for_board_name board_name in
   let name = Tool_name.Board_name.to_string board_name in
-  let metadata = Tool_catalog.metadata name in
-  let readonly =
-    match metadata.readonly with
-    | Some readonly -> readonly
-    | None -> List.mem name Board_tool_dispatch.tool_spec_read_only
+  let readonly = not (Tool_name.Board_name.is_resource_write board_name) in
+  let effect_domain =
+    if readonly then Tool_catalog.Read_only else Tool_catalog.Masc_workspace
   in
   let visibility, keeper_model_projection =
     match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-    | Keeper_tool_name.Direct_masc -> metadata.visibility, Internal_name
+    | Keeper_tool_name.Direct_masc -> Tool_catalog.Default, Internal_name
     | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
       Tool_catalog.Hidden, Dispatch_only
   in
@@ -1329,7 +1327,7 @@ let masc_board_descriptor board_name =
     policy
       ~visibility
       ~readonly
-      ?effect_domain:metadata.effect_domain
+      ~effect_domain
       ~approval:No_approval
       ~retryable:readonly
       ()

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -22,6 +22,32 @@ type approval =
   | Policy_selected
   | Human_required
 
+type keeper_model_projection =
+  | Preferred_public_name
+  | Internal_name
+  | Dispatch_only
+
+type model_description_projection =
+  | Static_description
+  | Current_task_state
+
+type keeper_tool_group =
+  | Execute_group
+  | Search_files_group
+  | Filesystem_group
+  | Board_group
+  | Voice_group
+  | Workspace_group
+  | Surface_group
+  | Memory_group
+  | Meta_group
+  | Core_group
+
+type input_schema_source =
+  | Descriptor_owned
+  | Canonical_registry
+  | Missing_canonical_registry
+
 type readonly_of_input = Yojson.Safe.t -> bool option
 
 type runtime_handler =
@@ -59,6 +85,9 @@ type runtime_handler =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch
   | Tool_analyze_image
 
 type policy =
@@ -76,6 +105,10 @@ type policy =
 
 type t =
   { id : string
+  ; keeper_model_projection : keeper_model_projection
+  ; model_description_projection : model_description_projection
+  ; keeper_tool_group : keeper_tool_group
+  ; input_schema_source : input_schema_source
   ; public_name : string
   ; public_aliases : string list
   ; internal_name : string
@@ -119,6 +152,36 @@ let approval_to_string = function
   | Human_required -> "human_required"
 ;;
 
+let keeper_model_projection_to_string = function
+  | Preferred_public_name -> "preferred_public_name"
+  | Internal_name -> "internal_name"
+  | Dispatch_only -> "dispatch_only"
+;;
+
+let model_description_projection_to_string = function
+  | Static_description -> "static_description"
+  | Current_task_state -> "current_task_state"
+;;
+
+let keeper_tool_group_to_string = function
+  | Execute_group -> "execute"
+  | Search_files_group -> "search_files"
+  | Filesystem_group -> "fs"
+  | Board_group -> "board"
+  | Voice_group -> "voice"
+  | Workspace_group -> "workspace"
+  | Surface_group -> "surface"
+  | Memory_group -> "memory"
+  | Meta_group -> "meta"
+  | Core_group -> "core"
+;;
+
+let input_schema_source_to_string = function
+  | Descriptor_owned -> "descriptor_owned"
+  | Canonical_registry -> "canonical_registry"
+  | Missing_canonical_registry -> "missing_canonical_registry"
+;;
+
 let runtime_handler_to_string = function
   | Tool_execute -> "tool_execute"
   | Tool_search_files -> "tool_search_files"
@@ -154,7 +217,45 @@ let runtime_handler_to_string = function
   | Tool_masc_surface_audit -> "tool_masc_surface_audit"
   | Tool_masc_fusion_dispatch -> "tool_masc_fusion_dispatch"
   | Tool_masc_fusion_status -> "tool_masc_fusion_status"
+  | Tool_masc_library_dispatch -> "tool_masc_library_dispatch"
+  | Tool_masc_recurring_dispatch -> "tool_masc_recurring_dispatch"
+  | Tool_masc_local_runtime_dispatch -> "tool_masc_local_runtime_dispatch"
   | Tool_analyze_image -> "tool_analyze_image"
+;;
+
+let keeper_tool_group_of_runtime_handler = function
+  | Tool_execute -> Execute_group
+  | Tool_search_files -> Search_files_group
+  | Tool_read_file | Tool_edit_file | Tool_write_file -> Filesystem_group
+  | Board_tool_dispatch | Tool_masc_board_dispatch -> Board_group
+  | Tool_voice_dispatch -> Voice_group
+  | Tool_task_dispatch | Tool_masc_task_dispatch | Tool_masc_plan_dispatch ->
+    Workspace_group
+  | Tool_masc_run_dispatch
+  | Tool_masc_agent_dispatch
+  | Tool_masc_workspace_dispatch
+  | Tool_masc_control_dispatch
+  | Tool_masc_agent_timeline_dispatch
+  | Tool_masc_schedule_dispatch
+  | Tool_masc_keeper_dispatch
+  | Tool_masc_fusion_dispatch
+  | Tool_masc_fusion_status
+  | Tool_masc_misc_dispatch
+  | Tool_masc_surface_audit
+  | Tool_masc_local_runtime_dispatch
+  | Tool_analyze_image -> Core_group
+  | Tool_surface_read | Tool_surface_post | Tool_person_note_set -> Surface_group
+  | Tool_memory_search
+  | Tool_memory_write
+  | Tool_library_search
+  | Tool_library_read
+  | Tool_masc_library_dispatch -> Memory_group
+  | Tool_masc_recurring_dispatch -> Workspace_group
+  | Tool_time_now
+  | Tool_tools_list
+  | Tool_tool_search
+  | Tool_context_status
+  | Tool_ide_annotate -> Meta_group
 ;;
 
 let discovery_example ~label ?cwd ~executable ~argv () =
@@ -457,6 +558,8 @@ let search_files_readonly_of_input _input = Some true
 
 let descriptor_with_public_aliases
       ?(examples = [])
+      ~keeper_model_projection
+      ~input_schema_source
       ~validate_translated_input
       ~public_aliases
       ~id
@@ -474,15 +577,25 @@ let descriptor_with_public_aliases
   =
   let receipt_labels =
     [ "descriptor_id", id
+    ; ( "keeper_model_projection"
+      , keeper_model_projection_to_string keeper_model_projection )
     ; "public_name", public_name
     ; "canonical_name", internal_name
     ; "executor", executor_to_string executor
     ; "backend", backend_to_string backend
     ; "sandbox", sandbox_to_string sandbox
     ; "runtime_handler", runtime_handler_to_string runtime_handler
+    ; ( "keeper_tool_group"
+      , keeper_tool_group_to_string
+          (keeper_tool_group_of_runtime_handler runtime_handler) )
+    ; "input_schema_source", input_schema_source_to_string input_schema_source
     ]
   in
   { id
+  ; keeper_model_projection
+  ; model_description_projection = Static_description
+  ; keeper_tool_group = keeper_tool_group_of_runtime_handler runtime_handler
+  ; input_schema_source
   ; public_name
   ; public_aliases
   ; internal_name
@@ -503,6 +616,8 @@ let descriptor_with_public_aliases
 
 let descriptor
       ?(examples = [])
+      ~keeper_model_projection
+      ~input_schema_source
       ~validate_translated_input
       ~id
       ~public_name
@@ -519,6 +634,8 @@ let descriptor
   =
   descriptor_with_public_aliases
     ~examples
+    ~keeper_model_projection
+    ~input_schema_source
     ~validate_translated_input
     ~public_aliases:[]
     ~id
@@ -541,6 +658,8 @@ let with_eval_tags eval_tags descriptor =
 
 let public_descriptors =
   [ descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.execute"
       ~public_name:"Execute"
       ~internal_name:"tool_execute"
@@ -603,6 +722,8 @@ let public_descriptors =
       ~translate:translate_identity
       ()
   ; descriptor_with_public_aliases
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.search_files"
       ~public_name:"Grep"
       ~public_aliases:[ "Search"; "search_files" ]
@@ -631,6 +752,8 @@ let public_descriptors =
       ~translate:translate_search_files
       ()
   ; descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.read_file"
       ~public_name:"Read"
       ~internal_name:"tool_read_file"
@@ -655,6 +778,8 @@ let public_descriptors =
       ~translate:translate_read_file
       ()
   ; descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.edit_file"
       ~public_name:"Edit"
       ~internal_name:"tool_edit_file"
@@ -679,6 +804,8 @@ let public_descriptors =
       ~translate:translate_edit_file
       ()
   ; descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.write_file"
       ~public_name:"Write"
       ~internal_name:"tool_write_file"
@@ -698,6 +825,8 @@ let public_descriptors =
       ~translate:translate_write_file
       ()
   ; descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.search_web"
       ~public_name:"WebSearch"
       ~internal_name:"masc_web_search"
@@ -723,6 +852,8 @@ let public_descriptors =
       ~translate:translate_identity
       ()
   ; descriptor
+      ~keeper_model_projection:Preferred_public_name
+      ~input_schema_source:Descriptor_owned
       ~id:"agent.fetch_web"
       ~public_name:"WebFetch"
       ~internal_name:"masc_web_fetch"
@@ -767,17 +898,6 @@ let empty_object_schema =
     ; "properties", `Assoc []
     ; "additionalProperties", `Bool false
     ]
-;;
-
-(* Workspace tools historically dispatched by name in [Keeper_tool_dispatch_runtime]
-   without input-schema validation — the underlying handlers (Board_tool,
-   Tool_library, Keeper_tool_task_runtime, Keeper_tool_voice_runtime, etc.) parse
-   their own input. The descriptor input_schema is informational only
-   (these tools are Hidden visibility; no LLM sees the schema). A
-   passthrough object schema preserves behavior. *)
-let passthrough_object_schema =
-  `Assoc
-    [ "type", `String "object"; "additionalProperties", `Bool true ]
 ;;
 
 let find_schema_input_opt schemas name =
@@ -865,10 +985,16 @@ let find_cluster_schema_opt name =
         | None -> find_masc_schema_opt name))
 ;;
 
-let required_base_schema_input name =
+let base_schema_input name =
   match find_base_schema_opt name with
-  | Some schema -> schema
-  | None -> unavailable_input_schema ("missing base tool schema for " ^ name)
+  | Some schema -> Canonical_registry, schema
+  | None ->
+    ( Missing_canonical_registry
+    , unavailable_input_schema ("missing base tool schema for " ^ name) )
+
+let model_projection_for_schema_source requested = function
+  | Descriptor_owned | Canonical_registry -> requested
+  | Missing_canonical_registry -> Dispatch_only
 
 
 let tool_search_schema =
@@ -953,16 +1079,16 @@ let person_note_set_schema =
     ]
 ;;
 
-let memory_search_schema =
-  required_base_schema_input "keeper_memory_search"
+let memory_search_schema_source, memory_search_schema =
+  base_schema_input "keeper_memory_search"
 ;;
 
-let memory_write_schema =
-  required_base_schema_input "keeper_memory_write"
+let memory_write_schema_source, memory_write_schema =
+  base_schema_input "keeper_memory_write"
 ;;
 
-let ide_annotate_schema =
-  required_base_schema_input "keeper_ide_annotate"
+let ide_annotate_schema_source, ide_annotate_schema =
+  base_schema_input "keeper_ide_annotate"
 ;;
 
 let masc_fusion_schema =
@@ -1070,8 +1196,12 @@ let write_in_process_policy ?(retryable = false) ?(inline_safe = false)
     ()
 ;;
 
-let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler =
+let in_process_descriptor_with_schema_source ~keeper_model_projection
+      ~input_schema_source ~id ~name ~description ~input_schema ~policy ~handler
+  =
   descriptor
+    ~keeper_model_projection
+    ~input_schema_source
     ~id
     ~public_name:name
     ~internal_name:name
@@ -1087,33 +1217,12 @@ let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler 
     ()
 ;;
 
-(* Cluster-dispatched tools (board / voice / task) share a single
-   [runtime_handler] variant but expose distinct [internal_name]s so each
-   tool retains its own descriptor entry and receipt evidence. The
-   [keeper_tool_in_process_runtime] handler routes by descriptor.internal_name. *)
-let cluster_descriptor ?(polling_read = false) ~id ~name ~description ~handler ~readonly
-      ~inline_safe ~maintenance_only
-      ()
+let in_process_descriptor ~keeper_model_projection ~id ~name ~description
+      ~input_schema ~policy ~handler
   =
-  if polling_read && not readonly then
-    invalid_arg "polling_read descriptors must declare readonly=true";
-  if inline_safe && not readonly then
-    invalid_arg "inline_safe descriptors must declare readonly=true";
-  let policy =
-    if readonly
-    then read_only_in_process_policy ~inline_safe ~maintenance_only ~polling_read ()
-    else write_in_process_policy ~inline_safe ~maintenance_only ()
-  in
-  let input_schema =
-    match find_cluster_schema_opt name with
-    | Some schema -> schema
-    | None
-      when Option.is_some
-             (Keeper_tool_name.masc_board_name_of_keeper_name name) ->
-      unavailable_input_schema ("missing board registry schema for " ^ name)
-    | None -> passthrough_object_schema
-  in
-  in_process_descriptor
+  in_process_descriptor_with_schema_source
+    ~keeper_model_projection
+    ~input_schema_source:Descriptor_owned
     ~id
     ~name
     ~description
@@ -1122,8 +1231,74 @@ let cluster_descriptor ?(polling_read = false) ~id ~name ~description ~handler ~
     ~handler
 ;;
 
+(* Cluster-dispatched tools (board / voice / task) share a single
+   [runtime_handler] variant but expose distinct [internal_name]s so each
+   tool retains its own descriptor entry and receipt evidence. The
+   [keeper_tool_in_process_runtime] handler routes by descriptor.internal_name. *)
+let cluster_policy ?(polling_read = false) ~readonly ~inline_safe ~maintenance_only
+      () =
+  if polling_read && not readonly then
+    invalid_arg "polling_read descriptors must declare readonly=true";
+  if inline_safe && not readonly then
+    invalid_arg "inline_safe descriptors must declare readonly=true";
+  if readonly
+  then read_only_in_process_policy ~inline_safe ~maintenance_only ~polling_read ()
+  else write_in_process_policy ~inline_safe ~maintenance_only ()
+;;
+
+let cluster_descriptor_with_schema_source ?(polling_read = false)
+      ~keeper_model_projection ~input_schema_source ~input_schema ~id ~name
+      ~description ~handler ~readonly ~inline_safe ~maintenance_only () =
+  let policy =
+    cluster_policy ~polling_read ~readonly ~inline_safe ~maintenance_only ()
+  in
+  in_process_descriptor_with_schema_source
+    ~keeper_model_projection
+    ~input_schema_source
+    ~id
+    ~name
+    ~description
+    ~input_schema
+    ~policy
+    ~handler
+;;
+
+let cluster_descriptor ?(polling_read = false) ~keeper_model_projection ~id ~name
+      ~description ~handler ~readonly ~inline_safe ~maintenance_only
+      ()
+  =
+  let input_schema_source, input_schema =
+    match find_cluster_schema_opt name with
+    | Some schema -> Canonical_registry, schema
+    | None ->
+      ( Missing_canonical_registry
+      , unavailable_input_schema ("missing canonical registry schema for " ^ name) )
+  in
+  let keeper_model_projection =
+    model_projection_for_schema_source keeper_model_projection input_schema_source
+  in
+  cluster_descriptor_with_schema_source
+    ~polling_read
+    ~keeper_model_projection
+    ~input_schema_source
+    ~input_schema
+    ~id
+    ~name
+    ~description
+    ~handler
+    ~readonly
+    ~inline_safe
+    ~maintenance_only
+    ()
+;;
+
+let with_current_task_state_description descriptor =
+  { descriptor with model_description_projection = Current_task_state }
+;;
+
 let board_descriptor name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("keeper.board." ^ String.sub name (String.length "keeper_board_")
          (String.length name - String.length "keeper_board_"))
     ~name
@@ -1144,13 +1319,13 @@ let masc_board_descriptor board_name =
     | Some readonly -> readonly
     | None -> List.mem name Board_tool_dispatch.tool_spec_read_only
   in
+  let visibility, keeper_model_projection =
+    match Keeper_tool_name.board_projection_of_masc_board_name board_name with
+    | Keeper_tool_name.Direct_masc -> metadata.visibility, Internal_name
+    | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
+      Tool_catalog.Hidden, Dispatch_only
+  in
   let policy =
-    let visibility =
-      match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-      | Keeper_tool_name.Direct_masc -> metadata.visibility
-      | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
-        Tool_catalog.Hidden
-    in
     policy
       ~visibility
       ~readonly
@@ -1164,13 +1339,15 @@ let masc_board_descriptor board_name =
       (Board_tool_registry.identity_fields_for_board_name board_name)
       schema.input_schema
   in
-  in_process_descriptor
-    ~id:("masc.board." ^ Tool_name.Board_name.operation_name board_name)
-    ~name
-    ~description:schema.description
-    ~input_schema
-    ~policy
-    ~handler:Tool_masc_board_dispatch
+  in_process_descriptor_with_schema_source
+       ~keeper_model_projection
+       ~input_schema_source:Canonical_registry
+       ~id:("masc.board." ^ Tool_name.Board_name.operation_name board_name)
+       ~name
+       ~description:schema.description
+       ~input_schema
+       ~policy
+       ~handler:Tool_masc_board_dispatch
 ;;
 
 let masc_board_descriptors =
@@ -1179,6 +1356,7 @@ let masc_board_descriptors =
 
 let voice_descriptor name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("keeper.voice." ^ String.sub name (String.length "keeper_voice_")
          (String.length name - String.length "keeper_voice_"))
     ~name
@@ -1192,6 +1370,7 @@ let voice_descriptor name description ~readonly =
 
 let task_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("keeper.task." ^ id)
     ~name
     ~description
@@ -1211,6 +1390,20 @@ let task_descriptor id name description ~readonly =
    through the existing typed dispatcher. *)
 let masc_task_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
+    ~id:("masc.task." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_task_dispatch
+    ~readonly
+    ~inline_safe:false
+    ~maintenance_only:false
+    ()
+;;
+
+let masc_task_transport_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~keeper_model_projection:Dispatch_only
     ~id:("masc.task." ^ id)
     ~name
     ~description
@@ -1223,6 +1416,7 @@ let masc_task_descriptor id name description ~readonly =
 
 let masc_plan_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.plan." ^ id)
     ~name
     ~description
@@ -1235,6 +1429,7 @@ let masc_plan_descriptor id name description ~readonly =
 
 let masc_run_descriptor name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.run." ^ String.sub name (String.length "masc_run_")
          (String.length name - String.length "masc_run_"))
     ~name
@@ -1248,6 +1443,7 @@ let masc_run_descriptor name description ~readonly =
 
 let masc_agent_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.agent." ^ id)
     ~name
     ~description
@@ -1258,17 +1454,30 @@ let masc_agent_descriptor id name description ~readonly =
     ()
 ;;
 
-let masc_workspace_descriptor ?(maintenance_only = false) id
-      name description ~readonly
+let masc_workspace_descriptor id name description ~readonly
   =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.workspace." ^ id)
     ~name
     ~description
     ~handler:Tool_masc_workspace_dispatch
     ~readonly
     ~inline_safe:false
-    ~maintenance_only
+    ~maintenance_only:false
+    ()
+;;
+
+let masc_workspace_maintenance_descriptor id name description ~readonly =
+  cluster_descriptor
+    ~keeper_model_projection:Dispatch_only
+    ~id:("masc.workspace." ^ id)
+    ~name
+    ~description
+    ~handler:Tool_masc_workspace_dispatch
+    ~readonly
+    ~inline_safe:false
+    ~maintenance_only:true
     ()
 ;;
 
@@ -1276,6 +1485,7 @@ let masc_workspace_descriptor ?(maintenance_only = false) id
    misc / control / agent_timeline / local_runtime). *)
 let masc_misc_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.misc." ^ id)
     ~name
     ~description
@@ -1288,6 +1498,7 @@ let masc_misc_descriptor id name description ~readonly =
 
 let masc_control_descriptor id name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:("masc.control." ^ id)
     ~name
     ~description
@@ -1300,6 +1511,7 @@ let masc_control_descriptor id name description ~readonly =
 
 let masc_agent_timeline_descriptor name description ~readonly =
   cluster_descriptor
+    ~keeper_model_projection:Internal_name
     ~id:"masc.agent_timeline"
     ~name
     ~description
@@ -1312,23 +1524,24 @@ let masc_agent_timeline_descriptor name description ~readonly =
 
 let masc_schedule_descriptor (definition : Tool_schemas_schedule.definition) =
   let schema : Masc_domain.tool_schema = definition.schema in
-  { (cluster_descriptor
-       ~id:("masc.schedule." ^ definition.id)
-       ~name:schema.name
-       ~description:schema.description
-       ~handler:Tool_masc_schedule_dispatch
-       ~readonly:definition.read_only
-       ~inline_safe:false
-       ~maintenance_only:false
-       ())
-    with
-    input_schema = schema.input_schema
-  }
+  cluster_descriptor_with_schema_source
+    ~keeper_model_projection:Internal_name
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:("masc.schedule." ^ definition.id)
+    ~name:schema.name
+    ~description:schema.description
+    ~handler:Tool_masc_schedule_dispatch
+    ~readonly:definition.read_only
+    ~inline_safe:false
+    ~maintenance_only:false
+    ()
 ;;
 
 let masc_keeper_descriptor ?(polling_read = false) id name description ~readonly =
   cluster_descriptor
     ~polling_read
+    ~keeper_model_projection:Internal_name
     ~id:("masc.keeper." ^ id)
     ~name
     ~description
@@ -1339,9 +1552,87 @@ let masc_keeper_descriptor ?(polling_read = false) id name description ~readonly
     ()
 ;;
 
+let masc_library_descriptor (definition : Tool_schemas_library.definition) =
+  let schema = definition.schema in
+  let keeper_model_projection, description =
+    match definition.operation with
+    | Tool_schemas_library.List_documents ->
+      ( Internal_name
+      , "List all documents in the agent knowledge library with title, confidence, \
+         source, and tags. Use keeper_library_read to fetch a document or \
+         keeper_library_search to query by content." )
+    | Tool_schemas_library.Read_document
+    | Tool_schemas_library.Search_documents -> Dispatch_only, schema.description
+    | Tool_schemas_library.Add_document
+    | Tool_schemas_library.Promote_document -> Internal_name, schema.description
+  in
+  cluster_descriptor_with_schema_source
+    ~keeper_model_projection
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:("masc.library." ^ Tool_schemas_library.operation_id definition.operation)
+    ~name:schema.name
+    ~description
+    ~handler:Tool_masc_library_dispatch
+    ~readonly:definition.read_only
+    ~inline_safe:false
+    ~maintenance_only:false
+    ()
+;;
+
+let masc_library_descriptors =
+  List.map masc_library_descriptor Tool_schemas_library.definitions
+;;
+
+let masc_recurring_descriptor (definition : Tool_schemas_recurring.definition) =
+  let schema = definition.schema in
+  cluster_descriptor_with_schema_source
+    ~keeper_model_projection:Internal_name
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:("masc.recurring." ^ Tool_schemas_recurring.operation_id definition.operation)
+    ~name:schema.name
+    ~description:schema.description
+    ~handler:Tool_masc_recurring_dispatch
+    ~readonly:definition.read_only
+    ~inline_safe:false
+    ~maintenance_only:false
+    ()
+;;
+
+let masc_recurring_descriptors =
+  List.map masc_recurring_descriptor Tool_schemas_recurring.definitions
+;;
+
+let masc_local_runtime_descriptor
+      (definition : Tool_schemas_local_runtime.definition) =
+  let schema = definition.schema in
+  cluster_descriptor_with_schema_source
+    ~keeper_model_projection:Internal_name
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:
+      ("masc.local_runtime."
+       ^ Tool_schemas_local_runtime.operation_id definition.operation)
+    ~name:schema.name
+    ~description:schema.description
+    ~handler:Tool_masc_local_runtime_dispatch
+    ~readonly:true
+    ~inline_safe:false
+    ~maintenance_only:false
+    ()
+;;
+
+let masc_local_runtime_descriptors =
+  List.map
+    masc_local_runtime_descriptor
+    Tool_schemas_local_runtime.definitions
+;;
+
 let internal_descriptors : t list =
   [ (* ── time / catalog (RFC-0179 PR-2 + PR-3) ────────── *)
     in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.time.now"
       ~name:"keeper_time_now"
       ~description:
@@ -1351,6 +1642,7 @@ let internal_descriptors : t list =
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_time_now
   ; (in_process_descriptor
+       ~keeper_model_projection:Internal_name
        ~id:"keeper.tools_list"
        ~name:"keeper_tools_list"
        ~description:
@@ -1363,6 +1655,7 @@ let internal_descriptors : t list =
        ~handler:Tool_tools_list
      |> with_eval_tags [ "capability_introspection" ])
   ; (in_process_descriptor
+       ~keeper_model_projection:Internal_name
        ~id:"keeper.tool_search"
        ~name:"keeper_tool_search"
        ~description:
@@ -1374,6 +1667,7 @@ let internal_descriptors : t list =
      |> with_eval_tags [ "capability_introspection" ])
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.context.status"
       ~name:"keeper_context_status"
       ~description:
@@ -1382,7 +1676,10 @@ let internal_descriptors : t list =
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_context_status
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~keeper_model_projection:
+        (model_projection_for_schema_source Internal_name memory_search_schema_source)
+      ~input_schema_source:memory_search_schema_source
       ~id:"keeper.memory.search"
       ~name:"keeper_memory_search"
       ~description:
@@ -1390,7 +1687,10 @@ let internal_descriptors : t list =
       ~input_schema:memory_search_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_memory_search
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~keeper_model_projection:
+        (model_projection_for_schema_source Internal_name memory_write_schema_source)
+      ~input_schema_source:memory_write_schema_source
       ~id:"keeper.memory.write"
       ~name:"keeper_memory_write"
       ~description:"Persist a memory entry for this keeper."
@@ -1399,6 +1699,7 @@ let internal_descriptors : t list =
       ~handler:Tool_memory_write
     (* ── library (RFC-0179 PR-3) ──────────────────────────────── *)
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.library.search"
       ~name:"keeper_library_search"
       ~description:"Search the keeper library catalog."
@@ -1406,6 +1707,7 @@ let internal_descriptors : t list =
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_search
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.library.read"
       ~name:"keeper_library_read"
       ~description:"Read a library entry by id."
@@ -1414,6 +1716,7 @@ let internal_descriptors : t list =
       ~handler:Tool_library_read
     (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
   ; (in_process_descriptor
+       ~keeper_model_projection:Internal_name
        ~id:"keeper.surface.read"
        ~name:"keeper_surface_read"
        ~description:
@@ -1429,6 +1732,7 @@ let internal_descriptors : t list =
        ~handler:Tool_surface_read
      |> with_eval_tags [ "surface_context_read" ])
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.surface.post"
       ~name:"keeper_surface_post"
       ~description:
@@ -1439,6 +1743,7 @@ let internal_descriptors : t list =
       ~policy:(write_in_process_policy ())
       ~handler:Tool_surface_post
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.person.note_set"
       ~name:"keeper_person_note_set"
       ~description:
@@ -1450,7 +1755,10 @@ let internal_descriptors : t list =
       ~policy:(write_in_process_policy ())
       ~handler:Tool_person_note_set
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
-  ; in_process_descriptor
+  ; in_process_descriptor_with_schema_source
+      ~keeper_model_projection:
+        (model_projection_for_schema_source Internal_name ide_annotate_schema_source)
+      ~input_schema_source:ide_annotate_schema_source
       ~id:"keeper.ide.annotate"
       ~name:"keeper_ide_annotate"
       ~description:"Emit an IDE annotation event for the current keeper."
@@ -1459,6 +1767,7 @@ let internal_descriptors : t list =
       ~handler:Tool_ide_annotate
     (* ── fusion deliberation (RFC-0252) ───────────────────────── *)
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"masc.fusion.deliberate"
       ~name:"masc_fusion"
       ~description:
@@ -1476,15 +1785,14 @@ let internal_descriptors : t list =
          their answers with web_search / web_fetch. Gated by runtime.toml \
          [fusion] (disabled by default)."
       ~input_schema:masc_fusion_schema
-      (* RFC-0252 §159/§177: 심의 가치는 키퍼(이미 LLM)가 스스로 판단해
-         masc_fusion 을 직접 호출하는 것으로 표현된다. 따라서 키퍼가 LLM 도구
-         목록에서 이 도구를 볼 수 있어야 한다 → visibility=Default. 다른
-         in-process write 도구의 기본값(Hidden, playground_write 공통)을 그대로
-         쓰면 키퍼가 도구를 못 봐 자율 호출이 불가능해 RFC 의도와 모순된다. *)
+      (* RFC-0252 §159/§177: the explicit [Internal_name] projection above
+         makes Fusion available to the Keeper model. Catalog visibility remains
+         metadata only and no longer decides Keeper exposure. *)
       ~policy:(write_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_masc_fusion_dispatch
     (* ── fusion status (RFC-0266 §7 Phase 3) ──────────────────── *)
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"masc.fusion.status"
       ~name:"masc_fusion_status"
       ~description:
@@ -1498,14 +1806,13 @@ let internal_descriptors : t list =
          start a deliberation. In-memory and server-lifetime: runs do not \
          survive a restart."
       ~input_schema:masc_fusion_status_schema
-      (* read-only, but visibility=Default so the keeper LLM can poll its own
-         fusion runs (sibling to masc_fusion, which is also Default). Without
-         the override read_only_in_process_policy defaults to Hidden and the
-         keeper could not see the tool. *)
+      (* [Internal_name] is the model exposure authority. Keep the catalog
+         visibility metadata unchanged in this migration-only slice. *)
       ~policy:(read_only_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_masc_fusion_status
     (* ── vision delegation (RFC-keeper-vision-delegation-tool §2.6) ─ *)
   ; in_process_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"keeper.vision.analyze_image"
       ~name:"analyze_image"
       ~description:
@@ -1517,9 +1824,8 @@ let internal_descriptors : t list =
          invalid_request | no_capable_runtime | empty_extraction | \
          truncated_extraction | timeout | provider_error)."
       ~input_schema:analyze_image_schema
-      (* read-only (a sub-call, no side effects) but visibility=Default so the
-         keeper LLM can see and call it — read_only_in_process_policy defaults to
-         Hidden (same gotcha as masc_fusion_status above). *)
+      (* [Internal_name] keeps the read-only vision sub-call model-visible;
+         catalog visibility remains separate metadata. *)
       ~policy:(read_only_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_analyze_image
     (* ── voice cluster (RFC-0179 PR-3, 6 tools) ───────────────── *)
@@ -1650,10 +1956,11 @@ let internal_descriptors : t list =
       "Add multiple tasks in a single call." ~readonly:false
   ; masc_task_descriptor "task_history" "masc_task_history"
       "Read history events for a task." ~readonly:true
-  ; masc_task_descriptor "tasks" "masc_tasks"
+  ; masc_task_transport_descriptor "tasks" "masc_tasks"
       "List tasks visible to the caller." ~readonly:true
-  ; masc_task_descriptor "transition" "masc_transition"
-      "Transition a task to a new status." ~readonly:false
+  ; (masc_task_descriptor "transition" "masc_transition"
+       "Transition a task to a new status." ~readonly:false
+     |> with_current_task_state_description)
   ; masc_task_descriptor "update_priority" "masc_update_priority"
       "Update the priority of a task." ~readonly:false
   ; masc_task_descriptor "set_goal" "masc_task_set_goal"
@@ -1699,7 +2006,9 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_workspace_* cluster (8 entries) ────────── *)
   ; masc_workspace_descriptor "status" "masc_status"
       "Read overall workspace status." ~readonly:true
-  ; masc_workspace_descriptor ~maintenance_only:true "heartbeat" "masc_heartbeat"
+  ; masc_workspace_maintenance_descriptor
+      "heartbeat"
+      "masc_heartbeat"
       "Emit an agent heartbeat." ~readonly:false
   ; masc_workspace_descriptor "check" "masc_check"
       "Read a workspace assertion check." ~readonly:true
@@ -1709,6 +2018,11 @@ let internal_descriptors : t list =
       "List workspace goals." ~readonly:true
   ; masc_workspace_descriptor "goal_upsert" "masc_goal_upsert"
       "Create or update a workspace goal." ~readonly:false
+  ; masc_workspace_descriptor
+      "goal_hygiene_review"
+      "masc_goal_hygiene_review"
+      "Review Goal Store hygiene and optionally block executable hygiene violations."
+      ~readonly:false
   ; masc_workspace_descriptor "goal_transition" "masc_goal_transition"
       "Transition a goal status." ~readonly:false
   ; masc_workspace_descriptor "goal_verify" "masc_goal_verify"
@@ -1726,6 +2040,9 @@ let internal_descriptors : t list =
       "Read tool-usage statistics." ~readonly:true
   ; masc_misc_descriptor "tool_help" "masc_tool_help"
       "Read help text for a tool name." ~readonly:true
+  ; masc_misc_descriptor "gc" "masc_gc"
+      "Run workspace garbage collection and return the collection result."
+      ~readonly:false
   (* [masc_web_search] / [masc_web_fetch] are already owned by the
      MASC-owned web descriptors above. Do not add
      duplicate internal descriptors here; that would make runtime receipt
@@ -1777,6 +2094,7 @@ let internal_descriptors : t list =
       "Bring a keeper online (create new or update existing)." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_surface_audit singleton ────────────── *)
   ; cluster_descriptor
+      ~keeper_model_projection:Internal_name
       ~id:"masc.surface.audit"
       ~name:"masc_surface_audit"
       ~description:"Read dashboard surface readiness snapshot (optionally for a single surface)."
@@ -1787,19 +2105,41 @@ let internal_descriptors : t list =
       ()
   ]
   @ masc_board_descriptors
+  @ masc_library_descriptors
+  @ masc_recurring_descriptors
+  @ masc_local_runtime_descriptors
 ;;
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 
+let keeper_model_names descriptor =
+  match descriptor.input_schema_source, descriptor.keeper_model_projection with
+  | Missing_canonical_registry, _ -> []
+  | (Descriptor_owned | Canonical_registry), Preferred_public_name ->
+    [ descriptor.public_name ]
+  | (Descriptor_owned | Canonical_registry), Internal_name ->
+    [ descriptor.internal_name ]
+  | (Descriptor_owned | Canonical_registry), Dispatch_only -> []
+;;
+
+let keeper_candidate_names descriptor =
+  match descriptor.input_schema_source, descriptor.keeper_model_projection with
+  | Missing_canonical_registry, _ -> []
+  | (Descriptor_owned | Canonical_registry), Preferred_public_name ->
+    descriptor.public_name :: descriptor.internal_name :: descriptor.public_aliases
+    |> List.sort_uniq String.compare
+  | (Descriptor_owned | Canonical_registry), Internal_name ->
+    [ descriptor.internal_name ]
+  | (Descriptor_owned | Canonical_registry), Dispatch_only -> []
+;;
+
 let model_visible_descriptors () =
-  let visible_internal_descriptors =
-    internal_descriptors
-    |> List.filter (fun descriptor ->
-      match descriptor.policy.visibility with
-      | Tool_catalog.Default -> true
-      | Tool_catalog.Hidden -> false)
-  in
-  public_descriptors @ visible_internal_descriptors
+  all_descriptors ()
+  |> List.filter (fun descriptor ->
+    match descriptor.input_schema_source, keeper_model_names descriptor with
+    | Missing_canonical_registry, _ -> false
+    | (Descriptor_owned | Canonical_registry), [] -> false
+    | (Descriptor_owned | Canonical_registry), _ :: _ -> true)
 ;;
 
 let public_names_of_descriptor d = d.public_name :: d.public_aliases
@@ -1918,6 +2258,8 @@ let route_evidence_json d =
   let policy = d.policy in
   `Assoc
     ([ "descriptor_id", `String d.id
+     ; ( "keeper_model_projection"
+       , `String (keeper_model_projection_to_string d.keeper_model_projection) )
      ; "public_name", `String d.public_name
      ; "canonical_name", `String d.internal_name
      ; "description", `String d.description
@@ -1945,6 +2287,13 @@ let discovery_fields d =
     | examples -> [ "examples", `List examples ]
   in
   [ "id", `String d.id
+  ; ( "keeper_model_projection"
+    , `String (keeper_model_projection_to_string d.keeper_model_projection) )
+  ; ( "model_description_projection"
+    , `String
+        (model_description_projection_to_string d.model_description_projection) )
+  ; "keeper_tool_group", `String (keeper_tool_group_to_string d.keeper_tool_group)
+  ; "input_schema_source", `String (input_schema_source_to_string d.input_schema_source)
   ; "public_name", `String d.public_name
   ; "public_aliases", Json_util.json_string_list d.public_aliases
   ; "internal_name", `String d.internal_name

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -27,6 +27,43 @@ type approval =
   | Policy_selected
   | Human_required
 
+(** One explicit Keeper-model exposure choice per descriptor. Compatibility
+    aliases remain routable at transport boundaries but never become a second
+    model-facing name. [Dispatch_only] keeps an internal runtime route out of
+    the Keeper model surface. *)
+type keeper_model_projection =
+  | Preferred_public_name
+  | Internal_name
+  | Dispatch_only
+
+(** Descriptor-owned model description enrichment. The dynamic task-state
+    context is explicit metadata rather than an internal-name comparison in
+    the OAS bundle assembler. *)
+type model_description_projection =
+  | Static_description
+  | Current_task_state
+
+(** Typed display group for Keeper capability discovery. *)
+type keeper_tool_group =
+  | Execute_group
+  | Search_files_group
+  | Filesystem_group
+  | Board_group
+  | Voice_group
+  | Workspace_group
+  | Surface_group
+  | Memory_group
+  | Meta_group
+  | Core_group
+
+(** Provenance of the descriptor input schema. A missing canonical cluster
+    schema makes that descriptor dispatch-only and is reported by the schema
+    injection boundary. *)
+type input_schema_source =
+  | Descriptor_owned
+  | Canonical_registry
+  | Missing_canonical_registry
+
 type readonly_of_input = Yojson.Safe.t -> bool option
 
 type runtime_handler =
@@ -64,6 +101,9 @@ type runtime_handler =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch
   | Tool_analyze_image
 
 type policy =
@@ -81,6 +121,10 @@ type policy =
 
 type t =
   { id : string
+  ; keeper_model_projection : keeper_model_projection
+  ; model_description_projection : model_description_projection
+  ; keeper_tool_group : keeper_tool_group
+  ; input_schema_source : input_schema_source
   ; public_name : string
   ; public_aliases : string list
   ; internal_name : string
@@ -110,6 +154,10 @@ val executor_to_string : executor -> string
 val backend_to_string : backend -> string
 val sandbox_to_string : sandbox -> string
 val approval_to_string : approval -> string
+val keeper_model_projection_to_string : keeper_model_projection -> string
+val model_description_projection_to_string : model_description_projection -> string
+val keeper_tool_group_to_string : keeper_tool_group -> string
+val input_schema_source_to_string : input_schema_source -> string
 val runtime_handler_to_string : runtime_handler -> string
 
 (** [public_descriptors] is the LLM-native public surface (RFC-0064 hard-cut).
@@ -128,10 +176,18 @@ val internal_descriptors : t list
     descriptor-backed tool, regardless of LLM-native vs workspace origin. *)
 val all_descriptors : unit -> t list
 
-(** [model_visible_descriptors ()] is [public_descriptors] plus internal
-    descriptors whose policy visibility is [Default]. Hidden internal
-    descriptors remain executable only through non-model dispatcher paths. *)
+(** Descriptors with one explicit model-facing projection and a resolved input
+    schema. Missing canonical schemas are fail-closed. *)
 val model_visible_descriptors : unit -> t list
+
+(** The sole active Keeper model name. Empty only for [Dispatch_only]. *)
+val keeper_model_names : t -> string list
+
+(** Names admitted by the Keeper execution/candidate boundary. A preferred
+    public descriptor retains compatibility aliases and its internal handler
+    route for transport/runtime dispatch. Only [keeper_model_names] controls
+    the model schema, so these aliases cannot become duplicate model tools. *)
+val keeper_candidate_names : t -> string list
 
 val public_names_of_descriptor : t -> string list
 val public_names : unit -> string list

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -189,6 +189,10 @@ val keeper_model_names : t -> string list
     the model schema, so these aliases cannot become duplicate model tools. *)
 val keeper_candidate_names : t -> string list
 
+(** Every name owned by a descriptor, including dispatch-only names. This is
+    for name-integrity checks, never Keeper execution admission. *)
+val registered_names : t -> string list
+
 val public_names_of_descriptor : t -> string list
 val public_names : unit -> string list
 val internal_names : t -> string list

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -65,7 +65,7 @@ let dedupe_tool_search_schemas schemas =
 ;;
 
 let default_tool_search_schemas () =
-  descriptor_model_tool_schemas () |> dedupe_tool_search_schemas
+  all_keeper_model_tool_schemas () |> dedupe_tool_search_schemas
 ;;
 
 let score_tool_schema terms (schema : Masc_domain.tool_schema) =

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -65,8 +65,7 @@ let dedupe_tool_search_schemas schemas =
 ;;
 
 let default_tool_search_schemas () =
-  Tool_shard.all_keeper_tool_schemas @ [ keeper_tool_search_schema ]
-  |> dedupe_tool_search_schemas
+  descriptor_model_tool_schemas () |> dedupe_tool_search_schemas
 ;;
 
 let score_tool_schema terms (schema : Masc_domain.tool_schema) =
@@ -431,6 +430,9 @@ let tool_tutor_for_validation ~tool_name ~input =
      | Keeper_tool_descriptor.Tool_masc_surface_audit
      | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
      | Keeper_tool_descriptor.Tool_masc_fusion_status
+     | Keeper_tool_descriptor.Tool_masc_library_dispatch
+     | Keeper_tool_descriptor.Tool_masc_recurring_dispatch
+     | Keeper_tool_descriptor.Tool_masc_local_runtime_dispatch
      | Keeper_tool_descriptor.Tool_analyze_image -> None)
 ;;
 
@@ -453,8 +455,80 @@ let add_tool_tutor_to_payload raw_payload tutor =
   Yojson.Safe.to_string (append_assoc_fields json [ "tool_tutor", tutor ])
 ;;
 
-(* Workspace tools dispatch through [Keeper_tool_runtime.handle_internal].
+(* Descriptor and registered-only routes are distinct dispatch sources.
    Outcome is inferred from raw JSON via [classify_tool_result_payload]. *)
+
+type descriptor_dispatch =
+  | Descriptor_route of Keeper_tool_descriptor.t * string option
+  | Validation_rejected of string
+  | Undescribed_route
+
+type descriptor_dispatch_resolution =
+  | Return_output of string
+  | Return_descriptor_invariant of Keeper_tool_descriptor.t
+  | Try_registered_only_route
+
+let resolve_descriptor_dispatch = function
+  | Descriptor_route (_, Some raw_output) | Validation_rejected raw_output ->
+    Return_output raw_output
+  | Descriptor_route (descriptor, None) -> Return_descriptor_invariant descriptor
+  | Undescribed_route -> Try_registered_only_route
+;;
+
+let descriptor_route_invariant_payload ~tool_name descriptor =
+  let descriptor_id = descriptor.Keeper_tool_descriptor.id in
+  let executor =
+    Keeper_tool_descriptor.executor_to_string descriptor.executor
+  in
+  let runtime_handler =
+    Keeper_tool_descriptor.runtime_handler_to_string descriptor.runtime_handler
+  in
+  `Assoc
+    [ "ok", `Bool false
+    ; "error", `String "keeper_tool_descriptor_route_invariant"
+    ; "failure_class", `String "runtime_failure"
+    ; "tool", `String tool_name
+    ; "descriptor_id", `String descriptor_id
+    ; "executor", `String executor
+    ; "runtime_handler", `String runtime_handler
+    ]
+;;
+
+let descriptor_route_invariant_error ~keeper_name ~tool_name descriptor =
+  let payload = descriptor_route_invariant_payload ~tool_name descriptor in
+  let descriptor_id = descriptor.Keeper_tool_descriptor.id in
+  let executor =
+    Keeper_tool_descriptor.executor_to_string descriptor.executor
+  in
+  let runtime_handler =
+    Keeper_tool_descriptor.runtime_handler_to_string descriptor.runtime_handler
+  in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string AgentToolDispatchRuntimeFailures)
+    ~labels:
+      [ "keeper", keeper_name
+      ; "tool", tool_name
+      ; "reason", "descriptor_route_unhandled"
+      ; "descriptor_id", descriptor_id
+      ; "executor", executor
+      ; "runtime_handler", runtime_handler
+      ]
+    ();
+  Log.Keeper.emit
+    Log.Error
+    ~keeper_name
+    ~category:Log.Tool
+    ~details:
+      (`Assoc
+         [ "error_kind", `String "keeper_tool_descriptor_route_invariant"
+         ; "tool", `String tool_name
+         ; "descriptor_id", `String descriptor_id
+         ; "executor", `String executor
+         ; "runtime_handler", `String runtime_handler
+         ])
+    "keeper descriptor route resolved but its typed runtime handler returned no result";
+  Yojson.Safe.to_string payload
+;;
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)
 
@@ -618,17 +692,19 @@ let execute_keeper_tool_call_with_outcome
            ; mcp_session_id
            }
        in
-       let descriptor_output =
+       let descriptor_dispatch =
          match
            Keeper_tool_descriptor_resolution.validated_descriptor_and_input_for_tool_call
              ~tool_name:name
              ~input:args
          with
          | Some (Ok (descriptor, translated_args)) ->
-           Keeper_tool_runtime.handle
-             keeper_tool_runtime_context
-             ~descriptor
-             ~args:translated_args
+           Descriptor_route
+             ( descriptor
+             , Keeper_tool_runtime.handle
+                 keeper_tool_runtime_context
+                 ~descriptor
+                 ~args:translated_args )
          | Some (Error validation_result) ->
            let raw_payload = Yojson.Safe.to_string (Tool_result.data validation_result) in
            let raw_payload =
@@ -636,15 +712,21 @@ let execute_keeper_tool_call_with_outcome
              | Some tutor -> add_tool_tutor_to_payload raw_payload tutor
              | None -> raw_payload
            in
-           Some raw_payload
-         | None -> Keeper_tool_runtime.handle_internal keeper_tool_runtime_context ~name ~args
+           Validation_rejected raw_payload
+         | None -> Undescribed_route
        in
-       match descriptor_output with
-       | Some raw_output -> make_executed_tool_result raw_output
-       | None ->
-         (* Descriptor-backed dispatch did not recognize this name. Check
-            registered backend tools before returning a suggestion-enriched
-            unknown-tool error. *)
+       match resolve_descriptor_dispatch descriptor_dispatch with
+       | Return_output raw_output -> make_executed_tool_result raw_output
+       | Return_descriptor_invariant descriptor ->
+         make_executed_tool_result
+           (descriptor_route_invariant_error
+              ~keeper_name:meta.name
+              ~tool_name:name
+              descriptor)
+       | Try_registered_only_route ->
+         (* Registered-only tools are a separate dispatch source. A descriptor
+            route that resolves but returns [None] is handled above as a typed
+            invariant failure and can never fall through to this backend. *)
          let unknown_name = name in
          (match
             Keeper_tool_registered_runtime.handle_registered_tool
@@ -760,8 +842,21 @@ let execute_keeper_tool_call
 ;;
 
 module For_testing = struct
+  type descriptor_route_kind =
+    | Output
+    | Invariant
+    | Registered_only
+
   let set_on_keeper_tool_call = set_on_keeper_tool_call
   let record_keeper_tool_call = record_keeper_tool_call
   let set_tool_search_fn = set_tool_search_fn
   let search_tools = search_tools
+  let descriptor_route_invariant_payload = descriptor_route_invariant_payload
+
+  let descriptor_route_kind ~descriptor ~output =
+    match resolve_descriptor_dispatch (Descriptor_route (descriptor, output)) with
+    | Return_output _ -> Output
+    | Return_descriptor_invariant _ -> Invariant
+    | Try_registered_only_route -> Registered_only
+  ;;
 end

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -17,8 +17,8 @@ val keeper_universe_tool_names : keeper_meta -> string list
 (** Keeper-facing runtime candidate names before policy filtering. *)
 val keeper_internal_candidate_tool_names : string list
 
-(** Universe model tool schemas.  Returns schemas for all universe tools
-    so [make_tools] can build {!Agent_sdk.Tool.t} for the full search scope. *)
+(** Descriptor-projected universe model schemas. [make_tools] consumes the
+    same closed surface; non-descriptor schema fallback is forbidden. *)
 val keeper_universe_model_tools : keeper_meta -> Masc_domain.tool_schema list
 
 (** Tool-access scoped universe: configured candidate profile list + core_always - denied.
@@ -81,6 +81,11 @@ val dedupe_tool_names : string list -> string list
 
 (** Test-only hooks for the global recorder/searcher refs converted to Atomic.t. *)
 module For_testing : sig
+  type descriptor_route_kind =
+    | Output
+    | Invariant
+    | Registered_only
+
   val set_on_keeper_tool_call
     : (tool_name:string -> success:bool -> duration_ms:int -> unit) -> unit
 
@@ -91,6 +96,16 @@ module For_testing : sig
     : (query:string -> max_results:int -> Yojson.Safe.t) -> unit
 
   val search_tools : query:string -> max_results:int -> Yojson.Safe.t
+
+  val descriptor_route_invariant_payload
+    :  tool_name:string
+    -> Keeper_tool_descriptor.t
+    -> Yojson.Safe.t
+
+  val descriptor_route_kind
+    :  descriptor:Keeper_tool_descriptor.t
+    -> output:string option
+    -> descriptor_route_kind
 end
 
 (** Inject all masc_* schemas for keeper descriptor/registry surface filtering.

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -397,7 +397,7 @@ let handle_masc_task ~(config : Workspace.config) ~(meta : keeper_meta) ~name ~a
   let ctx : Task.Tool.context =
     { config; agent_name = meta.name; sw = None }
   in
-  Task.Tool.dispatch ctx ~name ~args |> dispatch_option_to_string ~name
+  Task.Tool.dispatch_for_keeper ctx ~name ~args |> dispatch_option_to_string ~name
 ;;
 
 let handle_masc_plan ~(config : Workspace.config) ~name ~args =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -184,22 +184,88 @@ let keeper_supported_masc_tool_names_from_schemas schemas =
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
   |> dedupe_tool_names
 
+type descriptor_coverage =
+  | Projected
+  | Dispatch_only
+  | Missing_descriptor
+  | Missing_canonical_schema
+  | Duplicate_descriptors
+
+let missing_canonical_schema_names descriptors =
+  descriptors
+  |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
+    match descriptor.input_schema_source with
+    | Keeper_tool_descriptor.Missing_canonical_registry ->
+      Some descriptor.internal_name
+    | Keeper_tool_descriptor.Descriptor_owned
+    | Keeper_tool_descriptor.Canonical_registry -> None)
+  |> List.sort_uniq String.compare
+;;
+
+let descriptor_coverage_for_internal_name name =
+  match Keeper_tool_descriptor.descriptors_for_internal name with
+  | [] -> Missing_descriptor
+  | [ descriptor ] ->
+    (match descriptor.Keeper_tool_descriptor.input_schema_source with
+     | Keeper_tool_descriptor.Missing_canonical_registry -> Missing_canonical_schema
+     | Keeper_tool_descriptor.Descriptor_owned
+     | Keeper_tool_descriptor.Canonical_registry ->
+       if List.mem name (Keeper_tool_descriptor.keeper_candidate_names descriptor)
+       then Projected
+       else Dispatch_only)
+  | _ :: _ :: _ -> Duplicate_descriptors
+;;
+
 let inject_masc_schemas (schemas : Masc_domain.tool_schema list) =
-  set_masc_schemas (keeper_supported_masc_schemas schemas)
+  let supported = keeper_supported_masc_schemas schemas in
+  let projected, missing, missing_schemas, duplicates =
+    List.fold_left
+      (fun (projected, missing, missing_schemas, duplicates)
+           (schema : Masc_domain.tool_schema) ->
+         match descriptor_coverage_for_internal_name schema.name with
+         | Projected -> schema :: projected, missing, missing_schemas, duplicates
+         | Dispatch_only -> projected, missing, missing_schemas, duplicates
+         | Missing_descriptor ->
+           projected, schema.name :: missing, missing_schemas, duplicates
+         | Missing_canonical_schema ->
+           projected, missing, schema.name :: missing_schemas, duplicates
+         | Duplicate_descriptors ->
+           projected, missing, missing_schemas, schema.name :: duplicates)
+      ([], [], [], [])
+      supported
+  in
+  let missing = List.sort_uniq String.compare missing in
+  let missing_schemas =
+    (missing_schemas
+     @ missing_canonical_schema_names (Keeper_tool_descriptor.all_descriptors ()))
+    |> List.sort_uniq String.compare
+  in
+  let duplicates = List.sort_uniq String.compare duplicates in
+  (match missing, missing_schemas, duplicates with
+   | [], [], [] -> ()
+   | _, _, _ ->
+     Log.Keeper.emit
+       Log.Error
+       ~keeper_name:"system"
+       ~category:Log.Tool
+       ~details:
+         (`Assoc
+            [ "error_kind", `String "invalid_keeper_tool_descriptor_coverage"
+            ; "tool_names", Json_util.json_string_list missing
+            ; "missing_schema_tool_names", Json_util.json_string_list missing_schemas
+            ; "duplicate_tool_names", Json_util.json_string_list duplicates
+            ])
+       "keeper tool schema projection rejected");
+  set_masc_schemas (List.rev projected)
 
 let is_keeper_maintenance_only_tool name =
   List.mem name (Keeper_tool_descriptor.keeper_maintenance_only_names ())
 
-(* ── Candidate aggregation (descriptor/registry-driven) ───────── *)
-
-let tool_schema_names schemas =
-  List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas
+(* ── Candidate aggregation (descriptor-driven) ────────────────── *)
 
 let descriptor_candidate_tool_names () =
   Keeper_tool_descriptor.all_descriptors ()
-  |> List.concat_map (fun descriptor ->
-    Keeper_tool_descriptor.public_names_of_descriptor descriptor
-    @ Keeper_tool_descriptor.internal_names descriptor)
+  |> List.concat_map Keeper_tool_descriptor.keeper_candidate_names
   |> List.filter is_keeper_model_board_route
   |> dedupe_tool_names
 
@@ -208,10 +274,8 @@ let keeper_base_candidate_tool_names () =
      Denylist filtering only; no secondary allowlist layer. *)
   dedupe_tool_names
     ( effective_core_tools ()
-    @ tool_schema_names Tool_shard.all_keeper_tool_schemas
     @ descriptor_candidate_tool_names ()
-    @ keeper_internal_candidate_tool_names
-    @ injected_masc_tool_names () )
+    )
   |> List.filter is_keeper_model_board_route
   |> List.filter (fun name -> not (is_keeper_maintenance_only_tool name))
 
@@ -392,9 +456,9 @@ let keeper_universe_tool_names (meta : keeper_meta) : string list =
 let keeper_tool_search_scope = keeper_universe_tool_names
 
 let descriptor_model_tool_schemas () =
-  Keeper_tool_descriptor.all_descriptors ()
+  Keeper_tool_descriptor.model_visible_descriptors ()
   |> List.concat_map (fun (descriptor : Keeper_tool_descriptor.t) ->
-    Keeper_tool_descriptor.internal_names descriptor
+    Keeper_tool_descriptor.keeper_model_names descriptor
     |> List.filter is_keeper_model_board_route
     |> List.map (fun name ->
       { Masc_domain.name
@@ -403,19 +467,11 @@ let descriptor_model_tool_schemas () =
       }))
   |> dedupe_tool_schemas
 
-(** Shared schema assembly: computes the full tool schema list once.
-    [masc_schemas_fn] selects policy-filtered or universe-filtered MASC schemas
-    depending on the caller's access scope. Descriptor-backed internal tools
-    are first so descriptor-owned schemas win dedupe over older shard entries,
-    and so descriptor-only tools such as [masc_fusion] cannot appear in
-    candidate names without a matching Agent.run [Tool.t]. *)
-let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schema list)
-    (meta : keeper_meta) : Masc_domain.tool_schema list =
+(** The model schema surface is descriptor-only. Shard and injected schemas
+    remain handler/schema inputs, but never act as a permissive exposure
+    fallback when a descriptor is absent. *)
+let all_keeper_schemas () : Masc_domain.tool_schema list =
   descriptor_model_tool_schemas ()
-  @ keeper_model_tools
-  @ keeper_voice_tool_schemas
-  @ [ keeper_tool_search_schema ]
-  @ (masc_schemas_fn meta)
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup
     instead of List.mem (O(n) per schema). *)
@@ -430,14 +486,14 @@ let filter_schemas_by_names (names : string list)
     Returns schemas for the active descriptor/registry surface minus denied tools. *)
 let keeper_model_tool_schemas (meta : keeper_meta) : Masc_domain.tool_schema list =
   let scoped = keeper_tool_search_scope meta in
-  all_keeper_schemas ~masc_schemas_fn:keeper_universe_masc_tool_schemas meta
+  all_keeper_schemas ()
   |> filter_schemas_by_names scoped
 
 (** Universe model tool schemas for make_tools.
     Returns schemas for all universe tools so Agent.run() can call them. *)
 let keeper_universe_model_tools (meta : keeper_meta) : Masc_domain.tool_schema list =
   let universe = keeper_universe_tool_names meta in
-  all_keeper_schemas ~masc_schemas_fn:keeper_universe_masc_tool_schemas meta
+  all_keeper_schemas ()
   |> filter_schemas_by_names universe
 
 (* ── Tool description lookup (for prompt auto-hints) ─────────── *)
@@ -499,17 +555,11 @@ let required_hints_of_schema (schema : Yojson.Safe.t) : string =
     else "required: " ^ String.concat ", " names
   | _ -> ""
 
-(** Lookup tool description by name from all available schema sources.
+(** Lookup tool description by name from the descriptor-owned model surface.
     Returns [Some first_sentence] + optional enum/required hints if found, [None] otherwise.
-    Searches shard-resolved tools (voice included via shard), inline schemas,
-    injected masc_* schemas, and tool_search schema. *)
+    Non-descriptor schemas cannot re-enter the model prompt through hints. *)
 let tool_hint_of (name : string) : string option =
-  let all_schemas =
-    Tool_shard.keeper_model_tools
-    @ [ Keeper_tool_registry.keeper_tool_search_schema ]
-    @ Tool_schemas_inline.schemas
-    @ masc_schemas_snapshot ()
-  in
+  let all_schemas = descriptor_model_tool_schemas () in
   match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) all_schemas with
   | Some s ->
     let base = first_sentence s.description in

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -455,7 +455,7 @@ let keeper_universe_tool_names (meta : keeper_meta) : string list =
     a named alias for call-site clarity at the search-index boundary. *)
 let keeper_tool_search_scope = keeper_universe_tool_names
 
-let descriptor_model_tool_schemas () =
+let all_keeper_model_tool_schemas () =
   Keeper_tool_descriptor.model_visible_descriptors ()
   |> List.concat_map (fun (descriptor : Keeper_tool_descriptor.t) ->
     Keeper_tool_descriptor.keeper_model_names descriptor
@@ -471,7 +471,7 @@ let descriptor_model_tool_schemas () =
     remain handler/schema inputs, but never act as a permissive exposure
     fallback when a descriptor is absent. *)
 let all_keeper_schemas () : Masc_domain.tool_schema list =
-  descriptor_model_tool_schemas ()
+  all_keeper_model_tool_schemas ()
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup
     instead of List.mem (O(n) per schema). *)
@@ -559,7 +559,7 @@ let required_hints_of_schema (schema : Yojson.Safe.t) : string =
     Returns [Some first_sentence] + optional enum/required hints if found, [None] otherwise.
     Non-descriptor schemas cannot re-enter the model prompt through hints. *)
 let tool_hint_of (name : string) : string option =
-  let all_schemas = descriptor_model_tool_schemas () in
+  let all_schemas = all_keeper_model_tool_schemas () in
   match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) all_schemas with
   | Some s ->
     let base = first_sentence s.description in

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -15,9 +15,15 @@ module StringSet : Set.S with type elt = string
 
 val is_keeper_safe_inline_tool : string -> bool
 
-(** Filter and inject MASC schemas for keeper tool selection.
-    Call once after MASC schemas are registered. *)
+(** Filter and inject descriptor-backed MASC handler schemas.
+    Dispatch-only routes are retained outside the model surface. A supported
+    schema with no descriptor, duplicate descriptors, or any descriptor with a
+    missing canonical schema is rejected and emitted as a structured error. *)
 val inject_masc_schemas : Masc_domain.tool_schema list -> unit
+
+(** Pure diagnostic projection used by startup validation and invariant tests. *)
+val missing_canonical_schema_names :
+  Keeper_tool_descriptor.t list -> string list
 
 (** Filter raw schemas down to the masc_* subset a keeper can actually see. *)
 val keeper_supported_masc_schemas :
@@ -106,10 +112,11 @@ val keeper_tool_search_scope : keeper_meta -> string list
 
 (** {1 Tool Schema Assembly} *)
 
-(** Universe model tool schemas for Agent.run(). *)
+(** Descriptor-projected universe model schemas for Agent.run(). No shard or
+    injected-schema fallback is admitted. *)
 val keeper_universe_model_tools : keeper_meta -> Masc_domain.tool_schema list
 
-(** Active descriptor/registry model tool schemas for BM25 indexing. *)
+(** Active descriptor-projected model tool schemas for BM25 indexing. *)
 val keeper_model_tool_schemas : keeper_meta -> Masc_domain.tool_schema list
 
 (** Filter schemas by a set of allowed names.  O(1) per schema. *)
@@ -122,7 +129,7 @@ val dedupe_tool_schemas :
 
 (** {1 Tool Description Lookup} *)
 
-(** Lookup tool hint (first sentence + enum/required hints) by name.
+(** Lookup a descriptor-projected tool hint by model name.
     Returns [None] for unknown tools. *)
 val tool_hint_of : string -> string option
 

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -112,6 +112,11 @@ val keeper_tool_search_scope : keeper_meta -> string list
 
 (** {1 Tool Schema Assembly} *)
 
+(** Complete descriptor-projected Keeper model schema inventory before
+    per-Keeper candidate and deny filtering. No shard or injected-schema
+    fallback is admitted. *)
+val all_keeper_model_tool_schemas : unit -> Masc_domain.tool_schema list
+
 (** Descriptor-projected universe model schemas for Agent.run(). No shard or
     injected-schema fallback is admitted. *)
 val keeper_universe_model_tools : keeper_meta -> Masc_domain.tool_schema list

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -91,9 +91,8 @@ let base_core_tools =
 
 let core_discovery_tools =
   base_core_tools
-  (* RFC-0064/RFC-016x: public capability names replace internal names
-     in the LLM-facing discovery surface. *)
-  @ Keeper_tool_descriptor.public_names ()
+  @ (Keeper_tool_descriptor.public_descriptors
+     |> List.concat_map Keeper_tool_descriptor.keeper_model_names)
 ;;
 
 (* [effective_core_tools] is defined below (see "Universe-aware effective core
@@ -337,7 +336,7 @@ let effective_core_tools () =
         Set_util.StringSet.mem
           d.Keeper_tool_descriptor.internal_name
           universe_set)
-    |> List.concat_map Keeper_tool_descriptor.public_names_of_descriptor
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
   in
   base_core_tools @ descriptor_publics
 ;;

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -19,8 +19,8 @@ type tried_source =
   | Registry_internal_candidate (** S5: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** S6: Keeper_tool_registry.effective_core_tools *)
   | Tool_schema                 (** S7: policy tool-schema inventory name extraction *)
-  | Descriptor_registry         (** S7.5: Keeper_tool_descriptor.all_descriptors public_name —
-                                    flat SSOT incl. internal_descriptors (masc_keeper_* live here) *)
+  | Descriptor_registry         (** S7.5: candidate names projected by
+                                    Keeper_tool_descriptor.all_descriptors *)
   | System_internal             (** S8: Tool_catalog_surfaces.is_system_internal_hidden —
                                     system-internal tools (masc_gc, masc_reset,
                                     masc_cleanup_zombies, …) dispatched via tool_misc and
@@ -83,16 +83,13 @@ let resolve name =
       else if
         List.exists
           (fun (d : Keeper_tool_descriptor.t) ->
-             String.equal d.Keeper_tool_descriptor.public_name normalized)
+             List.mem normalized (Keeper_tool_descriptor.keeper_candidate_names d))
           (Keeper_tool_descriptor.all_descriptors ())
       then
-        (* Flat descriptor registry. Descriptor-backed tools live in
-           [public_descriptors @ internal_descriptors]. masc_keeper_* (dispatched
-           via Keeper_tool_surface.dispatch, not the handler registry) sit in
-           internal_descriptors and were orphaned from resolution when #19797
-           purged the surface lists. This flat-name source restores admission
-           without touching dispatch — resolve is a validity gate; [via] is only
-           used for the error string. *)
+        (* Only Keeper-candidate descriptor names are admitted here. A
+           dispatch-only descriptor still owns runtime metadata, but must not
+           shadow the later System_internal source or become a Keeper tool by
+           virtue of existing in the descriptor registry. *)
         Resolved { canonical = normalized; via = Descriptor_registry }
       else if Tool_catalog_surfaces.is_system_internal_hidden normalized then
         (* System-internal tools (masc_gc, masc_reset, masc_cleanup_zombies, …)

--- a/lib/keeper/keeper_tool_resolution.ml
+++ b/lib/keeper/keeper_tool_resolution.ml
@@ -19,7 +19,7 @@ type tried_source =
   | Registry_internal_candidate (** S5: Keeper_tool_registry.keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** S6: Keeper_tool_registry.effective_core_tools *)
   | Tool_schema                 (** S7: policy tool-schema inventory name extraction *)
-  | Descriptor_registry         (** S7.5: candidate names projected by
+  | Descriptor_registry         (** S7.5: registered names projected by
                                     Keeper_tool_descriptor.all_descriptors *)
   | System_internal             (** S8: Tool_catalog_surfaces.is_system_internal_hidden —
                                     system-internal tools (masc_gc, masc_reset,
@@ -83,13 +83,12 @@ let resolve name =
       else if
         List.exists
           (fun (d : Keeper_tool_descriptor.t) ->
-             List.mem normalized (Keeper_tool_descriptor.keeper_candidate_names d))
+             List.mem normalized (Keeper_tool_descriptor.registered_names d))
           (Keeper_tool_descriptor.all_descriptors ())
       then
-        (* Only Keeper-candidate descriptor names are admitted here. A
-           dispatch-only descriptor still owns runtime metadata, but must not
-           shadow the later System_internal source or become a Keeper tool by
-           virtue of existing in the descriptor registry. *)
+        (* This resolver validates names embedded in prompt/continuity text; it
+           does not grant Keeper execution. Registered dispatch-only names must
+           therefore remain valid without entering the candidate projection. *)
         Resolved { canonical = normalized; via = Descriptor_registry }
       else if Tool_catalog_surfaces.is_system_internal_hidden normalized then
         (* System-internal tools (masc_gc, masc_reset, masc_cleanup_zombies, …)
@@ -145,7 +144,7 @@ let all_admitting_sources name =
   if
     List.exists
       (fun (d : Keeper_tool_descriptor.t) ->
-        String.equal d.Keeper_tool_descriptor.public_name normalized)
+        List.mem normalized (Keeper_tool_descriptor.registered_names d))
       (Keeper_tool_descriptor.all_descriptors ())
   then sources := Descriptor_registry :: !sources;
   if Tool_catalog_surfaces.is_system_internal_hidden normalized then

--- a/lib/keeper/keeper_tool_resolution.mli
+++ b/lib/keeper/keeper_tool_resolution.mli
@@ -13,7 +13,8 @@ type tried_source =
   | Registry_internal_candidate (** keeper_internal_candidate_tool_names *)
   | Registry_core_tools         (** effective_core_tools *)
   | Tool_schema                 (** Tool_shard.all_keeper_tool_schemas + inline schemas *)
-  | Descriptor_registry         (** Keeper_tool_descriptor.all_descriptors public_name (flat SSOT) *)
+  | Descriptor_registry         (** Keeper-tool candidate names projected by
+                                    Keeper_tool_descriptor.all_descriptors *)
   | System_internal             (** Tool_catalog_surfaces.is_system_internal_hidden — system-internal
                                     tools hidden from keeper surfaces but still real/dispatchable *)
 

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -77,6 +77,9 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch
   | Tool_analyze_image -> None
 ;;
 
@@ -134,6 +137,9 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch
   | Tool_analyze_image -> None
 ;;
 
@@ -316,6 +322,14 @@ let handle_in_process ctx descriptor args =
          ~meta:ctx.meta
          ~args
          ())
+  | Tool_masc_library_dispatch
+  | Tool_masc_recurring_dispatch
+  | Tool_masc_local_runtime_dispatch ->
+    Keeper_tool_registered_runtime.handle_registered_tool
+      ~config:ctx.config
+      ~keeper_name:ctx.meta.name
+      ~name
+      ~args
   | Tool_analyze_image ->
     (* read-only vision sub-call; needs [net] (like masc_fusion), threaded from
        the turn-scoped dispatch context. *)
@@ -339,10 +353,4 @@ let handle ctx ~descriptor ~args =
   | Filesystem -> handle_filesystem ctx descriptor args
   | Shell_ir -> handle_shell_ir ctx descriptor args
   | In_process -> handle_in_process ctx descriptor args
-;;
-
-let handle_internal ctx ~name ~args =
-  match descriptor_for_internal name with
-  | None -> None
-  | Some descriptor -> handle ctx ~descriptor ~args
 ;;

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -27,5 +27,3 @@ val descriptor_for_internal : string -> Keeper_tool_descriptor.t option
 
 val handle :
   context -> descriptor:Keeper_tool_descriptor.t -> args:Yojson.Safe.t -> string option
-
-val handle_internal : context -> name:string -> args:Yojson.Safe.t -> string option

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -949,11 +949,8 @@ let tag_dispatch_fn
 ;;
 
 let descriptor_active_names active_name_set descriptor =
-  let descriptor_names =
-    Keeper_tool_descriptor.public_names_of_descriptor descriptor
-    @ Keeper_tool_descriptor.internal_names descriptor
-  in
-  List.filter (fun name -> StringSet.mem name active_name_set) descriptor_names
+  Keeper_tool_descriptor.keeper_model_names descriptor
+  |> List.filter (fun name -> StringSet.mem name active_name_set)
 ;;
 
 let descriptor_discovery_json active_name_set descriptor =
@@ -966,37 +963,31 @@ let descriptor_discovery_json active_name_set descriptor =
 ;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
-  let names = Keeper_tool_policy.keeper_allowed_tool_names meta in
   let active_name_set =
-    List.fold_left
-      (fun acc name -> StringSet.add name acc)
-      StringSet.empty
-      names
+    Keeper_tool_policy.keeper_model_tool_schemas meta
+    |> List.fold_left
+         (fun names (schema : Masc_domain.tool_schema) ->
+            StringSet.add schema.name names)
+         StringSet.empty
   in
-  let has_prefix prefix name = String.starts_with ~prefix name in
-  (* Display-only grouping for the keeper tools list. The typed [tool_group]
-     classifier was deleted in the surface-cut refactor; this prefix categorizer
-     (formerly the fallback for non-typed names) now categorizes all names. *)
-  let categorize n =
-    if has_prefix "keeper_board_" n || has_prefix "masc_board_" n then "board"
-    else if has_prefix "keeper_voice_" n then "voice"
-    else if has_prefix "keeper_task_" n || has_prefix "keeper_tasks_" n then "workspace"
-    else if has_prefix "keeper_surface_" n || has_prefix "keeper_person_note_" n then "surface"
-    else if String.equal n "tool_execute" then "execute"
-    else if String.equal n "tool_search_files" then "search_files"
-    else if has_prefix "tool_" n then "fs"
-    else if has_prefix "keeper_library_" n || has_prefix "keeper_memory_" n then "memory"
-    else if has_prefix "keeper_" n then "meta"
-    else "core"
+  let active_descriptor_names =
+    Keeper_tool_descriptor.model_visible_descriptors ()
+    |> List.concat_map (fun descriptor ->
+      Keeper_tool_descriptor.keeper_model_names descriptor
+      |> List.filter_map (fun name ->
+        if StringSet.mem name active_name_set then Some (name, descriptor) else None))
   in
   let map =
     List.fold_left
-      (fun acc n ->
-         let cat = categorize n in
+      (fun acc (name, descriptor) ->
+         let cat =
+           Keeper_tool_descriptor.keeper_tool_group_to_string
+             descriptor.Keeper_tool_descriptor.keeper_tool_group
+         in
          let list = StringMap.find_opt cat acc |> Option.value ~default:[] in
-         StringMap.add cat (n :: list) acc)
+         StringMap.add cat (name :: list) acc)
       StringMap.empty
-      names
+      active_descriptor_names
   in
   let assoc =
     StringMap.fold
@@ -1005,7 +996,12 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
       []
   in
   let descriptor_surface =
-    Keeper_tool_descriptor_resolution.descriptors_for_tool_names names
+    active_descriptor_names
+    |> List.map snd
+    |> List.sort_uniq
+         (fun (left : Keeper_tool_descriptor.t)
+              (right : Keeper_tool_descriptor.t) ->
+            String.compare left.id right.id)
     |> List.map (descriptor_discovery_json active_name_set)
   in
   Yojson.Safe.to_string

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -593,6 +593,7 @@ let handle_keeper_task_tool
        if needs_start then begin
          let start_result =
            Task.Tool.handle_transition
+             ~task_list_projection:Tool_capability_projection.Keeper_tasks_list
              ~tool_name:"keeper_auto_start"
              ~start_time:0.0
              { Task.Tool.config; agent_name = keeper_agent_sender ~meta;
@@ -894,6 +895,7 @@ let handle_keeper_task_tool
       in
       let transition_result =
         Task.Tool.handle_transition
+          ~task_list_projection:Tool_capability_projection.Keeper_tasks_list
           ~tool_name:"keeper_task_done"
           ~start_time:0.0
           {

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -1,8 +1,8 @@
 (** Tool bundle assembly for keeper OAS execution.
 
-    [make_tool_bundle] builds the full [tool_bundle] (internal tools +
-    alias-registered public names) and [make_tools] is the convenience
-    wrapper returning only [.tools].
+    [make_tool_bundle] builds the full [tool_bundle] from each descriptor's
+    single explicit Keeper-model projection, and [make_tools] is the
+    convenience wrapper returning only [.tools].
 
     Extracted from [Keeper_tools_oas_handler] to keep that module
     focused on per-tool handler construction. *)
@@ -12,7 +12,8 @@ open Keeper_tools_oas
 let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) : string =
   let meta = Keeper_current_task_reconcile.sync_current_task_id_from_backlog ~config meta in
   match meta.current_task_id with
-  | None -> "No task currently assigned. Use keeper_task_claim or masc_tasks to find one."
+  | None ->
+    "No task currently assigned. Use keeper_task_claim or keeper_tasks_list to find one."
   | Some tid ->
     let task_id = Keeper_id.Task_id.to_string tid in
     (match Workspace_backlog.read_backlog_r config with
@@ -51,88 +52,27 @@ let make_tool_bundle
      (AllowList filter in before_turn_hook) controls LLM visibility;
      execute_keeper_tool_call uses can_execute for the execution gate. *)
   let universe_names = Keeper_tool_dispatch_runtime.keeper_universe_tool_names meta in
-  let tool_defs = Keeper_tool_dispatch_runtime.keeper_universe_model_tools meta in
-  (* RFC-0064 Phase 2 (Copilot review #14662 threads 5/6): aliased internal
-     names backing public aliases must NOT appear on
-     the LLM-visible surface alongside their public alias.  Mirrors the
-     pattern already established in [keeper_run_tools.ml] PRs #14574/#14596. *)
+  (* Every model-visible tool is materialized from one explicit descriptor
+     projection. Shard/injected schemas remain descriptor inputs but cannot
+     create a fallback model tool when descriptor coverage is absent. *)
   let model_visible_descriptors = Keeper_tool_descriptor.model_visible_descriptors () in
-  let aliased_internal_names =
-    model_visible_descriptors
-    |> List.map Keeper_tool_descriptor.internal_names
-    |> List.concat
-  in
   let failure_counts = create_failure_counts () in
-  (* Pass A: internal tools that have no public alias.  Aliased internals
-     are registered only via Pass B under their public name so the LLM
-     surface holds at most one entry per logical tool. *)
-  let internal_tools =
-    List.filter_map
-      (fun (td : Masc_domain.tool_schema) ->
-         if
-           List.mem td.name universe_names
-           && not (List.mem td.name aliased_internal_names)
-         then (
-           let h =
-             Keeper_tools_oas_handler.make_keeper_tool_handler
-               ~name:td.name
-               ~input_schema:td.input_schema
-               ~config
-                 ~meta
-                 ~ctx_snapshot
-                 ?turn_sandbox_factory
-                 ~exec_cache
-               ?search_fn
-               ?on_tool_called
-               ?clock
-               ~failure_counts
-               ()
-           in
-           let description =
-             if String.equal td.name "masc_transition"
-             then td.description ^ "\n\n" ^ task_state_hint ~config ~meta
-             else td.description
-           in
-           Some
-             (Tool_bridge.oas_tool_of_masc
-                ~name:td.name
-                ~description
-                ~input_schema:td.input_schema
-                (fun input -> h input)))
-         else None)
-      tool_defs
-  in
-  (* Pass B: register LLM-native capability names (Execute/Read/etc)
-     via descriptor projection. The handler dispatches with
+  (* The handler dispatches with
      [~name:descriptor.internal_name] so all telemetry SSOT remains internal;
-     only the Tool.schema.name (LLM-visible) is the public name.
+     exactly one projected Tool.schema.name is model-visible.
      [descriptor.translate] reshapes the LLM's payload before dispatch;
      [descriptor.input_schema] provides the LLM-facing schema. *)
-  let alias_tools =
+  let descriptor_tools =
     List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
-         if not (List.mem internal universe_names)
-         then []
-         else (
-           (* Descriptor-backed aliases own their public schema.  Some aliases
-              (notably WebSearch/WebFetch) can be present in the descriptor
-              universe before the injected masc_* schema snapshot is populated. *)
-           let handler_input_schema =
-             match
-               List.find_opt
-                 (fun (td : Masc_domain.tool_schema) -> String.equal td.name internal)
-                 tool_defs
-             with
-             | Some internal_def -> internal_def.input_schema
-             | None -> descriptor.input_schema
-           in
-           Keeper_tool_descriptor.public_names_of_descriptor descriptor
-           |> List.map (fun public_name ->
+         Keeper_tool_descriptor.keeper_model_names descriptor
+         |> List.filter (fun model_name -> List.mem model_name universe_names)
+         |> List.map (fun model_name ->
              let h =
                Keeper_tools_oas_handler.make_keeper_tool_handler
                  ~name:internal
-                 ~input_schema:handler_input_schema
+                 ~input_schema:descriptor.input_schema
                  ~config
                    ~meta
                    ~ctx_snapshot
@@ -144,7 +84,7 @@ let make_tool_bundle
                  ~pre_validate_input:(fun input ->
                    match
                      Keeper_tool_descriptor_resolution.validate_public_input_for_tool_call
-                       ~tool_name:public_name
+                       ~tool_name:model_name
                        ~input
                    with
                  | Some result -> result
@@ -154,20 +94,25 @@ let make_tool_bundle
                  ~failure_counts
                  ()
              in
-             (* Public aliases (e.g. WebSearch) are not present in
-                [Tool_catalog] metadata, so derive the descriptor from the
-                internal name and pass it explicitly. *)
+             (* The projected model name may differ from the internal route,
+                so derive OAS metadata from the internal handler identity. *)
              let oas_descriptor = Tool_bridge.oas_descriptor_of_masc_tool internal in
+             let description =
+               match descriptor.model_description_projection with
+               | Keeper_tool_descriptor.Static_description -> descriptor.description
+               | Keeper_tool_descriptor.Current_task_state ->
+                 descriptor.description ^ "\n\n" ^ task_state_hint ~config ~meta
+             in
              Tool_bridge.oas_tool_of_masc
                ?descriptor:oas_descriptor
-               ~name:public_name
-               ~description:descriptor.description
+               ~name:model_name
+               ~description
                ~input_schema:descriptor.input_schema
-               (fun input -> h input))))
+               (fun input -> h input)))
       model_visible_descriptors
   in
   let bundle =
-      { tools = internal_tools @ alias_tools
+      { tools = descriptor_tools
       ; cleanup =
           (fun () ->
             Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory)

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -226,8 +226,6 @@ let public_mcp_non_descriptor_names =
      the surface entries without this allowlist edit while main was red. *)
   ; "masc_persona_create"
   ; "masc_persona_update"
-  ; "masc_runtime_verify"
-  ; "masc_runtime_ollama_probe"
   ]
 ;;
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -604,5 +604,5 @@ let execute_tool_eio
 let () =
   Workspace_dispatch_ref.dispatch
   := fun ~config ~agent_name ~name ~args ->
-    Tool_workspace.dispatch { config; agent_name } ~name ~args
+    Tool_workspace.dispatch_for_keeper { config; agent_name } ~name ~args
 ;;

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -21,7 +21,11 @@ let task_log_error ~task_id fmt =
     (fun message -> Log.Task.error "task_id=%s %s" task_id message)
     fmt
 
-let missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~action_s =
+let missing_live_task_transition_rejection ~task_list_projection ~tool_name
+      ~start_time ctx ~task_id ~action_s =
+  let task_list_name =
+    Tool_capability_projection.task_list_name task_list_projection
+  in
   sync_owner_current_task_binding ctx;
   sync_planning_current_task_with_owned_task ctx;
   task_log_warn ~task_id
@@ -33,13 +37,13 @@ let missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~
     ~start_time
     (workflow_rejection_payload_json
        ~rule_id:"stale_task_id_not_found"
-       ~tool_suggestion:"keeper_tasks_list"
+       ~tool_suggestion:task_list_name
        ~hint:
          "The requested task_id is absent from the live backlog. Do not retry \
-          this task_id from memory; refresh keeper_tasks_list or masc_tasks and \
+          this task_id from memory; refresh the projected task-list tool and \
           choose a live task."
        ~scope_policy:"observe"
-       ~alternatives:[ "keeper_tasks_list"; "masc_tasks"; "keeper_task_claim" ]
+       ~alternatives:[ task_list_name; "keeper_task_claim" ]
        ~extra_fields:
          [ "task_id", `String task_id
          ; "action", `String action_s
@@ -51,10 +55,12 @@ let missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~
            bindings and suppressed transition action=%s."
           task_id action_s))
 
-let rec handle_done ~tool_name ~start_time ctx args =
+let rec handle_done
+      ?(task_list_projection = Tool_capability_projection.External_masc_tasks)
+      ~tool_name ~start_time ctx args =
   let notes = get_string args "notes" "" in
   let evidence_refs = get_string_list args "evidence_refs" in
-  handle_transition ~tool_name ~start_time ctx
+  handle_transition ~task_list_projection ~tool_name ~start_time ctx
     (`Assoc
        [
          ("task_id", Json_util.assoc_member_opt "task_id" args |> Option.value ~default:`Null);
@@ -119,7 +125,12 @@ and handle_cancel_task ~tool_name ~start_time ctx args =
        task_log_error ~task_id "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
   result_to_response ~tool_name ~start_time result
 
-and handle_transition ~tool_name ~start_time ctx args =
+and handle_transition
+      ?(task_list_projection = Tool_capability_projection.External_masc_tasks)
+      ~tool_name ~start_time ctx args =
+  let task_list_name =
+    Tool_capability_projection.task_list_name task_list_projection
+  in
   (* Underscore-prefixed keys (e.g. "_agent_name") are internal protocol markers
      injected by the HTTP transport and dashboard client for identity
      propagation. They are consumed upstream in Client_identity and must not
@@ -212,7 +223,13 @@ and handle_transition ~tool_name ~start_time ctx args =
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
   match task_opt with
   | None ->
-    missing_live_task_transition_rejection ~tool_name ~start_time ctx ~task_id ~action_s
+    missing_live_task_transition_rejection
+      ~task_list_projection
+      ~tool_name
+      ~start_time
+      ctx
+      ~task_id
+      ~action_s
   | Some _ ->
   let release_owner_mismatch_rejection =
     match action, task_opt with
@@ -246,7 +263,7 @@ and handle_transition ~tool_name ~start_time ctx args =
                     on the board, or inspect and claim different unowned work."
                  ~scope_policy:"observe"
                  ~alternatives:
-                   [ "keeper_board_post"; "masc_board_post"; "keeper_tasks_list"; "keeper_task_claim" ]
+                   [ "keeper_board_post"; "masc_board_post"; task_list_name; "keeper_task_claim" ]
                  ~extra_fields:
                    [ "task_id", `String task_id
                    ; "task_status", `String status
@@ -304,26 +321,26 @@ and handle_transition ~tool_name ~start_time ctx args =
             "The task is still todo. Use masc_transition with action=claim for \
              this task_id, then action=start, and call keeper_task_done only \
              after the deliverable is complete."
-        , [ "masc_transition"; "keeper_task_claim"; "keeper_tasks_list" ] )
+        , [ "masc_transition"; "keeper_task_claim"; task_list_name ] )
       | Masc_domain.Task (Masc_domain.Task_error.AlreadyClaimed _) ->
         ( Some "task_done_requires_current_owner"
-        , Some "keeper_tasks_list"
+        , Some task_list_name
         , Some
             "Another agent owns this task. Inspect the task list, ask for handoff, \
              or claim different unowned work instead of retrying keeper_task_done."
-        , [ "keeper_tasks_list"; "keeper_board_post"; "keeper_task_claim" ] )
+        , [ task_list_name; "keeper_board_post"; "keeper_task_claim" ] )
       | Masc_domain.Task (Masc_domain.Task_error.InvalidState _) ->
         ( Some "task_done_invalid_lifecycle_state"
-        , Some "keeper_tasks_list"
+        , Some task_list_name
         , Some
             "The task lifecycle state does not accept keeper_task_done. Inspect \
              task status and use the valid next lifecycle action."
-        , [ "keeper_tasks_list"; "masc_transition" ] )
+        , [ task_list_name; "masc_transition" ] )
       | _ ->
         ( Some "task_done_lifecycle_rejected"
-        , Some "keeper_tasks_list"
+        , Some task_list_name
         , Some "Inspect the task status before trying another lifecycle action."
-        , [ "keeper_tasks_list"; "masc_transition" ] )
+        , [ task_list_name; "masc_transition" ] )
     in
     Tool_result.error
       ~failure_class:(Some Tool_result.Workflow_rejection)
@@ -350,14 +367,14 @@ and handle_transition ~tool_name ~start_time ctx args =
       ~start_time
       (workflow_rejection_payload_json
          ~rule_id:"task_transition_invalid_state"
-         ~tool_suggestion:"keeper_tasks_list"
+         ~tool_suggestion:task_list_name
          ~hint:
            "The requested lifecycle transition is not valid for the task's current \
             state. Inspect the task status and use a valid next action instead of \
             retrying the same transition."
          ~scope_policy:"observe"
          ~recoverable:false
-         ~alternatives:[ "keeper_tasks_list"; "masc_tasks"; "masc_transition" ]
+         ~alternatives:[ task_list_name; "masc_transition" ]
          ~extra_fields:
            [ "task_id", `String task_id
            ; "action", `String action_s
@@ -861,7 +878,7 @@ let handle_task_history ~tool_name ~start_time ctx args =
 
 include Tool_task_schemas
 (* Dispatch function *)
-let dispatch ctx ~name ~args : Tool_result.result option =
+let dispatch_with_task_list_projection task_list_projection ctx ~name ~args =
   let start = Time_compat.now () in
   match name with
   | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
@@ -871,9 +888,32 @@ let dispatch ctx ~name ~args : Tool_result.result option =
       if String.equal task_id ""
       then Some (handle_claim_next ~tool_name:name ~start_time:start ctx args)
       else Some (handle_claim ~tool_name:name ~start_time:start ctx args)
-  | "masc_transition" -> Some (handle_transition ~tool_name:name ~start_time:start ctx args)
+  | "masc_transition" ->
+    Some
+      (handle_transition
+         ~task_list_projection
+         ~tool_name:name
+         ~start_time:start
+         ctx
+         args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_task_set_goal" -> Some (handle_set_goal ~tool_name:name ~start_time:start ctx args)
   | "masc_tasks" -> Some (handle_tasks ~tool_name:name ~start_time:start ctx args)
   | "masc_task_history" -> Some (handle_task_history ~tool_name:name ~start_time:start ctx args)
   | _ -> None
+
+let dispatch ctx ~name ~args =
+  dispatch_with_task_list_projection
+    Tool_capability_projection.External_masc_tasks
+    ctx
+    ~name
+    ~args
+;;
+
+let dispatch_for_keeper ctx ~name ~args =
+  dispatch_with_task_list_projection
+    Tool_capability_projection.Keeper_tasks_list
+    ctx
+    ~name
+    ~args
+;;

--- a/lib/task/tool_task.mli
+++ b/lib/task/tool_task.mli
@@ -12,9 +12,13 @@ val handle_batch_add_tasks : tool_name:string -> start_time:float -> context -> 
 val handle_claim : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_claim_next : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_release : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_done : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_done :
+  ?task_list_projection:Tool_capability_projection.task_list ->
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_cancel_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
-val handle_transition : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
+val handle_transition :
+  ?task_list_projection:Tool_capability_projection.task_list ->
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_update_priority : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_tasks : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
 val handle_task_history : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.result
@@ -22,6 +26,14 @@ val task_history_events_json :
   Workspace_core.config -> task_id:string -> limit:int -> Yojson.Safe.t
 
 val dispatch :
+  context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  Tool_result.result option
+
+(** Keeper-model dispatch projects semantic task-list guidance to
+    [keeper_tasks_list] instead of the external [masc_tasks] transport name. *)
+val dispatch_for_keeper :
   context ->
   name:string ->
   args:Yojson.Safe.t ->

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -373,6 +373,14 @@ let public_mcp_set : (string, unit) Hashtbl.t =
 
 let is_public_mcp name = Hashtbl.mem public_mcp_set name
 
+let effective_registered_visibility ~name ~declared =
+  if
+    Tool_catalog_surfaces.is_system_internal_hidden name
+    && declared = Default
+  then Hidden
+  else declared
+;;
+
 let full_surface_override () = Env_config.Tools.full_surface_enabled ()
 
 (* ================================================================ *)

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -58,6 +58,12 @@ val public_mcp_tools : string list
 val is_public_mcp : string -> bool
 (** O(1) membership check against the public surface. *)
 
+val effective_registered_visibility :
+  name:string -> declared:visibility -> visibility
+(** Apply the immutable system-internal surface override used by
+    {!Tool_spec.register}. Definition builders can use this before runtime
+    registration without depending on mutable catalog initialization order. *)
+
 val full_surface_override : unit -> bool
 (** [true] when MASC_FULL_SURFACE=1 is set. *)
 

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -490,7 +490,8 @@ let tool_definitions = [
 
 let () =
   List.iter
-    (fun (s : Masc_domain.tool_schema) ->
+    (fun (definition : Tool_schemas_library.definition) ->
+      let s = definition.schema in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -498,8 +499,9 @@ let () =
            ~module_tag:Tool_dispatch.Mod_library
            ~input_schema:s.input_schema
            ~handler_binding:Tag_dispatch
+           ~is_read_only:definition.read_only
+           ~is_idempotent:definition.read_only
            ()))
-    Tool_schemas_library.schemas
+    Tool_schemas_library.definitions
 
 let schemas = Tool_schemas_library.schemas
-

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -253,11 +253,10 @@ let dispatch ctx ~name ~args : Core.tool_result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let tool_spec_read_only = [ "masc_runtime_verify"; "masc_runtime_ollama_probe" ]
-
 let () =
   List.iter
-    (fun (s : tool_schema) ->
+    (fun (definition : Tool_schemas_local_runtime.definition) ->
+      let s = definition.schema in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -265,9 +264,9 @@ let () =
            ~module_tag:Tool_dispatch.Mod_local_runtime
            ~input_schema:s.input_schema
            ~handler_binding:Tag_dispatch
-           ~is_read_only:(List.mem s.name tool_spec_read_only)
-           ~is_idempotent:(List.mem s.name tool_spec_read_only)
+           ~is_read_only:true
+           ~is_idempotent:true
            ()))
-    Tool_schemas_local_runtime.schemas
+    Tool_schemas_local_runtime.definitions
 
 let schemas = Tool_schemas_local_runtime.schemas

--- a/lib/tool_schemas/tool_schemas_library.ml
+++ b/lib/tool_schemas/tool_schemas_library.ml
@@ -4,9 +4,30 @@ open Masc_domain
 
 let valid_source_strings = [ "direct_experience"; "research"; "experiment"; "observation" ]
 
-let schemas : Masc_domain.tool_schema list = [
+type operation =
+  | List_documents
+  | Read_document
+  | Add_document
+  | Promote_document
+  | Search_documents
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+let operation_id = function
+  | List_documents -> "list"
+  | Read_document -> "read"
+  | Add_document -> "add"
+  | Promote_document -> "promote"
+  | Search_documents -> "search"
+;;
+
+let definitions : definition list = [
   (* masc_library_list *)
-  {
+  { operation = List_documents; read_only = true; schema = {
     name = "masc_library_list";
     description = "List all documents in the agent knowledge library with title, confidence, source, and tags. \
 Use when browsing available knowledge or checking if a topic is already documented. \
@@ -20,10 +41,10 @@ Pair with masc_library_read to fetch a specific document or masc_library_search 
         ]);
       ]);
     ];
-  };
+  } };
 
   (* masc_library_read *)
-  {
+  { operation = Read_document; read_only = true; schema = {
     name = "masc_library_read";
     description = "Read a specific library document by topic name or partial match. \
 Use when you need the full content of a known knowledge document. \
@@ -38,10 +59,10 @@ After masc_library_list or masc_library_search to find the topic name.";
       ]);
       ("required", `List [`String "topic"]);
     ];
-  };
+  } };
 
   (* masc_library_add *)
-  {
+  { operation = Add_document; read_only = false; schema = {
     name = "masc_library_add";
     description = "Add a new document to the agent knowledge library (confidence < 0.5 goes to candidates/ for review). \
 Use when recording a new finding, experiment result, or pattern that other agents should know about. \
@@ -77,10 +98,10 @@ Follow up with masc_library_promote to move candidates to the main library after
       ]);
       ("required", `List [`String "title"; `String "source"; `String "confidence"; `String "content"]);
     ];
-  };
+  } };
 
   (* masc_library_promote *)
-  {
+  { operation = Promote_document; read_only = false; schema = {
     name = "masc_library_promote";
     description = "Promote a candidate document to the main library after verification (new confidence must be >= 0.5). \
 Use when a candidate document has been reviewed and confirmed as accurate. \
@@ -99,10 +120,10 @@ After masc_library_add placed the document in candidates/.";
       ]);
       ("required", `List [`String "topic"; `String "confidence"]);
     ];
-  };
+  } };
 
   (* masc_library_search *)
-  {
+  { operation = Search_documents; read_only = true; schema = {
     name = "masc_library_search";
     description = "Search the agent knowledge library by content keywords or tags. \
 Use when looking for documents on a specific topic without knowing the exact title. \
@@ -116,5 +137,7 @@ Pair with masc_library_read to fetch matching documents in full.";
         ]);
       ]);
     ];
-  };
+  } };
 ]
+
+let schemas = List.map (fun definition -> definition.schema) definitions

--- a/lib/tool_schemas/tool_schemas_library.mli
+++ b/lib/tool_schemas/tool_schemas_library.mli
@@ -1,1 +1,16 @@
+type operation =
+  | List_documents
+  | Read_document
+  | Add_document
+  | Promote_document
+  | Search_documents
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+val operation_id : operation -> string
+val definitions : definition list
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -2,9 +2,23 @@
 
 open Masc_domain
 
-let schemas : Masc_domain.tool_schema list =
+type operation =
+  | Verify
+  | Ollama_probe
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  }
+
+let operation_id = function
+  | Verify -> "verify"
+  | Ollama_probe -> "ollama_probe"
+;;
+
+let definitions : definition list =
   [
-    {
+    { operation = Verify; schema = {
       name = "masc_runtime_verify";
       description =
         "Strictly verify the active provider/runtime contract used for swarm and benchmark runs. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and blocker codes such as provider_unreachable, provider_model_mismatch, slot_count_insufficient, ctx_mismatch, or chat_contract_incompatible.";
@@ -21,8 +35,8 @@ let schemas : Masc_domain.tool_schema list =
                   ("expected_ctx", `Assoc [ ("type", `String "integer") ]);
                 ] );
           ];
-    };
-    {
+    } };
+    { operation = Ollama_probe; schema = {
       name = "masc_runtime_ollama_probe";
       description =
         "Probe native Ollama timing behavior with repeated /api/generate calls. Returns loaded models from /api/ps, per-run load/prompt-eval/generation timings, tok/sec estimates, and a timing-based repeated-prefix reuse inference. This does not expose direct KV occupancy or hit-rate.";
@@ -69,5 +83,7 @@ let schemas : Masc_domain.tool_schema list =
                   ("run_generate", `Assoc [ ("type", `String "boolean") ]);
                 ] );
           ];
-    };
+    } };
   ]
+
+let schemas = List.map (fun definition -> definition.schema) definitions

--- a/lib/tool_schemas/tool_schemas_local_runtime.mli
+++ b/lib/tool_schemas/tool_schemas_local_runtime.mli
@@ -1,1 +1,12 @@
+type operation =
+  | Verify
+  | Ollama_probe
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  }
+
+val operation_id : operation -> string
+val definitions : definition list
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_schemas/tool_schemas_recurring.ml
+++ b/lib/tool_schemas/tool_schemas_recurring.ml
@@ -3,9 +3,26 @@
 
 open Masc_domain
 
-let schemas : Masc_domain.tool_schema list = [
+type operation =
+  | Add
+  | List
+  | Remove
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+let operation_id = function
+  | Add -> "add"
+  | List -> "list"
+  | Remove -> "remove"
+;;
+
+let definitions : definition list = [
   (* masc_recurring_add *)
-  {
+  { operation = Add; read_only = false; schema = {
     name = "masc_recurring_add";
     description = "Register a new recurring task for the calling keeper. \
 Returns task id, label, interval_sec, and enabled status on success. \
@@ -25,10 +42,10 @@ Fails if a task with the same label already exists for this keeper.";
       ]);
       ("required", `List [`String "label"; `String "interval_sec"]);
     ];
-  };
+  } };
 
   (* masc_recurring_list *)
-  {
+  { operation = List; read_only = true; schema = {
     name = "masc_recurring_list";
     description = "List recurring tasks registered by the calling keeper. \
 Returns task id, label, interval_sec, enabled status, last_run_ts, \
@@ -38,10 +55,10 @@ run_count, and failure_count for each task.";
       ("additionalProperties", `Bool false);
       ("properties", `Assoc []);
     ];
-  };
+  } };
 
   (* masc_recurring_remove *)
-  {
+  { operation = Remove; read_only = false; schema = {
     name = "masc_recurring_remove";
     description = "Remove a recurring task by its ID. Only tasks belonging to \
 the calling keeper can be removed. Returns success or not_found error.";
@@ -56,5 +73,7 @@ the calling keeper can be removed. Returns success or not_found error.";
       ]);
       ("required", `List [`String "id"]);
     ];
-  };
+  } };
 ]
+
+let schemas = List.map (fun definition -> definition.schema) definitions

--- a/lib/tool_schemas/tool_schemas_recurring.mli
+++ b/lib/tool_schemas/tool_schemas_recurring.mli
@@ -1,4 +1,17 @@
 (** Tool_schemas_recurring — SSOT for recurring task tool schemas.
     RFC-0314 — Keeper Recurring Producer. *)
 
+type operation =
+  | Add
+  | List
+  | Remove
+
+type definition =
+  { operation : operation
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+val operation_id : operation -> string
+val definitions : definition list
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -111,9 +111,9 @@ let register (spec : t) =
     Tool_catalog_surfaces.is_system_internal_hidden spec.name
   in
   let effective_visibility =
-    if is_system_internal && spec.visibility = Tool_catalog.Default
-    then Tool_catalog.Hidden
-    else spec.visibility
+    Tool_catalog.effective_registered_visibility
+      ~name:spec.name
+      ~declared:spec.visibility
   in
   let effective_allow_direct =
     spec.allow_direct_call_when_hidden || is_system_internal

--- a/lib/tool_types/tool_capability_projection.ml
+++ b/lib/tool_types/tool_capability_projection.ml
@@ -1,0 +1,8 @@
+type task_list =
+  | External_masc_tasks
+  | Keeper_tasks_list
+
+let task_list_name = function
+  | External_masc_tasks -> "masc_tasks"
+  | Keeper_tasks_list -> "keeper_tasks_list"
+;;

--- a/lib/tool_types/tool_capability_projection.mli
+++ b/lib/tool_types/tool_capability_projection.mli
@@ -1,0 +1,8 @@
+(** Typed audience projection for MASC capabilities that have distinct
+    external-transport and Keeper-model names. *)
+
+type task_list =
+  | External_masc_tasks
+  | Keeper_tasks_list
+
+val task_list_name : task_list -> string

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -315,7 +315,7 @@ let planning_context_state
        { planning_missing_task = None; deliverable_conflict_task })
 ;;
 
-let status_summary_string (ctx : context) =
+let status_summary_string ~task_list_projection (ctx : context) =
   Workspace.ensure_initialized ctx.config;
   let state = Workspace.read_state ctx.config in
   let backlog = safe_read_backlog ctx in
@@ -578,6 +578,7 @@ let status_summary_string (ctx : context) =
     else items
   in
   Workspace_status_rendering.status_summary_string
+    ~task_list_projection
     ~ctx
     ~bound:session_bound
     ~actual_name
@@ -601,8 +602,13 @@ let status_summary_string (ctx : context) =
     ~backlog
 ;;
 
-let handle_status ~tool_name ~start_time ctx _args =
-  let cache_key = Printf.sprintf "%s::%s" ctx.config.base_path ctx.agent_name in
+let handle_status ~task_list_projection ~tool_name ~start_time ctx _args =
+  let task_list_name =
+    Tool_capability_projection.task_list_name task_list_projection
+  in
+  let cache_key =
+    Printf.sprintf "%s::%s::%s" ctx.config.base_path ctx.agent_name task_list_name
+  in
   Tool_result.ok
     ~tool_name
     ~start_time
@@ -610,7 +616,7 @@ let handle_status ~tool_name ~start_time ctx _args =
        status_cache
        ~key:cache_key
        ~ttl_s:(status_cache_ttl_s ())
-       (fun () -> status_summary_string ctx))
+       (fun () -> status_summary_string ~task_list_projection ctx))
 ;;
 
 let handle_reset ~tool_name ~start_time ctx args =
@@ -708,8 +714,7 @@ let handle_check ~tool_name ~start_time ctx args =
 ;;
 
 let dispatch_bindings : (string * dispatch_handler) list =
-  [ "masc_status", handle_status
-  ; "masc_heartbeat", handle_heartbeat
+  [ "masc_heartbeat", handle_heartbeat
   ; "masc_goal_list", Workspace_goals.handle_goal_list
   ; "masc_goal_upsert", Workspace_goals.handle_goal_upsert
   ; "masc_goal_hygiene_review", Workspace_goals.handle_goal_hygiene_review
@@ -720,13 +725,39 @@ let dispatch_bindings : (string * dispatch_handler) list =
   ]
 ;;
 
-let dispatchable_names = List.map fst dispatch_bindings
+let dispatchable_names = "masc_status" :: List.map fst dispatch_bindings
 
-let dispatch ctx ~name ~args : Tool_result.result option =
+let dispatch_with_task_list_projection task_list_projection ctx ~name ~args =
   let start_time = Time_compat.now () in
-  match List.assoc_opt name dispatch_bindings with
-  | Some handle -> Some (handle ~tool_name:name ~start_time ctx args)
-  | None -> None
+  if String.equal name "masc_status"
+  then
+    Some
+      (handle_status
+         ~task_list_projection
+         ~tool_name:name
+         ~start_time
+         ctx
+         args)
+  else
+    match List.assoc_opt name dispatch_bindings with
+    | Some handle -> Some (handle ~tool_name:name ~start_time ctx args)
+    | None -> None
+;;
+
+let dispatch ctx ~name ~args =
+  dispatch_with_task_list_projection
+    Tool_capability_projection.External_masc_tasks
+    ctx
+    ~name
+    ~args
+;;
+
+let dispatch_for_keeper ctx ~name ~args =
+  dispatch_with_task_list_projection
+    Tool_capability_projection.Keeper_tasks_list
+    ctx
+    ~name
+    ~args
 ;;
 
 let schemas = Tool_schemas_workspace.schemas

--- a/lib/tool_workspace.mli
+++ b/lib/tool_workspace.mli
@@ -94,3 +94,8 @@ val dispatchable_names : string list
     text-cache to absorb repeated dashboard polls; cache
     invalidates on workspace state mutations. *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option
+
+(** Keeper-model dispatch uses Keeper-facing semantic capability names in
+    rendered follow-up guidance. *)
+val dispatch_for_keeper :
+  context -> name:string -> args:Yojson.Safe.t -> Tool_result.result option

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -141,6 +141,7 @@ let task_id_list_label = function
   | ids -> "[" ^ String.concat "," ids ^ "]"
 
 let status_summary_string
+    ~(task_list_projection : Tool_capability_projection.task_list)
     ~(ctx : context)
     ~(bound : bool)
     ~(actual_name : string)
@@ -162,6 +163,9 @@ let status_summary_string
     ~(attention_items : string list)
     ~(state : Masc_domain.workspace_state)
     ~(backlog : Masc_domain.backlog) =
+  let task_list_name =
+    Tool_capability_projection.task_list_name task_list_projection
+  in
   let max_agents_display = 40 in
   let max_active_tasks_display = 30 in
   let shown_agents = take_items max_agents_display agents_with_state in
@@ -278,8 +282,9 @@ let status_summary_string
   if List.length active_tasks > max_active_tasks_display then
     Buffer.add_string buf
       (Printf.sprintf
-         "  … and %d more active tasks (use masc_tasks for full list)\n"
-         (List.length active_tasks - max_active_tasks_display));
+         "  … and %d more active tasks (use %s for full list)\n"
+         (List.length active_tasks - max_active_tasks_display)
+         task_list_name);
   Buffer.add_string buf
     (Printf.sprintf "  Summary: active=%d, done=%d, cancelled=%d, total=%d\n"
        (List.length active_tasks) done_count cancelled_count

--- a/lib/workspace_status_rendering.mli
+++ b/lib/workspace_status_rendering.mli
@@ -45,6 +45,7 @@ val assigned_task_ids :
     for the [masc_status] response. *)
 
 val status_summary_string :
+  task_list_projection:Tool_capability_projection.task_list ->
   ctx:Workspace_types.context ->
   bound:bool ->
   actual_name:string ->
@@ -68,9 +69,13 @@ val status_summary_string :
   backlog:Masc_domain.backlog ->
   string
 (** [status_summary_string] renders the full [masc_status]
-    operator-visible string.  All 21 named arguments are
+    operator-visible string.  All 22 named arguments are
     required — there is no convenience overload because every
     line is a deliberate operator surface.
+
+    [task_list_projection] is the typed audience projection for follow-up
+    guidance: external callers receive [masc_tasks], Keeper models receive
+    [keeper_tasks_list].
 
     {2 Display caps}
 

--- a/test/test_fusion_status_tool.ml
+++ b/test/test_fusion_status_tool.ml
@@ -6,9 +6,8 @@
       mislabels a run status (e.g.
       reports a denied/sink-failed run as "completed"), or returns the wrong
       shape for list vs single-run vs unknown-run_id; and
-   2. the tool is wired but NOT visible to the keeper LLM (Pass B requires
-      visibility=Default; read_only_in_process_policy defaults to Hidden, so a
-      missing override would silently hide the tool while compiling fine).
+   2. the tool is wired but its descriptor is Dispatch_only, so the Keeper LLM
+      cannot see it even though runtime dispatch still compiles.
 
    [fusion_status_json] is pure over a registry instance, so it is exercised on
    isolated [Fusion_run_registry.create ()] tables (no global-state coupling). *)
@@ -140,20 +139,20 @@ let test_empty_registry () =
   check int "empty runs list" 0 (List.length (runs_of json))
 ;;
 
-(* (2) keeper-LLM visibility: masc_fusion_status must be in the Pass-B set
-   (model_visible_descriptors filters visibility=Default). Hidden would compile
-   but silently strip it from the keeper's tool list. Also runs the unified
+(* (2) keeper-LLM visibility: masc_fusion_status must have an explicit model
+   projection. Dispatch_only would compile but keep it out of the Keeper tool
+   list. Also runs the unified
    registry boot invariant (enforce_visible_tag_coverage) so a Default-visible
    tool without a dispatch tag would fail loudly here. *)
 let test_tool_is_keeper_visible () =
   Masc_test_deps.init_keeper_tool_registry ();
   let visible_names =
     Keeper_tool_descriptor.model_visible_descriptors ()
-    |> List.map (fun (d : Keeper_tool_descriptor.t) -> d.public_name)
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
   in
   check
     bool
-    "masc_fusion_status is keeper-LLM-visible (Pass B Default gate)"
+    "masc_fusion_status is keeper-LLM-visible by descriptor projection"
     true
     (List.mem "masc_fusion_status" visible_names)
 ;;

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -43,8 +43,25 @@ let build_keeper_index () =
   in
   Agent_sdk.Tool_index.build ~config:tool_index_config tool_entries
 
+let model_name_for_tool name =
+  match Keeper_tool_descriptor_resolution.descriptor_for_tool_name name with
+  | None -> name
+  | Some descriptor ->
+    (match Keeper_tool_descriptor.keeper_model_names descriptor with
+     | [ model_name ] -> model_name
+     | [] ->
+       Alcotest.failf
+         "tool %S has no Keeper model projection"
+         name
+     | model_names ->
+       Alcotest.failf
+         "tool %S has multiple Keeper model projections: %s"
+         name
+         (String.concat ", " model_names))
+
 (** Check that [expected_tool] appears in BM25 top-k results for [query]. *)
 let assert_retrieves ~label index query expected_tool =
+  let expected_tool = model_name_for_tool expected_tool in
   let retrieved = Agent_sdk.Tool_index.retrieve index query in
   let names = List.map fst retrieved in
   let rank = match List.find_index (fun n -> String.equal n expected_tool) names with
@@ -62,6 +79,8 @@ let assert_retrieves ~label index query expected_tool =
   rank
 
 let assert_ranks_before ~label index query ~preferred ~discouraged =
+  let preferred = model_name_for_tool preferred in
+  let discouraged = model_name_for_tool discouraged in
   let retrieved = Agent_sdk.Tool_index.retrieve index query in
   let names = List.map fst retrieved in
   let rank name =
@@ -280,8 +299,10 @@ let test_prefer_fs_edit_over_bash () =
   let retrieved = Agent_sdk.Tool_index.retrieve idx
     "create a new file called notes.md with some content" in
   let names = List.map fst retrieved in
-  let fs_edit_rank = List.find_index (fun n -> String.equal n "tool_edit_file") names in
-  let bash_rank = List.find_index (fun n -> String.equal n "tool_execute") names in
+  let edit_name = model_name_for_tool "tool_edit_file" in
+  let execute_name = model_name_for_tool "tool_execute" in
+  let fs_edit_rank = List.find_index (fun n -> String.equal n edit_name) names in
+  let bash_rank = List.find_index (fun n -> String.equal n execute_name) names in
   match fs_edit_rank, bash_rank with
   | Some fe, Some ba ->
     Alcotest.(check bool)
@@ -313,7 +334,12 @@ let test_search_alias_entries_target_keeper_universe () =
   let missing =
     Keeper_agent_tool_surface.tool_search_alias_entries
     |> List.map fst
-    |> List.filter (fun name -> not (List.mem name tool_names))
+    |> List.filter (fun name ->
+      match Keeper_tool_descriptor_resolution.descriptor_for_tool_name name with
+      | Some descriptor ->
+        Keeper_tool_descriptor.keeper_model_names descriptor
+        |> List.for_all (fun model_name -> not (List.mem model_name tool_names))
+      | None -> not (List.mem name tool_names))
   in
   Alcotest.(check (list string))
     "alias entries resolve to keeper universe tools" [] missing

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -39,6 +39,18 @@ let () = ignore Masc.Keeper_tool_surface.schemas
 
 let all_descriptors () : Descriptor.t list = Descriptor.all_descriptors ()
 
+let required_public_descriptor name =
+  match Descriptor.find_public name with
+  | Some descriptor -> descriptor
+  | None -> Alcotest.failf "missing public descriptor: %s" name
+;;
+
+let required_internal_descriptor name =
+  match Descriptor.descriptors_for_internal name with
+  | descriptor :: _ -> descriptor
+  | [] -> Alcotest.failf "missing internal descriptor: %s" name
+;;
+
 (* RFC-0190 — Descriptor as Visibility/Metadata SSOT.
 
    [Tool_catalog_surfaces.public_mcp_surface_tools] is the operator-facing
@@ -445,18 +457,6 @@ let test_internal_name_snake_case () =
 let test_registry_not_empty () =
   if all_descriptors () = []
   then Alcotest.failf "Keeper_tool_descriptor.all_descriptors () returned []"
-
-let required_public_descriptor name =
-  match Descriptor.find_public name with
-  | Some descriptor -> descriptor
-  | None -> Alcotest.failf "missing public descriptor: %s" name
-;;
-
-let required_internal_descriptor name =
-  match Descriptor.descriptors_for_internal name with
-  | descriptor :: _ -> descriptor
-  | [] -> Alcotest.failf "missing internal descriptor: %s" name
-;;
 
 let schema_property_description schema name =
   let open Yojson.Safe.Util in

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -30,6 +30,7 @@ module Keeper_dispatch_ref = Masc.Keeper_dispatch_ref
 module Workspace = Masc.Workspace
 module Task = Masc.Task
 module Keeper_tool_surface = Masc.Keeper_tool_surface
+module Capability_registry = Masc.Capability_registry
 
 (* Force-link [Keeper_tool_surface] so its module-load registration of
    keeper tools into [Keeper_dispatch_ref.dispatch] runs before the
@@ -123,6 +124,207 @@ let test_internal_name_uniqueness () =
       "duplicate internal_name(s) across Keeper_tool_descriptor.all_descriptors: %s"
       (String.concat ", "
          (List.map (fun (n, c) -> Printf.sprintf "%S×%d" n c) dups))
+
+let test_keeper_model_projection_is_single_and_unique () =
+  let model_names =
+    all_descriptors () |> List.concat_map Descriptor.keeper_model_names
+  in
+  let unique_names = List.sort_uniq String.compare model_names in
+  Alcotest.(check int)
+    "one descriptor owns each Keeper model name"
+    (List.length model_names)
+    (List.length unique_names);
+  List.iter
+    (fun (descriptor : Descriptor.t) ->
+       let projected = Descriptor.keeper_model_names descriptor in
+       let candidates = Descriptor.keeper_candidate_names descriptor in
+       match descriptor.keeper_model_projection with
+       | Descriptor.Preferred_public_name ->
+         Alcotest.(check (list string))
+           (descriptor.id ^ " preferred model projection")
+           [ descriptor.public_name ]
+           projected;
+         Alcotest.(check bool)
+           (descriptor.id ^ " keeps internal dispatch candidate")
+           true
+           (List.mem descriptor.internal_name candidates);
+         descriptor.public_aliases
+         |> List.iter (fun alias ->
+           Alcotest.(check bool)
+             (descriptor.id ^ " keeps compatibility dispatch alias " ^ alias)
+             true
+             (List.mem alias candidates))
+       | Descriptor.Internal_name ->
+         Alcotest.(check (list string))
+           (descriptor.id ^ " internal model projection")
+           [ descriptor.internal_name ]
+           projected
+       | Descriptor.Dispatch_only ->
+         Alcotest.(check (list string))
+           (descriptor.id ^ " has no model projection")
+           []
+           projected;
+         Alcotest.(check (list string))
+           (descriptor.id ^ " has no Keeper candidates")
+           []
+           candidates)
+    (all_descriptors ())
+;;
+
+let test_semantic_capability_has_at_most_one_keeper_model_projection () =
+  Capability_registry.all_capabilities_from Masc.Config.raw_all_tool_schemas
+  |> List.iter (fun (capability : Capability_registry.capability_def) ->
+    let descriptors =
+      capability.projections
+      |> List.filter_map (fun (projection : Capability_registry.projection) ->
+        Resolution.descriptor_for_tool_name projection.tool_name)
+      |> List.sort_uniq
+           (fun (left : Descriptor.t) (right : Descriptor.t) ->
+              String.compare left.id right.id)
+    in
+    let model_names =
+      descriptors
+      |> List.concat_map Descriptor.keeper_model_names
+      |> List.sort_uniq String.compare
+    in
+    if List.length model_names > 1
+    then
+      Alcotest.failf
+        "semantic capability %S has multiple Keeper model projections: %s"
+        capability.capability_id
+        (String.concat ", " model_names))
+;;
+
+let test_model_visible_descriptors_have_canonical_input_schemas () =
+  Descriptor.model_visible_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    match descriptor.input_schema_source with
+    | Descriptor.Descriptor_owned | Descriptor.Canonical_registry -> ()
+    | Descriptor.Missing_canonical_registry ->
+      Alcotest.failf
+        "model-visible descriptor %S is missing its canonical input schema"
+        descriptor.id)
+;;
+
+let test_cluster_descriptors_have_no_missing_canonical_schemas () =
+  all_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    match descriptor.input_schema_source with
+    | Descriptor.Descriptor_owned | Descriptor.Canonical_registry -> ()
+    | Descriptor.Missing_canonical_registry ->
+      Alcotest.failf
+        "descriptor %S (%s) is missing its canonical input schema"
+        descriptor.id
+        descriptor.internal_name)
+;;
+
+let test_missing_canonical_schema_is_fail_closed () =
+  let base = required_internal_descriptor "masc_transition" in
+  let missing =
+    { base with
+      input_schema_source = Descriptor.Missing_canonical_registry
+    ; keeper_model_projection = Descriptor.Internal_name
+    }
+  in
+  Alcotest.(check (list string))
+    "missing schema has no model names"
+    []
+    (Descriptor.keeper_model_names missing);
+  Alcotest.(check (list string))
+    "missing schema has no execution candidates"
+    []
+    (Descriptor.keeper_candidate_names missing);
+  Alcotest.(check (list string))
+    "startup diagnostic reports missing canonical schema"
+    [ missing.internal_name ]
+    (Policy.missing_canonical_schema_names [ missing ])
+;;
+
+let test_registered_cluster_model_projections_are_explicit () =
+  let check_projection internal_name expected =
+    let descriptor = required_internal_descriptor internal_name in
+    Alcotest.(check bool)
+      (internal_name ^ " model projection")
+      true
+      (descriptor.keeper_model_projection = expected)
+  in
+  List.iter
+    (fun name -> check_projection name Descriptor.Internal_name)
+    [ "masc_library_list"
+    ; "masc_library_add"
+    ; "masc_library_promote"
+    ; "masc_recurring_add"
+    ; "masc_recurring_list"
+    ; "masc_recurring_remove"
+    ; "masc_runtime_verify"
+    ; "masc_runtime_ollama_probe"
+    ; "masc_goal_hygiene_review"
+    ; "masc_gc"
+    ];
+  List.iter
+    (fun name -> check_projection name Descriptor.Dispatch_only)
+    [ "masc_library_read"; "masc_library_search" ];
+  List.iter
+    (fun name -> check_projection name Descriptor.Internal_name)
+    [ "keeper_library_read"; "keeper_library_search" ]
+;;
+
+let test_dynamic_model_description_projection_is_explicit () =
+  all_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    let expected =
+      if String.equal descriptor.internal_name "masc_transition"
+      then Descriptor.Current_task_state
+      else Descriptor.Static_description
+    in
+    Alcotest.(check bool)
+      (descriptor.id ^ " model description projection")
+      true
+      (descriptor.model_description_projection = expected))
+;;
+
+let test_all_keeper_shard_schemas_are_descriptor_backed () =
+  Tool_shard.all_keeper_tool_schemas
+  |> List.iter (fun (schema : Masc_domain.tool_schema) ->
+    match Descriptor.descriptors_for_internal schema.name with
+    | [ _ ] -> ()
+    | [] -> Alcotest.failf "Keeper shard schema %S has no descriptor" schema.name
+    | descriptors ->
+      Alcotest.failf
+        "Keeper shard schema %S has %d descriptors"
+        schema.name
+        (List.length descriptors))
+;;
+
+let test_supported_masc_schemas_are_descriptor_backed () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  Policy.keeper_supported_masc_schemas Masc.Config.raw_all_tool_schemas
+  |> List.iter (fun (schema : Masc_domain.tool_schema) ->
+    match Descriptor.descriptors_for_internal schema.name with
+    | [ _ ] -> ()
+    | [] ->
+      Alcotest.failf
+        "supported MASC schema %S has no descriptor"
+        schema.name
+    | descriptors ->
+      Alcotest.failf
+        "supported MASC schema %S has %d descriptors"
+        schema.name
+        (List.length descriptors))
+;;
+
+let test_maintenance_descriptors_are_dispatch_only () =
+  all_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    if descriptor.policy.maintenance_only
+    then
+      match descriptor.keeper_model_projection with
+      | Descriptor.Dispatch_only -> ()
+      | Descriptor.Preferred_public_name | Descriptor.Internal_name ->
+        Alcotest.failf
+          "maintenance descriptor %S is model-visible"
+          descriptor.internal_name)
+;;
 
 let is_blank s = String.trim s = ""
 
@@ -681,7 +883,12 @@ let test_masc_board_registry_has_descriptor_projection () =
           Alcotest.(check int)
             (keeper_name ^ " has exactly one descriptor")
             1
-            (List.length (Descriptor.descriptors_for_internal keeper_name))
+            (List.length (Descriptor.descriptors_for_internal keeper_name));
+          let wrapper_descriptor = required_internal_descriptor keeper_name in
+          Alcotest.(check bool)
+            (keeper_name ^ " is the model projection")
+            true
+            (wrapper_descriptor.keeper_model_projection = Descriptor.Internal_name)
         | Keeper_tool_name.Direct_masc | Keeper_tool_name.External_only -> ());
        match Descriptor.descriptors_for_internal schema.name with
        | [ descriptor ] ->
@@ -710,7 +917,17 @@ let test_masc_board_registry_has_descriptor_projection () =
          Alcotest.(check bool)
            (schema.name ^ " descriptor visibility follows typed projection")
            true
-           (descriptor.policy.visibility = expected_visibility)
+           (descriptor.policy.visibility = expected_visibility);
+         let expected_model_projection =
+           match Keeper_tool_name.board_projection_of_masc_board_name board_name with
+           | Keeper_tool_name.Direct_masc -> Descriptor.Internal_name
+           | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
+             Descriptor.Dispatch_only
+         in
+         Alcotest.(check bool)
+           (schema.name ^ " descriptor model projection follows typed projection")
+           true
+           (descriptor.keeper_model_projection = expected_model_projection)
        | [] -> Alcotest.failf "missing descriptor for %s" schema.name
        | _ :: _ :: _ -> Alcotest.failf "duplicate descriptor for %s" schema.name)
     Tool_name.Board_name.all
@@ -1182,7 +1399,7 @@ let test_effective_core_tools_without_universe_keeps_only_native_executor_public
     let effective = Registry.effective_core_tools () in
     List.iter
       (fun (d : Descriptor.t) ->
-         let public_names = Descriptor.public_names_of_descriptor d in
+         let model_names = Descriptor.keeper_model_names d in
          match d.Descriptor.executor with
          | Descriptor.Shell_ir | Descriptor.Filesystem ->
            List.iter
@@ -1193,7 +1410,7 @@ let test_effective_core_tools_without_universe_keeps_only_native_executor_public
                     "native-executor public %S missing from effective_core_tools \
                      with empty universe"
                     name)
-             public_names
+             model_names
          | Descriptor.In_process ->
            List.iter
              (fun name ->
@@ -1203,7 +1420,7 @@ let test_effective_core_tools_without_universe_keeps_only_native_executor_public
                     "in-process (masc-backed) public %S present in \
                      effective_core_tools when universe is empty"
                     name)
-             public_names)
+             model_names)
       Descriptor.public_descriptors)
 ;;
 
@@ -1233,6 +1450,46 @@ let () =
       , [ test_case "registry not empty" `Quick test_registry_not_empty
         ; test_case "public_name is unique" `Quick test_public_name_uniqueness
         ; test_case "internal_name is unique" `Quick test_internal_name_uniqueness
+        ; test_case
+            "Keeper model projection is single and unique"
+            `Quick
+            test_keeper_model_projection_is_single_and_unique
+        ; test_case
+            "semantic capability has at most one Keeper model projection"
+            `Quick
+            test_semantic_capability_has_at_most_one_keeper_model_projection
+        ; test_case
+            "model-visible descriptors have canonical input schemas"
+            `Quick
+            test_model_visible_descriptors_have_canonical_input_schemas
+        ; test_case
+            "cluster descriptors have no missing canonical schemas"
+            `Quick
+            test_cluster_descriptors_have_no_missing_canonical_schemas
+        ; test_case
+            "missing canonical schema is fail-closed"
+            `Quick
+            test_missing_canonical_schema_is_fail_closed
+        ; test_case
+            "registered cluster model projections are explicit"
+            `Quick
+            test_registered_cluster_model_projections_are_explicit
+        ; test_case
+            "dynamic model description projection is explicit"
+            `Quick
+            test_dynamic_model_description_projection_is_explicit
+        ; test_case
+            "all Keeper shard schemas are descriptor-backed"
+            `Quick
+            test_all_keeper_shard_schemas_are_descriptor_backed
+        ; test_case
+            "supported MASC schemas are descriptor-backed"
+            `Quick
+            test_supported_masc_schemas_are_descriptor_backed
+        ; test_case
+            "maintenance descriptors are dispatch-only"
+            `Quick
+            test_maintenance_descriptors_are_dispatch_only
         ] )
     ; ( "format"
       , [ test_case "no blank name fields" `Quick test_no_blank_names

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -263,23 +263,37 @@ let test_registered_cluster_model_projections_are_explicit () =
   in
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
-    [ "masc_library_list"
-    ; "masc_library_add"
-    ; "masc_library_promote"
-    ; "masc_recurring_add"
+    [ "masc_recurring_add"
     ; "masc_recurring_list"
     ; "masc_recurring_remove"
     ; "masc_runtime_verify"
     ; "masc_runtime_ollama_probe"
     ; "masc_goal_hygiene_review"
-    ; "masc_gc"
     ];
   List.iter
     (fun name -> check_projection name Descriptor.Dispatch_only)
-    [ "masc_library_read"; "masc_library_search" ];
+    [ "masc_library_add"
+    ; "masc_library_list"
+    ; "masc_library_promote"
+    ; "masc_library_read"
+    ; "masc_library_search"
+    ; "masc_pause"
+    ; "masc_resume"
+    ];
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
     [ "keeper_library_read"; "keeper_library_search" ]
+;;
+
+let test_system_internal_descriptors_are_dispatch_only () =
+  all_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    if Tool_catalog_surfaces.is_system_internal_hidden descriptor.internal_name
+    then
+      Alcotest.(check bool)
+        (descriptor.internal_name ^ " stays outside the Keeper model surface")
+        true
+        (descriptor.keeper_model_projection = Descriptor.Dispatch_only))
 ;;
 
 let test_dynamic_model_description_projection_is_explicit () =
@@ -1510,6 +1524,10 @@ let () =
             "registered cluster model projections are explicit"
             `Quick
             test_registered_cluster_model_projections_are_explicit
+        ; test_case
+            "system-internal descriptors are dispatch-only"
+            `Quick
+            test_system_internal_descriptors_are_dispatch_only
         ; test_case
             "dynamic model description projection is explicit"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -840,6 +840,22 @@ let test_masc_board_descriptions_disambiguate_post_id_flow () =
 ;;
 
 let test_masc_board_registry_has_descriptor_projection () =
+  let expected_resource_writes =
+    let open Tool_name.Board_name in
+    [ Board_post
+    ; Board_post_update
+    ; Board_comment
+    ; Board_vote
+    ; Board_comment_vote
+    ; Board_reaction
+    ; Board_curation_submit
+    ; Board_delete
+    ; Board_cleanup
+    ; Board_sub_board_create
+    ; Board_sub_board_update
+    ; Board_sub_board_delete
+    ]
+  in
   let wire_names =
     List.map Tool_name.Board_name.to_string Tool_name.Board_name.all
   in
@@ -918,8 +934,12 @@ let test_masc_board_registry_has_descriptor_projection () =
            true
            (descriptor.policy.visibility = expected_visibility);
          let expected_readonly =
-           not (Tool_name.Board_name.is_resource_write board_name)
+           not (List.mem board_name expected_resource_writes)
          in
+         Alcotest.(check bool)
+           (schema.name ^ " typed resource classification follows Board contract")
+           (not expected_readonly)
+           (Tool_name.Board_name.is_resource_write board_name);
          Alcotest.(check (option bool))
            (schema.name ^ " descriptor readonly follows typed resource projection")
            (Some expected_readonly)

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -31,6 +31,7 @@ module Workspace = Masc.Workspace
 module Task = Masc.Task
 module Keeper_tool_surface = Masc.Keeper_tool_surface
 module Capability_registry = Masc.Capability_registry
+module Tool_shard = Masc.Tool_shard
 
 (* Force-link [Keeper_tool_surface] so its module-load registration of
    keeper tools into [Keeper_dispatch_ref.dispatch] runs before the

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -940,7 +940,11 @@ let test_masc_board_registry_has_descriptor_projection () =
              (List.mem identity_field descriptor_properties));
          let expected_visibility =
            match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-           | Keeper_tool_name.Direct_masc -> Tool_catalog.Default
+           | Keeper_tool_name.Direct_masc ->
+             let operation_policy = Board_tool_registry.operation_policy board_name in
+             Tool_catalog.effective_registered_visibility
+               ~name:schema.name
+               ~declared:operation_policy.visibility
            | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
              Tool_catalog.Hidden
          in
@@ -969,10 +973,9 @@ let test_masc_board_registry_has_descriptor_projection () =
            true
            (descriptor.policy.effect_domain = expected_effect_domain);
          let expected_model_projection =
-           match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-           | Keeper_tool_name.Direct_masc -> Descriptor.Internal_name
-           | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
-             Descriptor.Dispatch_only
+           match expected_visibility with
+           | Tool_catalog.Default -> Descriptor.Internal_name
+           | Tool_catalog.Hidden -> Descriptor.Dispatch_only
          in
          Alcotest.(check bool)
            (schema.name ^ " descriptor model projection follows typed projection")

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -909,8 +909,7 @@ let test_masc_board_registry_has_descriptor_projection () =
              (List.mem identity_field descriptor_properties));
          let expected_visibility =
            match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-           | Keeper_tool_name.Direct_masc ->
-             (Tool_catalog.metadata schema.name).visibility
+           | Keeper_tool_name.Direct_masc -> Tool_catalog.Default
            | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
              Tool_catalog.Hidden
          in
@@ -918,6 +917,22 @@ let test_masc_board_registry_has_descriptor_projection () =
            (schema.name ^ " descriptor visibility follows typed projection")
            true
            (descriptor.policy.visibility = expected_visibility);
+         let expected_readonly =
+           not (Tool_name.Board_name.is_resource_write board_name)
+         in
+         Alcotest.(check (option bool))
+           (schema.name ^ " descriptor readonly follows typed resource projection")
+           (Some expected_readonly)
+           descriptor.policy.readonly_hint;
+         let expected_effect_domain =
+           if expected_readonly
+           then Some Tool_catalog.Read_only
+           else Some Tool_catalog.Masc_workspace
+         in
+         Alcotest.(check bool)
+           (schema.name ^ " descriptor effect domain follows typed resource projection")
+           true
+           (descriptor.policy.effect_domain = expected_effect_domain);
          let expected_model_projection =
            match Keeper_tool_name.board_projection_of_masc_board_name board_name with
            | Keeper_tool_name.Direct_masc -> Descriptor.Internal_name

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -589,6 +589,8 @@ let test_keeper_tools_list_json_uses_typed_groups () =
              "keeper_board_fake";
              "keeper_voice_speak";
              "keeper_task_claim";
+             "masc_transition";
+             "masc_plan_get";
              "keeper_surface_read";
              "tool_search_files";
              "tool_read_file";
@@ -609,16 +611,22 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (member "voice" "keeper_voice_speak");
   check bool "task tool grouped as workspace" true
     (member "workspace" "keeper_task_claim");
+  check bool "MASC task tool grouped as workspace" true
+    (member "workspace" "masc_transition");
+  check bool "MASC plan tool grouped as workspace" true
+    (member "workspace" "masc_plan_get");
   check bool "surface read grouped as surface" true
     (member "surface" "keeper_surface_read");
   check bool "surface read not hidden under meta" false
     (member "meta" "keeper_surface_read");
   check bool "tools_list remains a meta introspection tool" true
     (member "meta" "keeper_tools_list");
-  check bool "Grep tool grouped" true
+  check bool "Grep tool grouped under its sole model name" true
+    (member "search_files" "Grep");
+  check bool "Grep internal route omitted from model list" false
     (member "search_files" "tool_search_files");
-  check bool "fs tool grouped" true
-    (member "fs" "tool_read_file");
+  check bool "fs tool grouped under its sole model name" true
+    (member "fs" "Read");
   check bool "memory tool grouped" true
     (member "memory" "keeper_memory_search");
   let descriptor_surface =
@@ -662,10 +670,12 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (string_member "public_name" execute);
   check string "Execute executor" "shell_ir"
     (string_member "executor" execute);
-  check bool "Execute active internal name listed" true
+  check bool "Execute internal route is not a model name" false
     (list_member_contains "active_names" "tool_execute" execute);
   check bool "Execute active public name listed" true
     (list_member_contains "active_names" "Execute" execute);
+  check string "Execute model projection" "preferred_public_name"
+    (string_member "keeper_model_projection" execute);
   let policy = Yojson.Safe.Util.member "policy" execute in
   check string "Execute effect domain" "playground_write"
     (string_member "effect_domain" policy);
@@ -719,8 +729,12 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (string_member "effect_domain" grep_policy);
   check bool "Grep policy group omitted" true
     (Yojson.Safe.Util.member "policy_group" grep_policy = `Null);
-  check bool "Grep active internal name listed" true
+  check bool "Grep internal route is not a model name" false
     (list_member_contains "active_names" "tool_search_files" grep);
+  check bool "Grep preferred model name listed" true
+    (list_member_contains "active_names" "Grep" grep);
+  check bool "Grep compatibility alias is not a model name" false
+    (list_member_contains "active_names" "Search" grep);
   let malformed_execute =
     { (descriptor_for_internal "tool_execute") with
       KTD.input_schema =
@@ -1540,6 +1554,42 @@ let make_dummy_oas_tool name =
     (fun _ -> Tool_result.make_ok ~tool_name:name ~start_time:0.0 ~data:(`String "") ())
 ;;
 
+let test_descriptor_route_miss_payload_is_typed_runtime_failure () =
+  let descriptor =
+    match KTD.descriptors_for_internal "tool_execute" with
+    | [ descriptor ] -> descriptor
+    | [] -> fail "missing tool_execute descriptor"
+    | _ :: _ :: _ -> fail "duplicate tool_execute descriptors"
+  in
+  let payload =
+    KET.For_testing.descriptor_route_invariant_payload
+      ~tool_name:"Execute"
+      descriptor
+  in
+  (match
+     KET.For_testing.descriptor_route_kind ~descriptor ~output:None
+   with
+   | KET.For_testing.Invariant -> ()
+   | KET.For_testing.Output | KET.For_testing.Registered_only ->
+     fail "resolved descriptor without output must not reach registered fallback");
+  check bool "descriptor route miss is not ok" false
+    Yojson.Safe.Util.(member "ok" payload |> to_bool);
+  check string
+    "descriptor route miss has typed error"
+    "keeper_tool_descriptor_route_invariant"
+    Yojson.Safe.Util.(member "error" payload |> to_string);
+  check string
+    "descriptor route miss is a runtime failure"
+    "runtime_failure"
+    Yojson.Safe.Util.(member "failure_class" payload |> to_string);
+  check string "descriptor identity is retained" "agent.execute"
+    Yojson.Safe.Util.(member "descriptor_id" payload |> to_string);
+  check string "executor identity is retained" "shell_ir"
+    Yojson.Safe.Util.(member "executor" payload |> to_string);
+  check string "runtime handler identity is retained" "tool_execute"
+    Yojson.Safe.Util.(member "runtime_handler" payload |> to_string)
+;;
+
 let string_of_concurrency_class = function
   | Agent_sdk.Tool.Parallel_read -> "parallel_read"
   | Agent_sdk.Tool.Sequential_workspace -> "sequential_workspace"
@@ -1808,6 +1858,8 @@ let () =
     ("keeper_tools_list_json", [
       test_case "uses typed groups" `Quick
         test_keeper_tools_list_json_uses_typed_groups;
+      test_case "descriptor route miss is typed runtime failure" `Quick
+        test_descriptor_route_miss_payload_is_typed_runtime_failure;
     ]);
     ("oas_descriptor", [
       test_case "masc_web_search is Exclusive_external" `Quick

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -522,42 +522,55 @@ let merge_expectation base extras =
       Expect_success_or_guard (fragments @ extras)
 
 let case_for_name name =
-  if string_starts_with ~prefix:"masc_" name then
+  let runtime_name =
+    match Masc.Keeper_tool_descriptor_resolution.descriptor_for_tool_name name with
+    | Some (descriptor : Masc.Keeper_tool_descriptor.t) -> descriptor.internal_name
+    | None -> name
+  in
+  if string_starts_with ~prefix:"masc_" runtime_name then
     let generic_case_opt =
-      try Some (Generic.case_for_name name) with Failure _ -> None
+      try Some (Generic.case_for_name runtime_name) with Failure _ -> None
     in
     (match generic_case_opt with
      | Some generic_case ->
        {
          init_mode = generic_case.init_mode;
-         prepare = (fun fixture -> Generic.prepare_for_name fixture.generic name);
+         prepare = (fun fixture -> Generic.prepare_for_name fixture.generic runtime_name);
          arguments =
-           (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
+           (fun fixture schema ->
+             Generic.tool_arguments
+               fixture.generic
+               { schema with name = runtime_name });
          expectation =
            merge_expectation generic_case.expectation
-             (extra_guard_fragments_for_name name);
+             (extra_guard_fragments_for_name runtime_name);
        }
      | None ->
        {
          init_mode = Init_only;
          prepare = (fun _fixture -> ());
          arguments =
-           (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
+           (fun fixture schema ->
+             Generic.tool_arguments
+               fixture.generic
+               { schema with name = runtime_name });
          expectation =
            Expect_success_or_guard
-             (Generic.guard_fragments_for_name name
-              @ extra_guard_fragments_for_name name);
+             (Generic.guard_fragments_for_name runtime_name
+              @ extra_guard_fragments_for_name runtime_name);
        })
   else if
-    string_starts_with ~prefix:"keeper_" name
-    || string_starts_with ~prefix:"tool_" name
-    || String.equal name "analyze_image"
+    string_starts_with ~prefix:"keeper_" runtime_name
+    || string_starts_with ~prefix:"tool_" runtime_name
+    || String.equal runtime_name "analyze_image"
   then
     {
       init_mode = Init_joined;
-      prepare = (fun fixture -> prepare_keeper_name fixture name);
-      arguments = keeper_arguments;
-      expectation = keeper_expectation_for_name name;
+      prepare = (fun fixture -> prepare_keeper_name fixture runtime_name);
+      arguments =
+        (fun fixture schema ->
+          keeper_arguments fixture { schema with name = runtime_name });
+      expectation = keeper_expectation_for_name runtime_name;
     }
   else
     failwith ("missing keeper tool contract for " ^ name)

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -82,6 +82,27 @@ let test_masc_spawn_is_not_generated () =
     (has_schema "masc_spawn" Tool_schemas_misc.schemas)
 ;;
 
+let test_control_schemas_are_generated () =
+  let properties schema =
+    match schema.input_schema with
+    | `Assoc fields ->
+      (match List.assoc_opt "properties" fields with
+       | Some (`Assoc properties) -> properties
+       | _ -> Alcotest.failf "%s has no object properties" schema.name)
+    | _ -> Alcotest.failf "%s has a non-object schema" schema.name
+  in
+  let pause = find_by_name "masc_pause" Tool_descriptors_gen.schemas in
+  let resume = find_by_name "masc_resume" Tool_descriptors_gen.schemas in
+  Alcotest.(check bool)
+    "masc_pause has reason property"
+    true
+    (List.mem_assoc "reason" (properties pause));
+  Alcotest.(check int)
+    "masc_resume has no input properties"
+    0
+    (List.length (properties resume))
+;;
+
 let test_masc_tool_help_name_matches () =
   let gen = find_by_name "masc_tool_help" Tool_descriptors_gen.schemas in
   let hand = find_by_name "masc_tool_help" Tool_schemas_misc.schemas in
@@ -334,6 +355,12 @@ let () =
         ] )
     ; ( "retired tool exclusion"
       , [ Alcotest.test_case "masc_spawn removed" `Quick test_masc_spawn_is_not_generated
+        ] )
+    ; ( "control schema SSOT"
+      , [ Alcotest.test_case
+            "pause and resume are generated"
+            `Quick
+            test_control_schemas_are_generated
         ] )
     ; ( "masc_tool_help field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_tool_help_name_matches

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -2252,10 +2252,37 @@ let () = test "transition_missing_task_clears_stale_current_task" (fun () ->
     | Some diagnosis ->
       Json_util.get_string diagnosis "rule_id" = Some "stale_task_id_not_found"
       && Json_util.get_string diagnosis "tool_suggestion"
-         = Some "keeper_tasks_list"
+         = Some "masc_tasks"
     | None -> false);
   assert (str_contains (Tool_result.message result) "absent from the live backlog")
 )
+
+let () = test "keeper transition rejection projects Keeper task-list guidance" (fun () ->
+  let ctx = make_test_ctx () in
+  let result =
+    Task.Tool.dispatch_for_keeper
+      ctx
+      ~name:"masc_transition"
+      ~args:
+        (`Assoc
+           [ "task_id", `String "task-1468"; "action", `String "start" ])
+  in
+  match result with
+  | None -> failwith "Keeper transition dispatch returned None"
+  | Some result ->
+    assert (not (Tool_result.is_success result));
+    let data = Tool_result.data result in
+    (match Json_util.assoc_member_opt "diagnosis" data with
+     | Some diagnosis ->
+       assert
+         (Json_util.get_string diagnosis "tool_suggestion"
+          = Some "keeper_tasks_list")
+     | None -> failwith "missing Keeper transition diagnosis");
+    (match Json_util.assoc_member_opt "alternatives" data with
+     | Some (`List alternatives) ->
+       assert (List.mem (`String "keeper_tasks_list") alternatives);
+       assert (not (List.mem (`String "masc_tasks") alternatives))
+     | _ -> failwith "missing Keeper transition alternatives"))
 
 (* RFC-0109 Phase E (#18822, 2026-05-27) retired the transition-layer
    substring evidence gate. The two tests that previously locked in

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -294,7 +294,19 @@ let () =
       assert (str_contains msg "Attention:");
       assert_contains msg "35 unclaimed task(s) are available right now.";
       assert (str_contains msg "Summary: active=35, done=0, cancelled=0, total=35");
-      assert (str_contains msg "and 5 more active tasks")
+      assert_contains msg "and 5 more active tasks (use masc_tasks for full list)";
+      assert_not_contains msg "use keeper_tasks_list for full list";
+      (match
+         Tool_workspace.dispatch_for_keeper ctx ~name:"masc_status" ~args
+       with
+       | Some keeper_result ->
+         let keeper_message = Tool_result.message keeper_result in
+         assert (Tool_result.is_success keeper_result);
+         assert_contains
+           keeper_message
+           "and 5 more active tasks (use keeper_tasks_list for full list)";
+         assert_not_contains keeper_message "use masc_tasks for full list"
+       | None -> failwith "Keeper status dispatch returned None")
     | None -> failwith "dispatch returned None")
 ;;
 

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -88,7 +88,7 @@ let filter_core_by_tool_access (meta : Keeper_meta_contract.keeper_meta) =
 let write_tools = [ "Edit" ]
 
 let shell_bridge_tools = [ "Execute" ]
-let read_alias_tools = [ "Grep"; "Search"; "Read" ]
+let read_model_tools = [ "Grep"; "Read" ]
 
 let write_enabled_tool_access =
   [ "tool_edit_file"; "tool_execute" ]
@@ -107,12 +107,12 @@ let test_core_tools_visible_with_empty_tool_access () =
   List.iter (fun t ->
     if not (List.mem t unfiltered_core) then
       fail (Printf.sprintf "precondition: %s missing from effective_core_tools" t)
-  ) (write_tools @ read_alias_tools);
+  ) (write_tools @ read_model_tools);
   let filtered = filter_core_by_tool_access meta in
   List.iter (fun t ->
     if not (List.mem t filtered) then
       fail (Printf.sprintf "%s must stay visible without explicit tool_access" t)
-  ) (write_tools @ read_alias_tools);
+  ) (write_tools @ read_model_tools);
   (* Core always-tools must survive *)
   List.iter (fun t ->
     if not (List.mem t filtered) then
@@ -130,7 +130,7 @@ let test_core_tools_visible_with_read_only_tool_access () =
   List.iter (fun t ->
     if not (List.mem t filtered) then
       fail (Printf.sprintf "%s should stay visible for read-only tool_access" t)
-  ) (write_tools @ read_alias_tools)
+  ) (write_tools @ read_model_tools)
 
 let test_core_tools_include_write_for_write_enabled_tool_access () =
   ignore (init_registry ());
@@ -192,7 +192,19 @@ let test_web_alias_bundle_visible_without_injected_masc_schema () =
           check bool "WebSearch remains bundle-visible" true
             (List.mem "WebSearch" names);
           check bool "WebFetch remains bundle-visible" true
-            (List.mem "WebFetch" names)))
+            (List.mem "WebFetch" names);
+          check bool "Grep preferred projection is bundle-visible" true
+            (List.mem "Grep" names);
+          check bool "Search compatibility alias is not model-visible" false
+            (List.mem "Search" names);
+          check bool "search_files compatibility alias is not model-visible" false
+            (List.mem "search_files" names);
+          check bool "Grep internal route is not model-visible" false
+            (List.mem "tool_search_files" names);
+          check int
+            "bundle model names are unique"
+            (List.length names)
+            (List.length (List.sort_uniq String.compare names))))
 
 let test_fusion_default_descriptor_is_bundle_visible () =
   ignore (init_registry ());


### PR DESCRIPTION
## Summary

- make `Keeper_tool_descriptor` the only Keeper-model schema and route projection authority
- remove the non-descriptor OAS bundle pass and shard/injected schema exposure fallback
- project exactly one model name per descriptor while retaining compatibility aliases only at transport/runtime boundaries
- fail closed on missing canonical schemas and descriptor-resolved runtime misses with structured diagnostics
- project task-list guidance by typed external-vs-Keeper audience, including status cache separation
- restore the 12 real library/recurring/local-runtime/goal-hygiene/GC tools through closed schema definitions; raw library read/search stay dispatch-only behind Keeper wrappers
- make Board descriptor visibility, readonly, and effect-domain projection independent of `Tool_catalog` registration order

## Boundary

- MASC-only change; OAS remains unaware of MASC types and policy
- descriptor model projection only; capability permission/risk ownership and legacy alias/prefix removal remain follow-up slices
- closes the PR-B portion of #24032

## Verification

- OCaml parse pass for every changed `.ml`/`.mli`
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- deterministic-boundary, OCaml structure, stringly-boundary, OAS-boundary, Keeper tool matrix, and silent-failure ratchets: pass
- two adversarial flow/type review passes plus the Board CI-regression and compile-fix delta reviews: P0=0, P1=0, P2=0
- rebased without conflict onto `main@cace07b48e`; exact candidate head `6fb2bd443d`
- Health exposed one wrapped-test namespace error (`Tool_shard`); exact-head fix binds the established `Masc.Tool_shard` module explicitly
- Board resource policy is pinned over all 21 typed operations; the old manual ToolSpec readonly string list is derived from the same closed vocabulary
- local Dune build/test intentionally not run; PR CI is the build authority

## Merge gate

Draft and `status:do-not-merge` until required Build/Test CI and review-bot feedback are complete.
