### PR TITLE
fix(keeper): join lane before registry teardown

### DIFF
--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -5,22 +5,28 @@
     Keeper_agent_tool_surface, so lifecycle transitions can update keeper meta
     without creating a keeper tool-surface dependency cycle. *)
 
+let resolved_agent_names_result ~(config : Workspace.config) ~(agent_name : string) =
+  try
+    let actual_name = Workspace.resolve_agent_name config agent_name in
+    Ok ([ agent_name; actual_name ] |> List.sort_uniq String.compare)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
 let resolved_agent_names ~(config : Workspace.config) ~(agent_name : string) =
-  let actual_name =
-    try Workspace.resolve_agent_name config agent_name
-    with
-    | Sys_error _ | Yojson.Json_error _ -> agent_name
-    | exn ->
+  match resolved_agent_names_result ~config ~agent_name with
+  | Ok names -> names
+  | Error detail ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ReconcileFailures)
         ~labels:[("keeper", agent_name); ("phase", "resolve_agent")]
         ();
       Log.Keeper.warn
         "resolve_agent_name failed while reconciling current task for %s: %s"
-        agent_name (Printexc.to_string exn);
-      agent_name
-  in
-  [ agent_name; actual_name ] |> List.sort_uniq String.compare
+        agent_name
+        detail;
+      [ agent_name ]
 
 let task_id_of_owned_active_task ~(keeper_name : string) (task : Masc_domain.task) =
   match Keeper_id.Task_id.of_string task.id with
@@ -40,9 +46,8 @@ type owned_active_task =
   ; task : Masc_domain.task
   }
 
-let owned_active_tasks_for_meta ~(config : Workspace.config)
-    ~(meta : Keeper_meta_contract.keeper_meta) =
-  let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
+let owned_active_tasks_for_names ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) names =
   let matches assignee = List.mem assignee names in
   try
     match Workspace_backlog.read_backlog_r config with
@@ -83,6 +88,28 @@ let owned_active_tasks_for_meta ~(config : Workspace.config)
       "owned task reconciliation failed: %s"
       message;
     Error message
+
+let owned_active_tasks_for_meta ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
+  owned_active_tasks_for_names ~config ~meta names
+;;
+
+let owned_active_tasks_for_meta_strict ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  match resolved_agent_names_result ~config ~agent_name:meta.agent_name with
+  | Error detail ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ReconcileFailures)
+      ~labels:[ "keeper", meta.name; "phase", "shutdown_resolve_agent" ]
+      ();
+    Log.Keeper.warn
+      ~keeper_name:meta.name
+      "shutdown task ownership resolution failed: %s"
+      detail;
+    Error detail
+  | Ok names -> owned_active_tasks_for_names ~config ~meta names
+;;
 
 let active_status_rank = function
   | Masc_domain.InProgress _ -> 0

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -46,7 +46,13 @@ type owned_active_task =
   ; task : Masc_domain.task
   }
 
-let owned_active_tasks_for_names ~(config : Workspace.config)
+type owned_active_tasks_snapshot =
+  { tasks : owned_active_task list
+  ; backlog_tasks : Masc_domain.task list
+  ; backlog_version : int
+  }
+
+let owned_active_tasks_snapshot_for_names ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) names =
   let matches assignee = List.mem assignee names in
   try
@@ -61,21 +67,23 @@ let owned_active_tasks_for_names ~(config : Workspace.config)
         message;
       Error message
     | Ok backlog ->
-      backlog.tasks
-      |> List.filter_map (fun (task : Masc_domain.task) ->
-           match task.task_status with
-           | Masc_domain.Claimed { assignee; _ }
-           | Masc_domain.InProgress { assignee; _ }
-             when matches assignee ->
-               task_id_of_owned_active_task ~keeper_name:meta.name task
-               |> Option.map (fun task_id -> { task_id; task })
-           | Masc_domain.Claimed _
-           | Masc_domain.InProgress _
-           | Masc_domain.AwaitingVerification _
-           | Masc_domain.Todo
-           | Masc_domain.Done _
-           | Masc_domain.Cancelled _ -> None)
-      |> fun tasks -> Ok tasks
+      let tasks =
+        backlog.tasks
+        |> List.filter_map (fun (task : Masc_domain.task) ->
+          match task.task_status with
+          | Masc_domain.Claimed { assignee; _ }
+          | Masc_domain.InProgress { assignee; _ }
+            when matches assignee ->
+            task_id_of_owned_active_task ~keeper_name:meta.name task
+            |> Option.map (fun task_id -> { task_id; task })
+          | Masc_domain.Claimed _
+          | Masc_domain.InProgress _
+          | Masc_domain.AwaitingVerification _
+          | Masc_domain.Todo
+          | Masc_domain.Done _
+          | Masc_domain.Cancelled _ -> None)
+      in
+      Ok { tasks; backlog_tasks = backlog.tasks; backlog_version = backlog.version }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -88,6 +96,10 @@ let owned_active_tasks_for_names ~(config : Workspace.config)
       "owned task reconciliation failed: %s"
       message;
     Error message
+
+let owned_active_tasks_for_names ~config ~meta names =
+  owned_active_tasks_snapshot_for_names ~config ~meta names
+  |> Result.map (fun snapshot -> snapshot.tasks)
 
 let owned_active_tasks_for_meta ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) =
@@ -109,6 +121,22 @@ let owned_active_tasks_for_meta_strict ~(config : Workspace.config)
       detail;
     Error detail
   | Ok names -> owned_active_tasks_for_names ~config ~meta names
+;;
+
+let owned_active_tasks_snapshot_for_meta_strict ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  match resolved_agent_names_result ~config ~agent_name:meta.agent_name with
+  | Error detail ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ReconcileFailures)
+      ~labels:[ "keeper", meta.name; "phase", "shutdown_resolve_agent" ]
+      ();
+    Log.Keeper.warn
+      ~keeper_name:meta.name
+      "shutdown task ownership resolution failed: %s"
+      detail;
+    Error detail
+  | Ok names -> owned_active_tasks_snapshot_for_names ~config ~meta names
 ;;
 
 let active_status_rank = function

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -5,6 +5,12 @@ type owned_active_task = {
   task : Masc_domain.task;
 }
 
+type owned_active_tasks_snapshot =
+  { tasks : owned_active_task list
+  ; backlog_tasks : Masc_domain.task list
+  ; backlog_version : int
+  }
+
 (** Return every Claimed/InProgress backlog task owned by [meta]'s agent
     binding. *)
 val owned_active_tasks_for_meta :
@@ -19,6 +25,14 @@ val owned_active_tasks_for_meta_strict :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   (owned_active_task list, string) result
+
+(** Strict ownership, task records, and the backlog CAS version captured by the
+    same read. The complete task snapshot lets lifecycle transactions reconcile
+    their own durable receipts without racing a second backlog read. *)
+val owned_active_tasks_snapshot_for_meta_strict :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  (owned_active_tasks_snapshot, string) result
 
 (** Find the deterministic active task a keeper should treat as current.
 

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -12,6 +12,14 @@ val owned_active_tasks_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   (owned_active_task list, string) result
 
+(** Shutdown transaction variant: agent-name resolution and backlog reads are
+    both strict. No fallback name is guessed when ownership identity cannot be
+    resolved. *)
+val owned_active_tasks_for_meta_strict :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  (owned_active_task list, string) result
+
 (** Find the deterministic active task a keeper should treat as current.
 
     Only [Claimed] and [InProgress] tasks are active bindings. Tasks awaiting

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -162,7 +162,13 @@ let run_keeper_cycle
          ?hitl_resolution)
   with
   | `Ran updated -> updated
-  | `Busy in_flight ->
+  | `Busy (Keeper_turn_admission.Shutdown_requested operation_id) ->
+    Log.Keeper.info
+      "%s: autonomous turn admission closed by shutdown operation %s"
+      meta_after_triage.name
+      (Keeper_shutdown_types.Operation_id.to_string operation_id);
+    meta_after_triage
+  | `Busy (Keeper_turn_admission.Turn_busy in_flight) ->
     (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
        cycle and return the pre-cycle meta unchanged. The next heartbeat
        retries naturally — same shape as the pre-existing skip decisions. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1008,6 +1008,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         in
         let terminalize_lane = function
           | Keeper_lane.Completed -> record_completed_lane ()
+          | Keeper_lane.Shutdown_requested -> record_stopped "shutdown requested"
           | Keeper_lane.Cancelled_by_parent _ ->
             if Atomic.get stop || Shutdown.is_shutting_down_global ()
             then record_stopped "cancelled during shutdown"

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -763,8 +763,11 @@ let record_keeper_stopped
   =
   if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
   then (
-    ignore (dispatch_event_exact_unit entry Keeper_state_machine.Stop_requested);
-    ignore (dispatch_event_exact_unit entry Keeper_state_machine.Drain_complete);
+    (match dispatch_event_exact_unit entry Keeper_state_machine.Stop_requested with
+     | false -> ()
+     | true ->
+       (match dispatch_event_exact_unit entry Keeper_state_machine.Drain_complete with
+        | true | false -> ()));
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Stopped
       ~keeper_name

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -709,23 +709,62 @@ let resolve_registry_done
   | Keeper_registry.Done_already_resolved _ -> false
 ;;
 
+let log_exact_update_outcome
+      (entry : Keeper_registry.registry_entry)
+      ~site
+  = function
+  | Keeper_registry.Exact_updated -> true
+  | Keeper_registry.Exact_update_missing ->
+    Log.Keeper.warn
+      "%s: exact registry update skipped because lane is no longer registered site=%s"
+      entry.name
+      site;
+    false
+  | Keeper_registry.Exact_update_replaced ->
+    Log.Keeper.warn
+      "%s: exact registry update retained newer same-name lane site=%s"
+      entry.name
+      site;
+    false
+  | Keeper_registry.Exact_update_invalid validation_error ->
+    Log.Keeper.warn
+      "%s: exact registry update validation failed site=%s error=%s"
+      entry.name
+      site
+      (Keeper_registry.registry_entry_validation_error_to_string validation_error);
+    false
+;;
+
+let dispatch_event_exact_unit
+      (entry : Keeper_registry.registry_entry)
+      event
+  =
+  match Keeper_registry.dispatch_event_exact entry event with
+  | Ok _ -> true
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:[ "keeper", entry.name; "site", "exact_lane_terminal" ]
+      ();
+    Log.Keeper.warn
+      "%s: exact-lane terminal dispatch failed event=%s error=%s"
+      entry.name
+      (Keeper_state_machine.event_to_string event)
+      (Keeper_state_machine.transition_error_to_string error);
+    false
+;;
+
 let record_keeper_stopped
       (entry : Keeper_registry.registry_entry)
-      ~base_path
+      ~base_path:_
       ~keeper_name
       ~detail
   : bool
   =
   if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
   then (
-    Keeper_registry.dispatch_event_unit
-      ~base_path
-      keeper_name
-      Keeper_state_machine.Stop_requested;
-    Keeper_registry.dispatch_event_unit
-      ~base_path
-      keeper_name
-      Keeper_state_machine.Drain_complete;
+    ignore (dispatch_event_exact_unit entry Keeper_state_machine.Stop_requested);
+    ignore (dispatch_event_exact_unit entry Keeper_state_machine.Drain_complete);
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Stopped
       ~keeper_name
@@ -737,7 +776,7 @@ let record_keeper_stopped
 
 let record_keeper_crashed
       (entry : Keeper_registry.registry_entry)
-      ~base_path
+      ~base_path:_
       ~keeper_name
       ~failure_reason
   : unit
@@ -746,13 +785,18 @@ let record_keeper_crashed
   if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
   then (
     let outcome = reason in
-    Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
-    Keeper_registry.dispatch_event_unit
-      ~base_path
-      keeper_name
-      (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
-    Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
-    Keeper_registry_error_recording.record ~base_path keeper_name reason;
+    ignore
+      (Keeper_registry.set_failure_reason_exact entry (Some failure_reason)
+       |> log_exact_update_outcome entry ~site:"record_keeper_crashed.failure_reason");
+    ignore
+      (dispatch_event_exact_unit
+         entry
+         (Keeper_state_machine.Fiber_terminated
+            { outcome; provider_id = None; http_status = None }));
+    ignore
+      (Keeper_registry.record_crash_exact entry (Time_compat.now ()) reason
+       |> log_exact_update_outcome entry ~site:"record_keeper_crashed.crash_log");
+    Keeper_registry_error_recording.record_exact entry reason;
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Crashed
       ~keeper_name
@@ -897,17 +941,127 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         let stop = reg.fiber_stop in
         let wakeup = reg.fiber_wakeup in
         let live_meta = bootstrap_live_keeper_meta ~ctx m in
-        Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
+        let live_meta_installed =
+          Keeper_registry.update_entry_exact reg (fun current ->
+            { current with meta = live_meta })
+          |> log_exact_update_outcome reg ~site:"start_keepalive.live_meta"
+        in
+        if not live_meta_installed
+        then (
+          let failure_reason = Keeper_registry.Exception "lane_ownership_lost_before_fork" in
+          record_keeper_crashed
+            reg
+            ~base_path:ctx.config.base_path
+            ~keeper_name:live_meta.name
+            ~failure_reason;
+          match
+            Keeper_lane.reject_before_start
+              reg.lane
+              ~reason:(Failure "lane ownership lost before fork")
+          with
+          | Ok () -> ()
+          | Error error ->
+            Log.Keeper.warn
+              "%s: failed to close rejected stale lane: %s"
+              live_meta.name
+              (Keeper_lane.start_error_to_string error))
+        else (
         (* Telemetry feedback refresh loop removed in #6814:
          behavioral_stats no longer consumed by build_prompt. *)
+        let current_failure_reason () =
+          match Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name with
+          | Some current
+            when Keeper_lane.Id.equal
+                   (Keeper_lane.id current.lane)
+                   (Keeper_lane.id reg.lane) ->
+            current.last_failure_reason
+          | Some _ | None -> None
+        in
+        let record_crash failure_reason =
+          record_keeper_crashed
+            reg
+            ~base_path:ctx.config.base_path
+            ~keeper_name:live_meta.name
+            ~failure_reason
+        in
+        let record_stopped detail =
+          ignore
+            (record_keeper_stopped
+               reg
+               ~base_path:ctx.config.base_path
+               ~keeper_name:live_meta.name
+               ~detail)
+        in
+        let record_completed_lane () =
+          match current_failure_reason () with
+          | Some
+              (( Keeper_registry.Stale_turn_timeout _
+               | Keeper_registry.Stale_termination_storm _
+               | Keeper_registry.Stale_fleet_batch _
+               | Keeper_registry.Provider_timeout_loop _ ) as reason) ->
+            record_crash reason
+          | Some _ | None ->
+            record_stopped (if Atomic.get stop then "manual stop" else "normal exit")
+        in
+        let terminalize_lane = function
+          | Keeper_lane.Completed -> record_completed_lane ()
+          | Keeper_lane.Cancelled_by_parent _ ->
+            if Atomic.get stop || Shutdown.is_shutting_down_global ()
+            then record_stopped "cancelled during shutdown"
+            else
+              record_crash
+                (Keeper_registry.Fiber_unresolved Keeper_registry.Cancelled_by_parent)
+          | Keeper_lane.Failed Keeper_registry.Keeper_fiber_crash ->
+            (match current_failure_reason () with
+             | Some reason -> record_crash reason
+             | None when Atomic.get stop -> record_stopped "manual stop"
+             | None -> record_crash (Keeper_registry.Exception "fiber_crash"))
+          | Keeper_lane.Failed exn ->
+            if Atomic.get stop
+            then record_stopped "manual stop"
+            else (
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string HeartbeatFailures)
+                ~labels:[ "keeper", live_meta.name; "phase", "lane_crash" ]
+                ();
+              Log.Keeper.emit
+                Log.Error
+                ~category:Log.Heartbeat
+                ~details:
+                  (`Assoc
+                    [ "keeper", `String live_meta.name
+                    ; "error", `String (Printexc.to_string exn)
+                    ])
+                (Printf.sprintf
+                   "keeper lane for %s crashed: %s"
+                   live_meta.name
+                   (Printexc.to_string exn));
+              record_crash (Keeper_registry.Exception (Printexc.to_string exn)))
+        in
         (* Lane cleanup is declared outside [run] because [Keeper_lane.fork]
            invokes it only after the run scope and all child fibers join. *)
-        let cleanup_tracking _outcome =
+        let cleanup_tracking outcome =
+          let terminal_result =
+            try
+              terminalize_lane outcome;
+              Ok ()
+            with
+            | exn -> Error (Printexc.to_string exn)
+          in
+          let tracking_result =
           try
-            Keeper_registry.cleanup_tracking
-              ~base_path:ctx.config.base_path
-              live_meta.name;
-            Ok ()
+            (match Keeper_registry.cleanup_tracking_exact reg with
+             | Keeper_registry.Exact_updated
+             | Keeper_registry.Exact_update_missing -> Ok ()
+             | Keeper_registry.Exact_update_replaced ->
+               Log.Keeper.info
+                 "%s: lane cleanup retained newer same-name registry entry"
+                 live_meta.name;
+               Ok ()
+             | Keeper_registry.Exact_update_invalid validation_error ->
+               Error
+                 (Keeper_registry.registry_entry_validation_error_to_string
+                    validation_error))
           with
           | Eio.Cancel.Cancelled _ as exn -> Error (Printexc.to_string exn)
           | e ->
@@ -929,6 +1083,16 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                  live_meta.name
                  detail);
             Error detail
+          in
+          match terminal_result, tracking_result with
+          | Ok (), Ok () -> Ok ()
+          | Error detail, Ok () | Ok (), Error detail -> Error detail
+          | Error terminal_detail, Error tracking_detail ->
+            Error
+              (Printf.sprintf
+                 "terminal cleanup failed: %s; tracking cleanup failed: %s"
+                 terminal_detail
+                 tracking_detail)
         in
         publish_keeper_started ~live_meta;
         (match
@@ -942,78 +1106,9 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         let grpc_close = start_keeper_grpc_heartbeat ~ctx ~m ~stop in
         (match grpc_close with
          | Some _ ->
-           Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name grpc_close
+           Atomic.set reg.grpc_close grpc_close
          | None -> ());
-        let record_crash failure_reason =
-          record_keeper_crashed
-            reg
-            ~base_path:ctx.config.base_path
-            ~keeper_name:live_meta.name
-            ~failure_reason
-        in
-        let record_stopped detail =
-          ignore
-            (record_keeper_stopped
-               reg
-               ~base_path:ctx.config.base_path
-               ~keeper_name:live_meta.name
-               ~detail)
-        in
-        let record_loop_exit () =
-          match Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name with
-          | Some
-              { Keeper_registry.last_failure_reason =
-                  Some
-                    (( Keeper_registry.Stale_turn_timeout _
-                     | Keeper_registry.Stale_termination_storm _
-                     | Keeper_registry.Stale_fleet_batch _
-                     | Keeper_registry.Provider_timeout_loop _ ) as reason)
-              ; _
-              } -> record_crash reason
-          | _ -> record_stopped "normal exit"
-        in
-        (try
-           run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup;
-           record_loop_exit ()
-         with
-         | Keeper_registry.Keeper_fiber_crash ->
-           if Atomic.get stop
-           then record_stopped "manual stop"
-           else (
-             let reason =
-               match
-                 Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name
-               with
-               | Some e ->
-                 Option.value
-                   ~default:(Keeper_registry.Exception "fiber_crash")
-                   e.last_failure_reason
-               | None -> Keeper_registry.Exception "fiber_crash"
-             in
-             record_crash reason)
-         | Eio.Cancel.Cancelled _ ->
-           record_stopped "cancelled"
-         | exn ->
-           if Atomic.get stop
-           then record_stopped "manual stop"
-           else (
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string HeartbeatFailures)
-               ~labels:[ "keeper", live_meta.name; "phase", "loop_crash" ]
-               ();
-             Log.Keeper.emit
-               Log.Error
-               ~category:Log.Heartbeat
-               ~details:
-                 (`Assoc
-                   [ "keeper", `String live_meta.name
-                   ; "error", `String (Printexc.to_string exn)
-                   ])
-               (Printf.sprintf
-                  "heartbeat loop for %s crashed: %s"
-                  live_meta.name
-                  (Printexc.to_string exn));
-             record_crash (Keeper_registry.Exception (Printexc.to_string exn)))))
+        run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup)
              ~cleanup:cleanup_tracking
          with
          | Ok () -> ()
@@ -1024,6 +1119,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
              ~base_path:ctx.config.base_path
              ~keeper_name:live_meta.name
              ~failure_reason:(Keeper_registry.Exception detail)))
+        )
 ;;
 
 type joined_stop =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -780,7 +780,10 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
       Keeper_registry.get ~base_path:ctx.config.base_path m.name
     in
     let reclaimable_stale_entry (entry : Keeper_registry.registry_entry) =
-      let finished = Option.is_some (Eio.Promise.peek entry.done_p) in
+      let finished =
+        Option.is_some (Eio.Promise.peek entry.done_p)
+        && Keeper_registry.lane_has_exited entry
+      in
       match entry.phase with
       | Keeper_state_machine.Stopped -> finished
       | Keeper_state_machine.Failing
@@ -810,7 +813,13 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
             "start_keepalive: reclaiming stale registered entry %s phase=%s"
             m.name
             (Keeper_state_machine.phase_to_string entry.phase));
-       Keeper_registry.unregister ~base_path:ctx.config.base_path m.name
+       (match Keeper_registry.unregister_exact entry with
+        | Keeper_registry.Exact_unregistered
+        | Keeper_registry.Exact_entry_missing -> ()
+        | Keeper_registry.Exact_entry_replaced ->
+          Log.Keeper.info
+            "start_keepalive: stale entry for %s was already replaced; keeping the newer lane"
+            m.name)
      | _ -> ());
     if Keeper_registry.is_registered ~base_path:ctx.config.base_path m.name
     then
@@ -876,22 +885,35 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
             ~phase:Keeper_state_machine.Crashed
             ~keeper_name:m.name
             ~detail:reason
-            ()
+            ();
+        (match Keeper_lane.reject_before_start reg.lane ~reason:(Failure reason) with
+         | Ok () -> ()
+         | Error lane_error ->
+           Log.Keeper.error
+             "%s: rejected launch could not close lane join contract: %s"
+             m.name
+             (Keeper_lane.start_error_to_string lane_error))
       | Ok () ->
         let stop = reg.fiber_stop in
         let wakeup = reg.fiber_wakeup in
-        (* Start optional gRPC heartbeat fiber *)
-        let grpc_close = start_keeper_grpc_heartbeat ~ctx ~m ~stop in
-        (match grpc_close with
-         | Some _ ->
-           Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name grpc_close
-         | None -> ());
         let live_meta = bootstrap_live_keeper_meta ~ctx m in
         Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
         (* Telemetry feedback refresh loop removed in #6814:
          behavioral_stats no longer consumed by build_prompt. *)
         publish_keeper_started ~live_meta;
-        Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+        (match
+           Keeper_lane.fork
+             ~sw:ctx.sw
+             reg.lane
+             ~run:(fun lane_sw ->
+        let ctx = { ctx with sw = lane_sw } in
+        (* The sidecar is part of this Keeper lane. It cannot outlive the
+           lane's structured-concurrency scope. *)
+        let grpc_close = start_keeper_grpc_heartbeat ~ctx ~m ~stop in
+        (match grpc_close with
+         | Some _ ->
+           Keeper_registry.set_grpc_close ~base_path:ctx.config.base_path m.name grpc_close
+         | None -> ());
         let record_crash failure_reason =
           record_keeper_crashed
             reg
@@ -927,14 +949,16 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
          Cancelled (the outer one is in flight) and log non-cancel
          exceptions instead of propagating them. Mirrors
          keeper_agent_run.ml and keeper_unified_turn.ml:990. *)
-        let safe_cleanup_tracking () =
+        let cleanup_tracking _outcome =
           try
             Keeper_registry.cleanup_tracking
               ~base_path:ctx.config.base_path
-              live_meta.name
+              live_meta.name;
+            Ok ()
           with
-          | Eio.Cancel.Cancelled _ -> ()
+          | Eio.Cancel.Cancelled _ as exn -> Error (Printexc.to_string exn)
           | e ->
+            let detail = Printexc.to_string e in
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string CleanupTrackingFailures)
               ~labels:[ "keeper", live_meta.name; "site", "heartbeat_finally" ]
@@ -945,67 +969,78 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
               ~details:
                 (`Assoc
                   [ "keeper", `String live_meta.name
-                  ; "error", `String (Printexc.to_string e)
+                  ; "error", `String detail
                   ])
               (Printf.sprintf
                  "%s: cleanup_tracking in heartbeat finally raised: %s"
                  live_meta.name
-                 (Printexc.to_string e))
+                 detail);
+            Error detail
         in
-        Eio_guard.protect
-          (fun () ->
-             try
-               run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup;
-               record_loop_exit ()
-             with
-             | Keeper_registry.Keeper_fiber_crash ->
-               if Atomic.get stop
-               then record_stopped "manual stop"
-               else (
-                 let reason =
-                   match
-                     Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name
-                   with
-                   | Some e ->
-                     Option.value
-                       ~default:(Keeper_registry.Exception "fiber_crash")
-                       e.last_failure_reason
-                   | None -> Keeper_registry.Exception "fiber_crash"
-                 in
-                 record_crash reason)
-             | Eio.Cancel.Cancelled _ ->
-               record_stopped "cancelled"
-             | exn ->
-               if Atomic.get stop
-               then record_stopped "manual stop"
-               else (
-                 Otel_metric_store.inc_counter
-                   Keeper_metrics.(to_string HeartbeatFailures)
-                   ~labels:[ "keeper", live_meta.name; "phase", "loop_crash" ]
-                   ();
-                 Log.Keeper.emit
-                   Log.Error
-                   ~category:Log.Heartbeat
-                   ~details:
-                     (`Assoc
-                       [ "keeper", `String live_meta.name
-                       ; "error", `String (Printexc.to_string exn)
-                       ])
-                   (Printf.sprintf
-                      "heartbeat loop for %s crashed: %s"
-                      live_meta.name
-                      (Printexc.to_string exn));
-                 record_crash (Keeper_registry.Exception (Printexc.to_string exn))))
-          ~finally:safe_cleanup_tracking))
+        (try
+           run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup;
+           record_loop_exit ()
+         with
+         | Keeper_registry.Keeper_fiber_crash ->
+           if Atomic.get stop
+           then record_stopped "manual stop"
+           else (
+             let reason =
+               match
+                 Keeper_registry.get ~base_path:ctx.config.base_path live_meta.name
+               with
+               | Some e ->
+                 Option.value
+                   ~default:(Keeper_registry.Exception "fiber_crash")
+                   e.last_failure_reason
+               | None -> Keeper_registry.Exception "fiber_crash"
+             in
+             record_crash reason)
+         | Eio.Cancel.Cancelled _ ->
+           record_stopped "cancelled"
+         | exn ->
+           if Atomic.get stop
+           then record_stopped "manual stop"
+           else (
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string HeartbeatFailures)
+               ~labels:[ "keeper", live_meta.name; "phase", "loop_crash" ]
+               ();
+             Log.Keeper.emit
+               Log.Error
+               ~category:Log.Heartbeat
+               ~details:
+                 (`Assoc
+                   [ "keeper", `String live_meta.name
+                   ; "error", `String (Printexc.to_string exn)
+                   ])
+               (Printf.sprintf
+                  "heartbeat loop for %s crashed: %s"
+                  live_meta.name
+                  (Printexc.to_string exn));
+             record_crash (Keeper_registry.Exception (Printexc.to_string exn)))))
+             ~cleanup:cleanup_tracking
+         with
+         | Ok () -> ()
+         | Error error ->
+           let detail = Keeper_lane.start_error_to_string error in
+           record_keeper_crashed
+             reg
+             ~base_path:ctx.config.base_path
+             ~keeper_name:live_meta.name
+             ~failure_reason:(Keeper_registry.Exception detail)))
 ;;
 
-let stop_keepalive ?base_path name =
-  let entries =
-    Keeper_registry.all ?base_path ()
-    |> List.filter (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name)
-  in
-  List.iter
-    (fun (entry : Keeper_registry.registry_entry) ->
+type joined_stop =
+  { lane_exit : Keeper_lane.exit
+  ; terminal : Keeper_registry.done_resolution
+  }
+
+type joined_stop_result =
+  | Keeper_not_registered
+  | Keeper_joined of joined_stop
+
+let request_entry_stop (entry : Keeper_registry.registry_entry) =
        (* tla-lint: allow-mutation: fiber signal — stop+wakeup pair triggers cooperative shutdown *)
        Atomic.set entry.fiber_stop true;
        Atomic.set entry.fiber_wakeup true;
@@ -1023,18 +1058,24 @@ let stop_keepalive ?base_path name =
                "masc_keeper_grpc_close_failures"
                ~labels:[ "keeper", entry.meta.name ]
                ())
-        | None -> ());
-       match entry.phase with
-       | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> ()
-       | _ ->
-         if
-           record_keeper_stopped
-             entry
-             ~base_path:entry.base_path
-             ~keeper_name:entry.name
-             ~detail:"manual stop"
-         then Keeper_registry.cleanup_tracking ~base_path:entry.base_path entry.name)
-    entries
+        | None -> ())
+;;
+
+let stop_keepalive ?base_path name =
+  Keeper_registry.all ?base_path ()
+  |> List.filter (fun (entry : Keeper_registry.registry_entry) ->
+    String.equal entry.name name)
+  |> List.iter request_entry_stop
+;;
+
+let stop_keepalive_and_await ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> Keeper_not_registered
+  | Some entry ->
+    request_entry_stop entry;
+    let lane_exit = Keeper_lane.await_exit entry.lane in
+    let terminal = Eio.Promise.await entry.done_p in
+    Keeper_joined { lane_exit; terminal }
 ;;
 
 (** Stop all running keepers. Used in test cleanup to prevent orphaned

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -900,6 +900,36 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
         (* Telemetry feedback refresh loop removed in #6814:
          behavioral_stats no longer consumed by build_prompt. *)
+        (* Lane cleanup is declared outside [run] because [Keeper_lane.fork]
+           invokes it only after the run scope and all child fibers join. *)
+        let cleanup_tracking _outcome =
+          try
+            Keeper_registry.cleanup_tracking
+              ~base_path:ctx.config.base_path
+              live_meta.name;
+            Ok ()
+          with
+          | Eio.Cancel.Cancelled _ as exn -> Error (Printexc.to_string exn)
+          | e ->
+            let detail = Printexc.to_string e in
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string CleanupTrackingFailures)
+              ~labels:[ "keeper", live_meta.name; "site", "heartbeat_finally" ]
+              ();
+            Log.Keeper.emit
+              Log.Warn
+              ~category:Log.Heartbeat
+              ~details:
+                (`Assoc
+                  [ "keeper", `String live_meta.name
+                  ; "error", `String detail
+                  ])
+              (Printf.sprintf
+                 "%s: cleanup_tracking in heartbeat finally raised: %s"
+                 live_meta.name
+                 detail);
+            Error detail
+        in
         publish_keeper_started ~live_meta;
         (match
            Keeper_lane.fork
@@ -941,41 +971,6 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
               ; _
               } -> record_crash reason
           | _ -> record_stopped "normal exit"
-        in
-        (* Cancel-safe finally (#9747 iter 2): [cleanup_tracking] touches
-         registry state that can raise transiently during shutdown.
-         Stdlib [Fun.protect] would wrap that as [Fun.Finally_raised],
-         masking the body's Cancelled / Keeper_fiber_crash. Swallow
-         Cancelled (the outer one is in flight) and log non-cancel
-         exceptions instead of propagating them. Mirrors
-         keeper_agent_run.ml and keeper_unified_turn.ml:990. *)
-        let cleanup_tracking _outcome =
-          try
-            Keeper_registry.cleanup_tracking
-              ~base_path:ctx.config.base_path
-              live_meta.name;
-            Ok ()
-          with
-          | Eio.Cancel.Cancelled _ as exn -> Error (Printexc.to_string exn)
-          | e ->
-            let detail = Printexc.to_string e in
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string CleanupTrackingFailures)
-              ~labels:[ "keeper", live_meta.name; "site", "heartbeat_finally" ]
-              ();
-            Log.Keeper.emit
-              Log.Warn
-              ~category:Log.Heartbeat
-              ~details:
-                (`Assoc
-                  [ "keeper", `String live_meta.name
-                  ; "error", `String detail
-                  ])
-              (Printf.sprintf
-                 "%s: cleanup_tracking in heartbeat finally raised: %s"
-                 live_meta.name
-                 detail);
-            Error detail
         in
         (try
            run_heartbeat_loop ~proactive_warmup_sec ctx live_meta stop ~wakeup;

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -888,11 +888,25 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
           ~keeper_name:m.name
           ~detail:(Keeper_registry.spawn_slot_denial_reason_to_detail reason)
           ()
-      | Ok () -> (
+      | Ok () ->
       (* Register in Keeper_registry first — single source of truth. *)
-      let reg =
-        Keeper_registry.register_offline ~base_path:ctx.config.base_path m.name m
-      in
+      (match
+         Keeper_registry.register_offline_if_admitted
+           ~base_path:ctx.config.base_path
+           m.name
+           m
+       with
+       | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+         Log.Keeper.info
+           "start_keepalive: skipped %s because shutdown operation %s owns admission"
+           m.name
+           (Keeper_shutdown_types.Operation_id.to_string operation_id)
+       | Error (Keeper_registry.Registration_invalid validation_error) ->
+         Log.Keeper.error
+           "start_keepalive: registry validation rejected %s: %s"
+           m.name
+           (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+       | Ok reg ->
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,
@@ -1008,6 +1022,8 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         in
         let terminalize_lane = function
           | Keeper_lane.Completed -> record_completed_lane ()
+          | Keeper_lane.Shutdown_before_start ->
+            record_stopped "shutdown requested before lane start"
           | Keeper_lane.Shutdown_requested -> record_stopped "shutdown requested"
           | Keeper_lane.Cancelled_by_parent _ ->
             if Atomic.get stop || Shutdown.is_shutting_down_global ()

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -117,5 +117,22 @@ val percentile : float array -> float -> float
 
 val start_keepalive :
   ?proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
+
+type joined_stop =
+  { lane_exit : Keeper_lane.exit
+  ; terminal : Keeper_registry.done_resolution
+  }
+
+type joined_stop_result =
+  | Keeper_not_registered
+  | Keeper_joined of joined_stop
+
+(** Request cooperative stop without claiming that the lane has exited. *)
 val stop_keepalive : ?base_path:string -> string -> unit
+
+(** Request cooperative stop and join the exact registry entry observed by
+    this call. No timeout is invented: callers choose whether to await. *)
+val stop_keepalive_and_await :
+  base_path:string -> string -> joined_stop_result
+
 val stop_all_keepalives : unit -> unit

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -130,6 +130,9 @@ type joined_stop_result =
 (** Request cooperative stop without claiming that the lane has exited. *)
 val stop_keepalive : ?base_path:string -> string -> unit
 
+(** Signal only the exact captured registry entry. *)
+val request_entry_stop : Keeper_registry.registry_entry -> unit
+
 (** Request cooperative stop and join the exact registry entry observed by
     this call. No timeout is invented: callers choose whether to await. *)
 val stop_keepalive_and_await :

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -19,7 +19,7 @@ module Id = struct
   let prefix = "lane-"
   (* NDT-OK: UUID entropy is identity only; lifecycle decisions compare the
      typed value and never branch on its random contents. *)
-  let rng = Random.State.make_self_init ()
+  let rng = Random.State.make_self_init () (* NDT-OK: identity entropy only *)
   let rng_mutex = Eio.Mutex.create ()
 
   let generate () =

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,0 +1,98 @@
+type outcome =
+  | Completed
+  | Cancelled_by_parent of exn
+  | Failed of exn
+
+type exit =
+  { outcome : outcome
+  ; cleanup_error : string option
+  }
+
+type state =
+  | Not_started
+  | Running
+  | Exited
+
+type t =
+  { state : state Atomic.t
+  ; exited_p : exit Eio.Promise.t
+  ; exited_r : exit Eio.Promise.u
+  }
+
+type start_error =
+  | Already_started
+  | Already_exited
+  | Fork_failed of exn
+
+let start_error_to_string = function
+  | Already_started -> "lane already started"
+  | Already_exited -> "lane already exited"
+  | Fork_failed exn -> Printf.sprintf "lane fork failed: %s" (Printexc.to_string exn)
+;;
+
+let create () =
+  let exited_p, exited_r = Eio.Promise.create () in
+  { state = Atomic.make Not_started; exited_p; exited_r }
+;;
+
+let exited t = t.exited_p
+let peek_exit t = Eio.Promise.peek t.exited_p
+let await_exit t = Eio.Promise.await t.exited_p
+
+let rec claim_start t =
+  if Atomic.compare_and_set t.state Not_started Running
+  then Ok ()
+  else
+    match Atomic.get t.state with
+    | Not_started -> claim_start t
+    | Running -> Error Already_started
+    | Exited -> Error Already_exited
+;;
+
+let cleanup_result cleanup outcome =
+  Eio.Cancel.protect (fun () ->
+    try
+      match cleanup outcome with
+      | Ok () -> None
+      | Error detail -> Some detail
+    with
+    | exn -> Some (Printexc.to_string exn))
+;;
+
+let resolve_exit t outcome cleanup_error =
+  Atomic.set t.state Exited;
+  Eio.Promise.resolve t.exited_r { outcome; cleanup_error }
+;;
+
+let fork ~sw t ~run ~cleanup =
+  match claim_start t with
+  | Error _ as error -> error
+  | Ok () ->
+    (try
+       Eio.Fiber.fork ~sw (fun () ->
+         let outcome =
+           try
+             Eio.Switch.run (fun lane_sw -> run lane_sw);
+             Completed
+           with
+           | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
+           | exn -> Failed exn
+         in
+         let cleanup_error = cleanup_result cleanup outcome in
+         resolve_exit t outcome cleanup_error);
+       Ok ()
+     with
+     | exn ->
+       let outcome = Failed exn in
+       let cleanup_error = cleanup_result cleanup outcome in
+       resolve_exit t outcome cleanup_error;
+       Error (Fork_failed exn))
+;;
+
+let reject_before_start t ~reason =
+  match claim_start t with
+  | Error _ as error -> error
+  | Ok () ->
+    resolve_exit t (Failed reason) None;
+    Ok ()
+;;

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -118,7 +118,11 @@ let fork ~sw t ~run ~cleanup =
            | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
            | exn -> Failed exn
          in
-         ignore (resolve_exit_once t outcome cleanup));
+         match resolve_exit_once t outcome cleanup with
+         | true -> ()
+         | false ->
+           (* A concurrent rejected-fork path already settled the same lane. *)
+           ());
        if Atomic.get started
        then Ok ()
        else
@@ -136,7 +140,11 @@ let fork ~sw t ~run ~cleanup =
      with
      | exn ->
        let outcome = Failed exn in
-       ignore (resolve_exit_once t outcome cleanup);
+       (match resolve_exit_once t outcome cleanup with
+        | true -> ()
+        | false ->
+          (* The child won the exact-once settlement race before fork raised. *)
+          ());
        Error (Fork_failed exn))
 ;;
 
@@ -144,6 +152,7 @@ let reject_before_start t ~reason =
   match claim_start t with
   | Error _ as error -> error
   | Ok () ->
-    ignore (resolve_exit_once t (Failed reason) (fun _ -> Ok ()));
-    Ok ()
+    if resolve_exit_once t (Failed reason) (fun _ -> Ok ())
+    then Ok ()
+    else Error Already_exited
 ;;

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,5 +1,6 @@
 type outcome =
   | Completed
+  | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -10,8 +11,13 @@ type exit =
 
 type state =
   | Not_started
-  | Running
+  | Starting
+  | Running of Eio.Switch.t
+  | Cancellation_requested
+  | Finalizing
   | Exited
+
+exception Shutdown_cancel
 
 module Id = struct
   type t = string
@@ -57,6 +63,12 @@ type start_error =
   | Already_exited
   | Fork_failed of exn
 
+type cancel_result =
+  | Cancel_requested
+  | Cancel_already_requested
+  | Cancel_already_exiting
+  | Cancel_signal_failed of exn
+
 let start_error_to_string = function
   | Already_started -> "lane already started"
   | Already_exited -> "lane already exited"
@@ -74,13 +86,29 @@ let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p
 
 let rec claim_start t =
-  if Atomic.compare_and_set t.state Not_started Running
+  if Atomic.compare_and_set t.state Not_started Starting
   then Ok ()
   else
     match Atomic.get t.state with
     | Not_started -> claim_start t
-    | Running -> Error Already_started
-    | Exited -> Error Already_exited
+    | Starting | Running _ | Cancellation_requested -> Error Already_started
+    | Finalizing | Exited -> Error Already_exited
+;;
+
+type attach_result =
+  | Scope_attached
+  | Cancel_before_attach
+
+let rec attach_scope t lane_sw =
+  let current = Atomic.get t.state in
+  match current with
+  | Starting ->
+    if Atomic.compare_and_set t.state current (Running lane_sw)
+    then Scope_attached
+    else attach_scope t lane_sw
+  | Cancellation_requested -> Cancel_before_attach
+  | Not_started | Running _ | Finalizing | Exited ->
+    invalid_arg "Keeper_lane.attach_scope: invalid lane state"
 ;;
 
 let cleanup_result cleanup outcome =
@@ -93,13 +121,56 @@ let cleanup_result cleanup outcome =
     | exn -> Some (Printexc.to_string exn))
 ;;
 
