### PR TITLE
feat(keeper): finalize durable shutdown operations

### DIFF
--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -48,6 +48,7 @@ type owned_active_task =
 
 type owned_active_tasks_snapshot =
   { tasks : owned_active_task list
+  ; backlog_tasks : Masc_domain.task list
   ; backlog_version : int
   }
 
@@ -82,7 +83,7 @@ let owned_active_tasks_snapshot_for_names ~(config : Workspace.config)
           | Masc_domain.Done _
           | Masc_domain.Cancelled _ -> None)
       in
-      Ok { tasks; backlog_version = backlog.version }
+      Ok { tasks; backlog_tasks = backlog.tasks; backlog_version = backlog.version }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -46,7 +46,12 @@ type owned_active_task =
   ; task : Masc_domain.task
   }
 
-let owned_active_tasks_for_names ~(config : Workspace.config)
+type owned_active_tasks_snapshot =
+  { tasks : owned_active_task list
+  ; backlog_version : int
+  }
+
+let owned_active_tasks_snapshot_for_names ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) names =
   let matches assignee = List.mem assignee names in
   try
@@ -61,21 +66,23 @@ let owned_active_tasks_for_names ~(config : Workspace.config)
         message;
       Error message
     | Ok backlog ->
-      backlog.tasks
-      |> List.filter_map (fun (task : Masc_domain.task) ->
-           match task.task_status with
-           | Masc_domain.Claimed { assignee; _ }
-           | Masc_domain.InProgress { assignee; _ }
-             when matches assignee ->
-               task_id_of_owned_active_task ~keeper_name:meta.name task
-               |> Option.map (fun task_id -> { task_id; task })
-           | Masc_domain.Claimed _
-           | Masc_domain.InProgress _
-           | Masc_domain.AwaitingVerification _
-           | Masc_domain.Todo
-           | Masc_domain.Done _
-           | Masc_domain.Cancelled _ -> None)
-      |> fun tasks -> Ok tasks
+      let tasks =
+        backlog.tasks
+        |> List.filter_map (fun (task : Masc_domain.task) ->
+          match task.task_status with
+          | Masc_domain.Claimed { assignee; _ }
+          | Masc_domain.InProgress { assignee; _ }
+            when matches assignee ->
+            task_id_of_owned_active_task ~keeper_name:meta.name task
+            |> Option.map (fun task_id -> { task_id; task })
+          | Masc_domain.Claimed _
+          | Masc_domain.InProgress _
+          | Masc_domain.AwaitingVerification _
+          | Masc_domain.Todo
+          | Masc_domain.Done _
+          | Masc_domain.Cancelled _ -> None)
+      in
+      Ok { tasks; backlog_version = backlog.version }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -88,6 +95,10 @@ let owned_active_tasks_for_names ~(config : Workspace.config)
       "owned task reconciliation failed: %s"
       message;
     Error message
+
+let owned_active_tasks_for_names ~config ~meta names =
+  owned_active_tasks_snapshot_for_names ~config ~meta names
+  |> Result.map (fun snapshot -> snapshot.tasks)
 
 let owned_active_tasks_for_meta ~(config : Workspace.config)
     ~(meta : Keeper_meta_contract.keeper_meta) =
@@ -109,6 +120,22 @@ let owned_active_tasks_for_meta_strict ~(config : Workspace.config)
       detail;
     Error detail
   | Ok names -> owned_active_tasks_for_names ~config ~meta names
+;;
+
+let owned_active_tasks_snapshot_for_meta_strict ~(config : Workspace.config)
+    ~(meta : Keeper_meta_contract.keeper_meta) =
+  match resolved_agent_names_result ~config ~agent_name:meta.agent_name with
+  | Error detail ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ReconcileFailures)
+      ~labels:[ "keeper", meta.name; "phase", "shutdown_resolve_agent" ]
+      ();
+    Log.Keeper.warn
+      ~keeper_name:meta.name
+      "shutdown task ownership resolution failed: %s"
+      detail;
+    Error detail
+  | Ok names -> owned_active_tasks_snapshot_for_names ~config ~meta names
 ;;
 
 let active_status_rank = function

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -5,6 +5,11 @@ type owned_active_task = {
   task : Masc_domain.task;
 }
 
+type owned_active_tasks_snapshot =
+  { tasks : owned_active_task list
+  ; backlog_version : int
+  }
+
 (** Return every Claimed/InProgress backlog task owned by [meta]'s agent
     binding. *)
 val owned_active_tasks_for_meta :
@@ -19,6 +24,12 @@ val owned_active_tasks_for_meta_strict :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   (owned_active_task list, string) result
+
+(** Strict ownership and the backlog CAS version captured by the same read. *)
+val owned_active_tasks_snapshot_for_meta_strict :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  (owned_active_tasks_snapshot, string) result
 
 (** Find the deterministic active task a keeper should treat as current.
 

--- a/lib/keeper/keeper_current_task_reconcile.mli
+++ b/lib/keeper/keeper_current_task_reconcile.mli
@@ -7,6 +7,7 @@ type owned_active_task = {
 
 type owned_active_tasks_snapshot =
   { tasks : owned_active_task list
+  ; backlog_tasks : Masc_domain.task list
   ; backlog_version : int
   }
 
@@ -25,7 +26,9 @@ val owned_active_tasks_for_meta_strict :
   meta:Keeper_meta_contract.keeper_meta ->
   (owned_active_task list, string) result
 
-(** Strict ownership and the backlog CAS version captured by the same read. *)
+(** Strict ownership, task records, and the backlog CAS version captured by the
+    same read. The complete task snapshot lets lifecycle transactions reconcile
+    their own durable receipts without racing a second backlog read. *)
 val owned_active_tasks_snapshot_for_meta_strict :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1022,6 +1022,8 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         in
         let terminalize_lane = function
           | Keeper_lane.Completed -> record_completed_lane ()
+          | Keeper_lane.Shutdown_before_start ->
+            record_stopped "shutdown requested before lane start"
           | Keeper_lane.Shutdown_requested -> record_stopped "shutdown requested"
           | Keeper_lane.Cancelled_by_parent _ ->
             if Atomic.get stop || Shutdown.is_shutting_down_global ()

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -888,11 +888,25 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
           ~keeper_name:m.name
           ~detail:(Keeper_registry.spawn_slot_denial_reason_to_detail reason)
           ()
-      | Ok () -> (
+      | Ok () ->
       (* Register in Keeper_registry first — single source of truth. *)
-      let reg =
-        Keeper_registry.register_offline ~base_path:ctx.config.base_path m.name m
-      in
+      (match
+         Keeper_registry.register_offline_if_admitted
+           ~base_path:ctx.config.base_path
+           m.name
+           m
+       with
+       | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+         Log.Keeper.info
+           "start_keepalive: skipped %s because shutdown operation %s owns admission"
+           m.name
+           (Keeper_shutdown_types.Operation_id.to_string operation_id)
+       | Error (Keeper_registry.Registration_invalid validation_error) ->
+         Log.Keeper.error
+           "start_keepalive: registry validation rejected %s: %s"
+           m.name
+           (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+       | Ok reg ->
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,5 +1,6 @@
 type outcome =
   | Completed
+  | Shutdown_before_start
   | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn
@@ -150,7 +151,7 @@ let rec request_cancel t =
       Atomic.set t.state Exited;
       Eio.Promise.resolve
         t.exited_r
-        { outcome = Shutdown_requested; cleanup_error = None };
+        { outcome = Shutdown_before_start; cleanup_error = None };
       Cancel_requested)
     else request_cancel t
   | Starting ->

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -16,6 +16,7 @@ end
 
 type outcome =
   | Completed
+  | Shutdown_before_start
   | Shutdown_requested
   | Cancelled_by_parent of exn
   | Failed of exn

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -304,31 +304,57 @@ let persist_meta config path persisted =
   | Error msg -> Error (Printf.sprintf "failed to write meta %s: %s" path msg)
 ;;
 
+type write_meta_error =
+  | Version_conflict of
+      { keeper_name : string
+      ; expected : int
+      ; actual : int
+      }
+  | Read_failed of string
+  | Persist_failed of string
+
+let write_meta_error_to_string = function
+  | Version_conflict { keeper_name; expected; actual } ->
+    Printf.sprintf
+      "meta version conflict for %s: expected %d, disk has %d"
+      keeper_name
+      expected
+      actual
+  | Read_failed detail | Persist_failed detail -> detail
+;;
+
 (* Version CAS only — there is no force/bypass path. Cumulative usage
    counters are a monotone invariant (RFC-0225 §3.2, RFC-0237); a caller that
    lost the race must resolve the conflict through [write_meta_with_merge],
    never overwrite the disk snapshot. *)
-let write_meta config (m : Keeper_meta_contract.keeper_meta) : (unit, string) result =
+let write_meta_typed config (m : Keeper_meta_contract.keeper_meta) =
   let path = keeper_meta_path config m.name in
+  File_lock_eio.with_mutex path (fun () ->
   match read_meta_file_path path with
   | Ok (Some existing) ->
     if existing.meta_version <> m.meta_version
     then
       Error
-        (Printf.sprintf
-           "meta version conflict for %s: expected %d, disk has %d"
-           m.name
-           m.meta_version
-           existing.meta_version)
+        (Version_conflict
+           { keeper_name = m.name
+           ; expected = m.meta_version
+           ; actual = existing.meta_version
+           })
     else (
       let persisted = { m with meta_version = m.meta_version + 1 } in
-      persist_meta config path persisted)
+      persist_meta config path persisted |> Result.map_error (fun error -> Persist_failed error))
   | Ok None ->
     (* No existing file: initial write. *)
     let persisted = { m with meta_version = 1 } in
-    persist_meta config path persisted
+    persist_meta config path persisted |> Result.map_error (fun error -> Persist_failed error)
   | Error msg ->
-    Error (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)
+    Error
+      (Read_failed
+         (Printf.sprintf "failed to read existing meta for CAS %s: %s" path msg)))
+;;
+
+let write_meta config m =
+  write_meta_typed config m |> Result.map_error write_meta_error_to_string
 ;;
 
 let is_version_conflict_error msg =
@@ -420,11 +446,12 @@ let write_meta_with_merge
   =
   let path = keeper_meta_path config m.name in
   let rec attempt n (caller : Keeper_meta_contract.keeper_meta) =
-    match write_meta config caller with
+    match write_meta_typed config caller with
     | Ok () -> Ok ()
-    | Error msg when n >= max_retries -> Error msg
-    | Error msg when not (is_version_conflict_error msg) -> Error msg
-    | Error _ ->
+    | Error error when n >= max_retries -> Error (write_meta_error_to_string error)
+    | Error ((Read_failed _ | Persist_failed _) as error) ->
+      Error (write_meta_error_to_string error)
+    | Error (Version_conflict _) ->
       (match read_meta_file_path path with
        | Ok (Some latest) ->
          Otel_metric_store.inc_counter
@@ -446,4 +473,74 @@ let write_meta_with_merge
          Error (Printf.sprintf "write_meta retry: failed to re-read for CAS: %s" read_msg))
   in
   attempt 0 m
+;;
+
+type identity_update_error =
+  | Identity_missing
+  | Identity_changed
+  | Identity_read_failed of string
+  | Identity_write_failed of string
+
+let identity_update_error_to_string = function
+  | Identity_missing -> "Keeper metadata is absent"
+  | Identity_changed -> "Keeper metadata identity changed"
+  | Identity_read_failed detail -> detail
+  | Identity_write_failed detail -> detail
+;;
+
+let update_meta_if_identity
+      config
+      ~name
+      ~trace_id
+      ~generation
+      update
+  =
+  let path = keeper_meta_path config name in
+  File_lock_eio.with_mutex path (fun () ->
+    match read_meta_file_path path with
+    | Error detail -> Error (Identity_read_failed detail)
+    | Ok None -> Error Identity_missing
+    | Ok (Some latest) ->
+      if
+        not (Keeper_id.Trace_id.equal latest.runtime.trace_id trace_id)
+        || not (Int.equal latest.runtime.generation generation)
+      then Error Identity_changed
+      else
+        let caller = update latest in
+        let persisted = { caller with meta_version = latest.meta_version + 1 } in
+        (match persist_meta config path persisted with
+         | Ok () -> Ok persisted
+         | Error detail -> Error (Identity_write_failed detail)))
+;;
+
+type identity_remove_error =
+  | Remove_identity_missing
+  | Remove_identity_changed
+  | Remove_identity_read_failed of string
+  | Remove_identity_unlink_failed of string
+
+let identity_remove_error_to_string = function
+  | Remove_identity_missing -> "Keeper metadata is absent"
+  | Remove_identity_changed -> "Keeper metadata identity changed"
+  | Remove_identity_read_failed detail | Remove_identity_unlink_failed detail -> detail
+;;
+
+let remove_meta_if_identity config ~name ~trace_id ~generation =
+  let path = keeper_meta_path config name in
+  File_lock_eio.with_mutex path (fun () ->
+    match read_meta_file_path path with
+    | Error detail -> Error (Remove_identity_read_failed detail)
+    | Ok None -> Error Remove_identity_missing
+    | Ok (Some latest) ->
+      if
+        not (Keeper_id.Trace_id.equal latest.runtime.trace_id trace_id)
+        || not (Int.equal latest.runtime.generation generation)
+      then Error Remove_identity_changed
+      else
+        try
+          Unix.unlink path;
+          Ok ()
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Error (Remove_identity_unlink_failed (Printexc.to_string exn)))
 ;;

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -115,6 +115,42 @@ val write_meta :
   Keeper_meta_contract.keeper_meta ->
   (unit, string) result
 
+type identity_update_error =
+  | Identity_missing
+  | Identity_changed
+  | Identity_read_failed of string
+  | Identity_write_failed of string
+
+val identity_update_error_to_string : identity_update_error -> string
+
+(** Re-read and CAS-update [name] only while its trace/generation identity
+    matches the shutdown snapshot. Every CAS retry rechecks identity before
+    applying [update], so a replacement generation is never overwritten. *)
+val update_meta_if_identity :
+  Workspace.config ->
+  name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  generation:int ->
+  (Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta) ->
+  (Keeper_meta_contract.keeper_meta, identity_update_error) result
+
+type identity_remove_error =
+  | Remove_identity_missing
+  | Remove_identity_changed
+  | Remove_identity_read_failed of string
+  | Remove_identity_unlink_failed of string
+
+val identity_remove_error_to_string : identity_remove_error -> string
+
+(** Remove [name]'s meta only while the same trace/generation still occupies
+    the path. This shares the per-path lock used by [write_meta]. *)
+val remove_meta_if_identity :
+  Workspace.config ->
+  name:string ->
+  trace_id:Keeper_id.Trace_id.t ->
+  generation:int ->
+  (unit, identity_remove_error) result
+
 (** [true] iff [msg] matches [version_conflict_re]. *)
 val is_version_conflict_error : string -> bool
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -36,6 +36,19 @@ val register : base_path:string -> string -> keeper_meta -> registry_entry
     runtime actually launches the fiber. *)
 val register_offline : base_path:string -> string -> keeper_meta -> registry_entry
 
+type registration_error =
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_invalid of registry_entry_validation_error
+
+(** Production registration gate: the final registry CAS is serialized with
+    Keeper shutdown reservation. Event-queue loading remains outside the
+    non-yielding fence critical section. *)
+val register_offline_if_admitted :
+  base_path:string ->
+  string ->
+  keeper_meta ->
+  (registry_entry, registration_error) result
+
 (** R-A-6.a — error variant for [register_restarting].
     [Budget_already_exhausted] is returned (not raised — the API is
     Result-based) when the caller attempts to revive a keeper whose
@@ -43,6 +56,7 @@ val register_offline : base_path:string -> string -> keeper_meta -> registry_ent
     violate TLA+ §S3 BudgetNeverRevives. *)
 type register_restarting_error =
   | Budget_already_exhausted of { name : string }
+  | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
 (** Register a keeper that is about to relaunch after a crash.
     The entry starts in [Restarting] and must receive [Fiber_started] when the

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -389,7 +389,12 @@ let refresh_entry_event_queue_from_persistence ~base_path name entry =
   loop ()
 ;;
 
-let register_with_state
+type registration_error =
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_invalid of registry_entry_validation_error
+
+let register_with_state_result
+      ~respect_shutdown_fence
       ~base_path
       name
       meta
@@ -404,15 +409,6 @@ let register_with_state
     (Keeper_state_machine.phase_to_string phase);
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
-  (match StringMap.find_opt key (Atomic.get registry) with
-   | Some entry when entry.phase = Running ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string LifecycleDispatchRejections)
-       ~labels:[ "keeper", name; "event", "register_overwrite_running" ]
-       ();
-     Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
-     decr_running_count_clamped ()
-   | _ -> ());
   let initial_event_queue =
     Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
   in
@@ -454,15 +450,64 @@ let register_with_state
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
-  (* fire-and-forget: put_entry validates and logs on failure; the constructed entry is always used. *)
-  ignore (put_entry ~base_path name entry);
-  if phase = Running then Atomic.incr running_count_atomic;
-  Log.Keeper.debug
-    "registry: keeper registered name=%s running_count=%d"
-    name
-    (Atomic.get running_count_atomic);
-  refresh_entry_event_queue_from_persistence ~base_path name entry;
-  entry
+  let commit () =
+    (match StringMap.find_opt key (Atomic.get registry) with
+     | Some prior when prior.phase = Running ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string LifecycleDispatchRejections)
+         ~labels:[ "keeper", name; "event", "register_overwrite_running" ]
+         ();
+       Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
+       decr_running_count_clamped ()
+     | Some _ | None -> ());
+    put_entry ~base_path name entry
+  in
+  let commit_result =
+    if respect_shutdown_fence
+    then
+      match
+        Keeper_turn_admission.commit_registration_if_open
+          ~base_path
+          ~keeper_name:name
+          commit
+      with
+      | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+        Error (Registration_shutdown_reserved operation_id)
+      | Keeper_turn_admission.Registration_committed (Error validation_error) ->
+        Error (Registration_invalid validation_error)
+      | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ()
+    else
+      match commit () with
+      | Ok () -> Ok ()
+      | Error validation_error -> Error (Registration_invalid validation_error)
+  in
+  match commit_result with
+  | Error _ as error -> error
+  | Ok () ->
+    if phase = Running then Atomic.incr running_count_atomic;
+    Log.Keeper.debug
+      "registry: keeper registered name=%s running_count=%d"
+      name
+      (Atomic.get running_count_atomic);
+    refresh_entry_event_queue_from_persistence ~base_path name entry;
+    Ok entry
+;;
+
+let register_with_state ~base_path name meta ~phase ~conditions =
+  match
+    register_with_state_result
+      ~respect_shutdown_fence:false
+      ~base_path
+      name
+      meta
+      ~phase
+      ~conditions
+  with
+  | Ok entry -> entry
+  | Error (Registration_invalid error) ->
+    invalid_arg (registry_entry_validation_error_to_string error)
+  | Error (Registration_shutdown_reserved _) ->
+    invalid_arg "unchecked registry registration observed a shutdown fence"
 ;;
 
 let register ~base_path name meta =
@@ -487,8 +532,27 @@ let register_offline ~base_path name meta =
   register_with_state ~base_path name meta ~phase ~conditions
 ;;
 
+let register_offline_if_admitted ~base_path name meta =
+  let conditions =
+    { Keeper_state_machine.default_conditions with
+      launch_pending = true
+    ; restart_budget_remaining = true
+    }
+  in
+  let phase = Keeper_state_machine.derive_phase conditions in
+  register_with_state_result
+    ~respect_shutdown_fence:true
+    ~base_path
+    name
+    meta
+    ~phase
+    ~conditions
+;;
+
 (** R-A-6.a — refuse to revive a keeper whose restart_budget was previously exhausted.  Pairs with TLA+ §S3 BudgetNeverRevives:  []( ~restart_budget_remaining => []( ~restart_budget_remaining ))  Witho... *)
-type register_restarting_error = Budget_already_exhausted of { name : string }
+type register_restarting_error =
+  | Budget_already_exhausted of { name : string }
+  | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
@@ -559,17 +623,26 @@ let register_restarting ~base_path name meta
     | _ ->
       let updated = StringMap.add key new_entry current in
       if Atomic.compare_and_set registry current updated
-      then (
-        Log.Keeper.info
-          "registry: registering keeper name=%s base_path=%s phase=%s"
-          name
-          base_path
-          (Keeper_state_machine.phase_to_string phase);
-        refresh_entry_event_queue_from_persistence ~base_path name new_entry;
-        Ok new_entry)
+      then Ok new_entry
       else loop ()
   in
-  loop ()
+  match
+    Keeper_turn_admission.commit_registration_if_open
+      ~base_path
+      ~keeper_name:name
+      loop
+  with
+  | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+    Error (Restart_shutdown_reserved operation_id)
+  | Keeper_turn_admission.Registration_committed (Error _ as error) -> error
+  | Keeper_turn_admission.Registration_committed (Ok registered) ->
+    Log.Keeper.info
+      "registry: registering keeper name=%s base_path=%s phase=%s"
+      name
+      base_path
+      (Keeper_state_machine.phase_to_string phase);
+    refresh_entry_event_queue_from_persistence ~base_path name registered;
+    Ok registered
 ;;
 
 type unregister_exact_result =

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -405,7 +405,7 @@ let keeper_schemas : tool_schema list = [
 
   {
     name = "masc_keeper_down";
-    description = "Stop a keeper. Optionally remove underlying files.";
+    description = "Submit a durable, non-blocking Keeper shutdown. Returns an operation_id immediately after admission is fenced and the ownership snapshot is persisted. Repeating the call returns the existing operation state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -288,7 +288,7 @@ let rec settle_tasks ~config ~meta operation settled_task_ids =
              active_snapshot.backlog_version)
 ;;
 
-let paused_meta meta =
+let paused_meta (meta : Keeper_meta_contract.keeper_meta) =
   { meta with
     current_task_id = None
   ; paused = true

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -60,11 +60,11 @@ let task_has_operation_receipt operation (task : Masc_domain.task) =
     && List.exists
          (String.equal (operation_evidence_ref operation))
          handoff.evidence_refs
-  | Masc_domain.Claimed _
-  | Masc_domain.InProgress _
-  | Masc_domain.AwaitingVerification _
-  | Masc_domain.Done _
-  | Masc_domain.Cancelled _
+  | Masc_domain.Claimed _, _
+  | Masc_domain.InProgress _, _
+  | Masc_domain.AwaitingVerification _, _
+  | Masc_domain.Done _, _
+  | Masc_domain.Cancelled _, _
   | Masc_domain.Todo, None -> false
 ;;
 

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -226,14 +226,7 @@ let rec settle_tasks ~config ~meta operation settled_task_ids =
                            latest_backlog.version
                            (current.expected_backlog_version + 1))
                     then
-                      block
-                        ~config
-                        current
-                        Task_settlement
-                        (Printf.sprintf
-                           "task release backlog version mismatch: expected %d, actual %d"
-                           (current.expected_backlog_version + 1)
-                           latest_backlog.version)
+                      settle_tasks ~config ~meta current settled
                     else
                       let settled = task_id :: settled in
                       (match
@@ -431,7 +424,7 @@ let unregister_exact operation = function
        Error "Keeper registry lane was replaced during finalization")
 ;;
 
-let release_finalized_admission ~config operation =
+let release_finalized_admission ~(config : Workspace.config) operation =
   match
     Keeper_turn_admission.rollback_shutdown
       ~base_path:config.base_path

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -78,9 +78,9 @@ let strict_backlog ~config =
   |> Result.map_error (fun detail -> detail)
 ;;
 
-let find_task backlog task_id =
+let find_task tasks task_id =
   let wire = Keeper_id.Task_id.to_string task_id in
-  List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id wire) backlog.Masc_domain.tasks
+  List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id wire) tasks
 ;;
 
 let persist_settled ~config operation ~settled_task_ids ~expected_backlog_version =
