### PR TITLE
[DO NOT MERGE] keeper terminal append experiment (superseded by #24191)

### DIFF
--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -50,6 +50,10 @@ let message_request_status_to_string = function
   | Lost -> "lost"
   | Cancelled -> "cancelled"
 
+let message_request_status_is_success = function
+  | Accepted | Queued | Running | Done -> true
+  | Failed | Lost | Cancelled -> false
+
 let message_request_status_of_string = function
   | "accepted" -> Some Accepted
   | "queued" -> Some Queued

--- a/lib/gate/gate_protocol.mli
+++ b/lib/gate/gate_protocol.mli
@@ -65,6 +65,11 @@ type message_request = {
 }
 
 val message_request_status_to_string : message_request_status -> string
+val message_request_status_is_success : message_request_status -> bool
+(** Canonical success projection for request envelopes and terminal events.
+    Accepted/queued/running/done are non-failure states; failed/lost/cancelled
+    are failures. Callers must not carry a second independently-derived [ok]
+    bit. *)
 (** Parse the canonical status labels emitted by [keeper_msg_async].
     Unknown labels return [None] so callers fail closed instead of silently
     treating protocol drift as acceptance. *)

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -699,7 +699,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
 let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
+    ?(kind = Row_kind.Utterance) ?surface ?conversation_id ?audio ?blocks
+    ?turn_ref ?stream_lifecycle () :
     (unit, string) result =
   try
     ensure_dir_once ~base_dir;
@@ -710,8 +711,8 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
-        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+      encode_line ~role:Role.Assistant ~content ~ts ~kind ?surface
+        ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
     in
     Fs_compat.append_file path (line ^ "\n");
     Ok ()
@@ -730,10 +731,11 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
    failure is already counted + logged inside the [_result] variant). New callers
    that must surface the failure call [append_assistant_message_result] directly. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () =
+    ?(kind = Row_kind.Utterance) ?surface ?conversation_id ?audio ?blocks
+    ?turn_ref ?stream_lifecycle () =
   ignore
-    (append_assistant_message_result ~base_dir ~keeper_name ~content ?surface
-       ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+    (append_assistant_message_result ~base_dir ~keeper_name ~content ~kind
+       ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
       : (unit, string) result)
 
 (* RFC-0226: inbound user line recorded at delivery time, before (and

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -249,12 +249,15 @@ val append_turn :
 
 (** [append_assistant_message_result] is {!append_assistant_message} that
     returns [Error msg] on a write failure instead of swallowing it (the failure
-    is still counted + warn-logged). For callers whose own contract requires
-    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}. *)
+    is still counted + warn-logged). [kind] defaults to [Utterance]; terminal
+    transport paths pass [Transport_failure] so an assistant-only failure does
+    not advance the conversation watermark. For callers whose own contract
+    requires surfacing a chat-append failure — e.g. {!Fusion_sink.emit}. *)
 val append_assistant_message_result :
   base_dir:string ->
   keeper_name:string ->
   content:string ->
+  ?kind:Row_kind.t ->
   ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?audio:audio_clip ->
@@ -273,6 +276,7 @@ val append_assistant_message :
   base_dir:string ->
   keeper_name:string ->
   content:string ->
+  ?kind:Row_kind.t ->
   ?surface:Surface_ref.t ->
   ?conversation_id:string ->
   ?audio:audio_clip ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1231,14 +1231,15 @@ let start_keeper_loops
                    ; detail =
                        Printf.sprintf
                          "turn failed (%s): %s; terminal connector delivery also failed: %s"
-                         (queued_turn_failure_kind_to_string turn_kind)
+                         (turn_failure_kind_to_string turn_kind)
                          turn_detail delivery_detail
                    ; outcome_ref = None
                    }
              | Some (Failed { kind; detail }), Ok () ->
                  let kind =
                    match kind with