+let rec claim_finalization t =
+  let current = Atomic.get t.state in
+  match current with
+  | Starting | Running _ | Cancellation_requested ->
+    if Atomic.compare_and_set t.state current Finalizing
+    then true
+    else claim_finalization t
+  | Not_started | Finalizing | Exited -> false
+;;
+
 let resolve_exit_once t outcome cleanup =
-  if Atomic.compare_and_set t.state Running Exited
+  if claim_finalization t
   then (
     let cleanup_error = cleanup_result cleanup outcome in
+    Atomic.set t.state Exited;
     Eio.Promise.resolve t.exited_r { outcome; cleanup_error };
     true)
   else false
+;;
+
+let rec request_cancel t =
+  let current = Atomic.get t.state in
+  match current with
+  | Not_started ->
+    if Atomic.compare_and_set t.state current Finalizing
+    then (
+      Atomic.set t.state Exited;
+      Eio.Promise.resolve
+        t.exited_r
+        { outcome = Shutdown_requested; cleanup_error = None };
+      Cancel_requested)
+    else request_cancel t
+  | Starting ->
+    if Atomic.compare_and_set t.state current Cancellation_requested
+    then Cancel_requested
+    else request_cancel t
+  | Running lane_sw ->
+    if Atomic.compare_and_set t.state current Cancellation_requested
+    then
+      (try
+         Eio.Switch.fail lane_sw Shutdown_cancel;
+         Cancel_requested
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         ignore (Atomic.compare_and_set t.state Cancellation_requested current);
+         Cancel_signal_failed exn)
+    else request_cancel t
+  | Cancellation_requested -> Cancel_already_requested
+  | Finalizing | Exited -> Cancel_already_exiting
 ;;
 
 let fork ~sw t ~run ~cleanup =
@@ -112,9 +183,15 @@ let fork ~sw t ~run ~cleanup =
          Atomic.set started true;
          let outcome =
            try
-             Eio.Switch.run (fun lane_sw -> run lane_sw);
+             Eio.Switch.run (fun lane_sw ->
+               match attach_scope t lane_sw with
+               | Scope_attached -> run lane_sw
+               | Cancel_before_attach ->
+                 Eio.Switch.fail lane_sw Shutdown_cancel;
+                 Eio.Switch.check lane_sw);
              Completed
            with
+           | Shutdown_cancel -> Shutdown_requested
            | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
            | exn -> Failed exn
          in

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -141,6 +141,15 @@ let resolve_exit_once t outcome cleanup =
   else false
 ;;
 
+let resolve_exit_without_cleanup t outcome =
+  if claim_finalization t
+  then (
+    Atomic.set t.state Exited;
+    Eio.Promise.resolve t.exited_r { outcome; cleanup_error = None };
+    true)
+  else false
+;;
+
 let rec request_cancel t =
   let current = Atomic.get t.state in
   match current with
@@ -229,7 +238,7 @@ let reject_before_start t ~reason =
   match claim_start t with
   | Error _ as error -> error
   | Ok () ->
-    if resolve_exit_once t (Failed reason) (fun _ -> Ok ())
+    if resolve_exit_without_cleanup t (Failed reason)
     then Ok ()
     else Error Already_exited
 ;;

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,5 +1,6 @@
 type outcome =
   | Completed
+  | Shutdown_before_start
   | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
@@ -159,7 +160,7 @@ let rec request_cancel t =
       Atomic.set t.state Exited;
       Eio.Promise.resolve
         t.exited_r
-        { outcome = Shutdown_requested; cleanup_error = None };
+        { outcome = Shutdown_before_start; cleanup_error = None };
       Cancel_requested)
     else request_cancel t
   | Starting ->

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -93,17 +93,23 @@ let cleanup_result cleanup outcome =
     | exn -> Some (Printexc.to_string exn))
 ;;
 
-let resolve_exit t outcome cleanup_error =
-  Atomic.set t.state Exited;
-  Eio.Promise.resolve t.exited_r { outcome; cleanup_error }
+let resolve_exit_once t outcome cleanup =
+  if Atomic.compare_and_set t.state Running Exited
+  then (
+    let cleanup_error = cleanup_result cleanup outcome in
+    Eio.Promise.resolve t.exited_r { outcome; cleanup_error };
+    true)
+  else false
 ;;
 
 let fork ~sw t ~run ~cleanup =
   match claim_start t with
   | Error _ as error -> error
   | Ok () ->
+    let started = Atomic.make false in
     (try
        Eio.Fiber.fork ~sw (fun () ->
+         Atomic.set started true;
          let outcome =
            try
              Eio.Switch.run (fun lane_sw -> run lane_sw);
@@ -112,14 +118,25 @@ let fork ~sw t ~run ~cleanup =
            | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
            | exn -> Failed exn
          in
-         let cleanup_error = cleanup_result cleanup outcome in
-         resolve_exit t outcome cleanup_error);
-       Ok ()
+         ignore (resolve_exit_once t outcome cleanup));
+       if Atomic.get started
+       then Ok ()
+       else
+         match Eio.Switch.get_error sw with
+         | None ->
+           (* [Fiber.fork] accepted the child. It may not have been scheduled
+              yet, but Eio only drops the fork when the target switch is
+              already cancelling. *)
+           Ok ()
+         | Some cause ->
+           let outcome = Cancelled_by_parent cause in
+           if resolve_exit_once t outcome cleanup
+           then Error (Fork_failed cause)
+           else Ok ()
      with
      | exn ->
        let outcome = Failed exn in
-       let cleanup_error = cleanup_result cleanup outcome in
-       resolve_exit t outcome cleanup_error;
+       ignore (resolve_exit_once t outcome cleanup);
        Error (Fork_failed exn))
 ;;
 
@@ -127,6 +144,6 @@ let reject_before_start t ~reason =
   match claim_start t with
   | Error _ as error -> error
   | Ok () ->
-    resolve_exit t (Failed reason) None;
+    ignore (resolve_exit_once t (Failed reason) (fun _ -> Ok ()));
     Ok ()
 ;;

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -166,7 +166,7 @@ let rec request_cancel t =
        with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | exn ->
-         ignore (Atomic.compare_and_set t.state Cancellation_requested current);
+         let _ = Atomic.compare_and_set t.state Cancellation_requested current in
          Cancel_signal_failed exn)
     else request_cancel t
   | Cancellation_requested -> Cancel_already_requested

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -13,8 +13,41 @@ type state =
   | Running
   | Exited
 
+module Id = struct
+  type t = string
+
+  let prefix = "lane-"
+  (* NDT-OK: UUID entropy is identity only; lifecycle decisions compare the
+     typed value and never branch on its random contents. *)
+  let rng = Random.State.make_self_init ()
+  let rng_mutex = Eio.Mutex.create ()
+
+  let generate () =
+    let uuid =
+      Eio.Mutex.use_ro rng_mutex (fun () -> Uuidm.v4_gen rng ())
+    in
+    prefix ^ Uuidm.to_string uuid
+  ;;
+
+  let of_string value =
+    let prefix_length = String.length prefix in
+    if
+      String.length value = prefix_length + 36
+      && String.equal (String.sub value 0 prefix_length) prefix
+    then
+      match Uuidm.of_string (String.sub value prefix_length 36) with
+      | Some _ -> Ok value
+      | None -> Error (Printf.sprintf "invalid Keeper lane id: %S" value)
+    else Error (Printf.sprintf "invalid Keeper lane id: %S" value)
+  ;;
+
+  let to_string value = value
+  let equal = String.equal
+end
+
 type t =
-  { state : state Atomic.t
+  { id : Id.t
+  ; state : state Atomic.t
   ; exited_p : exit Eio.Promise.t
   ; exited_r : exit Eio.Promise.u
   }
@@ -32,9 +65,10 @@ let start_error_to_string = function
 
 let create () =
   let exited_p, exited_r = Eio.Promise.create () in
-  { state = Atomic.make Not_started; exited_p; exited_r }
+  { id = Id.generate (); state = Atomic.make Not_started; exited_p; exited_r }
 ;;
 
+let id t = t.id
 let exited t = t.exited_p
 let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -40,6 +40,9 @@ val fork :
   run:(Eio.Switch.t -> unit) ->
   cleanup:(outcome -> (unit, string) result) ->
   (unit, start_error) result
+(** A fork rejected by an already-cancelling Eio switch returns
+    [Error (Fork_failed _)] and resolves [exited]. Cleanup and exit resolution
+    are exact-once even if switch cancellation races the child start. *)
 
 (** Resolve a lane for which the launch gate rejected the fiber before it
     started.  This keeps the join contract total for every registry entry. *)

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -1,0 +1,41 @@
+(** One structured-concurrency lane owned by one Keeper registry entry.
+
+    The lane switch is created inside the forked fiber.  [exited] resolves
+    only after [Eio.Switch.run] has joined every child fiber and released
+    every resource attached to that switch. *)
+
+type t
+
+type outcome =
+  | Completed
+  | Cancelled_by_parent of exn
+  | Failed of exn
+
+type exit =
+  { outcome : outcome
+  ; cleanup_error : string option
+  }
+
+type start_error =
+  | Already_started
+  | Already_exited
+  | Fork_failed of exn
+
+val start_error_to_string : start_error -> string
+
+val create : unit -> t
+
+val fork :
+  sw:Eio.Switch.t ->
+  t ->
+  run:(Eio.Switch.t -> unit) ->
+  cleanup:(outcome -> (unit, string) result) ->
+  (unit, start_error) result
+
+(** Resolve a lane for which the launch gate rejected the fiber before it
+    started.  This keeps the join contract total for every registry entry. *)
+val reject_before_start : t -> reason:exn -> (unit, start_error) result
+
+val exited : t -> exit Eio.Promise.t
+val peek_exit : t -> exit option
+val await_exit : t -> exit

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -16,6 +16,7 @@ end
 
 type outcome =
   | Completed
+  | Shutdown_before_start
   | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -6,6 +6,14 @@
 
 type t
 
+module Id : sig
+  type t
+
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
 type outcome =
   | Completed
   | Cancelled_by_parent of exn
@@ -24,6 +32,7 @@ type start_error =
 val start_error_to_string : start_error -> string
 
 val create : unit -> t
+val id : t -> Id.t
 
 val fork :
   sw:Eio.Switch.t ->

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -16,6 +16,7 @@ end
 
 type outcome =
   | Completed
+  | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -28,6 +29,12 @@ type start_error =
   | Already_started
   | Already_exited
   | Fork_failed of exn
+
+type cancel_result =
+  | Cancel_requested
+  | Cancel_already_requested
+  | Cancel_already_exiting
+  | Cancel_signal_failed of exn
 
 val start_error_to_string : start_error -> string
 
@@ -47,6 +54,11 @@ val fork :
 (** Resolve a lane for which the launch gate rejected the fiber before it
     started.  This keeps the join contract total for every registry entry. *)
 val reject_before_start : t -> reason:exn -> (unit, start_error) result
+
+(** Request cancellation of this exact lane scope. The request is remembered
+    even if the fiber has not attached its switch yet. This does not join; use
+    [await_exit] for that boundary. *)
+val request_cancel : t -> cancel_result
 
 val exited : t -> exit Eio.Promise.t
 val peek_exit : t -> exit option

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -304,31 +304,57 @@ let persist_meta config path persisted =
   | Error msg -> Error (Printf.sprintf "failed to write meta %s: %s" path msg)
 ;;
 
+type write_meta_error =
+  | Version_conflict of
+      { keeper_name : string
+      ; expected : int
+      ; actual : int
+      }
+  | Read_failed of string
+  | Persist_failed of string
+
+let write_meta_error_to_string = function
+  | Version_conflict { keeper_name; expected; actual } ->
+    Printf.sprintf
+      "meta version conflict for %s: expected %d, disk has %d"
+      keeper_name
+      expected
+      actual
+  | Read_failed detail | Persist_failed detail -> detail
+;;
+
 (* Version CAS only — there is no force/bypass path. Cumulative usage
    counters are a monotone invariant (RFC-0225 §3.2, RFC-0237); a caller that
    lost the race must resolve the conflict through [write_meta_with_merge],
    never overwrite the disk snapshot. *)
-let write_meta config (m : Keeper_meta_contract.keeper_meta) : (unit, string) result =
+let write_meta_typed config (m : Keeper_meta_contract.keeper_meta) =
   let path = keeper_meta_path config m.name in
+  File_lock_eio.with_mutex path (fun () ->
   match read_meta_file_path path with
   | Ok (Some existing) ->
     if existing.meta_version <> m.meta_version
     then
       Error
-        (Printf.sprintf
-           "meta version conflict for %s: expected %d, disk has %d"
-           m.name
-           m.meta_version
-           existing.meta_version)
+        (Version_conflict
+           { keeper_name = m.name
+           ; expected = m.meta_version
+           ; actual = existing.meta_version
+           })
     else (
       let persisted = { m with meta_version = m.meta_version + 1 } in
-      persist_meta config path persisted)
+      persist_meta config path persisted |> Result.map_error (fun error -> Persist_failed error))
   | Ok None ->
     (* No existing file: initial write. *)
     let persisted = { m with meta_version = 1 } in
-    persist_meta config path persisted
+    persist_meta config path persisted |> Result.map_error (fun error -> Persist_failed error)
   | Error msg ->
-    Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)
+    Error
+      (Read_failed
+         (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)))
+;;
+
+let write_meta config m =
+  write_meta_typed config m |> Result.map_error write_meta_error_to_string
 ;;
 
 let is_version_conflict_error msg =
@@ -420,11 +446,12 @@ let write_meta_with_merge
   =
   let path = keeper_meta_path config m.name in
   let rec attempt n (caller : Keeper_meta_contract.keeper_meta) =
-    match write_meta config caller with
+    match write_meta_typed config caller with
     | Ok () -> Ok ()
