### PR TITLE
feat(fusion): carry the originating connector channel through the completion wake

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -282,28 +282,74 @@ let broadcast_run_status ~registry ~run_id =
     Log.Keeper.warn "fusion_run_broadcast run_id=%s failed: %s" run_id
       (Printexc.to_string exn)
 
+(* Fail-closed durable wake. The reply route is the sole in-memory carrier of
+   the originating channel, so it must not be destroyed before the stimulus that
+   carries it is durably persisted. [peek] reads the route WITHOUT removing it;
+   the completion stimulus is committed through the shared fail-closed durable
+   path ([enqueue_durable_result] — the same commit boundary HITL uses for its
+   sole-carrier resolution); only on [Ok] is the route consumed ([take]) and the
+   best-effort wake hint flipped. A failed commit leaves the route intact for a
+   later retry and returns [Error] to the caller instead of swallowing the loss.
+   The wake hint (Running-gated) is best-effort AFTER a committed payload — its
+   failure is logged, not raised, because the keeper replays the durable
+   stimulus on its next admitted turn (mirrors HITL's post-commit signal).
+   Eio structural cancellation (Cancelled) is always re-raised. *)
 let wake_keeper_on_fusion_completion
-      ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id =
-  try
-    let fusion_completion =
-      Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id }
-    in
-    let post_id = Keeper_event_queue.fusion_completion_post_id fusion_completion in
-    let stimulus : Keeper_event_queue.stimulus =
-      { Keeper_event_queue.post_id
-      ; urgency = Keeper_event_queue.Normal
-      ; arrived_at = Time_compat.now ()
-      ; payload = Keeper_event_queue.Fusion_completed fusion_completion
-      }
-    in
-    Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
-    Keeper_keepalive_signal.wakeup_keeper ~base_path:base_dir ~stimulus keeper
+      ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id :
+    (unit, string) result =
+  (* A run started outside a connector conversation has no route; the wake then
+     says so explicitly instead of inventing a destination. *)
+  let channel =
+    match Fusion_wake_route.peek ~run_id with
+    | Some channel -> channel
+    | None -> Keeper_continuation_channel.unrouted "no originating connector"
+  in
+  let fusion_completion =
+    Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id; channel }
+  in
+  let post_id = Keeper_event_queue.fusion_completion_post_id fusion_completion in
+  let stimulus : Keeper_event_queue.stimulus =
+    { Keeper_event_queue.post_id
+    ; urgency = Keeper_event_queue.Normal
+    ; arrived_at = Time_compat.now ()
+    ; payload = Keeper_event_queue.Fusion_completed fusion_completion
+    }
+  in
+  match
+    try
+      Keeper_registry_event_queue.enqueue_durable_result
+        ~base_path:base_dir keeper stimulus
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
   with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Log.Keeper.warn ~keeper_name:keeper "fusion completion wake failed run_id=%s: %s"
-      run_id
-      (Printexc.to_string exn)
+  | Error reason ->
+    (* Route left intact (peek, not take): the reply channel survives the
+       failed write so a later retry can still deliver it. *)
+    Log.Keeper.error ~keeper_name:keeper
+      "fusion completion wake durable-commit failed run_id=%s: %s" run_id reason;
+    Error reason
+  | Ok () ->
+    (* RFC-0266: [take] removes the route now that its channel is durably committed above; the discarded value is exactly that already-committed channel, so this is pure route cleanup, not a dropped contract. *)
+    ignore (Fusion_wake_route.take ~run_id);
+    Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
+    (* Best-effort wake hint: the payload is already durable, so a withheld or
+       failed hint only defers pickup to the keeper's next turn. The Running-gate
+       outcome is intentionally discarded (typed [_] so a signature change surfaces
+       here), and a hint exception is logged — not swallowed — then dropped. *)
+    (try
+       let (_ : Keeper_registry.wakeup_running_outcome) =
+         Keeper_registry.wakeup_running ~base_path:base_dir keeper
+       in
+       ()
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn ~keeper_name:keeper
+         "fusion completion wake hint failed after durable commit run_id=%s: %s"
+         run_id
+         (Printexc.to_string exn));
+    Ok ()
 
 let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage :
     (unit, string) result =
@@ -468,23 +514,38 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
        (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake 직전 무조건 호출.
           실패 시 사유/태그를 함께 기록해 masc_fusion_status·SSE가 opaque
           "failed"가 되지 않게 한다. *)
-       (match judge with
-        | Ok j ->
-          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
-            ~ok:true ();
-          broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
-          wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
-            ~resolved_answer:j.Fusion_types.resolved_answer ~board_post_id
-        | Error e ->
-          Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
-            ~failure:(Fusion_types.judge_failure_text e)
-            ~failure_code:(Fusion_types.judge_failure_tag e)
-            ~ok:false ();
-          broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
-          wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
-            ~resolved_answer:
-              (Printf.sprintf "fusion run failed — %s" (render_failure e))
-            ~board_post_id);
+       let wake_result =
+         match judge with
+         | Ok j ->
+           Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+             ~ok:true ();
+           broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
+           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
+             ~resolved_answer:j.Fusion_types.resolved_answer ~board_post_id
+         | Error e ->
+           Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+             ~failure:(Fusion_types.judge_failure_text e)
+             ~failure_code:(Fusion_types.judge_failure_tag e)
+             ~ok:false ();
+           broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
+           wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
+             ~resolved_answer:
+               (Printf.sprintf "fusion run failed — %s" (render_failure e))
+             ~board_post_id
+       in
+       (* The conclusion is already durable on the keeper chat lane
+          ([chat_lane_result = Ok] above), so a failed completion wake is
+          degraded delivery of the *reply-channel routing*, not a sink failure.
+          Record it for operators (the wake itself ERROR-logs the reason) but do
+          NOT raise [Sink_failed] — that would double-notify a "(sink failed)"
+          note over a conclusion the keeper already received. *)
+       (match wake_result with
+        | Ok () -> ()
+        | Error _reason ->
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string KeepaliveSignalFailures)
+            ~labels:[ ("keeper", keeper); ("phase", "fusion_completion_wake") ]
+            ());
        Ok ())
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -76,8 +76,13 @@ val emit
     [board_post_id = ""]). 실패 경로는 fusion_tool의 append_chat_failure가
     호출한다(completion 타입당 단일 wake로 중복 방지).
 
