### PR TITLE
fix(security): centralize request authority admission

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -176,30 +176,35 @@ let try_rate_limit_block ~path ~client_addr ~request reqd =
                 true
               end
 
-(** Path predicate: requests that go through the MCP transport surface
-    (HTTP-based sessions, SSE, JSON-RPC messages) and therefore must pass
-    origin and protocol-version checks. *)
-let is_mcp_like_path path =
-  String.equal path "/mcp"
-  || String.equal path "/mcp/managed"
-  || String.equal path "/mcp/operator"
-  || String.equal path "/sse"
-
 (** Returns true if the request failed origin or protocol-version
     validation and the corresponding error response was sent on [reqd].
     Caller should short-circuit further handling in that case. *)
-let try_mcp_validation_block ~is_mcp_like ~request ~protocol_version ~origin reqd =
-  if is_mcp_like && not (validate_origin request) then begin
+let try_mcp_validation_block
+    ~request_authority
+    ~request
+    ~protocol_version
+    ~origin
+    reqd
+  =
+  let is_mcp_transport = is_mcp_transport_request request in
+  if
+    is_mcp_transport
+    && not (validate_origin ~request_authority request)
+  then begin
     let body = json_rpc_error Masc.Mcp_error_code.Invalid_request "Invalid origin" in
-    let headers = Httpun.Headers.of_list (
-      ("content-length", string_of_int (String.length body))
-      :: json_headers "-" protocol_version origin
-    ) in
+    let headers =
+      Httpun.Headers.of_list
+        ([ ("content-length", string_of_int (String.length body))
+         ; ("content-type", "application/json")
+         ; ("vary", "Origin")
+         ]
+         @ mcp_headers "-" protocol_version)
+    in
     let response = Httpun.Response.create ~headers `Forbidden in
     safe_reqd_respond reqd response body;
     true
   end
-  else if is_mcp_like && request.Httpun.Request.meth <> `OPTIONS &&
+  else if is_mcp_transport && request.Httpun.Request.meth <> `OPTIONS &&
           not (is_valid_protocol_version protocol_version) then begin
     let body = json_rpc_error Masc.Mcp_error_code.Invalid_request "Unsupported protocol version" in
     let headers = Httpun.Headers.of_list (
@@ -325,6 +330,13 @@ let try_internal_error_response reqd msg =
           Log.Http.warn "main_eio internal_error response failed: %s"
             (Printexc.to_string exn))
 
+let respond_request_authority_bad_request ~error_code ~message reqd =
+  Http.Response.json_value
+    ~status:`Bad_request
+    (`Assoc [ "error_code", `String error_code; "error", `String message ])
+    reqd
+;;
+
 (** Extended router to handle OPTIONS *)
 let make_extended_handler routes =
   fun client_addr gluten_reqd ->
@@ -335,32 +347,61 @@ let make_extended_handler routes =
        RFC-0281. *)
     let upgrade = gluten_reqd.Gluten.Reqd.upgrade in
     let request = Httpun.Reqd.request reqd in
-    (* Rate limiting: enforce before any auth or routing. *)
-    let path = Http.Request.path request in
-    if try_rate_limit_block ~path ~client_addr ~request reqd then ()
-    else
-    try
-      let is_mcp_like = is_mcp_like_path path in
-      let session_id_for_version = get_session_id_any request in
-      let protocol_version =
-        get_protocol_version_for_session ?session_id:session_id_for_version request
-      in
-      let origin = get_origin request in
-      if try_mcp_validation_block ~is_mcp_like ~request ~protocol_version ~origin reqd then ()
-      else dispatch_route ~router:routes ~request ~path ~upgrade reqd
-    with
-    (* Re-raise cancellation so Eio structured concurrency propagates cleanly.
-       Previously the catch-all swallowed Cancelled and tried to write a 500
-       response; that masks shutdown signals and interferes with per-connection
-       switch cleanup. *)
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> (
-      let msg = Printexc.to_string exn in
-      match Http.Late_response.classify_write_failure exn with
-      | Some failure_msg ->
-          log_late_response_failure ~context:"main_eio request handler"
-            failure_msg
-      | None -> try_internal_error_response reqd msg)
+    match Server_request_authority.classify_http1_request request with
+    | Server_request_authority.Missing ->
+      respond_request_authority_bad_request
+        ~error_code:"request_authority_missing"
+        ~message:"request is missing its Host authority"
+        reqd
+    | Server_request_authority.Multiple ->
+      respond_request_authority_bad_request
+        ~error_code:"request_authority_multiple"
+        ~message:"request contains more than one Host field"
+        reqd
+    | Server_request_authority.Malformed ->
+      respond_request_authority_bad_request
+        ~error_code:"request_authority_malformed"
+        ~message:"request Host authority is malformed"
+        reqd
+    | Server_request_authority.Single request_authority ->
+      Server_request_authority.with_current request_authority (fun () ->
+        (* Authority admission precedes rate limiting, auth, and routing so no
+           credential I/O or URL projection can observe ambiguous Host input. *)
+        let path = Http.Request.path request in
+        if try_rate_limit_block ~path ~client_addr ~request reqd
+        then ()
+        else
+          try
+            let session_id_for_version = get_session_id_any request in
+            let protocol_version =
+              get_protocol_version_for_session
+                ?session_id:session_id_for_version
+                request
+            in
+            let origin = get_origin request in
+            if
+              try_mcp_validation_block
+                ~request_authority
+                ~request
+                ~protocol_version
+                ~origin
+                reqd
+            then ()
+            else dispatch_route ~router:routes ~request ~path ~upgrade reqd
+          with
+          (* Re-raise cancellation so Eio structured concurrency propagates
+             cleanly.  Previously the catch-all swallowed Cancelled and tried
+             to write a 500 response; that masks shutdown signals and
+             interferes with per-connection switch cleanup. *)
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
+            let msg = Printexc.to_string exn in
+            (match Http.Late_response.classify_write_failure exn with
+             | Some failure_msg ->
+               log_late_response_failure
+                 ~context:"main_eio request handler"
+                 failure_msg
+             | None -> try_internal_error_response reqd msg))
 
 (** Main server loop *)
 let run_server ~sw ~env ~host ~port ~base_path =

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -326,6 +326,22 @@ Sse.subscribe_external ~id:"ws-123"
 
 ## 6. HTTP Route Map
 
+### 6.0 Request authority admission
+
+라우팅, 인증, credential I/O보다 먼저 `Server_request_authority`가 요청의
+authority를 한 번만 분류한다. HTTP/1.1은 case-insensitive `Host` 필드 전체를
+읽어 `Missing | Single authority | Multiple | Malformed`로 닫고, `Single`만
+request fiber에 바인딩한다. HTTP/2는 `:authority`만 authority 원천으로 쓰며
+`Host`가 함께 있으면 정규화한 host와 scheme 기본 port가 같은지 교차 검증한다.
+반복 `:authority`, 반복 `Host`, userinfo, 불완전 IPv6/port, 두 authority의
+불일치는 모두 route projection 전에 400이다. H2의 authority 없는
+`OPTIONS *`는 일반 missing authority와 합치지 않고 지원하지 않는 request
+target으로 명시적으로 거부한다.
+
+Auth/CORS, redirect, OpenAPI, agent-card, discovery/runtime projection은 이
+typed authority만 소비한다. downstream에서 raw `Host`/`:authority`를 다시
+고르거나 설정 host로 fallback하는 경로는 두지 않는다.
+
 ### 6.1 MCP 엔드포인트 (main_eio.ml에서 직접 매칭)
 
 | Method | Path | Handler | 설명 |
@@ -350,9 +366,9 @@ Sse.subscribe_external ~id:"ws-123"
 `make_routes`가 HTTP Router를 조립한다:
 
 ```ocaml
-let make_routes ~port ~host ~sw ~clock =
+let make_routes ~port ~host:_ ~sw ~clock =
   Http.Router.empty
-  |> Server_routes_http_routes_frontend.add_routes ~port ~host
+  |> Server_routes_http_routes_frontend.add_routes ~port
   |> Server_routes_http_routes_workspace.add_routes
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
   |> Server_routes_http_routes_provider_runs.add_routes ~sw
@@ -447,7 +463,13 @@ Access-Control-Expose-Headers: Mcp-Session-Id, Mcp-Protocol-Version
 Access-Control-Allow-Credentials: true
 ```
 
-MCP 경로(`/mcp`, `/sse`)에서 Origin 검증을 수행한다. 유효하지 않은 origin은 `403 Forbidden`.
+HTTP/1.1과 HTTP/2 모두 MCP 경로(`/mcp`, `/mcp/managed`,
+`/mcp/operator`, `/sse`, `POST /`)에서 같은 typed request authority를 기준으로
+Origin을 비교한다. HTTP(S)가 아닌 scheme, userinfo, host/port 불일치는
+`403 Forbidden`이며, `http://localhost.attacker` 같은 prefix 혼동은 허용하지
+않는다. Origin이 없는 native client는 허용한다. 로컬 Vite cross-port는
+명시된 loopback dev-origin 목록에 속하고 request authority도 같은 정규화된
+loopback host일 때만 허용한다.
 
 ---
 

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -163,9 +163,9 @@ let normalize_loopback_base_url base_url =
         |> Uri.to_string |> trim_trailing_slashes
   | None -> trimmed
 
-(** Default port for the dashboard's Vite dev server.  Used by
-    [Server_auth.default_loopback_dev_mutation_origins] to whitelist
-    the frontend dev origin on each loopback variant. *)
+(** Default port for the dashboard's Vite dev server.  The request-authority
+    boundary uses the corresponding origins below for explicit local
+    cross-port development. *)
 let vite_dev_default_port = 5173
 
 (** Loopback dev-server origins for the Vite frontend on
@@ -191,15 +191,3 @@ let otel_default_port = 4318
 (** Default URL for OpenTelemetry OTLP HTTP endpoint. *)
 let otel_default_url =
   Printf.sprintf "http://localhost:%d" otel_default_port
-
-(** Allowed origins for DNS rebinding / CORS protection.
-    Update here; [server_routes_http_common.ml] reads this list. *)
-let allowed_origins = [
-  "http://localhost";
-  "https://localhost";
-  "http://127.0.0.1";
-  "https://127.0.0.1";
-  (* Cloudflare tunnel *)
-  "https://masc.crying.pictures";
-  "https://masc-dev.crying.pictures";
-]

--- a/lib/config/masc_network_defaults.mli
+++ b/lib/config/masc_network_defaults.mli
@@ -106,9 +106,3 @@ val searxng_default_url : string
 val otel_default_port : int
 
 val otel_default_url : string
-
-(** {1 CORS / DNS rebinding allowlist} *)
-
-(** Allowed origins read by [server_routes_http_common.ml]. Update
-    here to add/remove CORS origins. *)
-val allowed_origins : string list

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -455,6 +455,7 @@ let host_port_scheme_of_origin origin =
 
 type request_host_rejection =
   | Missing_request_host
+  | Multiple_request_hosts
   | Malformed_request_host
   | Non_loopback_request_host of string
 
@@ -551,23 +552,27 @@ let parse_request_host_header raw =
         | Error () -> None
 ;;
 
-let admit_loopback_request_host request =
-  match Httpun.Headers.get request.Httpun.Request.headers "host" with
-  | None -> Error Missing_request_host
-  | Some raw ->
+let request_host_of_request request =
+  match Httpun.Headers.get_multi request.Httpun.Request.headers "host" with
+  | [] -> Error Missing_request_host
+  | [ raw ] ->
     (match parse_request_host_header raw with
-     | None -> Error Malformed_request_host
-     | Some ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
-     | Some { host; _ } -> Error (Non_loopback_request_host host))
+     | Some admitted -> Ok admitted
+     | None -> Error Malformed_request_host)
+  | _ -> Error Multiple_request_hosts
+;;
+
+let admit_loopback_request_host request =
+  match request_host_of_request request with
+  | Error rejection -> Error rejection
+  | Ok ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
+  | Ok { host; _ } -> Error (Non_loopback_request_host host)
 ;;
 
 let host_port_of_request request =
-  match Httpun.Headers.get request.Httpun.Request.headers "host" with
-  | None -> None
-  | Some host_header ->
-    Option.map
-      (fun { host; port } -> host, port)
-      (parse_request_host_header host_header)
+  match request_host_of_request request with
+  | Ok { host; port } -> Some (host, port)
+  | Error _ -> None
 
 (* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
    can be toggled without restarting the server process. *)

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -424,10 +424,18 @@ let sanitized_dashboard_actor_for_request ~base_path request =
     uses https (port 443) but we parse Host with a synthetic "http://" prefix
     (port 80).  Comparing explicit ports avoids this class of bug. *)
 
-let default_port_of_scheme = function
-  | Some "http" -> Some 80
-  | Some "https" -> Some 443
-  | _ -> None
+type browser_scheme =
+  | Http
+  | Https
+
+let browser_scheme_of_uri uri =
+  match Uri.scheme uri |> Option.map String.lowercase_ascii with
+  | Some "http" -> Some Http
+  | Some "https" -> Some Https
+  | Some _ | None -> None
+;;
+
+let default_port_of_scheme = function Http -> Some 80 | Https -> Some 443
 
 let normalize_loopback_host host =
   match String.lowercase_ascii (String.trim host) with
@@ -439,140 +447,26 @@ let normalize_loopback_host host =
 let split_csv_nonempty raw =
   raw |> String.split_on_char ',' |> List.filter_map String_util.trim_nonempty
 
-(** Returns (host, explicit_port, scheme). *)
+(** Returns [(host, explicit_port, scheme)] for an HTTP(S) origin or
+    referrer.  Userinfo is never part of a browser origin and accepting it
+    would make the displayed authority differ from the authenticated one. *)
 let host_port_scheme_of_origin origin =
   try
     let uri = Uri.of_string origin in
-    match Uri.host uri with
-    | None -> None
-    | Some host ->
-        Some (String.trim host |> String.lowercase_ascii,
-              Uri.port uri, Uri.scheme uri)
+    match browser_scheme_of_uri uri, Uri.userinfo uri, Uri.host uri with
+    | Some scheme, None, Some host ->
+      String_util.trim_nonempty host
+      |> Option.map (fun host ->
+        String.lowercase_ascii host, Uri.port uri, scheme)
+    | Some _, Some _, _ | Some _, None, None | None, _, _ -> None
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Auth.debug "host_port_scheme_of_origin: parse failed for %S: %s"
       origin (Printexc.to_string exn);
     None
 
