### PR TITLE
feat(fusion): council preset — first staged_judge_of_judges-eligible preset

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1167,3 +1167,108 @@ spots and unique insights, and prefer the most complete resolution. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
 timeout_s = 300.0
+
+# ── Staged-JoJ-capable preset (RFC-0283 staged_judge_of_judges) ──────────────
+# staged_judge_of_judges는 judge 수가 [fusion].staged_judge_group_size(=3)의
+# 정확한 배수이면서 group_size*2(=6) 이상이어야 한다 (fusion_policy.staged_judge_groups).
+# 지금까지 충족 preset이 0이라 topology가 도구 스키마에 노출되고도 모든 호출이
+# config 에러로 fail-closed되는 죽은 옵션이었다. council은 6개 lens 심판을
+# 3개씩 2 stage로 나눈다: stage 1 = evidence/coverage/risk, stage 2 =
+# feasibility/simplicity/adversarial. 각 stage meta가 그룹 종합을 만들고 최종
+# meta judge(judge=)가 stage 종합들을 재조정한다. label이 정체성을 주므로
+# 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다 (quorum 주석과
+# 동일 계약). judge/meta 경로는 provider-native structured output을 요구하므로
+# 심판 런타임은 전부 supports-structured-output=true 선언 모델만 쓴다.
+# 키퍼 사용: masc_fusion preset="council" topology="staged_judge_of_judges"
+# (judge_of_judges topology도 동일 preset으로 사용 가능 — 6 lens 병렬 후 meta).
+[fusion.presets.council]
+panel = [
+  "ollama_cloud.ollama-cloud-devstral-2-123b",
+  "ollama_cloud.ollama-cloud-devstral-small-2-24b",
+  "ollama_cloud.ollama-cloud-ministral-3-14b",
+]
+panel_system_prompt = """
+You are an expert panelist. Answer the user's question directly and concisely \
+with your best independent analysis. Do not defer to other models; give your \
+own view.
+"""
+judge = "ollama_cloud.ollama-cloud-ministral-3-14b"
+judge_system_prompt = """
+You are the meta-judge. You are given stage syntheses, each produced by a group \
+of judges evaluating the same panel of model answers through different lenses. \
+Reconcile them: where the stages agree, state the consensus; where they diverge, \
+adjudicate with reasons; surface any blind spot that a single stage missed. \
+Produce one resolved answer. Respond with ONLY the requested JSON object, no \
+prose and no code fences.
+"""
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
+meta_timeout_s = 300.0
+web_tools = false
+max_tool_calls_per_panel = 0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-devstral-2-123b"
+label = "evidence"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through an EVIDENCE lens: weigh each claim by how well it is supported, flag \
+unsupported assertions, and prefer conclusions grounded in verifiable reasoning. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
+label = "coverage"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through a COVERAGE lens: map what each answer addresses and omits, surface blind \
+spots and unique insights, and prefer the most complete resolution. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-ministral-3-14b"
+label = "risk"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through a RISK lens: identify failure modes, hidden assumptions, and worst-case \
+consequences each answer implies, and prefer the resolution that degrades most \
+gracefully. Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-devstral-2-123b"
+label = "feasibility"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through a FEASIBILITY lens: judge how implementable each proposal is with the \
+stated constraints and resources, and prefer the most actionable resolution. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
+label = "simplicity"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through a SIMPLICITY lens: prefer the resolution with the fewest moving parts \
+that still answers the question fully, and flag accidental complexity. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0
+
+[[fusion.presets.council.judges]]
+model = "ollama_cloud.ollama-cloud-ministral-3-14b"
+label = "adversarial"
+system_prompt = """
+You are an impartial first-pass judge. Synthesize the panel of model answers \
+through an ADVERSARIAL lens: actively try to refute each answer's key claims, \
+keep only what survives refutation, and prefer the most defensible resolution. \
+Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+timeout_s = 300.0

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1179,6 +1179,11 @@ timeout_s = 300.0
 # 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다 (quorum 주석과
 # 동일 계약). judge/meta 경로는 provider-native structured output을 요구하므로
 # 심판 런타임은 전부 supports-structured-output=true 선언 모델만 쓴다.
+# 비용/지연: LLM 호출 12회(panel 3 + 1차 심판 6 + stage meta 2 + 최종 meta 1).
+# 실행은 4단 순차 파이프라인(panel → 1차 심판 병렬 → stage meta 병렬 → 최종
+# meta, fusion_orchestrator run_staged_judge_of_judges)이라 각 단의
+# timeout(300s)이 누적된다 — 동시성 캡이 각 단을 한 웨이브로 소화할 때 최악
+# ~20분. 빠른 종합이 필요하면 단이 짧은 quorum/judge_of_judges 계열을 쓴다.
 # 키퍼 사용: masc_fusion preset="council" topology="staged_judge_of_judges"
 # (judge_of_judges topology도 동일 preset으로 사용 가능 — 6 lens 병렬 후 meta).
 [fusion.presets.council]

--- a/test/fusion_core/dune
+++ b/test/fusion_core/dune
@@ -5,4 +5,5 @@
 (tests
  (names test_fusion test_fusion_harness test_fusion_run_registry
    test_fusion_config_json)
+ (deps ../../config/runtime.toml)
  (libraries alcotest otoml yojson masc.fusion_core))

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -717,6 +717,47 @@ let test_config_council_preset_is_staged_eligible () =
      | presets ->
        Alcotest.failf "expected exactly one preset, got %d" (List.length presets))
 
+let test_shipped_runtime_council_is_staged_eligible () =
+  let runtime_toml =
+    In_channel.with_open_bin "../../config/runtime.toml" In_channel.input_all
+  in
+  match Fusion_config.of_toml (parse runtime_toml) with
+  | Error errors ->
+    Alcotest.failf "shipped runtime.toml must validate, got: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error errors))
+  | Ok policy ->
+    (match
+       List.find_opt
+         (fun validated ->
+            String.equal
+              (raw validated).Fusion_policy.name
+              "council")
+         policy.Fusion_policy.presets
+     with
+     | None -> Alcotest.fail "shipped runtime.toml has no council preset"
+     | Some validated ->
+       let preset = raw validated in
+       match
+         Fusion_policy.staged_judge_groups
+           ~group_size:policy.Fusion_policy.staged_judge_group_size
+           preset.Fusion_policy.judges
+       with
+       | Ok [ first_stage; second_stage ] ->
+         Alcotest.(check (list string))
+           "shipped first stage lenses"
+           [ "evidence"; "coverage"; "risk" ]
+           (List.map (fun judge -> judge.Fusion_policy.jlabel) first_stage);
+         Alcotest.(check (list string))
+           "shipped second stage lenses"
+           [ "feasibility"; "simplicity"; "adversarial" ]
+           (List.map (fun judge -> judge.Fusion_policy.jlabel) second_stage)
+       | Ok groups ->
+         Alcotest.failf "shipped council must have two stages, got %d"
+           (List.length groups)
+       | Error error ->
+         Alcotest.failf "shipped council is not staged-eligible: %s"
+           (Fusion_policy.staged_judge_group_error_message error))
+
 (* 회귀 가드: quorum 형태(2 judges)는 staged 비자격 — 이 fail-closed가 council
    추가 전 모든 shipped preset의 상태였다. *)
 let test_config_two_judges_not_staged_eligible () =
@@ -1771,6 +1812,8 @@ let () =
             test_config_bad_staged_judge_group_size
         ; Alcotest.test_case "council_staged_eligible" `Quick
             test_config_council_preset_is_staged_eligible
+        ; Alcotest.test_case "shipped_runtime_council_staged_eligible" `Quick
+            test_shipped_runtime_council_is_staged_eligible
         ; Alcotest.test_case "two_judges_not_staged_eligible" `Quick
             test_config_two_judges_not_staged_eligible
         ; Alcotest.test_case "invalid_max_tool_calls" `Quick

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -637,6 +637,110 @@ judge_system_prompt = "j"
       (List.mem (Fusion_config.Invalid_staged_judge_group_size 1) es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_staged_judge_group_size"
 
+(* council 프리셋 계약 (config/runtime.toml [fusion.presets.council] 미러):
+   judge 6명 = staged_judge_group_size(3)의 정확한 배수이자 >= group_size*2 —
+   staged_judge_of_judges 자격을 만족하는 최초의 shipped preset shape.
+   staged_judge_groups가 lens 입력 순서를 보존한 2 그룹을 만드는 것까지 고정해,
+   프리셋을 줄이거나(ragged) group_size를 키우는 회귀가 여기서 잡히게 한다. *)
+let council_shaped_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "council"
+staged_judge_group_size = 3
+[fusion.presets.council]
+panel = ["pa", "pb", "pc"]
+judge = "meta-reducer"
+panel_system_prompt = "answer independently"
+judge_system_prompt = "reconcile the stage syntheses"
+
+[[fusion.presets.council.judges]]
+model = "j1"
+label = "evidence"
+system_prompt = "evidence lens"
+
+[[fusion.presets.council.judges]]
+model = "j2"
+label = "coverage"
+system_prompt = "coverage lens"
+
+[[fusion.presets.council.judges]]
+model = "j3"
+label = "risk"
+system_prompt = "risk lens"
+
+[[fusion.presets.council.judges]]
+model = "j1"
+label = "feasibility"
+system_prompt = "feasibility lens"
+
+[[fusion.presets.council.judges]]
+model = "j2"
+label = "simplicity"
+system_prompt = "simplicity lens"
+
+[[fusion.presets.council.judges]]
+model = "j3"
+label = "adversarial"
+system_prompt = "adversarial lens"
+|}
+
+let test_config_council_preset_is_staged_eligible () =
+  match Fusion_config.of_toml (parse council_shaped_toml) with
+  | Error es ->
+    Alcotest.failf "council fixture must parse+validate, got: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = raw vp in
+       Alcotest.(check int) "six first-round judges" 6
+         (List.length preset.Fusion_policy.judges);
+       (match
+          Fusion_policy.staged_judge_groups
+            ~group_size:p.Fusion_policy.staged_judge_group_size
+            preset.Fusion_policy.judges
+        with
+        | Error e ->
+          Alcotest.failf "council must be staged-eligible, got: %s"
+            (Fusion_policy.staged_judge_group_error_message e)
+        | Ok groups ->
+          Alcotest.(check int) "two exact stages" 2 (List.length groups);
+          Alcotest.(check (list (list string)))
+            "stage grouping preserves lens input order"
+            [ [ "evidence"; "coverage"; "risk" ]
+            ; [ "feasibility"; "simplicity"; "adversarial" ]
+            ]
+            (List.map
+               (List.map (fun j -> j.Fusion_policy.jlabel))
+               groups))
+     | presets ->
+       Alcotest.failf "expected exactly one preset, got %d" (List.length presets))
+
+(* 회귀 가드: quorum 형태(2 judges)는 staged 비자격 — 이 fail-closed가 council
+   추가 전 모든 shipped preset의 상태였다. *)
+let test_config_two_judges_not_staged_eligible () =
+  let judge ~model ~label =
+    { Fusion_policy.jmodel = model
+    ; jlabel = label
+    ; jsystem_prompt = label ^ " lens"
+    ; jweb_tools = false
+    ; jmax_tool_calls = 0
+    ; jmax_output_tokens = None
+    ; jtimeout_s = 300.0
+    ; jmax_timeout_s = None
+    }
+  in
+  let judges =
+    [ judge ~model:"j1" ~label:"evidence"; judge ~model:"j2" ~label:"coverage" ]
+  in
+  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
+  | Error (Fusion_policy.Staged_too_few_judges { group_size = 3; judges = 2 }) -> ()
+  | Error e ->
+    Alcotest.failf "expected Staged_too_few_judges, got: %s"
+      (Fusion_policy.staged_judge_group_error_message e)
+  | Ok _ -> Alcotest.fail "two judges must not be staged-eligible"
+
 let test_config_invalid_max_tool_calls () =
   let s =
     {|
@@ -1665,6 +1769,10 @@ let () =
             test_config_bad_judge_concurrency
         ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
             test_config_bad_staged_judge_group_size
+        ; Alcotest.test_case "council_staged_eligible" `Quick
+            test_config_council_preset_is_staged_eligible
+        ; Alcotest.test_case "two_judges_not_staged_eligible" `Quick
+            test_config_two_judges_not_staged_eligible
         ; Alcotest.test_case "invalid_max_tool_calls" `Quick
             test_config_invalid_max_tool_calls
         ; Alcotest.test_case "invalid_max_output_tokens" `Quick


### PR DESCRIPTION
## 무엇

기능지도 Gap(P2): `staged_judge_of_judges` topology가 도구 스키마에 노출되나 충족 preset 0 → 모든 호출이 config 에러인 죽은 옵션. 6-lens `council` preset(evidence/coverage/risk ∥ feasibility/simplicity/adversarial, 3×2 stage)을 추가해 소생.

## 검증

- `test_fusion` 89/89 (+2: council staged-eligible 계약 고정, 2-judge 비자격 가드 — 회귀 시 여기서 잡힘)
- `test_runtime_config_validity` 38/38, `test_keeper_structured_output_coverage` 19/19 (judge 런타임 전부 structured-output 선언 모델만 사용)
- 대시보드: 기존 fusion judge topology 렌더(`classifyFusionJudgeShape`)가 stage meta 노드를 이미 표현 — UI 추가 배선 불필요

## 사용

`masc_fusion preset="council" topology="staged_judge_of_judges"` (같은 preset으로 `judge_of_judges`도 사용 가능 — 6 lens 병렬 후 meta)

지도: claude.ai/code/artifact/01478ad0 · RFC-0283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
