### PR TITLE
fix(keeper): persist worker failure from latest revision

### DIFF
--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -42,25 +42,40 @@ let release_worker operation =
 ;;
 
 let persist_unhandled_failure ~config operation exn =
-  let blocked =
-    { operation with
-      revision = operation.revision + 1
-    ; phase = Blocked { stage = Record_update; detail = Printexc.to_string exn }
-    ; updated_at = Masc_domain.now_iso ()
-    }
-  in
-  match
-    Keeper_shutdown_store.replace
-      ~config
-      ~expected_revision:operation.revision
-      blocked
-  with
-  | Ok () -> ()
-  | Error store_error ->
+  let detail = Printexc.to_string exn in
+  Eio.Cancel.protect (fun () ->
     Log.Keeper.error
-      "shutdown operation %s failed and its blocked state could not be persisted: %s"
+      "shutdown worker failed; persisting durable failure evidence: keeper=%s operation=%s error=%s"
+      operation.keeper_name
       (worker_key operation)
-      (Keeper_shutdown_store.error_to_string store_error)
+      detail;
+    match
+      Keeper_shutdown_store.persist_blocked_latest
+        ~config
+        ~identity:operation
+        ~failure:{ stage = Record_update; detail }
+        ~updated_at:(Masc_domain.now_iso ())
+    with
+    | Ok (Keeper_shutdown_store.Blocked_persisted blocked) ->
+      Log.Keeper.error
+        "shutdown worker failed; blocked state persisted: keeper=%s operation=%s revision=%d error=%s"
+        blocked.keeper_name
+        (worker_key blocked)
+        blocked.revision
+        detail
+    | Ok (Keeper_shutdown_store.State_preserved current) ->
+      Log.Keeper.error
+        "shutdown worker failed after a durable non-progress state; preserving it: keeper=%s operation=%s revision=%d error=%s"
+        current.keeper_name
+        (worker_key current)
+        current.revision
+        detail
+    | Error store_error ->
+      Log.Keeper.error
+        "shutdown operation %s failed and its blocked state could not be persisted: worker_error=%s store_error=%s"
+        (worker_key operation)
+        detail
+        (Keeper_shutdown_store.error_to_string store_error))
 ;;
 
 let finalize_if_ready ~config ~entry operation =
@@ -224,3 +239,7 @@ let recover_at_boot ~config =
   | Error error -> [ Error (Keeper_shutdown_store.error_to_string error) ]
   | Ok operations -> List.map (recover_operation ~config) operations
 ;;
+
+module For_testing = struct
+  let persist_unhandled_failure = persist_unhandled_failure
+end

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -34,3 +34,11 @@ val recover_operation :
   config:Workspace.config ->
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, string) result
+
+module For_testing : sig
+  val persist_unhandled_failure :
+    config:Workspace.config ->
+    Keeper_shutdown_types.t ->
+    exn ->
+    unit
+end

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -11,6 +11,10 @@ type error =
       ; actual : int
       }
 
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
+
 let error_to_string = function
   | Already_exists path -> Printf.sprintf "shutdown operation already exists: %s" path
   | Not_found path -> Printf.sprintf "shutdown operation not found: %s" path
@@ -547,6 +551,30 @@ let replace ~config ~expected_revision operation =
            (Operation_id.to_string operation.operation_id)))
 ;;
 
+let persist_blocked_latest ~config ~identity ~failure ~updated_at =
+  let operation_path = path ~config identity.operation_id in
+  with_operation_lock ~access:Write operation_path (fun () ->
+    match load_unlocked ~config identity.operation_id with
+    | Error _ as error -> error
+    | Ok existing when not (same_identity existing identity) ->
+      Error (Identity_mismatch (Operation_id.to_string identity.operation_id))
+    | Ok existing ->
+      (match existing.phase with
+       | Finalized _ | Blocked _ | Reconciliation_required _ ->
+         Ok (State_preserved existing)
+       | Prepared | Joined_idle | Finalizing_tasks _ | Cleanup_ready _ ->
+         let blocked =
+           { existing with
+             revision = existing.revision + 1
+           ; phase = Blocked failure
+           ; updated_at
+           }
+         in
+         Keeper_fs.save_json_atomic operation_path (to_json blocked)
+         |> Result.map_error (fun detail -> Io_error detail)
+         |> Result.map (fun () -> Blocked_persisted blocked)))
+;;
+
 let load ~config operation_id =
   let operation_path = path ~config operation_id in
   with_operation_lock ~access:Read operation_path (fun () ->
@@ -592,3 +620,10 @@ let list_for_keeper ~config ~keeper_name =
   |> Result.map
        (List.filter (fun operation -> String.equal operation.keeper_name keeper_name))
 ;;
+
+module For_testing = struct
+  let with_operation_write_lock ~config operation_id f =
+    let operation_path = path ~config operation_id in
+    with_operation_lock ~access:Write operation_path f
+  ;;
+end

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -14,6 +14,10 @@ type error =
       ; actual : int
       }
 
