### PR TITLE
fix(dashboard): bind MCP sessions to auth revisions

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -5,6 +5,7 @@ import {
   clearStoredToken,
   confirmOperatorAction,
   currentDashboardActor,
+  currentStoredTokenRevision,
   dashboardBearerToken,
   defaultBoardVoter,
   extractApiError,
@@ -66,6 +67,7 @@ describe('stored token metadata', () => {
   it('notifies token listeners only when the semantic token state changes', () => {
     const listener = vi.fn()
     const unsubscribe = subscribeStoredTokenChanges(listener)
+    const revisionBeforeChanges = currentStoredTokenRevision()
 
     setStoredToken('manual-token', { source: 'manual', actor: 'dashboard-user' })
     setStoredToken(' manual-token ', { source: 'manual', actor: 'dashboard-user' })
@@ -75,6 +77,7 @@ describe('stored token metadata', () => {
     unsubscribe()
 
     expect(listener).toHaveBeenCalledTimes(3)
+    expect(currentStoredTokenRevision()).toBe(revisionBeforeChanges + 3)
     expect(listener).toHaveBeenNthCalledWith(1, {
       token: 'manual-token',
       meta: { source: 'manual', actor: 'dashboard-user', scope: null },

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -45,8 +45,10 @@ export interface StoredTokenChange {
 type StoredTokenChangeListener = (change: StoredTokenChange) => void
 
 const storedTokenChangeListeners = new Set<StoredTokenChangeListener>()
+let storedTokenRevision = 0
 
 function notifyStoredTokenChange(change: StoredTokenChange): void {
+  storedTokenRevision += 1
   for (const listener of storedTokenChangeListeners) {
     try {
       listener(change)
@@ -54,6 +56,10 @@ function notifyStoredTokenChange(change: StoredTokenChange): void {
       console.warn('[dashboard-auth] token change listener failed', err)
     }
   }
+}
+
+export function currentStoredTokenRevision(): number {
+  return storedTokenRevision
 }
 
 export function subscribeStoredTokenChanges(

--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -7,6 +7,7 @@ const {
   authHeaders,
   clearStoredToken,
   currentDashboardActor,
+  currentStoredTokenRevision,
   getStoredToken,
   getStoredTokenMeta,
   isRemoteAccess,
@@ -19,6 +20,7 @@ const {
   authHeaders: vi.fn().mockReturnValue({}),
   clearStoredToken: vi.fn(),
   currentDashboardActor: vi.fn().mockReturnValue('dashboard'),
+  currentStoredTokenRevision: vi.fn().mockReturnValue(0),
   // Default to a non-empty stored token so ensureDevToken() short-circuits
   // without consuming a fetchWithTimeout mock. Individual tests that want
   // to exercise the dev-token bootstrap can override this.
@@ -39,6 +41,7 @@ vi.mock('./core', () => ({
   authHeaders,
   clearStoredToken,
   currentDashboardActor,
+  currentStoredTokenRevision,
   getStoredToken,
   getStoredTokenMeta,
   isRemoteAccess,
@@ -60,6 +63,7 @@ beforeEach(() => {
   // test (e.g. authHeaders). The dev-token bootstrap must stay inert unless
   // a test explicitly exercises it.
   currentDashboardActor.mockReturnValue('dashboard')
+  currentStoredTokenRevision.mockReturnValue(0)
   getStoredToken.mockReturnValue('test-stored-token')
   getStoredTokenMeta.mockReturnValue({
     source: 'manual',
@@ -90,8 +94,12 @@ function setupMcpSessionMocks(sessionId: string) {
 
 /** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
 function findCallByMethod(method: string) {
+  return callsByMethod(method)[0]
+}
+
+function callsByMethod(method: string) {
   const calls = fetchWithTimeout.mock.calls as Array<[string, RequestInit, number]>
-  return calls.find(([, init]) => {
+  return calls.filter(([, init]) => {
     const body = init.body
     if (typeof body !== 'string') return false
     try { return JSON.parse(body).method === method }
@@ -100,6 +108,45 @@ function findCallByMethod(method: string) {
 }
 
 describe('mcpHeaders auth integration', () => {
+  it('reinitializes instead of reusing a session after the stored token changes', async () => {
+    setupMcpSessionMocks('sess-before-token-clear')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    currentStoredTokenRevision.mockReturnValue(1)
+    setupMcpSessionMocks('sess-after-token-clear')
+    await callMcpTool('masc_status', {})
+
+    const initializeCalls = callsByMethod('initialize')
+    const toolCalls = callsByMethod('tools/call')
+    expect(initializeCalls).toHaveLength(2)
+    expect(toolCalls).toHaveLength(2)
+    expect((initializeCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBeUndefined()
+    expect((toolCalls[0]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-before-token-clear')
+    expect((toolCalls[1]![1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-after-token-clear')
+  }, 60_000)
+
+  it('rejects an initialization response created under an older token revision', async () => {
+    fetchWithTimeout.mockImplementationOnce(async () => {
+      currentStoredTokenRevision.mockReturnValue(1)
+      return new Response('{}', {
+        status: 200,
+        headers: { 'Mcp-Session-Id': 'sess-stale-auth' },
+      })
+    })
+
+    const { callMcpTool } = await import('./mcp')
+    await expect(callMcpTool('masc_status', {}))
+      .rejects.toThrow('MCP authentication changed during session initialization')
+
+    expect(callsByMethod('notifications/initialized')).toHaveLength(0)
+    expect(callsByMethod('tools/call')).toHaveLength(0)
+  }, 60_000)
+
   it('includes Authorization header from authHeaders in MCP initialize request', async () => {
     authHeaders.mockReturnValue({
       'Authorization': 'Bearer test-token-123',

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -5,6 +5,7 @@ import {
   fetchWithTimeout,
   DEFAULT_MCP_TIMEOUT_MS,
   authHeaders,
+  currentStoredTokenRevision,
   currentDashboardActor,
   getStoredToken,
   getStoredTokenMeta,
@@ -26,6 +27,7 @@ const MCP_SESSION_BLOCKED = '__blocked__'
 const MCP_UNKNOWN_SESSION_MESSAGE = 'Unknown Mcp-Session-Id'
 
 let mcpSessionId: string | null = null
+let observedTokenRevision = currentStoredTokenRevision()
 let initPromise: Promise<void> | null = null
 let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -123,6 +125,15 @@ function resetMcpSessionOnly(): void {
   }
 }
 
+function synchronizeMcpAuthRevision(): void {
+  const currentRevision = currentStoredTokenRevision()
+  if (observedTokenRevision !== currentRevision) {
+    resetMcpSessionOnly()
+    resetDevTokenBootstrap()
+    observedTokenRevision = currentRevision
+  }
+}
+
 function mcpBodyMethod(body: unknown): string | null {
   if (typeof body !== 'object' || body === null) return null
   const method = (body as Record<string, unknown>).method
@@ -186,6 +197,7 @@ async function mcpPost(
 let blockedToastShown = false
 
 async function ensureSession(): Promise<void> {
+  synchronizeMcpAuthRevision()
   if (mcpSessionId === MCP_SESSION_BLOCKED) {
     if (!blockedToastShown) {
       blockedToastShown = true
@@ -202,6 +214,8 @@ async function ensureSession(): Promise<void> {
   if (initPromise) return initPromise
   initPromise = (async () => {
     await ensureDevToken()
+    const tokenRevision = currentStoredTokenRevision()
+    observedTokenRevision = tokenRevision
     try {
       const res = await fetchWithTimeout('/mcp', {
         method: 'POST',
@@ -217,6 +231,9 @@ async function ensureSession(): Promise<void> {
           id: 0,
         }),
       }, MCP_INITIALIZE_TIMEOUT_MS)
+      if (currentStoredTokenRevision() !== tokenRevision) {
+        throw new Error('MCP authentication changed during session initialization')
+      }
       if (!res.ok) {
         if (res.status === 403) {
           mcpSessionId = MCP_SESSION_BLOCKED
@@ -225,7 +242,9 @@ async function ensureSession(): Promise<void> {
         throw await apiRequestErrorFromResponse('POST', '/mcp initialize', res)
       }
       const sid = res.headers.get('Mcp-Session-Id')
-      if (sid) mcpSessionId = sid
+      if (sid) {
+        mcpSessionId = sid
+      }
       // Send initialized notification
       if (mcpSessionId) {
         await fetchWithTimeout('/mcp', {
@@ -256,6 +275,7 @@ async function ensureSession(): Promise<void> {
 export function resetMcpClientState(): void {
   resetMcpSessionOnly()
   resetDevTokenBootstrap()
+  observedTokenRevision = currentStoredTokenRevision()
 }
 
 // --- MCP over HTTP helper ---
@@ -288,6 +308,7 @@ async function callMcpToolInternal(
   args: Record<string, unknown>,
 ): Promise<string> {
   const requestId = String(Math.floor(Date.now() % 1000000))
+  synchronizeMcpAuthRevision()
   let phase = mcpSessionId ? 'tools/call' : 'initialize'
   try {
     await ensureSession()


### PR DESCRIPTION
## Summary

- make semantic stored-token changes advance one monotonic auth revision in the token SSOT
- bind every MCP session to the token revision observed after dev-token bootstrap
- invalidate both the MCP session and managed dev-token bootstrap before any later MCP request can reuse an older auth identity
- fail explicitly if auth changes while an MCP initialize request is in flight

## Why

Post-merge audit of #24159 found two token-clear implementations with different semantics. AuthStatus called `resetMcpClientState()`, while the new Settings Account clear path only removed storage and refreshed the shell. The MCP client could therefore continue sending the old `Mcp-Session-Id`; the server caches the resolved agent for that session.

This fix does not add another component-specific reset call. Token mutation remains owned by `api/core.ts`, which exposes a semantic revision. The MCP client may reuse a session only while that revision is unchanged, covering Settings, AuthStatus, managed dev-token refresh, URL/manual tokens, and stale-token recovery without string matching.

## Validation

- dashboard TypeScript no-emit: pass
- focused Vitest `src/api/core.test.ts src/api/mcp.test.ts`: 54/54 pass
- `git diff --check`

Regression coverage proves:
- semantically identical token writes do not advance the revision
- a changed token forces a second initialize and never sends the old session ID
- an initialize response produced under an older revision is rejected before initialized notification or tool dispatch

## Merge guard

Draft + `p1` + `status:do-not-merge` until exact-head Dashboard/CI Gate and independent review complete. This PR is based on current main `b72806c7a3` (#24152).