### PR TITLE
chore(keeper): dead fail_open_health_filtered_candidates 제거 (#20720 조각1)

### DIFF
--- a/docs/rfc/RFC-0102-pre-turn-runtime-availability-gate.md
+++ b/docs/rfc/RFC-0102-pre-turn-runtime-availability-gate.md
@@ -1,17 +1,25 @@
 ---
 rfc: "0102"
 title: "Pre-turn runtime availability gate — reuse, not new surface"
-status: Implemented
+status: Superseded
 created: 2026-05-17
-updated: 2026-05-22
+updated: 2026-07-11
 author: vincent
 supersedes: []
-superseded_by: null
-related: ["0009", "0012", "0022", "0042", "0072", "0088"]
+superseded_by: "0206"
+related: ["0009", "0012", "0022", "0042", "0072", "0088", "0206", "0207"]
 implementation_prs: [15814]
 ---
 
 # RFC-0102 — Pre-turn runtime availability gate
+
+> **Superseded (2026-07-11):** RFC-0206 replaced the legacy health-filtered
+> candidate fail-open decision point with the typed `Runtime` boundary. RFC-0207
+> subsequently introduced per-Keeper ordered runtime lanes, whose candidates are
+> resolved by `Keeper_turn_driver` and checked per attempt by
+> `Keeper_turn_driver_provider_attempt`. It did not restore the helper removed in
+> PR #24186. The design and examples below describe the historical RFC-0102
+> implementation, not the current dispatch path.
 
 - Related RFCs (layer hand-offs):
   - **RFC-0009** Runtime Trust Phase 2 — *pre-attempt ordering*
@@ -56,7 +64,7 @@ call site and (b) a case-split in an existing fail-open policy.
 | Per-provider cooldown read | `Runtime_health_tracker.is_in_cooldown : t -> provider_key:string -> bool` | `lib/runtime/runtime_health_tracker.mli:276` |
 | `Phase_gating → Done(Skipped)` emission template (with `record_pre_dispatch_terminal_observation` + `Trajectory.Gated`) | already in 4 arms (`supervisor_stop`, `non_executable_phase`, etc.) | `lib/keeper/keeper_unified_turn.ml:155,164,195,204,235,415,466,479` |
 | Runtime-recovery probe (already in production) | `runtime_recovered` closure using named-provider runtime resolution + `Runtime_health_filter.filter_healthy_strict` | `lib/keeper/keeper_stale_watchdog.ml:749-770` |
-| Current fail-open policy site (decision point) | `fail_open_health_filtered_candidates` + the `health_cooldown_fail_open` branch | `lib/keeper/keeper_turn_driver.ml:325-345` |
+| Historical fail-open policy site (removed by RFC-0206 / PR #24186) | pre-filter candidate fallback + `health_cooldown_fail_open` | archived RFC-0102 implementation |
 
 The watchdog and the (to-be-added) phase_gating gate need the **same**
 logical question — *is this runtime currently capable of producing any
@@ -154,17 +162,18 @@ first iteration — it preserves the watchdog's existing semantics
 (active resolve + strict filter). A cached variant is a follow-up
 *if and only if* per-turn invocation cost proves measurable (see §8 Q3).
 
-### 4.2 Case-split the fail-open policy
+### 4.2 Historical case-split policy (superseded)
 
-In `keeper_turn_driver.ml`'s `fail_open_health_filtered_candidates`,
-replace the boolean fail-open with a typed dispatch:
+The original implementation replaced its boolean fail-open decision with a
+typed dispatch. This is retained as historical rationale only; the current
+runtime-lane path uses the typed boundaries named in the supersession note.
 
 ```
 match rejection_or_ok with
 | Ok healthy -> healthy
 | Error (All_local_unhealthy _) ->
   (* unchanged: fail-open, surface provider result *)
-  fail_open_health_filtered_candidates ~... ; []
+  retry the pre-filter candidates
 | Error (All_missing_api_key _) ->
   (* new: fail-closed, return No_providers_available directly *)
   ... raise No_providers_available

--- a/docs/rfc/RFC-0102-pre-turn-runtime-availability-gate.md
+++ b/docs/rfc/RFC-0102-pre-turn-runtime-availability-gate.md
@@ -14,12 +14,12 @@ implementation_prs: [15814]
 # RFC-0102 — Pre-turn runtime availability gate
 
 > **Superseded (2026-07-11):** RFC-0206 replaced the legacy health-filtered
-> candidate fail-open decision point with the typed `Runtime` boundary. RFC-0207
-> subsequently introduced per-Keeper ordered runtime lanes, whose candidates are
-> resolved by `Keeper_turn_driver` and checked per attempt by
-> `Keeper_turn_driver_provider_attempt`. It did not restore the helper removed in
-> PR #24186. The design and examples below describe the historical RFC-0102
-> implementation, not the current dispatch path.
+> candidate fail-open decision point with the typed `Runtime` boundary. The
+> current dispatch path resolves candidates in `Keeper_turn_driver` and checks
+> each attempt in `Keeper_turn_driver_provider_attempt`; the follow-up ordered
+> lane design remains documented separately in draft RFC-0207. The design and
+> examples below describe the historical RFC-0102 implementation, not the
+> current dispatch path.
 
 - Related RFCs (layer hand-offs):
   - **RFC-0009** Runtime Trust Phase 2 — *pre-attempt ordering*

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -28,14 +28,6 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, Some _ -> "runtime_mcp_connect_only"
   | false, false, None -> "none"
 
-let fail_open_health_filtered_candidates
-    ~(tool_filtered_candidates : 'a list)
-    ~(health_filtered_candidates : 'a list)
-  : 'a list * bool =
-  match health_filtered_candidates with
-  | [] when tool_filtered_candidates <> [] -> tool_filtered_candidates, true
-  | _ -> health_filtered_candidates, false
-
 (* RFC-0206: provider_rejections_for_no_tool_error deleted — multi-candidate
    tool-filter rejection lists have no meaning under single-runtime dispatch. *)
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -8,18 +8,6 @@ val resolved_tool_lane_label :
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
   string
 
-val fail_open_health_filtered_candidates :
-  tool_filtered_candidates:'a list ->
-  health_filtered_candidates:'a list ->
-  'a list * bool
-(** [fail_open_health_filtered_candidates ~tool_filtered_candidates
-    ~health_filtered_candidates] preserves health-filtered candidates unless
-    the health/cooldown filter would empty an otherwise tool-capable candidate
-    set. In that all-cooldown case it returns the pre-health-filter candidates
-    plus [true], allowing the runtime to attempt at least one provider and
-    surface the real upstream result instead of stopping at
-    [no_providers_available]. *)
-
 val apply_stream_idle_timeout_default : float option -> float option
 
 val checkpoint_after_attempt :


### PR DESCRIPTION
## 목표
`#20720` 조각 1 — 호출자 0인 dead code `fail_open_health_filtered_candidates`를 제거합니다.

## 근거
- `rg fail_open_health_filtered_candidates lib/ bin/ test/` → 정의(.ml)와 시그니처(.mli) 외 **호출자 0** (origin/main `8607fff28d`).
- RFC-0206이 keeper attempt를 single-runtime dispatch로 축소하면서 이 helper가 서비스하던 multi-candidate health/tool 필터 경로가 사라짐 → 진짜 dead code.
- fail-open 자체가 워크어라운드(cooldown 필터된 후보를 되살려 실제 upstream 가용성 상태를 가림)이므로 제거 방향이 옳습니다.

## 변경
- `keeper_turn_driver_helpers.ml`/`.mli`에서 함수 + 시그니처 제거 (20줄 삭제).
- 무관한 RFC-0206 `provider_rejections` 주석은 보존.

## 검증
- `dune build lib/keeper` green.
- 삭제 후 `rg` 잔존 참조 0 확인.
- `ocamlformat` 준수.

## 스코프
- `#20720`의 조각 1(fail_open dead code)만. 조각 2(tui_decode AG-UI 수용)는 issue 지시대로 별도 PR.
- 부차적 언급된 `Keeper_preflight_health_tracker` 제거는 이 PR 범위 밖(별도 판단 필요).
- gated subsystem(credential/gh/host_config/sandbox/shell) 무관 → RFC 불필요.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
