### PR TITLE
fix(keeper): centralize lifecycle admission before autonomous work

### DIFF
--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -1,9 +1,15 @@
+type autonomous_blocker =
+  | Lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
+  | Autoboot_disabled
+  | Proactive_disabled
+
 type autonomous_activation =
   { ok : bool
   ; autoboot_enabled : bool
   ; proactive_enabled : bool
   ; paused : bool
-  ; blocker : string option
+  ; lifecycle_state : Keeper_lifecycle_admission.state
+  ; blocker : autonomous_blocker option
   ; hint : string option
   }
 
@@ -18,26 +24,37 @@ type t =
    per-keeper flag), rather than re-deriving the enabled state from
    [meta.autoboot_enabled] / [meta.proactive.enabled] here. This is the same
    resolver [keeper_cycle_decision] uses, so the two sites cannot drift. *)
-let autonomous_blocker (meta : Keeper_meta_contract.keeper_meta) =
-  if meta.paused then Some "paused"
-  else if not (Keeper_lifecycle_gate_env.enabled Autonomous meta) then
-    Some "autoboot_disabled"
-  else if not (Keeper_lifecycle_gate_env.enabled Proactive meta) then
-    Some "proactive_disabled"
-  else None
+let autonomous_blocker (meta : Keeper_meta_contract.keeper_meta) lifecycle_state =
+  match Keeper_lifecycle_admission.admit_autonomous lifecycle_state with
+  | Keeper_lifecycle_admission.Autonomous_denied denial ->
+    Some (Lifecycle_denied denial)
+  | Keeper_lifecycle_admission.Autonomous_admitted ->
+    if not (Keeper_lifecycle_gate_env.enabled Autonomous meta) then
+      Some Autoboot_disabled
+    else if not (Keeper_lifecycle_gate_env.enabled Proactive meta) then
+      Some Proactive_disabled
+    else None
 ;;
 
-(* [blocker] strings ("autoboot_disabled" / "proactive_disabled") are shared
-   with [Keeper_lifecycle_gate_env.enabled]'s combined global-AND-meta
-   verdict, so the same string fires whether the *global* kill-switch or the
-   *per-keeper* meta flag caused the block. The hint must check the meta
-   flag directly to tell an operator which one to fix -- pointing them at
-   meta when it's already true would send them editing the wrong knob. *)
+let autonomous_blocker_to_wire = function
+  | Lifecycle_denied denial ->
+    Keeper_lifecycle_admission.autonomous_denial_to_wire denial
+  | Autoboot_disabled -> "autoboot_disabled"
+  | Proactive_disabled -> "proactive_disabled"
+;;
+
+(* The typed blocker is shared with the lifecycle and feature-gate verdicts.
+   The hint checks the meta flag directly to distinguish a global kill-switch
+   from a per-keeper flag without parsing the boundary string projection. *)
 let autonomous_hint (meta : Keeper_meta_contract.keeper_meta) = function
   | None -> None
-  | Some "paused" ->
+  | Some
+      (Lifecycle_denied (Keeper_lifecycle_admission.Autonomous_paused _)) ->
     Some "resume keeper before expecting autonomous keepalive or PR fan-out"
-  | Some "autoboot_disabled" ->
+  | Some
+      (Lifecycle_denied Keeper_lifecycle_admission.Autonomous_dead_tombstone) ->
+    Some "transition the dead keeper lifecycle before starting a new lane"
+  | Some Autoboot_disabled ->
     if meta.autoboot_enabled
     then
       Some
@@ -46,7 +63,7 @@ let autonomous_hint (meta : Keeper_meta_contract.keeper_meta) = function
          autonomous keepalive or PR fan-out"
     else
       Some "set autoboot_enabled=true before expecting autonomous keepalive or PR fan-out"
-  | Some "proactive_disabled" ->
+  | Some Proactive_disabled ->
     if meta.proactive.enabled
     then
       Some
@@ -55,15 +72,20 @@ let autonomous_hint (meta : Keeper_meta_contract.keeper_meta) = function
          scheduled autonomous work"
     else
       Some "set proactive_enabled=true before expecting scheduled autonomous work"
-  | Some reason -> Some ("activation blocked: " ^ reason)
 ;;
 
 let autonomous_activation (meta : Keeper_meta_contract.keeper_meta) =
-  let blocker = autonomous_blocker meta in
+  let lifecycle_state =
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  in
+  let blocker = autonomous_blocker meta lifecycle_state in
   { ok = Option.is_none blocker
   ; autoboot_enabled = meta.autoboot_enabled
   ; proactive_enabled = meta.proactive.enabled
   ; paused = meta.paused
+  ; lifecycle_state
   ; blocker
   ; hint = autonomous_hint meta blocker
   }
@@ -80,7 +102,7 @@ let ready_for_unclaimed_backlog meta = (of_meta meta).ready_for_unclaimed_backlo
 let autonomous_check_value (activation : autonomous_activation) =
   match activation.blocker with
   | None -> "ok"
-  | Some blocker -> blocker
+  | Some blocker -> autonomous_blocker_to_wire blocker
 ;;
 
 let autonomous_activation_to_yojson (activation : autonomous_activation) =
@@ -89,7 +111,12 @@ let autonomous_activation_to_yojson (activation : autonomous_activation) =
     ; "autoboot_enabled", `Bool activation.autoboot_enabled
     ; "proactive_enabled", `Bool activation.proactive_enabled
     ; "paused", `Bool activation.paused
-    ; "blocker", Json_util.string_opt_to_json activation.blocker
+    ; ( "lifecycle_state"
+      , `String
+          (Keeper_lifecycle_admission.state_to_wire activation.lifecycle_state) )
+    ; ( "blocker"
+      , Json_util.string_opt_to_json
+          (Option.map autonomous_blocker_to_wire activation.blocker) )
     ; "hint", Json_util.string_opt_to_json activation.hint
     ]
 ;;

--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -3,6 +3,47 @@ type autonomous_blocker =
   | Autoboot_disabled
   | Proactive_disabled
 
+type pause_kind =
+  | Active
+  | Reconcile_gated
+  | Auto_recoverable
+  | Operator_paused
+  | Latched_paused
+  | Unclassified_paused
+  | Dead_tombstone
+
+let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
+  match
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  with
+  | Keeper_lifecycle_admission.Dead_tombstone -> Dead_tombstone
+  | Keeper_lifecycle_admission.Active -> Active
+  | Keeper_lifecycle_admission.Paused latch ->
+    if Keeper_supervisor_types.paused_meta_requires_reconcile_recovery meta
+    then Reconcile_gated
+    else
+      (match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
+       | Some _ -> Auto_recoverable
+       | None ->
+         (match latch with
+          | Keeper_lifecycle_admission.Classified
+              (Keeper_latched_reason.Operator_paused _) -> Operator_paused
+          | Keeper_lifecycle_admission.Classified _ -> Latched_paused
+          | Keeper_lifecycle_admission.Unclassified -> Unclassified_paused))
+;;
+
+let pause_kind_to_wire = function
+  | Active -> "active"
+  | Reconcile_gated -> "reconcile_gated"
+  | Auto_recoverable -> "auto_recoverable"
+  | Operator_paused -> "operator_paused"
+  | Latched_paused -> "latched_paused"
+  | Unclassified_paused -> "unclassified_paused"
+  | Dead_tombstone -> "dead_tombstone"
+;;
+
 type autonomous_activation =
   { ok : bool
   ; autoboot_enabled : bool

--- a/lib/keeper/keeper_activation_readiness.mli
+++ b/lib/keeper/keeper_activation_readiness.mli
@@ -8,6 +8,21 @@ type autonomous_blocker =
   | Autoboot_disabled
   | Proactive_disabled
 
+(** Typed operator-facing projection of the persisted Keeper lifecycle and
+    supervisor recovery policy. Server/dashboard code consumes this value; it
+    must not reclassify pause/dead states independently. *)
+type pause_kind =
+  | Active
+  | Reconcile_gated
+  | Auto_recoverable
+  | Operator_paused
+  | Latched_paused
+  | Unclassified_paused
+  | Dead_tombstone
+
+val pause_kind : Keeper_meta_contract.keeper_meta -> pause_kind
+val pause_kind_to_wire : pause_kind -> string
+
 type autonomous_activation =
   { ok : bool
   ; autoboot_enabled : bool

--- a/lib/keeper/keeper_activation_readiness.mli
+++ b/lib/keeper/keeper_activation_readiness.mli
@@ -3,12 +3,18 @@
     Used by both keeper preflight tools and dashboard fleet projections so
     operator-visible readiness does not drift from execution gates. *)
 
+type autonomous_blocker =
+  | Lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
+  | Autoboot_disabled
+  | Proactive_disabled
+
 type autonomous_activation =
   { ok : bool
   ; autoboot_enabled : bool
   ; proactive_enabled : bool
   ; paused : bool
-  ; blocker : string option
+  ; lifecycle_state : Keeper_lifecycle_admission.state
+  ; blocker : autonomous_blocker option
   ; hint : string option
   }
 
@@ -23,5 +29,7 @@ val of_meta : Keeper_meta_contract.keeper_meta -> t
 val ready_for_unclaimed_backlog : Keeper_meta_contract.keeper_meta -> bool
 
 val autonomous_check_value : autonomous_activation -> string
+
+val autonomous_blocker_to_wire : autonomous_blocker -> string
 
 val to_yojson : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -888,7 +888,12 @@ let record_resolution_delivery_failure ~keeper_name ~approval_id reason =
 
 let signal_resolution_after_commit ~base_path ~keeper_name ~approval_id =
   try
-    let outcome = Keeper_registry.wakeup_running ~base_path keeper_name in
+    let outcome =
+      Keeper_registry.wakeup_running
+        ~intent:Keeper_registry.Hitl_resolution
+        ~base_path
+        keeper_name
+    in
     let outcome_label, detail =
       match outcome with
       | Keeper_registry.Signaled -> "signaled", "running"
@@ -896,6 +901,9 @@ let signal_resolution_after_commit ~base_path ~keeper_name ~approval_id =
         "deferred_unregistered", "unregistered"
       | Keeper_registry.Deferred_not_running phase ->
         "deferred_not_running", Keeper_state_machine.phase_to_string phase
+      | Keeper_registry.Deferred_lifecycle denial ->
+        ( "deferred_lifecycle"
+        , Keeper_lifecycle_admission.autonomous_denial_to_wire denial )
     in
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string ApprovalResolutionSignal)

--- a/lib/keeper/keeper_goal_assignment_wake.ml
+++ b/lib/keeper/keeper_goal_assignment_wake.ml
@@ -41,7 +41,13 @@ let enqueue_goal_assigned_wakes
         stimulus;
       match Keeper_registry.get ~base_path:config.base_path keeper_name with
       | Some entry when entry.phase = Keeper_state_machine.Running ->
