### PR TITLE
fix(keeper): separate terminal disposition from runtime completion

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -335,9 +335,12 @@ let terminal_reason_requires_attention trust =
     (match terminal_reason_severity trust with
      | Some ("bad" | "warn") -> true
      | _ ->
-       (match terminal_reason_code trust |> Option.map String.lowercase_ascii with
-        | Some ("success" | "completed") | None -> false
-        | Some _ -> true))
+       (match terminal_reason_code trust with
+        | None -> false
+        | Some code ->
+          not
+            (Keeper_turn_disposition.is_success
+               (Keeper_turn_disposition.of_wire code))))
 ;;
 
 let trust_disposition_requires_attention trust =

--- a/lib/dashboard/dashboard_execution.mli
+++ b/lib/dashboard/dashboard_execution.mli
@@ -44,3 +44,8 @@ val record_render_phase_timings : render_phase_timings_ms -> unit
 (** Emit the render phase breakdown into Otel_metric_store.  This mirrors the
     slow-render log payload so dashboard N+1 / enrichment cost is visible
     even when the render stays below the warning threshold. *)
+
+val terminal_reason_requires_attention : Yojson.Safe.t -> bool
+(** Strict typed projection for a runtime-trust [latest_terminal_reason].
+    Missing reason is non-attention; malformed or non-success dispositions are
+    attention. Exposed for wire-contract regression tests. *)

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -109,8 +109,10 @@ let finalize
     match turn_result with
     | Ok _ ->
       (match !receipt_stop_reason_ref with
-       | Some sr -> Keeper_execution_receipt.stop_reason_to_string sr
-       | None -> "success")
+       | Some sr ->
+         Keeper_execution_receipt.receipt_terminal_reason_code_of_stop_reason sr
+       | None ->
+         Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success)
     | Error err ->
       Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err
       |> Keeper_turn_terminal_code.to_wire

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -209,8 +209,8 @@ let passive_only_without_work_scope receipt =
 ;;
 
 let terminal_reason_is_success receipt =
-  let code = String.lowercase_ascii (String.trim receipt.terminal_reason_code) in
-  String.equal code "completed" || String.equal code "success"
+  Keeper_turn_disposition.is_success
+    (Keeper_turn_disposition.of_wire receipt.terminal_reason_code)
 ;;
 
 let operator_disposition (receipt : t)
@@ -456,9 +456,12 @@ let operator_disposition (receipt : t)
         Disp_unknown, Reason_unmapped_runtime_state)
 ;;
 
-let to_json (receipt : t) =
+let to_json_with_operator_disposition
+      (receipt : t)
+      ~disposition
+      ~disposition_reason
+  =
   let terminal_reason_code = enrich_contract_violation_reason receipt in
-  let disposition, disposition_reason = operator_disposition receipt in
   let operator_disposition = operator_disposition_kind_to_string disposition in
   let operator_disposition_reason =
     operator_disposition_reason_to_string disposition_reason
@@ -592,6 +595,11 @@ let to_json (receipt : t) =
     ]
 ;;
 
