### PR TITLE
fix(runtime): restore max tokens profile build

### DIFF
--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -132,13 +132,11 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     Result.bind result (fun () -> tool_access_defaults_result)
   in
   let result =
-    Result.bind result (fun () -> validate_unified_max_tokens_toml_value doc)
-  in
-  let result =
-    Result.bind result (fun () ->
-      Result.map
-        (fun _ -> ())
-        (parse_unified_max_tokens_override_of_oas_env oas_env))
+    Result.bind result (fun tool_access ->
+      Result.bind (validate_unified_max_tokens_toml_value doc) (fun () ->
+        Result.map
+          (fun _ -> tool_access)
+          (parse_unified_max_tokens_override_of_oas_env oas_env)))
   in
   Result.map
     (fun tool_access ->

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -179,9 +179,14 @@ val string_of_toml_value_for_env :
   Keeper_toml_loader.toml_value -> string option
 val oas_env_key_prefix : string
 val keeper_unified_max_tokens_oas_env_key : string
+val keeper_unified_max_tokens_toml_key : string
 val oas_env_key_is_allowed : string -> bool
 val extract_oas_env_from_doc :
   Keeper_toml_loader.toml_doc -> (string * string) list
+val validate_unified_max_tokens_toml_value :
+  Keeper_toml_loader.toml_doc -> (unit, string) result
+val parse_unified_max_tokens_override_of_oas_env :
+  (string * string) list -> (int option, string) result
 val unified_max_tokens_override_of_oas_env :
   ?keeper_name:string -> (string * string) list -> int option
 val profile_defaults_of_toml :

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1298,6 +1298,7 @@ let test_oas_env_parses_allowed_keys () =
   let input = {|
 [keeper]
 persona_name = "analyst"
+tool_access = ["masc_board_list"]
 [keeper.oas_env]
 OAS_DEFAULT_MODEL = "provider-a/fast"
 OAS_MAX_TOKENS_DEFAULT = 16384
@@ -1309,6 +1310,8 @@ MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS = 8192
     match KTP.profile_defaults_of_toml doc with
     | Error e -> fail e
     | Ok d ->
+      check (option (list string)) "tool access survives max_tokens validation"
+        (Some [ "masc_board_list" ]) d.tool_access;
       check int "oas_env count" 3 (List.length d.oas_env);
       check string "default model value"
         "provider-a/fast" (List.assoc "OAS_DEFAULT_MODEL" d.oas_env);


### PR DESCRIPTION
## Summary

- preserve the parsed tool_access value while validating unified max_tokens
- propagate the new OAS env validation contract through all hand-maintained TOML interfaces
- add regression coverage that tool_access survives unified max_tokens validation
- restore the main library build broken by #24098

## Verification

- scripts/dune-local.sh build lib/masc.cmxa
- scripts/dune-local.sh build test/test_keeper_toml.exe
- _build/default/test/test_keeper_toml.exe (86/86)
- ocamlformat --check on all five changed files
- git diff --check

Fixes #24130

[근거] local focused build and Keeper TOML test run at d37071d6dd; 확인일시 2026-07-11 KST; 신뢰도 High.