-        Keeper_registry.wakeup ~base_path:config.base_path keeper_name
+        let (_ : Keeper_registry.wakeup_outcome) =
+          Keeper_registry.wakeup
+            ~intent:Keeper_registry.Goal_signal
+            ~base_path:config.base_path
+            keeper_name
+        in
+        ()
       | Some entry ->
         Log.Keeper.info
           "goal assignment wake queued without fiber wake keeper=%s phase=%s \

--- a/lib/keeper/keeper_goal_stagnation_wake.ml
+++ b/lib/keeper/keeper_goal_stagnation_wake.ml
@@ -77,7 +77,13 @@ let enqueue_goal_stagnation_wakes
                 Keeper_registry.get ~base_path:config.base_path keeper_name
               with
               | Some entry when entry.phase = Keeper_state_machine.Running ->
-                Keeper_registry.wakeup ~base_path:config.base_path keeper_name
+                let (_ : Keeper_registry.wakeup_outcome) =
+                  Keeper_registry.wakeup
+                    ~intent:Keeper_registry.Goal_signal
+                    ~base_path:config.base_path
+                    keeper_name
+                in
+                ()
               | Some entry ->
                 Log.Keeper.info
                   "goal stagnation wake queued without fiber wake keeper=%s \

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1571,9 +1571,9 @@ let run_heartbeat_loop
         let t_turn_end = Time_compat.now () in
         let t_recurring_start = t_turn_end in
         (* Recurring task dispatch (#3190) *)
-        let _recurring_dispatched =
+        let _recurring_dispatch_count =
           if lifecycle_blocked
-          then false
+          then 0
           else dispatch_recurring_keepalive ~ctx ~meta_after_proactive ~now_ts
         in
         let t_recurring_end = Time_compat.now () in

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -69,19 +69,25 @@ type single_claim_admission = Stimulus_intake.single_claim_admission =
 
 type turn_intake_admission =
   | Intake_admitted
+  | Intake_lifecycle_blocked of Keeper_lifecycle_admission.autonomous_denial
   | Intake_pressure_blocked of Keeper_pressure_admission.block
   | Intake_blocking_approval_pending
-  | Intake_keeper_paused
 
-let classify_turn_intake_admission ~pressure ~blocking_approval_pending ~keeper_paused =
-  match pressure with
-  | Keeper_pressure_admission.Blocked block -> Intake_pressure_blocked block
-  | Keeper_pressure_admission.Admitted ->
-    if blocking_approval_pending
-    then Intake_blocking_approval_pending
-    else if keeper_paused
-    then Intake_keeper_paused
-    else Intake_admitted
+let classify_turn_intake_admission
+      ~lifecycle
+      ~pressure
+      ~blocking_approval_pending
+  =
+  match lifecycle with
+  | Keeper_lifecycle_admission.Autonomous_denied denial ->
+    Intake_lifecycle_blocked denial
+  | Keeper_lifecycle_admission.Autonomous_admitted ->
+    (match pressure with
+     | Keeper_pressure_admission.Blocked block -> Intake_pressure_blocked block
+     | Keeper_pressure_admission.Admitted ->
+       if blocking_approval_pending
+       then Intake_blocking_approval_pending
+       else Intake_admitted)
 ;;
 
 let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat_stimulus
@@ -1329,8 +1335,8 @@ let run_heartbeat_loop
           proactive_warmup_sec <= 0
           || now_ts -. keepalive_started_ts >= float_of_int proactive_warmup_sec
         in
-        (* Turn-intake preconditions (fd/disk pressure and a typed Blocking HITL
-           lane) are evaluated ONCE here, BEFORE board collection and durable
+        (* Turn-intake preconditions (typed lifecycle, fd/disk pressure, and a
+           typed Blocking HITL lane) are evaluated ONCE here, BEFORE board collection and durable
            stimulus intake. A blocked keeper therefore neither advances the
            board cursor nor leases and requeues the same event every heartbeat.
            Nonblocking approvals never enter this gate.
@@ -1349,19 +1355,40 @@ let run_heartbeat_loop
           Keeper_approval_queue.has_blocking_pending_for_keeper
             ~keeper_name:meta_current.name
         in
+        let lifecycle_state =
+          Keeper_lifecycle_admission.state
+            ~paused:meta_current.paused
+            ~latched_reason:meta_current.latched_reason
+        in
         let intake_admission =
           classify_turn_intake_admission
+            ~lifecycle:
+              (Keeper_lifecycle_admission.admit_autonomous lifecycle_state)
             ~pressure:turn_admission
             ~blocking_approval_pending:approval_pending
-            ~keeper_paused:meta_current.paused
         in
         let admitted_turn =
           match intake_admission with
           | Intake_admitted -> true
+          | Intake_lifecycle_blocked _
           | Intake_pressure_blocked _
-          | Intake_blocking_approval_pending
-          | Intake_keeper_paused ->
-            false
+          | Intake_blocking_approval_pending -> false
+        in
+        let lifecycle_blocked =
+          match intake_admission with
+          | Intake_lifecycle_blocked _ -> true
+          | Intake_admitted
+          | Intake_pressure_blocked _
+          | Intake_blocking_approval_pending -> false
+        in
+        let terminal_lifecycle_blocked =
+          match intake_admission with
+          | Intake_lifecycle_blocked
+              Keeper_lifecycle_admission.Autonomous_dead_tombstone -> true
+          | Intake_lifecycle_blocked (Keeper_lifecycle_admission.Autonomous_paused _) -> false
+          | Intake_admitted
+          | Intake_pressure_blocked _
+          | Intake_blocking_approval_pending -> false
         in
         let keeper_health_blocker =
           if Health.is_healthy ~agent_name:meta_current.name then None else Some "unhealthy"
@@ -1375,6 +1402,35 @@ let run_heartbeat_loop
         let provider_cooldown_pending = Option.is_some provider_cooldown_remaining_sec in
         (match intake_admission with
          | Intake_admitted -> ()
+         | Intake_lifecycle_blocked denial ->
+           let reason =
+             Keeper_lifecycle_admission.autonomous_denial_to_wire denial
+           in
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string LifecycleDispatchRejections)
+             ~labels:
+               [ "keeper", meta_current.name
+               ; "event", "heartbeat_pre_intake"
+               ; "reason", reason
+               ]
+             ();
+           Keeper_registry.record_skip_reasons
+             ~base_path:ctx.config.base_path
+             meta_current.name
+             ~reasons:[ "lifecycle_" ^ reason ];
+           Log.Keeper.info
+             "%s: heartbeat intake denied by lifecycle admission: %s"
+             meta_current.name
+             reason;
+           if terminal_lifecycle_blocked
+           then
+             (* A dead tombstone owns no runnable lane. Ordinary pause keeps
+                its lane parked so an explicit resume remains local. *)
+             Atomic.set stop true
+           else
+             Keeper_registry.touch_last_turn_ts
+               ~base_path:ctx.config.base_path
+               meta_current.name
          | Intake_pressure_blocked block ->
            Keeper_registry.record_skip_reasons
              ~base_path:ctx.config.base_path
@@ -1390,17 +1446,6 @@ let run_heartbeat_loop
              ~reasons:
                [ Keeper_world_observation.skip_reason_to_string
                    Keeper_world_observation.Approval_pending
-               ];
-           Keeper_registry.touch_last_turn_ts
-             ~base_path:ctx.config.base_path
-             meta_current.name
-         | Intake_keeper_paused ->
-           Keeper_registry.record_skip_reasons
-             ~base_path:ctx.config.base_path
-             meta_current.name
-             ~reasons:
-               [ Keeper_world_observation.skip_reason_to_string
-                   Keeper_world_observation.Keeper_paused
                ];
            Keeper_registry.touch_last_turn_ts
              ~base_path:ctx.config.base_path
@@ -1475,51 +1520,61 @@ let run_heartbeat_loop
             r)
         in
         let meta_after_proactive = turn_outcome.meta in
-        (* Turn failure threshold: registry tracks count (via unified_turn,
-                 and via [record_crashed_cycle_failure] for swallowed cycle
-                 exceptions), keepalive raises to terminate the fiber for
-                 supervisor restart. *)
-        let turn_fail_count =
-          Keeper_registry.get_turn_failures ~base_path:ctx.config.base_path m.name
-        in
-        (* RFC-0002: dispatch turn status event *)
-        Keeper_keepalive_signal.dispatch_keepalive_event
-          ~ctx
-          ~keeper_name:m.name
-          (turn_status_event
-             ~turn_fail_count
-             ~max_allowed:(Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()));
-        if turn_fail_count >= Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()
+        if not lifecycle_blocked
         then (
-          Keeper_registry.set_failure_reason
-            ~base_path:ctx.config.base_path
-            m.name
-            (Some (Keeper_registry.Turn_consecutive_failures turn_fail_count));
-          raise Keeper_registry.Keeper_fiber_crash);
-        (* Phase 1: work-as-heartbeat — renew point (b).
-                 After turn, call Workspace.heartbeat to prove workspace I/O health.
-                 On success: refresh freshness lease + reset consecutive_failures.
-                 On failure: leave timestamp unchanged → presence sync resumes next cycle.
-                 T6 audit: a crashed cycle proves nothing about health — do not
-                 refresh the lease or reset consecutive_failures for it. *)
-        if turn_outcome.cycle_crashed
-        then
-          Log.Keeper.info
-            "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
-            m.name
-        else
-          refresh_work_as_heartbeat
+          (* Turn failure threshold: registry tracks count (via unified_turn,
+             and via [record_crashed_cycle_failure] for swallowed cycle
+             exceptions), keepalive raises to terminate the fiber for
+             supervisor restart. A lifecycle-blocked cycle did not run a turn
+             and must not emit a false [Turn_succeeded]. *)
+          let turn_fail_count =
+            Keeper_registry.get_turn_failures
+              ~base_path:ctx.config.base_path
+              m.name
+          in
+          (* RFC-0002: dispatch turn status event *)
+          Keeper_keepalive_signal.dispatch_keepalive_event
             ~ctx
-            ~meta_after_proactive
-            ~proactive_warmup_elapsed
-            ~work_as_hb
-            ~last_successful_heartbeat_ts
-            ~consecutive_failures;
+            ~keeper_name:m.name
+            (turn_status_event
+               ~turn_fail_count
+               ~max_allowed:
+                 (Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()));
+          if
+            turn_fail_count
+            >= Keeper_heartbeat_snapshot.max_consecutive_turn_failures ()
+          then (
+            Keeper_registry.set_failure_reason
+              ~base_path:ctx.config.base_path
+              m.name
+              (Some (Keeper_registry.Turn_consecutive_failures turn_fail_count));
+            raise Keeper_registry.Keeper_fiber_crash);
+          (* Phase 1: work-as-heartbeat — renew point (b).
+             After turn, call Workspace.heartbeat to prove workspace I/O health.
+             On success: refresh freshness lease + reset consecutive_failures.
+             On failure: leave timestamp unchanged → presence sync resumes next cycle.
+             T6 audit: a crashed cycle proves nothing about health — do not
+             refresh the lease or reset consecutive_failures for it. *)
+          if turn_outcome.cycle_crashed
+          then
+            Log.Keeper.info
+              "%s: skipping work-as-heartbeat refresh after crashed keepalive cycle"
+              m.name
+          else
+            refresh_work_as_heartbeat
+              ~ctx
+              ~meta_after_proactive
+              ~proactive_warmup_elapsed
+              ~work_as_hb
+              ~last_successful_heartbeat_ts
+              ~consecutive_failures);
         let t_turn_end = Time_compat.now () in
         let t_recurring_start = t_turn_end in
         (* Recurring task dispatch (#3190) *)
         let _recurring_dispatched =
-          dispatch_recurring_keepalive ~ctx ~meta_after_proactive ~now_ts
+          if lifecycle_blocked
+          then false
+          else dispatch_recurring_keepalive ~ctx ~meta_after_proactive ~now_ts
         in
         let t_recurring_end = Time_compat.now () in
         let base =

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -75,11 +75,13 @@ type single_claim_admission =
     a blocked cycle does not repeatedly lease and requeue the same stimulus. *)
 type turn_intake_admission =
   | Intake_admitted
+  | Intake_lifecycle_blocked of Keeper_lifecycle_admission.autonomous_denial
   | Intake_pressure_blocked of Keeper_pressure_admission.block
   | Intake_blocking_approval_pending
   | Intake_keeper_paused
 
 val classify_turn_intake_admission :
+  lifecycle:Keeper_lifecycle_admission.autonomous_admission ->
   pressure:Keeper_pressure_admission.decision ->
   blocking_approval_pending:bool ->
   keeper_paused:bool ->
@@ -179,7 +181,7 @@ val turn_status_event :
   turn_fail_count:int -> max_allowed:int -> Keeper_state_machine.event
 
 (** Runs one keepalive turn (event intake, scheduling, optional cycle dispatch).
-    The caller classifies fd/disk pressure and typed Blocking HITL ownership
+    The caller classifies lifecycle state, fd/disk pressure, and typed Blocking HITL ownership
     with {!classify_turn_intake_admission} BEFORE this is invoked, so this
     function must not re-add inline admission gates: doing so would reinstate
     the consume-before-gate churn that hoisting the decision removed. *)

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -70,21 +70,19 @@ type single_claim_admission =
   | Admit_ready_single
   | Defer_failure_judgment
 
-(** Closed pre-intake admission result. Blocking approval and explicit Keeper
-    pause are classified before durable dequeue, just like fd/disk pressure, so
-    a blocked cycle does not repeatedly lease and requeue the same stimulus. *)
+(** Closed pre-intake admission result. Lifecycle, blocking approval, and
+    fd/disk pressure are classified before durable dequeue, so a blocked cycle
+    does not repeatedly lease and requeue the same stimulus. *)
 type turn_intake_admission =
   | Intake_admitted
   | Intake_lifecycle_blocked of Keeper_lifecycle_admission.autonomous_denial
   | Intake_pressure_blocked of Keeper_pressure_admission.block
   | Intake_blocking_approval_pending
-  | Intake_keeper_paused
 
 val classify_turn_intake_admission :
   lifecycle:Keeper_lifecycle_admission.autonomous_admission ->
   pressure:Keeper_pressure_admission.decision ->
   blocking_approval_pending:bool ->
-  keeper_paused:bool ->
   turn_intake_admission
 
 val heartbeat_event_intake :

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -809,6 +809,7 @@ let record_keeper_crashed
 type start_keepalive_outcome =
   | Keepalive_started of Keeper_registry.registry_entry
   | Keepalive_already_registered of Keeper_registry.registry_entry
+  | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
   | Keepalive_spawn_slot_denied of Keeper_registry.spawn_slot_denial_reason
   | Keepalive_registration_rejected of Keeper_registry.registration_error
@@ -824,6 +825,8 @@ let start_keepalive_outcome_to_string = function
       "already registered phase=%s lane=%s"
       (Keeper_state_machine.phase_to_string entry.phase)
       (Keeper_lane.Id.to_string (Keeper_lane.id entry.lane))
+  | Keepalive_lifecycle_denied denial ->
+    Keeper_lifecycle_admission.autonomous_denial_to_wire denial
   | Keepalive_identity_unrepairable -> "keeper identity drift could not be repaired"
   | Keepalive_spawn_slot_denied reason ->
     Keeper_registry.spawn_slot_denial_reason_to_detail reason
@@ -850,13 +853,65 @@ let start_keepalive_outcome_to_string = function
   | Keepalive_lane_ownership_lost -> "lane ownership lost before fiber fork"
   | Keepalive_fork_rejected error -> Keeper_lane.start_error_to_string error
 
+let record_lifecycle_start_denial
+      (meta : keeper_meta)
+      (denial : Keeper_lifecycle_admission.autonomous_denial)
+  =
+  let reason = Keeper_lifecycle_admission.autonomous_denial_to_wire denial in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string LifecycleDispatchRejections)
+    ~labels:
+      [ "keeper", meta.name
+      ; "event", "autonomous_keepalive_start"
+      ; "reason", reason
+      ]
+    ();
+  publish_keeper_lifecycle
+    ~event:
+      (Keeper_lifecycle_events.Custom_event
+         { verb = Keeper_lifecycle_events.Admission_denied
+         ; phase = Some Keeper_state_machine.Offline
+         })
+    ~keeper_name:meta.name
+    ~detail:reason
+    ();
+  Log.Keeper.emit
+    Log.Info
+    ~category:Log.Heartbeat
+    ~details:
+      (`Assoc
+        [ "keeper", `String meta.name
+        ; "reason", `String reason
+        ; "lifecycle_state"
+        , `String
+            (Keeper_lifecycle_admission.state_to_wire
+               (Keeper_lifecycle_admission.state
+                  ~paused:meta.paused
+                  ~latched_reason:meta.latched_reason))
+        ])
+    (Printf.sprintf
+       "start_keepalive denied for %s by lifecycle admission: %s"
+       meta.name
+       reason)
+;;
+
 let start_keepalive
       ?(proactive_warmup_sec = 0)
       ?lifecycle_token
       (ctx : _ context)
-      (m : keeper_meta)
+  (m : keeper_meta)
   : start_keepalive_outcome
   =
+  let lifecycle_state =
+    Keeper_lifecycle_admission.state
+      ~paused:m.paused
+      ~latched_reason:m.latched_reason
+  in
+  match Keeper_lifecycle_admission.admit_autonomous lifecycle_state with
+  | Keeper_lifecycle_admission.Autonomous_denied denial ->
+    record_lifecycle_start_denial m denial;
+    Keepalive_lifecycle_denied denial
+  | Keeper_lifecycle_admission.Autonomous_admitted ->
   match repair_identity_drift_for_keepalive ?lifecycle_token ~ctx m with
   | None ->
     Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -118,6 +118,7 @@ val percentile : float array -> float -> float
 type start_keepalive_outcome =
   | Keepalive_started of Keeper_registry.registry_entry
   | Keepalive_already_registered of Keeper_registry.registry_entry
+  | Keepalive_lifecycle_denied of Keeper_lifecycle_admission.autonomous_denial
   | Keepalive_identity_unrepairable
   | Keepalive_spawn_slot_denied of Keeper_registry.spawn_slot_denial_reason
   | Keepalive_registration_rejected of Keeper_registry.registration_error

--- a/lib/keeper/keeper_lifecycle_admission.ml
+++ b/lib/keeper/keeper_lifecycle_admission.ml
@@ -1,0 +1,57 @@
+type paused_latch =
+  | Classified of Keeper_latched_reason.t
+  | Unclassified
+
+type state =
+  | Active
+  | Paused of paused_latch
+  | Dead_tombstone
+
+let state ~paused ~latched_reason =
+  match latched_reason with
+  | Some Keeper_latched_reason.Dead_tombstone -> Dead_tombstone
+  | Some reason when paused -> Paused (Classified reason)
+  | None when paused -> Paused Unclassified
+  | Some _ | None -> Active
+;;
+
+type manual_one_shot_admission =
+  | Manual_admitted_active
+  | Manual_admitted_paused_recovery of paused_latch
+  | Manual_denied_dead_tombstone
+
+let admit_manual_one_shot = function
+  | Active -> Manual_admitted_active
+  | Paused latch -> Manual_admitted_paused_recovery latch
+  | Dead_tombstone -> Manual_denied_dead_tombstone
+;;
+
+type autonomous_denial =
+  | Autonomous_paused of paused_latch
+  | Autonomous_dead_tombstone
+
+type autonomous_admission =
+  | Autonomous_admitted
+  | Autonomous_denied of autonomous_denial
+
+let admit_autonomous = function
+  | Active -> Autonomous_admitted
+  | Paused latch -> Autonomous_denied (Autonomous_paused latch)
+  | Dead_tombstone -> Autonomous_denied Autonomous_dead_tombstone
+;;
+
+let paused_latch_to_wire = function
+  | Classified reason -> Keeper_latched_reason.to_wire reason
+  | Unclassified -> "unclassified"
+;;
+
+let state_to_wire = function
+  | Active -> "active"
+  | Paused _ -> "paused"
+  | Dead_tombstone -> "dead_tombstone"
+;;
+
+let autonomous_denial_to_wire = function
+  | Autonomous_paused _ -> "paused"
+  | Autonomous_dead_tombstone -> "dead_tombstone"
+;;

--- a/lib/keeper/keeper_lifecycle_admission.mli
+++ b/lib/keeper/keeper_lifecycle_admission.mli
@@ -1,0 +1,43 @@
+(** Pure lifecycle admission for keeper execution boundaries.
+
+    The persisted [paused] bit remains the pause authority.  A typed
+    [Dead_tombstone] latch refines that state into a terminal lifecycle state,
+    even if a racing/stale writer cleared [paused].  Missing or malformed latch
+    detail while [paused = true] is fail-closed as an unclassified pause. *)
+
+type paused_latch = private
+  | Classified of Keeper_latched_reason.t
+  | Unclassified
+
+type state = private
+  | Active
+  | Paused of paused_latch
+  | Dead_tombstone
+
+val state :
+  paused:bool ->
+  latched_reason:Keeper_latched_reason.t option ->
+  state
+
+type manual_one_shot_admission =
+  | Manual_admitted_active
+  | Manual_admitted_paused_recovery of paused_latch
+  | Manual_denied_dead_tombstone
+
+val admit_manual_one_shot : state -> manual_one_shot_admission
+
+type autonomous_denial =
+  | Autonomous_paused of paused_latch
+  | Autonomous_dead_tombstone
+
+type autonomous_admission =
+  | Autonomous_admitted
+  | Autonomous_denied of autonomous_denial
+
+val admit_autonomous : state -> autonomous_admission
+
+(** Stable boundary projections.  Execution decisions must pattern-match on
+    the typed values above rather than compare these strings. *)
+val paused_latch_to_wire : paused_latch -> string
+val state_to_wire : state -> string
+val autonomous_denial_to_wire : autonomous_denial -> string

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -642,9 +642,9 @@ type keeper_meta =
     (** Typed companion to [paused]: {i why} this keeper is latched.
         Producers set it alongside [paused = true] (bool-only pause sites
         record their [Keeper_latched_reason.t]); consumers surface it via
-        the status bridge. Display/observability only — the control
-        decision is still carried by [paused]. [None] means paused was
-        set by a site that has not yet been wired to a reason. *)
+        the status bridge. [paused] remains the pause authority, while
+        [Dead_tombstone] refines it into a terminal lifecycle state. [None]
+        while paused is a fail-closed unclassified pause. *)
   ; auto_resume_after_sec : float option
     (** Self-healing circuit breaker: when [Some sec] the supervisor will
         auto-resume this keeper after [sec] seconds following the last

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -345,12 +345,12 @@ let parse_keeper_state
 	    | _ -> None
 	  in
 	  let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
-  (* [latched_reason] is a display-only annotation on the pause, not the
-     authoritative control bit ([paused] is). A malformed/unknown persisted
-     value degrades to [None] rather than failing the whole meta parse —
-     mirroring the lenient [last_blocker] read above. Losing the annotation
-     costs observability, never control. Degradation is logged and counted
-     so observability loss is visible. *)
+  (* [paused] is the authoritative pause bit. [latched_reason] refines the
+     lifecycle state, notably distinguishing a terminal [Dead_tombstone]. A
+     malformed/unknown value degrades to [None] without clearing [paused];
+     lifecycle admission therefore treats that combination as an unclassified
+     pause. Degradation is logged and counted so the lost classification is
+     visible rather than silently activating the keeper. *)
   let ps_latched_reason =
     match Json_util.assoc_member_opt "latched_reason" json with
     | None | Some `Null -> None

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -27,17 +27,17 @@ let monotonic_usage_counters ~(latest : Keeper_meta_contract.keeper_meta) ~(call
   ; runtime = { caller.runtime with usage }
   }
 
-let has_operator_latched_reason (meta : Keeper_meta_contract.keeper_meta) =
+let has_latched_pause_reason (meta : Keeper_meta_contract.keeper_meta) =
   match meta.latched_reason with
-  | Some (Keeper_latched_reason.Operator_paused _) -> true
-  | Some _ | None -> false
+  | Some _ -> true
+  | None -> false
 
-let preserve_operator_pause_from_disk
+let preserve_latched_pause_from_disk
       ~(latest : Keeper_meta_contract.keeper_meta)
       ~(caller : Keeper_meta_contract.keeper_meta)
   =
   let merged = monotonic_usage_counters ~latest ~caller in
-  if latest.paused && has_operator_latched_reason latest
+  if latest.paused && has_latched_pause_reason latest
   then
     {
       merged with
@@ -45,11 +45,11 @@ let preserve_operator_pause_from_disk
       (* [latched_reason] is the typed companion to [paused]; preserve it
          from disk for the same reason [paused = true] is preserved. A
          heartbeat writer that raced in with a stale [latched_reason = None]
-         must not erase the reason a pause site recorded on disk. *)
+         must not erase a terminal or operator pause reason recorded on disk. *)
       latched_reason = latest.latched_reason;
       auto_resume_after_sec = None;
       runtime = { merged.runtime with last_blocker = None };
     }
   else merged
 
-let heartbeat_fields_from_disk = preserve_operator_pause_from_disk
+let heartbeat_fields_from_disk = preserve_latched_pause_from_disk

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -435,37 +435,92 @@ let record_spawn_slot_denied ~keeper_name ~surface reason =
   Spawn_slots.record_denied ~keeper_name ~surface reason
 ;;
 
-let wakeup ~base_path name =
-  (* RFC-0303 Phase 3: the no-progress wake-tombstone gate is removed (the
-     detector that fed it is retired), so a wake always signals the fiber. *)
-  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  (* tla-lint: allow-mutation: fiber signal — public wakeup API for a single keeper *)
-  | Some entry -> Atomic.set entry.fiber_wakeup true
-  | None -> ()
+type wakeup_intent =
+  | Reactive_signal
+  | Scheduled_signal
+  | Goal_signal
+  | Supervisor_resume
+  | Hitl_resolution
+  | Broadcast_signal
+
+let wakeup_intent_to_wire = function
+  | Reactive_signal -> "reactive_signal"
+  | Scheduled_signal -> "scheduled_signal"
+  | Goal_signal -> "goal_signal"
+  | Supervisor_resume -> "supervisor_resume"
+  | Hitl_resolution -> "hitl_resolution"
+  | Broadcast_signal -> "broadcast_signal"
 ;;
 
-type wakeup_running_outcome =
+type wakeup_outcome =
   | Signaled
   | Deferred_unregistered
   | Deferred_not_running of Keeper_state_machine.phase
+  | Deferred_lifecycle of Keeper_lifecycle_admission.autonomous_denial
 
-let wakeup_running ~base_path name =
-  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | None -> Deferred_unregistered
-  | Some entry when entry.phase = Keeper_state_machine.Running ->
-    Atomic.set entry.fiber_wakeup true;
-    Signaled
-  | Some entry -> Deferred_not_running entry.phase
+let record_lifecycle_wakeup_denial ~intent (entry : registry_entry) denial =
+  let reason = Keeper_lifecycle_admission.autonomous_denial_to_wire denial in
+  let intent = wakeup_intent_to_wire intent in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string LifecycleDispatchRejections)
+    ~labels:
+      [ "keeper", entry.name
+      ; "event", "registry_wakeup"
+      ; "reason", reason
+      ; "intent", intent
+      ]
+    ();
+  Log.Keeper.info
+    "%s: registry wake deferred by lifecycle admission intent=%s reason=%s"
+    entry.name
+    intent
+    reason
 ;;
 
-let wakeup_all ?base_path () =
+let wakeup_entry ~intent ~require_running (entry : registry_entry) =
+  let lifecycle_state =
+    Keeper_lifecycle_admission.state
+      ~paused:entry.meta.paused
+      ~latched_reason:entry.meta.latched_reason
+  in
+  match Keeper_lifecycle_admission.admit_autonomous lifecycle_state with
+  | Keeper_lifecycle_admission.Autonomous_denied denial ->
+    record_lifecycle_wakeup_denial ~intent entry denial;
+    Deferred_lifecycle denial
+  | Keeper_lifecycle_admission.Autonomous_admitted ->
+    if require_running && entry.phase <> Keeper_state_machine.Running
+    then Deferred_not_running entry.phase
+    else (
+      (* tla-lint: allow-mutation: lifecycle-admitted fiber hint signal *)
+      Atomic.set entry.fiber_wakeup true;
+      Signaled)
+;;
+
+let wakeup ~intent ~base_path name =
+  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
+  | None -> Deferred_unregistered
+  | Some entry -> wakeup_entry ~intent ~require_running:true entry
+;;
+
+let wakeup_running ~intent ~base_path name =
+  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
+  | None -> Deferred_unregistered
+  | Some entry -> wakeup_entry ~intent ~require_running:true entry
+;;
+
+let wakeup_all ~intent ?base_path () =
   let base_path = Option.map canonical_base_path_exn base_path in
   StringMap.iter
     (fun _k entry ->
        match base_path with
        | Some expected when not (String.equal expected entry.base_path) -> ()
-       (* tla-lint: allow-mutation: fiber signal — bulk wakeup for Running keepers under base_path filter *)
-       | _ -> if entry.phase = Running then Atomic.set entry.fiber_wakeup true)
+       | _ ->
+         if entry.phase = Running
+         then
+           let (_ : wakeup_outcome) =
+             wakeup_entry ~intent ~require_running:true entry
+           in
+           ())
     (Atomic.get registry)
 ;;
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -488,24 +488,36 @@ module For_testing : sig
     bool
 end
 
-(** Set fiber_wakeup for a specific keeper. RFC-0303 Phase 3: the no-progress
-    wake-tombstone gate is removed (retired detector), so a wake always signals
-    the fiber. *)
-val wakeup : base_path:string -> string -> unit
+type wakeup_intent =
+  | Reactive_signal
+  | Scheduled_signal
+  | Goal_signal
+  | Supervisor_resume
+  | Hitl_resolution
+  | Broadcast_signal
 
-type wakeup_running_outcome =
+type wakeup_outcome =
   | Signaled
   | Deferred_unregistered
   | Deferred_not_running of Keeper_state_machine.phase
+  | Deferred_lifecycle of Keeper_lifecycle_admission.autonomous_denial
 
-val wakeup_running : base_path:string -> string -> wakeup_running_outcome
+(** Signal a registered keeper without requiring a Running phase. Lifecycle
+    admission is still mandatory: paused and dead-tombstone lanes are never
+    made runnable by a hint signal. The typed intent is observability data,
+    not a policy bypass. *)
+val wakeup :
+  intent:wakeup_intent -> base_path:string -> string -> wakeup_outcome
+
+val wakeup_running :
+  intent:wakeup_intent -> base_path:string -> string -> wakeup_outcome
 (** Signal a registered Keeper only while its fiber phase is [Running]. The
     typed deferred outcomes let durable event producers distinguish an absent
     or inactive live hint without treating the already-committed payload as a
     delivery failure. *)
 
 (** Set fiber_wakeup for all running keepers. *)
-val wakeup_all : ?base_path:string -> unit -> unit
+val wakeup_all : intent:wakeup_intent -> ?base_path:string -> unit -> unit
 
 (** Fiber-level health based on Promise resolution state.
     Returns Fiber_unknown if the keeper is not registered. *)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -794,19 +794,57 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
   List.iter
     (fun ((old_entry : Keeper_registry.registry_entry), crash_msg) ->
        let attempt = old_entry.restart_count + 1 in
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string RestartAttempts)
-         ~labels:[ "keeper", old_entry.name ]
-         ();
        match read_effective_meta ctx.config old_entry.name with
        | Ok (Some meta) ->
-         (* RFC-0002: dispatch restart attempt event *)
-         Keeper_registry.dispatch_event_unit
-           ~base_path
-           old_entry.name
-           (Keeper_state_machine.Supervisor_restart_attempt { attempt });
-         let old_crash_log = old_entry.crash_log in
-         (* R-A-6.a guard: register_restarting refuses revival when the
+         let lifecycle_state =
+           Keeper_lifecycle_admission.state
+             ~paused:meta.paused
+             ~latched_reason:meta.latched_reason
+         in
+         (match Keeper_lifecycle_admission.admit_autonomous lifecycle_state with
+          | Keeper_lifecycle_admission.Autonomous_denied denial ->
+            let reason =
+              Keeper_lifecycle_admission.autonomous_denial_to_wire denial
+            in
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string LifecycleDispatchRejections)
+              ~labels:
+                [ "keeper", old_entry.name
+                ; "event", "supervisor_restart"
+                ; "reason", reason
+                ]
+              ();
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "lifecycle_denied" ]
+              ();
+            publish_lifecycle
+              ~event:
+                (Keeper_lifecycle_events.Custom_event
+                   { verb = Keeper_lifecycle_events.Admission_denied
+                   ; phase = Some old_entry.phase
+                   })
+              old_entry.name
+              reason
+              ();
+            Log.Keeper.info
+              "%s: supervisor restart denied by lifecycle admission: %s"
+              old_entry.name
+              reason
+          | Keeper_lifecycle_admission.Autonomous_admitted ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartAttempts)
+              ~labels:[ "keeper", old_entry.name ]
+              ();
+            (* RFC-0002: dispatch restart attempt event only after lifecycle
+               admission. A paused/terminal lane must not consume restart
+               budget or enter the restarting FSM. *)
+            Keeper_registry.dispatch_event_unit
+              ~base_path
+              old_entry.name
+              (Keeper_state_machine.Supervisor_restart_attempt { attempt });
+            let old_crash_log = old_entry.crash_log in
+            (* R-A-6.a guard: register_restarting refuses revival when the
             prior entry's restart_budget was already exhausted (TLA+ §S3
             BudgetNeverRevives).  In normal sweeps this never fires —
             the [restart_count >= max_restarts] gate at line ~1468 routes
@@ -905,7 +943,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
               Otel_metric_store.inc_counter
                 Keeper_metrics.(to_string NearExhaustionTotal)
                 ~labels:[ "keeper", old_entry.name ]
-                ()))
+                ())))
        | _ ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)
@@ -1052,6 +1090,10 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
                 resumed_meta
             with
             | Ok () ->
+              Keeper_registry.update_meta
+                ~base_path:ctx.config.base_path
+                name
+                resumed_meta;
               Keeper_turn_livelock.reset_keeper_livelock
                 ~base_path:ctx.config.base_path
                 ~keeper:name;
@@ -1061,7 +1103,13 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
                    ~base_path:ctx.config.base_path
                    name
                    Keeper_state_machine.Operator_resume;
-                 Keeper_registry.wakeup ~base_path:ctx.config.base_path name
+                 let (_ : Keeper_registry.wakeup_outcome) =
+                   Keeper_registry.wakeup
+                     ~intent:Keeper_registry.Supervisor_resume
+                     ~base_path:ctx.config.base_path
+                     name
+                 in
+                 ()
                | None -> ());
               publish_lifecycle
                 ~event:

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -806,6 +806,25 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
             let reason =
               Keeper_lifecycle_admission.autonomous_denial_to_wire denial
             in
+            (* The persisted meta won the admission decision, so make the
+               registry observe that same authoritative snapshot before
+               publishing the denial.  In particular, a stale [Running]
+               registry entry paired with a persisted dead tombstone must
+               become [Dead], not remain an apparently live lane that can be
+               selected by phase-only consumers. *)
+            Keeper_registry.update_meta
+              ~base_path
+              old_entry.name
+              meta;
+            (match denial with
+             | Keeper_lifecycle_admission.Autonomous_dead_tombstone ->
+               Keeper_registry.mark_dead ~base_path old_entry.name ~at:now
+             | Keeper_lifecycle_admission.Autonomous_paused _ -> ());
+            let denial_phase =
+              match Keeper_registry.get ~base_path old_entry.name with
+              | Some entry -> Some entry.phase
+              | None -> None
+            in
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string LifecycleDispatchRejections)
               ~labels:
@@ -822,7 +841,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
               ~event:
                 (Keeper_lifecycle_events.Custom_event
                    { verb = Keeper_lifecycle_events.Admission_denied
-                   ; phase = Some old_entry.phase
+                   ; phase = denial_phase
                    })
               old_entry.name
               reason

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -47,10 +47,40 @@ let supervise_keepalive
       (ctx : _ context)
       (meta : keeper_meta)
   =
-  if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
-  then ()
-  else
-    match Keeper_registry.spawn_slots_decision () with
+  let lifecycle_state =
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  in
+  match Keeper_lifecycle_admission.admit_autonomous lifecycle_state with
+  | Keeper_lifecycle_admission.Autonomous_denied denial ->
+    let reason = Keeper_lifecycle_admission.autonomous_denial_to_wire denial in
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string LifecycleDispatchRejections)
+      ~labels:
+        [ "keeper", meta.name
+        ; "event", "supervisor_keepalive_start"
+        ; "reason", reason
+        ]
+      ();
+    publish_lifecycle
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Admission_denied
+           ; phase = Some Keeper_state_machine.Offline
+           })
+      meta.name
+      reason
+      ();
+    Log.Keeper.info
+      "%s: supervisor keepalive start denied by lifecycle admission: %s"
+      meta.name
+      reason
+  | Keeper_lifecycle_admission.Autonomous_admitted ->
+    if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
+    then ()
+    else
+      match Keeper_registry.spawn_slots_decision () with
     | Error reason ->
       Keeper_registry.record_spawn_slot_denied
         ~keeper_name:meta.name

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -520,6 +520,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ] in
         tool_result_ok (Yojson.Safe.to_string json)
          | ( Keepalive_already_registered _
+           | Keepalive_lifecycle_denied _
            | Keepalive_identity_unrepairable
            | Keepalive_spawn_slot_denied _
            | Keepalive_registration_rejected _

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -434,7 +434,8 @@ let update_keeper ?(preserve_prompt_defaults = false)
                        stop_detail
                        (start_keepalive_outcome_to_string
                           (Keepalive_already_registered entry)))
-                | ( Keepalive_identity_unrepairable
+                | ( Keepalive_lifecycle_denied _
+                  | Keepalive_identity_unrepairable
                   | Keepalive_spawn_slot_denied _
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -655,7 +655,13 @@ let handle_ambient ~base_dir
            }
          in
          Keeper_registry_event_queue.enqueue ~base_path:base_dir keeper_name stimulus;
-         Keeper_registry.wakeup ~base_path:base_dir keeper_name
+         let (_ : Keeper_registry.wakeup_outcome) =
+           Keeper_registry.wakeup
+             ~intent:Keeper_registry.Reactive_signal
+             ~base_path:base_dir
+             keeper_name
+         in
+         ()
        | Some _ | None -> ());
       Discord_observability.record_ambient
         Discord_observability.Ambient_recorded

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -35,7 +35,7 @@ let pause_elapsed_sec now (meta : Keeper_meta_contract.keeper_meta) =
   | Some updated_ts when updated_ts > 0.0 -> Some (max 0.0 (now -. updated_ts))
   | Some _ | None -> None
 
-type pause_kind =
+type pause_kind = Keeper_activation_readiness.pause_kind =
   | Active
   | Reconcile_gated
   | Auto_recoverable
@@ -44,36 +44,8 @@ type pause_kind =
   | Unclassified_paused
   | Dead_tombstone
 
-let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
-  let lifecycle_state =
-    Keeper_lifecycle_admission.state
-      ~paused:meta.paused
-      ~latched_reason:meta.latched_reason
-  in
-  match lifecycle_state with
-  | Keeper_lifecycle_admission.Dead_tombstone -> Dead_tombstone
-  | Keeper_lifecycle_admission.Active -> Active
-  | Keeper_lifecycle_admission.Paused latch ->
-    if Keeper_supervisor_types.paused_meta_requires_reconcile_recovery meta then
-      Reconcile_gated
-    else
-      (match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
-       | Some _ -> Auto_recoverable
-       | None ->
-         (match latch with
-          | Keeper_lifecycle_admission.Classified
-              (Keeper_latched_reason.Operator_paused _) -> Operator_paused
-          | Keeper_lifecycle_admission.Classified _ -> Latched_paused
-          | Keeper_lifecycle_admission.Unclassified -> Unclassified_paused))
-
-let pause_kind_to_wire = function
-  | Active -> "active"
-  | Reconcile_gated -> "reconcile_gated"
-  | Auto_recoverable -> "auto_recoverable"
-  | Operator_paused -> "operator_paused"
-  | Latched_paused -> "latched_paused"
-  | Unclassified_paused -> "unclassified_paused"
-  | Dead_tombstone -> "dead_tombstone"
+let pause_kind = Keeper_activation_readiness.pause_kind
+let pause_kind_to_wire = Keeper_activation_readiness.pause_kind_to_wire
 
 let pause_auto_resume_source (meta : Keeper_meta_contract.keeper_meta) =
   match meta.auto_resume_after_sec with

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -35,13 +35,45 @@ let pause_elapsed_sec now (meta : Keeper_meta_contract.keeper_meta) =
   | Some updated_ts when updated_ts > 0.0 -> Some (max 0.0 (now -. updated_ts))
   | Some _ | None -> None
 
+type pause_kind =
+  | Active
+  | Reconcile_gated
+  | Auto_recoverable
+  | Operator_paused
+  | Latched_paused
+  | Unclassified_paused
+  | Dead_tombstone
+
 let pause_kind (meta : Keeper_meta_contract.keeper_meta) =
-  if Keeper_supervisor_types.paused_meta_requires_reconcile_recovery meta then
-    "reconcile_gated"
-  else
-    match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
-    | Some _ -> "auto_recoverable"
-    | None -> "operator_paused"
+  let lifecycle_state =
+    Keeper_lifecycle_admission.state
+      ~paused:meta.paused
+      ~latched_reason:meta.latched_reason
+  in
+  match lifecycle_state with
+  | Keeper_lifecycle_admission.Dead_tombstone -> Dead_tombstone
+  | Keeper_lifecycle_admission.Active -> Active
+  | Keeper_lifecycle_admission.Paused latch ->
+    if Keeper_supervisor_types.paused_meta_requires_reconcile_recovery meta then
+      Reconcile_gated
+    else
+      (match Keeper_supervisor_types.paused_meta_effective_auto_resume_after_sec meta with
+       | Some _ -> Auto_recoverable
+       | None ->
+         (match latch with
+          | Keeper_lifecycle_admission.Classified
+              (Keeper_latched_reason.Operator_paused _) -> Operator_paused
+          | Keeper_lifecycle_admission.Classified _ -> Latched_paused
+          | Keeper_lifecycle_admission.Unclassified -> Unclassified_paused))
+
+let pause_kind_to_wire = function
+  | Active -> "active"
+  | Reconcile_gated -> "reconcile_gated"
+  | Auto_recoverable -> "auto_recoverable"
+  | Operator_paused -> "operator_paused"
+  | Latched_paused -> "latched_paused"
+  | Unclassified_paused -> "unclassified_paused"
+  | Dead_tombstone -> "dead_tombstone"
 
 let pause_auto_resume_source (meta : Keeper_meta_contract.keeper_meta) =
   match meta.auto_resume_after_sec with
@@ -67,7 +99,7 @@ let paused_keeper_detail_json ~now ~name ~(autoboot_enabled : bool)
   `Assoc [
     ("name", `String name);
     ("autoboot_enabled", `Bool autoboot_enabled);
-    ("pause_kind", `String (pause_kind meta));
+    ("pause_kind", `String (pause_kind_to_wire (pause_kind meta)));
     ("auto_resume_after_sec", Json_util.float_opt_to_json effective_auto_resume_after_sec);
     ( "persisted_auto_resume_after_sec"
     , Json_util.float_opt_to_json meta.auto_resume_after_sec );

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -13,8 +13,17 @@ val effective_autoboot_enabled :
 val pause_elapsed_sec :
   float ->
   Keeper_meta_contract.keeper_meta -> float option
-val pause_kind :
-  Keeper_meta_contract.keeper_meta -> string
+type pause_kind =
+  | Active
+  | Reconcile_gated
+  | Auto_recoverable
+  | Operator_paused
+  | Latched_paused
+  | Unclassified_paused
+  | Dead_tombstone
+
+val pause_kind : Keeper_meta_contract.keeper_meta -> pause_kind
+val pause_kind_to_wire : pause_kind -> string
 val pause_auto_resume_source :
   Keeper_meta_contract.keeper_meta ->
   string option

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -13,7 +13,7 @@ val effective_autoboot_enabled :
 val pause_elapsed_sec :
   float ->
   Keeper_meta_contract.keeper_meta -> float option
-type pause_kind =
+type pause_kind = Keeper_activation_readiness.pause_kind =
   | Active
   | Reconcile_gated
   | Auto_recoverable

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -334,7 +334,31 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     ~base_path:config.Workspace_utils.base_path
     keeper_name
     stimulus;
-  Keeper_registry.wakeup ~base_path:config.Workspace_utils.base_path keeper_name;
+  let wakeup_outcome =
+    Keeper_registry.wakeup
+      ~intent:Keeper_registry.Scheduled_signal
+      ~base_path:config.Workspace_utils.base_path
+      keeper_name
+  in
+  (match wakeup_outcome with
+   | Keeper_registry.Signaled -> ()
+   | Keeper_registry.Deferred_unregistered ->
+     Log.Keeper.info
+       "schedule stimulus queued for unregistered keeper schedule_id=%s keeper=%s"
+       request.schedule_id
+       keeper_name
+   | Keeper_registry.Deferred_not_running phase ->
+     Log.Keeper.info
+       "schedule stimulus queued without runnable fiber schedule_id=%s keeper=%s phase=%s"
+       request.schedule_id
+       keeper_name
+       (Keeper_state_machine.phase_to_string phase)
+   | Keeper_registry.Deferred_lifecycle denial ->
+     Log.Keeper.info
+       "schedule stimulus queued but lifecycle admission deferred wake schedule_id=%s keeper=%s reason=%s"
+       request.schedule_id
+       keeper_name
+       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial));
   let reaction_ledger_status =
     record_keeper_wake_stimulus
       ~base_path:config.Workspace_utils.base_path

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -157,7 +157,13 @@ let enqueue_goal_verification_failed_wake
             stimulus;
           match Keeper_registry.get ~base_path:ctx.config.base_path keeper_name with
           | Some entry when entry.phase = Keeper_state_machine.Running ->
-            Keeper_registry.wakeup ~base_path:ctx.config.base_path keeper_name
+            let (_ : Keeper_registry.wakeup_outcome) =
+              Keeper_registry.wakeup
+                ~intent:Keeper_registry.Goal_signal
+                ~base_path:ctx.config.base_path
+                keeper_name
+            in
+            ()
           | Some entry ->
             Log.Keeper.info
               "goal verification wake queued without fiber wake keeper=%s phase=%s goal_id=%s"

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1914,6 +1914,37 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
       | Ok _ -> fail "task receipt recovery did not reach Finalized"
       | Error error -> fail (Shutdown_finalize.error_to_string error))
 
