### PR TITLE
fix(keeper): make shutdown a lane-local transaction

### DIFF
--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -121,6 +121,12 @@ let get_net_opt () : eio_net option =
 let get_clock_opt () =
   Atomic.get current_clock
 
+let get_bound_turn_switch_opt () =
+  try Eio.Fiber.get sw_key with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Stdlib.Effect.Unhandled _ -> None
+;;
+
 let get_switch_opt () =
   (* RFC-0107 §3.3 / audit §10.5 — fiber-local first, then atomic fallback.
 
@@ -135,12 +141,7 @@ let get_switch_opt () =
      [Eio.Fiber.get] raises if called outside any Eio fiber context
      (e.g. test setup before [Eio_main.run]). In that case there is no
      fiber-local state to consult, so we fall through to the atomic. *)
-  let from_fiber =
-    try Eio.Fiber.get sw_key
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> None
-  in
+  let from_fiber = get_bound_turn_switch_opt () in
   match from_fiber with
   | Some _ as some_sw -> some_sw
   | None -> Atomic.get current_sw

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -77,6 +77,11 @@ val get_clock_opt : unit -> float Eio.Time.clock_ty Eio.Resource.t option
 val get_switch_opt : unit -> Eio.Switch.t option
 (** Get the Eio switch if available. *)
 
+val get_bound_turn_switch_opt : unit -> Eio.Switch.t option
+(** Return only the turn-scoped fiber binding, without falling back to the
+    server root switch.  This is an exact boundary check for operations that
+    must reject self-cancellation of their owning turn. *)
+
 val get_net : unit -> (eio_net, string) result
 (** Get the Eio network handle.
     Returns Error if not initialized. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -319,6 +319,65 @@ let run_turn
          meta.name (Printexc.to_string exn));
     Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
   in
+  let persist_shutdown_fallback () =
+    match Keeper_registry.get ~base_path:config.base_path meta.name with
+    | None ->
+      Log.Keeper.error
+        "%s: shutdown fallback could not find its registered lane"
+        meta.name
+    | Some entry ->
+      let persist record =
+        match Keeper_shutdown_record.persist ~config record with
+        | Error error ->
+          (match
+             Keeper_registry.record_shutdown_turn_persist_failed
+               entry
+               record
+               ~error
+           with
+           | Ok () -> ()
+           | Error state_error ->
+             Log.Keeper.error
+               "%s: shutdown fallback persistence failed and state could not be recorded: persistence=%s registry=%s"
+               meta.name
+               error
+               (Keeper_registry.shutdown_state_error_to_string state_error))
+        | Ok persisted ->
+          (match Keeper_registry.record_shutdown_turn_persisted entry persisted with
+           | Ok () -> ()
+           | Error state_error ->
+             Log.Keeper.error
+               "%s: shutdown fallback persisted but state could not be committed: %s"
+               meta.name
+               (Keeper_registry.shutdown_state_error_to_string state_error))
+      in
+      (match Keeper_registry.shutdown_turn_settlement entry with
+       | Some
+           (Keeper_shutdown_types.Interrupted_turn_persisted _
+           | Keeper_shutdown_types.No_interrupted_turn) -> ()
+       | Some
+           (Keeper_shutdown_types.Interrupted_turn_persist_failed
+              { record; error = _ }) ->
+         persist record
+       | Some (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id }) ->
+         let record =
+           Keeper_shutdown_types.make_interrupted_turn
+             ~keeper_name:meta.name
+             ~trace_id:meta.runtime.trace_id
+             ~turn_id
+             ~current_task_id:entry.meta.current_task_id
+             ~interrupted_at:(Time_compat.now ())
+             ~committed_mutating_tools:[]
+             ~event_bus_integrity_error:
+               (Some
+                  "shutdown interruption occurred outside the event-bus settlement boundary; committed mutation status is unavailable")
+         in
+         persist record
+       | None ->
+         Log.Keeper.error
+           "%s: shutdown fallback ran without a shutdown transaction"
+           meta.name)
+  in
   Eio_guard.protect ~finally:safe_emit_turn_end
   @@ fun () ->
   try
@@ -1114,6 +1173,10 @@ let run_turn
           ());
        receipt_result)
 with
+| Eio.Cancel.Cancelled Keeper_registry.Shutdown_interrupt as ce ->
+  turn_cancelled := Some ce;
+  Eio.Cancel.protect persist_shutdown_fallback;
+  raise ce
 | Eio.Cancel.Cancelled Keeper_registry.Operator_interrupt as ce ->
   turn_cancelled := Some ce;
   Keeper_registry.set_failure_reason

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -716,7 +716,9 @@ let record_keeper_stopped
       ~detail
   : bool
   =
-  if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
+  if Keeper_registry.shutdown_requested entry
+  then false
+  else if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
   then (
     Keeper_registry.dispatch_event_unit
       ~base_path
@@ -743,7 +745,9 @@ let record_keeper_crashed
   : unit
   =
   let reason = Keeper_registry.failure_reason_to_string failure_reason in
-  if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
+  if Keeper_registry.shutdown_requested entry
+  then ()
+  else if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
   then (
     let outcome = reason in
     Keeper_registry.set_failure_reason ~base_path keeper_name (Some failure_reason);
@@ -845,6 +849,9 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
          heartbeat before the gate left a live gRPC resource behind a
          rejected launch — the same half-commit class this change removes
          from the fiber-fork path. *)
+      if Keeper_registry.shutdown_requested reg
+      then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+      else
       match dispatch_fiber_started ~base_path:ctx.config.base_path m.name with
       | Error err ->
         (* Fail closed: the registry FSM refused [Fiber_started], so no
@@ -876,8 +883,35 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
             ~phase:Keeper_state_machine.Crashed
             ~keeper_name:m.name
             ~detail:reason
-            ()
+            ();
+        ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+      | Ok () when Keeper_registry.shutdown_requested reg ->
+        (* Shutdown won the register-to-fork race.  No lane fiber exists, so
+           resolve the physical join signal and leave terminal FSM/done
+           settlement to the shutdown transaction. *)
+        ignore (Keeper_registry.resolve_fiber_exited reg : bool)
       | Ok () ->
+        let launch_claimed =
+          match Keeper_registry.claim_fiber_launch reg with
+          | Keeper_registry.Fiber_launch_claimed -> true
+          | Keeper_registry.Fiber_launch_already_exited ->
+            if not (Keeper_registry.shutdown_requested reg)
+            then
+              Log.Keeper.error
+                "%s: direct keepalive launch found an exited physical-lane state"
+                m.name;
+            false
+          | Keeper_registry.Fiber_launch_already_running ->
+            Log.Keeper.error
+              "%s: duplicate direct keepalive launch rejected for a running physical lane"
+              m.name;
+            false
+        in
+        if not launch_claimed
+        then ()
+        else if Keeper_registry.shutdown_requested reg
+        then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+        else
         let stop = reg.fiber_stop in
         let wakeup = reg.fiber_wakeup in
         (* Start optional gRPC heartbeat fiber *)
@@ -891,7 +925,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         (* Telemetry feedback refresh loop removed in #6814:
          behavioral_stats no longer consumed by build_prompt. *)
         publish_keeper_started ~live_meta;
-        Eio.Fiber.fork ~sw:ctx.sw (fun () ->
+        (try Eio.Fiber.fork ~sw:ctx.sw (fun () ->
         let record_crash failure_reason =
           record_keeper_crashed
             reg
@@ -952,6 +986,10 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                  live_meta.name
                  (Printexc.to_string e))
         in
+        let finalize_fiber_exit () =
+          safe_cleanup_tracking ();
+          ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+        in
         Eio_guard.protect
           (fun () ->
              try
@@ -996,16 +1034,55 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                       live_meta.name
                       (Printexc.to_string exn));
                  record_crash (Keeper_registry.Exception (Printexc.to_string exn))))
-          ~finally:safe_cleanup_tracking))
+          ~finally:finalize_fiber_exit)
+         with
+         | exn ->
+           let backtrace = Printexc.get_raw_backtrace () in
+           (match grpc_close with
+            | None -> ()
+            | Some close_fn ->
+              (try close_fn () with
+               | Eio.Cancel.Cancelled _ -> ()
+               | close_error ->
+                 Log.Keeper.error
+                   "%s: gRPC close failed after direct lane fork failure: %s"
+                   m.name
+                   (Printexc.to_string close_error)));
+           record_keeper_crashed
+             reg
+             ~base_path:ctx.config.base_path
+             ~keeper_name:m.name
+             ~failure_reason:
+               (Keeper_registry.Exception
+                  ("direct lane fork failed: " ^ Printexc.to_string exn));
+           ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+           Printexc.raise_with_backtrace exn backtrace))
 ;;
 
-let stop_keepalive ?base_path name =
-  let entries =
-    Keeper_registry.all ?base_path ()
-    |> List.filter (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name)
-  in
-  List.iter
-    (fun (entry : Keeper_registry.registry_entry) ->
+type joined_stop =
+  { interrupted_turn_id : int option
+  ; terminal : Keeper_registry.done_resolution
+  }
+
+type joined_stop_result =
+  | Keeper_not_registered
+  | Keeper_joined of joined_stop
+  | Keeper_stop_owned_by_shutdown
+  | Keeper_self_stop_rejected
+  | Keeper_exit_without_terminal
+
+type shutdown_lane_join =
+  { entry : Keeper_registry.registry_entry
+  ; interrupt : Keeper_registry.shutdown_interrupt_result
+  ; grpc_close_error : string option
+  }
+
+type shutdown_lane_join_result =
+  | Shutdown_keeper_not_registered
+  | Shutdown_self_join_rejected
+  | Shutdown_lane_joined of shutdown_lane_join
+
+let signal_entry_stop (entry : Keeper_registry.registry_entry) =
        (* tla-lint: allow-mutation: fiber signal — stop+wakeup pair triggers cooperative shutdown *)
        Atomic.set entry.fiber_stop true;
        Atomic.set entry.fiber_wakeup true;
@@ -1014,27 +1091,104 @@ let stop_keepalive ?base_path name =
           as TRUE before the heartbeat fiber consumes its termination
           signal. *)
        post_wakeup_signal ~wakeup:entry.fiber_wakeup;
-       (match Atomic.get entry.grpc_close with
-        | Some close_fn ->
-          (try close_fn () with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | _exn ->
-             Otel_metric_store.inc_counter
-               "masc_keeper_grpc_close_failures"
-               ~labels:[ "keeper", entry.meta.name ]
-               ())
-        | None -> ());
-       match entry.phase with
-       | Keeper_state_machine.Crashed | Keeper_state_machine.Dead -> ()
-       | _ ->
-         if
-           record_keeper_stopped
-             entry
-             ~base_path:entry.base_path
-             ~keeper_name:entry.name
-             ~detail:"manual stop"
-         then Keeper_registry.cleanup_tracking ~base_path:entry.base_path entry.name)
-    entries
+       match Atomic.get entry.grpc_close with
+       | None -> None
+       | Some close_fn ->
+         (try
+            close_fn ();
+            None
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Otel_metric_store.inc_counter
+              "masc_keeper_grpc_close_failures"
+              ~labels:[ "keeper", entry.meta.name ]
+              ();
+            Some (Printexc.to_string exn))
+;;
+
+let request_entry_stop (entry : Keeper_registry.registry_entry) =
+  let grpc_close_error = signal_entry_stop entry in
+  Option.iter
+    (fun error ->
+       Log.Keeper.error
+         "%s: gRPC close failed while requesting lane stop: %s"
+         entry.name
+         error)
+    grpc_close_error;
+  if Keeper_registry.shutdown_requested entry
+  then (
+    match
+      Keeper_registry.interrupt_current_turn_for_shutdown
+        ~base_path:entry.base_path
+        entry.name
+    with
+    | Keeper_registry.Shutdown_turn_interrupted { turn_id }
+    | Keeper_registry.Shutdown_turn_interrupt_pending { turn_id } -> Some turn_id
+    | Keeper_registry.Shutdown_no_turn_in_flight -> None
+    | Keeper_registry.Shutdown_turn_state_error error ->
+      Log.Keeper.error
+        "%s: shutdown turn interrupt state failed while requesting stop: %s"
+        entry.name
+        (Keeper_registry.shutdown_state_error_to_string error);
+      None)
+  else
+    match Keeper_registry.interrupt_current_turn ~base_path:entry.base_path entry.name with
+    | `Cancelled turn_id -> Some turn_id
+    | `No_turn_in_flight -> None
+;;
+
+let stop_keepalive ?base_path name =
+  Keeper_registry.all ?base_path ()
+  |> List.filter (fun (entry : Keeper_registry.registry_entry) ->
+    String.equal entry.name name)
+  |> List.iter (fun entry -> ignore (request_entry_stop entry : int option))
+;;
+
+let stop_keepalive_and_await ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> Keeper_not_registered
+  | Some entry when Keeper_registry.current_fiber_owns_turn entry ->
+    Keeper_self_stop_rejected
+  | Some entry when Keeper_registry.shutdown_requested entry ->
+    Keeper_stop_owned_by_shutdown
+  | Some entry ->
+    let interrupted_turn_id = request_entry_stop entry in
+    let settled_before_launch =
+      Keeper_registry.settle_unlaunched_fiber_exit entry
+    in
+    if settled_before_launch
+    then
+      ignore
+        (record_keeper_stopped
+           entry
+           ~base_path
+           ~keeper_name:name
+           ~detail:"stopped before physical lane launch"
+          : bool);
+    Keeper_registry.await_fiber_exit entry;
+    if Keeper_registry.shutdown_requested entry
+    then Keeper_stop_owned_by_shutdown
+    else
+      (match Eio.Promise.peek entry.done_p with
+       | Some terminal -> Keeper_joined { interrupted_turn_id; terminal }
+       | None -> Keeper_exit_without_terminal)
+;;
+
+let request_shutdown_and_await_exit ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> Shutdown_keeper_not_registered
+  | Some entry when Keeper_registry.current_fiber_owns_turn entry ->
+    Shutdown_self_join_rejected
+  | Some entry ->
+    ignore (Keeper_registry.begin_shutdown entry : Keeper_registry.shutdown_begin_result);
+    let grpc_close_error = signal_entry_stop entry in
+    let interrupt =
+      Keeper_registry.interrupt_current_turn_for_shutdown ~base_path name
+    in
+    ignore (Keeper_registry.settle_unlaunched_fiber_exit entry : bool);
+    Keeper_registry.await_fiber_exit entry;
+    Shutdown_lane_joined { entry; interrupt; grpc_close_error }
 ;;
 
 (** Stop all running keepers. Used in test cleanup to prevent orphaned

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -709,6 +709,13 @@ let resolve_registry_done
   | Keeper_registry.Done_already_resolved _ -> false
 ;;
 
+let resolve_physical_lane_exit (entry : Keeper_registry.registry_entry) =
+  let (_was_first_resolver : bool) =
+    Keeper_registry.resolve_fiber_exited entry
+  in
+  ()
+;;
+
 let record_keeper_stopped
       (entry : Keeper_registry.registry_entry)
       ~base_path
@@ -850,7 +857,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
          rejected launch — the same half-commit class this change removes
          from the fiber-fork path. *)
       if Keeper_registry.shutdown_requested reg