-    예외 안전: [Eio.Cancel.Cancelled]는 재전파, 그 외 예외는 흡수(sink 결과 비오염).
-    Running이 아닌 키퍼는 silent no-op이며 결과는 board/chat 영속으로 남는다. *)
+    Fail-closed durable delivery: 원 채널을 나르는 route는 in-memory 유일 carrier
+    이므로, 먼저 [Fusion_wake_route.peek]로 route를 소비하지 않고 읽어 stimulus를
+    만들고 공유 fail-closed 경로([enqueue_durable_result])로 durable 커밋한 뒤에만
+    route를 [take]하고 Running 키퍼에 best-effort wake hint를 flip한다. durable 커밋
+    실패 시 route를 남겨 재시도를 보존하고 [Error]를 반환한다(silent drop 아님).
+    커밋 성공 후의 wake hint 실패는 로깅만 한다(키퍼가 durable stimulus를 다음 턴에
+    replay). [Eio.Cancel.Cancelled]는 항상 재전파. *)
 val wake_keeper_on_fusion_completion :
      base_dir:string
   -> keeper:string
@@ -85,7 +90,7 @@ val wake_keeper_on_fusion_completion :
   -> ok:bool
   -> resolved_answer:string
   -> board_post_id:string
-  -> unit
+  -> (unit, string) result
 
 (** RFC-0266 §7 Phase 4: broadcast a [fusion_run_status] SSE event carrying the
     current registry snapshot of [run_id] so the dashboard fusion-runs panel

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -43,8 +43,15 @@ let append_chat_failure ~base_dir ~keeper ~run_id ~failure_code content =
      (generic append 실패는 warn 후 계속 진행해 도달한다), registry는 위에서 이미 갱신됐으므로
      어느 경우든 가시성은 보존된다. *)
   Fusion_sink.broadcast_run_status ~registry:(Fusion_run_registry.global ()) ~run_id;
-  Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
-    ~resolved_answer:content ~board_post_id:""
+  (* The failure conclusion is already durable on the chat lane above, and the
+     wake ERROR-logs its own durable-commit failure, so a degraded completion
+     wake here is degraded reply-channel routing — not a change to the
+     failure-notification contract. Match explicitly rather than swallow. *)
+  match
+    Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
+      ~resolved_answer:content ~board_post_id:""
+  with
+  | Ok () | Error _ -> ()
 
 type orchestrator_runner =
   sw:Eio.Switch.t
@@ -57,7 +64,7 @@ type orchestrator_runner =
   -> Fusion_orchestrator.outcome
 
 let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~run_id
-      ~policy ~args : string =
+      ~policy ?continuation_channel ~args () : string =
   let prompt = Tool_args.get_string args "prompt" "" in
   let preset = Tool_args.get_string args "preset" policy.Fusion_policy.default_preset in
   let web_tools = Tool_args.get_bool args "web_tools" false in
@@ -104,6 +111,13 @@ let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~r
          뿐, 키퍼를 깨우지 않는다(wake는 별개). *)
       Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id ~keeper
         ~preset ~started_at:now_unix;
+      (* Reply route: captured next to [register_running] so route lifetime
+         tracks the run. [register] drops [Unrouted] itself; the completion
+         wake ([Fusion_sink.wake_keeper_on_fusion_completion], success AND
+         failure paths) consumes it exactly once. *)
+      Option.iter
+        (fun channel -> Fusion_wake_route.register ~run_id channel)
+        continuation_channel;
       (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
          (no polling). wake-free, broadcast-failure-safe; see
          Fusion_sink.broadcast_run_status. *)
@@ -139,6 +153,9 @@ let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~r
           Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
             ~failure:"cancelled: structural cancellation (shutdown or sibling switch failure)"
             ~failure_code:"cancelled" ~ok:false ();
+          (* No completion wake fires on this path, so drop the reply route
+             here or it leaks for the process lifetime. *)
+          Fusion_wake_route.discard ~run_id;
           raise exn
         | exception exn ->
           append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
@@ -158,9 +175,10 @@ let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~r
                your chat lane. No need to poll masc_fusion_status." )
         ]
 
-let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ~args : string =
+let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ?continuation_channel
+      ~args () : string =
   handle_with_runner ~run_orchestrator:Fusion_orchestrator.run ~sw ~net ~base_dir
-    ~keeper ~now_unix ~run_id ~policy ~args
+    ~keeper ~now_unix ~run_id ~policy ?continuation_channel ~args ()
 
 module For_test = struct
   type nonrec orchestrator_runner = orchestrator_runner

--- a/lib/fusion/fusion_tool.mli
+++ b/lib/fusion/fusion_tool.mli
@@ -14,6 +14,9 @@
     @param now_unix 현재 유닉스초 (키퍼 clock에서; run 시작 시각 기록).
     @param run_id correlation id (호출자가 생성 — fusion_tool은 무작위성 비포함).
     @param policy runtime.toml [fusion]에서 로드한 정책.
+    @param continuation_channel 호출 턴이 시작된 connector 대화(RFC-0320).
+           [Allow] 시 {!Fusion_wake_route}에 등록되어 [Fusion_completed] wake가
+           원 채널로 회신을 라우팅할 수 있게 한다. 생략/Unrouted면 미등록.
     @param args 도구 입력 JSON (prompt 필수; preset/web_tools 선택). *)
 val handle
   :  sw:Eio.Switch.t
@@ -23,7 +26,9 @@ val handle
   -> now_unix:float
   -> run_id:string
   -> policy:Fusion_policy.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> args:Yojson.Safe.t
+  -> unit
   -> string
 
 module For_test : sig
@@ -56,6 +61,8 @@ module For_test : sig
     -> now_unix:float
     -> run_id:string
     -> policy:Fusion_policy.t
+    -> ?continuation_channel:Keeper_continuation_channel.t
     -> args:Yojson.Safe.t
+    -> unit
     -> string
 end

--- a/lib/fusion/fusion_wake_route.ml
+++ b/lib/fusion/fusion_wake_route.ml
@@ -1,0 +1,35 @@
+(* Fusion_wake_route — see .mli for the contract.
+
+   Lock-free Atomic + CAS over persistent immutable map snapshots. There is no
+   Fusion call-rate limit, so lookup/update complexity must not depend on an
+   assumed small number of concurrent runs. *)
+
+module Routes = Map.Make (String)
+
+let routes : Keeper_continuation_channel.t Routes.t Atomic.t =
+  Atomic.make Routes.empty
+
+let rec update f =
+  let cur = Atomic.get routes in
+  let next = f cur in
+  if not (Atomic.compare_and_set routes cur next) then update f
+
+let register ~run_id channel =
+  if Keeper_continuation_channel.is_routable channel then
+    update (Routes.add run_id channel)
+
+let take ~run_id =
+  (* Read-then-CAS: the value returned is the one observed in [cur]; the CAS
+     retry re-reads, so a concurrent register/take converges like the
+     registry's [update]. A completion wake fires once per run, so the only
+     realistic contention is with [discard] on the cancellation path — either
+     order leaves the route removed. *)
+  let found = ref None in
+  update (fun cur ->
+    found := Routes.find_opt run_id cur;
+    Routes.remove run_id cur);
+  !found
+
+let peek ~run_id = Routes.find_opt run_id (Atomic.get routes)
+
+let discard ~run_id = update (Routes.remove run_id)

