### PR TITLE
feat(timeline): emit keeper in-turn tool executions to the activity graph (#23540)

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.test.ts
+++ b/dashboard/src/components/agent-detail-timeline.test.ts
@@ -1,5 +1,10 @@
+// @vitest-environment jsdom
+
 import { describe, it, expect } from 'vitest'
-import { timelineEventLabel } from './agent-detail-timeline'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { timelineEventLabel, ToolCallEventRow } from './agent-detail-timeline'
+import type { AgentTimelineEvent } from '../api'
 
 describe('timelineEventLabel', () => {
   it('returns Korean label for joined', () => {
@@ -25,6 +30,37 @@ describe('timelineEventLabel', () => {
     expect(timelineEventLabel('unknown')).toBe('unknown')
     expect(timelineEventLabel('')).toBe('')
     expect(timelineEventLabel('custom_event')).toBe('custom_event')
+  })
+})
+
+describe('ToolCallEventRow source badge', () => {
+  const toolCallEvent = (detail: Record<string, unknown>): AgentTimelineEvent => ({
+    ts: '',
+    type: 'tool_call',
+    detail,
+  })
+
+  const renderRow = (evt: AgentTimelineEvent): HTMLElement => {
+    const host = document.createElement('div')
+    render(html`<${ToolCallEventRow} evt=${evt} idx=${0} />`, host)
+    return host
+  }
+
+  it('marks keeper in-turn executions (keeper.tool_exec producer)', () => {
+    const host = renderRow(
+      toolCallEvent({ tool_name: 'masc_status', success: true, source: 'keeper_in_turn' }),
+    )
+    const badge = host.querySelector('[data-tool-source="keeper_in_turn"]')
+    expect(badge).not.toBeNull()
+    expect(badge?.textContent).toBe('턴 내')
+  })
+
+  it('renders no source badge when the source is absent (external tool.called)', () => {
+    const host = renderRow(
+      toolCallEvent({ tool_name: 'external_tool', success: true, source: null }),
+    )
+    expect(host.querySelector('[data-tool-source]')).toBeNull()
+    expect(host.textContent).toContain('external_tool')
   })
 })
 

--- a/dashboard/src/components/agent-detail-timeline.test.ts
+++ b/dashboard/src/components/agent-detail-timeline.test.ts
@@ -48,11 +48,18 @@ describe('ToolCallEventRow source badge', () => {
 
   it('marks keeper in-turn executions (keeper.tool_exec producer)', () => {
     const host = renderRow(
-      toolCallEvent({ tool_name: 'masc_status', success: true, source: 'keeper_in_turn' }),
+      toolCallEvent({
+        tool_name: 'masc_status',
+        success: true,
+        source: 'keeper_in_turn',
+        keeper_turn_id: 7,
+        oas_turn: 2,
+      }),
     )
     const badge = host.querySelector('[data-tool-source="keeper_in_turn"]')
     expect(badge).not.toBeNull()
     expect(badge?.textContent).toBe('턴 내')
+    expect(host.querySelector('[data-keeper-turn-id="7"]')?.textContent).toBe('턴 7 · 스텝 2')
   })
 
   it('renders no source badge when the source is absent (external tool.called)', () => {
@@ -63,4 +70,3 @@ describe('ToolCallEventRow source badge', () => {
     expect(host.textContent).toContain('external_tool')
   })
 })
-

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -106,6 +106,8 @@ export function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: n
   // keeper_in_turn = keeper executed the tool inside its own turn
   // (keeper.tool_exec producer, #23540); absent/other = external MCP dispatch.
   const isKeeperInTurn = d.source === 'keeper_in_turn'
+  const keeperTurnId = typeof d.keeper_turn_id === 'number' ? d.keeper_turn_id : null
+  const oasTurn = typeof d.oas_turn === 'number' ? d.oas_turn : null
 
   return html`
     <div class="v2-monitoring-row flex flex-col py-1.5 px-2 rounded-[var(--r-1)] hover:bg-[var(--color-bg-elevated)] transition-colors" key=${idx} style=${{ animation: 'activityFadeIn 0.25s var(--ease-out)' }}>
@@ -123,6 +125,9 @@ export function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: n
           : html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--bad-10)] text-[var(--color-status-err)]">err</span>`}
         ${isKeeperInTurn
           ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)]" data-tool-source="keeper_in_turn" title="keeper가 자기 턴 안에서 실행한 도구">턴 내</span>`
+          : null}
+        ${keeperTurnId != null
+          ? html`<span class="text-2xs font-mono text-[var(--color-fg-secondary)]" data-keeper-turn-id=${keeperTurnId} title="Keeper 절대 턴과 그 안의 모델 스텝">턴 ${keeperTurnId}${oasTurn != null ? ` · 스텝 ${oasTurn}` : ''}</span>`
           : null}
         <span class="flex-1"></span>
         ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -95,7 +95,7 @@ function timelineCategoryCounts(
 const timelineCategoryFilter = signal<TimelineEventCategory>('all')
 const timelineSearchQuery = signal('')
 
-function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }) {
+export function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }) {
   const d = evt.detail as Record<string, unknown>
   const toolName = (d.tool_name as string) ?? 'unknown'
   const success = d.success !== false
@@ -103,6 +103,9 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
   const errorMsg = d.error as string | null
   const args = d.args as Record<string, unknown> | string | undefined
   const cat = toolCategory(toolName)
+  // keeper_in_turn = keeper executed the tool inside its own turn
+  // (keeper.tool_exec producer, #23540); absent/other = external MCP dispatch.
+  const isKeeperInTurn = d.source === 'keeper_in_turn'
 
   return html`
     <div class="v2-monitoring-row flex flex-col py-1.5 px-2 rounded-[var(--r-1)] hover:bg-[var(--color-bg-elevated)] transition-colors" key=${idx} style=${{ animation: 'activityFadeIn 0.25s var(--ease-out)' }}>
@@ -118,6 +121,9 @@ function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }
         ${success
           ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--ok-soft)] text-[var(--color-status-ok)]">ok</span>`
           : html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--bad-10)] text-[var(--color-status-err)]">err</span>`}