-                   | Turn_failed -> Keeper_chat_queue.Turn_failed
+                   | Turn_failed | Dispatch_failed ->
+                       Keeper_chat_queue.Turn_failed
                    | Turn_timed_out -> Keeper_chat_queue.Timed_out
                    | Turn_cancelled -> Keeper_chat_queue.Cancelled
                    | No_visible_reply

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1023,14 +1023,52 @@ let body_with_rewritten_payload ~fallback payload_json_opt =
   | Some (`Assoc _ as payload_json) -> Yojson.Safe.to_string payload_json
   | Some _ | None -> fallback
 
-let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
+type turn_failure_kind =
+  | Turn_failed
+  | Dispatch_failed
+  | Turn_timed_out
+  | Turn_cancelled
+  | No_visible_reply
+  | Continuation_checkpoint_without_reply
+  | Transcript_persist_failed
+  | Stream_projection_failed
+
+type turn_failure =
+  { kind : turn_failure_kind
+  ; detail : string
+  }
+
+type queued_turn_outcome =
+  | Delivered of { outcome_ref : string option }
+  | Failed of turn_failure
+
+let turn_failure_kind_to_string = function
+  | Turn_failed -> "turn_failed"
+  | Dispatch_failed -> "dispatch_failed"
+  | Turn_timed_out -> "turn_timed_out"
+  | Turn_cancelled -> "turn_cancelled"
+  | No_visible_reply -> "no_visible_reply"
+  | Continuation_checkpoint_without_reply ->
+      "continuation_checkpoint_without_reply"
+  | Transcript_persist_failed -> "transcript_persist_failed"
+  | Stream_projection_failed -> "stream_projection_failed"
+
+let transcript_persist_failure detail =
+  { kind = Transcript_persist_failed
+  ; detail =
+      Printf.sprintf "failed to persist terminal transcript: %s" detail
+  }
+
+let keeper_request_terminal_payload ~request_id ~keeper_name ~status
     ?(message = "") () =
+  let status_label = Gate_protocol.message_request_status_to_string status in
   let fields =
     [
       ("request_id", `String request_id);
       ("keeper_name", `String keeper_name);
-      ("status", `String status);
-      ("ok", `Bool ok);
+      ("status", `String status_label);
+      ( "ok"
+      , `Bool (Gate_protocol.message_request_status_is_success status) );
     ]
   in
   let fields =
@@ -1039,42 +1077,77 @@ let keeper_request_terminal_payload ~request_id ~keeper_name ~status ~ok
   in
   `Assoc fields
 
+let terminal_failure_stream_lifecycle =
+  [ Keeper_chat_store.Run_started
+  ; Keeper_chat_store.Text_message_start
+  ; Keeper_chat_store.Text_message_end
+  ; Keeper_chat_store.Run_error
+  ]
+
+let persist_terminal_failure ~base_path ~user_line_recorded_upstream ~payload
+    ~kind ~detail =
+  let chat_surface = chat_surface_of_request payload in
+  let chat_source = Surface_ref.lane_label chat_surface in
+  let chat_speaker = chat_speaker_of_request payload in
+  let content = persisted_error_reply detail in
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ChatTransportFailures)
+    ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
+    ();
+  let persisted =
+    if user_line_recorded_upstream then
+      Keeper_chat_store.append_assistant_message_result
+        ~base_dir:base_path
+        ~keeper_name:payload.name
+        ~content
+        ~kind:Keeper_chat_store.Row_kind.Transport_failure
+        ~surface:chat_surface
+        ~stream_lifecycle:terminal_failure_stream_lifecycle
+        ()
+    else
+      Keeper_chat_store.append_turn_result
+        ~base_dir:base_path
+        ~keeper_name:payload.name
+        ~user_content:payload.message
+        ~user_attachments:payload.attachments
+        ~surface:chat_surface
+        ~speaker:chat_speaker
+        ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+        ~assistant_content:content
+        ~stream_lifecycle:terminal_failure_stream_lifecycle
+        ()
+  in
+  match persisted with
+  | Ok () ->
+      Keeper_chat_broadcast.chat_appended ~keeper_name:payload.name
+        ~source:chat_source ~content ();
+      { kind; detail }
+  | Error detail -> transcript_persist_failure detail
+
+let terminal_of_worker_abort = function
+  | Keeper_msg_async.Timeout { timeout_sec } ->
+      ( Gate_protocol.Failed
+      , Turn_timed_out
+      , Printf.sprintf
+          "keeper_msg request exceeded timeout_sec=%.3f before completion"
+          timeout_sec )
+  | Keeper_msg_async.Worker_cancelled { cancelled_by; reason } ->
+      let cancelled_by =
+        Keeper_msg_async.worker_cancel_source_to_string cancelled_by
+      in
+      ( Gate_protocol.Cancelled
+      , Turn_cancelled
+      , Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by )
+
 type keeper_stream_worker_event =
   | Stream_event of Agent_sdk.Types.sse_event
   | Stream_client_disconnected
   | Stream_dashboard_queued of dashboard_deferred_chat
   | Stream_terminal of
-      { ok : bool
-      ; status : string
+      { status : Gate_protocol.message_request_status
       ; body : string
       ; queued_outcome : queued_turn_outcome option
       }
-
-and queued_turn_failure_kind =
-  | Turn_failed
-  | Turn_timed_out
-  | Turn_cancelled
-  | No_visible_reply
-  | Continuation_checkpoint_without_reply
-  | Transcript_persist_failed
-  | Stream_projection_failed
-
-and queued_turn_outcome =
-  | Delivered of { outcome_ref : string option }
-  | Failed of
-      { kind : queued_turn_failure_kind
-      ; detail : string
-      }
-
-let queued_turn_failure_kind_to_string = function
-  | Turn_failed -> "turn_failed"
-  | Turn_timed_out -> "turn_timed_out"
-  | Turn_cancelled -> "turn_cancelled"
-  | No_visible_reply -> "no_visible_reply"
-  | Continuation_checkpoint_without_reply ->
-      "continuation_checkpoint_without_reply"
-  | Transcript_persist_failed -> "transcript_persist_failed"
-  | Stream_projection_failed -> "stream_projection_failed"
 
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
@@ -1114,13 +1187,6 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     ; Keeper_chat_store.Text_message_start
     ; Keeper_chat_store.Text_message_end
     ; Keeper_chat_store.Run_finished
-    ]
-  in
-  let errored_stream_lifecycle =
-    [ Keeper_chat_store.Run_started
-    ; Keeper_chat_store.Text_message_start
-    ; Keeper_chat_store.Text_message_end
-    ; Keeper_chat_store.Run_error
     ]
   in
   let args = args_of_request payload in
