### PR TITLE
fix(auth): reject repeated Host fields before token I/O

### DIFF
--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -137,6 +137,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
   in
+  (* [tool_access_defaults_result] must remain the final bind: its successful
+     payload is consumed by the record-building [Result.map] below. *)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -129,9 +129,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> runtime_assignment_result)
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  let result =
     Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
   in
   let result =
@@ -139,6 +136,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Result.map
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
+  in
+  let result =
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
     (fun tool_access ->

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -455,6 +455,7 @@ let host_port_scheme_of_origin origin =
 
 type request_host_rejection =
   | Missing_request_host
+  | Multiple_request_hosts
   | Malformed_request_host
   | Non_loopback_request_host of string
 
@@ -551,23 +552,27 @@ let parse_request_host_header raw =
         | Error () -> None
 ;;
 
-let admit_loopback_request_host request =
-  match Httpun.Headers.get request.Httpun.Request.headers "host" with
-  | None -> Error Missing_request_host
-  | Some raw ->
+let request_host_of_request request =
+  match Httpun.Headers.get_multi request.Httpun.Request.headers "host" with
+  | [] -> Error Missing_request_host
+  | [ raw ] ->
     (match parse_request_host_header raw with
-     | None -> Error Malformed_request_host
-     | Some ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
-     | Some { host; _ } -> Error (Non_loopback_request_host host))
+     | Some admitted -> Ok admitted
+     | None -> Error Malformed_request_host)
+  | _ -> Error Multiple_request_hosts
+;;
+
+let admit_loopback_request_host request =
+  match request_host_of_request request with
+  | Error rejection -> Error rejection
+  | Ok ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
+  | Ok { host; _ } -> Error (Non_loopback_request_host host)
 ;;
 
 let host_port_of_request request =
-  match Httpun.Headers.get request.Httpun.Request.headers "host" with
-  | None -> None
-  | Some host_header ->
-    Option.map
-      (fun { host; port } -> host, port)
-      (parse_request_host_header host_header)
+  match request_host_of_request request with
+  | Ok { host; port } -> Some (host, port)
+  | Error _ -> None
 
 (* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
    can be toggled without restarting the server process. *)

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -168,6 +168,7 @@ val host_port_scheme_of_origin :
 
 type request_host_rejection =
   | Missing_request_host
+  | Multiple_request_hosts
   | Malformed_request_host
   | Non_loopback_request_host of string
 
