### PR TITLE
feat(keeper): persist shutdown prepare and join

### DIFF
--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -5,22 +5,28 @@
     Keeper_agent_tool_surface, so lifecycle transitions can update keeper meta
     without creating a keeper tool-surface dependency cycle. *)
 
+let resolved_agent_names_result ~(config : Workspace.config) ~(agent_name : string) =
+  try
+    let actual_name = Workspace.resolve_agent_name config agent_name in
+    Ok ([ agent_name; actual_name ] |> List.sort_uniq String.compare)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
 let resolved_agent_names ~(config : Workspace.config) ~(agent_name : string) =
-  let actual_name =
-    try Workspace.resolve_agent_name config agent_name
-    with
-    | Sys_error _ | Yojson.Json_error _ -> agent_name
-    | exn ->
+  match resolved_agent_names_result ~config ~agent_name with
+  | Ok names -> names
+  | Error detail ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string ReconcileFailures)
         ~labels:[("keeper", agent_name); ("phase", "resolve_agent")]
         ();
       Log.Keeper.warn
         "resolve_agent_name failed while reconciling current task for %s: %s"
-        agent_name (Printexc.to_string exn);
-      agent_name
-  in
-  [ agent_name; actual_name ] |> List.sort_uniq String.compare
+        agent_name
+        detail;
+      [ agent_name ]
 
 let task_id_of_owned_active_task ~(keeper_name : string) (task : Masc_domain.task) =
   match Keeper_id.Task_id.of_string task.id with
@@ -40,9 +46,8 @@ type owned_active_task =
   ; task : Masc_domain.task
   }
 
-let owned_active_tasks_for_meta ~(config : Workspace.config)
-    ~(meta : Keeper_meta_contract.keeper_meta) =
-  let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
+let owned_active_tasks_for_names ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) names =
   let matches assignee = List.mem assignee names in
   try
     match Workspace_backlog.read_backlog_r config with
@@ -83,6 +88,28 @@ let owned_active_tasks_for_meta ~(config : Workspace.config)
       "owned task reconciliation failed: %s"
       message;
     Error message
+
+let owned_active_tasks_for_meta ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  let names = resolved_agent_names ~config ~agent_name:meta.agent_name in
+  owned_active_tasks_for_names ~config ~meta names
+;;
+
+let owned_active_tasks_for_meta_strict ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  match resolved_agent_names_result ~config ~agent_name:meta.agent_name with
+  | Error detail ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ReconcileFailures)
+      ~labels:[ "keeper", meta.name; "phase", "shutdown_resolve_agent" ]
+      ();
+    Log.Keeper.warn
+      ~keeper_name:meta.name
+      "shutdown task ownership resolution failed: %s"
+      detail;
+    Error detail
+  | Ok names -> owned_active_tasks_for_names ~config ~meta names
+;;
 
 let active_status_rank = function
   | Masc_domain.InProgress _ -> 0

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -12,6 +12,14 @@ val owned_active_tasks_for_meta :
   meta:Keeper_meta_contract.keeper_meta ->
   (owned_active_task list, string) result
 
+(** Shutdown transaction variant: agent-name resolution and backlog reads are
+    both strict. No fallback name is guessed when ownership identity cannot be
+    resolved. *)
+val owned_active_tasks_for_meta_strict :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  (owned_active_task list, string) result
+
 (** Find the deterministic active task a keeper should treat as current.
 
     Only [Claimed] and [InProgress] tasks are active bindings. Tasks awaiting

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -162,7 +162,13 @@ let run_keeper_cycle
          ?hitl_resolution)
   with
   | `Ran updated -> updated
-  | `Busy in_flight ->
+  | `Busy (Keeper_turn_admission.Shutdown_requested operation_id) ->
+    Log.Keeper.info
+      "%s: autonomous turn admission closed by shutdown operation %s"
+      meta_after_triage.name
+      (Keeper_shutdown_types.Operation_id.to_string operation_id);
+    meta_after_triage
+  | `Busy (Keeper_turn_admission.Turn_busy in_flight) ->
     (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
        cycle and return the pre-cycle meta unchanged. The next heartbeat
        retries naturally — same shape as the pre-existing skip decisions. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1005,6 +1005,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         in
         let terminalize_lane = function
           | Keeper_lane.Completed -> record_completed_lane ()
+          | Keeper_lane.Shutdown_requested -> record_stopped "shutdown requested"
           | Keeper_lane.Cancelled_by_parent _ ->
             if Atomic.get stop || Shutdown.is_shutting_down_global ()
             then record_stopped "cancelled during shutdown"

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -130,6 +130,9 @@ type joined_stop_result =
 (** Request cooperative stop without claiming that the lane has exited. *)
 val stop_keepalive : ?base_path:string -> string -> unit
 
+(** Signal only the exact captured registry entry. *)
+val request_entry_stop : Keeper_registry.registry_entry -> unit
+
 (** Request cooperative stop and join the exact registry entry observed by
     this call. No timeout is invented: callers choose whether to await. *)
 val stop_keepalive_and_await :

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,5 +1,6 @@
 type outcome =
   | Completed
+  | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -10,8 +11,13 @@ type exit =
 
 type state =
   | Not_started
-  | Running
+  | Starting
+  | Running of Eio.Switch.t
+  | Cancellation_requested
+  | Finalizing
   | Exited
+
+exception Shutdown_cancel
 
 module Id = struct
   type t = string
@@ -57,6 +63,12 @@ type start_error =
   | Already_exited
   | Fork_failed of exn
 
+type cancel_result =
+  | Cancel_requested
+  | Cancel_already_requested
+  | Cancel_already_exiting
+  | Cancel_signal_failed of exn
+
 let start_error_to_string = function
   | Already_started -> "lane already started"
   | Already_exited -> "lane already exited"
@@ -74,13 +86,29 @@ let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p
 
 let rec claim_start t =
-  if Atomic.compare_and_set t.state Not_started Running
+  if Atomic.compare_and_set t.state Not_started Starting
   then Ok ()
   else
     match Atomic.get t.state with
     | Not_started -> claim_start t
-    | Running -> Error Already_started
-    | Exited -> Error Already_exited
+    | Starting | Running _ | Cancellation_requested -> Error Already_started
+    | Finalizing | Exited -> Error Already_exited
+;;
+
+type attach_result =
+  | Scope_attached
+  | Cancel_before_attach
+
+let rec attach_scope t lane_sw =
+  let current = Atomic.get t.state in
+  match current with
+  | Starting ->
+    if Atomic.compare_and_set t.state current (Running lane_sw)
+    then Scope_attached
+    else attach_scope t lane_sw
+  | Cancellation_requested -> Cancel_before_attach
+  | Not_started | Running _ | Finalizing | Exited ->
+    invalid_arg "Keeper_lane.attach_scope: invalid lane state"
 ;;
 
 let cleanup_result cleanup outcome =
@@ -93,13 +121,56 @@ let cleanup_result cleanup outcome =
     | exn -> Some (Printexc.to_string exn))
 ;;
 
+let rec claim_finalization t =
+  let current = Atomic.get t.state in
+  match current with
+  | Starting | Running _ | Cancellation_requested ->
+    if Atomic.compare_and_set t.state current Finalizing
+    then true
+    else claim_finalization t
+  | Not_started | Finalizing | Exited -> false
+;;
+
 let resolve_exit_once t outcome cleanup =
-  if Atomic.compare_and_set t.state Running Exited
+  if claim_finalization t
   then (
     let cleanup_error = cleanup_result cleanup outcome in
+    Atomic.set t.state Exited;
     Eio.Promise.resolve t.exited_r { outcome; cleanup_error };
     true)
   else false
+;;
+
+let rec request_cancel t =
+  let current = Atomic.get t.state in
+  match current with
+  | Not_started ->
+    if Atomic.compare_and_set t.state current Finalizing
+    then (
+      Atomic.set t.state Exited;
+      Eio.Promise.resolve
+        t.exited_r
+        { outcome = Shutdown_requested; cleanup_error = None };
+      Cancel_requested)
+    else request_cancel t
+  | Starting ->
+    if Atomic.compare_and_set t.state current Cancellation_requested
+    then Cancel_requested
+    else request_cancel t
+  | Running lane_sw ->
+    if Atomic.compare_and_set t.state current Cancellation_requested
+    then
+      (try
+         Eio.Switch.fail lane_sw Shutdown_cancel;
+         Cancel_requested
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         ignore (Atomic.compare_and_set t.state Cancellation_requested current);
+         Cancel_signal_failed exn)
+    else request_cancel t
+  | Cancellation_requested -> Cancel_already_requested
+  | Finalizing | Exited -> Cancel_already_exiting
 ;;
 
 let fork ~sw t ~run ~cleanup =
@@ -112,9 +183,15 @@ let fork ~sw t ~run ~cleanup =
          Atomic.set started true;
          let outcome =
            try
-             Eio.Switch.run (fun lane_sw -> run lane_sw);
+             Eio.Switch.run (fun lane_sw ->
+               match attach_scope t lane_sw with
+               | Scope_attached -> run lane_sw
+               | Cancel_before_attach ->
+                 Eio.Switch.fail lane_sw Shutdown_cancel;
+                 Eio.Switch.check lane_sw);
              Completed
            with
+           | Shutdown_cancel -> Shutdown_requested
            | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
            | exn -> Failed exn
          in

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -16,6 +16,7 @@ end
 
 type outcome =
   | Completed
+  | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -28,6 +29,12 @@ type start_error =
   | Already_started
   | Already_exited
   | Fork_failed of exn
+
+type cancel_result =
+  | Cancel_requested
+  | Cancel_already_requested
+  | Cancel_already_exiting
+  | Cancel_signal_failed of exn
 
 val start_error_to_string : start_error -> string
 
@@ -47,6 +54,11 @@ val fork :
 (** Resolve a lane for which the launch gate rejected the fiber before it
     started.  This keeps the join contract total for every registry entry. *)
 val reject_before_start : t -> reason:exn -> (unit, start_error) result
+
+(** Request cancellation of this exact lane scope. The request is remembered
+    even if the fiber has not attached its switch yet. This does not join; use
+    [await_exit] for that boundary. *)
+val request_cancel : t -> cancel_result
 
 val exited : t -> exit Eio.Promise.t
 val peek_exit : t -> exit option

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -301,6 +301,19 @@ val clear_turn_switch : base_path:string -> string -> unit
 val interrupt_current_turn :
   base_path:string -> string -> [ `Cancelled of int | `No_turn_in_flight ]
 