+        ${isKeeperInTurn
+          ? html`<span class="text-2xs px-1.5 py-0.5 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-secondary)]" data-tool-source="keeper_in_turn" title="keeper가 자기 턴 안에서 실행한 도구">턴 내</span>`
+          : null}
         <span class="flex-1"></span>
         ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
       </div>

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -84,6 +84,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper_hooks_oas_types/keeper_hooks_oas_types.mli` - hook-observation
 - `lib/keeper/keeper_hooks_oas.ml` - hook-observation
 - `lib/keeper/keeper_hooks_oas.mli` - hook-observation
+- `lib/keeper/keeper_tool_activity.ml` - hook-observation
+- `lib/keeper/keeper_tool_activity.mli` - hook-observation
 - `lib/keeper/keeper_sandbox_containment.ml` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_containment.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_control.ml` - sandbox-runtime

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -57,7 +57,7 @@ let semantic_multiplier = function
   | "keeper.autonomy_started" | "keeper.autonomy_completed" -> 1.5
   | "operation.paused" | "operation.stopped" -> 0.5
   | "keeper.turn_completed" -> 0.4
-  | "tool.called" -> 0.3
+  | "tool.called" | "keeper.tool_exec" -> 0.3
   | _ -> 1.0
 
 let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
@@ -332,7 +332,7 @@ let reduce_event ~nodes ~edges (value : event) =
   | "keeper.autonomy_completed" -> set_actor_status Active
   | "keeper.guardrail" -> set_actor_status Guardrail
   | "keeper.compaction" -> set_actor_status Compacting
-  | "tool.called" ->
+  | "tool.called" | "keeper.tool_exec" ->
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"calls_tool" ~active:false

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -40,7 +40,11 @@ let is_generic_status = function
 
 (* Semantic weight multiplier by event kind.
    Completion events score high; routine lifecycle events score low. *)
-let semantic_multiplier = function
+let semantic_multiplier kind =
+  match tool_execution_event_kind_of_string kind with
+  | Some (External_tool_called | Keeper_in_turn_tool_executed) -> 0.3
+  | None ->
+    (match kind with
   | "task.done" | "task.approved" | "decision.resolved" | "operation.finalized" -> 5.0
   | "task.created" | "task.claimed" | "decision.opened" -> 3.0
   | "agent.handoff" | "agent.spawned" -> 3.0
@@ -56,9 +60,8 @@ let semantic_multiplier = function
   | "keeper.compaction" | "keeper.guardrail" -> 0.5
   | "keeper.autonomy_started" | "keeper.autonomy_completed" -> 1.5
   | "operation.paused" | "operation.stopped" -> 0.5
-  | "keeper.turn_completed" -> 0.4
-  | "tool.called" | "keeper.tool_exec" -> 0.3
-  | _ -> 1.0
+     | "keeper.turn_completed" -> 0.4
+     | _ -> 1.0)
 
 let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
     ~(kind : string) ~(label : string)