--- a/lib/fusion/fusion_wake_route.mli
+++ b/lib/fusion/fusion_wake_route.mli
@@ -1,0 +1,37 @@
+(** Fusion_wake_route — in-memory reply-channel routes for in-flight fusion
+    runs (feature-map gap: wake-family continuation-channel parity).
+
+    [masc_fusion] is asynchronous: the keeper turn that starts a deliberation
+    ends long before the [Fusion_completed] wake fires, so the originating
+    connector conversation (RFC-0320 [Keeper_continuation_channel]) must be
+    carried across that gap.  The pure run registry
+    ([Fusion_run_registry], lib/fusion_core) cannot hold the channel — that
+    layer is deliberately keeper-free — so this lib/fusion-local map owns it:
+    registered at gate-Allow time next to [register_running], consumed exactly
+    once by [Fusion_sink.wake_keeper_on_fusion_completion].
+
+    Lifetime matches the wake itself, not the run record: routes live in
+    process memory only.  A server restart drops them together with the
+    in-flight fibers they route for (boot replay already drops [Running]
+    runs), so a persisted route could never fire anyway. *)
+
+(** [register ~run_id channel] remembers the originating channel for an
+    in-flight run.  Unroutable channels ([Unrouted]) are not stored — the
+    wake-side default already says "no originating connector". *)
+val register : run_id:string -> Keeper_continuation_channel.t -> unit
+
+(** [take ~run_id] returns the registered channel and removes the route
+    (a completion wake fires once; keeping the route would leak).  [None]
+    when the run was started without a routable channel. *)
+val take : run_id:string -> Keeper_continuation_channel.t option
+
+(** [peek ~run_id] returns the registered channel without removing the route.
+    The completion wake builds its stimulus from this value and durably commits
+    it before calling [take]: the route is the sole in-memory carrier of the
+    reply channel, so a failed durable commit must leave it intact for a later
+    retry instead of destroying it up front. [None] mirrors [take]. *)
+val peek : run_id:string -> Keeper_continuation_channel.t option
+
+(** [discard ~run_id] drops the route without returning it — the structural
+    cancellation path terminates a run without emitting a completion wake. *)
+val discard : run_id:string -> unit

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -254,7 +254,7 @@ let run_turn
       ?event_bus
       ?trace_link
       ?continuation_channel
-      ?hitl_delivery_channel
+      ?continuation_delivery_channel
       ?hitl_approval_grant
       ?autonomous_yield_requested
       ()
@@ -500,6 +500,7 @@ let run_turn
     Keeper_run_tools.prepare_agent_setup
       ~config
       ~meta
+      ?continuation_channel
       ~turn_ctx_cell
       ~ctx_work
       ~session
@@ -944,7 +945,7 @@ let run_turn
                           ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
                           ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
                           ~raw_response_text:response_text
