### PR TITLE
fix(dashboard): refresh keeper runtime surfaces after prompt/tool-policy save

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -970,6 +970,8 @@ const mocks = vi.hoisted(() => {
       ],
     })),
     patchKeeperConfig: vi.fn(),
+    refreshKeeperRuntimeStatus: vi.fn(async () => undefined),
+    showToast: vi.fn(),
     updateKeeperRuntime: vi.fn(async () => ({ ok: true })),
     setKeeperToolPolicy: vi.fn(async () => makeKeeperConfig()),
     fetchDashboardTools: vi.fn(async () => ({
@@ -1007,6 +1009,14 @@ vi.mock('../api/keeper', () => ({
   resumeKeeper: mocks.resumeKeeper,
   wakeKeeper: mocks.wakeKeeper,
   fetchKeeperComposite: mocks.fetchKeeperComposite,
+}))
+
+vi.mock('../store', () => ({
+  refreshKeeperRuntimeStatus: mocks.refreshKeeperRuntimeStatus,
+}))
+
+vi.mock('./common/toast', () => ({
+  showToast: mocks.showToast,
 }))
 
 import {
@@ -1048,6 +1058,9 @@ describe('KeeperConfigPanel', () => {
     mocks.fetchRuntimeProfiles.mockClear()
     mocks.fetchRuntimeProviders.mockClear()
     mocks.patchKeeperConfig.mockClear()
+    mocks.refreshKeeperRuntimeStatus.mockReset()
+    mocks.refreshKeeperRuntimeStatus.mockResolvedValue(undefined)
+    mocks.showToast.mockClear()
     mocks.updateKeeperRuntime.mockClear()
     mocks.setKeeperToolPolicy.mockClear()
     mocks.fetchDashboardTools.mockClear()
@@ -1493,6 +1506,84 @@ describe('KeeperConfigPanel', () => {
       tool_access: ['tool_read_file', 'masc_status'],
       deny: ['Execute', 'DangerTool'],
     })
+    expect(mocks.refreshKeeperRuntimeStatus).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('refreshes shared keeper surfaces after prompt save', async () => {
+    const updated = makeKeeperConfig({
+      prompt: {
+        ...makeKeeperConfig().prompt,
+        goal: 'Ship refreshed keeper surfaces',
+      },
+    })
+    mocks.patchKeeperConfig.mockResolvedValueOnce(updated)
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '프롬프트')
+    await flush()
+    const editButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('편집하기'),
+    )
+    expect(editButton).toBeDefined()
+    editButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    const goal = container.querySelector('textarea') as HTMLTextAreaElement | null
+    expect(goal).not.toBeNull()
+    goal!.value = 'Ship refreshed keeper surfaces'
+    goal!.dispatchEvent(new Event('input', { bubbles: true }))
+    goal!.dispatchEvent(new FocusEvent('blur', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.trim() === '저장',
+    )
+    expect(saveButton).toBeDefined()
+    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      expect.objectContaining({ goal: 'Ship refreshed keeper surfaces' }),
+    )
+    expect(mocks.refreshKeeperRuntimeStatus).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('surfaces post-save refresh failure without turning the save into failure', async () => {
+    mocks.refreshKeeperRuntimeStatus.mockRejectedValueOnce(new Error('runtime projection unavailable'))
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+    selectKcfTab(container, '실행 정책')
+    await flush()
+
+    const toolAccess = container.querySelector(
+      'textarea[aria-label="tool_access"]',
+    ) as HTMLTextAreaElement | null
+    expect(toolAccess).not.toBeNull()
+    toolAccess!.value = 'tool_read_file\nmasc_status'
+    toolAccess!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('정책 저장'),
+    )
+    expect(saveButton).toBeDefined()
+    expect(saveButton!.hasAttribute('disabled')).toBe(false)
+    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.setKeeperToolPolicy).toHaveBeenCalledTimes(1)
+    expect(mocks.showToast).toHaveBeenCalledWith('도구 정책 저장 완료', 'success')
+    expect(mocks.showToast).toHaveBeenCalledWith('runtime projection unavailable', 'warning')
   })
 
   it('patches runtime_id from the dashboard panel', async () => {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1862,6 +1862,12 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         deny,
       })
       applyKeeperConfigUpdate(keeperName, updated)
+      // Mirror saveRuntimeConfig: refresh shell + execution surfaces so the
+      // dashboard reflects the persisted tool policy without a manual reload.
+      void refreshKeeperRuntimeStatus().catch(err => {
+        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
+        showToast(message, 'warning')
+      })
       toolAccessDraftText.value = null
       denylistDraftText.value = null
       showToast('도구 정책 저장 완료', 'success')
@@ -1898,6 +1904,12 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     try {
       const updated = await patchKeeperConfig(keeperName, payload)
       applyKeeperConfigUpdate(keeperName, updated)
+      // Mirror saveRuntimeConfig: refresh shell + execution surfaces so the
+      // dashboard reflects the persisted prompt without a manual reload.
+      void refreshKeeperRuntimeStatus().catch(err => {
+        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
+        showToast(message, 'warning')
+      })
       editMode.value = false
       editDraft.value = null
       lastSavedAt.value = new Date().toISOString()

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -53,6 +53,15 @@ import {
   registerKeeperConfigUpdateHandler,
 } from './keeper-config-state'
 
+async function refreshKeeperSurfacesAfterConfigSave(): Promise<void> {
+  try {
+    await refreshKeeperRuntimeStatus({ force: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
+    showToast(message, 'warning')
+  }
+}
+
 export {
   applyKeeperConfigUpdate,
   configState,
@@ -1804,10 +1813,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     try {
       const updated = await patchKeeperConfig(keeperName, payload)
       applyKeeperConfigUpdate(keeperName, updated)
-      void refreshKeeperRuntimeStatus().catch(err => {
-        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
-        showToast(message, 'warning')
-      })
+      void refreshKeeperSurfacesAfterConfigSave()
       showToast('런타임 설정 저장 완료', 'success')
     } catch (err) {
       const msg = err instanceof Error ? err.message : '저장 실패'
@@ -1862,12 +1868,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         deny,
       })
       applyKeeperConfigUpdate(keeperName, updated)
-      // Mirror saveRuntimeConfig: refresh shell + execution surfaces so the
-      // dashboard reflects the persisted tool policy without a manual reload.
-      void refreshKeeperRuntimeStatus().catch(err => {
-        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
-        showToast(message, 'warning')
-      })
+      void refreshKeeperSurfacesAfterConfigSave()
       toolAccessDraftText.value = null
       denylistDraftText.value = null
       showToast('도구 정책 저장 완료', 'success')
@@ -1904,12 +1905,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     try {
       const updated = await patchKeeperConfig(keeperName, payload)
       applyKeeperConfigUpdate(keeperName, updated)
-      // Mirror saveRuntimeConfig: refresh shell + execution surfaces so the
-      // dashboard reflects the persisted prompt without a manual reload.
-      void refreshKeeperRuntimeStatus().catch(err => {
-        const message = err instanceof Error ? err.message : '런타임 상태 새로고침 실패'
-        showToast(message, 'warning')
-      })
+      void refreshKeeperSurfacesAfterConfigSave()
       editMode.value = false
       editDraft.value = null
       lastSavedAt.value = new Date().toISOString()


### PR DESCRIPTION
## 목표

keeper 상세의 프롬프트 탭에서 goal/instructions(및 도구 정책) 저장 후 대시보드 다른 표면(keeper 카드, 런타임 상태, execution)이 즉시 갱신되지 않는 결함 수정. 저장 자체는 성공하지만 refresh 누락으로 "저장이 안 됨 / 실시간 반영이 안 됨"으로 인식됨.

## 원인

`saveConfig()`(prompt.goal/instructions)와 `saveToolPolicy()`가 `applyKeeperConfigUpdate()`(keeper-config 패널 자신만 갱신) 이후 `refreshKeeperRuntimeStatus()`를 호출하지 않음. 반면 `saveRuntimeConfig()`는 호출(`refreshShell` + `refreshExecution`)함. 비대칭 결함.

config update handler 구독자는 `syncRuntimeDraftFromConfig` 1개뿐이라 keeper 카드/로스터/런타임은 이 저장 이벤트를 받지 못했고, 새로고침 전까지 stale 상태로 남았음.

## 변경

- `dashboard/src/components/keeper-config-panel.ts`
  - `saveToolPolicy`: 저장 성공 후 `refreshKeeperRuntimeStatus()` non-blocking 호출 추가 (`saveRuntimeConfig` 패턴, catch → warning toast).
  - `saveConfig`: 동일.

## 검증

- `pnpm typecheck` ✓
- keeper-config-panel 기존 73 테스트 ✓ (회귀 없음)
- `pnpm lint` ✓

## 미검증 / 한계

- `saveConfig`/`saveToolPolicy`/`saveRuntimeConfig` 모두 컴포넌트 클로저로, 렌더 기반 회귀 테스트 인프라가 현재 없음 (기존 기술 부채 — `saveRuntimeConfig`조차 미커버). 저장 후 refresh 호출 자체를 단위 테스트로 증명하지 못함. 회귀는 typecheck + 기존 테스트로 봉쇄.
- keeper 런타임이 새 prompt로 "즉시" 다음 턴을 돌리는 것(백엔드 wake)은 본 PR 범위 외. keeper는 매 턴 prompt를 재조립(`keeper_agent_run.ml`)하므로 다음 자연 턴에는 반영됨.

## RFC / 워크어라운드

- RFC 대상 아님 (credential/identity/operator/sandbox/hooks/workflow 외, dashboard component).
- 워크어라운드 시그니처 아님 — 실제 UI 갱신 경로(refresh) 추가이지 telemetry-as-fix / string 분류기 / N-of-M 패치가 아님.

Co-Authored-By: Claude <noreply@anthropic.com>