@@ -167,6 +170,14 @@ let reduce_event ~nodes ~edges (value : event) =
         | None -> ())
     | None -> ()
   in
+  (match tool_execution_event_kind_of_string value.kind with
+  | Some (External_tool_called | Keeper_in_turn_tool_executed) ->
+    (match actor_id, subject_id with
+     | Some source, Some target ->
+       ensure_edge edges ~source ~target ~kind:"calls_tool" ~active:false
+         ~ts_iso:value.ts_iso ~meta:value.payload
+     | None, _ | _, None -> ())
+  | None ->
   (match value.kind with
   | "agent.session_bound" -> set_subject_status Active
   | "agent.left" -> set_subject_status Offline
@@ -332,10 +343,4 @@ let reduce_event ~nodes ~edges (value : event) =
   | "keeper.autonomy_completed" -> set_actor_status Active
   | "keeper.guardrail" -> set_actor_status Guardrail
   | "keeper.compaction" -> set_actor_status Compacting
-  | "tool.called" | "keeper.tool_exec" ->
-      (match (actor_id, subject_id) with
-      | Some source, Some target ->
-          ensure_edge edges ~source ~target ~kind:"calls_tool" ~active:false
-            ~ts_iso:value.ts_iso ~meta:value.payload
-      | (None, _) | (_, None) -> ())
-  | _kind -> Log.Misc.debug "reduce_event: unhandled kind=%s" _kind)
+  | _kind -> Log.Misc.debug "reduce_event: unhandled kind=%s" _kind))

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -60,6 +60,25 @@ let span_status_of_string_opt = function
   | "ended" -> Some Span_ended
   | _ -> None
 
+type tool_execution_event_kind =
+  | External_tool_called
+  | Keeper_in_turn_tool_executed
+
+let tool_execution_event_kind_to_string = function
+  | External_tool_called -> "tool.called"
+  | Keeper_in_turn_tool_executed -> "keeper.tool_exec"
+;;
+
+let tool_execution_event_kind_of_string = function
+  | "tool.called" -> Some External_tool_called
+  | "keeper.tool_exec" -> Some Keeper_in_turn_tool_executed
+  | _ -> None
+;;
+
+let all_tool_execution_event_kinds =
+  [ External_tool_called; Keeper_in_turn_tool_executed ]
+;;
+
 type entity_ref = {
   kind : string;
   id : string;

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -41,6 +41,17 @@ val span_status_to_string : span_status -> string
     explicitly (drop / fallback / route). See #8605. *)
 val span_status_of_string_opt : string -> span_status option
 
+(** Closed activity kinds whose payload describes one executed tool. Producers,
+    reducers, and timeline readers share this type rather than maintaining
+    independent string lists. *)
+type tool_execution_event_kind =
+  | External_tool_called
+  | Keeper_in_turn_tool_executed
+
+val tool_execution_event_kind_to_string : tool_execution_event_kind -> string
+val tool_execution_event_kind_of_string : string -> tool_execution_event_kind option
+val all_tool_execution_event_kinds : tool_execution_event_kind list
+
 (** {1 Graph entities} *)
 
 type entity_ref = {

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -290,7 +290,22 @@ let assemble_hooks
              ; output_text
              ; tool_name
              ; success
-             }))
+             };
+           (* #23540: keeper in-turn tool executions never reached the
+              activity log ([tool.called] is emitted only by the external MCP
+              path), so the agent timeline reported tool_calls = 0 for any
+              keeper working through its own turn. *)
+           Keeper_tool_activity.emit_tool_exec
+             ~config
+             ~agent_name:acc.meta.Keeper_meta_contract.agent_name
+             ~keeper_name:acc.meta.name
+             ~tool_name
+             ~success
+             ~duration_ms:(int_of_float (Float.round duration_ms))
+             ~outcome:typed_outcome_str
+             ~provider
+             ~turn_id
+             ()))
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()
     in

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -297,14 +297,15 @@ let assemble_hooks
               keeper working through its own turn. *)
            Keeper_tool_activity.emit_tool_exec
              ~config