-type request_host_rejection =
-  | Missing_request_host
-  | Multiple_request_hosts
-  | Malformed_request_host
-  | Non_loopback_request_host of string
-
-type admitted_request_host =
-  { host : string
-  ; port : int option
-  }
-
-let ascii_is_digit c = c >= '0' && c <= '9'
-
-let ascii_is_hex_digit c =
-  ascii_is_digit c
-  || (c >= 'a' && c <= 'f')
-  || (c >= 'A' && c <= 'F')
-;;
-
-let reg_name_char_is_allowed c =
-  ascii_is_digit c
-  || (c >= 'a' && c <= 'z')
-  || (c >= 'A' && c <= 'Z')
-  || String.contains "-._~!$&'()*+,;=" c
-;;
-
-let reg_name_is_valid host =
-  let length = String.length host in
-  let rec consume index =
-    if index = length
-    then true
-    else if Char.equal host.[index] '%'
-    then
-      index + 2 < length
-      && ascii_is_hex_digit host.[index + 1]
-      && ascii_is_hex_digit host.[index + 2]
-      && consume (index + 3)
-    else reg_name_char_is_allowed host.[index] && consume (index + 1)
-  in
-  length > 0 && consume 0
-;;
-
-let parse_request_host_port_suffix suffix =
-  if String.equal suffix ""
-  then Ok None
-  else if not (Char.equal suffix.[0] ':')
-  then Error ()
-  else
-    let raw_port = String.sub suffix 1 (String.length suffix - 1) in
-    if String.equal raw_port "" || not (String.for_all ascii_is_digit raw_port)
-    then Error ()
-    else
-      match int_of_string_opt raw_port with
-      | Some port when port <= 65_535 -> Ok (Some port)
-      | Some _ | None -> Error ()
-;;
-
-let parse_request_host_header raw =
-  let authority = String.trim raw in
-  if String.equal authority ""
-  then None
-  else if Char.equal authority.[0] '['
-  then
-    match String.index_opt authority ']' with
-    | None | Some 1 -> None
-    | Some closing_bracket ->
-      let host = String.sub authority 1 (closing_bracket - 1) in
-      let suffix_start = closing_bracket + 1 in
-      let suffix =
-        String.sub authority suffix_start (String.length authority - suffix_start)
-      in
-      (match Ipaddr.V6.of_string host, parse_request_host_port_suffix suffix with
-       | Ok _, Ok port -> Some { host = String.lowercase_ascii host; port }
-       | Error _, _ | _, Error () -> None)
-  else
-    let colon_count =
-      String.fold_left
-        (fun count char -> if Char.equal char ':' then count + 1 else count)
-        0
-        authority
-    in
-    if colon_count > 1
-    then None
-    else
-      let host, suffix =
-        match String.index_opt authority ':' with
-        | None -> authority, ""
-        | Some separator ->
-          ( String.sub authority 0 separator
-          , String.sub authority separator (String.length authority - separator) )
-      in
-      if not (reg_name_is_valid host)
-      then None
-      else
-        match parse_request_host_port_suffix suffix with
-        | Ok port -> Some { host = String.lowercase_ascii host; port }
-        | Error () -> None
-;;
-
-let request_host_of_request request =
-  match Httpun.Headers.get_multi request.Httpun.Request.headers "host" with
-  | [] -> Error Missing_request_host
-  | [ raw ] ->
-    (match parse_request_host_header raw with
-     | Some admitted -> Ok admitted
-     | None -> Error Malformed_request_host)
-  | _ -> Error Multiple_request_hosts
-;;
-
-let admit_loopback_request_host request =
-  match request_host_of_request request with
-  | Error rejection -> Error rejection
-  | Ok ({ host; _ } as admitted) when is_loopback_host host -> Ok admitted
-  | Ok { host; _ } -> Error (Non_loopback_request_host host)
-;;
-
-let host_port_of_request request =
-  match request_host_of_request request with
-  | Ok { host; port } -> Some (host, port)
-  | Error _ -> None
+let host_port_of_authority authority =
+  ( Server_request_authority.host authority
+  , Server_request_authority.port authority )
 
 (* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
    can be toggled without restarting the server process. *)
@@ -596,7 +490,7 @@ let normalized_origin_key origin =
       Some
         ( normalize_loopback_host host,
           (match port with Some _ -> port | None -> default),
-          Option.map String.lowercase_ascii scheme )
+          scheme )
   | None -> None
 
 let is_allowlisted_loopback_dev_origin origin =
@@ -607,28 +501,57 @@ let is_allowlisted_loopback_dev_origin origin =
       |> List.exists (fun allowed -> allowed = candidate)
   | _ -> false
 
-(* Browsers omit Origin for same-origin requests per the Fetch spec, but
-   always include Referer.  If the Referer's host:port matches the
-   request's Host header, the request is same-origin and trusted. *)
-let is_same_server_referer referer request =
-  match host_port_scheme_of_origin referer, host_port_of_request request with
-  | Some (ref_host, ref_port, scheme), Some (req_host, req_port)
-    when String.equal
-           (normalize_loopback_host ref_host)
-           (normalize_loopback_host req_host) ->
-    let default = default_port_of_scheme scheme in
-    let norm p = match p with Some _ -> p | None -> default in
-    norm ref_port = norm req_port
-  | _ -> false
+let origin_matches_request_authority ~request_authority origin =
+  match host_port_scheme_of_origin origin with
+  | Some (origin_host, origin_port, scheme) ->
+    let request_host, request_port =
+      host_port_of_authority request_authority
+    in
+    if
+      String.equal
+        (normalize_loopback_host origin_host)
+        (normalize_loopback_host request_host)
+    then
+      let default = default_port_of_scheme scheme in
+      let normalize_port = function
+        | Some _ as explicit -> explicit
+        | None -> default
+      in
+      normalize_port origin_port = normalize_port request_port
+    else false
+  | None -> false
+;;
 
-let ensure_same_origin_browser_request request :
+let allowlisted_dev_origin_matches_request ~request_authority origin =
+  match host_port_scheme_of_origin origin with
+  | Some (origin_host, _, _) ->
+    let request_host = Server_request_authority.host request_authority in
+    String.equal
+      (normalize_loopback_host origin_host)
+      (normalize_loopback_host request_host)
+    && is_loopback_host (normalize_loopback_host origin_host)
+    && is_allowlisted_loopback_dev_origin origin
+  | None -> false
+;;
+
+let browser_origin_matches_request_authority ~request_authority origin =
+  origin_matches_request_authority ~request_authority origin
+  || allowlisted_dev_origin_matches_request ~request_authority origin
+;;
+
+(* Browsers omit Origin for same-origin requests per the Fetch spec, but
+   always include Referer.  The admitted request authority is already parsed
+   at the request entry; this path never re-reads Host. *)
+let ensure_same_origin_browser_request ~request_authority request :
     (unit, Masc_domain.masc_error) result =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
   | None ->
     (* Same-origin browser requests don't send Origin.  Check Referer
        as a fallback — browsers always include it even for same-origin. *)
     (match Httpun.Headers.get request.Httpun.Request.headers "referer" with
-     | Some referer when is_same_server_referer referer request -> Ok ()
+     | Some referer
+       when origin_matches_request_authority ~request_authority referer ->
+       Ok ()
      | _ ->
        if allow_anonymous_mutations () then Ok ()
        else
@@ -637,46 +560,18 @@ let ensure_same_origin_browser_request request :
            ; message = "Authentication required: provide a bearer token or Origin header. \
                         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development."
            })))
-  | Some origin -> (
-      match host_port_scheme_of_origin origin, host_port_of_request request with
-      | Some (origin_host, origin_port, scheme),
-        Some (request_host, request_port)
-        when String.equal
-               (normalize_loopback_host origin_host)
-               (normalize_loopback_host request_host) ->
-          let default = default_port_of_scheme scheme in
-          let norm p = match p with Some _ -> p | None -> default in
-          (* Loopback same-port remains allowed, but cross-port mutations now
-             require an explicit dev-origin allowlist instead of trusting any
-             localhost page. This preserves the default Vite dashboard proxy
-             flow (5173 -> backend) while shrinking the browser trust boundary. *)
-          if norm origin_port = norm request_port then
-            Ok ()
-          else if
-            is_loopback_host (normalize_loopback_host origin_host)
-            && is_allowlisted_loopback_dev_origin origin
-          then
-            Ok ()
-          else (
-            Log.Auth.debug
-              "same-origin port mismatch: origin=%S host=%s"
-              origin
-              (match Httpun.Headers.get request.Httpun.Request.headers "host" with
-               | Some h -> Printf.sprintf "%S" h | None -> "<absent>");
-            Error
-              (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden
-                 { agent = "browser";
-                   action = "cross-origin HTTP mutation" })))
-      | _ ->
-          Log.Auth.debug
-            "same-origin check failed: origin=%S host=%s"
-            origin
-            (match Httpun.Headers.get request.Httpun.Request.headers "host" with
-             | Some h -> Printf.sprintf "%S" h | None -> "<absent>");
-          Error
-            (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden
-               { agent = "browser";
-                 action = "cross-origin HTTP mutation" })))
+  | Some origin ->
+    if browser_origin_matches_request_authority ~request_authority origin
+    then Ok ()
+    else (
+      Log.Auth.debug
+        "same-origin check failed: origin=%S authority=%S"
+        origin
+        (Server_request_authority.rendered request_authority);
+      Error
+        (Masc_domain.Auth
+           (Masc_domain.Auth_error.Forbidden
+              { agent = "browser"; action = "cross-origin HTTP mutation" })))
 
 (* Mirrors [Masc_error.code] (the typed SSOT in lib/types/masc_error.ml).
    Previously the catch-all [_ -> `Internal_server_error] silently demoted
@@ -716,29 +611,13 @@ let get_origin (request : Httpun.Request.t) =
   Httpun.Headers.get request.headers "origin"
   |> Option.value ~default:"*"
 
-let public_read_cors_origin_opt (request : Httpun.Request.t) =
+let public_read_cors_origin_opt ~request_authority (request : Httpun.Request.t) =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
   | None -> None
-  | Some origin -> (
-      match host_port_scheme_of_origin origin, host_port_of_request request with
-      | Some (origin_host, origin_port, scheme),
-        Some (request_host, request_port)
-        when String.equal
-               (normalize_loopback_host origin_host)
-               (normalize_loopback_host request_host) ->
-          let default = default_port_of_scheme scheme in
-          let norm p = match p with Some _ -> p | None -> default in
-          if norm origin_port = norm request_port then
-            Some origin
-          else if
-            is_loopback_host (normalize_loopback_host origin_host)
-            && is_allowlisted_loopback_dev_origin origin
-          then
-            Some origin
-          else
-            None
-      | _ when is_allowlisted_loopback_dev_origin origin -> Some origin
-      | _ -> None)
+  | Some origin ->
+    if browser_origin_matches_request_authority ~request_authority origin
+    then Some origin
+    else None
 
 (** CORS headers *)
 let cors_allow_headers_value =
@@ -774,9 +653,13 @@ let respond_json_value_with_cors ?(status = `OK) request reqd value =
     ~extra_headers:(cors_headers origin) value reqd
 
 let public_read_cors_headers request =
-  match public_read_cors_origin_opt request with
-  | Some origin -> cors_headers origin
+  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
   | None -> [ ("vary", "Origin") ]
+  | Some _ ->
+    let request_authority = Server_request_authority.current_exn () in
+    (match public_read_cors_origin_opt ~request_authority request with
+     | Some origin -> cors_headers origin
+     | None -> [ ("vary", "Origin") ])
 
 let respond_public_read_json ?(status = `OK) request reqd body =
   Http_server_eio.Response.json ~status
@@ -960,13 +843,13 @@ let authorize_permission_request ~base_path ~permission request :
 let authorize_read_request ~base_path request : (unit, Masc_domain.masc_error) result =
   authorize_permission_request ~base_path ~permission:Masc_domain.CanReadState request
 
-let authorize_tool_request ~base_path ~tool_name request :
+let authorize_tool_request ~base_path ~tool_name ~request_authority request :
     (unit, Masc_domain.masc_error) result =
   let auth_cfg = Auth.load_auth_config base_path in
   let token = auth_token_from_request request in
   let* () =
     if Option.is_some token then Ok ()
-    else ensure_same_origin_browser_request request
+    else ensure_same_origin_browser_request ~request_authority request
   in
   let* auth_cfg =
     ensure_strict_http_token_auth
@@ -1113,7 +996,14 @@ and with_tool_auth ~tool_name handler request reqd =
   | None -> Http_server_eio.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = (Mcp_server.workspace_config state).base_path in
-      (match authorize_tool_request ~base_path ~tool_name request with
+      let request_authority = Server_request_authority.current_exn () in
+      (match
+         authorize_tool_request
+           ~base_path
+           ~tool_name
+           ~request_authority
+           request
+       with
       | Ok () ->
           (match check_agent_rate_limit request reqd with
           | Ok () -> handler state request reqd

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -168,6 +168,7 @@ val host_port_scheme_of_origin :
 
 type request_host_rejection =
   | Missing_request_host
+  | Multiple_request_hosts
   | Malformed_request_host
   | Non_loopback_request_host of string
 
@@ -179,8 +180,9 @@ type admitted_request_host =
 val admit_loopback_request_host :
   Httpun.Request.t -> (admitted_request_host, request_host_rejection) result
 (** Parse the request [Host] authority and admit exact loopback hosts only.
-    Missing, malformed, and non-loopback authorities remain distinct typed
-    rejections. Credential-bearing endpoints must run this gate before I/O. *)
+    Missing, repeated, malformed, and non-loopback authorities remain distinct
+    typed rejections. Credential-bearing endpoints must run this gate before
+    I/O. *)
 
 val host_port_of_request : Httpun.Request.t -> (string * int option) option
 (** Host/port from the request's [Host] header. *)

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -155,57 +155,20 @@ val sanitized_dashboard_actor_for_request :
 
 (** {1 Origin / CORS} *)
 
-val default_port_of_scheme : string option -> int option
-(** Default port for [http]/[https]/[ws]/[wss], or [None]. *)
-
-val normalize_loopback_host : string -> string
-(** Map [127.0.0.1]/[::1]/[localhost] to a single canonical form so
-    origin comparisons are scheme/host-equivalent. *)
-
-val host_port_scheme_of_origin :
-  string -> (string * int option * string option) option
-(** Parse an [Origin] header value into [(host, port, scheme)]. *)
-
-type request_host_rejection =
-  | Missing_request_host
-  | Multiple_request_hosts
-  | Malformed_request_host
-  | Non_loopback_request_host of string
-
-type admitted_request_host =
-  { host : string
-  ; port : int option
-  }
-
-val admit_loopback_request_host :
-  Httpun.Request.t -> (admitted_request_host, request_host_rejection) result
-(** Parse the request [Host] authority and admit exact loopback hosts only.
-    Missing, repeated, malformed, and non-loopback authorities remain distinct
-    typed rejections. Credential-bearing endpoints must run this gate before
-    I/O. *)
-
-val host_port_of_request : Httpun.Request.t -> (string * int option) option
-(** Host/port from the request's [Host] header. *)
-
 val allow_anonymous_mutations : unit -> bool
 (** Re-reads [MASC_ALLOW_ANONYMOUS_MUTATIONS] on each call.
     When [true] non-loopback mutations skip auth (test fixtures only). *)
 
-val default_loopback_dev_mutation_origins : string list
-(** Built-in allowlist of dev-loopback origins (e.g. Vite). *)
-
-val configured_loopback_dev_mutation_origins : unit -> string list
-(** Configured allowlist (env / TOML), unioned with the default. *)
-
-val normalized_origin_key :
-  string -> (string * int option * string option) option
-(** Stable key for origin allowlist comparisons. *)
-
-val is_allowlisted_loopback_dev_origin : string -> bool
-(** [true] when [origin] matches the loopback dev allowlist. *)
+val browser_origin_matches_request_authority :
+  request_authority:Server_request_authority.authority -> string -> bool
+(** Compare an HTTP(S) browser origin with the admitted request authority.
+    The explicit loopback development allowlist is accepted only when its
+    normalized host is also the admitted loopback host. *)
 
 val ensure_same_origin_browser_request :
-  Httpun.Request.t -> (unit, Masc_domain.masc_error) result
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  (unit, Masc_domain.masc_error) result
 (** Reject mutations from off-origin browsers; allows the loopback dev
     allowlist. *)
 
@@ -236,9 +199,11 @@ val get_origin : Httpun.Request.t -> Httpun.Headers.value
     missing). *)
 
 val public_read_cors_origin_opt :
-  Httpun.Request.t -> Httpun.Headers.value option
-(** Origin to echo back on public-read CORS responses; [None] when the
-    request is not eligible for public-read. *)
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Httpun.Headers.value option
+(** Origin to echo back on public-read CORS responses after comparison with the
+    admitted authority; [None] when the request is not eligible. *)
 
 val cors_allow_headers_value : string
 (** Static [Access-Control-Allow-Headers] value used for protected
@@ -331,7 +296,9 @@ val authorize_read_request :
 
 val authorize_tool_request :
   base_path:string ->
-  tool_name:string -> Httpun.Request.t -> (unit, Masc_domain.masc_error) result
+  tool_name:string ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t -> (unit, Masc_domain.masc_error) result
 (** Check that the request is allowed to call [tool_name]. *)
 
 val authorize_token_bound_permission_request :

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -644,7 +644,14 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
       Auth.resolve_role_with_auth_config config.base_path ~auth_cfg ~agent_name ~token
   in
   let endpoint_gate_result =
-    match if token_present then Ok () else ensure_same_origin_browser_request request with
+    match
+      if token_present
+      then Ok ()
+      else
+        ensure_same_origin_browser_request
+          ~request_authority:(Server_request_authority.current_exn ())
+          request
+    with
     | Error err -> Error err
     | Ok () ->
       (match

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -5,6 +5,13 @@ open Server_dashboard_http
 open Server_h2_gateway_helpers
 open Server_routes_http
 
+let h2_request_authority_bad_request ~error_code ~message h2_reqd =
+  h2_respond_json_value
+    h2_reqd
+    (`Assoc [ "error_code", `String error_code; "error", `String message ])
+    ~status:`Bad_request
+;;
+
 let make_error_handler () =
   (* HTTP/2 error handler *)
   let h2_error_handler _client_addr ?request:_ error respond =
@@ -62,11 +69,17 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `CONNECT -> `CONNECT | `TRACE -> `TRACE | `Other s -> `Other s
     in
     let httpun_request = Httpun.Request.create ~headers:httpun_headers httpun_meth h2_req.target in
+    let handle_admitted_request request_authority =
     let path = Http.Request.path httpun_request in
-    let origin = match H2.Headers.get h2_headers "origin" with
-      | Some o -> o | None -> "*"
+    let origin = get_origin httpun_request in
+    let reflected_cors_origin =
+      public_read_cors_origin_opt ~request_authority httpun_request
     in
-    let cors = cors_headers origin in
+    let cors =
+      match reflected_cors_origin with
+      | Some origin -> cors_headers origin
+      | None -> [ "vary", "Origin" ]
+    in
     (* [with_server_state] (#9793): HTTP-layer wrapper around
        [get_server_state_result]. Returns a controlled 500 JSON error when
        server state is not initialized, instead of crashing the request
@@ -174,7 +187,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
     let _h2_authorize_tool state ~tool_name =
       authorize_tool_request
         ~base_path:(Mcp_server.workspace_config state).base_path
-        ~tool_name httpun_request
+        ~tool_name ~request_authority httpun_request
     in
 
     let dispatch_h2_route () =
@@ -184,7 +197,10 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
          ───────────────────────────────────────────────────────────────────── *)
       | `GET, "/health" ->
           let json =
-            Server_routes_http_runtime.make_health_response_json ~listener:"h2" httpun_request
+            Server_routes_http_runtime.make_health_response_json
+              ~listener:"h2"
+              ~request_authority
+              httpun_request
           in
           h2_respond_json_value h2_reqd json ~extra_headers:cors
 
@@ -219,12 +235,16 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, ("/.well-known/agent.json" | "/.well-known/agent-card.json") ->
           h2_respond_json_value h2_reqd
-            (Server_routes_http_runtime.agent_card_json httpun_request)
+            (Server_routes_http_runtime.agent_card_json
+               ~request_authority
+               httpun_request)
             ~extra_headers:cors
 
       | `GET, "/ws" ->
           let json =
-            Server_routes_http_runtime.websocket_discovery_json httpun_request
+            Server_routes_http_runtime.websocket_discovery_json
+              ~request_authority
+              httpun_request
           in
           h2_respond_json_value h2_reqd json ~extra_headers:cors
 
@@ -304,7 +324,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
          CORS Preflight
          ───────────────────────────────────────────────────────────────────── *)
       | `OPTIONS, _ ->
-          h2_respond_empty h2_reqd ~extra_headers:(cors_preflight_headers origin)
+          let headers =
+            match reflected_cors_origin with
+            | Some reflected -> cors_preflight_headers reflected
+            | None -> [ "vary", "Origin" ]
+          in
+          h2_respond_empty h2_reqd ~extra_headers:headers
 
       (* ─────────────────────────────────────────────────────────────────────
          MCP Endpoints
@@ -863,11 +888,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/openapi.json" ->
-          let host_header = get_header_any_case httpun_request.headers "host" in
-          let (resolved_host, resolved_port) = match host_header with
-            | Some header -> parse_host_port (Some header)
-                (Env_config_core.masc_host ()) (Env_config_core.masc_http_port_int ())
-            | None -> ("", 0)
+          let resolved_host = Server_request_authority.host request_authority in
+          let resolved_port =
+            Option.value
+              ~default:(Env_config_core.masc_http_port_int ())
+              (Server_request_authority.port request_authority)
           in
           let json =
             Transport.Rest.generate_openapi_document
@@ -948,12 +973,63 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           h2_respond_text h2_reqd (Printf.sprintf "404 Not Found: %s" path) ~status:`Not_found ~extra_headers:cors
 
     in
-    try
-      dispatch_h2_route ()
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      let msg = Printexc.to_string exn in
-      Log.Http.error "Handler error: %s" msg;
-      h2_respond_text h2_reqd ("500 Internal Server Error: " ^ msg) ~status:`Internal_server_error ~extra_headers:cors
+    if
+      is_mcp_transport_request httpun_request
+      && not (validate_origin ~request_authority httpun_request)
+    then
+      h2_respond_json_value
+        h2_reqd
+        (`Assoc
+           [ "jsonrpc", `String "2.0"
+           ; ( "error"
+             , `Assoc
+                 [ ( "code"
+                   , `Int
+                       (Mcp_error_code.to_wire_code
+                          Mcp_error_code.Invalid_request) )
+                 ; "message", `String "Invalid origin"
+                 ] )
+           ; "id", `Null
+           ])
+        ~status:`Forbidden
+        ~extra_headers:cors
+    else
+      try dispatch_h2_route () with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        let msg = Printexc.to_string exn in
+        Log.Http.error "Handler error: %s" msg;
+        h2_respond_text
+          h2_reqd
+          ("500 Internal Server Error: " ^ msg)
+          ~status:`Internal_server_error
+          ~extra_headers:cors
+    in
+    match Server_request_authority.classify_h2_request h2_req with
+    | Server_request_authority.H2_authority
+        (Server_request_authority.Single request_authority) ->
+      Server_request_authority.with_current request_authority (fun () ->
+        handle_admitted_request request_authority)
+    | Server_request_authority.H2_authority Server_request_authority.Missing ->
+      h2_request_authority_bad_request
+        ~error_code:"request_authority_missing"
+        ~message:"request is missing :authority"
+        h2_reqd
+    | Server_request_authority.H2_authority Server_request_authority.Multiple ->
+      h2_request_authority_bad_request
+        ~error_code:"request_authority_multiple"
+        ~message:"request contains multiple authority fields"
+        h2_reqd
+    | Server_request_authority.H2_authority Server_request_authority.Malformed ->
+      h2_request_authority_bad_request
+        ~error_code:"request_authority_malformed"
+        ~message:"request authority is malformed"
+        h2_reqd
+    | Server_request_authority.Unsupported_asterisk_form_options ->
+      h2_request_authority_bad_request
+        ~error_code:"request_target_asterisk_unsupported"
+        ~message:"MASC does not support authority-free OPTIONS *"
+        h2_reqd
   in
   (* H2 error handler *)
   let _h2_error_handler _client_addr ?request:_ error respond =

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -1245,9 +1245,12 @@ let mcp_websocket_handler
     [handler] builds the per-connection [input_handlers] from the
     [Wsd.t]; the MCP session ({!mcp_websocket_handler}) and the IDE LSP
     session each supply their own. *)