@@ -179,8 +180,9 @@ type admitted_request_host =
 val admit_loopback_request_host :
   Httpun.Request.t -> (admitted_request_host, request_host_rejection) result
 (** Parse the request [Host] authority and admit exact loopback hosts only.
-    Missing, malformed, and non-loopback authorities remain distinct typed
-    rejections. Credential-bearing endpoints must run this gate before I/O. *)
+    Missing, repeated, malformed, and non-loopback authorities remain distinct
+    typed rejections. Credential-bearing endpoints must run this gate before
+    I/O. *)
 
 val host_port_of_request : Httpun.Request.t -> (string * int option) option
 (** Host/port from the request's [Host] header. *)

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -10,9 +10,21 @@ type request_error =
   | Request_host_rejected of Server_auth.request_host_rejection
   | Token_operation_failed of string
 
+let request_error_status : request_error -> Httpun.Status.t = function
+  | Request_host_rejected
+      ( Server_auth.Missing_request_host
+      | Server_auth.Multiple_request_hosts
+      | Server_auth.Malformed_request_host ) ->
+    `Bad_request
+  | Request_host_rejected (Server_auth.Non_loopback_request_host _) -> `Forbidden
+  | Token_operation_failed _ -> `Internal_server_error
+;;
+
 let request_error_code = function
   | Request_host_rejected Server_auth.Missing_request_host ->
     "dashboard_dev_token_host_missing"
+  | Request_host_rejected Server_auth.Multiple_request_hosts ->
+    "dashboard_dev_token_host_multiple"
   | Request_host_rejected Server_auth.Malformed_request_host ->
     "dashboard_dev_token_host_malformed"
   | Request_host_rejected (Server_auth.Non_loopback_request_host _) ->
@@ -23,6 +35,8 @@ let request_error_code = function
 let request_error_to_string = function
   | Request_host_rejected Server_auth.Missing_request_host ->
     "dashboard dev-token request is missing the Host header"
+  | Request_host_rejected Server_auth.Multiple_request_hosts ->
+    "dashboard dev-token request contains more than one Host header field"
   | Request_host_rejected Server_auth.Malformed_request_host ->
     "dashboard dev-token request has a malformed Host authority"
   | Request_host_rejected (Server_auth.Non_loopback_request_host host) ->

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -5,6 +5,7 @@ type request_error =
   | Token_operation_failed of string
 
 val dashboard_dev_token_path : string -> string
+val request_error_status : request_error -> Httpun.Status.t
 val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -515,11 +515,7 @@ let add_routes ~sw ~clock router =
                  (`Assoc [ ("token", `String raw) ]) reqd
              | Error err ->
                let status =
-                 match err with
-                 | Server_routes_http_dashboard_dev_token.Request_host_rejected _ ->
-                   `Forbidden
-                 | Server_routes_http_dashboard_dev_token.Token_operation_failed _ ->
-                   `Internal_server_error
+                 Server_routes_http_dashboard_dev_token.request_error_status err
                in
                let error_code =
                  Server_routes_http_dashboard_dev_token.request_error_code err

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,12 +1,19 @@
 open Alcotest
 
+let request_with_headers headers =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list headers)
+    `GET
+    "/api/v1/dashboard/dev-token"
+;;
+
 let request ?host () =
   let headers =
     match host with
-    | None -> Httpun.Headers.empty
-    | Some value -> Httpun.Headers.of_list [ "host", value ]
+    | None -> []
+    | Some value -> [ "host", value ]
   in
-  Httpun.Request.create ~headers `GET "/api/v1/dashboard/dev-token"
+  request_with_headers headers
 ;;
 
 let check_admitted raw expected_host expected_port =
@@ -47,6 +54,17 @@ let test_host_rejections_are_typed () =
   (match Server_auth.admit_loopback_request_host (request ()) with
    | Error Server_auth.Missing_request_host -> ()
    | _ -> fail "missing Host must have a typed rejection");
+  let repeated_host_request =
+    request_with_headers [ "Host", "localhost"; "hOsT", "localhost" ]
+  in
+  (match
+     Server_auth.admit_loopback_request_host repeated_host_request
+   with
+   | Error Server_auth.Multiple_request_hosts -> ()
+   | _ -> fail "multiple Host field lines must have a typed rejection");
+  (match Server_auth.host_port_of_request repeated_host_request with
+   | None -> ()
+   | Some _ -> fail "generic Host projection must reject multiple field lines");
   (match
      Server_auth.admit_loopback_request_host
        (request ~host:"localhost/path" ())
@@ -61,6 +79,29 @@ let test_host_rejections_are_typed () =
    | _ -> fail "non-loopback Host must retain its typed rejection")
 ;;
 
+let test_request_error_statuses () =
+  let status_of rejection =
+    Server_routes_http_dashboard_dev_token.request_error_status
+      (Server_routes_http_dashboard_dev_token.Request_host_rejected rejection)
+    |> Httpun.Status.to_code
+  in
+  check int "missing Host" 400 (status_of Server_auth.Missing_request_host);
+  check int "multiple Host fields" 400 (status_of Server_auth.Multiple_request_hosts);
+  check int "malformed Host" 400 (status_of Server_auth.Malformed_request_host);
+  check
+    string
+    "multiple Host error code"
+    "dashboard_dev_token_host_multiple"
+    (Server_routes_http_dashboard_dev_token.request_error_code
+       (Server_routes_http_dashboard_dev_token.Request_host_rejected
+          Server_auth.Multiple_request_hosts));
+  check
+    int
+    "valid non-loopback Host"
+    403
+    (status_of (Server_auth.Non_loopback_request_host "attacker.example"))
+;;
+
 let test_rejection_precedes_token_io () =
   let base_path = Filename.temp_file "masc-dev-token-host-" ".workspace" in
   Sys.remove base_path;
@@ -68,18 +109,24 @@ let test_rejection_precedes_token_io () =
     ~finally:(fun () -> if Sys.file_exists base_path then Unix.rmdir base_path)
     (fun () ->
        List.iter
-         (fun raw ->
+         (fun (label, request) ->
            match
              Server_routes_http_dashboard_dev_token
              .ensure_dashboard_dev_token_for_request
-               ~request:(request ~host:raw ())
+               ~request
                ~base_path
            with
            | Error
                (Server_routes_http_dashboard_dev_token.Request_host_rejected _) ->
              check bool "base path remains absent" false (Sys.file_exists base_path)
-           | _ -> failf "Host %S must fail before token I/O" raw)
-         [ "attacker.example"; "localhost:8935<suffix>" ])
+           | _ -> failf "%s must fail before token I/O" label)
+         [ "missing Host", request ()
+         ; ( "multiple Host fields"
+           , request_with_headers
+               [ "host", "localhost:8935"; "host", "localhost:8935" ] )
+         ; "non-loopback Host", request ~host:"attacker.example" ()
+         ; "malformed Host", request ~host:"localhost:8935<suffix>" ()
+         ])
 ;;
 
 let () =
@@ -92,6 +139,7 @@ let () =
             `Quick
             test_malformed_suffixes_are_fully_rejected
         ; test_case "typed rejections" `Quick test_host_rejections_are_typed
+        ; test_case "HTTP status mapping" `Quick test_request_error_statuses
         ; test_case "rejection precedes token I/O" `Quick test_rejection_precedes_token_io
         ] )
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1360,6 +1360,29 @@ let test_oas_env_rejects_invalid_unified_max_tokens () =
              (contains_substring detail "positive integer")))
     [ "\"not-an-int\""; "\"8192\""; "true"; "1.5"; "0"; "-1" ]
 
+let test_oas_env_max_tokens_validation_preserves_tool_access () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+tool_access = ["masc_status", "masc_tasks"]
+[keeper.oas_env]
+MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok defaults ->
+       check (option (list string))
+         "max_tokens validation preserves the successful tool_access payload"
+         (Some [ "masc_status"; "masc_tasks" ])
+         defaults.tool_access;
+       check (option int)
+         "valid unified max_tokens remains available after validation"
+         (Some 8192)
+         (KTP.unified_max_tokens_override_of_oas_env defaults.oas_env))
+
 let test_oas_env_drops_non_oas_prefix () =
   (* Guards against ambient env injection via keeper TOML: arbitrary keys
      outside the audited allowlist are silently dropped. *)
@@ -1752,6 +1775,8 @@ let () =
             test_oas_env_rejects_legacy_unified_max_tokens_alias;
           test_case "rejects invalid unified max tokens" `Quick
             test_oas_env_rejects_invalid_unified_max_tokens;
+          test_case "max tokens validation preserves tool_access" `Quick
+            test_oas_env_max_tokens_validation_preserves_tool_access;
           test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
             test_oas_env_drops_non_oas_prefix;
           test_case "empty when table absent" `Quick


### PR DESCRIPTION
## Root cause

`Server_auth.admit_loopback_request_host` used `Httpun.Headers.get`, so the request's Host-field cardinality was discarded and a repeated loopback Host could reach dashboard dev-token credential I/O. The dashboard route also mapped every typed Host rejection to 403, including missing and malformed Host fields.

## Changes

- inspect all case-insensitive Host field lines with `Httpun.Headers.get_multi`
- add `Multiple_request_hosts` to the typed Host rejection algebra
- reuse one request-Host parser for loopback admission and generic Host projection
- centralize the request-error-to-HTTP-status mapping:
  - missing, repeated, or malformed Host -> 400
  - syntactically valid non-loopback Host -> 403
  - token operation failure -> 500
- keep every Host rejection ahead of dashboard token/credential filesystem access
- add regressions for mixed-case repeated Host fields, status mapping, shared projection rejection, and no-I/O failure ordering

RFC 9112 section 3.2 requires 400 for a missing Host field, more than one Host field line, or an invalid Host field value: https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2

## Validation

- `ocamlformat --check` on all six changed OCaml files
- `ocamlc -stop-after parsing` on all six changed OCaml files
- `ocamldep` on all six changed OCaml files
- `git diff --check`
- focused dangerous-pattern scan

Local Dune was intentionally not run; repository CI is the Dune build/test authority.

## Review status

- P0: none found
- P1: none found after patch
- P2: none found
- P3: CI confirmation pending

Follow-up to merged PR #24104.