-             ~agent_name:acc.meta.Keeper_meta_contract.agent_name
-             ~keeper_name:acc.meta.name
+             ~meta:acc.meta
              ~tool_name
              ~success
              ~duration_ms:(int_of_float (Float.round duration_ms))
-             ~outcome:typed_outcome_str
+             ~typed_outcome
              ~provider
-             ~turn_id
+             ~keeper_turn_id:manifest_keeper_turn_id
+             ~oas_turn:acc.current_turn
+             ~task_id
              ()))
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()

--- a/lib/keeper/keeper_tool_activity.ml
+++ b/lib/keeper/keeper_tool_activity.ml
@@ -1,0 +1,44 @@
+let tool_exec_kind = "keeper.tool_exec"
+
+let emit_tool_exec
+      ~config
+      ~agent_name
+      ~keeper_name
+      ~tool_name
+      ~success
+      ~duration_ms
+      ~outcome
+      ~provider
+      ~turn_id
+      ()
+  =
+  try
+    ignore
+      (Activity_graph.emit
+         config
+         ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
+         ~subject:(Activity_graph.entity ~kind:"tool" tool_name)
+         ~kind:tool_exec_kind
+         ~payload:
+           (`Assoc
+               [ "tool_name", `String tool_name
+               ; "success", `Bool success
+               ; "duration_ms", `Int duration_ms
+               ; "outcome", `String outcome
+               ; "provider", `String provider
+               ; "keeper_name", `String keeper_name
+               ; "turn_id", `String turn_id
+               ; "source", `String "keeper_in_turn"
+               ])
+         ~tags:[ "tool"; "keeper"; (if success then "success" else "failure") ]
+         ()
+        : Activity_graph.event)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      ~keeper_name
+      "keeper.tool_exec activity emit failed for %s: %s"
+      tool_name
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_tool_activity.ml
+++ b/lib/keeper/keeper_tool_activity.ml
@@ -1,33 +1,39 @@
-let tool_exec_kind = "keeper.tool_exec"
-
 let emit_tool_exec
       ~config
-      ~agent_name
-      ~keeper_name
+      ~(meta : Keeper_meta_contract.keeper_meta)
       ~tool_name
       ~success
       ~duration_ms
-      ~outcome
+      ~typed_outcome
       ~provider
-      ~turn_id
+      ~keeper_turn_id
+      ~oas_turn
+      ~task_id
       ()
   =
   try
     ignore
       (Activity_graph.emit
          config
-         ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
+         ~actor:(Activity_graph.entity ~kind:"agent" meta.agent_name)
          ~subject:(Activity_graph.entity ~kind:"tool" tool_name)
-         ~kind:tool_exec_kind
+         ~kind:
+           (Activity_graph.tool_execution_event_kind_to_string
+              Activity_graph.Keeper_in_turn_tool_executed)
          ~payload:
            (`Assoc
                [ "tool_name", `String tool_name
                ; "success", `Bool success
                ; "duration_ms", `Int duration_ms
-               ; "outcome", `String outcome
+               ; ( "typed_outcome"
+                 , match typed_outcome with
+                   | Some outcome -> Keeper_tool_outcome.to_json outcome
+                   | None -> `Null )
                ; "provider", `String provider
-               ; "keeper_name", `String keeper_name
-               ; "turn_id", `String turn_id
+               ; "keeper_name", `String meta.name
+               ; "keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id
+               ; "oas_turn", `Int oas_turn
+               ; "task_id", Json_util.string_opt_to_json task_id
                ; "source", `String "keeper_in_turn"
                ])
          ~tags:[ "tool"; "keeper"; (if success then "success" else "failure") ]
@@ -36,9 +42,9 @@ let emit_tool_exec
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-    Log.Keeper.warn
-      ~keeper_name
-      "keeper.tool_exec activity emit failed for %s: %s"
-      tool_name
-      (Printexc.to_string exn)
+    Keeper_callback_failure.record
+      ~base_dir:config.base_path
+      ~meta
+      ~callback:"keeper_tool_activity_emit"
+      exn
 ;;

--- a/lib/keeper/keeper_tool_activity.mli
+++ b/lib/keeper/keeper_tool_activity.mli
@@ -12,25 +12,24 @@
     Emission is fire-and-forget: a failed append must never change the tool
     call's result. [Eio.Cancel.Cancelled] is re-raised (never absorbed). *)
 
-val tool_exec_kind : string
-(** ["keeper.tool_exec"] — matched by the agent-timeline read model and the
-    activity-graph reducer. *)
-
 val emit_tool_exec :
   config:Workspace_utils.config ->
-  agent_name:string ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
   tool_name:string ->
   success:bool ->
   duration_ms:int ->
-  outcome:string ->
+  typed_outcome:Keeper_tool_outcome.t option ->
   provider:string ->
-  turn_id:string ->
+  keeper_turn_id:int option ->
+  oas_turn:int ->
+  task_id:string option ->
   unit ->
   unit
-(** Appends one [keeper.tool_exec] event. [agent_name] becomes the actor id
+(** Appends one [keeper.tool_exec] event. [meta.agent_name] becomes the actor id
     (the same identity form [keeper.turn_completed] uses, so
     [Tool_agent_timeline.identity_matches] resolves both through one
-    predicate); [keeper_name] is carried in the payload for the payload-side
-    identity fallback. [tool_name]/[success]/[duration_ms] follow the
-    [tool.called] payload contract the timeline detail projection reads. *)
+    predicate); [meta.name] is carried for the payload-side identity fallback.
+    [keeper_turn_id] is the absolute Keeper-lane turn and [oas_turn] is the
+    model/tool-loop step inside it; task identity is carried separately and is
+    never substituted for either turn id. Typed outcome JSON is preserved
+    without reconstructing a string category. *)

--- a/lib/keeper/keeper_tool_activity.mli
+++ b/lib/keeper/keeper_tool_activity.mli
@@ -1,0 +1,36 @@
+(** Activity-graph producer for keeper in-turn tool executions.
+
+    The agent timeline's tool source ([tool.called]) is emitted only by the
+    external MCP dispatch path, so tools a keeper runs inside its own turn
+    never reached the activity log and the dashboard timeline reported
+    [tool_calls = 0] for busy keepers (#23540). This module emits the
+    keeper-side counterpart under its own kind, [keeper.tool_exec], instead
+    of reusing [tool.called]: the two producers carry different actor
+    identities and payload provenance, and folding them into one kind would
+    make the actor back-reference ambiguous.
+
+    Emission is fire-and-forget: a failed append must never change the tool
+    call's result. [Eio.Cancel.Cancelled] is re-raised (never absorbed). *)
+
+val tool_exec_kind : string
+(** ["keeper.tool_exec"] — matched by the agent-timeline read model and the
+    activity-graph reducer. *)
+
+val emit_tool_exec :
+  config:Workspace_utils.config ->
+  agent_name:string ->
+  keeper_name:string ->
+  tool_name:string ->
+  success:bool ->
+  duration_ms:int ->
+  outcome:string ->
+  provider:string ->
+  turn_id:string ->
+  unit ->
+  unit
+(** Appends one [keeper.tool_exec] event. [agent_name] becomes the actor id
+    (the same identity form [keeper.turn_completed] uses, so
+    [Tool_agent_timeline.identity_matches] resolves both through one
+    predicate); [keeper_name] is carried in the payload for the payload-side
+    identity fallback. [tool_name]/[success]/[duration_ms] follow the
+    [tool.called] payload contract the timeline detail projection reads. *)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -790,7 +790,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ignore (Activity_graph.emit (Mcp_server.workspace_config state)
       ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
       ~subject:(Activity_graph.entity ~kind:"tool" name)
-      ~kind:"tool.called"
+      ~kind:
+        (Activity_graph.tool_execution_event_kind_to_string
+           Activity_graph.External_tool_called)
       ~payload:activity_payload
       ~tags:(if success then ["tool"; "success"] else ["tool"; "failure"])
       ())

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -94,6 +94,7 @@ let dashboard_retention_json =
         `List
           [
             `String "tool.called";
+            `String "keeper.tool_exec";
             `String "keeper.contract_verdict";
             `String "keeper.friction";
             `String "keeper.turn_completed";
@@ -290,7 +291,11 @@ let take_last n xs =
       in
       skip (len - n) xs
 
-(* Collect tool call events from Activity Graph *)
+(* Collect tool call events from Activity Graph. Two producers feed this
+   source: the external MCP dispatch path ([tool.called]) and the keeper
+   in-turn execution hook ([keeper.tool_exec], #23540 — without it a keeper
+   working through its own turn reported tool_calls = 0). Both share the
+   tool_name/success/duration_ms payload contract projected below. *)
 let tool_call_events (config : Workspace.config) ~agent_name ~limit :
     timeline_event list =
   (* `list_events` limits globally before we filter by actor, so fetch a
@@ -302,7 +307,7 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
   in
   let all_events =
     Activity_graph.list_events config
-      ~kinds:["tool.called"] ~after_seq:0 ~limit:scan_limit ()
+      ~kinds:["tool.called"; "keeper.tool_exec"] ~after_seq:0 ~limit:scan_limit ()
   in
   all_events
   |> List.filter (activity_event_matches_agent ~agent_name)
@@ -318,6 +323,7 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
          Safe_ops.json_int ~default:0 "duration_ms" e.payload
        in
        let error_str = Safe_ops.json_string_opt "error" e.payload in
+       let source_str = Safe_ops.json_string_opt "source" e.payload in
        Some
          {
            ts;
@@ -330,6 +336,7 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
                  ("success", `Bool success);
                  ("duration_ms", `Int duration_ms);
                  ("error", Json_util.string_opt_to_json error_str);
+                 ("source", Json_util.string_opt_to_json source_str);
                ];
          })
   |> take_last limit

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -92,13 +92,15 @@ let dashboard_retention_json =
           ] );
       ( "activity_event_kinds",
         `List
-          [
-            `String "tool.called";
-            `String "keeper.tool_exec";
-            `String "keeper.contract_verdict";
-            `String "keeper.friction";
-            `String "keeper.turn_completed";
-          ] );
+          (List.map
+             (fun kind ->
+               `String
+                 (Activity_graph.tool_execution_event_kind_to_string kind))
+             Activity_graph.all_tool_execution_event_kinds
+           @ [ `String "keeper.contract_verdict"
+             ; `String "keeper.friction"
+             ; `String "keeper.turn_completed"
+             ]) );
     ]
 
 let event_to_json (e : timeline_event) : Yojson.Safe.t =
@@ -307,7 +309,13 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
   in
   let all_events =
     Activity_graph.list_events config
-      ~kinds:["tool.called"; "keeper.tool_exec"] ~after_seq:0 ~limit:scan_limit ()
+      ~kinds:
+        (List.map
+           Activity_graph.tool_execution_event_kind_to_string
+           Activity_graph.all_tool_execution_event_kinds)
+      ~after_seq:0
+      ~limit:scan_limit
+      ()
   in
   all_events
   |> List.filter (activity_event_matches_agent ~agent_name)
@@ -324,6 +332,11 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
        in
        let error_str = Safe_ops.json_string_opt "error" e.payload in
        let source_str = Safe_ops.json_string_opt "source" e.payload in
+       let keeper_turn_id = Safe_ops.json_int_opt "keeper_turn_id" e.payload in
+       let oas_turn = Safe_ops.json_int_opt "oas_turn" e.payload in
+       let task_id = Safe_ops.json_string_opt "task_id" e.payload in
+       let provider = Safe_ops.json_string_opt "provider" e.payload in
+       let typed_outcome = Yojson.Safe.Util.member "typed_outcome" e.payload in
        Some
          {
            ts;
@@ -337,6 +350,11 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
                  ("duration_ms", `Int duration_ms);
                  ("error", Json_util.string_opt_to_json error_str);
                  ("source", Json_util.string_opt_to_json source_str);
+                 ("keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id);
+                 ("oas_turn", Json_util.int_opt_to_json oas_turn);
+                 ("task_id", Json_util.string_opt_to_json task_id);
+                 ("provider", Json_util.string_opt_to_json provider);
+                 ("typed_outcome", typed_outcome);
                ];
          })
   |> take_last limit

--- a/test/test_tool_agent_timeline_build.ml
+++ b/test/test_tool_agent_timeline_build.ml
@@ -94,6 +94,9 @@ let ev_type e = Yojson.Safe.Util.(e |> member "type" |> to_string)
 let ev_detail_str e key =
   Yojson.Safe.Util.(e |> member "detail" |> member key |> to_string)
 
+let ev_detail_int e key =
+  Yojson.Safe.Util.(e |> member "detail" |> member key |> to_int)
+
 let chat_field key json =
   events_list json
   |> List.filter (fun e -> String.equal (ev_type e) "chat")
@@ -287,10 +290,29 @@ let test_turn_completed_keeps_newest () =
    same end-to-end read path. *)
 
 let emit_keeper_tool_exec config ~keeper_name ~tool_name ~success =
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+            [ "name", `String keeper_name
+            ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
+            ; "trace_id", `String ("trace-" ^ keeper_name)
+            ])
+    with
+    | Ok meta -> meta
+    | Error error -> failwith error
+  in
   Lib.Keeper_tool_activity.emit_tool_exec ~config
-    ~agent_name:("keeper-" ^ keeper_name ^ "-agent")
-    ~keeper_name ~tool_name ~success ~duration_ms:42 ~outcome:"progress"
-    ~provider:"in_process" ~turn_id:"turn-1" ()
+    ~meta
+    ~tool_name
+    ~success
+    ~duration_ms:42
+    ~typed_outcome:(Some Keeper_tool_outcome.Progress)
+    ~provider:"in_process"
+    ~keeper_turn_id:(Some 7)
+    ~oas_turn:2
+    ~task_id:(Some "task-1")
+    ()
 
 let tool_call_events_of json =
   events_list json
@@ -308,13 +330,22 @@ let test_keeper_tool_exec_surfaces_in_timeline () =
         check string "tool name projected" "masc_status"
           (ev_detail_str e "tool_name");
         check string "source distinguishes the keeper producer"
-          "keeper_in_turn" (ev_detail_str e "source")
+          "keeper_in_turn" (ev_detail_str e "source");
+        check int "absolute Keeper turn is projected" 7
+          (ev_detail_int e "keeper_turn_id");
+        check int "OAS model step is projected separately" 2
+          (ev_detail_int e "oas_turn");
+        check string "task identity is not used as a turn id" "task-1"
+          (ev_detail_str e "task_id")
       | events -> failf "expected one tool_call event, got %d" (List.length events))
 
 let test_tool_call_sources_merge () =
   with_config (fun config ->
       ignore
-        (Activity_graph.emit config ~kind:"tool.called"
+        (Activity_graph.emit config
+           ~kind:
+             (Activity_graph.tool_execution_event_kind_to_string
+                Activity_graph.External_tool_called)
            ~actor:(Activity_graph.entity ~kind:"agent" "testkeeper")
            ~subject:(Activity_graph.entity ~kind:"tool" "external_tool")
            ~payload:(`Assoc [ ("tool_name", `String "external_tool") ])

--- a/test/test_tool_agent_timeline_build.ml
+++ b/test/test_tool_agent_timeline_build.ml
@@ -281,6 +281,58 @@ let test_turn_completed_keeps_newest () =
         ~payload_of:(fun s -> `Assoc [ ("model_used", `String s) ]);
       check_keeps_newest ~label:"turn_completed" config)
 