-(* RFC 6455 §4.2.1 scrutiny: the request must be a GET with Host, an
-   [Upgrade: websocket] header, a [Connection] list containing "upgrade", a 16-
-   byte base64 [Sec-WebSocket-Key], and [Sec-WebSocket-Version: 13]. *)
+(* RFC 6455 §4.2.1 scrutiny after the shared request-entry authority gate: the
+   request must be a GET with [Upgrade: websocket], a [Connection] list
+   containing "upgrade", a 16-byte base64 [Sec-WebSocket-Key], and
+   [Sec-WebSocket-Version: 13].  Host cardinality and syntax are already
+   represented by [Server_request_authority.authority] in the request fiber;
+   this downstream handshake must not re-read the raw Host field. *)
 let ws_upgrade_accept (request : Httpun.Request.t) : (string, string) result =
   let h name = Httpun.Headers.get request.Httpun.Request.headers name in
   let ci_eq a b = String.equal (String.lowercase_ascii a) b in
@@ -1257,10 +1260,10 @@ let ws_upgrade_accept (request : Httpun.Request.t) : (string, string) result =
       (String.split_on_char ',' v)
   in
   match
-    request.Httpun.Request.meth, h "host", h "upgrade", h "connection",
+    request.Httpun.Request.meth, h "upgrade", h "connection",
     h "sec-websocket-key", h "sec-websocket-version"
   with
-  | `GET, Some _host, Some upgrade, Some connection, Some key, Some "13"
+  | `GET, Some upgrade, Some connection, Some key, Some "13"
     when ci_eq upgrade "websocket"
          && connection_lists_upgrade connection
          && (try String.length (Base64.decode_exn key) = 16 with _ -> false) ->

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -289,7 +289,9 @@ val ws_upgrade_accept : Httpun.Request.t -> (string, string) result
 (** Validate an HTTP/1.1 -> WebSocket upgrade request (RFC 6455 §4.2.1): [GET],
     [Upgrade: websocket], [Connection] listing [upgrade], [Sec-WebSocket-Version:
     13], and a [Sec-WebSocket-Key] that base64-decodes to exactly 16 bytes.
-    Returns the accept token on success.  Exposed for unit tests. *)
+    Returns the accept token on success.  Authority validation belongs to the
+    shared request-entry gate, so this function intentionally does not re-read
+    [Host].  Exposed for unit tests. *)
 
 val respond_and_drive_upgrade :
   upgrade:(Gluten.impl -> unit) ->

--- a/lib/server/server_request_authority.ml
+++ b/lib/server/server_request_authority.ml
@@ -1,0 +1,226 @@
+type authority =
+  { host : string
+  ; port : int option
+  }
+
+type classification =
+  | Missing
+  | Single of authority
+  | Multiple
+  | Malformed
+
+type h2_classification =
+  | H2_authority of classification
+  | Unsupported_asterisk_form_options
+
+exception Unbound_request_authority
+
+let ascii_is_digit c = c >= '0' && c <= '9'
+
+let ascii_is_hex_digit c =
+  ascii_is_digit c
+  || (c >= 'a' && c <= 'f')
+  || (c >= 'A' && c <= 'F')
+;;
+
+let reg_name_char_is_allowed c =
+  ascii_is_digit c
+  || (c >= 'a' && c <= 'z')
+  || (c >= 'A' && c <= 'Z')
+  || String.contains "-._~!$&'()*+,;=" c
+;;
+
+let reg_name_is_valid host =
+  let length = String.length host in
+  let rec consume index =
+    if index = length
+    then true
+    else if Char.equal host.[index] '%'
+    then
+      index + 2 < length
+      && ascii_is_hex_digit host.[index + 1]
+      && ascii_is_hex_digit host.[index + 2]
+      && consume (index + 3)
+    else reg_name_char_is_allowed host.[index] && consume (index + 1)
+  in
+  length > 0 && consume 0
+;;
+
+let parse_port_suffix suffix =
+  if String.equal suffix ""
+  then Ok None
+  else if not (Char.equal suffix.[0] ':')
+  then Error ()
+  else
+    let raw_port = String.sub suffix 1 (String.length suffix - 1) in
+    if String.equal raw_port "" || not (String.for_all ascii_is_digit raw_port)
+    then Error ()
+    else
+      match int_of_string_opt raw_port with
+      | Some port when port <= 65_535 -> Ok (Some port)
+      | Some _ | None -> Error ()
+;;
+
+let canonical_reg_name host =
+  match Ipaddr.V4.of_string host with
+  | Ok address -> Ipaddr.V4.to_string address
+  | Error _ -> String.lowercase_ascii host
+;;
+
+let parse raw =
+  let value = String.trim raw in
+  if String.equal value ""
+  then None
+  else if Char.equal value.[0] '['
+  then
+    match String.index_opt value ']' with
+    | None | Some 1 -> None
+    | Some closing_bracket ->
+      let raw_host = String.sub value 1 (closing_bracket - 1) in
+      let suffix_start = closing_bracket + 1 in
+      let suffix =
+        String.sub value suffix_start (String.length value - suffix_start)
+      in
+      (match Ipaddr.V6.of_string raw_host, parse_port_suffix suffix with
+       | Ok address, Ok port ->
+         Some { host = Ipaddr.V6.to_string address; port }
+       | Error _, _ | _, Error () -> None)
+  else
+    let colon_count =
+      String.fold_left
+        (fun count char -> if Char.equal char ':' then count + 1 else count)
+        0
+        value
+    in
+    if colon_count > 1
+    then None
+    else
+      let raw_host, suffix =
+        match String.index_opt value ':' with
+        | None -> value, ""
+        | Some separator ->
+          ( String.sub value 0 separator
+          , String.sub value separator (String.length value - separator) )
+      in
+      if not (reg_name_is_valid raw_host)
+      then None
+      else
+        match parse_port_suffix suffix with
+        | Ok port -> Some { host = canonical_reg_name raw_host; port }
+        | Error () -> None
+;;
+
+let parse_h2 raw =
+  if String.equal raw (String.trim raw) then parse raw else None
+;;
+
+let classify_values ~multiple values =
+  match values with
+  | [] -> Missing
+  | [ raw ] -> Option.fold ~none:Malformed ~some:(fun value -> Single value) (parse raw)
+  | _ -> multiple
+;;
+
+let classify_http1_request request =
+  classify_values
+    ~multiple:Multiple
+    (Httpun.Headers.get_multi request.Httpun.Request.headers "host")
+;;
+
+let default_port_for_scheme scheme =
+  match String.lowercase_ascii scheme with
+  | "http" -> Some 80
+  | "https" -> Some 443
+  | _ -> None
+;;
+
+let effective_port ~scheme authority =
+  match authority.port with
+  | Some _ as explicit -> explicit
+  | None -> default_port_for_scheme scheme
+;;
+
+let equivalent_for_scheme ~scheme left right =
+  String.equal left.host right.host
+  && Option.equal Int.equal
+       (effective_port ~scheme left)
+       (effective_port ~scheme right)
+;;
+
+let classify_h2_request request =
+  let authorities = H2.Headers.get_multi request.H2.Request.headers ":authority" in
+  let hosts = H2.Headers.get_multi request.H2.Request.headers "host" in
+  match authorities with
+  | []
+    when request.H2.Request.meth = `OPTIONS
+         && String.equal request.H2.Request.target "*" ->
+    (match hosts with
+     | [] -> Unsupported_asterisk_form_options
+     | [ raw_host ] ->
+       (match parse_h2 raw_host with
+        | Some _ -> Unsupported_asterisk_form_options
+        | None -> H2_authority Malformed)
+     | _ -> H2_authority Malformed)
+  | [] ->
+    H2_authority
+      (match hosts with
+       | [] | [ _ ] -> Missing
+       | _ -> Malformed)
+  | [ raw_authority ] ->
+    let classification =
+      match parse_h2 raw_authority with
+      | None -> Malformed
+      | Some authority ->
+        (match hosts with
+         | [] -> Single authority
+         | [ raw_host ] ->
+           (match parse_h2 raw_host with
+            | Some host
+              when equivalent_for_scheme
+                     ~scheme:request.H2.Request.scheme
+                     authority
+                     host ->
+              Single authority
+            | Some _ | None -> Malformed)
+         | _ -> Malformed)
+    in
+    H2_authority classification
+  | _ -> H2_authority Malformed
+;;
+
+let host authority = authority.host
+let port authority = authority.port
+
+let rendered_host authority =
+  match Ipaddr.V6.of_string authority.host with
+  | Ok _ -> "[" ^ authority.host ^ "]"
+  | Error _ -> authority.host
+;;
+
+let rendered authority =
+  match authority.port with
+  | None -> rendered_host authority
+  | Some port -> Printf.sprintf "%s:%d" (rendered_host authority) port
+;;
+
+let of_host_port ~host ~port =
+  let raw_host =
+    match Ipaddr.V6.of_string host with
+    | Ok _ -> "[" ^ host ^ "]"
+    | Error _ -> host
+  in
+  match parse (Printf.sprintf "%s:%d" raw_host port) with
+  | Some authority -> Ok authority
+  | None -> Error `Malformed
+;;
+
+let current_key : authority Eio.Fiber.key = Eio.Fiber.create_key ()
+
+let with_current authority f = Eio.Fiber.with_binding current_key authority f
+let current () = Eio.Fiber.get current_key
+
+let current_exn () =
+  match current () with
+  | Some authority -> authority
+  | None -> raise Unbound_request_authority
+;;