+type exact_turn_interrupt_result =
+  | Exact_turn_cancelled of int
+  | Exact_no_turn_in_flight
+  | Exact_turn_cancel_failed of
+      { turn_id : int option
+      ; detail : string
+      }
+
+(** Cancel the turn switch retained by this exact registry entry. Unlike the
+    name-based compatibility API, failure is returned explicitly. *)
+val interrupt_current_turn_exact :
+  registry_entry -> exact_turn_interrupt_result
+
 (** Record the verdict reasons from a [keeper_cycle_decision] that
     chose to skip the next turn.  Stamps [last_skip_observation] with
     [(now, reasons)] so the stale watchdog can surface *why* a keeper

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -1076,17 +1076,76 @@ let clear_turn_switch ~base_path name =
   set_turn_switch ~base_path name None
 ;;
 
+type exact_turn_interrupt_result =
+  | Exact_turn_cancelled of int
+  | Exact_no_turn_in_flight
+  | Exact_turn_cancel_failed of
+      { turn_id : int option
+      ; detail : string
+      }
+
+let interrupt_current_turn_exact observed_entry =
+  let current_entry =
+    StringMap.find_opt
+      (registry_key
+         ~base_path:observed_entry.base_path
+         observed_entry.name)
+      (Atomic.get registry)
+  in
+  match current_entry with
+  | None ->
+    Exact_turn_cancel_failed
+      { turn_id = None; detail = "registry entry disappeared before turn cancellation" }
+  | Some entry
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id entry.lane)
+              (Keeper_lane.id observed_entry.lane)) ->
+    Exact_turn_cancel_failed
+      { turn_id = None; detail = "a newer same-name lane owns the registry entry" }
+  | Some entry ->
+  let turn_id =
+    Option.map
+      (fun observation -> observation.turn_id)
+      entry.current_turn_observation
+  in
+    match Atomic.exchange entry.current_turn_switch None, turn_id with
+    | None, None -> Exact_no_turn_in_flight
+    | None, Some turn_id ->
+       Exact_turn_cancel_failed
+         { turn_id = Some turn_id
+         ; detail = "turn observation exists without a live turn switch"
+         }
+    | Some turn_sw, observed_turn_id ->
+      (try
+         Eio.Switch.fail turn_sw Operator_interrupt;
+         match observed_turn_id with
+         | Some turn_id -> Exact_turn_cancelled turn_id
+         | None ->
+           Exact_turn_cancel_failed
+             { turn_id = None
+             ; detail = "live turn switch exists without a turn observation"
+             }
+       with
+       | exn ->
+         Exact_turn_cancel_failed
+           { turn_id = observed_turn_id
+           ; detail = Printexc.to_string exn
+           })
+;;
+
 let interrupt_current_turn ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> `No_turn_in_flight
   | Some entry ->
-    (match entry.current_turn_observation with
-     | None -> `No_turn_in_flight
-     | Some obs ->
-       match Atomic.exchange entry.current_turn_switch None with
-       | None -> `No_turn_in_flight
-       | Some sw ->
-         (try Eio.Switch.fail sw Operator_interrupt with
-          | Invalid_argument _ -> ());
-         `Cancelled obs.turn_id)
+    (match interrupt_current_turn_exact entry with
+     | Exact_turn_cancelled turn_id -> `Cancelled turn_id
+     | Exact_no_turn_in_flight -> `No_turn_in_flight
+     | Exact_turn_cancel_failed { detail; _ } ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string LifecycleDispatchRejections)
+         ~labels:[ "keeper", name; "event", "turn_cancel_failed" ]
+         ();
+       Log.Keeper.warn "%s: turn cancellation failed: %s" name detail;
+       `No_turn_in_flight)
 ;;

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -40,7 +40,7 @@ let same_lane left right =
     (Keeper_lane.id right.Keeper_registry.lane)
 ;;
 
-let current_entry ~config observed =
+let current_entry ~config (observed : Keeper_registry.registry_entry) =
   match Keeper_registry.get ~base_path:config.Workspace.base_path observed.name with
   | Some current when same_lane current observed -> Ok current
   | Some _ | None -> Error Registry_lane_replaced

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -1,0 +1,229 @@
+open Keeper_shutdown_types
+
+type request =
+  { actor : string
+  ; cleanup_intent : cleanup_intent
+  }
+
+type error =
+  | Registry_lane_replaced
+  | Existing_operation of Operation_id.t
+  | Task_discovery_failed of string
+  | Prepare_persist_failed of Keeper_shutdown_store.error
+  | Cancellation_failed of Keeper_shutdown_types.t
+  | Join_failed of Keeper_shutdown_types.t
+  | Join_record_update_failed of Keeper_shutdown_store.error
+
+let error_to_string = function
+  | Registry_lane_replaced -> "Keeper registry lane changed before shutdown prepare"
+  | Existing_operation operation_id ->
+    Printf.sprintf
+      "Keeper shutdown already reserved by operation %s"
+      (Operation_id.to_string operation_id)
+  | Task_discovery_failed detail ->
+    Printf.sprintf "Keeper shutdown task discovery failed: %s" detail
+  | Prepare_persist_failed error -> Keeper_shutdown_store.error_to_string error
+  | Cancellation_failed operation ->
+    Printf.sprintf
+      "Keeper shutdown cancellation blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+  | Join_failed operation ->
+    Printf.sprintf
+      "Keeper shutdown join blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+  | Join_record_update_failed error -> Keeper_shutdown_store.error_to_string error
+;;
+
+let same_lane left right =
+  Keeper_lane.Id.equal
+    (Keeper_lane.id left.Keeper_registry.lane)
+    (Keeper_lane.id right.Keeper_registry.lane)
+;;
+
+let current_entry ~config observed =
+  match Keeper_registry.get ~base_path:config.Workspace.base_path observed.name with
+  | Some current when same_lane current observed -> Ok current
+  | Some _ | None -> Error Registry_lane_replaced
+;;
+
+let admission_lane = function
+  | Keeper_turn_admission.Autonomous -> Autonomous
+  | Keeper_turn_admission.Chat -> Chat
+;;
+
+let active_turn_of_snapshots reservation current =
+  let observation = current.Keeper_registry.current_turn_observation in
+  match reservation.Keeper_turn_admission.in_flight, observation with
+  | None, None -> No_inflight_turn
+  | in_flight, observation ->
+    let lane, admitted_at =
+      match in_flight with
+      | Some info -> Some (admission_lane info.lane), Some info.started_at
+      | None -> None, None
+    in
+    Inflight_effect_unknown
+      { lane
+      ; admitted_at
+      ; observed_turn_id = Option.map (fun obs -> obs.turn_id) observation
+      ; observation_started_at = Option.map (fun obs -> obs.started_at) observation
+      }
+;;
+
+let rollback_reservation ~config ~entry operation_id =
+  match
+    Keeper_turn_admission.rollback_shutdown
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:entry.Keeper_registry.name
+      ~operation_id
+  with
+  | Keeper_turn_admission.Shutdown_rolled_back
+  | Keeper_turn_admission.Shutdown_not_reserved -> ()
+  | Keeper_turn_admission.Shutdown_reserved_by_other existing ->
+    Log.Keeper.error
+      "%s: shutdown rollback for %s found reservation %s"
+      entry.name
+      (Operation_id.to_string operation_id)
+      (Operation_id.to_string existing)
+;;
+
+let persist_blocked ~config operation stage detail =
+  let blocked =
+    { operation with
+      phase = Blocked { stage; detail }
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match Keeper_shutdown_store.replace ~config blocked with
+  | Ok () -> Ok blocked
+  | Error error -> Error error
+;;
+
+let cancellation_error ~config operation stage detail =
+  match persist_blocked ~config operation stage detail with
+  | Ok blocked -> Error (Cancellation_failed blocked)
+  | Error error -> Error (Join_record_update_failed error)
+;;
+
+let lane_outcome = function
+  | Keeper_lane.Completed -> Lane_completed
+  | Keeper_lane.Shutdown_requested -> Lane_shutdown_requested
+  | Keeper_lane.Cancelled_by_parent exn ->
+    Lane_cancelled_by_parent (Printexc.to_string exn)
+  | Keeper_lane.Failed exn -> Lane_failed (Printexc.to_string exn)
+;;
+
+let terminal = function
+  | `Stopped -> Terminal_stopped
+  | `Crashed detail -> Terminal_crashed detail
+;;
+
+let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
+  let operation_id = Operation_id.generate () in
+  match
+    Keeper_turn_admission.begin_shutdown
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:entry.name
+      ~operation_id
+  with
+  | Keeper_turn_admission.Shutdown_already_reserved reservation ->
+    Error (Existing_operation reservation.operation_id)
+  | Keeper_turn_admission.Shutdown_reserved reservation ->
+    (match current_entry ~config entry with
+     | Error error ->
+       rollback_reservation ~config ~entry operation_id;
+       Error error
+     | Ok current ->
+       (match
+          Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict
+            ~config
+            ~meta:current.meta
+        with
+        | Error detail ->
+          rollback_reservation ~config ~entry:current operation_id;
+          Error (Task_discovery_failed detail)
+        | Ok owned_tasks ->
+          let now = Masc_domain.now_iso () in
+          let turn_disposition = active_turn_of_snapshots reservation current in
+          let operation =
+            { schema_version
+            ; operation_id
+            ; keeper_name = current.name
+            ; lane_id = Keeper_lane.id current.lane
+            ; trace_id = current.meta.runtime.trace_id
+            ; generation = current.meta.runtime.generation
+            ; actor = request.actor
+            ; cleanup_intent = request.cleanup_intent
+            ; turn_disposition
+            ; owned_task_ids =
+                List.map
+                  (fun task -> task.Keeper_current_task_reconcile.task_id)
+                  owned_tasks
+            ; join_evidence = None
+            ; phase = Prepared
+            ; created_at = now
+            ; updated_at = now
+            }
+          in
+          (match Keeper_shutdown_store.persist_new ~config operation with
+           | Error store_error ->
+             rollback_reservation ~config ~entry:current operation_id;
+             Error (Prepare_persist_failed store_error)
+           | Ok () ->
+             Keeper_keepalive.request_entry_stop current;
+             let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
+             let turn_cancel_error =
+               match turn_disposition, turn_cancel with
+               | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
+               | ( Inflight_effect_unknown _
+                 , Keeper_registry.Exact_turn_cancelled _ ) -> None
+               | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
+                 Some "turn appeared after shutdown admission was fenced"
+               | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
+               | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
+             in
+             (match turn_cancel_error with
+              | Some detail -> cancellation_error ~config operation Turn_cancel detail
+              | None ->
+                (match Keeper_lane.request_cancel current.lane with
+                 | Keeper_lane.Cancel_signal_failed exn ->
+                   cancellation_error
+                     ~config
+                     operation
+                     Lane_cancel
+                     (Printexc.to_string exn)
+                 | Keeper_lane.Cancel_requested
+                 | Keeper_lane.Cancel_already_requested
+                 | Keeper_lane.Cancel_already_exiting ->
+                   Keeper_turn_admission.await_idle_after_shutdown
+                     ~base_path:config.Workspace.base_path
+                     ~keeper_name:current.name;
+                   let lane_exit = Keeper_lane.await_exit current.lane in
+                   let terminal_result = Eio.Promise.await current.done_p in
+                   let evidence =
+                     { lane_outcome = lane_outcome lane_exit.outcome
+                     ; terminal = terminal terminal_result
+                     ; cleanup_error = lane_exit.cleanup_error
+                     }
+                   in
+                   let phase =
+                     match turn_disposition with
+                     | No_inflight_turn -> Joined_idle
+                     | Inflight_effect_unknown turn -> Reconciliation_required turn
+                   in
+                   let joined =
+                     { operation with
+                       join_evidence = Some evidence
+                     ; phase
+                     ; updated_at = Masc_domain.now_iso ()
+                     }
+                   in
+                   (match lane_exit.cleanup_error with
+                    | Some detail ->
+                      (match persist_blocked ~config joined Lane_join detail with
+                       | Ok blocked -> Error (Join_failed blocked)
+                       | Error error -> Error (Join_record_update_failed error))
+                    | None ->
+                      (match Keeper_shutdown_store.replace ~config joined with
+                       | Ok () -> Ok joined
+                       | Error error -> Error (Join_record_update_failed error))))))))
+;;

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -52,7 +52,9 @@ let admission_lane = function
 ;;
 
 let active_turn_of_snapshots reservation current =
-  let observation = current.Keeper_registry.current_turn_observation in
+  let observation : Keeper_registry.turn_observation option =
+    current.Keeper_registry.current_turn_observation
+  in
   match reservation.Keeper_turn_admission.in_flight, observation with
   | None, None -> No_inflight_turn
   | in_flight, observation ->
@@ -128,19 +130,21 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
   | Keeper_turn_admission.Shutdown_already_reserved reservation ->
     Error (Existing_operation reservation.operation_id)
   | Keeper_turn_admission.Shutdown_reserved reservation ->
+    let durable_prepare_committed = Atomic.make false in
+    Fun.protect
+      ~finally:(fun () ->
+        if not (Atomic.get durable_prepare_committed)
+        then rollback_reservation ~config ~entry operation_id)
+      (fun () ->
     (match current_entry ~config entry with
-     | Error error ->
-       rollback_reservation ~config ~entry operation_id;
-       Error error
+     | Error error -> Error error
      | Ok current ->
        (match
           Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict
             ~config
             ~meta:current.meta
         with
-        | Error detail ->
-          rollback_reservation ~config ~entry:current operation_id;
-          Error (Task_discovery_failed detail)
+        | Error detail -> Error (Task_discovery_failed detail)
         | Ok owned_tasks ->
           let now = Masc_domain.now_iso () in
           let turn_disposition = active_turn_of_snapshots reservation current in
@@ -164,9 +168,16 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
             ; updated_at = now
             }
           in
-          (match Keeper_shutdown_store.persist_new ~config operation with
+          let persist_result =
+            Eio.Cancel.protect (fun () ->
+              match Keeper_shutdown_store.persist_new ~config operation with
+              | Ok () as committed ->
+                Atomic.set durable_prepare_committed true;
+                committed
+              | Error _ as error -> error)
+          in
+          (match persist_result with
            | Error store_error ->
-             rollback_reservation ~config ~entry:current operation_id;
              Error (Prepare_persist_failed store_error)
            | Ok () ->
              Keeper_keepalive.request_entry_stop current;
@@ -225,5 +236,5 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
                     | None ->
                       (match Keeper_shutdown_store.replace ~config joined with
                        | Ok () -> Ok joined
-                       | Error error -> Error (Join_record_update_failed error))))))))
+                       | Error error -> Error (Join_record_update_failed error)))))))))
 ;;

--- a/lib/keeper/keeper_shutdown_prepare_join.mli
+++ b/lib/keeper/keeper_shutdown_prepare_join.mli
@@ -1,0 +1,25 @@
+(** Durable prepare, admission fence, cancellation, and join for one Keeper
+    lane. This module deliberately does not release tasks or remove metadata;
+    those are later finalization phases. *)
+
+type request =
+  { actor : string
+  ; cleanup_intent : Keeper_shutdown_types.cleanup_intent
+  }
+
+type error =
+  | Registry_lane_replaced
+  | Existing_operation of Keeper_shutdown_types.Operation_id.t
+  | Task_discovery_failed of string
+  | Prepare_persist_failed of Keeper_shutdown_store.error
+  | Cancellation_failed of Keeper_shutdown_types.t
+  | Join_failed of Keeper_shutdown_types.t
+  | Join_record_update_failed of Keeper_shutdown_store.error
+
+val error_to_string : error -> string
+
+val run :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:request ->
+  (Keeper_shutdown_types.t, error) result

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -1,0 +1,463 @@
+open Keeper_shutdown_types
+
+type error =
+  | Already_exists of string
+  | Not_found of string
+  | Io_error of string
+  | Decode_error of string
+  | Identity_mismatch of string
+
+let error_to_string = function
+  | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
+  | Not_found path -> Printf.sprintf "shutdown operation not found: %s" path
+  | Io_error detail -> Printf.sprintf "shutdown operation I/O failed: %s" detail
+  | Decode_error detail -> Printf.sprintf "shutdown operation decode failed: %s" detail
+  | Identity_mismatch detail ->
+    Printf.sprintf "shutdown operation identity mismatch: %s" detail
+;;
+
+let store_mutex = Eio.Mutex.create ()
+
+let records_dir (config : Workspace.config) =
+  Filename.concat (Workspace.keepers_runtime_dir config) ".shutdown-operations"
+;;
+
+let path ~config operation_id =
+  Filename.concat
+    (records_dir config)
+    (Keeper_shutdown_types.Operation_id.to_string operation_id ^ ".json")
+;;
+
+let int_option_to_json = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+let float_option_to_json = function
+  | None -> `Null
+  | Some value -> `Float value
+;;
+
+let active_turn_to_json turn =
+  `Assoc
+    [ ( "lane"
+      , match turn.lane with
+        | None -> `Null
+        | Some lane -> `String (admission_lane_to_string lane) )
+    ; "admitted_at", float_option_to_json turn.admitted_at
+    ; "observed_turn_id", int_option_to_json turn.observed_turn_id
+    ; "observation_started_at", float_option_to_json turn.observation_started_at
+    ]
+;;
+
+let turn_disposition_to_json = function
+  | No_inflight_turn -> `Assoc [ "kind", `String "no_inflight_turn" ]
+  | Inflight_effect_unknown turn ->
+    `Assoc
+      [ "kind", `String "inflight_effect_unknown"
+      ; "active_turn", active_turn_to_json turn
+      ]
+;;
+
+let failure_to_json failure =
+  `Assoc
+    [ "stage", `String (failure_stage_to_string failure.stage)
+    ; "detail", `String failure.detail
+    ]
+;;
+
+let phase_to_json = function
+  | Prepared -> `Assoc [ "kind", `String "prepared" ]
+  | Joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
+  | Reconciliation_required turn ->
+    `Assoc
+      [ "kind", `String "reconciliation_required"
+      ; "active_turn", active_turn_to_json turn
+      ]
+  | Blocked failure ->
+    `Assoc
+      [ "kind", `String "blocked"
+      ; "failure", failure_to_json failure
+      ]
+;;
+
+let lane_outcome_to_json = function
+  | Lane_completed -> `Assoc [ "kind", `String "completed" ]
+  | Lane_shutdown_requested -> `Assoc [ "kind", `String "shutdown_requested" ]
+  | Lane_cancelled_by_parent detail ->
+    `Assoc
+      [ "kind", `String "cancelled_by_parent"
+      ; "detail", `String detail
+      ]
+  | Lane_failed detail ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "detail", `String detail
+      ]
+;;
+
+let terminal_to_json = function
+  | Terminal_stopped -> `Assoc [ "kind", `String "stopped" ]
+  | Terminal_crashed detail ->
+    `Assoc
+      [ "kind", `String "crashed"
+      ; "detail", `String detail
+      ]
+;;
+
+let join_evidence_to_json evidence =
+  `Assoc
+    [ "lane_outcome", lane_outcome_to_json evidence.lane_outcome
+    ; "terminal", terminal_to_json evidence.terminal
+    ; ( "cleanup_error"
+      , match evidence.cleanup_error with
+        | None -> `Null
+        | Some detail -> `String detail )
+    ]
+;;
+
+let to_json operation =
+  `Assoc
+    [ "schema_version", `Int operation.schema_version
+    ; "operation_id", `String (Operation_id.to_string operation.operation_id)
+    ; "keeper_name", `String operation.keeper_name
+    ; "lane_id", `String (Keeper_lane.Id.to_string operation.lane_id)
+    ; "trace_id", `String (Keeper_id.Trace_id.to_string operation.trace_id)
+    ; "generation", `Int operation.generation
+    ; "actor", `String operation.actor
+    ; ( "cleanup_intent"
+      , `Assoc
+          [ "remove_meta", `Bool operation.cleanup_intent.remove_meta
+          ; "remove_session", `Bool operation.cleanup_intent.remove_session
+          ] )
+    ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
+    ; ( "owned_task_ids"
+      , `List
+          (List.map
+             (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
+             operation.owned_task_ids) )
+    ; ( "join_evidence"
+      , match operation.join_evidence with
+        | None -> `Null
+        | Some evidence -> join_evidence_to_json evidence )
+    ; "phase", phase_to_json operation.phase
+    ; "created_at", `String operation.created_at
+    ; "updated_at", `String operation.updated_at
+    ]
+;;
+
+let decode_error field expected =
+  Decode_error (Printf.sprintf "%s must be %s" field expected)
+;;
+
+let assoc field = function
+  | `Assoc fields ->
+    (match List.assoc_opt field fields with
+     | Some value -> Ok value
+     | None -> Error (Decode_error (Printf.sprintf "missing field %s" field)))
+  | _ -> Error (decode_error field "inside an object")
+;;
+
+let string field json =
+  match assoc field json with
+  | Ok (`String value) -> Ok value
+  | Ok _ -> Error (decode_error field "a string")
+  | Error _ as error -> error
+;;
+
+let int field json =
+  match assoc field json with
+  | Ok (`Int value) -> Ok value
+  | Ok _ -> Error (decode_error field "an integer")
+  | Error _ as error -> error
+;;
+
+let bool field json =
+  match assoc field json with
+  | Ok (`Bool value) -> Ok value
+  | Ok _ -> Error (decode_error field "a boolean")
+  | Error _ as error -> error
+;;
+
+let optional_int field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`Int value) -> Ok (Some value)
+  | Ok _ -> Error (decode_error field "an integer or null")
+  | Error _ as error -> error
+;;
+
+let optional_float field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`Float value) -> Ok (Some value)
+  | Ok (`Int value) -> Ok (Some (float_of_int value))
+  | Ok _ -> Error (decode_error field "a number or null")
+  | Error _ as error -> error
+;;
+
+let optional_string field json =
+  match assoc field json with
+  | Ok `Null -> Ok None
+  | Ok (`String value) -> Ok (Some value)
+  | Ok _ -> Error (decode_error field "a string or null")
+  | Error _ as error -> error
+;;
+
+let ( let* ) result f = Result.bind result f
+
+let active_turn_of_json json =
+  let* lane =
+    match assoc "lane" json with
+    | Ok `Null -> Ok None
+    | Ok (`String lane_wire) ->
+      admission_lane_of_string lane_wire
+      |> Result.map Option.some
+      |> Result.map_error (fun e -> Decode_error e)
+    | Ok _ -> Error (decode_error "lane" "a string or null")
+    | Error _ as error -> error
+  in
+  let* admitted_at = optional_float "admitted_at" json in
+  let* observed_turn_id = optional_int "observed_turn_id" json in
+  let* observation_started_at = optional_float "observation_started_at" json in
+  Ok { lane; admitted_at; observed_turn_id; observation_started_at }
+;;
+
+let turn_disposition_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "no_inflight_turn" -> Ok No_inflight_turn
+  | "inflight_effect_unknown" ->
+    let* active_json = assoc "active_turn" json in
+    let* turn = active_turn_of_json active_json in
+    Ok (Inflight_effect_unknown turn)
+  | value -> Error (Decode_error (Printf.sprintf "unknown turn disposition: %S" value))
+;;
+
+let failure_of_json json =
+  let* stage_wire = string "stage" json in
+  let* stage = failure_stage_of_string stage_wire |> Result.map_error (fun e -> Decode_error e) in
+  let* detail = string "detail" json in
+  Ok { stage; detail }
+;;
+
+let phase_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "prepared" -> Ok Prepared
+  | "joined_idle" -> Ok Joined_idle
+  | "reconciliation_required" ->
+    let* active_json = assoc "active_turn" json in
+    let* turn = active_turn_of_json active_json in
+    Ok (Reconciliation_required turn)
+  | "blocked" ->
+    let* failure_json = assoc "failure" json in
+    let* failure = failure_of_json failure_json in
+    Ok (Blocked failure)
+  | value -> Error (Decode_error (Printf.sprintf "unknown shutdown phase: %S" value))
+;;
+
+let lane_outcome_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "completed" -> Ok Lane_completed
+  | "shutdown_requested" -> Ok Lane_shutdown_requested
+  | "cancelled_by_parent" ->
+    let* detail = string "detail" json in
+    Ok (Lane_cancelled_by_parent detail)
+  | "failed" ->
+    let* detail = string "detail" json in
+    Ok (Lane_failed detail)
+  | value -> Error (Decode_error (Printf.sprintf "unknown lane outcome: %S" value))
+;;
+
+let terminal_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "stopped" -> Ok Terminal_stopped
+  | "crashed" ->
+    let* detail = string "detail" json in
+    Ok (Terminal_crashed detail)
+  | value -> Error (Decode_error (Printf.sprintf "unknown terminal outcome: %S" value))
+;;
+
+let join_evidence_of_json json =
+  let* lane_json = assoc "lane_outcome" json in
+  let* lane_outcome = lane_outcome_of_json lane_json in
+  let* terminal_json = assoc "terminal" json in
+  let* terminal = terminal_of_json terminal_json in
+  let* cleanup_error = optional_string "cleanup_error" json in
+  Ok { lane_outcome; terminal; cleanup_error }
+;;
+
+let optional_join_evidence_of_json json =
+  match assoc "join_evidence" json with
+  | Ok `Null -> Ok None
+  | Ok evidence_json -> join_evidence_of_json evidence_json |> Result.map Option.some
+  | Error _ as error -> error
+;;
+
+let task_ids_of_json json =
+  match assoc "owned_task_ids" json with
+  | Error _ as error -> error
+  | Ok (`List values) ->
+    List.fold_left
+      (fun result value ->
+         let* task_ids = result in
+         match value with
+         | `String raw ->
+           let* task_id =
+             Keeper_id.Task_id.of_string raw
+             |> Result.map_error (fun e -> Decode_error e)
+           in
+           Ok (task_id :: task_ids)
+         | _ -> Error (decode_error "owned_task_ids[]" "a string"))
+      (Ok [])
+      values
+    |> Result.map List.rev
+  | Ok _ -> Error (decode_error "owned_task_ids" "an array")
+;;
+
+let of_json json =
+  let* decoded_schema_version = int "schema_version" json in
+  if decoded_schema_version <> schema_version
+  then
+    Error
+      (Decode_error
+         (Printf.sprintf
+            "unsupported shutdown schema version: %d"
+            decoded_schema_version))
+  else
+    let* operation_id_wire = string "operation_id" json in
+    let* operation_id =
+      Operation_id.of_string operation_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* keeper_name = string "keeper_name" json in
+    let* lane_id_wire = string "lane_id" json in
+    let* lane_id =
+      Keeper_lane.Id.of_string lane_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* trace_id_wire = string "trace_id" json in
+    let* trace_id =
+      Keeper_id.Trace_id.of_string trace_id_wire
+      |> Result.map_error (fun e -> Decode_error e)
+    in
+    let* generation = int "generation" json in
+    let* actor = string "actor" json in
+    let* cleanup_json = assoc "cleanup_intent" json in
+    let* remove_meta = bool "remove_meta" cleanup_json in
+    let* remove_session = bool "remove_session" cleanup_json in
+    let* turn_json = assoc "turn_disposition" json in
+    let* turn_disposition = turn_disposition_of_json turn_json in
+    let* owned_task_ids = task_ids_of_json json in
+    let* join_evidence = optional_join_evidence_of_json json in
+    let* phase_json = assoc "phase" json in
+    let* phase = phase_of_json phase_json in
+    let* created_at = string "created_at" json in
+    let* updated_at = string "updated_at" json in
+    Ok
+      { schema_version = decoded_schema_version
+      ; operation_id
+      ; keeper_name
+      ; lane_id
+      ; trace_id
+      ; generation
+      ; actor
+      ; cleanup_intent = { remove_meta; remove_session }
+      ; turn_disposition
+      ; owned_task_ids
+      ; join_evidence
+      ; phase
+      ; created_at
+      ; updated_at
+      }
+;;
+
+let load_unlocked ~config operation_id =
+  let operation_path = path ~config operation_id in
+  if not (Fs_compat.file_exists operation_path)
+  then Error (Not_found operation_path)
+  else
+    try
+      Fs_compat.load_file operation_path
+      |> Yojson.Safe.from_string
+      |> of_json
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Yojson.Json_error detail -> Error (Decode_error detail)
+    | exn -> Error (Io_error (Printexc.to_string exn))
+;;
+
+let persist_new ~config operation =
+  Eio.Mutex.use_rw ~protect:true store_mutex (fun () ->
+    let operation_path = path ~config operation.operation_id in
+    if Fs_compat.file_exists operation_path
+    then Error (Already_exists operation_path)
+    else
+      Keeper_fs.save_json_atomic operation_path (to_json operation)
+      |> Result.map_error (fun detail -> Io_error detail))
+;;
+
+let same_identity left right =
+  Operation_id.equal left.operation_id right.operation_id
+  && String.equal left.keeper_name right.keeper_name
+  && Keeper_lane.Id.equal left.lane_id right.lane_id
+  && Keeper_id.Trace_id.equal left.trace_id right.trace_id
+  && Int.equal left.generation right.generation
+;;
+
+let replace ~config operation =
+  Eio.Mutex.use_rw ~protect:true store_mutex (fun () ->
+    match load_unlocked ~config operation.operation_id with
+    | Error _ as error -> error
+    | Ok existing when same_identity existing operation ->
+      Keeper_fs.save_json_atomic (path ~config operation.operation_id) (to_json operation)
+      |> Result.map_error (fun detail -> Io_error detail)
+    | Ok _ ->
+      Error
+        (Identity_mismatch
+           (Operation_id.to_string operation.operation_id)))
+;;
+
+let load ~config operation_id =
+  Eio.Mutex.use_ro store_mutex (fun () -> load_unlocked ~config operation_id)
+;;
+
+let list_for_keeper ~config ~keeper_name =
+  Eio.Mutex.use_ro store_mutex (fun () ->
+    let dir = records_dir config in
+    if not (Fs_compat.file_exists dir)
+    then Ok []
+    else
+      try
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.sort String.compare
+        |> List.fold_left
+             (fun result filename ->
+                let* operations = result in
+                if not (Filename.check_suffix filename ".json")
+                then
+                  Error
+                    (Decode_error
+                       (Printf.sprintf
+                          "unexpected shutdown store entry: %s"
+                          filename))
+                else
+                  let raw_id = Filename.chop_suffix filename ".json" in
+                  let* operation_id =
+                    Operation_id.of_string raw_id
+                    |> Result.map_error (fun e -> Decode_error e)
+                  in
+                  let* operation = load_unlocked ~config operation_id in
+                  if String.equal operation.keeper_name keeper_name
+                  then Ok (operation :: operations)
+                  else Ok operations)
+             (Ok [])
+        |> Result.map List.rev
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn -> Error (Io_error (Printexc.to_string exn)))
+;;

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -16,7 +16,49 @@ let error_to_string = function
     Printf.sprintf "shutdown operation identity mismatch: %s" detail
 ;;
 
-let store_mutex = Eio.Mutex.create ()
+type operation_lock =
+  { mutex : Eio.Mutex.t
+  ; mutable users : int
+  }
+
+let operation_locks : (string, operation_lock) Hashtbl.t = Hashtbl.create 16
+let operation_locks_mutex = Stdlib.Mutex.create ()
+
+type lock_access =
+  | Read
+  | Write
+
+let acquire_operation_lock key =
+  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
+    match Hashtbl.find_opt operation_locks key with
+    | Some lock ->
+      lock.users <- lock.users + 1;
+      lock
+    | None ->
+      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
+      Hashtbl.add operation_locks key lock;
+      lock)
+;;
+
+let release_operation_lock key lock =
+  Stdlib.Mutex.protect operation_locks_mutex (fun () ->
+    lock.users <- lock.users - 1;
+    if lock.users = 0
+    then
+      match Hashtbl.find_opt operation_locks key with
+      | Some current when current == lock -> Hashtbl.remove operation_locks key
+      | Some _ | None -> ())
+;;
+
+let with_operation_lock ~access key f =
+  let lock = acquire_operation_lock key in
+  Fun.protect
+    ~finally:(fun () -> release_operation_lock key lock)
+    (fun () ->
+       match access with
+       | Write -> Eio.Mutex.use_rw ~protect:true lock.mutex f
+       | Read -> Eio.Mutex.use_ro lock.mutex f)
+;;
 
 let records_dir (config : Workspace.config) =
   Filename.concat (Workspace.keepers_runtime_dir config) ".shutdown-operations"
@@ -391,8 +433,8 @@ let load_unlocked ~config operation_id =
 ;;
 
 let persist_new ~config operation =
-  Eio.Mutex.use_rw ~protect:true store_mutex (fun () ->
-    let operation_path = path ~config operation.operation_id in
+  let operation_path = path ~config operation.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
     if Fs_compat.file_exists operation_path
     then Error (Already_exists operation_path)
     else
@@ -409,11 +451,12 @@ let same_identity left right =
 ;;
 
 let replace ~config operation =
-  Eio.Mutex.use_rw ~protect:true store_mutex (fun () ->
+  let operation_path = path ~config operation.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
     match load_unlocked ~config operation.operation_id with
     | Error _ as error -> error
     | Ok existing when same_identity existing operation ->
-      Keeper_fs.save_json_atomic (path ~config operation.operation_id) (to_json operation)
+      Keeper_fs.save_json_atomic operation_path (to_json operation)
       |> Result.map_error (fun detail -> Io_error detail)
     | Ok _ ->
       Error
@@ -422,42 +465,43 @@ let replace ~config operation =
 ;;
 
 let load ~config operation_id =
-  Eio.Mutex.use_ro store_mutex (fun () -> load_unlocked ~config operation_id)
+  let operation_path = path ~config operation_id in
+  with_operation_lock ~access:Read operation_path (fun () ->
+    load_unlocked ~config operation_id)
 ;;
 
 let list_for_keeper ~config ~keeper_name =
-  Eio.Mutex.use_ro store_mutex (fun () ->
-    let dir = records_dir config in
-    if not (Fs_compat.file_exists dir)
-    then Ok []
-    else
-      try
-        Sys.readdir dir
-        |> Array.to_list
-        |> List.sort String.compare
-        |> List.fold_left
-             (fun result filename ->
-                let* operations = result in
-                if not (Filename.check_suffix filename ".json")
-                then
-                  Error
-                    (Decode_error
-                       (Printf.sprintf
-                          "unexpected shutdown store entry: %s"
-                          filename))
-                else
-                  let raw_id = Filename.chop_suffix filename ".json" in
-                  let* operation_id =
-                    Operation_id.of_string raw_id
-                    |> Result.map_error (fun e -> Decode_error e)
-                  in
-                  let* operation = load_unlocked ~config operation_id in
-                  if String.equal operation.keeper_name keeper_name
-                  then Ok (operation :: operations)
-                  else Ok operations)
-             (Ok [])
-        |> Result.map List.rev
-      with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn -> Error (Io_error (Printexc.to_string exn)))
+  let dir = records_dir config in
+  if not (Fs_compat.file_exists dir)
+  then Ok []
+  else
+    try
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.sort String.compare
+      |> List.fold_left
+           (fun result filename ->
+              let* operations = result in
+              if not (Filename.check_suffix filename ".json")
+              then
+                Error
+                  (Decode_error
+                     (Printf.sprintf
+                        "unexpected shutdown store entry: %s"
+                        filename))
+              else
+                let raw_id = Filename.chop_suffix filename ".json" in
+                let* operation_id =
+                  Operation_id.of_string raw_id
+                  |> Result.map_error (fun e -> Decode_error e)
+                in
+                let* operation = load ~config operation_id in
+                if String.equal operation.keeper_name keeper_name
+                then Ok (operation :: operations)
+                else Ok operations)
+           (Ok [])
+      |> Result.map List.rev
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Io_error (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -1,0 +1,39 @@
+(** Atomic persistence for Keeper shutdown operations under the configured
+    MASC base path. *)
+
+type error =
+  | Already_exists of string
+  | Not_found of string
+  | Io_error of string
+  | Decode_error of string
+  | Identity_mismatch of string
+
+val error_to_string : error -> string
+
+val path :
+  config:Workspace.config ->
+  Keeper_shutdown_types.Operation_id.t ->
+  string
+
+val to_json : Keeper_shutdown_types.t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (Keeper_shutdown_types.t, error) result
+
+val persist_new :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (unit, error) result
+
+val replace :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (unit, error) result
+
+val load :
+  config:Workspace.config ->
+  Keeper_shutdown_types.Operation_id.t ->
+  (Keeper_shutdown_types.t, error) result
+
+val list_for_keeper :
+  config:Workspace.config ->
+  keeper_name:string ->
+  (Keeper_shutdown_types.t list, error) result

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -1,5 +1,7 @@
 (** Atomic persistence for Keeper shutdown operations under the configured
-    MASC base path. *)
+    MASC base path. Reads and writes are serialized per operation path; an
+    unrelated Keeper operation never holds the same lock across filesystem
+    I/O. *)
 
 type error =
   | Already_exists of string

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -1,0 +1,136 @@
+module Operation_id = struct
+  type t = string
+
+  let prefix = "shutdown-"
+  (* NDT-OK: UUID entropy is an operation identity only. No lifecycle
+     decision branches on the generated contents. *)
+  let rng = Random.State.make_self_init () (* NDT-OK: identity entropy only *)
+  let rng_mutex = Eio.Mutex.create ()
+
+  let generate () =
+    let uuid = Eio.Mutex.use_ro rng_mutex (fun () -> Uuidm.v4_gen rng ()) in
+    prefix ^ Uuidm.to_string uuid
+  ;;
+
+  let of_string value =
+    let prefix_length = String.length prefix in
+    if
+      String.length value = prefix_length + 36
+      && String.equal (String.sub value 0 prefix_length) prefix
+    then
+      match Uuidm.of_string (String.sub value prefix_length 36) with
+      | Some _ -> Ok value
+      | None -> Error (Printf.sprintf "invalid Keeper shutdown operation id: %S" value)
+    else Error (Printf.sprintf "invalid Keeper shutdown operation id: %S" value)
+  ;;
+
+  let to_string value = value
+  let equal = String.equal
+end
+
+type cleanup_intent =
+  { remove_meta : bool
+  ; remove_session : bool
+  }
+
+type admission_lane =
+  | Autonomous
+  | Chat
+
+type active_turn =
+  { lane : admission_lane option
+  ; admitted_at : float option
+  ; observed_turn_id : int option
+  ; observation_started_at : float option
+  }
+
+type turn_disposition =
+  | No_inflight_turn
+  | Inflight_effect_unknown of active_turn
+
+type failure_stage =
+  | Task_discovery
+  | Record_persist
+  | Turn_cancel
+  | Lane_cancel
+  | Turn_join
+  | Lane_join
+  | Record_update
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  }
+
+type lane_outcome =
+  | Lane_completed
+  | Lane_shutdown_requested
+  | Lane_cancelled_by_parent of string
+  | Lane_failed of string
+
+type terminal =
+  | Terminal_stopped
+  | Terminal_crashed of string
+
+type join_evidence =
+  { lane_outcome : lane_outcome
+  ; terminal : terminal
+  ; cleanup_error : string option
+  }
+
+type phase =
+  | Prepared
+  | Joined_idle
+  | Reconciliation_required of active_turn
+  | Blocked of failure
+
+type t =
+  { schema_version : int
+  ; operation_id : Operation_id.t
+  ; keeper_name : string
+  ; lane_id : Keeper_lane.Id.t
+  ; trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; actor : string
+  ; cleanup_intent : cleanup_intent
+  ; turn_disposition : turn_disposition
+  ; owned_task_ids : Keeper_id.Task_id.t list
+  ; join_evidence : join_evidence option
+  ; phase : phase
+  ; created_at : string
+  ; updated_at : string
+  }
+
+let schema_version = 1
+
+let admission_lane_to_string = function
+  | Autonomous -> "autonomous"
+  | Chat -> "chat"
+;;
+
+let admission_lane_of_string = function
+  | "autonomous" -> Ok Autonomous
+  | "chat" -> Ok Chat
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown admission lane: %S" value)
+;;
+
+let failure_stage_to_string = function
+  | Task_discovery -> "task_discovery"
+  | Record_persist -> "record_persist"
+  | Turn_cancel -> "turn_cancel"
+  | Lane_cancel -> "lane_cancel"
+  | Turn_join -> "turn_join"
+  | Lane_join -> "lane_join"
+  | Record_update -> "record_update"
+;;
+
+let failure_stage_of_string = function
+  | "task_discovery" -> Ok Task_discovery
+  | "record_persist" -> Ok Record_persist
+  | "turn_cancel" -> Ok Turn_cancel
+  | "lane_cancel" -> Ok Lane_cancel
+  | "turn_join" -> Ok Turn_join
+  | "lane_join" -> Ok Lane_join
+  | "record_update" -> Ok Record_update
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown failure stage: %S" value)
+;;

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -1,0 +1,91 @@
+(** Durable types for one Keeper shutdown operation.  These records describe
+    lifecycle coordination only; task ownership remains authoritative in the
+    Workspace backlog. *)
+
+module Operation_id : sig
+  type t
+
+  val generate : unit -> t
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+type cleanup_intent =
+  { remove_meta : bool
+  ; remove_session : bool
+  }
+
+type admission_lane =
+  | Autonomous
+  | Chat
+
+type active_turn =
+  { lane : admission_lane option
+  ; admitted_at : float option
+  ; observed_turn_id : int option
+  ; observation_started_at : float option
+  }
+
+type turn_disposition =
+  | No_inflight_turn
+  | Inflight_effect_unknown of active_turn
+
+type failure_stage =
+  | Task_discovery
+  | Record_persist
+  | Turn_cancel
+  | Lane_cancel
+  | Turn_join
+  | Lane_join
+  | Record_update
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  }
+
+type lane_outcome =
+  | Lane_completed
+  | Lane_shutdown_requested
+  | Lane_cancelled_by_parent of string
+  | Lane_failed of string
+
+type terminal =
+  | Terminal_stopped
+  | Terminal_crashed of string
+
+type join_evidence =
+  { lane_outcome : lane_outcome
+  ; terminal : terminal
+  ; cleanup_error : string option
+  }
+
+type phase =
+  | Prepared
+  | Joined_idle
+  | Reconciliation_required of active_turn
+  | Blocked of failure
+
+type t =
+  { schema_version : int
+  ; operation_id : Operation_id.t
+  ; keeper_name : string
+  ; lane_id : Keeper_lane.Id.t
+  ; trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; actor : string
+  ; cleanup_intent : cleanup_intent
+  ; turn_disposition : turn_disposition
+  ; owned_task_ids : Keeper_id.Task_id.t list
+  ; join_evidence : join_evidence option
+  ; phase : phase
+  ; created_at : string
+  ; updated_at : string
+  }
+
+val schema_version : int
+val admission_lane_to_string : admission_lane -> string
+val admission_lane_of_string : string -> (admission_lane, string) result
+val failure_stage_to_string : failure_stage -> string
+val failure_stage_of_string : string -> (failure_stage, string) result

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1353,7 +1353,20 @@ let handle_keeper_msg
             args)
     with
     | `Ran result -> result
-    | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+    | `Rejected
+        { Keeper_turn_admission.shutdown_operation_id = Some operation_id
+        ; _
+        } ->
+        tool_result_error
+          (Printf.sprintf
+             "keeper %s is stopping under operation %s"
+             name
+             (Keeper_shutdown_types.Operation_id.to_string operation_id))
+    | `Rejected
+        { Keeper_turn_admission.waiting
+        ; in_flight
+        ; shutdown_operation_id = None
+        } ->
         let in_flight_text =
           match in_flight with
           | None -> ""

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -9,10 +9,30 @@ type in_flight_info =
   ; started_at : float
   }
 
+type autonomous_block =
+  | Turn_busy of in_flight_info option
+  | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
+
 type rejection =
   { waiting : int
   ; in_flight : in_flight_info option
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
+
+type shutdown_reservation =
+  { operation_id : Keeper_shutdown_types.Operation_id.t
+  ; in_flight : in_flight_info option
+  ; waiting : int
+  }
+
+type begin_shutdown_result =
+  | Shutdown_reserved of shutdown_reservation
+  | Shutdown_already_reserved of shutdown_reservation
+
+type rollback_shutdown_result =
+  | Shutdown_rolled_back
+  | Shutdown_not_reserved
+  | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
 type slot_snapshot =
   { snapshot_keeper_name : string
@@ -23,6 +43,7 @@ type slot_snapshot =
   ; snapshot_waiting_cap : int
   ; snapshot_waiting_full : bool
   ; snapshot_rejected_chat_count : int
+  ; snapshot_shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 type fleet_snapshot =
@@ -32,6 +53,7 @@ type fleet_snapshot =
   ; fleet_waiting_full_keeper_count : int
   ; fleet_rejected_chat_total : int
   ; fleet_in_flight_keeper_count : int
+  ; fleet_shutdown_keeper_count : int
   ; fleet_slots : slot_snapshot list
   }
 
@@ -63,6 +85,7 @@ type slot =
   ; mutable waiting_entries : (int * float) list
   ; mutable next_waiter_id : int
   ; mutable rejected_chat_count : int
+  ; mutable shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 let slots : (string, slot) Hashtbl.t = Hashtbl.create 16
@@ -88,6 +111,7 @@ let slot_for ~base_path ~keeper_name =
         ; waiting_entries = []
         ; next_waiter_id = 0
         ; rejected_chat_count = 0
+        ; shutdown_operation_id = None
         }
       in
       Hashtbl.add slots key slot;
@@ -96,23 +120,36 @@ let slot_for ~base_path ~keeper_name =
 
 let set_info slot info = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info <- info)
 let peek_info slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.info)
+let peek_shutdown slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.shutdown_operation_id)
 
 (* Precondition: the calling fiber holds [slot.turn_mu]. There is no
    suspension point between acquiring the mutex and entering [f], so
    cancellation cannot leak the slot; the exception arm releases on every
    raise out of [f], including [Eio.Cancel.Cancelled]. *)
 let run_locked slot ~lane f =
-  (* NDT-OK: gettimeofday timestamps the in-flight info for observability only *)
-  set_info slot (Some { lane; started_at = Unix.gettimeofday () });
-  match f () with
-  | v ->
-    set_info slot None;
+  let admission =
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      match slot.shutdown_operation_id with
+      | Some operation_id -> Error operation_id
+      | None ->
+        (* NDT-OK: admission timestamp is observability evidence only. *)
+        slot.info <- Some { lane; started_at = Unix.gettimeofday () };
+        Ok ())
+  in
+  match admission with
+  | Error operation_id ->
     Eio.Mutex.unlock slot.turn_mu;
-    `Ran v
-  | exception exn ->
-    set_info slot None;
-    Eio.Mutex.unlock slot.turn_mu;
-    raise exn
+    `Shutdown_requested operation_id
+  | Ok () ->
+    (match f () with
+     | v ->
+       set_info slot None;
+       Eio.Mutex.unlock slot.turn_mu;
+       `Ran v
+     | exception exn ->
+       set_info slot None;
+       Eio.Mutex.unlock slot.turn_mu;
+       raise exn)
 ;;
 
 let waiting_count slot = Stdlib.Mutex.protect slot.state_mu (fun () -> slot.waiting)
@@ -130,7 +167,10 @@ let oldest_waiting_since entries =
 let rejected_snapshot slot =
   Stdlib.Mutex.protect slot.state_mu (fun () ->
     slot.rejected_chat_count <- slot.rejected_chat_count + 1;
-    { waiting = slot.waiting; in_flight = slot.info })
+    { waiting = slot.waiting
+    ; in_flight = slot.info
+    ; shutdown_operation_id = None
+    })
 ;;
 
 let run_if_free ~base_path ~keeper_name f =
@@ -148,32 +188,42 @@ let run_if_free ~base_path ~keeper_name f =
      gap: the autonomous lane cooperates on the same backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
      deterministically instead of racing the next autonomous cycle. *)
-  if waiting_count slot > 0
-  then `Busy (peek_info slot)
-  else if Keeper_chat_queue.length ~keeper_name > 0
-  then `Busy (peek_info slot)
-  else if Eio.Mutex.try_lock slot.turn_mu
-  then run_locked slot ~lane:Autonomous f
-  else `Busy (peek_info slot)
+  match peek_shutdown slot with
+  | Some operation_id -> `Busy (Shutdown_requested operation_id)
+  | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
+  | None when Keeper_chat_queue.length ~keeper_name > 0 ->
+    `Busy (Turn_busy (peek_info slot))
+  | None when Eio.Mutex.try_lock slot.turn_mu ->
+    (match run_locked slot ~lane:Autonomous f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+  | None -> `Busy (Turn_busy (peek_info slot))
 ;;
 
 let run_serialized ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   let waiter_id =
     Stdlib.Mutex.protect slot.state_mu (fun () ->
-      if slot.waiting >= max_waiting_chat_requests
-      then None
-      else (
+      match slot.shutdown_operation_id with
+      | Some operation_id -> `Shutdown_requested operation_id
+      | None when slot.waiting >= max_waiting_chat_requests -> `Rejected
+      | None ->
         let waiter_id = slot.next_waiter_id in
         slot.next_waiter_id <- slot.next_waiter_id + 1;
         (* NDT-OK: waiter age timestamp for observability only. *)
         slot.waiting_entries <- (waiter_id, Unix.gettimeofday ()) :: slot.waiting_entries;
         slot.waiting <- slot.waiting + 1;
-        Some waiter_id))
+        `Waiting waiter_id)
   in
   match waiter_id with
-  | None -> `Rejected (rejected_snapshot slot)
-  | Some waiter_id ->
+  | `Shutdown_requested operation_id ->
+    `Rejected
+      { waiting = waiting_count slot
+      ; in_flight = peek_info slot
+      ; shutdown_operation_id = Some operation_id
+      }
+  | `Rejected -> `Rejected (rejected_snapshot slot)
+  | `Waiting waiter_id ->
     (* [Fun.protect] rather than [Switch.on_release]: there is no ambient
        switch here, the finally never raises and never yields, and the only
        suspension point it covers is the cancellable [Eio.Mutex.lock] wait
@@ -188,21 +238,36 @@ let run_serialized ~base_path ~keeper_name f =
                (fun (entry_waiter_id, _since) -> entry_waiter_id <> waiter_id)
                slot.waiting_entries))
       (fun () -> Eio.Mutex.lock slot.turn_mu);
-    run_locked slot ~lane:Chat f
+    (match run_locked slot ~lane:Chat f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id -> `Rejected (Shutdown_requested operation_id))
 ;;
 
 let rejection_snapshot slot =
   let waiting = waiting_count slot in
