### PR TITLE
fix(keeper): preserve shutdown worker failure provenance

### DIFF
--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -41,7 +41,7 @@ let release_worker operation =
     Hashtbl.remove active_workers (worker_key operation))
 ;;
 
-let persist_unhandled_failure ~config operation exn =
+let persist_unhandled_failure ~now ~config operation exn =
   let detail = Printexc.to_string exn in
   Eio.Cancel.protect (fun () ->
     Log.Keeper.error
@@ -53,8 +53,8 @@ let persist_unhandled_failure ~config operation exn =
       Keeper_shutdown_store.persist_blocked_latest
         ~config
         ~identity:operation
-        ~failure:{ stage = Record_update; detail }
-        ~updated_at:(Masc_domain.now_iso ())
+        ~failure:{ stage = Unhandled_worker; detail }
+        ~now
     with
     | Ok (Keeper_shutdown_store.Blocked_persisted blocked) ->
       Log.Keeper.error
@@ -147,7 +147,12 @@ let start_worker ~config ~entry operation =
                       "Keeper shutdown worker cancelled by server teardown; durable recovery retained: keeper=%s operation=%s"
                       operation.keeper_name
                       (worker_key operation)
-                  | exn -> persist_unhandled_failure ~config operation exn));
+                  | exn ->
+                    persist_unhandled_failure
+                      ~now:Masc_domain.now_iso
+                      ~config
+                      operation
+                      exn));
            if Atomic.get started
            then Worker_started
            else

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -37,6 +37,7 @@ val recover_operation :
 
 module For_testing : sig
   val persist_unhandled_failure :
+    now:(unit -> string) ->
     config:Workspace.config ->
     Keeper_shutdown_types.t ->
     exn ->

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -551,7 +551,7 @@ let replace ~config ~expected_revision operation =
            (Operation_id.to_string operation.operation_id)))
 ;;
 
-let persist_blocked_latest ~config ~identity ~failure ~updated_at =
+let persist_blocked_latest ~config ~identity ~failure ~now =
   let operation_path = path ~config identity.operation_id in
   with_operation_lock ~access:Write operation_path (fun () ->
     match load_unlocked ~config identity.operation_id with
@@ -567,7 +567,7 @@ let persist_blocked_latest ~config ~identity ~failure ~updated_at =
            { existing with
              revision = existing.revision + 1
            ; phase = Blocked failure
-           ; updated_at
+           ; updated_at = now ()
            }
          in
          Keeper_fs.save_json_atomic operation_path (to_json blocked)

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -41,12 +41,13 @@ val replace :
 
 (** Read the latest durable revision and persist [Blocked failure] while
     holding the operation's write lock. Existing [Finalized], [Blocked], and
-    effect-unknown reconciliation states are preserved. *)
+    effect-unknown reconciliation states are preserved. [now] is sampled only
+    after the lock is acquired and the latest revision is loaded. *)
 val persist_blocked_latest :
   config:Workspace.config ->
   identity:Keeper_shutdown_types.t ->
   failure:Keeper_shutdown_types.failure ->
-  updated_at:string ->
+  now:(unit -> string) ->
   (persist_blocked_result, error) result
 
 val load :

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -56,6 +56,7 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Unhandled_worker
   | Task_settlement
   | Pending_confirm_cleanup
   | Meta_update
@@ -145,6 +146,7 @@ let failure_stage_to_string = function
   | Turn_join -> "turn_join"
   | Lane_join -> "lane_join"
   | Record_update -> "record_update"
+  | Unhandled_worker -> "unhandled_worker"
   | Task_settlement -> "task_settlement"
   | Pending_confirm_cleanup -> "pending_confirm_cleanup"
   | Meta_update -> "meta_update"
@@ -161,6 +163,7 @@ let failure_stage_of_string = function
   | "turn_join" -> Ok Turn_join
   | "lane_join" -> Ok Lane_join
   | "record_update" -> Ok Record_update