--- a/lib/server/server_request_authority.mli
+++ b/lib/server/server_request_authority.mli
@@ -1,0 +1,53 @@
+(** Typed request-authority admission shared by HTTP/1.1 and HTTP/2.
+
+    A request entry point classifies its authority exactly once, rejects every
+    non-[Single] result, and binds the admitted value for the lifetime of the
+    request fiber.  Downstream auth and projection code consumes [authority]
+    rather than re-reading wire headers. *)
+
+type authority
+
+type classification =
+  | Missing
+  | Single of authority
+  | Multiple
+  | Malformed
+
+type h2_classification =
+  | H2_authority of classification
+  | Unsupported_asterisk_form_options
+
+exception Unbound_request_authority
+
+val classify_http1_request : Httpun.Request.t -> classification
+(** Classify the case-insensitive HTTP/1.1 [Host] field set. *)
+
+val classify_h2_request : H2.Request.t -> h2_classification
+(** Classify HTTP/2 [:authority].  A same-authority [Host] field is accepted
+    only as a cross-check; it is never used as the authority source.  Repeated
+    [:authority], repeated [Host], or a scheme-normalized mismatch is
+    [Malformed].  Authority-free [OPTIONS *] is reported separately because
+    MASC does not implement asterisk-form routing. *)
+
+val of_host_port : host:string -> port:int -> (authority, [ `Malformed ]) result
+(** Validate a trusted configured host/port through the same authority parser.
+    This is for synthetic background requests, not wire admission. *)
+
+val host : authority -> string
+val port : authority -> int option
+val rendered : authority -> string
+
+val equivalent_for_scheme :
+  scheme:string -> authority -> authority -> bool
+(** Compare normalized host and effective port.  [http] and [https] apply
+    their standard default ports; IPv4/IPv6 textual aliases are canonicalized
+    during parsing. *)
+
+val with_current : authority -> (unit -> 'a) -> 'a
+(** Bind an admitted authority to the current Eio request fiber. *)
+
+val current : unit -> authority option
+val current_exn : unit -> authority
+(** Return the request-fiber authority or raise
+    {!Unbound_request_authority}.  There is intentionally no raw-header or
+    configured-host fallback. *)

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -6,7 +6,7 @@ include Server_routes_http_keeper_stream
 
 module Http = Http_server_eio
 
-let make_routes ~port ~host ~sw ~clock =
+let make_routes ~port ~host:_ ~sw ~clock =
   (* Register connectors before routes are wired up *)
   Channel_gate_connector.register (module Channel_gate_discord_state);
   Channel_gate_connector.register (module Channel_gate_imessage_state);
@@ -19,7 +19,7 @@ let make_routes ~port ~host ~sw ~clock =
   Server_routes_http_routes_multimodal.bind_workspace_getter
     Multimodal.Workspace_holder.get;
   Http.Router.create ()
-  |> Server_routes_http_routes_frontend.add_routes ~port ~host ~sw ~clock
+  |> Server_routes_http_routes_frontend.add_routes ~port ~sw ~clock
   |> Server_routes_http_routes_workspace.add_routes
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
   |> Server_routes_http_routes_provider_runs.add_routes ~sw

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -103,41 +103,23 @@ let state_net_opt = function
   | None -> Eio_context.get_net_opt ()
 
 
-let host_header_has_forbidden_authority_chars value =
-  let has_forbidden_char =
-    String.exists
-      (function
-        | '/' | '@' | '?' | '#' | '%' | ' ' | '\t' -> true
-        | _ -> false)
-      value
-  in
-  has_forbidden_char || String_util.contains_substring value "://"
+(** Requests that enter the MCP transport surface.  [/]'s GET representation
+    is the dashboard, while its POST representation is the legacy MCP endpoint;
+    keep that method distinction explicit instead of using a path prefix. *)
+let is_mcp_transport_request (request : Httpun.Request.t) =
+  match request.meth, Http.Request.path request with
+  | `POST, "/" -> true
+  | _, ("/mcp" | "/mcp/managed" | "/mcp/operator" | "/sse") -> true
+  | _ -> false
+;;
 
-let parse_host_port host_header default_host default_port =
-  match host_header with
-  | None -> (default_host, default_port)
-  | Some host_value -> (
-      let trimmed = String.trim host_value in
-      if trimmed = "" || host_header_has_forbidden_authority_chars trimmed then
-        (default_host, default_port)
-      else
-        try
-          let uri = Uri.of_string ("http://" ^ trimmed) in
-          let host = Uri.host uri |> Option.value ~default:default_host in
-          let port = Uri.port uri |> Option.value ~default:default_port in
-          (host, port)
-        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> (default_host, default_port))
-
-(** Allowed origins for DNS rebinding protection.
-    SSOT: [Masc_network_defaults.allowed_origins]. *)
-let allowed_origins = Masc_network_defaults.allowed_origins
-
-(** Validate Origin header for DNS rebinding protection *)
-let validate_origin (request : Httpun.Request.t) =
+(** Validate an HTTP(S) Origin against the authority admitted at request entry.
+    Native clients without an Origin remain valid. *)
+let validate_origin ~request_authority (request : Httpun.Request.t) =
   match Httpun.Headers.get request.headers "origin" with
   | None -> true
   | Some origin ->
-      List.exists (fun prefix -> String.starts_with ~prefix origin) allowed_origins
+    browser_origin_matches_request_authority ~request_authority origin
 
 (** Check if client accepts SSE *)
 let accepts_sse (request : Httpun.Request.t) =

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -128,8 +128,15 @@ val state_net_opt :
 
 (** {1 Origin / Accept negotiation} *)
 
-val allowed_origins : string list
-val validate_origin : Httpun.Request.t -> bool
+val is_mcp_transport_request : Httpun.Request.t -> bool
+(** [true] only for requests entering the MCP HTTP/SSE surface. *)
+
+val validate_origin :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t -> bool
+(** Validate a browser Origin against the authority admitted at request entry.
+    Requests without Origin are native clients and remain valid. *)
+
 val accepts_sse : Httpun.Request.t -> bool
 val accepts_streamable_mcp : Httpun.Request.t -> bool
 val request_force_json_response : Httpun.Request.t -> bool
@@ -187,11 +194,6 @@ val handle_presence_events :
 
 val mcp_transport_http_deps :
   unit -> Server_mcp_transport_http.deps
-val host_header_has_forbidden_authority_chars :
-  string -> bool
-val parse_host_port :
-  string option -> string -> int -> string * int
-
 (** [respond_cached_read ~request ~reqd ~cache_key ~ttl compute] wraps a
     dashboard read [compute] in the SWR cache and the shared Executor_pool,
     then writes the JSON response. Collapses parallel read bursts to one

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -7,39 +7,21 @@
 let dashboard_dev_actor_name = "dashboard"
 
 type request_error =
-  | Request_host_rejected of Server_auth.request_host_rejection
+  | Non_loopback_request_host of string
   | Token_operation_failed of string
 
 let request_error_status : request_error -> Httpun.Status.t = function
-  | Request_host_rejected
-      ( Server_auth.Missing_request_host
-      | Server_auth.Multiple_request_hosts
-      | Server_auth.Malformed_request_host ) ->
-    `Bad_request
-  | Request_host_rejected (Server_auth.Non_loopback_request_host _) -> `Forbidden
+  | Non_loopback_request_host _ -> `Forbidden
   | Token_operation_failed _ -> `Internal_server_error
 ;;
 
 let request_error_code = function
-  | Request_host_rejected Server_auth.Missing_request_host ->
-    "dashboard_dev_token_host_missing"
-  | Request_host_rejected Server_auth.Multiple_request_hosts ->
-    "dashboard_dev_token_host_multiple"
-  | Request_host_rejected Server_auth.Malformed_request_host ->
-    "dashboard_dev_token_host_malformed"
-  | Request_host_rejected (Server_auth.Non_loopback_request_host _) ->
-    "dashboard_dev_token_host_non_loopback"
+  | Non_loopback_request_host _ -> "dashboard_dev_token_host_non_loopback"
   | Token_operation_failed _ -> "dashboard_dev_token_operation_failed"
 ;;
 
 let request_error_to_string = function
-  | Request_host_rejected Server_auth.Missing_request_host ->
-    "dashboard dev-token request is missing the Host header"
-  | Request_host_rejected Server_auth.Multiple_request_hosts ->
-    "dashboard dev-token request contains more than one Host header field"
-  | Request_host_rejected Server_auth.Malformed_request_host ->
-    "dashboard dev-token request has a malformed Host authority"
-  | Request_host_rejected (Server_auth.Non_loopback_request_host host) ->
+  | Non_loopback_request_host host ->
     Printf.sprintf
       "dashboard dev-token request Host %S is not an exact loopback host"
       host
@@ -119,10 +101,11 @@ let ensure_dashboard_dev_token base_path : (string, string) result =
   | Ok (Some raw) -> Ok raw
   | Ok None -> mint_dashboard_dev_token base_path
 
-let ensure_dashboard_dev_token_for_request ~request ~base_path =
-  match Server_auth.admit_loopback_request_host request with
-  | Error rejection -> Error (Request_host_rejected rejection)
-  | Ok _ ->
+let ensure_dashboard_dev_token_for_authority ~request_authority ~base_path =
+  let host = Server_request_authority.host request_authority in
+  if not (Server_auth.is_loopback_host host)
+  then Error (Non_loopback_request_host host)
+  else
     Result.map_error
       (fun detail -> Token_operation_failed detail)
       (ensure_dashboard_dev_token base_path)

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -10,9 +10,21 @@ type request_error =
   | Request_host_rejected of Server_auth.request_host_rejection
   | Token_operation_failed of string
 
+let request_error_status : request_error -> Httpun.Status.t = function
+  | Request_host_rejected
+      ( Server_auth.Missing_request_host
+      | Server_auth.Multiple_request_hosts
+      | Server_auth.Malformed_request_host ) ->
+    `Bad_request
+  | Request_host_rejected (Server_auth.Non_loopback_request_host _) -> `Forbidden
+  | Token_operation_failed _ -> `Internal_server_error
+;;
+
 let request_error_code = function
   | Request_host_rejected Server_auth.Missing_request_host ->
     "dashboard_dev_token_host_missing"
+  | Request_host_rejected Server_auth.Multiple_request_hosts ->
+    "dashboard_dev_token_host_multiple"
   | Request_host_rejected Server_auth.Malformed_request_host ->
     "dashboard_dev_token_host_malformed"
   | Request_host_rejected (Server_auth.Non_loopback_request_host _) ->
@@ -23,6 +35,8 @@ let request_error_code = function
 let request_error_to_string = function
   | Request_host_rejected Server_auth.Missing_request_host ->
     "dashboard dev-token request is missing the Host header"
+  | Request_host_rejected Server_auth.Multiple_request_hosts ->
+    "dashboard dev-token request contains more than one Host header field"
   | Request_host_rejected Server_auth.Malformed_request_host ->
     "dashboard dev-token request has a malformed Host authority"
   | Request_host_rejected (Server_auth.Non_loopback_request_host host) ->

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -5,6 +5,7 @@ type request_error =
   | Token_operation_failed of string
 
 val dashboard_dev_token_path : string -> string
+val request_error_status : request_error -> Httpun.Status.t
 val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -1,7 +1,7 @@
 (** Dashboard dev-token file and minting helpers for dashboard routes. *)
 
 type request_error =
-  | Request_host_rejected of Server_auth.request_host_rejection
+  | Non_loopback_request_host of string
   | Token_operation_failed of string
 
 val dashboard_dev_token_path : string -> string
@@ -10,8 +10,9 @@ val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result
 
-val ensure_dashboard_dev_token_for_request :
-  request:Httpun.Request.t ->
+val ensure_dashboard_dev_token_for_authority :
+  request_authority:Server_request_authority.authority ->
   base_path:string ->
   (string, request_error) result
-(** Admit an exact loopback request Host before token or credential I/O. *)
+(** Enforce the dev-token endpoint's loopback-only policy on an authority
+    already admitted at request entry, before token or credential I/O. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -504,8 +504,8 @@ let add_routes ~sw ~clock router =
          with_public_read (fun state req reqd ->
            let base_path = (Mcp_server.workspace_config state).base_path in
            let raw_result =
-             Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token_for_request
-               ~request:req
+             Server_routes_http_dashboard_dev_token.ensure_dashboard_dev_token_for_authority
+               ~request_authority:(Server_request_authority.current_exn ())
                ~base_path
            in
            begin

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -515,11 +515,7 @@ let add_routes ~sw ~clock router =
                  (`Assoc [ ("token", `String raw) ]) reqd
              | Error err ->
                let status =
-                 match err with
-                 | Server_routes_http_dashboard_dev_token.Request_host_rejected _ ->
-                   `Forbidden
-                 | Server_routes_http_dashboard_dev_token.Token_operation_failed _ ->
-                   `Internal_server_error
+                 Server_routes_http_dashboard_dev_token.request_error_status err
                in
                let error_code =
                  Server_routes_http_dashboard_dev_token.request_error_code err

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -22,24 +22,23 @@ let respond_redirect ~location reqd =
   in
   Httpun.Reqd.respond_with_string reqd response ""
 
-let canonical_loopback_location ~default_port request =
-  let (host, port) =
-    parse_host_port
-      (Httpun.Headers.get request.Httpun.Request.headers "host")
-      (Env_config_core.masc_host ()) default_port
-  in
+let authority_host_port ~default_port request_authority =
+  ( Server_request_authority.host request_authority
+  , Option.value
+      ~default:default_port
+      (Server_request_authority.port request_authority) )
+;;
+
+let canonical_loopback_location ~default_port ~request_authority request =
+  let host, port = authority_host_port ~default_port request_authority in
   let canonical_host = Transport_read_model.normalize_advertised_host host in
   if String.equal canonical_host host then
     None
   else
     Some (Printf.sprintf "http://%s:%d%s" canonical_host port request.target)
 
-let canonical_root_dashboard_location ~default_port request =
-  let (host, port) =
-    parse_host_port
-      (Httpun.Headers.get request.Httpun.Request.headers "host")
-      (Env_config_core.masc_host ()) default_port
-  in
+let canonical_root_dashboard_location ~default_port ~request_authority =
+  let host, port = authority_host_port ~default_port request_authority in
   let canonical_host = Transport_read_model.normalize_advertised_host host in
   if String.equal canonical_host host then
     None
@@ -47,7 +46,10 @@ let canonical_root_dashboard_location ~default_port request =
     Some (Printf.sprintf "http://%s:%d/dashboard" canonical_host port)
 
 let with_canonical_loopback_host ~port handler request reqd =
-  match canonical_loopback_location ~default_port:port request with
+  let request_authority = Server_request_authority.current_exn () in
+  match
+    canonical_loopback_location ~default_port:port ~request_authority request
+  with
   | Some location -> respond_redirect ~location reqd
   | None -> handler request reqd
 
@@ -55,7 +57,10 @@ let redirect_to_dashboard reqd =
   respond_redirect ~location:"/dashboard" reqd
 
 let websocket_discovery_handler request reqd =
-  Http.Response.json_value (websocket_discovery_json request) reqd
+  let request_authority = Server_request_authority.current_exn () in
+  Http.Response.json_value
+    (websocket_discovery_json ~request_authority request)
+    reqd
 
 let header_contains_token request name token =
   match Httpun.Headers.get request.Httpun.Request.headers name with
@@ -93,11 +98,11 @@ let websocket_auth_error message =
     (Masc_domain.Auth_error.Unauthorized
        { reason = Masc_domain.Auth_error.Generic; message })
 
-let websocket_upgrade_authorized ~base_path request =
+let websocket_upgrade_authorized ~base_path ~request_authority request =
   match verify_mcp_auth ~base_path request with
   | Ok _ -> Ok ()
   | Error token_error ->
-    (match ensure_same_origin_browser_request request with
+    (match ensure_same_origin_browser_request ~request_authority request with
      | Ok () -> Ok ()
      | Error origin_error ->
        let message =
@@ -117,7 +122,10 @@ let websocket_handler ?sw ?clock ~upgrade request reqd =
         | Some state -> (Mcp_server.workspace_config state).base_path
         | None -> Server_mcp_transport_http.default_base_path ()
       in
-      (match websocket_upgrade_authorized ~base_path request with
+      let request_authority = Server_request_authority.current_exn () in
+      (match
+         websocket_upgrade_authorized ~base_path ~request_authority request
+       with
        | Error err -> respond_auth_error request reqd err
        | Ok () ->
          (match
@@ -152,18 +160,24 @@ let webrtc_signaling_handler signaling_fn request reqd =
                 reqd))
     request reqd
 
-let add_routes ?sw ?clock ~port ~host router =
+let add_routes ?sw ?clock ~port router =
   router
   |> Http.Router.get "/health" health_handler
   |> Http.Router.get Server_health_paths.liveness liveness_handler
   |> Http.Router.get Server_health_paths.readiness readiness_handler
   |> Http.Router.get "/.well-known/agent.json" (fun request reqd ->
          with_public_read (fun _state req reqd ->
-         Http.Response.json_value (Runtime.agent_card_json req) reqd)
+         let request_authority = Server_request_authority.current_exn () in
+         Http.Response.json_value
+           (Runtime.agent_card_json ~request_authority req)
+           reqd)
          request reqd)
   |> Http.Router.get "/.well-known/agent-card.json" (fun request reqd ->
          with_public_read (fun _state req reqd ->
-         Http.Response.json_value (Runtime.agent_card_json req) reqd)
+         let request_authority = Server_request_authority.current_exn () in
+         Http.Response.json_value
+           (Runtime.agent_card_json ~request_authority req)
+           reqd)
          request reqd)
   |> Http.Router.ws_get "/ws" (websocket_handler ?sw ?clock)
   (* RFC-0217 S4-2 — Otel_metric_store scrape endpoint removed; metrics now
@@ -258,10 +272,9 @@ let add_routes ?sw ?clock ~port ~host router =
            request reqd)
   |> Http.Router.get "/api/v1/openapi.json" (fun request reqd ->
        with_public_read (fun _state req reqd ->
-         let host_header = Httpun.Headers.get req.Httpun.Request.headers "host" in
-         let (resolved_host, resolved_port) = match host_header with
-           | Some header -> parse_host_port (Some header) host port
-           | None -> ("", 0)
+         let request_authority = Server_request_authority.current_exn () in
+         let resolved_host, resolved_port =
+           authority_host_port ~default_port:port request_authority
          in
          let json =
            Transport.Rest.generate_openapi_document
@@ -278,7 +291,10 @@ let add_routes ?sw ?clock ~port ~host router =
          Http.Response.json_value ~status json reqd
        ) request reqd)
   |> Http.Router.get "/" (fun request reqd ->
-       match canonical_root_dashboard_location ~default_port:port request with
+       let request_authority = Server_request_authority.current_exn () in
+       match
+         canonical_root_dashboard_location ~default_port:port ~request_authority
+       with
        | Some location -> respond_redirect ~location reqd
        | None -> redirect_to_dashboard reqd)
   |> Http.Router.get "/static/css/middleware.css"

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -29,7 +29,11 @@ let authority_host_port ~default_port request_authority =
       (Server_request_authority.port request_authority) )
 ;;
 
-let canonical_loopback_location ~default_port ~request_authority request =
+let canonical_loopback_location
+    ~default_port
+    ~request_authority
+    (request : Httpun.Request.t)
+  =
   let host, port = authority_host_port ~default_port request_authority in
   let canonical_host = Transport_read_model.normalize_advertised_host host in
   if String.equal canonical_host host then

--- a/lib/server/server_routes_http_routes_frontend.mli
+++ b/lib/server/server_routes_http_routes_frontend.mli
@@ -11,7 +11,6 @@ val add_routes :
   ?sw:Eio.Switch.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   port:int ->
-  host:string ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
 
 val websocket_upgrade_unavailable_reason : unit -> string option
@@ -20,7 +19,10 @@ val websocket_upgrade_unavailable_reason : unit -> string option
     regression test; production requests still go through {!add_routes}. *)
 
 val websocket_upgrade_authorized :
-  base_path:string -> Httpun.Request.t -> (unit, Masc_domain.masc_error) result
+  base_path:string ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  (unit, Masc_domain.masc_error) result
 (** Token-or-same-origin admission gate for [/ws] upgrades, mirroring the
     [/mcp] POST chain: [verify_mcp_auth] first, falling back to
     [ensure_same_origin_browser_request].  [base_path] locates the auth
@@ -29,12 +31,17 @@ val websocket_upgrade_authorized :
     still go through {!add_routes}. *)
 
 val canonical_loopback_location :
-  default_port:int -> Httpun.Request.t -> string option
-(** [Some redirect_url] when the request's [Host] header advertises a
-    non-canonical loopback host that should redirect, [None] when the
-    current host already matches canonical advertisement. *)
+  default_port:int ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  string option
+(** [Some redirect_url] when the admitted authority advertises a non-canonical
+    loopback host that should redirect, [None] when it already matches the
+    canonical advertisement. *)
 
 val canonical_root_dashboard_location :
-  default_port:int -> Httpun.Request.t -> string option
+  default_port:int ->
+  request_authority:Server_request_authority.authority ->
+  string option
 (** Like {!canonical_loopback_location} but rewrites the path to
     [/dashboard] for root-route redirects. *)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -71,41 +71,26 @@ let authority_host host =
 let authority_of_host_port host port =
   Printf.sprintf "%s:%d" (authority_host host) port
 
-let advertised_host_port_authority request =
-  let default_host = configured_http_host () in
+let advertised_host_port_authority ~request_authority =
   let default_port = configured_http_port () in
-  let fallback () =
-    let host = Transport_read_model.normalize_advertised_host default_host in
-    (host, default_port, authority_of_host_port host default_port)
+  let request_host = Server_request_authority.host request_authority in
+  let port_opt = Server_request_authority.port request_authority in
+  let port = Option.value ~default:default_port port_opt in
+  let host = Transport_read_model.normalize_advertised_host request_host in
+  let authority =
+    match port_opt with
+    | Some _ -> authority_of_host_port host port
+    | None ->
+      if String.equal host request_host
+      then authority_host host
+      else authority_of_host_port host port
   in
-  match Httpun.Headers.get request.Httpun.Request.headers "host" with
-  | None -> fallback ()
-  | Some raw -> (
-      let trimmed = String.trim raw in
-      if trimmed = "" || host_header_has_forbidden_authority_chars trimmed
-      then fallback ()
-      else
-        try
-          let uri = Uri.of_string ("http://" ^ trimmed) in
-          let parsed_host = Uri.host uri |> Option.value ~default:default_host in
-          let port_opt = Uri.port uri in
-          let port = Option.value ~default:default_port port_opt in
-          let host = Transport_read_model.normalize_advertised_host parsed_host in
-          let authority =
-            match port_opt with
-            | Some _ -> authority_of_host_port host port
-            | None ->
-              if String.equal host parsed_host
-              then authority_host host
-              else authority_of_host_port host port
-          in
-          (host, port, authority)
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _ -> fallback ())
+  host, port, authority
 
-let advertised_host_port request =
-  let host, port, _authority = advertised_host_port_authority request in
+let advertised_host_port ~request_authority =
+  let host, port, _authority =
+    advertised_host_port_authority ~request_authority
+  in
   (host, port)
 
 let normalize_forwarded_proto raw =
@@ -154,29 +139,31 @@ let advertised_scheme request =
       | Some raw -> Option.value ~default:"http" (first_forwarded_proto raw)
       | None -> "http")
 
-let advertised_base_url request =
-  let _host, _port, authority = advertised_host_port_authority request in
+let advertised_base_url ~request_authority request =
+  let _host, _port, authority =
+    advertised_host_port_authority ~request_authority
+  in
   Printf.sprintf "%s://%s" (advertised_scheme request) authority
 
-let websocket_discovery_json request =
-  let (host, _port) = advertised_host_port request in
+let websocket_discovery_json ~request_authority request =
+  let host, _port = advertised_host_port ~request_authority in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~host ~base_url:(advertised_base_url request) ()
+      ~host ~base_url:(advertised_base_url ~request_authority request) ()
   in
   Transport_read_model.websocket_discovery_json ctx
 
-let transport_json request =
-  let (host, _port) = advertised_host_port request in
+let transport_json ~request_authority request =
+  let host, _port = advertised_host_port ~request_authority in
   let ctx =
     Transport_read_model.make_http_context ~include_configured:true
-      ~host ~base_url:(advertised_base_url request) ()
+      ~host ~base_url:(advertised_base_url ~request_authority request) ()
   in
   Transport_read_model.transport_status_json ctx
 
-let agent_card_json request =
-  let (host, port) = advertised_host_port request in
-  let base_url = advertised_base_url request in
+let agent_card_json ~request_authority request =
+  let host, port = advertised_host_port ~request_authority in
+  let base_url = advertised_base_url ~request_authority request in
   let build = Build_identity.current () in
   `Assoc
     [
@@ -324,7 +311,7 @@ let schedule_runner_status_json () =
 ;;
 
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
-    ?(health_detail = "probe") request =
+    ?(health_detail = "probe") ~request_authority request =
   let uptime_secs = health_uptime_secs () in
   let build = Build_identity.current () in
   let path_diagnostics = health_path_diagnostics () in
@@ -343,7 +330,7 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
   @ full_health_url_fields
   @ [
       ("protocol", protocol_json ~listener);
-      ("transport", transport_json request);
+      ("transport", transport_json ~request_authority request);
       ("http_listener", Transport_metrics.http_listener_json ());
       ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
       ( "internal_mcp_auth"
@@ -360,10 +347,10 @@ let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
       ("gc", quick_gc_json ());
     ]
 
-let make_health_probe_json ?(listener = "http/1.1") request =
+let make_health_probe_json ?(listener = "http/1.1") ~request_authority request =
   Tool_args.ok_assoc
     (make_health_probe_fields ~listener ~health_detail:"probe"
-       ~full_health_url:"/health?full=1" request)
+       ~full_health_url:"/health?full=1" ~request_authority request)
 
 (* Keeper fleet scan / paused-keeper diagnostics / phase counts / fleet safety
    extracted to [Server_routes_http_runtime_fleet_scan] (godfile decomp). *)
@@ -508,7 +495,8 @@ let full_health_operator_summary ~keeper_fleet_safety
   let reasons = List.rev !reasons in
   (!status, reasons <> [], reasons)
 
-let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
+let make_health_json ?(listener = "http/1.1") ?section_timings_ref
+    ~request_authority request =
   let uptime_secs = health_uptime_secs () in
   let build = Build_identity.current () in
   let keeper_config_parse_errors =
@@ -674,7 +662,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
     ("build", Build_identity.to_yojson build);
     ("health_detail", `String "full");
     ("protocol", protocol_json ~listener);
-    ("transport", transport_json request);
+    ("transport", transport_json ~request_authority request);
     ("http_listener", Transport_metrics.http_listener_json ());
     ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
     ( "internal_mcp_auth"
@@ -943,12 +931,14 @@ let cached_full_health_fields = function
 let duration_ms ~started_at ~finished_at =
   max 0 (int_of_float ((finished_at -. started_at) *. 1000.))
 
-let compute_full_health_snapshot ?(listener = "http/1.1") request =
+let compute_full_health_snapshot ?(listener = "http/1.1") ~request_authority
+    request =
   let started_at = Unix.gettimeofday () in
   let section_timings_ref = ref [] in
   try
     let fields =
-      cached_full_health_fields (make_health_json ~listener ~section_timings_ref request)
+      cached_full_health_fields
+        (make_health_json ~listener ~section_timings_ref ~request_authority request)
     in
     let finished_at = Unix.gettimeofday () in
     {
@@ -1072,15 +1062,17 @@ let mark_full_health_snapshot_error exn =
           ~labels:[ "reason", "consecutive_failures" ]
           ())
 
-let compute_full_health_snapshot_for_refresh ?(listener = "http/1.1") request =
+let compute_full_health_snapshot_for_refresh ?(listener = "http/1.1")
+    ~request_authority request =
   with_full_health_snapshot_lock (fun () ->
       full_health_refresh_in_flight := true;
       full_health_refresh_started_at := Some (Unix.gettimeofday ());
       full_health_refresh_requested := false);
-  compute_full_health_snapshot ~listener request
+  compute_full_health_snapshot ~listener ~request_authority request
 
-let refresh_full_health_snapshot_sync ?(listener = "http/1.1") request =
-  compute_full_health_snapshot_for_refresh ~listener request
+let refresh_full_health_snapshot_sync ?(listener = "http/1.1")
+    ~request_authority request =
+  compute_full_health_snapshot_for_refresh ~listener ~request_authority request
   |> store_full_health_snapshot
 
 let snapshot_is_stale ~now snapshot =
@@ -1208,7 +1200,8 @@ let full_health_snapshot_state () =
         !full_health_refresh_started_at,
         !full_health_refresh_requested ))
 
-let make_cached_full_health_json ?(listener = "http/1.1") request =
+let make_cached_full_health_json ?(listener = "http/1.1") ~request_authority
+    request =
   let now = Unix.gettimeofday () in
   let snapshot, _refresh_in_flight, _refresh_started_at, _refresh_requested =
     full_health_snapshot_state ()
@@ -1228,7 +1221,8 @@ let make_cached_full_health_json ?(listener = "http/1.1") request =
     | None -> full_health_placeholder_fields ()
   in
   Tool_args.ok_assoc
-    (make_health_probe_fields ~listener ~health_detail:"full" request
+    (make_health_probe_fields ~listener ~health_detail:"full" ~request_authority
+       request
      @ fields
      @ [
          ( "full_health_snapshot",
@@ -1238,6 +1232,16 @@ let make_cached_full_health_json ?(listener = "http/1.1") request =
 
 let start_full_health_snapshot_refresh_loop ~sw ~clock =
   let request = Httpun.Request.create `GET "/health?full=1" in
+  let request_authority =
+    match
+      Server_request_authority.of_host_port
+        ~host:(configured_http_host ())
+        ~port:(configured_http_port ())
+    with
+    | Ok authority -> authority
+    | Error `Malformed ->
+      invalid_arg "configured HTTP host/port is not a valid authority"
+  in
   Proactive_refresh.start
     ~sw
     ~clock
@@ -1264,7 +1268,7 @@ let start_full_health_snapshot_refresh_loop ~sw ~clock =
        the main domain so concurrent HTTP requests are not stalled. *)
     ~compute:(fun () ->
       Domain_pool_ref.submit_io_or_inline (fun () ->
-        compute_full_health_snapshot_for_refresh request))
+        compute_full_health_snapshot_for_refresh ~request_authority request))
     ~on_result:store_full_health_snapshot
 
 module For_testing = struct
@@ -1276,8 +1280,9 @@ module For_testing = struct
         full_health_refresh_requested := false;
         full_health_consecutive_failures := 0)
 
-  let refresh_full_health_snapshot_now ?(listener = "http/1.1") request =
-    refresh_full_health_snapshot_sync ~listener request
+  let refresh_full_health_snapshot_now ?(listener = "http/1.1")
+      ~request_authority request =
+    refresh_full_health_snapshot_sync ~listener ~request_authority request
 
   let mark_full_health_snapshot_error = mark_full_health_snapshot_error
 
@@ -1290,13 +1295,18 @@ end
 let full_health_requested request =
   Server_utils.bool_query_param request "full" ~default:false
 
-let make_health_response_json ?(listener = "http/1.1") request =
-  if full_health_requested request then make_cached_full_health_json ~listener request
-  else make_health_probe_json ~listener request
+let make_health_response_json ?(listener = "http/1.1") ~request_authority
+    request =
+  if full_health_requested request
+  then make_cached_full_health_json ~listener ~request_authority request
+  else make_health_probe_json ~listener ~request_authority request
 
 (** Health check handler *)
 let health_handler request reqd =
-  Http.Response.json_value (make_health_response_json request) reqd
+  let request_authority = Server_request_authority.current_exn () in
+  Http.Response.json_value
+    (make_health_response_json ~request_authority request)
+    reqd
 
 (** Liveness probe: responds 200 as soon as the HTTP accept loop is running.
     Does not depend on server_state initialization.
@@ -1399,9 +1409,14 @@ let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
 
 (** CORS preflight handler *)
 let options_handler request reqd =
-  let origin = get_origin request in
-  let headers = Httpun.Headers.of_list (
-    ("content-length", "0") :: cors_preflight_headers origin
-  ) in
+  let request_authority = Server_request_authority.current_exn () in
+  let cors =
+    match public_read_cors_origin_opt ~request_authority request with
+    | Some origin -> cors_preflight_headers origin
+    | None -> [ "vary", "Origin" ]
+  in
+  let headers =
+    Httpun.Headers.of_list (("content-length", "0") :: cors)
+  in
   let response = Httpun.Response.create ~headers `No_content in
   Httpun.Reqd.respond_with_string reqd response ""

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -75,7 +75,11 @@ let advertised_host_port_authority ~request_authority =
   let default_port = configured_http_port () in
   let request_host = Server_request_authority.host request_authority in
   let port_opt = Server_request_authority.port request_authority in
-  let port = Option.value ~default:default_port port_opt in
+  let port =
+    match port_opt with
+    | Some explicit_port -> explicit_port
+    | None -> default_port
+  in
   let host = Transport_read_model.normalize_advertised_host request_host in
   let authority =
     match port_opt with

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -67,38 +67,47 @@ val configured_http_host : unit -> string
     var, supporting tests that override mid-process. *)
 
 val advertised_host_port :
-  Httpun.Request.t -> string * int
-(** [advertised_host_port request] returns the
+  request_authority:Server_request_authority.authority -> string * int
+(** [advertised_host_port ~request_authority] returns the
     [(canonical_host, port)] pair the server should advertise
-    in JSON projections.  Reads the [Host:] header (if present)
-    via {!parse_host_port}, then routes the host through
-    {!Transport_read_model.normalize_advertised_host} (loopback
-    aliases collapse to the configured default).  Falls back to
-    [(configured_http_host (), configured_http_port ())] when
-    the header is absent. *)
+    in JSON projections.  The authority was validated at request entry;
+    this function never reads wire headers. *)
 
-val advertised_base_url : Httpun.Request.t -> string
-(** [advertised_base_url request] returns the browser-visible HTTP(S) base URL.
-    It derives the authority from [Host:] and the scheme from
+val advertised_base_url :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  string
+(** [advertised_base_url ~request_authority request] returns the
+    browser-visible HTTP(S) base URL.  It derives the authority from the typed
+    request-entry value and the scheme from
     [X-Forwarded-Proto] / [Forwarded: proto=...] when present, falling back to
     local [http]. *)
 
 (** {1 Discovery / status JSON} *)
 
-val websocket_discovery_json : Httpun.Request.t -> Yojson.Safe.t
-(** [websocket_discovery_json request] returns the WebSocket
+val websocket_discovery_json :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [websocket_discovery_json ~request_authority request] returns the WebSocket
     discovery payload using {!advertised_host_port}.  Always
     sets [include_configured = true] so dashboards see the
-    enabled / runtime-listening pair.  Used by [GET /ws.json]
+    enabled / runtime-listening pair.  Used by [GET /ws]
     on both HTTP/1.1 and HTTP/2 listeners. *)
 
-val transport_json : Httpun.Request.t -> Yojson.Safe.t
-(** [transport_json request] returns the full transport status
+val transport_json :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [transport_json ~request_authority request] returns the full transport status
     JSON (HTTP + WS + protocol set).  Sub-projection used by
     {!make_health_json}'s [transport] field. *)
 
-val agent_card_json : Httpun.Request.t -> Yojson.Safe.t
-(** [agent_card_json request] returns the public well-known MASC server
+val agent_card_json :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [agent_card_json ~request_authority request] returns the public well-known MASC server
     card served from [/.well-known/agent.json].  This route is public
     discovery metadata; mutable operations still require normal tool auth. *)
 
@@ -115,8 +124,12 @@ val health_path_diagnostics :
     default base path computed from env. *)
 
 val make_health_json :
-  ?listener:string -> ?section_timings_ref:(string * int) list ref -> Httpun.Request.t -> Yojson.Safe.t
-(** [make_health_json ?listener request] builds the full health diagnostics
+  ?listener:string ->
+  ?section_timings_ref:(string * int) list ref ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [make_health_json ?listener ~request_authority request] builds the full health diagnostics
     JSON body.  [listener] defaults to ["http/1.1"] and is overridden to
     ["h2"] by the H2 gateway.  This is the force-compute diagnostic builder
     used by tests and snapshot refreshes.  The public [/health] route uses
@@ -205,16 +218,22 @@ val make_health_json :
     must touch this. *)
 
 val make_health_probe_json :
-  ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
-(** [make_health_probe_json ?listener request] builds the cheap default
+  ?listener:string ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [make_health_probe_json ?listener ~request_authority request] builds the cheap default
     [/health] probe body.  It keeps liveness/readiness-facing fields such as
     [startup], [paths], [transport], [logs], and quick GC counters, but skips
     durable keeper scans, reaction-ledger JSONL reads, config TOML scans, and
     contract-verdict ledger inspection. *)
 
 val make_health_response_json :
-  ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
-(** [make_health_response_json ?listener request] is the public [/health]
+  ?listener:string ->
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** [make_health_response_json ?listener ~request_authority request] is the public [/health]
     renderer.  It returns {!make_health_probe_json} by default.  When the
     request query contains [full=1] / [full=true], it returns the latest cached
     full-health snapshot plus cheap request-local fields and marks the snapshot
@@ -235,7 +254,10 @@ module For_testing : sig
   (** Clears the cached full-health snapshot and in-flight refresh marker. *)
 
   val refresh_full_health_snapshot_now :
-    ?listener:string -> Httpun.Request.t -> unit
+    ?listener:string ->
+    request_authority:Server_request_authority.authority ->
+    Httpun.Request.t ->
+    unit
   (** Synchronously recomputes and stores the cached full-health snapshot. *)
 
   val mark_full_health_snapshot_error : exn -> unit
@@ -339,6 +361,6 @@ val board_post_detail_json :
 
 val options_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [options_handler request reqd] handles [OPTIONS *] and
-    [OPTIONS <path>] CORS preflights.  Always responds
-    [204 No Content] with {!cors_preflight_headers} for the
-    request origin and [content-length: 0]. *)
+    [OPTIONS <path>] CORS preflights.  It responds [204 No Content], reflecting
+    only origins admitted against the typed request authority, and always sets
+    [content-length: 0]. *)

--- a/test/dune
+++ b/test/dune
@@ -96,7 +96,6 @@
   test_with_cleanups_on_release
   test_auth_login
   test_dashboard_dev_token_host_gate
-  test_server_request_authority
   test_audit_log
   test_console_sink
   test_governance_anomaly
@@ -760,6 +759,14 @@
   test_board_rest_routes
   test_board_context_inference_resolution)
  (libraries masc_test_deps masc_schedule multimodal bigstringaf))
+
+; Request-authority admission uses Eio fiber-local bindings and therefore owns
+; an explicit executable stanza instead of borrowing the pure synchronous test
+; group above.
+(test
+ (name test_server_request_authority)
+ (modules test_server_request_authority)
+ (libraries alcotest masc_test_deps eio_main))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.
 

--- a/test/dune
+++ b/test/dune
@@ -96,6 +96,7 @@
   test_with_cleanups_on_release
   test_auth_login
   test_dashboard_dev_token_host_gate
+  test_server_request_authority
   test_audit_log
   test_console_sink
   test_governance_anomaly

--- a/test/dune
+++ b/test/dune
@@ -766,7 +766,7 @@
 (test
  (name test_server_request_authority)
  (modules test_server_request_authority)
- (libraries alcotest masc_test_deps eio_main))
+ (libraries alcotest masc_test_deps eio_main h2))
 
 ; Operator snapshot cache: stale-while-revalidate + background refresh.
 

--- a/test/stanzas/test_openapi_api_e2e.inc
+++ b/test/stanzas/test_openapi_api_e2e.inc
@@ -1,6 +1,6 @@
 (test
  (name test_openapi_api_e2e)
  (modules test_openapi_api_e2e)
- (libraries alcotest yojson unix)
+ (libraries alcotest yojson unix masc.server)
  (deps ../bin/main_eio.exe)
  (enabled_if (= %{env:MASC_E2E_TESTS=false} "true")))

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,146 +1,64 @@
 open Alcotest
 
-let request_with_headers headers =
-  Httpun.Request.create
-    ~headers:(Httpun.Headers.of_list headers)
-    `GET
-    "/api/v1/dashboard/dev-token"
-;;
+module Dev_token = Server_routes_http_dashboard_dev_token
 
-let request ?host () =
-  let headers =
-    match host with
-    | None -> []
-    | Some value -> [ "host", value ]
+let authority_exn raw =
+  let request =
+    Httpun.Request.create
+      ~headers:(Httpun.Headers.of_list [ "host", raw ])
+      `GET
+      "/api/v1/dashboard/dev-token"
   in
-  request_with_headers headers
+  match Server_request_authority.classify_http1_request request with
+  | Server_request_authority.Single authority -> authority
+  | ( Server_request_authority.Missing
+    | Server_request_authority.Multiple
+    | Server_request_authority.Malformed ) ->
+    failf "expected valid authority %S" raw
 ;;
 
-let check_admitted raw expected_host expected_port =
-  match Server_auth.admit_loopback_request_host (request ~host:raw ()) with
-  | Ok admitted ->
-    check string "host" expected_host admitted.host;
-    check (option int) "port" expected_port admitted.port
-  | Error _ -> failf "expected Host %S to be admitted" raw
-;;
-
-let test_exact_loopback_authorities () =
-  check_admitted "localhost:8935" "localhost" (Some 8935);
-  check_admitted " LOCALHOST:8935 " "localhost" (Some 8935);
-  check_admitted "127.0.0.1" "127.0.0.1" None;
-  check_admitted "[::1]:8935" "::1" (Some 8935);
-  check_admitted "[0:0:0:0:0:0:0:1]" "0:0:0:0:0:0:0:1" None
-;;
-
-let test_malformed_suffixes_are_fully_rejected () =
-  List.iter
-    (fun raw ->
-      match Server_auth.admit_loopback_request_host (request ~host:raw ()) with
-      | Error Server_auth.Malformed_request_host -> ()
-      | _ -> failf "Host %S must be rejected as malformed" raw)
-    [ "localhost:8935<suffix>"
-    ; "localhost:8935/ignored"
-    ; "localhost:8935:80"
-    ; "localhost:"
-    ; "localhost:65536"
-    ; "localhost#fragment"
-    ; "user@localhost:8935"
-    ; "[::1]garbage"
-    ; "[::1]:8935garbage"
-    ]
-;;
-
-let test_host_rejections_are_typed () =
-  (match Server_auth.admit_loopback_request_host (request ()) with
-   | Error Server_auth.Missing_request_host -> ()
-   | _ -> fail "missing Host must have a typed rejection");
-  let repeated_host_request =
-    request_with_headers [ "Host", "localhost"; "hOsT", "localhost" ]
-  in
-  (match
-     Server_auth.admit_loopback_request_host repeated_host_request
-   with
-   | Error Server_auth.Multiple_request_hosts -> ()
-   | _ -> fail "multiple Host field lines must have a typed rejection");
-  (match Server_auth.host_port_of_request repeated_host_request with
-   | None -> ()
-   | Some _ -> fail "generic Host projection must reject multiple field lines");
-  (match
-     Server_auth.admit_loopback_request_host
-       (request ~host:"localhost/path" ())
-   with
-   | Error Server_auth.Malformed_request_host -> ()
-   | _ -> fail "Host containing a path must be malformed");
-  (match
-     Server_auth.admit_loopback_request_host
-       (request ~host:"attacker.example:8935" ())
-   with
-   | Error (Server_auth.Non_loopback_request_host "attacker.example") -> ()
-   | _ -> fail "non-loopback Host must retain its typed rejection")
-;;
-
-let test_request_error_statuses () =
-  let status_of rejection =
-    Server_routes_http_dashboard_dev_token.request_error_status
-      (Server_routes_http_dashboard_dev_token.Request_host_rejected rejection)
-    |> Httpun.Status.to_code
-  in
-  check int "missing Host" 400 (status_of Server_auth.Missing_request_host);
-  check int "multiple Host fields" 400 (status_of Server_auth.Multiple_request_hosts);
-  check int "malformed Host" 400 (status_of Server_auth.Malformed_request_host);
+let test_non_loopback_error_contract () =
+  let error = Dev_token.Non_loopback_request_host "attacker.example" in
+  check int "HTTP status" 403 (Httpun.Status.to_code (Dev_token.request_error_status error));
   check
     string
-    "multiple Host error code"
-    "dashboard_dev_token_host_multiple"
-    (Server_routes_http_dashboard_dev_token.request_error_code
-       (Server_routes_http_dashboard_dev_token.Request_host_rejected
-          Server_auth.Multiple_request_hosts));
+    "typed code"
+    "dashboard_dev_token_host_non_loopback"
+    (Dev_token.request_error_code error);
   check
-    int
-    "valid non-loopback Host"
-    403
-    (status_of (Server_auth.Non_loopback_request_host "attacker.example"))
+    string
+    "operator message"
+    "dashboard dev-token request Host \"attacker.example\" is not an exact loopback host"
+    (Dev_token.request_error_to_string error)
 ;;
 
-let test_rejection_precedes_token_io () =
+let test_non_loopback_rejection_precedes_token_io () =
   let base_path = Filename.temp_file "masc-dev-token-host-" ".workspace" in
   Sys.remove base_path;
   Fun.protect
     ~finally:(fun () -> if Sys.file_exists base_path then Unix.rmdir base_path)
     (fun () ->
-       List.iter
-         (fun (label, request) ->
-           match
-             Server_routes_http_dashboard_dev_token
-             .ensure_dashboard_dev_token_for_request
-               ~request
-               ~base_path
-           with
-           | Error
-               (Server_routes_http_dashboard_dev_token.Request_host_rejected _) ->
-             check bool "base path remains absent" false (Sys.file_exists base_path)
-           | _ -> failf "%s must fail before token I/O" label)
-         [ "missing Host", request ()
-         ; ( "multiple Host fields"
-           , request_with_headers
-               [ "host", "localhost:8935"; "host", "localhost:8935" ] )
-         ; "non-loopback Host", request ~host:"attacker.example" ()
-         ; "malformed Host", request ~host:"localhost:8935<suffix>" ()
-         ])
+      match
+        Dev_token.ensure_dashboard_dev_token_for_authority
+          ~request_authority:(authority_exn "attacker.example:8935")
+          ~base_path
+      with
+      | Error (Dev_token.Non_loopback_request_host "attacker.example") ->
+        check bool "base path remains absent" false (Sys.file_exists base_path)
+      | Error error ->
+        failf "unexpected error: %s" (Dev_token.request_error_to_string error)
+      | Ok _ -> fail "non-loopback authority must not reach token I/O")
 ;;
 
 let () =
   run
     "dashboard-dev-token-host-gate"
-    [ ( "host admission"
-      , [ test_case "exact loopback authorities" `Quick test_exact_loopback_authorities
+    [ ( "validated authority policy"
+      , [ test_case "non-loopback error contract" `Quick test_non_loopback_error_contract
         ; test_case
-            "malformed suffixes are fully rejected"
+            "non-loopback rejected before token I/O"
             `Quick
-            test_malformed_suffixes_are_fully_rejected
-        ; test_case "typed rejections" `Quick test_host_rejections_are_typed
-        ; test_case "HTTP status mapping" `Quick test_request_error_statuses
-        ; test_case "rejection precedes token I/O" `Quick test_rejection_precedes_token_io
+            test_non_loopback_rejection_precedes_token_io
         ] )
     ]
 ;;

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,12 +1,19 @@
 open Alcotest
 
+let request_with_headers headers =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list headers)
+    `GET
+    "/api/v1/dashboard/dev-token"
+;;
+
 let request ?host () =
   let headers =
     match host with
-    | None -> Httpun.Headers.empty
-    | Some value -> Httpun.Headers.of_list [ "host", value ]
+    | None -> []
+    | Some value -> [ "host", value ]
   in
-  Httpun.Request.create ~headers `GET "/api/v1/dashboard/dev-token"
+  request_with_headers headers
 ;;
 
 let check_admitted raw expected_host expected_port =
@@ -47,6 +54,17 @@ let test_host_rejections_are_typed () =
   (match Server_auth.admit_loopback_request_host (request ()) with
    | Error Server_auth.Missing_request_host -> ()
    | _ -> fail "missing Host must have a typed rejection");
+  let repeated_host_request =
+    request_with_headers [ "Host", "localhost"; "hOsT", "localhost" ]
+  in
+  (match
+     Server_auth.admit_loopback_request_host repeated_host_request
+   with
+   | Error Server_auth.Multiple_request_hosts -> ()
+   | _ -> fail "multiple Host field lines must have a typed rejection");
+  (match Server_auth.host_port_of_request repeated_host_request with
+   | None -> ()
+   | Some _ -> fail "generic Host projection must reject multiple field lines");
   (match
      Server_auth.admit_loopback_request_host
        (request ~host:"localhost/path" ())
@@ -61,6 +79,29 @@ let test_host_rejections_are_typed () =
    | _ -> fail "non-loopback Host must retain its typed rejection")
 ;;
 
+let test_request_error_statuses () =
+  let status_of rejection =
+    Server_routes_http_dashboard_dev_token.request_error_status
+      (Server_routes_http_dashboard_dev_token.Request_host_rejected rejection)
+    |> Httpun.Status.to_code
+  in
+  check int "missing Host" 400 (status_of Server_auth.Missing_request_host);
+  check int "multiple Host fields" 400 (status_of Server_auth.Multiple_request_hosts);
+  check int "malformed Host" 400 (status_of Server_auth.Malformed_request_host);
+  check
+    string
+    "multiple Host error code"
+    "dashboard_dev_token_host_multiple"
+    (Server_routes_http_dashboard_dev_token.request_error_code
+       (Server_routes_http_dashboard_dev_token.Request_host_rejected
+          Server_auth.Multiple_request_hosts));
+  check
+    int
+    "valid non-loopback Host"
+    403
+    (status_of (Server_auth.Non_loopback_request_host "attacker.example"))
+;;
+
 let test_rejection_precedes_token_io () =
   let base_path = Filename.temp_file "masc-dev-token-host-" ".workspace" in
   Sys.remove base_path;
@@ -68,18 +109,24 @@ let test_rejection_precedes_token_io () =
     ~finally:(fun () -> if Sys.file_exists base_path then Unix.rmdir base_path)
     (fun () ->
        List.iter
-         (fun raw ->
+         (fun (label, request) ->
            match
              Server_routes_http_dashboard_dev_token
              .ensure_dashboard_dev_token_for_request
-               ~request:(request ~host:raw ())
+               ~request
                ~base_path
            with
            | Error
                (Server_routes_http_dashboard_dev_token.Request_host_rejected _) ->
              check bool "base path remains absent" false (Sys.file_exists base_path)
-           | _ -> failf "Host %S must fail before token I/O" raw)
-         [ "attacker.example"; "localhost:8935<suffix>" ])
+           | _ -> failf "%s must fail before token I/O" label)
+         [ "missing Host", request ()
+         ; ( "multiple Host fields"
+           , request_with_headers
+               [ "host", "localhost:8935"; "host", "localhost:8935" ] )
+         ; "non-loopback Host", request ~host:"attacker.example" ()
+         ; "malformed Host", request ~host:"localhost:8935<suffix>" ()
+         ])
 ;;
 
 let () =