-    | Error msg when n >= max_retries -> Error msg
-    | Error msg when not (is_version_conflict_error msg) -> Error msg
-    | Error _ ->
+    | Error error when n >= max_retries -> Error (write_meta_error_to_string error)
+    | Error ((Read_failed _ | Persist_failed _) as error) ->
+      Error (write_meta_error_to_string error)
+    | Error (Version_conflict _) ->
       (match read_meta_file_path path with
        | Ok (Some latest) ->
          Otel_metric_store.inc_counter
@@ -446,4 +473,74 @@ let write_meta_with_merge
          Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
   in
   attempt 0 m
+;;
+
+type identity_update_error =
+  | Identity_missing
+  | Identity_changed
+  | Identity_read_failed of string
+  | Identity_write_failed of string
+
+let identity_update_error_to_string = function
+  | Identity_missing -> "Keeper metadata is absent"
+  | Identity_changed -> "Keeper metadata identity changed"
+  | Identity_read_failed detail -> detail
+  | Identity_write_failed detail -> detail
+;;
+
+let update_meta_if_identity
+      config
+      ~name
+      ~trace_id
+      ~generation
+      update
+  =
+  let path = keeper_meta_path config name in
+  File_lock_eio.with_mutex path (fun () ->
+    match read_meta_file_path path with
+    | Error detail -> Error (Identity_read_failed detail)
+    | Ok None -> Error Identity_missing
+    | Ok (Some latest) ->
+      if
+        not (Keeper_id.Trace_id.equal latest.runtime.trace_id trace_id)
+        || not (Int.equal latest.runtime.generation generation)
+      then Error Identity_changed
+      else
+        let caller = update latest in
+        let persisted = { caller with meta_version = latest.meta_version + 1 } in
+        (match persist_meta config path persisted with
+         | Ok () -> Ok persisted
+         | Error detail -> Error (Identity_write_failed detail)))
+;;
+
+type identity_remove_error =
+  | Remove_identity_missing
+  | Remove_identity_changed
+  | Remove_identity_read_failed of string
+  | Remove_identity_unlink_failed of string
+
+let identity_remove_error_to_string = function
+  | Remove_identity_missing -> "Keeper metadata is absent"
+  | Remove_identity_changed -> "Keeper metadata identity changed"
+  | Remove_identity_read_failed detail | Remove_identity_unlink_failed detail -> detail
+;;
+
+let remove_meta_if_identity config ~name ~trace_id ~generation =
+  let path = keeper_meta_path config name in
+  File_lock_eio.with_mutex path (fun () ->
+    match read_meta_file_path path with
+    | Error detail -> Error (Remove_identity_read_failed detail)
+    | Ok None -> Error Remove_identity_missing
+    | Ok (Some latest) ->
+      if
+        not (Keeper_id.Trace_id.equal latest.runtime.trace_id trace_id)
+        || not (Int.equal latest.runtime.generation generation)
+      then Error Remove_identity_changed
+      else
+        try
+          Unix.unlink path;
+          Ok ()
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Error (Remove_identity_unlink_failed (Printexc.to_string exn)))
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -115,6 +115,42 @@ val write_meta :
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
 
+type identity_update_error =
+  | Identity_missing
+  | Identity_changed
+  | Identity_read_failed of string
+  | Identity_write_failed of string
+
+val identity_update_error_to_string : identity_update_error -> string
+
+(** Re-read and CAS-update [name] only while its trace/generation identity
+    matches the shutdown snapshot. Every CAS retry rechecks identity before
+    applying [update], so a replacement generation is never overwritten. *)
+val update_meta_if_identity :
+  Workspace.config ->
+  name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  generation:int ->
+  (Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta) ->
+  (Keeper_meta_contract.keeper_meta, identity_update_error) result
+
+type identity_remove_error =
+  | Remove_identity_missing
+  | Remove_identity_changed
+  | Remove_identity_read_failed of string
+  | Remove_identity_unlink_failed of string
+
+val identity_remove_error_to_string : identity_remove_error -> string
+
+(** Remove [name]'s meta only while the same trace/generation still occupies
+    the path. This shares the per-path lock used by [write_meta]. *)
+val remove_meta_if_identity :
+  Workspace.config ->
+  name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  generation:int ->
+  (unit, identity_remove_error) result
+
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
 

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -334,6 +334,20 @@ let record_crash ~base_path name ts msg =
   Error_tracking.record_crash ~base_path name ts msg ~update_entry:update_entry_unit
 ;;
 
+let set_failure_reason_exact entry reason =
+  update_entry_exact entry (fun current -> { current with last_failure_reason = reason })
+;;
+
+let set_last_error_exact entry err =
+  update_entry_exact entry (fun current -> { current with last_error = Some err })
+;;
+
+let record_crash_exact entry ts msg =
+  Log.Keeper.error "registry: recording exact-lane crash name=%s msg=%s" entry.name msg;
+  update_entry_exact entry (fun current ->
+    Error_tracking.record_crash_entry current ts msg)
+;;
+
 let set_grpc_close ~base_path name close_fn =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | Some entry -> Atomic.set entry.grpc_close close_fn
@@ -538,6 +552,16 @@ let cleanup_tracking ~base_path name =
   | None -> ()
 ;;
 
+let cleanup_tracking_exact (entry : registry_entry) =
+  update_entry_exact entry (fun current ->
+    { current with
+      board_wakeups = StringMap.empty
+    ; tool_usage = StringMap.empty
+    ; board_cursor_ts = 0.0
+    ; board_cursor_post_id = None
+    })
+;;
+
 let clear () =
   Atomic.set registry StringMap.empty;
   Atomic.set running_count_atomic 0
@@ -674,12 +698,13 @@ let compaction_stage_after_event entry event =
   new_stage
 ;;
 
-(** Registry mutation is still non-yielding (StringMap lookup + put,
-    Atomic.set). Entry actions run only after [put_entry], so any
+(** Registry mutation is still non-yielding (StringMap lookup + CAS).
+    Entry actions run only after [install_entry_if_current], so any
     observability or follow-up state transitions happen after the registry
     state is consistent. *)
-let rec dispatch_event_with_audit
+let rec dispatch_event_with_audit_internal
           ~base_path
+          ?expected_lane
           ?(origin = Generic_dispatch)
           ?snapshot
           ?events_fired
@@ -695,6 +720,17 @@ let rec dispatch_event_with_audit
          { from_phase = Keeper_state_machine.Offline
          ; to_phase = Keeper_state_machine.Offline
          ; reason = Printf.sprintf "keeper %s not registered" name
+         })
+  | Some entry
+    when Option.exists
+           (fun lane_id ->
+              not (Keeper_lane.Id.equal lane_id (Keeper_lane.id entry.lane)))
+           expected_lane ->
+    Error
+      (Keeper_state_machine.Invalid_transition
+         { from_phase = entry.phase
+         ; to_phase = entry.phase
+         ; reason = Printf.sprintf "keeper %s lane ownership changed" name
          })
   | Some entry ->
     let now = Time_compat.now () in
@@ -772,9 +808,8 @@ let rec dispatch_event_with_audit
        in
        let new_seq = entry.transition_seq + 1 in
        (match
-          put_entry
-            ~base_path
-            name
+          install_entry_if_current
+            ~observed:entry
             { entry with
               phase = tr.new_phase
             ; conditions = tr.updated_conditions
@@ -785,13 +820,37 @@ let rec dispatch_event_with_audit
             ; compaction_stage
             }
         with
-        | Error err ->
+        | Entry_install_invalid err ->
           reject_dispatch
             (registry_write_error
                ~from_phase:tr.prev_phase
                ~to_phase:tr.new_phase
                err)
-        | Ok () ->
+        | Entry_install_conflict ->
+          dispatch_event_with_audit_internal
+            ~base_path
+            ?expected_lane
+            ~origin
+            ?snapshot
+            ?events_fired
+            ?selected_event
+            name
+            event
+        | Entry_install_missing ->
+          reject_dispatch
+            (Keeper_state_machine.Invalid_transition
+               { from_phase = tr.prev_phase
+               ; to_phase = tr.prev_phase
+               ; reason = Printf.sprintf "keeper %s was unregistered during dispatch" name
+               })
+        | Entry_install_replaced ->
+          reject_dispatch
+            (Keeper_state_machine.Invalid_transition
+               { from_phase = tr.prev_phase
+               ; to_phase = tr.prev_phase
+               ; reason = Printf.sprintf "keeper %s lane ownership changed during dispatch" name
+               })
+        | Entry_installed ->
           record_transition_attribution tr;
           Log.Keeper.emit
             Log.Info
@@ -873,7 +932,13 @@ let rec dispatch_event_with_audit
             tr.entry_actions;
           List.iter
             (fun followup_event ->
-               match dispatch_event_with_audit ~base_path name followup_event with
+               match
+                 dispatch_event_with_audit_internal
+                   ~base_path
+                   ?expected_lane
+                   name
+                   followup_event
+               with
             | Ok _ -> ()
             | Error
                 (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason })
@@ -938,9 +1003,8 @@ let rec dispatch_event_with_audit
        (* No phase change — still update conditions *)
        let new_seq = entry.transition_seq + 1 in
        (match
-          put_entry
-            ~base_path
-            name
+          install_entry_if_current
+            ~observed:entry
             { entry with
               conditions = tr.updated_conditions
             ; transition_seq = new_seq
@@ -949,13 +1013,37 @@ let rec dispatch_event_with_audit
             ; compaction_stage
             }
         with
-        | Error err ->
+        | Entry_install_invalid err ->
           reject_dispatch
             (registry_write_error
                ~from_phase:tr.prev_phase
                ~to_phase:tr.new_phase
                err)
-        | Ok () ->
+        | Entry_install_conflict ->
+          dispatch_event_with_audit_internal
+            ~base_path
+            ?expected_lane
+            ~origin
+            ?snapshot
+            ?events_fired
+            ?selected_event
+            name
+            event
+        | Entry_install_missing ->
+          reject_dispatch
+            (Keeper_state_machine.Invalid_transition
+               { from_phase = tr.prev_phase
+               ; to_phase = tr.prev_phase
+               ; reason = Printf.sprintf "keeper %s was unregistered during dispatch" name
+               })
+        | Entry_install_replaced ->
+          reject_dispatch
+            (Keeper_state_machine.Invalid_transition
+               { from_phase = tr.prev_phase
+               ; to_phase = tr.prev_phase
+               ; reason = Printf.sprintf "keeper %s lane ownership changed during dispatch" name
+               })
+        | Entry_installed ->
           record_transition_attribution tr;
           if Keeper_trace_emit.enabled ()
           then
@@ -971,6 +1059,38 @@ let rec dispatch_event_with_audit
           broadcast_composite_changed ~name ~ts_unix:now;
           Ok tr)
      | Error e -> reject_dispatch e)
+;;
+
+let dispatch_event_with_audit
+      ~base_path
+      ?(origin = Generic_dispatch)
+      ?snapshot
+      ?events_fired
+      ?selected_event
+      name
+      event
+  =
+  dispatch_event_with_audit_internal
+    ~base_path
+    ~origin
+    ?snapshot
+    ?events_fired
+    ?selected_event
+    name
+    event
+;;
+
+let dispatch_event_exact
+      (entry : registry_entry)
+      ?(origin = Generic_dispatch)
+      event
+  =
+  dispatch_event_with_audit_internal
+    ~base_path:entry.base_path
+    ~expected_lane:(Keeper_lane.id entry.lane)
+    ~origin
+    entry.name
+    event
 ;;
 
 let dispatch_event ~base_path ?(origin = Generic_dispatch) name event =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -441,16 +441,22 @@ let fiber_health_of ~base_path name =
          Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
        in
        if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie
-     | Stopped | Offline -> Fiber_unknown
+     | Stopped ->
+       if lane_has_exited entry then Fiber_unknown else Fiber_alive
+     | Offline -> Fiber_unknown
      | Running | Paused | Failing | Overflowed | Compacting | HandingOff | Draining ->
        (match Eio.Promise.peek entry.done_p with
         | None -> Fiber_alive
-        | Some `Stopped -> Fiber_unknown
+        | Some `Stopped ->
+          if lane_has_exited entry then Fiber_unknown else Fiber_alive
         | Some (`Crashed _) ->
-          let max_restarts =
-            Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
-          in
-          if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie))
+          if not (lane_has_exited entry)
+          then Fiber_alive
+          else
+            let max_restarts =
+              Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
+            in
+            if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie))
 ;;
 
 let crash_log_of ~base_path name =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -66,6 +66,16 @@ val prepare_fiber_launch :
 (** Unregister a keeper (removes from registry). *)
 val unregister : base_path:string -> string -> unit
 
+type unregister_exact_result =
+  | Exact_unregistered
+  | Exact_entry_missing
+  | Exact_entry_replaced
+
+(** Remove [entry] only if it is still the exact registry value for its
+    [(base_path, name)] key. This prevents a stale sweep from unregistering a
+    newer same-name lane. *)
+val unregister_exact : registry_entry -> unregister_exact_result
+
 (** Look up a keeper by name. *)
 val get : base_path:string -> string -> registry_entry option
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -36,6 +36,19 @@ val register : base_path:string -> string -> keeper_meta -> registry_entry
     runtime actually launches the fiber. *)
 val register_offline : base_path:string -> string -> keeper_meta -> registry_entry
 
+type registration_error =
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_invalid of registry_entry_validation_error
+
+(** Production registration gate: the final registry CAS is serialized with
+    Keeper shutdown reservation. Event-queue loading remains outside the
+    non-yielding fence critical section. *)
+val register_offline_if_admitted :
+  base_path:string ->
+  string ->
+  keeper_meta ->
+  (registry_entry, registration_error) result
+
 (** R-A-6.a — error variant for [register_restarting].
     [Budget_already_exhausted] is returned (not raised — the API is
     Result-based) when the caller attempts to revive a keeper whose
@@ -43,6 +56,7 @@ val register_offline : base_path:string -> string -> keeper_meta -> registry_ent
     violate TLA+ §S3 BudgetNeverRevives. *)
 type register_restarting_error =
   | Budget_already_exhausted of { name : string }
+  | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
 (** Register a keeper that is about to relaunch after a crash.
     The entry starts in [Restarting] and must receive [Fiber_started] when the

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -301,6 +301,19 @@ val clear_turn_switch : base_path:string -> string -> unit
 val interrupt_current_turn :
   base_path:string -> string -> [ `Cancelled of int | `No_turn_in_flight ]
 
+type exact_turn_interrupt_result =
+  | Exact_turn_cancelled of int
+  | Exact_no_turn_in_flight
+  | Exact_turn_cancel_failed of
+      { turn_id : int option
+      ; detail : string
+      }
+
+(** Cancel the turn switch retained by this exact registry entry. Unlike the
+    name-based compatibility API, failure is returned explicitly. *)
+val interrupt_current_turn_exact :
+  registry_entry -> exact_turn_interrupt_result
+
 (** Record the verdict reasons from a [keeper_cycle_decision] that
     chose to skip the next turn.  Stamps [last_skip_observation] with
     [(now, reasons)] so the stale watchdog can surface *why* a keeper

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -121,6 +121,20 @@ val update_entry :
   (registry_entry -> registry_entry) ->
   (unit, registry_entry_validation_error) result
 
+type exact_update_result =
+  | Exact_updated
+  | Exact_update_missing
+  | Exact_update_replaced
+  | Exact_update_invalid of registry_entry_validation_error
+
+(** Update only while the lane identity captured in [expected] still owns the
+    registry key. CAS conflicts within that lane retry against the latest
+    immutable entry; a same-name replacement is never mutated. *)
+val update_entry_exact :
+  registry_entry ->
+  (registry_entry -> registry_entry) ->
+  exact_update_result
+
 (** Update a registered entry and return [true] only when a validated write
     was installed.  Missing keepers, no-op closures, and validation failures
     return [false]. *)
@@ -313,6 +327,15 @@ val get_turn_failures : base_path:string -> string -> int
 (** Record a crash entry in the crash log (keeps last 5). *)
 val record_crash : base_path:string -> string -> float -> string -> unit
 
+(** Failure mutations scoped to the exact lane captured by [entry]. *)
+val set_failure_reason_exact :
+  registry_entry -> failure_reason option -> exact_update_result
+
+val set_last_error_exact : registry_entry -> string -> exact_update_result
+
+val record_crash_exact :
+  registry_entry -> float -> string -> exact_update_result
+
 (** Set or clear the gRPC close callback. *)
 val set_grpc_close : base_path:string -> string -> (unit -> unit) option -> unit
 
@@ -333,6 +356,10 @@ val is_registered : base_path:string -> string -> bool
 
 (** Mark a keeper as dead tombstone and record the transition timestamp. *)
 val mark_dead : base_path:string -> string -> at:float -> unit
+
+(** Mark only [entry]'s lane dead. The running-count transition is applied
+    once, after the exact-lane CAS succeeds. *)
+val mark_dead_exact : registry_entry -> at:float -> exact_update_result
 
 (** Return the started_at timestamp, or None if not registered. *)
 val started_at : base_path:string -> string -> float option
@@ -426,6 +453,9 @@ val clear_board_wakeups : base_path:string -> string -> unit
 (** Reset tracking state (agent count + board wakeups) for a keeper. *)
 val cleanup_tracking : base_path:string -> string -> unit
 
+(** Reset tracking only if [entry]'s lane still owns its registry key. *)
+val cleanup_tracking_exact : registry_entry -> exact_update_result
+
 (** Clear the registry. For testing only. *)
 val clear : unit -> unit
 
@@ -477,6 +507,15 @@ val dispatch_event :
   base_path:string ->
   ?origin:lifecycle_event_origin ->
   string -> Keeper_state_machine.event ->
+  (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
+
+(** Dispatch only while [entry]'s lane still owns the registry key. The event
+    is recomputed after same-lane CAS conflicts and is rejected before mutating
+    a same-name replacement lane. *)
+val dispatch_event_exact :
+  registry_entry ->
+  ?origin:lifecycle_event_origin ->
+  Keeper_state_machine.event ->
   (Keeper_state_machine.transition_result, Keeper_state_machine.transition_error) result
 
 (** Like [dispatch_event], but preserves richer audit metadata when the event

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -71,9 +71,10 @@ type unregister_exact_result =
   | Exact_entry_missing
   | Exact_entry_replaced
 
-(** Remove [entry] only if it is still the exact registry value for its
-    [(base_path, name)] key. This prevents a stale sweep from unregistering a
-    newer same-name lane. *)
+(** Remove [entry] only if its typed lane identity still owns the
+    [(base_path, name)] key. Immutable registry field updates may replace the
+    record value while preserving the same lane; a newer same-name lane has a
+    different identity and is retained. *)
 val unregister_exact : registry_entry -> unregister_exact_result
 
 (** Look up a keeper by name. *)

--- a/lib/keeper/keeper_registry_error_recording.ml
+++ b/lib/keeper/keeper_registry_error_recording.ml
@@ -7,7 +7,7 @@
     [Keeper_registry.set_last_error_entry] so this module does not need
     to know about the central Atomic. *)
 
-let record ~base_path ?details name err =
+let record_common ~base_path ?details name err persist =
   let details =
     match details with
     | Some _ as details -> details
@@ -42,5 +42,29 @@ let record ~base_path ?details name err =
       ~labels:[ "keeper", name; "error_kind", kind_label ]
       ();
   Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
-  Keeper_registry.set_last_error_entry ~base_path ~name err
+  persist ()
+;;
+
+let record ~base_path ?details name err =
+  record_common ~base_path ?details name err (fun () ->
+    Keeper_registry.set_last_error_entry ~base_path ~name err)
+;;
+
+let record_exact ?details (entry : Keeper_registry.registry_entry) err =
+  record_common ~base_path:entry.base_path ?details entry.name err (fun () ->
+    match Keeper_registry.set_last_error_exact entry err with
+    | Keeper_registry.Exact_updated -> ()
+    | Keeper_registry.Exact_update_missing ->
+      Log.Keeper.warn
+        "registry: exact error record skipped because lane is no longer registered name=%s"
+        entry.name
+    | Keeper_registry.Exact_update_replaced ->
+      Log.Keeper.warn
+        "registry: exact error record retained newer same-name lane name=%s"
+        entry.name
+    | Keeper_registry.Exact_update_invalid validation_error ->
+      Log.Keeper.warn
+        "registry: exact error record validation failed name=%s error=%s"
+        entry.name
+        (Keeper_registry.registry_entry_validation_error_to_string validation_error))
 ;;

--- a/lib/keeper/keeper_registry_error_recording.mli
+++ b/lib/keeper/keeper_registry_error_recording.mli
@@ -10,3 +10,8 @@
       [Keeper_registry.set_last_error_entry] (CAS retry). *)
 val record :
   base_path:string -> ?details:Yojson.Safe.t -> string -> string -> unit
+
+(** Record observability for [entry]'s lane without mutating a newer
+    same-name lane's [last_error]. *)
+val record_exact :
+  ?details:Yojson.Safe.t -> Keeper_registry.registry_entry -> string -> unit

--- a/lib/keeper/keeper_registry_error_tracking.ml
+++ b/lib/keeper/keeper_registry_error_tracking.ml
@@ -4,6 +4,13 @@ open Keeper_registry_types
 
 let max_crash_log_entries = 5
 
+let record_crash_entry entry ts msg =
+  { entry with
+    crash_log =
+      List.filteri (fun i _ -> i < max_crash_log_entries) ((ts, msg) :: entry.crash_log)
+  }
+;;
+
 let mark_dead ~base_path name ~at ~decr_running_count_clamped ~update_entry =
   (* Same metric is also incremented by transition dispatch via
      [phase_to_string tr.new_phase], which emits lowercase wire format
@@ -77,11 +84,7 @@ let set_last_correlation_id ~base_path name cid ~update_entry =
 
 let record_crash ~base_path name ts msg ~update_entry =
   Log.Keeper.error "registry: recording crash name=%s msg=%s" name msg;
-  update_entry ~base_path name (fun e ->
-    { e with
-      crash_log =
-        List.filteri (fun i _ -> i < max_crash_log_entries) ((ts, msg) :: e.crash_log)
-    })
+  update_entry ~base_path name (fun entry -> record_crash_entry entry ts msg)
 ;;
 
 let restore_supervisor_state

--- a/lib/keeper/keeper_registry_error_tracking.mli
+++ b/lib/keeper/keeper_registry_error_tracking.mli
@@ -6,6 +6,8 @@
 
 open Keeper_registry_types
 
+val record_crash_entry : registry_entry -> float -> string -> registry_entry
+
 val mark_dead :
   base_path:string ->
   string ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -243,6 +243,77 @@ let update_entry ~base_path name f =
   loop ()
 ;;
 
+type exact_update_result =
+  | Exact_updated
+  | Exact_update_missing
+  | Exact_update_replaced
+  | Exact_update_invalid of registry_entry_validation_error
+
+let update_entry_exact (expected : registry_entry) f =
+  let base_path = expected.base_path in
+  let name = expected.name in
+  let key = registry_key ~base_path name in
+  let expected_lane = Keeper_lane.id expected.lane in
+  let rec loop () =
+    let current = Atomic.get registry in
+    match StringMap.find_opt key current with
+    | None -> Exact_update_missing
+    | Some entry
+      when not (Keeper_lane.Id.equal expected_lane (Keeper_lane.id entry.lane)) ->
+      Exact_update_replaced
+    | Some entry ->
+      let new_entry = f entry in
+      (match validate_registry_entry ~base_path name new_entry with
+       | Error err ->
+         record_invalid_registry_entry ~operation:"update_exact" ~name err;
+         Exact_update_invalid err
+       | Ok () ->
+         let updated = StringMap.add key new_entry current in
+         if Atomic.compare_and_set registry current updated
+         then (
+           Orphan_drops.clear ~base_path name;
+           Exact_updated)
+         else loop ())
+  in
+  loop ()
+;;
+
+type install_entry_result =
+  | Entry_installed
+  | Entry_install_conflict
+  | Entry_install_missing
+  | Entry_install_replaced
+  | Entry_install_invalid of registry_entry_validation_error
+
+let install_entry_if_current
+      ~(observed : registry_entry)
+      (replacement : registry_entry)
+  =
+  let base_path = observed.base_path in
+  let name = observed.name in
+  match validate_registry_entry ~base_path name replacement with
+  | Error err ->
+    record_invalid_registry_entry ~operation:"install_if_current" ~name err;
+    Entry_install_invalid err
+  | Ok () ->
+    let current = Atomic.get registry in
+    let key = registry_key ~base_path name in
+    (match StringMap.find_opt key current with
+     | None -> Entry_install_missing
+     | Some entry
+       when not
+              (Keeper_lane.Id.equal
+                 (Keeper_lane.id observed.lane)
+                 (Keeper_lane.id entry.lane)) ->
+       Entry_install_replaced
+     | Some entry when entry != observed -> Entry_install_conflict
+     | Some _ ->
+       let updated = StringMap.add key replacement current in
+       if Atomic.compare_and_set registry current updated
+       then Entry_installed
+       else Entry_install_conflict)
+;;
+
 let update_entry_unit ~base_path name f =
   (* fire-and-forget: unit wrapper discards Ok/Error; callers only need side effects and logged metrics. *)
   ignore (update_entry ~base_path name f)
@@ -692,6 +763,61 @@ let mark_dead ~base_path name ~at =
     ~at
     ~decr_running_count_clamped
     ~update_entry:update_entry_unit
+;;
+
+let mark_dead_exact (expected : registry_entry) ~at =
+  let base_path = expected.base_path in
+  let name = expected.name in
+  let key = registry_key ~base_path name in
+  let expected_lane = Keeper_lane.id expected.lane in
+  let rec loop () =
+    let current = Atomic.get registry in
+    match StringMap.find_opt key current with
+    | None -> Exact_update_missing
+    | Some entry
+      when not (Keeper_lane.Id.equal expected_lane (Keeper_lane.id entry.lane)) ->
+      Exact_update_replaced
+    | Some entry ->
+      let replacement =
+        if entry.phase = Dead
+        then
+          { entry with
+            dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts)
+          }
+        else
+          let conditions =
+            { Keeper_state_machine.default_conditions with
+              launch_pending = false
+            ; fiber_alive = false
+            ; restart_budget_remaining = false
+            }
+          in
+          { entry with
+            dead_since_ts = Some at
+          ; phase = Keeper_state_machine.derive_phase conditions
+          ; conditions
+          }
+      in
+      (match validate_registry_entry ~base_path name replacement with
+       | Error error -> Exact_update_invalid error
+       | Ok () ->
+         let updated = StringMap.add key replacement current in
+         if Atomic.compare_and_set registry current updated
+         then (
+           if entry.phase = Running then decr_running_count_clamped ();
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string LifecycleTransitions)
+             ~labels:
+               [ "keeper", name
+               ; "from_phase", Keeper_state_machine.phase_to_string entry.phase
+               ; "to_phase", Keeper_state_machine.phase_to_string replacement.phase
+               ]
+             ();
+           Log.Keeper.error "registry: marked exact keeper lane dead name=%s at=%.0f" name at;
+           Exact_updated)
+         else loop ())
+  in
+  loop ()
 ;;
 
 let record_restart ~base_path name =

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -780,10 +780,7 @@ let mark_dead_exact (expected : registry_entry) ~at =
     | Some entry ->
       let replacement =
         if entry.phase = Dead
-        then
-          { entry with
-            dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts)
-          }
+        then entry
         else
           let conditions =
             { Keeper_state_machine.default_conditions with

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -389,7 +389,12 @@ let refresh_entry_event_queue_from_persistence ~base_path name entry =
   loop ()
 ;;
 
-let register_with_state
+type registration_error =
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_invalid of registry_entry_validation_error
+
+let register_with_state_result
+      ~respect_shutdown_fence
       ~base_path
       name
       meta
@@ -404,15 +409,6 @@ let register_with_state
     (Keeper_state_machine.phase_to_string phase);
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
-  (match StringMap.find_opt key (Atomic.get registry) with
-   | Some entry when entry.phase = Running ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string LifecycleDispatchRejections)
-       ~labels:[ "keeper", name; "event", "register_overwrite_running" ]
-       ();
-     Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
-     decr_running_count_clamped ()
-   | _ -> ());
   let initial_event_queue =
     Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
   in
@@ -454,15 +450,64 @@ let register_with_state
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
-  (* fire-and-forget: put_entry validates and logs on failure; the constructed entry is always used. *)
-  ignore (put_entry ~base_path name entry);
-  if phase = Running then Atomic.incr running_count_atomic;
-  Log.Keeper.debug
-    "registry: keeper registered name=%s running_count=%d"
-    name
-    (Atomic.get running_count_atomic);
-  refresh_entry_event_queue_from_persistence ~base_path name entry;
-  entry
+  let commit () =
+    (match StringMap.find_opt key (Atomic.get registry) with
+     | Some prior when prior.phase = Running ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string LifecycleDispatchRejections)
+         ~labels:[ "keeper", name; "event", "register_overwrite_running" ]
+         ();
+       Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
+       decr_running_count_clamped ()
+     | Some _ | None -> ());
+    put_entry ~base_path name entry
+  in
+  let commit_result =
+    if respect_shutdown_fence
+    then
+      match
+        Keeper_turn_admission.commit_registration_if_open
+          ~base_path
+          ~keeper_name:name
+          commit
+      with
+      | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+        Error (Registration_shutdown_reserved operation_id)
+      | Keeper_turn_admission.Registration_committed (Error validation_error) ->
+        Error (Registration_invalid validation_error)
+      | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ()
+    else
+      match commit () with
+      | Ok () -> Ok ()
+      | Error validation_error -> Error (Registration_invalid validation_error)
+  in
+  match commit_result with
+  | Error _ as error -> error
+  | Ok () ->
+    if phase = Running then Atomic.incr running_count_atomic;
+    Log.Keeper.debug
+      "registry: keeper registered name=%s running_count=%d"
+      name
+      (Atomic.get running_count_atomic);
+    refresh_entry_event_queue_from_persistence ~base_path name entry;
+    Ok entry
+;;
+
+let register_with_state ~base_path name meta ~phase ~conditions =
+  match
+    register_with_state_result
+      ~respect_shutdown_fence:false
+      ~base_path
+      name
+      meta
+      ~phase
+      ~conditions
+  with
+  | Ok entry -> entry
+  | Error (Registration_invalid error) ->
+    invalid_arg (registry_entry_validation_error_to_string error)
+  | Error (Registration_shutdown_reserved _) ->
+    invalid_arg "unchecked registry registration observed a shutdown fence"
 ;;
 
 let register ~base_path name meta =
@@ -487,8 +532,27 @@ let register_offline ~base_path name meta =
   register_with_state ~base_path name meta ~phase ~conditions
 ;;
 
+let register_offline_if_admitted ~base_path name meta =
+  let conditions =
+    { Keeper_state_machine.default_conditions with
+      launch_pending = true
+    ; restart_budget_remaining = true
+    }
+  in
+  let phase = Keeper_state_machine.derive_phase conditions in
+  register_with_state_result
+    ~respect_shutdown_fence:true
+    ~base_path
+    name
+    meta
+    ~phase
+    ~conditions
+;;
+
 (** R-A-6.a — refuse to revive a keeper whose restart_budget was previously exhausted.  Pairs with TLA+ §S3 BudgetNeverRevives:  []( ~restart_budget_remaining => []( ~restart_budget_remaining ))  Witho... *)
-type register_restarting_error = Budget_already_exhausted of { name : string }
+type register_restarting_error =
+  | Budget_already_exhausted of { name : string }
+  | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
@@ -559,17 +623,26 @@ let register_restarting ~base_path name meta
     | _ ->
       let updated = StringMap.add key new_entry current in
       if Atomic.compare_and_set registry current updated
-      then (
-        Log.Keeper.info
-          "registry: registering keeper name=%s base_path=%s phase=%s"
-          name
-          base_path
-          (Keeper_state_machine.phase_to_string phase);
-        refresh_entry_event_queue_from_persistence ~base_path name new_entry;
-        Ok new_entry)
+      then Ok new_entry
       else loop ()
   in
-  loop ()
+  match
+    Keeper_turn_admission.commit_registration_if_open
+      ~base_path
+      ~keeper_name:name
+      loop
+  with
+  | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+    Error (Restart_shutdown_reserved operation_id)
+  | Keeper_turn_admission.Registration_committed (Error _ as error) -> error
+  | Keeper_turn_admission.Registration_committed (Ok registered) ->
+    Log.Keeper.info
+      "registry: registering keeper name=%s base_path=%s phase=%s"
+      name
+      base_path
+      (Keeper_state_machine.phase_to_string phase);
+    refresh_entry_event_queue_from_persistence ~base_path name registered;
+    Ok registered
 ;;
 
 type unregister_exact_result =

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -1076,17 +1076,76 @@ let clear_turn_switch ~base_path name =
   set_turn_switch ~base_path name None
 ;;
 
+type exact_turn_interrupt_result =
+  | Exact_turn_cancelled of int
+  | Exact_no_turn_in_flight
+  | Exact_turn_cancel_failed of
+      { turn_id : int option
+      ; detail : string
+      }
+
+let interrupt_current_turn_exact observed_entry =
+  let current_entry =
+    StringMap.find_opt
+      (registry_key
+         ~base_path:observed_entry.base_path
+         observed_entry.name)
+      (Atomic.get registry)
+  in
+  match current_entry with
+  | None ->
+    Exact_turn_cancel_failed
+      { turn_id = None; detail = "registry entry disappeared before turn cancellation" }
+  | Some entry
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id entry.lane)
+              (Keeper_lane.id observed_entry.lane)) ->
+    Exact_turn_cancel_failed
+      { turn_id = None; detail = "a newer same-name lane owns the registry entry" }
+  | Some entry ->
+  let turn_id =
+    Option.map
+      (fun observation -> observation.turn_id)
+      entry.current_turn_observation
+  in
+    match Atomic.exchange entry.current_turn_switch None, turn_id with
+    | None, None -> Exact_no_turn_in_flight
+    | None, Some turn_id ->
+       Exact_turn_cancel_failed
+         { turn_id = Some turn_id
+         ; detail = "turn observation exists without a live turn switch"
+         }
+    | Some turn_sw, observed_turn_id ->
+      (try
+         Eio.Switch.fail turn_sw Operator_interrupt;
+         match observed_turn_id with
+         | Some turn_id -> Exact_turn_cancelled turn_id
+         | None ->
+           Exact_turn_cancel_failed
+             { turn_id = None
+             ; detail = "live turn switch exists without a turn observation"
+             }
+       with
+       | exn ->
+         Exact_turn_cancel_failed
+           { turn_id = observed_turn_id
+           ; detail = Printexc.to_string exn
+           })
+;;
+
 let interrupt_current_turn ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> `No_turn_in_flight
   | Some entry ->
-    (match entry.current_turn_observation with
-     | None -> `No_turn_in_flight
-     | Some obs ->
-       match Atomic.exchange entry.current_turn_switch None with
-       | None -> `No_turn_in_flight
-       | Some sw ->
-         (try Eio.Switch.fail sw Operator_interrupt with
-          | Invalid_argument _ -> ());
-         `Cancelled obs.turn_id)
+    (match interrupt_current_turn_exact entry with
+     | Exact_turn_cancelled turn_id -> `Cancelled turn_id
+     | Exact_no_turn_in_flight -> `No_turn_in_flight
+     | Exact_turn_cancel_failed { detail; _ } ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string LifecycleDispatchRejections)
+         ~labels:[ "keeper", name; "event", "turn_cancel_failed" ]
+         ();
+       Log.Keeper.warn "%s: turn cancellation failed: %s" name detail;
+       `No_turn_in_flight)
 ;;

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -519,7 +519,12 @@ let remove_entry ?expected ~base_path name =
     | None -> Entry_missing
     | Some entry ->
       (match expected with
-       | Some expected_entry when entry != expected_entry -> Entry_replaced
+       | Some expected_entry
+         when not
+                (Keeper_lane.Id.equal
+                   (Keeper_lane.id entry.lane)
+                   (Keeper_lane.id expected_entry.lane)) ->
+         Entry_replaced
        | None | Some _ ->
          let updated = StringMap.remove key current in
          if Atomic.compare_and_set registry current updated

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -356,6 +356,7 @@ let register_with_state
     ; event_queue = Atomic.make initial_event_queue
     ; started_at = Time_compat.now ()
     ; grpc_close = Atomic.make None
+    ; lane = Keeper_lane.create ()
     ; done_p
     ; done_r
     ; restart_count = 0
@@ -451,6 +452,7 @@ let register_restarting ~base_path name meta
     ; event_queue = Atomic.make initial_event_queue
     ; started_at = Time_compat.now ()
     ; grpc_close = Atomic.make None
+    ; lane = Keeper_lane.create ()
     ; done_p
     ; done_r
     ; restart_count = 0
@@ -499,36 +501,78 @@ let register_restarting ~base_path name meta
   loop ()
 ;;
 
-let unregister ~base_path name =
-  Log.Keeper.info "registry: unregistering keeper name=%s base_path=%s" name base_path;
+type unregister_exact_result =
+  | Exact_unregistered
+  | Exact_entry_missing
+  | Exact_entry_replaced
+
+type remove_entry_result =
+  | Entry_removed of registry_entry
+  | Entry_missing
+  | Entry_replaced
+
+let remove_entry ?expected ~base_path name =
   let key = registry_key ~base_path name in
   let rec loop () =
     let current = Atomic.get registry in
-    let before = StringMap.find_opt key current in
-    let updated = StringMap.remove key current in
-    if not (Atomic.compare_and_set registry current updated) then loop () else before
+    match StringMap.find_opt key current with
+    | None -> Entry_missing
+    | Some entry ->
+      (match expected with
+       | Some expected_entry when entry != expected_entry -> Entry_replaced
+       | None | Some _ ->
+         let updated = StringMap.remove key current in
+         if Atomic.compare_and_set registry current updated
+         then Entry_removed entry
+         else loop ())
   in
-  let signal_fibers_to_stop entry =
-(* The watchdog and heartbeat fibers hold their own reference to [entry] via the closure they were forked with, so removing the entry from the registry map does not stop them. Without an explicit fibe... *)
-    Atomic.set entry.fiber_stop true;
-    Atomic.set entry.fiber_wakeup true
-  in
-  match loop () with
-  | Some entry when entry.phase = Running ->
-    signal_fibers_to_stop entry;
-    decr_running_count_clamped ();
+  loop ()
+;;
+
+let finish_unregistration entry =
+  (* The watchdog and heartbeat fibers retain [entry] in their closures.
+     Removing the map binding therefore must also signal that exact lane. *)
+  Atomic.set entry.fiber_stop true;
+  Atomic.set entry.fiber_wakeup true;
+  if entry.phase = Running then decr_running_count_clamped ()
+;;
+
+let unregister ~base_path name =
+  Log.Keeper.info "registry: unregistering keeper name=%s base_path=%s" name base_path;
+  match remove_entry ~base_path name with
+  | Entry_removed entry when entry.phase = Running ->
+    finish_unregistration entry;
     Log.Keeper.debug
       "registry: unregistered running keeper name=%s running_count=%d"
       name
       (Atomic.get running_count_atomic)
-  | Some entry ->
-    signal_fibers_to_stop entry;
+  | Entry_removed entry ->
+    finish_unregistration entry;
     Log.Keeper.debug
       "registry: unregistered non-running keeper name=%s state=%s"
       name
       (Keeper_state_machine.phase_to_string entry.phase)
-  | None ->
+  | Entry_missing ->
     Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name
+  | Entry_replaced ->
+    Log.Keeper.error
+      "registry: unconditional unregister reported a replaced entry name=%s base_path=%s"
+      name
+      base_path
+;;
+
+let unregister_exact entry =
+  match
+    remove_entry
+      ~expected:entry
+      ~base_path:entry.base_path
+      entry.name
+  with
+  | Entry_removed removed ->
+    finish_unregistration removed;
+    Exact_unregistered
+  | Entry_missing -> Exact_entry_missing
+  | Entry_replaced -> Exact_entry_replaced
 ;;
 
 let health_of_entry ~base_path name entry =

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -102,6 +102,7 @@ type registry_entry =
   ; event_queue : Keeper_event_queue.t Atomic.t
   ; started_at : float
   ; grpc_close : (unit -> unit) option Atomic.t
+  ; lane : Keeper_lane.t
   ; done_p : done_resolution Eio.Promise.t
   ; done_r : done_resolution Eio.Promise.u
   ; restart_count : int
@@ -186,6 +187,8 @@ let resolve_done entry ~source (value : done_resolution) =
        in
        Done_already_resolved { source; previous })
 ;;
+
+let lane_has_exited entry = Option.is_some (Keeper_lane.peek_exit entry.lane)
 
 let registry_key ~base_path name =
   if String.contains name '\x1f'

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -456,6 +456,9 @@ type registry_entry = {
           and the [TurnDequeue] action. *)
   started_at : float;
   grpc_close : (unit -> unit) option Atomic.t;
+  lane : Keeper_lane.t;
+      (** Structured-concurrency scope owned by this exact registry entry.
+          Its exit promise is the authoritative lane join signal. *)
   done_p : done_resolution Eio.Promise.t;
   done_r : done_resolution Eio.Promise.u;
       (** Completion resolver owned by {!resolve_done}. Runtime callers must
@@ -604,6 +607,8 @@ type registry_entry_validation_error = registry_entry_health
     already-resolved outcome. *)
 val resolve_done :
   registry_entry -> source:string -> done_resolution -> done_resolve_result
+
+val lane_has_exited : registry_entry -> bool
 
 (** Internal: keeper registry key composition (base_path ^ \\x1f ^ name).
     Exposed via mli so keeper_registry.ml's state functions can use it

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -405,7 +405,7 @@ let keeper_schemas : tool_schema list = [
 
   {
     name = "masc_keeper_down";
-    description = "Stop a keeper. Optionally remove underlying files.";
+    description = "Submit a durable, non-blocking Keeper shutdown. Returns an operation_id immediately after admission is fenced and the ownership snapshot is persisted. Repeating the call returns the existing operation state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -1,0 +1,525 @@
+open Keeper_shutdown_types
+
+type error =
+  | Store_error of Keeper_shutdown_store.error
+  | Unsupported_phase
+  | Finalization_blocked of Keeper_shutdown_types.t
+
+let error_to_string = function
+  | Store_error error -> Keeper_shutdown_store.error_to_string error
+  | Unsupported_phase -> "Keeper shutdown operation is not ready for finalization"
+  | Finalization_blocked operation ->
+    Printf.sprintf
+      "Keeper shutdown finalization blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+;;
+
+let remove_pending_confirms_by_target_callback
+    : (Workspace.config ->
+       target_type:Operator_action_constants.target_type ->
+       target_id:string option ->
+       (int, string) result)
+        Atomic.t
+  =
+  Atomic.make (fun _config ~target_type:_ ~target_id:_ ->
+    Error "pending-confirm cleanup implementation is not registered")
+;;
+
+let register_remove_pending_confirms_by_target fn =
+  Atomic.set remove_pending_confirms_by_target_callback fn
+;;
+
+let replace ~config operation =
+  let next = { operation with revision = operation.revision + 1 } in
+  Keeper_shutdown_store.replace
+    ~config
+    ~expected_revision:operation.revision
+    next
+  |> Result.map (fun () -> next)
+  |> Result.map_error (fun error -> Store_error error)
+;;
+
+let block ~config operation stage detail =
+  let blocked =
+    { operation with
+      phase = Blocked { stage; detail }
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match replace ~config blocked with
+  | Ok persisted -> Error (Finalization_blocked persisted)
+  | Error _ as error -> error
+;;
+
+let task_id_equal = Keeper_id.Task_id.equal
+let task_id_mem task_id task_ids = List.exists (task_id_equal task_id) task_ids
+
+let operation_evidence_ref operation =
+  "masc://keeper-shutdown/" ^ Operation_id.to_string operation.operation_id
+;;
+
+let task_has_operation_receipt operation (task : Masc_domain.task) =
+  match task.task_status, task.handoff_context with
+  | Masc_domain.Todo, Some handoff ->
+    handoff.reclaim_policy = Some Masc_domain.Allow_reclaim
+    && List.exists
+         (String.equal (operation_evidence_ref operation))
+         handoff.evidence_refs
+  | Masc_domain.Claimed _, _
+  | Masc_domain.InProgress _, _
+  | Masc_domain.AwaitingVerification _, _
+  | Masc_domain.Done _, _
+  | Masc_domain.Cancelled _, _
+  | Masc_domain.Todo, None -> false
+;;
+
+let strict_backlog ~config =
+  Workspace_backlog.read_backlog_r config
+  |> Result.map_error (fun detail -> detail)
+;;
+
+let find_task tasks task_id =
+  let wire = Keeper_id.Task_id.to_string task_id in
+  List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id wire) tasks
+;;
+
+let persist_settled ~config operation ~settled_task_ids ~expected_backlog_version =
+  let updated =
+    { operation with
+      expected_backlog_version
+    ; phase = Finalizing_tasks settled_task_ids
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match replace ~config updated with
+  | Ok persisted -> Ok persisted
+  | Error _ as error -> error
+;;
+
+let release_task ~config operation (owned : Keeper_current_task_reconcile.owned_active_task) =
+  let assignee =
+    match owned.task.task_status with
+    | Masc_domain.Claimed { assignee; _ }
+    | Masc_domain.InProgress { assignee; _ } -> Ok assignee
+    | Masc_domain.Todo
+    | Masc_domain.AwaitingVerification _
+    | Masc_domain.Done _
+    | Masc_domain.Cancelled _ -> Error "snapshotted task is no longer actively owned"
+  in
+  let handoff_context : Masc_domain.task_handoff_context =
+    { summary = "Keeper stopped; task returned to the durable backlog"
+    ; reason = Some "Keeper shutdown operation completed lane join"
+    ; next_step = Some "A live Keeper may reclaim this task"
+    ; failure_mode = None
+    ; reclaim_policy = Some Masc_domain.Allow_reclaim
+    ; evidence_refs = [ operation_evidence_ref operation ]
+    ; updated_at = Some (Masc_domain.now_iso ())
+    ; updated_by = Some operation.actor
+    }
+  in
+  match assignee with
+  | Error _ as error -> error
+  | Ok agent_name ->
+    Workspace.release_task_r
+      config
+      ~agent_name
+      ~task_id:(Keeper_id.Task_id.to_string owned.task_id)
+      ~expected_version:operation.expected_backlog_version
+      ~handoff_context
+      ()
+    |> Result.map_error Masc_domain.masc_error_to_string
+;;
+
+let rec settle_tasks ~config ~meta operation settled_task_ids =
+  match
+    Keeper_current_task_reconcile.owned_active_tasks_snapshot_for_meta_strict
+      ~config
+      ~meta
+  with
+  | Error detail -> block ~config operation Task_settlement detail
+  | Ok active_snapshot ->
+    let active_tasks = active_snapshot.tasks in
+    let unexpected =
+      List.filter
+        (fun task -> not (task_id_mem task.Keeper_current_task_reconcile.task_id operation.owned_task_ids))
+        active_tasks
+    in
+    if unexpected <> []
+    then
+      let ids =
+        unexpected
+        |> List.map (fun task ->
+          Keeper_id.Task_id.to_string task.Keeper_current_task_reconcile.task_id)
+        |> String.concat ","
+      in
+      block ~config operation Task_settlement ("new active task ownership: " ^ ids)
+    else
+      let active_ids =
+        List.map
+          (fun task -> task.Keeper_current_task_reconcile.task_id)
+          active_tasks
+      in
+      let outstanding_ids =
+        List.filter
+          (fun task_id -> not (task_id_mem task_id settled_task_ids))
+          operation.owned_task_ids
+      in
+      let receipted_ids =
+        List.filter
+          (fun task_id ->
+             match find_task active_snapshot.backlog_tasks task_id with
+             | Some task -> task_has_operation_receipt operation task
+             | None -> false)
+          outstanding_ids
+      in
+      let outstanding_accounted_for receipt_ids =
+        List.for_all
+          (fun task_id ->
+             task_id_mem task_id receipt_ids || task_id_mem task_id active_ids)
+          outstanding_ids
+      in
+      if Int.equal active_snapshot.backlog_version operation.expected_backlog_version
+      then
+        if receipted_ids <> []
+        then
+          block
+            ~config
+            operation
+            Task_settlement
+            "shutdown receipt exists without a corresponding backlog version change"
+        else
+          let backlog = active_snapshot.backlog_tasks in
+          let rec loop current settled = function
+            | [] -> Ok (current, settled)
+            | task_id :: rest when task_id_mem task_id settled ->
+              loop current settled rest
+            | task_id :: rest ->
+              let settle_result =
+                if task_id_mem task_id active_ids
+                then
+                  (match
+                     List.find_opt
+                       (fun task ->
+                          task_id_equal
+                            task.Keeper_current_task_reconcile.task_id
+                            task_id)
+                       active_tasks
+                   with
+                   | None -> Error "active task snapshot disappeared"
+                   | Some owned -> release_task ~config current owned)
+                else
+                  match find_task backlog task_id with
+                  | Some task when task_has_operation_receipt current task ->
+                    Ok "already released"
+                  | Some _ -> Error "snapshotted task changed without shutdown receipt"
+                  | None -> Error "snapshotted task disappeared from the durable backlog"
+              in
+              (match settle_result with
+               | Error detail -> block ~config current Task_settlement detail
+               | Ok _ ->
+                 (match strict_backlog ~config with
+                  | Error detail -> block ~config current Task_settlement detail
+                  | Ok latest_backlog ->
+                    if
+                      not
+                        (Int.equal
+                           latest_backlog.version
+                           (current.expected_backlog_version + 1))
+                    then
+                      settle_tasks ~config ~meta current settled
+                    else
+                      let settled = task_id :: settled in
+                      (match
+                         persist_settled
+                           ~config
+                           current
+                           ~settled_task_ids:settled
+                           ~expected_backlog_version:latest_backlog.version
+                       with
+                       | Error _ as error -> error
+                       | Ok persisted -> loop persisted settled rest)))
+          in
+          loop operation settled_task_ids operation.owned_task_ids
+      else if outstanding_accounted_for receipted_ids
+      then
+        (match receipted_ids with
+         | [] ->
+           (match
+              persist_settled
+                ~config
+                operation
+                ~settled_task_ids
+                ~expected_backlog_version:active_snapshot.backlog_version
+            with
+            | Error _ as error -> error
+            | Ok rebased -> settle_tasks ~config ~meta rebased settled_task_ids)
+         | [ receipted_id ] ->
+           let settled_task_ids = receipted_id :: settled_task_ids in
+           (match
+              persist_settled
+                ~config
+                operation
+                ~settled_task_ids
+                ~expected_backlog_version:active_snapshot.backlog_version
+            with
+            | Error _ as error -> error
+            | Ok recovered -> settle_tasks ~config ~meta recovered settled_task_ids)
+         | _ ->
+           block
+             ~config
+             operation
+             Task_settlement
+             "multiple uncommitted shutdown receipts require operator reconciliation")
+      else
+        block
+          ~config
+          operation
+          Task_settlement
+          (Printf.sprintf
+             "backlog changed and snapshotted task ownership diverged: expected version %d, actual %d"
+             operation.expected_backlog_version
+             active_snapshot.backlog_version)
+;;
+
+let paused_meta (meta : Keeper_meta_contract.keeper_meta) =
+  { meta with
+    current_task_id = None
+  ; paused = true
+  ; latched_reason =
+      Some
+        (Keeper_latched_reason.Operator_paused
+           { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let update_registry_meta_exact operation entry retained =
+  match entry with
+  | None -> Ok ()
+  | Some registry_entry
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id registry_entry.Keeper_registry.lane)
+              operation.lane_id) -> Error "Keeper registry lane changed before meta update"
+  | Some registry_entry ->
+    (match
+       Keeper_registry.update_entry_exact registry_entry (fun current ->
+         { current with meta = retained })
+     with
+     | Keeper_registry.Exact_updated -> Ok ()
+     | Keeper_registry.Exact_update_missing ->
+       Error "Keeper registry entry disappeared before meta update"
+     | Keeper_registry.Exact_update_replaced ->
+       Error "Keeper registry lane changed during meta update"
+     | Keeper_registry.Exact_update_invalid validation_error ->
+       Error
+         (Keeper_registry.registry_entry_validation_error_to_string validation_error))
+;;
+
+let prepare_cleanup ~config ~entry operation settled_task_ids =
+  match
+    Keeper_meta_store.update_meta_if_identity
+      config
+      ~name:operation.keeper_name
+      ~trace_id:operation.trace_id
+      ~generation:operation.generation
+      paused_meta
+  with
+  | Error error ->
+    block
+      ~config
+      operation
+      Meta_update
+      (Keeper_meta_store.identity_update_error_to_string error)
+  | Ok retained ->
+    (match update_registry_meta_exact operation entry retained with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok () ->
+         (match
+            Atomic.get remove_pending_confirms_by_target_callback
+              config
+              ~target_type:Operator_action_constants.Keeper
+              ~target_id:(Some operation.keeper_name)
+          with
+          | Error detail -> block ~config operation Pending_confirm_cleanup detail
+          | Ok pending_confirms_removed ->
+            let cleanup = { settled_task_ids; pending_confirms_removed } in
+            let ready =
+              { operation with
+                phase = Cleanup_ready cleanup
+              ; updated_at = Masc_domain.now_iso ()
+              }
+            in
+            (match replace ~config ready with
+             | Ok persisted -> Ok persisted
+             | Error _ as error -> error)))
+;;
+
+let rec remove_tree path =
+  if not (Fs_compat.file_exists path)
+  then Ok ()
+  else
+    try
+      match (Unix.lstat path).Unix.st_kind with
+      | Unix.S_DIR ->
+        let entries = Sys.readdir path |> Array.to_list in
+        let rec remove_entries = function
+          | [] ->
+            Unix.rmdir path;
+            Ok ()
+          | entry :: rest ->
+            (match remove_tree (Filename.concat path entry) with
+             | Error _ as error -> error
+             | Ok () -> remove_entries rest)
+        in
+        remove_entries entries
+      | Unix.S_REG
+      | Unix.S_LNK
+      | Unix.S_CHR
+      | Unix.S_BLK
+      | Unix.S_FIFO
+      | Unix.S_SOCK ->
+        Unix.unlink path;
+        Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+;;
+
+let remove_meta_file ~config operation =
+  if operation.cleanup_intent.remove_meta
+  then
+    match
+      Keeper_meta_store.remove_meta_if_identity
+        config
+        ~name:operation.keeper_name
+        ~trace_id:operation.trace_id
+        ~generation:operation.generation
+    with
+    | Ok () | Error Keeper_meta_store.Remove_identity_missing -> Ok ()
+    | Error error -> Error (Keeper_meta_store.identity_remove_error_to_string error)
+  else Ok ()
+;;
+
+let remove_session_dir ~config operation =
+  if operation.cleanup_intent.remove_session
+  then
+    remove_tree
+      (Filename.concat
+         (Keeper_types_profile.session_base_dir config)
+         (Keeper_id.Trace_id.to_string operation.trace_id))
+  else Ok ()
+;;
+
+let unregister_exact operation = function
+  | None -> Ok false
+  | Some entry
+    when not (Keeper_lane.Id.equal (Keeper_lane.id entry.Keeper_registry.lane) operation.lane_id) ->
+    Error "Keeper registry lane changed before finalization"
+  | Some entry ->
+    (match Keeper_registry.unregister_exact entry with
+     | Keeper_registry.Exact_unregistered
+     | Keeper_registry.Exact_entry_missing -> Ok true
+     | Keeper_registry.Exact_entry_replaced ->
+       Error "Keeper registry lane was replaced during finalization")
+;;
+
+let release_finalized_admission ~(config : Workspace.config) operation =
+  match
+    Keeper_turn_admission.rollback_shutdown
+      ~base_path:config.base_path
+      ~keeper_name:operation.keeper_name
+      ~operation_id:operation.operation_id
+  with
+  | Keeper_turn_admission.Shutdown_rolled_back
+  | Keeper_turn_admission.Shutdown_not_reserved -> Ok operation
+  | Keeper_turn_admission.Shutdown_reserved_by_other operation_id ->
+    Log.Keeper.warn
+      "finalized Keeper shutdown found a newer admission owner: keeper=%s finalized_operation=%s current_operation=%s"
+      operation.keeper_name
+      (Operation_id.to_string operation.operation_id)
+      (Operation_id.to_string operation_id);
+    Ok operation
+;;
+
+let complete_cleanup ~config ~entry operation cleanup =
+  match unregister_exact operation entry with
+  | Error detail -> block ~config operation Registry_unregister detail
+  | Ok registry_unregistered ->
+    (match remove_session_dir ~config operation with
+     | Error detail -> block ~config operation Session_remove detail
+     | Ok () ->
+       (match remove_meta_file ~config operation with
+        | Error detail -> block ~config operation Meta_remove detail
+        | Ok () ->
+          if operation.cleanup_intent.remove_meta
+          then Keeper_tool_emission_hook.drop_keeper_accumulator operation.keeper_name;
+          let evidence =
+            { cleanup
+            ; meta_removed = operation.cleanup_intent.remove_meta
+            ; session_removed = operation.cleanup_intent.remove_session
+            ; registry_unregistered
+            }
+          in
+          let finalized =
+            { operation with
+              phase = Finalized evidence
+            ; updated_at = Masc_domain.now_iso ()
+            }
+          in
+          (match replace ~config finalized with
+           | Error _ as error -> error
+           | Ok persisted_finalized ->
+             release_finalized_admission ~config persisted_finalized)))
+;;
+
+let run ~config ~entry operation =
+  match operation.phase with
+  | Joined_idle ->
+    (match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok None -> block ~config operation Meta_update "Keeper metadata is absent"
+     | Ok (Some (_, meta)) ->
+       (match settle_tasks ~config ~meta operation [] with
+        | Error _ as error -> error
+        | Ok (settled_operation, settled_task_ids) ->
+          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
+           | Error _ as error -> error
+           | Ok ready ->
+             (match ready.phase with
+              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | _ -> Error Unsupported_phase))))
+  | Finalizing_tasks settled_task_ids ->
+    (match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok None -> block ~config operation Meta_update "Keeper metadata is absent"
+     | Ok (Some (_, meta)) ->
+       (match settle_tasks ~config ~meta operation settled_task_ids with
+        | Error _ as error -> error
+        | Ok (settled_operation, settled_task_ids) ->
+          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
+           | Error _ as error -> error
+           | Ok ready ->
+             (match ready.phase with
+              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | _ -> Error Unsupported_phase))))
+  | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
+  | Finalized _ -> release_finalized_admission ~config operation
+  | Prepared
+  | Reconciliation_required _
+  | Blocked _ -> Error Unsupported_phase
+;;
+
+module For_testing = struct
+  let paused_meta = paused_meta
+
+  let remove_pending_confirms_by_target ~config ~target_type ~target_id =
+    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+  ;;
+
+  let reset_remove_pending_confirms_by_target () =
+    Atomic.set remove_pending_confirms_by_target_callback
+      (fun _config ~target_type:_ ~target_id:_ ->
+        Error "pending-confirm cleanup implementation is not registered")
+  ;;
+end

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -1,0 +1,36 @@
+(** Durable task settlement and Keeper identity cleanup after an exact lane
+    has joined. Every externally visible side effect is either recorded in the
+    operation or returned as a typed failure. *)
+
+type error =
+  | Store_error of Keeper_shutdown_store.error
+  | Unsupported_phase
+  | Finalization_blocked of Keeper_shutdown_types.t
+
+val error_to_string : error -> string
+
+val register_remove_pending_confirms_by_target :
+  (Workspace.config ->
+   target_type:Operator_action_constants.target_type ->
+   target_id:string option ->
+   (int, string) result) ->
+  unit
+
+val run :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry option ->
+  Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, error) result
+
+module For_testing : sig
+  val paused_meta :
+    Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
+
+  val remove_pending_confirms_by_target :
+    config:Workspace.config ->
+    target_type:Operator_action_constants.target_type ->
+    target_id:string option ->
+    (int, string) result
+
+  val reset_remove_pending_confirms_by_target : unit -> unit
+end

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -66,8 +66,14 @@ let active_turn_of_snapshots reservation current =
     Inflight_effect_unknown
       { lane
       ; admitted_at
-      ; observed_turn_id = Option.map (fun obs -> obs.turn_id) observation
-      ; observation_started_at = Option.map (fun obs -> obs.started_at) observation
+      ; observed_turn_id =
+          Option.map
+            (fun (obs : Keeper_registry.turn_observation) -> obs.turn_id)
+            observation
+      ; observation_started_at =
+          Option.map
+            (fun (obs : Keeper_registry.turn_observation) -> obs.started_at)
+            observation
       }
 ;;
 

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -1,0 +1,240 @@
+open Keeper_shutdown_types
+
+type request =
+  { actor : string
+  ; cleanup_intent : cleanup_intent
+  }
+
+type error =
+  | Registry_lane_replaced
+  | Existing_operation of Operation_id.t
+  | Task_discovery_failed of string
+  | Prepare_persist_failed of Keeper_shutdown_store.error
+  | Cancellation_failed of Keeper_shutdown_types.t
+  | Join_failed of Keeper_shutdown_types.t
+  | Join_record_update_failed of Keeper_shutdown_store.error
+
+let error_to_string = function
+  | Registry_lane_replaced -> "Keeper registry lane changed before shutdown prepare"
+  | Existing_operation operation_id ->
+    Printf.sprintf
+      "Keeper shutdown already reserved by operation %s"
+      (Operation_id.to_string operation_id)
+  | Task_discovery_failed detail ->
+    Printf.sprintf "Keeper shutdown task discovery failed: %s" detail
+  | Prepare_persist_failed error -> Keeper_shutdown_store.error_to_string error
+  | Cancellation_failed operation ->
+    Printf.sprintf
+      "Keeper shutdown cancellation blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+  | Join_failed operation ->
+    Printf.sprintf
+      "Keeper shutdown join blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+  | Join_record_update_failed error -> Keeper_shutdown_store.error_to_string error
+;;
+
+let same_lane left right =
+  Keeper_lane.Id.equal
+    (Keeper_lane.id left.Keeper_registry.lane)
+    (Keeper_lane.id right.Keeper_registry.lane)
+;;
+
+let current_entry ~config (observed : Keeper_registry.registry_entry) =
+  match Keeper_registry.get ~base_path:config.Workspace.base_path observed.name with
+  | Some current when same_lane current observed -> Ok current
+  | Some _ | None -> Error Registry_lane_replaced
+;;
+
+let admission_lane = function
+  | Keeper_turn_admission.Autonomous -> Autonomous
+  | Keeper_turn_admission.Chat -> Chat
+;;
+
+let active_turn_of_snapshots reservation current =
+  let observation : Keeper_registry.turn_observation option =
+    current.Keeper_registry.current_turn_observation
+  in
+  match reservation.Keeper_turn_admission.in_flight, observation with
+  | None, None -> No_inflight_turn
+  | in_flight, observation ->
+    let lane, admitted_at =
+      match in_flight with
+      | Some info -> Some (admission_lane info.lane), Some info.started_at
+      | None -> None, None
+    in
+    Inflight_effect_unknown
+      { lane
+      ; admitted_at
+      ; observed_turn_id = Option.map (fun obs -> obs.turn_id) observation
+      ; observation_started_at = Option.map (fun obs -> obs.started_at) observation
+      }
+;;
+
+let rollback_reservation ~config ~entry operation_id =
+  match
+    Keeper_turn_admission.rollback_shutdown
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:entry.Keeper_registry.name
+      ~operation_id
+  with
+  | Keeper_turn_admission.Shutdown_rolled_back
+  | Keeper_turn_admission.Shutdown_not_reserved -> ()
+  | Keeper_turn_admission.Shutdown_reserved_by_other existing ->
+    Log.Keeper.error
+      "%s: shutdown rollback for %s found reservation %s"
+      entry.name
+      (Operation_id.to_string operation_id)
+      (Operation_id.to_string existing)
+;;
+
+let persist_blocked ~config operation stage detail =
+  let blocked =
+    { operation with
+      phase = Blocked { stage; detail }
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match Keeper_shutdown_store.replace ~config blocked with
+  | Ok () -> Ok blocked
+  | Error error -> Error error
+;;
+
+let cancellation_error ~config operation stage detail =
+  match persist_blocked ~config operation stage detail with
+  | Ok blocked -> Error (Cancellation_failed blocked)
+  | Error error -> Error (Join_record_update_failed error)
+;;
+
+let lane_outcome = function
+  | Keeper_lane.Completed -> Lane_completed
+  | Keeper_lane.Shutdown_requested -> Lane_shutdown_requested
+  | Keeper_lane.Cancelled_by_parent exn ->
+    Lane_cancelled_by_parent (Printexc.to_string exn)
+  | Keeper_lane.Failed exn -> Lane_failed (Printexc.to_string exn)
+;;
+
+let terminal = function
+  | `Stopped -> Terminal_stopped
+  | `Crashed detail -> Terminal_crashed detail
+;;
+
+let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
+  let operation_id = Operation_id.generate () in
+  match
+    Keeper_turn_admission.begin_shutdown
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:entry.name
+      ~operation_id
+  with
+  | Keeper_turn_admission.Shutdown_already_reserved reservation ->
+    Error (Existing_operation reservation.operation_id)
+  | Keeper_turn_admission.Shutdown_reserved reservation ->
+    let durable_prepare_committed = Atomic.make false in
+    Fun.protect
+      ~finally:(fun () ->
+        if not (Atomic.get durable_prepare_committed)
+        then rollback_reservation ~config ~entry operation_id)
+      (fun () ->
+    (match current_entry ~config entry with
+     | Error error -> Error error
+     | Ok current ->
+       (match
+          Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict
+            ~config
+            ~meta:current.meta
+        with
+        | Error detail -> Error (Task_discovery_failed detail)
+        | Ok owned_tasks ->
+          let now = Masc_domain.now_iso () in
+          let turn_disposition = active_turn_of_snapshots reservation current in
+          let operation =
+            { schema_version
+            ; operation_id
+            ; keeper_name = current.name
+            ; lane_id = Keeper_lane.id current.lane
+            ; trace_id = current.meta.runtime.trace_id
+            ; generation = current.meta.runtime.generation
+            ; actor = request.actor
+            ; cleanup_intent = request.cleanup_intent
+            ; turn_disposition
+            ; owned_task_ids =
+                List.map
+                  (fun task -> task.Keeper_current_task_reconcile.task_id)
+                  owned_tasks
+            ; join_evidence = None
+            ; phase = Prepared
+            ; created_at = now
+            ; updated_at = now
+            }
+          in
+          let persist_result =
+            Eio.Cancel.protect (fun () ->
+              match Keeper_shutdown_store.persist_new ~config operation with
+              | Ok () as committed ->
+                Atomic.set durable_prepare_committed true;
+                committed
+              | Error _ as error -> error)
+          in
+          (match persist_result with
+           | Error store_error ->
+             Error (Prepare_persist_failed store_error)
+           | Ok () ->
+             Keeper_keepalive.request_entry_stop current;
+             let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
+             let turn_cancel_error =
+               match turn_disposition, turn_cancel with
+               | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
+               | ( Inflight_effect_unknown _
+                 , Keeper_registry.Exact_turn_cancelled _ ) -> None
+               | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
+                 Some "turn appeared after shutdown admission was fenced"
+               | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
+               | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
+             in
+             (match turn_cancel_error with
+              | Some detail -> cancellation_error ~config operation Turn_cancel detail
+              | None ->
+                (match Keeper_lane.request_cancel current.lane with
+                 | Keeper_lane.Cancel_signal_failed exn ->
+                   cancellation_error
+                     ~config
+                     operation
+                     Lane_cancel
+                     (Printexc.to_string exn)
+                 | Keeper_lane.Cancel_requested
+                 | Keeper_lane.Cancel_already_requested
+                 | Keeper_lane.Cancel_already_exiting ->
+                   Keeper_turn_admission.await_idle_after_shutdown
+                     ~base_path:config.Workspace.base_path
+                     ~keeper_name:current.name;
+                   let lane_exit = Keeper_lane.await_exit current.lane in
+                   let terminal_result = Eio.Promise.await current.done_p in
+                   let evidence =
+                     { lane_outcome = lane_outcome lane_exit.outcome
+                     ; terminal = terminal terminal_result
+                     ; cleanup_error = lane_exit.cleanup_error
+                     }
+                   in
+                   let phase =
+                     match turn_disposition with
+                     | No_inflight_turn -> Joined_idle
+                     | Inflight_effect_unknown turn -> Reconciliation_required turn
+                   in
+                   let joined =
+                     { operation with
+                       join_evidence = Some evidence
+                     ; phase
+                     ; updated_at = Masc_domain.now_iso ()
+                     }
+                   in
+                   (match lane_exit.cleanup_error with
+                    | Some detail ->
+                      (match persist_blocked ~config joined Lane_join detail with
+                       | Ok blocked -> Error (Join_failed blocked)
+                       | Error error -> Error (Join_record_update_failed error))
+                    | None ->
+                      (match Keeper_shutdown_store.replace ~config joined with
+                       | Ok () -> Ok joined
+                       | Error error -> Error (Join_record_update_failed error)))))))))
+;;

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -97,11 +97,17 @@ let rollback_reservation ~config ~entry operation_id =
 let persist_blocked ~config operation stage detail =
   let blocked =
     { operation with
-      phase = Blocked { stage; detail }
+      revision = operation.revision + 1
+    ; phase = Blocked { stage; detail }
     ; updated_at = Masc_domain.now_iso ()
     }
   in
-  match Keeper_shutdown_store.replace ~config blocked with
+  match
+    Keeper_shutdown_store.replace
+      ~config
+      ~expected_revision:operation.revision
+      blocked
+  with
   | Ok () -> Ok blocked
   | Error error -> Error error
 ;;
@@ -114,6 +120,7 @@ let cancellation_error ~config operation stage detail =
 
 let lane_outcome = function
   | Keeper_lane.Completed -> Lane_completed
+  | Keeper_lane.Shutdown_before_start -> Lane_shutdown_requested
   | Keeper_lane.Shutdown_requested -> Lane_shutdown_requested
   | Keeper_lane.Cancelled_by_parent exn ->
     Lane_cancelled_by_parent (Printexc.to_string exn)
@@ -125,7 +132,7 @@ let terminal = function
   | `Crashed detail -> Terminal_crashed detail
 ;;
 
-let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
+let prepare ~config ~(entry : Keeper_registry.registry_entry) ~request =
   let operation_id = Operation_id.generate () in
   match
     Keeper_turn_admission.begin_shutdown
@@ -146,16 +153,18 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
      | Error error -> Error error
      | Ok current ->
        (match
-          Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict
+          Keeper_current_task_reconcile.owned_active_tasks_snapshot_for_meta_strict
             ~config
             ~meta:current.meta
         with
         | Error detail -> Error (Task_discovery_failed detail)
-        | Ok owned_tasks ->
+        | Ok owned_snapshot ->
+          let owned_tasks = owned_snapshot.tasks in
           let now = Masc_domain.now_iso () in
           let turn_disposition = active_turn_of_snapshots reservation current in
           let operation =
             { schema_version
+            ; revision = 0
             ; operation_id
             ; keeper_name = current.name
             ; lane_id = Keeper_lane.id current.lane
@@ -164,6 +173,7 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
             ; actor = request.actor
             ; cleanup_intent = request.cleanup_intent
             ; turn_disposition
+            ; expected_backlog_version = owned_snapshot.backlog_version
             ; owned_task_ids =
                 List.map
                   (fun task -> task.Keeper_current_task_reconcile.task_id)
@@ -185,62 +195,111 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
           (match persist_result with
            | Error store_error ->
              Error (Prepare_persist_failed store_error)
-           | Ok () ->
-             Keeper_keepalive.request_entry_stop current;
-             let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
-             let turn_cancel_error =
-               match turn_disposition, turn_cancel with
-               | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
-               | ( Inflight_effect_unknown _
-                 , Keeper_registry.Exact_turn_cancelled _ ) -> None
-               | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
-                 Some "turn appeared after shutdown admission was fenced"
-               | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
-               | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
+           | Ok () -> Ok operation))))
+;;
+
+let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
+  match current_entry ~config entry with
+  | Error error -> Error error
+  | Ok current
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id current.lane)
+              operation.lane_id) -> Error Registry_lane_replaced
+  | Ok current ->
+    Keeper_keepalive.request_entry_stop current;
+    let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
+    let turn_cancel_error =
+      match operation.turn_disposition, turn_cancel with
+      | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
+      | Inflight_effect_unknown _, Keeper_registry.Exact_turn_cancelled _ -> None
+      | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
+        Some "turn appeared after shutdown admission was fenced"
+      | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
+      | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
+    in
+    (match turn_cancel_error with
+     | Some detail -> cancellation_error ~config operation Turn_cancel detail
+     | None ->
+       (match Keeper_lane.request_cancel current.lane with
+        | Keeper_lane.Cancel_signal_failed exn ->
+          cancellation_error ~config operation Lane_cancel (Printexc.to_string exn)
+        | Keeper_lane.Cancel_requested
+        | Keeper_lane.Cancel_already_requested
+        | Keeper_lane.Cancel_already_exiting ->
+          Keeper_turn_admission.await_idle_after_shutdown
+            ~base_path:config.Workspace.base_path
+            ~keeper_name:current.name;
+          let lane_exit = Keeper_lane.await_exit current.lane in
+          (match lane_exit.outcome with
+           | Keeper_lane.Shutdown_before_start ->
+             (match
+                Keeper_registry.resolve_done
+                  current
+                  ~source:"shutdown_before_lane_start"
+                  `Stopped
+              with
+              | Keeper_registry.Done_resolved _
+              | Keeper_registry.Done_already_resolved { previous = `Stopped; _ } -> ()
+              | Keeper_registry.Done_already_resolved
+                  { previous = `Crashed detail; _ } ->
+                Log.Keeper.warn
+                  "%s: shutdown before lane start preserved prior crash terminal: %s"
+                  current.name
+                  detail)
+           | Keeper_lane.Completed
+           | Keeper_lane.Shutdown_requested
+           | Keeper_lane.Cancelled_by_parent _
+           | Keeper_lane.Failed _ -> ());
+          let terminal_result = Eio.Promise.await current.done_p in
+          let evidence =
+            { lane_outcome = lane_outcome lane_exit.outcome
+            ; terminal = terminal terminal_result
+            ; cleanup_error = lane_exit.cleanup_error
+            }
+          in
+          let phase =
+            match operation.turn_disposition with
+            | No_inflight_turn -> Joined_idle
+            | Inflight_effect_unknown turn -> Reconciliation_required turn
+          in
+          let joined =
+            { operation with
+              revision = operation.revision + 1
+            ; join_evidence = Some evidence
+            ; phase
+            ; updated_at = Masc_domain.now_iso ()
+            }
+          in
+          (match lane_exit.cleanup_error with
+           | Some detail ->
+             let blocked =
+               { joined with
+                 phase = Blocked { stage = Lane_join; detail }
+               ; updated_at = Masc_domain.now_iso ()
+               }
              in
-             (match turn_cancel_error with
-              | Some detail -> cancellation_error ~config operation Turn_cancel detail
-              | None ->
-                (match Keeper_lane.request_cancel current.lane with
-                 | Keeper_lane.Cancel_signal_failed exn ->
-                   cancellation_error
-                     ~config
-                     operation
-                     Lane_cancel
-                     (Printexc.to_string exn)
-                 | Keeper_lane.Cancel_requested
-                 | Keeper_lane.Cancel_already_requested
-                 | Keeper_lane.Cancel_already_exiting ->
-                   Keeper_turn_admission.await_idle_after_shutdown
-                     ~base_path:config.Workspace.base_path
-                     ~keeper_name:current.name;
-                   let lane_exit = Keeper_lane.await_exit current.lane in
-                   let terminal_result = Eio.Promise.await current.done_p in
-                   let evidence =
-                     { lane_outcome = lane_outcome lane_exit.outcome
-                     ; terminal = terminal terminal_result
-                     ; cleanup_error = lane_exit.cleanup_error
-                     }
-                   in
-                   let phase =
-                     match turn_disposition with
-                     | No_inflight_turn -> Joined_idle
-                     | Inflight_effect_unknown turn -> Reconciliation_required turn
-                   in
-                   let joined =
-                     { operation with
-                       join_evidence = Some evidence
-                     ; phase
-                     ; updated_at = Masc_domain.now_iso ()
-                     }
-                   in
-                   (match lane_exit.cleanup_error with
-                    | Some detail ->
-                      (match persist_blocked ~config joined Lane_join detail with
-                       | Ok blocked -> Error (Join_failed blocked)
-                       | Error error -> Error (Join_record_update_failed error))
-                    | None ->
-                      (match Keeper_shutdown_store.replace ~config joined with
-                       | Ok () -> Ok joined
-                       | Error error -> Error (Join_record_update_failed error)))))))))
+             (match
+                Keeper_shutdown_store.replace
+                  ~config
+                  ~expected_revision:operation.revision
+                  blocked
+              with
+              | Ok () -> Error (Join_failed blocked)
+              | Error error -> Error (Join_record_update_failed error))
+           | None ->
+             (match
+                Keeper_shutdown_store.replace
+                  ~config
+                  ~expected_revision:operation.revision
+                  joined
+              with
+              | Ok () -> Ok joined
+              | Error error -> Error (Join_record_update_failed error)))))
+;;
+
+let run ~config ~entry ~request =
+  match prepare ~config ~entry ~request with
+  | Error _ as error -> error
+  | Ok operation -> join_prepared ~config ~entry ~operation
 ;;

