### PR TITLE
fix(keeper): freeze max tokens once per turn

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -203,9 +203,10 @@ end
     @param temperature Subsystem temperature fallback; a selected runtime model
            declaration takes precedence. When omitted,
            [Keeper_config.keeper_unified_temperature] is the fallback.
-    @param max_tokens Explicit output-token request override. [None] (the
-           default) sends no [max_tokens] field on the request — masc#24067 /
-           oas#2517: the keeper lane never synthesizes one
+    @param max_tokens Explicit caller output-token override. When omitted, the
+           turn-start profile snapshot may provide the validated keeper OAS
+           override; absent both, no [max_tokens] field is sent. The keeper lane
+           never synthesizes a model-derived value (masc#24067 / oas#2517)
     @param is_retry When [true], replays the current user message into the
            working context without persisting it again, so transient retry
            attempts do not duplicate the user entry in session history *)
@@ -362,11 +363,12 @@ let run_turn
       ~generation
       ()
   in
-  let requested_max_tokens = max_tokens in
   let meta = ctx.meta in
   let temperature = ctx.temperature in
-  (* Carry explicit caller/profile intent only. OAS owns model ceiling
-     validation and envelope-specific clamp/fallback policy. *)
+  (* The single turn-start snapshot. This exact binding feeds every runtime
+     candidate, OAS provider/lifecycle config, and the Turn_record sampling
+     payload below. OAS owns model-ceiling validation and envelope-specific
+     clamp/fallback policy. *)
   let max_tokens = ctx.max_tokens in
   let context_injector = ctx.context_injector in
   let shared_context = ctx.shared_context in
@@ -693,14 +695,6 @@ let run_turn
               let keeper_oas_guardrails =
                 keeper_oas_visibility_neutral_guardrails ?guardrails ()
               in