-  { waiting; in_flight = peek_info slot }
+  { waiting; in_flight = peek_info slot; shutdown_operation_id = None }
 ;;
 
 let run_chat_if_free ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
-  if waiting_count slot > 0
-  then `Busy (rejection_snapshot slot)
-  else if Eio.Mutex.try_lock slot.turn_mu
-  then run_locked slot ~lane:Chat f
-  else `Busy (rejection_snapshot slot)
+  match peek_shutdown slot with
+  | Some operation_id ->
+    `Busy
+      { waiting = waiting_count slot
+      ; in_flight = peek_info slot
+      ; shutdown_operation_id = Some operation_id
+      }
+  | None when waiting_count slot > 0 -> `Busy (rejection_snapshot slot)
+  | None when Eio.Mutex.try_lock slot.turn_mu ->
+    (match run_locked slot ~lane:Chat f with
+     | `Ran value -> `Ran value
+     | `Shutdown_requested operation_id ->
+       `Busy
+         { waiting = waiting_count slot
+         ; in_flight = peek_info slot
+         ; shutdown_operation_id = Some operation_id
+         })
+  | None -> `Busy (rejection_snapshot slot)
 ;;
 
 let in_flight ~base_path ~keeper_name =
@@ -210,6 +275,38 @@ let in_flight ~base_path ~keeper_name =
   match Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key) with
   | None -> None
   | Some slot -> peek_info slot
+;;
+
+let reservation_of_slot slot operation_id =
+  { operation_id; in_flight = slot.info; waiting = slot.waiting }
+;;
+
+let begin_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None ->
+      slot.shutdown_operation_id <- Some operation_id;
+      Shutdown_reserved (reservation_of_slot slot operation_id)
+    | Some existing ->
+      Shutdown_already_reserved (reservation_of_slot slot existing))
+;;
+
+let rollback_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None -> Shutdown_not_reserved
+    | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+      slot.shutdown_operation_id <- None;
+      Shutdown_rolled_back
+    | Some existing -> Shutdown_reserved_by_other existing)
+;;
+
+let await_idle_after_shutdown ~base_path ~keeper_name =
+  let slot = slot_for ~base_path ~keeper_name in
+  Eio.Mutex.lock slot.turn_mu;
+  Eio.Mutex.unlock slot.turn_mu
 ;;
 
 let chat_waiting ~base_path ~keeper_name =
@@ -237,6 +334,7 @@ let zero_snapshot ~keeper_name =
   ; snapshot_waiting_cap = max_waiting_chat_requests
   ; snapshot_waiting_full = false
   ; snapshot_rejected_chat_count = 0
+  ; snapshot_shutdown_operation_id = None
   }
 ;;
 
@@ -250,6 +348,7 @@ let snapshot_of_slot slot =
     ; snapshot_waiting_cap = max_waiting_chat_requests
     ; snapshot_waiting_full = slot.waiting >= max_waiting_chat_requests
     ; snapshot_rejected_chat_count = slot.rejected_chat_count
+    ; snapshot_shutdown_operation_id = slot.shutdown_operation_id
     })
 ;;
 
@@ -309,12 +408,22 @@ let fleet_snapshot ~base_path ~keeper_names =
       0
       fleet_slots
   in
+  let fleet_shutdown_keeper_count =
+    List.fold_left
+      (fun acc slot ->
+        match slot.snapshot_shutdown_operation_id with
+        | Some _ -> acc + 1
+        | None -> acc)
+      0
+      fleet_slots
+  in
   { fleet_keeper_count = List.length keeper_names
   ; fleet_waiting_keeper_count
   ; fleet_waiting_total
   ; fleet_waiting_full_keeper_count
   ; fleet_rejected_chat_total
   ; fleet_in_flight_keeper_count
+  ; fleet_shutdown_keeper_count
   ; fleet_slots
   }
 ;;
@@ -337,6 +446,11 @@ let slot_snapshot_to_yojson slot =
     ; "chat_waiting_cap", `Int slot.snapshot_waiting_cap
     ; "chat_waiting_full", `Bool slot.snapshot_waiting_full
     ; "chat_rejected_count", `Int slot.snapshot_rejected_chat_count