@@ -92,6 +139,7 @@ let () =
             `Quick
             test_malformed_suffixes_are_fully_rejected
         ; test_case "typed rejections" `Quick test_host_rejections_are_typed
+        ; test_case "HTTP status mapping" `Quick test_request_error_statuses
         ; test_case "rejection precedes token I/O" `Quick test_rejection_precedes_token_io
         ] )
     ]

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -163,7 +163,18 @@ let with_test_env f =
         ~clock:(Eio.Stdenv.clock env)
         ~mono_clock:(Eio.Stdenv.mono_clock env)
         ~sw
-        (fun () -> f ~env ~sw ~config))
+        (fun () ->
+          let request_authority =
+            match
+              Server_request_authority.of_host_port
+                ~host:"localhost"
+                ~port:8935
+            with
+            | Ok authority -> authority
+            | Error `Malformed -> fail "test authority must be valid"
+          in
+          Server_request_authority.with_current request_authority (fun () ->
+            f ~env ~sw ~config)))
 
 let test_run_dashboard_compute_without_pool_stays_in_current_domain () =
   with_test_env @@ fun ~env ~sw ~config ->
@@ -802,15 +813,26 @@ let test_dashboard_shell_auth_json_reports_missing_token () =
     { Masc_domain.default_auth_config with enabled = true; require_token = true }
   in
   Auth.save_auth_config config.base_path cfg;
+  let request =
+    request_with_headers "/api/v1/dashboard/shell"
+      [
+        ("origin", "http://localhost:5173");
+        ("host", "localhost:5173");
+      ]
+  in
+  let request_authority =
+    match Server_request_authority.classify_http1_request request with
+    | Server_request_authority.Single authority -> authority
+    | ( Server_request_authority.Missing
+      | Server_request_authority.Multiple
+      | Server_request_authority.Malformed ) ->
+      fail "expected valid authority"
+  in
   let json =
-    Server_dashboard_http_core.dashboard_shell_http_json
-      ~request:
-        (request_with_headers "/api/v1/dashboard/shell"
-           [
-             ("origin", "http://localhost:5173");
-             ("host", "localhost:5173");
-           ])
-      config
+    Server_request_authority.with_current request_authority (fun () ->
+      Server_dashboard_http_core.dashboard_shell_http_json
+        ~request
+        config)
   in
   let open Yojson.Safe.Util in
   let auth = json |> member "auth" in

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -5,6 +5,15 @@
 
 open Masc.Http_server_eio
 
+let request_authority_exn request =
+  match Server_request_authority.classify_http1_request request with
+  | Server_request_authority.Single authority -> authority
+  | ( Server_request_authority.Missing
+    | Server_request_authority.Multiple
+    | Server_request_authority.Malformed ) ->
+    Alcotest.fail "expected one valid request authority"
+;;
+
 (* ===== Unit Tests for Router ===== *)
 
 let test_router_empty () =
@@ -129,7 +138,6 @@ let test_frontend_transport_routes_present () =
   let routes =
     Server_routes_http_routes_frontend.add_routes
       ~port:8935
-      ~host:"127.0.0.1"
       (Router.create ())
   in
   let has_route meth path =
@@ -255,6 +263,7 @@ let test_frontend_canonical_loopback_location_localhost () =
   let location =
     Server_routes_http_routes_frontend.canonical_loopback_location
       ~default_port:8935
+      ~request_authority:(request_authority_exn request)
       request
   in
   Alcotest.(check (option string))
@@ -269,6 +278,7 @@ let test_frontend_canonical_loopback_location_ipv6 () =
   let location =
     Server_routes_http_routes_frontend.canonical_loopback_location
       ~default_port:8935
+      ~request_authority:(request_authority_exn request)
       request
   in
   Alcotest.(check (option string))
@@ -283,6 +293,7 @@ let test_frontend_canonical_loopback_location_canonical_host () =
   let location =
     Server_routes_http_routes_frontend.canonical_loopback_location
       ~default_port:8935
+      ~request_authority:(request_authority_exn request)
       request
   in
   Alcotest.(check (option string))
@@ -297,38 +308,12 @@ let test_frontend_canonical_root_dashboard_location_localhost () =
   let location =
     Server_routes_http_routes_frontend.canonical_root_dashboard_location
       ~default_port:8935
-      request
+      ~request_authority:(request_authority_exn request)
   in
   Alcotest.(check (option string))
     "localhost root redirects directly to dashboard"
     (Some "http://127.0.0.1:8935/dashboard")
     location
-;;
-
-let test_parse_host_port_rejects_scheme_in_host_header () =
-  let parsed =
-    Server_routes_http_common.parse_host_port
-      (Some "http://localhost:8935")
-      "127.0.0.1"
-      8935
-  in
-  Alcotest.(check (pair string int))
-    "scheme-bearing host header falls back"
-    ("127.0.0.1", 8935)
-    parsed
-;;
-
-let test_parse_host_port_rejects_userinfo_in_host_header () =
-  let parsed =
-    Server_routes_http_common.parse_host_port
-      (Some "user@localhost:8935")
-      "127.0.0.1"
-      8935
-  in
-  Alcotest.(check (pair string int))
-    "userinfo-bearing host header falls back"
-    ("127.0.0.1", 8935)
-    parsed
 ;;
 
 (* ===== Unit Tests for Config ===== *)
@@ -558,12 +543,6 @@ let router_tests =
   ; ( "frontend canonical root goes direct to dashboard"
     , `Quick
     , test_frontend_canonical_root_dashboard_location_localhost )