-                          ?hitl_delivery_channel
+                          ?continuation_delivery_channel
                           ~capture_replay_response:
                             (fun ~response_text ->
                               (* Phase O observability: capture the exact

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -186,7 +186,7 @@ val run_turn
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?trace_link:string * string
   -> ?continuation_channel:Keeper_continuation_channel.t
-  -> ?hitl_delivery_channel:Keeper_continuation_channel.t
+  -> ?continuation_delivery_channel:Keeper_continuation_channel.t
   -> ?hitl_approval_grant:Governance_pipeline.hitl_approval_grant
   -> ?autonomous_yield_requested:(unit -> autonomous_yield_request option)
        (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -325,7 +325,7 @@ let finalize
     ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
     ~capture_replay_response
-    ?hitl_delivery_channel
+    ?continuation_delivery_channel
     () =
   let budget_exhausted =
     Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted
@@ -390,13 +390,12 @@ let finalize
        assistant_msg;
      capture_replay_response ~response_text
    | _ -> ());
-  (* RFC-0320 W3c: deterministic HITL continuation delivery. When this turn was
-     opened by a Hitl_resolved wake carrying a routable originating channel, and
-     the keeper did not itself post a reply this turn (the W3b prompt steer is
-     best-effort), deliver the visible response to that channel so the
-     conversation is always answered. Routing is deterministic (the captured
-     channel); [Keeper_continuation_delivery] fails closed on [Unrouted]. *)
-  (match hitl_delivery_channel, replay_response_text with
+  (* Deterministic continuation delivery for a turn opened by a typed wake
+     carrying an originating channel. If the keeper did not itself post a
+     reply, deliver the visible response to that exact channel. Routing never
+     infers a destination; [Keeper_continuation_delivery] fails closed on
+     [Unrouted]. *)
+  (match continuation_delivery_channel, replay_response_text with
    | Some channel, Some content ->
      let already_replied = has_reply_delivery_effect acc.tool_calls in
      let outcome =

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -773,6 +773,20 @@ let run_keepalive_unified_turn
                 | _ -> None)
               !consumed_stimuli
           in
+          (* Non-board intake consumes exactly one stimulus per turn. Project
+             its exact reply route without choosing between wake families or
+             coalescing unrelated connector conversations. Board batches carry
+             no continuation channel and therefore leave this [None]. *)
+          let continuation_delivery_channel =
+            match !consumed_stimuli with
+            | [ { Keeper_event_queue.payload = Hitl_resolved resolution; _ } ]
+              when Keeper_continuation_channel.is_routable resolution.channel ->
+              Some resolution.channel
+            | [ { Keeper_event_queue.payload = Fusion_completed completion; _ } ]
+              when Keeper_continuation_channel.is_routable completion.channel ->
+              Some completion.channel
+            | [] | [ _ ] | _ :: _ :: _ -> None
+          in
           (* #16 (38-bug campaign PR-5): [reactive_wake] tells us this cycle
              was triggered by an external signal rather than the proactive
              cadence tick, but by itself does not say *which* stimulus (or
@@ -795,6 +809,7 @@ let run_keepalive_unified_turn
             run_keeper_cycle
               ?event_bus
               ?hitl_resolution
+              ?continuation_delivery_channel
               ~ctx
               ~meta_after_triage
               ~stop

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -184,6 +184,7 @@ let prepare_failure_judgment_turn
 let run_keeper_cycle_admitted
       ?event_bus
       ?hitl_resolution
+      ?continuation_delivery_channel
       ~ctx
       ~meta_after_triage
       ~stop
@@ -218,6 +219,7 @@ let run_keeper_cycle_admitted
              ~wake
              ~channel:turn_decision.channel
              ?hitl_resolution
+             ?continuation_delivery_channel
              (* RFC-0315: pass the whole decision, not just its channel — the
                 prompt renders the verdict reasons so the turn knows why it woke. *)
              ~turn_decision
@@ -298,6 +300,7 @@ let run_keeper_cycle_admitted
 let run_keeper_cycle
       ?event_bus
       ?hitl_resolution
+      ?continuation_delivery_channel
       ~ctx
       ~meta_after_triage
       ~stop
@@ -322,7 +325,8 @@ let run_keeper_cycle
          ~wake
          ?failure_judgment
          ?event_bus
-         ?hitl_resolution)
+         ?hitl_resolution
+         ?continuation_delivery_channel)
   with
   | `Ran outcome -> outcome
   | `Busy ((Keeper_turn_admission.Shutdown_requested operation_id) as block) ->

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -33,6 +33,7 @@ val meta : cycle_outcome -> Keeper_meta_contract.keeper_meta
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?continuation_delivery_channel:Keeper_continuation_channel.t
   -> ctx:_ Keeper_types_profile.context
   -> meta_after_triage:Keeper_meta_contract.keeper_meta
   -> stop:bool Atomic.t

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -270,32 +270,49 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
     + the data-channel half of the layer split — [fiber_wakeup] remains the
     hint signal, the queue is the authoritative payload. *)
 let wakeup_keeper ?base_path ?stimulus name =
-  Keeper_registry.all ?base_path ()
-  |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
-    if String.equal entry.name name
-    then
-      if entry.phase = Keeper_state_machine.Running
-      then begin
-        Option.iter
-          (fun s ->
-            Keeper_registry_event_queue.enqueue ~base_path:entry.base_path name s)
-          stimulus;
-        Keeper_registry.wakeup ~base_path:entry.base_path name
-      end
-      else
-        (* 비-Running 키퍼로의 stimulus는 배달하지 않는다(보수적 기본값 유지 —
-           Paused를 강제 재개하지 않음). 단, 유실을 조용히 두지 않는다: payload가
-           있는 wake가 여기서 떨어지면 발신자(예: fusion sink)는 배달됐다고 믿는데
-           수신자는 아무것도 못 받는다. durable 표면(chat/board)이 사유를 따로
-           나르지 않던 2026-07-01 fusion 사고에서 이 무로그 drop이 두 run의 결과를
-           완전히 증발시켰다(fus-c9a63064/fus-46fce8a8 — 로그에 delivery 라인
-           부재). *)
-        Log.Keeper.info ~keeper_name:name
-          "wakeup_keeper: dropped (keeper not Running, phase=%s) stimulus=%s"
-          (Keeper_state_machine.phase_to_string entry.phase)
-          (match stimulus with
-           | None -> "none"
-           | Some s -> Keeper_event_queue.payload_kind_label s.Keeper_event_queue.payload))
+  let entries =
+    Keeper_registry.all ?base_path ()
+    |> List.filter (fun (entry : Keeper_registry.registry_entry) ->
+         String.equal entry.name name)
+  in
+  (* Payload admission is independent of current lifecycle phase. A completion
+     that arrives while the keeper is paused/restarting must remain durable for
+     the lane's next admitted turn; only the wake hint is phase-gated. *)
+  (match entries, stimulus, base_path with
+   | [], Some value, Some resolved_base_path ->
+     Keeper_registry_event_queue.enqueue
+       ~base_path:resolved_base_path
+       name
+       value;
+     Log.Keeper.info ~keeper_name:name
+       "wakeup_keeper: stimulus queued without live registry entry stimulus=%s"
+       (Keeper_event_queue.payload_kind_label value.Keeper_event_queue.payload)
+   | [], Some value, None ->
+     Log.Keeper.error ~keeper_name:name
+       "wakeup_keeper: cannot persist stimulus without registry entry or base_path \
+        stimulus=%s"
+       (Keeper_event_queue.payload_kind_label value.Keeper_event_queue.payload)
+   | [], None, _ | _ :: _, _, _ -> ());
+  List.iter
+    (fun (entry : Keeper_registry.registry_entry) ->
+       Option.iter
+         (fun value ->
+            Keeper_registry_event_queue.enqueue
+              ~base_path:entry.base_path
+              name
+              value)
+         stimulus;
+       if entry.phase = Keeper_state_machine.Running
+       then Keeper_registry.wakeup ~base_path:entry.base_path name
+       else
+         Log.Keeper.info ~keeper_name:name
+           "wakeup_keeper: stimulus queued; wake hint withheld phase=%s stimulus=%s"
+           (Keeper_state_machine.phase_to_string entry.phase)
+           (match stimulus with
+            | None -> "none"
+            | Some value ->
+              Keeper_event_queue.payload_kind_label value.Keeper_event_queue.payload))
+    entries
 ;;
 
 (** Wake up all running keepers — used when a broadcast mentions @@all

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -122,12 +122,13 @@ val interruptible_sleep :
 
 (** Wake up a specific keeper immediately.
 
-    When [?stimulus] is given, the stimulus is appended to the keeper's
-    Event Layer queue ([Keeper_registry_event_queue.enqueue]) before the wakeup
-    flag flips. Callers that have a real payload (board post, mention,
-    operator directive) should pass it; callers that only need to break
-    the keeper out of [interruptible_sleep] may omit it and the call
-    behaves as before. See RFC-0020 §3 (data channel vs hint signal). *)
+    When [?stimulus] is given, the stimulus is durably appended to the keeper's
+    Event Layer queue ([Keeper_registry_event_queue.enqueue]) independently of
+    lifecycle phase. Only the wake hint is restricted to [Running]. If no live
+    registry entry exists, callers must supply [base_path] so the payload can
+    be persisted for replay. Callers that only need to break the keeper out of
+    [interruptible_sleep] may omit the stimulus. See RFC-0020 §3 (data channel
+    vs hint signal). *)
 val wakeup_keeper :
   ?base_path:string ->
   ?stimulus:Keeper_event_queue.stimulus ->

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -112,5 +112,6 @@ val prepare_agent_setup
   -> tool_overlay:Agent_sdk.Tool_op.t ref option
   -> ?runtime_manifest_context:Keeper_runtime_manifest.turn_context
   -> ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit)
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> unit
   -> (agent_setup, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -37,6 +37,7 @@ let prepare_agent_setup
       ~(tool_overlay : Agent_sdk.Tool_op.t ref option)
       ?runtime_manifest_context
       ?runtime_manifest_append
+      ?continuation_channel
       ()
   : (Keeper_run_tools_hooks.agent_setup, Agent_sdk.Error.sdk_error) result
   =
@@ -126,6 +127,7 @@ let prepare_agent_setup
       ~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
       ~on_tool_called:(fun name ->
         Keeper_discovered_tools.mark_used acc.discovered ~turn:acc.current_turn ~name)
+      ?continuation_channel
       ()
   in
   let tools = keeper_tools in

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -546,6 +546,7 @@ let execute_keeper_tool_call_with_outcome
       ?proc_mgr
       ?net
       ?mcp_session_id
+      ?continuation_channel
       ~(name : string)
       ~(input : Yojson.Safe.t)
       ()
@@ -690,6 +691,7 @@ let execute_keeper_tool_call_with_outcome
            ; proc_mgr
            ; net
            ; mcp_session_id
+           ; continuation_channel
            }
        in
        let descriptor_dispatch =

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -179,6 +179,7 @@ val execute_keeper_tool_call_with_outcome
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?mcp_session_id:string
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> name:string
   -> input:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -474,7 +474,8 @@ let handle_masc_schedule ~(config : Workspace.config) ~(meta : keeper_meta) ~nam
    the server net capability (not turn-scoped) from the same context.  When
    either is unavailable we return an explicit error JSON rather than
    silently dropping the request (CLAUDE.md Silent-Failure avoidance). *)