+let test_start_keepalive_denies_dead_tombstone_before_registration () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.clear ();
+  let base_dir = temp_dir "dead-tombstone-keepalive-admission" in
+  let keeper_name = "dead-tombstone-admission" in
+  Fun.protect
+    ~finally:(fun () ->
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let meta =
+        { (make_meta keeper_name) with
+          paused = true
+        ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+        }
+      in
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = None
+        }
+      in
+      Masc.Keeper_keepalive.start_keepalive ctx meta;
+      check bool "dead keeper never reaches registry registration" false
+        (R.is_registered ~base_path:config.base_path keeper_name))
 let test_start_keepalive_preserves_unresolved_failing_entry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2259,39 +2290,68 @@ let test_pacing_block_delays_requested_turn () =
   check bool "default pacing closure never blocks" true admitted.should_run_turn
 
 let test_blocking_gates_are_classified_before_intake () =
+  let lifecycle =
+    Keeper_lifecycle_admission.Autonomous_admitted
+  in
   (match
      KHL.classify_turn_intake_admission
+       ~lifecycle
        ~pressure:Keeper_pressure_admission.Admitted
        ~blocking_approval_pending:true
-       ~keeper_paused:false
    with
    | KHL.Intake_blocking_approval_pending -> ()
    | KHL.Intake_admitted
-   | KHL.Intake_pressure_blocked _
-   | KHL.Intake_keeper_paused ->
+   | KHL.Intake_lifecycle_blocked _
+   | KHL.Intake_pressure_blocked _ ->
      fail "blocking approval must stop intake before durable dequeue");
   (match
      KHL.classify_turn_intake_admission
+       ~lifecycle:
+         (Keeper_lifecycle_admission.Autonomous_denied
+            (Keeper_lifecycle_admission.Autonomous_paused
+               Keeper_lifecycle_admission.Unclassified))
        ~pressure:Keeper_pressure_admission.Admitted
        ~blocking_approval_pending:false
-       ~keeper_paused:true
    with
-   | KHL.Intake_keeper_paused -> ()
+   | KHL.Intake_lifecycle_blocked
+       (Keeper_lifecycle_admission.Autonomous_paused _) -> ()
    | KHL.Intake_admitted
+   | KHL.Intake_lifecycle_blocked
+       Keeper_lifecycle_admission.Autonomous_dead_tombstone
    | KHL.Intake_blocking_approval_pending
    | KHL.Intake_pressure_blocked _ ->
      fail "explicit Keeper pause must stop intake before durable dequeue");
   match
     KHL.classify_turn_intake_admission
