### PR TITLE
feat(dashboard): typed failure card for transport_failure chat rows

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -344,7 +344,7 @@ describe('ChatTranscript', () => {
     )
   })
 
-  it('renders REST replay failure and no-turn-ref gaps as visible stream contract badges', () => {
+  it('renders REST replay failure and no-turn-ref gaps as visible stream contract badges', async () => {
     const entries = chatHistoryEntriesFromRest('sangsu', [
       {
         id: 'smoke-legacy-user',
@@ -418,7 +418,16 @@ describe('ChatTranscript', () => {
     expect(failure.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('server_lifecycle_replay_only')
     expect(failure.getAttribute('data-chat-stream-contract-badge-state')).toBe('server-replay')
     expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 replay')
-    expect(failure.textContent).toContain('Timeout after 630.0s')
+    // transport_failure renders the typed card, so the raw diagnostic is
+    // collapsed by default (the legacy banner is suppressed for card rows)
+    // and surfaces only on expand.
+    const errCard = failure.querySelector('[data-chat-failure-card]')
+    expect(errCard).not.toBeNull()
+    expect(failure.textContent).not.toContain('Timeout after 630.0s')
+    const errToggle = errCard?.querySelector('[data-chat-failure-detail-toggle]') as HTMLButtonElement
+    errToggle.click()
+    await flushUi()
+    expect(failure.querySelector('[data-chat-failure-detail]')?.textContent).toContain('Timeout after 630.0s')
     expect(
       [...container.querySelectorAll('[data-chat-stream-contract-delivery-receipt]')]
         .map(node => node.getAttribute('data-chat-stream-contract-delivery-receipt')),

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -158,8 +158,8 @@ describe('ChatTranscript', () => {
             role: 'assistant',
             source: 'direct_assistant',
             label: 'sangsu',
-            text,
-            rawText: text,
+            text: '응답을 만들지 못했습니다',
+            rawText: '응답을 만들지 못했습니다',
             delivery: 'error',
             error: text,
           }),
@@ -177,7 +177,7 @@ describe('ChatTranscript', () => {
     // The raw internal error no longer replaces the reply: the card leads
     // with the reassurance that the pending message survives the failure.
     expect(card?.querySelector('[data-chat-failure-reassurance]')?.textContent)
-      .toContain('다음 턴')
+      .toContain('다음 턴을 시작하면')
     // Diagnostic detail is collapsed by default…
     expect(container.querySelector('[data-chat-failure-detail]')).toBeNull()
     expect(card?.textContent).not.toContain('no_usable_progress')

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -160,7 +160,7 @@ describe('ChatTranscript', () => {
             label: 'sangsu',
             text: '응답을 만들지 못했습니다',
             rawText: '응답을 만들지 못했습니다',
-            delivery: 'error',
+            delivery: 'transport_failure',
             error: text,
           }),
         ]}
@@ -177,7 +177,7 @@ describe('ChatTranscript', () => {
     // The raw internal error no longer replaces the reply: the card leads
     // with the reassurance that the pending message survives the failure.
     expect(card?.querySelector('[data-chat-failure-reassurance]')?.textContent)
-      .toContain('다음 턴을 시작하면')
+      .toContain('정상 응답하기 전까지')
     // Diagnostic detail is collapsed by default…
     expect(container.querySelector('[data-chat-failure-detail]')).toBeNull()
     expect(card?.textContent).not.toContain('no_usable_progress')
@@ -193,6 +193,29 @@ describe('ChatTranscript', () => {
       node.textContent?.includes('ollama_cloud.deepseek-v4-flash'),
     )).toBe(true)
     expect(container.querySelector('[data-chat-blocks]')).toBeNull()
+  })
+
+  it('keeps generic client errors distinct from durable transport failures', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'client-error-user',
+            text: '내 질문은 계속 보여야 해',
+            delivery: 'error',
+            error: 'queue poll lost its delivery receipt',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-entry-id="client-error-user"]')
+    expect(bubble?.textContent).toContain('내 질문은 계속 보여야 해')
+    expect(bubble?.textContent).toContain('queue poll lost its delivery receipt')
+    expect(bubble?.querySelector('[data-chat-failure-card]')).toBeNull()
   })
 
   it('exposes entry provenance as rendered attributes and surface links', () => {
@@ -409,7 +432,7 @@ describe('ChatTranscript', () => {
 
     const failure = container.querySelector('[data-chat-entry-id="smoke-error-assistant"]') as HTMLElement
     expect(failure).not.toBeNull()
-    expect(failure.getAttribute('data-chat-delivery-state')).toBe('error')
+    expect(failure.getAttribute('data-chat-delivery-state')).toBe('transport_failure')
     expect(failure.getAttribute('data-chat-turn-ref')).toBe('trace-chat-contract-smoke#8')
     expect(failure.getAttribute('data-chat-stream-contract-source')).toBe('backend_stream_lifecycle')
     expect(failure.getAttribute('data-chat-stream-contract-status')).toBe('backend_lifecycle_replay')

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -148,7 +148,7 @@ describe('ChatTranscript', () => {
     expect(bubble?.textContent).toContain('✓')
   })
 
-  it('preserves structured failure messages as preformatted text', () => {
+  it('renders failure rows as a typed card with collapsed diagnostic detail', async () => {
     const text = 'Keeper request failed: Internal error: [masc_oas_error] {"kind":"accept_rejected","scope":"ollama_cloud.deepseek-v4-flash","reason_kind":"no_usable_progress","last_tool_effect":"mutating"}'
     render(
       html`<${ChatTranscript}
@@ -170,10 +170,24 @@ describe('ChatTranscript', () => {
       container,
     )
 
-    const pre = container.querySelector('[data-chat-structured-error]')
+    // Typed failure card: discriminated by the row's delivery/kind signal,
+    // never by matching the content string.
+    const card = container.querySelector('[data-chat-failure-card]')
+    expect(card).not.toBeNull()
+    // The raw internal error no longer replaces the reply: the card leads
+    // with the reassurance that the pending message survives the failure.
+    expect(card?.querySelector('[data-chat-failure-reassurance]')?.textContent)
+      .toContain('다음 턴')
+    // Diagnostic detail is collapsed by default…
+    expect(container.querySelector('[data-chat-failure-detail]')).toBeNull()
+    expect(card?.textContent).not.toContain('no_usable_progress')
+    // …and expands to the preformatted token view on demand.
+    const toggle = card?.querySelector('[data-chat-failure-detail-toggle]') as HTMLButtonElement
+    toggle.click()
+    await flushUi()
+    const pre = container.querySelector('[data-chat-failure-detail]')
     expect(pre?.tagName).toBe('PRE')
     expect(pre?.classList.contains('chat-error-text')).toBe(true)
-    expect(pre?.classList.contains('break-words')).toBe(false)
     expect(pre?.textContent).toContain('ollama_cloud.deepseek-v4-flash')
     expect(Array.from(pre?.querySelectorAll('.chat-error-token') ?? []).some(node =>
       node.textContent?.includes('ollama_cloud.deepseek-v4-flash'),

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2352,8 +2352,13 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
+  // delivery='error' is the persisted transport_failure row (keeper-state.ts
+  // maps kind=transport_failure → 'error'); only that row renders the typed
+  // failure card, because its reassurance ("보낸 메시지는 사라지지 않았습니다")
+  // holds only when the keeper never answered. interrupted/timeout keep any
+  // partial text and render as prose plus the diagnostic banner below.
   const isFailureMessage =
-    isFailedDelivery(entry.delivery) && !!entry.error?.trim()
+    entry.delivery === 'error' && !!entry.error?.trim()
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
   const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))
@@ -2626,7 +2631,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       ${entry.audio
         ? html`<${AudioPlayer} clip=${entry.audio} />`
         : null}
-      ${entry.error
+      ${entry.error && !isFailureMessage
         ? html`
             <div class="rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-soft)] px-3 py-2 text-sm font-medium leading-paragraph text-[var(--bad-light)]">
               ${entry.error}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2056,6 +2056,63 @@ function renderStructuredFailureText(text: string): Array<string | VNode> {
   })
 }
 
+/** Typed failure card for kind=transport_failure rows.
+ *
+ * The discriminator is the writer-declared row kind (normalized to
+ * delivery='error'), never a string match on the content — the raw error
+ * text is diagnostic payload, shown collapsed. The reassurance line states
+ * what the backend guarantees: a Transport_failure row is watermark-neutral
+ * (keeper_chat_store), so the user message it failed to answer stays pending
+ * for the keeper's next turn. */
+function ChatFailureCard({ text }: { text: string }) {
+  const [detailOpen, setDetailOpen] = useState(false)
+  return html`
+    <div
+      class="flex flex-col gap-2 rounded-[var(--r-1)] border border-[var(--color-status-error)]/40 bg-[var(--color-bg-surface)] p-3"
+      data-chat-structured-error
+      data-chat-failure-card
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <span
+          class="inline-flex items-center rounded-[var(--r-0)] bg-[var(--color-status-error)]/15 px-2 py-0.5 text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-status-error)]"
+        >
+          응답 실패
+        </span>
+        <span class="text-sm font-semibold text-[var(--color-fg-primary)]">
+          이 턴은 응답을 만들지 못했습니다
+        </span>
+      </div>
+      <p class="m-0 text-sm leading-airy text-[var(--color-fg-secondary)]" data-chat-failure-reassurance>
+        보낸 메시지는 사라지지 않았습니다 — 대기 상태로 남아 keeper의 다음 턴에서 다시 처리됩니다.
+      </p>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="self-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING}"
+          aria-expanded=${detailOpen}
+          data-chat-failure-detail-toggle
+          onClick=${() => { setDetailOpen(!detailOpen) }}
+        >
+          ${detailOpen ? '상세 접기' : '오류 상세 보기'}
+        </button>
+        <button
+          type="button"
+          class="self-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING}"
+          data-chat-failure-copy
+          onClick=${() => { void copyWithToast(text, '오류 내용을 복사했습니다') }}
+        >
+          오류 복사
+        </button>
+      </div>
+      ${detailOpen
+        ? html`
+            <pre class="chat-error-text" data-chat-failure-detail>${renderStructuredFailureText(text)}</pre>
+          `
+        : null}
+    </div>
+  `
+}
+
 function AttachmentCard({ attachment }: { attachment: KeeperConversationAttachment }) {
   const [open, setOpen] = useState(false)
   const canDownload = isSafeAttachmentHref(attachment)
@@ -2533,12 +2590,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
         ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
         : html`
             ${isFailureMessage
-              ? html`
-                  <pre
-                    class="chat-error-text"
-                    data-chat-structured-error
-                  >${renderStructuredFailureText(messageText)}</pre>
-                `
+              ? html`<${ChatFailureCard} text=${messageText} />`
               : hasEffectiveBlocks
               ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`
               : html`

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2064,7 +2064,7 @@ function renderStructuredFailureText(text: string): Array<string | VNode> {
  * what the backend guarantees: a Transport_failure row is watermark-neutral
  * (keeper_chat_store), so the user message it failed to answer stays pending
  * for the keeper's next turn. */
-function ChatFailureCard({ text }: { text: string }) {
+function ChatFailureCard({ diagnostic }: { diagnostic: string }) {
   const [detailOpen, setDetailOpen] = useState(false)
   return html`
     <div
@@ -2083,7 +2083,7 @@ function ChatFailureCard({ text }: { text: string }) {
         </span>
       </div>
       <p class="m-0 text-sm leading-airy text-[var(--color-fg-secondary)]" data-chat-failure-reassurance>
-        보낸 메시지는 사라지지 않았습니다 — 대기 상태로 남아 keeper의 다음 턴에서 다시 처리됩니다.
+        보낸 메시지는 사라지지 않았습니다 — 대기 상태로 유지되며, keeper가 다음 턴을 시작하면 다시 처리 대상이 됩니다.
       </p>
       <div class="flex items-center gap-2">
         <button
@@ -2091,7 +2091,7 @@ function ChatFailureCard({ text }: { text: string }) {
           class="self-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING}"
           aria-expanded=${detailOpen}
           data-chat-failure-detail-toggle
-          onClick=${() => { setDetailOpen(!detailOpen) }}
+          onClick=${() => { setDetailOpen(open => !open) }}
         >
           ${detailOpen ? '상세 접기' : '오류 상세 보기'}
         </button>
@@ -2099,14 +2099,14 @@ function ChatFailureCard({ text }: { text: string }) {
           type="button"
           class="self-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING}"
           data-chat-failure-copy
-          onClick=${() => { void copyWithToast(text, '오류 내용을 복사했습니다') }}
+          onClick=${() => { void copyWithToast(diagnostic, '오류 내용을 복사했습니다') }}
         >
           오류 복사
         </button>
       </div>
       ${detailOpen
         ? html`
-            <pre class="chat-error-text" data-chat-failure-detail>${renderStructuredFailureText(text)}</pre>
+            <pre class="chat-error-text" data-chat-failure-detail>${renderStructuredFailureText(diagnostic)}</pre>
           `
         : null}
     </div>
@@ -2590,7 +2590,9 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
         ? html`<${LiveMessagePlaceholder} label=${liveLabel} />`
         : html`
             ${isFailureMessage
-              ? html`<${ChatFailureCard} text=${messageText} />`
+              ? html`<${ChatFailureCard}
+                  diagnostic=${entry.error?.trim() ? entry.error : messageText}
+                />`
               : hasEffectiveBlocks
               ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`
               : html`

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -411,6 +411,8 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
       return 'no reply'
     case 'error':
       return 'error'
+    case 'transport_failure':
+      return 'transport failure'
     case 'interrupted':
       return 'interrupted'
     case 'history':
@@ -2058,9 +2060,9 @@ function renderStructuredFailureText(text: string): Array<string | VNode> {
 
 /** Typed failure card for kind=transport_failure rows.
  *
- * The discriminator is the writer-declared row kind (normalized to
- * delivery='error'), never a string match on the content — the raw error
- * text is diagnostic payload, shown collapsed. The reassurance line states
+ * The discriminator is the writer-declared row kind (normalized to the closed
+ * delivery='transport_failure' variant), never a string match on the content.
+ * The raw error text is diagnostic payload, shown collapsed. The reassurance line states
  * what the backend guarantees: a Transport_failure row is watermark-neutral
  * (keeper_chat_store), so the user message it failed to answer stays pending
  * for the keeper's next turn. */
@@ -2083,7 +2085,7 @@ function ChatFailureCard({ diagnostic }: { diagnostic: string }) {
         </span>
       </div>
       <p class="m-0 text-sm leading-airy text-[var(--color-fg-secondary)]" data-chat-failure-reassurance>
-        보낸 메시지는 사라지지 않았습니다 — 대기 상태로 유지되며, keeper가 다음 턴을 시작하면 다시 처리 대상이 됩니다.
+        보낸 메시지는 사라지지 않았습니다. 이 실패 기록은 처리 완료로 간주되지 않으며, keeper가 이후 정상 응답하기 전까지 다시 처리 대상에 남습니다.
       </p>
       <div class="flex items-center gap-2">
         <button
@@ -2352,13 +2354,13 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
-  // delivery='error' is the persisted transport_failure row (keeper-state.ts
-  // maps kind=transport_failure → 'error'); only that row renders the typed
+  // keeper-state.ts maps the writer-declared kind=transport_failure to its own
+  // closed delivery variant; only that durable row renders the typed
   // failure card, because its reassurance ("보낸 메시지는 사라지지 않았습니다")
   // holds only when the keeper never answered. interrupted/timeout keep any
   // partial text and render as prose plus the diagnostic banner below.
   const isFailureMessage =
-    entry.delivery === 'error' && !!entry.error?.trim()
+    entry.delivery === 'transport_failure' && !!entry.error?.trim()
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
   const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1740,7 +1740,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       const assistants = thread.filter(entry => entry.role === 'assistant')
       expect(assistants).toHaveLength(2)
       expect(assistants.some(entry => entry.delivery === 'queued')).toBe(true)
-      expect(assistants.some(entry => entry.delivery === 'error')).toBe(true)
+      expect(assistants.some(entry => entry.delivery === 'transport_failure')).toBe(true)
       expect(keeperActionErrors.value.echo).toBeNull()
 
       // Let the resume loop finish.

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -602,6 +602,7 @@ describe('thread history merge & persistence', () => {
       { role: 'assistant', content: 'Keeper request failed: timeout', ts: 1_780_000_000, kind: 'transport_failure' },
     ])
     expect(entries[1]?.delivery).toBe('error')
+    expect(entries[1]?.error).toBe('Keeper request failed: timeout')
     // A normal reply on the same role stays 'history'.
     const ok = chatHistoryEntriesFromRest('echo', [
       { role: 'assistant', content: 'done', ts: 1_780_000_000 },

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -601,7 +601,7 @@ describe('thread history merge & persistence', () => {
       { role: 'user', content: 'do it', ts: 1_780_000_000 },
       { role: 'assistant', content: 'Keeper request failed: timeout', ts: 1_780_000_000, kind: 'transport_failure' },
     ])
-    expect(entries[1]?.delivery).toBe('error')
+    expect(entries[1]?.delivery).toBe('transport_failure')
     expect(entries[1]?.error).toBe('Keeper request failed: timeout')
     // A normal reply on the same role stays 'history'.
     const ok = chatHistoryEntriesFromRest('echo', [

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -895,6 +895,7 @@ function normalizeHistoryEntry(
     timestamp,
     turnRef,
     delivery,
+    error: delivery === 'error' ? rawText : null,
     streamState: null,
     streamContract,
     details: null,

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -868,10 +868,11 @@ function normalizeHistoryEntry(
   const turnRef = asString(raw.turn_ref) ?? null
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
-  // apart from a real reply. Map it to the existing error delivery state so
-  // the bubble renders the error label/styling instead of a saved reply.
+  // apart from a real reply. Preserve that writer-declared provenance as its
+  // own delivery variant: generic client/tool errors have different watermark
+  // semantics and must not inherit the durable-row reassurance.
   const delivery: KeeperConversationDelivery =
-    asString(raw.kind) === 'transport_failure' ? 'error' : 'history'
+    asString(raw.kind) === 'transport_failure' ? 'transport_failure' : 'history'
   const serverBlocks = normalizeBlocks(raw.blocks, role)
   const blocks = serverBlocks
     ?? ((role === 'assistant' || role === 'system') && text
@@ -895,7 +896,7 @@ function normalizeHistoryEntry(
     timestamp,
     turnRef,
     delivery,
-    error: delivery === 'error' ? rawText : null,
+    error: delivery === 'transport_failure' ? rawText : null,
     streamState: null,
     streamContract,
     details: null,

--- a/dashboard/src/lib/keeper-delivery.test.ts
+++ b/dashboard/src/lib/keeper-delivery.test.ts
@@ -21,14 +21,15 @@ const EXPECTED: Record<KeeperConversationDelivery, 'in-flight' | 'failed' | 'oth
   timeout: 'failed',
   cancelled: 'other',
   error: 'failed',
+  transport_failure: 'failed',
   interrupted: 'failed',
 }
 
 describe('keeper-delivery classifiers', () => {
   const all = Object.keys(EXPECTED) as KeeperConversationDelivery[]
 
-  it('covers all 10 delivery variants', () => {
-    expect(all).toHaveLength(10)
+  it('covers all 11 delivery variants', () => {
+    expect(all).toHaveLength(11)
   })
 
   it('classifies every variant into exactly one bucket', () => {
@@ -51,7 +52,12 @@ describe('keeper-delivery classifiers', () => {
     expect([...IN_FLIGHT_DELIVERY].sort()).toEqual(['queued', 'sending', 'streaming'])
   })
 
-  it('preserves the original failed membership {error, timeout, interrupted}', () => {
-    expect([...FAILED_DELIVERY].sort()).toEqual(['error', 'interrupted', 'timeout'])
+  it('classifies durable transport failure separately from generic errors', () => {
+    expect([...FAILED_DELIVERY].sort()).toEqual([
+      'error',
+      'interrupted',
+      'timeout',
+      'transport_failure',
+    ])
   })
 })

--- a/dashboard/src/lib/keeper-delivery.ts
+++ b/dashboard/src/lib/keeper-delivery.ts
@@ -21,6 +21,7 @@ export const IN_FLIGHT_DELIVERY = [
 /** Deliveries representing a failed terminal outcome. */
 export const FAILED_DELIVERY = [
   'error',
+  'transport_failure',
   'timeout',
   'interrupted',
 ] as const satisfies ReadonlyArray<KeeperConversationDelivery>
@@ -33,9 +34,9 @@ export function isInFlightDelivery(delivery: KeeperConversationDelivery): boolea
   return IN_FLIGHT_SET.has(delivery)
 }
 
-/** True when the turn ended in a failed terminal state (error / timeout /
- *  interrupted). Callers that additionally require a non-empty error string
- *  must keep that conjunct at the callsite. */
+/** True when the turn ended in a failed terminal state. Callers that
+ *  additionally require a non-empty error string must keep that conjunct at
+ *  the callsite. */
 export function isFailedDelivery(delivery: KeeperConversationDelivery): boolean {
   return FAILED_SET.has(delivery)
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -742,6 +742,10 @@ export type KeeperConversationDelivery =
   | 'timeout'
   | 'cancelled'
   | 'error'
+  // Durable keeper_chat_store row written when a request failed before the
+  // keeper produced an utterance. Unlike generic client/tool errors, this
+  // writer-declared state is watermark-neutral.
+  | 'transport_failure'
   // Stream ended without a terminal RUN_FINISHED / RUN_ERROR event —
   // the transport was cut mid-response, so the text may be incomplete.
   | 'interrupted'


### PR DESCRIPTION
## 무엇

기능지도 Gap(P1, 실패 턴 UX): raw 내부 에러 문자열이 답변 자리를 대체하던 것을 **typed 실패 카드**로 교체 — "응답 실패" 뱃지 + 안심 문구(메시지는 watermark-중립이라 다음 턴에 재처리됨 = 백엔드가 이미 보장하는 사실, `keeper_chat_store` 계약) + 접힌 진단 상세 + 복사 버튼.

실측 배경: 07-11 keeper_chat 감사에서 실패 327건 중 87.2%가 dead-end로 보였는데, 그 표면이 바로 이 raw 에러 노출이었습니다 (원인이던 truncation은 max_tokens 체인으로 별도 해소).

## 원칙

판별자는 writer-declared row kind(`transport_failure` → delivery `error`) — **콘텐츠 문자열 매칭 없음**. raw 텍스트는 진단 payload로 원문 보존(접힘+복사).

## 검증

- `primitives` 129/129 — 실패 렌더 테스트를 카드 계약으로 재작성: 카드 존재 / 안심 문구 / 상세 기본 접힘(가시 텍스트에 진단 문자열 부재 단언) / 토글 확장 시 기존 token `<pre>` 유지
- `keeper-state` pass, `tsc --noEmit` clean

## 후속 (이슈 예정)

typed `sdk_error`를 `persist_failure_reply`까지 스레딩해 카드에 typed 실패 kind를 표시 — 현재 4개 call site 전부 string으로 평탄화되어 도달.

지도: claude.ai/code/artifact/01478ad0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