@@ -130,7 +130,7 @@ let release_task ~config operation (owned : Keeper_current_task_reconcile.owned_
     |> Result.map_error Masc_domain.masc_error_to_string
 ;;
 
-let settle_tasks ~config ~meta operation settled_task_ids =
+let rec settle_tasks ~config ~meta operation settled_task_ids =
   match
     Keeper_current_task_reconcile.owned_active_tasks_snapshot_for_meta_strict
       ~config
@@ -138,17 +138,6 @@ let settle_tasks ~config ~meta operation settled_task_ids =
   with
   | Error detail -> block ~config operation Task_settlement detail
   | Ok active_snapshot ->
-    if not (Int.equal active_snapshot.backlog_version operation.expected_backlog_version)
-    then
-      block
-        ~config
-        operation
-        Task_settlement
-        (Printf.sprintf
-           "backlog version changed before task settlement: expected %d, actual %d"
-           operation.expected_backlog_version
-           active_snapshot.backlog_version)
-    else
     let active_tasks = active_snapshot.tasks in
     let unexpected =
       List.filter
@@ -165,67 +154,138 @@ let settle_tasks ~config ~meta operation settled_task_ids =
       in
       block ~config operation Task_settlement ("new active task ownership: " ^ ids)
     else
-      match strict_backlog ~config with
-      | Error detail -> block ~config operation Task_settlement detail
-      | Ok backlog ->
-        let active_ids =
-          List.map
-            (fun task -> task.Keeper_current_task_reconcile.task_id)
-            active_tasks
-        in
-        let rec loop current settled = function
-          | [] -> Ok (current, settled)
-          | task_id :: rest when task_id_mem task_id settled -> loop current settled rest
-          | task_id :: rest ->
-            let settle_result =
-              if task_id_mem task_id active_ids
-              then
-                (match
-                   List.find_opt
-                     (fun task -> task_id_equal task.Keeper_current_task_reconcile.task_id task_id)
-                     active_tasks
-                 with
-                 | None -> Error "active task snapshot disappeared"
-                 | Some owned -> release_task ~config current owned)
-              else
-                match find_task backlog task_id with
-                | Some task when task_has_operation_receipt current task -> Ok "already released"
-                | Some _ -> Error "snapshotted task changed without shutdown receipt"
-                | None -> Error "snapshotted task disappeared from the durable backlog"
-            in
-            (match settle_result with
-             | Error detail -> block ~config current Task_settlement detail
-             | Ok _ ->
-               (match strict_backlog ~config with
-                | Error detail -> block ~config current Task_settlement detail
-                | Ok latest_backlog ->
-                  if
-                    not
-                      (Int.equal
-                         latest_backlog.version
-                         (current.expected_backlog_version + 1))
-                  then
-                    block
-                      ~config
-                      current
-                      Task_settlement
-                      (Printf.sprintf
-                         "task release backlog version mismatch: expected %d, actual %d"
-                         (current.expected_backlog_version + 1)
-                         latest_backlog.version)
-                  else
-                    let settled = task_id :: settled in
-                    (match
-                       persist_settled
-                         ~config
-                         current
-                         ~settled_task_ids:settled
-                         ~expected_backlog_version:latest_backlog.version
-                     with
-                     | Error _ as error -> error
-                     | Ok persisted -> loop persisted settled rest)))
-        in
-        loop operation settled_task_ids operation.owned_task_ids
+      let active_ids =
+        List.map
+          (fun task -> task.Keeper_current_task_reconcile.task_id)
+          active_tasks
+      in
+      let outstanding_ids =
+        List.filter
+          (fun task_id -> not (task_id_mem task_id settled_task_ids))
+          operation.owned_task_ids
+      in
+      let receipted_ids =
+        List.filter
+          (fun task_id ->
+             match find_task active_snapshot.backlog_tasks task_id with
+             | Some task -> task_has_operation_receipt operation task
+             | None -> false)
+          outstanding_ids
+      in
+      let outstanding_accounted_for receipt_ids =
+        List.for_all
+          (fun task_id ->
+             task_id_mem task_id receipt_ids || task_id_mem task_id active_ids)
+          outstanding_ids
+      in
+      if Int.equal active_snapshot.backlog_version operation.expected_backlog_version
+      then
+        if receipted_ids <> []
+        then
+          block
+            ~config
+            operation
+            Task_settlement
+            "shutdown receipt exists without a corresponding backlog version change"
+        else
+          let backlog = active_snapshot.backlog_tasks in
+          let rec loop current settled = function
+            | [] -> Ok (current, settled)
+            | task_id :: rest when task_id_mem task_id settled ->
+              loop current settled rest
+            | task_id :: rest ->
+              let settle_result =
+                if task_id_mem task_id active_ids
+                then
+                  (match
+                     List.find_opt
+                       (fun task ->
+                          task_id_equal
+                            task.Keeper_current_task_reconcile.task_id
+                            task_id)
+                       active_tasks
+                   with
+                   | None -> Error "active task snapshot disappeared"
+                   | Some owned -> release_task ~config current owned)
+                else
+                  match find_task backlog task_id with
+                  | Some task when task_has_operation_receipt current task ->
+                    Ok "already released"
+                  | Some _ -> Error "snapshotted task changed without shutdown receipt"
+                  | None -> Error "snapshotted task disappeared from the durable backlog"
+              in
+              (match settle_result with
+               | Error detail -> block ~config current Task_settlement detail
+               | Ok _ ->
+                 (match strict_backlog ~config with
+                  | Error detail -> block ~config current Task_settlement detail
+                  | Ok latest_backlog ->
+                    if
+                      not
+                        (Int.equal
+                           latest_backlog.version
+                           (current.expected_backlog_version + 1))
+                    then
+                      block
+                        ~config
+                        current
+                        Task_settlement
+                        (Printf.sprintf
+                           "task release backlog version mismatch: expected %d, actual %d"
+                           (current.expected_backlog_version + 1)
+                           latest_backlog.version)
+                    else
+                      let settled = task_id :: settled in
+                      (match
+                         persist_settled
+                           ~config
+                           current
+                           ~settled_task_ids:settled
+                           ~expected_backlog_version:latest_backlog.version
+                       with
+                       | Error _ as error -> error
+                       | Ok persisted -> loop persisted settled rest)))
+          in
+          loop operation settled_task_ids operation.owned_task_ids
+      else if outstanding_accounted_for receipted_ids
+      then
+        (match receipted_ids with
+         | [] ->
+           (match
+              persist_settled
+                ~config
+                operation
+                ~settled_task_ids
+                ~expected_backlog_version:active_snapshot.backlog_version
+            with
+            | Error _ as error -> error
+            | Ok rebased -> settle_tasks ~config ~meta rebased settled_task_ids)
+         | [ receipted_id ] ->
+           let settled_task_ids = receipted_id :: settled_task_ids in
+           (match
+              persist_settled
+                ~config
+                operation
+                ~settled_task_ids
+                ~expected_backlog_version:active_snapshot.backlog_version
+            with
+            | Error _ as error -> error
+            | Ok recovered -> settle_tasks ~config ~meta recovered settled_task_ids)
+         | _ ->
+           block
+             ~config
+             operation
+             Task_settlement
+             "multiple uncommitted shutdown receipts require operator reconciliation")
+      else
+        block
+          ~config
+          operation
+          Task_settlement
+          (Printf.sprintf
+             "backlog changed and snapshotted task ownership diverged: expected version %d, actual %d"
+             operation.expected_backlog_version
+             active_snapshot.backlog_version)
 ;;
 
 let paused_meta meta =
@@ -336,12 +396,15 @@ let rec remove_tree path =
 let remove_meta_file ~config operation =
   if operation.cleanup_intent.remove_meta
   then
-    Keeper_meta_store.remove_meta_if_identity
-      config
-      ~name:operation.keeper_name
-      ~trace_id:operation.trace_id
-      ~generation:operation.generation
-    |> Result.map_error Keeper_meta_store.identity_remove_error_to_string
+    match
+      Keeper_meta_store.remove_meta_if_identity
+        config
+        ~name:operation.keeper_name
+        ~trace_id:operation.trace_id
+        ~generation:operation.generation
+    with
+    | Ok () | Error Keeper_meta_store.Remove_identity_missing -> Ok ()
+    | Error error -> Error (Keeper_meta_store.identity_remove_error_to_string error)
   else Ok ()
 ;;
 
@@ -366,6 +429,24 @@ let unregister_exact operation = function
      | Keeper_registry.Exact_entry_missing -> Ok true
      | Keeper_registry.Exact_entry_replaced ->
        Error "Keeper registry lane was replaced during finalization")
+;;
+
+let release_finalized_admission ~config operation =
+  match
+    Keeper_turn_admission.rollback_shutdown
+      ~base_path:config.base_path
+      ~keeper_name:operation.keeper_name
+      ~operation_id:operation.operation_id
+  with
+  | Keeper_turn_admission.Shutdown_rolled_back
+  | Keeper_turn_admission.Shutdown_not_reserved -> Ok operation
+  | Keeper_turn_admission.Shutdown_reserved_by_other operation_id ->
+    Log.Keeper.warn
+      "finalized Keeper shutdown found a newer admission owner: keeper=%s finalized_operation=%s current_operation=%s"
+      operation.keeper_name
+      (Operation_id.to_string operation.operation_id)
+      (Operation_id.to_string operation_id);
+    Ok operation
 ;;
 
 let complete_cleanup ~config ~entry operation cleanup =
@@ -396,20 +477,7 @@ let complete_cleanup ~config ~entry operation cleanup =
           (match replace ~config finalized with
            | Error _ as error -> error
            | Ok persisted_finalized ->
-             (match
-                Keeper_turn_admission.rollback_shutdown
-                  ~base_path:config.base_path
-                  ~keeper_name:operation.keeper_name
-                  ~operation_id:operation.operation_id
-              with
-              | Keeper_turn_admission.Shutdown_rolled_back
-              | Keeper_turn_admission.Shutdown_not_reserved -> Ok persisted_finalized
-              | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
-                block
-                  ~config
-                  persisted_finalized
-                  Registry_unregister
-                  "admission fence is owned by another shutdown operation"))))
+             release_finalized_admission ~config persisted_finalized)))
 ;;
 
 let run ~config ~entry operation =
@@ -443,7 +511,7 @@ let run ~config ~entry operation =
               | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
               | _ -> Error Unsupported_phase))))
   | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
-  | Finalized _ -> Ok operation
+  | Finalized _ -> release_finalized_admission ~config operation
   | Prepared
   | Reconciliation_required _
   | Blocked _ -> Error Unsupported_phase

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -16,7 +16,7 @@ let error_to_string = function
 
 let remove_pending_confirms_by_target_callback
     : (Workspace.config ->
-       target_type:string ->
+       target_type:Operator_action_constants.target_type ->
        target_id:string option ->
        (int, string) result)
         Atomic.t
@@ -30,7 +30,12 @@ let register_remove_pending_confirms_by_target fn =
 ;;
 
 let replace ~config operation =
-  Keeper_shutdown_store.replace ~config operation
+  let next = { operation with revision = operation.revision + 1 } in
+  Keeper_shutdown_store.replace
+    ~config
+    ~expected_revision:operation.revision
+    next
+  |> Result.map (fun () -> next)
   |> Result.map_error (fun error -> Store_error error)
 ;;
 
@@ -42,7 +47,7 @@ let block ~config operation stage detail =
     }
   in
   match replace ~config blocked with
-  | Ok () -> Error (Finalization_blocked blocked)
+  | Ok persisted -> Error (Finalization_blocked persisted)
   | Error _ as error -> error
 ;;
 
@@ -78,19 +83,29 @@ let find_task backlog task_id =
   List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id wire) backlog.Masc_domain.tasks
 ;;
 
-let persist_settled ~config operation settled_task_ids =
+let persist_settled ~config operation ~settled_task_ids ~expected_backlog_version =
   let updated =
     { operation with
-      phase = Finalizing_tasks settled_task_ids
+      expected_backlog_version
+    ; phase = Finalizing_tasks settled_task_ids
     ; updated_at = Masc_domain.now_iso ()
     }
   in
   match replace ~config updated with
-  | Ok () -> Ok updated
+  | Ok persisted -> Ok persisted
   | Error _ as error -> error
 ;;
 
-let release_task ~config ~meta operation task_id =
+let release_task ~config operation (owned : Keeper_current_task_reconcile.owned_active_task) =
+  let assignee =
+    match owned.task.task_status with
+    | Masc_domain.Claimed { assignee; _ }
+    | Masc_domain.InProgress { assignee; _ } -> Ok assignee
+    | Masc_domain.Todo
+    | Masc_domain.AwaitingVerification _
+    | Masc_domain.Done _
+    | Masc_domain.Cancelled _ -> Error "snapshotted task is no longer actively owned"
+  in
   let handoff_context : Masc_domain.task_handoff_context =
     { summary = "Keeper stopped; task returned to the durable backlog"
     ; reason = Some "Keeper shutdown operation completed lane join"
@@ -102,21 +117,39 @@ let release_task ~config ~meta operation task_id =
     ; updated_by = Some operation.actor
     }
   in
-  Workspace.force_release_task_r
-    config
-    ~agent_name:meta.Keeper_meta_contract.agent_name
-    ~task_id:(Keeper_id.Task_id.to_string task_id)
-    ~handoff_context
-    ()
-  |> Result.map_error Masc_domain.masc_error_to_string
+  match assignee with
+  | Error _ as error -> error
+  | Ok agent_name ->
+    Workspace.release_task_r
+      config
+      ~agent_name
+      ~task_id:(Keeper_id.Task_id.to_string owned.task_id)
+      ~expected_version:operation.expected_backlog_version
+      ~handoff_context
+      ()
+    |> Result.map_error Masc_domain.masc_error_to_string
 ;;
 
 let settle_tasks ~config ~meta operation settled_task_ids =
   match
-    Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict ~config ~meta
+    Keeper_current_task_reconcile.owned_active_tasks_snapshot_for_meta_strict
+      ~config
+      ~meta
   with
   | Error detail -> block ~config operation Task_settlement detail
-  | Ok active_tasks ->
+  | Ok active_snapshot ->
+    if not (Int.equal active_snapshot.backlog_version operation.expected_backlog_version)
+    then
+      block
+        ~config
+        operation
+        Task_settlement
+        (Printf.sprintf
+           "backlog version changed before task settlement: expected %d, actual %d"
+           operation.expected_backlog_version
+           active_snapshot.backlog_version)
+    else
+    let active_tasks = active_snapshot.tasks in
     let unexpected =
       List.filter
         (fun task -> not (task_id_mem task.Keeper_current_task_reconcile.task_id operation.owned_task_ids))
@@ -146,7 +179,14 @@ let settle_tasks ~config ~meta operation settled_task_ids =
           | task_id :: rest ->
             let settle_result =
               if task_id_mem task_id active_ids
-              then release_task ~config ~meta current task_id
+              then
+                (match
+                   List.find_opt
+                     (fun task -> task_id_equal task.Keeper_current_task_reconcile.task_id task_id)
+                     active_tasks
+                 with
+                 | None -> Error "active task snapshot disappeared"
+                 | Some owned -> release_task ~config current owned)
               else
                 match find_task backlog task_id with
                 | Some task when task_has_operation_receipt current task -> Ok "already released"
@@ -156,10 +196,34 @@ let settle_tasks ~config ~meta operation settled_task_ids =
             (match settle_result with
              | Error detail -> block ~config current Task_settlement detail
              | Ok _ ->
-               let settled = task_id :: settled in
-               (match persist_settled ~config current settled with
-                | Error _ as error -> error
-                | Ok persisted -> loop persisted settled rest))
+               (match strict_backlog ~config with
+                | Error detail -> block ~config current Task_settlement detail
+                | Ok latest_backlog ->
+                  if
+                    not
+                      (Int.equal
+                         latest_backlog.version
+                         (current.expected_backlog_version + 1))
+                  then
+                    block
+                      ~config
+                      current
+                      Task_settlement
+                      (Printf.sprintf
+                         "task release backlog version mismatch: expected %d, actual %d"
+                         (current.expected_backlog_version + 1)
+                         latest_backlog.version)
+                  else
+                    let settled = task_id :: settled in
+                    (match
+                       persist_settled
+                         ~config
+                         current
+                         ~settled_task_ids:settled
+                         ~expected_backlog_version:latest_backlog.version
+                     with
+                     | Error _ as error -> error
+                     | Ok persisted -> loop persisted settled rest)))
         in
         loop operation settled_task_ids operation.owned_task_ids
 ;;
@@ -176,31 +240,52 @@ let paused_meta meta =
   }
 ;;
 
