### PR TITLE
fix(keeper): restore keeper_types_profile interface parity broken by #24098

### DIFF
--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -129,9 +129,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> runtime_assignment_result)
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  let result =
     Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
   in
   let result =
@@ -139,6 +136,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Result.map
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
+  in
+  (* [tool_access_defaults_result] must stay the last bind in this chain:
+     its Ok payload (the parsed tool_access value) is what the final
+     [Result.map] below consumes.  Unit-payload validations belong above. *)
+  let result =
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
     (fun tool_access ->

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :


### PR DESCRIPTION
## 증상 (main compile-red)

main(caf8eaf470)에서 `dune build`가 두 에러로 실패합니다. OCaml 5.5 Build Canary도 동일 원인으로 failure.

1. `keeper_types_profile.ml` — 인터페이스 불일치: `keeper_unified_max_tokens_toml_key` / `validate_unified_max_tokens_toml_value` / `parse_unified_max_tokens_override_of_oas_env` "required but not provided"
2. `keeper_types_profile_toml_parser.ml:135` — `fun () ->` 패턴이 `string list option` payload와 불일치

## 뿌리

#24098(squash 5642331f98)이 `keeper_types_profile_oas_env.mli`에 새 값 3개를 추가했는데:

- `keeper_types_profile.mli`는 `include module type of Keeper_types_profile_oas_env`라 인터페이스가 자동 확장됨
- 구현은 `toml → toml_io → toml_parser → oas_env` include 체인으로 흐르는데, **손미러 .mli 3장**(toml_parser/toml_io/toml)이 갱신되지 않아 새 값이 체인 경계에서 필터링됨
- `profile_defaults_of_toml`의 새 검증 bind 2개가 `tool_access` bind(payload `string list option`) **뒤에** 삽입되어 `fun () ->` 타입 불일치

#24098은 CI 미완주 상태로 admin-bypass 병합됨(#24115 웨이브) — latent-red가 실현된 사례입니다.

## 수정

- 미러 .mli 3장에 새 val 3개 선언 추가 (oas_env.mli와 동일 순서/시그니처)
- 검증 bind 2개를 `tool_access_defaults_result` bind 앞으로 이동 + "tool_access가 마지막 bind여야 한다"는 불변식 주석

동작 변경 없음 — #24098이 의도한 typed 검증 계약 그대로, 배선만 수리.

## 검증

- 로컬 `dune build --root . @check`: main 재현 실패 → 본 브랜치 clean
- `@fmt`: 본 PR 파일 diff 없음 (`test/fusion_core/dune` 드리프트는 07-08부터 존재한 기존 건, 범위 외)
- 전체 Build/Test는 CI에서 확인

## 후속 제안 (범위 외)

toml 패밀리 .mli 4중 손미러가 이 사고의 구조적 뿌리입니다. 시그니처를 한 곳에 두고 `include module type of`로 수렴하거나 sync 가드를 두는 정리를 제안합니다 — #24096(sort_order enum mirror drift)과 동일 클래스.

연계: #24098(원인), #24115(병합 규율), #24067(계약 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