+    ; ( "shutdown_operation_id"
+      , match slot.snapshot_shutdown_operation_id with
+        | None -> `Null
+        | Some operation_id ->
+          `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
     ]
 ;;
 
@@ -365,6 +479,7 @@ let fleet_health_json ~base_path ~keeper_names =
     ; "chat_waiting_full_keeper_count", `Int snapshot.fleet_waiting_full_keeper_count
     ; "chat_rejected_total_count", `Int snapshot.fleet_rejected_chat_total
     ; "in_flight_keeper_count", `Int snapshot.fleet_in_flight_keeper_count
+    ; "shutdown_keeper_count", `Int snapshot.fleet_shutdown_keeper_count
     ; "keepers", `List (List.map slot_snapshot_to_yojson snapshot.fleet_slots)
     ]
 ;;

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -240,7 +240,12 @@ let run_serialized ~base_path ~keeper_name f =
       (fun () -> Eio.Mutex.lock slot.turn_mu);
     (match run_locked slot ~lane:Chat f with
      | `Ran value -> `Ran value
-     | `Shutdown_requested operation_id -> `Rejected (Shutdown_requested operation_id))
+     | `Shutdown_requested operation_id ->
+       `Rejected
+         { waiting = waiting_count slot
+         ; in_flight = peek_info slot
+         ; shutdown_operation_id = Some operation_id
+         })
 ;;
 
 let rejection_snapshot slot =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -23,11 +23,32 @@ type in_flight_info =
   ; started_at : float (** Unix epoch seconds when the turn was admitted *)
   }
 
+type autonomous_block =
+  | Turn_busy of in_flight_info option
+  | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
+
 type rejection =
   { waiting : int (** chat requests already waiting on this keeper's slot *)
   ; in_flight : in_flight_info option
     (** the turn holding the slot, if observable at rejection time *)
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
+    (** [Some id] when admission is fenced by a durable shutdown operation. *)
   }
+
+type shutdown_reservation =
+  { operation_id : Keeper_shutdown_types.Operation_id.t
+  ; in_flight : in_flight_info option
+  ; waiting : int
+  }
+
+type begin_shutdown_result =
+  | Shutdown_reserved of shutdown_reservation
+  | Shutdown_already_reserved of shutdown_reservation
+
+type rollback_shutdown_result =
+  | Shutdown_rolled_back
+  | Shutdown_not_reserved
+  | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
 type slot_snapshot =
   { snapshot_keeper_name : string
@@ -38,6 +59,7 @@ type slot_snapshot =
   ; snapshot_waiting_cap : int
   ; snapshot_waiting_full : bool
   ; snapshot_rejected_chat_count : int
+  ; snapshot_shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 type fleet_snapshot =
@@ -47,6 +69,7 @@ type fleet_snapshot =
   ; fleet_waiting_full_keeper_count : int
   ; fleet_rejected_chat_total : int
   ; fleet_in_flight_keeper_count : int
+  ; fleet_shutdown_keeper_count : int
   ; fleet_slots : slot_snapshot list
   }
 
@@ -64,13 +87,15 @@ val run_if_free
   :  base_path:string
   -> keeper_name:string
   -> (unit -> 'a)
-  -> [ `Ran of 'a | `Busy of in_flight_info option ]
+  -> [ `Ran of 'a | `Busy of autonomous_block ]
 (** Run [f] holding the keeper's turn slot, or return [`Busy] without
     blocking when another turn is in flight. The autonomous lane uses this:
     a busy slot skips the cycle and the next heartbeat retries naturally.
-    [`Busy None] means the slot is held but the holder has not yet published
-    its info (admission in progress on another fiber). Exceptions from [f]
-    (including [Eio.Cancel.Cancelled]) release the slot and re-raise.
+    [`Busy (Turn_busy None)] means the slot is held but the holder has not yet
+    published its info (admission in progress on another fiber).
+    [`Busy (Shutdown_requested id)] means a durable shutdown reservation owns
+    admission. Exceptions from [f] (including [Eio.Cancel.Cancelled]) release
+    the slot and re-raise.
 
     Also returns [`Busy] without attempting the lock when a chat request is
     already parked on this slot ([chat_waiting] is true), or when a busy
@@ -111,8 +136,9 @@ val run_serialized
 (** Run [f] holding the keeper's turn slot, waiting (fiber-cooperatively, in
     Eio.Mutex wakeup order) while another turn is in flight. The chat lane
     uses this: dashboard/connector messages queue rather than error. Returns
-    [`Rejected] only when [max_waiting_chat_requests] chat requests are
-    already waiting. Cancellation while waiting leaves the queue; exceptions
+    [`Rejected] when [max_waiting_chat_requests] chat requests are already
+    waiting or when [shutdown_operation_id] names the durable operation that
+    fenced admission. Cancellation while waiting leaves the queue; exceptions
     from [f] release the slot and re-raise.
 
     Caller contract: a synchronous self-targeted call from inside the same
@@ -130,7 +156,9 @@ val run_chat_if_free
     in-flight turn. Dashboard direct-stream callers use this to preserve live
     streaming for idle keepers while atomically routing busy keepers to the
     durable chat queue. Existing parked chat waiters have priority: when
-    [chat_waiting] is true this returns [`Busy] without attempting the lock. *)
+    [chat_waiting] is true this returns [`Busy] without attempting the lock.
+    [Busy.shutdown_operation_id] distinguishes lifecycle fencing from
+    ordinary turn contention. *)
 
 val in_flight
   :  base_path:string