+let to_json receipt =
+  let disposition, disposition_reason = operator_disposition receipt in
+  to_json_with_operator_disposition receipt ~disposition ~disposition_reason
+;;
+
 (* Operator broadcast hook (#fleet-stall 2026-04-26): operator_disposition
    was a derived display field — emitted nowhere. A pause_human/alert_exhausted
    verdict therefore had no transition out: dashboard turned a chip red, but
@@ -648,6 +656,16 @@ let needs_operator_broadcast = function
   | Disp_pass_next_model
   | Disp_user_cancelled
   | Disp_skipped -> false
+;;
+
+let reaction_kind_of_operator_disposition = function
+  | Disp_pass | Disp_skipped -> Keeper_reaction_ledger.Execution_receipt
+  | Disp_pause_human
+  | Disp_alert_exhausted
+  | Disp_fail_open_next_runtime
+  | Disp_pass_next_model
+  | Disp_user_cancelled
+  | Disp_unknown -> Keeper_reaction_ledger.Terminal_reason
 ;;
 
 module Broadcast_dedupe = struct
@@ -916,7 +934,13 @@ let append (config : Workspace.config) (receipt : t) =
   let store =
     Keeper_types_support.keeper_execution_receipt_store config receipt.keeper_name
   in
-  let receipt_json = to_json receipt in
+  let disposition, reason = operator_disposition receipt in
+  let receipt_json =
+    to_json_with_operator_disposition
+      receipt
+      ~disposition
+      ~disposition_reason:reason
+  in
   Dated_jsonl.append store receipt_json;
   (try
      Keeper_reaction_ledger.record_execution_receipt_reaction
@@ -927,6 +951,7 @@ let append (config : Workspace.config) (receipt : t) =
        ~current_task_id:receipt.current_task_id
        ~goal_ids:receipt.goal_ids
        ~outcome:(outcome_kind_to_tla_receipt receipt.outcome)
+       ~reaction_kind:(reaction_kind_of_operator_disposition disposition)
        ~terminal_reason_code:receipt.terminal_reason_code
        ~receipt_json
        ()
@@ -939,7 +964,6 @@ let append (config : Workspace.config) (receipt : t) =
        receipt.keeper_name
        receipt.trace_id
        (Printexc.to_string exn));
-  let disposition, reason = operator_disposition receipt in
   if needs_operator_broadcast disposition
   then (
     let disposition_s = operator_disposition_kind_to_string disposition in

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -213,6 +213,13 @@ type t =
   }
 
 val stop_reason_to_string : Runtime_agent.stop_reason -> string
+
+(** Receipt terminal-reason projection for the runtime-stop axis. Unlike
+    {!stop_reason_to_string}, normal completion serialises as canonical
+    [Keeper_turn_disposition.Success]. Completion-contract truth remains a
+    separate typed receipt field and feeds the final operator disposition. *)
+val receipt_terminal_reason_code_of_stop_reason : Runtime_agent.stop_reason -> string
+
 val sandbox_kind_of_meta : Keeper_meta_contract.keeper_meta -> Keeper_types_profile_sandbox.sandbox_profile
 val to_json : t -> Yojson.Safe.t
 
@@ -292,6 +299,13 @@ val is_auto_recoverable_turn_budget_terminal : string -> bool
 (** Derived display pair (disposition, reason) computed from receipt fields.
     Exposed for test access; the runtime path consumes it via [append]. *)
 val operator_disposition : t -> operator_disposition_kind * operator_disposition_reason
+
+(** Typed ledger projection owned by the receipt boundary. Successful/passive
+    terminal receipts are execution evidence; failed, cancelled, fallback, or
+    unknown terminal receipts retain terminal-reason evidence. *)
+val reaction_kind_of_operator_disposition
+  :  operator_disposition_kind
+  -> Keeper_reaction_ledger.reaction_kind
 
 (** [needs_operator_broadcast disposition] returns true when the disposition
     indicates a silent dead-end that operators must be notified about. *)

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -88,6 +88,9 @@ type runtime_outcome =
 
 let runtime_outcome_to_string = function
   | Runtime_passed_to_next_model -> "passed_to_next_model"
+  (* Runtime-attempt completion is intentionally distinct from the final turn
+     disposition: a completed provider attempt can still fail the Keeper
+     completion contract. This field therefore keeps its own typed wire. *)
   | Runtime_completed -> "completed"
   | Runtime_failed -> "failed"
   | Runtime_not_observed -> "not_observed"
@@ -335,6 +338,19 @@ let stop_reason_to_string = function
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
     Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
+;;
+
+(* This projects the runtime-stop axis into the receipt's terminal_reason_code
+   vocabulary. It does not classify the independent completion-contract axis;
+   [operator_disposition] remains the final typed receipt verdict. *)
+let receipt_terminal_reason_code_of_stop_reason = function
+  | Runtime_agent.Completed ->
+    Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
+  | ( Runtime_agent.TurnBudgetExhausted _
+    | Runtime_agent.MutationBoundaryReached _
+    | Runtime_agent.Yielded_to_chat_waiting _
+    | Runtime_agent.Yielded_to_durable_stimulus _ ) as stop_reason ->
+    stop_reason_to_string stop_reason
 ;;
 
 let enrich_contract_violation_reason (receipt : t) : string =

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -114,6 +114,13 @@ type t = {
   pre_dispatch_compaction_after_tokens : int option;
 }
 val stop_reason_to_string : Runtime_agent.stop_reason -> string
+
+(** Project the runtime-stop axis into the receipt terminal-reason field.
+    Runtime [Completed] stays ["completed"] in {!stop_reason_to_string}, while
+    the receipt field emits canonical [Keeper_turn_disposition.Success]. This
+    does not classify the independent completion-contract axis; the typed
+    operator disposition is the final receipt verdict. *)
+val receipt_terminal_reason_code_of_stop_reason : Runtime_agent.stop_reason -> string
 val enrich_contract_violation_reason : t -> string
 val sandbox_kind_of_meta :
   Keeper_meta_contract.keeper_meta -> Keeper_types_profile_sandbox.sandbox_profile

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -363,13 +363,6 @@ let record_board_cursor_ack
   Dated_jsonl.append (store_for_base_path ~base_path ~keeper_name) json
 ;;
 
-let receipt_reaction_kind ~terminal_reason_code =
-  let trimmed = String.trim terminal_reason_code in
-  if trimmed = "" || String.equal trimmed "completed"
-  then Execution_receipt
-  else Terminal_reason
-;;
-
 let record_execution_receipt_reaction
       config
       ~keeper_name
@@ -378,11 +371,11 @@ let record_execution_receipt_reaction
       ~current_task_id
       ~goal_ids
       ~outcome
+      ~reaction_kind
       ~terminal_reason_code
       ~receipt_json
       ()
   =
-  let reaction_kind = receipt_reaction_kind ~terminal_reason_code in
   let recorded_at = Time_compat.now () in
   let stimulus_id =
     match current_task_id with

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -109,12 +109,14 @@ val record_execution_receipt_reaction :
   current_task_id:string option ->
   goal_ids:string list ->
   outcome:string ->
+  reaction_kind:reaction_kind ->
   terminal_reason_code:string ->
   receipt_json:Yojson.Safe.t ->
   unit ->
   unit
 (** Append a reaction row that links a turn execution receipt back into the
-    keeper reaction ledger. *)
+    keeper reaction ledger. [reaction_kind] is a typed decision from the
+    receipt owner; this persistence boundary does not reclassify wire text. *)
 
 val read_recent_for_keeper :
   base_path:string -> keeper_name:string -> limit:int -> Yojson.Safe.t list

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -89,8 +89,8 @@ let terminal_reason_from_receipt receipt =
   in
   match terminal_reason_code with
   | Some code when receipt_requires_tool_attention
-                   && (String.equal code "completed"
-                       || String.equal code "success") ->
+                   && Keeper_turn_disposition.is_success
+                        (Keeper_turn_disposition.of_wire code) ->
       Some
         (Keeper_turn_terminal.of_disposition
            ~source:"execution_receipt"

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -276,6 +276,20 @@ let of_wire wire =
         | None -> Unknown { raw_error = other }))
 ;;
 