-let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args () =
+let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta)
+      ?continuation_channel ~args () =
   match Eio_context.get_root_switch_opt (), Eio_context.get_net_opt () with
   | Some sw, Some net ->
     (match Fusion_config_loader.load ~base_path:config.Workspace.base_path with
@@ -491,7 +492,9 @@ let handle_masc_fusion ~(config : Workspace.config) ~(meta : keeper_meta) ~args 
          ~now_unix
          ~run_id
          ~policy
-         ~args)
+         ?continuation_channel
+         ~args
+         ())
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -215,6 +215,7 @@ val handle_masc_schedule
 val handle_masc_fusion
   :  config:Workspace.config
   -> meta:keeper_meta
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> args:Yojson.Safe.t
   -> unit
   -> string

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -22,6 +22,11 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; continuation_channel : Keeper_continuation_channel.t option
+    (* RFC-0320: the connector conversation the current turn started from,
+       so async tools (masc_fusion) can route their completion wake back to
+       the originating channel. [None] on non-connector turns and on callers
+       without turn context (OAS handler defaults, tests). *)
   }
 
 let descriptor_for_internal internal_name =
@@ -313,6 +318,7 @@ let handle_in_process ctx descriptor args =
       (Keeper_tool_in_process_runtime.handle_masc_fusion
          ~config:ctx.config
          ~meta:ctx.meta
+         ?continuation_channel:ctx.continuation_channel
          ~args
          ())
   | Tool_masc_fusion_status ->

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -21,6 +21,9 @@ type context =
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; mcp_session_id : string option
+  ; continuation_channel : Keeper_continuation_channel.t option
+    (** RFC-0320: originating connector conversation of the current turn;
+        lets async tools (masc_fusion) route completion wakes back. *)
   }
 
 val descriptor_for_internal : string -> Keeper_tool_descriptor.t option

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -34,6 +34,7 @@ let make_tool_bundle
       ?search_fn
       ?on_tool_called
       ?clock
+      ?continuation_channel
       ()
   : tool_bundle
   =
@@ -81,6 +82,7 @@ let make_tool_bundle
                  ?search_fn
                  ?on_tool_called
                  ?clock
+                 ?continuation_channel
                  ~pre_validate_input:(fun input ->
                    match
                      Keeper_tool_descriptor_resolution.validate_public_input_for_tool_call

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -11,6 +11,7 @@ val make_tool_bundle
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> unit
   -> Keeper_tools_oas.tool_bundle
 

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -22,6 +22,7 @@ let make_keeper_tool_handler
       ?search_fn
       ?on_tool_called
       ?clock
+      ?continuation_channel
       ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
       ?(validate_translated_input = true)
@@ -155,6 +156,7 @@ let make_keeper_tool_handler
               ?clock
               ?proc_mgr
               ?net
+              ?continuation_channel
               ~failure_counts
               ~key
               ~input

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -29,6 +29,7 @@ val make_keeper_tool_handler
   -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
   -> ?on_tool_called:(string -> unit)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?pre_validate_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -103,6 +103,7 @@ let execute_with_observers
       ?proc_mgr
       ?net
       ?mcp_session_id
+      ?continuation_channel
       ~(failure_counts : failure_counts)
       ~(key : string)
       ~(input : Yojson.Safe.t)
@@ -125,6 +126,7 @@ let execute_with_observers
           ?proc_mgr
           ?net
           ?mcp_session_id
+          ?continuation_channel
           ~name
           ~input
           ())

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -21,6 +21,7 @@ val execute_with_observers
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> ?mcp_session_id:string
+  -> ?continuation_channel:Keeper_continuation_channel.t
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> key:string
   -> input:Yojson.Safe.t

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -47,6 +47,7 @@ let run_keeper_cycle
       ?shared_context
       ?event_bus
       ?hitl_resolution
+      ?continuation_delivery_channel
       ()
   : (turn_success, turn_failure) result
   =
@@ -65,11 +66,6 @@ let run_keeper_cycle
      phases like Overflowed. *)
   let registry_base_path = config.base_path in
   let exact_failure_execution = ref None in
-  let hitl_delivery_channel =
-    Option.map
-      (fun (resolution : Keeper_event_queue.hitl_resolution) -> resolution.channel)
-      hitl_resolution
-  in
   let hitl_approval_grant =
     Option.bind
       hitl_resolution
@@ -525,7 +521,7 @@ let run_keeper_cycle
                            ; base_dir
                            ; build_turn_prompt
                            ; channel
-                           ; hitl_delivery_channel
+                           ; continuation_delivery_channel
                            ; hitl_approval_grant
                            ; cleanup
                            ; committed_mutating_tools_snapshot

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -234,6 +234,7 @@ val run_keeper_cycle
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?continuation_delivery_channel:Keeper_continuation_channel.t
   -> unit
   -> (turn_success, turn_failure) result
 

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -63,10 +63,10 @@ type ctx =
       base_system_prompt:string -> messages:Agent_sdk.Types.message list ->
       Keeper_agent_run.turn_prompt
   ; channel : Keeper_world_observation.keeper_cycle_channel