@@ -1210,57 +1276,13 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~speaker:chat_speaker
         ()
   in
-  let persist_failure_reply err =
-    (* The failure marker is typed, not an utterance: it renders for the
-       operator but does not advance the lane watermark, so the user
-       message it failed to answer stays pending for the keeper's next
-       turn — and the keeper never reads the error as its own words. *)
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ChatTransportFailures)
-      ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
-      ();
-    (* RFC-connector-deferred-reply-via-chat-queue §3.4: the failure must be
-       DURABLE on both paths — a post-ACK deferred turn that fails must not
-       vanish on restart/replay (counter + live broadcast alone is silent
-       failure under this feature's "queued, will answer" contract).
-       - Dashboard route ([recorded_upstream = false]): the turn owns the user
-         line, so record the paired [Transport_failure] row (user message stays
-         pending for the next turn; keeper never reads the error as its words).
-       - Connector route ([recorded_upstream = true]): the gate inbound boundary
-         already persisted the user line (assistant-less). The paired
-         [append_turn] would double-record that user line, so persist an
-         assistant-only durable failure marker instead — the failure survives a
-         restart and stays joined to the already-pending user line. *)
-    let persisted =
-      if connector_user_line_recorded_upstream then
-       Keeper_chat_store.append_assistant_message_result
-         ~base_dir:base_path
-         ~keeper_name:payload.name
-         ~content:(persisted_error_reply err)
-         ~surface:chat_surface
-         ~stream_lifecycle:errored_stream_lifecycle
-         ()
-      else
-       Keeper_chat_store.append_turn_result
-         ~base_dir:base_path
-         ~keeper_name:payload.name
-         ~user_content:payload.message
-         ~user_attachments:payload.attachments
-         ~surface:chat_surface
-         ~speaker:chat_speaker
-         ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
-         ~assistant_content:(persisted_error_reply err)
-         ~stream_lifecycle:errored_stream_lifecycle
-         ()
-    in
-    (match persisted with
-     | Ok () ->
-         Keeper_chat_broadcast.chat_appended
-           ~keeper_name:payload.name ~source:chat_source
-           ~content:(persisted_error_reply err)
-           ()
-     | Error _ -> ());
-    persisted
+  let persist_failure_reply ~kind detail =
+    persist_terminal_failure ~base_path
+      ~user_line_recorded_upstream:connector_user_line_recorded_upstream
+      ~payload ~kind ~detail
+  in
+  let queued_outcome_of_failure failure =
+    if queued_turn then Some (Failed failure) else None
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let dashboard_direct_stream =
@@ -1276,35 +1298,13 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
      sites (never inside the cancelled [f]) so this turn still gets exactly
      one terminal event via the same serialized [push_worker_event]. *)
   let on_worker_aborted (reason : Keeper_msg_async.worker_abort_reason) =
-    let status, body, failure_kind =
-      match reason with
-      | Keeper_msg_async.Timeout { timeout_sec } ->
-          ( "timeout"
-          , Printf.sprintf
-              "keeper_msg request exceeded timeout_sec=%.3f before completion"
-              timeout_sec
-          , Turn_timed_out )
-      | Keeper_msg_async.Worker_cancelled { cancelled_by; reason } ->
-          let cancelled_by =
-            Keeper_msg_async.worker_cancel_source_to_string cancelled_by
-          in
-          ( "cancelled"
-          , Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
-          , Turn_cancelled )
-    in
+    let status, failure_kind, body = terminal_of_worker_abort reason in
+    let failure = persist_failure_reply ~kind:failure_kind body in
     let queued_outcome =
-      if not queued_turn then None
-      else
-        match persist_failure_reply body with
-        | Ok () -> Some (Failed { kind = failure_kind; detail = body })
-        | Error persist_error ->
-            Some
-              (Failed
-                 { kind = Transcript_persist_failed
-                 ; detail = persist_error
-                 })
+      queued_outcome_of_failure failure
     in
-    push_worker_event (Stream_terminal { ok = false; status; body; queued_outcome })
+    push_worker_event
+      (Stream_terminal { status; body = failure.detail; queued_outcome })
   in
   let request_id =
     Keeper_msg_async.submit ?timeout_sec ~clock ~sw ~on_worker_aborted
@@ -1412,24 +1412,14 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  visible_reply
              with
              | Some err ->
+                 let failure = persist_failure_reply ~kind:Turn_failed err in
                  let queued_outcome =