+let is_success = function
+  | Success -> true
+  | External_cancel
+  | Input_required
+  | Turn_wall_clock_timeout
+  | Runtime_attempts_exhausted
+  | Completion_contract_unsatisfied
+  | Completion_contract_no_progress
+  | Post_commit_ambiguous
+  | Turn_budget_exhausted _
+  | Provider_error _
+  | Unknown _ -> false
+;;
+
 let is_turn_budget_exhausted_wire wire =
   match of_wire (String.lowercase_ascii (String.trim wire)) with
   | Turn_budget_exhausted _ -> true

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -141,13 +141,16 @@ val next_action : t -> string option
     - [Unknown { raw_error }] → [raw_error] (verbatim) *)
 val to_wire : t -> string
 
-(** Best-effort deserialiser. Recognised application strings round-trip
+(** Best-effort deserialiser. Canonical application strings round-trip
     exactly. Unrecognised strings first try
     [Keeper_turn_terminal_code.of_wire]; if that succeeds, the result
     is wrapped via [of_termination_code] (which may itself collapse to
     a non-Provider_error disposition such as [Completion_contract_unsatisfied]).
     Otherwise [Unknown { raw_error = wire }] is returned. *)
 val of_wire : string -> t
+
+(** Typed success predicate for consumers of the strict canonical decoder. *)
+val is_success : t -> bool
 
 (** True iff {!of_wire} classifies [wire] as [Turn_budget_exhausted]. Strict:
     only the single paren grammar is recognised. The pre-fix colon form

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -440,10 +440,12 @@ let composite_execution_blocked execution =
   || composite_execution_contract_blocked execution
   || Option.is_some (composite_execution_completion_unsatisfied_reason execution)
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
-  || (match lower_string_opt (json_string "terminal_reason_code" execution) with
+  || (match json_string "terminal_reason_code" execution with
       | Some terminal ->
-        terminal <> ""
-        && terminal <> "completed"
+        not (String.equal terminal "")
+        && not
+             (Keeper_turn_disposition.is_success
+                (Keeper_turn_disposition.of_wire terminal))
         && not (composite_execution_budget_exhausted_pass execution)
       | None -> false)
   ||

--- a/test/test_keeper_execution_receipt_budget_wire.ml
+++ b/test/test_keeper_execution_receipt_budget_wire.ml
@@ -15,6 +15,10 @@
    [Turn_budget_exhausted]. It is non-vacuous against the original bug: reverting
    the producer to the colon form turns assertion 1 and 3 red. *)
 
+(* The same boundary must keep runtime-stop and final-disposition domains
+   distinct: [Runtime_agent.Completed] remains ["completed"] in runtime
+   telemetry, while a terminal receipt projects it to canonical ["success"]. *)
+
 module D = Masc.Keeper_turn_disposition
 module Receipt = Masc.Keeper_execution_receipt_types
 
@@ -22,6 +26,39 @@ let failures = ref []
 let check name cond = if not cond then failures := name :: !failures
 
 let () =
+  let runtime_stop_wire = Receipt.stop_reason_to_string Runtime_agent.Completed in
+  check
+    (Printf.sprintf "runtime stop keeps completed wire (got %S)" runtime_stop_wire)
+    (String.equal runtime_stop_wire "completed");
+  let success_wire =
+    Receipt.receipt_terminal_reason_code_of_stop_reason Runtime_agent.Completed
+  in
+  check
+    (Printf.sprintf "terminal receipt emits canonical success (got %S)" success_wire)
+    (String.equal success_wire "success");
+  check
+    "canonical success round-trips as Success"
+    (D.is_success (D.of_wire success_wire));
+  check
+    "runtime completed is not a final disposition"
+    (match D.of_wire "completed" with
+     | D.Unknown _ -> true
+     | _ -> false);
+  check
+    "whitespace success is not silently normalized"
+    (match D.of_wire " success " with
+     | D.Unknown _ -> true
+     | _ -> false);
+  check
+    "uppercase legacy spelling is not silently normalized"
+    (match D.of_wire "COMPLETED" with
+     | D.Unknown _ -> true
+     | _ -> false);
+  check
+    "runtime-attempt completion keeps its distinct typed wire"
+    (String.equal
+       (Receipt.runtime_outcome_to_string Receipt.Runtime_completed)
+       "completed");
   let used = 1070 and limit = 1070 in
   let wire =
     Receipt.stop_reason_to_string
@@ -62,5 +99,5 @@ let () =
   | xs ->
     List.iter (fun n -> print_endline ("FAIL: " ^ n)) (List.rev xs);
     failwith
-      (Printf.sprintf "%d budget-wire contract assertion(s) failed" (List.length xs))
+      (Printf.sprintf "%d disposition-wire contract assertion(s) failed" (List.length xs))
 ;;

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -267,6 +267,7 @@ let test_execution_receipt_links_to_reaction_ledger () =
     ~current_task_id:(Some "task-275")
     ~goal_ids:[ "goal-world-reactivity-p0-20260517" ]
     ~outcome:"receipt_failed"
+    ~reaction_kind:Keeper_reaction_ledger.Terminal_reason
     ~terminal_reason_code:"completion_contract_violation"
     ~receipt_json
     ();
@@ -294,7 +295,7 @@ let test_summary_observes_passive_only_without_attention () =
   with_temp_base @@ fun base_path ->
   let config = Workspace.default_config base_path in
   let keeper_name = "contract-attention-keeper" in
-  let record ?(terminal_reason_code = "completed") ?current_task_id
+  let record ?(terminal_reason_code = "success") ?current_task_id
         ~trace_id ~completion_contract_result () =
     let receipt_json =
       `Assoc
@@ -315,6 +316,7 @@ let test_summary_observes_passive_only_without_attention () =
       ~current_task_id
       ~goal_ids:[]
       ~outcome:"receipt_done"
+      ~reaction_kind:Keeper_reaction_ledger.Execution_receipt
       ~terminal_reason_code
       ~receipt_json
       ()
@@ -391,7 +393,7 @@ let test_summary_degrades_unknown_completion_contract_result () =
         [ "schema", `String "keeper.execution_receipt.v1"
         ; "trace_id", `String trace_id
         ; "outcome", `String "receipt_done"
-        ; "terminal_reason_code", `String "completed"
+        ; "terminal_reason_code", `String "success"
         ; "operator_disposition", `String "continue"
         ; "operator_disposition_reason", `String "none"
         ; "completion_contract_result", `String completion_contract_result
@@ -405,7 +407,8 @@ let test_summary_degrades_unknown_completion_contract_result () =
       ~current_task_id:None
       ~goal_ids:[]
       ~outcome:"receipt_done"
-      ~terminal_reason_code:"completed"
+      ~reaction_kind:Keeper_reaction_ledger.Execution_receipt
+      ~terminal_reason_code:"success"
       ~receipt_json
       ()
   in
@@ -517,7 +520,7 @@ let test_summary_observes_passive_only_without_work_scope_attention () =
       [ "schema", `String "keeper.execution_receipt.v1"
       ; "trace_id", `String "trace-passive-no-work"
       ; "outcome", `String "receipt_done"
-      ; "terminal_reason_code", `String "completed"
+      ; "terminal_reason_code", `String "success"
       ; "operator_disposition", `String "pass"
       ; "operator_disposition_reason", `String "healthy"
       ; "completion_contract_result", `String "passive_only"
@@ -531,7 +534,8 @@ let test_summary_observes_passive_only_without_work_scope_attention () =
     ~current_task_id:None
     ~goal_ids:[]
     ~outcome:"receipt_done"
-    ~terminal_reason_code:"completed"
+    ~reaction_kind:Keeper_reaction_ledger.Execution_receipt
+    ~terminal_reason_code:"success"
     ~receipt_json
     ();
   let summary =
@@ -756,7 +760,7 @@ let test_no_progress_recovery_unrelated_reaction_does_not_clear_pending () =
       [ "schema", `String "keeper.execution_receipt.v1"
       ; "trace_id", `String "trace-later-reaction"
       ; "outcome", `String "receipt_done"
-      ; "terminal_reason_code", `String "completed"
+      ; "terminal_reason_code", `String "success"
       ; "operator_disposition", `String "pass"
       ; "operator_disposition_reason", `String "healthy"
       ; "completion_contract_result", `String "satisfied_execution"
@@ -770,7 +774,8 @@ let test_no_progress_recovery_unrelated_reaction_does_not_clear_pending () =
     ~current_task_id:None
     ~goal_ids:[]
     ~outcome:"receipt_done"
-    ~terminal_reason_code:"completed"
+    ~reaction_kind:Keeper_reaction_ledger.Execution_receipt
+    ~terminal_reason_code:"success"
     ~receipt_json
     ();
   let unrelated_reaction_summary =
@@ -845,7 +850,7 @@ let test_summary_links_passive_only_observation_to_pending_recovery () =
       [ "schema", `String "keeper.execution_receipt.v1"
       ; "trace_id", `String "trace-passive"
       ; "outcome", `String "receipt_done"
-      ; "terminal_reason_code", `String "completed"
+      ; "terminal_reason_code", `String "success"
       ; "operator_disposition", `String "pause_human"
       ; "operator_disposition_reason", `String "completion_contract_unsatisfied"
       ; "completion_contract_result", `String "passive_only"
@@ -859,7 +864,8 @@ let test_summary_links_passive_only_observation_to_pending_recovery () =
     ~current_task_id:(Some "task-passive")
     ~goal_ids:[]
     ~outcome:"receipt_done"
-    ~terminal_reason_code:"completed"
+    ~reaction_kind:Keeper_reaction_ledger.Terminal_reason
+    ~terminal_reason_code:"success"
     ~receipt_json
     ();
   Keeper_reaction_ledger.record_event_queue_stimulus

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -52,7 +52,7 @@ let test_joins_recall_to_receipts () =
       (Filename.concat
          masc_root
          "keepers/alpha/execution-receipts/2026-06/27.jsonl")
-      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","current_task_id":"T-1","ended_at":"2026-06-27T00:00:00Z"}|}
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"success","current_task_id":"T-1","ended_at":"2026-06-27T00:00:00Z"}|}
       ];
     let report = Eval.evaluate ~masc_root in
     Alcotest.(check int) "read errors" 0 report.read_error_count;
@@ -132,7 +132,7 @@ let test_selects_newest_receipt_by_timestamp () =
          masc_root
          "keepers/alpha/execution-receipts/2026-06/27.jsonl")
       [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:02Z"}|}
-      ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:03Z"}|}
+      ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"success","ended_at":"2026-06-27T00:00:03Z"}|}
       ];
     let report = Eval.evaluate ~masc_root in
     Alcotest.(check int) "ok newest outcome" 1 report.outcome_ok;
@@ -168,7 +168,7 @@ let test_writes_fact_key_summary_index () =
       (Filename.concat
          masc_root
          "keepers/alpha/execution-receipts/2026-06/27.jsonl")
-      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-ok","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:00Z"}|}
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-ok","outcome":"receipt_done","terminal_reason_code":"success","ended_at":"2026-06-27T00:00:00Z"}|}
       ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"beta","trace_id":"trace-err","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:01Z"}|}
       ];
     let report = Eval.evaluate ~masc_root in

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -322,7 +322,7 @@ let test_completion_contract_result_rejects_drifted_label_before_parser () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String " Passive_Only "
              ]);
        let snapshot = K.snapshot_json ~config ~meta in
@@ -360,7 +360,7 @@ let test_legacy_satisfied_completion_contract_result_is_unknown () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String "satisfied"
              ]);
        let snapshot = K.snapshot_json ~config ~meta in
@@ -394,7 +394,7 @@ let test_passive_only_no_work_receipt_does_not_mark_attention () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String "passive_only"
              ; "current_task_id", `Null
              ; "goal_ids", `List []
@@ -444,7 +444,7 @@ let test_passive_only_active_receipt_does_not_mark_attention () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "passive_no_action"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String "passive_only"
              ; "current_task_id", `String "task-1844"
              ; "goal_ids", `List [ `String "goal-pm-flow" ]
@@ -506,7 +506,7 @@ let test_completion_blocker_supersedes_passive_only_receipt () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String "passive_only"
              ]);
        let snapshot = K.snapshot_json ~config ~meta in
