### PR TITLE
fix(server): enforce shutdown deadline outside Eio switch

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -466,6 +466,14 @@ let login_no_expiry =
     [Switch.run] wait forever. *)
 exception Graceful_shutdown
 
+type shutdown_signal =
+  | Sigterm
+  | Sigint
+
+let shutdown_signal_name = function
+  | Sigterm -> "SIGTERM"
+  | Sigint -> "SIGINT"
+
 let acquire_pid_lock port =
   match Server_startup_takeover.acquire_pid_lock port with
   | Server_startup_takeover.Acquired -> ()
@@ -568,13 +576,14 @@ let run_cmd host port cli_base_path =
      then enqueue the signal name for the Eio watcher fiber to consume.
      [Atomic.set]/[Atomic.get] are lock-free and signal-safe. *)
   let pending_shutdown_signal = Atomic.make None in
-  let request_shutdown signal_name =
+  let shutdown_watchdog : Masc.Shutdown.watchdog option Atomic.t = Atomic.make None in
+  let request_shutdown signal =
     Masc.Shutdown.mark_shutting_down ();
     if Option.is_none (Atomic.get pending_shutdown_signal) then
-      Atomic.set pending_shutdown_signal (Some signal_name)
+      Atomic.set pending_shutdown_signal (Some signal)
   in
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> request_shutdown "SIGTERM"));
-  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> request_shutdown "SIGINT"));
+  Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> request_shutdown Sigterm));
+  Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> request_shutdown Sigint));
 
   let max_bind_retries = 5 in
   let rec try_start attempt =
@@ -586,20 +595,25 @@ let run_cmd host port cli_base_path =
         | None ->
             Eio.Time.sleep clock 0.05;
             await_shutdown_signal ()
-        | Some signal_name ->
+        | Some signal ->
             let shutdown_cfg = Masc.Shutdown.config_from_env () in
             let force_timeout = shutdown_cfg.force_timeout_s in
             let t_shutdown_start = Unix.gettimeofday () in
-            Log.Server.info
-              "[MASC] Received %s, shutting down gracefully (timeout=%.0fs)..."
-              signal_name force_timeout;
-            Eio.Fiber.fork_daemon ~sw (fun () ->
-                Eio.Time.sleep clock force_timeout;
-                let elapsed = Unix.gettimeofday () -. t_shutdown_start in
-                Log.Server.error
-                  "[MASC] Graceful shutdown timed out after %.1fs (limit=%.0fs), forcing exit."
-                  elapsed force_timeout;
-                exit 1);
+            let signal_name = shutdown_signal_name signal in
+            (match
+               Masc.Shutdown.start_process_deadline_watchdog
+                 ~timeout_s:force_timeout
+             with
+             | Ok watchdog ->
+                 Atomic.set shutdown_watchdog (Some watchdog);
+                 Log.Server.info
+                   "[MASC] Received %s, shutting down gracefully (timeout=%.0fs, hard_exit=%d)..."
+                   signal_name force_timeout Masc.Shutdown.process_deadline_exit_code
+             | Error error ->
+                 Log.Server.error
+                   "[MASC] Invalid graceful shutdown deadline: %s"
+                   (Masc.Shutdown.deadline_error_to_string error);
+                 exit 1);
             (* Phase 1: Notify SSE clients *)
             let t_phase = Unix.gettimeofday () in
             let shutdown_data =
@@ -723,6 +737,13 @@ let run_cmd host port cli_base_path =
         exit 1)
   in
   try_start 0;
+  (match Atomic.get shutdown_watchdog with
+   | None -> ()
+   | Some watchdog ->
+       (match Masc.Shutdown.disarm_deadline_watchdog watchdog with
+        | Masc.Shutdown.Disarmed | Masc.Shutdown.Already_disarmed -> ()
+        | Masc.Shutdown.Already_fired ->
+            Masc.Shutdown.await_deadline_watchdog watchdog));
   Log.Server.info "MASC MCP: Shutdown complete."
 
 let run_cmd_exit host port base_path =

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -6,8 +6,9 @@
     3. Cleanup — Run registered hooks (cancel fibers, flush state, save checkpoint)
     4. Exit    — Terminate the Eio switch
 