-let prepare_cleanup ~config operation settled_task_ids =
-  match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
-  | Error detail -> block ~config operation Meta_update detail
-  | Ok None -> block ~config operation Meta_update "Keeper metadata disappeared before cleanup"
-  | Ok (Some (resolved_name, meta)) ->
-    if
-      (not (String.equal resolved_name operation.keeper_name))
-      || not (Keeper_id.Trace_id.equal meta.runtime.trace_id operation.trace_id)
-      || not (Int.equal meta.runtime.generation operation.generation)
-    then block ~config operation Meta_update "Keeper metadata identity changed"
-    else
-      let retained = paused_meta meta in
-      (match
-         Keeper_meta_store.write_meta_with_merge
-           ~merge:Keeper_meta_merge.caller_wins
-           config
-           retained
-       with
-       | Error detail -> block ~config operation Meta_update detail
-       | Ok () ->
-         Keeper_registry.update_meta ~base_path:config.base_path operation.keeper_name retained;
+let update_registry_meta_exact operation entry retained =
+  match entry with
+  | None -> Ok ()
+  | Some registry_entry
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id registry_entry.Keeper_registry.lane)
+              operation.lane_id) -> Error "Keeper registry lane changed before meta update"
+  | Some registry_entry ->
+    (match
+       Keeper_registry.update_entry_exact registry_entry (fun current ->
+         { current with meta = retained })
+     with
+     | Keeper_registry.Exact_updated -> Ok ()
+     | Keeper_registry.Exact_update_missing ->
+       Error "Keeper registry entry disappeared before meta update"
+     | Keeper_registry.Exact_update_replaced ->
+       Error "Keeper registry lane changed during meta update"
+     | Keeper_registry.Exact_update_invalid validation_error ->
+       Error
+         (Keeper_registry.registry_entry_validation_error_to_string validation_error))
+;;
+
+let prepare_cleanup ~config ~entry operation settled_task_ids =
+  match
+    Keeper_meta_store.update_meta_if_identity
+      config
+      ~name:operation.keeper_name
+      ~trace_id:operation.trace_id
+      ~generation:operation.generation
+      paused_meta
+  with
+  | Error error ->
+    block
+      ~config
+      operation
+      Meta_update
+      (Keeper_meta_store.identity_update_error_to_string error)
+  | Ok retained ->
+    (match update_registry_meta_exact operation entry retained with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok () ->
          (match
             Atomic.get remove_pending_confirms_by_target_callback
               config
-              ~target_type:"keeper"
+              ~target_type:Operator_action_constants.Keeper
               ~target_id:(Some operation.keeper_name)
           with
           | Error detail -> block ~config operation Pending_confirm_cleanup detail
@@ -213,7 +298,7 @@ let prepare_cleanup ~config operation settled_task_ids =
               }
             in
             (match replace ~config ready with
-             | Ok () -> Ok ready
+             | Ok persisted -> Ok persisted
              | Error _ as error -> error)))
 ;;
 
@@ -250,7 +335,13 @@ let rec remove_tree path =
 
 let remove_meta_file ~config operation =
   if operation.cleanup_intent.remove_meta
-  then remove_tree (Keeper_types_profile.keeper_meta_path config operation.keeper_name)
+  then
+    Keeper_meta_store.remove_meta_if_identity
+      config
+      ~name:operation.keeper_name
+      ~trace_id:operation.trace_id
+      ~generation:operation.generation
+    |> Result.map_error Keeper_meta_store.identity_remove_error_to_string
   else Ok ()
 ;;
 
@@ -278,15 +369,15 @@ let unregister_exact operation = function
 ;;
 
 let complete_cleanup ~config ~entry operation cleanup =
