### PR TITLE
feat(keeper): typed Shell IR docker env passthrough

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -151,9 +151,13 @@ let rec resolve_arg = function
 
 let resolve_env env_bindings =
   List.map
-    (fun (k, v) -> k ^ "=" ^ resolve_arg v)
+    (fun (key, value) ->
+      { Sandbox_target.key; value = resolve_arg value })
     env_bindings
   |> Array.of_list
+
+let render_env_binding (binding : Sandbox_target.env_binding) =
+  binding.key ^ "=" ^ binding.value
 
 let env_key entry =
   match String.index_opt entry '=' with
@@ -164,7 +168,9 @@ let resolve_host_env ?base_host_env = function
   | [] -> base_host_env
   | env_bindings ->
       let overrides = resolve_env env_bindings |> Array.to_list in
-      let override_keys = List.map env_key overrides in
+      let override_keys =
+        List.map (fun (binding : Sandbox_target.env_binding) -> binding.key) overrides
+      in
       let base =
         match base_host_env with
         | Some env -> env
@@ -176,7 +182,7 @@ let resolve_host_env ?base_host_env = function
         |> List.filter (fun entry ->
           not (List.mem (env_key entry) override_keys))
       in
-      Some (Array.of_list (inherited @ overrides))
+      Some (Array.of_list (inherited @ List.map render_env_binding overrides))
 
 (* --- simple command execution --- *)
 

--- a/lib/exec/sandbox_target.ml
+++ b/lib/exec/sandbox_target.ml
@@ -30,18 +30,23 @@
    [Exec_gate.run_argv_with_status_split], and [Docker] via the carried
    [runner]. *)
 
+type env_binding =
+  { key : string
+  ; value : string
+  }
+
 type runner =
   on_stdout_chunk:(string -> unit) option ->
   on_stderr_chunk:(string -> unit) option ->
   stdin_content:string option ->
   argv:string list ->
-  env:string array ->
+  env:env_binding array ->
   cwd:string option ->
   Unix.process_status * string * string
 
 type pipeline_stage = {
   argv : string list;
-  env : string array;
+  env : env_binding array;
   cwd : string option;
 }
 

--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -10,6 +10,14 @@
     directly to [Exec_gate], avoiding a circular dependency between
     [Sandbox_target] and [Exec_gate]. *)
 
+(** A resolved environment binding. Keeping the key and value structured
+    prevents sandbox backends from reparsing ["K=V"] strings or accepting
+    Docker's bare-key host-environment import form. *)
+type env_binding =
+  { key : string
+  ; value : string
+  }
+
 (** A runner closure executes an argv with the given env / cwd and returns
     the raw process status plus stdout/stderr buffers. Exceptions are
     propagated; callers in [Exec_dispatch] catch and translate them into
@@ -19,13 +27,13 @@ type runner =
   on_stderr_chunk:(string -> unit) option ->
   stdin_content:string option ->
   argv:string list ->
-  env:string array ->
+  env:env_binding array ->
   cwd:string option ->
   Unix.process_status * string * string
 
 type pipeline_stage = {
   argv : string list;
-  env : string array;
+  env : env_binding array;
   cwd : string option;
 }
 

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -269,10 +269,19 @@ val docker_sandbox_env_args
     override a sandbox invariant. *)
 val docker_sandbox_reserved_env_keys : string list
 
-(** Keeper-supplied env entries ("K=V", already resolved by the Shell IR
-    dispatch) as [docker exec] argv flags. Callers must reject entries whose
-    key is in [docker_sandbox_reserved_env_keys] first. *)
-val docker_keeper_env_args : string list -> string list
+type docker_keeper_env_error =
+  | Invalid_key of string
+  | Duplicate_key of string
+  | Reserved_key of string
+
+val docker_keeper_env_error_to_string : docker_keeper_env_error -> string
+
+(** Validate structured keeper bindings at the final Docker argv boundary and
+    render them as [--env K=V] pairs. Reserved, duplicate, and invalid keys are
+    typed errors; Docker's bare-key host import form is unrepresentable. *)
+val docker_keeper_env_args
+  :  Masc_exec.Sandbox_target.env_binding list
+  -> (string list, docker_keeper_env_error) result
 
 (** Docker [-v ...] argv fragment that supplies passwd/group entries for
     the numeric host uid/gid used inside the keeper container. *)

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -262,6 +262,18 @@ val docker_sandbox_env_args
   -> container_root:string
   -> string list
 
+(** Env keys the docker exec boundary itself owns (container identity plus
+    config projection). Keeper-supplied Shell IR env entries whose key is in
+    this list are rejected with a typed error before dispatch: [docker exec]
+    resolves duplicate [--env] flags last-wins, so a collision would silently
+    override a sandbox invariant. *)
+val docker_sandbox_reserved_env_keys : string list
+
+(** Keeper-supplied env entries ("K=V", already resolved by the Shell IR
+    dispatch) as [docker exec] argv flags. Callers must reject entries whose
+    key is in [docker_sandbox_reserved_env_keys] first. *)
+val docker_keeper_env_args : string list -> string list
+
 (** Docker [-v ...] argv fragment that supplies passwd/group entries for
     the numeric host uid/gid used inside the keeper container. *)
 val docker_user_identity_mount_args

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -307,15 +307,48 @@ let docker_masc_runtime_env_args ~container_root =
   |> List.concat_map (fun (key, value) -> [ "--env"; key ^ "=" ^ value ])
 ;;
 
+(* Container identity env keys owned by [docker_user_env_args]. *)
+let sandbox_env_key_home = "HOME"
+let sandbox_env_key_user = "USER"
+let sandbox_env_key_logname = "LOGNAME"
+let sandbox_env_key_shell = "SHELL"
+
+(* Env keys the docker exec boundary itself owns: container identity
+   ([docker_user_env_args]) plus the mounted config projection
+   ([docker_config_env_args]). Keeper-supplied Shell IR env entries must
+   not shadow these — [docker exec] resolves duplicate [--env] flags
+   last-wins, so a collision would silently override a sandbox
+   invariant. Shell IR dispatch rejects colliding keys with a typed
+   error instead (see [Keeper_sandbox_shell_ir_target]). The builders
+   below consume the same constants, so this list cannot drift from
+   what is actually injected. *)
+let docker_sandbox_reserved_env_keys =
+  [ sandbox_env_key_home
+  ; sandbox_env_key_user
+  ; sandbox_env_key_logname
+  ; sandbox_env_key_shell
+  ; Env_config_core.base_path_env_key
+  ; Env_config_core.base_path_input_env_key
+  ; Env_config_core.config_dir_env_key
+  ]
+;;
+
+(* Keeper-supplied env entries ("K=V", already resolved by the Shell IR
+   dispatch) as [docker exec] argv flags. Callers must reject entries
+   whose key is in [docker_sandbox_reserved_env_keys] first. *)
+let docker_keeper_env_args entries =
+  List.concat_map (fun entry -> [ "--env"; entry ]) entries
+;;
+
 let docker_user_env_args () =
   [ "--env"
-  ; "HOME=/tmp"
+  ; sandbox_env_key_home ^ "=/tmp"
   ; "--env"
-  ; "USER=keeper"
+  ; sandbox_env_key_user ^ "=keeper"
   ; "--env"
-  ; "LOGNAME=keeper"
+  ; sandbox_env_key_logname ^ "=keeper"
   ; "--env"
-  ; "SHELL=/bin/sh"
+  ; sandbox_env_key_shell ^ "=/bin/sh"
   ]
 ;;
 
@@ -421,11 +454,11 @@ let docker_config_env_args ~base_path ~container_root =
     let container_config_root = docker_config_container_root ~container_root in
     let container_base_path = container_masc_runtime_base ~container_root in
     [ "--env"
-    ; "MASC_BASE_PATH=" ^ container_base_path
+    ; Env_config_core.base_path_env_key ^ "=" ^ container_base_path
     ; "--env"
-    ; "MASC_BASE_PATH_INPUT=" ^ container_base_path
+    ; Env_config_core.base_path_input_env_key ^ "=" ^ container_base_path
     ; "--env"
-    ; "MASC_CONFIG_DIR=" ^ container_config_root
+    ; Env_config_core.config_dir_env_key ^ "=" ^ container_config_root
     ]
 ;;
 

--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -333,11 +333,51 @@ let docker_sandbox_reserved_env_keys =
   ]
 ;;
 
-(* Keeper-supplied env entries ("K=V", already resolved by the Shell IR
-   dispatch) as [docker exec] argv flags. Callers must reject entries
-   whose key is in [docker_sandbox_reserved_env_keys] first. *)
+type docker_keeper_env_error =
+  | Invalid_key of string
+  | Duplicate_key of string
+  | Reserved_key of string
+
+let docker_keeper_env_error_to_string = function
+  | Invalid_key key ->
+    Printf.sprintf "invalid Docker keeper env key %S" key
+  | Duplicate_key key ->
+    Printf.sprintf "duplicate Docker keeper env key %S" key
+  | Reserved_key key ->
+    Printf.sprintf
+      "typed Shell IR Docker dispatch rejects env key %s: the sandbox exec boundary owns it"
+      key
+;;
+
+let docker_env_key_is_valid key =
+  let valid_start = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+    | _ -> false
+  in
+  let valid_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+    | _ -> false
+  in
+  String.length key > 0 && valid_start key.[0] && String.for_all valid_char key
+;;
+
+(* This is the final argv-construction boundary, so validation lives here
+   rather than relying on a particular caller. Structured bindings make the
+   Docker bare-key host import form unrepresentable. *)
 let docker_keeper_env_args entries =
-  List.concat_map (fun entry -> [ "--env"; entry ]) entries
+  let rec loop seen acc = function
+    | [] -> Ok (List.rev acc |> List.concat)
+    | ({ Masc_exec.Sandbox_target.key; value } : Masc_exec.Sandbox_target.env_binding)
+      :: rest ->
+      if not (docker_env_key_is_valid key)
+      then Error (Invalid_key key)
+      else if List.mem key seen
+      then Error (Duplicate_key key)
+      else if List.mem key docker_sandbox_reserved_env_keys
+      then Error (Reserved_key key)
+      else loop (key :: seen) ([ "--env"; key ^ "=" ^ value ] :: acc) rest
+  in
+  loop [] [] entries
 ;;
 
 let docker_user_env_args () =

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -108,6 +108,19 @@ val docker_masc_config_mount_args :
 val docker_masc_runtime_env_pairs :
   container_root:'a -> (string * string) list
 val docker_masc_runtime_env_args : container_root:'a -> string list
+
+(** Env keys the docker exec boundary itself owns (container identity plus
+    config projection). Keeper-supplied Shell IR env entries whose key is in
+    this list are rejected with a typed error before dispatch: [docker exec]
+    resolves duplicate [--env] flags last-wins, so a collision would silently
+    override a sandbox invariant. *)
+val docker_sandbox_reserved_env_keys : string list
+
+(** Keeper-supplied env entries ("K=V", already resolved by the Shell IR
+    dispatch) as [docker exec] argv flags. Callers must reject entries whose
+    key is in [docker_sandbox_reserved_env_keys] first. *)
+val docker_keeper_env_args : string list -> string list
+
 val docker_user_env_args : unit -> string list
 val trim_env_opt : string -> string option
 val docker_config_host_root : base_path:string -> string

--- a/lib/keeper/keeper_sandbox_runtime_setup.mli
+++ b/lib/keeper/keeper_sandbox_runtime_setup.mli
@@ -116,10 +116,19 @@ val docker_masc_runtime_env_args : container_root:'a -> string list
     override a sandbox invariant. *)
 val docker_sandbox_reserved_env_keys : string list
 
