### PR TITLE
fix(ide): bind file focus to workspace identity

### DIFF
--- a/dashboard/src/api/workspace.test.ts
+++ b/dashboard/src/api/workspace.test.ts
@@ -17,11 +17,12 @@ function stubFetch(
   response: unknown,
   ok = true,
   headers: Record<string, string> = {},
+  status = ok ? 200 : 500,
 ): void {
   mockFetch.mockResolvedValue({
     ok,
-    status: ok ? 200 : 500,
-    statusText: ok ? 'OK' : 'Internal Server Error',
+    status,
+    statusText: ok ? 'OK' : status === 404 ? 'Not Found' : 'Internal Server Error',
     headers: new Headers(headers),
     json: () => Promise.resolve(response),
     text: () => Promise.resolve(JSON.stringify(response)),
@@ -97,6 +98,18 @@ describe('workspace API', () => {
 
     await fetchWorkspaceFile('lib/main.ml', { repoId: 'oas' })
     expect(mockFetch.mock.calls[0]![0]).toContain('repo_id=oas')
+  })
+
+  it('fetchWorkspaceFile projects the route HTTP 404 as typed not-found', async () => {
+    stubFetch({ ok: false, error: 'File not found' }, false, {}, 404)
+
+    await expect(fetchWorkspaceFile('missing.ml')).resolves.toEqual({ ok: false })
+  })
+
+  it('fetchWorkspaceFile preserves non-404 API failures', async () => {
+    stubFetch({ ok: false, error: 'Failed to read file' }, false, {}, 500)
+
+    await expect(fetchWorkspaceFile('broken.ml')).rejects.toMatchObject({ status: 500 })
   })
 
   it('fetchGitBlame returns blame blocks', async () => {

--- a/dashboard/src/api/workspace.test.ts
+++ b/dashboard/src/api/workspace.test.ts
@@ -86,8 +86,7 @@ describe('workspace API', () => {
     stubFetch({ ok: true, content: 'let x = 1\n', language: 'ocaml' })
 
     const result = await fetchWorkspaceFile('lib/main.ml')
-    expect(result?.ok).toBe(true)
-    expect(result?.content).toBe('let x = 1\n')
+    expect(result).toEqual({ ok: true, content: 'let x = 1\n', language: 'ocaml' })
 
     expect(mockFetch.mock.calls[0]![0]).toContain('/api/v1/workspace/file?path=')
     expect(mockFetch.mock.calls[0]![0]).toContain('lib%2Fmain.ml')

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -34,11 +34,15 @@ export interface UnifiedDiffRow {
 
 // --- Workspace File ---
 
-export interface WorkspaceFileResponse {
-  readonly ok: boolean
-  readonly content: string
-  readonly language?: string
-}
+export type WorkspaceFileResponse =
+  | {
+      readonly ok: true
+      readonly content: string
+      readonly language?: string
+    }
+  | {
+      readonly ok: false
+    }
 
 // --- API helpers ---
 

--- a/dashboard/src/api/workspace.ts
+++ b/dashboard/src/api/workspace.ts
@@ -1,4 +1,4 @@
-import { get, getWithResponse, type GetOptions } from './core'
+import { ApiRequestError, get, getWithResponse, type GetOptions } from './core'
 import type { FileTreeNode } from '../components/ide/file-tree-store'
 import { parseWorkspaceSource, type WorkspaceSource } from './workspace-source'
 
@@ -97,17 +97,29 @@ export function fetchWorkspaceChildren(
   )
 }
 
-export function fetchWorkspaceFile(
+export async function fetchWorkspaceFile(
   path: string,
   opts: WorkspaceApiOptions = {},
 ): Promise<WorkspaceFileResponse | null> {
   const params = new URLSearchParams()
   params.set('path', path)
   appendWorkspaceParams(params, opts)
-  return get<WorkspaceFileResponse | null>(
-    `/api/v1/workspace/file?${params.toString()}`,
-    opts,
-  )
+  try {
+    return await get<WorkspaceFileResponse | null>(
+      `/api/v1/workspace/file?${params.toString()}`,
+      opts,
+    )
+  } catch (error) {
+    // The workspace file route represents an absent file as HTTP 404 with an
+    // { ok: false } body. The generic GET boundary correctly rejects non-2xx
+    // responses, so recover only the typed status here. Authorization,
+    // validation, server, transport, and timeout failures remain errors and
+    // are projected as `unavailable` by the IDE focus state machine.
+    if (error instanceof ApiRequestError && error.status === 404) {
+      return { ok: false }
+    }
+    throw error
+  }
 }
 
 export function fetchGitBlame(

--- a/dashboard/src/components/ide/code-document-store.test.ts
+++ b/dashboard/src/components/ide/code-document-store.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../api/ide', () => ({
   fetchIdeRegions: vi.fn().mockResolvedValue([]),
 }))
 import { fetchIdeRegions } from '../../api/ide'
+import type { IdeCodeRegion } from '../../api/ide'
 import { createCodeDocumentStore } from './code-document-store'
 
 const fetchIdeRegionsMock = vi.mocked(fetchIdeRegions)
@@ -126,6 +127,38 @@ describe('createCodeDocumentStore', () => {
     expect(store.regions()).toHaveLength(1)
 
     store.load({ file_path: 'b.ts', language: 'typescript', content: 'export {}' })
+    expect(store.regions()).toEqual([])
+    expect(store.regionsState()).toBe('idle')
+  })
+
+  it('invalidates the document and prevents an older region request from repopulating it', async () => {
+    let resolveRegions: (regions: ReadonlyArray<IdeCodeRegion>) => void = () => {
+      throw new Error('region request resolver was not initialized')
+    }
+    fetchIdeRegionsMock.mockImplementationOnce(() => new Promise<ReadonlyArray<IdeCodeRegion>>(resolve => {
+      resolveRegions = resolve
+    }))
+    const store = createCodeDocumentStore({
+      file_path: 'repo-a.ml',
+      language: 'ocaml',
+      content: 'let workspace = "repo-a"\n',
+    })
+
+    const regions = store.loadRegions('repo-a.ml')
+    expect(store.regionsState()).toBe('loading')
+
+    store.invalidate()
+    expect(store.document()).toMatchObject({
+      file_path: null,
+      language: 'text',
+      content: '',
+      lines: [],
+    })
+    expect(store.regions()).toEqual([])
+    expect(store.regionsState()).toBe('idle')
+
+    resolveRegions([])
+    await regions
     expect(store.regions()).toEqual([])
     expect(store.regionsState()).toBe('idle')
   })

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -22,6 +22,7 @@ export type CodeDocumentRegionsState = 'idle' | 'loading' | 'ready' | 'error'
 
 export interface CodeDocumentStore {
   readonly load: (source: unknown) => boolean
+  readonly invalidate: () => void
   readonly document: () => CodeDocumentSnapshot
   readonly lines: () => ReadonlyArray<CodeDocumentLine>
   readonly line: (lineNumber: number) => CodeDocumentLine | null
@@ -66,6 +67,13 @@ export function createCodeDocumentStore(
     return true
   }
 
+  const invalidate = (): void => {
+    regionRequestId += 1
+    snapshot.value = EMPTY_DOCUMENT
+    regionsSignal.value = []
+    regionsStateSignal.value = 'idle'
+  }
+
   const loadRegions = async (
     filePath: string,
     opts?: { keeper?: string; repoId?: string | null; signal?: AbortSignal },
@@ -105,6 +113,7 @@ export function createCodeDocumentStore(
 
   return {
     load,
+    invalidate,
     document: () => snapshot.value,
     lines: () => snapshot.value.lines,
     line: lineNumber => snapshot.value.lines[lineNumber - 1] ?? null,

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -3,7 +3,7 @@ import { h } from 'preact'
 import { render as preactRender } from 'preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
 import { deriveIdeRunProgressSummary, IdeActivityPanel } from './ide-activity-panel'
-import { activeIdeFile, ideContextFocus } from './ide-state'
+import { activeIdeFile, focusIdeFile, ideContextFocus } from './ide-state'
 import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { goals, tasks } from '../../store'
@@ -36,7 +36,12 @@ afterEach(() => {
   vi.unstubAllGlobals()
   ideContextFocus.value = null
   lspDiagnosticSnapshot.value = new Map()
-  activeIdeFile.value = 'package.json'
+  focusIdeFile({
+    path: 'package.json',
+    origin: 'operator',
+    workspace_identity: { kind: 'project' },
+    availability: 'available',
+  })
   goals.value = []
   tasks.value = []
   window.location.hash = ''

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1089,7 +1089,7 @@ const ActivityRow = memo(function ActivityRow({
               source_id: item.id,
               keeper_id: item.keeper_id,
               route_links: routeLinks,
-            })}
+            }, 'operator')}
           >
             ↗ ${shortContextPath(eventFocusFile, eventFocusLine)}
           </button>

--- a/dashboard/src/components/ide/ide-annotation-rail.ts
+++ b/dashboard/src/components/ide/ide-annotation-rail.ts
@@ -71,7 +71,7 @@ function AnnotationRailCard({ annotation }: { readonly annotation: IdeAnnotation
       source_id: `annotation:${annotation.id}`,
       keeper_id: annotation.keeper_id,
       route_links: routeLinks,
-    })
+    }, 'operator')
   }
 
   return html`

--- a/dashboard/src/components/ide/ide-breadcrumb.ts
+++ b/dashboard/src/components/ide/ide-breadcrumb.ts
@@ -77,7 +77,7 @@ export function IdeBreadcrumb() {
         sourceId: `breadcrumb:${keeper.keeperId}:${keeper.line}`,
         keeperId: keeper.keeperId,
       }),
-    })
+    }, 'operator')
   }
 
   return html`

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -514,7 +514,7 @@ function activateIdeContextAnchor(anchor: IdeContextAnchor): void {
     source_id: anchor.id,
     keeper_id: anchor.keeper_id,
     route_links: anchor.route_links,
-  })
+  }, 'operator')
 }
 
 export function openIdeContextRouteLink(link: IdeContextRouteLink): void {

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -10,7 +10,7 @@ import {
   replayRailItems,
 } from './ide-conversation-rail'
 import { routeHashParams } from './ide-test-helpers'
-import { activeIdeFile, ideContextFocus } from './ide-state'
+import { activeIdeFile, focusIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
@@ -49,7 +49,12 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals()
-  activeIdeFile.value = 'package.json'
+  focusIdeFile({
+    path: 'package.json',
+    origin: 'operator',
+    workspace_identity: { kind: 'project' },
+    availability: 'available',
+  })
   ideContextFocus.value = null
   setIdeReplayUntilMs(null)
   cursorOverlaySignal.value = {
@@ -171,7 +176,12 @@ describe('IdeConversationRail', () => {
     }]
 
     expect(postsToAnchoredThreads(posts)).toEqual([])
-    activeIdeFile.value = 'lib/runtime.ml'
+    focusIdeFile({
+      path: 'lib/runtime.ml',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     expect(postsToAnchoredThreads(posts)).toEqual([])
   })
 

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -403,7 +403,7 @@ function PostCard(
             label: bodyText || post.title || 'board thread',
             source_id: `thread-${post.id}`,
             keeper_id: postAuthorId(post) || undefined,
-          })
+          }, 'operator')
         }}
         style=${{
           '--ide-conversation-bg': focused ? 'var(--color-bg-muted)' : 'var(--color-bg-elevated)',

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -44,8 +44,10 @@ import type { FileTreeNode } from './file-tree-store'
 import {
   activeIdeFocus,
   activeIdeWorkspaceIdentity,
+  clearIdeContextFocus,
   clearIdeFileFocus,
   focusIdeFile,
+  ideContextFocus,
   synchronizeIdeWorkspaceIdentity,
 } from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
@@ -148,6 +150,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   seedWorkspaceApiMocks()
   clearIdeFileFocus()
+  clearIdeContextFocus()
   synchronizeIdeWorkspaceIdentity({ kind: 'project' })
   activeKeeperName.value = ''
   selectedTask.value = null
@@ -314,6 +317,36 @@ describe('selectPreferredIdeRepositoryId', () => {
 })
 
 describe('IDE focus workspace provenance', () => {
+  it('keeps the newest repository refresh when the startup list resolves late', async () => {
+    const startupList = deferred<ReadonlyArray<Repository>>()
+    const scannedList = deferred<ReadonlyArray<Repository>>()
+    repositoryApiMocks.fetchRepositoriesList
+      .mockReturnValueOnce(startupList.promise)
+      .mockReturnValueOnce(scannedList.promise)
+    repositoryApiMocks.discoverRepositories.mockResolvedValue([
+      repo('repo-b', '/workspace/repo-b'),
+    ])
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      const scan = store.scanRepositories()
+      scannedList.resolve([repo('repo-b', '/workspace/repo-b')])
+      await scan
+
+      expect(store.repositories().map(repository => repository.id)).toEqual(['repo-b'])
+      expect(store.activeRepositoryId()).toBe('repo-b')
+
+      startupList.resolve([repo('repo-a', '/workspace/repo-a')])
+      await startupList.promise
+      await Promise.resolve()
+
+      expect(store.repositories().map(repository => repository.id)).toEqual(['repo-b'])
+      expect(store.activeRepositoryId()).toBe('repo-b')
+    } finally {
+      store.dispose()
+    }
+  })
+
   it('reselects observed focus for repo B and invalidates the repo A document before B resolves', async () => {
     const repoBTree = deferred<WorkspaceTreeResult>()
     repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
@@ -354,6 +387,17 @@ describe('IDE focus workspace provenance', () => {
         expect(store.documentStore.document().content).toContain('repo-a')
       })
 
+      ideContextFocus.value = {
+        file_path: 'lib/a.ml',
+        line: 1,
+        surface: 'Activity',
+        label: 'repo A event',
+        source_id: 'repo-a-event',
+        keeper_id: 'keeper-a',
+        route_links: [],
+        activated_at_ms: 1,
+      }
+
       store.setActiveRepositoryId('repo-b')
 
       expect(store.documentStore.document()).toMatchObject({
@@ -363,6 +407,7 @@ describe('IDE focus workspace provenance', () => {
       })
       expect(store.fileTreeStore.nodeCount()).toBe(0)
       expect(activeIdeFocus.value).toBeNull()
+      expect(ideContextFocus.value).toBeNull()
 
       repoBTree.resolve(repositoryTree('repo-b', [changedFile('lib/b.ml')]))
       await vi.waitFor(() => {

--- a/dashboard/src/components/ide/ide-data-workspace-store.test.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const workspaceApiMocks = vi.hoisted(() => ({
   fetchWorkspaceTree: vi.fn(),
@@ -13,11 +13,12 @@ const ideApiMocks = vi.hoisted(() => ({
   ideScopeFromKeeperLane: vi.fn((keeperId: string | undefined) =>
     keeperId ? { kind: 'keeper_lane' as const, keeperId } : null),
 }))
-
-vi.mock('../../api/repositories', () => ({
-  discoverRepositories: vi.fn().mockResolvedValue([]),
-  fetchRepositoriesList: vi.fn().mockResolvedValue([]),
+const repositoryApiMocks = vi.hoisted(() => ({
+  discoverRepositories: vi.fn(),
+  fetchRepositoriesList: vi.fn(),
 }))
+
+vi.mock('../../api/repositories', () => repositoryApiMocks)
 
 vi.mock('../../api/workspace', () => workspaceApiMocks)
 vi.mock('../../api/ide', () => ideApiMocks)
@@ -38,7 +39,15 @@ import {
 } from './ide-data-workspace-store'
 import { isDiffEditorView, viewFromRoute } from './ide-view-route'
 import type { Repository } from '../../api/repositories'
-import { activeIdeFile } from './ide-state'
+import type { WorkspaceTreeResult, WorkspaceFileResponse } from '../../api/workspace'
+import type { FileTreeNode } from './file-tree-store'
+import {
+  activeIdeFocus,
+  activeIdeWorkspaceIdentity,
+  clearIdeFileFocus,
+  focusIdeFile,
+  synchronizeIdeWorkspaceIdentity,
+} from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
 import { selectedTask } from '../goals/task-detail-selection'
 import { route } from '../../router'
@@ -62,6 +71,63 @@ function repo(
   }
 }
 
+interface Deferred<T> {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {
+    throw new Error('deferred promise resolver was not initialized')
+  }
+  const promise = new Promise<T>(promiseResolve => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+function changedFile(path: string): FileTreeNode {
+  const segments = path.split('/')
+  return {
+    path,
+    label: segments[segments.length - 1] ?? path,
+    depth: Math.max(0, segments.length - 1),
+    parent: segments.length > 1 ? segments.slice(0, -1).join('/') : null,
+    hasChildren: false,
+    diff: '+1',
+    keeperId: null,
+    hueIndex: null,
+  }
+}
+
+function repositoryTree(repoId: string, nodes: ReadonlyArray<FileTreeNode>): WorkspaceTreeResult {
+  return {
+    nodes,
+    source: { kind: 'repository', repoId },
+    basePath: `/workspace/${repoId}`,
+  }
+}
+
+function projectTree(nodes: ReadonlyArray<FileTreeNode>): WorkspaceTreeResult {
+  return {
+    nodes,
+    source: { kind: 'project' },
+    basePath: '/workspace/project',
+  }
+}
+
+function keeperTree(keeper: string, nodes: ReadonlyArray<FileTreeNode>): WorkspaceTreeResult {
+  return {
+    nodes,
+    source: { kind: 'playground', keeper },
+    basePath: `/workspace/keepers/${keeper}`,
+  }
+}
+
+function workspaceFile(content: string): WorkspaceFileResponse {
+  return { ok: true, content, language: 'ocaml' }
+}
+
 function seedWorkspaceApiMocks(): void {
   workspaceApiMocks.fetchWorkspaceTree.mockResolvedValue({
     nodes: [],
@@ -69,10 +135,32 @@ function seedWorkspaceApiMocks(): void {
     basePath: null,
   })
   workspaceApiMocks.fetchWorkspaceChildren.mockResolvedValue([])
+  workspaceApiMocks.fetchWorkspaceFile.mockResolvedValue(null)
   workspaceApiMocks.fetchGitBlame.mockResolvedValue([])
   workspaceApiMocks.fetchGitDiff.mockResolvedValue([])
   ideApiMocks.fetchIdeAnnotations.mockResolvedValue([])
+  ideApiMocks.fetchIdeRegions.mockResolvedValue([])
+  repositoryApiMocks.discoverRepositories.mockResolvedValue([])
+  repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([])
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seedWorkspaceApiMocks()
+  clearIdeFileFocus()
+  synchronizeIdeWorkspaceIdentity({ kind: 'project' })
+  activeKeeperName.value = ''
+  selectedTask.value = null
+  route.value = { tab: 'code', params: { view: 'source' }, postId: null }
+})
+
+afterEach(() => {
+  clearIdeFileFocus()
+  synchronizeIdeWorkspaceIdentity({ kind: 'project' })
+  activeKeeperName.value = ''
+  selectedTask.value = null
+  route.value = { tab: 'overview', params: {}, postId: null }
+})
 
 describe('firstObservedChangedFilePath', () => {
   it('keeps the server-observed hidden changed path ahead of an unchanged visible file', () => {
@@ -225,9 +313,392 @@ describe('selectPreferredIdeRepositoryId', () => {
   })
 })
 
+describe('IDE focus workspace provenance', () => {
+  it('reselects observed focus for repo B and invalidates the repo A document before B resolves', async () => {
+    const repoBTree = deferred<WorkspaceTreeResult>()
+    repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
+      repo('repo-a', '/workspace/repo-a'),
+      repo('repo-b', '/workspace/repo-b'),
+    ])
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a') {
+          return Promise.resolve(repositoryTree('repo-a', [changedFile('lib/a.ml')]))
+        }
+        if (opts.repoId === 'repo-b') return repoBTree.promise
+        return Promise.resolve(projectTree([]))
+      },
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementation(
+      (path: string, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a' && path === 'lib/a.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "repo-a"\n'))
+        }
+        if (opts.repoId === 'repo-b' && path === 'lib/b.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "repo-b"\n'))
+        }
+        return Promise.resolve(null)
+      },
+    )
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(store.activeRepositoryId()).toBe('repo-a')
+        expect(activeIdeFocus.value).toEqual({
+          path: 'lib/a.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+          availability: 'available',
+        })
+        expect(store.documentStore.document().content).toContain('repo-a')
+      })
+
+      store.setActiveRepositoryId('repo-b')
+
+      expect(store.documentStore.document()).toMatchObject({
+        file_path: null,
+        content: '',
+        lines: [],
+      })
+      expect(store.fileTreeStore.nodeCount()).toBe(0)
+      expect(activeIdeFocus.value).toBeNull()
+
+      repoBTree.resolve(repositoryTree('repo-b', [changedFile('lib/b.ml')]))
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'lib/b.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'repository', repoId: 'repo-b' },
+          availability: 'available',
+        })
+        expect(store.documentStore.document()).toMatchObject({
+          file_path: 'lib/b.ml',
+          content: 'let workspace = "repo-b"\n',
+        })
+      })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('ignores a repo A file completion that arrives after repo B owns the focus', async () => {
+    const staleRepoAFile = deferred<WorkspaceFileResponse | null>()
+    repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
+      repo('repo-a', '/workspace/repo-a'),
+      repo('repo-b', '/workspace/repo-b'),
+    ])
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a') {
+          return Promise.resolve(repositoryTree('repo-a', [changedFile('lib/a.ml')]))
+        }
+        if (opts.repoId === 'repo-b') {
+          return Promise.resolve(repositoryTree('repo-b', [changedFile('lib/b.ml')]))
+        }
+        return Promise.resolve(projectTree([]))
+      },
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementation(
+      (path: string, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a' && path === 'lib/a.ml') return staleRepoAFile.promise
+        if (opts.repoId === 'repo-b' && path === 'lib/b.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "repo-b"\n'))
+        }
+        return Promise.resolve(null)
+      },
+    )
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toMatchObject({
+          path: 'lib/a.ml',
+          workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+          availability: 'available',
+        })
+        expect(workspaceApiMocks.fetchWorkspaceFile).toHaveBeenCalledWith(
+          'lib/a.ml',
+          expect.objectContaining({ repoId: 'repo-a' }),
+        )
+      })
+
+      store.setActiveRepositoryId('repo-b')
+      await vi.waitFor(() => {
+        expect(store.documentStore.document()).toMatchObject({
+          file_path: 'lib/b.ml',
+          content: 'let workspace = "repo-b"\n',
+        })
+      })
+
+      staleRepoAFile.resolve(workspaceFile('let workspace = "stale-repo-a"\n'))
+      await staleRepoAFile.promise
+      await Promise.resolve()
+
+      expect(store.documentStore.document()).toMatchObject({
+        file_path: 'lib/b.ml',
+        content: 'let workspace = "repo-b"\n',
+      })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('drops project auto-focus when a late repository list selects a repository', async () => {
+    const repositories = deferred<ReadonlyArray<Repository>>()
+    const repoTree = deferred<WorkspaceTreeResult>()
+    repositoryApiMocks.fetchRepositoriesList.mockReturnValue(repositories.promise)
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-b') return repoTree.promise
+        return Promise.resolve(projectTree([changedFile('project.ml')]))
+      },
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementation(
+      (path: string, opts: { repoId?: string | null }) => {
+        if (!opts.repoId && path === 'project.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "project"\n'))
+        }
+        if (opts.repoId === 'repo-b' && path === 'repo.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "repo-b"\n'))
+        }
+        return Promise.resolve(null)
+      },
+    )
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'project.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'project' },
+          availability: 'available',
+        })
+        expect(store.documentStore.document().content).toContain('project')
+      })
+
+      repositories.resolve([repo('repo-b', '/workspace/repo-b')])
+      await vi.waitFor(() => {
+        expect(store.activeRepositoryId()).toBe('repo-b')
+      })
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+      expect(activeIdeFocus.value).toBeNull()
+
+      repoTree.resolve(repositoryTree('repo-b', [changedFile('repo.ml')]))
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'repo.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'repository', repoId: 'repo-b' },
+          availability: 'available',
+        })
+        expect(store.documentStore.document().content).toContain('repo-b')
+      })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('invalidates and reselects observed focus when the keeper workspace changes', async () => {
+    const keeperBTree = deferred<WorkspaceTreeResult>()
+    activeKeeperName.value = 'keeper-a'
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { keeper?: string }) => {
+        if (opts.keeper === 'keeper-a') {
+          return Promise.resolve(keeperTree('keeper-a', [changedFile('a.ml')]))
+        }
+        if (opts.keeper === 'keeper-b') return keeperBTree.promise
+        return Promise.resolve(projectTree([]))
+      },
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementation(
+      (path: string, opts: { keeper?: string }) => {
+        if (opts.keeper === 'keeper-a' && path === 'a.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "keeper-a"\n'))
+        }
+        if (opts.keeper === 'keeper-b' && path === 'b.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "keeper-b"\n'))
+        }
+        return Promise.resolve(null)
+      },
+    )
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(store.documentStore.document().content).toContain('keeper-a')
+        expect(activeIdeFocus.value?.workspace_identity).toEqual({
+          kind: 'keeper',
+          keeper: 'keeper-a',
+        })
+      })
+
+      activeKeeperName.value = 'keeper-b'
+
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+      expect(activeIdeFocus.value).toBeNull()
+
+      keeperBTree.resolve(keeperTree('keeper-b', [changedFile('b.ml')]))
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'b.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'keeper', keeper: 'keeper-b' },
+          availability: 'available',
+        })
+        expect(store.documentStore.document().content).toContain('keeper-b')
+      })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('keeps explicit provenance but materializes not-found when the target repo lacks the path', async () => {
+    repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
+      repo('repo-a', '/workspace/repo-a'),
+      repo('repo-b', '/workspace/repo-b'),
+    ])
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a') return Promise.resolve(repositoryTree('repo-a', []))
+        if (opts.repoId === 'repo-b') {
+          return Promise.resolve(repositoryTree('repo-b', [changedFile('only-in-b.ml')]))
+        }
+        return Promise.resolve(projectTree([]))
+      },
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockImplementation(
+      (path: string, opts: { repoId?: string | null }) => {
+        if (opts.repoId === 'repo-a' && path === 'shared.ml') {
+          return Promise.resolve(workspaceFile('let workspace = "repo-a"\n'))
+        }
+        return Promise.resolve({ ok: false })
+      },
+    )
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(store.activeRepositoryId()).toBe('repo-a')
+      })
+      focusIdeFile({
+        path: 'shared.ml',
+        origin: 'operator',
+        workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+        availability: 'available',
+      })
+      await vi.waitFor(() => {
+        expect(store.documentStore.document().content).toContain('repo-a')
+      })
+
+      store.setActiveRepositoryId('repo-b')
+
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'shared.ml',
+          origin: 'operator',
+          workspace_identity: { kind: 'repository', repoId: 'repo-b' },
+          availability: 'not_found',
+        })
+        expect(store.workspaceIssues()).toContainEqual(expect.objectContaining({
+          kind: 'file',
+          file_path: 'shared.ml',
+          repo_id: 'repo-b',
+          message: 'explicit IDE focus not found in selected workspace: shared.ml',
+        }))
+      })
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('terminates explicit validation as unavailable on transport failure without claiming not-found', async () => {
+    repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
+      repo('repo-a', '/workspace/repo-a'),
+    ])
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => opts.repoId === 'repo-a'
+        ? Promise.resolve(repositoryTree('repo-a', []))
+        : Promise.resolve(projectTree([])),
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockRejectedValue(new Error('workspace transport offline'))
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(store.activeRepositoryId()).toBe('repo-a')
+      })
+      focusIdeFile({
+        path: 'private.ml',
+        origin: 'route',
+        workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+        availability: 'pending',
+      })
+
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'private.ml',
+          origin: 'route',
+          workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+          availability: 'unavailable',
+        })
+        expect(store.workspaceIssues()).toContainEqual(expect.objectContaining({
+          kind: 'file',
+          file_path: 'private.ml',
+          repo_id: 'repo-a',
+          message: 'workspace transport offline',
+        }))
+      })
+      expect(activeIdeFocus.value?.availability).not.toBe('not_found')
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+    } finally {
+      store.dispose()
+    }
+  })
+
+  it('does not misclassify an unavailable observed file as an explicit not-found focus', async () => {
+    repositoryApiMocks.fetchRepositoriesList.mockResolvedValue([
+      repo('repo-a', '/workspace/repo-a'),
+    ])
+    workspaceApiMocks.fetchWorkspaceTree.mockImplementation(
+      (_depth: number, opts: { repoId?: string | null }) => opts.repoId === 'repo-a'
+        ? Promise.resolve(repositoryTree('repo-a', [changedFile('ghost.ml')]))
+        : Promise.resolve(projectTree([])),
+    )
+    workspaceApiMocks.fetchWorkspaceFile.mockResolvedValue(null)
+    const store = createIdeDataWorkspaceStore()
+
+    try {
+      await vi.waitFor(() => {
+        expect(activeIdeFocus.value).toEqual({
+          path: 'ghost.ml',
+          origin: 'observed_change',
+          workspace_identity: { kind: 'repository', repoId: 'repo-a' },
+          availability: 'unavailable',
+        })
+        expect(store.workspaceIssues()).toContainEqual(expect.objectContaining({
+          kind: 'file',
+          file_path: 'ghost.ml',
+          repo_id: 'repo-a',
+          message: 'workspace file response was unavailable or malformed',
+        }))
+      })
+      expect(workspaceApiMocks.fetchWorkspaceFile).toHaveBeenCalledTimes(1)
+      expect(activeIdeFocus.value?.availability).not.toBe('not_found')
+      expect(store.documentStore.document()).toMatchObject({ file_path: null, content: '' })
+    } finally {
+      store.dispose()
+    }
+  })
+})
+
 describe('workspace fetch diagnostics', () => {
   it('loads regions after the active file commits and projects them to source ownership', async () => {
-    const previousFile = activeIdeFile.value
+    const previousFocus = activeIdeFocus.value
+    const previousWorkspaceIdentity = activeIdeWorkspaceIdentity.value
     const previousKeeper = activeKeeperName.value
     const previousTask = selectedTask.value
     const previousRoute = route.value
@@ -251,8 +722,14 @@ describe('workspace fetch diagnostics', () => {
       source_note: null,
       timestamp_ms: 1_700_000_000_000,
     }])
-    activeIdeFile.value = 'lib/scheduler/round.ml'
     activeKeeperName.value = 'sangsu'
+    synchronizeIdeWorkspaceIdentity({ kind: 'keeper', keeper: 'sangsu' })
+    focusIdeFile({
+      path: 'lib/scheduler/round.ml',
+      origin: 'operator',
+      workspace_identity: { kind: 'keeper', keeper: 'sangsu' },
+      availability: 'available',
+    })
     selectedTask.value = null
     route.value = { tab: 'code', params: { view: 'source' }, postId: null }
     const store = createIdeDataWorkspaceStore()
@@ -285,7 +762,9 @@ describe('workspace fetch diagnostics', () => {
       })
     } finally {
       store.dispose()
-      activeIdeFile.value = previousFile
+      synchronizeIdeWorkspaceIdentity(previousWorkspaceIdentity)
+      if (previousFocus) focusIdeFile(previousFocus)
+      else clearIdeFileFocus()
       activeKeeperName.value = previousKeeper
       selectedTask.value = previousTask
       route.value = previousRoute

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -3,6 +3,7 @@ import {
   activeIdeFile,
   activeIdeFocus,
   activeIdeWorkspaceIdentity,
+  clearIdeContextFocus,
   clearIdeFileFocus,
   focusIdeFile,
   ideWorkspaceIdentityForSelection,
@@ -334,6 +335,10 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
   /** Track repo IDs that returned unreachable workspace sources, to avoid re-selecting them. */
   const unreachableRepoIds = new Set<string>()
+  // Repository discovery can overlap the initial list fetch. Only the newest
+  // list request may publish repository identity or its failure projection;
+  // otherwise a late startup response can rewind a completed scan.
+  let repositoryRefreshGeneration = 0
 
   let abortController = new AbortController()
   // Identity of the workspace source the file tree was last seeded for.
@@ -350,15 +355,20 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   }
 
   const refreshRepositories = async (): Promise<ReadonlyArray<Repository>> => {
+    const generation = ++repositoryRefreshGeneration
     try {
       const repositories = await fetchRepositoriesList()
-      clearIssue('repositories')
-      applyRepositories(repositories)
+      if (generation === repositoryRefreshGeneration) {
+        clearIssue('repositories')
+        applyRepositories(repositories)
+      }
       return repositories
     } catch (error) {
-      recordIssue('repositories', error, {
-        fallbackMessage: 'repository list fetch failed',
-      })
+      if (generation === repositoryRefreshGeneration) {
+        recordIssue('repositories', error, {
+          fallbackMessage: 'repository list fetch failed',
+        })
+      }
       throw error
     }
   }
@@ -370,11 +380,13 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   }
 
   refreshRepositories()
+    // The current-generation failure is already projected into workspaceIssues.
+    // Contain the background startup rejection without overwriting a newer scan.
     .catch(error => {
-      recordIssue('repositories', error, {
-        fallbackMessage: 'repository list fetch failed',
-      })
-      repositoriesSignal.value = []
+      console.warn(
+        '[IDE] initial repository refresh failed',
+        error instanceof Error ? error.message : error,
+      )
     })
 
   // Fetch the workspace snapshot for the current file/keeper/repo/task.
@@ -413,6 +425,11 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       && !sameIdeWorkspaceIdentity(focus.workspace_identity, workspaceIdentity)
     if (workspaceIdentityChanged || focusWorkspaceChanged) {
       invalidateWorkspaceDocument()
+      // Context-anchor labels, keeper attribution, and route links describe
+      // the workspace in which the anchor was selected. They cannot be safely
+      // rebound by path alone when a repository/project/keeper identity
+      // changes, even if the target workspace contains the same path.
+      clearIdeContextFocus()
     }
     if (workspaceIdentityChanged) {
       fileTreeStore.seed([])
@@ -840,6 +857,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       runWorkspaceFetches()
     },
     dispose: () => {
+      // Invalidate a non-abortable repository list request before tearing down
+      // subscriptions so a late completion cannot publish into a disposed store.
+      repositoryRefreshGeneration += 1
       abortController.abort()
       unregisterLiveRefresh()
       disposeEffect()

--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -1,5 +1,14 @@
-import { signal, effect } from '@preact/signals'
-import { activeIdeFile } from './ide-state'
+import { signal, effect, untracked } from '@preact/signals'
+import {
+  activeIdeFile,
+  activeIdeFocus,
+  activeIdeWorkspaceIdentity,
+  clearIdeFileFocus,
+  focusIdeFile,
+  ideWorkspaceIdentityForSelection,
+  sameIdeWorkspaceIdentity,
+  synchronizeIdeWorkspaceIdentity,
+} from './ide-state'
 import { activeKeeperName } from '../../keeper-state'
 import { route } from '../../router'
 import { selectedTask } from '../goals/task-detail-selection'
@@ -115,6 +124,13 @@ export function firstObservedChangedFilePath(
     && node.diff !== null
     && node.diff.trim().length > 0,
   )?.path ?? null
+}
+
+export function workspaceTreeHasFile(
+  nodes: ReadonlyArray<{ readonly path: string; readonly hasChildren: boolean }>,
+  filePath: string,
+): boolean {
+  return nodes.some(node => !node.hasChildren && node.path === filePath)
 }
 
 export function workspaceTreeIdentity(
@@ -329,8 +345,8 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
 
   const applyRepositories = (repositories: ReadonlyArray<Repository>): void => {
     const current = activeRepositoryIdSignal.value
-    activeRepositoryIdSignal.value = selectPreferredIdeRepositoryId(repositories, current, unreachableRepoIds)
     repositoriesSignal.value = repositories
+    activeRepositoryIdSignal.value = selectPreferredIdeRepositoryId(repositories, current, unreachableRepoIds)
   }
 
   const refreshRepositories = async (): Promise<ReadonlyArray<Repository>> => {
@@ -370,15 +386,59 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
   // refresh to stale data. The fetches are idempotent (server is SSOT), so a
   // coalesced live+nav refresh is safe.
   const runWorkspaceFetches = (): void => {
-    const filePath = activeIdeFile.value
+    const focus = activeIdeFocus.value
     const keeper = activeKeeperName.value
     const repoId = activeRepositoryIdSignal.value
     const task = selectedTask.value
+    const workspaceIdentity = ideWorkspaceIdentityForSelection(repoId, keeper)
+    const workspaceIdentityChanged = !sameIdeWorkspaceIdentity(
+      activeIdeWorkspaceIdentity.peek(),
+      workspaceIdentity,
+    )
 
-    // Cancel in-flight requests for previous file
+    // Cancel every request owned by the previous focus/workspace before any
+    // state transition can synchronously re-run this effect.
     abortController.abort()
     abortController = new AbortController()
     const { signal } = abortController
+
+    const invalidateWorkspaceDocument = (): void => {
+      documentStore.invalidate()
+      ownershipStore.reset(null)
+      diffRowsSignal.value = []
+      annotationsSignal.value = []
+    }
+
+    const focusWorkspaceChanged = focus !== null
+      && !sameIdeWorkspaceIdentity(focus.workspace_identity, workspaceIdentity)
+    if (workspaceIdentityChanged || focusWorkspaceChanged) {
+      invalidateWorkspaceDocument()
+    }
+    if (workspaceIdentityChanged) {
+      fileTreeStore.seed([])
+      synchronizeIdeWorkspaceIdentity(workspaceIdentity)
+    }
+
+    if (focusWorkspaceChanged) {
+      if (focus.origin === 'observed_change') {
+        clearIdeFileFocus()
+      } else {
+        focusIdeFile({
+          path: focus.path,
+          origin: focus.origin,
+          workspace_identity: workspaceIdentity,
+          availability: 'pending',
+        })
+      }
+      return
+    }
+
+    const requestedFilePath = focus?.path ?? null
+    const filePath = focus?.availability === 'available' ? focus.path : null
+    const loadedFilePath = untracked(() => documentStore.document().file_path)
+    if (loadedFilePath !== null && loadedFilePath !== filePath) {
+      invalidateWorkspaceDocument()
+    }
 
     ownershipStore.reset(filePath)
 
@@ -396,7 +456,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           signal,
         }
     workspaceIssuesSignal.value = retainCurrentWorkspaceFetchIssues(currentWorkspaceIssues(), {
-      filePath,
+      filePath: requestedFilePath,
       keeper: keeperParam ?? null,
       repoId,
     })
@@ -433,11 +493,118 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
         }
       }
 
-      const nextFile = filePath === null ? firstObservedChangedFilePath(nodes) : null
-      if (nextFile && nextFile !== activeIdeFile.value) {
-        activeIdeFile.value = nextFile
+      const currentFocus = activeIdeFocus.peek()
+      if (currentFocus?.availability === 'pending') {
+        if (!sameIdeWorkspaceIdentity(currentFocus.workspace_identity, workspaceIdentity)) return
+        if (workspaceTreeHasFile(nodes, currentFocus.path)) {
+          focusIdeFile({
+            ...currentFocus,
+            availability: 'available',
+          })
+          return
+        }
+        const pendingFocus = currentFocus
+        fetchWorkspaceFile(pendingFocus.path, opts).then(response => {
+          if (signal.aborted || activeIdeFocus.peek() !== pendingFocus) return
+          if (response?.ok === true && typeof response.content === 'string') {
+            const loaded = documentStore.load({
+              file_path: pendingFocus.path,
+              language: response.language ?? DEFAULT_LANGUAGE_ID,
+              content: response.content,
+            })
+            if (!loaded) {
+              documentStore.invalidate()
+              focusIdeFile({
+                ...pendingFocus,
+                availability: 'unavailable',
+              })
+              recordIssue('file', new Error('explicit IDE focus response was malformed'), {
+                filePath: pendingFocus.path,
+                keeper: keeperParam ?? null,
+                repoId,
+                fallbackMessage: 'explicit IDE focus validation failed',
+              })
+              return
+            }
+            clearIssue('file', {
+              filePath: pendingFocus.path,
+              keeper: keeperParam ?? null,
+              repoId,
+            })
+            focusIdeFile({
+              ...pendingFocus,
+              availability: 'available',
+            })
+            return
+          }
+          documentStore.invalidate()
+          if (response?.ok === false) {
+            focusIdeFile({
+              ...pendingFocus,
+              availability: 'not_found',
+            })
+            recordIssue(
+              'file',
+              new Error(`explicit IDE focus not found in selected workspace: ${pendingFocus.path}`),
+              {
+                filePath: pendingFocus.path,
+                keeper: keeperParam ?? null,
+                repoId,
+              },
+            )
+            return
+          }
+          focusIdeFile({
+            ...pendingFocus,
+            availability: 'unavailable',
+          })
+          recordIssue('file', new Error('explicit IDE focus response was unavailable'), {
+            filePath: pendingFocus.path,
+            keeper: keeperParam ?? null,
+            repoId,
+            fallbackMessage: 'explicit IDE focus validation failed',
+          })
+        }).catch(error => {
+          if (signal.aborted || activeIdeFocus.peek() !== pendingFocus) return
+          documentStore.invalidate()
+          focusIdeFile({
+            ...pendingFocus,
+            availability: 'unavailable',
+          })
+          recordIssue('file', error, {
+            filePath: pendingFocus.path,
+            keeper: keeperParam ?? null,
+            repoId,
+            fallbackMessage: 'explicit IDE focus validation failed',
+          })
+        })
+        return
+      }
+
+      if (currentFocus === null) {
+        const nextFile = firstObservedChangedFilePath(nodes)
+        if (nextFile) {
+          focusIdeFile({
+            path: nextFile,
+            origin: 'observed_change',
+            workspace_identity: workspaceIdentity,
+            availability: 'available',
+          })
+        }
       }
     }).catch(error => {
+      if (signal.aborted) return
+      const pendingFocus = activeIdeFocus.peek()
+      if (
+        pendingFocus?.availability === 'pending'
+        && sameIdeWorkspaceIdentity(pendingFocus.workspace_identity, workspaceIdentity)
+      ) {
+        documentStore.invalidate()
+        focusIdeFile({
+          ...pendingFocus,
+          availability: 'unavailable',
+        })
+      }
       recordIssue('tree', error, {
         keeper: keeperParam ?? null,
         repoId,
@@ -449,7 +616,9 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
     if (filePath === null) {
       diffRowsSignal.value = []
       annotationsSignal.value = []
-      workspaceIssuesSignal.value = currentWorkspaceIssues().filter(issue => issue.file_path === null)
+      if (requestedFilePath === null) {
+        workspaceIssuesSignal.value = currentWorkspaceIssues().filter(issue => issue.file_path === null)
+      }
       return
     }
 
@@ -463,6 +632,14 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           content: response.content,
         })
         if (!loaded) {
+          documentStore.invalidate()
+          const currentFocus = activeIdeFocus.peek()
+          if (currentFocus?.path === filePath && currentFocus.availability === 'available') {
+            focusIdeFile({
+              ...currentFocus,
+              availability: 'unavailable',
+            })
+          }
           recordIssue('file', new Error('workspace file response was malformed'), {
             filePath,
             keeper: keeperParam ?? null,
@@ -494,6 +671,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           }
           clearIssue('regions', { filePath, keeper: keeperParam ?? null, repoId })
         }).catch(error => {
+          if (signal.aborted) return
           recordIssue('regions', error, {
             filePath,
             keeper: keeperParam ?? null,
@@ -502,7 +680,25 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           })
         })
       } else {
-        recordIssue('file', new Error('workspace file response was not available'), {
+        documentStore.invalidate()
+        const currentFocus = activeIdeFocus.peek()
+        if (currentFocus?.path === filePath) {
+          if (response?.ok === false && currentFocus.origin !== 'observed_change') {
+            focusIdeFile({
+              ...currentFocus,
+              availability: 'not_found',
+            })
+          } else {
+            focusIdeFile({
+              ...currentFocus,
+              availability: 'unavailable',
+            })
+          }
+        }
+        const responseError = response?.ok === false
+          ? new Error('workspace file response reported that the file was not found')
+          : new Error('workspace file response was unavailable or malformed')
+        recordIssue('file', responseError, {
           filePath,
           keeper: keeperParam ?? null,
           repoId,
@@ -510,6 +706,15 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
         })
       }
     }).catch(error => {
+      if (signal.aborted) return
+      documentStore.invalidate()
+      const currentFocus = activeIdeFocus.peek()
+      if (currentFocus?.path === filePath && currentFocus.availability === 'available') {
+        focusIdeFile({
+          ...currentFocus,
+          availability: 'unavailable',
+        })
+      }
       recordIssue('file', error, {
         filePath,
         keeper: keeperParam ?? null,
@@ -540,6 +745,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           })
         }
       }).catch(error => {
+        if (signal.aborted) return
         recordIssue('blame', error, {
           filePath,
           keeper: keeperParam ?? null,
@@ -555,6 +761,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
         clearIssue('diff', { filePath, keeper: keeperParam ?? null, repoId })
         diffRowsSignal.value = rows
       }).catch(error => {
+        if (signal.aborted) return
         recordIssue('diff', error, {
           filePath,
           keeper: keeperParam ?? null,
@@ -572,6 +779,7 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
       clearIssue('annotations', { filePath, keeper: keeperParam ?? null, repoId })
       annotationsSignal.value = annotations
     }).catch(error => {
+      if (signal.aborted) return
       recordIssue('annotations', error, {
         filePath,
         keeper: keeperParam ?? null,

--- a/dashboard/src/components/ide/ide-editor-signals.ts
+++ b/dashboard/src/components/ide/ide-editor-signals.ts
@@ -180,7 +180,7 @@ export function focusTraceLineContext(
       keeperId: event.keeperName,
       telemetry: Boolean(event.logId || event.sessionId || event.operationId || event.workerRunId),
     }),
-  })
+  }, 'operator')
 }
 
 export function EditorCurrentFileSignals({

--- a/dashboard/src/components/ide/ide-editor.test.ts
+++ b/dashboard/src/components/ide/ide-editor.test.ts
@@ -5,7 +5,7 @@ import { fireEvent, waitFor } from '@testing-library/preact'
 import { annotationRouteLinks, currentFileFindMatches, IdeEditor } from './ide-editor'
 import { createCodeDocumentStore } from './code-document-store'
 import { createKeeperLineOwnershipStore } from './keeper-line-ownership-store'
-import { activeIdeFile, focusIdeContextAnchor, ideContextFocus } from './ide-state'
+import { focusIdeContextAnchor, focusIdeFile, ideContextFocus } from './ide-state'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
 import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
@@ -17,7 +17,12 @@ describe('IdeEditor', () => {
 
   beforeEach(() => {
     container = document.createElement('div')
-    activeIdeFile.value = 'package.json'
+    focusIdeFile({
+      path: 'package.json',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     ideContextFocus.value = null
     setIdeReplayUntilMs(null)
     clearTraces()
@@ -697,7 +702,7 @@ describe('IdeEditor', () => {
           evidence: 'Fleet telemetry event log · query turn-9',
         },
       ],
-    })
+    }, 'operator')
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid="ide-context-focus-status"]')?.textContent)

--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
-import { fireEvent } from '@testing-library/preact'
+import { signal } from '@preact/signals'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { explorerScopeLabel, IdeExplorer } from './ide-explorer'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
 import type { Repository } from '../../api/repositories'
@@ -174,6 +175,28 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
     expect(container.querySelector('[data-testid="ide-explorer-source"]')?.textContent).toBe('masc')
     expect(container.querySelector('[data-testid="ide-explorer-source"]')?.getAttribute('title'))
       .toBe('Workspace source: masc')
+  })
+
+  it('tracks an active repository change published after the repository list', async () => {
+    const store = createFileTreeStore()
+    const repositories = signal<ReadonlyArray<Repository>>([])
+    const activeRepositoryId = signal<string | null>(null)
+
+    render(h(IdeExplorer, {
+      fileTreeStore: store,
+      repositories: () => repositories.value,
+      activeRepositoryId: () => activeRepositoryId.value,
+      subscribeRepositories: listener => repositories.subscribe(listener),
+      subscribeActiveRepositoryId: listener => activeRepositoryId.subscribe(listener),
+    }), container)
+
+    repositories.value = [repo('repo-a', 'repo A'), repo('repo-b', 'repo B')]
+    activeRepositoryId.value = 'repo-b'
+
+    await waitFor(() => {
+      expect(container.querySelector<HTMLSelectElement>('[aria-label="IDE repository"]')?.value)
+        .toBe('repo-b')
+    })
   })
 
   it('labels loaded visible files distinctly from filtered results', () => {

--- a/dashboard/src/components/ide/ide-explorer.test.ts
+++ b/dashboard/src/components/ide/ide-explorer.test.ts
@@ -4,7 +4,7 @@ import { fireEvent } from '@testing-library/preact'
 import { explorerScopeLabel, IdeExplorer } from './ide-explorer'
 import { createFileTreeStore, type FileTreeNode } from './file-tree-store'
 import type { Repository } from '../../api/repositories'
-import { activeIdeFile, ideContextFocus } from './ide-state'
+import { activeIdeFile, focusIdeFile, ideContextFocus } from './ide-state'
 
 const SAMPLE: ReadonlyArray<FileTreeNode> = [
   { path: 'runtime', label: 'runtime', depth: 0, parent: null, hasChildren: true, diff: null, keeperId: null, hueIndex: null },
@@ -59,7 +59,12 @@ describe('IdeExplorer tree row keyboard accessibility', () => {
   afterEach(() => {
     render(null, container)
     window.location.hash = ''
-    activeIdeFile.value = 'package.json'
+    focusIdeFile({
+      path: 'package.json',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     ideContextFocus.value = null
   })
 

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -28,6 +28,7 @@ interface IdeExplorerProps {
   readonly subscribeWorkspaceSource?: (listener: () => void) => () => void
   readonly repositories?: () => ReadonlyArray<Repository>
   readonly activeRepositoryId?: () => string | null
+  readonly subscribeActiveRepositoryId?: (listener: () => void) => () => void
   readonly onRepositoryChange?: (repoId: string | null) => void
   readonly onRepositoryScan?: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories?: (listener: () => void) => () => void
@@ -90,6 +91,7 @@ export function IdeExplorer({
   subscribeWorkspaceSource,
   repositories,
   activeRepositoryId,
+  subscribeActiveRepositoryId,
   onRepositoryChange,
   onRepositoryScan,
   subscribeRepositories,
@@ -115,9 +117,14 @@ export function IdeExplorer({
     if (!subscribeRepositories || !repositories) return
     return subscribeRepositories(() => {
       setRepoList(repositories())
-      setSelectedRepoId(activeRepositoryId ? activeRepositoryId() : null)
     })
-  }, [activeRepositoryId, repositories, subscribeRepositories])
+  }, [repositories, subscribeRepositories])
+  useEffect(() => {
+    if (!subscribeActiveRepositoryId || !activeRepositoryId) return
+    return subscribeActiveRepositoryId(() => {
+      setSelectedRepoId(activeRepositoryId())
+    })
+  }, [activeRepositoryId, subscribeActiveRepositoryId])
 
   const [tick, setTick] = useState(0)
   useEffect(() => {

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -3,7 +3,12 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { Search } from 'lucide-preact'
 import { activeKeeperName } from '../../keeper-state'
 import { type FileTreeStore, type FileTreeNode, type FileTreeDiffSummary } from './file-tree-store'
-import { activeIdeFile, ideContextFocus, type IdeContextFocus } from './ide-state'
+import {
+  activeIdeFile,
+  focusIdeFile,
+  ideContextFocus,
+  type IdeContextFocus,
+} from './ide-state'
 import type { WorkspaceSource } from '../../api/workspace-source'
 import type { Repository } from '../../api/repositories'
 import { showToast } from '../common/toast'
@@ -359,7 +364,13 @@ export function IdeExplorer({
               // store.toggle -> expand -> loadChildren fetches this directory's
               // children on first open (no-op if already present/in flight).
               if (node.hasChildren) store.toggle(node.path)
-              else activeIdeFile.value = node.path
+              else {
+                focusIdeFile({
+                  path: node.path,
+                  origin: 'operator',
+                  availability: 'available',
+                })
+              }
             },
             contextFocus?.file_path === node.path ? contextFocus : null,
             keepersByFile.get(node.path),

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -301,7 +301,7 @@ function PresenceChip({ entry }: PresenceChipProps) {
 
   const canNavigate = contextAnchor !== null
   const navigate = (): void => {
-    if (contextAnchor) focusIdeContextAnchor(contextAnchor)
+    if (contextAnchor) focusIdeContextAnchor(contextAnchor, 'operator')
   }
   const onKeyDown = canNavigate
     ? (e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate() } }

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -44,7 +44,12 @@ import {
 } from './ide-shell'
 import { navigate, route } from '../../router'
 import { clearTraces, pushTrace } from './keeper-trace-store'
-import { activeIdeFile, ideContextFocus } from './ide-state'
+import {
+  activeIdeFile,
+  focusIdeFile,
+  ideContextFocus,
+  synchronizeIdeWorkspaceIdentity,
+} from './ide-state'
 import { resetIdeDataWorkspaceStoreForTest } from './ide-workspace-singleton'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
 import { EMPTY_LSP_STATUS_SNAPSHOT, lspStatusSnapshot } from './ide-lsp-client'
@@ -141,7 +146,7 @@ function dashboardFetchMockWithResponse(
 ): (input: RequestInfo | URL) => Promise<Response> {
   return (input: RequestInfo | URL): Promise<Response> => {
     const url = String(input)
-    if (pattern.test(url)) return Promise.resolve(response)
+    if (pattern.test(url)) return Promise.resolve(response.clone())
     return dashboardFetchMock(input)
   }
 }
@@ -152,6 +157,13 @@ describe('IdeShell', () => {
   beforeEach(() => {
     container = document.createElement('div')
     clearLocalStorage()
+    synchronizeIdeWorkspaceIdentity({ kind: 'project' })
+    focusIdeFile({
+      path: 'package.json',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     vi.stubGlobal('fetch', vi.fn(dashboardFetchMock))
   })
 
@@ -168,7 +180,12 @@ describe('IdeShell', () => {
     vi.unstubAllGlobals()
     window.location.hash = ''
     route.value = { tab: 'overview', params: {}, postId: null }
-    activeIdeFile.value = 'package.json'
+    focusIdeFile({
+      path: 'package.json',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     ideContextFocus.value = null
     cursorOverlaySignal.value = { cursors: new Map(), heatmap: new Map(), collisions: [], active_file: null }
     lspStatusSnapshot.value = EMPTY_LSP_STATUS_SNAPSHOT
@@ -685,7 +702,12 @@ describe('IdeShell', () => {
       params: { section: 'ide-shell', view: 'source' },
       postId: null,
     }
-    activeIdeFile.value = 'lib/runtime.ml'
+    focusIdeFile({
+      path: 'lib/runtime.ml',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'available',
+    })
     cursorOverlaySignal.value = {
       cursors: new Map([[
         'sangsu',
@@ -785,7 +807,7 @@ describe('IdeShell', () => {
     expect(container.querySelector('.ide-toolbar-spacer')).toBeNull()
   })
 
-  it('persists layer toggles back to the route', () => {
+  it('persists layer toggles back to the route', async () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'split-diff', layers: 'notes' },
@@ -793,7 +815,9 @@ describe('IdeShell', () => {
     }
 
     render(h(IdeShell, {}), container)
-    expect(container.querySelector('[aria-label="Split diff preview"]')).not.toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('[aria-label="Split diff preview"]')).not.toBeNull()
+    })
     fireEvent.click(buttonByText(container, 'Trace'))
 
     expect(route.value.params.view).toBe('split-diff')
@@ -803,7 +827,7 @@ describe('IdeShell', () => {
     expect(route.value.params.layers).toBe('keeper-trace')
   })
 
-  it('turns focus=review into a unified review workspace with review layers', () => {
+  it('turns focus=review into a unified review workspace with review layers', async () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'unified', focus: 'review' },
@@ -813,7 +837,9 @@ describe('IdeShell', () => {
     render(h(IdeShell, {}), container)
 
     expect(container.querySelector('[data-testid="ide-review-focus"]')).not.toBeNull()
-    expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('[aria-label="Unified diff preview"]')).not.toBeNull()
+    })
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
     expect(buttonByText(container, 'Notes').getAttribute('aria-pressed')).toBe('true')
     expect(container.querySelector('[data-testid="ide-toolbar-layers"]')?.textContent)
@@ -966,7 +992,9 @@ describe('IdeShell', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(route.value.params.find).toBe('open')
-    expect(container.querySelector('[data-testid="ide-find-panel"]')).not.toBeNull()
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="ide-find-panel"]')).not.toBeNull()
+    })
   })
 
   it('starts on the reference activity rail and keeps work context available without a fourth tab', () => {
@@ -1188,7 +1216,7 @@ describe('IdeShell', () => {
     expect(container.querySelector('.ide-plane-tree')).not.toBeNull()
   })
 
-  it('does not mount the polling rail on mobile and keeps annotation creation in the editor', () => {
+  it('does not mount the polling rail on mobile and keeps annotation creation in the editor', async () => {
     const originalWidth = window.innerWidth
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -1210,8 +1238,10 @@ describe('IdeShell', () => {
       expect(vi.mocked(fetch).mock.calls.some(([input]) =>
         String(input).includes('/api/v1/activity/events'),
       )).toBe(false)
-      expect(container.querySelector('.ide-v2-responsive-annotation-composer [data-testid="ide-annotation-composer-closed"]'))
-        .not.toBeNull()
+      await waitFor(() => {
+        expect(container.querySelector('.ide-v2-responsive-annotation-composer [data-testid="ide-annotation-composer-closed"]'))
+          .not.toBeNull()
+      })
     } finally {
       Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth })
     }
@@ -1275,7 +1305,7 @@ describe('IdeShell', () => {
     expect(getLocalStorageItem(IDE_TREE_WIDTH_STORAGE_KEY)).toBe(String(IDE_TREE_WIDTH_MAX))
   })
 
-  it('hydrates the trace layer button from the ?layers=keeper-trace URL param', () => {
+  it('hydrates the trace layer button from the ?layers=keeper-trace URL param', async () => {
     route.value = {
       tab: 'code',
       params: { section: 'ide-shell', view: 'source', layers: 'keeper-trace' },
@@ -1285,7 +1315,9 @@ describe('IdeShell', () => {
     render(h(IdeShell, {}), container)
 
     expect(buttonByText(container, 'Trace').getAttribute('aria-pressed')).toBe('true')
-    expect(container.textContent).toContain('Active overlays')
+    await waitFor(() => {
+      expect(container.textContent).toContain('Active overlays')
+    })
     expect(container.textContent).toContain('Trace')
   })
 

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1326,6 +1326,7 @@ export function IdeShell() {
               subscribeWorkspaceSource=${workspaceStore.subscribeWorkspaceSource}
               repositories=${workspaceStore.repositories}
               activeRepositoryId=${workspaceStore.activeRepositoryId}
+              subscribeActiveRepositoryId=${workspaceStore.subscribeActiveRepositoryId}
               onRepositoryChange=${workspaceStore.setActiveRepositoryId}
               onRepositoryScan=${workspaceStore.scanRepositories}
               subscribeRepositories=${workspaceStore.subscribeRepositories}

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -712,7 +712,7 @@ function focusCursor(cursor: KeeperCursor): void {
         cursor.tool_name ? `tool:${cursor.tool_name}` : null,
       ].filter((part): part is string => Boolean(part)).join(' '),
     }),
-  })
+  }, 'operator')
 }
 
 function IdeCursorRailPanel() {
@@ -1009,7 +1009,7 @@ export function IdeShell() {
         keeperId: routeKeeperFocus,
         telemetry,
       }),
-    })
+    }, 'route')
   }, [
     routeFileFocus,
     routeLineFocus,

--- a/dashboard/src/components/ide/ide-state.test.ts
+++ b/dashboard/src/components/ide/ide-state.test.ts
@@ -1,9 +1,21 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { activeIdeFile, focusIdeContextAnchor, ideContextFocus } from './ide-state'
+import {
+  activeIdeFile,
+  activeIdeFocus,
+  focusIdeContextAnchor,
+  focusIdeFile,
+  ideContextFocus,
+  synchronizeIdeWorkspaceIdentity,
+} from './ide-state'
 
 describe('ide-state', () => {
   beforeEach(() => {
-    activeIdeFile.value = 'package.json'
+    synchronizeIdeWorkspaceIdentity({ kind: 'project' })
+    focusIdeFile({
+      path: 'package.json',
+      origin: 'operator',
+      availability: 'available',
+    })
     ideContextFocus.value = null
   })
 
@@ -14,13 +26,19 @@ describe('ide-state', () => {
       surface: 'Log',
       label: 'runtime event',
       source_id: 'evt-1',
-    })
+    }, 'operator')
 
     expect(activeIdeFile.value).toBe('src/runtime/router.ts')
     expect(ideContextFocus.value).toMatchObject({
       file_path: 'src/runtime/router.ts',
       line: 12,
       source_id: 'evt-1',
+    })
+    expect(activeIdeFocus.value).toEqual({
+      path: 'src/runtime/router.ts',
+      origin: 'operator',
+      workspace_identity: { kind: 'project' },
+      availability: 'pending',
     })
   })
 
@@ -38,7 +56,7 @@ describe('ide-state', () => {
       surface: 'Log',
       label: 'runtime event',
       source_id: 'evt-1',
-    })
+    }, 'route')
 
     expect(activeIdeFile.value).toBe('package.json')
     expect(ideContextFocus.value).toBeNull()
@@ -51,7 +69,7 @@ describe('ide-state', () => {
       surface: 'Log',
       label: 'runtime event',
       source_id: 'evt-1',
-    })
+    }, 'operator')
 
     expect(activeIdeFile.value).toBe('src/runtime/router.ts')
     expect(ideContextFocus.value?.line).toBeUndefined()

--- a/dashboard/src/components/ide/ide-state.ts
+++ b/dashboard/src/components/ide/ide-state.ts
@@ -144,6 +144,10 @@ export interface IdeContextFocus {
 
 export const ideContextFocus = signal<IdeContextFocus | null>(null)
 
+export function clearIdeContextFocus(): void {
+  ideContextFocus.value = null
+}
+
 export function focusIdeContextAnchor(
   anchor: Omit<IdeContextFocus, 'activated_at_ms'>,
   origin: ExplicitIdeFileFocusOrigin,

--- a/dashboard/src/components/ide/ide-state.ts
+++ b/dashboard/src/components/ide/ide-state.ts
@@ -10,11 +10,118 @@
  * Keep this module side-effect free: only signals/types live here.
  */
 
-import { signal } from '@preact/signals'
+import { computed, signal } from '@preact/signals'
 import type { TabId } from '../../types'
 import { isPositiveSafeInteger } from '../common/normalize'
 
-export const activeIdeFile = signal<string | null>(null)
+export type IdeFileFocusOrigin = 'operator' | 'route' | 'observed_change'
+export type ExplicitIdeFileFocusOrigin = Exclude<IdeFileFocusOrigin, 'observed_change'>
+export type ExplicitIdeFileFocusAvailability =
+  | 'pending'
+  | 'available'
+  | 'not_found'
+  | 'unavailable'
+export type ObservedIdeFileFocusAvailability = 'available' | 'unavailable'
+export type IdeFileFocusAvailability =
+  | ExplicitIdeFileFocusAvailability
+  | ObservedIdeFileFocusAvailability
+
+export type IdeWorkspaceIdentity =
+  | { readonly kind: 'project' }
+  | { readonly kind: 'repository'; readonly repoId: string }
+  | { readonly kind: 'keeper'; readonly keeper: string }
+
+interface IdeFileFocusBase {
+  readonly path: string
+  readonly workspace_identity: IdeWorkspaceIdentity
+}
+
+export type IdeFileFocus = IdeFileFocusBase & (
+  | {
+      readonly origin: ExplicitIdeFileFocusOrigin
+      readonly availability: ExplicitIdeFileFocusAvailability
+    }
+  | {
+      readonly origin: 'observed_change'
+      readonly availability: ObservedIdeFileFocusAvailability
+    }
+)
+
+type IdeFileFocusRequestBase = {
+  readonly path: string
+  readonly workspace_identity?: IdeWorkspaceIdentity
+}
+
+export type IdeFileFocusRequest = IdeFileFocusRequestBase & (
+  | {
+      readonly origin: ExplicitIdeFileFocusOrigin
+      readonly availability: ExplicitIdeFileFocusAvailability
+    }
+  | {
+      readonly origin: 'observed_change'
+      readonly availability: ObservedIdeFileFocusAvailability
+    }
+)
+
+const activeIdeWorkspaceIdentitySignal = signal<IdeWorkspaceIdentity>({ kind: 'project' })
+const activeIdeFocusSignal = signal<IdeFileFocus | null>(null)
+
+/** Read-only projections. State transitions go through the typed functions below. */
+export const activeIdeWorkspaceIdentity = computed(() => activeIdeWorkspaceIdentitySignal.value)
+export const activeIdeFocus = computed(() => activeIdeFocusSignal.value)
+
+/** Compatibility-free path projection for render consumers; it is not writable. */
+export const activeIdeFile = computed(() => activeIdeFocus.value?.path ?? null)
+
+export function synchronizeIdeWorkspaceIdentity(identity: IdeWorkspaceIdentity): void {
+  if (!sameIdeWorkspaceIdentity(activeIdeWorkspaceIdentitySignal.peek(), identity)) {
+    activeIdeWorkspaceIdentitySignal.value = identity
+  }
+}
+
+export function ideWorkspaceIdentityForSelection(
+  repoId: string | null | undefined,
+  keeper: string | null | undefined,
+): IdeWorkspaceIdentity {
+  const normalizedRepoId = repoId?.trim()
+  if (normalizedRepoId) return { kind: 'repository', repoId: normalizedRepoId }
+  const normalizedKeeper = keeper?.trim()
+  if (normalizedKeeper) return { kind: 'keeper', keeper: normalizedKeeper }
+  return { kind: 'project' }
+}
+
+export function sameIdeWorkspaceIdentity(
+  left: IdeWorkspaceIdentity,
+  right: IdeWorkspaceIdentity,
+): boolean {
+  if (left.kind !== right.kind) return false
+  switch (left.kind) {
+    case 'project':
+      return true
+    case 'repository':
+      return right.kind === 'repository' && left.repoId === right.repoId
+    case 'keeper':
+      return right.kind === 'keeper' && left.keeper === right.keeper
+  }
+}
+
+export function focusIdeFile(
+  request: IdeFileFocusRequest,
+): boolean {
+  const path = normalizeIdeContextFilePath(request.path)
+  if (path === null) return false
+  const workspaceIdentity = request.workspace_identity ?? activeIdeWorkspaceIdentitySignal.value
+  activeIdeFocusSignal.value = {
+    ...request,
+    path,
+    workspace_identity: workspaceIdentity,
+  }
+  return true
+}
+
+export function clearIdeFileFocus(): void {
+  activeIdeFocusSignal.value = null
+}
 
 export interface IdeContextFocusRouteLink {
   readonly id: string
@@ -39,11 +146,16 @@ export const ideContextFocus = signal<IdeContextFocus | null>(null)
 
 export function focusIdeContextAnchor(
   anchor: Omit<IdeContextFocus, 'activated_at_ms'>,
+  origin: ExplicitIdeFileFocusOrigin,
 ): void {
   const filePath = normalizeIdeContextFilePath(anchor.file_path)
   if (filePath === null) return
   const line = normalizeIdeContextLine(anchor.line)
-  activeIdeFile.value = filePath
+  focusIdeFile({
+    path: filePath,
+    origin,
+    availability: 'pending',
+  })
   ideContextFocus.value = {
     ...anchor,
     file_path: filePath,

--- a/dashboard/src/components/ide/overlay-keeper-trace.ts
+++ b/dashboard/src/components/ide/overlay-keeper-trace.ts
@@ -351,7 +351,7 @@ function selectTraceEvent(event: KeeperTraceEvent): void {
     source_id: context.sourceId ?? `trace:${event.id}`,
     keeper_id: context.keeperId,
     route_links: routeLinksForContext(context),
-  })
+  }, 'operator')
 }
 
 function traceRouteLinks(events: ReadonlyArray<KeeperTraceEvent>): ReadonlyArray<IdeContextRouteLink> {


### PR DESCRIPTION
## Summary

- replace the writable path-only IDE focus with a typed, read-only focus projection carrying origin, logical workspace identity, and availability
- abort prior workspace requests and synchronously invalidate document, tree, ownership, diff, annotations, and context-anchor provenance before repository, project, or keeper identity publication
- reselect observed focus per workspace while validating explicit focus through the bounded tree and authoritative file endpoint
- distinguish explicit not-found from API, auth, transport, null, and malformed unavailable states without silent or infinite pending behavior
- reject stale file completions and stale repository-list completions by generation and exact focus identity
- subscribe the repository selector to list and active-identity projections independently

Tracks #24136.

## Root cause

The dashboard stored only `activeIdeFile` as string or null. Repository changes reused that path without provenance and left the previous `CodeDocumentStore` snapshot visible until another request succeeded. Late repository discovery could therefore move the UI from project scope to repository scope while retaining project content.

The first implementation test also mocked file absence as a resolved `{ ok: false }` value. The real route returns HTTP 404 and the shared API client raises a typed `ApiRequestError`, so the mock hid a wire-level `not_found` versus `unavailable` mismatch. The workspace API boundary now projects only status 404 to `{ ok: false }`; every other API, authorization, validation, server, transport, and timeout failure remains an error.

Adversarial review then found three additional provenance races: context labels from workspace A survived a same-path switch to workspace B; the repository list signal could publish before the active repository signal and leave the selector on a different identity; and an older startup list request could overwrite a completed scan. The latest delta clears workspace-bound context, observes both projections, and gives repository list publication a latest-request generation.

## Typed invariants

- operator and route focus: `pending`, `available`, `not_found`, or `unavailable`
- `observed_change` focus: `available` or `unavailable`; `not_found` is not representable
- typed HTTP 404 is the only `not_found` outcome
- non-404 API, authorization, transport, null, and malformed responses terminate as `unavailable` with a visible workspace issue
- repository scope is authoritative over keeper scope; keeper identity is used only without a selected repository
- context-anchor label, keeper attribution, and route links never cross a workspace-identity change
- only the latest repository-list request may publish list, active identity, or failure state

## Validation

- `pnpm typecheck`
- focused Vitest: 9 files, 172 tests passed
- `git diff --check`
- no local Dune build; CI is the Dune authority

## Base and merge guard

Rebased onto exact `main@cace07b48e56edf597033ad74b68f469b4a77e28`; the branch contains only three IDE commits above main.

Keep Draft + `status:do-not-merge` until exact-head CI and a fresh adversarial review complete. Do not use admin bypass.

## Adversarial status

- previous exact-head review: P0 none; two P1 and one P2 found
- all three findings have regression coverage in `5f7b91019aaa0ed5ef4cdc9aa5c88b68ecae8427`
- fresh exact-head review: pending