@@ -142,6 +170,28 @@ val in_flight
     while a turn runs) tolerate the narrow window where a holder has
     locked the slot but not yet published its info — a turn forked on a
     stale [None] simply waits at the slot. *)
+
+(** Atomically close admission for [keeper_name] and snapshot the turn that
+    already owns the slot. New autonomous/chat turns receive the typed
+    [`Shutdown_requested] result after this succeeds. *)
+val begin_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  begin_shutdown_result
+
+(** Re-open admission only when [operation_id] still owns the reservation.
+    Used when durable prepare fails before cancellation begins. *)
+val rollback_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  rollback_shutdown_result
+
+(** Join the current turn holder after admission has been closed. This waits
+    without an invented timeout, then immediately releases the slot. Never
+    call from the same admitted turn. *)
+val await_idle_after_shutdown : base_path:string -> keeper_name:string -> unit
 
 val snapshot_for : base_path:string -> keeper_name:string -> slot_snapshot
 (** Raw, read-only admission state for one keeper. Unknown keepers return a

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -187,6 +187,7 @@ type dashboard_deferred_chat =
   ; chat_waiting : bool
   ; queue_length : int
   ; receipt_id : string
+  ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
 
 let dashboard_busy_queue_state ~base_path ~keeper_name =
@@ -200,14 +201,26 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
   | Some info, false, _ -> Some (Some info, false)
   | Some info, true, _ -> Some (Some info, true)
 
-let dashboard_deferred_ack_text ~keeper_name =
-  Printf.sprintf
-    "%s is busy; your message is queued and will be answered after the current \
-     turn finishes."
-    keeper_name
+let dashboard_deferred_ack_text ~keeper_name deferred =
+  match deferred.shutdown_operation_id with
+  | Some operation_id ->
+    Printf.sprintf
+      "%s is stopping under operation %s; your message is queued for the next active lane."
+      keeper_name
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+  | None ->
+    Printf.sprintf
+      "%s is busy; your message is queued and will be answered after the current \
+       turn finishes."
+      keeper_name
 
 let dashboard_deferred_chat_to_json ~keeper_name
-    ({ in_flight; chat_waiting; queue_length; receipt_id } : dashboard_deferred_chat) =
+    ({ in_flight
+     ; chat_waiting
+     ; queue_length
+     ; receipt_id
+     ; shutdown_operation_id
+     } : dashboard_deferred_chat) =
   let in_flight_fields =
     match in_flight with
     | None -> []
@@ -225,10 +238,21 @@ let dashboard_deferred_chat_to_json ~keeper_name
      ; ("queue_length", `Int queue_length)
      ; ("chat_waiting", `Bool chat_waiting)
      ; ("receipt_id", `String receipt_id)
+     ; ( "shutdown_operation_id"
+       , match shutdown_operation_id with
+         | None -> `Null
+         | Some operation_id ->
+           `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
      ]
      @ in_flight_fields)
 