--- a/lib/keeper/keeper_shutdown_prepare_join.mli
+++ b/lib/keeper/keeper_shutdown_prepare_join.mli
@@ -1,0 +1,25 @@
+(** Durable prepare, admission fence, cancellation, and join for one Keeper
+    lane. This module deliberately does not release tasks or remove metadata;
+    those are later finalization phases. *)
+
+type request =
+  { actor : string
+  ; cleanup_intent : Keeper_shutdown_types.cleanup_intent
+  }
+
+type error =
+  | Registry_lane_replaced
+  | Existing_operation of Keeper_shutdown_types.Operation_id.t
+  | Task_discovery_failed of string
+  | Prepare_persist_failed of Keeper_shutdown_store.error
+  | Cancellation_failed of Keeper_shutdown_types.t
+  | Join_failed of Keeper_shutdown_types.t
+  | Join_record_update_failed of Keeper_shutdown_store.error
+
+val error_to_string : error -> string
+
+val run :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:request ->
+  (Keeper_shutdown_types.t, error) result

--- a/lib/keeper/keeper_shutdown_prepare_join.mli
+++ b/lib/keeper/keeper_shutdown_prepare_join.mli
@@ -23,3 +23,21 @@ val run :
   entry:Keeper_registry.registry_entry ->
   request:request ->
   (Keeper_shutdown_types.t, error) result
+
+(** Persist the shutdown admission fence and ownership snapshot without
+    waiting for the current turn or lane. Once this returns [Ok], the durable
+    operation owns admission and must be joined or recovered. *)
+val prepare :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:request ->
+  (Keeper_shutdown_types.t, error) result
+
+(** Cancel and join the exact lane captured by [prepare]. Never call this
+    from that Keeper's admitted turn; lifecycle tools fork it on the server
+    switch after returning the accepted operation id. *)
+val join_prepared :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  operation:Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, error) result

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -1,0 +1,245 @@
+open Keeper_shutdown_types
+
+type submit_error =
+  | Prepare_error of Keeper_shutdown_prepare_join.error
+  | Existing_operation_load_error of Keeper_shutdown_store.error
+  | Worker_start_error of worker_start_error
+
+and worker_start_error =
+  | Worker_supervisor_unavailable
+  | Worker_supervisor_stopping of exn
+  | Worker_fork_failed of exn
+
+let submit_error_to_string = function
+  | Prepare_error error -> Keeper_shutdown_prepare_join.error_to_string error
+  | Existing_operation_load_error error -> Keeper_shutdown_store.error_to_string error
+  | Worker_start_error Worker_supervisor_unavailable ->
+    "Keeper shutdown process supervisor is unavailable"
+  | Worker_start_error (Worker_supervisor_stopping exn) ->
+    Printf.sprintf "Keeper shutdown process supervisor is stopping: %s" (Printexc.to_string exn)
+  | Worker_start_error (Worker_fork_failed exn) ->
+    Printf.sprintf "Keeper shutdown worker fork failed: %s" (Printexc.to_string exn)
+;;
+
+let worker_mu = Eio.Mutex.create ()
+let active_workers : (string, unit) Hashtbl.t = Hashtbl.create 17
+
+let worker_key operation = Operation_id.to_string operation.operation_id
+
+let claim_worker operation =
+  Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
+    let key = worker_key operation in
+    if Hashtbl.mem active_workers key
+    then false
+    else (
+      Hashtbl.add active_workers key ();
+      true))
+;;
+
+let release_worker operation =
+  Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
+    Hashtbl.remove active_workers (worker_key operation))
+;;
+
+let persist_unhandled_failure ~config operation exn =
+  let detail = Printexc.to_string exn in
+  Eio.Cancel.protect (fun () ->
+    Log.Keeper.error
+      "shutdown worker failed; persisting durable failure evidence: keeper=%s operation=%s error=%s"
+      operation.keeper_name
+      (worker_key operation)
+      detail;
+    match
+      Keeper_shutdown_store.persist_blocked_latest
+        ~config
+        ~identity:operation
+        ~failure:{ stage = Record_update; detail }
+        ~updated_at:(Masc_domain.now_iso ())
+    with
+    | Ok (Keeper_shutdown_store.Blocked_persisted blocked) ->
+      Log.Keeper.error
+        "shutdown worker failed; blocked state persisted: keeper=%s operation=%s revision=%d error=%s"
+        blocked.keeper_name
+        (worker_key blocked)
+        blocked.revision
+        detail
+    | Ok (Keeper_shutdown_store.State_preserved current) ->
+      Log.Keeper.error
+        "shutdown worker failed after a durable non-progress state; preserving it: keeper=%s operation=%s revision=%d error=%s"
+        current.keeper_name
+        (worker_key current)
+        current.revision
+        detail
+    | Error store_error ->
+      Log.Keeper.error
+        "shutdown operation %s failed and its blocked state could not be persisted: worker_error=%s store_error=%s"
+        (worker_key operation)
+        detail
+        (Keeper_shutdown_store.error_to_string store_error))
+;;
+
+let finalize_if_ready ~config ~entry operation =
+  match operation.phase with
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _ ->
+    (match Keeper_shutdown_finalize.run ~config ~entry:(Some entry) operation with
+     | Ok finalized ->
+       Log.Keeper.info
+         "Keeper shutdown operation finalized: keeper=%s operation=%s"
+         finalized.keeper_name
+         (worker_key finalized)
+     | Error error ->
+       Log.Keeper.error
+         "Keeper shutdown finalization stopped: keeper=%s operation=%s error=%s"
+         operation.keeper_name
+         (worker_key operation)
+         (Keeper_shutdown_finalize.error_to_string error))
+  | Prepared
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _ -> ()
+;;
+
+let run_worker ~config ~entry operation =
+  match operation.phase with
+  | Prepared ->
+    (match Keeper_shutdown_prepare_join.join_prepared ~config ~entry ~operation with
+     | Ok joined -> finalize_if_ready ~config ~entry joined
+     | Error error ->
+       Log.Keeper.error
+         "Keeper shutdown join stopped: keeper=%s operation=%s error=%s"
+         operation.keeper_name
+         (worker_key operation)
+         (Keeper_shutdown_prepare_join.error_to_string error))
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _ -> finalize_if_ready ~config ~entry operation
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _ -> ()
+;;
+
+type worker_start_result =
+  | Worker_started
+  | Worker_already_active
+  | Worker_start_rejected of worker_start_error
+
+let start_worker ~config ~entry operation =
+  match Keeper_supervisor.get_global_switch () with
+  | None -> Worker_start_rejected Worker_supervisor_unavailable
+  | Some sw ->
+    Eio.Cancel.protect (fun () ->
+      match Eio.Switch.get_error sw with
+      | Some cause -> Worker_start_rejected (Worker_supervisor_stopping cause)
+      | None when not (claim_worker operation) -> Worker_already_active
+      | None ->
+        let started = Atomic.make false in
+        (try
+           Eio.Fiber.fork ~sw (fun () ->
+             Atomic.set started true;
+             Fun.protect
+               ~finally:(fun () -> release_worker operation)
+               (fun () ->
+                  try run_worker ~config ~entry operation with
+                  | Eio.Cancel.Cancelled _ ->
+                    Log.Keeper.info
+                      "Keeper shutdown worker cancelled by server teardown; durable recovery retained: keeper=%s operation=%s"
+                      operation.keeper_name
+                      (worker_key operation)
+                  | exn -> persist_unhandled_failure ~config operation exn));
+           if Atomic.get started
+           then Worker_started
+           else
+             (match Eio.Switch.get_error sw with
+              | None -> Worker_started
+              | Some cause ->
+                release_worker operation;
+                Worker_start_rejected (Worker_supervisor_stopping cause))
+         with
+         | exn ->
+           release_worker operation;
+           Worker_start_rejected (Worker_fork_failed exn)))
+;;
+
+let start_or_error ~config ~entry operation =
+  match start_worker ~config ~entry operation with
+  | Worker_started | Worker_already_active -> Ok operation
+  | Worker_start_rejected error -> Error (Worker_start_error error)
+;;
+
+let submit ~config ~entry ~request =
+  match Keeper_shutdown_prepare_join.prepare ~config ~entry ~request with
+  | Ok operation ->
+    start_or_error ~config ~entry operation
+  | Error (Keeper_shutdown_prepare_join.Existing_operation operation_id) ->
+    (match Keeper_shutdown_store.load ~config operation_id with
+     | Error error -> Error (Existing_operation_load_error error)
+     | Ok operation -> start_or_error ~config ~entry operation)
+  | Error error -> Error (Prepare_error error)
+;;
+
+let recovered_join_state operation =
+  let evidence =
+    { lane_outcome = Lane_cancelled_by_parent "server process ended before lane receipt"
+    ; terminal = Terminal_crashed "server process ended before lane receipt"
+    ; cleanup_error = None
+    }
+  in
+  let phase =
+    match operation.turn_disposition with
+    | No_inflight_turn -> Joined_idle
+    | Inflight_effect_unknown turn -> Reconciliation_required turn
+  in
+  { operation with
+    revision = operation.revision + 1
+  ; join_evidence = Some evidence
+  ; phase
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let recover_operation ~config operation =
+  let operation_result =
+    match operation.phase with
+    | Prepared ->
+      let recovered = recovered_join_state operation in
+      (match
+         Keeper_shutdown_store.replace
+           ~config
+           ~expected_revision:operation.revision
+           recovered
+       with
+       | Ok () -> Ok recovered
+       | Error error -> Error (Keeper_shutdown_store.error_to_string error))
+    | Joined_idle
+    | Finalizing_tasks _
+    | Cleanup_ready _
+    | Reconciliation_required _
+    | Finalized _
+    | Blocked _ -> Ok operation
+  in
+  match operation_result with
+  | Error _ as error -> error
+  | Ok recovered ->
+    (match recovered.phase with
+     | Joined_idle
+     | Finalizing_tasks _
+     | Cleanup_ready _ ->
+       Keeper_shutdown_finalize.run ~config ~entry:None recovered
+       |> Result.map_error Keeper_shutdown_finalize.error_to_string
+     | Prepared
+     | Reconciliation_required _
+     | Finalized _
+     | Blocked _ -> Ok recovered)
+;;
+
+let recover_at_boot ~config =
+  match Keeper_shutdown_store.list_all ~config with
+  | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
+  | Ok operations -> List.map (recover_operation ~config) operations
+;;
+
+module For_testing = struct
+  let persist_unhandled_failure = persist_unhandled_failure
+end

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -1,0 +1,44 @@
+(** Non-blocking lifecycle orchestration for durable Keeper shutdown. *)
+
+type submit_error =
+  | Prepare_error of Keeper_shutdown_prepare_join.error
+  | Existing_operation_load_error of Keeper_shutdown_store.error
+  | Worker_start_error of worker_start_error
+
+and worker_start_error =
+  | Worker_supervisor_unavailable
+  | Worker_supervisor_stopping of exn
+  | Worker_fork_failed of exn
+
+val submit_error_to_string : submit_error -> string
+
+(** Fence admission and persist the operation synchronously, then fork lane
+    join/finalization on the process-lifetime Keeper supervisor switch. The
+    returned operation id is durable before this function returns. *)
+val submit :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:Keeper_shutdown_prepare_join.request ->
+  (Keeper_shutdown_types.t, submit_error) result
+
+(** Recover operations left by an earlier server process. Must run before
+    Keeper autoboot so a stopped Keeper cannot acquire a replacement lane
+    ahead of settlement. Returns one explicit result per durable operation. *)
+val recover_at_boot :
+  config:Workspace.config ->
+  (Keeper_shutdown_types.t, string) result list
+
+(** Recover one durable operation without consulting global inventory. This
+    lets bootstrap isolate every Keeper in its own process-lifetime fiber. *)
+val recover_operation :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, string) result
+
+module For_testing : sig
+  val persist_unhandled_failure :
+    config:Workspace.config ->
+    Keeper_shutdown_types.t ->
+    exn ->
+    unit
+end

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -6,6 +6,14 @@ type error =
   | Io_error of string
   | Decode_error of string
   | Identity_mismatch of string
+  | Revision_conflict of
+      { expected : int
+      ; actual : int
+      }
+
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
 
 let error_to_string = function
   | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
@@ -14,6 +22,11 @@ let error_to_string = function
   | Decode_error detail -> Printf.sprintf "shutdown operation decode failed: %s" detail
   | Identity_mismatch detail ->
     Printf.sprintf "shutdown operation identity mismatch: %s" detail
+  | Revision_conflict { expected; actual } ->
+    Printf.sprintf
+      "shutdown operation revision conflict: expected %d, actual %d"
+      expected
+      actual
 ;;
 
 type operation_lock =
@@ -108,13 +121,51 @@ let failure_to_json failure =
     ]
 ;;
 