+      ~lifecycle
       ~pressure:Keeper_pressure_admission.Admitted
       ~blocking_approval_pending:false
-      ~keeper_paused:false
   with
   | KHL.Intake_admitted -> ()
+  | KHL.Intake_lifecycle_blocked _
   | KHL.Intake_blocking_approval_pending
-  | KHL.Intake_pressure_blocked _
-  | KHL.Intake_keeper_paused ->
+  | KHL.Intake_pressure_blocked _ ->
     fail "no blocking approval should leave intake admitted"
+
+let test_lifecycle_is_classified_before_intake () =
+  let lifecycle =
+    Keeper_lifecycle_admission.Autonomous_denied
+      Keeper_lifecycle_admission.Autonomous_dead_tombstone
+  in
+  match
+    KHL.classify_turn_intake_admission
+      ~lifecycle
+      ~pressure:Keeper_pressure_admission.Admitted
+      ~blocking_approval_pending:false
+  with
+  | KHL.Intake_lifecycle_blocked
+      Keeper_lifecycle_admission.Autonomous_dead_tombstone -> ()
+  | KHL.Intake_admitted
+  | KHL.Intake_lifecycle_blocked
+      (Keeper_lifecycle_admission.Autonomous_paused _)
+  | KHL.Intake_blocking_approval_pending
+  | KHL.Intake_pressure_blocked _ ->
+    fail "dead lifecycle must stop intake before durable dequeue"
 
 let test_crashed_cycle_records_health_failure () =
   Eio_main.run @@ fun env ->
