### PR TITLE
fix(board): make descriptor visibility initialization-independent

### DIFF
--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -111,39 +111,28 @@ let handle_tool name args : Tool_result.result =
 ;;
 
 let tool_spec_read_only =
-  [ "masc_board_list"
-  ; "masc_board_sub_board_list"
-  ; "masc_board_sub_board_get"
-  ; "masc_board_post_get"
-  ; "masc_board_stats"
-  ; "masc_board_search"
-  ; "masc_board_profile"
-  ; "masc_board_hearths"
-  ; "masc_board_curation_read"
-  ]
+  Tool_name.Board_name.all
+  |> List.filter (fun board_name ->
+    (Board_tool_registry.operation_policy board_name).readonly)
+  |> List.map Tool_name.Board_name.to_string
 ;;
-
-let destructive_board_tool_names =
-  let open Tool_name.Board_name in
-  [ to_string Board_delete; to_string Board_cleanup ]
-;;
-
-let is_destructive_board_tool name = List.mem name destructive_board_tool_names
 
 let register () =
   let handler ~name ~args = Some (handle_tool name args) in
-  let make_spec (s : Masc_domain.tool_schema) =
-    let ro = List.mem s.name tool_spec_read_only in
+  let make_spec board_name =
+    let s = Board_tool_registry.schema_for_board_name board_name in
+    let policy = Board_tool_registry.operation_policy board_name in
     Tool_spec.create
       ~name:s.name
       ~description:s.description
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
       ~handler_binding:(Shared handler)
-      ~is_read_only:ro
-      ~is_idempotent:ro
-      ~is_destructive:(is_destructive_board_tool s.name)
+      ~is_read_only:policy.readonly
+      ~is_idempotent:policy.idempotent
+      ~is_destructive:policy.destructive
+      ~visibility:policy.visibility
       ()
   in
-  Tool_spec.register_all (List.map make_spec Board_tool_registry.tools)
+  Tool_spec.register_all (List.map make_spec Tool_name.Board_name.all)
 ;;

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -177,6 +177,47 @@ let board_tool_curation_submit : Masc_domain.tool_schema =
   }
 ;;
 
+(** {1 Typed operation projection} *)
+type operation_policy =
+  { visibility : Tool_catalog.visibility
+  ; readonly : bool
+  ; idempotent : bool
+  ; destructive : bool
+  }
+
+let operation_policy board_name =
+  let readonly = not (Tool_name.Board_name.is_resource_write board_name) in
+  let destructive =
+    match board_name with
+    | Tool_name.Board_name.Board_delete
+    | Tool_name.Board_name.Board_cleanup -> true
+    | Tool_name.Board_name.Board_comment
+    | Tool_name.Board_name.Board_comment_vote
+    | Tool_name.Board_name.Board_curation_read
+    | Tool_name.Board_name.Board_curation_submit
+    | Tool_name.Board_name.Board_hearths
+    | Tool_name.Board_name.Board_list
+    | Tool_name.Board_name.Board_post
+    | Tool_name.Board_name.Board_post_get
+    | Tool_name.Board_name.Board_post_update
+    | Tool_name.Board_name.Board_profile
+    | Tool_name.Board_name.Board_reaction
+    | Tool_name.Board_name.Board_search
+    | Tool_name.Board_name.Board_stats
+    | Tool_name.Board_name.Board_sub_board_create
+    | Tool_name.Board_name.Board_sub_board_delete
+    | Tool_name.Board_name.Board_sub_board_get
+    | Tool_name.Board_name.Board_sub_board_list
+    | Tool_name.Board_name.Board_sub_board_update
+    | Tool_name.Board_name.Board_vote -> false
+  in
+  { visibility = Tool_catalog.Default
+  ; readonly
+  ; idempotent = readonly
+  ; destructive
+  }
+;;
+
 (** {1 Typed schema projection} *)
 let schema_for_board_name = function
   | Tool_name.Board_name.Board_post -> Board_tool_schemas.tool_post_create

--- a/lib/board_tool_adapter/board_tool_registry.mli
+++ b/lib/board_tool_adapter/board_tool_registry.mli
@@ -2,6 +2,17 @@
 
 val tools : Masc_domain.tool_schema list
 