+let task_ids_to_json task_ids =
+  `List
+    (List.map
+       (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
+       task_ids)
+;;
+
+let cleanup_evidence_to_json evidence =
+  `Assoc
+    [ "settled_task_ids", task_ids_to_json evidence.settled_task_ids
+    ; "pending_confirms_removed", `Int evidence.pending_confirms_removed
+    ]
+;;
+
+let finalization_evidence_to_json evidence =
+  `Assoc
+    [ "cleanup", cleanup_evidence_to_json evidence.cleanup
+    ; "meta_removed", `Bool evidence.meta_removed
+    ; "session_removed", `Bool evidence.session_removed
+    ; "registry_unregistered", `Bool evidence.registry_unregistered
+    ]
+;;
+
 let phase_to_json = function
   | Prepared -> `Assoc [ "kind", `String "prepared" ]
   | Joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
+  | Finalizing_tasks settled_task_ids ->
+    `Assoc
+      [ "kind", `String "finalizing_tasks"
+      ; "settled_task_ids", task_ids_to_json settled_task_ids
+      ]
+  | Cleanup_ready evidence ->
+    `Assoc
+      [ "kind", `String "cleanup_ready"
+      ; "evidence", cleanup_evidence_to_json evidence
+      ]
   | Reconciliation_required turn ->
     `Assoc
       [ "kind", `String "reconciliation_required"
       ; "active_turn", active_turn_to_json turn
+      ]
+  | Finalized evidence ->
+    `Assoc
+      [ "kind", `String "finalized"
+      ; "evidence", finalization_evidence_to_json evidence
       ]
   | Blocked failure ->
     `Assoc
@@ -161,6 +212,7 @@ let join_evidence_to_json evidence =
 let to_json operation =
   `Assoc
     [ "schema_version", `Int operation.schema_version
+    ; "revision", `Int operation.revision
     ; "operation_id", `String (Operation_id.to_string operation.operation_id)
     ; "keeper_name", `String operation.keeper_name
     ; "lane_id", `String (Keeper_lane.Id.to_string operation.lane_id)
@@ -173,11 +225,8 @@ let to_json operation =
           ; "remove_session", `Bool operation.cleanup_intent.remove_session
           ] )
     ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
-    ; ( "owned_task_ids"
-      , `List
-          (List.map
-             (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
-             operation.owned_task_ids) )
+    ; "expected_backlog_version", `Int operation.expected_backlog_version
+    ; "owned_task_ids", task_ids_to_json operation.owned_task_ids
     ; ( "join_evidence"
       , match operation.join_evidence with
         | None -> `Null
@@ -283,15 +332,62 @@ let failure_of_json json =
   Ok { stage; detail }
 ;;
 
+let task_ids_field_of_json field json =
+  match assoc field json with
+  | Error _ as error -> error
+  | Ok (`List values) ->
+    List.fold_left
+      (fun result value ->
+         let* task_ids = result in
+         match value with
+         | `String raw ->
+           let* task_id =
+             Keeper_id.Task_id.of_string raw
+             |> Result.map_error (fun e -> Decode_error e)
+           in
+           Ok (task_id :: task_ids)
+         | _ -> Error (decode_error (field ^ "[]") "a string"))
+      (Ok [])
+      values
+    |> Result.map List.rev
+  | Ok _ -> Error (decode_error field "an array")
+;;
+
+let cleanup_evidence_of_json json =
+  let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
+  let* pending_confirms_removed = int "pending_confirms_removed" json in
+  Ok { settled_task_ids; pending_confirms_removed }
+;;
+
+let finalization_evidence_of_json json =
+  let* cleanup_json = assoc "cleanup" json in
+  let* cleanup = cleanup_evidence_of_json cleanup_json in
+  let* meta_removed = bool "meta_removed" json in
+  let* session_removed = bool "session_removed" json in
+  let* registry_unregistered = bool "registry_unregistered" json in
+  Ok { cleanup; meta_removed; session_removed; registry_unregistered }
+;;
+
 let phase_of_json json =
   let* kind = string "kind" json in
   match kind with
   | "prepared" -> Ok Prepared
   | "joined_idle" -> Ok Joined_idle
+  | "finalizing_tasks" ->
+    let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
+    Ok (Finalizing_tasks settled_task_ids)
+  | "cleanup_ready" ->
+    let* evidence_json = assoc "evidence" json in
+    let* evidence = cleanup_evidence_of_json evidence_json in
+    Ok (Cleanup_ready evidence)
   | "reconciliation_required" ->
     let* active_json = assoc "active_turn" json in
     let* turn = active_turn_of_json active_json in
     Ok (Reconciliation_required turn)
+  | "finalized" ->
+    let* evidence_json = assoc "evidence" json in
+    let* evidence = finalization_evidence_of_json evidence_json in
+    Ok (Finalized evidence)
   | "blocked" ->
     let* failure_json = assoc "failure" json in
     let* failure = failure_of_json failure_json in
@@ -339,27 +435,6 @@ let optional_join_evidence_of_json json =
   | Error _ as error -> error
 ;;
 
-let task_ids_of_json json =
-  match assoc "owned_task_ids" json with
-  | Error _ as error -> error
-  | Ok (`List values) ->
-    List.fold_left
-      (fun result value ->
-         let* task_ids = result in
-         match value with
-         | `String raw ->
-           let* task_id =
-             Keeper_id.Task_id.of_string raw
-             |> Result.map_error (fun e -> Decode_error e)
-           in
-           Ok (task_id :: task_ids)
-         | _ -> Error (decode_error "owned_task_ids[]" "a string"))
-      (Ok [])
-      values
-    |> Result.map List.rev
-  | Ok _ -> Error (decode_error "owned_task_ids" "an array")
-;;
-
 let of_json json =
   let* decoded_schema_version = int "schema_version" json in
   if decoded_schema_version <> schema_version
@@ -371,6 +446,7 @@ let of_json json =
             decoded_schema_version))
   else
     let* operation_id_wire = string "operation_id" json in
+    let* revision = int "revision" json in
     let* operation_id =
       Operation_id.of_string operation_id_wire
       |> Result.map_error (fun e -> Decode_error e)
@@ -393,7 +469,8 @@ let of_json json =
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
     let* turn_disposition = turn_disposition_of_json turn_json in
-    let* owned_task_ids = task_ids_of_json json in
+    let* expected_backlog_version = int "expected_backlog_version" json in
+    let* owned_task_ids = task_ids_field_of_json "owned_task_ids" json in
     let* join_evidence = optional_join_evidence_of_json json in
     let* phase_json = assoc "phase" json in
     let* phase = phase_of_json phase_json in
@@ -401,6 +478,7 @@ let of_json json =
     let* updated_at = string "updated_at" json in
     Ok
       { schema_version = decoded_schema_version
+      ; revision
       ; operation_id
       ; keeper_name
       ; lane_id
@@ -409,6 +487,7 @@ let of_json json =
       ; actor
       ; cleanup_intent = { remove_meta; remove_session }
       ; turn_disposition
+      ; expected_backlog_version
       ; owned_task_ids
       ; join_evidence
       ; phase
@@ -450,11 +529,19 @@ let same_identity left right =
   && Int.equal left.generation right.generation
 ;;
 
-let replace ~config operation =
+let replace ~config ~expected_revision operation =
   let operation_path = path ~config operation.operation_id in
   with_operation_lock ~access:Write operation_path (fun () ->
     match load_unlocked ~config operation.operation_id with
     | Error _ as error -> error
+    | Ok existing when not (Int.equal existing.revision expected_revision) ->
+      Error (Revision_conflict { expected = expected_revision; actual = existing.revision })
+    | Ok _ when not (Int.equal operation.revision (expected_revision + 1)) ->
+      Error
+        (Revision_conflict
+           { expected = expected_revision + 1
+           ; actual = operation.revision
+           })
     | Ok existing when same_identity existing operation ->
       Keeper_fs.save_json_atomic operation_path (to_json operation)
       |> Result.map_error (fun detail -> Io_error detail)
@@ -464,13 +551,37 @@ let replace ~config operation =
            (Operation_id.to_string operation.operation_id)))
 ;;
 
+let persist_blocked_latest ~config ~identity ~failure ~updated_at =
+  let operation_path = path ~config identity.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
+    match load_unlocked ~config identity.operation_id with
+    | Error _ as error -> error
+    | Ok existing when not (same_identity existing identity) ->
+      Error (Identity_mismatch (Operation_id.to_string identity.operation_id))
+    | Ok existing ->
+      (match existing.phase with
+       | Finalized _ | Blocked _ | Reconciliation_required _ ->
+         Ok (State_preserved existing)
+       | Prepared | Joined_idle | Finalizing_tasks _ | Cleanup_ready _ ->
+         let blocked =
+           { existing with
+             revision = existing.revision + 1
+           ; phase = Blocked failure
+           ; updated_at
+           }
+         in
+         Keeper_fs.save_json_atomic operation_path (to_json blocked)
+         |> Result.map_error (fun detail -> Io_error detail)
+         |> Result.map (fun () -> Blocked_persisted blocked)))
+;;
+
 let load ~config operation_id =
   let operation_path = path ~config operation_id in
   with_operation_lock ~access:Read operation_path (fun () ->
     load_unlocked ~config operation_id)
 ;;
 
-let list_for_keeper ~config ~keeper_name =
+let list_unlocked ~config =
   let dir = records_dir config in
   if not (Fs_compat.file_exists dir)
   then Ok []
@@ -486,9 +597,7 @@ let list_for_keeper ~config ~keeper_name =
               then
                 Error
                   (Decode_error
-                     (Printf.sprintf
-                        "unexpected shutdown store entry: %s"
-                        filename))
+                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
               else
                 let raw_id = Filename.chop_suffix filename ".json" in
                 let* operation_id =
@@ -496,12 +605,25 @@ let list_for_keeper ~config ~keeper_name =
                   |> Result.map_error (fun e -> Decode_error e)
                 in
                 let* operation = load ~config operation_id in
-                if String.equal operation.keeper_name keeper_name
-                then Ok (operation :: operations)
-                else Ok operations)
+                Ok (operation :: operations))
            (Ok [])
       |> Result.map List.rev
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Io_error (Printexc.to_string exn))
 ;;
+
+let list_all ~config = list_unlocked ~config
+
+let list_for_keeper ~config ~keeper_name =
+  list_unlocked ~config
+  |> Result.map
+       (List.filter (fun operation -> String.equal operation.keeper_name keeper_name))
+;;
+
+module For_testing = struct
+  let with_operation_write_lock ~config operation_id f =
+    let operation_path = path ~config operation_id in
+    with_operation_lock ~access:Write operation_path f
+  ;;
+end

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -1,0 +1,507 @@
+open Keeper_shutdown_types
+
+type error =
+  | Already_exists of string
+  | Not_found of string
+  | Io_error of string
+  | Decode_error of string
+  | Identity_mismatch of string
+
+let error_to_string = function
+  | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
+  | Not_found path -> Printf.sprintf "shutdown operation not found: %s" path
+  | Io_error detail -> Printf.sprintf "shutdown operation I/O failed: %s" detail
+  | Decode_error detail -> Printf.sprintf "shutdown operation decode failed: %s" detail
+  | Identity_mismatch detail ->
+    Printf.sprintf "shutdown operation identity mismatch: %s" detail
+;;
+
+type operation_lock =
+  { mutex : Eio.Mutex.t
+  ; mutable users : int
+  }
+
+let operation_locks : (string, operation_lock) Hashtbl.t = Hashtbl.create 16
+let operation_locks_mutex = Stdlib.Mutex.create ()
+
+type lock_access =
+  | Read
+  | Write
+
+let acquire_operation_lock key =
+  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
+    match Hashtbl.find_opt operation_locks key with
+    | Some lock ->
+      lock.users <- lock.users + 1;
+      lock
+    | None ->
+      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
+      Hashtbl.add operation_locks key lock;
+      lock)
+;;
+
+let release_operation_lock key lock =
+  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
+    lock.users <- lock.users - 1;
+    if lock.users = 0
+    then
+      match Hashtbl.find_opt operation_locks key with
+      | Some current when current == lock -> Hashtbl.remove operation_locks key
+      | Some _ | None -> ())
+;;
+
+let with_operation_lock ~access key f =
+  let lock = acquire_operation_lock key in
+  Fun.protect
+    ~finally:(fun () -> release_operation_lock key lock)
+    (fun () ->
+       match access with
+       | Write -> Eio.Mutex.use_rw ~protect:true lock.mutex f
+       | Read -> Eio.Mutex.use_ro lock.mutex f)
+;;
+
+let records_dir (config : Workspace.config) =
+  Filename.concat (Workspace.keepers_runtime_dir config) ".shutdown-operations"
+;;
+
+let path ~config operation_id =
+  Filename.concat
+    (records_dir config)
+    (Keeper_shutdown_types.Operation_id.to_string operation_id ^ ".json")
+;;
+
+let int_option_to_json = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+let float_option_to_json = function
+  | None -> `Null
+  | Some value -> `Float value
+;;
+
+let active_turn_to_json turn =
+  `Assoc
+    [ ( "lane"
+      , match turn.lane with
+        | None -> `Null
+        | Some lane -> `String (admission_lane_to_string lane) )
+    ; "admitted_at", float_option_to_json turn.admitted_at
+    ; "observed_turn_id", int_option_to_json turn.observed_turn_id
+    ; "observation_started_at", float_option_to_json turn.observation_started_at
+    ]
+;;
+
+let turn_disposition_to_json = function
+  | No_inflight_turn -> `Assoc [ "kind", `String "no_inflight_turn" ]
+  | Inflight_effect_unknown turn ->
+    `Assoc
+      [ "kind", `String "inflight_effect_unknown"
+      ; "active_turn", active_turn_to_json turn
+      ]
+;;
+
+let failure_to_json failure =
+  `Assoc
+    [ "stage", `String (failure_stage_to_string failure.stage)
+    ; "detail", `String failure.detail
+    ]
+;;
+
+let phase_to_json = function
+  | Prepared -> `Assoc [ "kind", `String "prepared" ]
+  | Joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
+  | Reconciliation_required turn ->
+    `Assoc
+      [ "kind", `String "reconciliation_required"
+      ; "active_turn", active_turn_to_json turn
+      ]
+  | Blocked failure ->
+    `Assoc
+      [ "kind", `String "blocked"
+      ; "failure", failure_to_json failure
+      ]
+;;
+
+let lane_outcome_to_json = function
+  | Lane_completed -> `Assoc [ "kind", `String "completed" ]
+  | Lane_shutdown_requested -> `Assoc [ "kind", `String "shutdown_requested" ]
+  | Lane_cancelled_by_parent detail ->
+    `Assoc
+      [ "kind", `String "cancelled_by_parent"
+      ; "detail", `String detail
+      ]
+  | Lane_failed detail ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "detail", `String detail
+      ]
+;;
+
+let terminal_to_json = function
+  | Terminal_stopped -> `Assoc [ "kind", `String "stopped" ]
+  | Terminal_crashed detail ->
+    `Assoc
+      [ "kind", `String "crashed"
+      ; "detail", `String detail
+      ]
+;;
+
+let join_evidence_to_json evidence =
+  `Assoc
+    [ "lane_outcome", lane_outcome_to_json evidence.lane_outcome
+    ; "terminal", terminal_to_json evidence.terminal
+    ; ( "cleanup_error"
+      , match evidence.cleanup_error with
+        | None -> `Null
+        | Some detail -> `String detail )
+    ]
+;;
+
+let to_json operation =
+  `Assoc
+    [ "schema_version", `Int operation.schema_version
+    ; "operation_id", `String (Operation_id.to_string operation.operation_id)
+    ; "keeper_name", `String operation.keeper_name
+    ; "lane_id", `String (Keeper_lane.Id.to_string operation.lane_id)
+    ; "trace_id", `String (Keeper_id.Trace_id.to_string operation.trace_id)
+    ; "generation", `Int operation.generation
+    ; "actor", `String operation.actor
+    ; ( "cleanup_intent"
+      , `Assoc
+          [ "remove_meta", `Bool operation.cleanup_intent.remove_meta
+          ; "remove_session", `Bool operation.cleanup_intent.remove_session
+          ] )
+    ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
+    ; ( "owned_task_ids"
+      , `List
+          (List.map
+             (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
+             operation.owned_task_ids) )
+    ; ( "join_evidence"
+      , match operation.join_evidence with
+        | None -> `Null
+        | Some evidence -> join_evidence_to_json evidence )
+    ; "phase", phase_to_json operation.phase
+    ; "created_at", `String operation.created_at
+    ; "updated_at", `String operation.updated_at
+    ]
+;;
+
+let decode_error field expected =
+  Decode_error (Printf.sprintf "%s must be %s" field expected)
+;;
+
+let assoc field = function
+  | `Assoc fields ->
+    (match List.assoc_opt field fields with
+     | Some value -> Ok value
+     | None -> Error (Decode_error (Printf.sprintf "missing field %s" field)))
+  | _ -> Error (decode_error field "inside an object")
+;;
+
+let string field json =
+  match assoc field json with
+  | Ok (`String value) -> Ok value
+  | Ok _ -> Error (decode_error field "a string")
+  | Error _ as error -> error
+;;
+
+let int field json =
+  match assoc field json with
+  | Ok (`Int value) -> Ok value
+  | Ok _ -> Error (decode_error field "an integer")
+  | Error _ as error -> error
+;;
+
+let bool field json =
+  match assoc field json with
+  | Ok (`Bool value) -> Ok value
+  | Ok _ -> Error (decode_error field "a boolean")
+  | Error _ as error -> error
+;;
+
+let optional_int field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`Int value) -> Ok (Some value)
+  | Ok _ -> Error (decode_error field "an integer or null")
+  | Error _ as error -> error
+;;
+
+let optional_float field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`Float value) -> Ok (Some value)
+  | Ok (`Int value) -> Ok (Some (float_of_int value))
+  | Ok _ -> Error (decode_error field "a number or null")
+  | Error _ as error -> error
+;;
+
+let optional_string field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`String value) -> Ok (Some value)
+  | Ok _ -> Error (decode_error field "a string or null")
+  | Error _ as error -> error
+;;
+
+let ( let* ) result f = Result.bind result f
+
+let active_turn_of_json json =
+  let* lane =
+    match assoc "lane" json with
+    | Ok `Null -> Ok None
+    | Ok (`String lane_wire) ->
+      admission_lane_of_string lane_wire
+      |> Result.map Option.some
+      |> Result.map_error (fun e -> Decode_error e)
+    | Ok _ -> Error (decode_error "lane" "a string or null")
+    | Error _ as error -> error
+  in
+  let* admitted_at = optional_float "admitted_at" json in
+  let* observed_turn_id = optional_int "observed_turn_id" json in
+  let* observation_started_at = optional_float "observation_started_at" json in
+  Ok { lane; admitted_at; observed_turn_id; observation_started_at }
+;;
+
+let turn_disposition_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "no_inflight_turn" -> Ok No_inflight_turn
+  | "inflight_effect_unknown" ->
+    let* active_json = assoc "active_turn" json in
+    let* turn = active_turn_of_json active_json in
+    Ok (Inflight_effect_unknown turn)
+  | value -> Error (Decode_error (Printf.sprintf "unknown turn disposition: %S" value))
+;;
+
+let failure_of_json json =
+  let* stage_wire = string "stage" json in
+  let* stage = failure_stage_of_string stage_wire |> Result.map_error (fun e -> Decode_error e) in
+  let* detail = string "detail" json in
+  Ok { stage; detail }
+;;
+
+let phase_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "prepared" -> Ok Prepared
+  | "joined_idle" -> Ok Joined_idle
+  | "reconciliation_required" ->
+    let* active_json = assoc "active_turn" json in
+    let* turn = active_turn_of_json active_json in
+    Ok (Reconciliation_required turn)
+  | "blocked" ->
+    let* failure_json = assoc "failure" json in
+    let* failure = failure_of_json failure_json in
+    Ok (Blocked failure)
+  | value -> Error (Decode_error (Printf.sprintf "unknown shutdown phase: %S" value))
+;;
+
+let lane_outcome_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "completed" -> Ok Lane_completed
+  | "shutdown_requested" -> Ok Lane_shutdown_requested
+  | "cancelled_by_parent" ->
+    let* detail = string "detail" json in
+    Ok (Lane_cancelled_by_parent detail)
+  | "failed" ->
+    let* detail = string "detail" json in
+    Ok (Lane_failed detail)
+  | value -> Error (Decode_error (Printf.sprintf "unknown lane outcome: %S" value))
+;;
+
+let terminal_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "stopped" -> Ok Terminal_stopped
+  | "crashed" ->
+    let* detail = string "detail" json in
+    Ok (Terminal_crashed detail)
+  | value -> Error (Decode_error (Printf.sprintf "unknown terminal outcome: %S" value))
+;;
+
+let join_evidence_of_json json =
+  let* lane_json = assoc "lane_outcome" json in
+  let* lane_outcome = lane_outcome_of_json lane_json in
+  let* terminal_json = assoc "terminal" json in
+  let* terminal = terminal_of_json terminal_json in
+  let* cleanup_error = optional_string "cleanup_error" json in
+  Ok { lane_outcome; terminal; cleanup_error }
+;;
+
+let optional_join_evidence_of_json json =
+  match assoc "join_evidence" json with
+  | Ok `Null -> Ok None
+  | Ok evidence_json -> join_evidence_of_json evidence_json |> Result.map Option.some
+  | Error _ as error -> error
+;;
+
+let task_ids_of_json json =
+  match assoc "owned_task_ids" json with
+  | Error _ as error -> error
+  | Ok (`List values) ->
+    List.fold_left
+      (fun result value ->
+         let* task_ids = result in
+         match value with
+         | `String raw ->
+           let* task_id =
+             Keeper_id.Task_id.of_string raw
+             |> Result.map_error (fun e -> Decode_error e)
+           in
+           Ok (task_id :: task_ids)
+         | _ -> Error (decode_error "owned_task_ids[]" "a string"))
+      (Ok [])
+      values
+    |> Result.map List.rev
+  | Ok _ -> Error (decode_error "owned_task_ids" "an array")
+;;
+
+let of_json json =
+  let* decoded_schema_version = int "schema_version" json in
+  if decoded_schema_version <> schema_version
+  then
+    Error
+      (Decode_error
+         (Printf.sprintf
+            "unsupported shutdown schema version: %d"
+            decoded_schema_version))
+  else
+    let* operation_id_wire = string "operation_id" json in
+    let* operation_id =
+      Operation_id.of_string operation_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* keeper_name = string "keeper_name" json in
+    let* lane_id_wire = string "lane_id" json in
+    let* lane_id =
+      Keeper_lane.Id.of_string lane_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* trace_id_wire = string "trace_id" json in
+    let* trace_id =
+      Keeper_id.Trace_id.of_string trace_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* generation = int "generation" json in
+    let* actor = string "actor" json in
+    let* cleanup_json = assoc "cleanup_intent" json in
+    let* remove_meta = bool "remove_meta" cleanup_json in
+    let* remove_session = bool "remove_session" cleanup_json in
+    let* turn_json = assoc "turn_disposition" json in
+    let* turn_disposition = turn_disposition_of_json turn_json in
+    let* owned_task_ids = task_ids_of_json json in
+    let* join_evidence = optional_join_evidence_of_json json in
+    let* phase_json = assoc "phase" json in
+    let* phase = phase_of_json phase_json in
+    let* created_at = string "created_at" json in
+    let* updated_at = string "updated_at" json in
+    Ok
+      { schema_version = decoded_schema_version
+      ; operation_id
+      ; keeper_name
+      ; lane_id
+      ; trace_id
+      ; generation
+      ; actor
+      ; cleanup_intent = { remove_meta; remove_session }
+      ; turn_disposition
+      ; owned_task_ids
+      ; join_evidence
+      ; phase
+      ; created_at
+      ; updated_at
+      }
+;;
+
+let load_unlocked ~config operation_id =
+  let operation_path = path ~config operation_id in
+  if not (Fs_compat.file_exists operation_path)
+  then Error (Not_found operation_path)
+  else
+    try
+      Fs_compat.load_file operation_path
+      |> Yojson.Safe.from_string
+      |> of_json
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Yojson.Json_error detail -> Error (Decode_error detail)
+    | exn -> Error (Io_error (Printexc.to_string exn))
+;;
+
+let persist_new ~config operation =
+  let operation_path = path ~config operation.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
+    if Fs_compat.file_exists operation_path
+    then Error (Already_exists operation_path)
+    else
+      Keeper_fs.save_json_atomic operation_path (to_json operation)
+      |> Result.map_error (fun detail -> Io_error detail))
+;;
+
+let same_identity left right =
+  Operation_id.equal left.operation_id right.operation_id
+  && String.equal left.keeper_name right.keeper_name
+  && Keeper_lane.Id.equal left.lane_id right.lane_id
+  && Keeper_id.Trace_id.equal left.trace_id right.trace_id
+  && Int.equal left.generation right.generation
+;;
+
+let replace ~config operation =
+  let operation_path = path ~config operation.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
+    match load_unlocked ~config operation.operation_id with
+    | Error _ as error -> error
+    | Ok existing when same_identity existing operation ->
+      Keeper_fs.save_json_atomic operation_path (to_json operation)
+      |> Result.map_error (fun detail -> Io_error detail)
+    | Ok _ ->
+      Error
+        (Identity_mismatch
+           (Operation_id.to_string operation.operation_id)))
+;;
+
+let load ~config operation_id =
+  let operation_path = path ~config operation_id in
+  with_operation_lock ~access:Read operation_path (fun () ->
+    load_unlocked ~config operation_id)
+;;
+
+let list_for_keeper ~config ~keeper_name =
+  let dir = records_dir config in
+  if not (Fs_compat.file_exists dir)
+  then Ok []
+  else
+    try
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.sort String.compare
+      |> List.fold_left
+           (fun result filename ->
+              let* operations = result in
+              if not (Filename.check_suffix filename ".json")
+              then
+                Error
+                  (Decode_error
+                     (Printf.sprintf
+                        "unexpected shutdown store entry: %s"
+                        filename))
+              else
+                let raw_id = Filename.chop_suffix filename ".json" in
+                let* operation_id =
+                  Operation_id.of_string raw_id
+                  |> Result.map_error (fun e -> Decode_error e)
+                in
+                let* operation = load ~config operation_id in
+                if String.equal operation.keeper_name keeper_name
+                then Ok (operation :: operations)
+                else Ok operations)
+           (Ok [])
+      |> Result.map List.rev
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Io_error (Printexc.to_string exn))
+;;

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -1,0 +1,41 @@
+(** Atomic persistence for Keeper shutdown operations under the configured
+    MASC base path. Reads and writes are serialized per operation path; an
+    unrelated Keeper operation never holds the same lock across filesystem
+    I/O. *)
+
+type error =
+  | Already_exists of string
+  | Not_found of string
+  | Io_error of string
+  | Decode_error of string
+  | Identity_mismatch of string
+
+val error_to_string : error -> string
+
+val path :
+  config:Workspace.config ->
+  Keeper_shutdown_types.Operation_id.t ->
+  string
+
+val to_json : Keeper_shutdown_types.t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (Keeper_shutdown_types.t, error) result
+
+val persist_new :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (unit, error) result
+
+val replace :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (unit, error) result
+
+val load :
+  config:Workspace.config ->
+  Keeper_shutdown_types.Operation_id.t ->
+  (Keeper_shutdown_types.t, error) result
+
+val list_for_keeper :
+  config:Workspace.config ->
+  keeper_name:string ->
+  (Keeper_shutdown_types.t list, error) result

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -9,6 +9,14 @@ type error =
   | Io_error of string
   | Decode_error of string
   | Identity_mismatch of string
+  | Revision_conflict of
+      { expected : int
+      ; actual : int
+      }
+
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
 
 val error_to_string : error -> string
 
@@ -27,8 +35,19 @@ val persist_new :
 
 val replace :
   config:Workspace.config ->
+  expected_revision:int ->
   Keeper_shutdown_types.t ->
   (unit, error) result
+
+(** Read the latest durable revision and persist [Blocked failure] while
+    holding the operation's write lock. Existing [Finalized], [Blocked], and
+    effect-unknown reconciliation states are preserved. *)
+val persist_blocked_latest :
+  config:Workspace.config ->
+  identity:Keeper_shutdown_types.t ->
+  failure:Keeper_shutdown_types.failure ->
+  updated_at:string ->
+  (persist_blocked_result, error) result
 
 val load :
   config:Workspace.config ->
@@ -39,3 +58,15 @@ val list_for_keeper :
   config:Workspace.config ->
   keeper_name:string ->
   (Keeper_shutdown_types.t list, error) result
+
+val list_all :
+  config:Workspace.config ->
+  (Keeper_shutdown_types.t list, error) result
+
+module For_testing : sig
+  val with_operation_write_lock :
+    config:Workspace.config ->
+    Keeper_shutdown_types.Operation_id.t ->
+    (unit -> 'a) ->
+    'a
+end

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -56,6 +56,12 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Task_settlement
+  | Pending_confirm_cleanup
+  | Meta_update
+  | Meta_remove
+  | Session_remove
+  | Registry_unregister
 
 type failure =
   { stage : failure_stage
@@ -78,14 +84,30 @@ type join_evidence =
   ; cleanup_error : string option
   }
 
+type cleanup_evidence =
+  { settled_task_ids : Keeper_id.Task_id.t list
+  ; pending_confirms_removed : int
+  }
+
+type finalization_evidence =
+  { cleanup : cleanup_evidence
+  ; meta_removed : bool
+  ; session_removed : bool
+  ; registry_unregistered : bool
+  }
+
 type phase =
   | Prepared
   | Joined_idle
+  | Finalizing_tasks of Keeper_id.Task_id.t list
+  | Cleanup_ready of cleanup_evidence
   | Reconciliation_required of active_turn
+  | Finalized of finalization_evidence
   | Blocked of failure
 
 type t =
   { schema_version : int
+  ; revision : int
   ; operation_id : Operation_id.t
   ; keeper_name : string
   ; lane_id : Keeper_lane.Id.t
@@ -94,6 +116,7 @@ type t =
   ; actor : string
   ; cleanup_intent : cleanup_intent
   ; turn_disposition : turn_disposition
+  ; expected_backlog_version : int
   ; owned_task_ids : Keeper_id.Task_id.t list
   ; join_evidence : join_evidence option
   ; phase : phase
@@ -101,7 +124,7 @@ type t =
   ; updated_at : string
   }
 
-let schema_version = 1
+let schema_version = 2
 
 let admission_lane_to_string = function
   | Autonomous -> "autonomous"
@@ -122,6 +145,12 @@ let failure_stage_to_string = function
   | Turn_join -> "turn_join"
   | Lane_join -> "lane_join"
   | Record_update -> "record_update"
+  | Task_settlement -> "task_settlement"
+  | Pending_confirm_cleanup -> "pending_confirm_cleanup"
+  | Meta_update -> "meta_update"
+  | Meta_remove -> "meta_remove"
+  | Session_remove -> "session_remove"
+  | Registry_unregister -> "registry_unregister"
 ;;
 
 let failure_stage_of_string = function
@@ -132,5 +161,11 @@ let failure_stage_of_string = function
   | "turn_join" -> Ok Turn_join
   | "lane_join" -> Ok Lane_join
   | "record_update" -> Ok Record_update
+  | "task_settlement" -> Ok Task_settlement
+  | "pending_confirm_cleanup" -> Ok Pending_confirm_cleanup
+  | "meta_update" -> Ok Meta_update
+  | "meta_remove" -> Ok Meta_remove
+  | "session_remove" -> Ok Session_remove
+  | "registry_unregister" -> Ok Registry_unregister
   | value -> Error (Printf.sprintf "unknown Keeper shutdown failure stage: %S" value)
 ;;

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -1,0 +1,136 @@
+module Operation_id = struct
+  type t = string
+
+  let prefix = "shutdown-"
+  (* NDT-OK: UUID entropy is an operation identity only. No lifecycle
+     decision branches on the generated contents. *)
+  let rng = Random.State.make_self_init () (* NDT-OK: identity entropy only *)
+  let rng_mutex = Eio.Mutex.create ()
+
+  let generate () =
+    let uuid = Eio.Mutex.use_ro rng_mutex (fun () -> Uuidm.v4_gen rng ()) in
+    prefix ^ Uuidm.to_string uuid
+  ;;
+
+  let of_string value =
+    let prefix_length = String.length prefix in
+    if
+      String.length value = prefix_length + 36
+      && String.equal (String.sub value 0 prefix_length) prefix
+    then
+      match Uuidm.of_string (String.sub value prefix_length 36) with
+      | Some _ -> Ok value
+      | None -> Error (Printf.sprintf "invalid Keeper shutdown operation id: %S" value)
+    else Error (Printf.sprintf "invalid Keeper shutdown operation id: %S" value)
+  ;;
+
+  let to_string value = value
+  let equal = String.equal
+end
+
+type cleanup_intent =
+  { remove_meta : bool
+  ; remove_session : bool
+  }
+
+type admission_lane =
+  | Autonomous
+  | Chat
+
+type active_turn =
+  { lane : admission_lane option
+  ; admitted_at : float option
+  ; observed_turn_id : int option
+  ; observation_started_at : float option
+  }
+
+type turn_disposition =
+  | No_inflight_turn
+  | Inflight_effect_unknown of active_turn
+
+type failure_stage =
+  | Task_discovery
+  | Record_persist
+  | Turn_cancel
+  | Lane_cancel
+  | Turn_join
+  | Lane_join
+  | Record_update
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  }
+
+type lane_outcome =
+  | Lane_completed
+  | Lane_shutdown_requested
+  | Lane_cancelled_by_parent of string
+  | Lane_failed of string
+
+type terminal =
+  | Terminal_stopped
+  | Terminal_crashed of string
+
+type join_evidence =
+  { lane_outcome : lane_outcome
+  ; terminal : terminal
+  ; cleanup_error : string option
+  }
+
+type phase =
+  | Prepared
+  | Joined_idle
+  | Reconciliation_required of active_turn
+  | Blocked of failure
+
+type t =
+  { schema_version : int
+  ; operation_id : Operation_id.t
+  ; keeper_name : string
+  ; lane_id : Keeper_lane.Id.t
+  ; trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; actor : string
+  ; cleanup_intent : cleanup_intent
+  ; turn_disposition : turn_disposition
+  ; owned_task_ids : Keeper_id.Task_id.t list
+  ; join_evidence : join_evidence option
+  ; phase : phase
+  ; created_at : string
+  ; updated_at : string
+  }
+
+let schema_version = 1
+
+let admission_lane_to_string = function
+  | Autonomous -> "autonomous"
+  | Chat -> "chat"
+;;
+
+let admission_lane_of_string = function
+  | "autonomous" -> Ok Autonomous
+  | "chat" -> Ok Chat
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown admission lane: %S" value)
+;;
+
+let failure_stage_to_string = function
+  | Task_discovery -> "task_discovery"
+  | Record_persist -> "record_persist"
+  | Turn_cancel -> "turn_cancel"
+  | Lane_cancel -> "lane_cancel"
+  | Turn_join -> "turn_join"
+  | Lane_join -> "lane_join"
+  | Record_update -> "record_update"
+;;
+
+let failure_stage_of_string = function
+  | "task_discovery" -> Ok Task_discovery
+  | "record_persist" -> Ok Record_persist
+  | "turn_cancel" -> Ok Turn_cancel
+  | "lane_cancel" -> Ok Lane_cancel
+  | "turn_join" -> Ok Turn_join
+  | "lane_join" -> Ok Lane_join
+  | "record_update" -> Ok Record_update
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown failure stage: %S" value)
+;;

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -39,6 +39,12 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Task_settlement
+  | Pending_confirm_cleanup
+  | Meta_update
+  | Meta_remove
+  | Session_remove
+  | Registry_unregister
 
 type failure =
   { stage : failure_stage
@@ -61,14 +67,30 @@ type join_evidence =
   ; cleanup_error : string option
   }
 
+type cleanup_evidence =
+  { settled_task_ids : Keeper_id.Task_id.t list
+  ; pending_confirms_removed : int
+  }
+
+type finalization_evidence =
+  { cleanup : cleanup_evidence
+  ; meta_removed : bool
+  ; session_removed : bool
+  ; registry_unregistered : bool
+  }
+
 type phase =
   | Prepared
   | Joined_idle
+  | Finalizing_tasks of Keeper_id.Task_id.t list
+  | Cleanup_ready of cleanup_evidence
   | Reconciliation_required of active_turn
+  | Finalized of finalization_evidence
   | Blocked of failure
 
 type t =
   { schema_version : int
+  ; revision : int
   ; operation_id : Operation_id.t
   ; keeper_name : string
   ; lane_id : Keeper_lane.Id.t
@@ -77,6 +99,7 @@ type t =
   ; actor : string
   ; cleanup_intent : cleanup_intent
   ; turn_disposition : turn_disposition
+  ; expected_backlog_version : int
   ; owned_task_ids : Keeper_id.Task_id.t list
   ; join_evidence : join_evidence option
   ; phase : phase

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -1,0 +1,91 @@
+(** Durable types for one Keeper shutdown operation.  These records describe
+    lifecycle coordination only; task ownership remains authoritative in the
+    Workspace backlog. *)
+
+module Operation_id : sig
+  type t
+
+  val generate : unit -> t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+type cleanup_intent =
+  { remove_meta : bool
+  ; remove_session : bool
+  }
+
+type admission_lane =
+  | Autonomous
+  | Chat
+
+type active_turn =
+  { lane : admission_lane option
+  ; admitted_at : float option
+  ; observed_turn_id : int option
+  ; observation_started_at : float option
+  }
+
+type turn_disposition =
+  | No_inflight_turn
+  | Inflight_effect_unknown of active_turn
+
+type failure_stage =
+  | Task_discovery
+  | Record_persist
+  | Turn_cancel
+  | Lane_cancel
+  | Turn_join
+  | Lane_join
+  | Record_update
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  }
+
+type lane_outcome =
+  | Lane_completed
+  | Lane_shutdown_requested
+  | Lane_cancelled_by_parent of string
+  | Lane_failed of string
+
+type terminal =
+  | Terminal_stopped
+  | Terminal_crashed of string
+
+type join_evidence =
+  { lane_outcome : lane_outcome
+  ; terminal : terminal
+  ; cleanup_error : string option
+  }
+
+type phase =
+  | Prepared
+  | Joined_idle
+  | Reconciliation_required of active_turn
+  | Blocked of failure
+
+type t =
+  { schema_version : int
+  ; operation_id : Operation_id.t
+  ; keeper_name : string
+  ; lane_id : Keeper_lane.Id.t
+  ; trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; actor : string
+  ; cleanup_intent : cleanup_intent
+  ; turn_disposition : turn_disposition
+  ; owned_task_ids : Keeper_id.Task_id.t list
+  ; join_evidence : join_evidence option
+  ; phase : phase
+  ; created_at : string
+  ; updated_at : string
+  }
+
+val schema_version : int
+val admission_lane_to_string : admission_lane -> string
+val admission_lane_of_string : string -> (admission_lane, string) result
+val failure_stage_to_string : failure_stage -> string
+val failure_stage_of_string : string -> (failure_stage, string) result

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -833,6 +833,15 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
                append happened after the mark_dead post-processing above, so it
                had no effect in the current sweep. We keep the metric/log and
                intentionally do not accumulate, preserving the prior behavior. *)
+          | Error (Keeper_registry.Restart_shutdown_reserved operation_id) ->
+            Log.Keeper.info
+              "%s: restart skipped because shutdown operation %s owns admission"
+              old_entry.name
+              (Keeper_shutdown_types.Operation_id.to_string operation_id);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
+              ()
           | Ok reg ->
             Keeper_registry.restore_supervisor_state
               ~base_path

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -552,7 +552,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
       Keeper_registry.record_crash ~base_path entry.name ts msg;
       Keeper_registry_error_recording.record ~base_path entry.name msg;
       match Keeper_registry.get ~base_path entry.name with
-      | Some updated -> queue_crashed_entry acc updated msg
+      | Some updated when Keeper_registry.lane_has_exited updated ->
+        queue_crashed_entry acc updated msg
+      | Some _ -> acc
       | None -> acc
   in
   (* 2-level supervision slice: process the flat registry through stable
@@ -568,7 +570,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
          { acc with to_cleanup_dead = entry :: acc.to_cleanup_dead }
        | _ -> acc)
     | Keeper_state_machine.Stopped ->
-      { acc with to_unregister = entry :: acc.to_unregister }
+      if Keeper_registry.lane_has_exited entry
+      then { acc with to_unregister = entry :: acc.to_unregister }
+      else acc
     | Keeper_state_machine.Running
     | Keeper_state_machine.Paused
     | Keeper_state_machine.Crashed
@@ -652,8 +656,14 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
               ~stale_seconds
               ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts;
             acc)
-       | Some `Stopped -> { acc with to_unregister = entry :: acc.to_unregister }
-       | Some (`Crashed msg) -> queue_crashed_entry acc entry msg)
+       | Some `Stopped ->
+         if Keeper_registry.lane_has_exited entry
+         then { acc with to_unregister = entry :: acc.to_unregister }
+         else acc
+       | Some (`Crashed msg) ->
+         if Keeper_registry.lane_has_exited entry
+         then queue_crashed_entry acc entry msg
+         else acc)
   in
   let entry_cohorts = supervision_cohorts entries in
   let sweep_ym = Eio_guard.create_yield_meter () in
@@ -671,12 +681,27 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
       empty_sweep_acc
       entry_cohorts
   in
+  let unregister_exact_and_drop (entry : Keeper_registry.registry_entry) =
+    match Keeper_registry.unregister_exact entry with
+    | Keeper_registry.Exact_unregistered ->
+      Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
+      true
+    | Keeper_registry.Exact_entry_missing -> false
+    | Keeper_registry.Exact_entry_replaced ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string SupervisorCleanupFailures)
+        ~labels:[ "keeper", entry.name; "site", "stale_entry_replaced" ]
+        ();
+      Log.Keeper.warn
+        "%s: stale supervisor entry was not unregistered because a newer lane owns the name"
+        entry.name;
+      false
+  in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-       Keeper_registry.unregister ~base_path entry.name;
-       (* K4c — restart-budget exhaustion: keeper is permanently
-       removed (no respawn), so reclaim its accumulator slot. *)
-       Keeper_tool_emission_hook.drop_keeper_accumulator entry.name)
+       (* K4c — reclaim only when this exact lane was removed. A stale
+          sweep must not drop the accumulator of a newer same-name lane. *)
+       ignore (unregister_exact_and_drop entry : bool))
     final_acc.to_unregister;
   List.iter
     (fun ((entry : Keeper_registry.registry_entry), msg) ->
@@ -835,11 +860,11 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)
            ~labels:[ "keeper", old_entry.name; "outcome", "meta_unavailable" ]