@@ -2376,6 +2436,8 @@ let () =
         test_keeper_shutdown_cleanup_replays_after_meta_removal;
       test_case "shutdown recovers committed task receipt" `Quick
         test_keeper_shutdown_recovers_committed_task_receipt;
+      test_case "dead tombstone denied before registration" `Quick
+        test_start_keepalive_denies_dead_tombstone_before_registration;
       test_case "unresolved failing entry is preserved" `Quick
         test_start_keepalive_preserves_unresolved_failing_entry;
       test_case "finished failing entry is reclaimed" `Quick
@@ -2406,6 +2468,8 @@ let () =
         test_pacing_block_delays_requested_turn;
       test_case "blocking gates are classified before intake" `Quick
         test_blocking_gates_are_classified_before_intake;
+      test_case "lifecycle is classified before intake" `Quick
+        test_lifecycle_is_classified_before_intake;
       test_case "crashed cycles feed agent health breaker" `Quick
         test_crashed_cycle_records_health_failure;
     ];

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -21,6 +21,7 @@ module KT = Keeper_types
 module KSM = Keeper_state_machine
 module Cfg = Env_config
 module KHL = Masc.Keeper_heartbeat_loop
+module Keeper_lifecycle_admission = Masc.Keeper_lifecycle_admission
 module Obs = Masc.Keeper_heartbeat_loop_observations
 module WO = Masc.Keeper_world_observation
 module Health = Masc.Health

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2305,12 +2305,13 @@ let test_blocking_gates_are_classified_before_intake () =
    | KHL.Intake_lifecycle_blocked _
    | KHL.Intake_pressure_blocked _ ->
      fail "blocking approval must stop intake before durable dequeue");
+  let paused_lifecycle =
+    Keeper_lifecycle_admission.state ~paused:true ~latched_reason:None
+    |> Keeper_lifecycle_admission.admit_autonomous
+  in
   (match
      KHL.classify_turn_intake_admission
-       ~lifecycle:
-         (Keeper_lifecycle_admission.Autonomous_denied
-            (Keeper_lifecycle_admission.Autonomous_paused
-               Keeper_lifecycle_admission.Unclassified))
+       ~lifecycle:paused_lifecycle
        ~pressure:Keeper_pressure_admission.Admitted
        ~blocking_approval_pending:false
    with

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -289,7 +289,7 @@ let test_operator_resume_clears_dead_tombstone_latch () =
        ~now:after_auto_resume
        { paused_due with latched_reason = None })
 
-let test_heartbeat_merge_preserves_only_typed_operator_pause () =
+let test_heartbeat_merge_preserves_typed_latched_pause () =
   let caller =
     { (make_meta "typed-operator-pause-merge-caller") with
       paused = false
@@ -315,6 +315,22 @@ let test_heartbeat_merge_preserves_only_typed_operator_pause () =
     "typed operator pause preserves reason"
     (Some wire_keeper_down)
     (latched_reason_wire preserved);
+  let latest_dead_tombstone =
+    { latest_operator_pause with
+      latched_reason = Some Keeper_latched_reason.Dead_tombstone
+    }
+  in
+  let dead_preserved =
+    Keeper_meta_merge.heartbeat_fields_from_disk
+      ~latest:latest_dead_tombstone
+      ~caller
+  in
+  check bool "typed dead tombstone remains paused" true dead_preserved.paused;
+  check
+    (option string)
+    "typed dead tombstone preserves terminal reason"
+    (Some wire_dead_tombstone)
+    (latched_reason_wire dead_preserved);
   let latest_unlabeled_pause =
     { latest_operator_pause with latched_reason = None }
   in
@@ -354,7 +370,7 @@ let () =
             test_dead_tombstone_latch_blocks_legacy_auto_resume
         ; test_case "operator resume clears dead-tombstone latch to re-enable recovery"
             `Quick test_operator_resume_clears_dead_tombstone_latch
