### PR TITLE
fix(fs): preserve typed durability outcomes across atomic writers

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -842,7 +842,7 @@ let runtime_default_id =
 let runtime_default_set_cmd_exit base_path runtime_id =
   let runtime_config_path = runtime_config_path_for_base_path base_path in
   match
-    Runtime.set_runtime_default ~runtime_config_path ~runtime_id ()
+    Runtime.set_runtime_default_blocking ~runtime_config_path ~runtime_id ()
   with
   | Ok () ->
       Printf.printf "set [runtime].default = \"%s\" in %s\n" runtime_id

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -186,17 +186,26 @@ let repair_event_file_utf8_once config path =
                   invalid_bytes=%d action=read_only_current_day"
                  path repair.invalid_bytes
              else
-               match Fs_compat.save_file_atomic path repair.text with
-               | Ok () ->
-                   Log.Misc.warn
-                     "[activity_graph] UTF-8 repaired persisted event file path=%s \
-                      invalid_bytes=%d action=rewrite_once"
-                     path repair.invalid_bytes
-               | Error msg ->
+               let report = Fs_compat.save_file_atomic_eio path repair.text in
+               Fs_compat.Durable_mutation.fold_report report
+                 ~not_committed:(fun report ->
                    Log.Misc.warn
                      "[activity_graph] UTF-8 repaired event file in memory path=%s \
-                      invalid_bytes=%d action=rewrite_failed error=%s"
-                     path repair.invalid_bytes msg);
+                      invalid_bytes=%d action=rewrite_not_committed error=%s"
+                     path repair.invalid_bytes
+                     (Fs_compat.Durable_mutation.report_to_string report))
+                 ~committed_not_durable:(fun report ->
+                   Log.Misc.warn
+                     "[activity_graph] UTF-8 repair committed with sync debt path=%s \
+                      invalid_bytes=%d detail=%s"
+                     path repair.invalid_bytes
+                     (Fs_compat.Durable_mutation.report_to_string report))
+                 ~durable:(fun report ->
+                   Log.Misc.warn
+                     "[activity_graph] UTF-8 repaired persisted event file path=%s \
+                      invalid_bytes=%d action=rewrite_once detail=%s"
+                     path repair.invalid_bytes
+                     (Fs_compat.Durable_mutation.report_to_string report)));
             repair.text
           end)
 

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -735,9 +735,8 @@ let save_sub_boards_jsonl content =
   try
     ensure_masc_dir ();
     let path = sub_boards_path () in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg -> record_persist_error ~where:"rewrite_sub_boards" msg
+    Fs_compat.save_file_atomic_eio path content
+    |> atomic_persist_observe ~where:"rewrite_sub_boards"
   with
   | Sys_error msg -> record_persist_error ~where:"rewrite_sub_boards" msg
 ;;

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -50,6 +50,8 @@ end
     swallowed during JSONL append / rotate; consumed by the
     operator dashboard for at-a-glance health. *)
 val persist_error_count : unit -> int
+val atomic_persist_observe :
+  where:string -> unit Fs_compat.Durable_mutation.report -> unit
 
 (** Record and log a board persistence failure. *)
 val record_persist_error : where:string -> string -> unit

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -38,6 +38,47 @@ let persist_io_error ~where msg =
   Error (Io_error (Printf.sprintf "%s: %s" where msg))
 ;;
 
+let observe_committed_persist ~where report =
+  match report.Fs_compat.Durable_mutation.diagnostics with
+  | [] -> ()
+  | _ ->
+    Log.BoardLog.warn
+      "persist committed with durability diagnostics (%s): %s"
+      where
+      (Fs_compat.Durable_mutation.report_to_string report)
+;;
+
+let atomic_persist_result ~where report =
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      persist_io_error
+        ~where
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.BoardLog.warn
+        "persist committed with sync debt (%s): %s"
+        where
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      observe_committed_persist ~where report;
+      Ok ())
+;;
+
+let atomic_persist_observe ~where report =
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      record_persist_error
+        ~where
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.BoardLog.warn
+        "persist committed with sync debt (%s): %s"
+        where
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~durable:(fun report -> observe_committed_persist ~where report)
+;;
+
 let create_store () =
   { posts = Hashtbl.create 1024
   ; comments = Hashtbl.create 4096
@@ -429,9 +470,8 @@ let save_posts_jsonl_result content =
   try
     ensure_masc_dir ();
     let path = persist_path () in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> Ok ()
-    | Error msg -> persist_io_error ~where:"rewrite_posts" msg
+    Fs_compat.save_file_atomic_eio path content
+    |> atomic_persist_result ~where:"rewrite_posts"
   with
   | Sys_error msg -> persist_io_error ~where:"rewrite_posts" msg
 ;;
@@ -450,9 +490,8 @@ let rewrite_comments store =
          Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt));
          Buffer.add_char buf '\n')
       store.comments;
-    match Fs_compat.save_file_atomic path (Buffer.contents buf) with
-    | Ok () -> ()
-    | Error msg -> record_persist_error ~where:"rewrite_comments" msg
+    Fs_compat.save_file_atomic_eio path (Buffer.contents buf)
+    |> atomic_persist_observe ~where:"rewrite_comments"
   with
   | Sys_error msg -> record_persist_error ~where:"rewrite_comments" msg
 ;;
@@ -469,9 +508,8 @@ let save_reactions_jsonl content =
   try
     ensure_masc_dir ();
     let path = reactions_path () in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg -> record_persist_error ~where:"rewrite_reactions" msg
+    Fs_compat.save_file_atomic_eio path content
+    |> atomic_persist_observe ~where:"rewrite_reactions"
   with
   | Sys_error msg -> record_persist_error ~where:"rewrite_reactions" msg
 ;;

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -26,6 +26,10 @@ val flusher_schedule_dropped_count : unit -> int
 
 val persist_error_count : unit -> int
 val record_persist_error : where:string -> string -> unit
+val atomic_persist_observe :
+  where:string -> unit Fs_compat.Durable_mutation.report -> unit
+(** Exhaustively records all typed mutation outcomes. A committed sync debt is
+    observable but remains success, preventing duplicate rewrites. *)
 
 val create_store : unit -> store
 val reset_comment_rate_tracker : unit -> unit

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -97,9 +97,8 @@ let save_vote_log_jsonl content =
   try
     ensure_masc_dir ();
     let path = vote_log_path () in
-    (match Fs_compat.save_file_atomic path content with
-     | Ok () -> ()
-     | Error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg)
+    Fs_compat.save_file_atomic_eio path content
+    |> atomic_persist_observe ~where:"rewrite_vote_log"
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg
 
 let rewrite_vote_log store =
@@ -637,9 +636,8 @@ let reactions_jsonl_snapshot store =
 let save_jsonl_snapshot ~where ~path content =
   try
     ensure_masc_dir ();
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg -> record_persist_error ~where msg
+    Fs_compat.save_file_atomic_eio path content
+    |> atomic_persist_observe ~where
   with Sys_error msg -> record_persist_error ~where msg
 
 let delete_post store ~post_id : (unit, board_error) Result.t =

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -567,11 +567,28 @@ let persist_artifact_if_needed ~base_path ~keeper_name ~cmd ~output =
         dir
         (Printf.sprintf "%d-%s.txt" (int_of_float (now *. 1000.0)) digest_prefix)
     in
-    match Fs_compat.save_file_atomic path output with
-    | Ok () -> Some { path; bytes = String.length output; storage = Filesystem }
-    | Error err ->
-      Log.Backend.warn "exec artifact persist failed: %s" err;
-      None)
+    let report = Fs_compat.save_file_atomic_eio path output in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Log.Backend.warn
+          "exec artifact persist not committed: %s"
+          (Fs_compat.Durable_mutation.report_to_string report);
+        None)
+      ~committed_not_durable:(fun report ->
+        Log.Backend.warn
+          "exec artifact committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Some { path; bytes = String.length output; storage = Filesystem })
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Backend.warn
+             "exec artifact durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Some { path; bytes = String.length output; storage = Filesystem }))
 ;;
 
 let string_of_artifact_storage = function

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -1,73 +1,5 @@
 (* See [atomic_write.mli] for the contract. *)
 
-(* Durable atomic write: tmp → fsync(tmp) → rename → fsync(parent dir).
-   Without the fsync pair, a crash between the rename and the kernel's
-   dirty-page flush can leave the target truncated or zero-length —
-   observed on backlog.json after an abrupt shutdown (2026-04-18). *)
-let fsync_path path =
-  let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-  Stdlib.Fun.protect
-    ~finally:(fun () ->
-      try Unix.close fd with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Stdlib.Printf.eprintf
-          "[fs_compat] fsync_path close failed: %s\n%!"
-          (Printexc.to_string exn))
-    (fun () ->
-      try Unix.fsync fd with
-      | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
-           is still durable to the extent the underlying FS offers. *)
-        ())
-;;
-
-(* #10205 finding 2: keep the atomic-tmp filename shape in one place
-   so the writer ([save_file_atomic]) and the orphan-sweep matcher
-   ([is_atomic_orphan_name]) cannot drift independently. A
-   prefix/suffix change on one side without the other would cause
-   the sweep to either miss live orphans or scoop unrelated tmp
-   files. *)
-let atomic_tmp_prefix = ".atomic_"
-let atomic_tmp_suffix = ".tmp"
-
-let save_file_atomic
-  ~(save_file : string -> string -> unit)
-  (path : string)
-  (content : string)
-  : (unit, string) Result.t
-  =
-  let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
-  in
-  try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
-    Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    raise e
-  | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
-;;
-
-let is_atomic_orphan_name name =
-  let n = String.length name in
-  let p = String.length atomic_tmp_prefix in
-  let s = String.length atomic_tmp_suffix in
-  n >= p + s
-  && String.starts_with name ~prefix:atomic_tmp_prefix
-  && String.ends_with ~suffix:atomic_tmp_suffix name
-;;
-
 let cleanup_atomic_orphans
   ~(mkdir_p_unix : string -> unit)
   ~(base_path : string)
@@ -112,7 +44,7 @@ let cleanup_atomic_orphans
   in
   let scan_dir dir entries =
     Array.iter
-      (fun name -> if is_atomic_orphan_name name then handle_file dir name)
+      (fun name -> if Durable_mutation.is_temporary_name name then handle_file dir name)
       entries
   in
   let read_dir_entries dir =

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -9,32 +9,12 @@
 
     Crash recovery is provided by [cleanup_atomic_orphans], a
     boot-time sweep for [.atomic_*.tmp] files left behind when the
-    owning process was SIGKILL'd or [Filename.temp_file] itself
-    raised ENFILE/EMFILE before the with-handler could register.
+    owning process was SIGKILL'd after the descriptor-owned writer
+    created its exclusive temporary entry.
 