-           ();
+         ();
          Log.Keeper.error "%s: cannot read meta for restart, removing" old_entry.name;
-         Keeper_registry.unregister ~base_path old_entry.name;
-         (* K4c — restart-meta read failure: keeper abandoned, drop. *)
-         Keeper_tool_emission_hook.drop_keeper_accumulator old_entry.name)
+         (* K4c — restart-meta read failure: abandon only the exact crashed
+            lane observed by this sweep. *)
+         ignore (unregister_exact_and_drop old_entry : bool))
     restart_list;
   (* Phase 2: restore paused reconcile gates whose approval queue was lost
      on restart. The queue itself is in-memory, but paused keeper meta is

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -685,8 +685,8 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
     match Keeper_registry.unregister_exact entry with
     | Keeper_registry.Exact_unregistered ->
       Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-      true
-    | Keeper_registry.Exact_entry_missing -> false
+      ()
+    | Keeper_registry.Exact_entry_missing -> ()
     | Keeper_registry.Exact_entry_replaced ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string SupervisorCleanupFailures)
@@ -694,14 +694,13 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
         ();
       Log.Keeper.warn
         "%s: stale supervisor entry was not unregistered because a newer lane owns the name"
-        entry.name;
-      false
+        entry.name
   in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
        (* K4c — reclaim only when this exact lane was removed. A stale
           sweep must not drop the accumulator of a newer same-name lane. *)
-       ignore (unregister_exact_and_drop entry : bool))
+       unregister_exact_and_drop entry)
     final_acc.to_unregister;
   List.iter
     (fun ((entry : Keeper_registry.registry_entry), msg) ->
@@ -864,7 +863,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
          Log.Keeper.error "%s: cannot read meta for restart, removing" old_entry.name;
          (* K4c — restart-meta read failure: abandon only the exact crashed
             lane observed by this sweep. *)
-         ignore (unregister_exact_and_drop old_entry : bool))
+         unregister_exact_and_drop old_entry)
     restart_list;
   (* Phase 2: restore paused reconcile gates whose approval queue was lost
      on restart. The queue itself is in-memory, but paused keeper meta is

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -705,11 +705,39 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
   List.iter
     (fun ((entry : Keeper_registry.registry_entry), msg) ->
        (* RFC-0002: dispatch budget exhaustion before marking dead *)
-       Keeper_registry.dispatch_event_unit
-         ~base_path
-         entry.name
-         Keeper_state_machine.Restart_budget_exhausted;
-       Keeper_registry.mark_dead ~base_path entry.name ~at:now;
+       (match
+          Keeper_registry.dispatch_event_exact
+            entry
+            Keeper_state_machine.Restart_budget_exhausted
+        with
+        | Ok _ -> ()
+        | Error error ->
+          Log.Keeper.warn
+            "%s: exact restart-budget dispatch rejected: %s"
+            entry.name
+            (Keeper_state_machine.transition_error_to_string error));
+       let exact_dead =
+         match Keeper_registry.mark_dead_exact entry ~at:now with
+         | Keeper_registry.Exact_updated -> true
+         | Keeper_registry.Exact_update_missing ->
+           Log.Keeper.info
+             "%s: dead transition skipped because the observed lane was already removed"
+             entry.name;
+           false
+         | Keeper_registry.Exact_update_replaced ->
+           Log.Keeper.warn
+             "%s: dead transition retained a newer same-name lane"
+             entry.name;
+           false
+         | Keeper_registry.Exact_update_invalid validation_error ->
+           Log.Keeper.warn
+             "%s: dead transition validation failed: %s"
+             entry.name
+             (Keeper_registry.registry_entry_validation_error_to_string validation_error);
+           false
+       in
+       if exact_dead
+       then (
        (* Dead keepers cannot make progress on owned tasks.  Release from the
           backlog's typed ownership state, not from a possibly stale meta
           pointer, so an exhausted keeper cannot strand an InProgress task and
@@ -742,7 +770,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
           operator action required"
          entry.name
          msg
-         entry.restart_count)
+         entry.restart_count))
     final_acc.to_mark_dead;
   (* RFC-0036 Phase A.2: fire Tombstone_reaped after cleanup completes.
      Hook is exception-safe; supervisor never observes failure. *)

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -13,6 +13,23 @@ open Keeper_meta_store
 open Keeper_types_profile
 open Keeper_execution
 
+let unregister_exact_dead_entry (entry : Keeper_registry.registry_entry) =
+  match Keeper_registry.unregister_exact entry with
+  | Keeper_registry.Exact_unregistered ->
+    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
+    true
+  | Keeper_registry.Exact_entry_missing -> false
+  | Keeper_registry.Exact_entry_replaced ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SupervisorCleanupFailures)
+      ~labels:[ "keeper", entry.name; "site", "dead_tombstone_entry_replaced" ]
+      ();
+    Log.Keeper.warn
+      "%s: dead tombstone cleanup retained a newer same-name lane"
+      entry.name;
+    false
+;;
+
 let cleanup_dead_tombstone
       ~publish_lifecycle
       (ctx : _ context)
@@ -85,9 +102,9 @@ let cleanup_dead_tombstone
             err;
           false)
     in
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    if persisted_paused
+    if not (unregister_exact_dead_entry entry)
+    then ()
+    else if persisted_paused
     then (
       publish_lifecycle
         ~event:
@@ -116,39 +133,41 @@ let cleanup_dead_tombstone
           ]
         ())
   | Ok None ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    publish_lifecycle
-      ~event:
-        (Keeper_lifecycle_events.Custom_event
-           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-      entry.name
-      "meta missing"
-      ();
-    Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string SupervisorCleanupFailures)
-      ~labels:
-        [ "keeper", entry.name
-        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing))
-        ]
-      ()
+    if unregister_exact_dead_entry entry
+    then (
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name
+        "meta missing"
+        ();
+      Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string SupervisorCleanupFailures)
+        ~labels:
+          [ "keeper", entry.name
+          ; ( "site"
+            , Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing) )
+          ]
+        ())
   | Error err ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    publish_lifecycle
-      ~event:
-        (Keeper_lifecycle_events.Custom_event
-           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-      entry.name
-      (Printf.sprintf "meta read error: %s" err)
-      ();
-    Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string SupervisorCleanupFailures)
-      ~labels:
-        [ "keeper", entry.name
-        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error))
-        ]
-      ()
+    if unregister_exact_dead_entry entry
+    then (
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name
+        (Printf.sprintf "meta read error: %s" err)
+        ();
+      Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string SupervisorCleanupFailures)
+        ~labels:
+          [ "keeper", entry.name
+          ; ( "site"
+            , Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error) )
+          ]
+        ())
 ;;

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -110,9 +110,29 @@ let launch_supervised_fiber_body
       (* determinism-contract: allow — ctx.sw fallback is the same deterministic
          default used before the ref -> Atomic conversion. *)
       let sw = Option.value (Atomic.get global_switch) ~default:ctx.sw in
-      Eio.Fiber.fork ~sw body
+      match
+        Keeper_lane.fork
+          ~sw
+          reg.lane
+          ~run:body
+          ~cleanup:(fun _ -> Ok ())
+      with
+      | Ok () -> ()
+      | Error error ->
+        let detail = Keeper_lane.start_error_to_string error in
+        Keeper_registry.set_failure_reason
+          ~base_path
+          meta.name
+          (Some (Keeper_registry.Exception detail));
+        ignore
+          (Keeper_registry.resolve_done
+             reg
+             ~source:"supervisor_lane_start_rejected"
+             (`Crashed detail)
+           : Keeper_registry.done_resolve_result)
     in
-    fork_body (fun () ->
+    fork_body (fun lane_sw ->
+      let ctx = { ctx with sw = lane_sw } in
       let resolved = Atomic.make false in
       (* Issue #18901 follow-up: distinguish parent-cancellation from
          genuine missed-resolution in the finally branch. The body's
@@ -568,6 +588,13 @@ let launch_supervised_fiber
       |> should_publish_lifecycle_for_done_signal
     then
       publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed meta.name reason ();
+    (match Keeper_lane.reject_before_start reg.lane ~reason:(Failure reason) with
+     | Ok () -> ()
+     | Error lane_error ->
+       Log.Keeper.error
+         "%s: rejected launch could not close lane join contract: %s"
+         meta.name
+         (Keeper_lane.start_error_to_string lane_error));
     Error err
   | Ok _ ->
     launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg;

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -59,8 +59,9 @@ let reconcile_keepalive_keepers
          | Keeper_state_machine.Restarting -> true
          | Keeper_state_machine.Offline -> false
          | Keeper_state_machine.Stopped ->
-           (* Stopped with unresolved fiber → sweep will clean up *)
-             Eio.Promise.peek e.done_p = None)
+           (* A terminal event is not a join. The sweep owns cleanup until
+              the exact lane scope has released all fibers and resources. *)
+           not (Keeper_registry.lane_has_exited e))
     in
     if not dominated_by_sweep
     then (

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -98,8 +98,18 @@ let resume_keeper_after_reconcile_gate
   | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
     (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)
     Atomic.set entry.fiber_wakeup true
-  | Some _ ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path resumed_meta.name;
-    supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+  | Some entry when not (Keeper_registry.lane_has_exited entry) ->
+    Log.Keeper.warn
+      "%s: resume deferred because the prior lane has a terminal result but has not joined"
+      resumed_meta.name
+  | Some entry ->
+    (match Keeper_registry.unregister_exact entry with
+     | Keeper_registry.Exact_unregistered
+     | Keeper_registry.Exact_entry_missing ->
+       supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+     | Keeper_registry.Exact_entry_replaced ->
+       Log.Keeper.warn
+         "%s: resume retained a newer same-name lane"
+         resumed_meta.name)
   | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
 ;;

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -65,12 +65,26 @@ let supervise_keepalive
         meta.name
         (Keeper_registry.spawn_slot_denial_reason_to_detail reason)
         ()
-    | Ok () -> (
+    | Ok () ->
     Startup_helpers.log_persona_drift_if_missing ~base_path:ctx.config.base_path meta;
     (* Register in Keeper_registry — single source of truth. *)
-    let reg =
-      Keeper_registry.register_offline ~base_path:ctx.config.base_path meta.name meta
-    in
+    (match
+       Keeper_registry.register_offline_if_admitted
+         ~base_path:ctx.config.base_path
+         meta.name
+         meta
+     with
+     | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+       Log.Keeper.info
+         "supervisor launch skipped %s because shutdown operation %s owns admission"
+         meta.name
+         (Keeper_shutdown_types.Operation_id.to_string operation_id)
+     | Error (Keeper_registry.Registration_invalid validation_error) ->
+       Log.Keeper.error
+         "supervisor registry validation rejected %s: %s"
+         meta.name
+         (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+     | Ok reg ->
     (* Workspace initialization *)
     (try
        if not (Workspace_utils.is_initialized ctx.config)

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -826,10 +826,16 @@ let () =
     | "masc_keeper_down" ->
       Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
       Keeper_tool_surface_ops.invalidate_status_cache (Tool_args.get_string args "name" "");
-      Some
-        (tool_result_with_tool_name
-           ~tool_name:name
-           (Keeper_turn_lifecycle.handle_keeper_down_config ~config args))
+      (match sw, clock with
+       | Some sw, Some clock ->
+         let ctx : _ Keeper_types_profile.context =
+           { config; agent_name; sw; clock; proc_mgr; net }
+         in
+         Some
+           (tool_result_with_tool_name
+              ~tool_name:name
+              (Keeper_turn_lifecycle.handle_keeper_down ctx args))
+       | _ -> eio_context_missing name)
     (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools.  Require both
        sw and clock from caller; gracefully fail when invoked from a
        path without Eio context. *)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1353,7 +1353,20 @@ let handle_keeper_msg
             args)
     with
     | `Ran result -> result
-    | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+    | `Rejected
+        { Keeper_turn_admission.shutdown_operation_id = Some operation_id
+        ; _
+        } ->
+        tool_result_error
+          (Printf.sprintf
+             "keeper %s is stopping under operation %s"
+             name
+             (Keeper_shutdown_types.Operation_id.to_string operation_id))
+    | `Rejected
+        { Keeper_turn_admission.waiting
+        ; in_flight
+        ; shutdown_operation_id = None
+        } ->
         let in_flight_text =
           match in_flight with
           | None -> ""

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -9,10 +9,30 @@ type in_flight_info =
   ; started_at : float
   }
 
+type autonomous_block =
+  | Turn_busy of in_flight_info option
+  | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
+
 type rejection =
   { waiting : int
   ; in_flight : in_flight_info option
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
+
+type shutdown_reservation =
+  { operation_id : Keeper_shutdown_types.Operation_id.t
+  ; in_flight : in_flight_info option
+  ; waiting : int
+  }
+
+type begin_shutdown_result =
+  | Shutdown_reserved of shutdown_reservation
+  | Shutdown_already_reserved of shutdown_reservation
+
+type rollback_shutdown_result =
+  | Shutdown_rolled_back
+  | Shutdown_not_reserved
+  | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
 type slot_snapshot =
   { snapshot_keeper_name : string
@@ -23,6 +43,7 @@ type slot_snapshot =
   ; snapshot_waiting_cap : int
   ; snapshot_waiting_full : bool
   ; snapshot_rejected_chat_count : int
+  ; snapshot_shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 type fleet_snapshot =
@@ -32,6 +53,7 @@ type fleet_snapshot =
   ; fleet_waiting_full_keeper_count : int
   ; fleet_rejected_chat_total : int
   ; fleet_in_flight_keeper_count : int
+  ; fleet_shutdown_keeper_count : int
   ; fleet_slots : slot_snapshot list
   }
 
@@ -63,6 +85,7 @@ type slot =
   ; mutable waiting_entries : (int * float) list
   ; mutable next_waiter_id : int
   ; mutable rejected_chat_count : int
+  ; mutable shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 let slots : (string, slot) Hashtbl.t = Hashtbl.create 16
@@ -88,6 +111,7 @@ let slot_for ~base_path ~keeper_name =
         ; waiting_entries = []
         ; next_waiter_id = 0
         ; rejected_chat_count = 0
+        ; shutdown_operation_id = None
         }
       in
       Hashtbl.add slots key slot;
@@ -96,23 +120,36 @@ let slot_for ~base_path ~keeper_name =
 
 let set_info slot info = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info <- info)
 let peek_info slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info)
+let peek_shutdown slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.shutdown_operation_id)
 
 (* Precondition: the calling fiber holds [slot.turn_mu]. There is no
    suspension point between acquiring the mutex and entering [f], so
    cancellation cannot leak the slot; the exception arm releases on every
    raise out of [f], including [Eio.Cancel.Cancelled]. *)
 let run_locked slot ~lane f =
-  (* NDT-OK: gettimeofday timestamps the in-flight info for observability only *)
-  set_info slot (Some { lane; started_at = Unix.gettimeofday () });
-  match f () with
-  | v ->
-    set_info slot None;
+  let admission =
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      match slot.shutdown_operation_id with
+      | Some operation_id -> Error operation_id
+      | None ->
+        (* NDT-OK: admission timestamp is observability evidence only. *)
+        slot.info <- Some { lane; started_at = Unix.gettimeofday () };
+        Ok ())
+  in
+  match admission with
+  | Error operation_id ->
     Eio.Mutex.unlock slot.turn_mu;
-    `Ran v
-  | exception exn ->
-    set_info slot None;
-    Eio.Mutex.unlock slot.turn_mu;
-    raise exn
+    `Shutdown_requested operation_id
+  | Ok () ->
+    (match f () with
+     | v ->
+       set_info slot None;
+       Eio.Mutex.unlock slot.turn_mu;
+       `Ran v
+     | exception exn ->
+       set_info slot None;
+       Eio.Mutex.unlock slot.turn_mu;
+       raise exn)
 ;;
 
 let waiting_count slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting)
@@ -130,7 +167,10 @@ let oldest_waiting_since entries =
 let rejected_snapshot slot =
   Stdlib.Mutex.protect slot.state_mu (fun () ->
     slot.rejected_chat_count <- slot.rejected_chat_count + 1;
-    { waiting = slot.waiting; in_flight = slot.info })
+    { waiting = slot.waiting
+    ; in_flight = slot.info
+    ; shutdown_operation_id = None
+    })
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
@@ -148,32 +188,42 @@ let run_if_free ~base_path ~keeper_name f =
      gap: the autonomous lane cooperates on the same backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
      deterministically instead of racing the next autonomous cycle. *)
-  if waiting_count slot > 0
-  then `Busy (peek_info slot)
-  else if Keeper_chat_queue.length ~keeper_name > 0
-  then `Busy (peek_info slot)
-  else if Eio.Mutex.try_lock slot.turn_mu
-  then run_locked slot ~lane:Autonomous f
-  else `Busy (peek_info slot)
+  match peek_shutdown slot with
+  | Some operation_id -> `Busy (Shutdown_requested operation_id)
+  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
+  | None when Keeper_chat_queue.length ~keeper_name > 0 ->
+    `Busy (Turn_busy (peek_info slot))
+  | None when Eio.Mutex.try_lock slot.turn_mu ->
+    (match run_locked slot ~lane:Autonomous f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+  | None -> `Busy (Turn_busy (peek_info slot))
 ;;
 
 let run_serialized ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   let waiter_id =
     Stdlib.Mutex.protect slot.state_mu (fun () ->
-      if slot.waiting >= max_waiting_chat_requests
-      then None
-      else (
+      match slot.shutdown_operation_id with
+      | Some operation_id -> `Shutdown_requested operation_id
+      | None when slot.waiting >= max_waiting_chat_requests -> `Rejected
+      | None ->
         let waiter_id = slot.next_waiter_id in
         slot.next_waiter_id <- slot.next_waiter_id + 1;
         (* NDT-OK: waiter age timestamp for observability only. *)
         slot.waiting_entries <- (waiter_id, Unix.gettimeofday ()) :: slot.waiting_entries;
         slot.waiting <- slot.waiting + 1;
-        Some waiter_id))
+        `Waiting waiter_id)
   in
   match waiter_id with
-  | None -> `Rejected (rejected_snapshot slot)
-  | Some waiter_id ->
+  | `Shutdown_requested operation_id ->
+    `Rejected
+      { waiting = waiting_count slot
+      ; in_flight = peek_info slot
+      ; shutdown_operation_id = Some operation_id
+      }
+  | `Rejected -> `Rejected (rejected_snapshot slot)
+  | `Waiting waiter_id ->
     (* [Fun.protect] rather than [Switch.on_release]: there is no ambient
        switch here, the finally never raises and never yields, and the only
        suspension point it covers is the cancellable [Eio.Mutex.lock] wait
@@ -188,21 +238,41 @@ let run_serialized ~base_path ~keeper_name f =
                (fun (entry_waiter_id, _since) -> entry_waiter_id <> waiter_id)
                slot.waiting_entries))
       (fun () -> Eio.Mutex.lock slot.turn_mu);
-    run_locked slot ~lane:Chat f
+    (match run_locked slot ~lane:Chat f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id ->
+       `Rejected
+         { waiting = waiting_count slot
+         ; in_flight = peek_info slot
+         ; shutdown_operation_id = Some operation_id
+         })
 ;;
 
 let rejection_snapshot slot =
   let waiting = waiting_count slot in
-  { waiting; in_flight = peek_info slot }
+  { waiting; in_flight = peek_info slot; shutdown_operation_id = None }
 ;;
 
 let run_chat_if_free ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  if waiting_count slot > 0
-  then `Busy (rejection_snapshot slot)
-  else if Eio.Mutex.try_lock slot.turn_mu
-  then run_locked slot ~lane:Chat f
-  else `Busy (rejection_snapshot slot)
+  match peek_shutdown slot with
+  | Some operation_id ->
+    `Busy
+      { waiting = waiting_count slot
+      ; in_flight = peek_info slot
+      ; shutdown_operation_id = Some operation_id
+      }
+  | None when waiting_count slot > 0 -> `Busy (rejection_snapshot slot)
+  | None when Eio.Mutex.try_lock slot.turn_mu ->
+    (match run_locked slot ~lane:Chat f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id ->
+       `Busy
+         { waiting = waiting_count slot
+         ; in_flight = peek_info slot
+         ; shutdown_operation_id = Some operation_id
+         })
+  | None -> `Busy (rejection_snapshot slot)
 ;;
 
 let in_flight ~base_path ~keeper_name =
@@ -210,6 +280,38 @@ let in_flight ~base_path ~keeper_name =
   match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with
   | None -> None
   | Some slot -> peek_info slot
+;;
+
+let reservation_of_slot slot operation_id =
+  { operation_id; in_flight = slot.info; waiting = slot.waiting }
+;;
+
+let begin_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None ->
+      slot.shutdown_operation_id <- Some operation_id;
+      Shutdown_reserved (reservation_of_slot slot operation_id)
+    | Some existing ->
+      Shutdown_already_reserved (reservation_of_slot slot existing))
+;;
+
+let rollback_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None -> Shutdown_not_reserved
+    | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+      slot.shutdown_operation_id <- None;
+      Shutdown_rolled_back
+    | Some existing -> Shutdown_reserved_by_other existing)
+;;
+
+let await_idle_after_shutdown ~base_path ~keeper_name =
+  let slot = slot_for ~base_path ~keeper_name in
+  Eio.Mutex.lock slot.turn_mu;
+  Eio.Mutex.unlock slot.turn_mu
 ;;
 
 let chat_waiting ~base_path ~keeper_name =
@@ -237,6 +339,7 @@ let zero_snapshot ~keeper_name =
   ; snapshot_waiting_cap = max_waiting_chat_requests
   ; snapshot_waiting_full = false
   ; snapshot_rejected_chat_count = 0
+  ; snapshot_shutdown_operation_id = None
   }
 ;;
 
@@ -250,6 +353,7 @@ let snapshot_of_slot slot =
     ; snapshot_waiting_cap = max_waiting_chat_requests
     ; snapshot_waiting_full = slot.waiting >= max_waiting_chat_requests
     ; snapshot_rejected_chat_count = slot.rejected_chat_count
+    ; snapshot_shutdown_operation_id = slot.shutdown_operation_id
     })
 ;;
 
@@ -309,12 +413,22 @@ let fleet_snapshot ~base_path ~keeper_names =
       0
       fleet_slots
   in
+  let fleet_shutdown_keeper_count =
+    List.fold_left
+      (fun acc slot ->
+        match slot.snapshot_shutdown_operation_id with
+        | Some _ -> acc + 1
+        | None -> acc)
+      0
+      fleet_slots
+  in
   { fleet_keeper_count = List.length keeper_names
   ; fleet_waiting_keeper_count
   ; fleet_waiting_total
   ; fleet_waiting_full_keeper_count
   ; fleet_rejected_chat_total
   ; fleet_in_flight_keeper_count
+  ; fleet_shutdown_keeper_count
   ; fleet_slots
   }
 ;;
@@ -337,6 +451,11 @@ let slot_snapshot_to_yojson slot =
     ; "chat_waiting_cap", `Int slot.snapshot_waiting_cap
     ; "chat_waiting_full", `Bool slot.snapshot_waiting_full
     ; "chat_rejected_count", `Int slot.snapshot_rejected_chat_count
+    ; ( "shutdown_operation_id"
+      , match slot.snapshot_shutdown_operation_id with
+        | None -> `Null
+        | Some operation_id ->
+          `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
     ]
 ;;
 
@@ -365,6 +484,7 @@ let fleet_health_json ~base_path ~keeper_names =
     ; "chat_waiting_full_keeper_count", `Int snapshot.fleet_waiting_full_keeper_count
     ; "chat_rejected_total_count", `Int snapshot.fleet_rejected_chat_total
     ; "in_flight_keeper_count", `Int snapshot.fleet_in_flight_keeper_count
+    ; "shutdown_keeper_count", `Int snapshot.fleet_shutdown_keeper_count
     ; "keepers", `List (List.map slot_snapshot_to_yojson snapshot.fleet_slots)
     ]
 ;;

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -34,6 +34,15 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type restore_shutdown_result =
+  | Shutdown_restored
+  | Shutdown_already_restored
+  | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
+
+type 'a registration_commit_result =
+  | Registration_committed of 'a
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+
 type slot_snapshot =
   { snapshot_keeper_name : string
   ; snapshot_slot_created : bool
@@ -306,6 +315,26 @@ let rollback_shutdown ~base_path ~keeper_name ~operation_id =
       slot.shutdown_operation_id <- None;
       Shutdown_rolled_back
     | Some existing -> Shutdown_reserved_by_other existing)
+;;
+
+let restore_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None ->
+      slot.shutdown_operation_id <- Some operation_id;
+      Shutdown_restored
+    | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+      Shutdown_already_restored
+    | Some existing -> Shutdown_restore_conflict existing)
+;;
+
+let commit_registration_if_open ~base_path ~keeper_name commit =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | Some operation_id -> Registration_shutdown_reserved operation_id
+    | None -> Registration_committed (commit ()))
 ;;
 
 let await_idle_after_shutdown ~base_path ~keeper_name =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -50,6 +50,15 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type restore_shutdown_result =
+  | Shutdown_restored
+  | Shutdown_already_restored
+  | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
+
+type 'a registration_commit_result =
+  | Registration_committed of 'a
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+
 type slot_snapshot =
   { snapshot_keeper_name : string
   ; snapshot_slot_created : bool
@@ -187,6 +196,25 @@ val rollback_shutdown :
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   rollback_shutdown_result
+
+(** Restore the admission owner from a durable non-terminal shutdown record
+    before boot recovery or same-name registration starts. The operation id is
+    compared as a typed identity; a different in-memory owner is never
+    overwritten. *)
+val restore_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  restore_shutdown_result
+
+(** Run the non-yielding registry [commit] only while no shutdown operation
+    owns the Keeper admission fence. Shutdown reservation and same-name lane
+    installation are therefore totally ordered. *)
+val commit_registration_if_open :
+  base_path:string ->
+  keeper_name:string ->
+  (unit -> 'a) ->
+  'a registration_commit_result
 
 (** Join the current turn holder after admission has been closed. This waits
     without an invented timeout, then immediately releases the slot. Never

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -23,11 +23,32 @@ type in_flight_info =
   ; started_at : float (** Unix epoch seconds when the turn was admitted *)
   }
 
+type autonomous_block =
+  | Turn_busy of in_flight_info option
+  | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
+
 type rejection =
   { waiting : int (** chat requests already waiting on this keeper's slot *)
   ; in_flight : in_flight_info option
     (** the turn holding the slot, if observable at rejection time *)
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
+    (** [Some id] when admission is fenced by a durable shutdown operation. *)
   }
+
+type shutdown_reservation =
+  { operation_id : Keeper_shutdown_types.Operation_id.t
+  ; in_flight : in_flight_info option
+  ; waiting : int
+  }
+
+type begin_shutdown_result =
+  | Shutdown_reserved of shutdown_reservation
+  | Shutdown_already_reserved of shutdown_reservation
+
+type rollback_shutdown_result =
+  | Shutdown_rolled_back
+  | Shutdown_not_reserved
+  | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
 type slot_snapshot =
   { snapshot_keeper_name : string
@@ -38,6 +59,7 @@ type slot_snapshot =
   ; snapshot_waiting_cap : int
   ; snapshot_waiting_full : bool
   ; snapshot_rejected_chat_count : int
+  ; snapshot_shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 type fleet_snapshot =
@@ -47,6 +69,7 @@ type fleet_snapshot =
   ; fleet_waiting_full_keeper_count : int
   ; fleet_rejected_chat_total : int
   ; fleet_in_flight_keeper_count : int
+  ; fleet_shutdown_keeper_count : int
   ; fleet_slots : slot_snapshot list
   }
 
@@ -64,13 +87,15 @@ val run_if_free
   :  base_path:string
   -> keeper_name:string
   -> (unit -> 'a)
-  -> [ `Ran of 'a | `Busy of in_flight_info option ]
+  -> [ `Ran of 'a | `Busy of autonomous_block ]
 (** Run [f] holding the keeper's turn slot, or return [`Busy] without
     blocking when another turn is in flight. The autonomous lane uses this:
     a busy slot skips the cycle and the next heartbeat retries naturally.
-    [`Busy None] means the slot is held but the holder has not yet published
-    its info (admission in progress on another fiber). Exceptions from [f]
-    (including [Eio.Cancel.Cancelled]) release the slot and re-raise.
+    [`Busy (Turn_busy None)] means the slot is held but the holder has not yet
+    published its info (admission in progress on another fiber).
+    [`Busy (Shutdown_requested id)] means a durable shutdown reservation owns
+    admission. Exceptions from [f] (including [Eio.Cancel.Cancelled]) release
+    the slot and re-raise.
 
     Also returns [`Busy] without attempting the lock when a chat request is
     already parked on this slot ([chat_waiting] is true), or when a busy
@@ -111,8 +136,9 @@ val run_serialized
 (** Run [f] holding the keeper's turn slot, waiting (fiber-cooperatively, in
     Eio.Mutex wakeup order) while another turn is in flight. The chat lane
     uses this: dashboard/connector messages queue rather than error. Returns
-    [`Rejected] only when [max_waiting_chat_requests] chat requests are
-    already waiting. Cancellation while waiting leaves the queue; exceptions
+    [`Rejected] when [max_waiting_chat_requests] chat requests are already
+    waiting or when [shutdown_operation_id] names the durable operation that
+    fenced admission. Cancellation while waiting leaves the queue; exceptions
     from [f] release the slot and re-raise.
 
     Caller contract: a synchronous self-targeted call from inside the same
@@ -130,7 +156,9 @@ val run_chat_if_free
     in-flight turn. Dashboard direct-stream callers use this to preserve live
     streaming for idle keepers while atomically routing busy keepers to the
     durable chat queue. Existing parked chat waiters have priority: when
-    [chat_waiting] is true this returns [`Busy] without attempting the lock. *)
+    [chat_waiting] is true this returns [`Busy] without attempting the lock.
+    [Busy.shutdown_operation_id] distinguishes lifecycle fencing from
+    ordinary turn contention. *)
 
 val in_flight
   :  base_path:string
@@ -142,6 +170,28 @@ val in_flight
     while a turn runs) tolerate the narrow window where a holder has
     locked the slot but not yet published its info — a turn forked on a
     stale [None] simply waits at the slot. *)
+
+(** Atomically close admission for [keeper_name] and snapshot the turn that
+    already owns the slot. New autonomous/chat turns receive the typed
+    [`Shutdown_requested] result after this succeeds. *)
+val begin_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  begin_shutdown_result
+
+(** Re-open admission only when [operation_id] still owns the reservation.
+    Used when durable prepare fails before cancellation begins. *)
+val rollback_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  rollback_shutdown_result
+
+(** Join the current turn holder after admission has been closed. This waits
+    without an invented timeout, then immediately releases the slot. Never
+    call from the same admitted turn. *)
+val await_idle_after_shutdown : base_path:string -> keeper_name:string -> unit
 
 val snapshot_for : base_path:string -> keeper_name:string -> slot_snapshot
 (** Raw, read-only admission state for one keeper. Unknown keepers return a

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -1,143 +1,123 @@
-(** Keeper_turn_lifecycle -- keeper shutdown handlers.
-
-    Extracted from keeper_turn.ml. Provides [handle_keeper_down]. *)
+(** Keeper lifecycle tools submit durable, non-blocking shutdown operations. *)
 
 open Tool_args
-open Keeper_types
-open Keeper_meta_contract
-open Keeper_meta_store
 open Keeper_types_profile
-open Keeper_keepalive
 
 type tool_result = Keeper_types_profile.tool_result
 
-let remove_pending_confirms_by_target_callback
-    : (Workspace.config ->
-       target_type:string ->
-       target_id:string option ->
-       (int, string) result)
-        Atomic.t
-  =
-  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+let register_remove_pending_confirms_by_target =
+  Keeper_shutdown_finalize.register_remove_pending_confirms_by_target
+;;
 
-let register_remove_pending_confirms_by_target fn =
-  Atomic.set remove_pending_confirms_by_target_callback fn
+let operation_json ~accepted operation =
+  match Keeper_shutdown_store.to_json operation with
+  | `Assoc fields ->
+    `Assoc (("accepted", `Bool accepted) :: fields)
+  | json -> json
+;;
 