-      then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+      then resolve_physical_lane_exit reg
       else
       match dispatch_fiber_started ~base_path:ctx.config.base_path m.name with
       | Error err ->
@@ -884,12 +891,12 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
             ~keeper_name:m.name
             ~detail:reason
             ();
-        ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+        resolve_physical_lane_exit reg
       | Ok () when Keeper_registry.shutdown_requested reg ->
         (* Shutdown won the register-to-fork race.  No lane fiber exists, so
            resolve the physical join signal and leave terminal FSM/done
            settlement to the shutdown transaction. *)
-        ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+        resolve_physical_lane_exit reg
       | Ok () ->
         let launch_claimed =
           match Keeper_registry.claim_fiber_launch reg with
@@ -910,7 +917,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         if not launch_claimed
         then ()
         else if Keeper_registry.shutdown_requested reg
-        then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+        then resolve_physical_lane_exit reg
         else
         let stop = reg.fiber_stop in
         let wakeup = reg.fiber_wakeup in
@@ -988,7 +995,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         in
         let finalize_fiber_exit () =
           safe_cleanup_tracking ();
-          ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+          resolve_physical_lane_exit reg
         in
         Eio_guard.protect
           (fun () ->
@@ -1055,7 +1062,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
              ~failure_reason:
                (Keeper_registry.Exception
                   ("direct lane fork failed: " ^ Printexc.to_string exn));
-           ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+           resolve_physical_lane_exit reg;
            Printexc.raise_with_backtrace exn backtrace))
 ;;
 
@@ -1181,12 +1188,16 @@ let request_shutdown_and_await_exit ~base_path name =
   | Some entry when Keeper_registry.current_fiber_owns_turn entry ->
     Shutdown_self_join_rejected
   | Some entry ->
-    ignore (Keeper_registry.begin_shutdown entry : Keeper_registry.shutdown_begin_result);
+    (match Keeper_registry.begin_shutdown entry with
+     | Keeper_registry.Shutdown_started
+     | Keeper_registry.Shutdown_already_started _ -> ());
     let grpc_close_error = signal_entry_stop entry in
     let interrupt =
       Keeper_registry.interrupt_current_turn_for_shutdown ~base_path name
     in
-    ignore (Keeper_registry.settle_unlaunched_fiber_exit entry : bool);
+    let (_settled_before_launch : bool) =
+      Keeper_registry.settle_unlaunched_fiber_exit entry
+    in
     Keeper_registry.await_fiber_exit entry;
     Shutdown_lane_joined { entry; interrupt; grpc_close_error }
 ;;

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -118,4 +118,42 @@ val percentile : float array -> float -> float
 val start_keepalive :
   ?proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
 val stop_keepalive : ?base_path:string -> string -> unit
+
+type joined_stop =
+  { interrupted_turn_id : int option
+  ; terminal : Keeper_registry.done_resolution
+  }
+
+type joined_stop_result =
+  | Keeper_not_registered
+  | Keeper_joined of joined_stop
+  | Keeper_stop_owned_by_shutdown
+  | Keeper_self_stop_rejected
+  | Keeper_exit_without_terminal
+
+type shutdown_lane_join =
+  { entry : Keeper_registry.registry_entry
+  ; interrupt : Keeper_registry.shutdown_interrupt_result
+  ; grpc_close_error : string option
+  }
+
+type shutdown_lane_join_result =
+  | Shutdown_keeper_not_registered
+  | Shutdown_self_join_rejected
+  | Shutdown_lane_joined of shutdown_lane_join
+
+(** Request a non-destructive lane stop and join its concrete fiber.  The
+    result explicitly rejects self-join and a concurrent typed shutdown; a
+    physical exit without [done_p] is surfaced rather than waited on forever. *)
+val stop_keepalive_and_await :
+  base_path:string -> string -> joined_stop_result
+
+(** Begin a typed shutdown, cancel the current turn with
+    {!Keeper_registry.Shutdown_interrupt}, and join the concrete lane fiber.
+    This deliberately does not resolve [done_p] or unregister the lane; the
+    lifecycle transaction owns those steps after durable settlement.  A
+    caller running inside the target turn is rejected rather than deadlocking
+    on its own physical-exit promise. *)
+val request_shutdown_and_await_exit :
+  base_path:string -> string -> shutdown_lane_join_result
 val stop_all_keepalives : unit -> unit

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -54,6 +54,22 @@ let preserve_operator_pause_from_disk
 
 let heartbeat_fields_from_disk = preserve_operator_pause_from_disk
 
+let operator_pause_from_caller
+      ~(latest : Keeper_meta_contract.keeper_meta)
+      ~(caller : Keeper_meta_contract.keeper_meta)
+  =
+  { latest with
+    paused = caller.paused
+  ; latched_reason = caller.latched_reason
+  ; auto_resume_after_sec = caller.auto_resume_after_sec
+  ; updated_at = caller.updated_at
+  ; runtime =
+      { latest.runtime with
+        last_blocker = caller.runtime.last_blocker
+      }
+  }
+;;
+
 (* Dead-tombstone cleanup is the authoritative writer of [paused] and
    [latched_reason]: it records that the supervisor is tearing the keeper down
    as a dead tombstone. This is the inverse ownership of

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -17,6 +17,12 @@ val heartbeat_fields_from_disk : t
     already present on disk. This prevents stale turn/heartbeat writers from
     clearing [paused=true] after an operator paused the keeper. *)
 
+val operator_pause_from_caller : t
+(** Preserve the latest disk record and let the control-plane caller own only
+    [paused], [latched_reason], [auto_resume_after_sec], [updated_at], and
+    [runtime.last_blocker].  This prevents a shutdown pause written from a
+    stale registry snapshot from regressing turn usage or runtime state. *)
+
 val dead_tombstone_cleanup_from_disk : t
 (** {!monotonic_usage_counters}, with [paused] and [latched_reason] owned by the
     caller. Used by the dead-tombstone cleanup so a CAS retry that re-reads an

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -276,6 +276,17 @@ val clear_turn_switch : base_path:string -> string -> unit
 val interrupt_current_turn :
   base_path:string -> string -> [ `Cancelled of int | `No_turn_in_flight ]
 
+(** Cancel the in-flight turn as part of an already-started lane shutdown.
+    The typed result distinguishes an installed cancellation from the race in
+    which the turn switch has not been bound yet; [set_turn_switch] completes
+    that pending cancellation when the binding appears. *)
+val interrupt_current_turn_for_shutdown :
+  base_path:string -> string -> shutdown_interrupt_result
+
+(** Exact fiber-local ownership check for the entry's current turn switch.
+    This compares switch identity and never infers ownership from agent names. *)
+val current_fiber_owns_turn : registry_entry -> bool
+
 (** Record the verdict reasons from a [keeper_cycle_decision] that
     chose to skip the next turn.  Stamps [last_skip_observation] with
     [(now, reasons)] so the stale watchdog can surface *why* a keeper

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -324,6 +324,7 @@ let register_with_state
       meta
       ~(phase : Keeper_state_machine.phase)
       ~(conditions : Keeper_state_machine.conditions)
+      ~(fiber_lifecycle_state : fiber_lifecycle_state)
   =
   let meta = canonicalize_registry_meta ~operation:"register" ~base_path name meta in
   Log.Keeper.info
@@ -332,6 +333,7 @@ let register_with_state
     base_path
     (Keeper_state_machine.phase_to_string phase);
   let done_p, done_r = Eio.Promise.create () in
+  let fiber_exited_p, fiber_exited_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key (Atomic.get registry) with
    | Some entry when entry.phase = Running ->
@@ -358,6 +360,9 @@ let register_with_state
     ; grpc_close = Atomic.make None
     ; done_p
     ; done_r
+    ; fiber_exited_p
+    ; fiber_exited_r
+    ; fiber_lifecycle_state = Atomic.make fiber_lifecycle_state
     ; restart_count = 0
     ; last_restart_ts = 0.0
     ; dead_since_ts = None
@@ -367,6 +372,8 @@ let register_with_state
     ; turn_consecutive_failures = 0
     ; livelock_state = Atomic.make None
     ; current_turn_switch = Atomic.make None
+    ; shutdown_state = Atomic.make Keeper_shutdown_types.Not_requested
+    ; shutdown_transaction_claimed = Atomic.make false
     ; board_wakeups = StringMap.empty
     ; board_cursor_ts = 0.0
     ; board_cursor_post_id = None
@@ -401,7 +408,13 @@ let register ~base_path name meta =
     }
   in
   let phase = Keeper_state_machine.derive_phase conditions in
-  register_with_state ~base_path name meta ~phase ~conditions
+  register_with_state
+    ~base_path
+    name
+    meta
+    ~phase
+    ~conditions
+    ~fiber_lifecycle_state:Fiber_running
 ;;
 
 let register_offline ~base_path name meta =
@@ -412,7 +425,13 @@ let register_offline ~base_path name meta =
     }
   in
   let phase = Keeper_state_machine.derive_phase conditions in
-  register_with_state ~base_path name meta ~phase ~conditions
+  register_with_state
+    ~base_path
+    name
+    meta
+    ~phase
+    ~conditions
+    ~fiber_lifecycle_state:Fiber_not_started
 ;;
 
 (** R-A-6.a — refuse to revive a keeper whose restart_budget was previously exhausted.  Pairs with TLA+ §S3 BudgetNeverRevives:  []( ~restart_budget_remaining => []( ~restart_budget_remaining ))  Witho... *)
@@ -437,6 +456,7 @@ let register_restarting ~base_path name meta
      re-allocating. Pending Event Layer stimuli are restored from the durable
      queue snapshot instead of being reset across restart. *)
   let done_p, done_r = Eio.Promise.create () in
+  let fiber_exited_p, fiber_exited_r = Eio.Promise.create () in
   let initial_event_queue =
     Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
   in
@@ -453,6 +473,9 @@ let register_restarting ~base_path name meta
     ; grpc_close = Atomic.make None
     ; done_p
     ; done_r
+    ; fiber_exited_p
+    ; fiber_exited_r
+    ; fiber_lifecycle_state = Atomic.make Fiber_not_started
     ; restart_count = 0
     ; last_restart_ts = 0.0
     ; dead_since_ts = None
@@ -462,6 +485,8 @@ let register_restarting ~base_path name meta
     ; turn_consecutive_failures = 0
     ; livelock_state = Atomic.make None
     ; current_turn_switch = Atomic.make None
+    ; shutdown_state = Atomic.make Keeper_shutdown_types.Not_requested
+    ; shutdown_transaction_claimed = Atomic.make false
     ; board_wakeups = StringMap.empty
     ; board_cursor_ts = 0.0
     ; board_cursor_post_id = None
@@ -891,10 +916,61 @@ let mark_turn_runtime_done ~base_path name =
     (Packed Turn_finalizing)
 ;;
 
+let fail_turn_switch_for_shutdown entry sw =
+  try Eio.Switch.fail sw Shutdown_interrupt with
+  | Invalid_argument message ->
+    Log.Keeper.debug
+      "%s: shutdown interrupt reached an already-finished turn switch: %s"
+      entry.name
+      message
+;;
+
+let interrupt_entry_turn_for_shutdown entry =
+  match entry.current_turn_observation with
+  | None ->
+    if not (shutdown_requested entry)
+    then Shutdown_turn_state_error Shutdown_not_requested
+    else (
+      match Atomic.exchange entry.current_turn_switch None with
+      | None -> Shutdown_no_turn_in_flight
+      | Some sw ->
+        fail_turn_switch_for_shutdown entry sw;
+        Shutdown_no_turn_in_flight)
+  | Some observation ->
+    (match mark_shutdown_turn_pending entry ~turn_id:observation.turn_id with
+     | Error Shutdown_not_requested ->
+       Shutdown_turn_state_error Shutdown_not_requested
+     | Error state_error ->
+       (match Atomic.exchange entry.current_turn_switch None with
+        | Some sw -> fail_turn_switch_for_shutdown entry sw
+        | None -> ());
+       Shutdown_turn_state_error state_error
+     | Ok () ->
+       (match Atomic.exchange entry.current_turn_switch None with
+        | None ->
+          Shutdown_turn_interrupt_pending { turn_id = observation.turn_id }
+        | Some sw ->
+          fail_turn_switch_for_shutdown entry sw;
+          Shutdown_turn_interrupted { turn_id = observation.turn_id }))
+;;
+
 let set_turn_switch ~base_path name sw_opt =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | Some entry -> Atomic.set entry.current_turn_switch sw_opt
   | None -> ()
+  | Some entry ->
+    Atomic.set entry.current_turn_switch sw_opt;
+    (match sw_opt with
+     | Some _ when shutdown_requested entry ->
+       (match interrupt_entry_turn_for_shutdown entry with
+        | Shutdown_turn_state_error error ->
+          Log.Keeper.error
+            "%s: failed to arm shutdown interrupt for newly-bound turn: %s"
+            entry.name
+            (shutdown_state_error_to_string error)
+        | Shutdown_no_turn_in_flight
+        | Shutdown_turn_interrupted _
+        | Shutdown_turn_interrupt_pending _ -> ())
+     | Some _ | None -> ())
 ;;
 
 let clear_turn_switch ~base_path name =
