### PR TITLE
fix(runtime): declare Qwen3.6 reasoning carrier

### DIFF
--- a/oas-models.toml
+++ b/oas-models.toml
@@ -724,14 +724,10 @@ supports_seed = true
 input_per_million = 0.0
 output_per_million = 0.0
 
-# RunPod Models
-# WORKAROUND: current pinned OAS emits provider_label "openai_compat" for
-# RunPod proxy URLs because it does not recognize *.proxy.runpod.net base URLs.
-# The root fix is jeong-sik/oas#2374, which restores the dedicated
-# "runpod_mtp" label. Keep both provider-qualified rows during the OAS pin
-# transition so Runtime.init_default_strict resolves the model before and after
-# that OAS bump. Removal target: after #2374 is pinned here and proven stable,
-# drop the openai_compat row and keep runpod_mtp as canonical.
+# RunPod Qwen3.6 deployment contract. `runpod_mtp` is the MASC runtime-id
+# namespace; the generic OpenAI-compatible transport resolves through
+# `openai_compat`. Keep every explicit lookup form used by Runtime without
+# inferring capabilities from the rental host.
 
 [[models]]
 id_prefix = "runpod_mtp/qwen36-35b-a3b-mtp"
@@ -744,6 +740,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
@@ -759,6 +757,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
@@ -774,6 +774,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
@@ -789,6 +791,8 @@ supports_extended_thinking = true
 supports_reasoning_budget = true
 thinking_control_format = "chat_template_kwargs"
 preserve_thinking_control_format = "chat_template_kwargs_preserve_thinking"
+reasoning_streaming_format = "delta:reasoning_content"
+reasoning_replay = "drop_without_tool_preserve_with_tool"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -353,7 +353,11 @@ let test_repo_oas_model_catalog_covers_live_runpod_mtp () =
       check (option string) (model_id ^ " base") (Some "openai_chat")
         entry.base_label;
       check (option int) (model_id ^ " context") (Some 131072)
-        entry.max_context_tokens
+        entry.max_context_tokens;
+      check (option string) (model_id ^ " reasoning stream")
+        (Some "delta:reasoning_content") entry.reasoning_streaming_format;
+      check (option string) (model_id ^ " reasoning replay")
+        (Some "drop_without_tool_preserve_with_tool") entry.reasoning_replay
   in
   let expect_runpod_caps
         name
@@ -365,7 +369,15 @@ let test_repo_oas_model_catalog_covers_live_runpod_mtp () =
       caps.supports_extended_thinking;
     check bool (name ^ " chat-template thinking") true
       (Llm_provider.Capabilities.(
-         caps.thinking_control_format = Chat_template_kwargs))
+         caps.thinking_control_format = Chat_template_kwargs));
+    check bool (name ^ " reasoning_content stream") true
+      (Llm_provider.Capabilities.(
+         caps.reasoning_streaming_format
+         = Delta_reasoning_field "reasoning_content"));
+    check bool (name ^ " tool-call reasoning replay") true
+      (Llm_provider.Capabilities.(
+         caps.reasoning_replay_override
+         = Force_drop_without_tool_preserve_with_tool))
   in
   List.iter expect_lookup provider_model_ids;
   expect_lookup runpod_model_id;


### PR DESCRIPTION
## Problem

MASC supplies an external OAS capability catalog and that explicit overlay wins over the OAS bundled catalog. The live Qwen3.6 rows declared only the request-side `chat_template_kwargs` control. OAS therefore selected its unimplemented `Template_parser` response dialect and discarded llama.cpp `delta.reasoning_content`.

The 2026-07-11 sangsu incident recorded `thinking_present=false` across every Qwen tool subturn even though the live llama.cpp slot reported `reasoning_format=deepseek` / `reasoning_in_content=false`. Missing typed reasoning forced each subturn to reason again from visible narration and failed tool results.

## Contract

- declare `reasoning_streaming_format = delta:reasoning_content` on every explicit live Qwen3.6 lookup form
- declare `reasoning_replay = drop_without_tool_preserve_with_tool` so tool-call reasoning is replayable when historical preserve is not requested
- retain request control, response carrier, and replay as separate typed OAS axes
- do not infer capability from RunPod host/model strings at runtime
- replace the stale #2374 transition comment with the current runtime-id vs transport-label boundary

This is compatible with the currently pinned OAS v0.211.0: both catalog fields and typed dialects already exist there. OAS #2527 applies the same contract to OAS bundled defaults; this MASC overlay is the live blocking surface.

## Validation

- `ocamlformat --check test/test_runtime_config_validity.ml` passed
- Python `tomllib` parsed `oas-models.toml`
- `git diff --check` passed
- Dune build/test intentionally delegated to GitHub CI per repository workflow

## Sources

- Qwen3.6 preserve-thinking contract: https://huggingface.co/Qwen/Qwen3.6-35B-A3B-FP8#preserve-thinking
- Qwen3.6 official chat template: https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/chat_template.jinja
- llama.cpp reasoning response contract: https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#reasoning-support
- OAS companion: https://github.com/jeong-sik/oas/pull/2527

## Non-goals

This PR does not fix the independent MASC timeout persistence, pending-scope replay livelock, provider-capacity gate, or OAS stream-retry/tool-id transaction defects.

[근거] official Qwen/llama.cpp docs and live RunPod/OAS traces inspected 2026-07-11 KST; confidence High.