-              let max_tokens_for_runtime ~runtime_id =
-                Keeper_run_context.resolve_max_tokens_for_runtime_with_profile
-                  ~keeper_name:meta.name
-                  ~profile_defaults
-                  ~runtime_id
-                  ?max_tokens:requested_max_tokens
-                  ()
-              in
               (* Autonomous cooperative yield: OAS checks [exit_condition]
                  before the first provider dispatch as well as between turns.
                  A scheduled-idle waiting chat may preempt immediately, but a
@@ -799,7 +793,6 @@ let run_turn
                     ~body_timeout_s:timeout_s
                     ~temperature
                     ?max_tokens
-                    ~max_tokens_for_runtime
                     ~accept:
                       Keeper_tool_response.response_has_text_or_tool_progress
                     ~guardrails:keeper_oas_guardrails

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -137,9 +137,10 @@ val per_provider_timeout_for_turn
     @param guardrails Optional OAS guardrails for tool safety gates
     @param temperature Subsystem temperature fallback; a selected runtime model
            declaration takes precedence
-    @param max_tokens Explicit output-token request override. [None] (the
-           default) sends no [max_tokens] field on the request — masc#24067 /
-           oas#2517: the keeper lane never synthesizes one
+    @param max_tokens Explicit caller output-token override. When omitted, the
+           turn-start profile snapshot may provide the validated keeper OAS
+           override; absent both, no [max_tokens] field is sent. The keeper lane
+           never synthesizes a model-derived value (masc#24067 / oas#2517)
     @param on_event Optional event callback
     @param trajectory_acc Optional trajectory accumulator for recording
     @param tool_overlay Optional mutable tool overlay for dynamic tools

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -78,15 +78,9 @@ let max_tokens_override ~keeper_name profile_defaults =
     ~keeper_name
     profile_defaults.oas_env
 
-let resolve_max_tokens_for_runtime_with_profile ~keeper_name ~profile_defaults
-    ~runtime_id:(_ : string) ?max_tokens ()
-  =
+let resolve_turn_max_tokens ~keeper_name ~profile_defaults ?max_tokens () =
   match max_tokens with
-  (* Explicit caller override passes through unchanged; the OAS provider
-     serializer owns validation/clamp against the catalog ceiling
-     (oas#2517). The former [cap_max_tokens_to_runtime_ceiling] here was an
-     identity stub. *)
-  | Some _ as override -> override
+  | Some _ as caller_override -> caller_override
   | None -> max_tokens_override ~keeper_name profile_defaults
 
 let prepare_run_context
@@ -125,11 +119,13 @@ let prepare_run_context
       ~fallback:fallback_temperature
   in
   let max_tokens =
-    resolve_max_tokens_for_runtime_with_profile
+    (* Freeze caller/profile intent exactly once for this turn. Every runtime
+       candidate receives this immutable value; OAS owns provider-envelope
+       validation and catalog-ceiling clamp policy (oas#2517). *)
+    resolve_turn_max_tokens
       ~keeper_name:meta.name
       ~profile_defaults
       ?max_tokens
-      ~runtime_id
       ()
   in
   (* 0b. Create context injector for temporal awareness *)

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -36,23 +36,16 @@ val build_base_system_prompt :
 (** Build the keeper base system prompt from the same persisted meta/profile
     inputs used by {!prepare_run_context}. *)
 
-val resolve_max_tokens_for_runtime_with_profile :
+val resolve_turn_max_tokens :
      keeper_name:string
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
-  -> runtime_id:string
   -> ?max_tokens:int
   -> unit
   -> int option
-(** Resolve the keeper turn max-token request value for a concrete runtime id.
-
-    [Some caller_override] wins when [max_tokens] is an explicit argument
-    and passes through unchanged (the OAS provider serializer owns
-    validation/clamp against the catalog ceiling, oas#2517).
-    Otherwise, an explicit per-keeper profile/env override
-    ([MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS] via
-    {!Keeper_types_profile.unified_max_tokens_override_of_oas_env}) wins.
-    Absent both, the result is [None]: the caller must not synthesize a
-    request value — no [max_tokens] field goes on the request. *)
+(** Resolve output-token intent exactly once at turn start. An explicit caller
+    value wins; otherwise the validated keeper profile override is used.
+    Absent both, return [None]. Runtime candidates must receive this result
+    unchanged. *)
 
 val prepare_run_context :
      config:Workspace.config
@@ -69,4 +62,6 @@ val prepare_run_context :
   -> run_context
 (** Resolve [temperature] as the caller fallback; a temperature declared by the
     selected runtime model always wins. [profile_defaults] is the immutable
-    pre-dispatch snapshot and is never reloaded inside this function. *)
+    pre-dispatch snapshot. [max_tokens] is resolved once from the explicit
+    caller value or that snapshot and remains unchanged for every runtime
+    candidate in this turn. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -338,11 +338,10 @@ type attempt_inference_policy =
   }
 
 let attempt_inference_policy
-    ?max_tokens_for_runtime
     ~runtime_id
     ~fallback_temperature
     ~fallback_enable_thinking
-    ~fallback_max_tokens
+    ~turn_max_tokens
     ()
   =
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
@@ -356,15 +355,12 @@ let attempt_inference_policy
     | Some _ as enabled -> enabled
     | None -> fallback_enable_thinking
   in
-  let attempt_max_tokens =
-    match max_tokens_for_runtime with
-    | Some resolver -> resolver ~runtime_id
-    | None -> fallback_max_tokens
-  in
+  (* Temperature/thinking are runtime capabilities. Output-token intent is a
+     turn input, so candidate selection must not reinterpret or reload it. *)
   { attempt_temperature
   ; attempt_enable_thinking
   ; attempt_preserve_thinking = runtime_seed.preserve_thinking
-  ; attempt_max_tokens
+  ; attempt_max_tokens = turn_max_tokens
   }
 
 let run_named
@@ -387,7 +383,6 @@ let run_named
        means [None] — no request [max_tokens] field, not a synthesized
        fallback. *)
     ?max_tokens
-    ?max_tokens_for_runtime
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?guardrails
     ?hooks
@@ -676,11 +671,10 @@ let run_named
       let error_runtime_id = attempt_runtime_id in
       let inference_policy =
         attempt_inference_policy
-          ?max_tokens_for_runtime
           ~runtime_id:attempt_runtime_id
           ~fallback_temperature:temperature
           ~fallback_enable_thinking:enable_thinking
-          ~fallback_max_tokens:max_tokens
+          ~turn_max_tokens:max_tokens
           ()
       in
       let final_runtime_context_window =

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -117,7 +117,6 @@ val run_named :
   ?body_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
-  ?max_tokens_for_runtime:(runtime_id:string -> int option) ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?guardrails:Agent_sdk.Guardrails.t ->
   ?hooks:Agent_sdk.Hooks.hooks ->
@@ -160,7 +159,8 @@ val run_named :
 (** Run a single [Agent.run] call with MASC-driven runtime model fallback.
     MASC drives the runtime FSM directly: resolves runtime providers,
     resolves each candidate's model temperature before trying it with OAS, and
-    uses [Runtime_fsm.decide] on failure.
+    uses [Runtime_fsm.decide] on failure. The optional [max_tokens] value is a
+    turn-start snapshot shared unchanged by every candidate.
     The runtime loop runs inside a capacity-managed queue permit. *)
 
 type attempt_inference_policy =
@@ -258,11 +258,10 @@ module For_testing : sig
     (context_window_rebudget, Agent_sdk.Error.sdk_error) result
 
   val attempt_inference_policy :
-    ?max_tokens_for_runtime:(runtime_id:string -> int option) ->
     runtime_id:string ->
     fallback_temperature:float ->
     fallback_enable_thinking:bool option ->
-    fallback_max_tokens:int option ->
+    turn_max_tokens:int option ->
     unit ->
     attempt_inference_policy
 

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -351,30 +351,16 @@ let test_resolve_assignment_to_single_runtime () =
 let test_attempt_inference_policy_uses_attempt_runtime () =
   with_model_catalog_content runtime_thinking_lane_model_catalog @@ fun () ->
   with_runtime_config runtime_toml_thinking_lane (fun () ->
-    let max_tokens_for_runtime ~runtime_id =
-      Masc.Keeper_run_context.resolve_max_tokens_for_runtime_with_profile
-        ~keeper_name:"policy-test"
-        ~profile_defaults:Masc.Keeper_types_profile.empty_keeper_profile_defaults
-        ~runtime_id
-        ()
-    in
-    (* masc#24067 / oas#2517: [max_tokens_for_runtime] above always resolves
-       through [Keeper_run_context.resolve_max_tokens_for_runtime_with_profile]
-       with no
-       caller override and an unconfigured "policy-test" keeper profile, so
-       every candidate below gets [None] — including the reasoning candidate,
-       which under the deleted [Runtime_inference.resolve_max_tokens] used to
-       size itself from the OAS catalog ceiling. [fallback_max_tokens] is
-       [None] in all three calls because a resolver is always supplied, so it
-       is never consulted; see [test_max_tokens_for_runtime_omitted_uses_fallback]
-       below for the branch where it is. *)
+    (* Runtime candidates still resolve their own thinking and temperature
+       policy. The turn's max-token intent is an independent immutable input;
+       [None] remains [None] for every candidate and is never synthesized from
+       the model catalog. *)
     let lane_policy =
       Driver.For_testing.attempt_inference_policy
-        ~max_tokens_for_runtime
         ~runtime_id:"mixed"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:None
-        ~fallback_max_tokens:None
+        ~turn_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -395,11 +381,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       lane_policy.Driver.attempt_max_tokens;
     let thinking_policy =
       Driver.For_testing.attempt_inference_policy
-        ~max_tokens_for_runtime
         ~runtime_id:"thinking.reasoning_big"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some false)
-        ~fallback_max_tokens:None
+        ~turn_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -421,11 +406,10 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       thinking_policy.Driver.attempt_max_tokens;
     let non_thinking_policy =
       Driver.For_testing.attempt_inference_policy
-        ~max_tokens_for_runtime
         ~runtime_id:"plain.non_reasoning"
         ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some true)
-        ~fallback_max_tokens:None
+        ~turn_max_tokens:None
         ()
     in
     Alcotest.(check (option bool))
@@ -446,55 +430,36 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       None
       non_thinking_policy.Driver.attempt_max_tokens)
 
-(* masc#24067 / oas#2517 regression: when the caller supplies no
-   [max_tokens_for_runtime] resolver at all, [attempt_inference_policy] must
-   still honor an explicit [fallback_max_tokens] verbatim — the option
-   contract only forbids *synthesizing* a value, not carrying one the caller
-   deliberately provided. *)
-let test_max_tokens_for_runtime_omitted_uses_fallback () =
+let max_tokens_of_policy ~turn_max_tokens runtime_id =
   let policy =
     Driver.For_testing.attempt_inference_policy
-      ~runtime_id:"mixed"
+      ~runtime_id
       ~fallback_temperature:0.25
       ~fallback_enable_thinking:None
-      ~fallback_max_tokens:(Some 4096)
+      ~turn_max_tokens
       ()
   in
-  Alcotest.(check (option int))
-    "no resolver supplied -> caller fallback_max_tokens passes through"
-    (Some 4096)
-    policy.Driver.attempt_max_tokens;
-  let policy_no_fallback =
-    Driver.For_testing.attempt_inference_policy
-      ~runtime_id:"mixed"
-      ~fallback_temperature:0.25
-      ~fallback_enable_thinking:None
-      ~fallback_max_tokens:None
-      ()
-  in
-  Alcotest.(check (option int))
-    "no resolver, no fallback -> None (never synthesized)"
-    None
-    policy_no_fallback.Driver.attempt_max_tokens
+  policy.Driver.attempt_max_tokens
 
-let test_explicit_max_tokens_survives_each_failover_candidate () =
-  let max_tokens_for_runtime ~runtime_id:_ = Some 4096 in
-  List.iter
-    (fun runtime_id ->
-      let policy =
-        Driver.For_testing.attempt_inference_policy
-          ~max_tokens_for_runtime
-          ~runtime_id
-          ~fallback_temperature:0.25
-          ~fallback_enable_thinking:None
-          ~fallback_max_tokens:None
-          ()
-      in
-      Alcotest.(check (option int))
-        (runtime_id ^ " preserves explicit max_tokens")
-        (Some 4096)
-        policy.Driver.attempt_max_tokens)
-    [ "primary.test_model"; "fallback.test_model" ]
+let test_turn_max_tokens_snapshot_is_stable_across_candidates () =
+  let profile_at_turn_start = Some 4096 in
+  let turn_max_tokens = profile_at_turn_start in
+  let profile_after_first_candidate = Some 8192 in
+  Alcotest.(check (option int))
+    "first candidate receives turn-start snapshot"
+    (Some 4096)
+    (max_tokens_of_policy ~turn_max_tokens "primary.test_model");
+  Alcotest.(check (option int))
+    "fallback candidate ignores profile revision during current turn"
+    (Some 4096)
+    (max_tokens_of_policy ~turn_max_tokens "fallback.test_model");
+  let next_turn_max_tokens = profile_after_first_candidate in
+  Alcotest.(check (option int))
+    "next turn receives revised profile snapshot"
+    (Some 8192)
+    (max_tokens_of_policy
+       ~turn_max_tokens:next_turn_max_tokens
+       "primary.test_model")
 
 let test_resolve_assignment_missing () =
   with_runtime_config runtime_toml_with_lane (fun () ->
@@ -998,13 +963,9 @@ let () =
             `Quick
             test_attempt_inference_policy_uses_attempt_runtime;
           Alcotest.test_case
-            "max_tokens_for_runtime omitted uses caller fallback (masc#24067)"
+            "turn max_tokens snapshot survives failover and refreshes next turn"
             `Quick
-            test_max_tokens_for_runtime_omitted_uses_fallback;
-          Alcotest.test_case
-            "explicit max_tokens survives every failover candidate (masc#24067)"
-            `Quick
-            test_explicit_max_tokens_survives_each_failover_candidate;
+            test_turn_max_tokens_snapshot_is_stable_across_candidates;
           Alcotest.test_case
             "attempt loop stops on nonretryable failure"
             `Quick

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1527,45 +1527,35 @@ let test_seed_of_thinking_support_gate_contract () =
     (Runtime_inference.seed_of_thinking_support None).Runtime_inference.thinking_enabled
 ;;
 
-(* ---- masc#24067 / oas#2517: the keeper lane must not synthesize a request
-   [max_tokens] value. [Runtime_inference.resolve_max_tokens] — which sized a
-   reasoning turn from the model's declared OAS output ceiling, and otherwise
-   fell back to a flat keeper default — is deleted: BOTH arms invented a
-   request value the model catalog ceiling was never meant to supply. MASC
-   keeps that ceiling observable but does not reinterpret it as a request;
-   OAS owns envelope-specific validation and clamp policy.
-   [Keeper_run_context.resolve_max_tokens_for_runtime_with_profile] replaces it
-   with a two-source-only contract: an explicit caller [?max_tokens] argument,
-   or a per-keeper [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS] profile override
-   (exercised separately in test_keeper_toml.ml's oas_env tests). Absent both,
-   [None] — no [max_tokens] field goes on the OAS request, regardless of
-   whether the runtime is a reasoning model with a declared catalog ceiling. ---- *)
-
-let test_resolve_max_tokens_for_runtime_no_override_is_none () =
-  with_runtime_thinking (fun () ->
-    Alcotest.(check (option int))
-      "unconfigured keeper + no caller override sends no max_tokens, even for \
-       a reasoning runtime with a declared catalog ceiling"
-      None
-      (Keeper_run_context.resolve_max_tokens_for_runtime_with_profile
-         ~keeper_name:"masc24067-unconfigured-keeper"
-         ~profile_defaults:Keeper_types_profile.empty_keeper_profile_defaults
-         ~runtime_id:"ollama_cloud.thinkdefault"
-         ()))
-;;
-
-let test_resolve_max_tokens_for_runtime_caller_override_is_some () =
-  with_runtime_thinking (fun () ->
-    Alcotest.(check (option int))
-      "explicit caller max_tokens argument passes through as Some, unchanged \
-       by the target runtime's catalog ceiling"
-      (Some 4096)
-      (Keeper_run_context.resolve_max_tokens_for_runtime_with_profile
-         ~keeper_name:"masc24067-unconfigured-keeper"
-         ~profile_defaults:Keeper_types_profile.empty_keeper_profile_defaults
-         ~runtime_id:"ollama_cloud.thinkdefault"
-         ~max_tokens:4096
-         ()))
+let test_resolve_turn_max_tokens_precedence () =
+  let profile_defaults =
+    { Keeper_types_profile.empty_keeper_profile_defaults with
+      oas_env =
+        [ Keeper_types_profile.keeper_unified_max_tokens_oas_env_key, "4096" ]
+    }
+  in
+  Alcotest.(check (option int))
+    "profile supplies turn-start output-token intent"
+    (Some 4096)
+    (Keeper_run_context.resolve_turn_max_tokens
+       ~keeper_name:"max-token-snapshot"
+       ~profile_defaults
+       ());
+  Alcotest.(check (option int))
+    "explicit caller value wins over profile"
+    (Some 2048)
+    (Keeper_run_context.resolve_turn_max_tokens
+       ~keeper_name:"max-token-snapshot"
+       ~profile_defaults
+       ~max_tokens:2048
+       ());
+  Alcotest.(check (option int))
+    "absence remains None"
+    None
+    (Keeper_run_context.resolve_turn_max_tokens
+       ~keeper_name:"max-token-snapshot"
+       ~profile_defaults:Keeper_types_profile.empty_keeper_profile_defaults
+       ())
 ;;
 
 let test_max_output_tokens_accessor_projects_catalog () =
@@ -1927,15 +1917,11 @@ let () =
             `Quick
             test_seed_of_thinking_support_gate_contract
         ] )
-    ; ( "reasoning max_tokens resolution"
+    ; ( "runtime token capacity projection"
       , [ Alcotest.test_case
-            "no override configured -> None (masc#24067 / oas#2517)"
+            "turn-start max_tokens precedence"
             `Quick
-            test_resolve_max_tokens_for_runtime_no_override_is_none
-        ; Alcotest.test_case
-            "explicit caller override -> Some (masc#24067 / oas#2517)"
-            `Quick
-            test_resolve_max_tokens_for_runtime_caller_override_is_some
+            test_resolve_turn_max_tokens_precedence
         ; Alcotest.test_case
             "max_output_tokens_of_runtime_id projects catalog ceiling"
             `Quick


### PR DESCRIPTION
## Summary

- delete the runtime-candidate `max_tokens_for_runtime` callback and its stale public resolver API
- resolve caller/profile output-token intent exactly once in `prepare_run_context`
- pass the same immutable `int option` to every lane/failover candidate, provider request config, lifecycle telemetry, and Turn record
- retain runtime-specific temperature/thinking capability resolution without reinterpreting output-token intent
- replace resolver/fallback tests with turn-start precedence and cross-candidate snapshot regressions

Closes #24125.

## Contract

- explicit caller `max_tokens` wins
- otherwise the validated Keeper profile override wins
- absent both, the result is `None`; MASC does not synthesize a model-derived request value
- runtime/fallback selection cannot reload or alter this value during the turn
- a profile edit becomes visible only to the next turn

## Stack

This Draft is intentionally based on `codex/keeper-profile-fail-closed-24126-20260711@c747d0cea0cbdcd62ce686d6cd120ba16df237fa` (#24144). That lower PR supplies the typed, immutable profile snapshot consumed here.

Do not merge this PR before #24144. After #24144 lands, rebase onto main and run exact-head CI again.

## Validation

- OCaml parser pass for 8 changed `.ml`/`.mli` files
- `ocamlformat --check` pass for 8 changed `.ml`/`.mli` files
- `ocamldep` pass for 8 changed `.ml`/`.mli` files
- `git diff --check`
- removed-symbol sweep: `max_tokens_for_runtime`, `fallback_max_tokens`, `resolve_max_tokens_for_runtime`, and `requested_max_tokens` are absent from `lib/keeper` and tests
- no local Dune; PR CI is the build/test authority

## Merge guard

Keep Draft + `status:do-not-merge` until the lower stack lands, exact-head CI completes, and fresh independent adversarial review passes. Do not use admin bypass.
