### PR TITLE
refactor(keeper): claim_scope_mode closed variant (#20674)

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -51,9 +51,24 @@ let task_is_unclaimed_todo (task : Masc_domain.task) =
   | Masc_domain.Cancelled _ ->
     false
 
+(* Closed set of claim-scope modes. Was a bare [string] (#20674): producers
+   and consumers matched on free string literals, so the compiler could not
+   force a consumer to handle a new mode, and a dropped producer left a dead
+   [empty_goal_scope_fallback_all_tasks] arm frozen in the consumer. A closed
+   variant makes every producer/consumer exhaustive at compile time. *)
+type claim_scope_mode =
+  | All_tasks
+  | Active_goal_ids
+  | Empty_goal_scope_fallback_all_tasks
+
+let claim_scope_mode_to_string = function
+  | All_tasks -> "all_tasks"
+  | Active_goal_ids -> "active_goal_ids"
+  | Empty_goal_scope_fallback_all_tasks -> "empty_goal_scope_fallback_all_tasks"
+
 type claim_goal_scope = {
   task_filter : Masc_domain.task -> bool;
-  mode : string;
+  mode : claim_scope_mode;
   effective_goal_ids : string list;
   fallback_reason : string option;
 }
@@ -65,14 +80,14 @@ let meta_only_claim_goal_scope ?task_goal_index (meta : keeper_meta) =
   | [] ->
       {
         task_filter = (fun (_task : Masc_domain.task) -> true);
-        mode = "all_tasks";
+        mode = All_tasks;
         effective_goal_ids = [];
         fallback_reason = None;
       }
   | goal_ids ->
       {
         task_filter = task_is_linked_to_keeper_goals ?task_goal_index goal_ids;
-        mode = "active_goal_ids";
+        mode = Active_goal_ids;
         effective_goal_ids = goal_ids;
         fallback_reason = None;
       }
@@ -113,11 +128,9 @@ let resolve_claim_goal_scope_for_tasks ~(config : Workspace.config)
     else
       {
         task_filter = (fun (_task : Masc_domain.task) -> true);
-        (* Reuse the established mode label consumed by
-           [Keeper_tool_task_runtime.claim_scope_context_suffix] rather than
-           minting a new string — a second label for the same concept would
-           drift the two sites apart. *)
-        mode = "empty_goal_scope_fallback_all_tasks";
+        (* [Keeper_tool_task_runtime.claim_scope_context_suffix] exhaustively
+           matches this constructor; the variant keeps the two sites in sync. *)
+        mode = Empty_goal_scope_fallback_all_tasks;
         effective_goal_ids = goal_ids;
         fallback_reason = Some "no_scoped_claimable_tasks";
       }

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -13,9 +13,19 @@ val backend_of_meta : Keeper_meta_contract.keeper_meta -> string
 val task_is_linked_to_keeper_goals :
   ?task_goal_index:(string, string list) Hashtbl.t -> string list -> Masc_domain.task -> bool
 
+type claim_scope_mode =
+  | All_tasks
+  | Active_goal_ids
+  | Empty_goal_scope_fallback_all_tasks
+
+val claim_scope_mode_to_string : claim_scope_mode -> string
+(** Wire label for a claim-scope mode (e.g. observation JSON). Closed variant
+    (#20674) so producers/consumers stay exhaustive instead of drifting on a
+    bare [string]. *)
+
 type claim_goal_scope = {
   task_filter : Masc_domain.task -> bool;
-  mode : string;
+  mode : claim_scope_mode;
   effective_goal_ids : string list;
   fallback_reason : string option;
 }

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -157,9 +157,14 @@ let active_goal_scope_json
   =
   let scoped = meta.active_goal_ids <> [] in
   let mode =
-    match effective_mode with
-    | Some mode -> mode
-    | None -> if scoped then "active_goal_ids" else "all_tasks"
+    let scope_mode =
+      match effective_mode with
+      | Some mode -> mode
+      | None ->
+        if scoped then Keeper_runtime_contract.Active_goal_ids
+        else Keeper_runtime_contract.All_tasks
+    in
+    Keeper_runtime_contract.claim_scope_mode_to_string scope_mode
   in
   let effective_goal_ids =
     match effective_goal_ids with
@@ -201,17 +206,16 @@ let active_goal_scope_json
 
 let claim_scope_context_suffix ~(meta : keeper_meta) claim_goal_scope =
   match claim_goal_scope.Keeper_runtime_contract.mode with
-  | "active_goal_ids" ->
+  | Keeper_runtime_contract.Active_goal_ids ->
     (match meta.active_goal_ids with
      | [] -> " in active goal scope"
      | goal_ids ->
        Printf.sprintf
          " within active_goal_ids=[%s]"
          (String.concat ", " goal_ids))
-  | "all_tasks" -> " across all tasks"
-  | "empty_goal_scope_fallback_all_tasks" ->
+  | Keeper_runtime_contract.All_tasks -> " across all tasks"
+  | Keeper_runtime_contract.Empty_goal_scope_fallback_all_tasks ->
     " after active-goal fallback to all tasks"
-  | mode -> Printf.sprintf " in claim_scope.mode=%s" mode
 ;;
 
 let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
@@ -220,18 +224,20 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
     Printf.sprintf
       "ACTION: Stop scope-lock diagnosis; claim_scope.mode=%s already searched all \
        tasks; resolve blockers/excluded=%d."
-      claim_goal_scope.Keeper_runtime_contract.mode
+      (Keeper_runtime_contract.claim_scope_mode_to_string
+         claim_goal_scope.Keeper_runtime_contract.mode)
       excluded_count
   | None ->
     let scope_hint =
       match claim_goal_scope.Keeper_runtime_contract.mode with
-      | "active_goal_ids" ->
+      | Keeper_runtime_contract.Active_goal_ids ->
         (* Scope only stays in [active_goal_ids] mode when a Todo task IS linked
            to the goal (otherwise the resolver falls back to all_tasks). So a
            no-eligible here means those scoped tasks exist but are blocked /
            awaiting verification — not a scope lock to clear. *)
         " Scoped tasks exist but are blocked or awaiting verification; resolve those blockers."
-      | _ -> ""
+      | Keeper_runtime_contract.All_tasks
+      | Keeper_runtime_contract.Empty_goal_scope_fallback_all_tasks -> ""
     in
     Printf.sprintf
       "ACTION: Stop task-checking — blocked/excluded=%d.%s"

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -51,7 +51,8 @@ let test_active_goal_ids_filter_claimable_tasks () =
       let scope =
         Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
       in
-      check string "mode" "active_goal_ids" scope.mode;
+      check string "mode" "active_goal_ids"
+        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
       check (list string) "effective goal ids" [ "goal-a" ] scope.effective_goal_ids;
       let tasks = Workspace.get_tasks_raw config in
       let included =
@@ -90,7 +91,7 @@ let test_no_scoped_match_falls_back_to_all_tasks () =
         Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
       in
       check string "fallback mode" "empty_goal_scope_fallback_all_tasks"
-        scope.mode;
+        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
       check (option string) "fallback reason recorded"
         (Some "no_scoped_claimable_tasks") scope.fallback_reason;
       check (list string) "effective goal ids preserved" [ "goal-a" ]
@@ -124,7 +125,7 @@ let test_preloaded_tasks_fall_back_to_all_tasks () =
           ~meta ~tasks ()
       in
       check string "fallback mode" "empty_goal_scope_fallback_all_tasks"
-        scope.mode;
+        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
       check (option string) "fallback reason recorded"
         (Some "no_scoped_claimable_tasks") scope.fallback_reason;
       check (list string) "effective goal ids preserved" [ "goal-a" ]
@@ -145,7 +146,8 @@ let test_scoped_match_present_keeps_isolation () =
       let scope =
         Keeper_runtime_contract.resolve_claim_goal_scope ~config ~meta ()
       in
-      check string "scoped mode" "active_goal_ids" scope.mode;
+      check string "scoped mode" "active_goal_ids"
+        (Keeper_runtime_contract.claim_scope_mode_to_string scope.mode);
       check (option string) "no fallback reason" None scope.fallback_reason;
       let tasks = Workspace.get_tasks_raw config in
       let included =


### PR DESCRIPTION
## 목표
`#20674` — `claim_goal_scope.mode`를 bare `string`에서 closed variant로 전환해, producer↔consumer 정합성을 컴파일러가 강제하도록 합니다(CLAUDE.md string-drift 안티패턴 #1 root fix).

## 문제
`mode : string`이라 producer(`keeper_runtime_contract`)와 consumer(`keeper_tool_task_runtime`의 `claim_scope_context_suffix`/`no_eligible_action_for_claim_scope`)가 자유 문자열로 분기. 컴파일러가 새 mode 처리를 강제하지 못함. PR #20672에서 producer가 사라진 뒤 `"empty_goal_scope_fallback_all_tasks"` arm이 consumer에 dead로 박제된 채 발견됐고, 같은 개념에 `"all_tasks_fallback"`이라는 다른 문자열을 만들 뻔함(drift).

## 변경
```ocaml
type claim_scope_mode = All_tasks | Active_goal_ids | Empty_goal_scope_fallback_all_tasks
```
- producer 3곳이 variant 생성, consumer는 exhaustive match (`claim_scope_context_suffix`의 catch-all `| mode -> ...` 제거 — 이게 drift 증상이었음).
- `claim_scope_mode_to_string`이 유일한 wire 경계(observation JSON, operator hint). `active_goal_scope_json`이 variant를 받아 내부에서 to_string → `"active_goal_ids"`/`"all_tasks"` 기본값 리터럴이 자유 문자열로 새지 않음.
- `test_keeper_runtime_contract`은 `claim_scope_mode_to_string` 경유 assert.

## 검증
- masc 라이브러리 + 테스트 컴파일 green, 4 tests 통과.
- **Mutation check**: 4번째 constructor를 추가하고 미처리 → 빌드 실패(`warning 8 partial-match` + `.mli` 불일치). compile-time drift 가드 실증.
- `ocamlformat` 4파일 준수.

## 스코프
- `fallback_reason : string option`은 free-form reason이라 enum 전환 제외(issue가 별도 follow-up으로 명시).
- gated subsystem(credential/gh/host_config/sandbox/shell) 무관 → RFC 불필요.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