@@ -596,7 +596,7 @@ let test_unknown_completion_contract_result_is_explicit () =
              [ "ended_at", `String "2026-06-01T00:00:00Z"
              ; "operator_disposition", `String "pass"
              ; "operator_disposition_reason", `String "healthy"
-             ; "terminal_reason_code", `String "completed"
+             ; "terminal_reason_code", `String "success"
              ; "completion_contract_result", `String "passive-only"
              ]);
        let snapshot = K.snapshot_json ~config ~meta in

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -392,6 +392,38 @@ let base_receipt : R.t =
   }
 ;;
 
+let () =
+  let completed_stop = Runtime_agent.Completed in
+  let receipt =
+    { base_receipt with
+      outcome = `Ok
+    ; terminal_reason_code =
+        R.receipt_terminal_reason_code_of_stop_reason completed_stop
+    ; completion_contract_result = R.Contract_satisfied_execution
+    ; runtime_outcome = R.Runtime_completed
+    ; stop_reason = Some completed_stop
+    }
+  in
+  let json = R.to_json receipt in
+  check
+    "one receipt uses canonical terminal success"
+    (Json_util.get_string json "terminal_reason_code" = Some "success");
+  check
+    "the same receipt preserves runtime stop completed"
+    (Json_util.get_string json "stop_reason" = Some "completed");
+  let violated =
+    { receipt with completion_contract_result = R.Contract_violated }
+  in
+  let disposition = fst (R.operator_disposition violated) in
+  check
+    "runtime completion plus violated contract is not final success"
+    (disposition = R.Disp_pause_human);
+  check
+    "violated completed turn records a terminal reaction"
+    (R.reaction_kind_of_operator_disposition disposition
+     = Masc.Keeper_reaction_ledger.Terminal_reason)
+;;
+
 (* Field matrix axes. Kept small but covering the dimensions the
    classifier branches on. *)
 let codes = roundtrip_corpus
@@ -453,6 +485,26 @@ let operator_disposition_kinds =
 
 let () =
   List.iter
+    (fun (disposition, expected) ->
+      let actual = R.reaction_kind_of_operator_disposition disposition in
+      check
+        (Printf.sprintf
+           "typed reaction kind for %s"
+           (R.operator_disposition_kind_to_string disposition))
+        (actual = expected))
+    [ R.Disp_pass, Masc.Keeper_reaction_ledger.Execution_receipt
+    ; R.Disp_skipped, Masc.Keeper_reaction_ledger.Execution_receipt
+    ; R.Disp_pause_human, Masc.Keeper_reaction_ledger.Terminal_reason
+    ; R.Disp_alert_exhausted, Masc.Keeper_reaction_ledger.Terminal_reason
+    ; R.Disp_fail_open_next_runtime, Masc.Keeper_reaction_ledger.Terminal_reason
+    ; R.Disp_pass_next_model, Masc.Keeper_reaction_ledger.Terminal_reason
+    ; R.Disp_user_cancelled, Masc.Keeper_reaction_ledger.Terminal_reason
+    ; R.Disp_unknown, Masc.Keeper_reaction_ledger.Terminal_reason
+    ]
+;;
+
+let () =
+  List.iter
     (fun disposition ->
        let label = R.operator_disposition_kind_to_string disposition in
        let parsed =
@@ -497,8 +549,7 @@ let intentional_passive_only_policy_change (receipt : R.t) got =
            && receipt.actionable_signal = Some C.No_actionable_signal
            && receipt.outcome = `Ok
            && receipt.runtime_outcome = R.Runtime_completed
-           && (let c = String.lowercase_ascii receipt.terminal_reason_code in
-               c = "completed" || c = "success") ->
+           && String.equal receipt.terminal_reason_code "success" ->
       true
     | _ -> false
 ;;
@@ -687,7 +738,7 @@ let () =
 let () =
   let receipt =
     { base_receipt with
-      terminal_reason_code = "completed"
+      terminal_reason_code = "success"
     ; outcome = `Ok
     ; runtime_outcome = R.Runtime_completed
     ; completion_contract_result = R.Contract_passive_only
@@ -727,7 +778,7 @@ let () =
 let () =
   let coordination_passive ?(actionable_signal = Some C.No_actionable_signal) () =
     { base_receipt with
-      terminal_reason_code = "completed"
+      terminal_reason_code = "success"
     ; outcome = `Ok
     ; runtime_outcome = R.Runtime_completed
     ; completion_contract_result = R.Contract_passive_only

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -26,7 +26,7 @@ let check_invariant label (t : T.t) =
 let constructor_cases : (string * T.t) list =
   [ "success", T.success ()
   ; "of_code/explicit", T.of_code "post_commit_ambiguous"
-  ; "of_code/legacy_persisted/completed", T.of_code "completed"
+  ; "of_code/runtime_stop_not_final/completed", T.of_code "completed"
   ; ( "of_code/sdk_error/contract_violation"
     , T.of_code "completion_contract_violation:completion_contract" )
   ; "of_code/sdk_error/api_error_timeout", T.of_code "api_error_timeout"
@@ -73,6 +73,18 @@ let test_of_code_default_source_is_wire_code () =
   Alcotest.(check string) "default source" "wire_code" t.source
 ;;
 
+let test_runtime_completed_is_not_final_success () =
+  let terminal = T.of_code "completed" in
+  Alcotest.(check bool)
+    "runtime completed disposition is unknown"
+    false
+    (D.is_success terminal.disposition);
+  Alcotest.(check string)
+    "unknown runtime wire is preserved"
+    "completed"
+    (T.code terminal)
+;;
+
 let () =
   Alcotest.run
     "keeper_turn_terminal_disposition_field"
@@ -95,6 +107,10 @@ let () =
             "of_code default source is wire_code"
             `Quick
             test_of_code_default_source_is_wire_code
+        ; Alcotest.test_case
+            "runtime completed is not final success"
+            `Quick
+            test_runtime_completed_is_not_final_success
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -81,14 +81,14 @@ let active_passive_budget_execution =
     ]
 ;;
 
-let completed_passive_execution =
+let passive_execution_with_terminal_reason terminal_reason =
   `Assoc
     [ "latest_receipt_present", `Bool true
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `String "passive_only"
     ; "operator_disposition", `String "pass"
     ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "completed"
+    ; "terminal_reason_code", `String terminal_reason
     ; "current_task_id", `Null
     ; "goal_ids", `List []
     ; "error", `Null
@@ -97,14 +97,37 @@ let completed_passive_execution =
     ]
 ;;
 
-let active_completed_passive_execution =
+let legacy_completed_passive_execution =
+  passive_execution_with_terminal_reason "completed"
+;;
+
+let canonical_success_passive_execution =
+  passive_execution_with_terminal_reason "success"
+;;
+
+let malformed_success_passive_execution =
+  passive_execution_with_terminal_reason " SUCCESS "
+;;
+
+let trust_with_terminal_reason_code code =
+  `Assoc
+    [ ( "latest_terminal_reason"
+      , `Assoc
+          [ "code", `String code
+          ; "severity", `Null
+          ; "disposition", `Null
+          ] )
+    ]
+;;
+
+let active_success_passive_execution =
   `Assoc
     [ "latest_receipt_present", `Bool true
     ; "recorded_at", `String "2999-01-01T00:00:00Z"
     ; "completion_contract_result", `String "passive_only"
     ; "operator_disposition", `String "pass"
     ; "operator_disposition_reason", `String "healthy"
-    ; "terminal_reason_code", `String "completed"
+    ; "terminal_reason_code", `String "success"
     ; "current_task_id", `String "TASK-1"
     ; "goal_ids", `List []
     ; "error", `Null
@@ -226,11 +249,22 @@ let test_active_passive_budget_exhaustion_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
-let test_completed_passive_receipt_without_work_scope_is_not_blocked () =
+let test_legacy_completed_receipt_is_blocked () =
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
-      ~execution:completed_passive_execution
+      ~execution:legacy_completed_passive_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state
+;;
+
+let test_canonical_success_receipt_is_not_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:canonical_success_passive_execution
   in
   check bool "blocked" false attention.cra_blocked;
   check bool "needs_attention" false attention.cra_needs_attention;
@@ -238,14 +272,37 @@ let test_completed_passive_receipt_without_work_scope_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
-let test_active_completed_passive_receipt_is_not_blocked () =
-  (* RFC-0303 Phase 0: a completed passive-only turn with work scope is not a
+let test_malformed_success_receipt_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:malformed_success_passive_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state
+;;
+
+let test_dashboard_execution_uses_strict_typed_success () =
+  check bool "canonical success" false
+    (Dashboard_execution.terminal_reason_requires_attention
+       (trust_with_terminal_reason_code "success"));
+  check bool "runtime completed is not final success" true
+    (Dashboard_execution.terminal_reason_requires_attention
+       (trust_with_terminal_reason_code "completed"));
+  check bool "malformed success is not normalized" true
+    (Dashboard_execution.terminal_reason_requires_attention
+       (trust_with_terminal_reason_code " SUCCESS "))
+;;
+
+let test_active_success_passive_receipt_is_not_blocked () =
+  (* RFC-0303 Phase 0: a successful passive-only turn with work scope is not a
      block. "Should it have acted on the claimed task?" is a goal-layer semantic
      judgment, not a per-turn dashboard attention flag. *)
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
-      ~execution:active_completed_passive_execution
+      ~execution:active_success_passive_execution
   in
   check bool "blocked" false attention.cra_blocked;
   check bool "needs_attention" false attention.cra_needs_attention;
@@ -293,13 +350,25 @@ let () =
             `Quick
             test_active_passive_budget_exhaustion_is_not_blocked
         ; test_case
-            "completed passive receipt without work scope is not blocked"
+            "legacy completed receipt is blocked"
             `Quick
-            test_completed_passive_receipt_without_work_scope_is_not_blocked
+            test_legacy_completed_receipt_is_blocked
         ; test_case
-            "active completed passive receipt is not blocked"
+            "canonical success receipt is not blocked"
             `Quick
-            test_active_completed_passive_receipt_is_not_blocked
+            test_canonical_success_receipt_is_not_blocked
+        ; test_case
+            "malformed success receipt is blocked"
+            `Quick
+            test_malformed_success_receipt_is_blocked
+        ; test_case
+            "dashboard execution uses strict typed success"
+            `Quick
+            test_dashboard_execution_uses_strict_typed_success
+        ; test_case
+            "active canonical success passive receipt is not blocked"
+            `Quick
+            test_active_success_passive_receipt_is_not_blocked
         ; test_case
             "not-dispatched turn-budget exhaustion is blocked"
             `Quick


### PR DESCRIPTION
## 문제

#24073 조사에서 `Runtime_agent.Completed`의 runtime-stop wire(`completed`)와 Keeper final receipt terminal wire(`success`)가 다시 합쳐진 회귀를 확인했습니다. 정상 receipt가 reaction ledger/runtime trust/dashboard에서 raw string 비교로 서로 다르게 분류됐습니다.

## 변경

- runtime attempt/stop/telemetry/turn-record의 `completed`는 그대로 보존
- execution receipt의 `terminal_reason_code`만 typed boundary에서 canonical `Keeper_turn_disposition.Success`로 투영
- global `completed -> Success` compatibility alias를 두지 않고 canonical decoder를 strict하게 유지
- receipt owner가 typed `operator_disposition`을 한 번 계산해 JSON, reaction kind, operator broadcast가 같은 verdict를 소비
- reaction ledger는 terminal string을 재분류하지 않고 typed `reaction_kind`를 저장
- server composite와 dashboard execution consumer를 `Keeper_turn_disposition` typed parser로 통일
- canonical success / runtime completed / malformed success / completion-contract violation 경계를 focused regression으로 고정

## 검증

- `ocamlc -stop-after parsing` (touched `.ml`) green
- `ocamlformat --check` (touched `.ml/.mli`) green
- `git diff --check` green
- enum/string, determinism, MASC/OAS boundary, silent-failure, OCaml structure, stringly-boundary ratchets green
- 두 차례 적대 리뷰 최종 P0/P1/P2 0
- 로컬 Dune 미실행; CI가 build/test 권위

## 별도 baseline

`bash scripts/hardening-ratchet.sh --check`의 current-main `wildcard_silent_defaults` drift(`2016 -> 2084`)는 이 diff와 무관한 기존 #22510으로 갱신 기록했습니다.

Relates #24073.