-        ; test_case "heartbeat merge uses typed operator latch, not pause shape" `Quick
-            test_heartbeat_merge_preserves_only_typed_operator_pause
+        ; test_case "heartbeat merge preserves typed latch, not pause shape" `Quick
+            test_heartbeat_merge_preserves_typed_latched_pause
         ] )
     ]

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -20,6 +20,8 @@
 open Alcotest
 module WO = Masc.Keeper_world_observation
 module Readiness = Masc.Keeper_activation_readiness
+module Admission = Masc.Keeper_lifecycle_admission
+module Fleet_scan = Masc.Server_routes_http_runtime_fleet_scan
 
 let contains haystack needle =
   let hl = String.length haystack
@@ -219,8 +221,11 @@ let test_global_autonomous_off_blocks_readiness () =
   let r = Readiness.of_meta meta in
   check bool "global autonomous off blocks activation" false
     r.autonomous_activation.ok;
-  check (option string) "blocker is autoboot_disabled" (Some "autoboot_disabled")
-    r.autonomous_activation.blocker;
+  check bool "blocker is typed autoboot_disabled" true
+    (match r.autonomous_activation.blocker with
+     | Some Readiness.Autoboot_disabled -> true
+     | Some (Readiness.Lifecycle_denied _ | Readiness.Proactive_disabled) | None ->
+       false);
   (* Review-flagged: the hint must not tell the operator to set
      autoboot_enabled=true when the per-keeper flag is already true and the
      *global* kill-switch is the actual cause -- that would send them
@@ -230,6 +235,152 @@ let test_global_autonomous_off_blocks_readiness () =
     (match r.autonomous_activation.hint with
      | Some hint -> contains hint "MASC_KEEPER_AUTONOMOUS_ENABLED"
      | None -> false)
+
+let operator_pause =
+  Keeper_latched_reason.Operator_paused
+    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down }
+;;
+
+let lifecycle_state ~paused ~latched_reason =
+  Admission.state ~paused ~latched_reason
+;;
+
+let test_active_admission () =
+  let state = lifecycle_state ~paused:false ~latched_reason:None in
+  check bool "state is active" true
+    (match state with
+     | Admission.Active -> true
+     | Admission.Paused _ | Admission.Dead_tombstone -> false);
+  check bool "manual one-shot admitted" true
+    (match Admission.admit_manual_one_shot state with
+     | Admission.Manual_admitted_active -> true
+     | Admission.Manual_admitted_paused_recovery _
+     | Admission.Manual_denied_dead_tombstone -> false);
+  check bool "autonomous admitted" true
+    (match Admission.admit_autonomous state with
+     | Admission.Autonomous_admitted -> true
+     | Admission.Autonomous_denied _ -> false)
+;;
+
+let test_classified_pause_admission () =
+  let state =
+    lifecycle_state ~paused:true ~latched_reason:(Some operator_pause)
+  in
+  check bool "state is a classified pause" true
+    (match state with
+     | Admission.Paused (Admission.Classified reason) ->
+       Keeper_latched_reason.equal reason operator_pause
+     | Admission.Active | Admission.Paused Admission.Unclassified
+     | Admission.Dead_tombstone -> false);
+  check bool "manual one-shot is an explicit recovery" true
+    (match Admission.admit_manual_one_shot state with
+     | Admission.Manual_admitted_paused_recovery (Admission.Classified reason) ->
+       Keeper_latched_reason.equal reason operator_pause
+     | Admission.Manual_admitted_active
+     | Admission.Manual_admitted_paused_recovery Admission.Unclassified
+     | Admission.Manual_denied_dead_tombstone -> false);
+  check bool "autonomous execution is denied" true
+    (match Admission.admit_autonomous state with
+     | Admission.Autonomous_denied
+         (Admission.Autonomous_paused (Admission.Classified reason)) ->
+       Keeper_latched_reason.equal reason operator_pause
+     | Admission.Autonomous_admitted
+     | Admission.Autonomous_denied
+         ( Admission.Autonomous_paused Admission.Unclassified
+         | Admission.Autonomous_dead_tombstone ) -> false)
+;;
+
+let test_unclassified_pause_fails_closed () =
+  let state = lifecycle_state ~paused:true ~latched_reason:None in
+  check bool "missing latch remains paused" true
+    (match state with
+     | Admission.Paused Admission.Unclassified -> true
+     | Admission.Active | Admission.Paused (Admission.Classified _)
+     | Admission.Dead_tombstone -> false);
+  check bool "unclassified pause blocks autonomous execution" true
+    (match Admission.admit_autonomous state with
+     | Admission.Autonomous_denied
+         (Admission.Autonomous_paused Admission.Unclassified) -> true
+     | Admission.Autonomous_admitted
+     | Admission.Autonomous_denied
+         ( Admission.Autonomous_paused (Admission.Classified _)
+         | Admission.Autonomous_dead_tombstone ) -> false)
+;;
+
+let test_dead_tombstone_dominates_stale_paused_bit () =
+  let state =
+    lifecycle_state
+      ~paused:false
+      ~latched_reason:(Some Keeper_latched_reason.Dead_tombstone)
+  in
+  check bool "dead latch is terminal even when paused was cleared" true
+    (match state with
+     | Admission.Dead_tombstone -> true
+     | Admission.Active | Admission.Paused _ -> false);
+  check bool "manual one-shot denied" true
+    (match Admission.admit_manual_one_shot state with
+     | Admission.Manual_denied_dead_tombstone -> true
+     | Admission.Manual_admitted_active
+     | Admission.Manual_admitted_paused_recovery _ -> false);
+  check bool "autonomous execution denied as terminal" true
+    (match Admission.admit_autonomous state with
+     | Admission.Autonomous_denied Admission.Autonomous_dead_tombstone -> true
+     | Admission.Autonomous_admitted
+     | Admission.Autonomous_denied (Admission.Autonomous_paused _) -> false)
+;;
+
+let test_readiness_projects_dead_tombstone () =
+  without_overrides @@ fun () ->
+  let meta =
+    { (ready_meta ()) with
+      paused = false
+    ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+    }
+  in
+  let activation = (Readiness.of_meta meta).autonomous_activation in
+  check bool "dead keeper is not autonomously ready" false activation.ok;
+  check bool "readiness preserves typed terminal denial" true
+    (match activation.blocker with
+     | Some (Readiness.Lifecycle_denied Admission.Autonomous_dead_tombstone) ->
+       true
+     | Some
+         ( Readiness.Lifecycle_denied (Admission.Autonomous_paused _)
+         | Readiness.Autoboot_disabled
+         | Readiness.Proactive_disabled )
+     | None -> false);
+  check string "wire projection distinguishes dead from pause" "dead_tombstone"
+    (Readiness.autonomous_check_value activation)
+;;
+
+let test_health_projection_uses_typed_lifecycle () =
+  let dead_meta =
+    { (ready_meta ()) with
+      paused = true
+    ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+    }
+  in
+  let unclassified_meta =
+    { (ready_meta ()) with paused = true; latched_reason = None }
+  in
+  check bool "health classifies dead tombstone" true
+    (match Fleet_scan.pause_kind dead_meta with
+     | Fleet_scan.Dead_tombstone -> true
+     | Fleet_scan.Active
+     | Fleet_scan.Reconcile_gated
+     | Fleet_scan.Auto_recoverable
+     | Fleet_scan.Operator_paused
+     | Fleet_scan.Latched_paused
+     | Fleet_scan.Unclassified_paused -> false);
+  check bool "health does not mislabel missing reason as operator pause" true
+    (match Fleet_scan.pause_kind unclassified_meta with
+     | Fleet_scan.Unclassified_paused -> true
+     | Fleet_scan.Active
+     | Fleet_scan.Reconcile_gated
+     | Fleet_scan.Auto_recoverable
+     | Fleet_scan.Operator_paused
+     | Fleet_scan.Latched_paused
+     | Fleet_scan.Dead_tombstone -> false)
+;;
 
 let () = init_runtime_default_for_tests ()
 