-  ; ( "parse_host_port rejects scheme host header"
-    , `Quick
-    , test_parse_host_port_rejects_scheme_in_host_header )
-  ; ( "parse_host_port rejects userinfo host header"
-    , `Quick
-    , test_parse_host_port_rejects_userinfo_in_host_header )
   ]
 ;;
 

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -5,6 +5,22 @@ module KTP = Masc.Keeper_types_profile
 module KEP = Masc.Keeper_tool_persona_runtime
 module Runtime = Server_routes_http_runtime
 
+let health_request () =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list [ "host", "localhost:8935" ])
+    `GET
+    "/health"
+;;
+
+let request_authority_exn request =
+  match Server_request_authority.classify_http1_request request with
+  | Server_request_authority.Single authority -> authority
+  | ( Server_request_authority.Missing
+    | Server_request_authority.Multiple
+    | Server_request_authority.Malformed ) ->
+    fail "expected valid authority"
+;;
+
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
@@ -1543,8 +1559,12 @@ legacy_scope = "removed"
       ()
   in
   let before_unknown_metric = unknown_metric () in
-  let request = Httpun.Request.create `GET "/health" in
-  let json = Runtime.make_health_json request in
+  let request = health_request () in
+  let json =
+    Runtime.make_health_json
+      ~request_authority:(request_authority_exn request)
+      request
+  in
   let open Yojson.Safe.Util in
   let listener = json |> member "http_listener" in
   check bool "health exposes http listener diagnostics" true