-    Each phase logs its start/end. If total shutdown exceeds force_timeout,
-    the process is forcefully terminated.
+    Each phase logs its start/end. The process entrypoint owns the hard
+    [force_timeout_s] watchdog outside the Eio switch; phase execution never
+    disarms its own supervisor.
 
     @since 2.102.0 *)
 
@@ -39,6 +40,68 @@ let config_from_env () =
     cleanup_timeout_s = get_float "MASC_SHUTDOWN_CLEANUP_TIMEOUT" 3.0;
     force_timeout_s = get_float "MASC_SHUTDOWN_FORCE_TIMEOUT" 10.0;
   }
+
+(** {1 Process deadline supervision} *)
+
+type deadline_error =
+  | Non_finite_deadline_timeout of float
+  | Non_positive_deadline_timeout of float
+
+let deadline_error_to_string = function
+  | Non_finite_deadline_timeout value ->
+      Printf.sprintf "deadline timeout must be finite (received %g)" value
+  | Non_positive_deadline_timeout value ->
+      Printf.sprintf
+        "deadline timeout must be greater than zero (received %g)"
+        value
+
+type watchdog_state =
+  | Armed
+  | Disarmed_state
+  | Fired
+
+type watchdog = {
+  state : watchdog_state Atomic.t;
+  thread : Thread.t;
+}
+
+type disarm_result =
+  | Disarmed
+  | Already_disarmed
+  | Already_fired
+
+let process_deadline_exit_code = 124
+
+let start_process_deadline_watchdog ~timeout_s =
+  if not (Float.is_finite timeout_s) then
+    Error (Non_finite_deadline_timeout timeout_s)
+  else if timeout_s <= 0.0 then
+    Error (Non_positive_deadline_timeout timeout_s)
+  else
+    let state = Atomic.make Armed in
+    let thread =
+      Thread.create
+        (fun () ->
+          Thread.delay timeout_s;
+          if Atomic.compare_and_set state Armed Fired then
+            Unix._exit process_deadline_exit_code)
+        ()
+    in
+    Ok { state; thread }
+
+let rec disarm_deadline_watchdog watchdog =
+  if Atomic.compare_and_set watchdog.state Armed Disarmed_state then
+    Disarmed
+  else
+    match Atomic.get watchdog.state with
+    | Disarmed_state -> Already_disarmed
+    | Fired -> Already_fired
+    | Armed ->
+        (* A concurrent timeout can only move [Armed] to [Fired]. Retry so the
+           caller never receives an observation that contradicts the CAS. *)
+        disarm_deadline_watchdog watchdog
+
+let await_deadline_watchdog watchdog = Thread.join watchdog.thread
 
 (** {1 Phase Tracking} *)
 
@@ -205,24 +268,10 @@ let initiate state ~clock ~reason ~notify_fn ~drain_check ~exit_fn =
     state.reason <- reason;
     Log.Server.info "[Shutdown] initiated: %s" reason;
 
-    (* INTENTIONAL: force-exit watchdog uses stdlib Thread, NOT Eio.Fiber.
-       Runs outside the Eio domain so it can terminate the process even when
-       Eio is deadlocked or stuck.  Cancelled via done_flag on normal exit. *)
-    let done_flag = Atomic.make false in
-    ignore (Thread.create (fun () ->
-      Unix.sleepf state.config.force_timeout_s;
-      if not (Atomic.get done_flag) then begin
-        Log.Server.error "Shutdown exceeded %.0fs force timeout, forcing exit"
-          state.config.force_timeout_s;
-        exit 1
-      end
-    ) ());
-
     phase_notify state ~clock ~notify_fn;
     phase_drain state ~clock ~drain_check;
     phase_cleanup state ~clock;
-    phase_exit state ~exit_fn;
-    Atomic.set done_flag true
+    phase_exit state ~exit_fn
   end
 
 (** {1 Queries} *)

--- a/lib/shutdown.mli
+++ b/lib/shutdown.mli
@@ -6,6 +6,9 @@
     3. Cleanup — Run registered hooks (cancel fibers, flush state, save checkpoint)
     4. Exit    — Terminate the Eio switch
 