-    The [save_file] and [mkdir_p_unix] primitives are injected so
-    this module stays free of [Fs_compat]'s Eio bridge — same
-    cycle-free placement pattern as [Mkdir_memo] and [Fd_cache]. *)
-
-(** [save_file_atomic ~save_file path content] writes [content] to
-    a temp file in [path]'s directory, fsyncs the tmp, renames it
-    over [path], and best-effort fsyncs the parent directory.
-
-    Returns [Ok ()] on success or [Error msg] when the write or
-    rename fails (the tmp is cleaned up). Re-raises
-    [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
-    must not be swallowed (RFC-0143). *)
-val save_file_atomic
-  :  save_file:(string -> string -> unit)
-  -> string
-  -> string
-  -> (unit, string) Result.t
-
-(** [true] iff [name] matches the [.atomic_*.tmp] shape produced
-    by {!save_file_atomic}. Exposed so a periodic sweep can match
-    the same filename pattern without re-deriving the prefix and
-    suffix — #10205 finding 2. *)
-val is_atomic_orphan_name : string -> bool
+    The writer SSOT is {!Durable_mutation}; this module owns only the
+    legacy boot-time recovery traversal until #24083 replaces it with
+    schema-owned roots. *)
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans.
 

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,7 +3,10 @@
 (library
  (name fs_compat)
  (public_name masc.fs_compat)
- (modules fs_compat mkdir_memo fd_cache atomic_write)
+ (modules fs_compat mkdir_memo fd_cache atomic_write durable_mutation)
+ (foreign_stubs
+  (language c)
+  (names durable_mutation_stubs))
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/fs_compat/durable_mutation.ml
+++ b/lib/fs_compat/durable_mutation.ml
@@ -1,0 +1,276 @@
+module Segment = struct
+  type t = string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  let of_string = function
+    | "" -> Error Empty
+    | "." -> Error Dot
+    | ".." -> Error Dot_dot
+    | value when String.contains value '/' -> Error Contains_separator
+    | value when String.contains value '\000' -> Error Contains_nul
+    | value -> Ok value
+  ;;
+
+  let to_string value = value
+end
+
+type diagnostic_stage =
+  | Temporary_close
+  | Temporary_cleanup
+  | Parent_close
+  | Observer
+
+type diagnostic =
+  { stage : diagnostic_stage
+  ; cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a progress =
+  | Not_committed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Committed_not_durable of
+      { value : 'a
+      ; cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Durable of 'a
+
+type 'a report =
+  { progress : 'a progress
+  ; diagnostics : diagnostic list
+  }
+
+type observation =
+  | Observed
+  | Observer_failed of diagnostic
+
+external open_parent : string -> Unix.file_descr = "masc_durable_mutation_open_parent"
+
+external create_exclusive
+  :  Unix.file_descr
+  -> string
+  -> int
+  -> Unix.file_descr
+  = "masc_durable_mutation_create_exclusive"
+
+external rename_entry
+  :  Unix.file_descr
+  -> string
+  -> string
+  -> unit
+  = "masc_durable_mutation_rename"
+
+external unlink_entry
+  :  Unix.file_descr
+  -> string
+  -> unit
+  = "masc_durable_mutation_unlink"
+
+let diagnostic stage cause backtrace = { stage; cause; backtrace }
+
+let diagnostic_stage_to_string = function
+  | Temporary_close -> "temporary close"
+  | Temporary_cleanup -> "temporary cleanup"
+  | Parent_close -> "parent close"
+  | Observer -> "observer"
+;;
+
+let diagnostic_to_string diagnostic =
+  Printf.sprintf
+    "%s: %s"
+    (diagnostic_stage_to_string diagnostic.stage)
+    (Printexc.to_string diagnostic.cause)
+;;
+
+let temporary_prefix = ".atomic_"
+let temporary_suffix = ".tmp"
+
+let is_temporary_name name =
+  let name_length = String.length name in
+  let prefix_length = String.length temporary_prefix in
+  let suffix_length = String.length temporary_suffix in
+  name_length >= prefix_length + suffix_length
+  && String.starts_with name ~prefix:temporary_prefix
+  && String.ends_with name ~suffix:temporary_suffix
+;;
+
+let run_state_machine ~prepare ~commit ~publish ~cleanup =
+  let not_committed cause backtrace =
+    { progress = Not_committed { cause; backtrace }; diagnostics = cleanup () }
+  in
+  match prepare () with
+  | exception cause -> not_committed cause (Printexc.get_raw_backtrace ())
+  | () ->
+    (match commit () with
+     | exception cause -> not_committed cause (Printexc.get_raw_backtrace ())
+     | () ->
+       (match publish () with
+        | () -> { progress = Durable (); diagnostics = [] }
+        | exception cause ->
+          { progress =
+              Committed_not_durable
+                { value = (); cause; backtrace = Printexc.get_raw_backtrace () }
+          ; diagnostics = []
+          }))
+;;
+
+module For_testing = struct
+  let run_state_machine = run_state_machine
+end
+
+type temporary_owner =
+  | Not_created
+  | Open of Unix.file_descr
+  | Released
+
+let temp_counter = Atomic.make 0
+
+let rec create_temporary parent =
+  let sequence = Atomic.fetch_and_add temp_counter 1 in
+  (* NDT-OK: the process ID only mints an O_EXCL entry name. No policy, replay,
+     ordering, or identity decision depends on its value. *)
+  let process_id = Unix.getpid () in
+  let raw =
+    Printf.sprintf
+      "%s%x_%x%s"
+      temporary_prefix
+      process_id
+      sequence
+      temporary_suffix
+  in
+  match create_exclusive parent raw 0o600 with
+  | descriptor -> raw, descriptor
+  | exception Unix.Unix_error (Unix.EEXIST, _, _) -> create_temporary parent
+;;
+
+let write_all descriptor content =
+  let rec loop offset =
+    if offset < String.length content
+    then
+      match
+        Unix.write_substring
+          descriptor
+          content
+          offset
+          (String.length content - offset)
+      with
+      | 0 -> raise (Unix.Unix_error (Unix.EIO, "durable_mutation_write", ""))
+      | count -> loop (offset + count)
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop offset
+  in
+  loop 0
+;;
+
+let close_once owner stage =
+  match !owner with
+  | Not_created | Released -> []
+  | Open descriptor ->
+    owner := Released;
+    (match Unix.close descriptor with
+     | () -> []
+     | exception cause ->
+       [ diagnostic stage cause (Printexc.get_raw_backtrace ()) ])
+;;
+
+let cleanup_temporary parent temp_name owner =
+  let close_diagnostics = close_once owner Temporary_close in
+  match !temp_name with
+  | None -> close_diagnostics
+  | Some name ->
+    temp_name := None;
+    (match unlink_entry parent name with
+     | () ->
+       (match Unix.fsync parent with
+        | () -> close_diagnostics
+        | exception cause ->
+          close_diagnostics
+          @ [ diagnostic
+                Temporary_cleanup
+                cause
+                (Printexc.get_raw_backtrace ())
+            ])
+     | exception Unix.Unix_error (Unix.ENOENT, _, _) -> close_diagnostics
+     | exception cause ->
+       close_diagnostics
+       @ [ diagnostic
+             Temporary_cleanup
+             cause
+             (Printexc.get_raw_backtrace ())
+         ])
+;;
+
+let atomic_replace_at parent ~name ~perm content =
+  let temp_name = ref None in
+  let owner = ref Not_created in
+  let prepare () =
+    let name, descriptor = create_temporary parent in
+    temp_name := Some name;
+    owner := Open descriptor;
+    write_all descriptor content;
+    Unix.fchmod descriptor perm;
+    Unix.fsync descriptor;
+    match close_once owner Temporary_close with
+    | [] -> ()
+    | { cause; backtrace; _ } :: _ ->
+      Printexc.raise_with_backtrace cause backtrace
+  in
+  let commit () =
+    match !temp_name with
+    | None -> invalid_arg "durable mutation temporary entry is not prepared"
+    | Some temporary ->
+      rename_entry parent temporary (Segment.to_string name);
+      temp_name := None
+  in
+  run_state_machine
+    ~prepare
+    ~commit
+    ~publish:(fun () -> Unix.fsync parent)
+    ~cleanup:(fun () -> cleanup_temporary parent temp_name owner)
+;;
+
+let add_parent_close report parent =
+  match Unix.close parent with
+  | () -> report
+  | exception cause ->
+    { report with
+      diagnostics =
+        report.diagnostics
+        @ [ diagnostic Parent_close cause (Printexc.get_raw_backtrace ()) ]
+    }
+;;
+
+let atomic_replace_blocking ~parent ~name ~perm content =
+  match open_parent parent with
+  | exception cause ->
+    { progress =
+        Not_committed { cause; backtrace = Printexc.get_raw_backtrace () }
+    ; diagnostics = []
+    }
+  | parent_descriptor ->
+    let report = atomic_replace_at parent_descriptor ~name ~perm content in
+    add_parent_close report parent_descriptor
+;;
+
+let atomic_replace_eio ~parent ~name ~perm content =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"durable-mutation" (fun () ->
+      atomic_replace_blocking ~parent ~name ~perm content))
+;;
+
+let observe observer report =
+  match observer report with
+  | () -> Observed
+  | exception (Eio.Cancel.Cancelled _ as cause) -> raise cause
+  | exception cause ->
+    Observer_failed
+      (diagnostic Observer cause (Printexc.get_raw_backtrace ()))
+;;

--- a/lib/fs_compat/durable_mutation.ml
+++ b/lib/fs_compat/durable_mutation.ml
@@ -91,6 +91,31 @@ let diagnostic_to_string diagnostic =
     (Printexc.to_string diagnostic.cause)
 ;;
 
+let report_to_string report =
+  let progress =
+    match report.progress with
+    | Not_committed { cause; _ } ->
+      Printf.sprintf "not committed: %s" (Printexc.to_string cause)
+    | Committed_not_durable { cause; _ } ->
+      Printf.sprintf "committed but not durable: %s" (Printexc.to_string cause)
+    | Durable _ -> "durable"
+  in
+  match report.diagnostics with
+  | [] -> progress
+  | diagnostics ->
+    Printf.sprintf
+      "%s; diagnostics: %s"
+      progress
+      (String.concat "; " (List.map diagnostic_to_string diagnostics))
+;;
+
+let fold_report report ~not_committed ~committed_not_durable ~durable =
+  match report.progress with
+  | Not_committed _ -> not_committed report
+  | Committed_not_durable _ -> committed_not_durable report
+  | Durable _ -> durable report
+;;
+
 let temporary_prefix = ".atomic_"
 let temporary_suffix = ".tmp"
 
@@ -101,6 +126,47 @@ let is_temporary_name name =
   name_length >= prefix_length + suffix_length
   && String.starts_with name ~prefix:temporary_prefix
   && String.ends_with name ~suffix:temporary_suffix
+;;
+
+type durability_confirmation =
+  | Confirmed
+  | Not_confirmed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type durability_confirmation_report =
+  { confirmation : durability_confirmation
+  ; confirmation_diagnostics : diagnostic list
+  }
+
+let confirm_directory_durable_blocking path =
+  match open_parent path with
+  | exception cause ->
+    { confirmation =
+        Not_confirmed { cause; backtrace = Printexc.get_raw_backtrace () }
+    ; confirmation_diagnostics = []
+    }
+  | descriptor ->
+    let confirmation =
+      match Unix.fsync descriptor with
+      | () -> Confirmed
+      | exception cause ->
+        Not_confirmed { cause; backtrace = Printexc.get_raw_backtrace () }
+    in
+    let diagnostics =
+      match Unix.close descriptor with
+      | () -> []
+      | exception cause ->
+        [ diagnostic Parent_close cause (Printexc.get_raw_backtrace ()) ]
+    in
+    { confirmation; confirmation_diagnostics = diagnostics }
+;;
+
+let confirm_directory_durable_eio path =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"durability-confirmation" (fun () ->
+      confirm_directory_durable_blocking path))
 ;;
 
 let run_state_machine ~prepare ~commit ~publish ~cleanup =
@@ -237,7 +303,7 @@ let atomic_replace_at parent ~name ~perm content =
     ~cleanup:(fun () -> cleanup_temporary parent temp_name owner)
 ;;
 
-let add_parent_close report parent =
+let add_parent_close (report : 'a report) parent =
   match Unix.close parent with
   | () -> report
   | exception cause ->
@@ -273,4 +339,21 @@ let observe observer report =
   | exception cause ->
     Observer_failed
       (diagnostic Observer cause (Printexc.get_raw_backtrace ()))
+;;
+
+let observe_and_retain observer report =
+  match observe observer report with
+  | Observed -> report
+  | Observer_failed observer_diagnostic ->
+    { report with diagnostics = report.diagnostics @ [ observer_diagnostic ] }
+;;
+
+let observe_confirmation_and_retain observer report =
+  match observe observer report with
+  | Observed -> report
+  | Observer_failed observer_diagnostic ->
+    { report with
+      confirmation_diagnostics =
+        report.confirmation_diagnostics @ [ observer_diagnostic ]
+    }
 ;;

--- a/lib/fs_compat/durable_mutation.mli
+++ b/lib/fs_compat/durable_mutation.mli
@@ -53,6 +53,20 @@ type 'a report =
   ; diagnostics : diagnostic list
   }
 
+val report_to_string : 'a report -> string
+(** Human-readable evidence for logs and domain errors. Callers must still
+    branch on [progress]; this function is not a policy or retry classifier. *)
+
+val fold_report :
+  'a report ->
+  not_committed:('a report -> 'b) ->
+  committed_not_durable:('a report -> 'b) ->
+  durable:('a report -> 'b) ->
+  'b
+(** Exhaustive eliminator for a mutation report. Each caller must supply all
+    three progress handlers, so retry and observability policy stays at the
+    domain boundary instead of being flattened by the filesystem layer. *)
+
 type observation =
   | Observed
   | Observer_failed of diagnostic
@@ -60,6 +74,30 @@ type observation =
 val is_temporary_name : string -> bool
 (** [true] exactly for names minted by this mutation core. Recovery delegates
     to this predicate instead of duplicating the writer's naming contract. *)
+
+type durability_confirmation =
+  | Confirmed
+  | Not_confirmed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type durability_confirmation_report =
+  { confirmation : durability_confirmation
+  ; confirmation_diagnostics : diagnostic list
+  }
+
+val confirm_directory_durable_blocking :
+  string -> durability_confirmation_report
+(** Open a directory capability, fsync it, and close it through one auditable
+    owner. [Confirmed] means a previous committed entry is now safe to use as a
+    durability prerequisite. Open/fsync failure is [Not_confirmed]; a close
+    failure after successful fsync is retained as a [Parent_close] diagnostic. *)
+
+val confirm_directory_durable_eio :
+  string -> durability_confirmation_report
+(** Eio boundary for {!confirm_directory_durable_blocking}. The complete
+    descriptor operation runs in one cancellation-protected systhread. *)
 
 val atomic_replace_blocking :
   parent:string -> name:Segment.t -> perm:int -> string -> unit report
@@ -77,6 +115,19 @@ val observe : ('a report -> unit) -> 'a report -> observation
 (** Invoke an observer without allowing observer failure to replace or mutate
     the authoritative mutation report. Non-cancellation failure is returned
     explicitly; Eio cancellation remains a control signal and is re-raised. *)
+
+val observe_and_retain : ('a report -> unit) -> 'a report -> 'a report
+(** Run an observer and return the authoritative mutation report unchanged on
+    success. Observer failure is appended as an [Observer] diagnostic instead
+    of replacing the mutation progress; Eio cancellation still propagates. *)
+
+val observe_confirmation_and_retain :
+  (durability_confirmation_report -> unit) ->
+  durability_confirmation_report ->
+  durability_confirmation_report
+(** Run an observer and retain the authoritative directory confirmation.
+    Observer failure is appended to [confirmation_diagnostics]; Eio
+    cancellation still propagates. *)
 
 module For_testing : sig
   val run_state_machine :

--- a/lib/fs_compat/durable_mutation.mli
+++ b/lib/fs_compat/durable_mutation.mli
@@ -1,0 +1,90 @@
+(** Descriptor-owned durable filesystem mutations.
+
+    A mutation has one closed progress state. Once the final directory entry
+    operation succeeds, later failures can only produce
+    {!Committed_not_durable}; they can never be reported as retry-safe.
+
+    The blocking and Eio entry points are intentionally separate. The Eio
+    entry point protects the complete system-thread operation from
+    cancellation, so a caller always receives the committed state. *)
+
+module Segment : sig
+  type t = private string
+
+  type error =
+    | Empty
+    | Dot
+    | Dot_dot
+    | Contains_separator
+    | Contains_nul
+
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+end
+
+type diagnostic_stage =
+  | Temporary_close
+  | Temporary_cleanup
+  | Parent_close
+  | Observer
+
+type diagnostic =
+  { stage : diagnostic_stage
+  ; cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+val diagnostic_to_string : diagnostic -> string
+
+type 'a progress =
+  | Not_committed of
+      { cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Committed_not_durable of
+      { value : 'a
+      ; cause : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Durable of 'a
+
+type 'a report =
+  { progress : 'a progress
+  ; diagnostics : diagnostic list
+  }
+
+type observation =
+  | Observed
+  | Observer_failed of diagnostic
+
+val is_temporary_name : string -> bool
+(** [true] exactly for names minted by this mutation core. Recovery delegates
+    to this predicate instead of duplicating the writer's naming contract. *)
+
+val atomic_replace_blocking :
+  parent:string -> name:Segment.t -> perm:int -> string -> unit report
+(** Open [parent] once as a directory capability, create and fsync an exclusive
+    temporary file relative to it, rename that entry over [name], and fsync the
+    same parent descriptor. The descriptor has one owner and one close path. *)
+
+val atomic_replace_eio :
+  parent:string -> name:Segment.t -> perm:int -> string -> unit report
+(** Eio-safe counterpart of {!atomic_replace_blocking}. The whole blocking
+    state machine runs in a protected system-thread call. There is no runtime
+    detection or same-domain fallback. *)
+
+val observe : ('a report -> unit) -> 'a report -> observation
+(** Invoke an observer without allowing observer failure to replace or mutate
+    the authoritative mutation report. Non-cancellation failure is returned
+    explicitly; Eio cancellation remains a control signal and is re-raised. *)
+
+module For_testing : sig
+  val run_state_machine :
+    prepare:(unit -> unit) ->
+    commit:(unit -> unit) ->
+    publish:(unit -> unit) ->
+    cleanup:(unit -> diagnostic list) ->
+    unit report
+  (** Deterministic seam for phase-transition and cancellation tests. Production
+      mutations use this same state machine. *)
+end

--- a/lib/fs_compat/durable_mutation_stubs.c
+++ b/lib/fs_compat/durable_mutation_stubs.c
@@ -1,0 +1,121 @@
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/signals.h>
+#include <caml/unixsupport.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !defined(O_CLOEXEC) || !defined(O_DIRECTORY) || !defined(O_NOFOLLOW)
+#error "durable mutation requires O_CLOEXEC, O_DIRECTORY, and O_NOFOLLOW"
+#endif
+
+static int parent_fd(value descriptor)
+{
+  return Int_val(descriptor);
+}
+
+static void free_preserving_errno(void *pointer)
+{
+  int saved_errno = errno;
+  caml_stat_free(pointer);
+  errno = saved_errno;
+}
+
+CAMLprim value masc_durable_mutation_open_parent(value path)
+{
+  CAMLparam1(path);
+  char *copied_path;
+  int descriptor;
+
+  caml_unix_check_path(path, "durable_mutation_open_parent");
+  copied_path = caml_stat_strdup(String_val(path));
+  caml_enter_blocking_section();
+  descriptor = open(copied_path,
+                    O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_path);
+  if (descriptor == -1) uerror("durable_mutation_open_parent", path);
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value masc_durable_mutation_create_exclusive(value parent,
+                                                       value name,
+                                                       value mode)
+{
+  CAMLparam3(parent, name, mode);
+  char *copied_name;
+  int parent_descriptor;
+  int file_mode;
+  int descriptor;
+
+  caml_unix_check_path(name, "durable_mutation_create_exclusive");
+  copied_name = caml_stat_strdup(String_val(name));
+  parent_descriptor = parent_fd(parent);
+  file_mode = Int_val(mode);
+  caml_enter_blocking_section();
+  descriptor = openat(parent_descriptor, copied_name,
+                      O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                      file_mode);
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_name);
+  if (descriptor == -1) uerror("durable_mutation_create_exclusive", name);
+  CAMLreturn(Val_int(descriptor));
+}
+
+CAMLprim value masc_durable_mutation_rename(value parent,
+                                            value old_name,
+                                            value new_name)
+{
+  CAMLparam3(parent, old_name, new_name);
+  size_t old_length;
+  size_t new_length;
+  char *allocation;
+  char *old_copy;
+  char *new_copy;
+  int parent_descriptor;
+  int result;
+
+  caml_unix_check_path(old_name, "durable_mutation_rename_old");
+  caml_unix_check_path(new_name, "durable_mutation_rename_new");
+  old_length = caml_string_length(old_name);
+  new_length = caml_string_length(new_name);
+  allocation = caml_stat_alloc(old_length + new_length + 2);
+  old_copy = allocation;
+  new_copy = allocation + old_length + 1;
+  memcpy(old_copy, String_val(old_name), old_length);
+  old_copy[old_length] = '\0';
+  memcpy(new_copy, String_val(new_name), new_length);
+  new_copy[new_length] = '\0';
+  parent_descriptor = parent_fd(parent);
+  caml_enter_blocking_section();
+  result = renameat(parent_descriptor, old_copy,
+                    parent_descriptor, new_copy);
+  caml_leave_blocking_section();
+  free_preserving_errno(allocation);
+  if (result == -1) uerror("durable_mutation_rename", old_name);
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value masc_durable_mutation_unlink(value parent, value name)
+{
+  CAMLparam2(parent, name);
+  char *copied_name;
+  int parent_descriptor;
+  int result;
+
+  caml_unix_check_path(name, "durable_mutation_unlink");
+  copied_name = caml_stat_strdup(String_val(name));
+  parent_descriptor = parent_fd(parent);
+  caml_enter_blocking_section();
+  result = unlinkat(parent_descriptor, copied_name, 0);
+  caml_leave_blocking_section();
+  free_preserving_errno(copied_name);
+  if (result == -1) uerror("durable_mutation_unlink", name);
+  CAMLreturn(Val_unit);
+}

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -13,6 +13,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+module Durable_mutation = Durable_mutation
+
 (** Global fs — WORM Atomic (write-once at startup, read from any domain).
     Using Atomic.t is required for OCaml 5 multi-domain safety:
     Executor_pool workers run on a separate domain and read this value. *)
@@ -238,10 +240,52 @@ let save_file (path : string) (content : string) : unit =
 ;;
 
 let save_file_atomic path content =
-  Atomic_write.save_file_atomic ~save_file path content
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  let parent = Filename.dirname path in
+  match Durable_mutation.Segment.of_string (Filename.basename path) with
+  | Error _ -> Error (Printf.sprintf "save_file_atomic %s: invalid final segment" path)
+  | Ok name ->
+    let report =
+      Durable_mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        content
+    in
+    let diagnostic_suffix =
+      match report.diagnostics with
+      | [] -> ""
+      | diagnostics ->
+        "; diagnostics: "
+        ^ String.concat
+            "; "
+            (List.map Durable_mutation.diagnostic_to_string diagnostics)
+    in
+    (match report.progress, report.diagnostics with
+     | Durable_mutation.Durable (), [] -> Ok ()
+     | Durable_mutation.Durable (), _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: durable%s"
+            path
+            diagnostic_suffix)
+     | Durable_mutation.Not_committed { cause; _ }, _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: not committed: %s%s"
+            path
+            (Printexc.to_string cause)
+            diagnostic_suffix)
+     | Durable_mutation.Committed_not_durable { cause; _ }, _ ->
+       Error
+         (Printf.sprintf
+            "save_file_atomic %s: committed but not durable: %s%s"
+            path
+            (Printexc.to_string cause)
+            diagnostic_suffix))
 ;;
 
-let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
+let is_atomic_orphan_name = Durable_mutation.is_temporary_name
 
 let cleanup_atomic_orphans ~base_path ?recovered_subdir () =
   Atomic_write.cleanup_atomic_orphans ~mkdir_p_unix ~base_path ?recovered_subdir ()

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -239,50 +239,36 @@ let save_file (path : string) (content : string) : unit =
        Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
 ;;
 
-let save_file_atomic path content =
+exception Invalid_atomic_target of
+  { path : string
+  ; error : Durable_mutation.Segment.error
+  }
+
+let invalid_atomic_target_report path error =
+  let cause = Invalid_atomic_target { path; error } in
+  { Durable_mutation.progress =
+      Durable_mutation.Not_committed
+        { cause
+        ; backtrace = Printexc.get_callstack 32
+        }
+  ; diagnostics = []
+  }
+;;
+
+let save_file_atomic_with replace path content =
   test_exec_home_guard ~op:"save_file_atomic" path;
   let parent = Filename.dirname path in
   match Durable_mutation.Segment.of_string (Filename.basename path) with
-  | Error _ -> Error (Printf.sprintf "save_file_atomic %s: invalid final segment" path)
-  | Ok name ->
-    let report =
-      Durable_mutation.atomic_replace_blocking
-        ~parent
-        ~name
-        ~perm:0o600
-        content
-    in
-    let diagnostic_suffix =
-      match report.diagnostics with
-      | [] -> ""
-      | diagnostics ->
-        "; diagnostics: "
-        ^ String.concat
-            "; "
-            (List.map Durable_mutation.diagnostic_to_string diagnostics)
-    in
-    (match report.progress, report.diagnostics with
-     | Durable_mutation.Durable (), [] -> Ok ()
-     | Durable_mutation.Durable (), _ ->
-       Error
-         (Printf.sprintf
-            "save_file_atomic %s: durable%s"
-            path
-            diagnostic_suffix)
-     | Durable_mutation.Not_committed { cause; _ }, _ ->
-       Error
-         (Printf.sprintf
-            "save_file_atomic %s: not committed: %s%s"
-            path
-            (Printexc.to_string cause)
-            diagnostic_suffix)
-     | Durable_mutation.Committed_not_durable { cause; _ }, _ ->
-       Error
-         (Printf.sprintf
-            "save_file_atomic %s: committed but not durable: %s%s"
-            path
-            (Printexc.to_string cause)
-            diagnostic_suffix))
+  | Error error -> invalid_atomic_target_report path error
+  | Ok name -> replace ~parent ~name ~perm:0o600 content
+;;
+
+let save_file_atomic_blocking path content =
+  save_file_atomic_with Durable_mutation.atomic_replace_blocking path content
+;;
+
+let save_file_atomic_eio path content =
+  save_file_atomic_with Durable_mutation.atomic_replace_eio path content
 ;;
 
 let is_atomic_orphan_name = Durable_mutation.is_temporary_name

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -10,6 +10,10 @@
     [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
 exception Test_isolation_breach of string
 
+(** Typed descriptor-owned durable mutation core. The path API below is a
+    compatibility adapter until its callers are migrated under #24084. *)
+module Durable_mutation : module type of Durable_mutation
+
 (** Set global Eio filesystem. Call at server startup. *)
 val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 
@@ -35,19 +39,20 @@ val load_file_opt : string -> string option
 val save_file : string -> string -> unit
 
 (** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. *)
+    Returns [Error msg] on I/O failure instead of raising. Until #24084 migrates
+    callers, the message names whether the mutation was not committed, committed
+    but not durable, or durable with a descriptor-cleanup diagnostic. Callers
+    must not infer retry safety by matching this text. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
-(** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
-    by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
-    {!save_file_atomic}.  Exposed for tests and for a potential
-    periodic sweep. *)
+(** [true] iff [name] matches the [.atomic_*.tmp] pattern minted by
+    {!Durable_mutation}. Exposed for recovery and tests. *)
 val is_atomic_orphan_name : string -> bool
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
-    owning process was SIGKILL'd, or [Filename.temp_file] itself
-    raised ENFILE/EMFILE before the cleanup was registered).
+    owning process was SIGKILL'd after its exclusive temporary entry
+    was created).
 
     Scans [base_path] and its immediate subdirectories (skipping
     [recovered_subdir] and anything that isn't a directory).

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -10,9 +10,15 @@
     [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
 exception Test_isolation_breach of string
 
-(** Typed descriptor-owned durable mutation core. The path API below is a
-    compatibility adapter until its callers are migrated under #24084. *)
+(** Typed descriptor-owned durable mutation core. *)
 module Durable_mutation : module type of Durable_mutation
+
+exception Invalid_atomic_target of
+  { path : string
+  ; error : Durable_mutation.Segment.error
+  }
+(** Typed cause used in a [Not_committed] report when the path's final segment
+    cannot be represented by {!Durable_mutation.Segment}. *)
 
 (** Set global Eio filesystem. Call at server startup. *)
 val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
@@ -38,19 +44,24 @@ val load_file_opt : string -> string option
 (** Save string to file (overwrite). *)
 val save_file : string -> string -> unit
 
-(** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. Until #24084 migrates
-    callers, the message names whether the mutation was not committed, committed
-    but not durable, or durable with a descriptor-cleanup diagnostic. Callers
-    must not infer retry safety by matching this text. *)
-val save_file_atomic : string -> string -> (unit, string) Result.t
+(** Write content through the typed descriptor-owned state machine. Callers must
+    exhaustively handle [Not_committed], [Committed_not_durable], and [Durable];
+    only [Not_committed] is retry-safe. This entry point blocks the calling
+    domain and is intended for CLI, tests, or an existing system thread. *)
+val save_file_atomic_blocking :
+  string -> string -> unit Durable_mutation.report
+
+(** Eio-safe counterpart of {!save_file_atomic_blocking}. The complete mutation
+    is cancellation-protected and runs in a system thread. There is no runtime
+    detection or blocking fallback. *)
+val save_file_atomic_eio : string -> string -> unit Durable_mutation.report
 
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern minted by
     {!Durable_mutation}. Exposed for recovery and tests. *)
 val is_atomic_orphan_name : string -> bool
 
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
-    behind when [save_file_atomic]'s with-handler never ran (the
+    behind when the atomic writer's with-handler never ran (the
     owning process was SIGKILL'd after its exclusive temporary entry
     was created).
 
@@ -207,7 +218,7 @@ val close_all_cached_writers : unit -> unit
 
 (** [invalidate_cached_writer path] drops the cached [append_jsonl]
     writer for [path] (a no-op if none is cached). Call it after
-    replacing the inode at [path] with [save_file_atomic]: the cached
+    replacing the inode at [path] with a durable atomic writer: the cached
     [O_APPEND] channel still points at the pre-rename inode, so without
     this a later [append_jsonl] would write to the orphaned file.
     Serialization with concurrent [append_jsonl] calls is handled by the

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -226,7 +226,7 @@ let compact_replay_log path runs =
     |> String.concat ""
   in
   try
-    let report = Fs_compat.save_file_atomic_eio path content in
+    let report = Fs_compat.save_file_atomic_blocking path content in
     Fs_compat.Durable_mutation.fold_report report
       ~not_committed:(fun report ->
         Log.Misc.warn

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -226,10 +226,26 @@ let compact_replay_log path runs =
     |> String.concat ""
   in
   try
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg ->
-      Log.Misc.warn "fusion_run_registry: replay compaction failed for %s: %s" path msg
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Log.Misc.warn
+          "fusion_run_registry: replay compaction not committed for %s: %s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Misc.warn
+          "fusion_run_registry: replay compaction committed with sync debt for %s: %s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~durable:(fun report ->
+        match report.diagnostics with
+        | [] -> ()
+        | _ ->
+          Log.Misc.warn
+            "fusion_run_registry: replay compaction durable with cleanup diagnostics for %s: %s"
+            path
+            (Fs_compat.Durable_mutation.report_to_string report))
   with
   | exn ->
     Log.Misc.warn

--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -134,9 +134,24 @@ let save_bindings store (bindings : binding list) =
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
   let content = Yojson.Safe.pretty_to_string normalized ^ "\n" in
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
-  | Error msg -> raise (Sys_error msg)
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      raise
+        (Sys_error (Fs_compat.Durable_mutation.report_to_string report)))
+    ~committed_not_durable:(fun report ->
+      Log.Misc.warn
+        "channel gate bindings committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~durable:(fun report ->
+      match report.diagnostics with
+      | [] -> ()
+      | _ ->
+        Log.Misc.warn
+          "channel gate bindings durable with cleanup diagnostics path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
 
 let guild_id_items store event =
   match store.guild_id_field with

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -885,9 +885,26 @@ let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
           buf;
         Buffer.contents out
       in
-      match Fs_compat.save_file_atomic path content with
-      | Ok () -> total - max_lines
-      | Error msg ->
-        Log.Institution.warn "JSONL episode cap failed: %s" msg;
-        0)))
+      let report = Fs_compat.save_file_atomic_eio path content in
+      Fs_compat.Durable_mutation.fold_report report
+        ~not_committed:(fun report ->
+          Log.Institution.warn
+            "JSONL episode cap not committed: %s"
+            (Fs_compat.Durable_mutation.report_to_string report);
+          0)
+        ~committed_not_durable:(fun report ->
+          Log.Institution.warn
+            "JSONL episode cap committed with sync debt path=%s detail=%s"
+            path
+            (Fs_compat.Durable_mutation.report_to_string report);
+          total - max_lines)
+        ~durable:(fun report ->
+          (match report.diagnostics with
+           | [] -> ()
+           | _ ->
+             Log.Institution.warn
+               "JSONL episode cap durable with cleanup diagnostics path=%s detail=%s"
+               path
+               (Fs_compat.Durable_mutation.report_to_string report));
+          total - max_lines))))
 ;;

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -242,7 +242,27 @@ let save_rules_unlocked ~base_path rules : (unit, string) result =
   let path = rules_path ~base_path () in
   Fs_compat.mkdir_p (Filename.dirname path);
   let json = `List (List.map approval_rule_to_yojson rules) in
-  Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json)
+  let report =
+    Fs_compat.save_file_atomic_eio path (Yojson.Safe.pretty_to_string json)
+  in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Keeper.warn
+        "approval rules committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Keeper.warn
+           "approval rules durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok ())
 ;;
 
 let list_rules ~base_path () =

--- a/lib/keeper/keeper_chat_media_store.ml
+++ b/lib/keeper/keeper_chat_media_store.ml
@@ -228,9 +228,25 @@ let persist_result ~base_dir ~media_type ~data =
         | Some _ -> Ok (token, url)
         | None ->
             let path = Filename.concat dir (token ^ "." ^ ext) in
-            (match Fs_compat.save_file_atomic path data with
-             | Ok () -> Ok (token, url)
-             | Error msg -> Error msg)
+            let report = Fs_compat.save_file_atomic_eio path data in
+            Fs_compat.Durable_mutation.fold_report report
+              ~not_committed:(fun report ->
+                Error (Fs_compat.Durable_mutation.report_to_string report))
+              ~committed_not_durable:(fun report ->
+                Log.Keeper.warn
+                  "chat media committed with sync debt path=%s detail=%s"
+                  path
+                  (Fs_compat.Durable_mutation.report_to_string report);
+                Ok (token, url))
+              ~durable:(fun report ->
+                (match report.diagnostics with
+                 | [] -> ()
+                 | _ ->
+                   Log.Keeper.warn
+                     "chat media durable with cleanup diagnostics path=%s detail=%s"
+                     path
+                     (Fs_compat.Durable_mutation.report_to_string report));
+                Ok (token, url))
       with
       | exn ->
           Error

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -67,6 +67,8 @@ let schema = "keeper_chat_queue.v1"
 let persistence_file = "chat-queue.json"
 let persistence_base_path : string option Atomic.t = Atomic.make None
 let fail_next_persist_for_testing = Atomic.make false
+let force_next_sync_debt_for_testing = Atomic.make false
+let fail_next_durability_confirmation_for_testing = Atomic.make false
 let lease_counter = Atomic.make 0
 let receipt_counter = Atomic.make 0
 
@@ -269,10 +271,93 @@ let entry_state_of_yojson json =
 
 let save_json_atomic path json =
   Fs_compat.mkdir_p (Filename.dirname path);
-  json
-  |> Safe_ops.sanitize_json_utf8
-  |> Yojson.Safe.pretty_to_string
-  |> Fs_compat.save_file_atomic path
+  let content =
+    json
+    |> Safe_ops.sanitize_json_utf8
+    |> Yojson.Safe.pretty_to_string
+  in
+  let report = Fs_compat.save_file_atomic_eio path content in
+  let report =
+    if Atomic.exchange force_next_sync_debt_for_testing false
+    then
+      match report.progress with
+      | Fs_compat.Durable_mutation.Durable value ->
+        { report with
+          progress =
+            Fs_compat.Durable_mutation.Committed_not_durable
+              { value
+              ; cause = Failure "injected chat queue parent-sync debt"
+              ; backtrace = Printexc.get_callstack 8
+              }
+        }
+      | Fs_compat.Durable_mutation.Not_committed _
+      | Fs_compat.Durable_mutation.Committed_not_durable _ ->
+        report
+    else report
+  in
+  let report =
+    Fs_compat.Durable_mutation.observe_and_retain
+      (fun report ->
+         match report.progress with
+         | Fs_compat.Durable_mutation.Not_committed _ -> ()
+         | Fs_compat.Durable_mutation.Committed_not_durable _ ->
+           Log.Keeper.warn
+             "chat queue snapshot committed with sync debt path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report)
+         | Fs_compat.Durable_mutation.Durable () ->
+           (match report.diagnostics with
+            | [] -> ()
+            | _ ->
+              Log.Keeper.warn
+                "chat queue snapshot durable with cleanup diagnostics path=%s detail=%s"
+                path
+                (Fs_compat.Durable_mutation.report_to_string report)))
+      report
+  in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      let confirmation =
+        if Atomic.exchange fail_next_durability_confirmation_for_testing false
+        then
+          { Fs_compat.Durable_mutation.confirmation =
+              Fs_compat.Durable_mutation.Not_confirmed
+                { cause = Failure "injected chat queue durability confirmation failure"
+                ; backtrace = Printexc.get_callstack 8
+                }
+          ; confirmation_diagnostics = []
+          }
+        else
+          Fs_compat.Durable_mutation.confirm_directory_durable_eio
+            (Filename.dirname path)
+      in
+      let confirmation =
+        Fs_compat.Durable_mutation.observe_confirmation_and_retain
+          (fun report ->
+             match report.confirmation_diagnostics with
+             | [] -> ()
+             | diagnostics ->
+               Log.Keeper.warn
+                 "chat queue parent durability confirmation has diagnostics path=%s detail=%s"
+                 path
+                 (String.concat
+                    "; "
+                    (List.map
+                       Fs_compat.Durable_mutation.diagnostic_to_string
+                       diagnostics)))
+          confirmation
+      in
+      match confirmation.confirmation with
+      | Fs_compat.Durable_mutation.Confirmed -> Ok ()
+      | Fs_compat.Durable_mutation.Not_confirmed { cause; _ } ->
+        Error
+          (Printf.sprintf
+             "%s; parent durability confirmation failed: %s"
+             (Fs_compat.Durable_mutation.report_to_string report)
+             (Printexc.to_string cause)))
+    ~durable:(fun _report -> Ok ())
 
 let load_snapshot ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name with
@@ -697,8 +782,15 @@ let configure_persistence ~base_path =
 module For_testing = struct
   let reset () =
     Atomic.set fail_next_persist_for_testing false;
+    Atomic.set force_next_sync_debt_for_testing false;
+    Atomic.set fail_next_durability_confirmation_for_testing false;
     Atomic.set persistence_base_path None;
     Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)
 
   let fail_next_persist () = Atomic.set fail_next_persist_for_testing true
+  let force_next_sync_debt () = Atomic.set force_next_sync_debt_for_testing true
+
+  let fail_next_durability_confirmation () =
+    Atomic.set fail_next_durability_confirmation_for_testing true
+  ;;
 end

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -49,6 +49,9 @@ type lease = {
   messages : queued_message list;
 }
 
+exception Persistence_failed of string
+(** Raised when an enqueue mutation cannot be acknowledged as durable. *)
+
 (** [continuation_channel_of_message_source source] converts queued chat
     provenance into the RFC-0320 continuation-channel type. Dashboard queue
     sources may supply [dashboard_thread_id] from the local AG-UI thread; when
@@ -79,7 +82,9 @@ val persistence_configured : unit -> bool
     queue.  Creates the queue lazily if it does not yet exist. Returns a
     freshly minted [receipt_id] correlation token for this specific message
     (not persisted, not required to be unique across process restarts) so a
-    caller such as the dashboard busy-ack can echo it back to the sender. *)
+    caller such as the dashboard busy-ack can echo it back to the sender.
+    Raises [Persistence_failed] instead of returning a receipt when the
+    snapshot cannot be confirmed durable. *)
 val enqueue : keeper_name:string -> queued_message -> string
 
 (** [dequeue keeper_name] removes and returns the head message, or
@@ -182,4 +187,6 @@ val all_keeper_names : unit -> string list
 module For_testing : sig
   val reset : unit -> unit
   val fail_next_persist : unit -> unit
+  val force_next_sync_debt : unit -> unit
+  val fail_next_durability_confirmation : unit -> unit
 end

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -123,7 +123,7 @@ val create_session : session_id:string -> base_dir:string -> session_context
 
 (** {1 History migration} *)
 
-(** Stats returned by [migrate_session_history_logs]. *)
+(** Stats returned by the history migration entry points. *)
 type history_migration_stats =
   { moved_lines : int
   ; dropped_lines : int
@@ -131,16 +131,54 @@ type history_migration_stats =
   ; malformed_lines : int
   }
 
+type history_migration_stage =
+  | Internal_history
+  | Main_history
+
+type history_migration_error =
+  | History_write_not_committed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_write_committed_not_durable of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_directory_durability_not_confirmed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : Fs_compat.Durable_mutation.durability_confirmation_report
+      }
+
+val history_migration_error_to_string : history_migration_error -> string
+
 (** [true] iff [text] looks like a Current World State system
     context block (used to drop legacy world-state echoes from
     history.jsonl). *)
 val has_world_state_signature : string -> bool
 
 (** Move every internal-history entry from [history.jsonl] to
-    [history.internal.jsonl], drop world-state echoes, and dedupe
-    the merged internal log. *)
-val migrate_session_history_logs :
-  session_dir:string -> history_migration_stats
+    [history.internal.jsonl], drop world-state echoes, and dedupe the merged
+    internal log. The internal file commits first; a retry after a main-file
+    failure confirms the parent-directory durability of an already-identical
+    internal write before advancing, so moved lines are never lost or
+    duplicated. *)
+val migrate_session_history_logs_blocking :
+  session_dir:string -> (history_migration_stats, history_migration_error) result
+
+val migrate_session_history_logs_eio :
+  session_dir:string -> (history_migration_stats, history_migration_error) result
+
+module For_testing : sig
+  val migrate_session_history_logs_with :
+    ?confirm_parent_durable:
+      (string -> Fs_compat.Durable_mutation.durability_confirmation_report) ->
+    (string -> string -> unit Fs_compat.Durable_mutation.report) ->
+    session_dir:string ->
+    (history_migration_stats, history_migration_error) result
+end
 
 (** {1 JSONL persistence} *)
 

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -18,6 +18,59 @@ type history_migration_stats =
   ; malformed_lines : int
   }
 
+type history_migration_stage =
+  | Internal_history
+  | Main_history
+
+type history_migration_error =
+  | History_write_not_committed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_write_committed_not_durable of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_directory_durability_not_confirmed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : Fs_compat.Durable_mutation.durability_confirmation_report
+      }
+
+let history_migration_stage_to_string = function
+  | Internal_history -> "internal_history"
+  | Main_history -> "main_history"
+;;
+
+let history_migration_error_to_string = function
+  | History_write_not_committed { stage; path; report } ->
+    Printf.sprintf
+      "history migration %s write not committed path=%s: %s"
+      (history_migration_stage_to_string stage)
+      path
+      (Fs_compat.Durable_mutation.report_to_string report)
+  | History_write_committed_not_durable { stage; path; report } ->
+    Printf.sprintf
+      "history migration %s write committed but not durable path=%s: %s"
+      (history_migration_stage_to_string stage)
+      path
+      (Fs_compat.Durable_mutation.report_to_string report)
+  | History_directory_durability_not_confirmed { stage; path; report } ->
+    let detail =
+      match report.confirmation with
+      | Fs_compat.Durable_mutation.Not_confirmed { cause; _ } ->
+        Printexc.to_string cause
+      | Fs_compat.Durable_mutation.Confirmed -> "unexpected confirmed state"
+    in
+    Printf.sprintf
+      "history migration %s directory durability not confirmed path=%s: %s"
+      (history_migration_stage_to_string stage)
+      path
+      detail
+;;
+
 let empty_history_migration_stats =
   { moved_lines = 0; dropped_lines = 0; kept_lines = 0; malformed_lines = 0 }
 
@@ -88,23 +141,31 @@ let dedupe_preserve_order (lines : string list) : string list =
   in
   go StringSet.empty [] lines
 
-let migrate_session_history_logs ~(session_dir : string) :
-    history_migration_stats =
+let migrate_session_history_logs_with
+  ?(confirm_parent_durable =
+    Fs_compat.Durable_mutation.confirm_directory_durable_blocking)
+  writer
+  ~(session_dir : string)
+  =
   let main_path = Filename.concat session_dir "history.jsonl" in
   let internal_path = Filename.concat session_dir "history.internal.jsonl" in
   if (not (Fs_compat.file_exists main_path))
      && not (Fs_compat.file_exists internal_path)
-  then empty_history_migration_stats
+  then Ok empty_history_migration_stats
   else
+    let main_content =
+      if Fs_compat.file_exists main_path then Fs_compat.load_file main_path else ""
+    in
     let main_lines =
-      if Fs_compat.file_exists main_path
-      then split_jsonl_lines (Fs_compat.load_file main_path)
-      else []
+      split_jsonl_lines main_content
+    in
+    let existing_internal_content =
+      if Fs_compat.file_exists internal_path
+      then Fs_compat.load_file internal_path
+      else ""
     in
     let existing_internal =
-      if Fs_compat.file_exists internal_path
-      then split_jsonl_lines (Fs_compat.load_file internal_path)
-      else []
+      split_jsonl_lines existing_internal_content
     in
     let kept_rev, moved_rev, dropped_main, malformed_main =
       List.fold_left
@@ -138,55 +199,134 @@ let migrate_session_history_logs ~(session_dir : string) :
     let malformed_lines = malformed_main + malformed_internal in
     if moved_lines = [] && total_dropped = 0
     then
-      { moved_lines = 0
-      ; dropped_lines = 0
-      ; kept_lines = List.length kept_lines
-      ; malformed_lines
-      }
+      Ok
+        { moved_lines = 0
+        ; dropped_lines = 0
+        ; kept_lines = List.length kept_lines
+        ; malformed_lines
+        }
     else (
       let merged_internal =
         dedupe_preserve_order (sanitized_internal @ moved_lines)
       in
-      (match Fs_compat.save_file_atomic main_path (render_jsonl_lines kept_lines) with
-       | Ok () -> ()
-       | Error detail ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string CheckpointFailures)
-             ~labels:
-               [ ( "operation"
-                 , Keeper_checkpoint_failure_operation.(to_label Migrate_main_history)
-                 )
-               ]
-             ();
-           Log.Keeper.error
-             "migrate_session_history_logs: save main history failed for %s: %s"
-             main_path
-             detail);
-      (match
-         Fs_compat.save_file_atomic
-           internal_path
-           (render_jsonl_lines merged_internal)
-       with
-       | Ok () -> ()
-       | Error detail ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string CheckpointFailures)
-             ~labels:
-               [ ( "operation"
-                 , Keeper_checkpoint_failure_operation.(
-                     to_label Migrate_internal_history)
-                 )
-               ]
-             ();
-           Log.Keeper.error
-             "migrate_session_history_logs: save internal history failed for %s: %s"
-             internal_path
-             detail);
-      { moved_lines = List.length moved_lines
-      ; dropped_lines = total_dropped
-      ; kept_lines = List.length kept_lines
-      ; malformed_lines
-      })
+      let save_history ~stage ~path ~content ~operation =
+        let report = writer path content in
+        let report =
+          Fs_compat.Durable_mutation.observe_and_retain
+            (fun report ->
+               match report.progress with
+               | Fs_compat.Durable_mutation.Not_committed _ ->
+                 Otel_metric_store.inc_counter
+                   Keeper_metrics.(to_string CheckpointFailures)
+                   ~labels:
+                     [ ( "operation"
+                       , Keeper_checkpoint_failure_operation.(to_label operation)
+                       )
+                     ]
+                   ();
+                 Log.Keeper.error
+                   "migrate_session_history_logs: save not committed for %s: %s"
+                   path
+                   (Fs_compat.Durable_mutation.report_to_string report)
+               | Fs_compat.Durable_mutation.Committed_not_durable _ ->
+                 Log.Keeper.warn
+                   "migrate_session_history_logs: committed with sync debt path=%s detail=%s"
+                   path
+                   (Fs_compat.Durable_mutation.report_to_string report)
+               | Fs_compat.Durable_mutation.Durable () ->
+                 (match report.diagnostics with
+                  | [] -> ()
+                  | _ ->
+                    Log.Keeper.warn
+                      "migrate_session_history_logs: durable with cleanup diagnostics path=%s detail=%s"
+                      path
+                      (Fs_compat.Durable_mutation.report_to_string report)))
+            report
+        in
+        Fs_compat.Durable_mutation.fold_report report
+          ~not_committed:(fun report ->
+            Error (History_write_not_committed { stage; path; report }))
+          ~committed_not_durable:(fun report ->
+            Error (History_write_committed_not_durable { stage; path; report }))
+          ~durable:(fun _report -> Ok ())
+      in
+      let confirm_history_parent ~stage ~path =
+        let report = confirm_parent_durable (Filename.dirname path) in
+        let report =
+          Fs_compat.Durable_mutation.observe_confirmation_and_retain
+            (fun report ->
+               match report.confirmation_diagnostics with
+               | [] -> ()
+               | diagnostics ->
+                 Log.Keeper.warn
+                   "migrate_session_history_logs: directory durability confirmation has diagnostics path=%s detail=%s"
+                   path
+                   (String.concat
+                      "; "
+                      (List.map
+                         Fs_compat.Durable_mutation.diagnostic_to_string
+                         diagnostics)))
+            report
+        in
+        match report.confirmation with
+        | Fs_compat.Durable_mutation.Not_confirmed _ ->
+          Error
+            (History_directory_durability_not_confirmed
+               { stage; path; report })
+        | Fs_compat.Durable_mutation.Confirmed -> Ok ()
+      in
+      let next_internal_content = render_jsonl_lines merged_internal in
+      let internal_result =
+        if String.equal next_internal_content existing_internal_content
+        then
+          if moved_lines = []
+          then Ok ()
+          else confirm_history_parent ~stage:Internal_history ~path:internal_path
+        else
+          save_history
+            ~stage:Internal_history
+            ~path:internal_path
+            ~content:next_internal_content
+            ~operation:Keeper_checkpoint_failure_operation.Migrate_internal_history
+      in
+      match internal_result with
+      | Error _ as error -> error
+      | Ok () ->
+        let next_main_content = render_jsonl_lines kept_lines in
+        let main_result =
+          if String.equal next_main_content main_content
+          then Ok ()
+          else
+            save_history
+              ~stage:Main_history
+              ~path:main_path
+              ~content:next_main_content
+              ~operation:Keeper_checkpoint_failure_operation.Migrate_main_history
+        in
+        (match main_result with
+         | Error _ as error -> error
+         | Ok () ->
+           Ok
+             { moved_lines = List.length moved_lines
+             ; dropped_lines = total_dropped
+             ; kept_lines = List.length kept_lines
+             ; malformed_lines
+             }))
+;;
+
+let migrate_session_history_logs_blocking =
+  migrate_session_history_logs_with Fs_compat.save_file_atomic_blocking
+;;
+
+let migrate_session_history_logs_eio ~session_dir =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"keeper-history-migration" (fun () ->
+      migrate_session_history_logs_blocking ~session_dir))
+;;
+
+module For_testing = struct
+  let migrate_session_history_logs_with = migrate_session_history_logs_with
+end
 
 let history_path_for_source ~(session_dir : string) ~(source : string option) :
     string =

--- a/lib/keeper/keeper_context_core_history.mli
+++ b/lib/keeper/keeper_context_core_history.mli
@@ -11,6 +11,29 @@ type history_migration_stats =
   ; malformed_lines : int
   }
 
+type history_migration_stage =
+  | Internal_history
+  | Main_history
+
+type history_migration_error =
+  | History_write_not_committed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_write_committed_not_durable of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : unit Fs_compat.Durable_mutation.report
+      }
+  | History_directory_durability_not_confirmed of
+      { stage : history_migration_stage
+      ; path : string
+      ; report : Fs_compat.Durable_mutation.durability_confirmation_report
+      }
+
+val history_migration_error_to_string : history_migration_error -> string
+
 val empty_history_migration_stats : history_migration_stats
 
 val split_jsonl_lines : string -> string list
@@ -32,7 +55,20 @@ val render_jsonl_lines : string list -> string
 
 val dedupe_preserve_order : string list -> string list
 
-val migrate_session_history_logs : session_dir:string -> history_migration_stats
+val migrate_session_history_logs_blocking :
+  session_dir:string -> (history_migration_stats, history_migration_error) result
+
+val migrate_session_history_logs_eio :
+  session_dir:string -> (history_migration_stats, history_migration_error) result
+
+module For_testing : sig
+  val migrate_session_history_logs_with :
+    ?confirm_parent_durable:
+      (string -> Fs_compat.Durable_mutation.durability_confirmation_report) ->
+    (string -> string -> unit Fs_compat.Durable_mutation.report) ->
+    session_dir:string ->
+    (history_migration_stats, history_migration_error) result
+end
 
 val history_path_for_source : session_dir:string -> source:string option -> string
 

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -72,17 +72,18 @@ let clear_dir_cache () : unit =
 (* ================================================================ *)
 
 (** Atomically save [content] to [path].
-    Delegates to {!Fs_compat.save_file_atomic} (Eio-aware, re-raises
-    [Eio.Cancel.Cancelled]).  Ensures the parent directory exists first.
+    Delegates to {!Fs_compat.save_file_atomic_eio}. Ensures the parent
+    directory exists first.
 
     Returns [(unit, string) result] for explicit error handling. *)
 let save_atomic (path : string) (content : string) : (unit, string) result =
   try
     let dir = Filename.dirname path in
     ignore (ensure_dir dir);
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> Ok ()
-    | Error msg ->
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        let msg = Fs_compat.Durable_mutation.report_to_string report in
         Keeper_fd_pressure.note_if_fd_exhaustion
           ~site:"filesystem_runtime.save_atomic"
           msg;
@@ -94,7 +95,22 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
           ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Save_atomic_failed))]
           ();
         Log.Keeper.warn "filesystem_runtime: save_atomic failed path=%s error=%s" path msg;
-        Error msg
+        Error msg)
+      ~committed_not_durable:(fun report ->
+        Log.Keeper.warn
+          "filesystem_runtime: save_atomic committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Ok ())
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Keeper.warn
+             "filesystem_runtime: save_atomic durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Ok ())
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -172,30 +172,51 @@ let record_handoff_artifacts
       ~parent ~child ~parent_trace_id ~trigger_reason ~context_ratio
   in
   ignore (Keeper_fs.ensure_dir (Filename.dirname manifest_path));
-  match
-    Fs_compat.save_file_atomic manifest_path (Yojson.Safe.pretty_to_string manifest)
-  with
-  | Ok () ->
-      (try
-         Keeper_types_support.append_jsonl_line index_path index_entry
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string GenerationLineageFailures)
-             ~labels:[("keeper", child.name); ("site", Keeper_generation_lineage_failure_site.(to_label Index_append))]
-             ();
-           Log.Keeper.warn ~keeper_name:child.name
-             "failed to append generation index %s: %s"
-             index_path (Printexc.to_string exn))
-  | Error err ->
+  let append_index () =
+    try Keeper_types_support.append_jsonl_line index_path index_entry with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string GenerationLineageFailures)
+        ~labels:
+          [ ("keeper", child.name)
+          ; ("site", Keeper_generation_lineage_failure_site.(to_label Index_append))
+          ]
+        ();
+      Log.Keeper.warn ~keeper_name:child.name
+        "failed to append generation index %s: %s"
+        index_path (Printexc.to_string exn)
+  in
+  let report =
+    Fs_compat.save_file_atomic_eio
+      manifest_path
+      (Yojson.Safe.pretty_to_string manifest)
+  in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string GenerationLineageFailures)
         ~labels:[("keeper", child.name); ("site", Keeper_generation_lineage_failure_site.(to_label Manifest_save))]
         ();
       Log.Keeper.warn ~keeper_name:child.name
         "failed to save generation manifest %s: %s"
-        manifest_path err
+        manifest_path
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Keeper.warn ~keeper_name:child.name
+        "generation manifest committed with sync debt path=%s detail=%s"
+        manifest_path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      append_index ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Keeper.warn ~keeper_name:child.name
+           "generation manifest durable with cleanup diagnostics path=%s detail=%s"
+           manifest_path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      append_index ())
 
 let load_json_file_opt path =
   if not (Fs_compat.file_exists path) then None

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -421,7 +421,25 @@ let write_memory_bank_rows_unlocked
       |> String.concat "\n"
     in
     let content = if content <> "" then content ^ "\n" else content in
-    Fs_compat.save_file_atomic path content
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Error (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Keeper.warn
+          "memory bank rewrite committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Ok ())
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Keeper.warn
+             "memory bank rewrite durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Ok ())
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "failed to rewrite memory bank: %s" (Printexc.to_string exn))
 

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -170,14 +170,29 @@ let with_out_channel oc ~f =
    does not currently reach the keepers dir, so a SIGKILL between write and rename
    still leaves an uncollected [.atomic_*.tmp] here — a pre-existing gap (the old
    hand-rolled temp was not swept either), tracked separately, not worsened here.
-   The Memory OS write contract raises on failure (unit return), so map [Error] to
-   [Atomic_write_failed]; the temp is already cleaned up by [save_file_atomic], and
-   [Eio.Cancel.Cancelled] is re-raised by it (RFC-0143), never swallowed. *)
+   The Memory OS write contract raises only for [Not_committed]. A committed
+   parent-sync debt is observable but must not trigger a duplicate write. *)
 let write_file_atomically path content =
   ensure_dir (Filename.dirname path);
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
-  | Error msg -> raise (Atomic_write_failed msg)
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      raise
+        (Atomic_write_failed
+           (Fs_compat.Durable_mutation.report_to_string report)))
+    ~committed_not_durable:(fun report ->
+      Log.Keeper.warn
+        "memory-os file committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report))
+    ~durable:(fun report ->
+      match report.diagnostics with
+      | [] -> ()
+      | _ ->
+        Log.Keeper.warn
+          "memory-os file durable with cleanup diagnostics path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
 ;;
 
 let generation_counter_path ~keeper_id ~trace_id =

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -448,13 +448,45 @@ let docker_user_identity_mount_args ~host_root ~uid ~gid =
   let group = Printf.sprintf "root:x:0:\nkeeper:x:%d:\n" gid in
   try
     Fs_compat.mkdir_p dir;
-    match Fs_compat.save_file_atomic passwd_path passwd with
-    | Error err -> Error (Printf.sprintf "failed to write docker passwd file: %s" err)
-    | Ok () ->
-      (match Fs_compat.save_file_atomic group_path group with
-       | Error err -> Error (Printf.sprintf "failed to write docker group file: %s" err)
-       | Ok () ->
-         Ok [ "-v"; passwd_path ^ ":/etc/passwd:ro"; "-v"; group_path ^ ":/etc/group:ro" ])
+    let write_identity_file ~label ~path content =
+      let report = Fs_compat.save_file_atomic_eio path content in
+      Fs_compat.Durable_mutation.fold_report report
+        ~not_committed:(fun report ->
+          Error
+            (Printf.sprintf
+               "failed to write docker %s file: %s"
+               label
+               (Fs_compat.Durable_mutation.report_to_string report)))
+        ~committed_not_durable:(fun report ->
+          Log.Keeper.warn
+            "docker %s file committed with sync debt path=%s detail=%s"
+            label
+            path
+            (Fs_compat.Durable_mutation.report_to_string report);
+          Ok ())
+        ~durable:(fun report ->
+          (match report.diagnostics with
+           | [] -> ()
+           | _ ->
+             Log.Keeper.warn
+               "docker %s file durable with cleanup diagnostics path=%s detail=%s"
+               label
+               path
+               (Fs_compat.Durable_mutation.report_to_string report));
+          Ok ())
+    in
+    (match write_identity_file ~label:"passwd" ~path:passwd_path passwd with
+     | Error _ as error -> error
+     | Ok () ->
+       (match write_identity_file ~label:"group" ~path:group_path group with
+        | Error _ as error -> error
+        | Ok () ->
+          Ok
+            [ "-v"
+            ; passwd_path ^ ":/etc/passwd:ro"
+            ; "-v"
+            ; group_path ^ ":/etc/group:ro"
+            ]))
   with
   | Sys_error err | Unix.Unix_error (_, _, err) ->
     Error (Printf.sprintf "failed to prepare docker user identity: %s" err)

--- a/lib/keeper/keeper_secret_projection.ml
+++ b/lib/keeper/keeper_secret_projection.ml
@@ -556,6 +556,28 @@ let reject_base_keeper_scope_mutation ~keeper_name ~scope =
   else Ok ()
 ;;
 
+let save_secret_atomic path content =
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Keeper.warn
+        "keeper secret committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Keeper.warn
+           "keeper secret durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok ())
+;;
+
 let set_env_entry ~base_path ~keeper_name ~scope ~name ~value =
   match reject_base_keeper_scope_mutation ~keeper_name ~scope with
   | Error _ as err -> err
@@ -580,7 +602,7 @@ let set_env_entry ~base_path ~keeper_name ~scope ~name ~value =
               (match validate_env_entry_target path with
                | Error _ as err -> err
                | Ok () ->
-                 (match Fs_compat.save_file_atomic path value with
+                 (match save_secret_atomic path value with
                   | Error _ as err -> err
                   | Ok () ->
                     (try
@@ -766,7 +788,7 @@ let set_file_entry ~base_path ~keeper_name ~scope ~container_path ~value =
                  (match validate_file_entry_target path with
                   | Error _ as err -> err
                   | Ok () ->
-                    (match Fs_compat.save_file_atomic path value with
+                    (match save_secret_atomic path value with
                      | Error _ as err -> err
                      | Ok () ->
                        (try
@@ -914,7 +936,7 @@ let local_git_config_global_path ~base_path ~keeper_name =
 let ensure_local_git_config_global ~path =
   try
     ensure_dir (Filename.dirname path);
-    match Fs_compat.save_file_atomic path git_config_helper_content with
+    match save_secret_atomic path git_config_helper_content with
     | Ok () -> Ok ()
     | Error err -> Error err
   with
@@ -1107,7 +1129,7 @@ let ensure_docker_git_config_global ~base_path ~keeper_name =
   let path = docker_git_config_host_path ~base_path ~keeper_name in
   try
     ensure_dir (Filename.dirname path);
-    match Fs_compat.save_file_atomic path git_config_helper_content with
+    match save_secret_atomic path git_config_helper_content with
     | Ok () -> Ok path
     | Error err -> Error err
   with

--- a/lib/keeper/keeper_tool_persona_crud.ml
+++ b/lib/keeper/keeper_tool_persona_crud.ml
@@ -53,16 +53,30 @@ let write_profile persona_name json =
   let dir = Filename.concat (personas_dir ()) persona_name in
   let path = Filename.concat dir "profile.json" in
   (try Fs_compat.mkdir_p dir with _ -> ());
-  let tmp = path ^ ".tmp" in
   let content = Yojson.Safe.to_string ~std:true json in
-  match Fs_compat.save_file_atomic tmp content with
-  | Error msg -> Error ("Failed to write " ^ path ^ ": " ^ msg)
-  | Ok () ->
-      (try
-         Fs_compat.rename tmp path;
-         Ok (ok_assoc [("persona_name", `String persona_name); ("path", `String path)])
-       with exn ->
-         Error ("Failed to rename tmp file: " ^ Printexc.to_string exn))
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error
+        ("Failed to write "
+         ^ path
+         ^ ": "
+         ^ Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Keeper.warn
+        "persona profile committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok (ok_assoc [("persona_name", `String persona_name); ("path", `String path)]))
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Keeper.warn
+           "persona profile durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok (ok_assoc [("persona_name", `String persona_name); ("path", `String path)]))
 
 let validate_create_args args =
   let persona_name = get_string_opt args "persona_name" in

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -276,15 +276,35 @@ let persist_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
             | Error _ as err -> err
             | Ok content -> (
                 Fs_compat.mkdir_p (Filename.dirname path);
-                match Fs_compat.save_file_atomic path content with
-                | Error msg -> Error msg
-                | Ok () ->
+                let report = Fs_compat.save_file_atomic_eio path content in
+                Fs_compat.Durable_mutation.fold_report report
+                  ~not_committed:(fun report ->
+                    Error (Fs_compat.Durable_mutation.report_to_string report))
+                  ~committed_not_durable:(fun report ->
+                    Log.Keeper.warn
+                      "keeper persona runtime committed with sync debt path=%s detail=%s"
+                      path
+                      (Fs_compat.Durable_mutation.report_to_string report);
                     Ok
                       (`Assoc
                         [
                           ("path", `String path);
                           ("created", `Bool true);
-                        ])))
+                        ]))
+                  ~durable:(fun report ->
+                    (match report.diagnostics with
+                     | [] -> ()
+                     | _ ->
+                       Log.Keeper.warn
+                         "keeper persona runtime durable with cleanup diagnostics path=%s detail=%s"
+                         path
+                         (Fs_compat.Durable_mutation.report_to_string report));
+                    Ok
+                      (`Assoc
+                        [
+                          ("path", `String path);
+                          ("created", `Bool true);
+                        ]))))
 
 let resolved_keeper_args_from_persona args :
     ((persona_summary * Yojson.Safe.t), string) result =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -451,7 +451,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         match p.runtime_id_opt with
         | None -> Ok ()
         | Some runtime_id ->
-          Runtime.set_runtime_id_for_keeper
+          Runtime.set_runtime_id_for_keeper_eio
             ~keeper_name:p.name
             ~runtime_id
             ()

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -308,7 +308,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
            match p.runtime_id_opt with
            | None -> Ok ()
            | Some runtime_id ->
-             Runtime.set_runtime_id_for_keeper
+             Runtime.set_runtime_id_for_keeper_eio
                ~keeper_name:p.name
                ~runtime_id
                ()

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -7,6 +7,8 @@ type mode =
   | Eager
   | Store_only
 
+let store_artifact_ref = Atomic.make Keeper_vision_tool.store_artifact
+
 (* SSOT placeholder formats. The handle always lets the keeper re-read the
    pixels via the analyze_image tool; the eager [read] text carries the meaning
    so most follow-up turns answer without any further vision call. *)
@@ -146,7 +148,9 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                 (image_store_failed_placeholder ~reason:"unsupported image media type")
             | Ok media_type ->
               (match
-                 Keeper_vision_tool.store_artifact ~dir:(store_dir ~keeper_name) bytes
+                 (Atomic.get store_artifact_ref)
+                   ~dir:(store_dir ~keeper_name)
+                   bytes
                with
                | Error _ ->
                  record_eviction ~mode ~result:"error" ~reason:"store_failed";
@@ -216,3 +220,14 @@ let evict_message ~mode ~policy ~keeper_name (message : Agent_sdk.Types.message)
     }
   else message
 ;;
+
+module For_testing = struct
+  let with_store_artifact store f =
+    let previous = Atomic.get store_artifact_ref in
+    Fun.protect
+      ~finally:(fun () -> Atomic.set store_artifact_ref previous)
+      (fun () ->
+         Atomic.set store_artifact_ref store;
+         f ())
+  ;;
+end

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -40,9 +40,9 @@ val evict_blocks
   -> Agent_sdk.Types.content_block list
 (** Site 1. Evict every [Image] in the list when [policy = Mm_delegate]; return
     the list unchanged otherwise. Images are fail-closed before store on
-    base64 payload, size, and media type. [Eager] consults the
-    fiber-local Eio context for one bounded sub-call; with none present (tests)
-    it falls back to an unread placeholder, so eviction still holds. *)
+    base64 payload, size, and media type. The delegate path requires an Eio
+    context for durable storage. [Eager] then consults the fiber-local Eio
+    context for one bounded sub-call. *)
 
 val evict_message
   :  mode:mode
@@ -53,3 +53,13 @@ val evict_message
 (** Site 2. Same transform applied to a message's content blocks at the
     checkpoint write boundary. Use [Store_only] here — checkpoint writes must
     not block the turn fiber on a provider call. *)
+
+module For_testing : sig
+  val with_store_artifact :
+    (dir:string ->
+     string ->
+     (Multimodal.Vision_artifact_store.handle, string) result) ->
+    (unit -> 'a) ->
+    'a
+  (** Scope an explicit blocking/failure-injection store for non-Eio tests. *)
+end

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -151,7 +151,7 @@ let vision_store_dir ~keeper_name =
   Filename.concat (Config_dir_resolver.keepers_dir ()) (keeper_name ^ ".vision")
 
 let store_artifact ~dir bytes =
-  Eio_guard.run_in_systhread (fun () -> Store.store ~dir bytes)
+  Store.store_eio ~dir bytes
 
 let load_artifact ~dir handle =
   Eio_guard.run_in_systhread (fun () -> Store.load ~dir handle)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -50,7 +50,7 @@ let inflight_snapshot_filename = "event-queue-inflight.json"
 
 (* [Fs_compat.mkdir_p] raises (Sys_error / Unix_error) on ENOSPC/EROFS/ENOTDIR
    instead of returning a result, so route it through the same [(unit, string)
-   result] channel as [save_file_atomic]. This keeps [save_json_atomic] total:
+   result] channel as the typed atomic writer. This keeps [save_json_atomic] total:
    it never raises for a disk failure, so the enclosing [with_write_lock]
    critical section returns normally and the shared mutex is not poisoned.
    [Eio.Cancel.Cancelled] is re-raised so cancellation is not flattened into a
@@ -63,10 +63,30 @@ let save_json_atomic path json =
   with
   | Error _ as err -> err
   | Ok () ->
-    json
-    |> Safe_ops.sanitize_json_utf8
-    |> Yojson.Safe.pretty_to_string
-    |> Fs_compat.save_file_atomic path
+    let content =
+      json
+      |> Safe_ops.sanitize_json_utf8
+      |> Yojson.Safe.pretty_to_string
+    in
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Error (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Keeper.warn
+          "event queue snapshot committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Ok ())
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Keeper.warn
+             "event queue snapshot durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Ok ())
 
 let snapshot_path ~base_path ~keeper_name =
   if valid_keeper_name keeper_name

--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -6,6 +6,6 @@
  ; RFC-0071 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries shared_types unix yojson fs_compat digestif eio)
+ (libraries shared_types unix yojson fs_compat digestif eio eio.unix masc_log)
  (preprocess
   (pps ppx_tla)))

--- a/lib/multimodal/vision_artifact_store.ml
+++ b/lib/multimodal/vision_artifact_store.ml
@@ -23,7 +23,7 @@ let is_canonical (h : handle) : bool =
 
 let path_of ~dir (h : handle) = Filename.concat dir h
 
-let store ~dir (raw : string) : (handle, string) result =
+let store_with writer ~dir (raw : string) : (handle, string) result =
   let h = hash raw in
   (* [Fs_compat.mkdir_p] returns unit and raises on failure (EACCES, ENOSPC, a
      parent path component that is a regular file, test-isolation breach). Honor
@@ -45,9 +45,37 @@ let store ~dir (raw : string) : (handle, string) result =
   with
   | Error _ as e -> e
   | Ok () ->
-    (match Fs_compat.save_file_atomic (path_of ~dir h) raw with
-     | Ok () -> Ok h
-     | Error msg -> Error (Printf.sprintf "Vision_artifact_store.store: %s" msg))
+    let path = path_of ~dir h in
+    let report = writer path raw in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Error
+          (Printf.sprintf
+             "Vision_artifact_store.store: %s"
+             (Fs_compat.Durable_mutation.report_to_string report)))
+      ~committed_not_durable:(fun report ->
+        Log.Misc.warn
+          "vision artifact committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Ok h)
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Misc.warn
+             "vision artifact durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Ok h)
+
+let store_blocking = store_with Fs_compat.save_file_atomic_blocking
+
+let store_eio ~dir raw =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"vision-artifact-store" (fun () ->
+      store_blocking ~dir raw))
+;;
 
 let load ~dir (h : handle) : (string, string) result =
   if not (is_canonical h) then

--- a/lib/multimodal/vision_artifact_store.mli
+++ b/lib/multimodal/vision_artifact_store.mli
@@ -6,11 +6,11 @@
     checkpoint round-trips. This keeps the bytes off the lossy {!Payload}
     [Lazy_payload] path ([Payload.of_json] rebuilds an empty closure): a
     checkpoint persists only the handle and the bytes are reloaded on demand.
-    Mirrors the content-addressed atomic-write pattern of [Review_artifact_store]
-    (SHA-256 hashing + [Fs_compat.save_file_atomic]). *)
+    Mirrors the content-addressed typed durable-write pattern of
+    [Review_artifact_store]. *)
 
 type handle = private string
-(** Opaque content hash (SHA-256 hex). Produced by {!store}; reconstruct a
+(** Opaque content hash (SHA-256 hex). Produced by the store entry points; reconstruct a
     persisted handle string with {!of_string}. *)
 
 val to_string : handle -> string
@@ -20,10 +20,14 @@ val of_string : string -> handle
 (** Re-wrap a handle string read back from a checkpoint. No I/O; integrity is
     verified later by {!load} (a wrong string fails closed there). *)
 
-val store : dir:string -> string -> (handle, string) result
-(** [store ~dir bytes] writes [bytes] to a content-addressed file under [dir] and
+val store_blocking : dir:string -> string -> (handle, string) result
+(** [store_blocking ~dir bytes] writes [bytes] on the calling thread and
     returns its handle. Idempotent: identical bytes map to the same handle and
     file, so a re-store overwrites identical content. [Error msg] on I/O failure. *)
+
+val store_eio : dir:string -> string -> (handle, string) result
+(** Eio-safe counterpart of {!store_blocking}. Directory creation and the
+    durable write run as one cancellation-protected system-thread job. *)
 
 val load : dir:string -> handle -> (string, string) result
 (** [load ~dir h] reads the bytes for [h]. [Error] (never a silent empty success)

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -151,17 +151,37 @@ let save_procedure ?base_path ~agent_name (p : procedure) =
     Fs_compat.append_jsonl path (to_json p))
 
 let rewrite_procedures ?base_path ~agent_name (procs : procedure list) =
-  with_procedures_lock ?base_path ~agent_name (fun () ->
-    let path = procedures_path ?base_path ~agent_name () in
-    let content =
-      procs
-      |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
-      |> String.concat "\n"
-      |> fun s -> if s = "" then "" else s ^ "\n"
-    in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () -> Ok ()
-    | Error msg -> Error msg)
+  try
+    with_procedures_lock ?base_path ~agent_name (fun () ->
+      let path = procedures_path ?base_path ~agent_name () in
+      let content =
+        procs
+        |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
+        |> String.concat "\n"
+        |> fun s -> if s = "" then "" else s ^ "\n"
+      in
+      let report = Fs_compat.save_file_atomic_eio path content in
+      Fs_compat.Durable_mutation.fold_report report
+        ~not_committed:(fun report ->
+          Error (Fs_compat.Durable_mutation.report_to_string report))
+        ~committed_not_durable:(fun report ->
+          Log.Misc.warn
+            "procedural memory rewrite committed with sync debt path=%s detail=%s"
+            path
+            (Fs_compat.Durable_mutation.report_to_string report);
+          Ok ())
+        ~durable:(fun report ->
+          (match report.diagnostics with
+           | [] -> ()
+           | _ ->
+             Log.Misc.warn
+               "procedural memory rewrite durable with cleanup diagnostics path=%s detail=%s"
+               path
+               (Fs_compat.Durable_mutation.report_to_string report));
+          Ok ()))
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
 
 (** Minimum evidence count required for crystallization.
     Configurable via MASC_PROC_MIN_EVIDENCE (default: 3).

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -131,7 +131,9 @@ let get_entry path =
 let release_entry entry =
   ignore (Atomic.fetch_and_add entry.active (-1))
 
-let run_blocking_lock_op f = Eio_guard.run_in_systhread f
+let run_blocking_lock_op f =
+  Eio_unix.run_in_systhread ~label:"file-lock" f
+;;
 
 (** Acquire a non-blocking Unix file lock (F_TLOCK) with retry.
     This is the blocking variant for callers that already run in a systhread
@@ -220,10 +222,34 @@ let acquire_flock_fd ?clock lock_path =
     ~mode:[ Unix.O_CREAT; Unix.O_WRONLY ] ~perm:0o644
     ~caller:"File_lock_eio" ()
 
-let release_flock_fd fd =
-  run_blocking_lock_op (fun () ->
-      (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
-      Unix.close fd)
+let release_flock_fd_blocking fd =
+  (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
+  Unix.close fd
+;;
+
+let release_flock_fd_eio fd =
+  run_blocking_lock_op (fun () -> release_flock_fd_blocking fd)
+;;
+
+let ensure_lock_parent lock_path =
+  let dir = Filename.dirname lock_path in
+  if not (Sys.file_exists dir) then
+    try Unix.mkdir dir 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+;;
+
+let with_lock_blocking path f =
+  let lock_path = path ^ ".lock" in
+  ensure_lock_parent lock_path;
+  let fd =
+    acquire_flock_retry ~lock_path
+      ~mode:[ Unix.O_CREAT; Unix.O_WRONLY ] ~perm:0o644
+      ~caller:"File_lock_eio.blocking" ()
+  in
+  Common.protect ~module_name:"file_lock_eio" ~finally_label:"blocking_finalizer"
+    ~finally:(fun () -> release_flock_fd_blocking fd)
+    f
+;;
 
 (** Run [f] while holding only the cooperative per-path mutex.
     Use this for in-memory backends that need single-process fiber
@@ -241,12 +267,10 @@ let with_mutex path f =
 let with_lock ?clock path f =
   let run_with_flock () =
     let lock_path = path ^ ".lock" in
-    let dir = Filename.dirname lock_path in
-    if not (Sys.file_exists dir) then
-      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    ensure_lock_parent lock_path;
     let fd = acquire_flock_fd ?clock lock_path in
     Common.protect ~module_name:"file_lock_eio" ~finally_label:"finalizer"
-      ~finally:(fun () -> release_flock_fd fd)
+      ~finally:(fun () -> release_flock_fd_eio fd)
       f
   in
   with_mutex path (fun () -> run_with_flock ())

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -66,10 +66,19 @@ val acquire_flock_fd :
   string ->
   Unix.file_descr
 
-(** [release_flock_fd fd] unlocks (best-effort) and closes [fd]. *)
-val release_flock_fd : Unix.file_descr -> unit
+(** [release_flock_fd_blocking fd] unlocks (best-effort) and closes [fd] on
+    the calling thread. *)
+val release_flock_fd_blocking : Unix.file_descr -> unit
+
+(** Eio-safe counterpart of {!release_flock_fd_blocking}. *)
+val release_flock_fd_eio : Unix.file_descr -> unit
 
 (** {1 High-level scoped locking} *)
+
+(** [with_lock_blocking path f] runs [f] while holding an OS-level flock on
+    [path ^ ".lock"]. It blocks the calling thread; callers that also need
+    same-process cross-domain exclusion must compose their own shared mutex. *)
+val with_lock_blocking : string -> (unit -> 'a) -> 'a
 
 (** [with_mutex path f] runs [f] while holding the cooperative
     per-[path] Eio.Mutex only. Use for in-memory backends that need

--- a/lib/prompt_registry/prompt_override_persistence.ml
+++ b/lib/prompt_registry/prompt_override_persistence.ml
@@ -202,9 +202,27 @@ let save ~path entries =
   | Ok json ->
       let content = Yojson.Safe.pretty_to_string json ^ "\n" in
       (try
-         match Fs_compat.save_file_atomic path content with
-         | Ok () -> Ok ()
-         | Error message -> Error (Write_failed message)
+         let report = Fs_compat.save_file_atomic_eio path content in
+         Fs_compat.Durable_mutation.fold_report report
+           ~not_committed:(fun report ->
+             Error
+               (Write_failed
+                  (Fs_compat.Durable_mutation.report_to_string report)))
+           ~committed_not_durable:(fun report ->
+             Log.Misc.warn
+               "prompt overrides committed with sync debt path=%s detail=%s"
+               path
+               (Fs_compat.Durable_mutation.report_to_string report);
+             Ok ())
+           ~durable:(fun report ->
+             (match report.diagnostics with
+              | [] -> ()
+              | _ ->
+                Log.Misc.warn
+                  "prompt overrides durable with cleanup diagnostics path=%s detail=%s"
+                  path
+                  (Fs_compat.Durable_mutation.report_to_string report));
+             Ok ())
        with
        | Sys_error message -> Error (Write_failed message)
        | Unix.Unix_error (error, operation, argument) ->

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -28,6 +28,8 @@
   digestif
   yojson
   otoml
+  eio
+  eio.unix
   unix)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -433,7 +433,7 @@ let validate_access ~keeper_id ~repository_id ~base_path =
   | Access_allowed -> Ok ()
   | Access_denied denial -> Error (access_denial_to_string denial)
 
-let save_all ~base_path mappings =
+let save_all_with writer ~base_path mappings =
   let path = mappings_toml_path base_path in
   let table =
     List.map
@@ -444,13 +444,31 @@ let save_all ~base_path mappings =
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
   let content = Otoml.Printer.to_string toml in
-  match Fs_compat.save_file_atomic path content with
-  | Ok () ->
+  let report = writer path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Result.Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Misc.warn
+        "keeper repo mapping committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
       invalidate_load_all_cache ~base_path;
-      Ok ()
-  | Error msg -> Error msg
+      Result.Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Misc.warn
+           "keeper repo mapping durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      invalidate_load_all_cache ~base_path;
+      Result.Ok ())
 
-let save_mapping ~base_path mapping =
+let save_all_blocking = save_all_with Fs_compat.save_file_atomic_blocking
+
+let save_mapping_with lock save_all ~base_path mapping : (unit, string) result =
   let mapping =
     make_keeper_repo_mapping ~keeper_id:mapping.keeper_id
       ~repository_ids:mapping.repository_ids
@@ -458,7 +476,7 @@ let save_mapping ~base_path mapping =
   let path = mappings_toml_path base_path in
   try
     Fs_compat.mkdir_p (Filename.dirname path);
-    File_lock_eio.with_lock path (fun () ->
+    lock path (fun () ->
       let* mappings = load_all ~base_path in
       let filtered =
         List.filter
@@ -469,11 +487,21 @@ let save_mapping ~base_path mapping =
       save_all ~base_path (mapping :: filtered))
   with
   | File_lock_eio.Flock_timeout { path; attempts; _ } ->
-      Error
+      Result.Error
         (Printf.sprintf
            "timed out acquiring keeper repo mapping lock %s after %d attempts"
            path attempts)
-  | Sys_error msg -> Error msg
+  | Sys_error msg -> Result.Error msg
+
+let save_mapping_blocking =
+  save_mapping_with File_lock_eio.with_lock_blocking save_all_blocking
+;;
+
+let save_mapping_eio ~base_path mapping =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"keeper-repo-mapping" (fun () ->
+      save_mapping_blocking ~base_path mapping))
+;;
 
 let apply_mapping ~keeper_id ~base_path ~repositories =
   match lookup_mapping ~base_path ~keeper_id with

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -108,10 +108,16 @@ val validate_access :
 (** [validate_access ~keeper_id ~repository_id ~base_path] returns [Ok ()] if
     access is permitted, or [Error msg] otherwise. *)
 
-val save_mapping :
+val save_mapping_blocking :
   base_path:string -> keeper_repo_mapping -> (unit, string) result
-(** [save_mapping ~base_path mapping] saves or updates the mapping for the
-    given keeper, overwriting any existing mapping for that keeper. *)
+(** Blocking save for CLI and non-Eio tests. *)
+
+val save_mapping_eio :
+  base_path:string -> keeper_repo_mapping -> (unit, string) result
+(** Eio-safe counterpart of {!save_mapping_blocking}. Load, lock, write, and
+    cache invalidation run as one cancellation-protected system-thread job.
+    Both entry points update the mapping for the given keeper, overwriting any
+    existing mapping for that keeper. *)
 
 val apply_mapping :
   keeper_id:string -> base_path:string -> repositories:repository list -> repository list

--- a/lib/review_artifact_store.ml
+++ b/lib/review_artifact_store.ml
@@ -23,9 +23,29 @@ let component ~display_id ~identity_key =
 
 let write_file path content =
   Fs_compat.mkdir_p (Filename.dirname path);
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> Ok ()
-  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error
+        (Printf.sprintf
+           "%s: %s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report)))
+    ~committed_not_durable:(fun report ->
+      Log.Misc.warn
+        "review artifact committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Misc.warn
+           "review artifact durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok ())
 ;;
 
 let append_index index_path event =

--- a/lib/runtime/dune
+++ b/lib/runtime/dune
@@ -13,6 +13,7 @@
   unix
   logs
   eio
+  eio.unix
   agent_sdk
   agent_sdk.base
   agent_sdk.llm_provider

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1000,7 +1000,7 @@ let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
 
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
-let set_loaded
+let loaded_state_of_materialized
     ?startup_degradation
     ~config_path
     ( runtimes
@@ -1012,19 +1012,24 @@ let set_loaded
     , cross_verifier_id
     , media_failover
     , lanes ) =
+  { default_runtime = Some rt
+  ; runtimes
+  ; keeper_assignments = assignments
+  ; librarian_runtime_id = librarian_id
+  ; structured_judge_runtime_id = structured_judge_id
+  ; hitl_summary_runtime_id = hitl_summary_id
+  ; cross_verifier_runtime_id = cross_verifier_id
+  ; media_failover
+  ; lanes
+  ; config_path = Some config_path
+  ; startup_degradation
+  }
+;;
+
+let set_loaded ?startup_degradation ~config_path loaded =
   Atomic.set loaded_state_ref
-    { default_runtime = Some rt
-    ; runtimes
-    ; keeper_assignments = assignments
-    ; librarian_runtime_id = librarian_id
-    ; structured_judge_runtime_id = structured_judge_id
-    ; hitl_summary_runtime_id = hitl_summary_id
-    ; cross_verifier_runtime_id = cross_verifier_id
-    ; media_failover
-    ; lanes
-    ; config_path = Some config_path
-    ; startup_degradation
-    }
+    (loaded_state_of_materialized ?startup_degradation ~config_path loaded)
+;;
 
 let init_default ~config_path =
   let* loaded = load_list ~config_path in
@@ -1073,11 +1078,25 @@ let init_default_degraded_report ~config_path =
 
 let runtime_state () = Atomic.get loaded_state_ref
 
+let runtime_config_writer_ref :
+    (string -> string -> unit Fs_compat.Durable_mutation.report) Atomic.t =
+  Atomic.make Fs_compat.save_file_atomic_blocking
+;;
+
 module For_testing = struct
   type snapshot = loaded_state
 
   let snapshot () = runtime_state ()
   let restore snapshot = Atomic.set loaded_state_ref snapshot
+
+  let with_config_writer writer f =
+    let previous = Atomic.get runtime_config_writer_ref in
+    Fun.protect
+      ~finally:(fun () -> Atomic.set runtime_config_writer_ref previous)
+      (fun () ->
+         Atomic.set runtime_config_writer_ref writer;
+         f ())
+  ;;
 end
 
 let get_default_runtime () = (runtime_state ()).default_runtime
@@ -1607,7 +1626,7 @@ let runtime_parse_errors_to_string errs =
   |> String.concat "; "
 ;;
 
-let validate_runtime_config_text ~config_path content =
+let prepare_runtime_config_state ~config_path content =
   let* cfg =
     Runtime_toml.parse_string content
     |> Result.map_error (fun errs ->
@@ -1616,30 +1635,121 @@ let validate_runtime_config_text ~config_path content =
         config_path
         (runtime_parse_errors_to_string errs))
   in
-  let* (_
-         : t list
-           * t
-           * (string * string) list
-           * string option
-           * string option
-           * string option
-           * string option
-           * string list
-           * Runtime_lane.t list) =
-    materialize_config ~config_path cfg
+  let* loaded = materialize_config ~config_path cfg in
+  Ok (loaded_state_of_materialized ~config_path loaded)
+;;
+
+let validate_runtime_config_text ~config_path content =
+  prepare_runtime_config_state ~config_path content |> Result.map ignore
+;;
+
+let runtime_config_transaction_locks : (string, Mutex.t) Hashtbl.t =
+  Hashtbl.create 4
+;;
+
+let runtime_config_transaction_locks_mu = Mutex.create ()
+
+let runtime_config_transaction_lock path =
+  Mutex.lock runtime_config_transaction_locks_mu;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock runtime_config_transaction_locks_mu)
+    (fun () ->
+       match Hashtbl.find_opt runtime_config_transaction_locks path with
+       | Some lock -> lock
+       | None ->
+         let lock = Mutex.create () in
+         Hashtbl.add runtime_config_transaction_locks path lock;
+         lock)
+;;
+
+let with_runtime_config_transaction_blocking path f =
+  let lock = runtime_config_transaction_lock path in
+  Mutex.lock lock;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock lock)
+    (fun () ->
+       File_lock_eio.with_lock_blocking (path ^ ".runtime-transaction") f)
+;;
+
+let with_runtime_config_transaction_eio path f =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"runtime-config-transaction" (fun () ->
+      with_runtime_config_transaction_blocking path f))
+;;
+
+let durable_mutation_diagnostics diagnostics =
+  match diagnostics with
+  | [] -> ""
+  | diagnostics ->
+    Printf.sprintf
+      "; diagnostics=[%s]"
+      (String.concat
+         "; "
+         (List.map
+            Fs_compat.Durable_mutation.diagnostic_to_string
+            diagnostics))
+;;
+
+let commit_prepared_runtime_config_blocking ~path ~content ~prepared =
+  let report = (Atomic.get runtime_config_writer_ref) path content in
+  let report =
+    Fs_compat.Durable_mutation.observe_and_retain
+      (fun report ->
+         match report.progress with
+         | Fs_compat.Durable_mutation.Not_committed _ -> ()
+         | Fs_compat.Durable_mutation.Committed_not_durable { cause; _ } ->
+           Log.Runtime.warn
+             "runtime config committed with parent sync debt path=%s cause=%s%s"
+             path
+             (Printexc.to_string cause)
+             (durable_mutation_diagnostics report.diagnostics)
+         | Fs_compat.Durable_mutation.Durable () ->
+           (match report.diagnostics with
+            | [] -> ()
+            | diagnostics ->
+              Log.Runtime.warn
+                "runtime config committed durably with cleanup diagnostics path=%s%s"
+                path
+                (durable_mutation_diagnostics diagnostics)))
+      report
   in
-  Ok ()
+  match report.progress with
+  | Fs_compat.Durable_mutation.Not_committed { cause; _ } ->
+    Error
+      (Printf.sprintf
+         "runtime config write not committed (%s): %s%s"
+         path
+         (Printexc.to_string cause)
+         (durable_mutation_diagnostics report.diagnostics))
+  | Fs_compat.Durable_mutation.Committed_not_durable { cause; _ } ->
+    Atomic.set loaded_state_ref prepared;
+    Ok ()
+  | Fs_compat.Durable_mutation.Durable () ->
+    Atomic.set loaded_state_ref prepared;
+    Ok ()
 ;;
 
-let save_config_text ?runtime_config_path content =
+let save_config_text_with transaction ?runtime_config_path content =
   let* path = runtime_config_path_result ?runtime_config_path () in
-  let* () = validate_runtime_config_text ~config_path:path content in
-  let* () = Fs_compat.save_file_atomic path content in
-  let* () = init_default ~config_path:path in
-  Ok ()
+  transaction path (fun () ->
+    let* prepared = prepare_runtime_config_state ~config_path:path content in
+    commit_prepared_runtime_config_blocking ~path ~content ~prepared)
 ;;
 
-let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
+let save_config_text_blocking =
+  save_config_text_with with_runtime_config_transaction_blocking
+;;
+
+let save_config_text_eio =
+  save_config_text_with with_runtime_config_transaction_eio
+;;
+
+let set_runtime_id_for_keeper_with
+    transaction
+    ?runtime_config_path
+    ~keeper_name
+    ~runtime_id
+    () =
   let keeper_name = String.trim keeper_name in
   let runtime_id = String.trim runtime_id in
   if String.equal keeper_name ""
@@ -1652,15 +1762,22 @@ let set_runtime_id_for_keeper ?runtime_config_path ~keeper_name ~runtime_id () =
   then Error "runtime_id must not contain newlines"
   else
     let* path = runtime_config_path_result ?runtime_config_path () in
-    let* content = load_file_result path in
-    let next = update_runtime_assignment_text content ~keeper_name ~runtime_id in
-    let* () = validate_runtime_config_text ~config_path:path next in
-    let* () = Fs_compat.save_file_atomic path next in
-    let* () = init_default ~config_path:path in
-    Ok ()
+    transaction path (fun () ->
+      let* content = load_file_result path in
+      let next = update_runtime_assignment_text content ~keeper_name ~runtime_id in
+      let* prepared = prepare_runtime_config_state ~config_path:path next in
+      commit_prepared_runtime_config_blocking ~path ~content:next ~prepared)
 ;;
 
-let clear_runtime_id_for_keeper ?runtime_config_path ~keeper_name () =
+let set_runtime_id_for_keeper_blocking =
+  set_runtime_id_for_keeper_with with_runtime_config_transaction_blocking
+;;
+
+let set_runtime_id_for_keeper_eio =
+  set_runtime_id_for_keeper_with with_runtime_config_transaction_eio
+;;
+
+let clear_runtime_id_for_keeper_with transaction ?runtime_config_path ~keeper_name () =
   let keeper_name = String.trim keeper_name in
   if String.equal keeper_name ""
   then Error "keeper_name must not be empty"
@@ -1668,15 +1785,22 @@ let clear_runtime_id_for_keeper ?runtime_config_path ~keeper_name () =
   then Error "keeper_name must not contain newlines"
   else
     let* path = runtime_config_path_result ?runtime_config_path () in
-    let* content = load_file_result path in
-    let next = remove_runtime_assignment_text content ~keeper_name in
-    let* () = validate_runtime_config_text ~config_path:path next in
-    let* () = Fs_compat.save_file_atomic path next in
-    let* () = init_default ~config_path:path in
-    Ok ()
+    transaction path (fun () ->
+      let* content = load_file_result path in
+      let next = remove_runtime_assignment_text content ~keeper_name in
+      let* prepared = prepare_runtime_config_state ~config_path:path next in
+      commit_prepared_runtime_config_blocking ~path ~content:next ~prepared)
 ;;
 
-let set_runtime_scalar ?runtime_config_path ~key ~runtime_id () =
+let clear_runtime_id_for_keeper_blocking =
+  clear_runtime_id_for_keeper_with with_runtime_config_transaction_blocking
+;;
+
+let clear_runtime_id_for_keeper_eio =
+  clear_runtime_id_for_keeper_with with_runtime_config_transaction_eio
+;;
+
+let set_runtime_scalar_with transaction ?runtime_config_path ~key ~runtime_id () =
   let key = String.trim key in
   let runtime_id = Option.map String.trim runtime_id in
   if String.equal key ""
@@ -1691,15 +1815,19 @@ let set_runtime_scalar ?runtime_config_path ~key ~runtime_id () =
       Error "runtime_id must not contain newlines"
     | _ ->
       let* path = runtime_config_path_result ?runtime_config_path () in
-      let* content = load_file_result path in
-      let next = update_runtime_scalar_text content ~key ~runtime_id in
-      let* () = validate_runtime_config_text ~config_path:path next in
-      let* () = Fs_compat.save_file_atomic path next in
-      let* () = init_default ~config_path:path in
-      Ok ()
+      transaction path (fun () ->
+        let* content = load_file_result path in
+        let next = update_runtime_scalar_text content ~key ~runtime_id in
+        let* prepared = prepare_runtime_config_state ~config_path:path next in
+        commit_prepared_runtime_config_blocking ~path ~content:next ~prepared)
 ;;
 
-let set_runtime_string_array ?runtime_config_path ~key ~runtime_ids () =
+let set_runtime_string_array_with
+    transaction
+    ?runtime_config_path
+    ~key
+    ~runtime_ids
+    () =
   let key = String.trim key in
   let runtime_ids = List.map String.trim runtime_ids in
   if String.equal key ""
@@ -1712,36 +1840,83 @@ let set_runtime_string_array ?runtime_config_path ~key ~runtime_ids () =
   then Error "runtime_ids must not contain newlines"
   else (
     let* path = runtime_config_path_result ?runtime_config_path () in
-    let* content = load_file_result path in
-    let next = update_runtime_string_array_text content ~key ~values:runtime_ids in
-    let* () = validate_runtime_config_text ~config_path:path next in
-    let* () = Fs_compat.save_file_atomic path next in
-    let* () = init_default ~config_path:path in
-    Ok ())
+    transaction path (fun () ->
+      let* content = load_file_result path in
+      let next = update_runtime_string_array_text content ~key ~values:runtime_ids in
+      let* prepared = prepare_runtime_config_state ~config_path:path next in
+      commit_prepared_runtime_config_blocking ~path ~content:next ~prepared))
 ;;
 
-let set_runtime_default ?runtime_config_path ~runtime_id () =
-  set_runtime_scalar ?runtime_config_path ~key:"default" ~runtime_id:(Some runtime_id) ()
+let set_runtime_scalar_blocking =
+  set_runtime_scalar_with with_runtime_config_transaction_blocking
 ;;
 
-let set_runtime_librarian ?runtime_config_path ~runtime_id () =
-  set_runtime_scalar ?runtime_config_path ~key:"librarian" ~runtime_id ()
+let set_runtime_scalar_eio =
+  set_runtime_scalar_with with_runtime_config_transaction_eio
 ;;
 
-let set_runtime_structured_judge ?runtime_config_path ~runtime_id () =
-  set_runtime_scalar ?runtime_config_path ~key:"structured_judge" ~runtime_id ()
+let set_runtime_string_array_blocking =
+  set_runtime_string_array_with with_runtime_config_transaction_blocking
 ;;
 
-let set_runtime_hitl_summary ?runtime_config_path ~runtime_id () =
-  set_runtime_scalar ?runtime_config_path ~key:"hitl_summary" ~runtime_id ()
+let set_runtime_string_array_eio =
+  set_runtime_string_array_with with_runtime_config_transaction_eio
 ;;
 
-let set_runtime_cross_verifier ?runtime_config_path ~runtime_id () =
-  set_runtime_scalar ?runtime_config_path ~key:"cross_verifier" ~runtime_id ()
+let set_runtime_default_blocking ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_blocking
+    ?runtime_config_path ~key:"default" ~runtime_id:(Some runtime_id) ()
 ;;
 
-let set_runtime_media_failover ?runtime_config_path ~runtime_ids () =
-  set_runtime_string_array ?runtime_config_path ~key:"media_failover" ~runtime_ids ()
+let set_runtime_default_eio ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_eio
+    ?runtime_config_path ~key:"default" ~runtime_id:(Some runtime_id) ()
+;;
+
+let set_runtime_librarian_blocking ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_blocking ?runtime_config_path ~key:"librarian" ~runtime_id ()
+;;
+
+let set_runtime_librarian_eio ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_eio ?runtime_config_path ~key:"librarian" ~runtime_id ()
+;;
+
+let set_runtime_structured_judge_blocking ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_blocking
+    ?runtime_config_path ~key:"structured_judge" ~runtime_id ()
+;;
+
+let set_runtime_structured_judge_eio ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_eio
+    ?runtime_config_path ~key:"structured_judge" ~runtime_id ()
+;;
+
+let set_runtime_hitl_summary_blocking ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_blocking ?runtime_config_path ~key:"hitl_summary" ~runtime_id ()
+;;
+
+let set_runtime_hitl_summary_eio ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_eio ?runtime_config_path ~key:"hitl_summary" ~runtime_id ()
+;;
+
+let set_runtime_cross_verifier_blocking ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_blocking
+    ?runtime_config_path ~key:"cross_verifier" ~runtime_id ()
+;;
+
+let set_runtime_cross_verifier_eio ?runtime_config_path ~runtime_id () =
+  set_runtime_scalar_eio
+    ?runtime_config_path ~key:"cross_verifier" ~runtime_id ()
+;;
+
+let set_runtime_media_failover_blocking ?runtime_config_path ~runtime_ids () =
+  set_runtime_string_array_blocking
+    ?runtime_config_path ~key:"media_failover" ~runtime_ids ()
+;;
+
+let set_runtime_media_failover_eio ?runtime_config_path ~runtime_ids () =
+  set_runtime_string_array_eio
+    ?runtime_config_path ~key:"media_failover" ~runtime_ids ()
 ;;
 
 (* RFC-0206 single-binding: the deleted [Runtime_runtime.resolve_*_max_context]

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -165,6 +165,13 @@ module For_testing : sig
 
   val snapshot : unit -> snapshot
   val restore : snapshot -> unit
+
+  val with_config_writer :
+    (string -> string -> unit Fs_compat.Durable_mutation.report) ->
+    (unit -> 'a) ->
+    'a
+  (** Test-only failure-injection seam. The supplied blocking writer is scoped
+      to [f] and restored even when [f] raises. *)
 end
 
 val get_default_runtime : unit -> t option
@@ -377,63 +384,73 @@ val load_config_text :
   ?runtime_config_path:string -> unit -> ((string * string), string) result
 (** Load the raw runtime.toml source text. Returns [(path, source_text)]. *)
 
-val save_config_text :
+val save_config_text_blocking :
   ?runtime_config_path:string -> string -> (unit, string) result
-(** Validate and atomically persist raw runtime.toml source text, then refresh
-    the in-process runtime cache. *)
+(** Blocking runtime.toml transaction for CLI and non-Eio tests. Validation,
+    disk commit, and in-memory publication are serialized per config path. Both
+    committed mutation states publish the prepared immutable snapshot;
+    [Not_committed] preserves the previous snapshot. *)
 
-val set_runtime_id_for_keeper :
+val save_config_text_eio :
+  ?runtime_config_path:string -> string -> (unit, string) result
+(** Eio-safe counterpart of {!save_config_text_blocking}. The entire transaction
+    runs cancellation-protected in a system thread. *)
+
+val set_runtime_id_for_keeper_blocking :
   ?runtime_config_path:string ->
   keeper_name:string ->
   runtime_id:string ->
   unit ->
   (unit, string) result
-(** Persist [keeper_name] -> [runtime_id] in
-    [\[runtime.assignments\]] (runtime.toml SSOT), validate the resulting
-    runtime config, atomically write it, and refresh the in-process runtime
-    assignment cache. *)
 
-val clear_runtime_id_for_keeper :
+val set_runtime_id_for_keeper_eio :
+  ?runtime_config_path:string ->
+  keeper_name:string ->
+  runtime_id:string ->
+  unit ->
+  (unit, string) result
+
+val clear_runtime_id_for_keeper_blocking :
   ?runtime_config_path:string -> keeper_name:string -> unit -> (unit, string) result
-(** Remove [keeper_name] from [\[runtime.assignments\]], validate the resulting
-    runtime config, atomically write it, and refresh the in-process runtime
-    assignment cache. *)
 
-val set_runtime_default :
+val clear_runtime_id_for_keeper_eio :
+  ?runtime_config_path:string -> keeper_name:string -> unit -> (unit, string) result
+
+val set_runtime_default_blocking :
   ?runtime_config_path:string -> runtime_id:string -> unit -> (unit, string) result
-(** Persist [\[runtime\]].default through the runtime.toml SSOT writer,
-    validate the resulting config, atomically write it, and refresh the
-    in-process runtime cache. *)
 
-val set_runtime_librarian :
+val set_runtime_default_eio :
+  ?runtime_config_path:string -> runtime_id:string -> unit -> (unit, string) result
+
+val set_runtime_librarian_blocking :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
-(** Persist or clear [\[runtime\]].librarian through the runtime.toml SSOT
-    writer, validate the resulting config, atomically write it, and refresh the
-    in-process runtime cache. *)
 
-val set_runtime_structured_judge :
+val set_runtime_librarian_eio :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
-(** Persist or clear [\[runtime\]].structured_judge through the runtime.toml
-    SSOT writer, validate the resulting config, atomically write it, and refresh
-    the in-process runtime cache. *)
 
-val set_runtime_hitl_summary :
+val set_runtime_structured_judge_blocking :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
-(** Persist or clear [\[runtime\]].hitl_summary through the runtime.toml SSOT
-    writer, validate the resulting config, atomically write it, and refresh the
-    in-process runtime cache. *)
 
-val set_runtime_cross_verifier :
+val set_runtime_structured_judge_eio :
   ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
-(** Persist or clear [\[runtime\]].cross_verifier through the runtime.toml SSOT
-    writer, validate the resulting config, atomically write it, and refresh the
-    in-process runtime cache. *)
 
-val set_runtime_media_failover :
+val set_runtime_hitl_summary_blocking :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+
+val set_runtime_hitl_summary_eio :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+
+val set_runtime_cross_verifier_blocking :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+
+val set_runtime_cross_verifier_eio :
+  ?runtime_config_path:string -> runtime_id:string option -> unit -> (unit, string) result
+
+val set_runtime_media_failover_blocking :
   ?runtime_config_path:string -> runtime_ids:string list -> unit -> (unit, string) result
-(** Persist [\[runtime\]].media_failover through the runtime.toml SSOT writer,
-    validate the resulting config, atomically write it, and refresh the
-    in-process runtime cache. The list order is preserved. *)
+
+val set_runtime_media_failover_eio :
+  ?runtime_config_path:string -> runtime_ids:string list -> unit -> (unit, string) result
 
 val default_max_context : unit -> int
 (** Effective context-window budget of the default runtime's model (RFC-0206

--- a/lib/runtime/runtime_oas_checkpoint.ml
+++ b/lib/runtime/runtime_oas_checkpoint.ml
@@ -36,10 +36,33 @@ let persist_checkpoint ~dir ~session_id (ckpt : Agent_sdk.Checkpoint.t)
   let path = Filename.concat dir (session_id ^ ".json") in
   try
     Fs_compat.mkdir_p dir;
-    Result.map_error
-      (fun err ->
-         Printf.sprintf "checkpoint persist failed for %s: %s" session_id err)
-      (Fs_compat.save_file_atomic path (Agent_sdk.Checkpoint.to_string ckpt))
+    let report =
+      Fs_compat.save_file_atomic_eio path (Agent_sdk.Checkpoint.to_string ckpt)
+    in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Error
+          (Printf.sprintf
+             "checkpoint persist failed for %s: %s"
+             session_id
+             (Fs_compat.Durable_mutation.report_to_string report)))
+      ~committed_not_durable:(fun report ->
+        Log.Misc.warn
+          "checkpoint committed with sync debt session_id=%s path=%s detail=%s"
+          session_id
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        Ok ())
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Misc.warn
+             "checkpoint durable with cleanup diagnostics session_id=%s path=%s detail=%s"
+             session_id
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Ok ())
   with
   (* CancelledNeverAbsorbed (KeeperOASAdvanced.tla): re-raise [Cancelled]
      before the catch-all so a cancelled checkpoint fiber propagates the

--- a/lib/runtime_params.ml
+++ b/lib/runtime_params.ml
@@ -135,9 +135,27 @@ let persist ~base_path =
           registry_tbl [])
     in
     let json = `Assoc overrides in
-    (match Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) with
-     | Ok () -> ()
-     | Error msg -> Log.Config.error "Runtime_params.persist atomic: %s" msg)
+    let report =
+      Fs_compat.save_file_atomic_eio path (Yojson.Safe.pretty_to_string json)
+    in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Log.Config.error
+          "Runtime_params.persist not committed: %s"
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Config.warn
+          "Runtime_params.persist committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~durable:(fun report ->
+        match report.diagnostics with
+        | [] -> ()
+        | _ ->
+          Log.Config.warn
+            "Runtime_params.persist durable with cleanup diagnostics path=%s detail=%s"
+            path
+            (Fs_compat.Durable_mutation.report_to_string report))
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Config.error "Runtime_params.persist: %s" (Printexc.to_string exn)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -618,7 +618,7 @@ let add_routes ~sw ~clock router =
                   audit trail (actor + path + size) on top of the CanAdmin gate.
                   The config body is deliberately excluded: runtime.toml can carry
                   provider secrets (RFC-0132 redaction). *)
