### PR TITLE
fix(keeper): restore typed max-token profile validation flow

### DIFF
--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -137,6 +137,8 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
   in
+  (* [tool_access_defaults_result] must remain the final bind: its successful
+     payload is consumed by the record-building [Result.map] below. *)
   let result =
     Result.bind result (fun () -> tool_access_defaults_result)
   in

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -129,9 +129,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> runtime_assignment_result)
   in
   let result =
-    Result.bind result (fun () -> tool_access_defaults_result)
-  in
-  let result =
     Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
   in
   let result =
@@ -139,6 +136,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Result.map
         (fun _ -> ())
         (parse_unified_max_tokens_override_of_oas_env oas_env))
+  in
+  let result =
+    Result.bind result (fun () -> tool_access_defaults_result)
   in
   Result.map
     (fun tool_access ->

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1360,6 +1360,29 @@ let test_oas_env_rejects_invalid_unified_max_tokens () =
              (contains_substring detail "positive integer")))
     [ "\"not-an-int\""; "\"8192\""; "true"; "1.5"; "0"; "-1" ]
 
+let test_oas_env_max_tokens_validation_preserves_tool_access () =
+  let input = {|
+[keeper]
+persona_name = "analyst"
+tool_access = ["masc_status", "masc_tasks"]
+[keeper.oas_env]
+MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok defaults ->
+       check (option (list string))
+         "max_tokens validation preserves the successful tool_access payload"
+         (Some [ "masc_status"; "masc_tasks" ])
+         defaults.tool_access;
+       check (option int)
+         "valid unified max_tokens remains available after validation"
+         (Some 8192)
+         (KTP.unified_max_tokens_override_of_oas_env defaults.oas_env))
+
 let test_oas_env_drops_non_oas_prefix () =
   (* Guards against ambient env injection via keeper TOML: arbitrary keys
      outside the audited allowlist are silently dropped. *)
@@ -1752,6 +1775,8 @@ let () =
             test_oas_env_rejects_legacy_unified_max_tokens_alias;
           test_case "rejects invalid unified max tokens" `Quick
             test_oas_env_rejects_invalid_unified_max_tokens;
+          test_case "max tokens validation preserves tool_access" `Quick
+            test_oas_env_max_tokens_validation_preserves_tool_access;
           test_case "drops non-OAS_* keys (ambient injection guard)" `Quick
             test_oas_env_drops_non_oas_prefix;
           test_case "empty when table absent" `Quick


### PR DESCRIPTION
## 문제

`#24098`이 keeper max-token validation을 `tool_access_defaults_result` 뒤에 연결하면서 `result`의 성공 타입이 이미 `string list option`으로 바뀐 상태에서 `fun () -> ...`을 bind했습니다.

Current main `caf8eaf470`의 OCaml 5.5 canary가 다음 타입 오류로 컴파일되지 않습니다.

```text
File "lib/keeper/keeper_types_profile_toml_parser.ml", line 135:
Error: This variant pattern is expected to have type string list option
       There is no constructor () within type option
```

근거: Actions run `29143421645`, job `86520718045`.

## 수정

- 성공 타입이 `unit`인 validation chain을 먼저 모두 완료합니다.
- 마지막에 `tool_access_defaults_result`를 bind해 `string list option` payload를 최종 `Result.map`까지 보존합니다.
- valid unified max-token + non-empty `tool_access`가 둘 다 보존되는 회귀 테스트를 추가합니다.
- 기존 문자열/bool/float/0/음수 invalid-form rejection 테스트를 유지합니다.

## 검증

- OCaml 5.4.1 parser: PASS (2 files)
- `ocamlformat --check`: PASS
- OCaml 5.4.1 `ocamldep -modules`: PASS
- `git diff --check`: PASS
- 로컬 Dune: 정책에 따라 실행하지 않음; exact-head CI가 빌드 권위

## 범위 분리

적대 리뷰에서 발견한 별도 P1은 이 긴급 컴파일 수정에 섞지 않았습니다.

- #24125 — failover 후보마다 profile을 다시 읽는 mutable max-token intent
- #24126 — invalid keeper/base TOML을 persona/default로 대체하는 fail-open

Refs #24067, #24098