-                   if not queued_turn then None
-                   else
-                     match persist_failure_reply err with
-                     | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                     | Error persist_error ->
-                         Some
-                           (Failed
-                              { kind = Transcript_persist_failed
-                              ; detail = persist_error
-                              })
+                   queued_outcome_of_failure failure
                  in
-                 if not queued_turn then ignore (persist_failure_reply err : (unit, string) result);
                  push_worker_event
                    (Stream_terminal
-                      { ok = false
-                      ; status = "error"
-                      ; body = err
+                      { status = Gate_protocol.Failed
+                      ; body = failure.detail
                       ; queued_outcome
                       });
                  Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
@@ -1464,49 +1454,25 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                    | Ok () ->
                        Keeper_chat_broadcast.chat_appended
                          ~keeper_name:payload.name ~source:chat_source ?content ();
-                       if queued_turn
-                       then
-                         Some
-                           (Delivered
-                              { outcome_ref =
-                                  Option.map Ids.Turn_ref.to_string turn_ref
-                              })
-                       else None
+                       `Delivered (Option.map Ids.Turn_ref.to_string turn_ref)
                    | Error persist_error ->
-                       if queued_turn
-                       then
-                         Some
-                           (Failed
-                              { kind = Transcript_persist_failed
-                              ; detail = persist_error
-                              })
-                       else None
+                       `Failed (transcript_persist_failure persist_error)
                  in
                  let turn_outcome =
                    Keeper_turn_outcome.of_reply_payload payload_json_opt
                  in
-                 let queued_outcome =
+                 let turn_completion =
                    match turn_outcome, String_util.trim_to_option visible_reply with
                    | Keeper_turn_outcome.Continuation_checkpoint, _ when queued_turn ->
                        let detail =
                          "queued turn ended with a continuation checkpoint and no delivered reply"
                        in
-                       (match persist_failure_reply detail with
-                        | Ok () ->
-                            Some
-                              (Failed
-                                 { kind = Continuation_checkpoint_without_reply
-                                 ; detail
-                                 })
-                        | Error persist_error ->
-                            Some
-                              (Failed
-                                 { kind = Transcript_persist_failed
-                                 ; detail = persist_error
-                                 }))
+                       `Failed
+                         (persist_failure_reply
+                            ~kind:Continuation_checkpoint_without_reply detail)
                    | Keeper_turn_outcome.Continuation_checkpoint, _ ->
                        persist_user_message_only ();
-                       None
+                       `Direct_deferred
                    | Keeper_turn_outcome.No_visible_reply, _
                    | Keeper_turn_outcome.Visible_reply, None ->
                        if has_visible_blocks
@@ -1518,75 +1484,71 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                          let detail =
                            "no visible reply was produced for this queued message"
                          in
-                         (match persist_failure_reply detail with
-                          | Ok () -> Some (Failed { kind = No_visible_reply; detail })
-                          | Error persist_error ->
-                              Some
-                                (Failed
-                                   { kind = Transcript_persist_failed
-                                   ; detail = persist_error
-                                   }))
+                         `Failed
+                           (persist_failure_reply ~kind:No_visible_reply detail)
                        else (
                          persist_user_message_only ();
-                         None)
+                         `Direct_deferred)
                    | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                        persist_assistant_reply ~assistant_content:visible_reply
                        |> delivered_after_persist ~content:visible_reply
                  in
-                 (match queued_outcome with
-                  | Some (Failed { detail; _ }) ->
+                 (match turn_completion with
+                  | `Failed ({ detail; _ } as failure) ->
+                      let queued_outcome =
+                        queued_outcome_of_failure failure
+                      in
                       push_worker_event
                         (Stream_terminal
-                           { ok = false
-                           ; status = "error"
+                           { status = Gate_protocol.Failed
                            ; body = detail
                            ; queued_outcome
                            });
                       Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
-                  | Some (Delivered _) | None ->
+                  | `Delivered outcome_ref ->
+                      let queued_outcome =
+                        if queued_turn
+                        then Some (Delivered { outcome_ref })
+                        else None
+                      in
                       push_worker_event
                         (Stream_terminal
-                           { ok = true
-                           ; status = "done"
+                           { status = Gate_protocol.Done
                            ; body
                            ; queued_outcome
                            });
+                      Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
+                  | `Direct_deferred ->
+                      push_worker_event
+                        (Stream_terminal
+                           { status = Gate_protocol.Done
+                           ; body
+                           ; queued_outcome = None
+                           });
                       Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body))
         | Ok (`Ran (false, err)) ->
-            let persisted = persist_failure_reply err in
+            let failure = persist_failure_reply ~kind:Dispatch_failed err in
             let queued_outcome =
-              if not queued_turn then None
-              else
-                match persisted with
-                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                | Error persist_error ->
-                    Some
-                      (Failed
-                         { kind = Transcript_persist_failed
-                         ; detail = persist_error
-                         })
+              queued_outcome_of_failure failure
             in
             push_worker_event
               (Stream_terminal
-                 { ok = false; status = "error"; body = err; queued_outcome });
+                 { status = Gate_protocol.Failed
+                 ; body = failure.detail
+                 ; queued_outcome
+                 });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | Error err ->
-            let persisted = persist_failure_reply err in
+            let failure = persist_failure_reply ~kind:Dispatch_failed err in
             let queued_outcome =
-              if not queued_turn then None
-              else
-                match persisted with
-                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                | Error persist_error ->
-                    Some
-                      (Failed
-                         { kind = Transcript_persist_failed
-                         ; detail = persist_error
-                         })
+              queued_outcome_of_failure failure
             in
             push_worker_event
               (Stream_terminal
-                 { ok = false; status = "error"; body = err; queued_outcome });
+                 { status = Gate_protocol.Failed
+                 ; body = failure.detail
+                 ; queued_outcome
+                 });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
       ()
   in