+(* keeper.tool_exec producer -> read model (#23540): keeper in-turn tool
+   executions were invisible to the timeline because only the external MCP
+   path emitted [tool.called]; these tests drive the new producer through the
+   same end-to-end read path. *)
+
+let emit_keeper_tool_exec config ~keeper_name ~tool_name ~success =
+  Lib.Keeper_tool_activity.emit_tool_exec ~config
+    ~agent_name:("keeper-" ^ keeper_name ^ "-agent")
+    ~keeper_name ~tool_name ~success ~duration_ms:42 ~outcome:"progress"
+    ~provider:"in_process" ~turn_id:"turn-1" ()
+
+let tool_call_events_of json =
+  events_list json
+  |> List.filter (fun e -> String.equal (ev_type e) "tool_call")
+
+let test_keeper_tool_exec_surfaces_in_timeline () =
+  with_config (fun config ->
+      emit_keeper_tool_exec config ~keeper_name:"testkeeper"
+        ~tool_name:"masc_status" ~success:true;
+      let json = build config ~agent_name:"testkeeper" in
+      check int "keeper in-turn execution counts as a tool call" 1
+        (summary_int json "tool_calls");
+      match tool_call_events_of json with
+      | [ e ] ->
+        check string "tool name projected" "masc_status"
+          (ev_detail_str e "tool_name");
+        check string "source distinguishes the keeper producer"
+          "keeper_in_turn" (ev_detail_str e "source")
+      | events -> failf "expected one tool_call event, got %d" (List.length events))
+
+let test_tool_call_sources_merge () =
+  with_config (fun config ->
+      ignore
+        (Activity_graph.emit config ~kind:"tool.called"
+           ~actor:(Activity_graph.entity ~kind:"agent" "testkeeper")
+           ~subject:(Activity_graph.entity ~kind:"tool" "external_tool")
+           ~payload:(`Assoc [ ("tool_name", `String "external_tool") ])
+           ());
+      emit_keeper_tool_exec config ~keeper_name:"testkeeper"
+        ~tool_name:"masc_status" ~success:true;
+      let json = build config ~agent_name:"testkeeper" in
+      check int "external and keeper tool events both count" 2
+        (summary_int json "tool_calls"))
+
+let test_keeper_tool_exec_excludes_other_keeper () =
+  with_config (fun config ->
+      emit_keeper_tool_exec config ~keeper_name:"otherkeeper"
+        ~tool_name:"masc_status" ~success:true;
+      let json = build config ~agent_name:"testkeeper" in
+      check int "other keeper's execution is excluded" 0
+        (summary_int json "tool_calls"))
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -309,5 +361,14 @@ let () =
           test_case "tool_call keeps newest" `Quick test_tool_call_keeps_newest;
           test_case "turn_completed keeps newest" `Quick
             test_turn_completed_keeps_newest;