+type persist_blocked_result =
+  | State_preserved of Keeper_shutdown_types.t
+  | Blocked_persisted of Keeper_shutdown_types.t
+
 val error_to_string : error -> string
 
 val path :
@@ -35,6 +39,16 @@ val replace :
   Keeper_shutdown_types.t ->
   (unit, error) result
 
+(** Read the latest durable revision and persist [Blocked failure] while
+    holding the operation's write lock. Existing [Finalized], [Blocked], and
+    effect-unknown reconciliation states are preserved. *)
+val persist_blocked_latest :
+  config:Workspace.config ->
+  identity:Keeper_shutdown_types.t ->
+  failure:Keeper_shutdown_types.failure ->
+  updated_at:string ->
+  (persist_blocked_result, error) result
+
 val load :
   config:Workspace.config ->
   Keeper_shutdown_types.Operation_id.t ->
@@ -48,3 +62,11 @@ val list_for_keeper :
 val list_all :
   config:Workspace.config ->
   (Keeper_shutdown_types.t list, error) result
+
+module For_testing : sig
+  val with_operation_write_lock :
+    config:Workspace.config ->
+    Keeper_shutdown_types.Operation_id.t ->
+    (unit -> 'a) ->
+    'a
+end

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -29,6 +29,7 @@ module Shutdown_types = Masc.Keeper_shutdown_types
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
+module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Keeper_meta_store = Masc.Keeper_meta_store
 
 let bp = "/tmp/test-heartbeat-integ"
@@ -820,6 +821,77 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Error (Shutdown_store.Identity_mismatch _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
+      let worker_failure = Failure "worker exploded after durable join" in
+      let holder_locked_p, holder_locked_r = Eio.Promise.create () in
+      let release_holder_p, release_holder_r = Eio.Promise.create () in
+      let holder_done_p, holder_done_r = Eio.Promise.create () in
+      let worker_started_p, worker_started_r = Eio.Promise.create () in
+      let exception Cancel_worker in
+      Eio.Switch.run @@ fun test_sw ->
+      Eio.Fiber.fork ~sw:test_sw (fun () ->
+        Shutdown_store.For_testing.with_operation_write_lock
+          ~config
+          operation_id
+          (fun () ->
+             Eio.Promise.resolve holder_locked_r ();
+             Eio.Promise.await release_holder_p);
+        Eio.Promise.resolve holder_done_r ());
+      Eio.Promise.await holder_locked_p;
+      (try
+         Eio.Switch.run (fun worker_sw ->
+           Eio.Fiber.fork ~sw:worker_sw (fun () ->
+             Eio.Promise.resolve worker_started_r ();
+             Shutdown_runtime.For_testing.persist_unhandled_failure
+               ~config
+               operation
+               worker_failure);
+           Eio.Promise.await worker_started_p;
+           Eio.Switch.fail worker_sw Cancel_worker;
+           Eio.Promise.resolve release_holder_r ())
+       with
+       | Cancel_worker -> ());
+      Eio.Promise.await holder_done_p;
+      let blocked =
+        match Shutdown_store.load ~config operation_id with
+        | Ok blocked -> blocked
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "unhandled worker failure advances the latest durable revision"
+        (joined.revision + 1)
+        blocked.revision;
+      (match blocked.phase with
+       | Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail } ->
+         check string
+           "unhandled worker failure detail"
+           (Printexc.to_string worker_failure)
+           detail
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Blocked _ ->
+         fail "unhandled worker failure did not persist typed blocked evidence");
+      Shutdown_runtime.For_testing.persist_unhandled_failure
+        ~config
+        operation
+        (Failure "later worker failure");
+      let preserved =
+        match Shutdown_store.load ~config operation_id with
+        | Ok preserved -> preserved
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "later worker failure preserves blocked revision"
+        blocked.revision
+        preserved.revision;
+      check
+        bool
+        "later worker failure preserves first blocked evidence"
+        true
+        (preserved.phase = blocked.phase);
       (match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
        | Ok [ listed ] ->
          check bool


### PR DESCRIPTION
## Summary\n- persist unhandled shutdown-worker failures from the latest durable revision under the per-operation write lock\n- preserve Finalized, Blocked, and Reconciliation_required states instead of downgrading them\n- protect immediate error observation and durable failure persistence from supervisor cancellation\n- add deterministic lock-contention and worker-switch cancellation coverage\n\n## Boundary and invariants\n- MASC-only Keeper lifecycle change; no OAS dependency\n- exact operation identity and monotonic revision remain store invariants\n- no timeout, retry heuristic, string-based business branching, or silent failure\n\n## Validation\n- ocamlformat on changed OCaml files\n- parser checks on changed .ml/.mli files\n- git diff --check\n- adversarial reviewer: prior cancellation P1 fixed; no remaining P0/P1 in this delta\n- no local Dune; full build/test is CI authority\n\nStacked on #24146. Keep draft and do-not-merge until the parent stack and residual lifecycle blockers are resolved.