-  ; hitl_delivery_channel : Keeper_continuation_channel.t option
-      (* RFC-0320 W3c: the originating channel to deterministically deliver this
-         turn's reply to when the turn was opened by a Hitl_resolved wake; [None]
-         on every other lane (fail-closed: no delivery). *)
+  ; continuation_delivery_channel : Keeper_continuation_channel.t option
+      (* Exact originating channel for a continuation-bearing wake. Non-board
+         intake admits one stimulus per turn, so this never chooses between
+         unrelated conversations. [None] fails closed to no external delivery. *)
   ; hitl_approval_grant : Governance_pipeline.hitl_approval_grant option
       (* Exact operator authorization scoped to this cycle and shared across
          all runtime retry attempts so a retry cannot recreate the grant. *)
@@ -112,7 +112,7 @@ let run (ctx : ctx)
       ; keeper_turn_id
       ; turn_id
       ; channel
-      ; hitl_delivery_channel
+      ; continuation_delivery_channel
       ; hitl_approval_grant
       ; shared_context
       ; base_dir
@@ -191,7 +191,7 @@ let run (ctx : ctx)
                  ~config
                  ~meta:run_meta
                  ~profile_defaults
-                 ?hitl_delivery_channel
+                 ?continuation_delivery_channel
                  ?hitl_approval_grant
                  ~turn_ctx_cell
                  ~base_dir

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -108,6 +108,11 @@ and fusion_completion = {
   (* judge resolved answer; a failure label when [ok = false]. *)
   board_post_id : string;
   (* correlates to the sink's board evidence post; "" if none was created. *)
+  channel : Keeper_continuation_channel.t;
+  (* RFC-0320 pattern: the connector conversation the deliberation was started
+     from, captured at masc_fusion call time, so the woken keeper can deliver
+     the resolved answer back into the originating channel.  [Unrouted] when
+     the run was not started from a connector conversation. *)
 }
 
 and bg_job_completion = {
@@ -558,6 +563,7 @@ let payload_to_yojson = function
       ; "ok", `Bool fusion.ok
       ; "resolved_answer", `String fusion.resolved_answer
       ; "board_post_id", `String fusion.board_post_id
+      ; "channel", Keeper_continuation_channel.to_yojson fusion.channel
       ]
   | Bg_completed c ->
     let ok, payload =
@@ -682,7 +688,13 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
-    Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id })
+    (* [Fusion_completed] predates the reply-channel field and was persisted
+       without it, so a legacy snapshot row must replay as [Unrouted] rather
+       than failing the whole snapshot parse (which recovers to an empty queue,
+       dropping every co-resident stimulus). Same lenient contract as the
+       sibling [Connector_attention]/[Hitl_resolved] rows. *)
+    let* channel = continuation_channel_field fields in
+    Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id; channel })
   | "bg_completed" ->
     let* run_id = string_field ~context "run_id" fields in
     let* job_kind_s = string_field ~context "job_kind" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -112,6 +112,7 @@ and fusion_completion = {
   ok : bool;
   resolved_answer : string;
   board_post_id : string;
+  channel : Keeper_continuation_channel.t;
 }
 (** RFC-0266 payload for [Fusion_completed]: [ok] distinguishes a synthesized
     judge result from denied/sink_failed/aborted; [resolved_answer] carries the

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -154,6 +154,7 @@ let handle_keeper_catchup_judge_post state req reqd body_str =
                   ~run_id
                   ~policy
                   ~args:fusion_args
+                  ()
               in
               let fusion_json = parse_fusion_result raw in
               (match Json_util.assoc_member_opt "ok" fusion_json with

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -144,7 +144,12 @@ let fusion_payload
       ()
   : Keeper_event_queue.fusion_completion
   =
-  { run_id; ok; resolved_answer; board_post_id }
+  { run_id
+  ; ok
+  ; resolved_answer
+  ; board_post_id
+  ; channel = Keeper_continuation_channel.unrouted "test fixture"
+  }
 ;;
 
 let fusion_stimulus ?run_id ?ok ?resolved_answer ?board_post_id () : Keeper_event_queue.stimulus =
@@ -537,6 +542,142 @@ let test_emit_success_projects_board_chat_and_registry () =
     | None -> fail "fusion run should remain visible")
 ;;
 
+(* Fusion_wake_route contract: the reply route registered at masc_fusion call
+   time is consumed exactly once by the completion wake. Pure map semantics
+   plus the registration edge inside [handle_with_runner]. *)
+let discord_channel =
+  Keeper_continuation_channel.Discord
+    { guild_id = Some "g-1"
+    ; channel_id = "chan-9"
+    ; parent_channel_id = None
+    ; thread_id = None
+    ; user_id = "user-3"
+    }
+;;
+
+let test_wake_route_register_take_discard () =
+  let run_id = Printf.sprintf "fus-route-%d" (Random.bits ()) in
+  Fusion_wake_route.register ~run_id discord_channel;
+  (match Fusion_wake_route.take ~run_id with
+   | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> ()
+   | Some other ->
+     fail
+       (Printf.sprintf "unexpected route: %s"
+          (Keeper_continuation_channel.describe other))
+   | None -> fail "registered route must be takeable");
+  check bool "take removes the route" true (Fusion_wake_route.take ~run_id = None);
+  (* Unrouted is never stored: the wake-side default already says so. *)
+  Fusion_wake_route.register ~run_id
+    (Keeper_continuation_channel.unrouted "not a connector turn");
+  check bool "unrouted is not registered" true (Fusion_wake_route.take ~run_id = None);
+  Fusion_wake_route.register ~run_id discord_channel;
+  Fusion_wake_route.discard ~run_id;
+  check bool "discard drops the route" true (Fusion_wake_route.take ~run_id = None)
+;;
+
+(* P1-A: [peek] reads the route without consuming it, so the completion wake can
+   build+commit the stimulus before the destructive [take]. *)
+let test_wake_route_peek_is_non_destructive () =
+  let run_id = Printf.sprintf "fus-peek-%d" (Random.bits ()) in
+  Fusion_wake_route.register ~run_id discord_channel;
+  let is_chan9 = function
+    | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> true
+    | _ -> false
+  in
+  check bool "peek returns the registered route" true (is_chan9 (Fusion_wake_route.peek ~run_id));
+  check bool "peek is non-destructive (second peek still sees it)" true
+    (is_chan9 (Fusion_wake_route.peek ~run_id));
+  check bool "take still consumes after peeks" true (is_chan9 (Fusion_wake_route.take ~run_id));
+  check bool "route gone after take" true (Fusion_wake_route.peek ~run_id = None)
+;;
+
+(* P1-A: the completion wake commits the channel-carrying stimulus through the
+   fail-closed durable path BEFORE consuming the route, so the durable snapshot
+   holds the real Discord route and the in-memory route is consumed only after a
+   successful commit. *)
+let test_wake_durable_commit_carries_channel_and_consumes_route () =
+  with_isolated_base_path "fusion-wake-durable" (fun base_dir ->
+    let keeper = Printf.sprintf "fusion-wake-%d" (Random.bits ()) in
+    let run_id = Printf.sprintf "fus-wake-%d" (Random.bits ()) in
+    Fusion_wake_route.register ~run_id discord_channel;
+    let result =
+      Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
+        ~resolved_answer:"WAKE-DURABLE-ANSWER" ~board_post_id:"post-wake-1"
+    in
+    check bool "wake commits durably" true (Result.is_ok result);
+    check bool "route consumed only after the durable commit" true
+      (Fusion_wake_route.peek ~run_id = None);
+    match
+      Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+      |> Keeper_event_queue.dequeue
+    with
+    | Some ({ payload = Keeper_event_queue.Fusion_completed fc; _ }, _) ->
+      check string "durable completion run id" run_id fc.run_id;
+      (match fc.channel with
+       | Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ } -> ()
+       | other ->
+         fail
+           (Printf.sprintf "durable channel must be the originating route, got %s"
+              (Keeper_continuation_channel.describe other)))
+    | Some _ -> fail "unexpected durable stimulus kind"
+    | None -> fail "completion stimulus must be durably persisted with its channel")
+;;
+
+(* P1-A fail-closed: when the durable commit fails (here a conflicting durable
+   row already occupies the post_id), the wake returns [Error] AND leaves the
+   route intact — the sole in-memory carrier of the reply channel is not
+   destroyed on a failed write, so a retry can still deliver it. *)
+let test_wake_fail_closed_preserves_route () =
+  with_isolated_base_path "fusion-wake-failclosed" (fun base_dir ->
+    let keeper = Printf.sprintf "fusion-wake-fc-%d" (Random.bits ()) in
+    let run_id = Printf.sprintf "fus-wake-fc-%d" (Random.bits ()) in
+    let board_post_id = "post-wake-fc-1" in
+    let conflicting : Keeper_event_queue.stimulus =
+      { post_id = board_post_id
+      ; urgency = Keeper_event_queue.Normal
+      ; arrived_at = 1.0
+      ; payload =
+          Keeper_event_queue.Fusion_completed
+            (fusion_payload ~run_id ~board_post_id ~resolved_answer:"CONFLICTING-PRIOR-ANSWER" ())
+      }
+    in
+    (match
+       Keeper_registry_event_queue.enqueue_durable_result ~base_path:base_dir keeper conflicting
+     with
+     | Ok () -> ()
+     | Error e -> fail (Printf.sprintf "seeding the conflicting durable row should commit: %s" e));
+    Fusion_wake_route.register ~run_id discord_channel;
+    let result =
+      Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
+        ~resolved_answer:"REAL-ANSWER" ~board_post_id
+    in
+    check bool "conflicting durable commit fails the wake" true (Result.is_error result);
+    match Fusion_wake_route.peek ~run_id with
+    | Some (Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ }) -> ()
+    | _ -> fail "route must survive a failed durable commit (peek, not take)")
+;;
+
+let test_completion_stimulus_persists_without_live_registry () =
+  with_isolated_base_path "fusion-wake-offline" (fun base_dir ->
+    let keeper = Printf.sprintf "fusion-offline-%d" (Random.bits ()) in
+    let stimulus = fusion_stimulus ~run_id:"fus-offline" () in
+    Keeper_keepalive_signal.wakeup_keeper
+      ~base_path:base_dir
+      ~stimulus
+      keeper;
+    match
+      Keeper_event_queue_persistence.load
+        ~base_path:base_dir
+        ~keeper_name:keeper
+      |> Keeper_event_queue.dequeue
+    with
+    | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, rest) ->
+      check string "durable completion run" "fus-offline" completion.run_id;
+      check int "only one durable stimulus" 0 (Keeper_event_queue.length rest)
+    | Some _ -> fail "unexpected durable stimulus kind"
+    | None -> fail "completion stimulus must persist without a live registry entry")
+;;
+
 let test_tool_handle_async_success_projects_running_then_completed () =
   with_isolated_eio_base_path "fusion-tool-async-success" (fun env sw base_dir ->
     let keeper = "fusion-tool-keeper" in
@@ -580,6 +721,7 @@ let test_tool_handle_async_success_projects_running_then_completed () =
         ~net:(Eio.Stdenv.net env) ~base_dir ~keeper ~now_unix:4.0 ~run_id
         ~policy:(fusion_tool_policy ())
         ~args:(`Assoc [ ("prompt", `String question) ])
+        ()
     in
     let response_fields =
       Yojson.Safe.from_string response |> assoc_fields "fusion_tool.response"
@@ -728,6 +870,26 @@ let () =
             "emit success projects board, chat block, and registry"
             `Quick
             test_emit_success_projects_board_chat_and_registry
+        ; test_case
+            "wake route: register/take/discard, unrouted never stored"
+            `Quick
+            test_wake_route_register_take_discard
+        ; test_case
+            "wake route: peek is non-destructive"
+            `Quick
+            test_wake_route_peek_is_non_destructive
+        ; test_case
+            "wake durably commits the channel and consumes the route on Ok"
+            `Quick
+            test_wake_durable_commit_carries_channel_and_consumes_route
+        ; test_case
+            "wake fail-closed: a failed durable commit preserves the route"
+            `Quick
+            test_wake_fail_closed_preserves_route
+        ; test_case
+            "completion stimulus persists without live registry"
+            `Quick
+            test_completion_stimulus_persists_without_live_registry
         ; test_case
             "tool handle returns Running then async success projects evidence"
             `Quick

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -206,19 +206,105 @@ let () =
   (* RFC-0266: Fusion_completed is a non-board stimulus with its own label. *)
   let fusion_payload () =
     Fusion_completed
-      { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" }
+      { run_id = "fus-1"
+      ; ok = true
+      ; resolved_answer = "ok"
+      ; board_post_id = "post-1"
+      ; channel = Keeper_continuation_channel.unrouted "test fixture"
+      }
   in
   assert (not (is_board_signal (fusion_payload ())));
   assert (String.equal (payload_kind_label (fusion_payload ())) "fusion_completed");
   assert (
     String.equal
       (fusion_completion_post_id
-         { run_id = "fus-1"; ok = true; resolved_answer = "ok"; board_post_id = "post-1" })
+         { run_id = "fus-1"
+         ; ok = true
+         ; resolved_answer = "ok"
+         ; board_post_id = "post-1"
+         ; channel = Keeper_continuation_channel.unrouted "test fixture"
+         })
       "post-1");
+  (* Reply-route parity: the fusion wake serializes its originating channel,
+     and — like the sibling Connector_attention/Hitl_resolved rows — a legacy
+     Fusion_completed row persisted before the channel field existed replays as
+     [Unrouted] rather than failing the snapshot parse (a parse failure recovers
+     to an empty queue, dropping every co-resident stimulus). *)
+  (let routed : Keeper_event_queue.fusion_completion =
+     { run_id = "fus-routed"
+     ; ok = true
+     ; resolved_answer = "answer"
+     ; board_post_id = "post-9"
+     ; channel =
+         Keeper_continuation_channel.Discord
+           { guild_id = None
+           ; channel_id = "chan-42"
+           ; parent_channel_id = None
+           ; thread_id = Some "th-1"
+           ; user_id = "u-7"
+           }
+     }
+   in
+   let stim : Keeper_event_queue.stimulus =
+     { post_id = "post-9"
+     ; urgency = Normal
+     ; arrived_at = 42.0
+     ; payload = Fusion_completed routed
+     }
+   in
+   (match stimulus_of_yojson (stimulus_to_yojson stim) with
+    | Ok { payload = Fusion_completed fc; _ } ->
+      assert (
+        match fc.channel with
+        | Keeper_continuation_channel.Discord
+            { channel_id = "chan-42"; thread_id = Some "th-1"; user_id = "u-7"; _ } ->
+          true
+        | _ -> false)
+    | Ok _ -> assert false
+    | Error e -> failwith e);
+   let missing_channel_json =
+     match stimulus_to_yojson stim with
+     | `Assoc fields ->
+       `Assoc
+         (List.map
+            (fun (k, v) ->
+               if String.equal k "payload"
+               then
+                 ( k
+                 , match v with
+                   | `Assoc payload_fields ->
+                     `Assoc
+                       (List.filter
+                          (fun (pk, _) -> not (String.equal pk "channel"))
+                          payload_fields)
+                   | other -> other )
+               else (k, v))
+            fields)
+     | other -> other
+   in
+   match stimulus_of_yojson missing_channel_json with
+   | Ok { payload = Fusion_completed fc; _ } ->
+     assert (
+       match fc.channel with
+       | Keeper_continuation_channel.Unrouted { reason } ->
+         String.equal reason "legacy: channel not captured"
+       | _ -> false)
+   | Ok _ -> failwith "legacy fusion row must decode as Fusion_completed"
+   | Error e ->
+     failwith
+       (Printf.sprintf
+          "legacy fusion row without a channel key must replay Unrouted, not \
+           fail closed: %s"
+          e));
   assert (
     String.equal
       (fusion_completion_post_id
-         { run_id = "fus-2"; ok = false; resolved_answer = "sink_failed"; board_post_id = "" })
+         { run_id = "fus-2"
+         ; ok = false
+         ; resolved_answer = "sink_failed"
+         ; board_post_id = ""
+         ; channel = Keeper_continuation_channel.unrouted "test fixture"
+         })
       "fusion-run:fus-2");
 
   (* RFC-0290: Bg_completed is a non-board stimulus with its own label; its
@@ -632,6 +718,7 @@ let () =
                ; ok = false
                ; resolved_answer = "denied"
                ; board_post_id = ""
+               ; channel = Keeper_continuation_channel.unrouted "test fixture"
                }
          }
   in

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -50,7 +50,12 @@ let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
   ; arrived_at = 1234.5
   ; payload =
       Keeper_event_queue.Fusion_completed
-        { run_id; ok = true; resolved_answer = "use approach B"; board_post_id = "post-fus" }
+        { run_id
+        ; ok = true
+        ; resolved_answer = "use approach B"
+        ; board_post_id = "post-fus"
+        ; channel = Keeper_continuation_channel.unrouted "test fixture"
+        }
   }
 ;;
 


### PR DESCRIPTION
## 무엇

기능지도 Gap(P1, wake-family 회신 채널 불균일): `Hitl_resolved`·`Connector_attention`은 RFC-0320 continuation channel을 carry하는데 `Fusion_completed`는 안 해서, **Discord 대화에서 시작한 fusion의 결과가 원 채널로 회신 불가**였습니다. 이 PR로 fusion wake가 동일 계약에 합류합니다.

## 어떻게

- **Producer**: `run_turn`의 기존 `?continuation_channel`을 tool 체인(run_tools_setup→bundle→handler→exec→dispatch ctx)으로 관통, `masc_fusion` 핸들러가 gate-Allow 시 신설 `Fusion_wake_route`(lib/fusion, Atomic+CAS — `Fusion_run_registry` 관용구)에 등록. fusion_core(pure) 경계는 불변 — channel은 keeper-aware 레이어에만 존재.
- **Wake**: `fusion_completion.channel` 필드 추가. 단일 wake emitter(`wake_keeper_on_fusion_completion`, 성공+실패 공용)가 route를 exactly-once 소비. durable stimulus 직렬화는 connector/hitl과 동일 패턴, **구세대 row(channel 키 없음)는 기존 legacy default로 Unrouted 파싱**(queue 파스 실패 없음).
- **Consumer**: heartbeat loop이 hitl_resolution과 동일한 방식으로 fusion channel을 파생, unified turn의 기존 delivery 슬롯에 병합(동일 사이클에 HITL도 오면 HITL 우선 — grant 시맨틱). 회신 배달은 HITL이 이미 검증한 배선을 그대로 사용.
- 취소 경로(wake 미발화)는 route discard로 누수 방지. 대시보드발 fusion은 route 미등록(결론이 이미 chat lane에 착지).

## 검증

- 신규 테스트: wake-route 계약(register/take-removes/discard, Unrouted 미저장), Discord channel 보존 roundtrip, **legacy row Unrouted 파싱**
- `fusion_wake` 10/10, `keeper_event_queue` pass, `keeper_reaction_ledger` 26/26, `fusion_sink_meta` 18/18, `@check` green
- 대시보드: 변경 불필요 (fusion 결과는 기존 chat lane/SSE 그대로; 채널 회신은 서버측 delivery)

## 후속 (동일 seam, 별도 PR)

`Schedule_due`·`Goal_verification_failed`는 영속 스키마(schedule/verification 요청 저장) 변경이 필요해 다음 wave — 이 PR의 event-queue 직렬화 패턴을 그대로 재사용.

지도: claude.ai/code/artifact/01478ad0 · RFC-0320/0266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