+  | "unhandled_worker" -> Ok Unhandled_worker
   | "task_settlement" -> Ok Task_settlement
   | "pending_confirm_cleanup" -> Ok Pending_confirm_cleanup
   | "meta_update" -> Ok Meta_update

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -39,6 +39,7 @@ type failure_stage =
   | Turn_join
   | Lane_join
   | Record_update
+  | Unhandled_worker
   | Task_settlement
   | Pending_confirm_cleanup
   | Meta_update

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -825,6 +825,8 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
       let worker_failure = Failure "worker exploded after durable join" in
+      let failure_timestamp = "2026-07-11T11:00:01Z" in
+      let failure_clock_sampled = Atomic.make false in
       let holder_locked_p, holder_locked_r = Eio.Promise.create () in
       let release_holder_p, release_holder_r = Eio.Promise.create () in
       let holder_done_p, holder_done_r = Eio.Promise.create () in
@@ -845,10 +847,18 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
            Eio.Fiber.fork ~sw:worker_sw (fun () ->
              Eio.Promise.resolve worker_started_r ();
              Shutdown_runtime.For_testing.persist_unhandled_failure
+               ~now:(fun () ->
+                 Atomic.set failure_clock_sampled true;
+                 failure_timestamp)
                ~config
                operation
                worker_failure);
            Eio.Promise.await worker_started_p;
+           Eio.Fiber.yield ();
+           check bool
+             "failure clock is not sampled while the write lock is held"
+             false
+             (Atomic.get failure_clock_sampled);
            Eio.Switch.fail worker_sw Cancel_worker;
            Eio.Promise.resolve release_holder_r ())
        with
@@ -863,8 +873,16 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         "unhandled worker failure advances the latest durable revision"
         (joined.revision + 1)
         blocked.revision;
+      check bool
+        "failure clock is sampled after the write lock is acquired"
+        true
+        (Atomic.get failure_clock_sampled);
+      check string
+        "blocked evidence owns its post-lock timestamp"
+        failure_timestamp
+        blocked.updated_at;
       (match blocked.phase with
-       | Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail } ->
+       | Shutdown_types.Blocked { stage = Shutdown_types.Unhandled_worker; detail } ->
          check string
            "unhandled worker failure detail"
            (Printexc.to_string worker_failure)
@@ -878,6 +896,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Shutdown_types.Blocked _ ->
          fail "unhandled worker failure did not persist typed blocked evidence");
       Shutdown_runtime.For_testing.persist_unhandled_failure
+        ~now:Masc_domain.now_iso
         ~config
         operation
         (Failure "later worker failure");


### PR DESCRIPTION
## Summary

- preserve generic shutdown-worker exceptions as typed Unhandled_worker provenance instead of falsely reporting Record_update
- sample blocked-record timestamps only after the store lock is acquired and the latest revision is loaded
- pin cancellation and lock-contention behavior in the existing heartbeat integration family

## Why

Merged #24187 persisted a worker exception from the latest record revision, but every generic worker failure was hardcoded to the Record_update stage and its timestamp was sampled before lock acquisition. That made durable failure provenance false and allowed a contended writer to persist a pre-lock time.

## Current base and scope

- current base: main@5449256130
- current head: 89dda699c9
- the patch is intentionally surgical and does not claim to repair fleet isolation, identity teardown, Blocked/Reconciliation progress, or typed subprocess lifecycle receipts from the inherited shutdown stack
- the previously alleged Finalized-before-admission-release gap was refuted: admission release is process-local mutex state and terminal replay releases it again

## Validation

- earlier focused lib/masc.cmxa, heartbeat executable, and check target on the direct-main branch: pass
- focused direct_keepalive case 5: 1/1 pass
- after current-main rebase: ocamlformat, parser checks for all seven changed OCaml files, and git diff check pass
- focused Dune rerun is blocked by unrelated interactive bare dune build . PID 28037; it was not killed or bypassed
- fresh exact-head PR CI is authoritative before merge

## Gate

Draft + p1 + status:do-not-merge until exact-head Build/Test, review, and the relevant shutdown-stack blockers are terminal.

Follow-up to #24187. The premature #24146/#24135 merges remain recorded separately.