@@ -1589,8 +1609,12 @@ legacy_scope = "removed"
 
 let test_health_json_build_exposes_runtime_binary_identity () =
   with_config_dir @@ fun _config_dir ->
-  let request = Httpun.Request.create `GET "/health" in
-  let json = Runtime.make_health_json request in
+  let request = health_request () in
+  let json =
+    Runtime.make_health_json
+      ~request_authority:(request_authority_exn request)
+      request
+  in
   let open Yojson.Safe.Util in
   let build = json |> member "build" in
   check bool "build binary version populated" true

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -453,9 +453,19 @@ let ws_upgrade_request headers =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) `GET "/ws"
 
 let ws_gate_on ~base_path headers =
+  let request = ws_upgrade_request headers in
+  let request_authority =
+    match Server_request_authority.classify_http1_request request with
+    | Server_request_authority.Single authority -> authority
+    | ( Server_request_authority.Missing
+      | Server_request_authority.Multiple
+      | Server_request_authority.Malformed ) ->
+      fail "expected valid authority"
+  in
   Server_routes_http_routes_frontend.websocket_upgrade_authorized
     ~base_path
-    (ws_upgrade_request headers)
+    ~request_authority
+    request
 
 let ws_gate headers = ws_gate_on ~base_path:(ws_absent_base_path ()) headers
 

--- a/test/test_openapi_api_e2e.ml
+++ b/test/test_openapi_api_e2e.ml
@@ -43,12 +43,16 @@ let parse_status header_raw =
   in
   find_http lines
 
-let run_curl ~port ~path () =
+let run_curl ?(headers = []) ~port ~path () =
   let header_file = Filename.temp_file "openapi-api-header-" ".txt" in
   let body_file = Filename.temp_file "openapi-api-body-" ".txt" in
   let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let header_args =
+    List.fold_right (fun header acc -> "-H" :: header :: acc) headers []
+  in
   let args =
-    [|
+    Array.of_list
+      ([
       "curl";
       "-sS";
       "--http1.1";
@@ -60,8 +64,9 @@ let run_curl ~port ~path () =
       body_file;
       "-D";
       header_file;
-      url;
-    |]
+      ]
+      @ header_args
+      @ [ url ])
   in
   let (ic, oc, ec) =
     Unix.open_process_args_full "curl" args (Unix.environment ())
@@ -219,10 +224,10 @@ let with_server f =
     let logs = read_file log_file in
     fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs)
   );
-  Fun.protect ~finally:cleanup (fun () -> f ~port)
+  Fun.protect ~finally:cleanup (fun () -> f ~port ~base_path)
 
 let test_openapi_route_serves_document () =
-  with_server @@ fun ~port ->
+  with_server @@ fun ~port ~base_path:_ ->
   (* Retry up to 5 times: /health returns 200 before server_state is set,
      so the openapi route may initially return {"error":"not initialized"} *)
   let rec fetch_openapi retries =
@@ -258,6 +263,55 @@ let test_openapi_route_serves_document () =
        (fun row -> row |> member "operationId" |> to_string = "masc_status")
        operations)
 
+let test_invalid_authority_is_rejected_before_authority_routes () =
+  with_server @@ fun ~port ~base_path ->
+  let dev_token_path =
+    Server_routes_http_dashboard_dev_token.dashboard_dev_token_path base_path
+  in
+  check bool "dev token absent before invalid requests" false
+    (Sys.file_exists dev_token_path);
+  let routes =
+    [ "/"
+    ; "/dashboard"
+    ; "/dashboard/keepers"
+    ; "/api/v1/openapi.json"
+    ; "/.well-known/agent.json"
+    ; "/.well-known/agent-card.json"
+    ; "/ws"
+    ; "/health"
+    ; "/api/v1/dashboard/dev-token"
+    ]
+  in
+  let invalid_authorities =
+    [ ( "missing"
+      , [ "Host:" ]
+      , "request_authority_missing" )
+    ; ( "multiple"
+      , [ "Host: localhost:8935"; "hOsT: attacker.example" ]
+      , "request_authority_multiple" )
+    ; ( "malformed"
+      , [ "Host: user@localhost" ]
+      , "request_authority_malformed" )
+    ]
+  in
+  List.iter
+    (fun (case, headers, expected_code) ->
+      List.iter
+        (fun path ->
+          let result = run_curl ~headers ~port ~path () in
+          let label = case ^ " " ^ path in
+          check (option int) (label ^ " status") (Some 400) result.status;
+          let json = Yojson.Safe.from_string result.body in
+          check
+            string
+            (label ^ " error code")
+            expected_code
+            Yojson.Safe.Util.(json |> member "error_code" |> to_string))
+        routes)
+    invalid_authorities;
+  check bool "invalid authority performs no dev-token I/O" false
+    (Sys.file_exists dev_token_path)
+
 let () =
   run "openapi_api_e2e"
     [
@@ -265,5 +319,9 @@ let () =
         [
           test_case "route serves document" `Slow
             test_openapi_route_serves_document;
+          test_case
+            "invalid authority rejected before authority routes"
+            `Slow
+            test_invalid_authority_is_rejected_before_authority_routes;
         ] );
     ]

--- a/test/test_server_hibernation.ml
+++ b/test/test_server_hibernation.ml
@@ -36,8 +36,19 @@ let test_status_contract () =
 ;;
 
 let test_health_exposes_status () =
-  let request = Httpun.Request.create `GET "/health" in
-  let json = Server_routes_http_runtime.make_health_json request in
+  let headers = Httpun.Headers.of_list [ "host", "localhost:8935" ] in
+  let request = Httpun.Request.create ~headers `GET "/health" in
+  let request_authority =
+    match Server_request_authority.classify_http1_request request with
+    | Server_request_authority.Single authority -> authority
+    | ( Server_request_authority.Missing
+      | Server_request_authority.Multiple
+      | Server_request_authority.Malformed ) ->
+      fail "expected valid authority"
+  in
+  let json =
+    Server_routes_http_runtime.make_health_json ~request_authority request
+  in
   let hibernation = member "server_hibernation" json in
   check string "health status" "not_implemented" (string_field "status" hibernation);
   check string "health mode" "long_running" (string_field "mode" hibernation)