-let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
+let active_operation ~config keeper_name =
+  match Keeper_shutdown_store.list_for_keeper ~config ~keeper_name with
+  | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+  | Ok operations ->
+    let active =
+      List.filter
+        (fun operation ->
+           match operation.Keeper_shutdown_types.phase with
+           | Keeper_shutdown_types.Finalized _ -> false
+           | Keeper_shutdown_types.Prepared
+           | Keeper_shutdown_types.Joined_idle
+           | Keeper_shutdown_types.Finalizing_tasks _
+           | Keeper_shutdown_types.Cleanup_ready _
+           | Keeper_shutdown_types.Reconciliation_required _
+           | Keeper_shutdown_types.Blocked _ -> true)
+        operations
+    in
+    (match active with
+     | [] -> Ok None
+     | [ operation ] -> Ok (Some operation)
+     | _ -> Error "multiple non-terminal shutdown operations exist for one Keeper")
+;;
+
+let handle_keeper_down (ctx : _ context) args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
-  if not (validate_name requested_name) then
+  if not (validate_name requested_name)
+  then
     tool_result_error
       (Printf.sprintf
          "invalid keeper name %S (must be non-empty and match \
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    let remove_meta = get_bool args "remove_meta" false in
-    let remove_session = get_bool args "remove_session" false in
-    stop_keepalive ~base_path:config.base_path requested_name;
-    match read_meta_resolved config requested_name with
-    | Error e -> tool_result_error e
-    | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
-    | Ok (Some (name, m)) ->
+    match Keeper_registry.get ~base_path:ctx.config.base_path requested_name with
+    | None ->
+      (match active_operation ~config:ctx.config requested_name with
+       | Error detail ->
+         Log.Keeper.error
+           "Keeper shutdown inventory failed: keeper=%s error=%s"
+           requested_name
+           detail;
+         tool_result_error detail
+       | Ok (Some operation) ->
+         Log.Keeper.info
+           "Keeper shutdown operation observed: keeper=%s operation=%s"
+           requested_name
+           (Keeper_shutdown_types.Operation_id.to_string operation.operation_id);
+         tool_result_ok
+           (Yojson.Safe.to_string (operation_json ~accepted:false operation))
+       | Ok None ->
+         (match Keeper_meta_store.read_meta_resolved ctx.config requested_name with
+          | Error detail -> tool_result_error detail
+          | Ok None ->
+            Log.Keeper.info "Keeper shutdown found already absent: keeper=%s" requested_name;
+            tool_result_ok
+              (Yojson.Safe.to_string
+                 (`Assoc
+                    [ "name", `String requested_name
+                    ; "already_absent", `Bool true
+                    ]))
+          | Ok (Some _) ->
+            Log.Keeper.error
+              "Keeper shutdown refused metadata-only identity: keeper=%s"
+              requested_name;
+            tool_result_error
+              "Keeper metadata exists without a live lane; refusing untracked cleanup"))
+    | Some entry ->
+      let request : Keeper_shutdown_prepare_join.request =
+        { actor = ctx.agent_name
+        ; cleanup_intent =
+            { remove_meta = get_bool args "remove_meta" false
+            ; remove_session = get_bool args "remove_session" false
+            }
+        }
+      in
       (match
-         Atomic.get remove_pending_confirms_by_target_callback config
-           ~target_type:"keeper" ~target_id:(Some name)
+         Keeper_shutdown_runtime.submit
+           ~config:ctx.config
+           ~entry
+           ~request
        with
-       | Error msg ->
-         tool_result_error
-           (Printf.sprintf
-              "keeper pending-confirm cleanup failed for %s: %s"
-              name
-              msg)
-       | Ok pending_confirms_removed ->
-      Log.Misc.info
-        "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
-         remove_meta=%b remove_session=%b"
-        name pending_confirms_removed remove_meta remove_session;
-      (if remove_meta then
-         ( Safe_ops.remove_file_logged ~context:"keeper_down"
-             (keeper_meta_path config name);
-           Keeper_registry.unregister ~base_path:config.base_path name;
-           (* Tier K4c teardown — when the keeper is fully removed
-              (remove_meta=true), drop its tool-emission accumulator
-              from the registry so its slot is reclaimable. The
-              retain-paused branch (else) deliberately keeps the
-              accumulator alive so a future resume can drain any
-              pending items captured before pause. *)
-           Keeper_tool_emission_hook.drop_keeper_accumulator name )
-       else
-         let retained =
-           {
-             m with
-             updated_at = now_iso ();
-             paused = true;
-             (* keeper_down (remove_meta=false) is an operator-initiated
-                retain-paused shutdown; record it as an operator pause so the
-                status bridge can name it. Observability only — the
-                Operator_pause dispatch below is unchanged. *)
-             latched_reason =
-               Some
-                 (Keeper_latched_reason.Operator_paused
-                    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down });
-           }
-         in
-         ((match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.caller_wins config retained
-           with
-           | Ok () -> ()
-           | Error err ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string WriteMetaFailures)
-                 ~labels:[("keeper", name);
-                          ("phase",
-                           if Keeper_meta_store.is_version_conflict_error err
-                           then "keeper_down_cas_race"
-                           else "keeper_down")]
-                 ();
-               if Keeper_meta_store.is_version_conflict_error err then
-                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
-               else
-                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
-          Keeper_registry.update_meta ~base_path:config.base_path name retained;
-          Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
-            Keeper_state_machine.Operator_pause));
-      if remove_session then (
-        let rec rm_rf path =
-          if Fs_compat.file_exists path then begin
-            if Sys.is_directory path then begin
-              Sys.readdir path |> Array.iter (fun entry ->
-                rm_rf (Filename.concat path entry)
-              );
-              Fs_compat.rmdir path
-            end else
-              Sys.remove path
-          end
-        in
-        if validate_name (Keeper_id.Trace_id.to_string m.runtime.trace_id) then (
-          let dir = Filename.concat (session_base_dir config) (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
-          try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string SessionCleanupFailures)
-              ();
-            Log.Keeper.error "session dir cleanup failed: %s"
-              (Printexc.to_string exn)));
-      let json = `Assoc [
-        ("name", `String name);
-        ("stopped", `Bool true);
-        ("remove_meta", `Bool remove_meta);
-        ("remove_session", `Bool remove_session);
-        ("pending_confirms_removed", `Int pending_confirms_removed);
-      ] in
-      tool_result_ok (Yojson.Safe.to_string json))
-
-let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
+       | Error error ->
+         Log.Keeper.error
+           "Keeper shutdown submission failed: keeper=%s error=%s"
+           requested_name
+           (Keeper_shutdown_runtime.submit_error_to_string error);
+         tool_result_error (Keeper_shutdown_runtime.submit_error_to_string error)
+       | Ok operation ->
+         Log.Keeper.info
+           "Keeper shutdown operation accepted: keeper=%s operation=%s"
+           requested_name
+           (Keeper_shutdown_types.Operation_id.to_string operation.operation_id);
+         tool_result_ok
+           (Yojson.Safe.to_string (operation_json ~accepted:true operation)))
+;;
 
 module For_testing = struct
-  let remove_pending_confirms_by_target ~config ~target_type ~target_id =
-    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+  let remove_pending_confirms_by_target =
+    Keeper_shutdown_finalize.For_testing.remove_pending_confirms_by_target
+  ;;
 
-  let reset_remove_pending_confirms_by_target () =
-    Atomic.set remove_pending_confirms_by_target_callback
-      (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+  let reset_remove_pending_confirms_by_target =
+    Keeper_shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target
+  ;;
 end

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -1,33 +1,23 @@
-(** Keeper_turn_lifecycle — keeper shutdown handlers.
-
-    Extracted from keeper_turn.ml. *)
+(** Keeper lifecycle tools submit durable, non-blocking shutdown operations. *)
 
 type tool_result = Keeper_types_profile.tool_result
 
-(** Handle the [masc_keeper_down] MCP tool call: stop keepalive,
-    optionally remove meta and/or session directory, broadcast
-    Operator_pause to the registry. *)
 val handle_keeper_down :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 
-(** RFC-0182 §3.1 — ctx-free entry point for keeper_dispatch_ref path. *)
-val handle_keeper_down_config :
-  config:Workspace.config -> Yojson.Safe.t -> tool_result
-
 val register_remove_pending_confirms_by_target :
   (Workspace.config ->
-   target_type:string ->
+   target_type:Operator_action_constants.target_type ->
    target_id:string option ->
    (int, string) result) ->
   unit
 
-(** Test-only hooks for the Atomic-backed callback. *)
 module For_testing : sig
-  val remove_pending_confirms_by_target
-    : config:Workspace.config ->
-      target_type:string ->
-      target_id:string option ->
-      (int, string) result
+  val remove_pending_confirms_by_target :
+    config:Workspace.config ->
+    target_type:Operator_action_constants.target_type ->
+    target_id:string option ->
+    (int, string) result
 
   val reset_remove_pending_confirms_by_target : unit -> unit
 end

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -68,6 +68,25 @@ type available_action = {
   confirm_required : bool;
 }
 
+type target =
+  { target_type : Operator_action_constants.target_type
+  ; target_id : string option
+  }
+
+let target_gate_callback
+    : (Workspace.config -> target -> (unit, string) result) Atomic.t
+  =
+  Atomic.make (fun _config _target -> Ok ())
+;;
+
+let register_target_gate gate = Atomic.set target_gate_callback gate
+
+let target_of_entry (entry : pending_confirm) =
+  match Operator_action_constants.target_type_of_string entry.target_type with
+  | Some target_type -> Ok { target_type; target_id = entry.target_id }
+  | None -> Error (Printf.sprintf "invalid pending-confirm target type: %S" entry.target_type)
+;;
+
 let make_available_action ~action_type ~tool_name ~target_type ~description =
   { action_type; tool_name; target_type; description;
     confirm_required = Operator_approval.confirm_required action_type }
@@ -174,12 +193,16 @@ let write_pending_confirms config (entries : pending_confirm list) =
   Workspace_utils.write_json_result config (pending_confirms_path config)
     (pending_confirms_to_yojson entries)
 
+let with_store_lock config f =
+  File_lock_eio.with_mutex (pending_confirms_path config) f
+;;
+
 let pending_confirm_expired (entry : pending_confirm) =
   match entry.expires_at with
   | Some exp -> Masc_domain.now_iso () > exp
   | None -> false
 
-let read_pending_confirms_result config =
+let read_pending_confirms_result_unlocked config =
   match raw_pending_confirms_result config with
   | Error _ as error -> error
   | Ok entries ->
@@ -194,6 +217,10 @@ let read_pending_confirms_result config =
            msg)
   else Ok active
 
+let read_pending_confirms_result config =
+  with_store_lock config (fun () -> read_pending_confirms_result_unlocked config)
+;;
+
 let read_pending_confirms config : pending_confirm list =
   match read_pending_confirms_result config with
   | Ok entries -> entries
@@ -202,39 +229,59 @@ let read_pending_confirms config : pending_confirm list =
     []
 
 let upsert_pending_confirm config entry =
-  match read_pending_confirms_result config with
-  | Error _ as error -> error
-  | Ok entries ->
-    let remaining =
-      entries
-      |> List.filter (fun existing -> not (String.equal existing.token entry.token))
-    in
-    write_pending_confirms config (entry :: remaining)
+  with_store_lock config (fun () ->
+    match target_of_entry entry with
+    | Error _ as error -> error
+    | Ok target ->
+      (match Atomic.get target_gate_callback config target with
+       | Error _ as error -> error
+       | Ok () ->
+         (match read_pending_confirms_result_unlocked config with
+          | Error _ as error -> error
+          | Ok entries ->
+            let remaining =
+              entries
+              |> List.filter (fun existing -> not (String.equal existing.token entry.token))
+            in
+            write_pending_confirms config (entry :: remaining))))
 
 let remove_pending_confirm config token =
-  match read_pending_confirms_result config with
-  | Error _ as error -> error
-  | Ok entries ->
-    let remaining =
-      entries
-      |> List.filter (fun existing -> not (String.equal existing.token token))
-    in
-    write_pending_confirms config remaining
+  with_store_lock config (fun () ->
+    match read_pending_confirms_result_unlocked config with
+    | Error _ as error -> error
+    | Ok entries ->
+      let remaining =
+        entries
+        |> List.filter (fun existing -> not (String.equal existing.token token))
+      in
+      write_pending_confirms config remaining)
+
+let remove_pending_confirms_by_typed_target config target =
+  with_store_lock config (fun () ->
+    match raw_pending_confirms_result config with
+    | Error _ as error -> error
+    | Ok all ->
+      let target_type =
+        Operator_action_constants.target_type_to_string target.target_type
+      in
+      let remaining =
+        List.filter
+          (fun (entry : pending_confirm) ->
+             not
+               (String.equal entry.target_type target_type
+                && entry.target_id = target.target_id))
+          all
+      in
+      let removed = List.length all - List.length remaining in
+      if removed > 0
+      then write_pending_confirms config remaining |> Result.map (fun () -> removed)
+      else Ok 0)
 
 let remove_pending_confirms_by_target config ~target_type ~target_id =
-  let all = raw_pending_confirms config in
-  let remaining =
-    List.filter
-      (fun (entry : pending_confirm) ->
-        not
-          (String.equal entry.target_type target_type
-          && entry.target_id = target_id))
-      all
-  in
-  let removed = List.length all - List.length remaining in
-  if removed > 0 then
-    write_pending_confirms config remaining |> Result.map (fun () -> removed)
-  else Ok 0
+  match Operator_action_constants.target_type_of_string target_type with
+  | None -> Error (Printf.sprintf "invalid pending-confirm target type: %S" target_type)
+  | Some target_type ->
+    remove_pending_confirms_by_typed_target config { target_type; target_id }
 
 let normalize_pending_confirm_actor_filter = function
   | Some raw ->

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -34,6 +34,14 @@ type available_action = {
   confirm_required : bool;
 }
 
+type target =
+  { target_type : Operator_action_constants.target_type
+  ; target_id : string option
+  }
+
+val register_target_gate :
+  (Workspace.config -> target -> (unit, string) result) -> unit
+
 val preview_of_pending_confirm : pending_confirm -> Yojson.Safe.t
 val pending_confirm_to_yojson : pending_confirm -> Yojson.Safe.t
 val pending_confirm_of_yojson : Yojson.Safe.t -> (pending_confirm, string) result
@@ -51,6 +59,8 @@ val upsert_pending_confirm :
 val remove_pending_confirm : Workspace.config -> string -> (unit, string) result
 val remove_pending_confirms_by_target :
   Workspace.config -> target_type:string -> target_id:string option -> (int, string) result
+val remove_pending_confirms_by_typed_target :
+  Workspace.config -> target -> (int, string) result
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Workspace.config -> pending_confirm_scope

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -452,8 +452,31 @@ let () =
   Atomic.set
     Workspace_hooks.operator_pending_confirm_remove_fn
     Operator_pending_confirm.remove_pending_confirm;
+  Operator_pending_confirm.register_target_gate
+    (fun config target ->
+      match target.Operator_pending_confirm.target_type, target.target_id with
+      | Operator_action_constants.Keeper, Some keeper_name ->
+        let admission =
+          Keeper_turn_admission.snapshot_for
+            ~base_path:config.Workspace.base_path
+            ~keeper_name
+        in
+        (match admission.snapshot_shutdown_operation_id with
+         | None -> Ok ()
+         | Some operation_id ->
+           Error
+             (Printf.sprintf
+                "Keeper %s is shutting down under operation %s"
+                keeper_name
+                (Keeper_shutdown_types.Operation_id.to_string operation_id)))
+      | Operator_action_constants.Keeper, None ->
+        Error "Keeper pending-confirm target requires target_id"
+      | (Operator_action_constants.Workspace | Operator_action_constants.Goal), _ -> Ok ());
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
-    Operator_pending_confirm.remove_pending_confirms_by_target
+    (fun config ~target_type ~target_id ->
+      Operator_pending_confirm.remove_pending_confirms_by_typed_target
+        config
+        { Operator_pending_confirm.target_type = target_type; target_id })
 ;;
 
 let force_link = ()

--- a/lib/server/keeper_grpc_heartbeat.ml
+++ b/lib/server/keeper_grpc_heartbeat.ml
@@ -181,9 +181,8 @@ let start_keeper_grpc_heartbeat
         m.name
         (Int64.of_float (Time_compat.now () *. 1000.0))
     in
-    let sw = Option.value (Keeper_supervisor.get_global_switch ()) ~default:ctx.sw in
     run_grpc_heartbeat_fiber
-      ~sw
+      ~sw:ctx.sw
       ~stop
       ~grpc_client:client
       ~config:ctx.config

--- a/lib/server/keeper_grpc_heartbeat.ml
+++ b/lib/server/keeper_grpc_heartbeat.ml
@@ -117,6 +117,30 @@ let run_grpc_heartbeat_fiber
     None
   | Some env ->
     let close_ref = Atomic.make false in
+    let active_stream_close = Atomic.make None in
+    let close_active_stream () =
+      match Atomic.exchange active_stream_close None with
+      | None -> Ok ()
+      | Some close_stream ->
+        Eio.Cancel.protect (fun () ->
+          try
+            close_stream ();
+            Ok ()
+          with
+          | exn -> Error exn)
+    in
+    let report_close_error = function
+      | Ok () -> ()
+      | Error exn ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string HeartbeatFailures)
+          ~labels:[ "keeper", agent_name; "site", "grpc_stream_close" ]
+          ();
+        Log.Keeper.warn
+          "gRPC heartbeat stream close failed for %s: %s"
+          agent_name
+          (Printexc.to_string exn)
+    in
     Eio.Fiber.fork ~sw (fun () ->
       let rec connect_loop attempts =
         if Atomic.get stop || Atomic.get close_ref
@@ -135,34 +159,51 @@ let run_grpc_heartbeat_fiber
           let send, recv, close_stream =
             Masc_grpc_client.heartbeat_stream grpc_client ~sw ~env
           in
-          (try
-             run_grpc_heartbeat_stream
-               ~stop
-               ~close_ref
-               ~clock
-               ~interval_sec
-               ~config
-               ~agent_name
-               ~session_id
-               send
-               recv
-           with
-           | Eio.Cancel.Cancelled _ as e ->
-             close_stream ();
-             raise e
-           | End_of_file ->
-             log_grpc_heartbeat_stream_failure ~agent_name ~attempts `Closed;
-             close_stream ()
-           | exn ->
-             log_grpc_heartbeat_stream_failure ~agent_name ~attempts (`Error exn);
-             close_stream ());
+          let installed_close = Some close_stream in
+          Atomic.set active_stream_close installed_close;
+          let stream_outcome =
+            try
+              run_grpc_heartbeat_stream
+                ~stop
+                ~close_ref
+                ~clock
+                ~interval_sec
+                ~config
+                ~agent_name
+                ~session_id
+                send
+                recv;
+              `Completed
+            with
+            | Eio.Cancel.Cancelled _ as exn -> `Cancelled exn
+            | End_of_file ->
+              log_grpc_heartbeat_stream_failure ~agent_name ~attempts `Closed;
+              `Reconnect
+            | exn ->
+              log_grpc_heartbeat_stream_failure ~agent_name ~attempts (`Error exn);
+              `Reconnect
+          in
+          if Atomic.compare_and_set active_stream_close installed_close None
+          then
+            report_close_error
+              (Eio.Cancel.protect (fun () ->
+                 try
+                   close_stream ();
+                   Ok ()
+                 with
+                 | exn -> Error exn));
+          (match stream_outcome with
+           | `Cancelled exn -> raise exn
+           | `Completed | `Reconnect -> ());
           if not (Atomic.get stop || Atomic.get close_ref)
           then (
             Eio.Time.sleep clock reconnect_backoff_sec;
             connect_loop (attempts + 1)))
       in
       connect_loop 0);
-    Some (fun () -> Atomic.set close_ref true)
+    Some (fun () ->
+      Atomic.set close_ref true;
+      report_close_error (close_active_stream ()))
 ;;
 
 let start_keeper_grpc_heartbeat

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -333,6 +333,81 @@ let start_keeper_loops
         Log.Server.error "subsystem %s crashed: %s" name (Printexc.to_string exn))
       f
   in
+  let shutdown_inventory_p, shutdown_inventory_r = Eio.Promise.create () in
+  let config = Mcp_server.workspace_config state in
+  fork_subsystem "keeper_shutdown_recovery" (fun () ->
+    let operation_requires_fence operation =
+      match operation.Keeper_shutdown_types.phase with
+      | Keeper_shutdown_types.Finalized _ -> false
+      | Keeper_shutdown_types.Prepared
+      | Keeper_shutdown_types.Joined_idle
+      | Keeper_shutdown_types.Finalizing_tasks _
+      | Keeper_shutdown_types.Cleanup_ready _
+      | Keeper_shutdown_types.Reconciliation_required _
+      | Keeper_shutdown_types.Blocked _ -> true
+    in
+    let inventory =
+      match Keeper_shutdown_store.list_all ~config with
+      | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+      | Ok operations ->
+        List.fold_left
+          (fun restored operation ->
+             match restored with
+             | Error _ as error -> error
+             | Ok () when not (operation_requires_fence operation) -> Ok ()
+             | Ok () ->
+               (match
+                  Keeper_turn_admission.restore_shutdown
+                    ~base_path:config.base_path
+                    ~keeper_name:operation.keeper_name
+                    ~operation_id:operation.operation_id
+                with
+                | Keeper_turn_admission.Shutdown_restored
+                | Keeper_turn_admission.Shutdown_already_restored -> Ok ()
+                | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+                  Error
+                    (Printf.sprintf
+                       "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
+                       operation.keeper_name
+                       (Keeper_shutdown_types.Operation_id.to_string
+                          operation.operation_id)
+                       (Keeper_shutdown_types.Operation_id.to_string existing))))
+          (Ok ())
+          operations
+        |> Result.map (fun () -> operations)
+    in
+    Eio.Promise.resolve shutdown_inventory_r inventory;
+    match inventory with
+    | Error detail ->
+      Log.Keeper.error "shutdown recovery inventory failed: %s" detail;
+      failwith detail
+    | Ok operations ->
+      Eio.Switch.run (fun recovery_sw ->
+        List.iter
+          (fun operation ->
+             Eio.Fiber.fork ~sw:recovery_sw (fun () ->
+               try
+                 match Keeper_shutdown_runtime.recover_operation ~config operation with
+                 | Ok recovered ->
+                   Log.Keeper.info
+                     "recovered shutdown operation keeper=%s operation=%s"
+                     recovered.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string recovered.operation_id)
+                 | Error detail ->
+                   Log.Keeper.error
+                     "shutdown recovery failed keeper=%s operation=%s error=%s"
+                     operation.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                     detail
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 Log.Keeper.error
+                   "shutdown recovery crashed keeper=%s operation=%s error=%s"
+                   operation.Keeper_shutdown_types.keeper_name
+                   (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                   (Printexc.to_string exn)))
+          operations));
   let wait_for_lazy_startup () =
     (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
        a per-task boot guard.  The diagnostic surface stays as #10854
@@ -845,9 +920,27 @@ let start_keeper_loops
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
       Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
-      let config = (Mcp_server.workspace_config state) in
+      let config = Mcp_server.workspace_config state in
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
+      let shutdown_inventory = Eio.Promise.await shutdown_inventory_p in
+      let shutdown_blocked_names_result =
+        match shutdown_inventory with
+        | Error detail -> Error detail
+        | Ok operations ->
+          Ok
+            (operations
+             |> List.filter_map (fun operation ->
+               match operation.Keeper_shutdown_types.phase with
+               | Keeper_shutdown_types.Finalized _ -> None
+               | Keeper_shutdown_types.Prepared
+               | Keeper_shutdown_types.Joined_idle
+               | Keeper_shutdown_types.Finalizing_tasks _
+               | Keeper_shutdown_types.Cleanup_ready _
+               | Keeper_shutdown_types.Reconciliation_required _
+               | Keeper_shutdown_types.Blocked _ -> Some operation.keeper_name)
+             |> List.sort_uniq String.compare)
+      in
       let all_names = Keeper_meta_store.keeper_names config in
       let all_count = List.length all_names in
       Log.Keeper.info
@@ -856,7 +949,17 @@ let start_keeper_loops
         masc_root
         keeper_dir
         all_count;
-      let names = Keeper_runtime.bootable_keeper_names config in
+      let names =
+        match shutdown_blocked_names_result with
+        | Error detail ->
+          Log.Keeper.error
+            "autoboot blocked because shutdown inventory is uncertain: %s"
+            detail;
+          []
+        | Ok shutdown_blocked_names ->
+          Keeper_runtime.bootable_keeper_names config
+          |> List.filter (fun name -> not (List.mem name shutdown_blocked_names))
+      in
       let exclusions = Keeper_runtime.autoboot_excluded_keeper_reasons config in
       let keeper_boot_ctx : _ Keeper_types_profile.context =
         { config

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -187,6 +187,7 @@ type dashboard_deferred_chat =
   ; chat_waiting : bool
   ; queue_length : int
   ; receipt_id : string
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 let dashboard_busy_queue_state ~base_path ~keeper_name =
@@ -200,14 +201,26 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
   | Some info, false, _ -> Some (Some info, false)
   | Some info, true, _ -> Some (Some info, true)
 
-let dashboard_deferred_ack_text ~keeper_name =
-  Printf.sprintf
-    "%s is busy; your message is queued and will be answered after the current \
-     turn finishes."
-    keeper_name
+let dashboard_deferred_ack_text ~keeper_name deferred =
+  match deferred.shutdown_operation_id with
+  | Some operation_id ->
+    Printf.sprintf
+      "%s is stopping under operation %s; your message is queued for the next active lane."
+      keeper_name
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+  | None ->
+    Printf.sprintf
+      "%s is busy; your message is queued and will be answered after the current \
+       turn finishes."
+      keeper_name
 
 let dashboard_deferred_chat_to_json ~keeper_name
-    ({ in_flight; chat_waiting; queue_length; receipt_id } : dashboard_deferred_chat) =
+    ({ in_flight
+     ; chat_waiting
+     ; queue_length
+     ; receipt_id
+     ; shutdown_operation_id
+     } : dashboard_deferred_chat) =
   let in_flight_fields =
     match in_flight with
     | None -> []
@@ -225,10 +238,21 @@ let dashboard_deferred_chat_to_json ~keeper_name
      ; ("queue_length", `Int queue_length)
      ; ("chat_waiting", `Bool chat_waiting)
      ; ("receipt_id", `String receipt_id)
+     ; ( "shutdown_operation_id"
+       , match shutdown_operation_id with
+         | None -> `Null
+         | Some operation_id ->
+           `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
      ]
      @ in_flight_fields)
 
-let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
+let enqueue_dashboard_payload
+      ~clock
+      payload
+      ~in_flight
+      ~chat_waiting
+      ~shutdown_operation_id
+  =
   let receipt_id =
     Keeper_chat_queue.enqueue ~keeper_name:payload.name
       { Keeper_chat_queue.content = payload.message
@@ -240,17 +264,34 @@ let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
   in
   let queue_length = Keeper_chat_queue.length ~keeper_name:payload.name in
   Keeper_chat_broadcast.queue_changed ~keeper_name:payload.name ~depth:queue_length ();
-  { in_flight; chat_waiting; queue_length; receipt_id }
+  { in_flight; chat_waiting; queue_length; receipt_id; shutdown_operation_id }
 
 let dashboard_deferred_chat_of_rejection ~clock payload
-    ({ Keeper_turn_admission.waiting; in_flight } : Keeper_turn_admission.rejection) =
-  enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting:(waiting > 0)
+     ({ Keeper_turn_admission.waiting
+     ; in_flight
+     ; shutdown_operation_id
+     } : Keeper_turn_admission.rejection) =
+  (* Dashboard messages remain durable while a shutdown fence is active;
+     the queue is the continuation boundary for a later resume/replacement
+     lane, rather than starting a turn behind the fence. *)
+  enqueue_dashboard_payload
+    ~clock
+    payload
+    ~in_flight
+    ~chat_waiting:(waiting > 0)
+    ~shutdown_operation_id
 
 let defer_dashboard_payload_if_busy ~base_path ~clock payload =
   match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
   | None -> `Not_busy
   | Some (in_flight, chat_waiting) ->
-      `Queued (enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting)
+      `Queued
+        (enqueue_dashboard_payload
+           ~clock
+           payload
+           ~in_flight
+           ~chat_waiting
+           ~shutdown_operation_id:None)
 
 let keeper_chat_request_prefixes =
   [
@@ -1496,7 +1537,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
     | Stream_dashboard_queued queued ->
-        let message = dashboard_deferred_ack_text ~keeper_name:payload.name in
+        let message =
+          dashboard_deferred_ack_text ~keeper_name:payload.name queued
+        in
         publish_terminal ~status:"queued" ~ok:true ~message ();
         Keeper_chat_events.publish events (Text_delta message);
         Keeper_chat_events.publish events
@@ -1990,7 +2033,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                       { message_id; role = Keeper_chat_events.Assistant });
                  Keeper_chat_events.publish events
                    (Text_delta
-                      (dashboard_deferred_ack_text ~keeper_name:payload.name));
+                      (dashboard_deferred_ack_text
+                         ~keeper_name:payload.name
+                         queued));
                  Keeper_chat_events.publish events
                    (Custom
                       { name = "KEEPER_CHAT_QUEUED";

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -685,6 +685,19 @@ let test_keeper_lane_surfaces_cleanup_failure () =
     (Some "cleanup evidence")
     exit.cleanup_error
 
+let test_keeper_lane_identity_is_typed_and_unique () =
+  let first = Lane.create () in
+  let second = Lane.create () in
+  let first_id = Lane.id first in
+  let encoded = Lane.Id.to_string first_id in
+  check bool
+    "separate registry lanes have separate identities"
+    false
+    (Lane.Id.equal first_id (Lane.id second));
+  match Lane.Id.of_string encoded with
+  | Ok decoded -> check bool "lane id round-trip" true (Lane.Id.equal first_id decoded)
+  | Error detail -> fail detail
+
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1100,6 +1113,8 @@ let () =
         test_keeper_lane_join_waits_for_children_and_cleanup;
       test_case "lane join surfaces cleanup failure" `Quick
         test_keeper_lane_surfaces_cleanup_failure;
+      test_case "lane identity is typed and unique" `Quick
+        test_keeper_lane_identity_is_typed_and_unique;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -24,6 +24,7 @@ module KHL = Masc.Keeper_heartbeat_loop
 module Obs = Masc.Keeper_heartbeat_loop_observations
 module WO = Masc.Keeper_world_observation
 module Health = Masc.Health
+module Lane = Masc.Keeper_lane
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -99,7 +100,12 @@ let make_meta name =
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
 
 let resolve_done_for_test reg value =
-  ignore (R.resolve_done reg ~source:"test_fixture" value)
+  ignore (R.resolve_done reg ~source:"test_fixture" value);
+  match
+    Lane.reject_before_start reg.lane ~reason:(Failure "synthetic terminal fixture")
+  with
+  | Ok () -> ()
+  | Error error -> fail (Lane.start_error_to_string error)
 
 let eio_test name fn =
   test_case name `Quick (fun () -> Eio_main.run @@ fun env ->
@@ -332,8 +338,8 @@ let test_self_preservation_min_candidates_not_met () =
 
 (** Verify the dominated_by_sweep logic from reconcile_keepalive_keepers.
     Running/Paused/Crashed/Dead = sweep-owned (reconcile must skip).
-    Stopped with resolved done_p = reconcile-eligible.
-    Stopped with unresolved done_p = sweep will handle. *)
+    Stopped with a resolved terminal and joined lane = reconcile-eligible.
+    Stopped with an unjoined lane = sweep will handle. *)
 let test_reconcile_predicate_sweep_owned () =
   R.clear ();
   (* Running = sweep-owned *)
@@ -365,7 +371,7 @@ let test_reconcile_predicate_stopped_resolved () =
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Stop_requested);
   ignore (R.dispatch_event ~base_path:bp "s1" KSM.Drain_complete);
   resolve_done_for_test reg `Stopped;
-  (* Stopped + resolved done_p = reconcile-eligible *)
+  (* Stopped + resolved done_p + joined lane = reconcile-eligible *)
   (match R.get ~base_path:bp "s1" with
    | Some e ->
      check string "stopped" "stopped" (KSM.phase_to_string e.phase);
@@ -377,7 +383,7 @@ let test_reconcile_predicate_stopped_resolved () =
        | KSM.Failing | KSM.Overflowed | KSM.Compacting | KSM.HandingOff
        | KSM.Draining | KSM.Restarting -> true
        | KSM.Offline -> false
-       | KSM.Stopped -> Eio.Promise.peek e.done_p = None
+       | KSM.Stopped -> not (R.lane_has_exited e)
      in
      check bool "not dominated (reconcile-eligible)" false dominated
    | None -> fail "expected s1")
@@ -398,7 +404,7 @@ let test_reconcile_predicate_stopped_unresolved () =
        | KSM.Failing | KSM.Overflowed | KSM.Compacting | KSM.HandingOff
        | KSM.Draining | KSM.Restarting -> true
        | KSM.Offline -> false
-       | KSM.Stopped -> Eio.Promise.peek e.done_p = None
+       | KSM.Stopped -> not (R.lane_has_exited e)
      in
      check bool "dominated (sweep will handle)" true dominated
    | None -> fail "expected s2")
@@ -603,19 +609,81 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       let stopped_resolved =
         wait_until ~clock:ctx.clock ~timeout_s:1.0 (fun () ->
           match R.get ~base_path:config.base_path keeper_name with
-          | Some entry -> Option.is_some (Eio.Promise.peek entry.done_p)
+          | Some entry ->
+            Option.is_some (Eio.Promise.peek entry.done_p)
+            && R.lane_has_exited entry
           | None -> false)
       in
       match R.get ~base_path:config.base_path keeper_name with
       | None -> fail "expected direct-lifecycle registry entry"
       | Some entry ->
         check string "state stopped" "stopped" (KSM.phase_to_string entry.phase);
-        check bool "done promise resolved eventually" true stopped_resolved;
+        check bool "terminal and lane join resolve eventually" true stopped_resolved;
         (match Eio.Promise.peek entry.done_p with
          | Some `Stopped -> ()
          | Some (`Crashed reason) ->
            fail ("expected stopped promise, got crashed: " ^ reason)
          | None -> fail "expected done_p to resolve on stop"))
+
+let test_keeper_lane_join_waits_for_children_and_cleanup () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun parent_sw ->
+  let lane = Lane.create () in
+  let release_p, release_r = Eio.Promise.create () in
+  let child_finished = Atomic.make false in
+  let cleanup_observed_child = Atomic.make false in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~run:(fun lane_sw ->
+         Eio.Fiber.fork ~sw:lane_sw (fun () ->
+           Eio.Promise.await release_p;
+           Atomic.set child_finished true))
+       ~cleanup:(fun _outcome ->
+         Atomic.set cleanup_observed_child (Atomic.get child_finished);
+         Ok ())
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  Eio.Fiber.yield ();
+  check bool
+    "lane exit waits for attached child"
+    true
+    (Option.is_none (Lane.peek_exit lane));
+  Eio.Promise.resolve release_r ();
+  let exit = Lane.await_exit lane in
+  (match exit.outcome with
+   | Lane.Completed -> ()
+   | Lane.Cancelled_by_parent cause ->
+     fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
+   | Lane.Failed exn -> fail ("unexpected lane failure: " ^ Printexc.to_string exn));
+  check bool "child finished before join" true (Atomic.get child_finished);
+  check bool
+    "cleanup ran after child join"
+    true
+    (Atomic.get cleanup_observed_child);
+  check (option string) "cleanup succeeded" None exit.cleanup_error
+
+let test_keeper_lane_surfaces_cleanup_failure () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun parent_sw ->
+  let lane = Lane.create () in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~run:(fun _lane_sw -> ())
+       ~cleanup:(fun _outcome -> Error "cleanup evidence")
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  let exit = Lane.await_exit lane in
+  check
+    (option string)
+    "cleanup failure remains observable"
+    (Some "cleanup evidence")
+    exit.cleanup_error
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -703,7 +771,7 @@ let test_start_keepalive_reclaims_finished_failing_entry () =
           (Option.is_none (Eio.Promise.peek entry.done_p));
         Masc.Keeper_keepalive.stop_keepalive keeper_name)
 
-let test_stop_keepalive_resolves_running_entry_immediately () =
+let test_stop_keepalive_only_requests_lane_stop () =
   R.clear ();
   let keeper_name = "manual-stop-entry" in
   let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
@@ -711,12 +779,20 @@ let test_stop_keepalive_resolves_running_entry_immediately () =
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected manual-stop-entry in registry"
   | Some entry ->
-    check string "state stopped immediately" "stopped" (KSM.phase_to_string entry.phase);
-    (match Eio.Promise.peek reg.done_p with
-     | Some `Stopped -> ()
-     | Some (`Crashed reason) ->
-       fail ("expected stopped promise, got crashed: " ^ reason)
-     | None -> fail "expected manual stop to resolve done_p")
+    check bool "stop signal set" true (Atomic.get entry.fiber_stop);
+    check bool "wakeup signal set" true (Atomic.get entry.fiber_wakeup);
+    check string
+      "phase remains owned by lane"
+      "running"
+      (KSM.phase_to_string entry.phase);
+    check bool
+      "terminal promise is not a stop-request acknowledgement"
+      true
+      (Option.is_none (Eio.Promise.peek reg.done_p));
+    check bool
+      "unstarted synthetic entry has not joined"
+      true
+      (not (R.lane_has_exited entry))
 
 let test_stop_keepalive_preserves_existing_crash_outcome () =
   R.clear ();
@@ -1018,14 +1094,18 @@ let () =
         test_crashed_cycle_records_turn_failure;
     ];
     "direct_keepalive", [
-      test_case "stop resolves done promise" `Quick
+      test_case "stop resolves done after lane exit" `Quick
         test_direct_start_keepalive_resolves_done_on_stop;
+      test_case "lane join waits for children and cleanup" `Quick
+        test_keeper_lane_join_waits_for_children_and_cleanup;
+      test_case "lane join surfaces cleanup failure" `Quick
+        test_keeper_lane_surfaces_cleanup_failure;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick
         test_start_keepalive_reclaims_finished_failing_entry;
-      test_case "manual stop resolves running entry immediately" `Quick
-        test_stop_keepalive_resolves_running_entry_immediately;
+      test_case "manual stop only requests lane stop" `Quick
+        test_stop_keepalive_only_requests_lane_stop;
       test_case "manual stop preserves crashed outcome" `Quick
         test_stop_keepalive_preserves_existing_crash_outcome;
       test_case "resolve_done reports prior outcome" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -28,6 +28,9 @@ module Lane = Masc.Keeper_lane
 module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
+module Shutdown_finalize = Masc.Keeper_shutdown_finalize
+module Shutdown_runtime = Masc.Keeper_shutdown_runtime
+module Keeper_meta_store = Masc.Keeper_meta_store
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -661,6 +664,7 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
   let exit = Lane.await_exit lane in
   (match exit.outcome with
    | Lane.Completed -> ()
+   | Lane.Shutdown_before_start -> fail "unexpected shutdown before lane start"
    | Lane.Shutdown_requested -> fail "unexpected lane shutdown"
    | Lane.Cancelled_by_parent cause ->
      fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
@@ -728,6 +732,7 @@ let test_keeper_lane_cancel_is_lane_local_and_joinable () =
   let exit = Lane.await_exit lane in
   match exit.outcome with
   | Lane.Shutdown_requested -> ()
+  | Lane.Shutdown_before_start -> fail "running lane reported pre-start shutdown"
   | Lane.Completed -> fail "cancelled lane reported normal completion"
   | Lane.Cancelled_by_parent cause ->
     fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
@@ -741,13 +746,21 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
       let meta = make_meta "shutdown-store-keeper" in
       let operation_id = Shutdown_types.Operation_id.generate () in
       let lane = Lane.create () in
       let now = Masc_domain.now_iso () in
       let operation : Shutdown_types.t =
         { schema_version = Shutdown_types.schema_version
+        ; revision = 0
         ; operation_id
         ; keeper_name = meta.name
         ; lane_id = Lane.id lane
@@ -756,6 +769,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         ; actor = "tester"
         ; cleanup_intent = { remove_meta = false; remove_session = false }
         ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
         ; join_evidence = None
         ; phase = Shutdown_types.Prepared
@@ -782,18 +796,105 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         (Lane.Id.equal operation.lane_id loaded.lane_id);
       let joined =
         { loaded with
-          phase = Shutdown_types.Joined_idle
+          revision = loaded.revision + 1
+        ; phase = Shutdown_types.Joined_idle
         ; updated_at = Masc_domain.now_iso ()
         }
       in
-      (match Shutdown_store.replace ~config joined with
+      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision joined with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
+      let stale =
+        { loaded with
+          revision = loaded.revision + 1
+        ; phase = Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail = "stale" }
+        }
+      in
+      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision stale with
+       | Error (Shutdown_store.Revision_conflict _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "stale shutdown snapshot overwrote a newer revision");
       let mismatched = { joined with lane_id = Lane.id (Lane.create ()) } in
-      (match Shutdown_store.replace ~config mismatched with
+      (match
+         Shutdown_store.replace
+           ~config
+           ~expected_revision:joined.revision
+           { mismatched with revision = joined.revision + 1 }
+       with
        | Error (Shutdown_store.Identity_mismatch _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
+      let worker_failure = Failure "worker exploded after durable join" in
+      let holder_locked_p, holder_locked_r = Eio.Promise.create () in
+      let release_holder_p, release_holder_r = Eio.Promise.create () in
+      let holder_done_p, holder_done_r = Eio.Promise.create () in
+      let worker_started_p, worker_started_r = Eio.Promise.create () in
+      let exception Cancel_worker in
+      Eio.Switch.run @@ fun test_sw ->
+      Eio.Fiber.fork ~sw:test_sw (fun () ->
+        Shutdown_store.For_testing.with_operation_write_lock
+          ~config
+          operation_id
+          (fun () ->
+             Eio.Promise.resolve holder_locked_r ();
+             Eio.Promise.await release_holder_p);
+        Eio.Promise.resolve holder_done_r ());
+      Eio.Promise.await holder_locked_p;
+      (try
+         Eio.Switch.run (fun worker_sw ->
+           Eio.Fiber.fork ~sw:worker_sw (fun () ->
+             Eio.Promise.resolve worker_started_r ();
+             Shutdown_runtime.For_testing.persist_unhandled_failure
+               ~config
+               operation
+               worker_failure);
+           Eio.Promise.await worker_started_p;
+           Eio.Switch.fail worker_sw Cancel_worker;
+           Eio.Promise.resolve release_holder_r ())
+       with
+       | Cancel_worker -> ());
+      Eio.Promise.await holder_done_p;
+      let blocked =
+        match Shutdown_store.load ~config operation_id with
+        | Ok blocked -> blocked
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "unhandled worker failure advances the latest durable revision"
+        (joined.revision + 1)
+        blocked.revision;
+      (match blocked.phase with
+       | Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail } ->
+         check string
+           "unhandled worker failure detail"
+           (Printexc.to_string worker_failure)
+           detail
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Blocked _ ->
+         fail "unhandled worker failure did not persist typed blocked evidence");
+      Shutdown_runtime.For_testing.persist_unhandled_failure
+        ~config
+        operation
+        (Failure "later worker failure");
+      let preserved =
+        match Shutdown_store.load ~config operation_id with
+        | Ok preserved -> preserved
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "later worker failure preserves blocked revision"
+        blocked.revision
+        preserved.revision;
+      check
+        bool
+        "later worker failure preserves first blocked evidence"
+        true
+        (preserved.phase = blocked.phase);
       (match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
        | Ok [ listed ] ->
          check bool
@@ -868,7 +969,10 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
       (match operation.phase with
        | Shutdown_types.Joined_idle -> ()
        | Shutdown_types.Prepared
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
        | Shutdown_types.Blocked _ -> fail "idle lane did not reach Joined_idle");
       check bool
         "shutdown operation records lane join evidence"
@@ -885,8 +989,54 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+      | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
+
+let test_keeper_shutdown_prepare_joins_not_started_lane () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-prepare-not-started" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-not-started-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let operation =
+        match
+          Shutdown_prepare_join.run
+            ~config
+            ~entry
+            ~request:
+              { actor = "operator"
+              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              }
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+      in
+      (match operation.phase with
+       | Shutdown_types.Joined_idle -> ()
+       | Shutdown_types.Prepared
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Blocked _ -> fail "not-started lane did not reach Joined_idle");
+      (match Lane.peek_exit entry.lane with
+       | Some { outcome = Lane.Shutdown_before_start; cleanup_error = None } -> ()
+       | Some _ -> fail "not-started lane recorded the wrong exit evidence"
+       | None -> fail "not-started lane exit remained unresolved");
+      match Eio.Promise.peek entry.done_p with
+      | Some `Stopped -> ()
+      | Some (`Crashed detail) -> fail ("not-started lane crashed: " ^ detail)
+      | None -> fail "not-started lane terminal remained unresolved")
 
 let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
   Eio_main.run @@ fun env ->
@@ -930,6 +1080,278 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       with
       | `Ran () -> ()
       | `Busy _ -> fail "failed shutdown prepare left the keeper admission fence closed")
+
+let test_keeper_shutdown_finalizes_idle_operation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-finalize" in
+  Fun.protect
+    ~finally:(fun () ->
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let meta = make_meta "shutdown-finalize-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "fresh shutdown finalization fixture was already reserved");
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let finalized =
+        match Shutdown_finalize.run ~config ~entry:None operation with
+        | Ok finalized -> finalized
+        | Error error -> fail (Shutdown_finalize.error_to_string error)
+      in
+      (match finalized.phase with
+       | Shutdown_types.Finalized evidence ->
+         check int "no pending confirms" 0 evidence.cleanup.pending_confirms_removed
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _ -> fail "shutdown did not reach Finalized");
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "finalized shutdown did not release its admission fence");
+      (match Shutdown_finalize.run ~config ~entry:None finalized with
+       | Ok _ -> ()
+       | Error error -> fail (Shutdown_finalize.error_to_string error));
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (fun () -> ())
+       with
+       | `Ran () -> ()
+       | `Busy _ -> fail "finalized shutdown replay left admission fenced");
+      match Keeper_meta_store.read_meta config meta.name with
+      | Ok (Some retained) ->
+        check bool "retained Keeper is paused" true retained.paused;
+        check bool "retained Keeper task binding is cleared" true
+          (Option.is_none retained.current_task_id)
+      | Ok None -> fail "retained Keeper metadata disappeared"
+      | Error detail -> fail detail)
+
+let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-meta-replay" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let meta = make_meta "shutdown-meta-replay-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let cleanup : Shutdown_types.cleanup_evidence =
+        { settled_task_ids = []; pending_confirms_removed = 0 }
+      in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = true; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Cleanup_ready cleanup
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match
+         Keeper_meta_store.remove_meta_if_identity
+           config
+           ~name:meta.name
+           ~trace_id:meta.runtime.trace_id
+           ~generation:meta.runtime.generation
+       with
+       | Ok () -> ()
+       | Error error -> fail (Keeper_meta_store.identity_remove_error_to_string error));
+      match Shutdown_finalize.run ~config ~entry:None operation with
+      | Ok { phase = Shutdown_types.Finalized evidence; _ } ->
+        check bool "meta cleanup remains complete on replay" true evidence.meta_removed
+      | Ok _ -> fail "meta cleanup replay did not reach Finalized"
+      | Error error -> fail (Shutdown_finalize.error_to_string error))
+
+let test_keeper_shutdown_recovers_committed_task_receipt () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-task-receipt" in
+  Fun.protect
+    ~finally:(fun () ->
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let meta = make_meta "shutdown-task-receipt-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      let task_id_wire =
+        match
+          Masc.Workspace.add_task_with_result
+            config
+            ~title:"shutdown receipt fixture"
+            ~priority:1
+            ~description:"durable task settlement"
+        with
+        | Ok created -> created.task_id
+        | Error error -> fail (Masc.Workspace.add_task_error_to_string error)
+      in
+      (match
+         Masc.Workspace.claim_task_r
+           config
+           ~agent_name:meta.agent_name
+           ~task_id:task_id_wire
+           ()
+       with
+       | Ok _ -> ()
+       | Error error -> fail (Masc_domain.masc_error_to_string error));
+      let task_id =
+        match Keeper_id.Task_id.of_string task_id_wire with
+        | Ok task_id -> task_id
+        | Error detail -> fail detail
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = [ task_id ]
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let handoff_context : Masc_domain.task_handoff_context =
+        { summary = "Keeper stopped; task returned to the durable backlog"
+        ; reason = Some "Keeper shutdown operation completed lane join"
+        ; next_step = Some "A live Keeper may reclaim this task"
+        ; failure_mode = None
+        ; reclaim_policy = Some Masc_domain.Allow_reclaim
+        ; evidence_refs =
+            [ "masc://keeper-shutdown/"
+              ^ Shutdown_types.Operation_id.to_string operation_id
+            ]
+        ; updated_at = Some (Masc_domain.now_iso ())
+        ; updated_by = Some operation.actor
+        }
+      in
+      (match
+         Masc.Workspace.release_task_r
+           config
+           ~agent_name:meta.agent_name
+           ~task_id:task_id_wire
+           ~expected_version:backlog_version
+           ~handoff_context
+           ()
+       with
+       | Ok _ -> ()
+       | Error error -> fail (Masc_domain.masc_error_to_string error));
+      match Shutdown_finalize.run ~config ~entry:None operation with
+      | Ok { phase = Shutdown_types.Finalized evidence; _ } ->
+        check int
+          "committed release receipt is recovered exactly once"
+          1
+          (List.length evidence.cleanup.settled_task_ids)
+      | Ok _ -> fail "task receipt recovery did not reach Finalized"
+      | Error error -> fail (Shutdown_finalize.error_to_string error))
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1354,8 +1776,16 @@ let () =
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
+      test_case "shutdown prepare joins not-started lane" `Quick
+        test_keeper_shutdown_prepare_joins_not_started_lane;
       test_case "shutdown prepare failure rolls back admission fence" `Quick
         test_keeper_shutdown_prepare_failure_rolls_back_fence;
+      test_case "shutdown finalizes idle operation" `Quick
+        test_keeper_shutdown_finalizes_idle_operation;
+      test_case "shutdown cleanup replays after meta removal" `Quick
+        test_keeper_shutdown_cleanup_replays_after_meta_removal;
+      test_case "shutdown recovers committed task receipt" `Quick
+        test_keeper_shutdown_recovers_committed_task_receipt;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -588,7 +588,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
   let keeper_name = "direct-lifecycle" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
       cleanup_dir base_dir)
     (fun () ->
       ensure_default_runtime ();
@@ -608,7 +608,9 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       in
       Masc.Keeper_keepalive.start_keepalive ctx meta;
       Eio.Time.sleep ctx.clock 0.05;
-      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc.Keeper_keepalive.stop_keepalive
+        ~base_path:config.base_path
+        keeper_name;
       let stopped_resolved =
         wait_until ~clock:ctx.clock ~timeout_s:1.0 (fun () ->
           match R.get ~base_path:config.base_path keeper_name with

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -25,6 +25,9 @@ module Obs = Masc.Keeper_heartbeat_loop_observations
 module WO = Masc.Keeper_world_observation
 module Health = Masc.Health
 module Lane = Masc.Keeper_lane
+module Shutdown_types = Masc.Keeper_shutdown_types
+module Shutdown_store = Masc.Keeper_shutdown_store
+module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -655,6 +658,7 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
   let exit = Lane.await_exit lane in
   (match exit.outcome with
    | Lane.Completed -> ()
+   | Lane.Shutdown_requested -> fail "unexpected lane shutdown"
    | Lane.Cancelled_by_parent cause ->
      fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
    | Lane.Failed exn -> fail ("unexpected lane failure: " ^ Printexc.to_string exn));
@@ -697,6 +701,232 @@ let test_keeper_lane_identity_is_typed_and_unique () =
   match Lane.Id.of_string encoded with
   | Ok decoded -> check bool "lane id round-trip" true (Lane.Id.equal first_id decoded)
   | Error detail -> fail detail
+
+let test_keeper_lane_cancel_is_lane_local_and_joinable () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun parent_sw ->
+  let lane = Lane.create () in
+  let never_p, _never_r = Eio.Promise.create () in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~run:(fun _lane_sw -> Eio.Promise.await never_p)
+       ~cleanup:(fun _outcome -> Ok ())
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  Eio.Fiber.yield ();
+  (match Lane.request_cancel lane with
+   | Lane.Cancel_requested -> ()
+   | Lane.Cancel_already_requested
+   | Lane.Cancel_already_exiting
+   | Lane.Cancel_signal_failed _ -> fail "first lane cancellation was not accepted");
+  let exit = Lane.await_exit lane in
+  match exit.outcome with
+  | Lane.Shutdown_requested -> ()
+  | Lane.Completed -> fail "cancelled lane reported normal completion"
+  | Lane.Cancelled_by_parent cause ->
+    fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
+  | Lane.Failed exn -> fail ("lane cancellation failed: " ^ Printexc.to_string exn)
+
+let test_keeper_shutdown_store_round_trip_and_identity_guard () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-store" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta "shutdown-store-keeper" in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let lane = Lane.create () in
+      let now = Masc_domain.now_iso () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id lane
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "tester"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Prepared
+        ; created_at = now
+        ; updated_at = now
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_store.persist_new ~config operation with
+       | Error (Shutdown_store.Already_exists _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "duplicate shutdown operation overwrote its record");
+      let loaded =
+        match Shutdown_store.load ~config operation_id with
+        | Ok loaded -> loaded
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check string "shutdown keeper round-trip" operation.keeper_name loaded.keeper_name;
+      check bool
+        "shutdown lane identity round-trip"
+        true
+        (Lane.Id.equal operation.lane_id loaded.lane_id);
+      let joined =
+        { loaded with
+          phase = Shutdown_types.Joined_idle
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.replace ~config joined with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let mismatched = { joined with lane_id = Lane.id (Lane.create ()) } in
+      (match Shutdown_store.replace ~config mismatched with
+       | Error (Shutdown_store.Identity_mismatch _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "shutdown store accepted a different lane identity");
+      (match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
+       | Ok [ listed ] ->
+         check bool
+           "listed operation identity"
+           true
+           (Shutdown_types.Operation_id.equal listed.operation_id operation_id)
+       | Ok operations ->
+         fail (Printf.sprintf "expected one shutdown operation, got %d" (List.length operations))
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let unsupported_json =
+        match Shutdown_store.to_json joined with
+        | `Assoc fields ->
+          `Assoc (("schema_version", `Int 999) :: List.remove_assoc "schema_version" fields)
+        | _ -> fail "shutdown operation codec did not produce an object"
+      in
+      match Shutdown_store.of_json unsupported_json with
+      | Error (Shutdown_store.Decode_error _) -> ()
+      | Error error -> fail (Shutdown_store.error_to_string error)
+      | Ok _ -> fail "unsupported shutdown schema was accepted")
+
+let test_keeper_shutdown_prepare_joins_idle_lane () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun parent_sw ->
+  let base_dir = temp_dir "shutdown-prepare-join" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-idle-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let never_p, _never_r = Eio.Promise.create () in
+      (match
+         Lane.fork
+           ~sw:parent_sw
+           entry.lane
+           ~run:(fun _lane_sw -> Eio.Promise.await never_p)
+           ~cleanup:(fun _outcome ->
+             (match R.dispatch_event_exact entry KSM.Stop_requested with
+              | Ok _ -> ()
+              | Error error -> fail (KSM.transition_error_to_string error));
+             (match R.dispatch_event_exact entry KSM.Drain_complete with
+              | Ok _ -> ()
+              | Error error -> fail (KSM.transition_error_to_string error));
+             (match R.resolve_done entry ~source:"shutdown_test_lane_cleanup" `Stopped with
+              | R.Done_resolved _ -> ()
+              | R.Done_already_resolved _ -> fail "test lane terminal resolved twice");
+             Ok ())
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
+      Eio.Fiber.yield ();
+      let operation =
+        match
+          Shutdown_prepare_join.run
+            ~config
+            ~entry
+            ~request:
+              { actor = "operator"
+              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              }
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+      in
+      (match operation.phase with
+       | Shutdown_types.Joined_idle -> ()
+       | Shutdown_types.Prepared
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _ -> fail "idle lane did not reach Joined_idle");
+      check bool
+        "shutdown operation records lane join evidence"
+        true
+        (Option.is_some operation.join_evidence);
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:name
+           (fun () -> ())
+       with
+       | `Busy (Masc.Keeper_turn_admission.Shutdown_requested operation_id) ->
+         check bool
+           "shutdown admission fence retains operation identity"
+           true
+           (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "shutdown admission fence reopened before finalization"))
+
+let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-prepare-rollback" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-prepare-rollback-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let probe_operation_id = Shutdown_types.Operation_id.generate () in
+      let records_dir =
+        Filename.dirname (Shutdown_store.path ~config probe_operation_id)
+      in
+      let blocker = open_out records_dir in
+      close_out blocker;
+      (match
+         Shutdown_prepare_join.run
+           ~config
+           ~entry
+           ~request:
+             { actor = "operator"
+             ; cleanup_intent = { remove_meta = false; remove_session = false }
+             }
+       with
+       | Error (Shutdown_prepare_join.Prepare_persist_failed _) -> ()
+       | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+       | Ok _ -> fail "shutdown prepare unexpectedly persisted through a file blocker");
+      match
+        Masc.Keeper_turn_admission.run_if_free
+          ~base_path:config.base_path
+          ~keeper_name:name
+          (fun () -> ())
+      with
+      | `Ran () -> ()
+      | `Busy _ -> fail "failed shutdown prepare left the keeper admission fence closed")
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1115,6 +1345,14 @@ let () =
         test_keeper_lane_surfaces_cleanup_failure;
       test_case "lane identity is typed and unique" `Quick
         test_keeper_lane_identity_is_typed_and_unique;
+      test_case "lane cancellation is local and joinable" `Quick
+        test_keeper_lane_cancel_is_lane_local_and_joinable;
+      test_case "shutdown store round-trip and identity guard" `Quick
+        test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "shutdown prepare joins idle lane" `Quick
+        test_keeper_shutdown_prepare_joins_idle_lane;
+      test_case "shutdown prepare failure rolls back admission fence" `Quick
+        test_keeper_shutdown_prepare_failure_rolls_back_fence;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -613,7 +613,8 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
         wait_until ~clock:ctx.clock ~timeout_s:1.0 (fun () ->
           match R.get ~base_path:config.base_path keeper_name with
           | Some entry ->
-            Option.is_some (Eio.Promise.peek entry.done_p)
+            entry.phase = KSM.Stopped
+            && Option.is_some (Eio.Promise.peek entry.done_p)
             && R.lane_has_exited entry
           | None -> false)
       in

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -260,7 +260,12 @@ let test_turn_lifecycle_callback () =
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target (fun _config ~target_type:_ ~target_id:_ ->
     called := true;
     Ok 7);
-  let n = Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target ~config:(Obj.magic ()) ~target_type:"keeper" ~target_id:(Some "k") in
+  let n =
+    Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target
+      ~config:(Obj.magic ())
+      ~target_type:Operator_action_constants.Keeper
+      ~target_id:(Some "k")
+  in
   check bool "remove pending confirms callback invoked" true !called;
   check (result int string) "remove pending confirms returned value" (Ok 7) n;
   Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ()

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -6,7 +6,7 @@
     Sites under test:
     - gRPC pause directive ([Keeper_keepalive.process_directive "pause"]
       -> [directive_paused_meta]) -> [Operator_paused {grpc_directive}]
-    - keeper_down retain ([Keeper_turn_lifecycle.handle_keeper_down_config],
+    - keeper_down retain ([Keeper_shutdown_finalize.For_testing.paused_meta],
       remove_meta=false) -> [Operator_paused {keeper_down}]
     - dead-tombstone cleanup
       ([Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone])
@@ -187,44 +187,16 @@ let test_grpc_pause_directive_records_reason () =
 (* ── Site 2: keeper_down retain (remove_meta=false) ─────────── *)
 
 let test_keeper_down_retain_records_reason () =
-  Eio_main.run
-  @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base_path = Masc_test_deps.setup_test_workspace () in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.clear ();
-      Masc_test_deps.cleanup_test_workspace base_path)
-    (fun () ->
-       let config = Masc.Workspace.default_config base_path in
-       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       (* Avoid a leading "keeper-" — identity resolution strips that prefix
-          and the write/read names would diverge. *)
-       let keeper_name = "downretain-owner" in
-       let meta = make_meta keeper_name in
-       Keeper_registry.clear ();
-       (match Keeper_meta_store.write_meta config meta with
-        | Ok () -> ()
-        | Error err -> failf "seed meta write: %s" err);
-       ignore (Keeper_registry.register ~base_path:config.base_path keeper_name meta);
-       let args =
-         `Assoc
-           [ "name", `String keeper_name
-           ; "remove_meta", `Bool false
-           ; "remove_session", `Bool false
-           ]
-       in
-       let _result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
-       match Keeper_meta_store.read_meta config keeper_name with
-       | Ok (Some persisted) ->
-         check bool "keeper_down retain pauses keeper" true persisted.paused;
-         check
-           (option string)
-           "keeper_down retain records keeper_down operator pause"
-           (Some wire_keeper_down)
-           (latched_reason_wire persisted)
-       | Ok None -> fail "expected retained keeper meta on disk"
-       | Error err -> failf "read persisted meta: %s" err)
+  let retained =
+    Masc.Keeper_shutdown_finalize.For_testing.paused_meta
+      (make_meta "downretain-owner")
+  in
+  check bool "keeper_down retain pauses keeper" true retained.paused;
+  check
+    (option string)
+    "keeper_down retain records keeper_down operator pause"
+    (Some wire_keeper_down)
+    (latched_reason_wire retained)
 
 (* ── Site 1: dead-tombstone cleanup ─────────────────────────── *)
 

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -65,6 +65,24 @@ let test_update_entry_rejects_corrupted_result () =
   | Some e -> check string "original base_path preserved" original_base_path e.base_path
 ;;
 
+let test_unregister_exact_preserves_replacement_lane () =
+  KR.clear ();
+  let old_entry = register "alice" in
+  let replacement = register "alice" in
+  (match KR.unregister_exact old_entry with
+   | KR.Exact_entry_replaced -> ()
+   | KR.Exact_unregistered -> fail "stale entry removed its replacement lane"
+   | KR.Exact_entry_missing -> fail "replacement lane unexpectedly missing");
+  (match KR.get ~base_path "alice" with
+   | Some current ->
+     check bool "replacement remains registered" true (current == replacement)
+   | None -> fail "replacement lane was removed");
+  match KR.unregister_exact replacement with
+  | KR.Exact_unregistered -> ()
+  | KR.Exact_entry_missing -> fail "replacement disappeared before exact removal"
+  | KR.Exact_entry_replaced -> fail "replacement identity changed unexpectedly"
+;;
+
 let test_dispatch_write_failure_skips_phase_side_effects () =
   KR.clear ();
   KLH.reset_for_testing ();
@@ -218,6 +236,12 @@ let () =
             "rejects corrupted closure result and preserves original"
             `Quick
             test_update_entry_rejects_corrupted_result
+        ] )
+    ; ( "unregister_exact"
+      , [ test_case
+            "stale entry preserves replacement lane"
+            `Quick
+            test_unregister_exact_preserves_replacement_lane
         ] )
     ; ( "dispatch_event"
       , [ test_case

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -10,6 +10,7 @@ module KR = Masc.Keeper_registry
 module KET = Masc.Keeper_tool_dispatch_runtime
 module KLH = Masc.Keeper_lifecycle_hooks
 module KSM = Keeper_state_machine
+module Lane = Masc.Keeper_lane
 
 let base_path = "/tmp/test_keeper_registry_hardening"
 
@@ -96,6 +97,80 @@ let test_unregister_exact_accepts_same_lane_record_update () =
   | KR.Exact_unregistered -> ()
   | KR.Exact_entry_missing -> fail "same lane disappeared before removal"
   | KR.Exact_entry_replaced -> fail "same lane record update was treated as ABA"
+;;
+
+let test_update_entry_exact_preserves_replacement_lane () =
+  KR.clear ();
+  let old_entry = register "alice" in
+  let replacement = register "alice" in
+  (match
+     KR.update_entry_exact old_entry (fun entry ->
+       { entry with last_error = Some "stale lane mutation" })
+   with
+   | KR.Exact_update_replaced -> ()
+   | KR.Exact_updated -> fail "stale exact update mutated the replacement lane"
+   | KR.Exact_update_missing -> fail "replacement lane unexpectedly missing"
+   | KR.Exact_update_invalid error ->
+     fail (KR.registry_entry_validation_error_to_string error));
+  match KR.get ~base_path "alice" with
+  | Some current ->
+    check bool "replacement identity preserved" true (current == replacement);
+    check (option string) "replacement error field preserved" None current.last_error
+  | None -> fail "replacement lane disappeared"
+;;
+
+let test_dispatch_event_exact_preserves_replacement_lane () =
+  KR.clear ();
+  let old_meta = make_meta "alice" in
+  let old_entry = KR.register_offline ~base_path old_meta.name old_meta in
+  let replacement = KR.register_offline ~base_path old_meta.name old_meta in
+  (match KR.dispatch_event_exact old_entry KSM.Fiber_started with
+   | Error _ -> ()
+   | Ok _ -> fail "stale exact dispatch mutated the replacement lane");
+  match KR.get ~base_path "alice" with
+  | Some current ->
+    check bool "replacement identity preserved" true (current == replacement);
+    check
+      string
+      "replacement remains offline"
+      "offline"
+      (KSM.phase_to_string current.phase)
+  | None -> fail "replacement lane disappeared"
+;;
+
+let test_lane_fork_rejects_cancelling_switch () =
+  Eio_main.run @@ fun _env ->
+  let lane = Lane.create () in
+  let run_called = Atomic.make false in
+  let cleanup_calls = Atomic.make 0 in
+  let fork_result = Atomic.make None in
+  (try
+     Eio.Switch.run @@ fun sw ->
+     Eio.Switch.fail sw (Failure "synthetic parent cancellation");
+     Atomic.set
+       fork_result
+       (Some
+          (Lane.fork
+             ~sw
+             lane
+             ~run:(fun _ -> Atomic.set run_called true)
+             ~cleanup:(fun _ ->
+               Atomic.incr cleanup_calls;
+               Ok ())))
+   with
+   | Failure _ -> ()
+   | exn -> raise exn);
+  (match Atomic.get fork_result with
+   | Some (Error (Lane.Fork_failed _)) -> ()
+   | Some (Error error) -> fail (Lane.start_error_to_string error)
+   | Some (Ok ()) -> fail "fork reported success on an already-cancelling switch"
+   | None -> fail "fork result was not captured");
+  check bool "lane body was not run" false (Atomic.get run_called);
+  check int "cleanup ran exactly once" 1 (Atomic.get cleanup_calls);
+  match Lane.peek_exit lane with
+  | Some { outcome = Lane.Cancelled_by_parent _; _ } -> ()
+  | Some _ -> fail "lane exit did not preserve parent cancellation"
+  | None -> fail "lane exit promise remained unresolved"
 ;;
 
 let test_dispatch_write_failure_skips_phase_side_effects () =
@@ -251,6 +326,10 @@ let () =
             "rejects corrupted closure result and preserves original"
             `Quick
             test_update_entry_rejects_corrupted_result
+        ; test_case
+            "exact update preserves replacement lane"
+            `Quick
+            test_update_entry_exact_preserves_replacement_lane
         ] )
     ; ( "unregister_exact"
       , [ test_case
@@ -267,6 +346,16 @@ let () =
             "skips phase side effects when validated write fails"
             `Quick
             test_dispatch_write_failure_skips_phase_side_effects
+        ; test_case
+            "exact dispatch preserves replacement lane"
+            `Quick
+            test_dispatch_event_exact_preserves_replacement_lane
+        ] )
+    ; ( "keeper_lane"
+      , [ test_case
+            "rejects fork on an already-cancelling switch"
+            `Quick
+            test_lane_fork_rejects_cancelling_switch
         ] )
     ; ( "get_with_health"
       , [ test_case "get filters corrupted entry" `Quick test_get_filters_corrupted_entry ] )

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -83,6 +83,21 @@ let test_unregister_exact_preserves_replacement_lane () =
   | KR.Exact_entry_replaced -> fail "replacement identity changed unexpectedly"
 ;;
 
+let test_unregister_exact_accepts_same_lane_record_update () =
+  KR.clear ();
+  let observed = register "alice" in
+  (match
+     KR.update_entry ~base_path "alice" (fun entry ->
+       { entry with last_error = Some "immutable record replacement" })
+   with
+   | Ok () -> ()
+   | Error error -> fail (KR.registry_entry_validation_error_to_string error));
+  match KR.unregister_exact observed with
+  | KR.Exact_unregistered -> ()
+  | KR.Exact_entry_missing -> fail "same lane disappeared before removal"
+  | KR.Exact_entry_replaced -> fail "same lane record update was treated as ABA"
+;;
+
 let test_dispatch_write_failure_skips_phase_side_effects () =
   KR.clear ();
   KLH.reset_for_testing ();
@@ -242,6 +257,10 @@ let () =
             "stale entry preserves replacement lane"
             `Quick
             test_unregister_exact_preserves_replacement_lane
+        ; test_case
+            "same lane immutable update remains removable"
+            `Quick
+            test_unregister_exact_accepts_same_lane_record_update
         ] )
     ; ( "dispatch_event"
       , [ test_case

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -19,6 +19,7 @@ module KA = Masc.Keeper_keepalive
 module KFP = Keeper_failure_policy
 module KSP = Masc.Keeper_supervisor_self_preservation
 module KSR = Masc.Keeper_supervisor_reconcile_keepalive
+module Lane = Masc.Keeper_lane
 
 let supervisor_agent_name = Sup.supervisor_agent_name
 
@@ -55,7 +56,12 @@ let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
 let resolve_done_for_test reg value =
-  ignore (Reg.resolve_done reg ~source:"test_fixture" value)
+  ignore (Reg.resolve_done reg ~source:"test_fixture" value);
+  match
+    Lane.reject_before_start reg.lane ~reason:(Failure "synthetic terminal fixture")
+  with
+  | Ok () -> ()
+  | Error error -> fail (Lane.start_error_to_string error)
 
 let restore_env name = function
   | Some value -> Unix.putenv name value
@@ -2591,7 +2597,53 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
               (Keeper_state_machine.phase_to_string phase))
        | None -> fail "registry entry disappeared after rejected launch");
       check bool "done promise resolved through the crash path"
-        true (Option.is_some (Eio.Promise.peek reg.done_p)))
+        true (Option.is_some (Eio.Promise.peek reg.done_p));
+      check bool "rejected launch closes lane join contract"
+        true (Reg.lane_has_exited reg))
+
+let test_sweep_waits_for_lane_join_before_unregister () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+      let name = "joined-before-unregister" in
+      let meta = make_meta name in
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      ignore (Reg.dispatch_event ~base_path:config.base_path name KSM.Stop_requested);
+      ignore (Reg.dispatch_event ~base_path:config.base_path name KSM.Drain_complete);
+      ignore (Reg.resolve_done reg ~source:"test_unjoined_terminal" `Stopped);
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        }
+      in
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
+      check bool
+        "terminal event alone does not unregister lane"
+        true
+        (Reg.is_registered ~base_path:config.base_path name);
+      (match
+         Lane.reject_before_start reg.lane ~reason:(Failure "synthetic joined lane")
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
+      sweep_and_recover_no_materialize ~pacing_enforced:false ctx;
+      check bool
+        "joined terminal lane is unregistered"
+        false
+        (Reg.is_registered ~base_path:config.base_path name))
 
 let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
   Eio_main.run @@ fun env ->
@@ -2613,6 +2665,13 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
        | Error err -> fail err);
       let reg = Reg.register ~base_path:config.base_path name meta in
       Atomic.set reg.fiber_stop true;
+      (match
+         Lane.reject_before_start
+           reg.lane
+           ~reason:(Failure "synthetic unresolved lane exit")
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
@@ -2720,6 +2779,13 @@ let test_stale_run_sweep_sets_watchdog_stop_signal () =
               true (stall_seconds > 1800.0)
           | _ -> fail "expected idle stale-turn failure reason")
        | None -> fail "registry entry missing after first stale sweep");
+      (match
+         Lane.reject_before_start
+           reg.lane
+           ~reason:(Failure "synthetic watchdog lane exit")
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
       sweep_and_recover_no_materialize ctx;
       (match Reg.get ~base_path:config.base_path name with
        | Some updated ->
@@ -3863,6 +3929,8 @@ let () =
         test_stale_storm_pause_persist_failure_keeps_entry_registered;
       test_case "terminal-state launch reject does not announce Running" `Quick
         test_launch_rejected_terminal_state_does_not_announce_running;
+      test_case "sweep joins lane before unregister" `Quick
+        test_sweep_waits_for_lane_join_before_unregister;
       test_case "start_keepalive launch gate precedes side effects (source guard)" `Quick
         test_start_keepalive_gate_precedes_side_effects;
       test_case "unresolved watchdog-stopped budget loop is reaped" `Quick

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -492,6 +492,58 @@ let test_shutdown_reservation_fences_and_rolls_back () =
   | `Ran _ | `Busy _ -> check "rollback re-opens admission" false
 ;;
 
+let test_shutdown_reservation_restores_durable_owner () =
+  reset ();
+  Printf.printf "Test 12: durable shutdown owner restores before registration\n%!";
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  let other_operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_restored -> ()
+   | Keeper_turn_admission.Shutdown_already_restored
+   | Keeper_turn_admission.Shutdown_restore_conflict _ ->
+     check "fresh durable owner restores" false);
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_already_restored -> ()
+   | Keeper_turn_admission.Shutdown_restored
+   | Keeper_turn_admission.Shutdown_restore_conflict _ ->
+     check "same durable owner restores idempotently" false);
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id:other_operation_id
+   with
+   | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+     check
+       "different durable owner cannot replace restored fence"
+       (Keeper_shutdown_types.Operation_id.equal existing operation_id)
+   | Keeper_turn_admission.Shutdown_restored
+   | Keeper_turn_admission.Shutdown_already_restored ->
+     check "different durable owner is rejected" false);
+  match
+    Keeper_turn_admission.commit_registration_if_open
+      ~base_path
+      ~keeper_name
+      (fun () -> ())
+  with
+  | Keeper_turn_admission.Registration_shutdown_reserved existing ->
+    check
+      "registration sees restored durable owner"
+      (Keeper_shutdown_types.Operation_id.equal existing operation_id)
+  | Keeper_turn_admission.Registration_committed () ->
+    check "registration cannot cross restored fence" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -506,6 +558,7 @@ let () =
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
   test_shutdown_reservation_fences_and_rolls_back ();
+  test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -87,7 +87,9 @@ let test_autonomous_skips_in_flight_chat () =
       | `Rejected _ -> check "chat turn admitted on a free slot" false);
     Eio.Promise.await started;
     (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-     | `Busy (Some { Keeper_turn_admission.lane = Chat; _ }) ->
+     | `Busy
+         (Keeper_turn_admission.Turn_busy
+            (Some { Keeper_turn_admission.lane = Chat; _ })) ->
        check "run_if_free reports Busy with the in-flight chat lane" true
      | `Busy _ -> check "run_if_free reports Busy with the in-flight chat lane" false
      | `Ran () -> check "run_if_free must not admit during an in-flight turn" false);