+        ] );
+      ( "keeper-tool-exec-source",
+        [
+          test_case "keeper in-turn execution surfaces" `Quick
+            test_keeper_tool_exec_surfaces_in_timeline;
+          test_case "external and keeper sources merge" `Quick
+            test_tool_call_sources_merge;
+          test_case "other keeper's execution excluded" `Quick
+            test_keeper_tool_exec_excludes_other_keeper;
         ] );
     ]


### PR DESCRIPTION
## 무엇

기능지도 Gap(관측 축) + #23540의 tool 절반: agent timeline의 도구 소스는 external MCP 경로(`tool.called`, `mcp_server_eio_call_tool.ml`)만이 producer라, keeper가 **자기 턴 안에서** 실행한 도구 — 실제 도구 활동의 대부분 — 는 activity 로그에 도달하지 않았고 대시보드 timeline은 `tool_calls = 0`을 보고했습니다 (07-08 실측 재검증: producer 전수 1곳, keeper 경로 emit 부재).

## 어떻게

- **신규 producer** `Keeper_tool_activity.emit_tool_exec` — keeper in-turn 실행의 단일 수렴 지점인 `on_tool_executed` hook에서 `keeper.tool_exec` 이벤트 append. `tool.called` kind 재사용을 하지 않는 이유: 두 producer는 actor 정체성/provenance가 달라 합치면 actor 역추적이 모호해집니다 (07-08 진단의 권고 그대로). fire-and-forget + `Eio.Cancel.Cancelled` re-raise(external producer와 동일 계약).
- **read model**: 두 kind를 같은 `tool_name/success/duration_ms` payload 계약으로 스캔, `source`를 detail에 투영(미선언 producer는 null — permissive default 없음). retention 목록에 kind 추가.
- **reducer**: `keeper.tool_exec`에 `tool.called`과 동일한 semantic weight 0.3 + `calls_tool` 엣지.
- **대시보드**: `ToolCallEventRow`에 `source=keeper_in_turn` 배지("턴 내") — external MCP 호출과 구분.

**스코프 아웃**: 같은 이슈의 `turns_completed=0`은 재현 불가(07-08 재실측)이며 #22716이 identity fix를 이미 랜딩 — 손대지 않음. dead retention kinds(`keeper.friction`/`keeper.contract_verdict`, producer 부재)는 별도 추적.

## 검증

- timeline build 스위트에 producer 경유 E2E 3건 추가: 표면화+카운트+detail 계약 / `tool.called`과 병존 합산 / 타 keeper 배제 — 12/12
- activity_graph 16/16, name-match 5/5, `dune @check` green
- vitest: ToolCallEventRow 배지 계약 2건 추가 — 7/7, `tsc --noEmit` clean

지도: claude.ai/code/artifact/01478ad0 · #23540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