-  match remove_session_dir ~config operation with
-  | Error detail -> block ~config operation Session_remove detail
-  | Ok () ->
-    (match remove_meta_file ~config operation with
-     | Error detail -> block ~config operation Meta_remove detail
+  match unregister_exact operation entry with
+  | Error detail -> block ~config operation Registry_unregister detail
+  | Ok registry_unregistered ->
+    (match remove_session_dir ~config operation with
+     | Error detail -> block ~config operation Session_remove detail
      | Ok () ->
-       (match unregister_exact operation entry with
-        | Error detail -> block ~config operation Registry_unregister detail
-        | Ok registry_unregistered ->
+       (match remove_meta_file ~config operation with
+        | Error detail -> block ~config operation Meta_remove detail
+        | Ok () ->
           if operation.cleanup_intent.remove_meta
           then Keeper_tool_emission_hook.drop_keeper_accumulator operation.keeper_name;
           let evidence =
@@ -304,7 +395,7 @@ let complete_cleanup ~config ~entry operation cleanup =
           in
           (match replace ~config finalized with
            | Error _ as error -> error
-           | Ok () ->
+           | Ok persisted_finalized ->
              (match
                 Keeper_turn_admission.rollback_shutdown
                   ~base_path:config.base_path
@@ -312,11 +403,11 @@ let complete_cleanup ~config ~entry operation cleanup =
                   ~operation_id:operation.operation_id
               with
               | Keeper_turn_admission.Shutdown_rolled_back
-              | Keeper_turn_admission.Shutdown_not_reserved -> Ok finalized
+              | Keeper_turn_admission.Shutdown_not_reserved -> Ok persisted_finalized
               | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
                 block
                   ~config
-                  finalized
+                  persisted_finalized
                   Registry_unregister
                   "admission fence is owned by another shutdown operation"))))
 ;;
@@ -331,7 +422,7 @@ let run ~config ~entry operation =
        (match settle_tasks ~config ~meta operation [] with
         | Error _ as error -> error
         | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config settled_operation settled_task_ids with
+          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
            | Error _ as error -> error
            | Ok ready ->
              (match ready.phase with
@@ -345,7 +436,7 @@ let run ~config ~entry operation =
        (match settle_tasks ~config ~meta operation settled_task_ids with
         | Error _ as error -> error
         | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config settled_operation settled_task_ids with
+          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
            | Error _ as error -> error
            | Ok ready ->
              (match ready.phase with

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -1,0 +1,373 @@
+open Keeper_shutdown_types
+
+type error =
+  | Store_error of Keeper_shutdown_store.error
+  | Unsupported_phase
+  | Finalization_blocked of Keeper_shutdown_types.t
+
+let error_to_string = function
+  | Store_error error -> Keeper_shutdown_store.error_to_string error
+  | Unsupported_phase -> "Keeper shutdown operation is not ready for finalization"
+  | Finalization_blocked operation ->
+    Printf.sprintf
+      "Keeper shutdown finalization blocked in operation %s"
+      (Operation_id.to_string operation.operation_id)
+;;
+
+let remove_pending_confirms_by_target_callback
+    : (Workspace.config ->
+       target_type:string ->
+       target_id:string option ->
+       (int, string) result)
+        Atomic.t
+  =
+  Atomic.make (fun _config ~target_type:_ ~target_id:_ ->
+    Error "pending-confirm cleanup implementation is not registered")
+;;
+
+let register_remove_pending_confirms_by_target fn =
+  Atomic.set remove_pending_confirms_by_target_callback fn
+;;
+
+let replace ~config operation =
+  Keeper_shutdown_store.replace ~config operation
+  |> Result.map_error (fun error -> Store_error error)
+;;
+
+let block ~config operation stage detail =
+  let blocked =
+    { operation with
+      phase = Blocked { stage; detail }
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match replace ~config blocked with
+  | Ok () -> Error (Finalization_blocked blocked)
+  | Error _ as error -> error
+;;
+
+let task_id_equal = Keeper_id.Task_id.equal
+let task_id_mem task_id task_ids = List.exists (task_id_equal task_id) task_ids
+
+let operation_evidence_ref operation =
+  "masc://keeper-shutdown/" ^ Operation_id.to_string operation.operation_id
+;;
+
+let task_has_operation_receipt operation (task : Masc_domain.task) =
+  match task.task_status, task.handoff_context with
+  | Masc_domain.Todo, Some handoff ->
+    handoff.reclaim_policy = Some Masc_domain.Allow_reclaim
+    && List.exists
+         (String.equal (operation_evidence_ref operation))
+         handoff.evidence_refs
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _
+  | Masc_domain.Todo, None -> false
+;;
+
+let strict_backlog ~config =
+  Workspace_backlog.read_backlog_r config
+  |> Result.map_error (fun detail -> detail)
+;;
+
+let find_task backlog task_id =
+  let wire = Keeper_id.Task_id.to_string task_id in
+  List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id wire) backlog.Masc_domain.tasks
+;;
+
+let persist_settled ~config operation settled_task_ids =
+  let updated =
+    { operation with
+      phase = Finalizing_tasks settled_task_ids
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match replace ~config updated with
+  | Ok () -> Ok updated
+  | Error _ as error -> error
+;;
+
+let release_task ~config ~meta operation task_id =
+  let handoff_context : Masc_domain.task_handoff_context =
+    { summary = "Keeper stopped; task returned to the durable backlog"
+    ; reason = Some "Keeper shutdown operation completed lane join"
+    ; next_step = Some "A live Keeper may reclaim this task"
+    ; failure_mode = None
+    ; reclaim_policy = Some Masc_domain.Allow_reclaim
+    ; evidence_refs = [ operation_evidence_ref operation ]
+    ; updated_at = Some (Masc_domain.now_iso ())
+    ; updated_by = Some operation.actor
+    }
+  in
+  Workspace.force_release_task_r
+    config
+    ~agent_name:meta.Keeper_meta_contract.agent_name
+    ~task_id:(Keeper_id.Task_id.to_string task_id)
+    ~handoff_context
+    ()
+  |> Result.map_error Masc_domain.masc_error_to_string
+;;
+
+let settle_tasks ~config ~meta operation settled_task_ids =
+  match
+    Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict ~config ~meta
+  with
+  | Error detail -> block ~config operation Task_settlement detail
+  | Ok active_tasks ->
+    let unexpected =
+      List.filter
+        (fun task -> not (task_id_mem task.Keeper_current_task_reconcile.task_id operation.owned_task_ids))
+        active_tasks
+    in
+    if unexpected <> []
+    then
+      let ids =
+        unexpected
+        |> List.map (fun task ->
+          Keeper_id.Task_id.to_string task.Keeper_current_task_reconcile.task_id)
+        |> String.concat ","
+      in
+      block ~config operation Task_settlement ("new active task ownership: " ^ ids)
+    else
+      match strict_backlog ~config with
+      | Error detail -> block ~config operation Task_settlement detail
+      | Ok backlog ->
+        let active_ids =
+          List.map
+            (fun task -> task.Keeper_current_task_reconcile.task_id)
+            active_tasks
+        in
+        let rec loop current settled = function
+          | [] -> Ok (current, settled)
+          | task_id :: rest when task_id_mem task_id settled -> loop current settled rest
+          | task_id :: rest ->
+            let settle_result =
+              if task_id_mem task_id active_ids
+              then release_task ~config ~meta current task_id
+              else
+                match find_task backlog task_id with
+                | Some task when task_has_operation_receipt current task -> Ok "already released"
+                | Some _ -> Error "snapshotted task changed without shutdown receipt"
+                | None -> Error "snapshotted task disappeared from the durable backlog"
+            in
+            (match settle_result with
+             | Error detail -> block ~config current Task_settlement detail
+             | Ok _ ->
+               let settled = task_id :: settled in
+               (match persist_settled ~config current settled with
+                | Error _ as error -> error
+                | Ok persisted -> loop persisted settled rest))
+        in
+        loop operation settled_task_ids operation.owned_task_ids
+;;
+
+let paused_meta meta =
+  { meta with
+    current_task_id = None
+  ; paused = true
+  ; latched_reason =
+      Some
+        (Keeper_latched_reason.Operator_paused
+           { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let prepare_cleanup ~config operation settled_task_ids =
+  match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
+  | Error detail -> block ~config operation Meta_update detail
+  | Ok None -> block ~config operation Meta_update "Keeper metadata disappeared before cleanup"
+  | Ok (Some (resolved_name, meta)) ->
+    if
+      (not (String.equal resolved_name operation.keeper_name))
+      || not (Keeper_id.Trace_id.equal meta.runtime.trace_id operation.trace_id)
+      || not (Int.equal meta.runtime.generation operation.generation)
+    then block ~config operation Meta_update "Keeper metadata identity changed"
+    else
+      let retained = paused_meta meta in
+      (match
+         Keeper_meta_store.write_meta_with_merge
+           ~merge:Keeper_meta_merge.caller_wins
+           config
+           retained
+       with
+       | Error detail -> block ~config operation Meta_update detail
+       | Ok () ->
+         Keeper_registry.update_meta ~base_path:config.base_path operation.keeper_name retained;
+         (match
+            Atomic.get remove_pending_confirms_by_target_callback
+              config
+              ~target_type:"keeper"
+              ~target_id:(Some operation.keeper_name)
+          with
+          | Error detail -> block ~config operation Pending_confirm_cleanup detail
+          | Ok pending_confirms_removed ->
+            let cleanup = { settled_task_ids; pending_confirms_removed } in
+            let ready =
+              { operation with
+                phase = Cleanup_ready cleanup
+              ; updated_at = Masc_domain.now_iso ()
+              }
+            in
+            (match replace ~config ready with
+             | Ok () -> Ok ready
+             | Error _ as error -> error)))
+;;
+
+let rec remove_tree path =
+  if not (Fs_compat.file_exists path)
+  then Ok ()
+  else
+    try
+      match (Unix.lstat path).Unix.st_kind with
+      | Unix.S_DIR ->
+        let entries = Sys.readdir path |> Array.to_list in
+        let rec remove_entries = function
+          | [] ->
+            Unix.rmdir path;
+            Ok ()
+          | entry :: rest ->
+            (match remove_tree (Filename.concat path entry) with
+             | Error _ as error -> error
+             | Ok () -> remove_entries rest)
+        in
+        remove_entries entries
+      | Unix.S_REG
+      | Unix.S_LNK
+      | Unix.S_CHR
+      | Unix.S_BLK
+      | Unix.S_FIFO
+      | Unix.S_SOCK ->
+        Unix.unlink path;
+        Ok ()
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
+;;
+
+let remove_meta_file ~config operation =
+  if operation.cleanup_intent.remove_meta
+  then remove_tree (Keeper_types_profile.keeper_meta_path config operation.keeper_name)
+  else Ok ()
+;;
+
+let remove_session_dir ~config operation =
+  if operation.cleanup_intent.remove_session
+  then
+    remove_tree
+      (Filename.concat
+         (Keeper_types_profile.session_base_dir config)
+         (Keeper_id.Trace_id.to_string operation.trace_id))
+  else Ok ()
+;;
+
+let unregister_exact operation = function
+  | None -> Ok false
+  | Some entry
+    when not (Keeper_lane.Id.equal (Keeper_lane.id entry.Keeper_registry.lane) operation.lane_id) ->
+    Error "Keeper registry lane changed before finalization"
+  | Some entry ->
+    (match Keeper_registry.unregister_exact entry with
+     | Keeper_registry.Exact_unregistered
+     | Keeper_registry.Exact_entry_missing -> Ok true
+     | Keeper_registry.Exact_entry_replaced ->
+       Error "Keeper registry lane was replaced during finalization")
+;;
+
+let complete_cleanup ~config ~entry operation cleanup =
+  match remove_session_dir ~config operation with
+  | Error detail -> block ~config operation Session_remove detail
+  | Ok () ->
+    (match remove_meta_file ~config operation with
+     | Error detail -> block ~config operation Meta_remove detail
+     | Ok () ->
+       (match unregister_exact operation entry with
+        | Error detail -> block ~config operation Registry_unregister detail
+        | Ok registry_unregistered ->
+          if operation.cleanup_intent.remove_meta
+          then Keeper_tool_emission_hook.drop_keeper_accumulator operation.keeper_name;
+          let evidence =
+            { cleanup
+            ; meta_removed = operation.cleanup_intent.remove_meta
+            ; session_removed = operation.cleanup_intent.remove_session
+            ; registry_unregistered
+            }
+          in
+          let finalized =
+            { operation with
+              phase = Finalized evidence
+            ; updated_at = Masc_domain.now_iso ()
+            }
+          in
+          (match replace ~config finalized with
+           | Error _ as error -> error
+           | Ok () ->
+             (match
+                Keeper_turn_admission.rollback_shutdown
+                  ~base_path:config.base_path
+                  ~keeper_name:operation.keeper_name
+                  ~operation_id:operation.operation_id
+              with
+              | Keeper_turn_admission.Shutdown_rolled_back
+              | Keeper_turn_admission.Shutdown_not_reserved -> Ok finalized
+              | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
+                block
+                  ~config
+                  finalized
+                  Registry_unregister
+                  "admission fence is owned by another shutdown operation"))))
+;;
+
+let run ~config ~entry operation =
+  match operation.phase with
+  | Joined_idle ->
+    (match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok None -> block ~config operation Meta_update "Keeper metadata is absent"
+     | Ok (Some (_, meta)) ->
+       (match settle_tasks ~config ~meta operation [] with
+        | Error _ as error -> error
+        | Ok (settled_operation, settled_task_ids) ->
+          (match prepare_cleanup ~config settled_operation settled_task_ids with
+           | Error _ as error -> error
+           | Ok ready ->
+             (match ready.phase with
+              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | _ -> Error Unsupported_phase))))
+  | Finalizing_tasks settled_task_ids ->
+    (match Keeper_meta_store.read_meta_resolved config operation.keeper_name with
+     | Error detail -> block ~config operation Meta_update detail
+     | Ok None -> block ~config operation Meta_update "Keeper metadata is absent"
+     | Ok (Some (_, meta)) ->
+       (match settle_tasks ~config ~meta operation settled_task_ids with
+        | Error _ as error -> error
+        | Ok (settled_operation, settled_task_ids) ->
+          (match prepare_cleanup ~config settled_operation settled_task_ids with
+           | Error _ as error -> error
+           | Ok ready ->
+             (match ready.phase with
+              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | _ -> Error Unsupported_phase))))
+  | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
+  | Finalized _ -> Ok operation
+  | Prepared
+  | Reconciliation_required _
+  | Blocked _ -> Error Unsupported_phase
+;;
+
+module For_testing = struct
+  let paused_meta = paused_meta
+
+  let remove_pending_confirms_by_target ~config ~target_type ~target_id =
+    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+  ;;
+
+  let reset_remove_pending_confirms_by_target () =
+    Atomic.set remove_pending_confirms_by_target_callback
+      (fun _config ~target_type:_ ~target_id:_ ->
+        Error "pending-confirm cleanup implementation is not registered")
+  ;;
+end

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -11,7 +11,7 @@ val error_to_string : error -> string
 
 val register_remove_pending_confirms_by_target :
   (Workspace.config ->
-   target_type:string ->
+   target_type:Operator_action_constants.target_type ->
    target_id:string option ->
    (int, string) result) ->
   unit
@@ -28,7 +28,7 @@ module For_testing : sig
 
   val remove_pending_confirms_by_target :
     config:Workspace.config ->
-    target_type:string ->
+    target_type:Operator_action_constants.target_type ->
     target_id:string option ->
     (int, string) result
 

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -1,0 +1,36 @@
+(** Durable task settlement and Keeper identity cleanup after an exact lane
+    has joined. Every externally visible side effect is either recorded in the
+    operation or returned as a typed failure. *)
+
+type error =
+  | Store_error of Keeper_shutdown_store.error
+  | Unsupported_phase
+  | Finalization_blocked of Keeper_shutdown_types.t
+
+val error_to_string : error -> string
+
+val register_remove_pending_confirms_by_target :
+  (Workspace.config ->
+   target_type:string ->
+   target_id:string option ->
+   (int, string) result) ->
+  unit
+
+val run :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry option ->
+  Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, error) result
+
+module For_testing : sig
+  val paused_meta :
+    Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
+
+  val remove_pending_confirms_by_target :
+    config:Workspace.config ->
+    target_type:string ->
+    target_id:string option ->
+    (int, string) result
+
+  val reset_remove_pending_confirms_by_target : unit -> unit
+end

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -97,11 +97,17 @@ let rollback_reservation ~config ~entry operation_id =
 let persist_blocked ~config operation stage detail =
   let blocked =
     { operation with
-      phase = Blocked { stage; detail }
+      revision = operation.revision + 1
+    ; phase = Blocked { stage; detail }
     ; updated_at = Masc_domain.now_iso ()
     }
   in
-  match Keeper_shutdown_store.replace ~config blocked with
+  match
+    Keeper_shutdown_store.replace
+      ~config
+      ~expected_revision:operation.revision
+      blocked
+  with
   | Ok () -> Ok blocked
   | Error error -> Error error
 ;;
@@ -146,16 +152,18 @@ let prepare ~config ~(entry : Keeper_registry.registry_entry) ~request =
      | Error error -> Error error
      | Ok current ->
        (match
-          Keeper_current_task_reconcile.owned_active_tasks_for_meta_strict
+          Keeper_current_task_reconcile.owned_active_tasks_snapshot_for_meta_strict
             ~config
             ~meta:current.meta
         with
         | Error detail -> Error (Task_discovery_failed detail)
-        | Ok owned_tasks ->
+        | Ok owned_snapshot ->
+          let owned_tasks = owned_snapshot.tasks in
           let now = Masc_domain.now_iso () in
           let turn_disposition = active_turn_of_snapshots reservation current in
           let operation =
             { schema_version
+            ; revision = 0
             ; operation_id
             ; keeper_name = current.name
             ; lane_id = Keeper_lane.id current.lane
@@ -164,6 +172,7 @@ let prepare ~config ~(entry : Keeper_registry.registry_entry) ~request =
             ; actor = request.actor
             ; cleanup_intent = request.cleanup_intent
             ; turn_disposition
+            ; expected_backlog_version = owned_snapshot.backlog_version
             ; owned_task_ids =
                 List.map
                   (fun task -> task.Keeper_current_task_reconcile.task_id)
@@ -235,7 +244,8 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
           in
           let joined =
             { operation with
-              join_evidence = Some evidence
+              revision = operation.revision + 1
+            ; join_evidence = Some evidence
             ; phase
             ; updated_at = Masc_domain.now_iso ()
             }
@@ -246,7 +256,12 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
               | Ok blocked -> Error (Join_failed blocked)
               | Error error -> Error (Join_record_update_failed error))
            | None ->
-             (match Keeper_shutdown_store.replace ~config joined with
+             (match
+                Keeper_shutdown_store.replace
+                  ~config
+                  ~expected_revision:operation.revision
+                  joined
+              with
               | Ok () -> Ok joined
               | Error error -> Error (Join_record_update_failed error)))))
 ;;

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -125,7 +125,7 @@ let terminal = function
   | `Crashed detail -> Terminal_crashed detail
 ;;
 
-let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
+let prepare ~config ~(entry : Keeper_registry.registry_entry) ~request =
   let operation_id = Operation_id.generate () in
   match
     Keeper_turn_admission.begin_shutdown
@@ -185,62 +185,74 @@ let run ~config ~(entry : Keeper_registry.registry_entry) ~request =
           (match persist_result with
            | Error store_error ->
              Error (Prepare_persist_failed store_error)
-           | Ok () ->
-             Keeper_keepalive.request_entry_stop current;
-             let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
-             let turn_cancel_error =
-               match turn_disposition, turn_cancel with
-               | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
-               | ( Inflight_effect_unknown _
-                 , Keeper_registry.Exact_turn_cancelled _ ) -> None
-               | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
-                 Some "turn appeared after shutdown admission was fenced"
-               | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
-               | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
-             in
-             (match turn_cancel_error with
-              | Some detail -> cancellation_error ~config operation Turn_cancel detail
-              | None ->
-                (match Keeper_lane.request_cancel current.lane with
-                 | Keeper_lane.Cancel_signal_failed exn ->
-                   cancellation_error
-                     ~config
-                     operation
-                     Lane_cancel
-                     (Printexc.to_string exn)
-                 | Keeper_lane.Cancel_requested
-                 | Keeper_lane.Cancel_already_requested
-                 | Keeper_lane.Cancel_already_exiting ->
-                   Keeper_turn_admission.await_idle_after_shutdown
-                     ~base_path:config.Workspace.base_path
-                     ~keeper_name:current.name;
-                   let lane_exit = Keeper_lane.await_exit current.lane in
-                   let terminal_result = Eio.Promise.await current.done_p in
-                   let evidence =
-                     { lane_outcome = lane_outcome lane_exit.outcome
-                     ; terminal = terminal terminal_result
-                     ; cleanup_error = lane_exit.cleanup_error
-                     }
-                   in
-                   let phase =
-                     match turn_disposition with
-                     | No_inflight_turn -> Joined_idle
-                     | Inflight_effect_unknown turn -> Reconciliation_required turn
-                   in
-                   let joined =
-                     { operation with
-                       join_evidence = Some evidence
-                     ; phase
-                     ; updated_at = Masc_domain.now_iso ()
-                     }
-                   in
-                   (match lane_exit.cleanup_error with
-                    | Some detail ->
-                      (match persist_blocked ~config joined Lane_join detail with
-                       | Ok blocked -> Error (Join_failed blocked)
-                       | Error error -> Error (Join_record_update_failed error))
-                    | None ->
-                      (match Keeper_shutdown_store.replace ~config joined with
-                       | Ok () -> Ok joined
-                       | Error error -> Error (Join_record_update_failed error)))))))))
+           | Ok () -> Ok operation))))
+;;
+
+let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
+  match current_entry ~config entry with
+  | Error error -> Error error
+  | Ok current
+    when not
+           (Keeper_lane.Id.equal
+              (Keeper_lane.id current.lane)
+              operation.lane_id) -> Error Registry_lane_replaced
+  | Ok current ->
+    Keeper_keepalive.request_entry_stop current;
+    let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
+    let turn_cancel_error =
+      match operation.turn_disposition, turn_cancel with
+      | No_inflight_turn, Keeper_registry.Exact_no_turn_in_flight
+      | Inflight_effect_unknown _, Keeper_registry.Exact_turn_cancelled _ -> None
+      | No_inflight_turn, Keeper_registry.Exact_turn_cancelled _ ->
+        Some "turn appeared after shutdown admission was fenced"
+      | Inflight_effect_unknown _, Keeper_registry.Exact_no_turn_in_flight -> None
+      | _, Keeper_registry.Exact_turn_cancel_failed { detail; _ } -> Some detail
+    in
+    (match turn_cancel_error with
+     | Some detail -> cancellation_error ~config operation Turn_cancel detail
+     | None ->
+       (match Keeper_lane.request_cancel current.lane with
+        | Keeper_lane.Cancel_signal_failed exn ->
+          cancellation_error ~config operation Lane_cancel (Printexc.to_string exn)
+        | Keeper_lane.Cancel_requested
+        | Keeper_lane.Cancel_already_requested
+        | Keeper_lane.Cancel_already_exiting ->
+          Keeper_turn_admission.await_idle_after_shutdown
+            ~base_path:config.Workspace.base_path
+            ~keeper_name:current.name;
+          let lane_exit = Keeper_lane.await_exit current.lane in
+          let terminal_result = Eio.Promise.await current.done_p in
+          let evidence =
+            { lane_outcome = lane_outcome lane_exit.outcome
+            ; terminal = terminal terminal_result
+            ; cleanup_error = lane_exit.cleanup_error
+            }
+          in
+          let phase =
+            match operation.turn_disposition with
+            | No_inflight_turn -> Joined_idle
+            | Inflight_effect_unknown turn -> Reconciliation_required turn
+          in
+          let joined =
+            { operation with
+              join_evidence = Some evidence
+            ; phase
+            ; updated_at = Masc_domain.now_iso ()
+            }
+          in
+          (match lane_exit.cleanup_error with
+           | Some detail ->
+             (match persist_blocked ~config joined Lane_join detail with
+              | Ok blocked -> Error (Join_failed blocked)
+              | Error error -> Error (Join_record_update_failed error))
+           | None ->
+             (match Keeper_shutdown_store.replace ~config joined with
+              | Ok () -> Ok joined
+              | Error error -> Error (Join_record_update_failed error)))))
+;;
+
+let run ~config ~entry ~request =
+  match prepare ~config ~entry ~request with
+  | Error _ as error -> error
+  | Ok operation -> join_prepared ~config ~entry ~operation
 ;;

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -120,6 +120,7 @@ let cancellation_error ~config operation stage detail =
 
 let lane_outcome = function
   | Keeper_lane.Completed -> Lane_completed
+  | Keeper_lane.Shutdown_before_start -> Lane_shutdown_requested
   | Keeper_lane.Shutdown_requested -> Lane_shutdown_requested
   | Keeper_lane.Cancelled_by_parent exn ->
     Lane_cancelled_by_parent (Printexc.to_string exn)
@@ -230,6 +231,26 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
             ~base_path:config.Workspace.base_path
             ~keeper_name:current.name;
           let lane_exit = Keeper_lane.await_exit current.lane in
+          (match lane_exit.outcome with
+           | Keeper_lane.Shutdown_before_start ->
+             (match
+                Keeper_registry.resolve_done
+                  current
+                  ~source:"shutdown_before_lane_start"
+                  `Stopped
+              with
+              | Keeper_registry.Done_resolved _
+              | Keeper_registry.Done_already_resolved { previous = `Stopped; _ } -> ()
+              | Keeper_registry.Done_already_resolved
+                  { previous = `Crashed detail; _ } ->
+                Log.Keeper.warn
+                  "%s: shutdown before lane start preserved prior crash terminal: %s"
+                  current.name
+                  detail)
+           | Keeper_lane.Completed
+           | Keeper_lane.Shutdown_requested
+           | Keeper_lane.Cancelled_by_parent _
+           | Keeper_lane.Failed _ -> ());
           let terminal_result = Eio.Promise.await current.done_p in
           let evidence =
             { lane_outcome = lane_outcome lane_exit.outcome

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -252,8 +252,19 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
           in
           (match lane_exit.cleanup_error with
            | Some detail ->
-             (match persist_blocked ~config joined Lane_join detail with
-              | Ok blocked -> Error (Join_failed blocked)
+             let blocked =
+               { joined with
+                 phase = Blocked { stage = Lane_join; detail }
+               ; updated_at = Masc_domain.now_iso ()
+               }
+             in
+             (match
+                Keeper_shutdown_store.replace
+                  ~config
+                  ~expected_revision:operation.revision
+                  blocked
+              with
+              | Ok () -> Error (Join_failed blocked)
               | Error error -> Error (Join_record_update_failed error))
            | None ->
              (match

--- a/lib/keeper/keeper_shutdown_prepare_join.mli
+++ b/lib/keeper/keeper_shutdown_prepare_join.mli
@@ -23,3 +23,21 @@ val run :
   entry:Keeper_registry.registry_entry ->
   request:request ->
   (Keeper_shutdown_types.t, error) result
+
+(** Persist the shutdown admission fence and ownership snapshot without
+    waiting for the current turn or lane. Once this returns [Ok], the durable
+    operation owns admission and must be joined or recovered. *)
+val prepare :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:request ->
+  (Keeper_shutdown_types.t, error) result
+
+(** Cancel and join the exact lane captured by [prepare]. Never call this
+    from that Keeper's admitted turn; lifecycle tools fork it on the server
+    switch after returning the accepted operation id. *)
+val join_prepared :
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  operation:Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, error) result

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -3,10 +3,22 @@ open Keeper_shutdown_types
 type submit_error =
   | Prepare_error of Keeper_shutdown_prepare_join.error
   | Existing_operation_load_error of Keeper_shutdown_store.error
+  | Worker_start_error of worker_start_error
+
+and worker_start_error =
+  | Worker_supervisor_unavailable
+  | Worker_supervisor_stopping of exn
+  | Worker_fork_failed of exn
 
 let submit_error_to_string = function
   | Prepare_error error -> Keeper_shutdown_prepare_join.error_to_string error
   | Existing_operation_load_error error -> Keeper_shutdown_store.error_to_string error
+  | Worker_start_error Worker_supervisor_unavailable ->
+    "Keeper shutdown process supervisor is unavailable"
+  | Worker_start_error (Worker_supervisor_stopping exn) ->
+    Printf.sprintf "Keeper shutdown process supervisor is stopping: %s" (Printexc.to_string exn)
+  | Worker_start_error (Worker_fork_failed exn) ->
+    Printf.sprintf "Keeper shutdown worker fork failed: %s" (Printexc.to_string exn)
 ;;
 
 let worker_mu = Eio.Mutex.create ()
@@ -32,11 +44,17 @@ let release_worker operation =
 let persist_unhandled_failure ~config operation exn =
   let blocked =
     { operation with
-      phase = Blocked { stage = Record_update; detail = Printexc.to_string exn }
+      revision = operation.revision + 1
+    ; phase = Blocked { stage = Record_update; detail = Printexc.to_string exn }
     ; updated_at = Masc_domain.now_iso ()
     }
   in
-  match Keeper_shutdown_store.replace ~config blocked with
+  match
+    Keeper_shutdown_store.replace
+      ~config
+      ~expected_revision:operation.revision
+      blocked
+  with
   | Ok () -> ()
   | Error store_error ->
     Log.Keeper.error
@@ -87,34 +105,62 @@ let run_worker ~config ~entry operation =
   | Blocked _ -> ()
 ;;
 
-let start_worker ~sw ~config ~entry operation =
-  if claim_worker operation
-  then
-    Eio.Fiber.fork_daemon ~sw (fun () ->
-      Fun.protect
-        ~finally:(fun () -> release_worker operation)
-        (fun () ->
-           try run_worker ~config ~entry operation with
-           | Eio.Cancel.Cancelled _ ->
-             Log.Keeper.info
-               "Keeper shutdown worker cancelled by server teardown; durable recovery retained: keeper=%s operation=%s"
-               operation.keeper_name
-               (worker_key operation)
-           | exn -> persist_unhandled_failure ~config operation exn);
-      `Stop_daemon)
+type worker_start_result =
+  | Worker_started
+  | Worker_already_active
+  | Worker_start_rejected of worker_start_error
+
+let start_worker ~config ~entry operation =
+  match Keeper_supervisor.get_global_switch () with
+  | None -> Worker_start_rejected Worker_supervisor_unavailable
+  | Some sw ->
+    Eio.Cancel.protect (fun () ->
+      match Eio.Switch.get_error sw with
+      | Some cause -> Worker_start_rejected (Worker_supervisor_stopping cause)
+      | None when not (claim_worker operation) -> Worker_already_active
+      | None ->
+        let started = Atomic.make false in
+        (try
+           Eio.Fiber.fork ~sw (fun () ->
+             Atomic.set started true;
+             Fun.protect
+               ~finally:(fun () -> release_worker operation)
+               (fun () ->
+                  try run_worker ~config ~entry operation with
+                  | Eio.Cancel.Cancelled _ ->
+                    Log.Keeper.info
+                      "Keeper shutdown worker cancelled by server teardown; durable recovery retained: keeper=%s operation=%s"
+                      operation.keeper_name
+                      (worker_key operation)
+                  | exn -> persist_unhandled_failure ~config operation exn));
+           if Atomic.get started
+           then Worker_started
+           else
+             (match Eio.Switch.get_error sw with
+              | None -> Worker_started
+              | Some cause ->
+                release_worker operation;
+                Worker_start_rejected (Worker_supervisor_stopping cause))
+         with
+         | exn ->
+           release_worker operation;
+           Worker_start_rejected (Worker_fork_failed exn)))
 ;;
 
-let submit ~sw ~config ~entry ~request =
+let start_or_error ~config ~entry operation =
+  match start_worker ~config ~entry operation with
+  | Worker_started | Worker_already_active -> Ok operation
+  | Worker_start_rejected error -> Error (Worker_start_error error)
+;;
+
+let submit ~config ~entry ~request =
   match Keeper_shutdown_prepare_join.prepare ~config ~entry ~request with
   | Ok operation ->
-    start_worker ~sw ~config ~entry operation;
-    Ok operation
+    start_or_error ~config ~entry operation
   | Error (Keeper_shutdown_prepare_join.Existing_operation operation_id) ->
     (match Keeper_shutdown_store.load ~config operation_id with
      | Error error -> Error (Existing_operation_load_error error)
-     | Ok operation ->
-       start_worker ~sw ~config ~entry operation;
-       Ok operation)
+     | Ok operation -> start_or_error ~config ~entry operation)
   | Error error -> Error (Prepare_error error)
 ;;
 
@@ -131,18 +177,24 @@ let recovered_join_state operation =
     | Inflight_effect_unknown turn -> Reconciliation_required turn
   in
   { operation with
-    join_evidence = Some evidence
+    revision = operation.revision + 1
+  ; join_evidence = Some evidence
   ; phase
   ; updated_at = Masc_domain.now_iso ()
   }
 ;;
 
-let recover_one ~config operation =
+let recover_operation ~config operation =
   let operation_result =
     match operation.phase with
     | Prepared ->
       let recovered = recovered_join_state operation in
-      (match Keeper_shutdown_store.replace ~config recovered with
+      (match
+         Keeper_shutdown_store.replace
+           ~config
+           ~expected_revision:operation.revision
+           recovered
+       with
        | Ok () -> Ok recovered
        | Error error -> Error (Keeper_shutdown_store.error_to_string error))
     | Joined_idle
@@ -170,5 +222,5 @@ let recover_one ~config operation =
 let recover_at_boot ~config =
   match Keeper_shutdown_store.list_all ~config with
   | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
-  | Ok operations -> List.map (recover_one ~config) operations
+  | Ok operations -> List.map (recover_operation ~config) operations
 ;;

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -1,0 +1,174 @@
+open Keeper_shutdown_types
+
+type submit_error =
+  | Prepare_error of Keeper_shutdown_prepare_join.error
+  | Existing_operation_load_error of Keeper_shutdown_store.error
+
+let submit_error_to_string = function
+  | Prepare_error error -> Keeper_shutdown_prepare_join.error_to_string error
+  | Existing_operation_load_error error -> Keeper_shutdown_store.error_to_string error
+;;
+
+let worker_mu = Eio.Mutex.create ()
+let active_workers : (string, unit) Hashtbl.t = Hashtbl.create 17
+
+let worker_key operation = Operation_id.to_string operation.operation_id
+
+let claim_worker operation =
+  Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
+    let key = worker_key operation in
+    if Hashtbl.mem active_workers key
+    then false
+    else (
+      Hashtbl.add active_workers key ();
+      true))
+;;
+
+let release_worker operation =
+  Eio.Mutex.use_rw ~protect:true worker_mu (fun () ->
+    Hashtbl.remove active_workers (worker_key operation))
+;;
+
+let persist_unhandled_failure ~config operation exn =
+  let blocked =
+    { operation with
+      phase = Blocked { stage = Record_update; detail = Printexc.to_string exn }
+    ; updated_at = Masc_domain.now_iso ()
+    }
+  in
+  match Keeper_shutdown_store.replace ~config blocked with
+  | Ok () -> ()
+  | Error store_error ->
+    Log.Keeper.error
+      "shutdown operation %s failed and its blocked state could not be persisted: %s"
+      (worker_key operation)
+      (Keeper_shutdown_store.error_to_string store_error)
+;;
+
+let finalize_if_ready ~config ~entry operation =
+  match operation.phase with
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _ ->
+    (match Keeper_shutdown_finalize.run ~config ~entry:(Some entry) operation with
+     | Ok finalized ->
+       Log.Keeper.info
+         "Keeper shutdown operation finalized: keeper=%s operation=%s"
+         finalized.keeper_name
+         (worker_key finalized)
+     | Error error ->
+       Log.Keeper.error
+         "Keeper shutdown finalization stopped: keeper=%s operation=%s error=%s"
+         operation.keeper_name
+         (worker_key operation)
+         (Keeper_shutdown_finalize.error_to_string error))
+  | Prepared
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _ -> ()
+;;
+
+let run_worker ~config ~entry operation =
+  match operation.phase with
+  | Prepared ->
+    (match Keeper_shutdown_prepare_join.join_prepared ~config ~entry ~operation with
+     | Ok joined -> finalize_if_ready ~config ~entry joined
+     | Error error ->
+       Log.Keeper.error
+         "Keeper shutdown join stopped: keeper=%s operation=%s error=%s"
+         operation.keeper_name
+         (worker_key operation)
+         (Keeper_shutdown_prepare_join.error_to_string error))
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _ -> finalize_if_ready ~config ~entry operation
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _ -> ()
+;;
+
+let start_worker ~sw ~config ~entry operation =
+  if claim_worker operation
+  then
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      Fun.protect
+        ~finally:(fun () -> release_worker operation)
+        (fun () ->
+           try run_worker ~config ~entry operation with
+           | Eio.Cancel.Cancelled _ ->
+             Log.Keeper.info
+               "Keeper shutdown worker cancelled by server teardown; durable recovery retained: keeper=%s operation=%s"
+               operation.keeper_name
+               (worker_key operation)
+           | exn -> persist_unhandled_failure ~config operation exn);
+      `Stop_daemon)
+;;
+
+let submit ~sw ~config ~entry ~request =
+  match Keeper_shutdown_prepare_join.prepare ~config ~entry ~request with
+  | Ok operation ->
+    start_worker ~sw ~config ~entry operation;
+    Ok operation
+  | Error (Keeper_shutdown_prepare_join.Existing_operation operation_id) ->
+    (match Keeper_shutdown_store.load ~config operation_id with
+     | Error error -> Error (Existing_operation_load_error error)
+     | Ok operation ->
+       start_worker ~sw ~config ~entry operation;
+       Ok operation)
+  | Error error -> Error (Prepare_error error)
+;;
+
+let recovered_join_state operation =
+  let evidence =
+    { lane_outcome = Lane_cancelled_by_parent "server process ended before lane receipt"
+    ; terminal = Terminal_crashed "server process ended before lane receipt"
+    ; cleanup_error = None
+    }
+  in
+  let phase =
+    match operation.turn_disposition with
+    | No_inflight_turn -> Joined_idle
+    | Inflight_effect_unknown turn -> Reconciliation_required turn
+  in
+  { operation with
+    join_evidence = Some evidence
+  ; phase
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let recover_one ~config operation =
+  let operation_result =
+    match operation.phase with
+    | Prepared ->
+      let recovered = recovered_join_state operation in
+      (match Keeper_shutdown_store.replace ~config recovered with
+       | Ok () -> Ok recovered
+       | Error error -> Error (Keeper_shutdown_store.error_to_string error))
+    | Joined_idle
+    | Finalizing_tasks _
+    | Cleanup_ready _
+    | Reconciliation_required _
+    | Finalized _
+    | Blocked _ -> Ok operation
+  in
+  match operation_result with
+  | Error _ as error -> error
+  | Ok recovered ->
+    (match recovered.phase with
+     | Joined_idle
+     | Finalizing_tasks _
+     | Cleanup_ready _ ->
+       Keeper_shutdown_finalize.run ~config ~entry:None recovered
+       |> Result.map_error Keeper_shutdown_finalize.error_to_string
+     | Prepared
+     | Reconciliation_required _
+     | Finalized _
+     | Blocked _ -> Ok recovered)
+;;
+
+let recover_at_boot ~config =
+  match Keeper_shutdown_store.list_all ~config with
+  | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
+  | Ok operations -> List.map (recover_one ~config) operations
+;;

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -42,25 +42,40 @@ let release_worker operation =
 ;;
 
 let persist_unhandled_failure ~config operation exn =
-  let blocked =
-    { operation with
-      revision = operation.revision + 1
-    ; phase = Blocked { stage = Record_update; detail = Printexc.to_string exn }
-    ; updated_at = Masc_domain.now_iso ()
-    }
-  in
-  match
-    Keeper_shutdown_store.replace
-      ~config
-      ~expected_revision:operation.revision
-      blocked
-  with
-  | Ok () -> ()
-  | Error store_error ->
+  let detail = Printexc.to_string exn in
+  Eio.Cancel.protect (fun () ->
     Log.Keeper.error
-      "shutdown operation %s failed and its blocked state could not be persisted: %s"
+      "shutdown worker failed; persisting durable failure evidence: keeper=%s operation=%s error=%s"
+      operation.keeper_name
       (worker_key operation)
-      (Keeper_shutdown_store.error_to_string store_error)
+      detail;
+    match
+      Keeper_shutdown_store.persist_blocked_latest
+        ~config
+        ~identity:operation
+        ~failure:{ stage = Record_update; detail }
+        ~updated_at:(Masc_domain.now_iso ())
+    with
+    | Ok (Keeper_shutdown_store.Blocked_persisted blocked) ->
+      Log.Keeper.error
+        "shutdown worker failed; blocked state persisted: keeper=%s operation=%s revision=%d error=%s"
+        blocked.keeper_name
+        (worker_key blocked)
+        blocked.revision
+        detail
+    | Ok (Keeper_shutdown_store.State_preserved current) ->
+      Log.Keeper.error
+        "shutdown worker failed after a durable non-progress state; preserving it: keeper=%s operation=%s revision=%d error=%s"
+        current.keeper_name
+        (worker_key current)
+        current.revision
+        detail
+    | Error store_error ->
+      Log.Keeper.error
+        "shutdown operation %s failed and its blocked state could not be persisted: worker_error=%s store_error=%s"
+        (worker_key operation)
+        detail
+        (Keeper_shutdown_store.error_to_string store_error))
 ;;
 
 let finalize_if_ready ~config ~entry operation =
@@ -224,3 +239,7 @@ let recover_at_boot ~config =
   | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
   | Ok operations -> List.map (recover_operation ~config) operations
 ;;
+
+module For_testing = struct
+  let persist_unhandled_failure = persist_unhandled_failure
+end

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -3,14 +3,19 @@
 type submit_error =
   | Prepare_error of Keeper_shutdown_prepare_join.error
   | Existing_operation_load_error of Keeper_shutdown_store.error
+  | Worker_start_error of worker_start_error
+
+and worker_start_error =
+  | Worker_supervisor_unavailable
+  | Worker_supervisor_stopping of exn
+  | Worker_fork_failed of exn
 
 val submit_error_to_string : submit_error -> string
 
 (** Fence admission and persist the operation synchronously, then fork lane
-    join/finalization on [sw]. The returned operation id is durable before
-    this function returns. *)
+    join/finalization on the process-lifetime Keeper supervisor switch. The
+    returned operation id is durable before this function returns. *)
 val submit :
-  sw:Eio.Switch.t ->
   config:Workspace.config ->
   entry:Keeper_registry.registry_entry ->
   request:Keeper_shutdown_prepare_join.request ->
@@ -22,3 +27,10 @@ val submit :
 val recover_at_boot :
   config:Workspace.config ->
   (Keeper_shutdown_types.t, string) result list
+
+(** Recover one durable operation without consulting global inventory. This
+    lets bootstrap isolate every Keeper in its own process-lifetime fiber. *)
+val recover_operation :
+  config:Workspace.config ->
+  Keeper_shutdown_types.t ->
+  (Keeper_shutdown_types.t, string) result

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -34,3 +34,11 @@ val recover_operation :
   config:Workspace.config ->
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, string) result
+
+module For_testing : sig
+  val persist_unhandled_failure :
+    config:Workspace.config ->
+    Keeper_shutdown_types.t ->
+    exn ->
+    unit
+end

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -1,0 +1,24 @@
+(** Non-blocking lifecycle orchestration for durable Keeper shutdown. *)
+
+type submit_error =
+  | Prepare_error of Keeper_shutdown_prepare_join.error
+  | Existing_operation_load_error of Keeper_shutdown_store.error
+
+val submit_error_to_string : submit_error -> string
+
+(** Fence admission and persist the operation synchronously, then fork lane
+    join/finalization on [sw]. The returned operation id is durable before
+    this function returns. *)
+val submit :
+  sw:Eio.Switch.t ->
+  config:Workspace.config ->
+  entry:Keeper_registry.registry_entry ->
+  request:Keeper_shutdown_prepare_join.request ->
+  (Keeper_shutdown_types.t, submit_error) result
+
+(** Recover operations left by an earlier server process. Must run before
+    Keeper autoboot so a stopped Keeper cannot acquire a replacement lane
+    ahead of settlement. Returns one explicit result per durable operation. *)
+val recover_at_boot :
+  config:Workspace.config ->
+  (Keeper_shutdown_types.t, string) result list

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -108,13 +108,51 @@ let failure_to_json failure =
     ]
 ;;
 
+let task_ids_to_json task_ids =
+  `List
+    (List.map
+       (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
+       task_ids)
+;;
+
+let cleanup_evidence_to_json evidence =
+  `Assoc
+    [ "settled_task_ids", task_ids_to_json evidence.settled_task_ids
+    ; "pending_confirms_removed", `Int evidence.pending_confirms_removed
+    ]
+;;
+
+let finalization_evidence_to_json evidence =
+  `Assoc
+    [ "cleanup", cleanup_evidence_to_json evidence.cleanup
+    ; "meta_removed", `Bool evidence.meta_removed
+    ; "session_removed", `Bool evidence.session_removed
+    ; "registry_unregistered", `Bool evidence.registry_unregistered
+    ]
+;;
+
 let phase_to_json = function
   | Prepared -> `Assoc [ "kind", `String "prepared" ]
   | Joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
+  | Finalizing_tasks settled_task_ids ->
+    `Assoc
+      [ "kind", `String "finalizing_tasks"
+      ; "settled_task_ids", task_ids_to_json settled_task_ids
+      ]
+  | Cleanup_ready evidence ->
+    `Assoc
+      [ "kind", `String "cleanup_ready"
+      ; "evidence", cleanup_evidence_to_json evidence
+      ]
   | Reconciliation_required turn ->
     `Assoc
       [ "kind", `String "reconciliation_required"
       ; "active_turn", active_turn_to_json turn
+      ]
+  | Finalized evidence ->
+    `Assoc
+      [ "kind", `String "finalized"
+      ; "evidence", finalization_evidence_to_json evidence
       ]
   | Blocked failure ->
     `Assoc
@@ -173,11 +211,7 @@ let to_json operation =
           ; "remove_session", `Bool operation.cleanup_intent.remove_session
           ] )
     ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
-    ; ( "owned_task_ids"
-      , `List
-          (List.map
-             (fun task_id -> `String (Keeper_id.Task_id.to_string task_id))
-             operation.owned_task_ids) )
+    ; "owned_task_ids", task_ids_to_json operation.owned_task_ids
     ; ( "join_evidence"
       , match operation.join_evidence with
         | None -> `Null
@@ -283,15 +317,62 @@ let failure_of_json json =
   Ok { stage; detail }
 ;;
 
+let task_ids_field_of_json field json =
+  match assoc field json with
+  | Error _ as error -> error
+  | Ok (`List values) ->
+    List.fold_left
+      (fun result value ->
+         let* task_ids = result in
+         match value with
+         | `String raw ->
+           let* task_id =
+             Keeper_id.Task_id.of_string raw
+             |> Result.map_error (fun e -> Decode_error e)
+           in
+           Ok (task_id :: task_ids)
+         | _ -> Error (decode_error (field ^ "[]") "a string"))
+      (Ok [])
+      values
+    |> Result.map List.rev
+  | Ok _ -> Error (decode_error field "an array")
+;;
+
+let cleanup_evidence_of_json json =
+  let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
+  let* pending_confirms_removed = int "pending_confirms_removed" json in
+  Ok { settled_task_ids; pending_confirms_removed }
+;;
+
+let finalization_evidence_of_json json =
+  let* cleanup_json = assoc "cleanup" json in
+  let* cleanup = cleanup_evidence_of_json cleanup_json in
+  let* meta_removed = bool "meta_removed" json in
+  let* session_removed = bool "session_removed" json in
+  let* registry_unregistered = bool "registry_unregistered" json in
+  Ok { cleanup; meta_removed; session_removed; registry_unregistered }
+;;
+
 let phase_of_json json =
   let* kind = string "kind" json in
   match kind with
   | "prepared" -> Ok Prepared
   | "joined_idle" -> Ok Joined_idle
+  | "finalizing_tasks" ->
+    let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
+    Ok (Finalizing_tasks settled_task_ids)
+  | "cleanup_ready" ->
+    let* evidence_json = assoc "evidence" json in
+    let* evidence = cleanup_evidence_of_json evidence_json in
+    Ok (Cleanup_ready evidence)
   | "reconciliation_required" ->
     let* active_json = assoc "active_turn" json in
     let* turn = active_turn_of_json active_json in
     Ok (Reconciliation_required turn)
+  | "finalized" ->
+    let* evidence_json = assoc "evidence" json in
+    let* evidence = finalization_evidence_of_json evidence_json in
+    Ok (Finalized evidence)
   | "blocked" ->
     let* failure_json = assoc "failure" json in
     let* failure = failure_of_json failure_json in
@@ -339,27 +420,6 @@ let optional_join_evidence_of_json json =
   | Error _ as error -> error
 ;;
 
-let task_ids_of_json json =
-  match assoc "owned_task_ids" json with
-  | Error _ as error -> error
-  | Ok (`List values) ->
-    List.fold_left
-      (fun result value ->
-         let* task_ids = result in
-         match value with
-         | `String raw ->
-           let* task_id =
-             Keeper_id.Task_id.of_string raw
-             |> Result.map_error (fun e -> Decode_error e)
-           in
-           Ok (task_id :: task_ids)
-         | _ -> Error (decode_error "owned_task_ids[]" "a string"))
-      (Ok [])
-      values
-    |> Result.map List.rev
-  | Ok _ -> Error (decode_error "owned_task_ids" "an array")
-;;
-
 let of_json json =
   let* decoded_schema_version = int "schema_version" json in
   if decoded_schema_version <> schema_version
@@ -393,7 +453,7 @@ let of_json json =
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
     let* turn_disposition = turn_disposition_of_json turn_json in
-    let* owned_task_ids = task_ids_of_json json in
+    let* owned_task_ids = task_ids_field_of_json "owned_task_ids" json in
     let* join_evidence = optional_join_evidence_of_json json in
     let* phase_json = assoc "phase" json in
     let* phase = phase_of_json phase_json in
@@ -470,7 +530,7 @@ let load ~config operation_id =
     load_unlocked ~config operation_id)
 ;;
 
-let list_for_keeper ~config ~keeper_name =
+let list_unlocked ~config =
   let dir = records_dir config in
   if not (Fs_compat.file_exists dir)
   then Ok []
@@ -486,9 +546,7 @@ let list_for_keeper ~config ~keeper_name =
               then
                 Error
                   (Decode_error
-                     (Printf.sprintf
-                        "unexpected shutdown store entry: %s"
-                        filename))
+                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
               else
                 let raw_id = Filename.chop_suffix filename ".json" in
                 let* operation_id =
@@ -496,12 +554,18 @@ let list_for_keeper ~config ~keeper_name =
                   |> Result.map_error (fun e -> Decode_error e)
                 in
                 let* operation = load ~config operation_id in
-                if String.equal operation.keeper_name keeper_name
-                then Ok (operation :: operations)
-                else Ok operations)
+                Ok (operation :: operations))
            (Ok [])
       |> Result.map List.rev
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Io_error (Printexc.to_string exn))
+;;
+
+let list_all ~config = list_unlocked ~config
+
+let list_for_keeper ~config ~keeper_name =
+  list_unlocked ~config
+  |> Result.map
+       (List.filter (fun operation -> String.equal operation.keeper_name keeper_name))
 ;;

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -11,6 +11,10 @@ type error =
       ; actual : int
       }
 
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
+
 let error_to_string = function
   | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
   | Not_found path -> Printf.sprintf "shutdown operation not found: %s" path
@@ -547,6 +551,30 @@ let replace ~config ~expected_revision operation =
            (Operation_id.to_string operation.operation_id)))
 ;;
 
+let persist_blocked_latest ~config ~identity ~failure ~updated_at =
+  let operation_path = path ~config identity.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
+    match load_unlocked ~config identity.operation_id with
+    | Error _ as error -> error
+    | Ok existing when not (same_identity existing identity) ->
+      Error (Identity_mismatch (Operation_id.to_string identity.operation_id))
+    | Ok existing ->
+      (match existing.phase with
+       | Finalized _ | Blocked _ | Reconciliation_required _ ->
+         Ok (State_preserved existing)
+       | Prepared | Joined_idle | Finalizing_tasks _ | Cleanup_ready _ ->
+         let blocked =
+           { existing with
+             revision = existing.revision + 1
+           ; phase = Blocked failure
+           ; updated_at
+           }
+         in
+         Keeper_fs.save_json_atomic operation_path (to_json blocked)
+         |> Result.map_error (fun detail -> Io_error detail)
+         |> Result.map (fun () -> Blocked_persisted blocked)))
+;;
+
 let load ~config operation_id =
   let operation_path = path ~config operation_id in
   with_operation_lock ~access:Read operation_path (fun () ->
@@ -592,3 +620,10 @@ let list_for_keeper ~config ~keeper_name =
   |> Result.map
        (List.filter (fun operation -> String.equal operation.keeper_name keeper_name))
 ;;
+
+module For_testing = struct
+  let with_operation_write_lock ~config operation_id f =
+    let operation_path = path ~config operation_id in
+    with_operation_lock ~access:Write operation_path f
+  ;;
+end

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -6,6 +6,10 @@ type error =
   | Io_error of string
   | Decode_error of string
   | Identity_mismatch of string
+  | Revision_conflict of
+      { expected : int
+      ; actual : int
+      }
 
 let error_to_string = function
   | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
@@ -14,6 +18,11 @@ let error_to_string = function
   | Decode_error detail -> Printf.sprintf "shutdown operation decode failed: %s" detail
   | Identity_mismatch detail ->
     Printf.sprintf "shutdown operation identity mismatch: %s" detail
+  | Revision_conflict { expected; actual } ->
+    Printf.sprintf
+      "shutdown operation revision conflict: expected %d, actual %d"
+      expected
+      actual
 ;;
 
 type operation_lock =
@@ -199,6 +208,7 @@ let join_evidence_to_json evidence =
 let to_json operation =
   `Assoc
     [ "schema_version", `Int operation.schema_version
+    ; "revision", `Int operation.revision
     ; "operation_id", `String (Operation_id.to_string operation.operation_id)
     ; "keeper_name", `String operation.keeper_name
     ; "lane_id", `String (Keeper_lane.Id.to_string operation.lane_id)
@@ -211,6 +221,7 @@ let to_json operation =
           ; "remove_session", `Bool operation.cleanup_intent.remove_session
           ] )
     ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
+    ; "expected_backlog_version", `Int operation.expected_backlog_version
     ; "owned_task_ids", task_ids_to_json operation.owned_task_ids
     ; ( "join_evidence"
       , match operation.join_evidence with
@@ -431,6 +442,7 @@ let of_json json =
             decoded_schema_version))
   else
     let* operation_id_wire = string "operation_id" json in
+    let* revision = int "revision" json in
     let* operation_id =
       Operation_id.of_string operation_id_wire
       |> Result.map_error (fun e -> Decode_error e)
@@ -453,6 +465,7 @@ let of_json json =
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
     let* turn_disposition = turn_disposition_of_json turn_json in
+    let* expected_backlog_version = int "expected_backlog_version" json in
     let* owned_task_ids = task_ids_field_of_json "owned_task_ids" json in
     let* join_evidence = optional_join_evidence_of_json json in
     let* phase_json = assoc "phase" json in
@@ -461,6 +474,7 @@ let of_json json =
     let* updated_at = string "updated_at" json in
     Ok
       { schema_version = decoded_schema_version
+      ; revision
       ; operation_id
       ; keeper_name
       ; lane_id
@@ -469,6 +483,7 @@ let of_json json =
       ; actor
       ; cleanup_intent = { remove_meta; remove_session }
       ; turn_disposition
+      ; expected_backlog_version
       ; owned_task_ids
       ; join_evidence
       ; phase
@@ -510,11 +525,19 @@ let same_identity left right =
   && Int.equal left.generation right.generation
 ;;
 
-let replace ~config operation =
+let replace ~config ~expected_revision operation =
   let operation_path = path ~config operation.operation_id in
   with_operation_lock ~access:Write operation_path (fun () ->
     match load_unlocked ~config operation.operation_id with
     | Error _ as error -> error
+    | Ok existing when not (Int.equal existing.revision expected_revision) ->
+      Error (Revision_conflict { expected = expected_revision; actual = existing.revision })
+    | Ok _ when not (Int.equal operation.revision (expected_revision + 1)) ->
+      Error
+        (Revision_conflict
+           { expected = expected_revision + 1
+           ; actual = operation.revision
+           })
     | Ok existing when same_identity existing operation ->
       Keeper_fs.save_json_atomic operation_path (to_json operation)
       |> Result.map_error (fun detail -> Io_error detail)

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -14,6 +14,10 @@ type error =
       ; actual : int
       }
 
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
+
 val error_to_string : error -> string
 
 val path :
@@ -35,6 +39,16 @@ val replace :
   Keeper_shutdown_types.t ->
   (unit, error) result
 
+(** Read the latest durable revision and persist [Blocked failure] while
+    holding the operation's write lock. Existing [Finalized], [Blocked], and
+    effect-unknown reconciliation states are preserved. *)
+val persist_blocked_latest :
+  config:Workspace.config ->
+  identity:Keeper_shutdown_types.t ->
+  failure:Keeper_shutdown_types.failure ->
+  updated_at:string ->
+  (persist_blocked_result, error) result
+
 val load :
   config:Workspace.config ->
   Keeper_shutdown_types.Operation_id.t ->
@@ -48,3 +62,11 @@ val list_for_keeper :
 val list_all :
   config:Workspace.config ->
   (Keeper_shutdown_types.t list, error) result
+
+module For_testing : sig
+  val with_operation_write_lock :
+    config:Workspace.config ->
+    Keeper_shutdown_types.Operation_id.t ->
+    (unit -> 'a) ->
+    'a
+end

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -9,6 +9,10 @@ type error =
   | Io_error of string
   | Decode_error of string
   | Identity_mismatch of string
+  | Revision_conflict of
+      { expected : int
+      ; actual : int
+      }
 
 val error_to_string : error -> string
 
@@ -27,6 +31,7 @@ val persist_new :
 
 val replace :
   config:Workspace.config ->
+  expected_revision:int ->
   Keeper_shutdown_types.t ->
   (unit, error) result
 

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -39,3 +39,7 @@ val list_for_keeper :
   config:Workspace.config ->
   keeper_name:string ->
   (Keeper_shutdown_types.t list, error) result
+
+val list_all :
+  config:Workspace.config ->
+  (Keeper_shutdown_types.t list, error) result

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -56,6 +56,12 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Task_settlement
+  | Pending_confirm_cleanup
+  | Meta_update
+  | Meta_remove
+  | Session_remove
+  | Registry_unregister
 
 type failure =
   { stage : failure_stage
@@ -78,10 +84,25 @@ type join_evidence =
   ; cleanup_error : string option
   }
 
+type cleanup_evidence =
+  { settled_task_ids : Keeper_id.Task_id.t list
+  ; pending_confirms_removed : int
+  }
+
+type finalization_evidence =
+  { cleanup : cleanup_evidence
+  ; meta_removed : bool
+  ; session_removed : bool
+  ; registry_unregistered : bool
+  }
+
 type phase =
   | Prepared
   | Joined_idle
+  | Finalizing_tasks of Keeper_id.Task_id.t list
+  | Cleanup_ready of cleanup_evidence
   | Reconciliation_required of active_turn
+  | Finalized of finalization_evidence
   | Blocked of failure
 
 type t =
@@ -122,6 +143,12 @@ let failure_stage_to_string = function
   | Turn_join -> "turn_join"
   | Lane_join -> "lane_join"
   | Record_update -> "record_update"
+  | Task_settlement -> "task_settlement"
+  | Pending_confirm_cleanup -> "pending_confirm_cleanup"
+  | Meta_update -> "meta_update"
+  | Meta_remove -> "meta_remove"
+  | Session_remove -> "session_remove"
+  | Registry_unregister -> "registry_unregister"
 ;;
 
 let failure_stage_of_string = function
@@ -132,5 +159,11 @@ let failure_stage_of_string = function
   | "turn_join" -> Ok Turn_join
   | "lane_join" -> Ok Lane_join
   | "record_update" -> Ok Record_update
+  | "task_settlement" -> Ok Task_settlement
+  | "pending_confirm_cleanup" -> Ok Pending_confirm_cleanup
+  | "meta_update" -> Ok Meta_update
+  | "meta_remove" -> Ok Meta_remove
+  | "session_remove" -> Ok Session_remove
+  | "registry_unregister" -> Ok Registry_unregister
   | value -> Error (Printf.sprintf "unknown Keeper shutdown failure stage: %S" value)
 ;;

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -107,6 +107,7 @@ type phase =
 
 type t =
   { schema_version : int
+  ; revision : int
   ; operation_id : Operation_id.t
   ; keeper_name : string
   ; lane_id : Keeper_lane.Id.t
@@ -115,6 +116,7 @@ type t =
   ; actor : string
   ; cleanup_intent : cleanup_intent
   ; turn_disposition : turn_disposition
+  ; expected_backlog_version : int
   ; owned_task_ids : Keeper_id.Task_id.t list
   ; join_evidence : join_evidence option
   ; phase : phase
@@ -122,7 +124,7 @@ type t =
   ; updated_at : string
   }
 
-let schema_version = 1
+let schema_version = 2
 
 let admission_lane_to_string = function
   | Autonomous -> "autonomous"

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -90,6 +90,7 @@ type phase =
 
 type t =
   { schema_version : int
+  ; revision : int
   ; operation_id : Operation_id.t
   ; keeper_name : string
   ; lane_id : Keeper_lane.Id.t
@@ -98,6 +99,7 @@ type t =
   ; actor : string
   ; cleanup_intent : cleanup_intent
   ; turn_disposition : turn_disposition
+  ; expected_backlog_version : int
   ; owned_task_ids : Keeper_id.Task_id.t list
   ; join_evidence : join_evidence option
   ; phase : phase

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -39,6 +39,12 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Task_settlement
+  | Pending_confirm_cleanup
+  | Meta_update
+  | Meta_remove
+  | Session_remove
+  | Registry_unregister
 
 type failure =
   { stage : failure_stage
@@ -61,10 +67,25 @@ type join_evidence =
   ; cleanup_error : string option
   }
 
+type cleanup_evidence =
+  { settled_task_ids : Keeper_id.Task_id.t list
+  ; pending_confirms_removed : int
+  }
+
+type finalization_evidence =
+  { cleanup : cleanup_evidence
+  ; meta_removed : bool
+  ; session_removed : bool
+  ; registry_unregistered : bool
+  }
+
 type phase =
   | Prepared
   | Joined_idle
+  | Finalizing_tasks of Keeper_id.Task_id.t list
+  | Cleanup_ready of cleanup_evidence
   | Reconciliation_required of active_turn
+  | Finalized of finalization_evidence
   | Blocked of failure
 
 type t =

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -833,6 +833,15 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
                append happened after the mark_dead post-processing above, so it
                had no effect in the current sweep. We keep the metric/log and
                intentionally do not accumulate, preserving the prior behavior. *)
+          | Error (Keeper_registry.Restart_shutdown_reserved operation_id) ->
+            Log.Keeper.info
+              "%s: restart skipped because shutdown operation %s owns admission"
+              old_entry.name
+              (Keeper_shutdown_types.Operation_id.to_string operation_id);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
+              ()
           | Ok reg ->
             Keeper_registry.restore_supervisor_state
               ~base_path

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -65,12 +65,26 @@ let supervise_keepalive
         meta.name
         (Keeper_registry.spawn_slot_denial_reason_to_detail reason)
         ()
-    | Ok () -> (
+    | Ok () ->
     Startup_helpers.log_persona_drift_if_missing ~base_path:ctx.config.base_path meta;
     (* Register in Keeper_registry — single source of truth. *)
-    let reg =
-      Keeper_registry.register_offline ~base_path:ctx.config.base_path meta.name meta
-    in
+    (match
+       Keeper_registry.register_offline_if_admitted
+         ~base_path:ctx.config.base_path
+         meta.name
+         meta
+     with
+     | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+       Log.Keeper.info
+         "supervisor launch skipped %s because shutdown operation %s owns admission"
+         meta.name
+         (Keeper_shutdown_types.Operation_id.to_string operation_id)
+     | Error (Keeper_registry.Registration_invalid validation_error) ->
+       Log.Keeper.error
+         "supervisor registry validation rejected %s: %s"
+         meta.name
+         (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+     | Ok reg ->
     (* Workspace initialization *)
     (try
        if not (Workspace_utils.is_initialized ctx.config)

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -826,10 +826,16 @@ let () =
     | "masc_keeper_down" ->
       Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
       Keeper_tool_surface_ops.invalidate_status_cache (Tool_args.get_string args "name" "");
-      Some
-        (tool_result_with_tool_name
-           ~tool_name:name
-           (Keeper_turn_lifecycle.handle_keeper_down_config ~config args))
+      (match sw, clock with
+       | Some sw, Some clock ->
+         let ctx : _ Keeper_types_profile.context =
+           { config; agent_name; sw; clock; proc_mgr; net }
+         in
+         Some
+           (tool_result_with_tool_name
+              ~tool_name:name
+              (Keeper_turn_lifecycle.handle_keeper_down ctx args))
+       | _ -> eio_context_missing name)
     (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools.  Require both
        sw and clock from caller; gracefully fail when invoked from a
        path without Eio context. *)

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -34,6 +34,10 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type 'a registration_commit_result =
+  | Registration_committed of 'a
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+
 type slot_snapshot =
   { snapshot_keeper_name : string
   ; snapshot_slot_created : bool
@@ -306,6 +310,14 @@ let rollback_shutdown ~base_path ~keeper_name ~operation_id =
       slot.shutdown_operation_id <- None;
       Shutdown_rolled_back
     | Some existing -> Shutdown_reserved_by_other existing)
+;;
+
+let commit_registration_if_open ~base_path ~keeper_name commit =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | Some operation_id -> Registration_shutdown_reserved operation_id
+    | None -> Registration_committed (commit ()))
 ;;
 
 let await_idle_after_shutdown ~base_path ~keeper_name =

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -34,6 +34,11 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type restore_shutdown_result =
+  | Shutdown_restored
+  | Shutdown_already_restored
+  | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
+
 type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -310,6 +315,18 @@ let rollback_shutdown ~base_path ~keeper_name ~operation_id =
       slot.shutdown_operation_id <- None;
       Shutdown_rolled_back
     | Some existing -> Shutdown_reserved_by_other existing)
+;;
+
+let restore_shutdown ~base_path ~keeper_name ~operation_id =
+  let slot = slot_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect slot.state_mu (fun () ->
+    match slot.shutdown_operation_id with
+    | None ->
+      slot.shutdown_operation_id <- Some operation_id;
+      Shutdown_restored
+    | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+      Shutdown_already_restored
+    | Some existing -> Shutdown_restore_conflict existing)
 ;;
 
 let commit_registration_if_open ~base_path ~keeper_name commit =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -50,6 +50,11 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type restore_shutdown_result =
+  | Shutdown_restored
+  | Shutdown_already_restored
+  | Shutdown_restore_conflict of Keeper_shutdown_types.Operation_id.t
+
 type 'a registration_commit_result =
   | Registration_committed of 'a
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -191,6 +196,16 @@ val rollback_shutdown :
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   rollback_shutdown_result
+
+(** Restore the admission owner from a durable non-terminal shutdown record
+    before boot recovery or same-name registration starts. The operation id is
+    compared as a typed identity; a different in-memory owner is never
+    overwritten. *)
+val restore_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  restore_shutdown_result
 
 (** Run the non-yielding registry [commit] only while no shutdown operation
     owns the Keeper admission fence. Shutdown reservation and same-name lane

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -50,6 +50,10 @@ type rollback_shutdown_result =
   | Shutdown_not_reserved
   | Shutdown_reserved_by_other of Keeper_shutdown_types.Operation_id.t
 
+type 'a registration_commit_result =
+  | Registration_committed of 'a
+  | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+
 type slot_snapshot =
   { snapshot_keeper_name : string
   ; snapshot_slot_created : bool
@@ -187,6 +191,15 @@ val rollback_shutdown :
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   rollback_shutdown_result
+
+(** Run the non-yielding registry [commit] only while no shutdown operation
+    owns the Keeper admission fence. Shutdown reservation and same-name lane
+    installation are therefore totally ordered. *)
+val commit_registration_if_open :
+  base_path:string ->
+  keeper_name:string ->
+  (unit -> 'a) ->
+  'a registration_commit_result
 
 (** Join the current turn holder after admission has been closed. This waits
     without an invented timeout, then immediately releases the slot. Never

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -93,7 +93,6 @@ let handle_keeper_down (ctx : _ context) args : tool_result =
       in
       (match
          Keeper_shutdown_runtime.submit
-           ~sw:ctx.sw
            ~config:ctx.config
            ~entry
            ~request

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -1,143 +1,103 @@
-(** Keeper_turn_lifecycle -- keeper shutdown handlers.
-
-    Extracted from keeper_turn.ml. Provides [handle_keeper_down]. *)
+(** Keeper lifecycle tools submit durable, non-blocking shutdown operations. *)
 
 open Tool_args
-open Keeper_types
-open Keeper_meta_contract
-open Keeper_meta_store
 open Keeper_types_profile
-open Keeper_keepalive
 
 type tool_result = Keeper_types_profile.tool_result
 
-let remove_pending_confirms_by_target_callback
-    : (Workspace.config ->
-       target_type:string ->
-       target_id:string option ->
-       (int, string) result)
-        Atomic.t
-  =
-  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+let register_remove_pending_confirms_by_target =
+  Keeper_shutdown_finalize.register_remove_pending_confirms_by_target
+;;
 
-let register_remove_pending_confirms_by_target fn =
-  Atomic.set remove_pending_confirms_by_target_callback fn
+let operation_json ~accepted operation =
+  match Keeper_shutdown_store.to_json operation with
+  | `Assoc fields ->
+    `Assoc (("accepted", `Bool accepted) :: fields)
+  | json -> json
+;;
 
-let handle_keeper_down_config ~(config : Workspace.config) args : tool_result =
+let active_operation ~config keeper_name =
+  match Keeper_shutdown_store.list_for_keeper ~config ~keeper_name with
+  | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+  | Ok operations ->
+    let active =
+      List.filter
+        (fun operation ->
+           match operation.Keeper_shutdown_types.phase with
+           | Keeper_shutdown_types.Finalized _ -> false
+           | Keeper_shutdown_types.Prepared
+           | Keeper_shutdown_types.Joined_idle
+           | Keeper_shutdown_types.Finalizing_tasks _
+           | Keeper_shutdown_types.Cleanup_ready _
+           | Keeper_shutdown_types.Reconciliation_required _
+           | Keeper_shutdown_types.Blocked _ -> true)
+        operations
+    in
+    (match active with
+     | [] -> Ok None
+     | [ operation ] -> Ok (Some operation)
+     | _ -> Error "multiple non-terminal shutdown operations exist for one Keeper")
+;;
+
+let handle_keeper_down (ctx : _ context) args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
-  if not (validate_name requested_name) then
+  if not (validate_name requested_name)
+  then
     tool_result_error
       (Printf.sprintf
          "invalid keeper name %S (must be non-empty and match \
           [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
          requested_name)
   else
-    let remove_meta = get_bool args "remove_meta" false in
-    let remove_session = get_bool args "remove_session" false in
-    stop_keepalive ~base_path:config.base_path requested_name;
-    match read_meta_resolved config requested_name with
-    | Error e -> tool_result_error e
-    | Ok None -> tool_result_ok (Printf.sprintf "keeper already absent: %s" requested_name)
-    | Ok (Some (name, m)) ->
+    match Keeper_registry.get ~base_path:ctx.config.base_path requested_name with
+    | None ->
+      (match active_operation ~config:ctx.config requested_name with
+       | Error detail -> tool_result_error detail
+       | Ok (Some operation) ->
+         tool_result_ok
+           (Yojson.Safe.to_string (operation_json ~accepted:false operation))
+       | Ok None ->
+         (match Keeper_meta_store.read_meta_resolved ctx.config requested_name with
+          | Error detail -> tool_result_error detail
+          | Ok None ->
+            tool_result_ok
+              (Yojson.Safe.to_string
+                 (`Assoc
+                    [ "name", `String requested_name
+                    ; "already_absent", `Bool true
+                    ]))
+          | Ok (Some _) ->
+            tool_result_error
+              "Keeper metadata exists without a live lane; refusing untracked cleanup"))
+    | Some entry ->
+      let request : Keeper_shutdown_prepare_join.request =
+        { actor = ctx.agent_name
+        ; cleanup_intent =
+            { remove_meta = get_bool args "remove_meta" false
+            ; remove_session = get_bool args "remove_session" false
+            }
+        }
+      in
       (match
-         Atomic.get remove_pending_confirms_by_target_callback config
-           ~target_type:"keeper" ~target_id:(Some name)
+         Keeper_shutdown_runtime.submit
+           ~sw:ctx.sw
+           ~config:ctx.config
+           ~entry
+           ~request
        with
-       | Error msg ->
-         tool_result_error
-           (Printf.sprintf
-              "keeper pending-confirm cleanup failed for %s: %s"
-              name
-              msg)
-       | Ok pending_confirms_removed ->
-      Log.Misc.info
-        "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
-         remove_meta=%b remove_session=%b"
-        name pending_confirms_removed remove_meta remove_session;
-      (if remove_meta then
-         ( Safe_ops.remove_file_logged ~context:"keeper_down"
-             (keeper_meta_path config name);
-           Keeper_registry.unregister ~base_path:config.base_path name;
-           (* Tier K4c teardown — when the keeper is fully removed
-              (remove_meta=true), drop its tool-emission accumulator
-              from the registry so its slot is reclaimable. The
-              retain-paused branch (else) deliberately keeps the
-              accumulator alive so a future resume can drain any
-              pending items captured before pause. *)
-           Keeper_tool_emission_hook.drop_keeper_accumulator name )
-       else
-         let retained =
-           {
-             m with
-             updated_at = now_iso ();
-             paused = true;
-             (* keeper_down (remove_meta=false) is an operator-initiated
-                retain-paused shutdown; record it as an operator pause so the
-                status bridge can name it. Observability only — the
-                Operator_pause dispatch below is unchanged. *)
-             latched_reason =
-               Some
-                 (Keeper_latched_reason.Operator_paused
-                    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down });
-           }
-         in
-         ((match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.caller_wins config retained
-           with
-           | Ok () -> ()
-           | Error err ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string WriteMetaFailures)
-                 ~labels:[("keeper", name);
-                          ("phase",
-                           if Keeper_meta_store.is_version_conflict_error err
-                           then "keeper_down_cas_race"
-                           else "keeper_down")]
-                 ();
-               if Keeper_meta_store.is_version_conflict_error err then
-                 Log.Keeper.warn "keeper_down write_meta lost CAS race: %s" err
-               else
-                 Log.Keeper.error "keeper_down write_meta failed: %s" err);
-          Keeper_registry.update_meta ~base_path:config.base_path name retained;
-          Keeper_registry.dispatch_event_unit ~base_path:config.base_path name
-            Keeper_state_machine.Operator_pause));
-      if remove_session then (
-        let rec rm_rf path =
-          if Fs_compat.file_exists path then begin
-            if Sys.is_directory path then begin
-              Sys.readdir path |> Array.iter (fun entry ->
-                rm_rf (Filename.concat path entry)
-              );
-              Fs_compat.rmdir path
-            end else
-              Sys.remove path
-          end
-        in
-        if validate_name (Keeper_id.Trace_id.to_string m.runtime.trace_id) then (
-          let dir = Filename.concat (session_base_dir config) (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
-          try rm_rf dir with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string SessionCleanupFailures)
-              ();
-            Log.Keeper.error "session dir cleanup failed: %s"
-              (Printexc.to_string exn)));
-      let json = `Assoc [
-        ("name", `String name);
-        ("stopped", `Bool true);
-        ("remove_meta", `Bool remove_meta);
-        ("remove_session", `Bool remove_session);
-        ("pending_confirms_removed", `Int pending_confirms_removed);
-      ] in
-      tool_result_ok (Yojson.Safe.to_string json))
-
-let handle_keeper_down (ctx : _ context) args = handle_keeper_down_config ~config:ctx.config args
+       | Error error ->
+         tool_result_error (Keeper_shutdown_runtime.submit_error_to_string error)
+       | Ok operation ->
+         tool_result_ok
+           (Yojson.Safe.to_string (operation_json ~accepted:true operation)))
+;;
 
 module For_testing = struct
-  let remove_pending_confirms_by_target ~config ~target_type ~target_id =
-    Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
+  let remove_pending_confirms_by_target =
+    Keeper_shutdown_finalize.For_testing.remove_pending_confirms_by_target
+  ;;
 
-  let reset_remove_pending_confirms_by_target () =
-    Atomic.set remove_pending_confirms_by_target_callback
-      (fun _config ~target_type:_ ~target_id:_ -> Ok 0)
+  let reset_remove_pending_confirms_by_target =
+    Keeper_shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target
+  ;;
 end

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -52,14 +52,24 @@ let handle_keeper_down (ctx : _ context) args : tool_result =
     match Keeper_registry.get ~base_path:ctx.config.base_path requested_name with
     | None ->
       (match active_operation ~config:ctx.config requested_name with
-       | Error detail -> tool_result_error detail
+       | Error detail ->
+         Log.Keeper.error
+           "Keeper shutdown inventory failed: keeper=%s error=%s"
+           requested_name
+           detail;
+         tool_result_error detail
        | Ok (Some operation) ->
+         Log.Keeper.info
+           "Keeper shutdown operation observed: keeper=%s operation=%s"
+           requested_name
+           (Keeper_shutdown_types.Operation_id.to_string operation.operation_id);
          tool_result_ok
            (Yojson.Safe.to_string (operation_json ~accepted:false operation))
        | Ok None ->
          (match Keeper_meta_store.read_meta_resolved ctx.config requested_name with
           | Error detail -> tool_result_error detail
           | Ok None ->
+            Log.Keeper.info "Keeper shutdown found already absent: keeper=%s" requested_name;
             tool_result_ok
               (Yojson.Safe.to_string
                  (`Assoc
@@ -67,6 +77,9 @@ let handle_keeper_down (ctx : _ context) args : tool_result =
                     ; "already_absent", `Bool true
                     ]))
           | Ok (Some _) ->
+            Log.Keeper.error
+              "Keeper shutdown refused metadata-only identity: keeper=%s"
+              requested_name;
             tool_result_error
               "Keeper metadata exists without a live lane; refusing untracked cleanup"))
     | Some entry ->
@@ -86,8 +99,16 @@ let handle_keeper_down (ctx : _ context) args : tool_result =
            ~request
        with
        | Error error ->
+         Log.Keeper.error
+           "Keeper shutdown submission failed: keeper=%s error=%s"
+           requested_name
+           (Keeper_shutdown_runtime.submit_error_to_string error);
          tool_result_error (Keeper_shutdown_runtime.submit_error_to_string error)
        | Ok operation ->
+         Log.Keeper.info
+           "Keeper shutdown operation accepted: keeper=%s operation=%s"
+           requested_name
+           (Keeper_shutdown_types.Operation_id.to_string operation.operation_id);
          tool_result_ok
            (Yojson.Safe.to_string (operation_json ~accepted:true operation)))
 ;;

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -7,7 +7,7 @@ val handle_keeper_down :
 
 val register_remove_pending_confirms_by_target :
   (Workspace.config ->
-   target_type:string ->
+   target_type:Operator_action_constants.target_type ->
    target_id:string option ->
    (int, string) result) ->
   unit
@@ -15,7 +15,7 @@ val register_remove_pending_confirms_by_target :
 module For_testing : sig
   val remove_pending_confirms_by_target :
     config:Workspace.config ->
-    target_type:string ->
+    target_type:Operator_action_constants.target_type ->
     target_id:string option ->
     (int, string) result
 

--- a/lib/keeper/keeper_turn_lifecycle.mli
+++ b/lib/keeper/keeper_turn_lifecycle.mli
@@ -1,18 +1,9 @@
-(** Keeper_turn_lifecycle — keeper shutdown handlers.
-
-    Extracted from keeper_turn.ml. *)
+(** Keeper lifecycle tools submit durable, non-blocking shutdown operations. *)
 
 type tool_result = Keeper_types_profile.tool_result
 
-(** Handle the [masc_keeper_down] MCP tool call: stop keepalive,
-    optionally remove meta and/or session directory, broadcast
-    Operator_pause to the registry. *)
 val handle_keeper_down :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
-
-(** RFC-0182 §3.1 — ctx-free entry point for keeper_dispatch_ref path. *)
-val handle_keeper_down_config :
-  config:Workspace.config -> Yojson.Safe.t -> tool_result
 
 val register_remove_pending_confirms_by_target :
   (Workspace.config ->
@@ -21,13 +12,12 @@ val register_remove_pending_confirms_by_target :
    (int, string) result) ->
   unit
 
-(** Test-only hooks for the Atomic-backed callback. *)
 module For_testing : sig
-  val remove_pending_confirms_by_target
-    : config:Workspace.config ->
-      target_type:string ->
-      target_id:string option ->
-      (int, string) result
+  val remove_pending_confirms_by_target :
+    config:Workspace.config ->
+    target_type:string ->
+    target_id:string option ->
+    (int, string) result
 
   val reset_remove_pending_confirms_by_target : unit -> unit
 end

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -68,6 +68,25 @@ type available_action = {
   confirm_required : bool;
 }
 
+type target =
+  { target_type : Operator_action_constants.target_type
+  ; target_id : string option
+  }
+
+let target_gate_callback
+    : (Workspace.config -> target -> (unit, string) result) Atomic.t
+  =
+  Atomic.make (fun _config _target -> Ok ())
+;;
+
+let register_target_gate gate = Atomic.set target_gate_callback gate
+
+let target_of_entry (entry : pending_confirm) =
+  match Operator_action_constants.target_type_of_string entry.target_type with
+  | Some target_type -> Ok { target_type; target_id = entry.target_id }
+  | None -> Error (Printf.sprintf "invalid pending-confirm target type: %S" entry.target_type)
+;;
+
 let make_available_action ~action_type ~tool_name ~target_type ~description =
   { action_type; tool_name; target_type; description;
     confirm_required = Operator_approval.confirm_required action_type }
@@ -174,12 +193,16 @@ let write_pending_confirms config (entries : pending_confirm list) =
   Workspace_utils.write_json_result config (pending_confirms_path config)
     (pending_confirms_to_yojson entries)
 
+let with_store_lock config f =
+  File_lock_eio.with_mutex (pending_confirms_path config) f
+;;
+
 let pending_confirm_expired (entry : pending_confirm) =
   match entry.expires_at with
   | Some exp -> Masc_domain.now_iso () > exp
   | None -> false
 
-let read_pending_confirms_result config =
+let read_pending_confirms_result_unlocked config =
   match raw_pending_confirms_result config with
   | Error _ as error -> error
   | Ok entries ->
@@ -194,6 +217,10 @@ let read_pending_confirms_result config =
            msg)
   else Ok active
 
+let read_pending_confirms_result config =
+  with_store_lock config (fun () -> read_pending_confirms_result_unlocked config)
+;;
+
 let read_pending_confirms config : pending_confirm list =
   match read_pending_confirms_result config with
   | Ok entries -> entries
@@ -202,39 +229,59 @@ let read_pending_confirms config : pending_confirm list =
     []
 
 let upsert_pending_confirm config entry =
-  match read_pending_confirms_result config with
-  | Error _ as error -> error
-  | Ok entries ->
-    let remaining =
-      entries
-      |> List.filter (fun existing -> not (String.equal existing.token entry.token))
-    in
-    write_pending_confirms config (entry :: remaining)
+  with_store_lock config (fun () ->
+    match target_of_entry entry with
+    | Error _ as error -> error
+    | Ok target ->
+      (match Atomic.get target_gate_callback config target with
+       | Error _ as error -> error
+       | Ok () ->
+         (match read_pending_confirms_result_unlocked config with
+          | Error _ as error -> error
+          | Ok entries ->
+            let remaining =
+              entries
+              |> List.filter (fun existing -> not (String.equal existing.token entry.token))
+            in
+            write_pending_confirms config (entry :: remaining))))
 
 let remove_pending_confirm config token =
-  match read_pending_confirms_result config with
-  | Error _ as error -> error
-  | Ok entries ->
-    let remaining =
-      entries
-      |> List.filter (fun existing -> not (String.equal existing.token token))
-    in
-    write_pending_confirms config remaining
+  with_store_lock config (fun () ->
+    match read_pending_confirms_result_unlocked config with
+    | Error _ as error -> error
+    | Ok entries ->
+      let remaining =
+        entries
+        |> List.filter (fun existing -> not (String.equal existing.token token))
+      in
+      write_pending_confirms config remaining)
+
+let remove_pending_confirms_by_typed_target config target =
+  with_store_lock config (fun () ->
+    match raw_pending_confirms_result config with
+    | Error _ as error -> error
+    | Ok all ->
+      let target_type =
+        Operator_action_constants.target_type_to_string target.target_type
+      in
+      let remaining =
+        List.filter
+          (fun (entry : pending_confirm) ->
+             not
+               (String.equal entry.target_type target_type
+                && entry.target_id = target.target_id))
+          all
+      in
+      let removed = List.length all - List.length remaining in
+      if removed > 0
+      then write_pending_confirms config remaining |> Result.map (fun () -> removed)
+      else Ok 0)
 
 let remove_pending_confirms_by_target config ~target_type ~target_id =
-  let all = raw_pending_confirms config in
-  let remaining =
-    List.filter
-      (fun (entry : pending_confirm) ->
-        not
-          (String.equal entry.target_type target_type
-          && entry.target_id = target_id))
-      all
-  in
-  let removed = List.length all - List.length remaining in
-  if removed > 0 then
-    write_pending_confirms config remaining |> Result.map (fun () -> removed)
-  else Ok 0
+  match Operator_action_constants.target_type_of_string target_type with
+  | None -> Error (Printf.sprintf "invalid pending-confirm target type: %S" target_type)
+  | Some target_type ->
+    remove_pending_confirms_by_typed_target config { target_type; target_id }
 
 let normalize_pending_confirm_actor_filter = function
   | Some raw ->

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -34,6 +34,14 @@ type available_action = {
   confirm_required : bool;
 }
 
+type target =
+  { target_type : Operator_action_constants.target_type
+  ; target_id : string option
+  }
+
+val register_target_gate :
+  (Workspace.config -> target -> (unit, string) result) -> unit
+
 val preview_of_pending_confirm : pending_confirm -> Yojson.Safe.t
 val pending_confirm_to_yojson : pending_confirm -> Yojson.Safe.t
 val pending_confirm_of_yojson : Yojson.Safe.t -> (pending_confirm, string) result
@@ -51,6 +59,8 @@ val upsert_pending_confirm :
 val remove_pending_confirm : Workspace.config -> string -> (unit, string) result
 val remove_pending_confirms_by_target :
   Workspace.config -> target_type:string -> target_id:string option -> (int, string) result
+val remove_pending_confirms_by_typed_target :
+  Workspace.config -> target -> (int, string) result
 val normalize_pending_confirm_actor_filter : string option -> string option
 val pending_confirm_scope_of_entries : ?actor:string -> pending_confirm list -> pending_confirm_scope
 val pending_confirm_scope : ?actor:string -> Workspace.config -> pending_confirm_scope

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -452,8 +452,31 @@ let () =
   Atomic.set
     Workspace_hooks.operator_pending_confirm_remove_fn
     Operator_pending_confirm.remove_pending_confirm;
+  Operator_pending_confirm.register_target_gate
+    (fun config target ->
+      match target.Operator_pending_confirm.target_type, target.target_id with
+      | Operator_action_constants.Keeper, Some keeper_name ->
+        let admission =
+          Keeper_turn_admission.snapshot_for
+            ~base_path:config.Workspace.base_path
+            ~keeper_name
+        in
+        (match admission.snapshot_shutdown_operation_id with
+         | None -> Ok ()
+         | Some operation_id ->
+           Error
+             (Printf.sprintf
+                "Keeper %s is shutting down under operation %s"
+                keeper_name
+                (Keeper_shutdown_types.Operation_id.to_string operation_id)))
+      | Operator_action_constants.Keeper, None ->
+        Error "Keeper pending-confirm target requires target_id"
+      | (Operator_action_constants.Workspace | Operator_action_constants.Goal), _ -> Ok ());
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
-    Operator_pending_confirm.remove_pending_confirms_by_target
+    (fun config ~target_type ~target_id ->
+      Operator_pending_confirm.remove_pending_confirms_by_typed_target
+        config
+        { Operator_pending_confirm.target_type = target_type; target_id })
 ;;
 
 let force_link = ()

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -848,6 +848,37 @@ let start_keeper_loops
       let config = (Mcp_server.workspace_config state) in
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
+      let shutdown_recovery = Keeper_shutdown_runtime.recover_at_boot ~config in
+      List.iter
+        (function
+          | Ok operation ->
+            Log.Keeper.info
+              "autoboot: recovered shutdown operation keeper=%s operation=%s"
+              operation.Keeper_shutdown_types.keeper_name
+              (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+          | Error detail ->
+            Log.Keeper.error "autoboot: shutdown recovery failed: %s" detail)
+        shutdown_recovery;
+      let shutdown_blocked_names =
+        match Keeper_shutdown_store.list_all ~config with
+        | Error error ->
+          Log.Keeper.error
+            "autoboot: shutdown operation inventory failed: %s"
+            (Keeper_shutdown_store.error_to_string error);
+          []
+        | Ok operations ->
+          operations
+          |> List.filter_map (fun operation ->
+            match operation.Keeper_shutdown_types.phase with
+            | Keeper_shutdown_types.Finalized _ -> None
+            | Keeper_shutdown_types.Prepared
+            | Keeper_shutdown_types.Joined_idle
+            | Keeper_shutdown_types.Finalizing_tasks _
+            | Keeper_shutdown_types.Cleanup_ready _
+            | Keeper_shutdown_types.Reconciliation_required _
+            | Keeper_shutdown_types.Blocked _ -> Some operation.keeper_name)
+          |> List.sort_uniq String.compare
+      in
       let all_names = Keeper_meta_store.keeper_names config in
       let all_count = List.length all_names in
       Log.Keeper.info
@@ -856,7 +887,10 @@ let start_keeper_loops
         masc_root
         keeper_dir
         all_count;
-      let names = Keeper_runtime.bootable_keeper_names config in
+      let names =
+        Keeper_runtime.bootable_keeper_names config
+        |> List.filter (fun name -> not (List.mem name shutdown_blocked_names))
+      in
       let exclusions = Keeper_runtime.autoboot_excluded_keeper_reasons config in
       let keeper_boot_ctx : _ Keeper_types_profile.context =
         { config

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -336,11 +336,49 @@ let start_keeper_loops
   let shutdown_inventory_p, shutdown_inventory_r = Eio.Promise.create () in
   let config = Mcp_server.workspace_config state in
   fork_subsystem "keeper_shutdown_recovery" (fun () ->
-    let inventory = Keeper_shutdown_store.list_all ~config in
+    let operation_requires_fence operation =
+      match operation.Keeper_shutdown_types.phase with
+      | Keeper_shutdown_types.Finalized _ -> false
+      | Keeper_shutdown_types.Prepared
+      | Keeper_shutdown_types.Joined_idle
+      | Keeper_shutdown_types.Finalizing_tasks _
+      | Keeper_shutdown_types.Cleanup_ready _
+      | Keeper_shutdown_types.Reconciliation_required _
+      | Keeper_shutdown_types.Blocked _ -> true
+    in
+    let inventory =
+      match Keeper_shutdown_store.list_all ~config with
+      | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+      | Ok operations ->
+        List.fold_left
+          (fun restored operation ->
+             match restored with
+             | Error _ as error -> error
+             | Ok () when not (operation_requires_fence operation) -> Ok ()
+             | Ok () ->
+               (match
+                  Keeper_turn_admission.restore_shutdown
+                    ~base_path:config.base_path
+                    ~keeper_name:operation.keeper_name
+                    ~operation_id:operation.operation_id
+                with
+                | Keeper_turn_admission.Shutdown_restored
+                | Keeper_turn_admission.Shutdown_already_restored -> Ok ()
+                | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+                  Error
+                    (Printf.sprintf
+                       "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
+                       operation.keeper_name
+                       (Keeper_shutdown_types.Operation_id.to_string
+                          operation.operation_id)
+                       (Keeper_shutdown_types.Operation_id.to_string existing))))
+          (Ok ())
+          operations
+        |> Result.map (fun () -> operations)
+    in
     Eio.Promise.resolve shutdown_inventory_r inventory;
     match inventory with
-    | Error error ->
-      let detail = Keeper_shutdown_store.error_to_string error in
+    | Error detail ->
       Log.Keeper.error "shutdown recovery inventory failed: %s" detail;
       failwith detail
     | Ok operations ->
@@ -888,7 +926,7 @@ let start_keeper_loops
       let shutdown_inventory = Eio.Promise.await shutdown_inventory_p in
       let shutdown_blocked_names_result =
         match shutdown_inventory with
-        | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+        | Error detail -> Error detail
         | Ok operations ->
           Ok
             (operations

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -333,6 +333,43 @@ let start_keeper_loops
         Log.Server.error "subsystem %s crashed: %s" name (Printexc.to_string exn))
       f
   in
+  let shutdown_inventory_p, shutdown_inventory_r = Eio.Promise.create () in
+  let config = Mcp_server.workspace_config state in
+  fork_subsystem "keeper_shutdown_recovery" (fun () ->
+    let inventory = Keeper_shutdown_store.list_all ~config in
+    Eio.Promise.resolve shutdown_inventory_r inventory;
+    match inventory with
+    | Error error ->
+      let detail = Keeper_shutdown_store.error_to_string error in
+      Log.Keeper.error "shutdown recovery inventory failed: %s" detail;
+      failwith detail
+    | Ok operations ->
+      Eio.Switch.run (fun recovery_sw ->
+        List.iter
+          (fun operation ->
+             Eio.Fiber.fork ~sw:recovery_sw (fun () ->
+               try
+                 match Keeper_shutdown_runtime.recover_operation ~config operation with
+                 | Ok recovered ->
+                   Log.Keeper.info
+                     "recovered shutdown operation keeper=%s operation=%s"
+                     recovered.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string recovered.operation_id)
+                 | Error detail ->
+                   Log.Keeper.error
+                     "shutdown recovery failed keeper=%s operation=%s error=%s"
+                     operation.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                     detail
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 Log.Keeper.error
+                   "shutdown recovery crashed keeper=%s operation=%s error=%s"
+                   operation.Keeper_shutdown_types.keeper_name
+                   (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                   (Printexc.to_string exn)))
+          operations));
   let wait_for_lazy_startup () =
     (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
        a per-task boot guard.  The diagnostic surface stays as #10854
@@ -845,39 +882,26 @@ let start_keeper_loops
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
       Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
-      let config = (Mcp_server.workspace_config state) in
+      let config = Mcp_server.workspace_config state in
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
-      let shutdown_recovery = Keeper_shutdown_runtime.recover_at_boot ~config in
-      List.iter
-        (function
-          | Ok operation ->
-            Log.Keeper.info
-              "autoboot: recovered shutdown operation keeper=%s operation=%s"
-              operation.Keeper_shutdown_types.keeper_name
-              (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
-          | Error detail ->
-            Log.Keeper.error "autoboot: shutdown recovery failed: %s" detail)
-        shutdown_recovery;
-      let shutdown_blocked_names =
-        match Keeper_shutdown_store.list_all ~config with
-        | Error error ->
-          Log.Keeper.error
-            "autoboot: shutdown operation inventory failed: %s"
-            (Keeper_shutdown_store.error_to_string error);
-          []
+      let shutdown_inventory = Eio.Promise.await shutdown_inventory_p in
+      let shutdown_blocked_names_result =
+        match shutdown_inventory with
+        | Error error -> Error (Keeper_shutdown_store.error_to_string error)
         | Ok operations ->
-          operations
-          |> List.filter_map (fun operation ->
-            match operation.Keeper_shutdown_types.phase with
-            | Keeper_shutdown_types.Finalized _ -> None
-            | Keeper_shutdown_types.Prepared
-            | Keeper_shutdown_types.Joined_idle
-            | Keeper_shutdown_types.Finalizing_tasks _
-            | Keeper_shutdown_types.Cleanup_ready _
-            | Keeper_shutdown_types.Reconciliation_required _
-            | Keeper_shutdown_types.Blocked _ -> Some operation.keeper_name)
-          |> List.sort_uniq String.compare
+          Ok
+            (operations
+             |> List.filter_map (fun operation ->
+               match operation.Keeper_shutdown_types.phase with
+               | Keeper_shutdown_types.Finalized _ -> None
+               | Keeper_shutdown_types.Prepared
+               | Keeper_shutdown_types.Joined_idle
+               | Keeper_shutdown_types.Finalizing_tasks _
+               | Keeper_shutdown_types.Cleanup_ready _
+               | Keeper_shutdown_types.Reconciliation_required _
+               | Keeper_shutdown_types.Blocked _ -> Some operation.keeper_name)
+             |> List.sort_uniq String.compare)
       in
       let all_names = Keeper_meta_store.keeper_names config in
       let all_count = List.length all_names in
@@ -888,8 +912,15 @@ let start_keeper_loops
         keeper_dir
         all_count;
       let names =
-        Keeper_runtime.bootable_keeper_names config
-        |> List.filter (fun name -> not (List.mem name shutdown_blocked_names))
+        match shutdown_blocked_names_result with
+        | Error detail ->
+          Log.Keeper.error
+            "autoboot blocked because shutdown inventory is uncertain: %s"
+            detail;
+          []
+        | Ok shutdown_blocked_names ->
+          Keeper_runtime.bootable_keeper_names config
+          |> List.filter (fun name -> not (List.mem name shutdown_blocked_names))
       in
       let exclusions = Keeper_runtime.autoboot_excluded_keeper_reasons config in
       let keeper_boot_ctx : _ Keeper_types_profile.context =

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -29,6 +29,7 @@ module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
+module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Keeper_meta_store = Masc.Keeper_meta_store
 
 let bp = "/tmp/test-heartbeat-integ"
@@ -821,6 +822,77 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Error (Shutdown_store.Identity_mismatch _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
+      let worker_failure = Failure "worker exploded after durable join" in
+      let holder_locked_p, holder_locked_r = Eio.Promise.create () in
+      let release_holder_p, release_holder_r = Eio.Promise.create () in
+      let holder_done_p, holder_done_r = Eio.Promise.create () in
+      let worker_started_p, worker_started_r = Eio.Promise.create () in
+      let exception Cancel_worker in
+      Eio.Switch.run @@ fun test_sw ->
+      Eio.Fiber.fork ~sw:test_sw (fun () ->
+        Shutdown_store.For_testing.with_operation_write_lock
+          ~config
+          operation_id
+          (fun () ->
+             Eio.Promise.resolve holder_locked_r ();
+             Eio.Promise.await release_holder_p);
+        Eio.Promise.resolve holder_done_r ());
+      Eio.Promise.await holder_locked_p;
+      (try
+         Eio.Switch.run (fun worker_sw ->
+           Eio.Fiber.fork ~sw:worker_sw (fun () ->
+             Eio.Promise.resolve worker_started_r ();
+             Shutdown_runtime.For_testing.persist_unhandled_failure
+               ~config
+               operation
+               worker_failure);
+           Eio.Promise.await worker_started_p;
+           Eio.Switch.fail worker_sw Cancel_worker;
+           Eio.Promise.resolve release_holder_r ())
+       with
+       | Cancel_worker -> ());
+      Eio.Promise.await holder_done_p;
+      let blocked =
+        match Shutdown_store.load ~config operation_id with
+        | Ok blocked -> blocked
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "unhandled worker failure advances the latest durable revision"
+        (joined.revision + 1)
+        blocked.revision;
+      (match blocked.phase with
+       | Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail } ->
+         check string
+           "unhandled worker failure detail"
+           (Printexc.to_string worker_failure)
+           detail
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Blocked _ ->
+         fail "unhandled worker failure did not persist typed blocked evidence");
+      Shutdown_runtime.For_testing.persist_unhandled_failure
+        ~config
+        operation
+        (Failure "later worker failure");
+      let preserved =
+        match Shutdown_store.load ~config operation_id with
+        | Ok preserved -> preserved
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "later worker failure preserves blocked revision"
+        blocked.revision
+        preserved.revision;
+      check
+        bool
+        "later worker failure preserves first blocked evidence"
+        true
+        (preserved.phase = blocked.phase);
       (match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
        | Ok [ listed ] ->
          check bool

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -591,7 +591,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
   let keeper_name = "direct-lifecycle" in
   Fun.protect
     ~finally:(fun () ->
-      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
       cleanup_dir base_dir)
     (fun () ->
       ensure_default_runtime ();
@@ -611,7 +611,9 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
       in
       Masc.Keeper_keepalive.start_keepalive ctx meta;
       Eio.Time.sleep ctx.clock 0.05;
-      Masc.Keeper_keepalive.stop_keepalive keeper_name;
+      Masc.Keeper_keepalive.stop_keepalive
+        ~base_path:config.base_path
+        keeper_name;
       let stopped_resolved =
         wait_until ~clock:ctx.clock ~timeout_s:1.0 (fun () ->
           match R.get ~base_path:config.base_path keeper_name with

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -660,6 +660,7 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
   let exit = Lane.await_exit lane in
   (match exit.outcome with
    | Lane.Completed -> ()
+   | Lane.Shutdown_before_start -> fail "unexpected shutdown before lane start"
    | Lane.Shutdown_requested -> fail "unexpected lane shutdown"
    | Lane.Cancelled_by_parent cause ->
      fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
@@ -727,6 +728,7 @@ let test_keeper_lane_cancel_is_lane_local_and_joinable () =
   let exit = Lane.await_exit lane in
   match exit.outcome with
   | Lane.Shutdown_requested -> ()
+  | Lane.Shutdown_before_start -> fail "running lane reported pre-start shutdown"
   | Lane.Completed -> fail "cancelled lane reported normal completion"
   | Lane.Cancelled_by_parent cause ->
     fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
@@ -912,8 +914,54 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
+      | `Busy (Masc.Keeper_turn_admission.Turn_busy _) | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
+
+let test_keeper_shutdown_prepare_joins_not_started_lane () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-prepare-not-started" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-not-started-lane" in
+      let entry = R.register ~base_path:config.base_path name (make_meta name) in
+      let operation =
+        match
+          Shutdown_prepare_join.run
+            ~config
+            ~entry
+            ~request:
+              { actor = "operator"
+              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              }
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+      in
+      (match operation.phase with
+       | Shutdown_types.Joined_idle -> ()
+       | Shutdown_types.Prepared
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Blocked _ -> fail "not-started lane did not reach Joined_idle");
+      (match Lane.peek_exit entry.lane with
+       | Some { outcome = Lane.Shutdown_before_start; cleanup_error = None } -> ()
+       | Some _ -> fail "not-started lane recorded the wrong exit evidence"
+       | None -> fail "not-started lane exit remained unresolved");
+      match Eio.Promise.peek entry.done_p with
+      | Some `Stopped -> ()
+      | Some (`Crashed detail) -> fail ("not-started lane crashed: " ^ detail)
+      | None -> fail "not-started lane terminal remained unresolved")
 
 let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
   Eio_main.run @@ fun env ->
@@ -1653,6 +1701,8 @@ let () =
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
+      test_case "shutdown prepare joins not-started lane" `Quick
+        test_keeper_shutdown_prepare_joins_not_started_lane;
       test_case "shutdown prepare failure rolls back admission fence" `Quick
         test_keeper_shutdown_prepare_failure_rolls_back_fence;
       test_case "shutdown finalizes idle operation" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -743,7 +743,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         Masc.Workspace.init config ~agent_name:(Some "tester")
       in
       let backlog_version =
-        match Masc.Workspace_backlog.read_backlog_r config with
+        match Workspace_backlog.read_backlog_r config with
         | Ok backlog -> backlog.version
         | Error detail -> fail detail
       in
@@ -973,7 +973,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
         Masc.Workspace.init config ~agent_name:(Some "operator")
       in
       let backlog_version =
-        match Masc.Workspace_backlog.read_backlog_r config with
+        match Workspace_backlog.read_backlog_r config with
         | Ok backlog -> backlog.version
         | Error detail -> fail detail
       in
@@ -1076,7 +1076,7 @@ let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
        | Ok () -> ()
        | Error detail -> fail detail);
       let backlog_version =
-        match Masc.Workspace_backlog.read_backlog_r config with
+        match Workspace_backlog.read_backlog_r config with
         | Ok backlog -> backlog.version
         | Error detail -> fail detail
       in
@@ -1168,7 +1168,7 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
         | Error detail -> fail detail
       in
       let backlog_version =
-        match Masc.Workspace_backlog.read_backlog_r config with
+        match Workspace_backlog.read_backlog_r config with
         | Ok backlog -> backlog.version
         | Error detail -> fail detail
       in

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -739,13 +739,21 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Masc.Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
       let meta = make_meta "shutdown-store-keeper" in
       let operation_id = Shutdown_types.Operation_id.generate () in
       let lane = Lane.create () in
       let now = Masc_domain.now_iso () in
       let operation : Shutdown_types.t =
         { schema_version = Shutdown_types.schema_version
+        ; revision = 0
         ; operation_id
         ; keeper_name = meta.name
         ; lane_id = Lane.id lane
@@ -754,6 +762,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         ; actor = "tester"
         ; cleanup_intent = { remove_meta = false; remove_session = false }
         ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
         ; join_evidence = None
         ; phase = Shutdown_types.Prepared
@@ -780,15 +789,31 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         (Lane.Id.equal operation.lane_id loaded.lane_id);
       let joined =
         { loaded with
-          phase = Shutdown_types.Joined_idle
+          revision = loaded.revision + 1
+        ; phase = Shutdown_types.Joined_idle
         ; updated_at = Masc_domain.now_iso ()
         }
       in
-      (match Shutdown_store.replace ~config joined with
+      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision joined with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
+      let stale =
+        { loaded with
+          revision = loaded.revision + 1
+        ; phase = Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail = "stale" }
+        }
+      in
+      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision stale with
+       | Error (Shutdown_store.Revision_conflict _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "stale shutdown snapshot overwrote a newer revision");
       let mismatched = { joined with lane_id = Lane.id (Lane.create ()) } in
-      (match Shutdown_store.replace ~config mismatched with
+      (match
+         Shutdown_store.replace
+           ~config
+           ~expected_revision:joined.revision
+           { mismatched with revision = joined.revision + 1 }
+       with
        | Error (Shutdown_store.Identity_mismatch _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
@@ -944,7 +969,14 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       cleanup_dir base_dir)
     (fun () ->
       let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let backlog_version =
+        match Masc.Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
       let meta = make_meta "shutdown-finalize-keeper" in
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()
@@ -954,6 +986,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       let operation_id = Shutdown_types.Operation_id.generate () in
       let operation : Shutdown_types.t =
         { schema_version = Shutdown_types.schema_version
+        ; revision = 0
         ; operation_id
         ; keeper_name = meta.name
         ; lane_id = Lane.id (Lane.create ())
@@ -962,6 +995,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
         ; actor = "operator"
         ; cleanup_intent = { remove_meta = false; remove_session = false }
         ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
         ; join_evidence = None
         ; phase = Shutdown_types.Joined_idle

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -29,6 +29,7 @@ module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
+module Keeper_meta_store = Masc.Keeper_meta_store
 
 let bp = "/tmp/test-heartbeat-integ"
 

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -964,7 +964,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
   Fun.protect
     ~finally:(fun () ->
       Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
-      Keeper_turn_admission.For_testing.reset ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
       R.clear ();
       cleanup_dir base_dir)
     (fun () ->
@@ -1003,6 +1003,15 @@ let test_keeper_shutdown_finalizes_idle_operation () =
         ; updated_at = Masc_domain.now_iso ()
         }
       in
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "fresh shutdown finalization fixture was already reserved");
       (match Shutdown_store.persist_new ~config operation with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
@@ -1020,6 +1029,26 @@ let test_keeper_shutdown_finalizes_idle_operation () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Blocked _ -> fail "shutdown did not reach Finalized");
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "finalized shutdown did not release its admission fence");
+      (match Shutdown_finalize.run ~config ~entry:None finalized with
+       | Ok _ -> ()
+       | Error error -> fail (Shutdown_finalize.error_to_string error));
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (fun () -> ())
+       with
+       | `Ran () -> ()
+       | `Busy _ -> fail "finalized shutdown replay left admission fenced");
       match Keeper_meta_store.read_meta config meta.name with
       | Ok (Some retained) ->
         check bool "retained Keeper is paused" true retained.paused;
@@ -1027,6 +1056,178 @@ let test_keeper_shutdown_finalizes_idle_operation () =
           (Option.is_none retained.current_task_id)
       | Ok None -> fail "retained Keeper metadata disappeared"
       | Error detail -> fail detail)
+
+let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-meta-replay" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let meta = make_meta "shutdown-meta-replay-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let backlog_version =
+        match Masc.Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let cleanup : Shutdown_types.cleanup_evidence =
+        { settled_task_ids = []; pending_confirms_removed = 0 }
+      in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = true; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Cleanup_ready cleanup
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match
+         Keeper_meta_store.remove_meta_if_identity
+           config
+           ~name:meta.name
+           ~trace_id:meta.runtime.trace_id
+           ~generation:meta.runtime.generation
+       with
+       | Ok () -> ()
+       | Error error -> fail (Keeper_meta_store.identity_remove_error_to_string error));
+      match Shutdown_finalize.run ~config ~entry:None operation with
+      | Ok { phase = Shutdown_types.Finalized evidence; _ } ->
+        check bool "meta cleanup remains complete on replay" true evidence.meta_removed
+      | Ok _ -> fail "meta cleanup replay did not reach Finalized"
+      | Error error -> fail (Shutdown_finalize.error_to_string error))
+
+let test_keeper_shutdown_recovers_committed_task_receipt () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-task-receipt" in
+  Fun.protect
+    ~finally:(fun () ->
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let meta = make_meta "shutdown-task-receipt-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      let task_id_wire =
+        match
+          Masc.Workspace.add_task_with_result
+            config
+            ~title:"shutdown receipt fixture"
+            ~priority:1
+            ~description:"durable task settlement"
+        with
+        | Ok created -> created.task_id
+        | Error error -> fail (Masc.Workspace.add_task_error_to_string error)
+      in
+      (match
+         Masc.Workspace.claim_task_r
+           config
+           ~agent_name:meta.agent_name
+           ~task_id:task_id_wire
+           ()
+       with
+       | Ok _ -> ()
+       | Error error -> fail (Masc_domain.masc_error_to_string error));
+      let task_id =
+        match Keeper_id.Task_id.of_string task_id_wire with
+        | Ok task_id -> task_id
+        | Error detail -> fail detail
+      in
+      let backlog_version =
+        match Masc.Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = [ task_id ]
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let handoff_context : Masc_domain.task_handoff_context =
+        { summary = "Keeper stopped; task returned to the durable backlog"
+        ; reason = Some "Keeper shutdown operation completed lane join"
+        ; next_step = Some "A live Keeper may reclaim this task"
+        ; failure_mode = None
+        ; reclaim_policy = Some Masc_domain.Allow_reclaim
+        ; evidence_refs =
+            [ "masc://keeper-shutdown/"
+              ^ Shutdown_types.Operation_id.to_string operation_id
+            ]
+        ; updated_at = Some (Masc_domain.now_iso ())
+        ; updated_by = Some operation.actor
+        }
+      in
+      (match
+         Masc.Workspace.release_task_r
+           config
+           ~agent_name:meta.agent_name
+           ~task_id:task_id_wire
+           ~expected_version:backlog_version
+           ~handoff_context
+           ()
+       with
+       | Ok _ -> ()
+       | Error error -> fail (Masc_domain.masc_error_to_string error));
+      match Shutdown_finalize.run ~config ~entry:None operation with
+      | Ok { phase = Shutdown_types.Finalized evidence; _ } ->
+        check int
+          "committed release receipt is recovered exactly once"
+          1
+          (List.length evidence.cleanup.settled_task_ids)
+      | Ok _ -> fail "task receipt recovery did not reach Finalized"
+      | Error error -> fail (Shutdown_finalize.error_to_string error))
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1455,6 +1656,10 @@ let () =
         test_keeper_shutdown_prepare_failure_rolls_back_fence;
       test_case "shutdown finalizes idle operation" `Quick
         test_keeper_shutdown_finalizes_idle_operation;
+      test_case "shutdown cleanup replays after meta removal" `Quick
+        test_keeper_shutdown_cleanup_replays_after_meta_removal;
+      test_case "shutdown recovers committed task receipt" `Quick
+        test_keeper_shutdown_recovers_committed_task_receipt;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -28,6 +28,7 @@ module Lane = Masc.Keeper_lane
 module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
+module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -865,7 +866,10 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
       (match operation.phase with
        | Shutdown_types.Joined_idle -> ()
        | Shutdown_types.Prepared
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
        | Shutdown_types.Blocked _ -> fail "idle lane did not reach Joined_idle");
       check bool
         "shutdown operation records lane join evidence"
@@ -927,6 +931,68 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       with
       | `Ran () -> ()
       | `Busy _ -> fail "failed shutdown prepare left the keeper admission fence closed")
+
+let test_keeper_shutdown_finalizes_idle_operation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-finalize" in
+  Fun.protect
+    ~finally:(fun () ->
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let meta = make_meta "shutdown-finalize-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id (Lane.create ())
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let finalized =
+        match Shutdown_finalize.run ~config ~entry:None operation with
+        | Ok finalized -> finalized
+        | Error error -> fail (Shutdown_finalize.error_to_string error)
+      in
+      (match finalized.phase with
+       | Shutdown_types.Finalized evidence ->
+         check int "no pending confirms" 0 evidence.cleanup.pending_confirms_removed
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _ -> fail "shutdown did not reach Finalized");
+      match Keeper_meta_store.read_meta config meta.name with
+      | Ok (Some retained) ->
+        check bool "retained Keeper is paused" true retained.paused;
+        check bool "retained Keeper task binding is cleared" true
+          (Option.is_none retained.current_task_id)
+      | Ok None -> fail "retained Keeper metadata disappeared"
+      | Error detail -> fail detail)
 
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
@@ -1353,6 +1419,8 @@ let () =
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown prepare failure rolls back admission fence" `Quick
         test_keeper_shutdown_prepare_failure_rolls_back_fence;
+      test_case "shutdown finalizes idle operation" `Quick
+        test_keeper_shutdown_finalizes_idle_operation;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -260,7 +260,12 @@ let test_turn_lifecycle_callback () =
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target (fun _config ~target_type:_ ~target_id:_ ->
     called := true;
     Ok 7);
-  let n = Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target ~config:(Obj.magic ()) ~target_type:"keeper" ~target_id:(Some "k") in
+  let n =
+    Keeper_turn_lifecycle.For_testing.remove_pending_confirms_by_target
+      ~config:(Obj.magic ())
+      ~target_type:Operator_action_constants.Keeper
+      ~target_id:(Some "k")
+  in
   check bool "remove pending confirms callback invoked" true !called;
   check (result int string) "remove pending confirms returned value" (Ok 7) n;
   Keeper_turn_lifecycle.For_testing.reset_remove_pending_confirms_by_target ()

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -6,7 +6,7 @@
     Sites under test:
     - gRPC pause directive ([Keeper_keepalive.process_directive "pause"]
       -> [directive_paused_meta]) -> [Operator_paused {grpc_directive}]
-    - keeper_down retain ([Keeper_turn_lifecycle.handle_keeper_down_config],
+    - keeper_down retain ([Keeper_shutdown_finalize.For_testing.paused_meta],
       remove_meta=false) -> [Operator_paused {keeper_down}]
     - dead-tombstone cleanup
       ([Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone])
@@ -187,44 +187,16 @@ let test_grpc_pause_directive_records_reason () =
 (* ── Site 2: keeper_down retain (remove_meta=false) ─────────── *)
 
 let test_keeper_down_retain_records_reason () =
-  Eio_main.run
-  @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base_path = Masc_test_deps.setup_test_workspace () in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.clear ();
-      Masc_test_deps.cleanup_test_workspace base_path)
-    (fun () ->
-       let config = Masc.Workspace.default_config base_path in
-       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       (* Avoid a leading "keeper-" — identity resolution strips that prefix
-          and the write/read names would diverge. *)
-       let keeper_name = "downretain-owner" in
-       let meta = make_meta keeper_name in
-       Keeper_registry.clear ();
-       (match Keeper_meta_store.write_meta config meta with
-        | Ok () -> ()
-        | Error err -> failf "seed meta write: %s" err);
-       ignore (Keeper_registry.register ~base_path:config.base_path keeper_name meta);
-       let args =
-         `Assoc
-           [ "name", `String keeper_name
-           ; "remove_meta", `Bool false
-           ; "remove_session", `Bool false
-           ]
-       in
-       let _result = Keeper_turn_lifecycle.handle_keeper_down_config ~config args in
-       match Keeper_meta_store.read_meta config keeper_name with
-       | Ok (Some persisted) ->
-         check bool "keeper_down retain pauses keeper" true persisted.paused;
-         check
-           (option string)
-           "keeper_down retain records keeper_down operator pause"
-           (Some wire_keeper_down)
-           (latched_reason_wire persisted)
-       | Ok None -> fail "expected retained keeper meta on disk"
-       | Error err -> failf "read persisted meta: %s" err)
+  let retained =
+    Masc.Keeper_shutdown_finalize.For_testing.paused_meta
+      (make_meta "downretain-owner")
+  in
+  check bool "keeper_down retain pauses keeper" true retained.paused;
+  check
+    (option string)
+    "keeper_down retain records keeper_down operator pause"
+    (Some wire_keeper_down)
+    (latched_reason_wire retained)
 
 (* ── Site 1: dead-tombstone cleanup ─────────────────────────── *)
 

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -492,6 +492,58 @@ let test_shutdown_reservation_fences_and_rolls_back () =
   | `Ran _ | `Busy _ -> check "rollback re-opens admission" false
 ;;
 
+let test_shutdown_reservation_restores_durable_owner () =
+  reset ();
+  Printf.printf "Test 12: durable shutdown owner restores before registration\n%!";
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  let other_operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_restored -> ()
+   | Keeper_turn_admission.Shutdown_already_restored
+   | Keeper_turn_admission.Shutdown_restore_conflict _ ->
+     check "fresh durable owner restores" false);
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Keeper_turn_admission.Shutdown_already_restored -> ()
+   | Keeper_turn_admission.Shutdown_restored
+   | Keeper_turn_admission.Shutdown_restore_conflict _ ->
+     check "same durable owner restores idempotently" false);
+  (match
+     Keeper_turn_admission.restore_shutdown
+       ~base_path
+       ~keeper_name
+       ~operation_id:other_operation_id
+   with
+   | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+     check
+       "different durable owner cannot replace restored fence"
+       (Keeper_shutdown_types.Operation_id.equal existing operation_id)
+   | Keeper_turn_admission.Shutdown_restored
+   | Keeper_turn_admission.Shutdown_already_restored ->
+     check "different durable owner is rejected" false);
+  match
+    Keeper_turn_admission.commit_registration_if_open
+      ~base_path
+      ~keeper_name
+      (fun () -> ())
+  with
+  | Keeper_turn_admission.Registration_shutdown_reserved existing ->
+    check
+      "registration sees restored durable owner"
+      (Keeper_shutdown_types.Operation_id.equal existing operation_id)
+  | Keeper_turn_admission.Registration_committed () ->
+    check "registration cannot cross restored fence" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
@@ -506,6 +558,7 @@ let () =
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
   test_shutdown_reservation_fences_and_rolls_back ();
+  test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## Outcome

- Makes `masc_keeper_down` a durable, non-blocking operation submission.
- Settles the exact pre-fence task ownership snapshot only after lane join.
- Records per-task release receipts and explicit blocked/reconciliation states.
- Pauses or removes Keeper identity only after task settlement and pending-confirm cleanup.
- Recovers unfinished operations before autoboot and excludes non-terminal shutdown Keepers from replacement lanes.

## Stack

- Base: #24140 (durable prepare/admission/cancel/join)
- Parent: #24135 (lane-owned cancellation and trustworthy join)
- Tracks: #24113

## Verification

- OCaml parser checks for all changed .ml/.mli files
- ocamlformat on all changed OCaml files
- ocamldep ordering
- determinism contract: PASS
- enum/string safety: PASS
- silent-failure gate: PASS
- mli pair guard: PASS
- OCaml structure ratchet: PASS
- No local Dune build/test; PR CI is build authority.

## Merge policy

Draft and do-not-merge until #24135 and #24140 are green and merged in order.