@@ -197,7 +199,11 @@ let test_waiting_cap_rejects () =
          (waiting = Keeper_turn_admission.max_waiting_chat_requests)
      | None -> check "slot exists after queueing" false);
     (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
-     | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+     | `Rejected
+         { Keeper_turn_admission.waiting
+         ; in_flight
+         ; shutdown_operation_id = None
+         } ->
        check "request beyond the cap is rejected" true;
        check
          "rejection reports a full queue"
@@ -206,6 +212,8 @@ let test_waiting_cap_rejects () =
         | Some { Keeper_turn_admission.lane = Chat; _ } ->
           check "rejection reports the in-flight lane" true
         | Some _ | None -> check "rejection reports the in-flight lane" false)
+     | `Rejected { shutdown_operation_id = Some _; _ } ->
+       check "queue-cap rejection is not a shutdown" false
      | `Ran () -> check "request beyond the cap is rejected" false);
     let snapshot = Keeper_turn_admission.snapshot_for ~base_path ~keeper_name in
     check
@@ -438,6 +446,52 @@ let test_autonomous_yields_to_queued_connector_message () =
   | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false
 ;;
 
+let test_shutdown_reservation_fences_and_rolls_back () =
+  reset ();
+  Printf.printf "Test 11: shutdown reservation fences every turn lane\n%!";
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  (match
+     Keeper_turn_admission.begin_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_reserved reservation ->
+     check
+       "reservation records the requested operation"
+       (Keeper_shutdown_types.Operation_id.equal reservation.operation_id operation_id);
+     check "idle reservation has no in-flight turn" (Option.is_none reservation.in_flight)
+   | Keeper_turn_admission.Shutdown_already_reserved _ ->
+     check "fresh slot is not already reserved" false);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy (Keeper_turn_admission.Shutdown_requested reserved) ->
+     check
+       "autonomous lane sees typed shutdown fence"
+       (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
+   | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
+     check "autonomous lane cannot cross shutdown fence" false);
+  (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
+   | `Rejected { shutdown_operation_id = Some reserved; _ } ->
+     check
+       "chat lane sees typed shutdown fence"
+       (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
+   | `Rejected { shutdown_operation_id = None; _ } | `Ran () ->
+     check "chat lane cannot cross shutdown fence" false);
+  (match
+     Keeper_turn_admission.rollback_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_rolled_back -> ()
+   | Keeper_turn_admission.Shutdown_not_reserved
+   | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
+     check "own reservation rolls back" false);
+  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "open") with
+  | `Ran "open" -> check "rollback re-opens admission" true
+  | `Ran _ | `Busy _ -> check "rollback re-opens admission" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -451,6 +505,7 @@ let () =
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
+  test_shutdown_reservation_fences_and_rolls_back ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## Summary

- add one structured Eio lane scope per Keeper registry entry
- expose a join result only after Eio.Switch.run has joined child fibers and released lane resources
- stop treating stop request as an immediate terminal result
- gate sweep restart/unregister and stale-entry reclamation on lane exit
- add exact-entry CAS unregister so a stale sweep cannot remove a newer same-name lane
- move the direct gRPC heartbeat sidecar under the Keeper lane scope

This is phase 1 of the #24113 remediation. Durable interrupted-turn continuation and task settlement remain follow-up phases; this PR does not claim to close #24113.

## Correctness boundary

Eio.Switch.fail requests cancellation and returns immediately. Eio.Switch.run is the boundary that waits for attached fibers/resources before returning. The new lane exit promise is resolved only after that boundary and cleanup.

[근거] Eio 1.3 official Switch documentation: https://ocaml.org/p/eio/1.3/doc/eio/Eio/Switch/index.html — checked 2026-07-11 — High
[근거] Eio 1.3 official Fiber documentation: https://ocaml.org/p/eio/1.3/doc/eio/Eio/Fiber/index.html — checked 2026-07-11 — High

## Verification

- OCaml parser check for every changed .ml/.mli
- ocamlformat --check for every changed OCaml file
- standalone ocamlfind compile of Keeper_lane against installed Eio
- git diff --check
- determinism contract gate
- enum/string safety gate
- silent-failure gate and ratchet
- stringly-boundary and OCaml structure ratchets
- boundary .mli pair gate
- Fun.protect finalizer guard

No local Dune build or test was run. CI is the build authority.