+    The process entrypoint owns the hard [force_timeout_s] watchdog outside
+    the Eio switch; phase execution never disarms its own supervisor.
+
     @since 2.102.0 *)
 
 (** {1 Configuration} *)
@@ -19,6 +22,47 @@ type config = {
 
 val default_config : config
 val config_from_env : unit -> config
+
+(** {1 Process deadline supervision} *)
+
+type deadline_error =
+  | Non_finite_deadline_timeout of float
+  | Non_positive_deadline_timeout of float
+
+val deadline_error_to_string : deadline_error -> string
+
+type watchdog
+
+val process_deadline_exit_code : int
+(** Dedicated non-zero process status for a fired shutdown deadline. Process
+    supervisors and runtime telemetry may use this SSOT to distinguish a hard
+    deadline from generic exit status [1]. *)
+
+type disarm_result =
+  | Disarmed
+  | Already_disarmed
+  | Already_fired
+
+val start_process_deadline_watchdog :
+  timeout_s:float ->
+  (watchdog, deadline_error) result
+(** [start_process_deadline_watchdog] starts an OS-thread deadline authority.
+    When the deadline fires, it terminates the process with failure status via
+    {!Unix._exit}; no
+    logging, channel flushing, [at_exit] callback, or runtime finalization can
+    block the terminal action. It is
+    is not attached to any Eio switch, so a failed switch, a fibre that ignores
+    cooperative cancellation, or a stalled Eio domain cannot cancel its own
+    process deadline. The process entrypoint must own the returned handle and
+    disarm it only after the supervised switch has actually returned. *)
+
+val disarm_deadline_watchdog : watchdog -> disarm_result
+(** Atomically disarm an armed watchdog. The result distinguishes a successful
+    disarm from an already-disarmed or already-fired watchdog. *)
+
+val await_deadline_watchdog : watchdog -> unit
+(** Join the watchdog thread. Intended for deterministic lifecycle tests and
+    callers that need proof that the watchdog callback has finished. *)
 
 (** {1 Phase Tracking} *)
 
@@ -76,6 +120,10 @@ val initiate :
   drain_check:(unit -> bool) ->
   exit_fn:(unit -> unit) ->
   unit
+(** Run the cooperative shutdown phases. This function deliberately does not
+    own the hard process deadline: a caller supervising an Eio switch must
+    start {!start_process_deadline_watchdog} outside that switch and disarm it
+    only after the switch has actually returned. *)
 
 (** {1 Queries} *)
 

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -95,6 +95,67 @@ let () = test "inline shutdown hooks run registered cleanup hooks" (fun () ->
   Shutdown_hooks.run_all ();
   assert !called)
 
+exception Simulated_switch_shutdown
+
+let () = test "shutdown deadline outlives a stuck cancelled switch" (fun () ->
+  match Unix.fork () with
+  | 0 ->
+      (match
+         Shutdown.start_process_deadline_watchdog
+           ~timeout_s:0.05
+       with
+       | Error _ -> Unix._exit 25
+       | Ok _watchdog ->
+           (try
+              Eio_main.run @@ fun _env ->
+              Eio.Switch.run @@ fun sw ->
+              Eio.Fiber.fork_daemon ~sw (fun () ->
+                  Eio.Cancel.protect (fun () -> Eio.Fiber.await_cancel ());
+                  `Stop_daemon);
+              raise Simulated_switch_shutdown
+            with Simulated_switch_shutdown -> Unix._exit 24);
+           Unix._exit 24)
+  | child_pid ->
+      let waited_pid, status = Unix.waitpid [] child_pid in
+      assert (waited_pid = child_pid);
+      assert (status = Unix.WEXITED Shutdown.process_deadline_exit_code))
+
+let () = test "shutdown deadline disarm state is explicit" (fun () ->
+  let watchdog =
+    match
+      Shutdown.start_process_deadline_watchdog
+        ~timeout_s:1.0
+    with
+    | Ok watchdog -> watchdog
+    | Error error -> failwith (Shutdown.deadline_error_to_string error)
+  in
+  assert (Shutdown.disarm_deadline_watchdog watchdog = Shutdown.Disarmed);
+  assert
+    (Shutdown.disarm_deadline_watchdog watchdog = Shutdown.Already_disarmed))
+
+let () = test "shutdown deadline rejects invalid time values" (fun () ->
+  assert
+    (match
+       Shutdown.start_process_deadline_watchdog
+         ~timeout_s:nan
+     with
+     | Error (Shutdown.Non_finite_deadline_timeout _) -> true
+     | _ -> false);
+  assert
+    (match
+       Shutdown.start_process_deadline_watchdog
+         ~timeout_s:infinity
+     with
+     | Error (Shutdown.Non_finite_deadline_timeout _) -> true
+     | _ -> false);
+  assert
+    (match
+       Shutdown.start_process_deadline_watchdog
+         ~timeout_s:0.0
+     with
+     | Error (Shutdown.Non_positive_deadline_timeout _) -> true
+     | _ -> false))
+
 (* ── Summary ──────────────────────────────────── *)
 
 let () =

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -106,15 +106,17 @@ let () = test "shutdown deadline outlives a stuck cancelled switch" (fun () ->
        with
        | Error _ -> Unix._exit 25
        | Ok _watchdog ->
-           (try
-              Eio_main.run @@ fun _env ->
-              Eio.Switch.run @@ fun sw ->
-              Eio.Fiber.fork_daemon ~sw (fun () ->
-                  Eio.Cancel.protect (fun () -> Eio.Fiber.await_cancel ());
-                  `Stop_daemon);
-              raise Simulated_switch_shutdown
-            with Simulated_switch_shutdown -> Unix._exit 24);
-           Unix._exit 24)
+           (match
+              try
+                Eio_main.run @@ fun _env ->
+                Eio.Switch.run @@ fun sw ->
+                let () =
+                  Eio.Fiber.fork_daemon ~sw (fun () ->
+                      Eio.Cancel.protect (fun () -> Eio.Fiber.await_cancel ()))
+                in
+                raise Simulated_switch_shutdown
+              with Simulated_switch_shutdown -> `Shutdown_escaped_switch
+            with `Shutdown_escaped_switch -> Unix._exit 24))
   | child_pid ->
       let waited_pid, status = Unix.waitpid [] child_pid in
       assert (waited_pid = child_pid);


### PR DESCRIPTION
## Summary

- move the graceful-shutdown hard deadline out of the cancelled Eio switch
- arm one OS-thread watchdog before any shutdown logging or cooperative phase
- make `Armed | Disarmed | Fired` CAS state the single deadline lifecycle authority
- terminate a fired deadline with dedicated status `124` through `Unix._exit`, bypassing logs, channel flushes, `at_exit`, and runtime finalizers
- keep cooperative `Shutdown.initiate` phase-only; the process entrypoint owns and disarms the watchdog only after `Switch.run` actually returns
- replace raw signal-name state with a closed `Sigterm | Sigint` type

## Root cause

The old watchdog was `Eio.Fiber.fork_daemon ~sw` on the same switch that `Graceful_shutdown` failed. Eio cancels every fiber attached to a failed switch and still waits for daemon cancellation, so the deadline authority cancelled itself while the switch waited on a stuck background fiber.

## Verification

- process-level regression forks a child, fails an Eio switch containing a `Cancel.protect` background fiber that never cooperates, and proves the independent watchdog exits the child with status `124`
- disarm idempotency and non-finite/non-positive timeout outcomes are typed and pinned
- exact head OCaml parse and `ocamlformat --check`: pass
- Eio convention, OCaml structure, stringly-boundary, silent-failure, determinism, and diff ratchets: pass
- three adversarial review rounds; final exact delta P0=0, P1=0, P2=0
- local Dune build/test intentionally not run; PR CI is the build authority

Official contracts: [Eio Switch](https://ocaml-multicore.github.io/eio/eio/Eio/Switch/), [Eio Fiber](https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/), [OCaml 5.4 Unix._exit](https://ocaml.org/manual/5.4/api/Unix.html).

Closes #24131.

## Merge gate

Draft and `status:do-not-merge` until required Build/Test CI and review feedback are complete.
