### PR TITLE
feat(dashboard): align keeper workspace with v2 standalone

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -6,6 +6,7 @@ import {
   App,
   shouldBootstrapCommandPaletteShortcut,
   shouldShowCopilotFab,
+  shouldShowDashboardHealthStrip,
   shouldSuppressFloatingChrome,
   shouldUseCompactDashboardChrome,
 } from './app'
@@ -83,13 +84,15 @@ describe('App v2 header chrome', () => {
     expect(app?.hasAttribute('data-theme')).toBe(false)
   })
 
-  it('renders v2 shell header and health strip scopes', () => {
+  it('keeps primary v2 surfaces on the single 50px top chrome', () => {
     renderApp()
-    // The shell header is now TopBarV2's `.v2-top` (the old `header.v2-shell-header`
-    // element was replaced by the keeper-v2 prototype top bar). The health strip is
-    // re-mounted under the top bar, so its testid + scope class still hold.
     expect(container.querySelector('.v2-top')).not.toBeNull()
-    expect(container.querySelector('[data-testid="dashboard-health-strip"].v2-health-strip')).not.toBeNull()
+    const health = container.querySelector('[data-testid="dashboard-health-strip"].v2-health-strip') as HTMLElement
+    expect(health).not.toBeNull()
+    expect(health.style.display).toBe('none')
+    expect(shouldShowDashboardHealthStrip('overview')).toBe(false)
+    expect(shouldShowDashboardHealthStrip('keepers')).toBe(false)
+    expect(shouldShowDashboardHealthStrip('cockpit')).toBe(true)
   })
 
   it('renders v2 header structural classes', () => {
@@ -222,10 +225,12 @@ describe('App v2 header chrome', () => {
     expect(main?.style.overflowY).toBe('auto')
   })
 
-  it('renders health chips with the shared chip class', () => {
+  it('renders health chips with the shared chip class on non-primary diagnostics', () => {
+    route.value = { tab: 'cockpit', params: {}, postId: null }
     renderApp()
     const chip = container.querySelector('.dashboard-health-chip')
     expect(chip).not.toBeNull()
+    expect((container.querySelector('[data-testid="dashboard-health-strip"]') as HTMLElement).style.display).not.toBe('none')
   })
 
   it('sets data-mobile based on the viewport width', () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -88,6 +88,16 @@ export function shouldSuppressFloatingChrome({
   return keeperDetailMode || mobileDrawerOpen || isPrimaryDashboardSurface(currentTab)
 }
 
+// The keeper-v2 primary shell keeps its operational summary in the top bar and
+// routes deeper health evidence through Monitor. Rendering the same facts as a
+// second full-width strip shifts every primary surface below the prototype's
+// fixed 50px chrome and duplicates the existing navigation path. Retain the
+// strip for non-primary diagnostic/plugin surfaces where that top-level health
+// context is otherwise absent.
+export function shouldShowDashboardHealthStrip(currentTab: TabId): boolean {
+  return !isPrimaryDashboardSurface(currentTab)
+}
+
 const LazyAgentDetailOverlay = lazy(async () => ({
   default: (await import('./components/agent-detail')).AgentDetailOverlay,
 }))
@@ -320,7 +330,9 @@ export function App() {
           remote-auth warning + the runtime health chip bar. Both self-gate
           (render null when there is no warning / no health signal). */ ''}
       ${compactChromeMode ? null : html`<${RemoteWarningBanner} />`}
-      ${compactChromeMode ? null : html`<${DashboardHealthStrip} />`}
+      ${compactChromeMode
+        ? null
+        : html`<${DashboardHealthStrip} hidden=${!shouldShowDashboardHealthStrip(currentTab)} />`}
 
       <div class="v2-stage">
         <div class="v2-body" style=${{ gridTemplateColumns: cols }}>

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -3449,7 +3449,7 @@ describe('ChatComposer v2 prototype surface', () => {
         disabled=${false}
         streaming=${false}
         layout="primary"
-        showFooter="activity"
+        footerMode="activity"
         onDraftChange=${() => {}}
         onSend=${() => {}}
       />`,
@@ -3468,7 +3468,7 @@ describe('ChatComposer v2 prototype surface', () => {
         streaming=${false}
         queueCount=${2}
         layout="primary"
-        showFooter="activity"
+        footerMode="activity"
         onDraftChange=${() => {}}
         onSend=${() => {}}
       />`,

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -3441,6 +3441,42 @@ describe('ChatComposer v2 prototype surface', () => {
     expect(cls).not.toMatch(/\bbg-\[/)
   })
 
+  it('uses the single-row prototype composer and can omit the redundant workspace footer', () => {
+    render(
+      html`<${ChatComposer}
+        draft=""
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        layout="primary"
+        showFooter="activity"
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+    expect((container.querySelector('.composer-textarea') as HTMLTextAreaElement).rows).toBe(1)
+    expect(container.querySelector('.composer-foot')).toBeNull()
+  })
+
+  it('restores the compact footer when queue evidence exists in activity mode', () => {
+    render(
+      html`<${ChatComposer}
+        draft=""
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        queueCount=${2}
+        layout="primary"
+        showFooter="activity"
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+    expect(container.querySelector('[data-chat-queue-count]')?.textContent).toContain('대기 2')
+  })
+
   it('keeps send and attach controls operational', () => {
     const onSend = vi.fn()
     render(

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3742,6 +3742,7 @@ export function ChatComposer({
   layout = 'default',
   draftPersistKey,
   keeperLabel,
+  showFooter = true,
 }: {
   draft?: string
   placeholder: string
@@ -3766,6 +3767,10 @@ export function ChatComposer({
    *  intentionally separate from [draftPersistKey], which may be an opaque
    *  storage key. */
   keeperLabel?: string
+  /** `activity` keeps queue/stall evidence but removes the idle instruction
+   * row, allowing the dense keeper-v2 workspace to match its single-row
+   * composer. Other chat layouts retain the footer by default. */
+  showFooter?: boolean | 'activity'
   /** When set (and uncontrolled), the composer persists its unsent draft
    *  per key across remounts via keeper-chat-store, so switching keepers
    *  keeps each keeper's own half-typed message without leaking it to
@@ -4167,6 +4172,7 @@ export function ChatComposer({
                 <textarea
                   ref=${textareaRef}
                   class="composer-textarea"
+                  rows=${layout === 'primary' ? 1 : 2}
                   placeholder=${drag ? CHAT_COMPOSER_DROP_PLACEHOLDER : placeholder}
                   aria-label="메시지 입력"
                   value=${draft}
@@ -4236,17 +4242,21 @@ export function ChatComposer({
                 </div>
               `}
         </div>
-        <div class="composer-foot">
-          <span class="hint">
-            <kbd>⌘</kbd> <kbd>↵</kbd> 전송 · 끌어다 놓아 첨부
-            ${isStalled
-              ? html`<span class="ml-2 text-[var(--color-status-warn)]" data-chat-stall-hint>마지막 수신 ${sinceLastEvent}초 전 — 스트림 지연</span>`
-              : null}
-          </span>
-          ${queueCount > 0
-            ? html`<span class="queue-badge" data-chat-queue-count>대기 ${queueCount}</span>`
-            : null}
-        </div>
+        ${showFooter === true || (showFooter === 'activity' && (isStalled || queueCount > 0))
+          ? html`
+              <div class="composer-foot">
+                <span class="hint">
+                  <kbd>⌘</kbd> <kbd>↵</kbd> 전송 · 끌어다 놓아 첨부
+                  ${isStalled
+                    ? html`<span class="ml-2 text-[var(--color-status-warn)]" data-chat-stall-hint>마지막 수신 ${sinceLastEvent}초 전 — 스트림 지연</span>`
+                    : null}
+                </span>
+                ${queueCount > 0
+                  ? html`<span class="queue-badge" data-chat-queue-count>대기 ${queueCount}</span>`
+                  : null}
+              </div>
+            `
+          : null}
       </div>
     </div>
   `

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3742,7 +3742,7 @@ export function ChatComposer({
   layout = 'default',
   draftPersistKey,
   keeperLabel,
-  showFooter = true,
+  footerMode = 'always',
 }: {
   draft?: string
   placeholder: string
@@ -3770,7 +3770,7 @@ export function ChatComposer({
   /** `activity` keeps queue/stall evidence but removes the idle instruction
    * row, allowing the dense keeper-v2 workspace to match its single-row
    * composer. Other chat layouts retain the footer by default. */
-  showFooter?: boolean | 'activity'
+  footerMode?: 'always' | 'activity'
   /** When set (and uncontrolled), the composer persists its unsent draft
    *  per key across remounts via keeper-chat-store, so switching keepers
    *  keeps each keeper's own half-typed message without leaking it to
@@ -4242,7 +4242,7 @@ export function ChatComposer({
                 </div>
               `}
         </div>
-        ${showFooter === true || (showFooter === 'activity' && (isStalled || queueCount > 0))
+        ${footerMode === 'always' || (footerMode === 'activity' && (isStalled || queueCount > 0))
           ? html`
               <div class="composer-foot">
                 <span class="hint">

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -1106,7 +1106,7 @@ describe('DashboardHealthStrip v2 chrome', () => {
   })
 
   it('renders with the v2-health-strip marker class', () => {
-    render(h(DashboardHealthStrip, {}), container)
+    render(h(DashboardHealthStrip, { hidden: false }), container)
 
     const strip = container.querySelector('[data-testid="dashboard-health-strip"]')
     expect(strip).not.toBeNull()

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -704,7 +704,7 @@ function healthChipClass(tone: DashboardHealthChipTone): string {
   }
 }
 
-export function DashboardHealthStrip() {
+export function DashboardHealthStrip({ hidden = false }: { hidden?: boolean }) {
   useEffect(() => {
     let disposed = false
     let inFlight = false
@@ -783,6 +783,8 @@ export function DashboardHealthStrip() {
   return html`
     <div
       class="v2-health-strip flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-1.5 text-xs"
+      style=${hidden ? { display: 'none' } : undefined}
+      aria-hidden=${hidden ? 'true' : undefined}
       role="status"
       aria-label="Dashboard runtime health"
       data-testid="dashboard-health-strip"

--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -63,11 +63,9 @@ describe('KeeperWorkspaceRoster', () => {
     // v2 filter chips carry the SHORT label + count ('실행' + '1'), not the old
     // combined '실행중1' chip label (rails.jsx filter chips).
     expect(container.textContent).toContain('실행1')
-    // The roster now defaults to '최근순' (flat list, no status group headers).
-    // status-bucket grouping/headers are covered exhaustively in
-    // keeper-workspace-roster.test.ts, so this test asserts the flat default and
-    // the counts/search/selection it is named for (no redundant grouping checks).
-    expect(container.querySelectorAll('.roster-group').length).toBe(0)
+    // The standalone defaults to lifecycle grouping, so the integrated detail
+    // surface exposes running, waiting, and stopped groups immediately.
+    expect(container.querySelectorAll('.roster-group').length).toBe(3)
     expect(container.querySelectorAll('.kw-kp-row').length).toBe(3)
     // v2 mounts the search input only after toggling the '⌕' .rfilter-icon
     // (searchOpen defaults false); the class is now .roster-search.

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -366,8 +366,10 @@ describe('KeeperDetailPage', () => {
     expect(screen.queryByText('FSM Hub (6축 상태 머신)')).toBeNull()
     expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
 
-    // "상세" flips to the full tabbed detail (KeeperDetailBody is reused).
-    fireEvent.click(screen.getByRole('button', { name: '상세' }))
+    // Secondary inspectors live in the standalone-style overflow. Opening the
+    // menu and choosing "상세" flips to the reused full tabbed detail body.
+    fireEvent.click(screen.getByRole('button', { name: '대화 도구' }))
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: '상세' }))
     const statusTab = await screen.findByRole('tab', { name: '상태' })
     fireEvent.click(statusTab)
     expect(statusTab.getAttribute('aria-selected')).toBe('true')

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -528,12 +528,14 @@ export function KeeperConversationPanel({
   layout = 'default',
   composerCommands = [],
   onInspectTurn,
+  workspaceToolbarOpen = true,
 }: {
   keeperName: string
   placeholder: string
   layout?: 'default' | 'primary' | 'workspace'
   composerCommands?: ChatComposerCommand[]
   onInspectTurn?: (entry: KeeperConversationEntry) => void
+  workspaceToolbarOpen?: boolean
 }) {
   // Global view prefs (Tweaks panel owns the switches). Reading .value here
   // subscribes this component, so a Tweaks flip re-renders every mounted panel.
@@ -838,34 +840,38 @@ export function KeeperConversationPanel({
         class="flex min-h-0 flex-1 flex-col v2-monitoring-surface"
         data-keeper-chat-layout="workspace"
       >
-        <div class="kw-chat-toolbar v2-monitoring-toolbar">
-          <${TextInput}
-            class="max-w-50"
-            name="keeper_chat_search"
-            ariaLabel="대화 내용 검색"
-            autoComplete="off"
-            placeholder="대화 검색..."
-            value=${searchQuery}
-            onInput=${(e: Event) => { setSearchQuery((e.target as HTMLInputElement).value) }}
-          />
-          ${hasQuery
-            ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)] v2-monitoring-row" data-chat-search-count>
-                ${transcriptEntries.length} / ${visibleThreadWithQueue.length}
-              </span>`
-            : null}
-          <span class="spacer"></span>
-          ${!historyExpanded
-            ? html`
-                <${GhostButton} disabled=${hydrating} onClick=${() => { void expandHistory() }}>
-                  ${hydrating
-                    ? '불러오는 중...'
-                    : rawThread.length === 0
-                      ? '이력 불러오기'
-                      : `전체 이력 (${thread.length})`}
-                <//>
-              `
-            : null}
-        </div>
+        ${workspaceToolbarOpen
+          ? html`
+              <div class="kw-chat-toolbar v2-monitoring-toolbar">
+                <${TextInput}
+                  class="max-w-50"
+                  name="keeper_chat_search"
+                  ariaLabel="대화 내용 검색"
+                  autoComplete="off"
+                  placeholder="대화 검색..."
+                  value=${searchQuery}
+                  onInput=${(e: Event) => { setSearchQuery((e.target as HTMLInputElement).value) }}
+                />
+                ${hasQuery
+                  ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)] v2-monitoring-row" data-chat-search-count>
+                      ${transcriptEntries.length} / ${visibleThreadWithQueue.length}
+                    </span>`
+                  : null}
+                <span class="spacer"></span>
+                ${!historyExpanded
+                  ? html`
+                      <${GhostButton} disabled=${hydrating} onClick=${() => { void expandHistory() }}>
+                        ${hydrating
+                          ? '불러오는 중...'
+                          : rawThread.length === 0
+                            ? '이력 불러오기'
+                            : `전체 이력 (${thread.length})`}
+                      <//>
+                    `
+                  : null}
+              </div>
+            `
+          : null}
 
         ${chatAccess.message
           ? html`
@@ -947,6 +953,7 @@ export function KeeperConversationPanel({
               onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
               onAbort=${() => { cancelKeeperThreadFromUi(keeperName) }}
               layout="primary"
+              showFooter="activity"
             />
             ${renderError()}
           </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -953,7 +953,7 @@ export function KeeperConversationPanel({
               onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
               onAbort=${() => { cancelKeeperThreadFromUi(keeperName) }}
               layout="primary"
-              showFooter="activity"
+              footerMode="activity"
             />
             ${renderError()}
           </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -220,6 +220,13 @@ describe('KeeperWorkspaceChat', () => {
       search.click()
     })
     expect(container.querySelector('[data-testid="kw-conversation-panel"]')?.getAttribute('data-toolbar-open')).toBe('true')
+    await act(async () => {
+      ;(container.querySelector('[data-testid="kw-chat-command-menu-toggle"]') as HTMLButtonElement).click()
+    })
+    const activeSearch = container.querySelector('[data-testid="kw-chat-command-search"]')
+    expect(activeSearch?.getAttribute('role')).toBe('menuitemcheckbox')
+    expect(activeSearch?.getAttribute('aria-checked')).toBe('true')
+    expect(activeSearch?.classList.contains('active')).toBe(true)
   })
 
   it('keeps utility commands usable while a lifecycle command is pending', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -56,8 +56,8 @@ async function loadChat() {
     KeeperLifecycleButtons: () => html`<span data-testid="kw-lifecycle-buttons">Lifecycle</span>`,
   }))
   vi.doMock('../keeper-shared', () => ({
-    KeeperConversationPanel: ({ onInspectTurn }: { onInspectTurn?: (entry: unknown) => void }) => html`
-      <div data-testid="kw-conversation-panel">
+    KeeperConversationPanel: ({ onInspectTurn, workspaceToolbarOpen }: { onInspectTurn?: (entry: unknown) => void; workspaceToolbarOpen?: boolean }) => html`
+      <div data-testid="kw-conversation-panel" data-toolbar-open=${workspaceToolbarOpen ? 'true' : 'false'}>
         Conversation
         ${onInspectTurn
           ? html`
@@ -116,13 +116,13 @@ async function loadChat() {
   vi.doMock('../keeper-detail-state', () => ({
     keeperMobilePane: signal<'roster' | 'chat'>('chat'),
   }))
-  // Preserve the real router but capture navigate() so the pending-approval cue's
-  // "결재 큐 →" link can be asserted.
+  // Preserve the real router but capture navigate() so the compact approval
+  // badge link can be asserted.
   vi.doMock('../../router', async (importOriginal) => ({
     ...(await importOriginal<typeof import('../../router')>()),
     navigate: vi.fn(),
   }))
-  // The cue reads governanceData.approval_queue; inject a controllable signal in
+  // The badge reads governanceData.approval_queue; inject a controllable signal in
   // place of the real computed so a test can populate the queue directly.
   vi.doMock('../governance-signals', async (importOriginal) => ({
     ...(await importOriginal<typeof import('../governance-signals')>()),
@@ -159,10 +159,10 @@ describe('KeeperWorkspaceChat', () => {
     vi.doUnmock('../governance-signals')
   })
 
-  it('shows a pending-approval cue linking to the approvals queue when the keeper awaits a decision', async () => {
+  it('links the compact pending-approval header badge to the approvals queue', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
     const { navigate } = await import('../../router')
-    // The cue derives from the governance approval_queue (HITL SSOT), not
+    // The badge derives from the governance approval_queue (HITL SSOT), not
     // keeper.trust.approval_state (#23678).
     mockGovernanceData.value = governanceResponse([approvalItem('appr-1', 'sangsu', 'fs_write')])
 
@@ -170,32 +170,25 @@ describe('KeeperWorkspaceChat', () => {
       render(html`<${KeeperWorkspaceChat} keeper=${mockKeeper} />`, container)
     })
 
-    const cue = container.querySelector('[data-testid="keeper-pending-approval-cue"]')
-    expect(cue).not.toBeNull()
-    expect(cue?.textContent).toContain('승인 대기')
-    expect(cue?.textContent).toContain('fs_write')
-
-    // Chat remains read-only: the approvals surface is the single act-point
-    // that includes risk and input evidence before approve/reject.
-    const actions = Array.from(cue?.querySelectorAll('button') ?? [])
-    expect(actions).toHaveLength(1)
-    expect(cue?.textContent).not.toContain('거부')
-    const queueLink = actions[0]
-    expect(queueLink?.textContent).toContain('결재 큐')
+    const queueLink = container.querySelector('[data-testid="keeper-pending-approval-link"]') as HTMLButtonElement
+    expect(queueLink).not.toBeNull()
+    expect(queueLink.textContent).toContain('1')
+    expect(queueLink.getAttribute('aria-label')).toContain('결재 대기 1건')
+    expect(container.querySelector('[data-testid="keeper-pending-approval-cue"]')).toBeNull()
     await act(async () => {
-      queueLink?.click()
+      queueLink.click()
     })
     expect(navigate).toHaveBeenCalledWith('approvals')
   })
 
-  it('hides the pending-approval cue when the keeper has no pending decision', async () => {
+  it('hides the pending-approval badge when the keeper has no pending decision', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
 
     await act(async () => {
       render(html`<${KeeperWorkspaceChat} keeper=${mockKeeper} />`, container)
     })
 
-    expect(container.querySelector('[data-testid="keeper-pending-approval-cue"]')).toBeNull()
+    expect(container.querySelector('[data-testid="keeper-pending-approval-link"]')).toBeNull()
   })
 
   it('renders the chat header and conversation panel', async () => {
@@ -212,9 +205,21 @@ describe('KeeperWorkspaceChat', () => {
     expect(container.querySelector('[data-testid="kw-sigil"]')?.textContent).toBe('sangsu')
     expect(container.querySelector('[data-testid="kw-conversation-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="kw-chat-command-icons"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-config"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-search"]')).toBeNull()
+    expect(container.querySelector('[data-testid="kw-conversation-panel"]')?.getAttribute('data-toolbar-open')).toBe('false')
+
+    await act(async () => {
+      ;(container.querySelector('[data-testid="kw-chat-command-menu-toggle"]') as HTMLButtonElement).click()
+    })
     expect(container.querySelector('[data-testid="kw-chat-command-turn"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="kw-chat-command-artifacts"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="kw-chat-command-config"]')).not.toBeNull()
+    const search = container.querySelector('[data-testid="kw-chat-command-search"]') as HTMLButtonElement
+    expect(search).not.toBeNull()
+    await act(async () => {
+      search.click()
+    })
+    expect(container.querySelector('[data-testid="kw-conversation-panel"]')?.getAttribute('data-toolbar-open')).toBe('true')
   })
 
   it('keeps utility commands usable while a lifecycle command is pending', async () => {
@@ -234,9 +239,9 @@ describe('KeeperWorkspaceChat', () => {
     })
 
     const pause = container.querySelector('[data-testid="kw-chat-command-pause"]') as HTMLButtonElement
-    const turn = container.querySelector('[data-testid="kw-chat-command-turn"]') as HTMLButtonElement
+    const menuToggle = container.querySelector('[data-testid="kw-chat-command-menu-toggle"]') as HTMLButtonElement
     expect(pause).not.toBeNull()
-    expect(turn).not.toBeNull()
+    expect(menuToggle).not.toBeNull()
 
     await act(async () => {
       pause.click()
@@ -245,6 +250,11 @@ describe('KeeperWorkspaceChat', () => {
 
     expect(runKeeperAction).toHaveBeenCalledWith('sangsu', 'pause')
     expect(pause.disabled).toBe(true)
+    await act(async () => {
+      menuToggle.click()
+    })
+    const turn = container.querySelector('[data-testid="kw-chat-command-turn"]') as HTMLButtonElement
+    expect(turn).not.toBeNull()
     expect(turn.disabled).toBe(false)
 
     await act(async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -65,7 +65,7 @@ const COMMAND_GLYPHS: Partial<Record<WorkspaceCommandId, string>> = {
   boot: '⏻',
   shutdown: '■',
   search: '⌕',
-  turn: '⌕',
+  turn: '↳',
   artifacts: '▣',
   detail: 'ⓘ',
   config: '⚙',
@@ -480,6 +480,9 @@ function TurnInspectorDrawer({
 }
 
 
+// RFC keeper-conversation-hitl-flow §4.1-A: the compact header badge is
+// read-only and links to Approvals, which remains the single approve/reject
+// act-point with the complete risk and input evidence.
 // Pending approval queue scoped to this keeper. Reads governance
 // approval_queue (the HITL SSOT) directly instead of keeper.trust.
 // approval_state, which is a separate payload field and diverges from the

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -228,8 +228,9 @@ function WorkspaceCommandButtons({
       <button
         key=${command.id}
         type="button"
-        role="menuitem"
-        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
+        role=${command.active === undefined ? 'menuitem' : 'menuitemcheckbox'}
+        aria-checked=${command.active === undefined ? undefined : command.active ? 'true' : 'false'}
+        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}${command.active ? ' active' : ''}`}
         disabled=${isLifecycleWorkspaceCommand(command) && busyAction !== null}
         onClick=${() => { void run(command) }}
         data-testid=${`kw-chat-command-${command.id}`}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -44,7 +44,7 @@ const LazyChatArtifactPanel = lazy(async () => ({
   default: (await import('../chat/artifact-panel')).ChatArtifactPanel,
 }))
 
-type WorkspaceUtilityAction = 'turn' | 'artifacts' | 'detail' | 'config'
+type WorkspaceUtilityAction = 'search' | 'turn' | 'artifacts' | 'detail' | 'config'
 type WorkspaceCommandId = KeeperActionKey | WorkspaceUtilityAction
 type IconComponent = typeof Play
 
@@ -64,6 +64,7 @@ const COMMAND_GLYPHS: Partial<Record<WorkspaceCommandId, string>> = {
   wakeup: '↻',
   boot: '⏻',
   shutdown: '■',
+  search: '⌕',
   turn: '⌕',
   artifacts: '▣',
   detail: 'ⓘ',
@@ -93,21 +94,33 @@ function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
 }
 
 function workspaceUtilityCommands({
+  searchOpen,
   detailOpen,
   artifactsOpen,
+  onToggleSearch,
   onOpenTurnInspector,
   onToggleArtifacts,
   onToggleDetail,
   onOpenConfig,
 }: {
+  searchOpen: boolean
   detailOpen: boolean
   artifactsOpen: boolean
+  onToggleSearch: () => void
   onOpenTurnInspector: () => void
   onToggleArtifacts: () => void
   onToggleDetail: () => void
   onOpenConfig?: () => void
 }): WorkspaceCommand[] {
   return [
+    {
+      id: 'search',
+      label: searchOpen ? '검색·이력 닫기' : '대화 검색·이력',
+      title: searchOpen ? '검색·이력 닫기' : '대화 검색·이력',
+      icon: Search,
+      active: searchOpen,
+      onClick: onToggleSearch,
+    },
     {
       id: 'turn',
       label: '턴 검사',
@@ -158,6 +171,8 @@ function WorkspaceCommandButtons({
   onToggleArtifacts,
   onToggleDetail,
   onOpenConfig,
+  searchOpen,
+  onToggleSearch,
 }: {
   keeper: Keeper
   mobile: boolean
@@ -167,6 +182,8 @@ function WorkspaceCommandButtons({
   onToggleArtifacts: () => void
   onToggleDetail: () => void
   onOpenConfig?: () => void
+  searchOpen: boolean
+  onToggleSearch: () => void
 }): VNode {
   const [menuOpen, setMenuOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<WorkspaceCommandId | null>(null)
@@ -178,8 +195,10 @@ function WorkspaceCommandButtons({
   }, [menuOpen])
 
   const utilities = workspaceUtilityCommands({
+    searchOpen,
     detailOpen,
     artifactsOpen,
+    onToggleSearch,
     onOpenTurnInspector,
     onToggleArtifacts,
     onToggleDetail,
@@ -201,6 +220,24 @@ function WorkspaceCommandButtons({
     } finally {
       setBusyAction(null)
     }
+  }
+
+  const renderMenuItem = (command: WorkspaceCommand): VNode => {
+    const Icon = command.icon
+    return html`
+      <button
+        key=${command.id}
+        type="button"
+        role="menuitem"
+        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
+        disabled=${isLifecycleWorkspaceCommand(command) && busyAction !== null}
+        onClick=${() => { void run(command) }}
+        data-testid=${`kw-chat-command-${command.id}`}
+      >
+        <${Icon} size=${14} aria-hidden="true" />
+        <span>${command.label}</span>
+      </button>
+    `
   }
 
   if (mobile) {
@@ -225,23 +262,7 @@ function WorkspaceCommandButtons({
           ${menuOpen
             ? html`
                 <div class="kw-chat-command-popover v2-monitoring-surface" role="menu" onClick=${(event: Event) => event.stopPropagation()}>
-                  ${commands.map(command => {
-                    const Icon = command.icon
-                    return html`
-                      <button
-                        key=${command.id}
-                        type="button"
-                        role="menuitem"
-                        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
-                        disabled=${isLifecycleWorkspaceCommand(command) && busyAction !== null}
-                        onClick=${() => { void run(command) }}
-                        data-testid=${`kw-chat-command-${command.id}`}
-                      >
-                        <${Icon} size=${14} aria-hidden="true" />
-                        <span>${command.label}</span>
-                      </button>
-                    `
-                  })}
+                  ${commands.map(renderMenuItem)}
                 </div>
               `
             : null}
@@ -269,17 +290,48 @@ function WorkspaceCommandButtons({
     `
   }
 
-  // Lifecycle (명령) and navigation (이동) commands render as two visually
-  // separated clusters — one flat row of 7 look-alike icons was unreadable.
+  // Keep the prototype's five-command silhouette: lifecycle controls stay
+  // direct, secondary inspectors live in one overflow, and Settings remains a
+  // direct destination. The same commands also stay available in composer `/`.
   const lifecycle = commands.filter(isLifecycleWorkspaceCommand)
   const utility = commands.filter(command => !isLifecycleWorkspaceCommand(command))
+  const configCommand = utility.find(command => command.id === 'config')
+  const overflowCommands = utility.filter(command => command.id !== 'config')
   return html`
     <div class="kw-chat-command-icons" data-testid="kw-chat-command-icons">
       ${lifecycle.map(renderIcon)}
       ${lifecycle.length > 0 && utility.length > 0
         ? html`<span class="kw-chat-command-sep" role="separator" aria-orientation="vertical"></span>`
         : null}
-      ${utility.map(renderIcon)}
+      ${overflowCommands.length > 0
+        ? html`
+            <div class="kw-chat-command-menu">
+              <button
+                type="button"
+                class="kw-chat-command-icon v2-monitoring-action"
+                aria-label="대화 도구"
+                aria-haspopup="menu"
+                aria-expanded=${menuOpen ? 'true' : 'false'}
+                title="대화 도구"
+                onClick=${(event: Event) => {
+                  event.stopPropagation()
+                  setMenuOpen(open => !open)
+                }}
+                data-testid="kw-chat-command-menu-toggle"
+              >
+                <${MoreHorizontal} size=${16} aria-hidden="true" />
+              </button>
+              ${menuOpen
+                ? html`
+                    <div class="kw-chat-command-popover v2-monitoring-surface" role="menu" onClick=${(event: Event) => event.stopPropagation()}>
+                      ${overflowCommands.map(renderMenuItem)}
+                    </div>
+                  `
+                : null}
+            </div>
+          `
+        : null}
+      ${configCommand ? renderIcon(configCommand) : null}
     </div>
   `
 }
@@ -295,6 +347,8 @@ function ChatHeader({
   onBack,
   onOpenRail,
   onOpenConfig,
+  searchOpen,
+  onToggleSearch,
 }: {
   keeper: Keeper
   detailOpen: boolean
@@ -306,6 +360,8 @@ function ChatHeader({
   onBack?: () => void
   onOpenRail?: () => void
   onOpenConfig?: () => void
+  searchOpen: boolean
+  onToggleSearch: () => void
 }): VNode {
   const tone = keeperStatusTone(keeper)
   const pill = statePillTone(tone)
@@ -336,7 +392,18 @@ function ChatHeader({
         <div class="kw-chat-name-row">
           <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
           ${pendingApprovalCount > 0
-            ? html`<${Pill} tone="warn" dot="warn" title=${`결재 대기 ${pendingApprovalCount}건`}>${pendingApprovalCount}</${Pill}>`
+            ? html`
+                <button
+                  type="button"
+                  class="kw-pending-approval-link"
+                  title=${`결재 대기 ${pendingApprovalCount}건 · 결재 큐 열기`}
+                  aria-label=${`결재 대기 ${pendingApprovalCount}건 · 결재 큐 열기`}
+                  data-testid="keeper-pending-approval-link"
+                  onClick=${() => navigate('approvals')}
+                >
+                  <${Pill} tone="warn" dot="warn">${pendingApprovalCount}</${Pill}>
+                </button>
+              `
             : null}
           <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
             <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
@@ -354,6 +421,8 @@ function ChatHeader({
           onToggleArtifacts=${onToggleArtifacts}
           onToggleDetail=${onToggleDetail}
           onOpenConfig=${onOpenConfig}
+          searchOpen=${searchOpen}
+          onToggleSearch=${onToggleSearch}
         />
         ${mobile
           ? html`
@@ -410,10 +479,6 @@ function TurnInspectorDrawer({
 }
 
 
-// RFC keeper-conversation-hitl-flow §4.1-A: a slim, non-interactive cue at the
-// top of the conversation so an operator who arrives via "대화에서 검토" sees the
-// keeper is awaiting a decision. Read-only display + a link back to the approvals
-// queue (the single act-point); no approve/reject action here by design.
 // Pending approval queue scoped to this keeper. Reads governance
 // approval_queue (the HITL SSOT) directly instead of keeper.trust.
 // approval_state, which is a separate payload field and diverges from the
@@ -422,32 +487,6 @@ function TurnInspectorDrawer({
 function keeperPendingApprovals(keeperName: string) {
   const queue = governanceData.value?.approval_queue ?? []
   return queue.filter((a) => a.keeper_name === keeperName)
-}
-
-function PendingApprovalCue({ keeper }: { keeper: Keeper }): VNode | null {
-  const pending = keeperPendingApprovals(keeper.name)
-  if (pending.length === 0) return null
-  const first = pending[0]
-  if (!first) return null
-  const rest = pending.length - 1
-  const tool = first.tool_name?.trim() ?? ''
-  return html`
-    <div
-      class="kw-chat-pending-cue flex items-center gap-2 px-4 py-2 text-xs text-[var(--color-fg-secondary)]"
-      role="status"
-      data-testid="keeper-pending-approval-cue"
-    >
-      <${Pill} tone="warn" dot="warn">승인 대기 ${pending.length}</${Pill}>
-      <span>${tool || '결재 요청'}${rest > 0 ? ` 외 ${rest}건` : ''}</span>
-      <span class="flex-1"></span>
-      <button
-        type="button"
-        class="kw-act v2-monitoring-action"
-        onClick=${() => navigate('approvals')}
-        title="결재 큐에서 모든 요청을 봅니다"
-      >결재 큐 →</button>
-    </div>
-  `
 }
 
 export function KeeperWorkspaceChat({
@@ -468,6 +507,7 @@ export function KeeperWorkspaceChat({
   const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
   const [turnInspectorEntry, setTurnInspectorEntry] = useState<KeeperConversationEntry | null>(null)
   const [artifactsOpen, setArtifactsOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const [composerBusyAction, setComposerBusyAction] = useState<WorkspaceCommandId | null>(null)
   const entries = keeperThreads.value[keeper.name] ?? []
   const detailOpen = false
@@ -479,10 +519,12 @@ export function KeeperWorkspaceChat({
   const workspaceCommands = [
     ...lifecycleCommands(keeper),
     ...workspaceUtilityCommands({
+      searchOpen,
       detailOpen,
       artifactsOpen,
+      onToggleSearch: () => setSearchOpen(open => !open),
       onOpenTurnInspector: () => openTurnInspector(),
-          onToggleArtifacts: () => setArtifactsOpen((o) => !o),
+      onToggleArtifacts: () => setArtifactsOpen((o) => !o),
       onToggleDetail,
       onOpenConfig,
     }),
@@ -526,8 +568,9 @@ export function KeeperWorkspaceChat({
         onBack=${onBack}
         onOpenRail=${onOpenRail}
         onOpenConfig=${onOpenConfig}
+        searchOpen=${searchOpen}
+        onToggleSearch=${() => setSearchOpen(open => !open)}
       />
-      <${PendingApprovalCue} keeper=${keeper} />
       <div class="kw-chat-body">
         <${KeeperConversationPanel}
           keeperName=${keeper.name}
@@ -535,6 +578,7 @@ export function KeeperWorkspaceChat({
           layout="workspace"
           composerCommands=${composerCommands}
           onInspectTurn=${openTurnInspector}
+          workspaceToolbarOpen=${searchOpen}
         />
         ${artifactsOpen
           ? html`

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
   // View prefs are module-level persistent signals — reset to defaults so
   // sort/filter choices made by one test never leak into the next.
   rosterFilterPref.value = 'all'
-  rosterSortPref.value = 'recent'
+  rosterSortPref.value = 'status'
   vi.mocked(navigate).mockClear()
   vi.mocked(runKeeperAction).mockClear()
   host = document.createElement('div')
@@ -55,15 +55,16 @@ afterEach(() => {
 })
 
 describe('KeeperWorkspaceRoster', () => {
-  // The default sort is now '최근순' (flat, no headers); status grouping is opt-in.
+  // Status grouping is the keeper-v2 default; helper remains for tests that
+  // explicitly switch away and back.
   const selectStatusSort = () =>
     fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, { target: { value: 'status' } })
 
-  it('renders attention first while preserving status groups', () => {
+  it('renders each keeper once in lifecycle groups while attention stays a row signal', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     selectStatusSort()
     const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
-    expect(labels).toEqual(['주의 필요', '실행 중', '대기 · 일시정지'])
+    expect(labels).toEqual(['실행 중', '대기', '중지'])
     expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
   })
 
@@ -73,7 +74,7 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('.kw-roster.roster')).not.toBeNull()
     selectStatusSort()
     const firstHeader = host.querySelector('.kw-roster-group.roster-group') as HTMLElement
-    expect(firstHeader?.getAttribute('title')).toBe('주의 필요')
+    expect(firstHeader?.getAttribute('title')).toBe('실행 중')
 
     const toggle = host.querySelector('.rfilter-icon') as HTMLButtonElement
     expect(toggle).not.toBeNull()
@@ -165,7 +166,7 @@ describe('KeeperWorkspaceRoster', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="blocked" />`, host)
 
     const attention = host.querySelector('.kp-att') as HTMLElement
-    expect(attention?.textContent).toBe('주의 1')
+    expect(attention?.textContent).toBe('▲ 1')
     expect(attention?.getAttribute('title')).toContain('메시지 수가 아니라')
   })
 
@@ -296,14 +297,14 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('[data-testid="kw-roster-menu"]')?.textContent).toContain('rama')
   })
 
-  it('renders the v2.3 attention-first group headers with counts', () => {
+  it('renders lifecycle group headers with counts', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     selectStatusSort()
     const headers = Array.from(host.querySelectorAll('.kw-roster-group'))
     expect(headers.map(h => h.textContent)).toEqual([
-      expect.stringContaining('주의 필요'),
       expect.stringContaining('실행 중'),
-      expect.stringContaining('대기 · 일시정지'),
+      expect.stringContaining('대기'),
+      expect.stringContaining('중지'),
     ])
     expect(Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)).toEqual(['1', '1', '1'])
   })
@@ -374,26 +375,25 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('.kw-roster-group .kw-roster-group-label')?.textContent).toBe('실행 중')
   })
 
-  it('renders the sort select defaulting to 최근순 (recent) order', () => {
+  it('renders the sort select defaulting to lifecycle status groups', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const sortSel = host.querySelector('.kw-roster-sort') as HTMLSelectElement
     expect(sortSel).not.toBeNull()
-    expect(sortSel.value).toBe('recent')
+    expect(sortSel.value).toBe('status')
     expect(Array.from(sortSel.options).map(o => o.value)).toEqual(['recent', 'status', 'name', 'att'])
-    // recent mode is a flat list: no status/attention group headers by default
-    expect(host.querySelectorAll('.kw-roster-group').length).toBe(0)
-    // switching to 상태순 brings the bucket group headers back
-    selectStatusSort()
     expect(host.querySelectorAll('.kw-roster-group').length).toBeGreaterThan(0)
   })
 
-  it('defaults to most-recent-first order (activity, not name)', () => {
+  it('supports explicit most-recent-first order (activity, not name)', () => {
     keepers.value = [
       mk({ name: 'albini', status: 'running', last_activity_ago_s: 3600 }),
       mk({ name: 'zed', status: 'running', last_activity_ago_s: 5 }),
       mk({ name: 'mara', status: 'running', last_activity_ago_s: 120 }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="zed" />`, host)
+    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
+      target: { value: 'recent' },
+    })
     const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
       r.textContent?.includes('zed') ? 'zed' : r.textContent?.includes('mara') ? 'mara' : 'albini',
     )
@@ -469,7 +469,7 @@ describe('KeeperWorkspaceRoster', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     selectStatusSort()
     const counts = Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)
-    // FIXTURE: 1 attention row (rama), then running and paused status buckets.
+    // FIXTURE: one running, one paused, and one offline keeper.
     expect(counts).toEqual(['1', '1', '1'])
   })
 
@@ -482,7 +482,7 @@ describe('KeeperWorkspaceRoster', () => {
     selectStatusSort()
 
     const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
-    expect(labels).toEqual(['실행 중', '중지 · 종료됨'])
+    expect(labels).toEqual(['실행 중', '중지'])
   })
 
   it('closes the row command menu on Escape only (not on any keypress) and on scroll', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -41,7 +41,7 @@ type RosterFilter = 'all' | 'run' | 'att'
 type RosterSort = 'status' | 'recent' | 'name' | 'att'
 type KeeperWorkspaceRouteSurface = 'monitoring' | 'keepers'
 type RosterMenuState = { keeper: Keeper; x: number; y: number } | null
-type RosterHeaderBucket = KeeperBucket | 'attention'
+type RosterHeaderBucket = KeeperBucket
 type RosterFleetSummary = {
   total: number
   running: number
@@ -75,19 +75,18 @@ export const rosterFilterPref = persistentSignal<RosterFilter>({
   defaultValue: 'all',
   deserialize: memberOr(ROSTER_FILTER_VALUES, 'all'),
 })
-// Default '최근순' (most-recent-first): returning to #keepers should surface the
-// keeper that just did something, not an alphabetically-first name. 상태순 remains
-// available in the sort menu for operators who want running-first grouping.
+// The standalone's default is lifecycle grouping: running, waiting, then
+// stopped. Recency remains available as an explicit operator preference.
 export const rosterSortPref = persistentSignal<RosterSort>({
   key: 'dashboard:kw-roster:sort-v1',
-  defaultValue: 'recent',
-  deserialize: memberOr(ROSTER_SORT_VALUES, 'recent'),
+  defaultValue: 'status',
+  deserialize: memberOr(ROSTER_SORT_VALUES, 'status'),
 })
 
 const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'running', label: '실행 중' },
-  { bucket: 'paused', label: '대기 · 일시정지' },
-  { bucket: 'offline', label: '중지 · 종료됨' },
+  { bucket: 'paused', label: '대기' },
+  { bucket: 'offline', label: '중지' },
 ]
 
 /** Flattened roster item used by the virtualized render path. */
@@ -262,7 +261,7 @@ function RosterRow({
       <div class="kw-kp-right">
         ${activityText ? html`<span class="kw-kp-time" title=${rosterActivityTitle(activity)}>${activityText}</span>` : null}
         ${att > 0
-          ? html`<span class="kw-kp-att kp-att" title=${`주의 신호 ${att}건 · 메시지 수가 아니라 blocked/attention 상태입니다`}>주의 ${att}</span>`
+          ? html`<span class="kw-kp-att kp-att" aria-label=${`주의 신호 ${att}건`} title=${`주의 신호 ${att}건 · 메시지 수가 아니라 blocked/attention 상태입니다`}>▲ ${att}</span>`
           : null}
       </div>
       <button
@@ -344,7 +343,6 @@ function rosterActivityTitle(activity: KeeperActivityDisplay): string | undefine
 }
 
 function groupBucketClass(bucket: RosterHeaderBucket): string {
-  if (bucket === 'attention') return 'att'
   if (bucket === 'running') return 'run'
   if (bucket === 'paused') return 'pause'
   return 'off'
@@ -550,23 +548,14 @@ export function KeeperWorkspaceRoster({
     { id: 'att', label: '주의', tone: 'att', title: '주의 신호가 있는 키퍼 — 실행 중 키퍼도 포함되는 교차 집계' },
   ]
 
-  // Flatten to [{ type: 'header'|'row', ... }] for windowing. 'status' keeps the
-  // bucket grouping with headers; 'name'/'att' produce a flat sorted list with no
-  // headers, mirroring the v2 roster sort modes (rails.jsx Roster).
+  // Flatten to [{ type: 'header'|'row', ... }] for windowing. Attention is a
+  // cross-cutting row badge/filter, never a lifecycle bucket; status view keeps
+  // every keeper exactly once under running, paused, or offline.
   const items: RosterItem[] = []
   if (sort === 'status') {
-    const attentionRows = visible.filter(needsAttention).sort((a, b) =>
-      attentionScore(b) - attentionScore(a)
-      || keeperContextRatio(b) - keeperContextRatio(a)
-      || a.name.localeCompare(b.name),
-    )
-    if (attentionRows.length > 0) {
-      items.push({ type: 'header', bucket: 'attention', label: '주의 필요', count: attentionRows.length })
-      for (const keeper of attentionRows) items.push({ type: 'row', keeper })
-    }
     for (const group of GROUP_ORDER) {
       const rows = visible
-        .filter(k => !needsAttention(k) && keeperBucket(k) === group.bucket)
+        .filter(k => keeperBucket(k) === group.bucket)
         .sort(compareFleetRows)
       if (rows.length === 0) continue
       items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -92,7 +92,7 @@
    `.kw-rail` (context cards only). Verified on the running dashboard. */
 .v2-app[data-density="spacious"] .kw-rail-scroll   { padding: 20px; gap: 24px; }
 .v2-app[data-density="spacious"] .kw-rail .kw-sec  { padding: 14px 16px; }
-.v2-app[data-density="spacious"] .kw-roster-head   { padding: 16px 14px; }
+.v2-app[data-density="spacious"] .kw-roster-head   { padding: 0; }
 .v2-app[data-density="spacious"] .kw-roster-list   { padding: 10px 8px; }
 .v2-app[data-density="spacious"] .kw-roster-filters { padding: 12px 14px; }
 

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -88,7 +88,7 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-rail .kw-sec').padding)
       .toBe('14px 16px')
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-head').padding)
-      .toBe('16px 14px')
+      .toBe('0')
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-filters').padding)
       .toBe('12px 14px')
     expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-rail-scroll').padding)

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -434,14 +434,14 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(mobileRuleDecls('.kw-kp-menu')['max-width']).toContain('env(safe-area-inset-right, 0px)')
   })
 
-  it('hides the roster ⋮ action until hover/focus on desktop, keeps it for touch', () => {
+  it('hides the roster ⋮ action until hover/focus on desktop and uses detail commands on touch', () => {
     // v2 mock (.kp-more) is opacity:0 at rest and reveals on row hover/focus, so
-    // the card reads as identity + status. The 860px block restores it for touch
-    // where hover is unavailable.
+    // the card reads as identity + status. Touch selects the keeper first and
+    // uses the equivalent command controls in the detail header.
     expect(baseRuleDecls('.kw-kp-more').opacity).toBe('0')
     expect(baseRuleDecls('.kw-kp-row:hover .kw-kp-more').opacity).toBe('1')
     expect(baseRuleDecls('.kw-kp-row:focus-within .kw-kp-more').opacity).toBe('1')
-    expect(mobileRuleDecls('.kw-kp-more').opacity).toBe('1')
+    expect(mobileRuleDecls('.kw-kp-more').display).toBe('none')
   })
 
   it('keeps the mobile context drawer close to the v2 rail without prototype-local state', () => {

--- a/dashboard/src/styles/keeper-workspace-v23.test.ts
+++ b/dashboard/src/styles/keeper-workspace-v23.test.ts
@@ -32,7 +32,7 @@ describe('keeper-workspace v2.3 fleet surface CSS', () => {
     expect(gloss['white-space']).toBe('nowrap')
 
     const rightRail = declarationsForSelector(css, '.kw-kp-right')
-    expect(rightRail['padding-right']).toBe('34px')
+    expect(rightRail['padding-right']).toBeUndefined()
     expect(rightRail['align-items']).toBe('flex-end')
   })
 

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -680,6 +680,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   color: var(--color-fg-primary);
   background: var(--color-bg-surface);
 }
+.kw-chat-command-item.active {
+  color: var(--color-accent-fg);
+  background: var(--color-accent-bg-subtle);
+}
 .kw-act {
   font-size: var(--fs-12); font-weight: var(--fw-med); letter-spacing: 0.02em;
   padding: 8px 12px; border-radius: var(--r-1); cursor: pointer;

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -366,8 +366,8 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   pointer-events: auto;
 }
 .kw-kp-meta { min-width: 0; }
-.kw-kp-name { font-weight: var(--fw-bold); font-size: calc((var(--fs-14) + var(--fs-15)) / 2); line-height: 1.55; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: calc((var(--fs-11) + var(--fs-12)) / 2); line-height: 1.55; color: var(--color-fg-secondary); margin-top: 2px; min-width: 0; }
+.kw-kp-name { font-weight: var(--fw-bold); font-size: var(--fs-15); line-height: 1.55; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: var(--fs-12); line-height: 1.55; color: var(--color-fg-secondary); margin-top: 2px; min-width: 0; }
 .kw-kp-state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -473,8 +473,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   line-height: 1.4;
 }
 @media (max-width: 860px) {
-  .kw-kp-more { opacity: 1; }
-  .kw-kp-row .kw-kp-right { padding-right: 30px; }
+  /* The standalone touch roster is identity-first and opens commands from the
+   * selected keeper header. Hiding the duplicate row menu gives status/model
+   * text the full narrow-screen width without removing the command surface. */
+  .kw-kp-more { display: none; }
   .kw-kp-row:hover .kw-kp-right,
   .kw-kp-row:focus-within .kw-kp-right {
     opacity: 1;

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -31,6 +31,13 @@
   height: 100%;
 }
 
+/* `#main-content > div` owns generic card padding with ID specificity. Its
+ * padding defeats the `p-0` class emitted for the keeper workspace, leaving a
+ * 12px frame around a prototype that is intentionally edge-to-edge. */
+[data-keeper-detail-mode="true"] #main-content > div {
+  padding: 0;
+}
+
 /* Keeper detail is a focused single-keeper view. On mobile the prototype topbar
  * only keeps the breadcrumb + primary status chips; the re-mounted operational
  * cluster is too wide for the phone chrome and pushes the breadcrumb off-screen.
@@ -110,6 +117,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   .kw-rail-toggle.right { display: none; }
   /* Rail column is gone ≤1180px → its resize handle has nothing to drag. */
   .kw-pane-resizer.right { display: none; }
+  .kw-roster-filters.roster-filters { flex-wrap: wrap; row-gap: 6px; }
 }
 /* Below 860px the workspace becomes master-detail: the roster and chat/detail
  * panes share one grid column, and JS flips data-mobile-pane after selection.
@@ -185,9 +193,9 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-roster-head {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--color-border-divider);
+  gap: 0;
+  padding: 0;
+  border-bottom: 0;
 }
 .kw-roster-title {
   display: flex; align-items: center; gap: 8px;
@@ -217,15 +225,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   min-width: 0;
   align-items: center;
   gap: 6px;
+  width: 100%;
 }
-/* CJK chip labels have a wide min-content floor; at narrow roster widths the
-   sort <select> overflowed the aside instead of dropping to its own line.
-   The element carries both class vocabularies and keeper-v2/v2.css
-   (.roster-filters, deliberately loaded last) re-asserts flex-wrap: nowrap —
-   double up the classes (0,2,0) so the wrap fix actually wins the cascade. */
 .kw-roster-filters.roster-filters {
-  flex-wrap: wrap;
-  row-gap: 6px;
+  flex-wrap: nowrap;
 }
 .kw-rfilter {
   font-size: var(--fs-11); letter-spacing: 0.06em; text-transform: uppercase;
@@ -300,7 +303,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   border-radius: 50%;
   background: var(--color-fg-muted);
 }
-.kw-roster-group.att .rg-dot { background: var(--color-status-err); }
 .kw-roster-group.run .rg-dot { background: var(--color-status-ok); }
 .kw-roster-group.pause .rg-dot { background: var(--color-status-warn); }
 .kw-roster-group.off .rg-dot { background: var(--color-fg-muted); }
@@ -364,16 +366,16 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   pointer-events: auto;
 }
 .kw-kp-meta { min-width: 0; }
-.kw-kp-name { font-weight: var(--fw-bold); font-size: var(--fs-15); color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: var(--fs-12); color: var(--color-fg-secondary); margin-top: 3px; min-width: 0; }
+.kw-kp-name { font-weight: var(--fw-bold); font-size: calc((var(--fs-14) + var(--fs-15)) / 2); line-height: 1.55; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: calc((var(--fs-11) + var(--fs-12)) / 2); line-height: 1.55; color: var(--color-fg-secondary); margin-top: 2px; min-width: 0; }
 .kw-kp-state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; padding-right: 34px; }
+.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
 .kw-kp-time {
   max-width: 96px;
   font-family: var(--font-mono);
-  font-size: var(--fs-11);
-  line-height: 1.25;
+  font-size: var(--fs-10);
+  line-height: 1.55;
   color: var(--color-fg-muted);
   text-align: right;
 }
@@ -564,6 +566,20 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-state-pill.bad { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.50); background: rgb(var(--color-status-err-glow) / 0.12); }
 .kw-state-pill.busy { color: var(--color-status-info); border-color: rgb(var(--color-info-glow) / 0.45); background: rgb(var(--color-info-glow) / 0.10); }
 .kw-state-pill.off { color: var(--color-fg-muted); }
+
+.kw-pending-approval-link {
+  display: inline-flex;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.kw-pending-approval-link:focus-visible {
+  outline: 2px solid var(--color-accent-fg-dim);
+  outline-offset: 2px;
+  border-radius: 9999px;
+}
 
 .kw-chat-actions { display: flex; gap: 8px; align-items: center; flex: none; }
 /* Desktop header command row. These classes were referenced by
@@ -817,14 +833,14 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   flex: none;
   border-top: 1px solid var(--color-border-default);
   background: linear-gradient(0deg, var(--color-bg-panel-alt), var(--color-bg-page));
-  padding: 12px 24px 16px;
+  padding: 16px 30px 22px;
 }
 .kw-composer-inner { width: 100%; max-width: var(--kw-thread-w, 980px); margin: 0 auto; padding: 0 4px; }
-/* Composer floor: the reused ChatComposer applies min-h-30 (120px) to an empty
- * textarea, permanently reserving space the transcript (its flex:1 sibling)
- * would otherwise take. Lower the floor to ~2 rows, scoped to the workspace;
- * control-textarea keeps resize:vertical so a long draft can be dragged taller. */
-.kw-composer-inner .control-textarea { min-height: 80px; }
+/* Prototype composer is one row at rest; long drafts still grow through the
+ * shared composer autosize path. Keep both selector vocabularies for callers
+ * that still render the older control-textarea hook. */
+.kw-composer-inner .control-textarea,
+.kw-composer-inner .composer-textarea { min-height: 40px; }
 
 .kw-chat-toolbar {
   flex: none; display: flex; align-items: center; gap: 8px; flex-wrap: wrap;


### PR DESCRIPTION
## What changed

- remove the duplicate primary-surface health strip from layout flow while keeping its polling mounted
- make the keeper workspace full-bleed and align the 50px shell, 286px roster, 75px chat header, and 93px composer with the standalone reference
- default the roster to lifecycle grouping without duplicating attention keepers across buckets
- collapse secondary chat tools into an overflow menu and expose search/history on demand
- retain pending approval access as a compact, keyboard-focusable header badge
- use the standalone's single-row composer while restoring queue/stall evidence when activity exists

## Why

The production keeper detail route had accumulated generic shell padding, a second health band, permanent search/history chrome, and a two-row composer. Together those offsets displaced every main pane from the Keeper Agent v2 standalone geometry and reduced transcript space.

This change keeps existing live projections and commands intact. It does not add mock product values, frontend runtime heuristics, or backend fallbacks.

## Impact

- keeper detail uses the standalone's desktop pane geometry and denser roster typography
- each keeper appears exactly once in its lifecycle group; attention remains a filter/badge
- approval, search, history, turn inspector, artifact, detail, and config actions remain reachable
- the HITL badge remains read-only and routes to Approvals as the single approve/reject act-point (`keeper-conversation-hitl-flow §4.1-A`)
- non-primary diagnostic/plugin routes still render the dashboard health strip

## Validation

- `pnpm --dir dashboard run lint`
- `pnpm --dir dashboard run typecheck`
- `pnpm --dir dashboard run build`
- 10 focused test files / 304 tests passed
- `git diff --check`
- browser box comparison at 1440x1000: topbar 50px, columns 58/286/784/312px, chat header 75px, composer 93px
- rendered 390x844 roster comparison: standalone filter/group/row density and identity-first touch command layout

## Review notes

- visual evidence was captured while the existing local 8935 runtime was responsive; it later stopped answering health requests, so the shared runtime was intentionally not restarted as part of this frontend PR
- the full dashboard suite was sampled until it exposed the stale integrated roster expectation; that test was updated and the affected surface suite was rerun green