@@ -1638,20 +1600,22 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  ];
              }
        });
-  let publish_terminal ~status ~ok ?(message = "") () =
+  let publish_terminal ~status ?(message = "") () =
     let message = redact_text message in
+    let status_label = Gate_protocol.message_request_status_to_string status in
+    let ok = Gate_protocol.message_request_status_is_success status in
     let payload_json =
       keeper_request_terminal_payload ~request_id ~keeper_name:payload.name
-        ~status ~ok ~message ()
+        ~status ~message ()
     in
-    if ok || String.equal status "cancelled" then
+    if ok || Gate_protocol.(status = Cancelled) then
       Log.Keeper.info
         "keeper_stream: request terminal keeper=%s request_id=%s status=%s"
-        payload.name request_id status
+        payload.name request_id status_label
     else
       Log.Keeper.warn
         "keeper_stream: request terminal keeper=%s request_id=%s status=%s message=%s"
-        payload.name request_id status message;
+        payload.name request_id status_label message;
       Keeper_chat_events.publish events
         (Custom { name = "KEEPER_REQUEST_TERMINAL"; value = payload_json })
   in
@@ -1672,7 +1636,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         let message =
           dashboard_deferred_ack_text ~keeper_name:payload.name queued
         in
-        publish_terminal ~status:"queued" ~ok:true ~message ();
+        publish_terminal ~status:Gate_protocol.Queued ~message ();
         Keeper_chat_events.publish events (Text_delta message);
         Keeper_chat_events.publish events
           (Custom
@@ -1683,23 +1647,31 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         Keeper_chat_events.publish events (Run_finished { run_id });
         None
     | Stream_terminal
-        { ok = false
-        ; status = "cancelled"
+        { status = Gate_protocol.Cancelled
         ; body = message
         ; queued_outcome
         } ->
         let message = redact_text message in
-        publish_terminal ~status:"cancelled" ~ok:false ~message ();
+        publish_terminal ~status:Gate_protocol.Cancelled ~message ();
         Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Run_finished { run_id });
         queued_outcome
-    | Stream_terminal { ok = false; status; body = err; queued_outcome } ->
+    | Stream_terminal
+        { status = Gate_protocol.Failed; body = err; queued_outcome } ->
         let err = redact_text err in
-        publish_terminal ~status ~ok:false ~message:err ();
+        publish_terminal ~status:Gate_protocol.Failed ~message:err ();
         Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Event_error { message = err });
         queued_outcome
-    | Stream_terminal { ok = true; body; queued_outcome; _ } -> (
+    | Stream_terminal
+        { status = Gate_protocol.Lost; body = err; queued_outcome } ->
+        let err = redact_text err in
+        publish_terminal ~status:Gate_protocol.Lost ~message:err ();
+        Keeper_chat_events.publish events Text_message_end;
+        Keeper_chat_events.publish events (Event_error { message = err });
+        queued_outcome
+    | Stream_terminal
+        { status = Gate_protocol.Done; body; queued_outcome } -> (
         try
           let payload_json_opt, visible_reply = extract_visible_reply body in
           let visible_reply =
@@ -1748,7 +1720,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                        [ ("request_id", `String request_id);
                          ("message", `String visible_reply) ]
                  });
-          publish_terminal ~status:"done" ~ok:true ();
+          publish_terminal ~status:Gate_protocol.Done ();
           Keeper_chat_events.publish events Text_message_end;
           Keeper_chat_events.publish events (Run_finished { run_id });
           queued_outcome
@@ -1756,13 +1728,38 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
             let message = redact_text (Printexc.to_string exn) in
-            publish_terminal ~status:"error" ~ok:false ~message ();
+            let failure =
+              persist_terminal_failure ~base_path
+                ~user_line_recorded_upstream:true ~payload
+                ~kind:Stream_projection_failed ~detail:message
+            in
+            let queued_outcome = queued_outcome_of_failure failure in
+            let message = failure.detail in
+            publish_terminal ~status:Gate_protocol.Failed ~message ();
             Keeper_chat_events.publish events Text_message_end;
             Keeper_chat_events.publish events
               (Event_error { message });