@@ -251,6 +402,18 @@ let () =
       , [ test_case "default ready" `Quick test_default_autonomous_ready
         ; test_case "global off blocks readiness" `Quick
             test_global_autonomous_off_blocks_readiness
+        ] )
+    ; ( "typed lifecycle admission"
+      , [ test_case "active" `Quick test_active_admission
+        ; test_case "classified pause" `Quick test_classified_pause_admission
+        ; test_case "unclassified pause fails closed" `Quick
+            test_unclassified_pause_fails_closed
+        ; test_case "dead tombstone dominates stale pause bit" `Quick
+            test_dead_tombstone_dominates_stale_paused_bit
+        ; test_case "readiness projects dead tombstone" `Quick
+            test_readiness_projects_dead_tombstone
+        ; test_case "health projects typed lifecycle" `Quick
+            test_health_projection_uses_typed_lifecycle
         ] )
     ]
 ;;

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -21,7 +21,6 @@ open Alcotest
 module WO = Masc.Keeper_world_observation
 module Readiness = Masc.Keeper_activation_readiness
 module Admission = Masc.Keeper_lifecycle_admission
-module Fleet_scan = Masc.Server_routes_http_runtime_fleet_scan
 
 let contains haystack needle =
   let hl = String.length haystack
@@ -363,23 +362,23 @@ let test_health_projection_uses_typed_lifecycle () =
     { (ready_meta ()) with paused = true; latched_reason = None }
   in
   check bool "health classifies dead tombstone" true
-    (match Fleet_scan.pause_kind dead_meta with
-     | Fleet_scan.Dead_tombstone -> true
-     | Fleet_scan.Active
-     | Fleet_scan.Reconcile_gated
-     | Fleet_scan.Auto_recoverable
-     | Fleet_scan.Operator_paused
-     | Fleet_scan.Latched_paused
-     | Fleet_scan.Unclassified_paused -> false);
+    (match Readiness.pause_kind dead_meta with
+     | Readiness.Dead_tombstone -> true
+     | Readiness.Active
+     | Readiness.Reconcile_gated
+     | Readiness.Auto_recoverable
+     | Readiness.Operator_paused
+     | Readiness.Latched_paused
+     | Readiness.Unclassified_paused -> false);
   check bool "health does not mislabel missing reason as operator pause" true
-    (match Fleet_scan.pause_kind unclassified_meta with
-     | Fleet_scan.Unclassified_paused -> true
-     | Fleet_scan.Active
-     | Fleet_scan.Reconcile_gated
-     | Fleet_scan.Auto_recoverable
-     | Fleet_scan.Operator_paused
-     | Fleet_scan.Latched_paused
-     | Fleet_scan.Dead_tombstone -> false)
+    (match Readiness.pause_kind unclassified_meta with
+     | Readiness.Unclassified_paused -> true
+     | Readiness.Active
+     | Readiness.Reconcile_gated
+     | Readiness.Auto_recoverable
+     | Readiness.Operator_paused
+     | Readiness.Latched_paused
+     | Readiness.Dead_tombstone -> false)
 ;;
 
 let () = init_runtime_default_for_tests ()

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -225,25 +225,54 @@ let test_get_filters_corrupted_entry () =
 
 let test_wakeup_running_reports_typed_outcome () =
   KR.clear ();