-               (match Runtime_config_file.save_config_text source_text with
+               (match Runtime_config_file.save_config_text_eio source_text with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:Runtime_config_raw_save ~text:source_text
@@ -637,7 +637,7 @@ let add_routes ~sw ~clock router =
              | Error msg ->
                respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
              | Ok (Runtime_route_runtime_id (Runtime_default, Some runtime_id)) ->
-               (match Runtime_config_file.set_runtime_default ~runtime_id () with
+               (match Runtime_config_file.set_runtime_default_eio ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:(Runtime_config_routing (Runtime_default, Some runtime_id))
@@ -652,7 +652,7 @@ let add_routes ~sw ~clock router =
                respond_dashboard_error ~status:`Bad_request ~request:req reqd
                  "default runtime_id required"
              | Ok (Runtime_route_runtime_id (Runtime_librarian, runtime_id)) ->
-               (match Runtime_config_file.set_runtime_librarian ~runtime_id () with
+               (match Runtime_config_file.set_runtime_librarian_eio ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:(Runtime_config_routing (Runtime_librarian, runtime_id))
@@ -664,7 +664,7 @@ let add_routes ~sw ~clock router =
                     ~operation:(Runtime_config_routing (Runtime_librarian, runtime_id))
                     req reqd)
              | Ok (Runtime_route_runtime_id (Runtime_structured_judge, runtime_id)) ->
-               (match Runtime_config_file.set_runtime_structured_judge ~runtime_id () with
+               (match Runtime_config_file.set_runtime_structured_judge_eio ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:
@@ -678,7 +678,7 @@ let add_routes ~sw ~clock router =
                       (Runtime_config_routing (Runtime_structured_judge, runtime_id))
                     req reqd)
              | Ok (Runtime_route_runtime_id (Runtime_hitl_summary, runtime_id)) ->
-               (match Runtime_config_file.set_runtime_hitl_summary ~runtime_id () with
+               (match Runtime_config_file.set_runtime_hitl_summary_eio ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:
@@ -692,7 +692,7 @@ let add_routes ~sw ~clock router =
                       (Runtime_config_routing (Runtime_hitl_summary, runtime_id))
                     req reqd)
              | Ok (Runtime_route_runtime_id (Runtime_cross_verifier, runtime_id)) ->
-               (match Runtime_config_file.set_runtime_cross_verifier ~runtime_id () with
+               (match Runtime_config_file.set_runtime_cross_verifier_eio ~runtime_id () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:
@@ -709,7 +709,7 @@ let add_routes ~sw ~clock router =
                respond_dashboard_error ~status:`Bad_request ~request:req reqd
                  "media_failover runtime_ids required"
              | Ok (Runtime_route_runtime_ids (Runtime_media_failover, runtime_ids)) ->
-               (match Runtime_config_file.set_runtime_media_failover ~runtime_ids () with
+               (match Runtime_config_file.set_runtime_media_failover_eio ~runtime_ids () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:
@@ -738,7 +738,7 @@ let add_routes ~sw ~clock router =
                respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
              | Ok (keeper_name, Some runtime_id) ->
                (match
-                  Runtime_config_file.set_runtime_id_for_keeper
+                  Runtime_config_file.set_runtime_id_for_keeper_eio
                     ~keeper_name
                     ~runtime_id
                     ()
@@ -754,7 +754,7 @@ let add_routes ~sw ~clock router =
                     ~operation:(Runtime_config_assignment (keeper_name, Some runtime_id))
                     req reqd)
              | Ok (keeper_name, None) ->
-               (match Runtime_config_file.clear_runtime_id_for_keeper ~keeper_name () with
+               (match Runtime_config_file.clear_runtime_id_for_keeper_eio ~keeper_name () with
                 | Error msg ->
                   audit_runtime_config_write state agent_name
                     ~operation:(Runtime_config_assignment (keeper_name, None))

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -125,7 +125,7 @@ let handle_save_mapping state keeper_id req reqd =
           match mapping_of_json keeper_id json with
           | Error msg -> response `Bad_request msg
           | Ok mapping -> (
-              match Keeper_repo_mapping.save_mapping ~base_path mapping with
+              match Keeper_repo_mapping.save_mapping_eio ~base_path mapping with
               | Error msg -> response `Bad_request msg
               | Ok () ->
                   Http.Response.json_value ~request:req

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -4,6 +4,8 @@
 
 (* ── Startup pruning ───────────────────────────────── *)
 
+exception Startup_history_migration_failed of string
+
 let startup_prune_jsonl (state : Mcp_server.server_state) =
   (try
      let days =
@@ -69,44 +71,43 @@ let startup_migrate_retired_keeper_meta_keys (state : Mcp_server.server_state) =
        (Printexc.to_string exn))
 
 let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
-  (try
-     let traces_dir =
-       Filename.concat (Workspace.masc_root_dir (Mcp_server.workspace_config state)) "traces"
-     in
-     if Sys.file_exists traces_dir then begin
-       let moved_total = ref 0 in
-       let dropped_total = ref 0 in
-       let sessions_migrated = ref 0 in
-       Array.iter
-         (fun trace_name ->
-            let trace_dir = Filename.concat traces_dir trace_name in
-            if Sys.is_directory trace_dir then
-              let stats =
-                Keeper_context_core.migrate_session_history_logs
-                  ~session_dir:trace_dir
-              in
-              if stats.moved_lines > 0 || stats.dropped_lines > 0 then begin
-                incr sessions_migrated;
-                moved_total := !moved_total + stats.moved_lines;
-                dropped_total := !dropped_total + stats.dropped_lines;
-                Log.Misc.info
-                  "startup history migration: trace=%s moved=%d dropped=%d kept=%d malformed=%d"
-                  trace_name
-                  stats.moved_lines
-                  stats.dropped_lines
-                  stats.kept_lines
-                  stats.malformed_lines
-              end)
-         (Sys.readdir traces_dir);
-       if !sessions_migrated > 0 then
-         Log.Misc.info
-           "startup history migration: migrated %d session(s), moved %d internal line(s), dropped %d prompt line(s)"
-           !sessions_migrated
-           !moved_total
-           !dropped_total
-     end
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-       Log.Misc.warn "startup history migration failed: %s (next boot retries; legacy format readable)"
-         (Printexc.to_string exn))
+  let traces_dir =
+    Filename.concat (Workspace.masc_root_dir (Mcp_server.workspace_config state)) "traces"
+  in
+  if Sys.file_exists traces_dir then begin
+    let moved_total = ref 0 in
+    let dropped_total = ref 0 in
+    let sessions_migrated = ref 0 in
+    Array.iter
+      (fun trace_name ->
+         let trace_dir = Filename.concat traces_dir trace_name in
+         if Sys.is_directory trace_dir then
+           match
+             Keeper_context_core.migrate_session_history_logs_eio
+               ~session_dir:trace_dir
+           with
+           | Error error ->
+             raise
+               (Startup_history_migration_failed
+                  (Keeper_context_core.history_migration_error_to_string error))
+           | Ok stats ->
+             if stats.moved_lines > 0 || stats.dropped_lines > 0 then begin
+               incr sessions_migrated;
+               moved_total := !moved_total + stats.moved_lines;
+               dropped_total := !dropped_total + stats.dropped_lines;
+               Log.Misc.info
+                 "startup history migration: trace=%s moved=%d dropped=%d kept=%d malformed=%d"
+                 trace_name
+                 stats.moved_lines
+                 stats.dropped_lines
+                 stats.kept_lines
+                 stats.malformed_lines
+             end)
+      (Sys.readdir traces_dir);
+    if !sessions_migrated > 0 then
+      Log.Misc.info
+        "startup history migration: migrated %d session(s), moved %d internal line(s), dropped %d prompt line(s)"
+        !sessions_migrated
+        !moved_total
+        !dropped_total
+  end

--- a/lib/server/server_runtime_startup_maintenance.mli
+++ b/lib/server/server_runtime_startup_maintenance.mli
@@ -9,3 +9,5 @@ val startup_migrate_retired_keeper_meta_keys : Mcp_server.server_state -> unit
 
 val startup_migrate_keeper_histories :
   Mcp_server.server_state -> unit
+(** Runs the typed history migration. Failures escape to the lazy-task runner,
+    which records the task as failed instead of logging and marking success. *)

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -278,11 +278,27 @@ let save_excuse_patterns (patterns : (string * string) list) : (unit, string) re
     in
     let json = `List json_items in
     let content = Yojson.Safe.pretty_to_string json in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () ->
-      cached_patterns := Some patterns;
-      Ok ()
-    | Error msg -> Error msg
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Error (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Misc.warn
+          "anti-rationalization patterns committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report);
+        cached_patterns := Some patterns;
+        Ok ())
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Misc.warn
+             "anti-rationalization patterns durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        cached_patterns := Some patterns;
+        Ok ())
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -409,11 +409,26 @@ let save_stats () =
       snapshot;
     let content = Buffer.contents buf in
     let count = List.length snapshot in
-    match Fs_compat.save_file_atomic path content with
-    | Ok () ->
-        Log.Metrics.debug "thompson sampling saved stats for %d agents" count
-    | Error msg ->
-        Log.Thompson.error "Error saving stats: %s" msg
+    let report = Fs_compat.save_file_atomic_eio path content in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        Log.Thompson.error
+          "Error saving stats: %s"
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~committed_not_durable:(fun report ->
+        Log.Thompson.warn
+          "thompson stats committed with sync debt path=%s detail=%s"
+          path
+          (Fs_compat.Durable_mutation.report_to_string report))
+      ~durable:(fun report ->
+        (match report.diagnostics with
+         | [] -> ()
+         | _ ->
+           Log.Thompson.warn
+             "thompson stats durable with cleanup diagnostics path=%s detail=%s"
+             path
+             (Fs_compat.Durable_mutation.report_to_string report));
+        Log.Metrics.debug "thompson sampling saved stats for %d agents" count)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->

--- a/lib/tool_blob_store/dune
+++ b/lib/tool_blob_store/dune
@@ -17,4 +17,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries digestif digestif.c unix fs_compat masc_core))
+ (libraries digestif digestif.c unix fs_compat masc_core eio eio.unix))

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -40,22 +40,46 @@ let rec mkdir_p p =
 
 let ensure_parent_dir path = mkdir_p (Filename.dirname path)
 
-let put t ~bytes ~mime =
+exception Committed_not_durable of string
+exception Durable_with_diagnostics of string
+
+let put_with writer t ~bytes ~mime =
   let sha256 = Digestif.SHA256.(digest_string bytes |> to_hex) in
   let path = shard_path t sha256 in
   if not (Fs_compat.file_exists path) then begin
     ensure_parent_dir path;
     (* Propagate a failed write instead of swallowing it. Returning [Stored]
-       after [save_file_atomic] failed produced a blob marker for bytes that
+       after an atomic write failed produced a blob marker for bytes that
        were never persisted, so the keeper permanently lost the full tool
        output (only the preview survived). The sole caller,
        [Tool_bridge.maybe_externalize], already catches storage failures and
        falls back to the inline bytes (its docstring promises exactly this);
        raising here is what activates that fallback. *)
-    match Fs_compat.save_file_atomic path bytes with
-    | Ok () -> ()
-    | Error msg ->
-        raise (Sys_error (Printf.sprintf "tool_blob_store.put: %s" msg))
+    let report = writer path bytes in
+    Fs_compat.Durable_mutation.fold_report report
+      ~not_committed:(fun report ->
+        raise
+          (Sys_error
+             (Printf.sprintf
+                "tool_blob_store.put: %s"
+                (Fs_compat.Durable_mutation.report_to_string report))))
+      ~committed_not_durable:(fun report ->
+        raise
+          (Committed_not_durable
+             (Printf.sprintf
+                "tool blob committed with sync debt path=%s detail=%s"
+                path
+                (Fs_compat.Durable_mutation.report_to_string report))))
+      ~durable:(fun report ->
+        match report.diagnostics with
+        | [] -> ()
+        | _ ->
+          raise
+            (Durable_with_diagnostics
+               (Printf.sprintf
+                  "tool blob durable with cleanup diagnostics path=%s detail=%s"
+                  path
+                  (Fs_compat.Durable_mutation.report_to_string report))))
   end;
   Tool_output.Stored {
     sha256;
@@ -63,6 +87,14 @@ let put t ~bytes ~mime =
     preview = make_preview bytes;
     mime;
   }
+
+let put_blocking = put_with Fs_compat.save_file_atomic_blocking
+
+let put_eio t ~bytes ~mime =
+  Eio.Cancel.protect (fun () ->
+    Eio_unix.run_in_systhread ~label:"tool-blob-store" (fun () ->
+      put_blocking t ~bytes ~mime))
+;;
 
 let fetch t ~sha256 =
   let path = shard_path t sha256 in

--- a/lib/tool_blob_store/tool_blob_store.mli
+++ b/lib/tool_blob_store/tool_blob_store.mli
@@ -2,12 +2,19 @@
 
     Backend: filesystem under [base_path/.masc/tool_blobs/<sha[0..1]>/<sha>].
     Two-character sharding bounds each directory to ~256 of the total set.
-    Writes are atomic via [Fs_compat.save_file_atomic] (tempfile + rename).
+    Writes use the typed Fs_compat durable-mutation entry points.
 
     Concurrent writes of the same content are safe: same sha256 -> same path,
     last writer wins with byte-identical content. *)
 
 type t
+
+exception Committed_not_durable of string
+(** The blob entry was committed but the parent directory sync failed. Callers
+    must not retry the write; they may fall back to the original inline bytes. *)
+
+exception Durable_with_diagnostics of string
+(** The blob is durable but descriptor cleanup emitted a diagnostic. *)
 
 val create : base_path:string -> t
 (** Create a blob store rooted at [base_path/.masc/tool_blobs/].
@@ -16,8 +23,8 @@ val create : base_path:string -> t
 val root_dir : t -> string
 (** Absolute path of the store root. Mainly for diagnostics/testing. *)
 
-val put : t -> bytes:string -> mime:string -> Tool_output.t
-(** Store [bytes] under its sha256 digest.
+val put_blocking : t -> bytes:string -> mime:string -> Tool_output.t
+(** Store [bytes] under its sha256 digest on the calling thread.
 
     Returns [Tool_output.Stored {sha256; bytes; preview; mime}] where
     [preview] is the first ~200 sanitized chars of [bytes] (control bytes
@@ -25,9 +32,16 @@ val put : t -> bytes:string -> mime:string -> Tool_output.t
 
     Idempotent: re-putting the same bytes is a no-op (file already exists).
 
-    @raises Sys_error if the blob write fails (disk full, EACCES, ...). Callers
+    @raises Sys_error if the blob write was not committed (disk full, EACCES,
+    ...). @raises Committed_not_durable when the entry was committed but parent
+    sync failed. @raises Durable_with_diagnostics after a durable write with a
+    cleanup diagnostic. Callers
     that must not lose bytes should catch this and fall back to the inline
     payload rather than emitting a marker for bytes that were never persisted. *)
+
+val put_eio : t -> bytes:string -> mime:string -> Tool_output.t
+(** Eio-safe counterpart of {!put_blocking}. Directory inspection, creation,
+    and the durable write run as one cancellation-protected system-thread job. *)
 
 val fetch : t -> sha256:string -> string option
 (** Retrieve bytes by sha256. Returns [None] if not in store. *)

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -94,11 +94,19 @@ let maybe_externalize ?(mime = "text/plain") (msg : string) : string =
       | None -> msg
       | Some store ->
           (try
-             let stored = Tool_blob_store.put store ~bytes:msg ~mime in
+             let stored = Tool_blob_store.put_eio store ~bytes:msg ~mime in
              Tool_output.encode_for_oas stored
-           with
+          with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | _ -> msg)
+          | Tool_blob_store.Committed_not_durable detail
+          | Tool_blob_store.Durable_with_diagnostics detail ->
+            Log.Keeper.warn "tool blob externalization debt: %s" detail;
+            msg
+          | exn ->
+            Log.Keeper.warn
+              "tool blob externalization not committed: %s"
+              (Printexc.to_string exn);
+            msg)
 
 let success_result_preserves_full_content tr =
   match Tool_name.of_string (Tool_result.tool_name tr) with

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -751,8 +751,28 @@ let persist_aggregate_snapshot ~(masc_root : string) ~(keeper_name : string)
   let dir = trajectories_dir masc_root keeper_name in
   Fs_compat.mkdir_p dir;
   let path = aggregate_snapshot_path masc_root keeper_name in
-  Fs_compat.save_file_atomic path
-    (Yojson.Safe.to_string (tool_affinity_aggregate_to_json agg))
+  let report =
+    Fs_compat.save_file_atomic_eio path
+      (Yojson.Safe.to_string (tool_affinity_aggregate_to_json agg))
+  in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Misc.warn
+        "trajectory aggregate committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Misc.warn
+           "trajectory aggregate durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok ())
 
 (* ── In-memory aggregation ── *)
 

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -413,7 +413,29 @@ let save_request base_path req =
     Fs_compat.mkdir_p dir;
     let json = request_to_yojson req in
     let path = request_path base_path req.id in
-    let* () = Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json) in
+    let report =
+      Fs_compat.save_file_atomic_eio path (Yojson.Safe.pretty_to_string json)
+    in
+    let* () =
+      Fs_compat.Durable_mutation.fold_report report
+        ~not_committed:(fun report ->
+          Error (Fs_compat.Durable_mutation.report_to_string report))
+        ~committed_not_durable:(fun report ->
+          Log.Misc.warn
+            "verification request committed with sync debt path=%s detail=%s"
+            path
+            (Fs_compat.Durable_mutation.report_to_string report);
+          Ok ())
+        ~durable:(fun report ->
+          (match report.diagnostics with
+           | [] -> ()
+           | _ ->
+             Log.Misc.warn
+               "verification request durable with cleanup diagnostics path=%s detail=%s"
+               path
+               (Fs_compat.Durable_mutation.report_to_string report));
+          Ok ())
+    in
     invalidate_list_requests_cache ();
     Ok req.id
   with

--- a/lib/workspace/workspace_utils_ops.ml
+++ b/lib/workspace/workspace_utils_ops.ml
@@ -177,7 +177,25 @@ let json_to_pretty_utf8 json =
 let write_json_local path json =
   mkdir_p (Filename.dirname path);
   let content = json_to_pretty_utf8 json in
-  Fs_compat.save_file_atomic path content
+  let report = Fs_compat.save_file_atomic_eio path content in
+  Fs_compat.Durable_mutation.fold_report report
+    ~not_committed:(fun report ->
+      Error (Fs_compat.Durable_mutation.report_to_string report))
+    ~committed_not_durable:(fun report ->
+      Log.Misc.warn
+        "workspace JSON committed with sync debt path=%s detail=%s"
+        path
+        (Fs_compat.Durable_mutation.report_to_string report);
+      Ok ())
+    ~durable:(fun report ->
+      (match report.diagnostics with
+       | [] -> ()
+       | _ ->
+         Log.Misc.warn
+           "workspace JSON durable with cleanup diagnostics path=%s detail=%s"
+           path
+           (Fs_compat.Durable_mutation.report_to_string report));
+      Ok ())
 
 (* Root-scoped JSON helpers for shared root metadata. *)
 let read_json_root config path =

--- a/test/dune
+++ b/test/dune
@@ -2791,3 +2791,5 @@
  (deps
   (source_tree ../lib)
   (source_tree ../bin)))
+
+(include stanzas/test_durable_mutation_state_machine.inc)

--- a/test/dune
+++ b/test/dune
@@ -772,7 +772,7 @@
 (test
  (name test_runtime_config_validity)
  (modules test_runtime_config_validity)
- (libraries masc_test_deps))
+ (libraries masc_test_deps threads))
 
 (test
  (name test_keeper_structured_output_coverage)
@@ -1360,7 +1360,7 @@
   test_board_core_payload
   test_board_attachment_meta
   test_board_moderation)
- (libraries masc_test_deps masc.tool_orchestration bigstringaf)
+ (libraries masc_test_deps masc.tool_orchestration bigstringaf eio_main)
  (deps ../bin/main_eio.exe))
 
 (test
@@ -2793,3 +2793,8 @@
   (source_tree ../bin)))
 
 (include stanzas/test_durable_mutation_state_machine.inc)
+
+(test
+ (name test_durable_domain_eio_boundaries)
+ (modules test_durable_domain_eio_boundaries)
+ (libraries alcotest eio_main masc_test_deps))

--- a/test/multimodal/test_vision_artifact_store.ml
+++ b/test/multimodal/test_vision_artifact_store.ml
@@ -32,21 +32,21 @@ let mentions ~needle s =
 let test_round_trip () =
   let dir = temp_dir () in
   let bytes = "\x89PNG\r\n\x1a\n\x00\xffbinary\x00\x00bytes\xfe" in
-  let h = ok (S.store ~dir bytes) in
+  let h = ok (S.store_blocking ~dir bytes) in
   assert (String.equal (ok (S.load ~dir h)) bytes)
 
 (* content-addressed: identical bytes -> identical handle. *)
 let test_content_addressed () =
   let dir = temp_dir () in
-  let h1 = ok (S.store ~dir "abc") in
-  let h2 = ok (S.store ~dir "abc") in
+  let h1 = ok (S.store_blocking ~dir "abc") in
+  let h2 = ok (S.store_blocking ~dir "abc") in
   assert (String.equal (S.to_string h1) (S.to_string h2))
 
 (* distinct bytes -> distinct handles. *)
 let test_distinct () =
   let dir = temp_dir () in
-  let h1 = ok (S.store ~dir "abc") in
-  let h2 = ok (S.store ~dir "abd") in
+  let h1 = ok (S.store_blocking ~dir "abc") in
+  let h2 = ok (S.store_blocking ~dir "abd") in
   assert (not (String.equal (S.to_string h1) (S.to_string h2)))
 
 (* the handle survives a string round-trip (what a checkpoint persists) and the
@@ -54,7 +54,7 @@ let test_distinct () =
 let test_persisted_handle_reload () =
   let dir = temp_dir () in
   let bytes = "durable-across-checkpoint" in
-  let h = ok (S.store ~dir bytes) in
+  let h = ok (S.store_blocking ~dir bytes) in
   let persisted = S.to_string h in
   let rewrapped = S.of_string persisted in
   assert (String.equal (ok (S.load ~dir rewrapped)) bytes)
@@ -70,7 +70,7 @@ let test_missing_is_error () =
 (* a tampered file (bytes no longer hash to the handle) is rejected on read. *)
 let test_corruption_detected () =
   let dir = temp_dir () in
-  let h = ok (S.store ~dir "original") in
+  let h = ok (S.store_blocking ~dir "original") in
   let path = Filename.concat dir (S.to_string h) in
   let oc = open_out_bin path in
   output_string oc "tampered-content";
@@ -88,7 +88,7 @@ let test_corruption_detected () =
    the filesystem. *)
 let test_malformed_handle_rejected () =
   let dir = temp_dir () in
-  ignore (ok (S.store ~dir "seed so dir exists"));
+  ignore (ok (S.store_blocking ~dir "seed so dir exists"));
   List.iter
     (fun bad ->
       match S.load ~dir (S.of_string bad) with

--- a/test/stanzas/test_anti_rationalization_excuse_patterns_writeback.inc
+++ b/test/stanzas/test_anti_rationalization_excuse_patterns_writeback.inc
@@ -1,4 +1,4 @@
 (test
  (name test_anti_rationalization_excuse_patterns_writeback)
  (modules test_anti_rationalization_excuse_patterns_writeback)
- (libraries masc masc.config_dir_resolver alcotest unix yojson))
+ (libraries masc masc.config_dir_resolver alcotest unix yojson eio_main))

--- a/test/stanzas/test_durable_mutation_state_machine.inc
+++ b/test/stanzas/test_durable_mutation_state_machine.inc
@@ -1,0 +1,5 @@
+(test
+ (name test_durable_mutation_state_machine)
+ (modules test_durable_mutation_state_machine)
+ (modes native)
+ (libraries fs_compat eio eio_main alcotest unix))

--- a/test/stanzas/test_keeper_approval_queue_rules.inc
+++ b/test/stanzas/test_keeper_approval_queue_rules.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_approval_queue_rules)
  (modules test_keeper_approval_queue_rules)
- (libraries alcotest masc masc_test_deps unix yojson))
+ (libraries alcotest masc masc_test_deps unix yojson eio_main))

--- a/test/test_anti_rationalization_excuse_patterns_writeback.ml
+++ b/test/test_anti_rationalization_excuse_patterns_writeback.ml
@@ -101,6 +101,7 @@ let test_no_writeback_when_not_legacy () =
     mtime_before mtime_after
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "anti_rationalization_excuse_patterns_writeback"
     [
       ( "migration-writeback",

--- a/test/test_artifacts_endpoint.ml
+++ b/test/test_artifacts_endpoint.ml
@@ -84,7 +84,7 @@ let test_hit_returns_envelope () =
   with_temp_base_path (fun dir ->
       let store = B.create ~base_path:dir in
       let payload = "the actual blob bytes" in
-      let stored = B.put store ~bytes:payload ~mime:"text/plain" in
+      let stored = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
       match stored with
       | O.Stored { sha256; _ } ->
           let json, status = A.blob_response ~sha256 in

--- a/test/test_channel_gate_binding_store.ml
+++ b/test/test_channel_gate_binding_store.ml
@@ -128,6 +128,7 @@ let test_append_and_read_recent_audit () =
     (List.nth recent 1 |> U.member "action" |> U.to_string)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "channel_gate_binding_store"
     [
       ( "bindings",

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -54,7 +54,7 @@ let with_temperature_runtime f =
       try Sys.remove path with
       | Sys_error _ -> ())
     (fun () ->
-      match Runtime.save_config_text ~runtime_config_path:path temperature_runtime_toml with
+      match Runtime.save_config_text_blocking ~runtime_config_path:path temperature_runtime_toml with
       | Error detail -> Alcotest.failf "runtime config should load: %s" detail
       | Ok () ->
         (match Runtime.get_runtime_by_id temperature_runtime_id with

--- a/test/test_dashboard_verification.ml
+++ b/test/test_dashboard_verification.ml
@@ -498,28 +498,32 @@ let test_summary_recent_clamp () =
 
 (* ── Registration ───────────────────────────────────── *)
 
+let eio_test_case name speed test =
+  Alcotest.test_case name speed (fun () -> Eio_main.run (fun _env -> test ()))
+;;
+
 let () =
   Alcotest.run "dashboard_verification" [
     "requests_json", [
-      Alcotest.test_case "restores boot override config inputs" `Quick
+      eio_test_case "restores boot override config inputs" `Quick
         test_config_input_override_restores_boot_override;
-      Alcotest.test_case "overrides and restores env inputs" `Quick
+      eio_test_case "overrides and restores env inputs" `Quick
         test_temp_base_path_overrides_and_restores_env_inputs;
-      Alcotest.test_case "shape" `Quick test_requests_json_shape;
-      Alcotest.test_case "uses explicit base_path, not env" `Quick
+      eio_test_case "shape" `Quick test_requests_json_shape;
+      eio_test_case "uses explicit base_path, not env" `Quick
         test_requests_json_uses_explicit_base_path_not_env;
-      Alcotest.test_case "task_id filter" `Quick test_task_id_filter;
-      Alcotest.test_case "ignores legacy root entries" `Quick
+      eio_test_case "task_id filter" `Quick test_task_id_filter;
+      eio_test_case "ignores legacy root entries" `Quick
         test_requests_json_ignores_legacy_root_entries;
-      Alcotest.test_case "conflict triage fields" `Quick
+      eio_test_case "conflict triage fields" `Quick
         test_requests_json_surfaces_conflict_triage_fields;
-      Alcotest.test_case "fd pressure degraded projection" `Quick
+      eio_test_case "fd pressure degraded projection" `Quick
         test_requests_and_summary_degrade_under_fd_pressure;
     ];
     "summary_json", [
-      Alcotest.test_case "empty base_path" `Quick test_summary_empty;
-      Alcotest.test_case "bucket counts + recent rejections"
+      eio_test_case "empty base_path" `Quick test_summary_empty;
+      eio_test_case "bucket counts + recent rejections"
         `Quick test_summary_bucket_counts;
-      Alcotest.test_case "recent clamp" `Quick test_summary_recent_clamp;
+      eio_test_case "recent clamp" `Quick test_summary_recent_clamp;
     ];
   ]

--- a/test/test_durable_domain_eio_boundaries.ml
+++ b/test/test_durable_domain_eio_boundaries.ml
@@ -1,0 +1,109 @@
+module Blob_store = Tool_blob_store
+module Vision_store = Multimodal.Vision_artifact_store
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Sys.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_dir "durable-domain-eio-" "" in
+  Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
+;;
+
+let test_tool_blob_store_eio_boundary () =
+  with_temp_dir (fun base_path ->
+    let store = Blob_store.create ~base_path in
+    match Blob_store.put_eio store ~bytes:"typed blob" ~mime:"text/plain" with
+    | Tool_output.Stored { sha256; _ } ->
+      Alcotest.(check (option string))
+        "Eio entry point stores and fetches bytes"
+        (Some "typed blob")
+        (Blob_store.fetch store ~sha256)
+    | Tool_output.Inline _ -> Alcotest.fail "blob was not externalized")
+;;
+
+let test_vision_store_eio_boundary () =
+  with_temp_dir (fun base_path ->
+    let dir = Filename.concat base_path "vision" in
+    match Vision_store.store_eio ~dir "image-bytes" with
+    | Error detail -> Alcotest.fail detail
+    | Ok handle ->
+      Alcotest.(check (result string string))
+        "Eio entry point stores and loads artifact"
+        (Ok "image-bytes")
+        (Vision_store.load ~dir handle))
+;;
+
+let test_repo_mapping_eio_boundary () =
+  with_temp_dir (fun base_path ->
+    let mapping =
+      Repo_manager_types.make_keeper_repo_mapping
+        ~keeper_id:"keeper-a"
+        ~repository_ids:[ "repo-a" ]
+    in
+    (match Keeper_repo_mapping.save_mapping_eio ~base_path mapping with
+     | Error detail -> Alcotest.fail detail
+     | Ok () -> ());
+    match Keeper_repo_mapping.load_all ~base_path with
+    | Error detail -> Alcotest.fail detail
+    | Ok [ persisted ] ->
+      Alcotest.(check string) "keeper id" "keeper-a" persisted.keeper_id;
+      Alcotest.(check (list string))
+        "repository ids"
+        [ "repo-a" ]
+        persisted.repository_ids
+    | Ok mappings ->
+      Alcotest.failf "expected one persisted mapping, got %d" (List.length mappings))
+;;
+
+let test_history_migration_eio_boundary () =
+  with_temp_dir (fun session_dir ->
+    let main_path = Filename.concat session_dir "history.jsonl" in
+    let internal_path = Filename.concat session_dir "history.internal.jsonl" in
+    let moved =
+      {|{"role":"assistant","source":"internal_assistant","content_blocks":[]}|}
+    in
+    Fs_compat.save_file main_path (moved ^ "\n");
+    (match Masc.Keeper_context_core.migrate_session_history_logs_eio ~session_dir with
+     | Error error ->
+       Alcotest.fail
+         (Masc.Keeper_context_core.history_migration_error_to_string error)
+     | Ok stats -> Alcotest.(check int) "one line moved" 1 stats.moved_lines);
+    Alcotest.(check string) "main history emptied" "" (Fs_compat.load_file main_path);
+    Alcotest.(check string)
+      "internal history receives line"
+      (moved ^ "\n")
+      (Fs_compat.load_file internal_path))
+;;
+
+let () =
+  Eio_main.run @@ fun _env ->
+  Alcotest.run
+    "durable-domain-eio-boundaries"
+    [ ( "boundaries"
+      , [ Alcotest.test_case
+            "tool blob store"
+            `Quick
+            test_tool_blob_store_eio_boundary
+        ; Alcotest.test_case
+            "vision artifact store"
+            `Quick
+            test_vision_store_eio_boundary
+        ; Alcotest.test_case
+            "keeper repo mapping"
+            `Quick
+            test_repo_mapping_eio_boundary
+        ; Alcotest.test_case
+            "history migration"
+            `Quick
+            test_history_migration_eio_boundary
+        ] )
+    ]
+;;

--- a/test/test_durable_mutation_state_machine.ml
+++ b/test/test_durable_mutation_state_machine.ml
@@ -111,6 +111,42 @@ let test_observer_cancellation_propagates () =
     fail "observer swallowed Eio cancellation"
 ;;
 
+let test_observer_failure_is_retained_as_diagnostic () =
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:ignore
+      ~cleanup:(fun () -> [])
+  in
+  let report = Mutation.observe_and_retain (fun _ -> raise Exit) report in
+  check_progress `Durable report;
+  match report.Mutation.diagnostics with
+  | [ diagnostic ] ->
+    check bool "observer diagnostic retained" true
+      (diagnostic.Mutation.stage = Mutation.Observer)
+  | diagnostics ->
+    failf "expected one observer diagnostic, got %d" (List.length diagnostics)
+;;
+
+let test_confirmation_observer_failure_is_retained_as_diagnostic () =
+  let report =
+    { Mutation.confirmation = Mutation.Confirmed; confirmation_diagnostics = [] }
+  in
+  let report =
+    Mutation.observe_confirmation_and_retain (fun _ -> raise Exit) report
+  in
+  check bool "confirmation retained" true
+    (report.Mutation.confirmation = Mutation.Confirmed);
+  match report.Mutation.confirmation_diagnostics with
+  | [ diagnostic ] ->
+    check bool "confirmation observer diagnostic retained" true
+      (diagnostic.Mutation.stage = Mutation.Observer)
+  | diagnostics ->
+    failf "expected one confirmation observer diagnostic, got %d"
+      (List.length diagnostics)
+;;
+
 let with_temp_dir f =
   let path =
     Filename.concat
@@ -159,6 +195,27 @@ let test_real_blocking_replace () =
     check_progress `Durable second;
     check string "replacement visible" "second" (read_file path);
     check int "no temporary residue" 1 (Array.length (Sys.readdir parent)))
+;;
+
+let test_directory_durability_confirmation () =
+  with_temp_dir (fun parent ->
+    let report = Mutation.confirm_directory_durable_blocking parent in
+    (match report.confirmation with
+     | Mutation.Confirmed -> ()
+    | Mutation.Not_confirmed _ -> fail "existing directory was not confirmed");
+    check (list string) "no close diagnostics" []
+      (List.map
+         Mutation.diagnostic_to_string
+         report.confirmation_diagnostics))
+;;
+
+let test_missing_directory_durability_not_confirmed () =
+  with_temp_dir (fun parent ->
+    let missing = Filename.concat parent "missing" in
+    let report = Mutation.confirm_directory_durable_blocking missing in
+    match report.confirmation with
+    | Mutation.Not_confirmed _ -> ()
+    | Mutation.Confirmed -> fail "missing directory was confirmed")
 ;;
 
 let test_parent_symlink_is_rejected () =
@@ -214,6 +271,14 @@ let test_eio_boundary_returns_report () =
     check_progress `Durable report)
 ;;
 
+let test_confirmation_eio_boundary_returns_report () =
+  with_temp_dir (fun parent ->
+    Eio_main.run @@ fun _env ->
+    let report = Mutation.confirm_directory_durable_eio parent in
+    check bool "directory durability confirmed" true
+      (report.Mutation.confirmation = Mutation.Confirmed))
+;;
+
 let () =
   run
     "durable-mutation-state-machine"
@@ -239,7 +304,23 @@ let () =
             "observer cancellation propagates"
             `Quick
             test_observer_cancellation_propagates
+        ; test_case
+            "observer failure is retained"
+            `Quick
+            test_observer_failure_is_retained_as_diagnostic
+        ; test_case
+            "confirmation observer failure is retained"
+            `Quick
+            test_confirmation_observer_failure_is_retained_as_diagnostic
         ; test_case "blocking replace" `Quick test_real_blocking_replace
+        ; test_case
+            "directory durability confirmation"
+            `Quick
+            test_directory_durability_confirmation
+        ; test_case
+            "missing directory is not confirmed"
+            `Quick
+            test_missing_directory_durability_not_confirmed
         ; test_case
             "parent symlink rejected"
             `Quick
@@ -249,5 +330,9 @@ let () =
             `Quick
             test_final_symlink_is_replaced_not_followed
         ; test_case "Eio boundary" `Quick test_eio_boundary_returns_report
+        ; test_case
+            "confirmation Eio boundary"
+            `Quick
+            test_confirmation_eio_boundary_returns_report
         ] )
     ]

--- a/test/test_durable_mutation_state_machine.ml
+++ b/test/test_durable_mutation_state_machine.ml
@@ -1,0 +1,253 @@
+open Alcotest
+
+module Mutation = Fs_compat.Durable_mutation
+
+let segment value =
+  match Mutation.Segment.of_string value with
+  | Ok value -> value
+  | Error _ -> failf "invalid test segment: %S" value
+;;
+
+let progress_testable =
+  testable
+    (fun formatter -> function
+       | `Not_committed -> Format.pp_print_string formatter "Not_committed"
+       | `Committed_not_durable ->
+         Format.pp_print_string formatter "Committed_not_durable"
+       | `Durable -> Format.pp_print_string formatter "Durable")
+    ( = )
+;;
+
+let check_progress expected report =
+  let actual =
+    match report.Mutation.progress with
+    | Mutation.Not_committed _ -> `Not_committed
+    | Mutation.Committed_not_durable _ -> `Committed_not_durable
+    | Mutation.Durable () -> `Durable
+  in
+  check progress_testable "mutation progress" expected actual
+;;
+
+let test_segment_boundary () =
+  List.iter
+    (fun value ->
+      check bool value true (Result.is_error (Mutation.Segment.of_string value)))
+    [ ""; "."; ".."; "a/b"; "a\000b" ];
+  check bool "plain child accepted" true
+    (Result.is_ok (Mutation.Segment.of_string "state.json"))
+;;
+
+let test_prepare_failure_is_not_committed () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:(fun () -> raise Exit)
+      ~commit:(fun () -> fail "commit must not run")
+      ~publish:(fun () -> fail "publish must not run")
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Not_committed report;
+  check int "cleanup once" 1 !cleanup_calls
+;;
+
+let test_commit_failure_is_not_committed () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:(fun () -> raise Exit)
+      ~publish:(fun () -> fail "publish must not run")
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Not_committed report;
+  check int "cleanup once" 1 !cleanup_calls
+;;
+
+let test_cancellation_after_commit_preserves_committed_state () =
+  let cleanup_calls = ref 0 in
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:(fun () ->
+        raise (Eio.Cancel.Cancelled (Failure "cancel after rename")))
+      ~cleanup:(fun () -> incr cleanup_calls; [])
+  in
+  check_progress `Committed_not_durable report;
+  check int "committed entry is never cleaned up" 0 !cleanup_calls
+;;
+
+let test_observer_failure_is_separate () =
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:ignore
+      ~cleanup:(fun () -> [])
+  in
+  match Mutation.observe (fun _ -> raise Exit) report with
+  | Mutation.Observed -> fail "observer failure was not reported"
+  | Mutation.Observer_failed diagnostic ->
+    check bool "observer diagnostic" true
+      (diagnostic.Mutation.stage = Mutation.Observer);
+    check_progress `Durable report
+;;
+
+let test_observer_cancellation_propagates () =
+  let report =
+    Mutation.For_testing.run_state_machine
+      ~prepare:ignore
+      ~commit:ignore
+      ~publish:ignore
+      ~cleanup:(fun () -> [])
+  in
+  match
+    Mutation.observe
+      (fun _ -> raise (Eio.Cancel.Cancelled (Failure "observer cancelled")))
+      report
+  with
+  | exception Eio.Cancel.Cancelled _ -> ()
+  | Mutation.Observed | Mutation.Observer_failed _ ->
+    fail "observer swallowed Eio cancellation"
+;;
+
+let with_temp_dir f =
+  let path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "durable_mutation_%d_%08x"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      Array.iter
+        (fun name -> Sys.remove (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path)
+    (fun () -> f path)
+;;
+
+let read_file path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+;;
+
+let test_real_blocking_replace () =
+  with_temp_dir (fun parent ->
+    let name = segment "state.json" in
+    let path = Filename.concat parent "state.json" in
+    let first =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        "first"
+    in
+    check_progress `Durable first;
+    let second =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name
+        ~perm:0o600
+        "second"
+    in
+    check_progress `Durable second;
+    check string "replacement visible" "second" (read_file path);
+    check int "no temporary residue" 1 (Array.length (Sys.readdir parent)))
+;;
+
+let test_parent_symlink_is_rejected () =
+  with_temp_dir (fun root ->
+    let real_parent = Filename.concat root "real" in
+    let linked_parent = Filename.concat root "linked" in
+    Unix.mkdir real_parent 0o700;
+    Unix.symlink real_parent linked_parent;
+    let report =
+      Mutation.atomic_replace_blocking
+        ~parent:linked_parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "blocked"
+    in
+    check_progress `Not_committed report;
+    check bool "real directory untouched" false
+      (Sys.file_exists (Filename.concat real_parent "state.json"));
+    Unix.unlink linked_parent;
+    Unix.rmdir real_parent)
+;;
+
+let test_final_symlink_is_replaced_not_followed () =
+  with_temp_dir (fun parent ->
+    let outside = Filename.concat parent "outside.json" in
+    let target = Filename.concat parent "state.json" in
+    let channel = open_out_bin outside in
+    output_string channel "outside";
+    close_out channel;
+    Unix.symlink outside target;
+    let report =
+      Mutation.atomic_replace_blocking
+        ~parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "inside"
+    in
+    check_progress `Durable report;
+    check string "outside inode untouched" "outside" (read_file outside);
+    check string "target entry replaced" "inside" (read_file target))
+;;
+
+let test_eio_boundary_returns_report () =
+  with_temp_dir (fun parent ->
+    Eio_main.run @@ fun _env ->
+    let report =
+      Mutation.atomic_replace_eio
+        ~parent
+        ~name:(segment "state.json")
+        ~perm:0o600
+        "eio"
+    in
+    check_progress `Durable report)
+;;
+
+let () =
+  run
+    "durable-mutation-state-machine"
+    [ ( "contract"
+      , [ test_case "segment boundary" `Quick test_segment_boundary
+        ; test_case
+            "prepare failure is not committed"
+            `Quick
+            test_prepare_failure_is_not_committed
+        ; test_case
+            "commit failure is not committed"
+            `Quick
+            test_commit_failure_is_not_committed
+        ; test_case
+            "cancellation after commit preserves state"
+            `Quick
+            test_cancellation_after_commit_preserves_committed_state
+        ; test_case
+            "observer failure is separate"
+            `Quick
+            test_observer_failure_is_separate
+        ; test_case
+            "observer cancellation propagates"
+            `Quick
+            test_observer_cancellation_propagates
+        ; test_case "blocking replace" `Quick test_real_blocking_replace
+        ; test_case
+            "parent symlink rejected"
+            `Quick
+            test_parent_symlink_is_rejected
+        ; test_case
+            "final symlink replaced"
+            `Quick
+            test_final_symlink_is_replaced_not_followed
+        ; test_case "Eio boundary" `Quick test_eio_boundary_returns_report
+        ] )
+    ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -20,11 +20,11 @@ let with_temp_path f =
       cleanup_if_exists path)
     (fun () -> f path)
 
-let test_with_lock_without_eio () =
+let test_with_lock_blocking () =
   with_temp_path @@ fun path ->
   let calls = ref 0 in
   let result =
-    File_lock_eio.with_lock path (fun () ->
+    File_lock_eio.with_lock_blocking path (fun () ->
         incr calls;
         "ok")
   in
@@ -41,7 +41,7 @@ let test_acquire_flock_retry_without_eio () =
       ~max_attempts:1 ~caller:"test_file_lock_eio" ()
   in
   Fun.protect
-    ~finally:(fun () -> File_lock_eio.release_flock_fd fd)
+    ~finally:(fun () -> File_lock_eio.release_flock_fd_blocking fd)
     (fun () ->
       check bool "lock file created" true (Sys.file_exists lock_path))
 
@@ -64,7 +64,7 @@ let () =
     [
       ( "locks",
         [
-          test_case "works without Eio context" `Quick test_with_lock_without_eio;
+          test_case "explicit blocking boundary" `Quick test_with_lock_blocking;
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -79,9 +79,13 @@ let test_save_file_atomic_leaves_no_tmp_on_success () =
   with_tmp_dir
   @@ fun base ->
   let target = Filename.concat base "out.json" in
-  (match Fs_compat.save_file_atomic target {|{"ok":true}|} with
-   | Ok () -> ()
-   | Error msg -> fail msg);
+  let report = Fs_compat.save_file_atomic_eio target {|{"ok":true}|} in
+  (match report.progress with
+   | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+   | Fs_compat.Durable_mutation.Durable ()
+   | Fs_compat.Durable_mutation.Committed_not_durable _
+   | Fs_compat.Durable_mutation.Not_committed _ ->
+     fail (Fs_compat.Durable_mutation.report_to_string report));
   check bool "target exists" true (Sys.file_exists target);
   check string "content matches" {|{"ok":true}|} (Fs_compat.load_file target);
   let leftover_tmps =
@@ -98,10 +102,32 @@ let test_save_file_atomic_overwrites_existing () =
   @@ fun base ->
   let target = Filename.concat base "out.json" in
   Fs_compat.save_file target "old";
-  (match Fs_compat.save_file_atomic target "new" with
-   | Ok () -> ()
-   | Error msg -> fail msg);
+  let report = Fs_compat.save_file_atomic_eio target "new" in
+  (match report.progress with
+   | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+   | Fs_compat.Durable_mutation.Durable ()
+   | Fs_compat.Durable_mutation.Committed_not_durable _
+   | Fs_compat.Durable_mutation.Not_committed _ ->
+     fail (Fs_compat.Durable_mutation.report_to_string report));
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
+;;
+
+let test_save_file_atomic_rejects_invalid_final_segment () =
+  let path = Filename.concat (Filename.get_temp_dir_name ()) ".." in
+  let report = Fs_compat.save_file_atomic_eio path "not-written" in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Not_committed
+      { cause =
+          Fs_compat.Invalid_atomic_target
+            { error = Fs_compat.Durable_mutation.Segment.Dot_dot; _ }
+      ; _
+      } ->
+    check (list string) "no cleanup diagnostics" []
+      (List.map Fs_compat.Durable_mutation.diagnostic_to_string report.diagnostics)
+  | Fs_compat.Durable_mutation.Not_committed _
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Durable () ->
+    fail (Fs_compat.Durable_mutation.report_to_string report)
 ;;
 
 let with_redirected_stderr (f : unit -> 'a) : 'a * string =
@@ -323,6 +349,10 @@ let () =
             "overwrites existing target"
             `Quick
             test_save_file_atomic_overwrites_existing
+        ; test_case
+            "invalid final segment is typed not-committed"
+            `Quick
+            test_save_file_atomic_rejects_invalid_final_segment
         ] )
     ; ( "load_jsonl_diagnostics"
       , [ test_case

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -124,7 +124,7 @@ let test_provider_config_for_summary_routes_hitl_summary_lane () =
   let load_and_resolve ~with_hitl_summary =
     let text = summary_routing_runtime_toml ~with_hitl_summary in
     with_temp_runtime_toml text (fun path ->
-      match Runtime.save_config_text ~runtime_config_path:path text with
+      match Runtime.save_config_text_blocking ~runtime_config_path:path text with
       | Error msg -> Alcotest.failf "runtime config should load: %s" msg
       | Ok () ->
         (match AQ.provider_config_for_summary ~keeper_name:"no-such-keeper" with

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -137,6 +137,7 @@ let test_corrupt_rules_file_reports_read_drop () =
 ;;
 
 let () =
+  Eio_main.run @@ fun _env ->
   run
     "Keeper_approval_queue_rules"
     [ ( "persisted rules"

--- a/test/test_keeper_artifact_hydrator.ml
+++ b/test/test_keeper_artifact_hydrator.ml
@@ -33,7 +33,7 @@ let with_temp_dir f =
   match r with Ok v -> v | Error e -> raise e
 
 let store_a_blob store payload =
-  match B.put store ~bytes:payload ~mime:"text/plain" with
+  match B.put_blocking store ~bytes:payload ~mime:"text/plain" with
   | O.Stored { sha256; bytes; preview; mime } ->
       let marker =
         O.encode_for_oas

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -614,8 +614,64 @@ let test_inflight_lease_requeued_on_restart () =
        | `Leased { messages; _ } ->
          check "the unacknowledged lease is redelivered whole after restart"
            (contents messages = [ "leased-1"; "leased-2" ])
-       | `Empty | `Already_leased _ | `Persist_failed _ ->
+      | `Empty | `Already_leased _ | `Persist_failed _ ->
          check "the redelivered batch is leaseable" false))
+;;
+
+let test_enqueue_sync_debt_is_confirmed_before_receipt () =
+  Printf.printf
+    "Test 17: enqueue confirms parent durability before returning a receipt for sync debt\n%!";
+  let base_path = temp_dir "keeper-chat-queue-confirm-debt" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "confirm-debt-keeper" in
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      Keeper_chat_queue.For_testing.force_next_sync_debt ();
+      let receipt_id =
+        Keeper_chat_queue.enqueue ~keeper_name
+          (msg ~content:"confirmed" ~ts:1.0 Keeper_chat_queue.Dashboard)
+      in
+      check "confirmed enqueue returns a receipt" (not (String.equal receipt_id ""));
+      check "confirmed enqueue remains queued" (Keeper_chat_queue.length ~keeper_name = 1);
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check "confirmed enqueue replays after restart"
+        (Keeper_chat_queue.length ~keeper_name = 1))
+;;
+
+let test_enqueue_sync_debt_confirmation_failure_has_no_receipt () =
+  Printf.printf
+    "Test 18: enqueue returns no receipt when sync-debt confirmation fails\n%!";
+  let base_path = temp_dir "keeper-chat-queue-reject-debt" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "reject-debt-keeper" in
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      Keeper_chat_queue.For_testing.force_next_sync_debt ();
+      Keeper_chat_queue.For_testing.fail_next_durability_confirmation ();
+      let failed_without_receipt =
+        match
+          Keeper_chat_queue.enqueue ~keeper_name
+            (msg ~content:"uncertain" ~ts:1.0 Keeper_chat_queue.Dashboard)
+        with
+        | exception Keeper_chat_queue.Persistence_failed _ -> true
+        | _ -> false
+      in
+      check "failed confirmation does not return a receipt" failed_without_receipt;
+      check "failed enqueue rolls back live memory"
+        (Keeper_chat_queue.length ~keeper_name = 0);
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check "committed snapshot is conservatively replayed after restart"
+        (Keeper_chat_queue.length ~keeper_name = 1))
 ;;
 
 let () =
@@ -636,6 +692,8 @@ let () =
   test_lease_already_leased_blocks_second_lease ();
   test_ack_nack_unknown_lease ();
   test_inflight_lease_requeued_on_restart ();
+  test_enqueue_sync_debt_is_confirmed_before_receipt ();
+  test_enqueue_sync_debt_confirmation_failure_has_no_receipt ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -261,6 +261,249 @@ let test_legacy_thinking_type_is_not_promoted_to_signature () =
       Alcotest.(check string) "content" "signed" content
   | _ -> Alcotest.fail "expected legacy thinking block"
 
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Sys.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_dir "keeper-history-migration-" "" in
+  Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
+;;
+
+let keep_history_line =
+  {|{"role":"user","content_blocks":[]}|}
+;;
+
+let moved_history_line =
+  {|{"role":"assistant","source":"internal_assistant","content_blocks":[]}|}
+;;
+
+let write_migration_fixture session_dir =
+  let main_path = Filename.concat session_dir "history.jsonl" in
+  Fs_compat.save_file
+    main_path
+    (String.concat "\n" [ keep_history_line; moved_history_line ] ^ "\n");
+  main_path, Filename.concat session_dir "history.internal.jsonl"
+;;
+
+let not_committed_report detail =
+  { Fs_compat.Durable_mutation.progress =
+      Fs_compat.Durable_mutation.Not_committed
+        { cause = Failure detail
+        ; backtrace = Printexc.get_callstack 8
+        }
+  ; diagnostics = []
+  }
+;;
+
+let committed_not_durable_report detail =
+  { Fs_compat.Durable_mutation.progress =
+      Fs_compat.Durable_mutation.Committed_not_durable
+        { value = ()
+        ; cause = Failure detail
+        ; backtrace = Printexc.get_callstack 8
+        }
+  ; diagnostics = []
+  }
+;;
+
+let durability_not_confirmed_report detail =
+  { Fs_compat.Durable_mutation.confirmation =
+      Fs_compat.Durable_mutation.Not_confirmed
+        { cause = Failure detail
+        ; backtrace = Printexc.get_callstack 8
+        }
+  ; confirmation_diagnostics = []
+  }
+;;
+
+let test_history_migration_internal_failure_preserves_main () =
+  with_temp_dir (fun session_dir ->
+    let main_path, internal_path = write_migration_fixture session_dir in
+    let original_main = Fs_compat.load_file main_path in
+    let result =
+      C.For_testing.migrate_session_history_logs_with
+        (fun _path _content -> not_committed_report "injected internal failure")
+        ~session_dir
+    in
+    (match result with
+     | Error
+         (C.History_write_not_committed
+            { stage = C.Internal_history; _ }) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong migration error: %s"
+         (C.history_migration_error_to_string error)
+     | Ok _ -> Alcotest.fail "internal write failure was reported as success");
+    Alcotest.(check string)
+      "main history remains authoritative"
+      original_main
+      (Fs_compat.load_file main_path);
+    Alcotest.(check bool)
+      "internal history was not created"
+      false
+      (Fs_compat.file_exists internal_path))
+;;
+
+let test_history_migration_main_failure_retries_without_internal_rewrite () =
+  with_temp_dir (fun session_dir ->
+    let main_path, internal_path = write_migration_fixture session_dir in
+    let original_main = Fs_compat.load_file main_path in
+    let first_attempt_calls = ref 0 in
+    let fail_second_write path content =
+      incr first_attempt_calls;
+      if !first_attempt_calls = 2
+      then not_committed_report "injected main failure"
+      else Fs_compat.save_file_atomic_blocking path content
+    in
+    (match
+       C.For_testing.migrate_session_history_logs_with
+         fail_second_write
+         ~session_dir
+     with
+     | Error
+         (C.History_write_not_committed
+            { stage = C.Main_history; _ }) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong migration error: %s"
+         (C.history_migration_error_to_string error)
+     | Ok _ -> Alcotest.fail "main write failure was reported as success");
+    Alcotest.(check string)
+      "failed main write preserves source lines"
+      original_main
+      (Fs_compat.load_file main_path);
+    Alcotest.(check bool)
+      "internal copy committed before main removal"
+      true
+      (String.equal
+         (Fs_compat.load_file internal_path)
+         (moved_history_line ^ "\n"));
+    let retry_calls = ref 0 in
+    let counting_writer path content =
+      incr retry_calls;
+      Fs_compat.save_file_atomic_blocking path content
+    in
+    let stats =
+      match
+        C.For_testing.migrate_session_history_logs_with
+          counting_writer
+          ~session_dir
+      with
+      | Ok stats -> stats
+      | Error error ->
+        Alcotest.fail
+          ("retry failed: " ^ C.history_migration_error_to_string error)
+    in
+    Alcotest.(check int)
+      "retry skips already-committed internal overwrite"
+      1
+      !retry_calls;
+    Alcotest.(check int) "one line moved" 1 stats.moved_lines;
+    Alcotest.(check string)
+      "main keeps only public history"
+      (keep_history_line ^ "\n")
+      (Fs_compat.load_file main_path);
+    Alcotest.(check string)
+      "internal line remains exactly once"
+      (moved_history_line ^ "\n")
+         (Fs_compat.load_file internal_path))
+;;
+
+let test_history_migration_internal_sync_debt_blocks_main_advance () =
+  with_temp_dir (fun session_dir ->
+    let main_path, internal_path = write_migration_fixture session_dir in
+    let original_main = Fs_compat.load_file main_path in
+    let first_attempt_calls = ref 0 in
+    let commit_internal_with_sync_debt path content =
+      incr first_attempt_calls;
+      if not (String.equal path internal_path)
+      then Alcotest.fail "main rewrite advanced past internal sync debt";
+      let committed = Fs_compat.save_file_atomic_blocking path content in
+      (match committed.progress with
+       | Fs_compat.Durable_mutation.Durable _ -> ()
+       | _ -> Alcotest.fail "fixture internal write did not commit durably");
+      committed_not_durable_report "injected internal parent-sync failure"
+    in
+    (match
+       C.For_testing.migrate_session_history_logs_with
+         commit_internal_with_sync_debt
+         ~session_dir
+     with
+     | Error
+         (C.History_write_committed_not_durable
+            { stage = C.Internal_history; _ }) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong migration error: %s"
+         (C.history_migration_error_to_string error)
+     | Ok _ -> Alcotest.fail "internal sync debt was reported as success");
+    Alcotest.(check int) "only internal phase ran" 1 !first_attempt_calls;
+    Alcotest.(check string)
+      "main history remains authoritative until internal is durable"
+      original_main
+      (Fs_compat.load_file main_path);
+    Alcotest.(check string)
+      "committed internal copy is available for retry"
+      (moved_history_line ^ "\n")
+      (Fs_compat.load_file internal_path);
+    let unexpected_writer_calls = ref 0 in
+    (match
+       C.For_testing.migrate_session_history_logs_with
+         ~confirm_parent_durable:(fun _ ->
+           durability_not_confirmed_report "injected retry sync failure")
+         (fun _ _ ->
+           incr unexpected_writer_calls;
+           not_committed_report "unexpected writer call")
+         ~session_dir
+     with
+     | Error
+         (C.History_directory_durability_not_confirmed
+            { stage = C.Internal_history; _ }) -> ()
+     | Error error ->
+       Alcotest.failf
+         "wrong confirmation error: %s"
+         (C.history_migration_error_to_string error)
+     | Ok _ -> Alcotest.fail "failed durability confirmation advanced migration");
+    Alcotest.(check int)
+      "failed confirmation does not rewrite either history"
+      0
+      !unexpected_writer_calls;
+    Alcotest.(check string)
+      "failed confirmation still preserves main"
+      original_main
+      (Fs_compat.load_file main_path);
+    let retry_calls = ref 0 in
+    let counting_writer path content =
+      incr retry_calls;
+      Fs_compat.save_file_atomic_blocking path content
+    in
+    (match
+       C.For_testing.migrate_session_history_logs_with
+         counting_writer
+         ~session_dir
+     with
+     | Ok stats -> Alcotest.(check int) "one line moved on retry" 1 stats.moved_lines
+     | Error error ->
+       Alcotest.fail
+         ("retry failed: " ^ C.history_migration_error_to_string error));
+    Alcotest.(check int)
+      "retry skips the already-committed internal copy"
+      1
+      !retry_calls;
+    Alcotest.(check string)
+      "retry rewrites main only after internal equality proof"
+      (keep_history_line ^ "\n")
+      (Fs_compat.load_file main_path))
+;;
+
 let () =
   Alcotest.run "keeper_context_core_dedup"
     [
@@ -303,5 +546,19 @@ let () =
             test_tool_result_large_json_elided;
           Alcotest.test_case "no content no json" `Quick
             test_tool_result_no_content_no_json;
+        ] );
+      ( "history_migration",
+        [ Alcotest.test_case
+            "internal failure preserves main"
+            `Quick
+            test_history_migration_internal_failure_preserves_main
+        ; Alcotest.test_case
+            "main failure retry skips internal rewrite"
+            `Quick
+            test_history_migration_main_failure_retries_without_internal_rewrite
+        ; Alcotest.test_case
+            "internal sync debt blocks main advance"
+            `Quick
+            test_history_migration_internal_sync_debt_blocks_main_advance
         ] );
     ]

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -135,7 +135,7 @@ let seed_single_playground_repo ~config ~(meta : Keeper_meta_contract.keeper_met
     (Repo_manager_types.make_keeper_repo_mapping ~keeper_id:meta.name
        ~repository_ids:[ "masc" ])
   in
-  (match Keeper_repo_mapping.save_mapping ~base_path:config.Workspace.base_path mapping with
+  (match Keeper_repo_mapping.save_mapping_blocking ~base_path:config.Workspace.base_path mapping with
    | Ok () -> ()
    | Error msg -> Alcotest.failf "seed keeper repo mapping: %s" msg);
   repo

--- a/test/test_keeper_memory_bank_compaction_errors.ml
+++ b/test/test_keeper_memory_bank_compaction_errors.ml
@@ -14,9 +14,13 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 
 let write_file path content =
   let (_ : string) = Masc.Keeper_fs.ensure_dir (Filename.dirname path) in
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
-  | Error msg -> Alcotest.fail msg
+  let report = Fs_compat.save_file_atomic_blocking path content in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    Alcotest.fail (Fs_compat.Durable_mutation.report_to_string report)
 ;;
 
 let with_env key value f =

--- a/test/test_keeper_repo_claim_hitl.ml
+++ b/test/test_keeper_repo_claim_hitl.ml
@@ -149,7 +149,7 @@ let write_repositories base_path repos =
 
 let write_mapping base_path keeper_id repo_ids =
   let mapping = make_keeper_repo_mapping ~keeper_id ~repository_ids:repo_ids in
-  match Keeper_repo_mapping.save_mapping ~base_path mapping with
+  match Keeper_repo_mapping.save_mapping_blocking ~base_path mapping with
   | Ok () -> ()
   | Error detail -> Alcotest.fail ("save_mapping failed: " ^ detail)
 ;;

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -84,7 +84,7 @@ let write_mapping base_path keeper_id repo_ids =
     Repo_manager_types.make_keeper_repo_mapping ~keeper_id
       ~repository_ids:repo_ids
   in
-  match Keeper_repo_mapping.save_mapping ~base_path mapping with
+  match Keeper_repo_mapping.save_mapping_blocking ~base_path mapping with
   | Ok () -> ()
   | Error e -> Alcotest.fail ("write_mapping failed: " ^ e)
 
@@ -969,7 +969,7 @@ let test_save_mapping_creates_config_dir () =
         Repo_manager_types.make_keeper_repo_mapping ~keeper_id:"keeper-new"
           ~repository_ids:[ "repo-a"; "repo-b" ]
       in
-      match Keeper_repo_mapping.save_mapping ~base_path mapping with
+      match Keeper_repo_mapping.save_mapping_blocking ~base_path mapping with
       | Error e -> Alcotest.fail ("save_mapping failed: " ^ e)
       | Ok () -> (
           match Keeper_repo_mapping.allowed_repositories ~keeper_id:"keeper-new" ~base_path with

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -27,6 +27,16 @@ module Json = Yojson.Safe.Util
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
+let save_atomic_fixture path content =
+  let report = Fs_compat.save_file_atomic_blocking path content in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    Alcotest.fail (Fs_compat.Durable_mutation.report_to_string report)
+;;
+
 let resolve_sandbox_root_git_cwd_string ~config ~meta ~cwd ~cmd =
   match Masc_exec_bash_parser.Bash.parse_string cmd with
   | Masc_exec.Parsed.Parsed ir ->
@@ -401,7 +411,7 @@ let assert_docker_route_fires ~config ~meta ~playground =
   let rel_path = Filename.concat rel_dir "demo.txt" in
   let host_path = Filename.concat playground rel_path in
   ensure_dir (Filename.dirname host_path);
-  ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
+  save_atomic_fixture host_path "alpha\nbeta\ngamma\n";
   let cases =
     [
       ( "rg",
@@ -436,7 +446,7 @@ let test_cat_legacy_keeper_skips_docker () =
   @@ fun ~config ~meta ~playground ->
   let host_path = Filename.concat playground "mind/x" in
   ensure_dir (Filename.dirname host_path);
-  ignore (Fs_compat.save_file_atomic host_path "matrix");
+  save_atomic_fixture host_path "matrix";
   let raw =
     Keeper_tool_command_runtime.handle_tool_search_files ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String host_path) ])
@@ -550,7 +560,7 @@ let test_rg_no_match_remains_successful_in_docker_route () =
   @@ fun ~config ~meta ~playground ->
   let host_path = Filename.concat playground "mind/demo.txt" in
   ensure_dir (Filename.dirname host_path);
-  ignore (Fs_compat.save_file_atomic host_path "alpha\nbeta\ngamma\n");
+  save_atomic_fixture host_path "alpha\nbeta\ngamma\n";
   let raw =
     Keeper_tool_command_runtime.handle_tool_search_files ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:
@@ -2092,7 +2102,7 @@ let test_execute_rg_no_match_remains_successful_in_docker_route () =
   in
   ensure_git_repo (Filename.dirname lib);
   ensure_dir lib;
-  ignore (Fs_compat.save_file_atomic (Filename.concat lib "sample.ml") "alpha\n");
+  save_atomic_fixture (Filename.concat lib "sample.ml") "alpha\n";
   let log_path = Filename.concat config.Workspace.base_path "docker.log" in
   with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
   with_turn_sandbox_factory ~config ~meta @@ fun factory ->

--- a/test/test_keeper_tool_execute_retry_deterministic_close.ml
+++ b/test/test_keeper_tool_execute_retry_deterministic_close.ml
@@ -343,6 +343,7 @@ let bool_member name json =
 ;;
 
 let test_gh_approval_pending_helper_enqueues_nonblocking () =
+  Eio_main.run @@ fun _env ->
   let base_path = temp_dir () in
   let approval_id = ref None in
   Fun.protect
@@ -462,6 +463,7 @@ let require_durable_resolution
 ;;
 
 let test_gh_approval_resolution_does_not_install_retry_grant () =
+  Eio_main.run @@ fun _env ->
   let base_path = temp_dir () in
   let approval_ids = ref [] in
   let remember id =

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -25,6 +25,16 @@ open Repo_manager_types
 
 (* ── Helpers ─────────────────────────────────────────────────────── *)
 
+let save_atomic_fixture path content =
+  let report = Fs_compat.save_file_atomic_blocking path content in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    Alcotest.fail (Fs_compat.Durable_mutation.report_to_string report)
+;;
+
 let with_env key value f =
   let prior = try Some (Sys.getenv key) with Not_found -> None in
   Unix.putenv key value;
@@ -219,10 +229,10 @@ let json_list_contains_string json field value =
 let write_malformed_repositories ~base =
   let path = Filename.concat base ".masc/config/repositories.toml" in
   ensure_dir (Filename.dirname path);
-  ignore (Fs_compat.save_file_atomic path "[repository.demo\n")
+  save_atomic_fixture path "[repository.demo\n"
 
 let write_executable path content =
-  ignore (Fs_compat.save_file_atomic path content);
+  save_atomic_fixture path content;
   Unix.chmod path 0o755
 
 let normalize_realpath path =
@@ -336,7 +346,7 @@ let outside_in_root ~base name =
   let dir = Filename.concat base "outside_playground" in
   ensure_dir dir;
   let p = Filename.concat dir name in
-  ignore (Fs_compat.save_file_atomic p (name ^ " content"));
+  save_atomic_fixture p (name ^ " content");
   p
 
 let blocked_by_symmetric_sandbox raw =
@@ -396,7 +406,7 @@ let test_docker_keeper_blocks_rg_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   ignore
-    (Fs_compat.save_file_atomic
+    (save_atomic_fixture
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
@@ -424,7 +434,7 @@ let test_local_keeper_rg_file_path_uses_parent_workdir () =
   if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
   else (
     let file_path = Filename.concat playground "demo.ml" in
-    ignore (Fs_compat.save_file_atomic file_path "let run_named = true\n");
+    save_atomic_fixture file_path "let run_named = true\n";
     let raw =
       Keeper_tool_command_runtime.handle_tool_search_files
         ~turn_sandbox_factory:None
@@ -463,7 +473,7 @@ let test_local_keeper_rg_invalid_type_surfaces_stderr () =
   if not (Keeper_tool_execute_path.shell_command_available "rg") then ()
   else (
     let file_path = Filename.concat playground "demo.ml" in
-    ignore (Fs_compat.save_file_atomic file_path "let run_named = true\n");
+    save_atomic_fixture file_path "let run_named = true\n";
     let raw =
       Keeper_tool_command_runtime.handle_tool_search_files
         ~turn_sandbox_factory:None
@@ -506,7 +516,7 @@ let test_grep_unregistered_visible_repo_is_readable () =
     ensure_dir (Filename.concat repo_root ".git");
     ensure_dir (Filename.concat repo_root "lib");
     ignore
-      (Fs_compat.save_file_atomic
+      (save_atomic_fixture
          (Filename.concat repo_root "lib/demo.ml")
          "let visible_unregistered_repo = true\n");
     let raw =
@@ -537,7 +547,7 @@ let test_grep_registered_alias_repo_path_is_allowed () =
     ensure_dir (Filename.concat repo_root ".git");
     ensure_dir (Filename.concat repo_root "lib");
     ignore
-      (Fs_compat.save_file_atomic
+      (save_atomic_fixture
          (Filename.concat repo_root "lib/demo.ml")
          "let alias_registered_path = true\n");
     let raw =
@@ -651,7 +661,7 @@ let test_docker_keeper_blocks_second_rg_outside () =
   let outside_dir = Filename.concat base "outside_playground" in
   ensure_dir outside_dir;
   ignore
-    (Fs_compat.save_file_atomic
+    (save_atomic_fixture
        (Filename.concat outside_dir "leak.txt")
        "secret-token");
   let factory = Keeper_sandbox_factory.create ~config ~meta () in
@@ -677,7 +687,7 @@ let test_docker_keeper_allows_inside_playground () =
   setup ~keeper_name:"minjae" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let demo = Filename.concat playground "demo.txt" in
-  ignore (Fs_compat.save_file_atomic demo "hello inside playground");
+  save_atomic_fixture demo "hello inside playground";
   let raw =
     Keeper_tool_command_runtime.handle_tool_search_files ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
       ~args:(`Assoc [ ("op", `String "cat"); ("path", `String "demo.txt") ])
@@ -782,7 +792,7 @@ let test_docker_container_file_path_maps_to_host_worktree () =
       "repos/masc/.worktrees/task-186/lib/keeper/keeper_tool_policy.ml"
   in
   ensure_dir (Filename.dirname host_file);
-  ignore (Fs_compat.save_file_atomic host_file "let touched = true\n");
+  save_atomic_fixture host_file "let touched = true\n";
   let container_file =
     Filename.concat
       (Keeper_sandbox.container_root meta.name)
@@ -899,7 +909,7 @@ let test_read_unregistered_clone_surfaces_repository_hitl () =
     save_repositories base [ registered ];
     let repo_root = Filename.concat playground "repos/masc-mcp" in
     init_git_repo repo_root registered.url;
-    ignore (Fs_compat.save_file_atomic (Filename.concat repo_root "README.md") "Repository\n");
+    save_atomic_fixture (Filename.concat repo_root "README.md") "Repository\n";
     let raw =
       Keeper_tool_filesystem_runtime.handle_read_file
         ~turn_sandbox_factory:None

--- a/test/test_keeper_tool_search_files_via_field.ml
+++ b/test/test_keeper_tool_search_files_via_field.ml
@@ -10,6 +10,16 @@ module Keeper_types = Keeper_types
 module Fs_compat = Fs_compat
 module Json = Yojson.Safe.Util
 
+let save_atomic_fixture path content =
+  let report = Fs_compat.save_file_atomic_blocking path content in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    Alcotest.fail (Fs_compat.Durable_mutation.report_to_string report)
+;;
+
 let temp_dir () =
   let dir = Filename.temp_file "tool_search_files_via_" "" in
   Unix.unlink dir;
@@ -67,7 +77,7 @@ let setup f =
      once. *)
   let sample = Filename.concat playground "sample.txt" in
   ignore
-    (Fs_compat.save_file_atomic sample
+    (save_atomic_fixture sample
        "alpha via_marker_text\nbeta\ngamma\n");
   f ~config ~meta ~playground ~sample
 

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -124,7 +124,7 @@ let allow_repo ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) repo_id =
     (Repo_manager_types.make_keeper_repo_mapping ~keeper_id:meta.name
        ~repository_ids:[ repo_id ])
   in
-  match Keeper_repo_mapping.save_mapping ~base_path:config.Workspace.base_path mapping with
+  match Keeper_repo_mapping.save_mapping_blocking ~base_path:config.Workspace.base_path mapping with
   | Ok () -> ()
   | Error e -> Alcotest.fail ("failed to seed keeper repo mapping: " ^ e)
 ;;

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -143,7 +143,7 @@ let store_image meta bytes =
   let store_dir =
     Vt.vision_store_dir ~keeper_name:meta.Masc.Keeper_meta_contract.name
   in
-  match Store.store ~dir:store_dir bytes with
+  match Store.store_blocking ~dir:store_dir bytes with
   | Ok handle -> Store.to_string handle
   | Error msg -> failwith msg
 
@@ -1146,11 +1146,12 @@ let () =
     test_non_retryable_provider_error_stops_without_trying_next_runtime ();
     test_accept_rejected_is_policy_rejection_without_failover ();
     test_eager_eviction_reason_preserves_typed_outcome ());
-  test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
-  test_delegate_eviction_rejects_invalid_media_type_before_store ();
-  test_delegate_eviction_rejects_oversize_before_store ();
-  test_delegate_eviction_bad_base64_surfaces_redacted_text_error ();
-  test_delegate_eviction_rejects_non_base64_source_before_store ();
-  test_non_delegate_eviction_preserves_inline_image ();
-  test_evicted_history_has_no_image_modality ();
+  Vi.For_testing.with_store_artifact Store.store_blocking (fun () ->
+    test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
+    test_delegate_eviction_rejects_invalid_media_type_before_store ();
+    test_delegate_eviction_rejects_oversize_before_store ();
+    test_delegate_eviction_bad_base64_surfaces_redacted_text_error ();
+    test_delegate_eviction_rejects_non_base64_source_before_store ();
+    test_non_delegate_eviction_preserves_inline_image ();
+    test_evicted_history_has_no_image_modality ());
   print_endline "test_keeper_vision_tool: all assertions passed"

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -446,9 +446,15 @@ let test_live_turn_keeper_is_busy_without_waiting_rows () =
 
 let save_text path text =
   Fs_compat.mkdir_p (Filename.dirname path);
-  match Fs_compat.save_file_atomic path text with
-  | Ok () -> ()
-  | Error err -> fail ("save_file_atomic failed: " ^ err)
+  let report = Fs_compat.save_file_atomic_blocking path text in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    fail
+      ("save_file_atomic failed: "
+       ^ Fs_compat.Durable_mutation.report_to_string report)
 ;;
 
 let pending_confirm_fixture ?(target_type = "goal") ?target_id ()

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1536,6 +1536,8 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
   cleanup_dir base_path
 
 let test_execute_tool_domain_agent_name_does_not_reuse_joined_nickname () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
   let config = Masc.Workspace.default_config base_path in
   let _ = Masc.Workspace.init config ~agent_name:None in

--- a/test/test_playground_repo_readiness.ml
+++ b/test/test_playground_repo_readiness.ml
@@ -93,7 +93,7 @@ let write_mapping base_path keeper_id repo_ids =
     Repo_manager_types.make_keeper_repo_mapping ~keeper_id
       ~repository_ids:repo_ids
   in
-  match Keeper_repo_mapping.save_mapping ~base_path mapping with
+  match Keeper_repo_mapping.save_mapping_blocking ~base_path mapping with
   | Ok () -> ()
   | Error msg -> fail ("write_mapping failed: " ^ msg)
 

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -177,9 +177,13 @@ let test_skill_candidate_json_and_draft_are_candidate_only () =
 let read_file = Fs_compat.load_file
 
 let write_file_or_fail path content =
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> ()
-  | Error msg -> fail msg
+  let report = Fs_compat.save_file_atomic_blocking path content in
+  match report.progress with
+  | Fs_compat.Durable_mutation.Durable () when report.diagnostics = [] -> ()
+  | Fs_compat.Durable_mutation.Durable ()
+  | Fs_compat.Durable_mutation.Committed_not_durable _
+  | Fs_compat.Durable_mutation.Not_committed _ ->
+    fail (Fs_compat.Durable_mutation.report_to_string report)
 ;;
 
 let with_env name value f =
@@ -703,14 +707,17 @@ let test_load_procedures_strict_rejects_schema_mismatch () =
 let test_rewrite_procedures_returns_error_on_bad_path () =
   (* Use a path that is a file, not a directory, so the atomic write fails. *)
   let marker = Filename.temp_file "proc-bad-path-" ".tmp" in
-  let base_path = marker ^ "_not_a_dir" in
   let p = procedure ~id:"bad-path" () in
-  match P.rewrite_procedures ~base_path ~agent_name:"keeper" [ p ] with
-  | Ok () -> fail "expected rewrite to fail on bad path"
-  | Error _ -> check bool "rewrite failed" true true
+  Fun.protect
+    ~finally:(fun () -> Sys.remove marker)
+    (fun () ->
+       match P.rewrite_procedures ~base_path:marker ~agent_name:"keeper" [ p ] with
+       | Ok () -> fail "expected rewrite to fail on bad path"
+       | Error _ -> check bool "rewrite failed" true true)
 ;;
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "procedural_memory"
     [
       ( "crystallization",

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -133,6 +133,7 @@ let override_restore_failure_count () =
     ()
 
 let () =
+  Eio_main.run @@ fun _env ->
   let open Alcotest in
   run "Prompt_registry_defaults"
     [

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1217,6 +1217,8 @@ let with_temp_runtime_toml content f =
   Fun.protect
     ~finally:(fun () ->
        (try Sys.remove path with
+        | _ -> ());
+       (try Sys.remove (path ^ ".runtime-transaction.lock") with
         | _ -> ())
        )
     (fun () -> f path)
@@ -1914,7 +1916,7 @@ let test_structured_judge_runtime_routing () =
     | Error _ -> ());
   let librarian_fallback = base ^ "librarian = \"local.judge\"\n" in
   with_temp_runtime_toml librarian_fallback (fun path ->
-    match Runtime.save_config_text ~runtime_config_path:path librarian_fallback with
+    match Runtime.save_config_text_blocking ~runtime_config_path:path librarian_fallback with
     | Error msg -> failf "save_config_text should load librarian fallback: %s" msg
     | Ok () ->
       check string "structured judge falls back to librarian" "local.judge"
@@ -1922,7 +1924,7 @@ let test_structured_judge_runtime_routing () =
   let explicit_structured_judge = base ^ "structured_judge = \"local.judge\"\n" in
   with_temp_runtime_toml explicit_structured_judge (fun path ->
     match
-      Runtime.save_config_text ~runtime_config_path:path explicit_structured_judge
+      Runtime.save_config_text_blocking ~runtime_config_path:path explicit_structured_judge
     with
     | Error msg -> failf "save_config_text should load structured_judge: %s" msg
     | Ok () ->
@@ -1936,7 +1938,7 @@ let test_structured_judge_runtime_routing () =
   ;
   with_temp_runtime_toml base (fun path ->
     match
-      Runtime.set_runtime_structured_judge
+      Runtime.set_runtime_structured_judge_blocking
         ~runtime_config_path:path
         ~runtime_id:(Some "local.judge")
         ()
@@ -1954,7 +1956,7 @@ let test_structured_judge_runtime_routing () =
            "structured_judge = \"local.judge\""));
   with_temp_runtime_toml (base ^ "structured_judge = \"local.judge\"\n") (fun path ->
     match
-      Runtime.set_runtime_structured_judge
+      Runtime.set_runtime_structured_judge_blocking
         ~runtime_config_path:path
         ~runtime_id:None
         ()
@@ -2010,7 +2012,7 @@ let test_hitl_summary_runtime_routing () =
     | Error _ -> ());
   let explicit_hitl_summary = base ^ "hitl_summary = \"local.summary\"\n" in
   with_temp_runtime_toml explicit_hitl_summary (fun path ->
-    match Runtime.save_config_text ~runtime_config_path:path explicit_hitl_summary with
+    match Runtime.save_config_text_blocking ~runtime_config_path:path explicit_hitl_summary with
     | Error msg -> failf "save_config_text should load hitl_summary: %s" msg
     | Ok () ->
       check
@@ -2022,7 +2024,7 @@ let test_hitl_summary_runtime_routing () =
         (Runtime.runtime_id_for_hitl_summary ()));
   with_temp_runtime_toml base (fun path ->
     match
-      Runtime.set_runtime_hitl_summary
+      Runtime.set_runtime_hitl_summary_blocking
         ~runtime_config_path:path
         ~runtime_id:(Some "local.summary")
         ()
@@ -2040,7 +2042,7 @@ let test_hitl_summary_runtime_routing () =
            "hitl_summary = \"local.summary\""));
   with_temp_runtime_toml (base ^ "hitl_summary = \"local.summary\"\n") (fun path ->
     match
-      Runtime.set_runtime_hitl_summary ~runtime_config_path:path ~runtime_id:None ()
+      Runtime.set_runtime_hitl_summary_blocking ~runtime_config_path:path ~runtime_id:None ()
     with
     | Error msg -> failf "clear hitl_summary should validate: %s" msg
     | Ok () ->
@@ -2079,12 +2081,207 @@ let test_save_config_text_refreshes_cross_verifier_runtime () =
      cross_verifier = \"local.libr\"\n"
   in
   with_temp_runtime_toml content (fun path ->
-    match Runtime.save_config_text ~runtime_config_path:path content with
+    match Runtime.save_config_text_blocking ~runtime_config_path:path content with
     | Error msg -> failf "save_config_text should validate and reload: %s" msg
     | Ok () ->
       check (option string) "saved cross_verifier runtime id"
         (Some "local.libr")
         (Runtime.cross_verifier_runtime_id ()))
+
+let runtime_parity_config ?cross_verifier () =
+  "[providers.local]\n\
+   display-name = \"Local\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [models.chat]\n\
+   api-name = \"chat\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.libr]\n\
+   api-name = \"libr\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.libr.capabilities]\n\
+   supports-response-format-json = true\n\
+   \n\
+   [local.chat]\n\
+   \n\
+   [local.libr]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.chat\"\n"
+  ^
+  match cross_verifier with
+  | None -> ""
+  | Some runtime_id -> Printf.sprintf "cross_verifier = %S\n" runtime_id
+;;
+
+let test_runtime_committed_not_durable_publishes_prepared_snapshot () =
+  let initial = runtime_parity_config () in
+  let next = runtime_parity_config ~cross_verifier:"local.libr" () in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_temp_runtime_toml initial (fun path ->
+         (match Runtime.init_default ~config_path:path with
+          | Error msg -> failf "initial runtime config failed: %s" msg
+          | Ok () -> ());
+         let writer path content =
+           let report = Fs_compat.save_file_atomic_blocking path content in
+           match report.progress with
+           | Fs_compat.Durable_mutation.Durable () ->
+             { report with
+               progress =
+                 Fs_compat.Durable_mutation.Committed_not_durable
+                   { value = ()
+                   ; cause = Failure "injected parent fsync failure"
+                   ; backtrace = Printexc.get_callstack 8
+                   }
+             }
+           | Fs_compat.Durable_mutation.Not_committed _
+           | Fs_compat.Durable_mutation.Committed_not_durable _ ->
+             fail (Fs_compat.Durable_mutation.report_to_string report)
+         in
+         Runtime.For_testing.with_config_writer writer (fun () ->
+           match Runtime.save_config_text_blocking ~runtime_config_path:path next with
+           | Error msg -> failf "committed write must stay successful: %s" msg
+           | Ok () -> ());
+         check
+           (option string)
+           "committed snapshot published"
+           (Some "local.libr")
+           (Runtime.cross_verifier_runtime_id ());
+         check bool "committed bytes persisted" true
+           (String_util.contains_substring
+              (Fs_compat.load_file path)
+              "cross_verifier = \"local.libr\"")))
+;;
+
+let test_runtime_not_committed_preserves_disk_and_snapshot () =
+  let initial = runtime_parity_config () in
+  let next = runtime_parity_config ~cross_verifier:"local.libr" () in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_temp_runtime_toml initial (fun path ->
+         (match Runtime.init_default ~config_path:path with
+          | Error msg -> failf "initial runtime config failed: %s" msg
+          | Ok () -> ());
+         let writer _path _content =
+           { Fs_compat.Durable_mutation.progress =
+               Fs_compat.Durable_mutation.Not_committed
+                 { cause = Failure "injected prepare failure"
+                 ; backtrace = Printexc.get_callstack 8
+                 }
+           ; diagnostics = []
+           }
+         in
+         Runtime.For_testing.with_config_writer writer (fun () ->
+           match Runtime.save_config_text_blocking ~runtime_config_path:path next with
+           | Ok () -> fail "not-committed write must fail"
+           | Error _ -> ());
+         check (option string) "old snapshot preserved" None
+           (Runtime.cross_verifier_runtime_id ());
+         check bool "old bytes preserved" false
+           (String_util.contains_substring
+              (Fs_compat.load_file path)
+              "cross_verifier")))
+;;
+
+let test_runtime_config_transaction_prevents_lost_update () =
+  let initial = runtime_parity_config () in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_temp_runtime_toml initial (fun path ->
+         (match Runtime.init_default ~config_path:path with
+          | Error msg -> failf "initial runtime config failed: %s" msg
+          | Ok () -> ());
+         let coordination_mu = Mutex.create () in
+         let coordination_cv = Condition.create () in
+         let first_writer_entered = ref false in
+         let release_first_writer = ref false in
+         let writer_calls = ref 0 in
+         let writer path content =
+           Mutex.lock coordination_mu;
+           incr writer_calls;
+           let call_number = !writer_calls in
+           if call_number = 1
+           then (
+             first_writer_entered := true;
+             Condition.broadcast coordination_cv;
+             while not !release_first_writer do
+               Condition.wait coordination_cv coordination_mu
+             done);
+           Mutex.unlock coordination_mu;
+           Fs_compat.save_file_atomic_blocking path content
+         in
+         let result_a = ref None in
+         let result_b = ref None in
+         Runtime.For_testing.with_config_writer writer (fun () ->
+           let thread_a =
+             Thread.create
+               (fun () ->
+                  result_a :=
+                    Some
+                      (Runtime.set_runtime_id_for_keeper_blocking
+                         ~runtime_config_path:path
+                         ~keeper_name:"keeper-a"
+                         ~runtime_id:"local.chat"
+                         ()))
+               ()
+           in
+           Mutex.lock coordination_mu;
+           while not !first_writer_entered do
+             Condition.wait coordination_cv coordination_mu
+           done;
+           Mutex.unlock coordination_mu;
+           let thread_b =
+             Thread.create
+               (fun () ->
+                  result_b :=
+                    Some
+                      (Runtime.set_runtime_id_for_keeper_blocking
+                         ~runtime_config_path:path
+                         ~keeper_name:"keeper-b"
+                         ~runtime_id:"local.libr"
+                         ()))
+               ()
+           in
+           Thread.delay 0.05;
+           Mutex.lock coordination_mu;
+           release_first_writer := true;
+           Condition.broadcast coordination_cv;
+           Mutex.unlock coordination_mu;
+           Thread.join thread_a;
+           Thread.join thread_b);
+         let check_result label = function
+           | Some (Ok ()) -> ()
+           | Some (Error msg) -> failf "%s failed: %s" label msg
+           | None -> failf "%s did not finish" label
+         in
+         check_result "keeper-a mutation" !result_a;
+         check_result "keeper-b mutation" !result_b;
+         let persisted = Fs_compat.load_file path in
+         check bool "keeper-a assignment persisted" true
+           (String_util.contains_substring persisted "\"keeper-a\" = \"local.chat\"");
+         check bool "keeper-b assignment persisted" true
+           (String_util.contains_substring persisted "\"keeper-b\" = \"local.libr\"");
+         check
+           (option string)
+           "keeper-a assignment published"
+           (Some "local.chat")
+           (Runtime.runtime_id_for_keeper "keeper-a");
+         check
+           (option string)
+           "keeper-b assignment published"
+           (Some "local.libr")
+           (Runtime.runtime_id_for_keeper "keeper-b")))
+;;
 
 let test_deprecated_capability_notice_warns_once_per_process () =
   (* runtime.toml is re-parsed on every keeper boot; a per-parse deprecation
@@ -2354,6 +2551,15 @@ let () =
           test_case
             "save_config_text validates and refreshes cross_verifier runtime"
             `Quick test_save_config_text_refreshes_cross_verifier_runtime;
+          test_case
+            "committed sync debt publishes prepared runtime snapshot"
+            `Quick test_runtime_committed_not_durable_publishes_prepared_snapshot;
+          test_case
+            "not-committed runtime write preserves disk and snapshot"
+            `Quick test_runtime_not_committed_preserves_disk_and_snapshot;
+          test_case
+            "runtime config transaction prevents concurrent lost updates"
+            `Quick test_runtime_config_transaction_prevents_lost_update;
           test_case
             "lifecycle TOML keys resolve through the declarative catalog"
             `Quick test_toml_catalog_resolves_lifecycle_keys;

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -373,7 +373,7 @@ let test_assignment_drives_runtime_id_of_meta () =
 let test_runtime_assignment_writer_updates_runtime_toml () =
   with_runtime_file (fun path ->
     (match
-       Runtime.set_runtime_id_for_keeper
+       Runtime.set_runtime_id_for_keeper_blocking
          ~runtime_config_path:path
          ~keeper_name:"routingtest"
          ~runtime_id:"runpod_mtp.qwen"
@@ -589,7 +589,7 @@ let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
   with_runtime_file (fun path ->
     let before = Fs_compat.load_file path in
     (match
-       Runtime.set_runtime_id_for_keeper
+       Runtime.set_runtime_id_for_keeper_blocking
          ~runtime_config_path:path
          ~keeper_name:"routingtest"
          ~runtime_id:"missing.runtime"
@@ -613,7 +613,7 @@ let test_runtime_assignment_writer_rejects_unknown_runtime_without_write () =
 
 let test_runtime_assignment_writer_clears_assignment () =
   with_runtime_file (fun path ->
-    (match Runtime.clear_runtime_id_for_keeper ~runtime_config_path:path ~keeper_name:"routingtest" () with
+    (match Runtime.clear_runtime_id_for_keeper_blocking ~runtime_config_path:path ~keeper_name:"routingtest" () with
      | Ok () -> ()
      | Error msg -> Alcotest.failf "clear_runtime_id_for_keeper failed: %s" msg);
     Alcotest.(check bool)
@@ -628,7 +628,7 @@ let test_runtime_assignment_writer_clears_assignment () =
 
 let test_runtime_route_writer_updates_default () =
   with_runtime_file (fun path ->
-    (match Runtime.set_runtime_default ~runtime_config_path:path ~runtime_id:"openai.gpt" () with
+    (match Runtime.set_runtime_default_blocking ~runtime_config_path:path ~runtime_id:"openai.gpt" () with
      | Ok () -> ()
      | Error msg -> Alcotest.failf "set_runtime_default failed: %s" msg);
     Alcotest.(check bool)
@@ -644,7 +644,7 @@ let test_runtime_route_writer_updates_default () =
 let test_runtime_route_writer_rejects_unknown_default_without_write () =
   with_runtime_file (fun path ->
     let before = Fs_compat.load_file path in
-    (match Runtime.set_runtime_default ~runtime_config_path:path ~runtime_id:"missing.runtime" () with
+    (match Runtime.set_runtime_default_blocking ~runtime_config_path:path ~runtime_id:"missing.runtime" () with
      | Ok () -> Alcotest.fail "expected unknown default runtime to fail"
      | Error msg ->
        Alcotest.(check bool)
@@ -663,14 +663,14 @@ let test_runtime_route_writer_rejects_unknown_default_without_write () =
 
 let test_runtime_route_writer_clears_optional_librarian () =
   with_runtime_file (fun path ->
-    (match Runtime.set_runtime_librarian ~runtime_config_path:path ~runtime_id:(Some "openai.gpt") () with
+    (match Runtime.set_runtime_librarian_blocking ~runtime_config_path:path ~runtime_id:(Some "openai.gpt") () with
      | Ok () -> ()
      | Error msg -> Alcotest.failf "set_runtime_librarian failed: %s" msg);
     Alcotest.(check (option string))
       "librarian set"
       (Some "openai.gpt")
       (Runtime.librarian_runtime_id ());
-    (match Runtime.set_runtime_librarian ~runtime_config_path:path ~runtime_id:None () with
+    (match Runtime.set_runtime_librarian_blocking ~runtime_config_path:path ~runtime_id:None () with
      | Ok () -> ()
      | Error msg -> Alcotest.failf "clear runtime librarian failed: %s" msg);
     Alcotest.(check bool)
@@ -686,7 +686,7 @@ let test_runtime_route_writer_clears_optional_librarian () =
 let test_runtime_route_writer_updates_media_failover () =
   with_runtime_file (fun path ->
     (match
-       Runtime.set_runtime_media_failover
+       Runtime.set_runtime_media_failover_blocking
          ~runtime_config_path:path
          ~runtime_ids:[ "openai.gpt"; "runpod_mtp.qwen" ]
          ()
@@ -704,7 +704,7 @@ let test_runtime_route_writer_updates_media_failover () =
          (Fs_compat.load_file path)
          "media_failover = [\"openai.gpt\", \"runpod_mtp.qwen\"]");
     (match
-       Runtime.set_runtime_media_failover
+       Runtime.set_runtime_media_failover_blocking
          ~runtime_config_path:path
          ~runtime_ids:[]
          ()
@@ -725,7 +725,7 @@ let test_runtime_route_writer_clears_optional_structured_judge () =
   with_model_catalog_content runtime_structured_judge_model_catalog @@ fun () ->
   with_runtime_file (fun path ->
     (match
-       Runtime.set_runtime_structured_judge
+       Runtime.set_runtime_structured_judge_blocking
          ~runtime_config_path:path
          ~runtime_id:(Some "openai.gpt")
          ()
@@ -737,7 +737,7 @@ let test_runtime_route_writer_clears_optional_structured_judge () =
       (Some "openai.gpt")
       (Runtime.structured_judge_runtime_id ());
     (match
-       Runtime.set_runtime_structured_judge ~runtime_config_path:path ~runtime_id:None ()
+       Runtime.set_runtime_structured_judge_blocking ~runtime_config_path:path ~runtime_id:None ()
      with
      | Ok () -> ()
      | Error msg -> Alcotest.failf "clear runtime structured_judge failed: %s" msg);
@@ -763,7 +763,7 @@ let test_runtime_config_text_loads_runtime_toml () =
 let test_runtime_config_text_save_reloads_runtime_cache () =
   with_runtime_file (fun path ->
     (match
-       Runtime.save_config_text
+       Runtime.save_config_text_blocking
          ~runtime_config_path:path
          runtime_config_openai_default
      with
@@ -783,7 +783,7 @@ let test_runtime_config_text_save_rejects_invalid_without_write () =
   with_runtime_file (fun path ->
     let before = Fs_compat.load_file path in
     (match
-       Runtime.save_config_text
+       Runtime.save_config_text_blocking
          ~runtime_config_path:path
          "[runtime]\ndefault = \"missing.runtime\"\n"
      with

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -72,7 +72,7 @@ let test_encoded_marker_stays_under_externalization_threshold () =
       let store = B.create ~base_path:dir in
       let threshold = Masc.Tool_bridge.default_externalize_threshold_bytes in
       let payload = String.make (threshold + 1) '"' in
-      let encoded = B.put store ~bytes:payload ~mime:"text/plain" |> O.encode_for_oas in
+      let encoded = B.put_blocking store ~bytes:payload ~mime:"text/plain" |> O.encode_for_oas in
       Alcotest.(check bool)
         "marker stays below default externalization threshold"
         true
@@ -118,7 +118,7 @@ let test_put_returns_stored () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       let payload = "hello tool output" in
-      match B.put store ~bytes:payload ~mime:"text/plain" with
+      match B.put_blocking store ~bytes:payload ~mime:"text/plain" with
       | O.Stored { sha256; bytes; preview; mime } ->
           Alcotest.(check int) "sha length" 64 (String.length sha256);
           Alcotest.(check int) "bytes" (String.length payload) bytes;
@@ -130,7 +130,7 @@ let test_put_then_fetch () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       let payload = String.make 5000 'x' in
-      let stored = B.put store ~bytes:payload ~mime:"text/plain" in
+      let stored = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
       match stored with
       | O.Stored { sha256; _ } -> (
           match B.fetch store ~sha256 with
@@ -151,8 +151,8 @@ let test_idempotent_put () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       let payload = "idempotent payload" in
-      let r1 = B.put store ~bytes:payload ~mime:"text/plain" in
-      let r2 = B.put store ~bytes:payload ~mime:"text/plain" in
+      let r1 = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
+      let r2 = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
       let sha_of = function
         | O.Stored { sha256; _ } -> sha256
         | O.Inline _ -> Alcotest.fail "expected Stored"
@@ -165,7 +165,7 @@ let test_sharding_layout () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       let payload = "sharding test" in
-      let stored = B.put store ~bytes:payload ~mime:"text/plain" in
+      let stored = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
       match stored with
       | O.Stored { sha256; _ } ->
           let prefix = String.sub sha256 0 2 in
@@ -184,7 +184,7 @@ let test_gc_deletes_unkept () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       let stored payload =
-        match B.put store ~bytes:payload ~mime:"text/plain" with
+        match B.put_blocking store ~bytes:payload ~mime:"text/plain" with
         | O.Stored { sha256; _ } -> sha256
         | O.Inline _ -> Alcotest.fail "expected Stored"
       in
@@ -203,16 +203,16 @@ let test_gc_deletes_unkept () =
 let test_gc_empty_keep_clears_all () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
-      let _ = B.put store ~bytes:"a" ~mime:"text/plain" in
-      let _ = B.put store ~bytes:"b" ~mime:"text/plain" in
-      let _ = B.put store ~bytes:"c" ~mime:"text/plain" in
+      let _ = B.put_blocking store ~bytes:"a" ~mime:"text/plain" in
+      let _ = B.put_blocking store ~bytes:"b" ~mime:"text/plain" in
+      let _ = B.put_blocking store ~bytes:"c" ~mime:"text/plain" in
       let deleted = B.gc store ~keep_set:[] in
       Alcotest.(check int) "deleted all" 3 deleted;
       Alcotest.(check int) "store empty" 0 (List.length (B.list_all store)))
 
 (* --- Repeated put: documents the atomicity contract --- *)
 
-(* Atomicity is guaranteed at the OS layer by [Fs_compat.save_file_atomic]
+(* Atomicity is guaranteed at the OS layer by the typed Fs_compat durable writer
    (tempfile + rename). Same-content puts always produce same sha256 ->
    same path -> rename is idempotent. We don't need a true concurrency test
    here; serial repetition exercises the same code path. *)
@@ -221,7 +221,7 @@ let test_repeated_put_no_dup () =
       let store = B.create ~base_path:dir in
       let payload = String.make 1024 'z' in
       for _ = 1 to 8 do
-        let _ = B.put store ~bytes:payload ~mime:"text/plain" in
+        let _ = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
         ()
       done;
       Alcotest.(check int)
@@ -244,7 +244,7 @@ let test_put_raises_on_unwritable_store () =
   let store = B.create ~base_path:file in
   let raised =
     try
-      let _ = B.put store ~bytes:(String.make 5000 'x') ~mime:"text/plain" in
+      let _ = B.put_blocking store ~bytes:(String.make 5000 'x') ~mime:"text/plain" in
       false
     with _ -> true
   in

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -3,7 +3,7 @@
     Exercises the data flow across all the PRs in this series in one
     test, against real disk + real module boundaries:
 
-      [Tool_blob_store.put]   <- PR 1 (foundation)
+      [Tool_blob_store.put_blocking]   <- PR 1 (foundation)
         \u2193 sha256 + blob marker
       [Tool_output.encode_for_oas]   <- PR 1 (encoder)
         \u2193 marker string
@@ -66,7 +66,9 @@ let test_full_flow_externalize_hydrate_serve () =
          module the bridge would use). *)
       let store = B.create ~base_path:dir in
       let payload = String.make 5_000 'x' in
-      let stored_marker_value = B.put store ~bytes:payload ~mime:"text/plain" in
+      let stored_marker_value =
+        B.put_blocking store ~bytes:payload ~mime:"text/plain"
+      in
 
       (* Step 2: Verify the file landed in the sharded location. *)
       let sha256 =
@@ -151,7 +153,7 @@ let test_recency_budget_holds_across_modules () =
   with_temp_base_path (fun dir ->
       let store = B.create ~base_path:dir in
       let stored payload =
-        let v = B.put store ~bytes:payload ~mime:"text/plain" in
+        let v = B.put_blocking store ~bytes:payload ~mime:"text/plain" in
         O.encode_for_oas v
       in
       let m1 = stored "ancient one" in

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -967,6 +967,7 @@ let test_aggregate_update_noop_when_missing () =
 (* Once a snapshot exists, an incremental update folds success/failure
    counts and advances last_used to the max-ts entry. *)
 let test_aggregate_increment_after_seed () =
+  Eio_main.run @@ fun _env ->
   with_tmpdir (fun dir ->
     let masc_root = dir and keeper = "agg-inc" in
     let now = Unix.gettimeofday () in
@@ -995,6 +996,7 @@ let test_aggregate_increment_after_seed () =
    update an already-seeded snapshot too; otherwise those calls become
    invisible to future affinity reads until a full rebuild. *)
 let test_aggregate_direct_append_after_seed () =
+  Eio_main.run @@ fun _env ->
   with_tmpdir (fun dir ->
     let masc_root = dir and keeper = "agg-direct" in
     let now = Unix.gettimeofday () in
@@ -1051,6 +1053,7 @@ let test_aggregate_rejects_keeper_name_mismatch () =
 (* Rebuild reconstructs per-tool counts across all trace files and persists
    the snapshot. *)
 let test_aggregate_rebuild_from_jsonl () =
+  Eio_main.run @@ fun _env ->
   with_tmpdir (fun dir ->
     let masc_root = dir and keeper = "agg-rebuild" in
     let now = Unix.gettimeofday () in

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -468,6 +468,7 @@ let test_attribution_of_request_derives_origin () =
       | None -> Alcotest.fail "expected Some attribution")
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Verification" [
     "criterion", [
       Alcotest.test_case "roundtrip" `Quick test_criterion_roundtrip;

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -427,6 +427,7 @@ let test_correction_pipeline_log_preserves_detail_fields () =
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Warn_root_causes"
     [
       ( "allowlist_tool_access_filter",

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -2237,6 +2237,7 @@ let test_no_unclaimed_tasks_stop_signal () =
       true (str_contains result "ACTION: Stop task-checking"))
 
 let () =
+  Eio_main.run @@ fun _env ->
   Eio_guard.enable ();
   Random.init 42;
   Alcotest.run "Workspace" [

--- a/test/test_workspace_utils_coverage.ml
+++ b/test/test_workspace_utils_coverage.ml
@@ -638,6 +638,7 @@ let test_memory_backend_fallback_keys_by_backend_base_path () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Workspace_utils Coverage" [
     "parse_gitdir_to_main_root", [
       test_case "worktree" `Quick test_parse_gitdir_worktree;


### PR DESCRIPTION
## Summary

- add a descriptor-owned mutation state machine with explicit `Not_committed`, `Committed_not_durable`, and `Durable` outcomes
- keep cancellation and observer failures from erasing an already committed mutation
- migrate all current atomic-writer callers to exhaustive typed handling, with explicit blocking/Eio entry points
- make startup history migration retry-safe: internal history commits first, identical committed content is reused only after descriptor-based parent durability confirmation, and the source is rewritten only after the internal write is durable
- confirm chat-queue parent durability before returning an enqueue receipt for a committed snapshot with sync debt; confirmation failure rolls live memory back and conservatively replays the committed snapshot after restart
- retain mutation and directory-confirmation progress when logging or metrics observers fail
- run chat-queue durability confirmation across one cancellation-protected Eio systhread boundary
- move tool-blob, vision-artifact, repo-mapping, and history persistence operations across one Eio systhread boundary per operation

Closes #24082.
Addresses the atomic-writer and startup-history slice of #24084; durable append, durable mkdir, and orphan-recovery inventory remain follow-up scope.

## Contract

- retry is safe only for `Not_committed`
- `Committed_not_durable` is observable sync debt, never collapsed into a retry-safe error
- parent-directory authority remains descriptor-owned through final entry mutation
- observer failure is reported separately from mutation progress
- a committed-but-not-durable internal history blocks main-history removal; retry confirms the internal parent directory before advancing
- a committed-but-not-durable chat snapshot produces no success receipt until parent durability is confirmed; failed confirmation preserves at-least-once redelivery rather than risking loss
- repo-mapping semantics remain advisory/default-scope metadata per RFC-0312; this PR changes only persistence mechanics

## Verification

- `scripts/dune-local.sh build lib/masc.cmxa` plus 20 focused native test executables
- `scripts/dune-local.sh build @check`
- focused executables: 277 tests/assertion groups passed across durable mutation, fs compat, file locks, runtime routing/config, persistence callers, Eio domain boundaries, endpoint/hydrator/vision integration, and failure injection
- `git diff --check origin/main...HEAD`
- changed OCaml files pass `ocamlformat --check`
- `check-eio-conventions`, boundary guard, OCaml structure, stringly-boundary, OAS-boundary, and silent-failure ratchets pass
- cross-model adversarial review found and drove the C-FFI root-registration/blocking-section fix; the corrected stubs were re-reviewed with no remaining concrete finding

## RFC

- RFC-0312 (Accepted): keeper repo mappings remain advisory default scope, not an authorization cap
RFC-WAIVED: Other path-matched keeper RFCs are unaffected because this PR changes typed persistence mechanics only, not repository policy, identity, capability, credential, admission, or sandbox semantics.

Co-Authored-By: Codex <codex@openai.com>