-            if queued_turn
-            then Some (Failed { kind = Stream_projection_failed; detail = message })
-            else None)
+            queued_outcome)
+    | Stream_terminal
+        { status =
+            ( Gate_protocol.Accepted
+            | Gate_protocol.Queued
+            | Gate_protocol.Running )
+        ; body = _
+        ; queued_outcome = _
+        } ->
+        let message =
+          "keeper stream terminal event carried a non-terminal Gate status"
+        in
+        let failure =
+          persist_failure_reply ~kind:Stream_projection_failed message
+        in
+        let queued_outcome = queued_outcome_of_failure failure in
+        let message = failure.detail in
+        publish_terminal ~status:Gate_protocol.Failed ~message ();
+        Keeper_chat_events.publish events Text_message_end;
+        Keeper_chat_events.publish events (Event_error { message });
+        queued_outcome
   in
   match consume_worker_events empty_keeper_stream_bridge_state with
   | outcome ->
@@ -2163,6 +2160,8 @@ module For_testing = struct
   let turn_instructions_for_request = turn_instructions_for_request
   let args_of_request = args_of_request
   let modalities_for_request = modalities_for_request
+  let persist_terminal_failure = persist_terminal_failure
+  let terminal_of_worker_abort = terminal_of_worker_abort
   let defer_dashboard_payload_if_busy ~base_path ~clock payload =
     match defer_dashboard_payload_if_busy ~base_path ~clock payload with
     | `Not_busy -> `Not_busy

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -157,23 +157,31 @@ val handle_keeper_chat_stream :
 
 (** {1 Turn execution (shared between HTTP handler and queue consumer)} *)
 
-type queued_turn_failure_kind =
+type turn_failure_kind =
   | Turn_failed
+  | Dispatch_failed
   | Turn_timed_out
   | Turn_cancelled
   | No_visible_reply
   | Continuation_checkpoint_without_reply
   | Transcript_persist_failed
   | Stream_projection_failed
+(** Typed cause shared by direct and queued turn failure persistence. The queue
+    receipt projection maps this type to {!Keeper_chat_queue.failure_kind}; it
+    does not own the transcript failure contract. *)
+
+type turn_failure =
+  { kind : turn_failure_kind
+  ; detail : string
+  }
 
 type queued_turn_outcome =
   | Delivered of { outcome_ref : string option }
-  | Failed of
-      { kind : queued_turn_failure_kind
-      ; detail : string
-      }
+  | Failed of turn_failure
+(** Queue-receipt outcome only. Direct turns return [None] after publishing
+    their typed terminal event; they still persist the same transcript failure. *)
 
-val queued_turn_failure_kind_to_string : queued_turn_failure_kind -> string
+val turn_failure_kind_to_string : turn_failure_kind -> string
 
 val process_single_turn :
   connector_user_line_recorded_upstream:bool ->
@@ -202,22 +210,29 @@ val process_single_turn :
     cancel the accepted request. [auth_token] is [None] for queue-consumer
     turns where no HTTP request is available.
 
-    [connector_user_line_recorded_upstream] (default [false]) tells the turn
+    [connector_user_line_recorded_upstream] tells the turn
     that the inbound user line was already persisted by the gate inbound
     boundary ([Gate_keeper_backend.dispatch_core], RFC-0226 sole-recorder).
     When [true] the turn records the assistant reply only and never re-writes
     the user line — set by the queue consumer for connector ([Discord]/[Slack])
     sources whose busy message was enqueued after the gate already recorded it
     (RFC-connector-deferred-reply-via-chat-queue §3.4). [false] keeps the dashboard-route behaviour of recording
-    both sides.
+    both sides. For a direct request, {!Keeper_msg_async.submit} durably records
+    acceptance before returning its request id; the chat store then appends the
+    user row and terminal assistant row together in one payload. A timeout or
+    cancellation therefore cannot leave the chat transcript with an unpaired,
+    falsely successful assistant row.
 
-    [queued_turn] (default [false], set [true] only by
-    [Server_bootstrap_loops]'s queue-consumer [handle_turn] wiring) changes
-    ONLY the [No_visible_reply]/empty-[Visible_reply] outcome: the
+    [queued_turn] (set [true] only by [Server_bootstrap_loops]'s
+    queue-consumer [handle_turn] wiring) changes the queue-receipt return value
+    and the [No_visible_reply]/empty-[Visible_reply] outcome: the
     interactive HTTP stream keeps recording the user line only
     ([persist_user_message_only]), matching its existing "the keeper will
     answer on the next turn" semantics; a queued turn instead persists a
-    typed failure row via [persist_failure_reply]. A queued message was
+    typed failure row. Timeout, cancellation, dispatch, transcript, and stream
+    projection failures use that same persistence path for direct and queued
+    turns; only the receipt outcome remains conditional on [queued_turn]. A
+    queued message was
     already leased from [Keeper_chat_queue] — there is no "next turn" for
     it to ride along with, so silence here is terminal, not merely
     deferred. *)