-  (match KR.wakeup_running ~base_path "missing" with
+  (match
+     KR.wakeup_running ~intent:KR.Hitl_resolution ~base_path "missing"
+   with
    | KR.Deferred_unregistered -> ()
-   | KR.Signaled | KR.Deferred_not_running _ ->
+   | KR.Signaled | KR.Deferred_not_running _ | KR.Deferred_lifecycle _ ->
      fail "missing keeper did not return Deferred_unregistered");
   let running = register "running" in
   Atomic.set running.fiber_wakeup false;
-  (match KR.wakeup_running ~base_path "running" with
+  (match
+     KR.wakeup_running ~intent:KR.Hitl_resolution ~base_path "running"
+   with
    | KR.Signaled -> check bool "running keeper is signaled" true (Atomic.get running.fiber_wakeup)
-   | KR.Deferred_unregistered | KR.Deferred_not_running _ ->
+   | KR.Deferred_unregistered | KR.Deferred_not_running _
+   | KR.Deferred_lifecycle _ ->
      fail "running keeper was not signaled");
   let offline_meta = make_meta "offline" in
   let offline = KR.register_offline ~base_path offline_meta.name offline_meta in
   Atomic.set offline.fiber_wakeup false;
-  (match KR.wakeup_running ~base_path "offline" with
+  (match
+     KR.wakeup_running ~intent:KR.Hitl_resolution ~base_path "offline"
+   with
    | KR.Deferred_not_running phase ->
      check string "deferred phase is explicit" "offline" (KSM.phase_to_string phase);
      check bool "offline keeper is not signaled" false (Atomic.get offline.fiber_wakeup)
-   | KR.Signaled | KR.Deferred_unregistered ->
+   | KR.Signaled | KR.Deferred_unregistered | KR.Deferred_lifecycle _ ->
      fail "offline keeper did not return Deferred_not_running")
+;;
+
+let test_wakeup_denies_dead_tombstone_without_signaling () =
+  KR.clear ();
+  let meta =
+    { (make_meta "dead-wakeup") with
+      paused = true
+    ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+    }
+  in
+  let entry = KR.register ~base_path meta.name meta in
+  Atomic.set entry.fiber_wakeup false;
+  (match KR.wakeup ~intent:KR.Scheduled_signal ~base_path meta.name with
+   | KR.Deferred_lifecycle
+       Keeper_lifecycle_admission.Autonomous_dead_tombstone -> ()
+   | KR.Signaled
+   | KR.Deferred_unregistered
+   | KR.Deferred_not_running _
+   | KR.Deferred_lifecycle (Keeper_lifecycle_admission.Autonomous_paused _) ->
+     fail "dead tombstone wake was not lifecycle-deferred");
+  check bool "dead tombstone wake flag remains false" false
+    (Atomic.get entry.fiber_wakeup)
 ;;
 
 let temp_dir prefix =
@@ -370,6 +399,10 @@ let () =
             "reports signaled and deferred outcomes"
             `Quick
             test_wakeup_running_reports_typed_outcome
+        ; test_case
+            "dead tombstone never receives runnable signal"
+            `Quick
+            test_wakeup_denies_dead_tombstone_without_signaling
         ] )
     ; ( "tool_dispatch_fallback"
       , [ test_case "uses original meta on corrupted registry entry" `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -9,6 +9,7 @@ open Alcotest
 module KR = Masc.Keeper_registry
 module KET = Masc.Keeper_tool_dispatch_runtime
 module KLH = Masc.Keeper_lifecycle_hooks
+module Keeper_lifecycle_admission = Masc.Keeper_lifecycle_admission
 module KSM = Keeper_state_machine
 module Lane = Masc.Keeper_lane
 

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1626,8 +1626,8 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
         }
       in
       sweep_and_recover_no_materialize ctx;
-      check (float 0.001) "restart attempt metric incremented"
-        (attempts_before +. 1.0)
+      check (float 0.001) "restart attempt not recorded without admission meta"
+        attempts_before
         (Masc.Otel_metric_store.metric_value_or_zero
            Keeper_metrics.(to_string RestartAttempts)
            ~labels:attempt_labels ());
@@ -1697,6 +1697,85 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
            ~labels:outcome_labels ());
       check bool "keeper unregistered after missing meta" false
         (Reg.is_registered ~base_path:config.base_path name))
+
+let test_restart_denies_persisted_dead_tombstone () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
+  let base_dir = temp_dir () in
+  let name = "restart-dead-tombstone-admission" in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _init_msg =
+        Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
+      in
+      write_keeper_toml config_dir ~name;
+      let active_meta = make_meta name in
+      let dead_meta =
+        { active_meta with
+          paused = true
+        ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+        }
+      in
+      (match Keeper_meta_store.write_meta config dead_meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name active_meta in
+      resolve_done_for_test reg (`Crashed "crash before terminal persist");
+      Reg.restore_supervisor_state
+        ~base_path:config.base_path
+        name
+        ~restart_count:0
+        ~last_restart_ts:0.0
+        ~crash_log:[];
+      let attempt_labels = [ "keeper", name ] in
+      let denied_labels = [ "keeper", name; "outcome", "lifecycle_denied" ] in
+      let attempts_before =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string RestartAttempts)
+          ~labels:attempt_labels
+          ()
+      in
+      let denied_before =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string RestartOutcomes)
+          ~labels:denied_labels
+          ()
+      in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        }
+      in
+      sweep_and_recover_no_materialize ctx;
+      check (float 0.001) "terminal lane consumes no restart attempt"
+        attempts_before
+        (Masc.Otel_metric_store.metric_value_or_zero
+           Keeper_metrics.(to_string RestartAttempts)
+           ~labels:attempt_labels
+           ());
+      check (float 0.001) "typed lifecycle denial is observed"
+        (denied_before +. 1.0)
+        (Masc.Otel_metric_store.metric_value_or_zero
+           Keeper_metrics.(to_string RestartOutcomes)
+           ~labels:denied_labels
+           ());
+      match Reg.get ~base_path:config.base_path name with
+      | None -> fail "terminal registry entry unexpectedly disappeared"
+      | Some entry ->
+        check int "restart count unchanged" 0 entry.restart_count;
+        check bool "terminal lane never becomes Running" false
+          (entry.phase = Keeper_state_machine.Running))
 
 (* ── Dead-state loud alert (PR-C) ──────────────────────── *)
 
@@ -4127,6 +4206,8 @@ let () =
         test_restart_path_emits_attempt_and_started_outcome_metrics;
       test_case "restart path emits missing-meta outcome metrics" `Quick
         test_restart_path_emits_meta_unavailable_outcome_metric;
+      test_case "restart denies persisted dead tombstone" `Quick
+        test_restart_denies_persisted_dead_tombstone;
     ];
     "dead_state_alert", [
       test_case "max_restarts exhaustion emits Dead alert" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1626,8 +1626,8 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
         }
       in
       sweep_and_recover_no_materialize ctx;
-      check (float 0.001) "restart attempt not recorded without admission meta"
-        attempts_before
+      check (float 0.001) "restart attempt recorded after lifecycle admission"
+        (attempts_before +. 1.0)
         (Masc.Otel_metric_store.metric_value_or_zero
            Keeper_metrics.(to_string RestartAttempts)
            ~labels:attempt_labels ());
@@ -1685,8 +1685,8 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
         }
       in
       sweep_and_recover_no_materialize ctx;
-      check (float 0.001) "restart attempt metric incremented"
-        (attempts_before +. 1.0)
+      check (float 0.001) "restart attempt not recorded without admission meta"
+        attempts_before
         (Masc.Otel_metric_store.metric_value_or_zero
            Keeper_metrics.(to_string RestartAttempts)
            ~labels:attempt_labels ());
@@ -1774,8 +1774,14 @@ let test_restart_denies_persisted_dead_tombstone () =
       | None -> fail "terminal registry entry unexpectedly disappeared"
       | Some entry ->
         check int "restart count unchanged" 0 entry.restart_count;
-        check bool "terminal lane never becomes Running" false
-          (entry.phase = Keeper_state_machine.Running))
+        check bool "terminal registry phase is Dead" true
+          (entry.phase = Keeper_state_machine.Dead);
+        check bool "persisted tombstone meta becomes registry authority" true
+          (match entry.meta.latched_reason with
+           | Some Keeper_latched_reason.Dead_tombstone -> true
+           | Some _ | None -> false);
+        check bool "terminal transition records dead timestamp" true
+          (Option.is_some entry.dead_since_ts))
 
 (* ── Dead-state loud alert (PR-C) ──────────────────────── *)
 


### PR DESCRIPTION
## Summary

- introduce a pure, closed `Keeper_lifecycle_admission` SSOT
- keep manual one-shot recovery and autonomous activation as independent typed verdicts
- fail closed for paused metadata without a classified latch
- make `Dead_tombstone` terminal even if a stale writer cleared `paused`
- derive activation readiness and fleet health wire values from typed lifecycle state
- distinguish dead, unclassified, operator, and other latched pauses in health

## Scope status

The implementation for #24049 is wired across every execution edge while the PR remains Draft for CI and adversarial review.

- [x] manual chat cannot implicitly start autonomous keepalive
- [x] dead-tombstone manual chat is rejected until an explicit lifecycle transition
- [x] nonterminal paused manual recovery remains a separate admitted verdict
- [x] direct and supervisor keepalive launch deny paused/dead metadata before side effects
- [x] supervisor restart denies paused/dead metadata before attempt/FSM registration
- [x] registry wake uses typed intent/outcome and never signals paused/dead lanes
- [x] heartbeat lifecycle admission precedes board cursor collection and durable queue intake
- [x] lifecycle-blocked heartbeat stops only its own lane and skips recurring dispatch
- [x] health distinguishes dead, unclassified, operator, and other latched pauses
- [x] denials emit typed metrics/log/lifecycle projections

## Verification

- `ocamlformat --check` on every changed OCaml file
- `ocamlc -stop-after parsing -c` on every changed OCaml file
- `git diff --check`
- `bash scripts/ci/check-enum-string-safety.sh`
- `bash scripts/ci/check-silent-failure-patterns.sh`
- `bash scripts/ci/check-masc-oas-boundary.sh`
- `bash scripts/ci/check-determinism-contract.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/silent-failure-ratchet.sh`
- `scripts/ocaml-structure-ratchet.sh`

Focused regression coverage was added for the pure admission matrix, direct keepalive registration, supervisor restart attempts, registry wake flags, heartbeat pre-intake classification, and health projection.

Full Dune build/test is intentionally delegated to PR CI.

Fixes #24049