-(** Keeper-supplied env entries ("K=V", already resolved by the Shell IR
-    dispatch) as [docker exec] argv flags. Callers must reject entries whose
-    key is in [docker_sandbox_reserved_env_keys] first. *)
-val docker_keeper_env_args : string list -> string list
+type docker_keeper_env_error =
+  | Invalid_key of string
+  | Duplicate_key of string
+  | Reserved_key of string
+
+val docker_keeper_env_error_to_string : docker_keeper_env_error -> string
+
+(** Validate structured keeper bindings at the final Docker argv boundary and
+    render them as [--env K=V] pairs. Reserved, duplicate, and invalid keys are
+    typed errors; Docker's bare-key host import form is unrepresentable. *)
+val docker_keeper_env_args
+  :  Masc_exec.Sandbox_target.env_binding list
+  -> (string list, docker_keeper_env_error) result
 
 val docker_user_env_args : unit -> string list
 val trim_env_opt : string -> string option

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -55,6 +55,34 @@ let image_preflight_target_error (failure : Keeper_sandbox_runtime.classified_er
    stall) are the same domain — the sandbox's own. *)
 let internal_sandbox_timeout_sec = 30.0
 
+let env_entry_key entry =
+  match String.index_opt entry '=' with
+  | None -> entry
+  | Some idx -> String.sub entry 0 idx
+;;
+
+(* Keeper env entries must not shadow keys the docker exec boundary
+   itself injects ([docker exec] resolves duplicate [--env] flags
+   last-wins). Rejecting with the key name keeps the failure
+   self-explanatory instead of silently dropping either side. *)
+let reserved_env_collision env =
+  Array.find_opt
+    (fun entry ->
+      List.mem
+        (env_entry_key entry)
+        Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys)
+    env
+  |> Option.map env_entry_key
+;;
+
+let reserved_env_error key =
+  ( Unix.WEXITED 1
+  , ""
+  , Printf.sprintf
+      "typed Shell IR Docker dispatch rejects env key %s: the sandbox exec boundary owns it"
+      key )
+;;
+
 let docker_target ~turn_sandbox_factory ~meta ~cwd =
   let default_cwd = cwd in
   let stage_cwd_or_default = function
@@ -81,31 +109,31 @@ let docker_target ~turn_sandbox_factory ~meta ~cwd =
      | Error failure -> Error (image_preflight_target_error failure)
      | Ok () ->
       let runner ~on_stdout_chunk ~on_stderr_chunk ~stdin_content ~argv ~env ~cwd:stage_cwd =
-        if Array.length env > 0 then
-          (Unix.WEXITED 1, "", "typed Shell IR Docker dispatch does not support env yet")
-        else
+        match reserved_env_collision env with
+        | Some key -> reserved_env_error key
+        | None ->
           let cwd = stage_cwd_or_default stage_cwd in
-          match
-            Keeper_turn_sandbox_runtime.run_exec_with_status_split
-              ?stdin_content
-              ?on_stdout_chunk
-              ?on_stderr_chunk
-              ~timeout_sec
-              runtime
-              ~cwd
-              ~command_argv:argv
+          (match
+             Keeper_turn_sandbox_runtime.run_exec_with_status_split
+               ?stdin_content
+               ?on_stdout_chunk
+               ?on_stderr_chunk
+               ~env
+               ~timeout_sec
+               runtime
+               ~cwd
+               ~command_argv:argv
            with
            | Ok result -> result
-           | Error err -> Unix.WEXITED 1, "", err
+           | Error err -> Unix.WEXITED 1, "", err)
        in
       let pipeline_runner ~on_stdout_chunk ~on_stderr_chunk ~stages =
         match
-          List.find_opt
-            (fun stage -> Array.length stage.Masc_exec.Sandbox_target.env > 0)
-             stages
+          List.find_map
+            (fun stage -> reserved_env_collision stage.Masc_exec.Sandbox_target.env)
+            stages
          with
-         | Some _ ->
-           (Unix.WEXITED 1, "", "typed Shell IR Docker dispatch does not support env yet")
+         | Some key -> reserved_env_error key
          | None ->
            let stages =
              List.map
@@ -113,6 +141,7 @@ let docker_target ~turn_sandbox_factory ~meta ~cwd =
                   { Keeper_turn_sandbox_runtime.command_argv =
                       stage.Masc_exec.Sandbox_target.argv
                   ; cwd = stage.cwd
+                  ; env = Array.to_list stage.env
                   })
                stages
            in

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -55,34 +55,6 @@ let image_preflight_target_error (failure : Keeper_sandbox_runtime.classified_er
    stall) are the same domain — the sandbox's own. *)
 let internal_sandbox_timeout_sec = 30.0
 
-let env_entry_key entry =
-  match String.index_opt entry '=' with
-  | None -> entry
-  | Some idx -> String.sub entry 0 idx
-;;
-
-(* Keeper env entries must not shadow keys the docker exec boundary
-   itself injects ([docker exec] resolves duplicate [--env] flags
-   last-wins). Rejecting with the key name keeps the failure
-   self-explanatory instead of silently dropping either side. *)
-let reserved_env_collision env =
-  Array.find_opt
-    (fun entry ->
-      List.mem
-        (env_entry_key entry)
-        Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys)
-    env
-  |> Option.map env_entry_key
-;;
-
-let reserved_env_error key =
-  ( Unix.WEXITED 1
-  , ""
-  , Printf.sprintf
-      "typed Shell IR Docker dispatch rejects env key %s: the sandbox exec boundary owns it"
-      key )
-;;
-
 let docker_target ~turn_sandbox_factory ~meta ~cwd =
   let default_cwd = cwd in
   let stage_cwd_or_default = function
@@ -109,53 +81,43 @@ let docker_target ~turn_sandbox_factory ~meta ~cwd =
      | Error failure -> Error (image_preflight_target_error failure)
      | Ok () ->
       let runner ~on_stdout_chunk ~on_stderr_chunk ~stdin_content ~argv ~env ~cwd:stage_cwd =