-let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
+let enqueue_dashboard_payload
+      ~clock
+      payload
+      ~in_flight
+      ~chat_waiting
+      ~shutdown_operation_id
+  =
   let receipt_id =
     Keeper_chat_queue.enqueue ~keeper_name:payload.name
       { Keeper_chat_queue.content = payload.message
@@ -240,17 +264,34 @@ let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
   in
   let queue_length = Keeper_chat_queue.length ~keeper_name:payload.name in
   Keeper_chat_broadcast.queue_changed ~keeper_name:payload.name ~depth:queue_length ();
-  { in_flight; chat_waiting; queue_length; receipt_id }
+  { in_flight; chat_waiting; queue_length; receipt_id; shutdown_operation_id }
 
 let dashboard_deferred_chat_of_rejection ~clock payload
-    ({ Keeper_turn_admission.waiting; in_flight } : Keeper_turn_admission.rejection) =
-  enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting:(waiting > 0)
+     ({ Keeper_turn_admission.waiting
+     ; in_flight
+     ; shutdown_operation_id
+     } : Keeper_turn_admission.rejection) =
+  (* Dashboard messages remain durable while a shutdown fence is active;
+     the queue is the continuation boundary for a later resume/replacement
+     lane, rather than starting a turn behind the fence. *)
+  enqueue_dashboard_payload
+    ~clock
+    payload
+    ~in_flight
+    ~chat_waiting:(waiting > 0)
+    ~shutdown_operation_id
 
 let defer_dashboard_payload_if_busy ~base_path ~clock payload =
   match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
   | None -> `Not_busy
   | Some (in_flight, chat_waiting) ->
-      `Queued (enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting)
+      `Queued
+        (enqueue_dashboard_payload
+           ~clock
+           payload
+           ~in_flight
+           ~chat_waiting
+           ~shutdown_operation_id:None)
 
 let keeper_chat_request_prefixes =
   [
@@ -1496,7 +1537,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
     | Stream_dashboard_queued queued ->
-        let message = dashboard_deferred_ack_text ~keeper_name:payload.name in
+        let message =
+          dashboard_deferred_ack_text ~keeper_name:payload.name queued
+        in
         publish_terminal ~status:"queued" ~ok:true ~message ();
         Keeper_chat_events.publish events (Text_delta message);
         Keeper_chat_events.publish events
@@ -1990,7 +2033,9 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                       { message_id; role = Keeper_chat_events.Assistant });
                  Keeper_chat_events.publish events
                    (Text_delta
-                      (dashboard_deferred_ack_text ~keeper_name:payload.name));
+                      (dashboard_deferred_ack_text
+                         ~keeper_name:payload.name
+                         queued));
                  Keeper_chat_events.publish events
                    (Custom
                       { name = "KEEPER_CHAT_QUEUED";

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -818,7 +818,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
   let base_dir = temp_dir "shutdown-prepare-join" in
   Fun.protect
     ~finally:(fun () ->
-      Keeper_turn_admission.For_testing.reset ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
       R.clear ();
       cleanup_dir base_dir)
     (fun () ->

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -25,6 +25,9 @@ module Obs = Masc.Keeper_heartbeat_loop_observations
 module WO = Masc.Keeper_world_observation
 module Health = Masc.Health
 module Lane = Masc.Keeper_lane
+module Shutdown_types = Masc.Keeper_shutdown_types
+module Shutdown_store = Masc.Keeper_shutdown_store
+module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -655,6 +658,7 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
   let exit = Lane.await_exit lane in
   (match exit.outcome with
    | Lane.Completed -> ()
+   | Lane.Shutdown_requested -> fail "unexpected lane shutdown"
    | Lane.Cancelled_by_parent cause ->
      fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
    | Lane.Failed exn -> fail ("unexpected lane failure: " ^ Printexc.to_string exn));
@@ -697,6 +701,176 @@ let test_keeper_lane_identity_is_typed_and_unique () =
   match Lane.Id.of_string encoded with
   | Ok decoded -> check bool "lane id round-trip" true (Lane.Id.equal first_id decoded)
   | Error detail -> fail detail
+
+let test_keeper_lane_cancel_is_lane_local_and_joinable () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun parent_sw ->
+  let lane = Lane.create () in
+  let never_p, _never_r = Eio.Promise.create () in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~run:(fun _lane_sw -> Eio.Promise.await never_p)
+       ~cleanup:(fun _outcome -> Ok ())
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  Eio.Fiber.yield ();
+  (match Lane.request_cancel lane with
+   | Lane.Cancel_requested -> ()
+   | Lane.Cancel_already_requested
+   | Lane.Cancel_already_exiting
+   | Lane.Cancel_signal_failed _ -> fail "first lane cancellation was not accepted");
+  let exit = Lane.await_exit lane in
+  match exit.outcome with
+  | Lane.Shutdown_requested -> ()
+  | Lane.Completed -> fail "cancelled lane reported normal completion"
+  | Lane.Cancelled_by_parent cause ->
+    fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
+  | Lane.Failed exn -> fail ("lane cancellation failed: " ^ Printexc.to_string exn)
+
+let test_keeper_shutdown_store_round_trip_and_identity_guard () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-store" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta "shutdown-store-keeper" in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let lane = Lane.create () in
+      let now = Masc_domain.now_iso () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id lane
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "tester"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Prepared
+        ; created_at = now
+        ; updated_at = now
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_store.persist_new ~config operation with
+       | Error (Shutdown_store.Already_exists _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "duplicate shutdown operation overwrote its record");
+      let loaded =
+        match Shutdown_store.load ~config operation_id with
+        | Ok loaded -> loaded
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check string "shutdown keeper round-trip" operation.keeper_name loaded.keeper_name;
+      check bool
+        "shutdown lane identity round-trip"
+        true
+        (Lane.Id.equal operation.lane_id loaded.lane_id);
+      let joined =
+        { loaded with
+          phase = Shutdown_types.Joined_idle
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.replace ~config joined with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let mismatched = { joined with lane_id = Lane.id (Lane.create ()) } in
+      (match Shutdown_store.replace ~config mismatched with
+       | Error (Shutdown_store.Identity_mismatch _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "shutdown store accepted a different lane identity");
+      (match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
+       | Ok [ listed ] ->
+         check bool
+           "listed operation identity"
+           true
+           (Shutdown_types.Operation_id.equal listed.operation_id operation_id)
+       | Ok operations ->
+         fail (Printf.sprintf "expected one shutdown operation, got %d" (List.length operations))
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let unsupported_json =
+        match Shutdown_store.to_json joined with
+        | `Assoc fields ->
+          `Assoc (("schema_version", `Int 999) :: List.remove_assoc "schema_version" fields)
+        | _ -> fail "shutdown operation codec did not produce an object"
+      in
+      match Shutdown_store.of_json unsupported_json with
+      | Error (Shutdown_store.Decode_error _) -> ()
+      | Error error -> fail (Shutdown_store.error_to_string error)
+      | Ok _ -> fail "unsupported shutdown schema was accepted")
+
+let test_keeper_shutdown_prepare_joins_idle_lane () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun parent_sw ->
+  let base_dir = temp_dir "shutdown-prepare-join" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let name = "shutdown-idle-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let never_p, _never_r = Eio.Promise.create () in
+      (match
+         Lane.fork
+           ~sw:parent_sw
+           entry.lane
+           ~run:(fun _lane_sw -> Eio.Promise.await never_p)
+           ~cleanup:(fun _outcome ->
+             ignore (R.dispatch_event ~base_path:config.base_path name KSM.Stop_requested);
+             ignore (R.dispatch_event ~base_path:config.base_path name KSM.Drain_complete);
+             ignore (R.resolve_done entry ~source:"shutdown_test_lane_cleanup" `Stopped);
+             Ok ())
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
+      Eio.Fiber.yield ();
+      let operation =
+        match
+          Shutdown_prepare_join.run
+            ~config
+            ~entry
+            ~request:
+              { actor = "operator"
+              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              }
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+      in
+      (match operation.phase with
+       | Shutdown_types.Joined_idle -> ()
+       | Shutdown_types.Prepared
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _ -> fail "idle lane did not reach Joined_idle");
+      check bool
+        "shutdown operation records lane join evidence"
+        true
+        (Option.is_some operation.join_evidence);
+      (match Keeper_turn_admission.run_if_free ~base_path:config.base_path ~keeper_name:name (fun () -> ()) with
+       | `Busy (Keeper_turn_admission.Shutdown_requested operation_id) ->
+         check bool
+           "shutdown admission fence retains operation identity"
+           true
+           (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
+       | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
+         fail "shutdown admission fence reopened before finalization"))
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1115,6 +1289,12 @@ let () =
         test_keeper_lane_surfaces_cleanup_failure;
       test_case "lane identity is typed and unique" `Quick
         test_keeper_lane_identity_is_typed_and_unique;
+      test_case "lane cancellation is local and joinable" `Quick
+        test_keeper_lane_cancel_is_lane_local_and_joinable;
+      test_case "shutdown store round-trip and identity guard" `Quick
+        test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "shutdown prepare joins idle lane" `Quick
+        test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -823,7 +823,9 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
       let name = "shutdown-idle-lane" in
       let entry = R.register ~base_path:config.base_path name (make_meta name) in
       let never_p, _never_r = Eio.Promise.create () in
@@ -833,9 +835,15 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            entry.lane
            ~run:(fun _lane_sw -> Eio.Promise.await never_p)
            ~cleanup:(fun _outcome ->
-             ignore (R.dispatch_event ~base_path:config.base_path name KSM.Stop_requested);
-             ignore (R.dispatch_event ~base_path:config.base_path name KSM.Drain_complete);
-             ignore (R.resolve_done entry ~source:"shutdown_test_lane_cleanup" `Stopped);
+             (match R.dispatch_event_exact entry KSM.Stop_requested with
+              | Ok _ -> ()
+              | Error error -> fail (KSM.transition_error_to_string error));
+             (match R.dispatch_event_exact entry KSM.Drain_complete with
+              | Ok _ -> ()
+              | Error error -> fail (KSM.transition_error_to_string error));
+             (match R.resolve_done entry ~source:"shutdown_test_lane_cleanup" `Stopped with
+              | R.Done_resolved _ -> ()
+              | R.Done_already_resolved _ -> fail "test lane terminal resolved twice");
              Ok ())
        with
        | Ok () -> ()
@@ -863,14 +871,62 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
         "shutdown operation records lane join evidence"
         true
         (Option.is_some operation.join_evidence);
-      (match Keeper_turn_admission.run_if_free ~base_path:config.base_path ~keeper_name:name (fun () -> ()) with
-       | `Busy (Keeper_turn_admission.Shutdown_requested operation_id) ->
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:name
+           (fun () -> ())
+       with
+       | `Busy (Masc.Keeper_turn_admission.Shutdown_requested operation_id) ->
          check bool
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-       | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
+
+let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-prepare-rollback" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-prepare-rollback-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let probe_operation_id = Shutdown_types.Operation_id.generate () in
+      let records_dir =
+        Filename.dirname (Shutdown_store.path ~config probe_operation_id)
+      in
+      let blocker = open_out records_dir in
+      close_out blocker;
+      (match
+         Shutdown_prepare_join.run
+           ~config
+           ~entry
+           ~request:
+             { actor = "operator"
+             ; cleanup_intent = { remove_meta = false; remove_session = false }
+             }
+       with
+       | Error (Shutdown_prepare_join.Prepare_persist_failed _) -> ()
+       | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+       | Ok _ -> fail "shutdown prepare unexpectedly persisted through a file blocker");
+      match
+        Masc.Keeper_turn_admission.run_if_free
+          ~base_path:config.base_path
+          ~keeper_name:name
+          (fun () -> ())
+      with
+      | `Ran () -> ()
+      | `Busy _ -> fail "failed shutdown prepare left the keeper admission fence closed")
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1295,6 +1351,8 @@ let () =
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
+      test_case "shutdown prepare failure rolls back admission fence" `Quick
+        test_keeper_shutdown_prepare_failure_rolls_back_fence;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -87,7 +87,9 @@ let test_autonomous_skips_in_flight_chat () =
       | `Rejected _ -> check "chat turn admitted on a free slot" false);
     Eio.Promise.await started;
     (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
-     | `Busy (Some { Keeper_turn_admission.lane = Chat; _ }) ->
+     | `Busy
+         (Keeper_turn_admission.Turn_busy
+            (Some { Keeper_turn_admission.lane = Chat; _ })) ->
        check "run_if_free reports Busy with the in-flight chat lane" true
      | `Busy _ -> check "run_if_free reports Busy with the in-flight chat lane" false
      | `Ran () -> check "run_if_free must not admit during an in-flight turn" false);
@@ -197,7 +199,11 @@ let test_waiting_cap_rejects () =
          (waiting = Keeper_turn_admission.max_waiting_chat_requests)
      | None -> check "slot exists after queueing" false);
     (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
-     | `Rejected { Keeper_turn_admission.waiting; in_flight } ->
+     | `Rejected
+         { Keeper_turn_admission.waiting
+         ; in_flight
+         ; shutdown_operation_id = None
+         } ->
        check "request beyond the cap is rejected" true;
        check
          "rejection reports a full queue"
@@ -206,6 +212,8 @@ let test_waiting_cap_rejects () =
         | Some { Keeper_turn_admission.lane = Chat; _ } ->
           check "rejection reports the in-flight lane" true
         | Some _ | None -> check "rejection reports the in-flight lane" false)