@@ -914,4 +990,19 @@ let interrupt_current_turn ~base_path name =
          (try Eio.Switch.fail sw Operator_interrupt with
           | Invalid_argument _ -> ());
          `Cancelled obs.turn_id)
+;;
+
+let interrupt_current_turn_for_shutdown ~base_path name =
+  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
+  | None -> Shutdown_no_turn_in_flight
+  | Some entry -> interrupt_entry_turn_for_shutdown entry
+;;
+
+let current_fiber_owns_turn (entry : registry_entry) =
+  match
+    Eio_context.get_bound_turn_switch_opt (),
+    Atomic.get entry.current_turn_switch
+  with
+  | Some bound, Some target -> bound == target
+  | Some _, None | None, Some _ | None, None -> false
 ;;

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -13,6 +13,7 @@ module StringMap = Set_util.StringMap
 include Keeper_registry_types_failure
 
 exception Operator_interrupt
+exception Shutdown_interrupt
 
 (* Turn_phase FSM types, witnesses, transitions, and resolver extracted to
    [Keeper_registry_types_turn_phase] (500-line decomp). *)
@@ -89,6 +90,16 @@ type turn_measurement =
 
 type done_resolution = [ `Stopped | `Crashed of string ]
 
+type fiber_lifecycle_state =
+  | Fiber_not_started
+  | Fiber_running
+  | Fiber_exited
+
+type fiber_launch_claim_result =
+  | Fiber_launch_claimed
+  | Fiber_launch_already_running
+  | Fiber_launch_already_exited
+
 type registry_entry =
   { base_path : string
   ; name : string
@@ -104,6 +115,9 @@ type registry_entry =
   ; grpc_close : (unit -> unit) option Atomic.t
   ; done_p : done_resolution Eio.Promise.t
   ; done_r : done_resolution Eio.Promise.u
+  ; fiber_exited_p : unit Eio.Promise.t
+  ; fiber_exited_r : unit Eio.Promise.u
+  ; fiber_lifecycle_state : fiber_lifecycle_state Atomic.t
   ; restart_count : int
   ; last_restart_ts : float
   ; dead_since_ts : float option
@@ -113,6 +127,8 @@ type registry_entry =
   ; turn_consecutive_failures : int
   ; livelock_state : livelock_attempt_state option Atomic.t
   ; current_turn_switch : Eio.Switch.t option Atomic.t
+  ; shutdown_state : Keeper_shutdown_types.state Atomic.t
+  ; shutdown_transaction_claimed : bool Atomic.t
   ; board_wakeups : float StringMap.t
   ; board_cursor_ts : float
   ; board_cursor_post_id : string option
@@ -154,6 +170,24 @@ and completed_turn_observation =
   ; ct_wake : wake_reason
   }
 
+type shutdown_begin_result =
+  | Shutdown_started
+  | Shutdown_already_started of Keeper_shutdown_types.turn_settlement
+
+type shutdown_state_error =
+  | Shutdown_not_requested
+  | Shutdown_turn_mismatch of
+      { expected_turn_id : int
+      ; actual_turn_id : int
+      }
+  | Shutdown_turn_already_settled of { turn_id : int }
+
+type shutdown_interrupt_result =
+  | Shutdown_no_turn_in_flight
+  | Shutdown_turn_interrupted of { turn_id : int }
+  | Shutdown_turn_interrupt_pending of { turn_id : int }
+  | Shutdown_turn_state_error of shutdown_state_error
+
 type done_resolve_result =
   | Done_resolved of { source : string }
   | Done_already_resolved of
@@ -185,6 +219,185 @@ let resolve_done entry ~source (value : done_resolution) =
          | None -> value
        in
        Done_already_resolved { source; previous })
+;;
+
+let resolve_fiber_exited entry =
+  Atomic.set entry.fiber_lifecycle_state Fiber_exited;
+  match Eio.Promise.peek entry.fiber_exited_p with
+  | Some () -> false
+  | None ->
+    (try
+       Eio.Promise.resolve entry.fiber_exited_r ();
+       true
+     with
+     | Invalid_argument _ -> false)
+;;
+
+let await_fiber_exit entry = Eio.Promise.await entry.fiber_exited_p
+
+let rec claim_fiber_launch entry =
+  let current = Atomic.get entry.fiber_lifecycle_state in
+  match current with
+  | Fiber_not_started ->
+    if Atomic.compare_and_set entry.fiber_lifecycle_state current Fiber_running
+    then Fiber_launch_claimed
+    else claim_fiber_launch entry
+  | Fiber_running -> Fiber_launch_already_running
+  | Fiber_exited -> Fiber_launch_already_exited
+;;
+
+let rec settle_unlaunched_fiber_exit entry =
+  let current = Atomic.get entry.fiber_lifecycle_state in
+  match current with
+  | Fiber_not_started ->
+    if Atomic.compare_and_set entry.fiber_lifecycle_state current Fiber_exited
+    then (
+      ignore (resolve_fiber_exited entry : bool);
+      true)
+    else settle_unlaunched_fiber_exit entry
+  | Fiber_running | Fiber_exited -> false
+;;
+
+let try_claim_shutdown_transaction entry =
+  Atomic.compare_and_set entry.shutdown_transaction_claimed false true
+;;
+
+let release_shutdown_transaction entry =
+  Atomic.set entry.shutdown_transaction_claimed false
+;;
+
+let rec begin_shutdown entry =
+  let current = Atomic.get entry.shutdown_state in
+  match current with
+  | Keeper_shutdown_types.Not_requested ->
+    let requested =
+      Keeper_shutdown_types.Requested Keeper_shutdown_types.No_interrupted_turn
+    in
+    if Atomic.compare_and_set entry.shutdown_state current requested
+    then Shutdown_started
+    else begin_shutdown entry
+  | Keeper_shutdown_types.Requested settlement ->
+    Shutdown_already_started settlement
+;;
+
+let shutdown_requested entry =
+  match Atomic.get entry.shutdown_state with
+  | Keeper_shutdown_types.Not_requested -> false
+  | Keeper_shutdown_types.Requested _ -> true
+;;
+
+let shutdown_turn_settlement entry =
+  match Atomic.get entry.shutdown_state with
+  | Keeper_shutdown_types.Not_requested -> None
+  | Keeper_shutdown_types.Requested settlement -> Some settlement
+;;
+
+let settlement_turn_id = function
+  | Keeper_shutdown_types.No_interrupted_turn -> None
+  | Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id } -> Some turn_id
+  | Keeper_shutdown_types.Interrupted_turn_persisted { record; _ }
+  | Keeper_shutdown_types.Interrupted_turn_persist_failed { record; _ } ->
+    Some record.turn_id
+;;
+
+let rec mark_shutdown_turn_pending entry ~turn_id =
+  let current = Atomic.get entry.shutdown_state in
+  match current with
+  | Keeper_shutdown_types.Not_requested -> Error Shutdown_not_requested
+  | Keeper_shutdown_types.Requested Keeper_shutdown_types.No_interrupted_turn ->
+    let next =
+      Keeper_shutdown_types.Requested
+        (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id })
+    in
+    if Atomic.compare_and_set entry.shutdown_state current next
+    then Ok ()
+    else mark_shutdown_turn_pending entry ~turn_id
+  | Keeper_shutdown_types.Requested settlement ->
+    (match settlement_turn_id settlement with
+     | Some expected_turn_id when expected_turn_id = turn_id -> Ok ()
+     | Some expected_turn_id ->
+       Error (Shutdown_turn_mismatch { expected_turn_id; actual_turn_id = turn_id })
+     | None -> Error Shutdown_not_requested)
+;;
+
+let rec record_shutdown_turn_persisted entry
+      (persisted : Keeper_shutdown_types.persisted_interrupted_turn)
+  =
+  let turn_id = persisted.record.turn_id in
+  let current = Atomic.get entry.shutdown_state in
+  match current with
+  | Keeper_shutdown_types.Not_requested -> Error Shutdown_not_requested
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id = expected_turn_id })
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Interrupted_turn_persist_failed
+         { record = { turn_id = expected_turn_id; _ }; _ }) ->
+    if expected_turn_id <> turn_id
+    then Error (Shutdown_turn_mismatch { expected_turn_id; actual_turn_id = turn_id })
+    else
+      let next =
+        Keeper_shutdown_types.Requested
+          (Keeper_shutdown_types.Interrupted_turn_persisted persisted)
+      in
+      if Atomic.compare_and_set entry.shutdown_state current next
+      then Ok ()
+      else record_shutdown_turn_persisted entry persisted
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Interrupted_turn_persisted { record; _ }) ->
+    if record.turn_id = turn_id
+    then Ok ()
+    else
+      Error
+        (Shutdown_turn_mismatch
+           { expected_turn_id = record.turn_id; actual_turn_id = turn_id })
+  | Keeper_shutdown_types.Requested Keeper_shutdown_types.No_interrupted_turn ->
+    Error Shutdown_not_requested
+;;
+
+let rec record_shutdown_turn_persist_failed entry
+      (record : Keeper_shutdown_types.interrupted_turn)
+      ~error
+  =
+  let turn_id = record.turn_id in
+  let current = Atomic.get entry.shutdown_state in
+  match current with
+  | Keeper_shutdown_types.Not_requested -> Error Shutdown_not_requested
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id = expected_turn_id }) ->
+    if expected_turn_id <> turn_id
+    then Error (Shutdown_turn_mismatch { expected_turn_id; actual_turn_id = turn_id })
+    else
+      let next =
+        Keeper_shutdown_types.Requested
+          (Keeper_shutdown_types.Interrupted_turn_persist_failed { record; error })
+      in
+      if Atomic.compare_and_set entry.shutdown_state current next
+      then Ok ()
+      else record_shutdown_turn_persist_failed entry record ~error
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Interrupted_turn_persisted { record = prior; _ })
+  | Keeper_shutdown_types.Requested
+      (Keeper_shutdown_types.Interrupted_turn_persist_failed
+         { record = prior; _ }) ->
+    if prior.turn_id = turn_id
+    then Error (Shutdown_turn_already_settled { turn_id })
+    else
+      Error
+        (Shutdown_turn_mismatch
+           { expected_turn_id = prior.turn_id; actual_turn_id = turn_id })
+  | Keeper_shutdown_types.Requested Keeper_shutdown_types.No_interrupted_turn ->
+    Error Shutdown_not_requested
+;;
+
+let shutdown_state_error_to_string = function
+  | Shutdown_not_requested -> "shutdown was not requested"
+  | Shutdown_turn_mismatch { expected_turn_id; actual_turn_id } ->
+    Printf.sprintf
+      "shutdown turn mismatch: expected=%d actual=%d"
+      expected_turn_id
+      actual_turn_id
+  | Shutdown_turn_already_settled { turn_id } ->
+    Printf.sprintf "shutdown turn %d is already settled" turn_id
 ;;
 
 let registry_key ~base_path name =

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -252,7 +252,7 @@ let rec settle_unlaunched_fiber_exit entry =
   | Fiber_not_started ->
     if Atomic.compare_and_set entry.fiber_lifecycle_state current Fiber_exited
     then (
-      ignore (resolve_fiber_exited entry : bool);
+      let (_was_first_resolver : bool) = resolve_fiber_exited entry in
       true)
     else settle_unlaunched_fiber_exit entry
   | Fiber_running | Fiber_exited -> false

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -118,6 +118,10 @@ exception Operator_interrupt
     The turn runtime may catch this via [Eio.Cancel.Cancelled] and record
     [failure_reason.Operator_interrupt] for observability. *)
 
+exception Shutdown_interrupt
+(** Lane-shutdown cancellation.  The interrupted turn must durably settle a
+    {!Keeper_shutdown_types.interrupted_turn} before the lane may unregister. *)
+
 val ambiguous_partial_commit_kind_to_string :
   ambiguous_partial_commit_kind -> string
 
@@ -437,6 +441,16 @@ type turn_measurement = {
 
 type done_resolution = [ `Stopped | `Crashed of string ]
 
+type fiber_lifecycle_state =
+  | Fiber_not_started
+  | Fiber_running
+  | Fiber_exited
+
+type fiber_launch_claim_result =
+  | Fiber_launch_claimed
+  | Fiber_launch_already_running
+  | Fiber_launch_already_exited
+
 type registry_entry = {
   base_path : string;
   name : string;
@@ -461,6 +475,15 @@ type registry_entry = {
       (** Completion resolver owned by {!resolve_done}. Runtime callers must
           not resolve this field directly; use {!resolve_done} so
           double-resolve races return the prior terminal outcome. *)
+  fiber_exited_p : unit Eio.Promise.t;
+      (** Resolves only after the concrete keepalive fiber has left its body
+          and completed lane-local cleanup.  Unlike [done_p], this is a join
+          signal and must not be resolved when stop is merely requested. *)
+  fiber_exited_r : unit Eio.Promise.u;
+  fiber_lifecycle_state : fiber_lifecycle_state Atomic.t;
+      (** Exact launch/join ownership.  Launch and shutdown race through this
+          state instead of inferring physical fiber existence from the
+          lifecycle phase. *)
   restart_count : int;
   last_restart_ts : float;
   dead_since_ts : float option;
@@ -474,6 +497,12 @@ type registry_entry = {
   current_turn_switch : Eio.Switch.t option Atomic.t;
       (** Live turn-scoped switch exposed for operator interrupt.
           [Some sw] while a turn is running; [None] otherwise. *)
+  shutdown_state : Keeper_shutdown_types.state Atomic.t;
+      (** Lane-local shutdown transaction state. *)
+  shutdown_transaction_claimed : bool Atomic.t;
+      (** Ephemeral single-writer guard for the durable shutdown transaction.
+          This prevents concurrent operator fibers from releasing the same
+          task ownership or deleting the same session in parallel. *)
   board_wakeups : float StringMap.t;
   board_cursor_ts : float;
   board_cursor_post_id : string option;
@@ -575,6 +604,24 @@ and completed_turn_observation = {
           last turn ran, not only the live one. *)
 }
 
+type shutdown_begin_result =
+  | Shutdown_started
+  | Shutdown_already_started of Keeper_shutdown_types.turn_settlement
+
+type shutdown_state_error =
+  | Shutdown_not_requested
+  | Shutdown_turn_mismatch of
+      { expected_turn_id : int
+      ; actual_turn_id : int
+      }
+  | Shutdown_turn_already_settled of { turn_id : int }
+
+type shutdown_interrupt_result =
+  | Shutdown_no_turn_in_flight
+  | Shutdown_turn_interrupted of { turn_id : int }
+  | Shutdown_turn_interrupt_pending of { turn_id : int }
+  | Shutdown_turn_state_error of shutdown_state_error
+
 type done_resolve_result =
   | Done_resolved of { source : string }
   | Done_already_resolved of {
@@ -604,6 +651,48 @@ type registry_entry_validation_error = registry_entry_health
     already-resolved outcome. *)
 val resolve_done :
   registry_entry -> source:string -> done_resolution -> done_resolve_result
+
+(** Resolve the concrete keepalive-fiber join signal at most once.  Returns
+    [true] only for the resolver that completed the promise. *)
+val resolve_fiber_exited : registry_entry -> bool
+
+val await_fiber_exit : registry_entry -> unit
+
+(** Atomically claim the right to launch the concrete lane fiber. *)
+val claim_fiber_launch : registry_entry -> fiber_launch_claim_result
+
+(** Settle a lane that has not launched.  Returns [true] only when this call
+    changed [Fiber_not_started] to [Fiber_exited] and resolved the join
+    promise.  A running lane remains owned by its physical fiber. *)
+val settle_unlaunched_fiber_exit : registry_entry -> bool
+
+(** Acquire/release the lane-local single-writer guard.  A failed acquire is
+    an explicit concurrent-shutdown result; it must never wait on the other
+    operator fiber. *)
+val try_claim_shutdown_transaction : registry_entry -> bool
+val release_shutdown_transaction : registry_entry -> unit
+
+val begin_shutdown : registry_entry -> shutdown_begin_result
+val shutdown_requested : registry_entry -> bool
+
+val shutdown_turn_settlement :
+  registry_entry -> Keeper_shutdown_types.turn_settlement option
+
+val mark_shutdown_turn_pending :
+  registry_entry -> turn_id:int -> (unit, shutdown_state_error) result
+
+val record_shutdown_turn_persisted :
+  registry_entry ->
+  Keeper_shutdown_types.persisted_interrupted_turn ->
+  (unit, shutdown_state_error) result
+
+val record_shutdown_turn_persist_failed :
+  registry_entry ->
+  Keeper_shutdown_types.interrupted_turn ->
+  error:string ->
+  (unit, shutdown_state_error) result
+
+val shutdown_state_error_to_string : shutdown_state_error -> string
 
 (** Internal: keeper registry key composition (base_path ^ \\x1f ^ name).
     Exposed via mli so keeper_registry.ml's state functions can use it

--- a/lib/keeper/keeper_shutdown_record.ml
+++ b/lib/keeper/keeper_shutdown_record.ml
@@ -1,0 +1,59 @@
+let records_dir (config : Workspace.config) =
+  Filename.concat (Workspace.keepers_runtime_dir config) ".shutdown-continuations"
+;;
+
+let path ~config (record : Keeper_shutdown_types.interrupted_turn) =
+  let filename =
+    Printf.sprintf
+      "%s-%s-turn-%d.json"
+      record.keeper_name
+      (Keeper_id.Trace_id.to_string record.trace_id)
+      record.turn_id
+  in
+  Filename.concat (records_dir config) filename
+;;
+
+let outcome_to_json = function
+  | Keeper_shutdown_types.Continuation_required ->
+    `Assoc [ "kind", `String "continuation_required" ]
+  | Keeper_shutdown_types.Ambiguous_result
+      { committed_mutating_tools; event_bus_integrity_error } ->
+    `Assoc
+      [ "kind", `String "ambiguous_result"
+      ; ( "committed_mutating_tools"
+        , `List (List.map (fun name -> `String name) committed_mutating_tools) )
+      ; ( "event_bus_integrity_error"
+        , match event_bus_integrity_error with
+          | Some error -> `String error
+          | None -> `Null )
+      ]
+;;
+
+let to_json (record : Keeper_shutdown_types.interrupted_turn) =
+  `Assoc
+    [ "schema_version", `Int 1
+    ; "keeper_name", `String record.keeper_name
+    ; "trace_id", `String (Keeper_id.Trace_id.to_string record.trace_id)
+    ; "turn_id", `Int record.turn_id
+    ; ( "current_task_id"
+      , match record.current_task_id with
+        | Some task_id -> `String (Keeper_id.Task_id.to_string task_id)
+        | None -> `Null )
+    ; "interrupted_at", `Float record.interrupted_at
+    ; "outcome", outcome_to_json record.outcome
+    ]
+;;
+
+let persist ~config record =
+  let record_path = path ~config record in
+  Keeper_fs.save_json_atomic record_path (to_json record)
+  |> Result.map (fun () ->
+       Keeper_shutdown_types.persisted_interrupted_turn
+         ~record
+         ~path:record_path)
+  |> Result.map_error (fun error ->
+       Printf.sprintf
+         "failed to persist Keeper shutdown continuation %s: %s"
+         record_path
+         error)
+;;

--- a/lib/keeper/keeper_shutdown_record.mli
+++ b/lib/keeper/keeper_shutdown_record.mli
@@ -1,0 +1,12 @@
+(** Durable record written before a shutdown may unregister an interrupted
+    Keeper lane. *)
+
+val path :
+  config:Workspace.config ->
+  Keeper_shutdown_types.interrupted_turn ->
+  string
+
+val persist :
+  config:Workspace.config ->
+  Keeper_shutdown_types.interrupted_turn ->
+  (Keeper_shutdown_types.persisted_interrupted_turn, string) result

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -1,0 +1,71 @@
+type interrupted_turn_outcome =
+  | Continuation_required
+  | Ambiguous_result of
+      { committed_mutating_tools : string list
+      ; event_bus_integrity_error : string option
+      }
+
+type interrupted_turn =
+  { keeper_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; turn_id : int
+  ; current_task_id : Keeper_id.Task_id.t option
+  ; interrupted_at : float
+  ; outcome : interrupted_turn_outcome
+  }
+
+type persisted_interrupted_turn =
+  { record : interrupted_turn
+  ; path : string
+  }
+
+type turn_settlement =
+  | No_interrupted_turn
+  | Awaiting_interrupted_turn of { turn_id : int }
+  | Interrupted_turn_persisted of persisted_interrupted_turn
+  | Interrupted_turn_persist_failed of
+      { record : interrupted_turn
+      ; error : string
+      }
+
+type state =
+  | Not_requested
+  | Requested of turn_settlement
+
+let outcome_of_event_bus ~committed_mutating_tools ~event_bus_integrity_error =
+  match committed_mutating_tools, event_bus_integrity_error with
+  | [], None -> Continuation_required
+  | tools, integrity_error ->
+    Ambiguous_result
+      { committed_mutating_tools = tools
+      ; event_bus_integrity_error = integrity_error
+      }
+;;
+
+let make_interrupted_turn
+      ~keeper_name
+      ~trace_id
+      ~turn_id
+      ~current_task_id
+      ~interrupted_at
+      ~committed_mutating_tools
+      ~event_bus_integrity_error
+  =
+  { keeper_name
+  ; trace_id
+  ; turn_id
+  ; current_task_id
+  ; interrupted_at
+  ; outcome =
+      outcome_of_event_bus
+        ~committed_mutating_tools
+        ~event_bus_integrity_error
+  }
+;;
+
+let persisted_interrupted_turn ~record ~path = { record; path }
+
+let interrupted_turn_outcome_label = function
+  | Continuation_required -> "continuation_required"
+  | Ambiguous_result _ -> "ambiguous_result"
+;;

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -1,0 +1,57 @@
+(** Typed state carried by one Keeper lane while an operator shutdown is in
+    progress.  This module is pure: persistence and registry mutation live in
+    their owning modules. *)
+
+type interrupted_turn_outcome = private
+  | Continuation_required
+  | Ambiguous_result of
+      { committed_mutating_tools : string list
+      ; event_bus_integrity_error : string option
+      }
+
+type interrupted_turn = private
+  { keeper_name : string
+  ; trace_id : Keeper_id.Trace_id.t
+  ; turn_id : int
+  ; current_task_id : Keeper_id.Task_id.t option
+  ; interrupted_at : float
+  ; outcome : interrupted_turn_outcome
+  }
+
+type persisted_interrupted_turn = private
+  { record : interrupted_turn
+  ; path : string
+  }
+
+type turn_settlement =
+  | No_interrupted_turn
+  | Awaiting_interrupted_turn of { turn_id : int }
+  | Interrupted_turn_persisted of persisted_interrupted_turn
+  | Interrupted_turn_persist_failed of
+      { record : interrupted_turn
+      ; error : string
+      }
+
+type state =
+  | Not_requested
+  | Requested of turn_settlement
+
+val outcome_of_event_bus :
+  committed_mutating_tools:string list ->
+  event_bus_integrity_error:string option ->
+  interrupted_turn_outcome
+
+val make_interrupted_turn :
+  keeper_name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  turn_id:int ->
+  current_task_id:Keeper_id.Task_id.t option ->
+  interrupted_at:float ->
+  committed_mutating_tools:string list ->
+  event_bus_integrity_error:string option ->
+  interrupted_turn
+
+val persisted_interrupted_turn :
+  record:interrupted_turn -> path:string -> persisted_interrupted_turn
+
+val interrupted_turn_outcome_label : interrupted_turn_outcome -> string

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -561,6 +561,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
      stale registry records.  The iterator yields between cohort groups; the
      yield meter still protects unusually large cohorts or non-default sizes. *)
   let process_entry (acc : sweep_acc) (entry : Keeper_registry.registry_entry) =
+    if Keeper_registry.shutdown_requested entry
+    then acc
+    else
     match entry.phase with
     | Keeper_state_machine.Dead | Keeper_state_machine.Zombie ->
       (match entry.dead_since_ts with
@@ -790,10 +793,9 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
               ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
             (match launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg with
              | Error _ ->
-               (* Launch gate aborted fail-closed (no fiber; done resolved and
-                  Crashed published by the gate). Announcing Restarted/Running
-                  here would report a keeper that never started; the resolved
-                  Crashed outcome re-enters the sweep with backoff/budget. *)
+               (* Launch gate aborted fail-closed.  FSM rejection owns a crash
+                  settlement; a concurrent shutdown owns its terminal
+                  settlement.  Neither permits Restarted/Running. *)
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string RestartOutcomes)
                  ~labels:[ "keeper", old_entry.name; "outcome", "launch_rejected" ]

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -53,6 +53,20 @@ let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enable
 let with_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.with_noop
 let domain_pool_ignored_warning_emitted = Atomic.make false
 
+let resolve_physical_lane_exit (entry : Keeper_registry.registry_entry) =
+  let (_was_first_resolver : bool) =
+    Keeper_registry.resolve_fiber_exited entry
+  in
+  ()
+;;
+
+let settle_lane_before_launch (entry : Keeper_registry.registry_entry) =
+  let (_settled : bool) =
+    Keeper_registry.settle_unlaunched_fiber_exit entry
+  in
+  ()
+;;
+
 let launch_supervised_fiber_body
       ~proactive_warmup_sec
       ctx
@@ -62,7 +76,7 @@ let launch_supervised_fiber_body
   let base_path = ctx.config.base_path in
   let keepers_dir = Workspace.keepers_runtime_dir ctx.config in
   if restart_launch_noop_enabled_for_test ()
-  then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
+  then resolve_physical_lane_exit reg
   else (
     (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)
@@ -530,7 +544,7 @@ let launch_supervised_fiber_body
                Fun.Finally_raised): %s"
               meta.name
               (Printexc.to_string exn));
-          ignore (Keeper_registry.resolve_fiber_exited reg : bool))))
+          resolve_physical_lane_exit reg)))
 ;;
 
 (** Launch gate: the physical-lane CAS and registry FSM must both accept the
@@ -551,7 +565,7 @@ let launch_supervised_fiber
   in
   if Keeper_registry.shutdown_requested reg
   then (
-    ignore (Keeper_registry.settle_unlaunched_fiber_exit reg : bool);
+    settle_lane_before_launch reg;
     Error
       (launch_precondition_error
          "shutdown transaction claimed the lane before fiber launch"))
@@ -592,10 +606,10 @@ let launch_supervised_fiber
       |> should_publish_lifecycle_for_done_signal
     then
       publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed meta.name reason ();
-    ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+    resolve_physical_lane_exit reg;
     Error err
   | Ok _ when Keeper_registry.shutdown_requested reg ->
-    ignore (Keeper_registry.settle_unlaunched_fiber_exit reg : bool);
+    settle_lane_before_launch reg;
     Error
       (launch_precondition_error
          "shutdown transaction won the launch race after Fiber_started")
@@ -611,7 +625,7 @@ let launch_supervised_fiber
             "fiber launch attempted after the physical lane was settled")
      | Keeper_registry.Fiber_launch_claimed
        when Keeper_registry.shutdown_requested reg ->
-       ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+       resolve_physical_lane_exit reg;
        Error
          (launch_precondition_error
             "shutdown transaction won the launch race after the launch claim")
@@ -622,7 +636,7 @@ let launch_supervised_fiber
         with
         | exn ->
           let backtrace = Printexc.get_raw_backtrace () in
-          ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+          resolve_physical_lane_exit reg;
           Printexc.raise_with_backtrace exn backtrace)))
 ;;
 

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -62,7 +62,7 @@ let launch_supervised_fiber_body
   let base_path = ctx.config.base_path in
   let keepers_dir = Workspace.keepers_runtime_dir ctx.config in
   if restart_launch_noop_enabled_for_test ()
-  then ()
+  then ignore (Keeper_registry.resolve_fiber_exited reg : bool)
   else (
     (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)
@@ -126,7 +126,9 @@ let launch_supervised_fiber_body
          [fiber_drop_cause] payload accurate. *)
       let cancelled_by_parent = Atomic.make false in
       let resolve_done ~source value =
-        if not (Atomic.get resolved) then
+        if Keeper_registry.shutdown_requested reg
+        then Done_signal_already_seen
+        else if not (Atomic.get resolved) then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
              may have already resolved done_p via record_keeper_stopped.
              When the Promise is already resolved, suppress finally cleanup,
@@ -202,7 +204,9 @@ let launch_supervised_fiber_body
                   | None -> false)
                | None -> false
              in
-             if watchdog_triggered
+             if Keeper_registry.shutdown_requested reg
+             then ()
+             else if watchdog_triggered
              then (
                let reason =
                  match Keeper_registry.get ~base_path meta.name with
@@ -284,6 +288,11 @@ let launch_supervised_fiber_body
              Atomic.set cancelled_by_parent true;
              (* Do NOT re-raise Cancelled in a forked fiber, as it cancels the parent switch. *)
              ()
+           | exn when Keeper_registry.shutdown_requested reg ->
+             Log.Keeper.warn
+               "%s: lane exited with %s while shutdown owned terminal settlement"
+               meta.name
+               (Printexc.to_string exn)
            | exn ->
              (* RFC-0002: unified crash handler.
                 Keeper_fiber_crash carries no payload — failure_reason is
@@ -349,7 +358,7 @@ let launch_supervised_fiber_body
            crashing the server (see masc crash 2026-04-17). Swallow
            everything and log — cleanup is advisory, state-machine events
            already fired on the body's happy/error paths. *)
-          try
+          (try
             Keeper_registry.cleanup_tracking ~base_path meta.name;
             (* #14187 follow-up: a keeper that crashed after exhausting its
              turn-livelock budget would restart into the same turn_id
@@ -368,7 +377,9 @@ let launch_supervised_fiber_body
                previous lifetime would silently demote the new
                keeper's First block to DEBUG. *)
             Keeper_livelock_state.reset_for_keeper ~keeper:meta.name;
-            if not (Atomic.get resolved)
+            if Keeper_registry.shutdown_requested reg
+            then ()
+            else if not (Atomic.get resolved)
             then
               if Shutdown.is_shutting_down_global ()
               then (
@@ -518,13 +529,15 @@ let launch_supervised_fiber_body
               "%s: supervisor finally cleanup failed (suppressed to avoid \
                Fun.Finally_raised): %s"
               meta.name
-              (Printexc.to_string exn))))
+              (Printexc.to_string exn));
+          ignore (Keeper_registry.resolve_fiber_exited reg : bool))))
 ;;
 
-(** Launch gate: the registry FSM must accept [Fiber_started] before any
-    fiber is forked. Returns [Error _] when the launch was refused; in that
-    case nothing was forked, no [Started]/[Running] event may be published
-    by the caller, and [done_p] has been resolved through the crash path. *)
+(** Launch gate: the physical-lane CAS and registry FSM must both accept the
+    launch before any fiber is forked.  [Error _] always means no
+    [Started]/[Running] event may be published.  FSM rejection resolves
+    [done_p] through the crash path; a shutdown-race rejection leaves terminal
+    settlement to the shutdown transaction. *)
 let launch_supervised_fiber
       ~proactive_warmup_sec
       ctx
@@ -532,7 +545,18 @@ let launch_supervised_fiber
       (reg : Keeper_registry.registry_entry)
   =
   let base_path = ctx.config.base_path in
-  match Keeper_registry.prepare_fiber_launch ~base_path meta.name with
+  let launch_precondition_error reason =
+    Keeper_state_machine.Precondition_violation
+      { event = "fiber_launch"; reason }
+  in
+  if Keeper_registry.shutdown_requested reg
+  then (
+    ignore (Keeper_registry.settle_unlaunched_fiber_exit reg : bool);
+    Error
+      (launch_precondition_error
+         "shutdown transaction claimed the lane before fiber launch"))
+  else (
+    match Keeper_registry.prepare_fiber_launch ~base_path meta.name with
   | Error err ->
     (* Fail closed: a rejected [Fiber_started] (terminal state, invalid
        transition, precondition violation) means the registry refuses a
@@ -568,10 +592,38 @@ let launch_supervised_fiber
       |> should_publish_lifecycle_for_done_signal
     then
       publish_phase_lifecycle ~phase:Keeper_state_machine.Crashed meta.name reason ();
+    ignore (Keeper_registry.resolve_fiber_exited reg : bool);
     Error err
+  | Ok _ when Keeper_registry.shutdown_requested reg ->
+    ignore (Keeper_registry.settle_unlaunched_fiber_exit reg : bool);
+    Error
+      (launch_precondition_error
+         "shutdown transaction won the launch race after Fiber_started")
   | Ok _ ->
-    launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg;
-    Ok ()
+    (match Keeper_registry.claim_fiber_launch reg with
+     | Keeper_registry.Fiber_launch_already_running ->
+       Error
+         (launch_precondition_error
+            "duplicate launch attempted for an already-running lane")
+     | Keeper_registry.Fiber_launch_already_exited ->
+       Error
+         (launch_precondition_error
+            "fiber launch attempted after the physical lane was settled")
+     | Keeper_registry.Fiber_launch_claimed
+       when Keeper_registry.shutdown_requested reg ->
+       ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+       Error
+         (launch_precondition_error
+            "shutdown transaction won the launch race after the launch claim")
+     | Keeper_registry.Fiber_launch_claimed ->
+       (try
+          launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg;
+          Ok ()
+        with
+        | exn ->
+          let backtrace = Printexc.get_raw_backtrace () in
+          ignore (Keeper_registry.resolve_fiber_exited reg : bool);
+          Printexc.raise_with_backtrace exn backtrace)))
 ;;
 
 (* #10993: persona drift visibility.

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -57,54 +57,24 @@ let auto_pause_handoff_context ~meta ~reason_tag =
 ;;
 
 let release_owned_active_tasks_after_pause ~config ~meta ~reason_tag =
-  match Keeper_current_task_reconcile.owned_active_tasks_for_meta ~config ~meta with
-  | Error err ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ReconcileFailures)
-      ~labels:[ "keeper", meta.name; "phase", "auto_pause_task_release_discovery" ]
-      ();
+  let handoff_context = auto_pause_handoff_context ~meta ~reason_tag in
+  match
+    Keeper_task_ownership_settlement.release_owned_active_tasks
+      ~config
+      ~meta
+      ~actor:supervisor_agent_name
+      ~reason_tag:"auto_pause_task_release"
+      ~handoff_context
+  with
+  | Ok _ -> true
+  | Error error ->
     Log.Keeper.error
-      "%s: skipped auto-pause task release because owned-task discovery failed: %s"
+      "%s: auto-pause task settlement failed for owner %s (%s): %s"
       meta.name
-      err;
+      meta.agent_name
+      reason_tag
+      (Keeper_task_ownership_settlement.error_to_string error);
     false
-  | Ok owned_tasks ->
-    List.fold_left
-      (fun all_ok (owned : Keeper_current_task_reconcile.owned_active_task) ->
-         let task_id = Keeper_id.Task_id.to_string owned.task_id in
-         let handoff_context = auto_pause_handoff_context ~meta ~reason_tag in
-         match
-           Workspace.force_release_task_r
-             config
-             ~agent_name:supervisor_agent_name
-             ~task_id
-             ~handoff_context
-             ()
-         with
-         | Ok msg ->
-           Log.Keeper.warn
-             "%s: released active task %s from auto-paused owner %s (%s): %s"
-             meta.name
-             task_id
-             meta.agent_name
-             reason_tag
-             msg;
-           all_ok
-         | Error err ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string ReconcileFailures)
-             ~labels:[ "keeper", meta.name; "phase", "auto_pause_task_release" ]
-             ();
-           Log.Keeper.error
-             "%s: failed to release active task %s from auto-paused owner %s (%s): %s"
-             meta.name
-             task_id
-             meta.agent_name
-             reason_tag
-             (Masc_domain.masc_error_to_string err);
-           false)
-      true
-      owned_tasks
 ;;
 
 let clear_current_task_id_after_successful_pause_release ~config ~meta ~reason_tag =

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -113,10 +113,9 @@ let supervise_keepalive
     Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name live_meta;
     match launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg with
     | Error _ ->
-      (* The launch gate aborted fail-closed (no fiber forked; [done_p]
-         resolved through the crash path and Crashed published by the gate).
-         Announcing [Started]/[Running] here would report a keeper that is
-         not running. *)
+      (* The launch gate aborted fail-closed and no fiber was forked.  An FSM
+         rejection owns a crash settlement; a concurrent shutdown owns its
+         own terminal settlement.  Neither permits a Started/Running event. *)
       ()
     | Ok () ->
       publish_lifecycle

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -19,6 +19,6 @@ val supervise_keepalive :
   unit
 (** Register and launch a supervised keepalive fiber when spawn admission
     allows it. When the injected launch gate returns [Error _] (registry
-    FSM rejected [Fiber_started]), no [Started]/[Running] event is
-    published — the gate already resolved the entry through the crash
-    path. *)
+    FSM rejection or a concurrent shutdown), no [Started]/[Running] event is
+    published.  FSM rejection owns a crash settlement; shutdown rejection
+    leaves terminal settlement to the shutdown transaction. *)

--- a/lib/keeper/keeper_task_ownership_settlement.ml
+++ b/lib/keeper/keeper_task_ownership_settlement.ml
@@ -1,0 +1,68 @@
+type release_failure =
+  { task_id : Keeper_id.Task_id.t
+  ; error : Masc_domain.masc_error
+  }
+
+type error =
+  | Discovery_failed of string
+  | Release_failed of
+      { released : Keeper_id.Task_id.t list
+      ; failures : release_failure list
+      }
+
+let release_owned_active_tasks ~config ~meta ~actor ~reason_tag ~handoff_context =
+  match Keeper_current_task_reconcile.owned_active_tasks_for_meta ~config ~meta with
+  | Error detail -> Error (Discovery_failed detail)
+  | Ok owned_tasks ->
+    let released, failures =
+      List.fold_left
+        (fun (released, failures)
+             (owned : Keeper_current_task_reconcile.owned_active_task) ->
+           let task_id = Keeper_id.Task_id.to_string owned.task_id in
+           match
+             Workspace.force_release_task_r
+               config
+               ~agent_name:actor
+               ~task_id
+               ~handoff_context
+               ()
+           with
+           | Ok detail ->
+             Log.Keeper.warn
+               "%s: released active task %s during %s: %s"
+               meta.name
+               task_id
+               reason_tag
+               detail;
+             owned.task_id :: released, failures
+           | Error error ->
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string ReconcileFailures)
+               ~labels:[ "keeper", meta.name; "phase", reason_tag ]
+               ();
+             released, { task_id = owned.task_id; error } :: failures)
+        ([], [])
+        owned_tasks
+    in
+    (match List.rev failures with
+     | [] -> Ok (List.rev released)
+     | failures ->
+       Error
+         (Release_failed
+            { released = List.rev released
+            ; failures
+            }))
+;;
+
+let error_to_string = function
+  | Discovery_failed detail -> "owned-task discovery failed: " ^ detail
+  | Release_failed { failures; _ } ->
+    failures
+    |> List.map (fun failure ->
+      Printf.sprintf
+        "%s: %s"
+        (Keeper_id.Task_id.to_string failure.task_id)
+        (Masc_domain.masc_error_to_string failure.error))
+    |> String.concat "; "
+    |> Printf.sprintf "owned-task release failed: %s"
+;;

--- a/lib/keeper/keeper_task_ownership_settlement.mli
+++ b/lib/keeper/keeper_task_ownership_settlement.mli
@@ -1,0 +1,28 @@
+(** Typed, lane-local settlement of active backlog tasks owned by one Keeper. *)
+
+type release_failure =
+  { task_id : Keeper_id.Task_id.t
+  ; error : Masc_domain.masc_error
+  }
+
+type error =
+  | Discovery_failed of string
+  | Release_failed of
+      { released : Keeper_id.Task_id.t list
+      ; failures : release_failure list
+      }
+
+(** Discover every Claimed/InProgress task owned by [meta], attempt a typed
+    system-authority release for each, and return every released task id.
+    Discovery failure performs no release.  Release failure is aggregated
+    after attempting the whole lane-local ownership set and preserves the ids
+    already released so callers can report an explicit partial commit. *)
+val release_owned_active_tasks :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  actor:string ->
+  reason_tag:string ->
+  handoff_context:Masc_domain.task_handoff_context ->
+  (Keeper_id.Task_id.t list, error) result
+
+val error_to_string : error -> string

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -1,143 +1,699 @@
-(** Keeper_turn_lifecycle -- keeper shutdown handlers.
-
-    Extracted from keeper_turn.ml. Provides [handle_keeper_down]. *)
+(** Keeper_turn_lifecycle -- typed, lane-local Keeper shutdown transaction. *)
 
 open Tool_args
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_meta_store
 open Keeper_types_profile
-open Keeper_keepalive
+open Result.Syntax
 
 type tool_result = Keeper_types_profile.tool_result
 
+type shutdown_request =
+  { remove_meta : bool
+  ; remove_session : bool
+  }
+
+type shutdown_failure_stage =
+  | Self_shutdown
+  | Paused_intent_persist
+  | Stop_transition
+  | Lane_join
+  | Turn_settlement
+  | Task_ownership_settlement
+  | Pending_confirm_cleanup
+  | Session_removal
+  | Drain_complete
+  | Meta_removal
+  | Terminal_commit
+
+let shutdown_failure_stage_label = function
+  | Self_shutdown -> "self_shutdown"
+  | Paused_intent_persist -> "paused_intent_persist"
+  | Stop_transition -> "stop_transition"
+  | Lane_join -> "lane_join"
+  | Turn_settlement -> "turn_settlement"
+  | Task_ownership_settlement -> "task_ownership_settlement"
+  | Pending_confirm_cleanup -> "pending_confirm_cleanup"
+  | Session_removal -> "session_removal"
+  | Drain_complete -> "drain_complete"
+  | Meta_removal -> "meta_removal"
+  | Terminal_commit -> "terminal_commit"
+;;
+
+type remove_pending_confirms_by_target =
+  Workspace.config ->
+  target_type:string ->
+  target_id:string option ->
+  (int, string) result
+
 let remove_pending_confirms_by_target_callback
-    : (Workspace.config ->
-       target_type:string ->
-       target_id:string option ->
-       (int, string) result)
-        Atomic.t
+    : remove_pending_confirms_by_target option Atomic.t
   =
-  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+  Atomic.make None
+;;
 
 let register_remove_pending_confirms_by_target fn =
-  Atomic.set remove_pending_confirms_by_target_callback fn
+  Atomic.set remove_pending_confirms_by_target_callback (Some fn)
+;;
+
+let remove_pending_confirms_by_target config ~target_type ~target_id =
+  match Atomic.get remove_pending_confirms_by_target_callback with
+  | Some remove -> remove config ~target_type ~target_id
+  | None -> Error "operator pending-confirm cleanup is not registered"
+;;
+
+let task_ids_json task_ids =
+  `List
+    (List.map
+       (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
+       task_ids)
+;;
+
+let shutdown_failure
+      ~stage
+      ~name
+      ~request
+      ~lane_joined
+      ~continuation_path
+      ~released_task_ids
+      ~pending_confirms_removed
+      detail
+  =
+  let stage_label = shutdown_failure_stage_label stage in
+  Log.Keeper.error
+    "keeper_down partial failure keeper=%s stage=%s lane_joined=%b: %s"
+    name
+    stage_label
+    lane_joined
+    detail;
+  tool_result_error
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "error", `String "keeper_shutdown_partial_failure"
+         ; "failure_stage", `String stage_label
+         ; "detail", `String detail
+         ; "name", `String name
+         ; "lane_joined", `Bool lane_joined
+         ; "remove_meta", `Bool request.remove_meta
+         ; "remove_session", `Bool request.remove_session
+         ; ( "continuation_record"
+           , match continuation_path with
+             | Some path -> `String path
+             | None -> `Null )
+         ; "released_task_ids", task_ids_json released_task_ids
+         ; "pending_confirms_removed", `Int pending_confirms_removed
+         ; "retryable", `Bool true
+         ]))
+;;
+
+let keeper_down_success
+      ~name
+      ~request
+      ~lane_joined
+      ~continuation_path
+      ~released_task_ids
+      ~pending_confirms_removed
+  =
+  tool_result_ok
+    (Yojson.Safe.to_string
+       (`Assoc
+         [ "name", `String name
+         ; "stopped", `Bool true
+         ; "lane_joined", `Bool lane_joined
+         ; "remove_meta", `Bool request.remove_meta
+         ; "remove_session", `Bool request.remove_session
+         ; ( "continuation_record"
+           , match continuation_path with
+             | Some path -> `String path
+             | None -> `Null )
+         ; "released_task_ids", task_ids_json released_task_ids
+         ; "pending_confirms_removed", `Int pending_confirms_removed
+         ]))
+;;
+
+let persist_paused_shutdown_intent config name (meta : keeper_meta) =
+  let paused =
+    { meta with
+      updated_at = now_iso ()
+    ; paused = true
+    ; latched_reason =
+        Some
+          (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+    ; auto_resume_after_sec = None
+    ; runtime = { meta.runtime with last_blocker = None }
+    }
+  in
+  match
+    write_meta_with_merge
+      ~merge:Keeper_meta_merge.operator_pause_from_caller
+      config
+      paused
+  with
+  | Ok () ->
+    (match read_meta config name with
+     | Error error ->
+       Error
+         (Printf.sprintf
+            "shutdown pause was persisted but canonical meta reload failed: %s"
+            error)
+     | Ok None ->
+       Error "shutdown pause was persisted but canonical keeper meta disappeared"
+     | Ok (Some persisted) ->
+       Keeper_registry.update_meta
+         ~base_path:config.base_path
+         name
+         persisted;
+       Ok persisted)
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string WriteMetaFailures)
+      ~labels:
+        [ "keeper", name
+        ; ( "phase"
+          , if Keeper_meta_store.is_version_conflict_error error
+            then "keeper_down_cas_race"
+            else "keeper_down" )
+        ]
+      ();
+    Error error
+;;
+
+let settle_interrupted_turn config (entry : Keeper_registry.registry_entry) =
+  let persist_failed record prior_error =
+    match Keeper_shutdown_record.persist ~config record with
+    | Error retry_error ->
+      Error
+        (Printf.sprintf
+           "shutdown continuation persist failed: prior=%s retry=%s"
+           prior_error
+           retry_error)
+    | Ok persisted ->
+      (match Keeper_registry.record_shutdown_turn_persisted entry persisted with
+       | Ok () -> Ok (Some persisted.path)
+       | Error state_error ->
+         Error
+           (Keeper_registry.shutdown_state_error_to_string state_error))
+  in
+  match Keeper_registry.shutdown_turn_settlement entry with
+  | None -> Error "shutdown state disappeared before turn settlement"
+  | Some Keeper_shutdown_types.No_interrupted_turn -> Ok None
+  | Some (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id }) ->
+    Error
+      (Printf.sprintf
+         "lane exited before interrupted turn %d committed a continuation record"
+         turn_id)
+  | Some
+      (Keeper_shutdown_types.Interrupted_turn_persisted { path; _ }) ->
+    Ok (Some path)
+  | Some
+      (Keeper_shutdown_types.Interrupted_turn_persist_failed { record; error }) ->
+    persist_failed record error
+;;
+
+let shutdown_handoff_context (meta : keeper_meta) =
+  { Masc_domain.summary =
+      Printf.sprintf "Released by the Keeper shutdown transaction for %s" meta.name
+  ; reason = Some "keeper_shutdown"
+  ; next_step = Some "Reclaim after confirming the replacement Keeper lane is executable."
+  ; failure_mode = None
+  ; reclaim_policy = Some Masc_domain.Allow_reclaim
+  ; evidence_refs = []
+  ; updated_at = Some (now_iso ())
+  ; updated_by = Some Keeper_supervisor_types.supervisor_agent_name
+  }
+;;
+
+let clear_current_task_id config (meta : keeper_meta) =
+  match meta.current_task_id with
+  | None -> Ok meta
+  | Some _ ->
+    let cleared = { meta with current_task_id = None; updated_at = now_iso () } in
+    (match
+       write_meta_with_merge
+         ~merge:Keeper_current_task_reconcile.merge_current_task_id
+         config
+         cleared
+     with
+     | Error error -> Error error
+     | Ok () ->
+       (match read_meta config meta.name with
+        | Error error ->
+          Error
+            (Printf.sprintf
+               "current_task_id was persisted but canonical meta reload failed: %s"
+               error)
+        | Ok None ->
+          Error
+            "current_task_id was persisted but the canonical keeper meta disappeared"
+        | Ok (Some persisted) ->
+          Keeper_registry.update_meta
+            ~base_path:config.base_path
+            meta.name
+            persisted;
+          Ok persisted))
+;;
+
+let settle_task_ownership config (meta : keeper_meta) =
+  let handoff_context = shutdown_handoff_context meta in
+  match
+    Keeper_task_ownership_settlement.release_owned_active_tasks
+      ~config
+      ~meta
+      ~actor:Keeper_supervisor_types.supervisor_agent_name
+      ~reason_tag:"keeper_shutdown_task_release"
+      ~handoff_context
+  with
+  | Error
+      (Keeper_task_ownership_settlement.Release_failed
+         { released; failures = _ } as error) ->
+    Error
+      ( released
+      , Keeper_task_ownership_settlement.error_to_string error )
+  | Error (Keeper_task_ownership_settlement.Discovery_failed _ as error) ->
+    Error ([], Keeper_task_ownership_settlement.error_to_string error)
+  | Ok released ->
+    (match clear_current_task_id config meta with
+     | Ok settled_meta -> Ok (settled_meta, released)
+     | Error error ->
+       Error
+         ( released
+         , Printf.sprintf "failed to clear current_task_id after release: %s" error ))
+;;
+
+let remove_file_result path =
+  try
+    if Fs_compat.file_exists path then Sys.remove path;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string SessionCleanupFailures)
+      ~labels:[ "keeper", meta.name ]
+      ();
+    Error (Printexc.to_string error)
+;;
+
+let remove_keeper_session config (meta : keeper_meta) =
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let session_dir = Filename.concat (session_base_dir config) trace_id in
+  try
+    if Fs_compat.file_exists session_dir then Fs_compat.remove_tree session_dir;
+    Keeper_fs.invalidate_dir session_dir;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | error -> Error (Printexc.to_string error)
+;;
+
+let dispatch_stop_requested config name =
+  match Keeper_registry.get_phase ~base_path:config.Workspace.base_path name with
+  | Some (Keeper_state_machine.Draining | Keeper_state_machine.Stopped) -> Ok ()
+  | Some _ ->
+    Keeper_registry.dispatch_event
+      ~base_path:config.Workspace.base_path
+      name
+      Keeper_state_machine.Stop_requested
+    |> Result.map (fun _ -> ())
+    |> Result.map_error Keeper_state_machine.transition_error_to_string
+  | None -> Error "registered lane disappeared before Stop_requested"
+;;
+
+let dispatch_drain_complete config name =
+  match Keeper_registry.get_phase ~base_path:config.Workspace.base_path name with
+  | Some Keeper_state_machine.Stopped -> Ok ()
+  | Some _ ->
+    Keeper_registry.dispatch_event
+      ~base_path:config.Workspace.base_path
+      name
+      Keeper_state_machine.Drain_complete
+    |> Result.map (fun _ -> ())
+    |> Result.map_error Keeper_state_machine.transition_error_to_string
+  | None -> Error "registered lane disappeared before Drain_complete"
+;;
+
+let complete_registry_shutdown config (entry : Keeper_registry.registry_entry) =
+  match
+    Keeper_registry.resolve_done
+      entry
+      ~source:"keeper_shutdown_transaction"
+      `Stopped
+  with
+  | Keeper_registry.Done_resolved _ ->
+    Keeper_supervisor_publish_lifecycle.publish_phase_lifecycle
+      ~phase:Keeper_state_machine.Stopped
+      entry.name
+      "shutdown transaction committed"
+      ();
+    Keeper_registry.unregister ~base_path:config.Workspace.base_path entry.name;
+    Ok ()
+  | Keeper_registry.Done_already_resolved { previous = `Stopped; _ } ->
+    Keeper_registry.unregister ~base_path:config.Workspace.base_path entry.name;
+    Ok ()
+  | Keeper_registry.Done_already_resolved { previous = `Crashed reason; _ } ->
+    Error (Printf.sprintf "lane already resolved as crashed: %s" reason)
+;;
+
+type shutdown_progress =
+  { lane_joined : bool
+  ; continuation_path : string option
+  ; released_task_ids : Keeper_id.Task_id.t list
+  ; pending_confirms_removed : int
+  }
+
+type shutdown_transaction_error =
+  { stage : shutdown_failure_stage
+  ; progress : shutdown_progress
+  ; detail : string
+  }
+
+let initial_progress =
+  { lane_joined = false
+  ; continuation_path = None
+  ; released_task_ids = []
+  ; pending_confirms_removed = 0
+  }
+;;
+
+let transaction_error stage progress detail = Error { stage; progress; detail }
+
+let render_shutdown_transaction ~name ~request = function
+  | Error { stage; progress; detail } ->
+    shutdown_failure
+      ~stage
+      ~name
+      ~request
+      ~lane_joined:progress.lane_joined
+      ~continuation_path:progress.continuation_path
+      ~released_task_ids:progress.released_task_ids
+      ~pending_confirms_removed:progress.pending_confirms_removed
+      detail
+  | Ok progress ->
+    keeper_down_success
+      ~name
+      ~request
+      ~lane_joined:progress.lane_joined
+      ~continuation_path:progress.continuation_path
+      ~released_task_ids:progress.released_task_ids
+      ~pending_confirms_removed:progress.pending_confirms_removed
+;;
+
+let run_common_durable_cleanup
+      config
+      ~name
+      ~(meta : keeper_meta)
+      ~request
+      ~progress
+  =
+  let task_settlement = settle_task_ownership config meta in
+  let* settled_meta, released_task_ids =
+    match task_settlement with
+    | Ok value -> Ok value
+    | Error (released_task_ids, detail) ->
+      transaction_error
+        Task_ownership_settlement
+        { progress with released_task_ids }
+        detail
+  in
+  let progress = { progress with released_task_ids } in
+  let* pending_confirms_removed =
+    match
+      remove_pending_confirms_by_target
+        config
+        ~target_type:"keeper"
+        ~target_id:(Some name)
+    with
+    | Ok removed -> Ok removed
+    | Error detail -> transaction_error Pending_confirm_cleanup progress detail
+  in
+  let progress = { progress with pending_confirms_removed } in
+  let* () =
+    if not request.remove_session
+    then Ok ()
+    else
+      remove_keeper_session config settled_meta
+      |> Result.map_error (fun detail ->
+           { stage = Session_removal; progress; detail })
+  in
+  Ok progress
+;;
+
+let run_joined_shutdown
+      config
+      ~name
+      ~(meta : keeper_meta)
+      ~(entry : Keeper_registry.registry_entry)
+      ~request
+  =
+  let transaction () =
+    ignore
+      (Keeper_registry.begin_shutdown entry : Keeper_registry.shutdown_begin_result);
+    let* () =
+      dispatch_stop_requested config name
+      |> Result.map_error (fun detail ->
+           { stage = Stop_transition; progress = initial_progress; detail })
+    in
+    let* joined_entry, interrupt, grpc_close_error =
+      match
+        Keeper_keepalive.request_shutdown_and_await_exit
+          ~base_path:config.base_path
+          name
+      with
+      | Keeper_keepalive.Shutdown_keeper_not_registered ->
+        transaction_error
+          Lane_join
+          initial_progress
+          "registered lane disappeared before shutdown could join it"
+      | Keeper_keepalive.Shutdown_self_join_rejected ->
+        transaction_error
+          Self_shutdown
+          initial_progress
+          "the shutdown request moved into its target turn and cannot join itself"
+      | Keeper_keepalive.Shutdown_lane_joined
+          { entry; grpc_close_error; interrupt } ->
+        Ok (entry, interrupt, grpc_close_error)
+    in
+    let progress = { initial_progress with lane_joined = true } in
+    let* () =
+      match interrupt with
+      | Keeper_registry.Shutdown_turn_state_error error ->
+        transaction_error
+          Turn_settlement
+          progress
+          (Keeper_registry.shutdown_state_error_to_string error)
+      | Keeper_registry.Shutdown_no_turn_in_flight
+      | Keeper_registry.Shutdown_turn_interrupted _
+      | Keeper_registry.Shutdown_turn_interrupt_pending _ -> Ok ()
+    in
+    let* continuation_path =
+      settle_interrupted_turn config joined_entry
+      |> Result.map_error (fun detail ->
+           { stage = Turn_settlement; progress; detail })
+    in
+    let progress = { progress with continuation_path } in
+    let* () =
+      match grpc_close_error with
+      | None -> Ok ()
+      | Some detail ->
+        transaction_error
+          Lane_join
+          progress
+          ("gRPC lane resource close failed: " ^ detail)
+    in
+    let* progress =
+      run_common_durable_cleanup config ~name ~meta ~request ~progress
+    in
+    let* () =
+      dispatch_drain_complete config name
+      |> Result.map_error (fun detail ->
+           { stage = Drain_complete; progress; detail })
+    in
+    let* () =
+      complete_registry_shutdown config joined_entry
+      |> Result.map_error (fun detail ->
+           { stage = Terminal_commit; progress; detail })
+    in
+    let* () =
+      if not request.remove_meta
+      then Ok ()
+      else
+        remove_file_result (keeper_meta_path config name)
+        |> Result.map_error (fun detail ->
+             { stage = Meta_removal; progress; detail })
+    in
+    if request.remove_meta
+    then Keeper_tool_emission_hook.drop_keeper_accumulator name;
+    Ok progress
+  in
+  Eio.Cancel.protect transaction
+  |> render_shutdown_transaction ~name ~request
+;;
+
+let run_absent_lane_shutdown config ~name ~(meta : keeper_meta) ~request =
+  let transaction () =
+    let progress = initial_progress in
+    let* progress =
+      run_common_durable_cleanup config ~name ~meta ~request ~progress
+    in
+    let* () =
+      if not request.remove_meta
+      then Ok ()
+      else
+        remove_file_result (keeper_meta_path config name)
+        |> Result.map_error (fun detail ->
+             { stage = Meta_removal; progress; detail })
+    in
+    if request.remove_meta
+    then Keeper_tool_emission_hook.drop_keeper_accumulator name;
+    Ok progress
+  in
+  Eio.Cancel.protect transaction
+  |> render_shutdown_transaction ~name ~request
+;;
 
 let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
-  if not (validate_name requested_name) then
+  let request =
+    { remove_meta = get_bool args "remove_meta" false
+    ; remove_session = get_bool args "remove_session" false
+    }
+  in
+  if not (validate_name requested_name)
+  then
     tool_result_error
       (Printf.sprintf
          "invalid keeper name %S (must be non-empty and match \
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    let remove_meta = get_bool args "remove_meta" false in
-    let remove_session = get_bool args "remove_session" false in
-    stop_keepalive ~base_path:config.base_path requested_name;
     match read_meta_resolved config requested_name with
-    | Error e -> tool_result_error e
-    | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
-    | Ok (Some (name, m)) ->
-      (match
-         Atomic.get remove_pending_confirms_by_target_callback config
-           ~target_type:"keeper" ~target_id:(Some name)
-       with
-       | Error msg ->
-         tool_result_error
-           (Printf.sprintf
-              "keeper pending-confirm cleanup failed for %s: %s"
-              name
-              msg)
-       | Ok pending_confirms_removed ->
-      Log.Misc.info
-        "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
-         remove_meta=%b remove_session=%b"
-        name pending_confirms_removed remove_meta remove_session;
-      (if remove_meta then
-         ( Safe_ops.remove_file_logged ~context:"keeper_down"
-             (keeper_meta_path config name);
-           Keeper_registry.unregister ~base_path:config.base_path name;
-           (* Tier K4c teardown — when the keeper is fully removed
-              (remove_meta=true), drop its tool-emission accumulator
-              from the registry so its slot is reclaimable. The
-              retain-paused branch (else) deliberately keeps the
-              accumulator alive so a future resume can drain any
-              pending items captured before pause. *)
-           Keeper_tool_emission_hook.drop_keeper_accumulator name )
-       else
-         let retained =
-           {
-             m with
-             updated_at = now_iso ();
-             paused = true;
-             (* keeper_down (remove_meta=false) is an operator-initiated
-                retain-paused shutdown; record it as an operator pause so the
-                status bridge can name it. Observability only — the
-                Operator_pause dispatch below is unchanged. *)
-             latched_reason =
-               Some
-                 (Keeper_latched_reason.Operator_paused
-                    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down });
-           }
-         in
-         ((match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.caller_wins config retained
-           with
-           | Ok () -> ()
-           | Error err ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string WriteMetaFailures)
-                 ~labels:[("keeper", name);
-                          ("phase",
-                           if Keeper_meta_store.is_version_conflict_error err
-                           then "keeper_down_cas_race"
-                           else "keeper_down")]
-                 ();
-               if Keeper_meta_store.is_version_conflict_error err then
-                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
-               else
-                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
-          Keeper_registry.update_meta ~base_path:config.base_path name retained;
-          Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
-            Keeper_state_machine.Operator_pause));
-      if remove_session then (
-        let rec rm_rf path =
-          if Fs_compat.file_exists path then begin
-            if Sys.is_directory path then begin
-              Sys.readdir path |> Array.iter (fun entry ->
-                rm_rf (Filename.concat path entry)
-              );
-              Fs_compat.rmdir path
-            end else
-              Sys.remove path
-          end
-        in
-        if validate_name (Keeper_id.Trace_id.to_string m.runtime.trace_id) then (
-          let dir = Filename.concat (session_base_dir config) (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
-          try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string SessionCleanupFailures)
-              ();
-            Log.Keeper.error "session dir cleanup failed: %s"
-              (Printexc.to_string exn)));
-      let json = `Assoc [
-        ("name", `String name);
-        ("stopped", `Bool true);
-        ("remove_meta", `Bool remove_meta);
-        ("remove_session", `Bool remove_session);
-        ("pending_confirms_removed", `Int pending_confirms_removed);
-      ] in
-      tool_result_ok (Yojson.Safe.to_string json))
+    | Error error -> tool_result_error error
+    | Ok resolved ->
+      let entry = Keeper_registry.get ~base_path:config.base_path requested_name in
+      let resolved_keeper =
+        match resolved, entry with
+        | Some (name, meta), _ -> Some (name, meta)
+        | None, Some registered -> Some (registered.name, registered.meta)
+        | None, None -> None
+      in
+      (match resolved_keeper with
+       | None ->
+         if request.remove_session
+         then
+           shutdown_failure
+             ~stage:Session_removal
+             ~name:requested_name
+             ~request
+             ~lane_joined:false
+             ~continuation_path:None
+             ~released_task_ids:[]
+             ~pending_confirms_removed:0
+             "keeper meta is absent, so no typed trace_id is available for session removal"
+         else
+           (match
+              remove_pending_confirms_by_target
+                config
+                ~target_type:"keeper"
+                ~target_id:(Some requested_name)
+            with
+            | Error detail ->
+              shutdown_failure
+                ~stage:Pending_confirm_cleanup
+                ~name:requested_name
+                ~request
+                ~lane_joined:false
+                ~continuation_path:None
+                ~released_task_ids:[]
+                ~pending_confirms_removed:0
+                detail
+            | Ok pending_confirms_removed ->
+              keeper_down_success
+                ~name:requested_name
+                ~request
+                ~lane_joined:false
+                ~continuation_path:None
+                ~released_task_ids:[]
+                ~pending_confirms_removed)
+       | Some (name, meta) ->
+         let entry = Keeper_registry.get ~base_path:config.base_path name in
+         (match entry with
+          | Some registered when Keeper_registry.current_fiber_owns_turn registered ->
+            shutdown_failure
+              ~stage:Self_shutdown
+              ~name
+              ~request
+              ~lane_joined:false
+              ~continuation_path:None
+              ~released_task_ids:[]
+              ~pending_confirms_removed:0
+              "a Keeper turn cannot synchronously join its own lane; use an external operator lane"
+          | Some registered ->
+            if not (Keeper_registry.try_claim_shutdown_transaction registered)
+            then
+              shutdown_failure
+                ~stage:Lane_join
+                ~name
+                ~request
+                ~lane_joined:false
+                ~continuation_path:None
+                ~released_task_ids:[]
+                ~pending_confirms_removed:0
+                "another operator fiber already owns this Keeper shutdown transaction"
+            else
+              Fun.protect
+                ~finally:(fun () ->
+                  Keeper_registry.release_shutdown_transaction registered)
+                (fun () ->
+                   match persist_paused_shutdown_intent config name meta with
+                   | Error detail ->
+                     shutdown_failure
+                       ~stage:Paused_intent_persist
+                       ~name
+                       ~request
+                       ~lane_joined:false
+                       ~continuation_path:None
+                       ~released_task_ids:[]
+                       ~pending_confirms_removed:0
+                       detail
+                   | Ok paused_meta ->
+                     run_joined_shutdown
+                       config
+                       ~name
+                       ~meta:paused_meta
+                       ~entry:registered
+                       ~request)
+          | None ->
+            (match persist_paused_shutdown_intent config name meta with
+             | Error detail ->
+               shutdown_failure
+                 ~stage:Paused_intent_persist
+                 ~name
+                 ~request
+                 ~lane_joined:false
+                 ~continuation_path:None
+                 ~released_task_ids:[]
+                 ~pending_confirms_removed:0
+                 detail
+             | Ok paused_meta ->
+               run_absent_lane_shutdown
+                 config
+                 ~name
+                 ~meta:paused_meta
+                 ~request)))
+;;
 
-let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
+let handle_keeper_down (ctx : _ context) args =
+  handle_keeper_down_config ~config:ctx.config args
+;;
 
 module For_testing = struct
   let remove_pending_confirms_by_target ~config ~target_type ~target_id =
-    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+    remove_pending_confirms_by_target config ~target_type ~target_id
+  ;;
 
   let reset_remove_pending_confirms_by_target () =
-    Atomic.set remove_pending_confirms_by_target_callback
-      (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+    Atomic.set remove_pending_confirms_by_target_callback None
+  ;;
 end

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -4,9 +4,11 @@
 
 type tool_result = Keeper_types_profile.tool_result
 
-(** Handle the [masc_keeper_down] MCP tool call: stop keepalive,
-    optionally remove meta and/or session directory, broadcast
-    Operator_pause to the registry. *)
+(** Handle [masc_keeper_down] as a lane-local transaction: persist paused
+    intent, cancel and join the concrete lane fiber, settle an interrupted turn
+    and task ownership, then commit cleanup and unregister.  A failed stage
+    returns an explicit retryable partial-failure payload and leaves the paused
+    lane registered. *)
 val handle_keeper_down :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -363,6 +363,27 @@ let update_keeper ?(preserve_prompt_defaults = false)
                    ~new_ids:updated.active_goal_ids
                    ()
                in
-               stop_keepalive ~base_path:ctx.config.base_path updated.name;
-               start_keepalive ctx updated;
-               tool_result_ok (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated)))))
+               (match
+                  stop_keepalive_and_await
+                    ~base_path:ctx.config.base_path
+                    updated.name
+                with
+                | Keeper_not_registered | Keeper_joined _ ->
+                  start_keepalive ctx updated;
+                  tool_result_ok
+                    (Yojson.Safe.to_string (Keeper_meta_json.meta_to_json updated))
+                | Keeper_stop_owned_by_shutdown ->
+                  tool_result_error
+                    (Printf.sprintf
+                       "keeper %s is already owned by a shutdown transaction"
+                       updated.name)
+                | Keeper_self_stop_rejected ->
+                  tool_result_error
+                    (Printf.sprintf
+                       "keeper %s cannot synchronously restart its own active turn"
+                       updated.name)
+                | Keeper_exit_without_terminal ->
+                  tool_result_error
+                    (Printf.sprintf
+                       "keeper %s exited without a terminal lifecycle result"
+                       updated.name)))))

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -429,6 +429,9 @@ let run_keeper_cycle
                    entry.meta
                  | None -> meta
                in
+               let event_bus_cleanup_error : string option Atomic.t =
+                 Atomic.make None
+               in
                Keeper_registry.mark_turn_measurement ~base_path:config.base_path meta.name;
                (match Keeper_registry.get ~base_path:config.base_path meta.name with
                 | Some { current_turn_observation = Some { measurement = Some _; _ }; _ }
@@ -446,13 +449,27 @@ let run_keeper_cycle
            instead of propagating them. *)
                  let cleanup () =
                    (try unsubscribe_event_bus () with
-                    | Eio.Cancel.Cancelled _ -> ()
+                    | Eio.Cancel.Cancelled _ as cancelled ->
+                      let detail = Printexc.to_string cancelled in
+                      ignore
+                        (Atomic.compare_and_set
+                           event_bus_cleanup_error
+                           None
+                           (Some detail)
+                         : bool)
                     | e ->
+                      let detail = Printexc.to_string e in
+                      ignore
+                        (Atomic.compare_and_set
+                           event_bus_cleanup_error
+                           None
+                           (Some detail)
+                         : bool);
                       Log.Keeper.warn
                         ~keeper_name:meta.name
                         "%s: unsubscribe_event_bus in turn cleanup raised: %s"
                         meta.name
-                        (Printexc.to_string e);
+                        detail;
                       Otel_metric_store.inc_counter
                         Keeper_metrics.(to_string TurnCleanupFailures)
                         ~labels:[ "keeper", meta.name; "site", Keeper_turn_cleanup_failure_site.(to_label Unsubscribe_event_bus) ]
@@ -473,6 +490,71 @@ let run_keeper_cycle
                        Keeper_metrics.(to_string TurnCleanupFailures)
                        ~labels:[ "keeper", meta.name; "site", Keeper_turn_cleanup_failure_site.(to_label Mark_turn_finished) ]
                        ()
+                 in
+                 let persist_shutdown_interruption () =
+                   match Keeper_registry.get ~base_path:config.base_path meta.name with
+                   | None ->
+                     Log.Keeper.error
+                       ~keeper_name:meta.name
+                       "%s: shutdown interruption could not find its registered lane"
+                       meta.name
+                   | Some entry ->
+                     let event_bus_integrity_error =
+                       match
+                         event_bus_integrity_error_snapshot ()
+                         |> Option.map Agent_sdk.Error.to_string,
+                         Atomic.get event_bus_cleanup_error
+                       with
+                       | None, None -> None
+                       | Some tracked, None -> Some tracked
+                       | None, Some cleanup -> Some cleanup
+                       | Some tracked, Some cleanup ->
+                         Some
+                           (Printf.sprintf
+                              "event-bus integrity: %s; final drain cleanup: %s"
+                              tracked
+                              cleanup)
+                     in
+                     let record =
+                       Keeper_shutdown_types.make_interrupted_turn
+                         ~keeper_name:meta.name
+                         ~trace_id:meta.runtime.trace_id
+                         ~turn_id:keeper_turn_id
+                         ~current_task_id:entry.meta.current_task_id
+                         ~interrupted_at:(Time_compat.now ())
+                         ~committed_mutating_tools:
+                           (committed_mutating_tools_snapshot ())
+                         ~event_bus_integrity_error
+                     in
+                     (match Keeper_shutdown_record.persist ~config record with
+                      | Ok persisted ->
+                        (match
+                           Keeper_registry.record_shutdown_turn_persisted
+                             entry
+                             persisted
+                         with
+                         | Ok () -> ()
+                         | Error state_error ->
+                           Log.Keeper.error
+                             ~keeper_name:meta.name
+                             "%s: persisted shutdown interruption but registry settlement failed: %s"
+                             meta.name
+                             (Keeper_registry.shutdown_state_error_to_string state_error))
+                      | Error error ->
+                        (match
+                           Keeper_registry.record_shutdown_turn_persist_failed
+                             entry
+                             record
+                             ~error
+                         with
+                         | Ok () -> ()
+                         | Error state_error ->
+                           Log.Keeper.error
+                             ~keeper_name:meta.name
+                             "%s: shutdown interruption persistence and registry settlement failed: persistence=%s registry=%s"
+                             meta.name
+                             error
+                             (Keeper_registry.shutdown_state_error_to_string state_error)))
                  in
                  match
                    Keeper_context_runtime.timed (fun () ->
@@ -540,6 +622,13 @@ let run_keeper_cycle
                  | result ->
                    cleanup ();
                    result
+                 | exception
+                     (Eio.Cancel.Cancelled Keeper_registry.Shutdown_interrupt as e) ->
+                   let backtrace = Printexc.get_raw_backtrace () in
+                   Eio.Cancel.protect (fun () ->
+                     cleanup ();
+                     persist_shutdown_interruption ());
+                   Printexc.raise_with_backtrace e backtrace
                  | exception e ->
                    let backtrace = Printexc.get_raw_backtrace () in
                    cleanup ();

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -222,19 +222,21 @@ let remove_pending_confirm config token =
     write_pending_confirms config remaining
 
 let remove_pending_confirms_by_target config ~target_type ~target_id =
-  let all = raw_pending_confirms config in
-  let remaining =
-    List.filter
-      (fun (entry : pending_confirm) ->
-        not
-          (String.equal entry.target_type target_type
-          && entry.target_id = target_id))
-      all
-  in
-  let removed = List.length all - List.length remaining in
-  if removed > 0 then
-    write_pending_confirms config remaining |> Result.map (fun () -> removed)
-  else Ok 0
+  match read_pending_confirms_result config with
+  | Error _ as error -> error
+  | Ok all ->
+    let remaining =
+      List.filter
+        (fun (entry : pending_confirm) ->
+          not
+            (String.equal entry.target_type target_type
+            && entry.target_id = target_id))
+        all
+    in
+    let removed = List.length all - List.length remaining in
+    if removed > 0 then
+      write_pending_confirms config remaining |> Result.map (fun () -> removed)
+    else Ok 0
 
 let normalize_pending_confirm_actor_filter = function
   | Some raw ->

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -297,35 +297,47 @@ let purge_agent_filesystem_artifacts config agent_names =
   |> Result.map List.rev
 ;;
 
-let purge_keeper_artifacts config requested_name
+let purge_keeper_artifacts config
     ({ keeper_name; agent_name; trace_id; toml_path } : keeper_purge_target) =
   let keeper_dir = Keeper_fs.keeper_dir config in
   let keeper_runtime_dir = Filename.concat keeper_dir keeper_name in
-  let cleanup_names =
-    [ requested_name; keeper_name; agent_name ]
-    |> List.filter_map String_util.trim_to_option
-    |> Json_util.dedupe_keep_order
+  let shutdown_result =
+    Keeper_turn_lifecycle.handle_keeper_down_config
+      ~config
+      (`Assoc
+        [ "name", `String keeper_name
+        ; "remove_meta", `Bool true
+        ; "remove_session", `Bool false
+        ])
   in
-  cleanup_names
-  |> List.iter (fun name ->
-       Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
-  match
-    Operator_pending_confirm.remove_pending_confirms_by_target
-      config
-      ~target_type:"keeper"
-      ~target_id:(Some keeper_name)
-  with
-  | Error msg ->
-    Error
-      (Printf.sprintf
-         "pending-confirm cleanup failed for keeper %s: %s"
-         keeper_name
-         msg)
+  let shutdown_receipt =
+    if not (Tool_result.is_success shutdown_result)
+    then Error (Tool_result.message shutdown_result)
+    else
+      try
+        let receipt = Yojson.Safe.from_string (Tool_result.message shutdown_result) in
+        (match Safe_ops.json_int_opt "pending_confirms_removed" receipt with
+         | Some removed -> Ok removed
+         | None ->
+           Error
+             (Printf.sprintf
+                "keeper shutdown receipt for %s omitted pending_confirms_removed"
+                keeper_name))
+      with
+      | Yojson.Json_error error ->
+        Error
+          (Printf.sprintf
+             "keeper shutdown returned a malformed receipt for %s: %s"
+             keeper_name
+             error)
+  in
+  match shutdown_receipt with
+  | Error detail ->
+    Error (Printf.sprintf "keeper shutdown failed for %s: %s" keeper_name detail)
   | Ok keeper_pending_confirms_removed ->
   Log.Misc.info
     "[keeper_purge] cleanup keeper=%s pending_confirms_removed=%d"
     keeper_name keeper_pending_confirms_removed;
-  Keeper_registry.unregister ~base_path:config.base_path keeper_name;
   (match purge_agent_filesystem_artifacts config [ agent_name; keeper_name ] with
    | Error _ as err -> err
    | Ok agent_cleanup_results ->
@@ -495,7 +507,7 @@ let add_delete_action_routes router =
                (match resolve_keeper_purge_target config requested_name with
                 | Some keeper_target ->
                   let toml_deleted = Option.is_some keeper_target.toml_path in
-                  (match purge_keeper_artifacts config requested_name keeper_target with
+                  (match purge_keeper_artifacts config keeper_target with
                    | Error msg ->
                      respond_error
                        ~status:`Internal_server_error

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -703,7 +703,7 @@ let test_start_keepalive_reclaims_finished_failing_entry () =
           (Option.is_none (Eio.Promise.peek entry.done_p));
         Masc.Keeper_keepalive.stop_keepalive keeper_name)
 
-let test_stop_keepalive_resolves_running_entry_immediately () =
+let test_stop_keepalive_does_not_resolve_before_lane_exit () =
   R.clear ();
   let keeper_name = "manual-stop-entry" in
   let reg = R.register ~base_path:bp keeper_name (make_meta keeper_name) in
@@ -711,12 +711,11 @@ let test_stop_keepalive_resolves_running_entry_immediately () =
   match R.get ~base_path:bp keeper_name with
   | None -> fail "expected manual-stop-entry in registry"
   | Some entry ->
-    check string "state stopped immediately" "stopped" (KSM.phase_to_string entry.phase);
-    (match Eio.Promise.peek reg.done_p with
-     | Some `Stopped -> ()
-     | Some (`Crashed reason) ->
-       fail ("expected stopped promise, got crashed: " ^ reason)
-     | None -> fail "expected manual stop to resolve done_p")
+    check bool "stop signal is latched" true (Atomic.get entry.fiber_stop);
+    check bool "done waits for lane owner" true
+      (Option.is_none (Eio.Promise.peek reg.done_p));
+    check bool "physical exit remains unresolved" true
+      (Option.is_none (Eio.Promise.peek reg.fiber_exited_p))
 
 let test_stop_keepalive_preserves_existing_crash_outcome () =
   R.clear ();
@@ -1024,8 +1023,8 @@ let () =
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick
         test_start_keepalive_reclaims_finished_failing_entry;
-      test_case "manual stop resolves running entry immediately" `Quick
-        test_stop_keepalive_resolves_running_entry_immediately;
+      test_case "manual stop waits for concrete lane exit" `Quick
+        test_stop_keepalive_does_not_resolve_before_lane_exit;
       test_case "manual stop preserves crashed outcome" `Quick
         test_stop_keepalive_preserves_existing_crash_outcome;
       test_case "resolve_done reports prior outcome" `Quick

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -29,6 +29,7 @@ module Keeper_status_bridge = Masc.Keeper_status_bridge
 module Keeper_supervisor_cleanup_tombstone = Masc.Keeper_supervisor_cleanup_tombstone
 module Keeper_supervisor_types = Masc.Keeper_supervisor_types
 module Keeper_types_profile = Masc.Keeper_types_profile
+module Tool_result = Masc.Tool_result
 
 let base_json name =
   `Assoc
@@ -193,6 +194,7 @@ let test_keeper_down_retain_records_reason () =
   let base_path = Masc_test_deps.setup_test_workspace () in
   Fun.protect
     ~finally:(fun () ->
+      Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ();
       Keeper_registry.clear ();
       Masc_test_deps.cleanup_test_workspace base_path)
     (fun () ->
@@ -206,7 +208,10 @@ let test_keeper_down_retain_records_reason () =
        (match Keeper_meta_store.write_meta config meta with
         | Ok () -> ()
         | Error err -> failf "seed meta write: %s" err);
-       ignore (Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let entry = Keeper_registry.register ~base_path:config.base_path keeper_name meta in
+       ignore (Keeper_registry.resolve_fiber_exited entry : bool);
+       Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
+         (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
        let args =
          `Assoc
            [ "name", `String keeper_name
@@ -214,7 +219,11 @@ let test_keeper_down_retain_records_reason () =
            ; "remove_session", `Bool false
            ]
        in
-       let _result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
+       let result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
+       check bool "keeper_down transaction succeeds" true
+         (Tool_result.is_success result);
+       check bool "keeper_down unregisters joined lane" false
+         (Keeper_registry.is_registered ~base_path:config.base_path keeper_name);
        match Keeper_meta_store.read_meta config keeper_name with
        | Ok (Some persisted) ->
          check bool "keeper_down retain pauses keeper" true persisted.paused;
@@ -425,6 +434,46 @@ let test_heartbeat_merge_preserves_only_typed_operator_pause () =
     None
     (latched_reason_wire not_preserved)
 
+let test_operator_pause_merge_preserves_latest_runtime () =
+  let base = make_meta "operator-pause-owner-merge" in
+  let latest =
+    { base with
+      runtime =
+        { base.runtime with
+          usage = { base.runtime.usage with total_turns = 9 }
+        }
+    }
+  in
+  let caller =
+    { base with
+      paused = true
+    ; latched_reason =
+        Some
+          (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+    ; auto_resume_after_sec = None
+    ; runtime =
+        { base.runtime with
+          usage = { base.runtime.usage with total_turns = 1 }
+        ; last_blocker = None
+        }
+    }
+  in
+  let merged =
+    Keeper_meta_merge.operator_pause_from_caller ~latest ~caller
+  in
+  check bool "operator pause caller owns paused=true" true merged.paused;
+  check
+    (option string)
+    "operator pause caller owns the typed reason"
+    (Some wire_keeper_down)
+    (latched_reason_wire merged);
+  check
+    int
+    "operator pause merge preserves latest turn usage"
+    9
+    merged.runtime.usage.total_turns
+
 (* Reviewer P1 (2026-07-03): the overwrite test above only exercises the
    no-conflict write, where the merge never runs. On a CAS retry the cleanup
    re-reads disk; if that snapshot is an operator pause, reusing
@@ -538,6 +587,8 @@ let () =
             test_dead_tombstone_latch_blocks_legacy_auto_resume
         ; test_case "heartbeat merge uses typed operator latch, not pause shape" `Quick
             test_heartbeat_merge_preserves_only_typed_operator_pause
+        ; test_case "operator pause merge preserves latest runtime" `Quick
+            test_operator_pause_merge_preserves_latest_runtime
         ; test_case "dead-tombstone cleanup CAS retry preserves Dead_tombstone" `Quick
             test_dead_tombstone_cleanup_cas_retry_preserves_reason
         ] )

--- a/test/test_keeper_turn_interrupt.ml
+++ b/test/test_keeper_turn_interrupt.ml
@@ -124,9 +124,144 @@ let test_interrupt_no_turn_is_noop () =
      | `No_turn_in_flight -> true)
 ;;
 
+let test_shutdown_interrupt_persists_typed_settlement () =
+  Printf.printf "Test: shutdown interrupt persists typed turn settlement\n%!";
+  with_env
+  @@ fun ~base ->
+  let name = "shutdown-interrupt-keeper" in
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Masc_test_deps.init_eio_clock env;
+  let config = Workspace.default_config base in
+  ignore (Workspace.init config ~agent_name:(Some "operator"));
+  let unlaunched_name = "shutdown-unlaunched-keeper" in
+  let unlaunched =
+    Keeper_registry.register_offline
+      ~base_path:base
+      unlaunched_name
+      (make_meta unlaunched_name)
+  in
+  check
+    "shutdown settles an unlaunched physical lane"
+    (Keeper_registry.settle_unlaunched_fiber_exit unlaunched);
+  check
+    "unlaunched physical exit resolves its join promise"
+    (Option.is_some (Eio.Promise.peek unlaunched.fiber_exited_p));
+  check
+    "a settled unlaunched lane cannot launch later"
+    (match Keeper_registry.claim_fiber_launch unlaunched with
+     | Keeper_registry.Fiber_launch_already_exited -> true
+     | Keeper_registry.Fiber_launch_claimed
+     | Keeper_registry.Fiber_launch_already_running -> false);
+  let meta = make_meta name in
+  let entry = Keeper_registry.register ~base_path:base name meta in
+  check
+    "first shutdown transaction claim succeeds"
+    (Keeper_registry.try_claim_shutdown_transaction entry);
+  check
+    "concurrent shutdown transaction claim is rejected"
+    (not (Keeper_registry.try_claim_shutdown_transaction entry));
+  Keeper_registry.release_shutdown_transaction entry;
+  check
+    "shutdown transaction claim is retryable after release"
+    (Keeper_registry.try_claim_shutdown_transaction entry);
+  Keeper_registry.release_shutdown_transaction entry;
+  ignore (Keeper_registry.begin_shutdown entry : Keeper_registry.shutdown_begin_result);
+  Keeper_registry.mark_turn_started
+    ~base_path:base
+    ~wake:Keeper_registry.Proactive_tick
+    name;
+  Eio.Switch.run
+  @@ fun sw ->
+  let registered, set_registered = Eio.Promise.create () in
+  let cancelled, set_cancelled = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    (try
+       Eio.Switch.run
+       @@ fun turn_sw ->
+       Eio.Switch.on_release turn_sw (fun () ->
+         Keeper_registry.clear_turn_switch ~base_path:base name);
+       Keeper_registry.set_turn_switch ~base_path:base name (Some turn_sw);
+       Eio.Promise.resolve set_registered ();
+       Eio.Time.sleep (Eio.Stdenv.clock env) 10.0
+     with
+     | Keeper_registry.Shutdown_interrupt
+     | Eio.Cancel.Cancelled Keeper_registry.Shutdown_interrupt ->
+       Eio.Promise.resolve set_cancelled ()));
+  Eio.Promise.await registered;
+  Eio.Promise.await cancelled;
+  let turn_id =
+    match Keeper_registry.shutdown_turn_settlement entry with
+    | Some (Keeper_shutdown_types.Awaiting_interrupted_turn { turn_id }) ->
+      check "shutdown turn_id is 1" (turn_id = 1);
+      turn_id
+    | Some
+        (Keeper_shutdown_types.No_interrupted_turn
+        | Keeper_shutdown_types.Interrupted_turn_persisted _
+        | Keeper_shutdown_types.Interrupted_turn_persist_failed _)
+    | None ->
+      check "shutdown turn is awaiting settlement" false;
+      1
+  in
+  let record =
+    Keeper_shutdown_types.make_interrupted_turn
+      ~keeper_name:name
+      ~trace_id:meta.runtime.trace_id
+      ~turn_id
+      ~current_task_id:None
+      ~interrupted_at:(Time_compat.now ())
+      ~committed_mutating_tools:[]
+      ~event_bus_integrity_error:None
+  in
+  let ambiguous_record =
+    Keeper_shutdown_types.make_interrupted_turn
+      ~keeper_name:name
+      ~trace_id:meta.runtime.trace_id
+      ~turn_id
+      ~current_task_id:None
+      ~interrupted_at:(Time_compat.now ())
+      ~committed_mutating_tools:[ "fixture_mutation" ]
+      ~event_bus_integrity_error:None
+  in
+  check
+    "committed mutation yields an explicit ambiguous-result record"
+    (match ambiguous_record.outcome with
+     | Keeper_shutdown_types.Ambiguous_result
+         { committed_mutating_tools = [ _ ]; event_bus_integrity_error = None } ->
+       true
+     | Keeper_shutdown_types.Ambiguous_result _
+     | Keeper_shutdown_types.Continuation_required -> false);
+  (match Keeper_shutdown_record.persist ~config record with
+   | Error error ->
+     check ("shutdown record persisted: " ^ error) false
+   | Ok persisted ->
+     check "shutdown record exists" (Fs_compat.file_exists persisted.path);
+     (match Keeper_registry.record_shutdown_turn_persisted entry persisted with
+      | Error error ->
+        check
+          ("shutdown registry settlement committed: "
+           ^ Keeper_registry.shutdown_state_error_to_string error)
+          false
+      | Ok () ->
+        check
+          "shutdown registry points at durable record"
+          (match Keeper_registry.shutdown_turn_settlement entry with
+           | Some
+               (Keeper_shutdown_types.Interrupted_turn_persisted
+                  { path; record = _ }) ->
+             String.equal path persisted.path
+           | Some
+               (Keeper_shutdown_types.No_interrupted_turn
+               | Keeper_shutdown_types.Awaiting_interrupted_turn _
+               | Keeper_shutdown_types.Interrupted_turn_persist_failed _)
+           | None -> false)))
+;;
+
 let () =
   test_interrupt_cancels_turn ();
   test_interrupt_no_turn_is_noop ();
+  test_shutdown_interrupt_persists_typed_settlement ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## 요약
- Keeper shutdown이 물리 lane을 cancel/join한 뒤에만 unregister하도록 바꿨어용.
- 중단 turn을 typed continuation/ambiguous record로 BasePath 아래에 원자 저장했어용.
- active task ownership, pending confirm, session/meta 정리를 단계별 transaction으로 묶고 partial failure를 명시적으로 반환했어용.
- launch 전 lane과 동시 shutdown/self-join 경쟁을 typed CAS 상태로 차단했어용.
- 다른 Keeper lane에는 전역 barrier를 만들지 않았어용.

## 검증
- `ocamlformat` + 전 수정 파일 `ocamlc -stop-after parsing`
- determinism / enum-string / silent-failure / MASC-OAS boundary / BasePath / SSOT / anti-fake gates
- Dune build/test는 PR CI를 기준으로 확인할게용.

Fixes #24113