+type operation_policy =
+  { visibility : Tool_catalog.visibility
+  ; readonly : bool
+  ; idempotent : bool
+  ; destructive : bool
+  }
+
+val operation_policy : Tool_name.Board_name.t -> operation_policy
+(** Immutable registration policy shared by Board [Tool_spec] and Keeper
+    descriptor projection. *)
+
 val schema_for_board_name : Tool_name.Board_name.t -> Masc_domain.tool_schema
 (** Exhaustive typed projection to the advertised [masc_board_*] schema. *)
 

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1138,16 +1138,16 @@ let board_descriptor name description ~readonly =
 let masc_board_descriptor board_name =
   let schema = Board_tool_registry.schema_for_board_name board_name in
   let name = Tool_name.Board_name.to_string board_name in
+  let operation_policy = Board_tool_registry.operation_policy board_name in
   let metadata = Tool_catalog.metadata name in
-  let readonly =
-    match metadata.readonly with
-    | Some readonly -> readonly
-    | None -> List.mem name Board_tool_dispatch.tool_spec_read_only
-  in
+  let readonly = operation_policy.readonly in
   let policy =
     let visibility =
       match Keeper_tool_name.board_projection_of_masc_board_name board_name with
-      | Keeper_tool_name.Direct_masc -> metadata.visibility
+      | Keeper_tool_name.Direct_masc ->
+        Tool_catalog.effective_registered_visibility
+          ~name
+          ~declared:operation_policy.visibility
       | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
         Tool_catalog.Hidden
     in

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -373,6 +373,14 @@ let public_mcp_set : (string, unit) Hashtbl.t =
 
 let is_public_mcp name = Hashtbl.mem public_mcp_set name
 
+let effective_registered_visibility ~name ~declared =
+  if
+    Tool_catalog_surfaces.is_system_internal_hidden name
+    && declared = Default
+  then Hidden
+  else declared
+;;
+
 let full_surface_override () = Env_config.Tools.full_surface_enabled ()
 
 (* ================================================================ *)

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -58,6 +58,12 @@ val public_mcp_tools : string list
 val is_public_mcp : string -> bool
 (** O(1) membership check against the public surface. *)
 
+val effective_registered_visibility :
+  name:string -> declared:visibility -> visibility
+(** Apply the immutable system-internal surface override used by
+    {!Tool_spec.register}. Definition builders can use this before runtime
+    registration without depending on mutable catalog initialization order. *)
+
 val full_surface_override : unit -> bool
 (** [true] when MASC_FULL_SURFACE=1 is set. *)
 

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -111,9 +111,9 @@ let register (spec : t) =
     Tool_catalog_surfaces.is_system_internal_hidden spec.name
   in
   let effective_visibility =
-    if is_system_internal && spec.visibility = Tool_catalog.Default
-    then Tool_catalog.Hidden
-    else spec.visibility
+    Tool_catalog.effective_registered_visibility
+      ~name:spec.name
+      ~declared:spec.visibility
   in
   let effective_allow_direct =
     spec.allow_direct_call_when_hidden || is_system_internal

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -703,7 +703,10 @@ let test_masc_board_registry_has_descriptor_projection () =
          let expected_visibility =
            match Keeper_tool_name.board_projection_of_masc_board_name board_name with
            | Keeper_tool_name.Direct_masc ->
-             (Tool_catalog.metadata schema.name).visibility
+             let operation_policy = Board_tool_registry.operation_policy board_name in
+             Tool_catalog.effective_registered_visibility
+               ~name:schema.name
+               ~declared:operation_policy.visibility
            | Keeper_tool_name.Keeper_wrapper _ | Keeper_tool_name.External_only ->
              Tool_catalog.Hidden
          in


### PR DESCRIPTION
## Summary

- add one immutable typed Board operation-policy projection
- derive Board Tool_spec readonly/idempotent/destructive/visibility from that projection
- derive Keeper Board descriptors from the same projection instead of mutable Tool catalog registration state
- centralize the system-internal visibility override in Tool_catalog

## Why

`masc_board_post_update` was captured as Hidden when Keeper descriptors initialized before Board tool registration, then Tool_spec registration changed catalog metadata to Default. Model visibility therefore depended on module initialization order and main CI failed.

Closes #24193.

## Validation

- ocamlformat on all changed OCaml files
- parser checks on all changed `.ml` / `.mli` files
- `git diff --check`
- no local Dune; full build/test remains CI authority