-        match reserved_env_collision env with
-        | Some key -> reserved_env_error key
-        | None ->
-          let cwd = stage_cwd_or_default stage_cwd in
-          (match
-             Keeper_turn_sandbox_runtime.run_exec_with_status_split
-               ?stdin_content
-               ?on_stdout_chunk
-               ?on_stderr_chunk
-               ~env
-               ~timeout_sec
-               runtime
-               ~cwd
-               ~command_argv:argv
-           with
-           | Ok result -> result
-           | Error err -> Unix.WEXITED 1, "", err)
+        let cwd = stage_cwd_or_default stage_cwd in
+        match
+          Keeper_turn_sandbox_runtime.run_exec_with_status_split
+            ?stdin_content
+            ?on_stdout_chunk
+            ?on_stderr_chunk
+            ~env
+            ~timeout_sec
+            runtime
+            ~cwd
+            ~command_argv:argv
+        with
+        | Ok result -> result
+        | Error err -> Unix.WEXITED 1, "", err
        in
       let pipeline_runner ~on_stdout_chunk ~on_stderr_chunk ~stages =
-        match
-          List.find_map
-            (fun stage -> reserved_env_collision stage.Masc_exec.Sandbox_target.env)
+        let stages =
+          List.map
+            (fun stage ->
+              { Keeper_turn_sandbox_runtime.command_argv =
+                  stage.Masc_exec.Sandbox_target.argv
+              ; cwd = stage.cwd
+              ; env = stage.env
+              })
             stages
-         with
-         | Some key -> reserved_env_error key
-         | None ->
-           let stages =
-             List.map
-               (fun stage ->
-                  { Keeper_turn_sandbox_runtime.command_argv =
-                      stage.Masc_exec.Sandbox_target.argv
-                  ; cwd = stage.cwd
-                  ; env = Array.to_list stage.env
-                  })
-               stages
-           in
-           match
-            Keeper_turn_sandbox_runtime.run_exec_pipeline_with_status
-              ?on_stdout_chunk
-              ?on_stderr_chunk
-              ~timeout_sec
-              runtime
-              ~cwd
-              ~stages
-           with
-           | Ok result -> result
-           | Error err -> Unix.WEXITED 1, "", err
+        in
+        match
+          Keeper_turn_sandbox_runtime.run_exec_pipeline_with_status
+            ?on_stdout_chunk
+            ?on_stderr_chunk
+            ~timeout_sec
+            runtime
+            ~cwd
+            ~stages
+        with
+        | Ok result -> result
+        | Error err -> Unix.WEXITED 1, "", err
        in
        Ok (Masc_exec.Sandbox_target.docker ~image ~runner ~pipeline_runner ()))
 ;;

--- a/lib/keeper/keeper_sandbox_shell_ir_target.mli
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.mli
@@ -7,6 +7,14 @@ type target_error =
 
 val target_error : ?fields:(string * Yojson.Safe.t) list -> string -> target_error
 
+(** First keeper env entry ("K=V" or bare "K") whose key is in
+    [Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys], as the key.
+    [None] when every entry is safe to inject as a [docker exec --env]
+    flag. Dispatch rejects a colliding entry with a typed error because
+    [docker exec] resolves duplicate [--env] flags last-wins, which would
+    silently override a sandbox invariant. *)
+val reserved_env_collision : string array -> string option
+
 val docker_image : Keeper_meta_contract.keeper_meta -> string
 
 val docker_target

--- a/lib/keeper/keeper_sandbox_shell_ir_target.mli
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.mli
@@ -7,14 +7,6 @@ type target_error =
 
 val target_error : ?fields:(string * Yojson.Safe.t) list -> string -> target_error
 
-(** First keeper env entry ("K=V" or bare "K") whose key is in
-    [Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys], as the key.
-    [None] when every entry is safe to inject as a [docker exec --env]
-    flag. Dispatch rejects a colliding entry with a typed error because
-    [docker exec] resolves duplicate [--env] flags last-wins, which would
-    silently override a sandbox invariant. *)
-val reserved_env_collision : string array -> string option
-
 val docker_image : Keeper_meta_contract.keeper_meta -> string
 
 val docker_target

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -683,7 +683,8 @@ let typed_validation_recovery_fields
   | Keeper_tool_execute_typed_input.Cwd_not_absolute _
   | Keeper_tool_execute_typed_input.Pipeline_empty
   | Keeper_tool_execute_typed_input.Pipeline_too_short
-  | Keeper_tool_execute_typed_input.Env_key_invalid _ -> []
+  | Keeper_tool_execute_typed_input.Env_key_invalid _
+  | Keeper_tool_execute_typed_input.Env_key_duplicate _ -> []
 
 let normalize_path_for_keeper_tool_execute_shell_ir_containment path =
   Keeper_alerting_path.normalize_path_for_check path

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -607,7 +607,6 @@ end
 let has_typed_execute_input_key = Keeper_tool_execute_input.has_typed_execute_input_key
 let assoc_upsert = Keeper_tool_execute_input.assoc_upsert
 let typed_input_command_text = Keeper_tool_execute_input.typed_input_command_text
-let typed_input_has_env = Keeper_tool_execute_input.typed_input_has_env
 let typed_validation_error_text = Keeper_tool_execute_input.typed_validation_error_text
 
 let typed_validation_deterministic_retry_fields
@@ -818,27 +817,24 @@ let handle_tool_execute_typed
           match sandbox_profile with
           | Local -> local_dispatch_sandbox ()
           | Docker ->