+     | `Rejected { shutdown_operation_id = Some _; _ } ->
+       check "queue-cap rejection is not a shutdown" false
      | `Ran () -> check "request beyond the cap is rejected" false);
     let snapshot = Keeper_turn_admission.snapshot_for ~base_path ~keeper_name in
     check
@@ -438,6 +446,52 @@ let test_autonomous_yields_to_queued_connector_message () =
   | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false
 ;;
 
+let test_shutdown_reservation_fences_and_rolls_back () =
+  reset ();
+  Printf.printf "Test 11: shutdown reservation fences every turn lane\n%!";
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  (match
+     Keeper_turn_admission.begin_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_reserved reservation ->
+     check
+       "reservation records the requested operation"
+       (Keeper_shutdown_types.Operation_id.equal reservation.operation_id operation_id);
+     check "idle reservation has no in-flight turn" (Option.is_none reservation.in_flight)
+   | Keeper_turn_admission.Shutdown_already_reserved _ ->
+     check "fresh slot is not already reserved" false);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy (Keeper_turn_admission.Shutdown_requested reserved) ->
+     check
+       "autonomous lane sees typed shutdown fence"
+       (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
+   | `Busy (Keeper_turn_admission.Turn_busy _) | `Ran () ->
+     check "autonomous lane cannot cross shutdown fence" false);
+  (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
+   | `Rejected { shutdown_operation_id = Some reserved; _ } ->
+     check
+       "chat lane sees typed shutdown fence"
+       (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
+   | `Rejected { shutdown_operation_id = None; _ } | `Ran () ->
+     check "chat lane cannot cross shutdown fence" false);
+  (match
+     Keeper_turn_admission.rollback_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_rolled_back -> ()
+   | Keeper_turn_admission.Shutdown_not_reserved
+   | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
+     check "own reservation rolls back" false);
+  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "open") with
+  | `Ran "open" -> check "rollback re-opens admission" true
+  | `Ran _ | `Busy _ -> check "rollback re-opens admission" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -451,6 +505,7 @@ let () =
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
+  test_shutdown_reservation_fences_and_rolls_back ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## Stack

Depends on Draft #24135. This is phase 2 of #24113 and does not close the issue.

## Summary

- atomically fence autonomous and chat turn admission with a typed shutdown operation ID
- keep dashboard/connector messages in the durable Keeper chat queue and surface the operation ID instead of starting a turn behind the fence
- resolve agent identity and snapshot every owned Claimed/InProgress task through a strict shutdown query
- persist a versioned shutdown record under the configured MASC base path before cancellation
- record exact Keeper lane ID, trace, generation, cleanup intent, active-turn uncertainty, owned task IDs, join outcome, terminal result, and cleanup failure
- cancel the exact current turn and exact lane, then join both the turn-admission slot and lane scope
- classify any previously admitted turn as effect-unknown and require reconciliation; task ownership is deliberately retained so another actor cannot re-run ambiguous work
- rollback the admission fence when strict discovery or the initial durable write fails
- expose active shutdown operation IDs in turn-admission health snapshots

No task release, meta removal, session removal, or registry unregister occurs in this phase. Those are phase-3 finalization after idle/reconciliation evidence.

## Correctness boundary

Eio.Switch.fail requests cancellation but does not join. The operation persists its conservative turn disposition before cancellation, then waits for the turn slot and Keeper lane exit separately. Caller cancellation is not protected or swallowed: the durable Prepared record and admission fence remain for recovery, while the caller fiber can terminate without becoming a global shutdown blocker.

[근거] Eio 1.3 official Switch documentation: https://ocaml.org/p/eio/1.3/doc/eio/Eio/Switch/index.html — checked 2026-07-11 — High
[근거] Eio 1.3 official Fiber documentation: https://ocaml.org/p/eio/1.3/doc/eio/Eio/Fiber/index.html — checked 2026-07-11 — High

## Verification

- OCaml parser check for every changed .ml/.mli
- ocamlformat --check for every changed OCaml file
- ocamldep dependency scan
- git diff --check
- determinism contract gate
- enum/string safety gate
- silent-failure gate and ratchet
- stringly-boundary and OCaml structure ratchets
- boundary .mli pair gate
- Fun.protect finalizer guard
- focused tests added for lane-local cancellation, durable store identity/schema, idle prepare/join, admission fence/rollback, and strict ABA handling

No local Dune build or test was run. CI is the build authority.