--- a/test/test_server_request_authority.ml
+++ b/test/test_server_request_authority.ml
@@ -1,0 +1,371 @@
+open Alcotest
+
+module Authority = Server_request_authority
+
+let http1_request ?(headers = []) path =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list headers)
+    `GET
+    path
+;;
+
+let h2_request ?(scheme = "https") ?(meth = `GET) ?(headers = []) target =
+  H2.Request.create
+    ~headers:(H2.Headers.of_list headers)
+    ~scheme
+    meth
+    target
+;;
+
+let admitted_http1 headers =
+  match Authority.classify_http1_request (http1_request ~headers "/") with
+  | Authority.Single authority -> authority
+  | Authority.Missing | Authority.Multiple | Authority.Malformed ->
+    fail "expected one valid HTTP/1.1 authority"
+;;
+
+let check_classification expected actual =
+  match expected, actual with
+  | `Missing, Authority.Missing
+  | `Multiple, Authority.Multiple
+  | `Malformed, Authority.Malformed
+  | `Single, Authority.Single _ ->
+    ()
+  | _ -> fail "unexpected request-authority classification"
+;;
+
+let test_http1_closed_classification () =
+  check_classification
+    `Missing
+    (Authority.classify_http1_request (http1_request "/"));
+  check_classification
+    `Multiple
+    (Authority.classify_http1_request
+       (http1_request
+          ~headers:[ "Host", "localhost"; "hOsT", "localhost" ]
+          "/"));
+  List.iter
+    (fun raw ->
+      check_classification
+        `Malformed
+        (Authority.classify_http1_request
+           (http1_request ~headers:[ "host", raw ] "/")))
+    [ ""
+    ; "http://localhost"
+    ; "user@localhost"
+    ; "localhost/path"
+    ; "localhost:"
+    ; "localhost:65536"
+    ; "localhost:8935<suffix>"
+    ; "localhost:8935:80"
+    ; "localhost#fragment"
+    ; "[::1"
+    ; "[::1]garbage"
+    ; "[::1]:8935garbage"
+    ]
+;;
+
+let test_http1_normalizes_authority () =
+  let dns = admitted_http1 [ "host", " ExAmPlE.COM:443 " ] in
+  check string "DNS case" "example.com" (Authority.host dns);
+  check (option int) "explicit port" (Some 443) (Authority.port dns);
+  let ipv6 = admitted_http1 [ "host", "[0:0:0:0:0:0:0:1]:8935" ] in
+  check string "IPv6 canonical form" "::1" (Authority.host ipv6);
+  check string "IPv6 rendered brackets" "[::1]:8935" (Authority.rendered ipv6)
+;;
+
+let check_h2_malformed request =
+  match Authority.classify_h2_request request with
+  | Authority.H2_authority Authority.Malformed -> ()
+  | _ -> fail "expected malformed HTTP/2 authority"
+;;
+
+let test_h2_repeated_or_userinfo_authority_is_malformed () =
+  check_h2_malformed
+    (h2_request
+       ~headers:
+         [ ":authority", "example.com"; ":authority", "example.com" ]
+       "/");
+  check_h2_malformed
+    (h2_request ~headers:[ ":authority", "user@example.com" ] "/")
+;;
+
+let test_h2_authority_whitespace_is_malformed () =
+  check_h2_malformed
+    (h2_request ~headers:[ ":authority", " example.com" ] "/");
+  check_h2_malformed
+    (h2_request ~headers:[ ":authority", "example.com " ] "/");
+  check_h2_malformed
+    (h2_request
+       ~headers:
+         [ ":authority", "example.com"; "host", "example.com " ]
+       "/")
+;;
+
+let test_h2_host_is_cross_check_only () =
+  let accepted headers =
+    match Authority.classify_h2_request (h2_request ~headers "/") with
+    | Authority.H2_authority (Authority.Single authority) -> authority
+    | _ -> fail "expected H2 authority + equivalent Host to be admitted"
+  in
+  let dns =
+    accepted [ ":authority", "Example.COM"; "host", "example.com:443" ]
+  in
+  check string "case-normalized authority" "example.com" (Authority.host dns);
+  let ipv6 =
+    accepted
+      [ ":authority", "[0:0:0:0:0:0:0:1]"; "host", "[::1]:443" ]
+  in
+  check string "IPv6-normalized authority" "::1" (Authority.host ipv6);
+  check_h2_malformed
+    (h2_request
+       ~headers:[ ":authority", "example.com"; "host", "other.example" ]
+       "/");
+  check_h2_malformed
+    (h2_request
+       ~headers:
+         [ ":authority", "example.com"
+         ; "host", "example.com"
+         ; "host", "example.com"
+         ]
+       "/");
+  (match
+     Authority.classify_h2_request
+       (h2_request ~headers:[ "host", "example.com" ] "/")
+   with
+   | Authority.H2_authority Authority.Missing -> ()
+   | _ -> fail "Host without :authority must not become the H2 authority")
+;;
+
+let test_h2_default_port_normalization_is_scheme_specific () =
+  let accepted ~scheme authority host =
+    match
+      Authority.classify_h2_request
+        (h2_request
+           ~scheme
+           ~headers:[ ":authority", authority; "host", host ]
+           "/")
+    with
+    | Authority.H2_authority (Authority.Single _) -> ()
+    | _ -> failf "%s authority default-port normalization failed" scheme
+  in
+  accepted ~scheme:"http" "example.com" "EXAMPLE.COM:80";
+  accepted ~scheme:"https" "example.com" "example.com:443";
+  check_h2_malformed
+    (h2_request
+       ~scheme:"https"
+       ~headers:[ ":authority", "example.com"; "host", "example.com:80" ]
+       "/")
+;;
+
+let test_h2_authority_free_asterisk_is_explicitly_unsupported () =
+  match
+    Authority.classify_h2_request
+      (h2_request ~meth:`OPTIONS ~headers:[] "*")
+  with
+  | Authority.Unsupported_asterisk_form_options -> ()
+  | _ -> fail "authority-free OPTIONS * must have a distinct rejection"
+;;
+
+let test_h2_asterisk_does_not_mask_repeated_host () =
+  check_h2_malformed
+    (h2_request
+       ~meth:`OPTIONS
+       ~headers:[ "host", "example.com"; "host", "example.com" ]
+       "*");
+  check_h2_malformed
+    (h2_request ~meth:`OPTIONS ~headers:[ "host", "user@example.com" ] "*")
+;;
+
+let authority_projection_routes =
+  [ "/"
+  ; "/dashboard"
+  ; "/dashboard/keepers"
+  ; "/api/v1/openapi.json"
+  ; "/.well-known/agent.json"
+  ; "/.well-known/agent-card.json"
+  ; "/ws"
+  ; "/health"
+  ; "/api/v1/dashboard/dev-token"
+  ]
+;;
+
+let test_projection_routes_share_case_insensitive_duplicate_gate () =
+  List.iter
+    (fun path ->
+      let request =
+        http1_request
+          ~headers:[ "Host", "localhost:8935"; "hOsT", "localhost:8935" ]
+          path
+      in
+      match Authority.classify_http1_request request with
+      | Authority.Multiple -> ()
+      | _ -> failf "%s bypassed the shared duplicate Host gate" path)
+    authority_projection_routes
+;;
+
+let test_auth_and_cors_consume_admitted_authority () =
+  let request =
+    http1_request
+      ~headers:
+        [ "host", "localhost:8935"; "origin", "http://localhost:8935" ]
+      "/api/v1/dashboard/shell"
+  in
+  let request_authority =
+    match Authority.classify_http1_request request with
+    | Authority.Single authority -> authority
+    | Authority.Missing | Authority.Multiple | Authority.Malformed ->
+      fail "expected admitted authority"
+  in
+  (match
+     Server_auth.ensure_same_origin_browser_request ~request_authority request
+   with
+   | Ok () -> ()
+   | Error error -> fail (Masc_domain.masc_error_to_string error));
+  check
+    (option string)
+    "public CORS reflects same origin"
+    (Some "http://localhost:8935")
+    (Server_auth.public_read_cors_origin_opt ~request_authority request);
+  let conflicting_raw_host =
+    http1_request
+      ~headers:
+        [ "host", "attacker.example"
+        ; "origin", "http://attacker.example"
+        ]
+      "/api/v1/dashboard/shell"
+  in
+  check
+    (option string)
+    "CORS ignores a downstream raw Host conflict"
+    None
+    (Server_auth.public_read_cors_origin_opt
+       ~request_authority
+       conflicting_raw_host);
+  (match
+     Server_auth.ensure_same_origin_browser_request
+       ~request_authority
+       conflicting_raw_host
+   with
+   | Error _ -> ()
+   | Ok () -> fail "auth must not re-admit a conflicting downstream raw Host");
+  List.iter
+    (fun origin ->
+      let request =
+        http1_request
+          ~headers:[ "host", "localhost:8935"; "origin", origin ]
+          "/api/v1/dashboard/shell"
+      in
+      (match
+         Server_auth.ensure_same_origin_browser_request
+           ~request_authority
+           request
+       with
+       | Error _ -> ()
+       | Ok () -> failf "auth admitted non-HTTP(S) origin %S" origin);
+      check
+        (option string)
+        (Printf.sprintf "CORS rejects invalid browser origin %S" origin)
+        None
+        (Server_auth.public_read_cors_origin_opt
+           ~request_authority
+           request))
+    [ "evil://localhost:8935"; "http://user@localhost:8935" ]
+;;
+
+let test_mcp_origin_validation_uses_admitted_authority () =
+  let request_authority = admitted_http1 [ "host", "localhost:8935" ] in
+  let valid origin =
+    Server_routes_http_common.validate_origin
+      ~request_authority
+      (http1_request ~headers:[ "origin", origin ] "/mcp")
+  in
+  check bool "same authority" true (valid "http://localhost:8935");
+  check bool "explicit Vite loopback origin" true (valid "http://localhost:5173");
+  check bool "prefix-confusable host" false (valid "http://localhost.attacker");
+  check bool "non-HTTP scheme" false (valid "evil://localhost:8935");
+  check bool "userinfo authority" false (valid "http://user@localhost:8935");
+  check
+    bool
+    "native client without Origin"
+    true
+    (Server_routes_http_common.validate_origin
+       ~request_authority
+       (http1_request "/mcp"));
+  check
+    bool
+    "POST root is MCP transport"
+    true
+    (Server_routes_http_common.is_mcp_transport_request
+       (Httpun.Request.create `POST "/"));
+  check
+    bool
+    "GET root is dashboard"
+    false
+    (Server_routes_http_common.is_mcp_transport_request
+       (http1_request "/"))
+;;
+
+let test_fiber_binding_has_no_fallback () =
+  Eio_main.run (fun _env ->
+    let authority = admitted_http1 [ "host", "localhost:8935" ] in
+    check bool "unbound before request" true (Option.is_none (Authority.current ()));
+    check_raises
+      "unbound lookup is explicit"
+      Authority.Unbound_request_authority
+      (fun () -> ignore (Authority.current_exn ()));
+    Authority.with_current authority (fun () ->
+      check
+        string
+        "bound request authority"
+        "localhost:8935"
+        (Authority.rendered (Authority.current_exn ())));
+    check bool "unbound after request" true (Option.is_none (Authority.current ())))
+;;
+
+let () =
+  run
+    "server-request-authority"
+    [ ( "HTTP/1.1"
+      , [ test_case "closed classification" `Quick test_http1_closed_classification
+        ; test_case "normalization" `Quick test_http1_normalizes_authority
+        ; test_case
+            "all projection routes reject duplicate Host"
+            `Quick
+            test_projection_routes_share_case_insensitive_duplicate_gate
+        ; test_case
+            "auth and CORS consume admitted authority"
+            `Quick
+            test_auth_and_cors_consume_admitted_authority
+        ; test_case
+            "MCP origin validation uses admitted authority"
+            `Quick
+            test_mcp_origin_validation_uses_admitted_authority
+        ] )
+    ; ( "HTTP/2"
+      , [ test_case
+            "repeated and userinfo authority malformed"
+            `Quick
+            test_h2_repeated_or_userinfo_authority_is_malformed
+        ; test_case "Host is cross-check only" `Quick test_h2_host_is_cross_check_only
+        ; test_case
+            "authority whitespace malformed"
+            `Quick
+            test_h2_authority_whitespace_is_malformed
+        ; test_case
+            "scheme default-port normalization"
+            `Quick
+            test_h2_default_port_normalization_is_scheme_specific
+        ; test_case
+            "authority-free asterisk is explicit"
+            `Quick
+            test_h2_authority_free_asterisk_is_explicitly_unsupported
+        ; test_case
+            "asterisk does not mask repeated Host"
+            `Quick
+            test_h2_asterisk_does_not_mask_repeated_host
+        ] )
+    ; ( "request context"
+      , [ test_case "fiber binding has no fallback" `Quick test_fiber_binding_has_no_fallback ] )
+    ]
+;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2,6 +2,44 @@ module Types = Masc_domain
 
 open Masc
 
+module Runtime_under_test = Server_routes_http_runtime
+
+let test_request_authority () =
+  match Server_request_authority.of_host_port ~host:"localhost" ~port:8935 with
+  | Ok authority -> authority
+  | Error `Malformed -> Alcotest.fail "test authority must be valid"
+;;
+
+module Server_routes_http_runtime = struct
+  include Runtime_under_test
+
+  let make_health_json ?listener ?section_timings_ref request =
+    Runtime_under_test.make_health_json
+      ?listener
+      ?section_timings_ref
+      ~request_authority:(test_request_authority ())
+      request
+  ;;
+
+  let make_health_response_json ?listener request =
+    Runtime_under_test.make_health_response_json
+      ?listener
+      ~request_authority:(test_request_authority ())
+      request
+  ;;
+
+  module For_testing = struct
+    include Runtime_under_test.For_testing
+
+    let refresh_full_health_snapshot_now ?listener request =
+      Runtime_under_test.For_testing.refresh_full_health_snapshot_now
+        ?listener
+        ~request_authority:(test_request_authority ())
+        request
+    ;;
+  end
+end
+
 let () = Mirage_crypto_rng_unix.use_default ()
 
 let with_env name value f =

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -246,8 +246,18 @@ let test_advertised_base_url_uses_forwarded_proto_without_internal_port () =
       [ "host", "masc.example.com"; "x-forwarded-proto", "https" ]
   in
   let request = Httpun.Request.create ~headers `GET "/ws" in
+  let request_authority =
+    match Server_request_authority.classify_http1_request request with
+    | Server_request_authority.Single authority -> authority
+    | ( Server_request_authority.Missing
+      | Server_request_authority.Multiple
+      | Server_request_authority.Malformed ) ->
+      fail "expected valid authority"
+  in
   check string "forwarded https base" "https://masc.example.com"
-    (Server_routes_http_runtime.advertised_base_url request)
+    (Server_routes_http_runtime.advertised_base_url
+       ~request_authority
+       request)
 
 let test_context_from_env_uses_default_loopback_base_url () =
   with_env "MASC_HTTP_BASE_URL" None (fun () ->


### PR DESCRIPTION
## Root cause

Request authority was parsed independently at credential, redirect, discovery, CORS, and projection leaves. Duplicate or malformed Host values could be rejected by the dashboard dev-token path while other routes still selected one raw header value. MCP Origin validation also used a string-prefix allowlist and HTTP/2 did not share that boundary.

## Changes

- classify HTTP/1 Host exactly once as Missing, Single, Multiple, or Malformed before rate limit, auth, credential I/O, and routing
- use HTTP/2 :authority as the sole authority source and cross-check any Host field with scheme-aware default-port normalization
- bind the admitted typed authority to the request fiber; remove downstream raw Host parsing and configured-host fallback
- feed auth, CORS, redirects, OpenAPI, agent-card, discovery, health, and WebSocket projections from the same authority
- replace MCP Origin prefix matching with typed HTTP(S) scheme, no-userinfo, normalized host/port comparison for both HTTP/1 and HTTP/2
- keep explicit loopback Vite cross-port support only when the request authority is the same normalized loopback host
- reject invalid authorities before dashboard token filesystem I/O across all projection routes

## Validation

- ocamlformat --check on all 31 changed OCaml interface/implementation/test files
- ocamlc -stop-after parsing on the same files
- ocamldep dependency extraction on the same files
- git diff --check
- raw Host/:authority consumer scan: only Server_request_authority reads wire authority fields
- local Dune intentionally not run; repository CI is the Dune build/test authority

Supersedes #24127 with the global boundary instead of retaining the endpoint-local implementation.

Closes #24134