@@ -246,6 +261,16 @@ module For_testing : sig
   val args_of_request : keeper_chat_stream_request -> Yojson.Safe.t
   val modalities_for_request : keeper_chat_stream_request -> string list
   val keeper_chat_stream_headers : string -> Httpun.Headers.t
+  val persist_terminal_failure :
+    base_path:string ->
+    user_line_recorded_upstream:bool ->
+    payload:keeper_chat_stream_request ->
+    kind:turn_failure_kind ->
+    detail:string ->
+    turn_failure
+  val terminal_of_worker_abort :
+    Keeper_msg_async.worker_abort_reason ->
+    Gate_protocol.message_request_status * turn_failure_kind * string
   val defer_dashboard_payload_if_busy :
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -283,6 +283,24 @@ let test_message_request_status_of_string () =
   check_status_parse "cancelled" "cancelled" (Some Gate_protocol.Cancelled);
   check_status_parse "unknown fails closed" "finished" None
 
+let test_message_request_status_success_projection () =
+  List.iter
+    (fun status ->
+      check bool
+        (Gate_protocol.message_request_status_to_string status)
+        true (Gate_protocol.message_request_status_is_success status))
+    [ Gate_protocol.Accepted
+    ; Gate_protocol.Queued
+    ; Gate_protocol.Running
+    ; Gate_protocol.Done
+    ];
+  List.iter
+    (fun status ->
+      check bool
+        (Gate_protocol.message_request_status_to_string status)
+        false (Gate_protocol.message_request_status_is_success status))
+    [ Gate_protocol.Failed; Gate_protocol.Lost; Gate_protocol.Cancelled ]
+
 let () =
   Alcotest.run "Gate_protocol"
     [
@@ -320,5 +338,7 @@ let () =
           test_case "gate error strings" `Quick test_gate_error_strings;
           test_case "message request status parse" `Quick
             test_message_request_status_of_string;
+          test_case "message request status success projection" `Quick
+            test_message_request_status_success_projection;
         ] );
     ]

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -3,6 +3,7 @@ module B = Masc.Keeper_chat_blocks
 module MS = Masc.Keeper_world_observation_message_scope
 module P = Masc.Otel_metric_store
 module KT = Masc.Keeper_turn
+module Keeper_stream = Server_routes_http_keeper_stream
 
 let rec remove_tree path =
   if Sys.file_exists path then
@@ -865,6 +866,99 @@ let test_failure_turn_kind_roundtrip () =
             (contains_substring raw {|"kind":"transport_failure"|})
       | messages ->
           Alcotest.failf "expected 2 rows, got %d" (List.length messages))
+
+let terminal_failure_payload keeper_name : Keeper_stream.keeper_chat_stream_request =
+  { name = keeper_name
+  ; message = "inspect the source"
+  ; user_blocks = []
+  ; timeout_sec = Some 300
+  ; turn_instructions = None
+  ; surface_context = None
+  ; channel = ""
+  ; channel_user_id = ""
+  ; channel_user_name = ""
+  ; channel_workspace_id = ""
+  ; attachments = []
+  }
+
+let check_transport_failure_rows ~base_dir ~keeper_name ~expected_count =
+  let messages = K.load ~base_dir ~keeper_name in
+  Alcotest.(check int) "row count" expected_count (List.length messages);
+  match List.rev messages with
+  | assistant :: _ ->
+      Alcotest.(check bool) "terminal row is a transport failure" true
+        (K.Row_kind.equal assistant.kind K.Row_kind.Transport_failure)
+  | [] -> Alcotest.fail "terminal failure did not persist a chat row"
+
+let test_direct_terminal_failure_persists_atomic_user_pair () =
+  let base_dir = temp_base_path "keeper-chat-direct-terminal-failure" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-direct-terminal-failure" in
+      let payload = terminal_failure_payload keeper_name in
+      let failure =
+        Keeper_stream.For_testing.persist_terminal_failure ~base_path:base_dir
+          ~user_line_recorded_upstream:false ~payload
+          ~kind:Keeper_stream.Turn_timed_out
+          ~detail:"keeper request timed out"
+      in
+      (match failure.kind with
+       | Keeper_stream.Turn_timed_out -> ()
+       | kind ->
+           Alcotest.failf "unexpected terminal failure kind: %s"
+             (Keeper_stream.turn_failure_kind_to_string kind));
+      check_transport_failure_rows ~base_dir ~keeper_name ~expected_count:2;
+      match K.load ~base_dir ~keeper_name with
+      | user :: _ ->
+          Alcotest.(check string) "direct user row survives timeout"
+            payload.message user.content
+      | [] -> Alcotest.fail "direct user row was not persisted")
+
+let test_upstream_terminal_failure_is_typed_without_duplicate_user () =
+  let base_dir = temp_base_path "keeper-chat-upstream-terminal-failure" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-upstream-terminal-failure" in
+      let payload = terminal_failure_payload keeper_name in
+      K.append_user_message ~base_dir ~keeper_name ~content:payload.message ();
+      ignore
+        (Keeper_stream.For_testing.persist_terminal_failure ~base_path:base_dir
+           ~user_line_recorded_upstream:true ~payload
+           ~kind:Keeper_stream.Turn_cancelled
+           ~detail:"keeper request was cancelled"
+          : Keeper_stream.turn_failure);
+      check_transport_failure_rows ~base_dir ~keeper_name ~expected_count:2)
+
+let test_worker_timeout_uses_gate_failed_status () =
+  let status, kind, _detail =
+    Keeper_stream.For_testing.terminal_of_worker_abort
+      (Masc.Keeper_msg_async.Timeout { timeout_sec = 300.0 })
+  in
+  Alcotest.(check string) "timeout wire status comes from Gate protocol"
+    "error" (Gate_protocol.message_request_status_to_string status);
+  match kind with
+  | Keeper_stream.Turn_timed_out -> ()
+  | kind ->
+      Alcotest.failf "unexpected timeout failure kind: %s"
+        (Keeper_stream.turn_failure_kind_to_string kind)
+
+let test_worker_cancel_uses_gate_cancelled_status () =
+  let status, kind, _detail =
+    Keeper_stream.For_testing.terminal_of_worker_abort
+      (Masc.Keeper_msg_async.Worker_cancelled
+         { cancelled_by = Masc.Keeper_msg_async.Operator_request
+         ; reason = "operator interrupted the turn"
+         })
+  in
+  Alcotest.(check string) "cancel wire status comes from Gate protocol"
+    "cancelled" (Gate_protocol.message_request_status_to_string status);
+  match kind with
+  | Keeper_stream.Turn_cancelled -> ()
+  | kind ->
+      Alcotest.failf "unexpected cancel failure kind: %s"
+        (Keeper_stream.turn_failure_kind_to_string kind)
 
 let test_kind_absent_reads_utterance () =
   (* Every row written before the [kind] field existed is an utterance;
@@ -1899,6 +1993,16 @@ let () =
         [
           Alcotest.test_case "failure turn kind roundtrip" `Quick
             test_failure_turn_kind_roundtrip;
+          Alcotest.test_case
+            "direct terminal failure persists atomic user pair" `Quick
+            test_direct_terminal_failure_persists_atomic_user_pair;
+          Alcotest.test_case
+            "upstream terminal failure is typed without duplicate user" `Quick
+            test_upstream_terminal_failure_is_typed_without_duplicate_user;
+          Alcotest.test_case "worker timeout uses gate failed status" `Quick
+            test_worker_timeout_uses_gate_failed_status;
+          Alcotest.test_case "worker cancel uses gate cancelled status" `Quick
+            test_worker_cancel_uses_gate_cancelled_status;
           Alcotest.test_case "absent kind reads utterance" `Quick
             test_kind_absent_reads_utterance;
           Alcotest.test_case "unknown kind reported, reads utterance" `Quick


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE.** Adversarial review found that this patch adds terminal appends without the durable identity and transaction needed to make them correct. Superseded by #24191.

This PR was stacked on #24139 and attempted to persist direct/queued timeout, cancellation, dispatch, and projection failures. The implementation is intentionally closed rather than extended because its API shape would preserve unsafe cross-store ordering.

## Confirmed blockers

1. Direct acceptance does not durably commit the user transcript. `Keeper_msg_async` persists a payload-free request record, and its save failure is only warn-logged.
2. Timeout/cancel polling state is terminal before the transcript callback. A later transcript persistence failure cannot replace that already-committed status.
3. Chat rows have no typed request/receipt idempotency key. Abort callback, cancellation, broadcast, or restart can append duplicate terminal rows.
4. Queue receipt IDs are discarded when `Keeper_chat_consumer` passes merged content to `process_single_turn`, so at-least-once replay cannot deduplicate transcripts.
5. Intermediate `Stream_event` translation/publication exceptions bypass the terminal projection catch.
6. Direct continuation/no-visible paths use a unit-returning user append and can emit `Done` after a silent failure.

The interim additions here must not be cherry-picked. The replacement design in #24191 introduces one typed delivery identity, an authoritative BasePath-owned journal, expected-phase transitions, idempotent transcript projection, receipt provenance through the turn boundary, and recovery that does not rerun inference after a terminal result exists. It also defines the shared primitive/semantic split with #24180 so MASC does not create two delivery SSOTs.

## Evidence-only validation history

- Latest head: `5210369a0f38d1c3b624245fcb298b7c636cab59`
- Formatting/diff guards passed.
- Earlier CI runs exposed and fixed two test-module qualification errors, but no completed full run establishes correctness.
- Green ancillary checks do not address the lifecycle blockers above.

[근거] Current source inspection of `Keeper_chat_store`, `Keeper_msg_async`, `Keeper_chat_queue`, `Keeper_chat_consumer`, `process_single_turn`, and PR #24139; 확인일시 2026-07-11 20:01 KST; 신뢰도 High.