-            if typed_input_has_env input
-            then
-              Error
-                (Keeper_sandbox_shell_ir_target.target_error
-                   "typed Shell IR Docker dispatch does not support env yet")
-            else (
-              match docker_local_fallback_target ~meta with
-              | Some (target, fields) when in_playground ->
-                (match target with
-                 | Masc_exec.Sandbox_target.Host ->
-                   local_dispatch_sandbox ~extra_fields:fields ()
-                 | Docker _ -> Ok (target, fields, None))
-              | Some _ | None ->
-                docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
-                |> Result.map (fun target ->
-                  ( target
-                  , [ "requested_sandbox", `String "docker"
-                    ; "via", `String "docker"
-                    ; "sandbox_profile", `String "docker"
-                    ]
-                  , None )))
+            (* Typed env entries flow into [docker exec --env] flags via
+               [Keeper_sandbox_shell_ir_target]; sandbox-reserved keys are
+               rejected there with a typed error. *)
+            (match docker_local_fallback_target ~meta with
+             | Some (target, fields) when in_playground ->
+               (match target with
+                | Masc_exec.Sandbox_target.Host ->
+                  local_dispatch_sandbox ~extra_fields:fields ()
+                | Docker _ -> Ok (target, fields, None))
+             | Some _ | None ->
+               docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
+               |> Result.map (fun target ->
+                 ( target
+                 , [ "requested_sandbox", `String "docker"
+                   ; "via", `String "docker"
+                   ; "sandbox_profile", `String "docker"
+                   ]
+                 , None )))
         in
         (match dispatch_sandbox with
          | Error ({ message; fields } : Keeper_sandbox_shell_ir_target.target_error) ->

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -53,6 +53,7 @@ type validation_error =
   | Pipeline_empty
   | Pipeline_too_short
   | Env_key_invalid of string
+  | Env_key_duplicate of string
 
 let json_type_name (json : Yojson.Safe.t) =
   match json with
@@ -396,18 +397,22 @@ let check_cwd = function
 let check_env env =
   let key_ok k =
     String.length k > 0
+    && (match k.[0] with
+        | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+        | _ -> false)
     && String.for_all
          (function
            | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
            | _ -> false)
          k
   in
-  let rec loop = function
+  let rec loop seen = function
     | [] -> Ok ()
     | (k, _) :: _ when not (key_ok k) -> Error (Env_key_invalid k)
-    | _ :: rest -> loop rest
+    | (k, _) :: _ when List.mem k seen -> Error (Env_key_duplicate k)
+    | (k, _) :: rest -> loop (k :: seen) rest
   in
-  loop env
+  loop [] env
 ;;
 
 let check_exec ~executable ~argv ~cwd ~env =
@@ -618,7 +623,9 @@ let pp_validation_error ppf = function
   | Pipeline_too_short ->
     Format.pp_print_string ppf "pipeline requires at least two stages"
   | Env_key_invalid k ->
-    Format.fprintf ppf "env key %S is not [A-Za-z0-9_]+" k
+    Format.fprintf ppf "env key %S is not [A-Za-z_][A-Za-z0-9_]*" k
+  | Env_key_duplicate k ->
+    Format.fprintf ppf "env key %S is duplicated" k
 ;;
 
 let validation_error_alternatives : validation_error -> string list = function

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -121,6 +121,7 @@ type validation_error =
   | Pipeline_empty
   | Pipeline_too_short
   | Env_key_invalid of string
+  | Env_key_duplicate of string
 
 val of_json : Yojson.Safe.t -> (execute_input, string) result
 (** Parse the typed Execute JSON boundary.  Accepts either

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -871,11 +871,31 @@ let ensure_started ?(validate_running = false) (t : t) ~timeout_sec =
   | Not_started -> start_container t ~timeout_sec
 ;;
 
+let rewrite_command_argv (t : t) command_argv =
+  List.map
+    (fun arg ->
+      let rewritten =
+        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+          ~host_root:t.host_root
+          ~container_root:t.container_root
+          arg
+      in
+      if String.equal t.raw_host_root t.host_root
+      then rewritten
+      else
+        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+          ~host_root:t.raw_host_root
+          ~container_root:t.container_root
+          rewritten)
+    command_argv
+;;
+
 let run_exec_with_status_split_once
       ?(validate_cached_container = false)
       ?(stdin_content : string option)
       ?on_stdout_chunk
       ?on_stderr_chunk
+      ?(env = [||])
       (t : t)
       ~timeout_sec
       ~(cwd : string)
@@ -885,23 +905,14 @@ let run_exec_with_status_split_once
   | Error _ as err -> err
   | Ok container_name ->
     let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-    let command_argv =
-      List.map
-        (fun arg ->
-           let rewritten =
-             Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-               ~host_root:t.host_root
-               ~container_root:t.container_root
-               arg
-           in
-           if String.equal t.raw_host_root t.host_root
-           then rewritten
-           else
-             Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-               ~host_root:t.raw_host_root
-               ~container_root:t.container_root
-               rewritten)
-        command_argv
+    let command_argv = rewrite_command_argv t command_argv in
+    (* Keeper env entries get the same host-root rewriting as argv:
+       values may carry playground paths that only resolve inside the
+       container. Reserved-key collisions are rejected upstream in
+       [Keeper_sandbox_shell_ir_target] before this point. *)
+    let keeper_env_args =
+      Keeper_sandbox_runtime.docker_keeper_env_args
+        (rewrite_command_argv t (Array.to_list env))
     in
     let argv =
       Keeper_sandbox_runtime.docker_command_argv ()
@@ -909,6 +920,7 @@ let run_exec_with_status_split_once
       @ Keeper_sandbox_runtime.docker_sandbox_env_args
           ~base_path:t.config.base_path
           ~container_root:t.container_root
+      @ keeper_env_args
       @ (match stdin_content with
          | Some _ -> [ "-i" ]
          | None -> [])
@@ -946,6 +958,7 @@ let run_exec_with_status_split
       ?stdin_content
       ?on_stdout_chunk
       ?on_stderr_chunk
+      ?env
       ~timeout_sec
       (t : t)
       ~(cwd : string)
@@ -960,6 +973,7 @@ let run_exec_with_status_split
       ?stdin_content
       ?on_stdout_chunk
       ?on_stderr_chunk
+      ?env
       t
       ~timeout_sec
       ~cwd
@@ -974,6 +988,7 @@ let run_exec_with_status_split
          ?stdin_content
          ?on_stdout_chunk
          ?on_stderr_chunk
+         ?env
          t
          ~timeout_sec
          ~cwd
@@ -1011,33 +1026,18 @@ let run_exec_with_status
 type exec_pipeline_stage = {
   command_argv : string list;
   cwd : string option;
+  env : string list;
 }
 
-let rewrite_command_argv (t : t) command_argv =
-  List.map
-    (fun arg ->
-      let rewritten =
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.host_root
-          ~container_root:t.container_root
-          arg
-      in
-      if String.equal t.raw_host_root t.host_root
-      then rewritten
-      else
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.raw_host_root
-          ~container_root:t.container_root
-          rewritten)
-    command_argv
-;;
-
-let docker_exec_pipeline_argv (t : t) ~container_name ~container_cwd command_argv =
+let docker_exec_pipeline_argv (t : t) ~container_name ~container_cwd ~env command_argv =
   Keeper_sandbox_runtime.docker_command_argv ()
   @ [ "exec"; "-i"; "--user"; Printf.sprintf "%d:%d" t.uid t.gid; "-w"; container_cwd ]
   @ Keeper_sandbox_runtime.docker_sandbox_env_args
       ~base_path:t.config.base_path
       ~container_root:t.container_root
+  (* Same host-root rewriting as argv; reserved-key collisions are
+     rejected upstream in [Keeper_sandbox_shell_ir_target]. *)
+  @ Keeper_sandbox_runtime.docker_keeper_env_args (rewrite_command_argv t env)
   @ (container_name :: rewrite_command_argv t command_argv)
 ;;
 
@@ -1055,10 +1055,12 @@ let run_exec_pipeline_with_status_once
   | Ok container_name ->
     let process_stages =
       List.map
-        (fun { command_argv; cwd = stage_cwd } ->
+        (fun { command_argv; cwd = stage_cwd; env } ->
           let cwd = Option.value stage_cwd ~default:cwd in
           let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-          let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
+          let argv =
+            docker_exec_pipeline_argv t ~container_name ~container_cwd ~env command_argv
+          in
           { Process_eio.argv
           ; env = Some (Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
           ; cwd = Some (Config_dir_resolver.current_working_dir ())

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -871,23 +871,29 @@ let ensure_started ?(validate_running = false) (t : t) ~timeout_sec =
   | Not_started -> start_container t ~timeout_sec
 ;;
 
-let rewrite_command_argv (t : t) command_argv =
-  List.map
-    (fun arg ->
-      let rewritten =
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.host_root
-          ~container_root:t.container_root
-          arg
-      in
-      if String.equal t.raw_host_root t.host_root
-      then rewritten
-      else
-        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
-          ~host_root:t.raw_host_root
-          ~container_root:t.container_root
-          rewritten)
-    command_argv
+let rewrite_host_value (t : t) value =
+  let rewritten =
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:t.host_root
+      ~container_root:t.container_root
+      value
+  in
+  if String.equal t.raw_host_root t.host_root
+  then rewritten
+  else
+    Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+      ~host_root:t.raw_host_root
+      ~container_root:t.container_root
+      rewritten
+;;
+
+let rewrite_command_argv t command_argv = List.map (rewrite_host_value t) command_argv
+
+let rewrite_env_bindings t env =
+  env
+  |> Array.to_list
+  |> List.map (fun (binding : Masc_exec.Sandbox_target.env_binding) ->
+    { binding with value = rewrite_host_value t binding.value })
 ;;
 
 let run_exec_with_status_split_once
@@ -898,60 +904,61 @@ let run_exec_with_status_split_once
       ?(env = [||])
       (t : t)
       ~timeout_sec
-      ~(cwd : string)
-      ~(command_argv : string list)
+  ~(cwd : string)
+  ~(command_argv : string list)
   =
-  match ensure_started ~validate_running:validate_cached_container t ~timeout_sec with
-  | Error _ as err -> err
-  | Ok container_name ->
-    let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-    let command_argv = rewrite_command_argv t command_argv in
-    (* Keeper env entries get the same host-root rewriting as argv:
-       values may carry playground paths that only resolve inside the
-       container. Reserved-key collisions are rejected upstream in
-       [Keeper_sandbox_shell_ir_target] before this point. *)
-    let keeper_env_args =
-      Keeper_sandbox_runtime.docker_keeper_env_args
-        (rewrite_command_argv t (Array.to_list env))
-    in
-    let argv =
-      Keeper_sandbox_runtime.docker_command_argv ()
-      @ [ "exec"; "--user"; Printf.sprintf "%d:%d" t.uid t.gid; "-w"; container_cwd ]
-      @ Keeper_sandbox_runtime.docker_sandbox_env_args
-          ~base_path:t.config.base_path
-          ~container_root:t.container_root
-      @ keeper_env_args
-      @ (match stdin_content with
-         | Some _ -> [ "-i" ]
-         | None -> [])
-      @ (container_name :: command_argv)
-    in
-    let has_output_callback =
-      Option.is_some on_stdout_chunk || Option.is_some on_stderr_chunk
-    in
-    let st, stdout, stderr =
-      match stdin_content, has_output_callback with
-      | Some content, false ->
-        run_argv_with_stdin_and_status_split_retry_eintr
-          ~timeout_sec
-          ~stdin_content:content
-          argv
-      | None, false -> run_argv_with_status_split_retry_eintr ~timeout_sec argv
-      | Some content, true ->
-        run_argv_with_stdin_and_status_split_retry_eintr
-          ~timeout_sec
-          ?on_stdout_chunk
-          ?on_stderr_chunk
-          ~stdin_content:content
-          argv
-      | None, true ->
-        run_argv_with_status_split_retry_eintr
-          ~timeout_sec
-          ?on_stdout_chunk
-          ?on_stderr_chunk
-          argv
-    in
-    Ok (st, stdout, stderr)
+  match Keeper_sandbox_runtime.docker_keeper_env_args (rewrite_env_bindings t env) with
+  | Error error ->
+    Error (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+  | Ok keeper_env_args ->
+    (match ensure_started ~validate_running:validate_cached_container t ~timeout_sec with
+     | Error _ as err -> err
+     | Ok container_name ->
+       let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
+       let command_argv = rewrite_command_argv t command_argv in
+       let argv =
+         Keeper_sandbox_runtime.docker_command_argv ()
+         @ [ "exec"
+           ; "--user"
+           ; Printf.sprintf "%d:%d" t.uid t.gid
+           ; "-w"
+           ; container_cwd
+           ]
+         @ Keeper_sandbox_runtime.docker_sandbox_env_args
+             ~base_path:t.config.base_path
+             ~container_root:t.container_root
+         @ keeper_env_args
+         @ (match stdin_content with
+            | Some _ -> [ "-i" ]
+            | None -> [])
+         @ (container_name :: command_argv)
+       in
+       let has_output_callback =
+         Option.is_some on_stdout_chunk || Option.is_some on_stderr_chunk
+       in
+       let st, stdout, stderr =
+         match stdin_content, has_output_callback with
+         | Some content, false ->
+           run_argv_with_stdin_and_status_split_retry_eintr
+             ~timeout_sec
+             ~stdin_content:content
+             argv
+         | None, false -> run_argv_with_status_split_retry_eintr ~timeout_sec argv
+         | Some content, true ->
+           run_argv_with_stdin_and_status_split_retry_eintr
+             ~timeout_sec
+             ?on_stdout_chunk
+             ?on_stderr_chunk
+             ~stdin_content:content
+             argv
+         | None, true ->
+           run_argv_with_status_split_retry_eintr
+             ~timeout_sec
+             ?on_stdout_chunk
+             ?on_stderr_chunk
+             argv
+       in
+       Ok (st, stdout, stderr))
 ;;
 
 let run_exec_with_status_split
@@ -1026,18 +1033,28 @@ let run_exec_with_status
 type exec_pipeline_stage = {
   command_argv : string list;
   cwd : string option;
-  env : string list;
+  env : Masc_exec.Sandbox_target.env_binding array;
 }
 
-let docker_exec_pipeline_argv (t : t) ~container_name ~container_cwd ~env command_argv =
+let docker_exec_pipeline_argv
+      (t : t)
+      ~container_name
+      ~container_cwd
+      ~keeper_env_args
+      command_argv
+  =
   Keeper_sandbox_runtime.docker_command_argv ()
-  @ [ "exec"; "-i"; "--user"; Printf.sprintf "%d:%d" t.uid t.gid; "-w"; container_cwd ]
+  @ [ "exec"
+    ; "-i"
+    ; "--user"
+    ; Printf.sprintf "%d:%d" t.uid t.gid
+    ; "-w"
+    ; container_cwd
+    ]
   @ Keeper_sandbox_runtime.docker_sandbox_env_args
       ~base_path:t.config.base_path
       ~container_root:t.container_root
-  (* Same host-root rewriting as argv; reserved-key collisions are
-     rejected upstream in [Keeper_sandbox_shell_ir_target]. *)
-  @ Keeper_sandbox_runtime.docker_keeper_env_args (rewrite_command_argv t env)
+  @ keeper_env_args
   @ (container_name :: rewrite_command_argv t command_argv)
 ;;
 
@@ -1047,32 +1064,60 @@ let run_exec_pipeline_with_status_once
       ?on_stderr_chunk
       (t : t)
       ~timeout_sec
-      ~(cwd : string)
-      ~(stages : exec_pipeline_stage list)
+  ~(cwd : string)
+  ~(stages : exec_pipeline_stage list)
   =
-  match ensure_started ~validate_running:validate_cached_container t ~timeout_sec with
-  | Error _ as err -> err
-  | Ok container_name ->
-    let process_stages =
-      List.map
-        (fun { command_argv; cwd = stage_cwd; env } ->
-          let cwd = Option.value stage_cwd ~default:cwd in
-          let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-          let argv =
-            docker_exec_pipeline_argv t ~container_name ~container_cwd ~env command_argv
-          in
-          { Process_eio.argv
-          ; env = Some (Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
-          ; cwd = Some (Config_dir_resolver.current_working_dir ())
-          })
-        stages
+  let rec validate_envs acc = function
+    | [] -> Ok (List.rev acc)
+    | ({ env; _ } as stage) :: rest ->
+      (match
+         Keeper_sandbox_runtime.docker_keeper_env_args
+           (rewrite_env_bindings t env)
+       with
+       | Error error ->
+         Error (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+       | Ok keeper_env_args ->
+         validate_envs ((stage, keeper_env_args) :: acc) rest)
+  in
+  match validate_envs [] stages with
+  | Error _ as error -> error
+  | Ok stages ->
+    (match ensure_started ~validate_running:validate_cached_container t ~timeout_sec with
+     | Error _ as err -> err
+     | Ok container_name ->
+    let rec build_process_stages acc = function
+      | [] -> Ok (List.rev acc)
+      | ({ command_argv; cwd = stage_cwd; env = _ }, keeper_env_args) :: rest ->
+        let cwd = Option.value stage_cwd ~default:cwd in
+        let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
+        let argv =
+          docker_exec_pipeline_argv
+            t
+            ~container_name
+            ~container_cwd
+            ~keeper_env_args
+            command_argv
+        in
+           let stage =
+             { Process_eio.argv
+             ; env =
+                 Some
+                   (Env_keeper_scrub.filter_environment_c_messages
+                      (Unix.environment ()))
+             ; cwd = Some (Config_dir_resolver.current_working_dir ())
+             }
+           in
+           build_process_stages (stage :: acc) rest
     in
-    Ok
-      (run_argv_pipeline_with_status_split_retry_eintr
-         ~timeout_sec
-         ?on_stdout_chunk
-         ?on_stderr_chunk
-         process_stages)
+    (match build_process_stages [] stages with
+     | Error _ as error -> error
+     | Ok process_stages ->
+       Ok
+         (run_argv_pipeline_with_status_split_retry_eintr
+            ~timeout_sec
+            ?on_stdout_chunk
+            ?on_stderr_chunk
+            process_stages)))
 ;;
 
 let run_exec_pipeline_with_status ?on_stdout_chunk ?on_stderr_chunk ~timeout_sec t ~cwd ~stages =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -1088,7 +1088,11 @@ let run_exec_pipeline_with_status_once
     let rec build_process_stages acc = function
       | [] -> Ok (List.rev acc)
       | ({ command_argv; cwd = stage_cwd; env = _ }, keeper_env_args) :: rest ->
-        let cwd = Option.value stage_cwd ~default:cwd in
+        let cwd =
+          match stage_cwd with
+          | Some stage_cwd -> stage_cwd
+          | None -> cwd
+        in
         let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
         let argv =
           docker_exec_pipeline_argv

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -82,7 +82,7 @@ val run_exec_with_status_split :
   ?stdin_content:string ->
   ?on_stdout_chunk:(string -> unit) ->
   ?on_stderr_chunk:(string -> unit) ->
-  ?env:string array ->
+  ?env:Masc_exec.Sandbox_target.env_binding array ->
   timeout_sec:float ->
   t ->
   cwd:string ->
@@ -92,18 +92,16 @@ val run_exec_with_status_split :
     stdout/stderr without applying success-code policy. This is the argv-level
     entrypoint used by Shell IR dispatch.
 
-    [env] carries resolved keeper "K=V" entries injected as [docker exec
-    --env] flags on top of the container environment (additive override,
-    mirroring the Host dispatch path). Entries get the same host-root ->
-    container-root rewriting as [command_argv]. Callers must reject keys in
-    [Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys] first. *)
+    [env] carries structured, resolved keeper bindings. Values get the same
+    host-root -> container-root rewriting as [command_argv]. The final Docker
+    argv builder rejects reserved, duplicate, and invalid keys. *)
 
 type exec_pipeline_stage = {
   command_argv : string list;
   cwd : string option;
-  env : string list;
-      (** Resolved "K=V" entries for this stage, same contract as the [env]
-          argument of {!run_exec_with_status_split}. *)
+  env : Masc_exec.Sandbox_target.env_binding array;
+      (** Structured resolved bindings for this stage, same contract as [env]
+          in {!run_exec_with_status_split}. *)
 }
 
 val run_exec_pipeline_with_status :

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -82,6 +82,7 @@ val run_exec_with_status_split :
   ?stdin_content:string ->
   ?on_stdout_chunk:(string -> unit) ->
   ?on_stderr_chunk:(string -> unit) ->
+  ?env:string array ->
   timeout_sec:float ->
   t ->
   cwd:string ->
@@ -89,11 +90,20 @@ val run_exec_with_status_split :
   (Unix.process_status * string * string, string) result
 (** Execute [command_argv] inside the turn-scoped container and return split
     stdout/stderr without applying success-code policy. This is the argv-level
-    entrypoint used by Shell IR dispatch. *)
+    entrypoint used by Shell IR dispatch.
+
+    [env] carries resolved keeper "K=V" entries injected as [docker exec
+    --env] flags on top of the container environment (additive override,
+    mirroring the Host dispatch path). Entries get the same host-root ->
+    container-root rewriting as [command_argv]. Callers must reject keys in
+    [Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys] first. *)
 
 type exec_pipeline_stage = {
   command_argv : string list;
   cwd : string option;
+  env : string list;
+      (** Resolved "K=V" entries for this stage, same contract as the [env]
+          argument of {!run_exec_with_status_split}. *)
 }
 
 val run_exec_pipeline_with_status :

--- a/test/dune
+++ b/test/dune
@@ -309,6 +309,7 @@
   test_keeper_transition_audit
   test_keeper_tool_search_files_containment
   test_keeper_sandbox_docker_route
+  test_keeper_sandbox_docker_env
   test_keeper_tool_search_files_via_field
   test_env_git_noninteractive
   test_orphan_surfacer
@@ -674,6 +675,7 @@
   test_keeper_transition_audit
   test_keeper_tool_search_files_containment
   test_keeper_sandbox_docker_route
+  test_keeper_sandbox_docker_env
   test_keeper_tool_search_files_via_field
   test_env_git_noninteractive
   test_orphan_surfacer

--- a/test/test_keeper_sandbox_docker_env.ml
+++ b/test/test_keeper_sandbox_docker_env.ml
@@ -1,15 +1,14 @@
 (** Tests for typed Shell IR docker env passthrough.
 
-    Keeper env entries flow into [docker exec --env] flags
-    ([Keeper_turn_sandbox_runtime.run_exec_with_status_split ~env] /
-    [exec_pipeline_stage.env]). These tests cover the pure policy layer:
-    the sandbox-reserved key gate ([reserved_env_collision]) and the
-    [--env] argv shaping ([docker_keeper_env_args]), plus a drift guard
-    asserting every key the sandbox exec boundary injects is listed in
-    [docker_sandbox_reserved_env_keys]. *)
+    Keeper env bindings flow into [docker exec --env] flags. These tests cover
+    the final argv boundary: structured rendering and typed rejection of
+    reserved, duplicate, and invalid keys, plus a drift guard asserting every
+    sandbox-owned injected key is reserved. *)
 
 module Keeper_sandbox_runtime = Masc.Keeper_sandbox_runtime
-module Keeper_sandbox_shell_ir_target = Masc.Keeper_sandbox_shell_ir_target
+module Sandbox_target = Masc_exec.Sandbox_target
+
+let binding key value : Sandbox_target.env_binding = { key; value }
 
 let env_arg_keys args =
   (* args shape: ["--env"; "K=V"; "--env"; "K2=V2"; ...] *)
@@ -26,52 +25,60 @@ let env_arg_keys args =
   in
   loop [] args
 
-let test_no_collision_on_plain_keys () =
-  Alcotest.(check (option string))
-    "unreserved keys pass"
-    None
-    (Keeper_sandbox_shell_ir_target.reserved_env_collision
-       [| "DUNE_CACHE=disabled"; "GIT_PAGER=cat"; "PATH_EXTRA=/x" |])
-
-let test_collision_on_reserved_key () =
-  Alcotest.(check (option string))
-    "HOME is reserved"
-    (Some "HOME")
-    (Keeper_sandbox_shell_ir_target.reserved_env_collision [| "HOME=/evil" |])
-
-let test_collision_reports_first_reserved_key () =
-  Alcotest.(check (option string))
-    "first reserved entry wins"
-    (Some "MASC_CONFIG_DIR")
-    (Keeper_sandbox_shell_ir_target.reserved_env_collision
-       [| "DUNE_CACHE=enabled"; "MASC_CONFIG_DIR=/elsewhere"; "USER=root" |])
-
-let test_collision_on_bare_key () =
-  (* An entry without '=' is treated as its own key: [docker exec --env K]
-     forwards the docker CLI process's own K, which for reserved keys is
-     just as much a shadow as an explicit value. *)
-  Alcotest.(check (option string))
-    "bare reserved token collides"
-    (Some "SHELL")
-    (Keeper_sandbox_shell_ir_target.reserved_env_collision [| "SHELL" |])
-
-let test_empty_env_never_collides () =
-  Alcotest.(check (option string))
-    "empty env passes"
-    None
-    (Keeper_sandbox_shell_ir_target.reserved_env_collision [||])
-
 let test_keeper_env_args_shape () =
-  Alcotest.(check (list string))
-    "entries interleave with --env flags"
-    [ "--env"; "A=1"; "--env"; "B=two words" ]
-    (Keeper_sandbox_runtime.docker_keeper_env_args [ "A=1"; "B=two words" ])
+  match
+    Keeper_sandbox_runtime.docker_keeper_env_args
+      [ binding "A" "1"; binding "B" "two words" ]
+  with
+  | Ok args ->
+    Alcotest.(check (list string))
+      "entries interleave with --env flags"
+      [ "--env"; "A=1"; "--env"; "B=two words" ]
+      args
+  | Error error ->
+    Alcotest.fail
+      (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
 
 let test_keeper_env_args_empty () =
-  Alcotest.(check (list string))
-    "no entries, no flags"
-    []
-    (Keeper_sandbox_runtime.docker_keeper_env_args [])
+  match Keeper_sandbox_runtime.docker_keeper_env_args [] with
+  | Ok args -> Alcotest.(check (list string)) "no entries, no flags" [] args
+  | Error error ->
+    Alcotest.fail
+      (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+
+let test_reserved_key_rejected () =
+  match
+    Keeper_sandbox_runtime.docker_keeper_env_args [ binding "HOME" "/evil" ]
+  with
+  | Error (Keeper_sandbox_runtime.Reserved_key "HOME") -> ()
+  | Error error ->
+    Alcotest.failf
+      "unexpected error: %s"
+      (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+  | Ok _ -> Alcotest.fail "reserved HOME unexpectedly accepted"
+
+let test_duplicate_key_rejected () =
+  match
+    Keeper_sandbox_runtime.docker_keeper_env_args
+      [ binding "TOKEN" "first"; binding "TOKEN" "second" ]
+  with
+  | Error (Keeper_sandbox_runtime.Duplicate_key "TOKEN") -> ()
+  | Error error ->
+    Alcotest.failf
+      "unexpected error: %s"
+      (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+  | Ok _ -> Alcotest.fail "duplicate TOKEN unexpectedly accepted"
+
+let test_invalid_key_rejected () =
+  match
+    Keeper_sandbox_runtime.docker_keeper_env_args [ binding "1TOKEN" "value" ]
+  with
+  | Error (Keeper_sandbox_runtime.Invalid_key "1TOKEN") -> ()
+  | Error error ->
+    Alcotest.failf
+      "unexpected error: %s"
+      (Keeper_sandbox_runtime.docker_keeper_env_error_to_string error)
+  | Ok _ -> Alcotest.fail "invalid 1TOKEN unexpectedly accepted"
 
 let test_user_env_keys_are_reserved () =
   let emitted = env_arg_keys (Keeper_sandbox_runtime.docker_user_env_args ()) in
@@ -117,19 +124,12 @@ let test_config_env_keys_are_reserved () =
 let () =
   Alcotest.run
     "keeper_sandbox_docker_env"
-    [ ( "reserved_env_collision"
-      , [ Alcotest.test_case "unreserved keys pass" `Quick test_no_collision_on_plain_keys
-        ; Alcotest.test_case "reserved key collides" `Quick test_collision_on_reserved_key
-        ; Alcotest.test_case
-            "first reserved key reported"
-            `Quick
-            test_collision_reports_first_reserved_key
-        ; Alcotest.test_case "bare reserved token collides" `Quick test_collision_on_bare_key
-        ; Alcotest.test_case "empty env passes" `Quick test_empty_env_never_collides
-        ] )
-    ; ( "docker_keeper_env_args"
+    [ ( "docker_keeper_env_args"
       , [ Alcotest.test_case "interleaved --env flags" `Quick test_keeper_env_args_shape
         ; Alcotest.test_case "empty entries" `Quick test_keeper_env_args_empty
+        ; Alcotest.test_case "reserved key rejected" `Quick test_reserved_key_rejected
+        ; Alcotest.test_case "duplicate key rejected" `Quick test_duplicate_key_rejected
+        ; Alcotest.test_case "invalid key rejected" `Quick test_invalid_key_rejected
         ] )
     ; ( "reserved list drift guard"
       , [ Alcotest.test_case

--- a/test/test_keeper_sandbox_docker_env.ml
+++ b/test/test_keeper_sandbox_docker_env.ml
@@ -1,0 +1,144 @@
+(** Tests for typed Shell IR docker env passthrough.
+
+    Keeper env entries flow into [docker exec --env] flags
+    ([Keeper_turn_sandbox_runtime.run_exec_with_status_split ~env] /
+    [exec_pipeline_stage.env]). These tests cover the pure policy layer:
+    the sandbox-reserved key gate ([reserved_env_collision]) and the
+    [--env] argv shaping ([docker_keeper_env_args]), plus a drift guard
+    asserting every key the sandbox exec boundary injects is listed in
+    [docker_sandbox_reserved_env_keys]. *)
+
+module Keeper_sandbox_runtime = Masc.Keeper_sandbox_runtime
+module Keeper_sandbox_shell_ir_target = Masc.Keeper_sandbox_shell_ir_target
+
+let env_arg_keys args =
+  (* args shape: ["--env"; "K=V"; "--env"; "K2=V2"; ...] *)
+  let rec loop acc = function
+    | "--env" :: entry :: rest ->
+      let key =
+        match String.index_opt entry '=' with
+        | None -> entry
+        | Some idx -> String.sub entry 0 idx
+      in
+      loop (key :: acc) rest
+    | _ :: rest -> loop acc rest
+    | [] -> List.rev acc
+  in
+  loop [] args
+
+let test_no_collision_on_plain_keys () =
+  Alcotest.(check (option string))
+    "unreserved keys pass"
+    None
+    (Keeper_sandbox_shell_ir_target.reserved_env_collision
+       [| "DUNE_CACHE=disabled"; "GIT_PAGER=cat"; "PATH_EXTRA=/x" |])
+
+let test_collision_on_reserved_key () =
+  Alcotest.(check (option string))
+    "HOME is reserved"
+    (Some "HOME")
+    (Keeper_sandbox_shell_ir_target.reserved_env_collision [| "HOME=/evil" |])
+
+let test_collision_reports_first_reserved_key () =
+  Alcotest.(check (option string))
+    "first reserved entry wins"
+    (Some "MASC_CONFIG_DIR")
+    (Keeper_sandbox_shell_ir_target.reserved_env_collision
+       [| "DUNE_CACHE=enabled"; "MASC_CONFIG_DIR=/elsewhere"; "USER=root" |])
+
+let test_collision_on_bare_key () =
+  (* An entry without '=' is treated as its own key: [docker exec --env K]
+     forwards the docker CLI process's own K, which for reserved keys is
+     just as much a shadow as an explicit value. *)
+  Alcotest.(check (option string))
+    "bare reserved token collides"
+    (Some "SHELL")
+    (Keeper_sandbox_shell_ir_target.reserved_env_collision [| "SHELL" |])
+
+let test_empty_env_never_collides () =
+  Alcotest.(check (option string))
+    "empty env passes"
+    None
+    (Keeper_sandbox_shell_ir_target.reserved_env_collision [||])
+
+let test_keeper_env_args_shape () =
+  Alcotest.(check (list string))
+    "entries interleave with --env flags"
+    [ "--env"; "A=1"; "--env"; "B=two words" ]
+    (Keeper_sandbox_runtime.docker_keeper_env_args [ "A=1"; "B=two words" ])
+
+let test_keeper_env_args_empty () =
+  Alcotest.(check (list string))
+    "no entries, no flags"
+    []
+    (Keeper_sandbox_runtime.docker_keeper_env_args [])
+
+let test_user_env_keys_are_reserved () =
+  let emitted = env_arg_keys (Keeper_sandbox_runtime.docker_user_env_args ()) in
+  Alcotest.(check bool) "user env args emit keys" true (emitted <> []);
+  List.iter
+    (fun key ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%s emitted by docker_user_env_args is reserved" key)
+        true
+        (List.mem key Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys))
+    emitted
+
+let test_config_env_keys_are_reserved () =
+  let tmp = Filename.temp_file "masc-docker-env" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o700;
+  Fun.protect
+    ~finally:(fun () -> try Unix.rmdir tmp with Unix.Unix_error _ -> ())
+    (fun () ->
+      let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+      Unix.putenv "MASC_CONFIG_DIR" tmp;
+      Fun.protect
+        ~finally:(fun () ->
+          match prior with
+          | Some v -> Unix.putenv "MASC_CONFIG_DIR" v
+          | None -> Unix.putenv "MASC_CONFIG_DIR" "")
+        (fun () ->
+          let emitted =
+            env_arg_keys
+              (Keeper_sandbox_runtime.docker_config_env_args
+                 ~base_path:tmp
+                 ~container_root:"/workspace")
+          in
+          Alcotest.(check bool) "config env args emit keys" true (emitted <> []);
+          List.iter
+            (fun key ->
+              Alcotest.(check bool)
+                (Printf.sprintf "%s emitted by docker_config_env_args is reserved" key)
+                true
+                (List.mem key Keeper_sandbox_runtime.docker_sandbox_reserved_env_keys))
+            emitted))
+
+let () =
+  Alcotest.run
+    "keeper_sandbox_docker_env"
+    [ ( "reserved_env_collision"
+      , [ Alcotest.test_case "unreserved keys pass" `Quick test_no_collision_on_plain_keys
+        ; Alcotest.test_case "reserved key collides" `Quick test_collision_on_reserved_key
+        ; Alcotest.test_case
+            "first reserved key reported"
+            `Quick
+            test_collision_reports_first_reserved_key
+        ; Alcotest.test_case "bare reserved token collides" `Quick test_collision_on_bare_key
+        ; Alcotest.test_case "empty env passes" `Quick test_empty_env_never_collides
+        ] )
+    ; ( "docker_keeper_env_args"
+      , [ Alcotest.test_case "interleaved --env flags" `Quick test_keeper_env_args_shape
+        ; Alcotest.test_case "empty entries" `Quick test_keeper_env_args_empty
+        ] )
+    ; ( "reserved list drift guard"
+      , [ Alcotest.test_case
+            "docker_user_env_args keys are reserved"
+            `Quick
+            test_user_env_keys_are_reserved
+        ; Alcotest.test_case
+            "docker_config_env_args keys are reserved"
+            `Quick
+            test_config_env_keys_are_reserved
+        ] )
+    ]

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -2097,10 +2097,12 @@ let test_execute_duplicate_env_rejected_before_docker () =
            "echo")
       ()
   in
-  Alcotest.(check (option bool)) "duplicate env execution rejected" (Some false)
-    (parse_bool_field raw "ok");
-  Alcotest.(check bool) "duplicate key is explicit" true
-    (response_mentions raw "error" "env key \"TOKEN\" is duplicated");
+  (* Duplicate env keys are a malformed typed-input shape, rejected at
+     input validation with the [command_shape_blocked] deterministic-retry
+     envelope (no ["ok"] field) — same class as shell-metachar-in-argv.
+     Reserved-key rejection differs: that is a runtime sandbox-boundary
+     policy caught during dispatch, so it carries ["ok":false]. *)
+  check_typed_validation_error "env key \"TOKEN\" is duplicated" raw;
   Alcotest.(check bool) "docker was not invoked" false (Sys.file_exists log_path)
 
 let test_turn_runtime_projects_keeper_secret_dir () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -647,14 +647,18 @@ let tool_execute_typed_pipeline_args ~cwd =
 let json_string_list values =
   `List (List.map (fun value -> `String value) values)
 
-let tool_execute_typed_exec_args ?(argv = []) ~cwd executable =
+let tool_execute_typed_exec_args ?(argv = []) ?(env = []) ~cwd executable =
   `Assoc
-    [
-      ("executable", `String executable);
-      ("argv", json_string_list argv);
-      ("cwd", `String cwd);
-      ("timeout_sec", `Float 5.0);
-    ]
+    ([ ("executable", `String executable)
+     ; ("argv", json_string_list argv)
+     ; ("cwd", `String cwd)
+     ; ("timeout_sec", `Float 5.0)
+     ]
+     @
+     match env with
+     | [] -> []
+     | bindings ->
+       [ "env", `Assoc (List.map (fun (key, value) -> key, `String value) bindings) ])
 
 let tool_execute_typed_pipeline_args_of ~cwd stages =
   `Assoc
@@ -2008,6 +2012,97 @@ let test_execute_fake_docker_executes () =
   Alcotest.(check bool) "bash output includes fake docker stdout" true
     (response_mentions raw "output" "stdout:")
 
+let test_execute_typed_env_reaches_docker_exec () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
+  with_turn_sandbox_factory ~config ~meta @@ fun factory ->
+  let container_root = Keeper_sandbox.container_root meta.name in
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_exec_args
+           ~cwd:playground
+           ~env:
+             [ "EXEC_TOKEN", "value=with=equals"
+             ; "EXEC_PATH", Filename.concat playground "repos"
+             ]
+           "echo"
+           ~argv:[ "hello" ])
+      ()
+  in
+  Alcotest.(check (option bool)) "typed env execution succeeds" (Some true)
+    (parse_bool_field raw "ok");
+  let log = read_file log_path in
+  Alcotest.(check bool) "structured env reaches docker exec" true
+    (contains_substring log "--env EXEC_TOKEN=value=with=equals");
+  Alcotest.(check bool) "env value uses container path" true
+    (contains_substring
+       log
+       ("--env EXEC_PATH=" ^ Filename.concat container_root "repos"))
+
+let test_execute_reserved_env_rejected_before_container_execution () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
+  with_turn_sandbox_factory ~config ~meta @@ fun factory ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:(Some factory)
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_exec_args
+           ~cwd:playground
+           ~env:[ "HOME", "/evil" ]
+           "echo")
+      ()
+  in
+  Alcotest.(check (option bool)) "reserved env execution rejected" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check bool) "typed reserved-key error surfaced" true
+    (response_mentions raw "error" "sandbox exec boundary owns it");
+  let log = if Sys.file_exists log_path then read_file log_path else "" in
+  Alcotest.(check bool) "container was not started or executed" false
+    (docker_log_has_container_execution log)
+
+let test_execute_duplicate_env_rejected_before_docker () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Workspace.base_path "docker.log" in
+  with_env "MASC_KEEPER_TEST_DOCKER_LOG" log_path @@ fun () ->
+  let raw =
+    Keeper_tool_command_runtime.handle_tool_execute
+      ~turn_sandbox_factory:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:
+        (tool_execute_typed_exec_args
+           ~cwd:playground
+           ~env:[ "TOKEN", "first"; "TOKEN", "second" ]
+           "echo")
+      ()
+  in
+  Alcotest.(check (option bool)) "duplicate env execution rejected" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check bool) "duplicate key is explicit" true
+    (response_mentions raw "error" "env key \"TOKEN\" is duplicated");
+  Alcotest.(check bool) "docker was not invoked" false (Sys.file_exists log_path)
+
 let test_turn_runtime_projects_keeper_secret_dir () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
@@ -2359,6 +2454,15 @@ let () =
           Alcotest.test_case
             "docker Execute executes through fake docker"
             `Quick test_execute_fake_docker_executes;
+          Alcotest.test_case
+            "docker Execute forwards structured env"
+            `Quick test_execute_typed_env_reaches_docker_exec;
+          Alcotest.test_case
+            "docker Execute rejects reserved env before container execution"
+            `Quick test_execute_reserved_env_rejected_before_container_execution;
+          Alcotest.test_case
+            "docker Execute rejects duplicate env before docker"
+            `Quick test_execute_duplicate_env_rejected_before_docker;
           Alcotest.test_case
             "docker Execute safe pipe redirect routes through docker"
             `Quick test_execute_allows_validator_safe_pipe_redirect_in_docker_route;

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1848,8 +1848,9 @@ let test_streaming_pipeline_forwards_timeout_to_split_exec () =
        ~stages:
          [ { Keeper_turn_sandbox_runtime.command_argv = [ "slow-timeout" ]
            ; cwd = None
+           ; env = []
            }
-         ; { command_argv = [ "slow-timeout" ]; cwd = None }
+         ; { command_argv = [ "slow-timeout" ]; cwd = None; env = [] }
          ]
    with
    | Error msg -> Alcotest.failf "expected pipeline timeout result, got %s" msg

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -1848,9 +1848,9 @@ let test_streaming_pipeline_forwards_timeout_to_split_exec () =
        ~stages:
          [ { Keeper_turn_sandbox_runtime.command_argv = [ "slow-timeout" ]
            ; cwd = None
-           ; env = []
+           ; env = [||]
            }
-         ; { command_argv = [ "slow-timeout" ]; cwd = None; env = [] }
+         ; { command_argv = [ "slow-timeout" ]; cwd = None; env = [||] }
          ]
    with
    | Error msg -> Alcotest.failf "expected pipeline timeout result, got %s" msg

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -915,6 +915,50 @@ let test_env_key_invalid () =
     (typed_ok input)
 ;;
 
+let test_env_key_cannot_start_with_digit () =
+  let input =
+    Execute_input.Exec
+      { executable = "ls"
+      ; argv = []
+      ; cwd = None
+      ; env = [ "1TOKEN", "value" ]
+      ; stdin = Execute_input.Inherit
+      ; stdout = Execute_input.Inherit
+      ; stderr = Execute_input.Inherit
+      }
+  in
+  match Execute_input.validate input with
+  | Error (Execute_input.Env_key_invalid "1TOKEN") -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected Env_key_invalid, got %a"
+      Execute_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.fail "digit-prefixed env key unexpectedly accepted"
+;;
+
+let test_env_key_duplicate () =
+  let input =
+    Execute_input.Exec
+      { executable = "ls"
+      ; argv = []
+      ; cwd = None
+      ; env = [ "TOKEN", "first"; "TOKEN", "second" ]
+      ; stdin = Execute_input.Inherit
+      ; stdout = Execute_input.Inherit
+      ; stderr = Execute_input.Inherit
+      }
+  in
+  match Execute_input.validate input with
+  | Error (Execute_input.Env_key_duplicate "TOKEN") -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected Env_key_duplicate, got %a"
+      Execute_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.fail "duplicate env key unexpectedly accepted"
+;;
+
 (* RFC-0198 Phase A: redirection-shape argv tokens.  Validation must
    reject these with the typed [Argv_contains_shell_redirection] error
    so the caller (LLM) receives a typed alternative instead of the
@@ -1366,6 +1410,11 @@ let suite =
           test_gh_multiline_body_lowers_to_literal_argv
       ; Alcotest.test_case "cwd_not_absolute" `Quick test_cwd_not_absolute
       ; Alcotest.test_case "env_key_invalid" `Quick test_env_key_invalid
+      ; Alcotest.test_case
+          "env_key_cannot_start_with_digit"
+          `Quick
+          test_env_key_cannot_start_with_digit
+      ; Alcotest.test_case "env_key_duplicate" `Quick test_env_key_duplicate
       ; Alcotest.test_case
           "rfc_0198_shell_redirection_token_rejected"
           `Quick


### PR DESCRIPTION
## 목적

typed Execute의 env 필드가 Docker 프로파일에서 3개 사이트의 fail-closed 가드(`"typed Shell IR Docker dispatch does not support env yet"`, #23716 도입)에 막혀 있던 것을 구현으로 해소한다. 12h tool-call 텔레메트리(2026-07-11 06:22–18:21)에서 이 가드로 인한 dispatch 실패 2건 관측 — Shell IR RFC 트랙 적대검증에서 typed Execute docker 경로의 유일한 미구현 브랜치로 확정된 항목.

## 변경

| 파일 | 변경 |
|---|---|
| `keeper_turn_sandbox_runtime.ml/.mli` | `run_exec_with_status_split ?env`(resolved "K=V" 배열) 추가, `docker exec` argv에 `--env` 플래그 주입. `exec_pipeline_stage`에 per-stage `env` 필드. env 값에도 argv와 동일한 host-root→container-root rewriting 적용. 중복이던 인라인 argv rewriting을 `rewrite_command_argv` 재사용으로 dedup |
| `keeper_sandbox_shell_ir_target.ml/.mli` | 두 runner(단일/pipeline)가 env를 passthrough. sandbox exec 경계가 직접 주입하는 예약 키(HOME/USER/LOGNAME/SHELL/MASC_BASE_PATH/MASC_BASE_PATH_INPUT/MASC_CONFIG_DIR) 충돌 시 키 이름을 명시한 typed error로 거부 — `docker exec`는 중복 `--env`를 last-wins로 해석하므로 충돌은 sandbox 불변식의 silent override가 됨 |
| `keeper_tool_execute_runtime.ml` | pre-dispatch has-env 거부 제거 (관측 실패의 발원지) + 미사용 alias 제거 |
| `keeper_sandbox_runtime_setup.ml/.mli`, `keeper_sandbox_runtime.mli` | `docker_sandbox_reserved_env_keys` SSOT — 예약 게이트와 arg 빌더가 같은 상수를 소비해 drift 구조적 차단. `docker_config_env_args`의 MASC_* 리터럴 3개를 `Env_config_core` 키 상수 재사용으로 교체(하드코딩 산포 해소) |
| `test/test_keeper_sandbox_docker_env.ml` (신규) | 예약 키 게이트 5케이스, `--env` argv shaping 2케이스, 예약 리스트 drift guard 2케이스 |

## 시맨틱

Host dispatch는 이미 env를 additive override로 적용 (`Exec_dispatch.resolve_host_env` — 상속 환경 위에 키 단위 덮어쓰기). `docker exec --env K=V`도 컨테이너 환경 위 additive override로 동일 — 두 sandbox 프로파일의 env 시맨틱이 이 PR로 일치한다.

## RFC

- `docs/rfc/RFC-0160-shell-ir-first-class.md` (Implemented) — 이 PR이 배선하는 typed Shell IR dispatch substrate. env 브랜치는 #23716에서 fail-closed로 이연된 잔여 구현.
- `docs/rfc/RFC-0091-execute-typed-argv.md` (Implemented) — typed Execute 입력 계약. env 키 유효성은 기존 `check_env`(typed_input) 게이트가 이미 담당.
- 예약 키 거부는 신규 정책이 아니라 기존 sandbox invariant(#23716의 fail-closed 의도)의 typed 유지 — permissive 강등 없음.

## 검증

- `dune build --root . @check` green
- 신규 `test_keeper_sandbox_docker_env` 9/9
- 인접 스위트: `test_keeper_sandbox_read_backend` 54, `test_keeper_sandbox_docker_route` 65, `test_keeper_tool_execute_typed_input` 54 — 전부 green
- 미검증: 실 docker 데몬 대상 E2E(`docker exec --env` 실주입)는 로컬 미실행 — CI/운영 turn에서 관측 예정

## Self-review (Best Programmer 기준)

- 목표: 미구현 브랜치 구현 (workaround 아님 — counter/string-classifier/N-of-M/catch-all 시그니처 해당 없음)
- Unknown→Permissive 없음: 예약 키 충돌은 Error, silent drop 없음
- 타입 강제: `exec_pipeline_stage.env` 필드 추가로 컴파일러가 모든 구성 사이트 강제 (test 1곳 컴파일러가 검출)

Evidence: 12h 텔레메트리 분석 대화 (tool_calls 440건 중 IR-4 클래스 2건), masc task-2286

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
