### PR TITLE
feat(keeper): finalize dead tombstones durably

### DIFF
--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -7,9 +7,9 @@
     - [Keeper_registry.dispatch_event_with_audit] fires [Phase_transition]
       after the state machine accepts a phase change and the registry write
       commits.
-    - [Keeper_supervisor.sweep_and_recover] fires [Tombstone_reaped] after
-      a dead-keeper unregister succeeds (see [Keeper_lifecycle_hooks.run]
-      invocation in keeper_supervisor.ml).
+    - [Keeper_supervisor_cleanup_tombstone.handle_completion] fires
+      [Tombstone_reaped] after the durable shutdown finalization receipt
+      records exact-lane unregister.
 
     Phase B/C uses the same registration API to attach the
     [Docker_runtime] bridge.
@@ -37,9 +37,9 @@ type event =
           phase changes after the registry write commits. Hooks observe an
           applied transition; they cannot veto. *)
   | Tombstone_reaped
-      (** Fired by [Keeper_supervisor.cleanup_dead_tombstone] after the
-          registry unregister completes. The keeper is fully gone from
-          in-process state at this point. *)
+      (** Fired by the durable dead-tombstone completion handler after exact
+          registry unregister and finalization persistence. The keeper is
+          fully gone from in-process state at this point. *)
 
 (** Hook callback. *)
 type hook = keeper_id:string -> event -> unit

--- a/lib/keeper/keeper_meta_merge.ml
+++ b/lib/keeper/keeper_meta_merge.ml
@@ -53,22 +53,3 @@ let preserve_operator_pause_from_disk
   else merged
 
 let heartbeat_fields_from_disk = preserve_operator_pause_from_disk
-
-(* Dead-tombstone cleanup is the authoritative writer of [paused] and
-   [latched_reason]: it records that the supervisor is tearing the keeper down
-   as a dead tombstone. This is the inverse ownership of
-   [preserve_operator_pause_from_disk], which lets a disk operator pause win so a
-   racing heartbeat (stale [latched_reason = None]) cannot erase it. On a CAS
-   retry the cleanup re-reads disk; were the retry to reuse the heartbeat merge
-   and find an operator pause on disk, [preserve_operator_pause_from_disk] would
-   copy the operator reason back and [write_meta_with_merge] would return [Ok ()]
-   while persisting [paused = true] with the wrong reason instead of
-   [Dead_tombstone]. This merge keeps [paused]/[latched_reason] with the cleanup
-   caller and still merges heartbeat-owned usage counters monotonically
-   (RFC-0225 §3.2) so a racing heartbeat increment is not lost. *)
-let dead_tombstone_cleanup_from_disk
-      ~(latest : Keeper_meta_contract.keeper_meta)
-      ~(caller : Keeper_meta_contract.keeper_meta)
-  =
-  let merged = monotonic_usage_counters ~latest ~caller in
-  { merged with paused = caller.paused; latched_reason = caller.latched_reason }

--- a/lib/keeper/keeper_meta_merge.mli
+++ b/lib/keeper/keeper_meta_merge.mli
@@ -16,10 +16,3 @@ val heartbeat_fields_from_disk : t
 (** {!monotonic_usage_counters}, plus preservation of an operator-owned pause
     already present on disk. This prevents stale turn/heartbeat writers from
     clearing [paused=true] after an operator paused the keeper. *)
-
-val dead_tombstone_cleanup_from_disk : t
-(** {!monotonic_usage_counters}, with [paused] and [latched_reason] owned by the
-    caller. Used by the dead-tombstone cleanup so a CAS retry that re-reads an
-    operator pause cannot copy the operator reason back over [Dead_tombstone].
-    The inverse of {!heartbeat_fields_from_disk}, which lets a disk operator
-    pause win. *)

--- a/lib/keeper/keeper_process_switch.ml
+++ b/lib/keeper/keeper_process_switch.ml
@@ -1,0 +1,8 @@
+(** Process-lifetime switch shared by Keeper orchestration producers.
+
+    This leaf owns the singleton so lifecycle workers do not depend back on
+    [Keeper_supervisor], which itself consumes those workers. *)
+
+let switch : Eio.Switch.t option Atomic.t = Atomic.make None
+let set sw = Atomic.set switch (Some sw)
+let get () = Atomic.get switch

--- a/lib/keeper/keeper_process_switch.mli
+++ b/lib/keeper/keeper_process_switch.mli
@@ -1,0 +1,4 @@
+(** Process-lifetime Keeper orchestration switch SSOT. *)
+
+val set : Eio.Switch.t -> unit
+val get : unit -> Eio.Switch.t option

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -959,8 +959,11 @@ let start_supervisor_sweep ctx =
     in
     with_sweeps_rw (fun () ->
       Hashtbl.replace supervisor_sweeps base_path p);
-    let sw = Option.value (Keeper_process_switch.get ()) ~default:ctx.sw in
-    Pulse.run ~sw p;
+    (* The sweep is owned by the context that constructed it. Detached
+       lifecycle workers use [Keeper_process_switch]; this context-bound
+       producer must not silently substitute one switch authority for the
+       other. *)
+    Pulse.run ~sw:ctx.sw p;
     (* #10125: counter increments once per actual Pulse start.
        After a server restart, if this stays at 0 the supervisor
        never came up — operators alert on absence of advancement. *)

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -959,7 +959,7 @@ let start_supervisor_sweep ctx =
     in
     with_sweeps_rw (fun () ->
       Hashtbl.replace supervisor_sweeps base_path p);
-    let sw = Option.value (Keeper_supervisor.get_global_switch ()) ~default:ctx.sw in
+    let sw = Option.value (Keeper_process_switch.get ()) ~default:ctx.sw in
     Pulse.run ~sw p;
     (* #10125: counter increments once per actual Pulse start.
        After a server restart, if this stays at 0 the supervisor

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -4,6 +4,7 @@ type error =
   | Store_error of Keeper_shutdown_store.error
   | Unsupported_phase
   | Finalization_blocked of Keeper_shutdown_types.t
+  | Completion_failed of Keeper_shutdown_types.t * string
 
 let error_to_string = function
   | Store_error error -> Keeper_shutdown_store.error_to_string error
@@ -12,6 +13,11 @@ let error_to_string = function
     Printf.sprintf
       "Keeper shutdown finalization blocked in operation %s"
       (Operation_id.to_string operation.operation_id)
+  | Completion_failed (operation, detail) ->
+    Printf.sprintf
+      "Keeper shutdown completion delivery failed in operation %s: %s"
+      (Operation_id.to_string operation.operation_id)
+      detail
 ;;
 
 let remove_pending_confirms_by_target_callback
@@ -28,6 +34,19 @@ let remove_pending_confirms_by_target_callback
 let register_remove_pending_confirms_by_target fn =
   Atomic.set remove_pending_confirms_by_target_callback fn
 ;;
+
+let completion_handler
+    : (Workspace.config ->
+       Keeper_shutdown_types.t ->
+       Keeper_shutdown_types.completion_action ->
+       (unit, string) result)
+        Atomic.t
+  =
+  Atomic.make (fun _config _operation _action ->
+    Error "shutdown completion handler is not registered")
+;;
+
+let register_completion_handler handler = Atomic.set completion_handler handler
 
 let replace ~config operation =
   let next = { operation with revision = operation.revision + 1 } in
@@ -293,6 +312,24 @@ let paused_meta (meta : Keeper_meta_contract.keeper_meta) =
   }
 ;;
 
+let dead_tombstone_meta (meta : Keeper_meta_contract.keeper_meta) =
+  { meta with
+    current_task_id = None
+  ; paused = true
+  ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
+  ; auto_resume_after_sec = None
+  ; updated_at = Masc_domain.now_iso ()
+  ; runtime = { meta.runtime with last_blocker = None }
+  }
+;;
+
+let final_meta_update cleanup_intent =
+  match cleanup_intent.meta_disposition with
+  | Retain_operator_pause
+  | Remove_meta -> paused_meta
+  | Retain_dead_tombstone -> dead_tombstone_meta
+;;
+
 let update_registry_meta_exact operation entry retained =
   match entry with
   | None -> Ok ()
@@ -323,7 +360,7 @@ let prepare_cleanup ~config ~entry operation settled_task_ids =
       ~name:operation.keeper_name
       ~trace_id:operation.trace_id
       ~generation:operation.generation
-      paused_meta
+      (final_meta_update operation.cleanup_intent)
   with
   | Error error ->
     block
@@ -387,8 +424,8 @@ let rec remove_tree path =
 ;;
 
 let remove_meta_file ~config operation =
-  if operation.cleanup_intent.remove_meta
-  then
+  match operation.cleanup_intent.meta_disposition with
+  | Remove_meta ->
     match
       Keeper_meta_store.remove_meta_if_identity
         config
@@ -398,7 +435,8 @@ let remove_meta_file ~config operation =
     with
     | Ok () | Error Keeper_meta_store.Remove_identity_missing -> Ok ()
     | Error error -> Error (Keeper_meta_store.identity_remove_error_to_string error)
-  else Ok ()
+  | Retain_operator_pause
+  | Retain_dead_tombstone -> Ok ()
 ;;
 
 let remove_session_dir ~config operation =
@@ -442,6 +480,40 @@ let release_finalized_admission ~(config : Workspace.config) operation =
     Ok operation
 ;;
 
+let invoke_completion_handler ~config operation action =
+  try Atomic.get completion_handler config operation action with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let deliver_finalized_completion ~config operation =
+  match operation.phase with
+  | Finalized { completion = Completion_not_requested; _ }
+  | Finalized { completion = Completion_delivered _; _ } ->
+    release_finalized_admission ~config operation
+  | Finalized ({ completion = Completion_pending action; _ } as evidence) ->
+    (match invoke_completion_handler ~config operation action with
+     | Error detail -> Error (Completion_failed (operation, detail))
+     | Ok () ->
+       let delivered =
+         { operation with
+           phase =
+             Finalized
+               { evidence with completion = Completion_delivered action }
+         ; updated_at = Masc_domain.now_iso ()
+         }
+       in
+       (match replace ~config delivered with
+        | Error _ as error -> error
+        | Ok persisted -> release_finalized_admission ~config persisted))
+  | Prepared
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _
+  | Reconciliation_required _
+  | Blocked _ -> Error Unsupported_phase
+;;
+
 let complete_cleanup ~config ~entry operation cleanup =
   match unregister_exact operation entry with
   | Error detail -> block ~config operation Registry_unregister detail
@@ -452,13 +524,26 @@ let complete_cleanup ~config ~entry operation cleanup =
        (match remove_meta_file ~config operation with
         | Error detail -> block ~config operation Meta_remove detail
         | Ok () ->
-          if operation.cleanup_intent.remove_meta
+          if registry_unregistered
           then Keeper_tool_emission_hook.drop_keeper_accumulator operation.keeper_name;
+          let meta_removed =
+            match operation.cleanup_intent.meta_disposition with
+            | Remove_meta -> true
+            | Retain_operator_pause
+            | Retain_dead_tombstone -> false
+          in
+          let completion =
+            match operation.cleanup_intent.meta_disposition with
+            | Retain_dead_tombstone -> Completion_pending Dead_tombstone_reaped
+            | Retain_operator_pause
+            | Remove_meta -> Completion_not_requested
+          in
           let evidence =
             { cleanup
-            ; meta_removed = operation.cleanup_intent.remove_meta
+            ; meta_removed
             ; session_removed = operation.cleanup_intent.remove_session
             ; registry_unregistered
+            ; completion
             }
           in
           let finalized =
@@ -470,7 +555,7 @@ let complete_cleanup ~config ~entry operation cleanup =
           (match replace ~config finalized with
            | Error _ as error -> error
            | Ok persisted_finalized ->
-             release_finalized_admission ~config persisted_finalized)))
+             deliver_finalized_completion ~config persisted_finalized)))
 ;;
 
 let run ~config ~entry operation =
@@ -504,7 +589,7 @@ let run ~config ~entry operation =
               | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
               | _ -> Error Unsupported_phase))))
   | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
-  | Finalized _ -> release_finalized_admission ~config operation
+  | Finalized _ -> deliver_finalized_completion ~config operation
   | Prepared
   | Reconciliation_required _
   | Blocked _ -> Error Unsupported_phase
@@ -512,6 +597,7 @@ let run ~config ~entry operation =
 
 module For_testing = struct
   let paused_meta = paused_meta
+  let dead_tombstone_meta = dead_tombstone_meta
 
   let remove_pending_confirms_by_target ~config ~target_type ~target_id =
     Atomic.get remove_pending_confirms_by_target_callback config ~target_type ~target_id
@@ -520,6 +606,11 @@ module For_testing = struct
   let reset_remove_pending_confirms_by_target () =
     Atomic.set remove_pending_confirms_by_target_callback
       (fun _config ~target_type:_ ~target_id:_ ->
-        Error "pending-confirm cleanup implementation is not registered")
+      Error "pending-confirm cleanup implementation is not registered")
+  ;;
+
+  let reset_completion_handler () =
+    Atomic.set completion_handler (fun _config _operation _action ->
+      Error "shutdown completion handler is not registered")
   ;;
 end

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -426,15 +426,16 @@ let rec remove_tree path =
 let remove_meta_file ~config operation =
   match operation.cleanup_intent.meta_disposition with
   | Remove_meta ->
-    match
-      Keeper_meta_store.remove_meta_if_identity
-        config
-        ~name:operation.keeper_name
-        ~trace_id:operation.trace_id
-        ~generation:operation.generation
-    with
-    | Ok () | Error Keeper_meta_store.Remove_identity_missing -> Ok ()
-    | Error error -> Error (Keeper_meta_store.identity_remove_error_to_string error)
+    (match
+       Keeper_meta_store.remove_meta_if_identity
+         config
+         ~name:operation.keeper_name
+         ~trace_id:operation.trace_id
+         ~generation:operation.generation
+     with
+     | Ok () | Error Keeper_meta_store.Remove_identity_missing -> Ok ()
+     | Error error ->
+       Error (Keeper_meta_store.identity_remove_error_to_string error))
   | Retain_operator_pause
   | Retain_dead_tombstone -> Ok ()
 ;;

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -6,6 +6,7 @@ type error =
   | Store_error of Keeper_shutdown_store.error
   | Unsupported_phase
   | Finalization_blocked of Keeper_shutdown_types.t
+  | Completion_failed of Keeper_shutdown_types.t * string
 
 val error_to_string : error -> string
 
@@ -14,6 +15,19 @@ val register_remove_pending_confirms_by_target :
    target_type:Operator_action_constants.target_type ->
    target_id:string option ->
    (int, string) result) ->
+  unit
+
+(** Register the process boundary that delivers a typed lifecycle completion
+    after [Finalized] is durable and before the Keeper admission fence is
+    released. The handler must be repeat-safe because a crash between delivery
+    and receipt persistence causes an explicit retry at boot. The stable
+    operation id is the deduplication identity for effects that require
+    exactly-once projection. *)
+val register_completion_handler :
+  (Workspace.config ->
+   Keeper_shutdown_types.t ->
+   Keeper_shutdown_types.completion_action ->
+   (unit, string) result) ->
   unit
 
 val run :
@@ -26,6 +40,9 @@ module For_testing : sig
   val paused_meta :
     Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
 
+  val dead_tombstone_meta :
+    Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta
+
   val remove_pending_confirms_by_target :
     config:Workspace.config ->
     target_type:Operator_action_constants.target_type ->
@@ -33,4 +50,5 @@ module For_testing : sig
     (int, string) result
 
   val reset_remove_pending_confirms_by_target : unit -> unit
+  val reset_completion_handler : unit -> unit
 end

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -208,7 +208,7 @@ type worker_start_result =
   | Worker_start_rejected of worker_start_error
 
 let start_worker ~config ~entry operation =
-  match Keeper_supervisor.get_global_switch () with
+  match Keeper_process_switch.get () with
   | None -> Worker_start_rejected Worker_supervisor_unavailable
   | Some sw ->
     Eio.Cancel.protect (fun () ->

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -27,9 +27,11 @@ let submit_error_to_string = function
     Printf.sprintf "Keeper shutdown worker fork failed: %s" (Printexc.to_string exn)
 ;;
 
-let operation_requires_fence operation =
+let operation_requires_fence (operation : Keeper_shutdown_types.t) =
   match operation.phase with
-  | Finalized _ -> false
+  | Finalized { completion = Completion_pending _; _ } -> true
+  | Finalized
+      { completion = (Completion_not_requested | Completion_delivered _); _ } -> false
   | Prepared
   | Joined_idle
   | Finalizing_tasks _
@@ -162,7 +164,8 @@ let finalize_if_ready ~config ~entry operation =
   match operation.phase with
   | Joined_idle
   | Finalizing_tasks _
-  | Cleanup_ready _ ->
+  | Cleanup_ready _
+  | Finalized _ ->
     (match Keeper_shutdown_finalize.run ~config ~entry:(Some entry) operation with
      | Ok finalized ->
        Log.Keeper.info
@@ -177,7 +180,6 @@ let finalize_if_ready ~config ~entry operation =
          (Keeper_shutdown_finalize.error_to_string error))
   | Prepared
   | Reconciliation_required _
-  | Finalized _
   | Blocked _ -> ()
 ;;
 
@@ -194,9 +196,9 @@ let run_worker ~config ~entry operation =
          (Keeper_shutdown_prepare_join.error_to_string error))
   | Joined_idle
   | Finalizing_tasks _
-  | Cleanup_ready _ -> finalize_if_ready ~config ~entry operation
+  | Cleanup_ready _
+  | Finalized _ -> finalize_if_ready ~config ~entry operation
   | Reconciliation_required _
-  | Finalized _
   | Blocked _ -> ()
 ;;
 
@@ -305,12 +307,12 @@ let recover_operation ~config operation =
     (match recovered.phase with
      | Joined_idle
      | Finalizing_tasks _
-     | Cleanup_ready _ ->
+     | Cleanup_ready _
+     | Finalized _ ->
        Keeper_shutdown_finalize.run ~config ~entry:None recovered
        |> Result.map_error Keeper_shutdown_finalize.error_to_string
      | Prepared
      | Reconciliation_required _
-     | Finalized _
      | Blocked _ -> Ok recovered)
 ;;
 

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -5,6 +5,7 @@ type error =
   | Not_found of string
   | Io_error of string
   | Decode_error of string
+  | Invalid_operation of Keeper_shutdown_types.invariant_error
   | Identity_mismatch of string
   | Revision_conflict of
       { expected : int
@@ -31,6 +32,10 @@ let error_to_string = function
   | Not_found path -> Printf.sprintf "shutdown operation not found: %s" path
   | Io_error detail -> Printf.sprintf "shutdown operation I/O failed: %s" detail
   | Decode_error detail -> Printf.sprintf "shutdown operation decode failed: %s" detail
+  | Invalid_operation error ->
+    Printf.sprintf
+      "shutdown operation invariant failed: %s"
+      (Keeper_shutdown_types.invariant_error_to_string error)
   | Identity_mismatch detail ->
     Printf.sprintf "shutdown operation identity mismatch: %s" detail
   | Revision_conflict { expected; actual } ->
@@ -210,12 +215,27 @@ let cleanup_evidence_to_json evidence =
     ]
 ;;
 
+let completion_receipt_to_json = function
+  | Completion_not_requested -> `Assoc [ "kind", `String "not_requested" ]
+  | Completion_pending action ->
+    `Assoc
+      [ "kind", `String "pending"
+      ; "action", `String (completion_action_to_string action)
+      ]
+  | Completion_delivered action ->
+    `Assoc
+      [ "kind", `String "delivered"
+      ; "action", `String (completion_action_to_string action)
+      ]
+;;
+
 let finalization_evidence_to_json evidence =
   `Assoc
     [ "cleanup", cleanup_evidence_to_json evidence.cleanup
     ; "meta_removed", `Bool evidence.meta_removed
     ; "session_removed", `Bool evidence.session_removed
     ; "registry_unregistered", `Bool evidence.registry_unregistered
+    ; "completion", completion_receipt_to_json evidence.completion
     ]
 ;;
 
@@ -296,7 +316,10 @@ let to_json operation =
     ; "actor", `String operation.actor
     ; ( "cleanup_intent"
       , `Assoc
-          [ "remove_meta", `Bool operation.cleanup_intent.remove_meta
+          [ ( "meta_disposition"
+            , `String
+                (meta_disposition_to_string
+                   operation.cleanup_intent.meta_disposition) )
           ; "remove_session", `Bool operation.cleanup_intent.remove_session
           ] )
     ; "turn_disposition", turn_disposition_to_json operation.turn_disposition
@@ -372,6 +395,11 @@ let optional_string field json =
 
 let ( let* ) result f = Result.bind result f
 
+let validate_operation operation =
+  Keeper_shutdown_types.validate operation
+  |> Result.map_error (fun error -> Invalid_operation error)
+;;
+
 let active_turn_of_json json =
   let* lane =
     match assoc "lane" json with
@@ -434,13 +462,39 @@ let cleanup_evidence_of_json json =
   Ok { settled_task_ids; pending_confirms_removed }
 ;;
 
+let completion_receipt_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "not_requested" -> Ok Completion_not_requested
+  | "pending" ->
+    let* action_wire = string "action" json in
+    let* action =
+      completion_action_of_string action_wire
+      |> Result.map_error (fun detail -> Decode_error detail)
+    in
+    Ok (Completion_pending action)
+  | "delivered" ->
+    let* action_wire = string "action" json in
+    let* action =
+      completion_action_of_string action_wire
+      |> Result.map_error (fun detail -> Decode_error detail)
+    in
+    Ok (Completion_delivered action)
+  | value ->
+    Error
+      (Decode_error
+         (Printf.sprintf "unknown shutdown completion receipt: %S" value))
+;;
+
 let finalization_evidence_of_json json =
   let* cleanup_json = assoc "cleanup" json in
   let* cleanup = cleanup_evidence_of_json cleanup_json in
   let* meta_removed = bool "meta_removed" json in
   let* session_removed = bool "session_removed" json in
   let* registry_unregistered = bool "registry_unregistered" json in
-  Ok { cleanup; meta_removed; session_removed; registry_unregistered }
+  let* completion_json = assoc "completion" json in
+  let* completion = completion_receipt_of_json completion_json in
+  Ok { cleanup; meta_removed; session_removed; registry_unregistered; completion }
 ;;
 
 let phase_of_json json =
@@ -540,7 +594,11 @@ let of_json json =
     let* generation = int "generation" json in
     let* actor = string "actor" json in
     let* cleanup_json = assoc "cleanup_intent" json in
-    let* remove_meta = bool "remove_meta" cleanup_json in
+    let* meta_disposition_wire = string "meta_disposition" cleanup_json in
+    let* meta_disposition =
+      meta_disposition_of_string meta_disposition_wire
+      |> Result.map_error (fun detail -> Decode_error detail)
+    in
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
     let* turn_disposition = turn_disposition_of_json turn_json in
@@ -551,7 +609,7 @@ let of_json json =
     let* phase = phase_of_json phase_json in
     let* created_at = string "created_at" json in
     let* updated_at = string "updated_at" json in
-    Ok
+    let operation =
       { schema_version = decoded_schema_version
       ; revision
       ; operation_id
@@ -560,7 +618,7 @@ let of_json json =
       ; trace_id
       ; generation
       ; actor
-      ; cleanup_intent = { remove_meta; remove_session }
+      ; cleanup_intent = { meta_disposition; remove_session }
       ; turn_disposition
       ; expected_backlog_version
       ; owned_task_ids
@@ -569,6 +627,9 @@ let of_json json =
       ; created_at
       ; updated_at
       }
+    in
+    let* () = validate_operation operation in
+    Ok operation
 ;;
 
 let contextualize_error operation_path = function
@@ -576,7 +637,8 @@ let contextualize_error operation_path = function
   | Io_error detail -> Io_error (Printf.sprintf "%s: %s" operation_path detail)
   | Identity_mismatch detail ->
     Identity_mismatch (Printf.sprintf "%s: %s" operation_path detail)
-  | (Already_exists _ | Not_found _ | Revision_conflict _) as error -> error
+  | (Already_exists _ | Not_found _ | Invalid_operation _ | Revision_conflict _) as error ->
+    error
 ;;
 
 let load_path_unlocked ~operation_path ~keeper_name ~operation_id =
@@ -616,6 +678,7 @@ let load_path_unlocked ~operation_path ~keeper_name ~operation_id =
 ;;
 
 let persist_new ~config operation =
+  let* () = validate_operation operation in
   let* operation_path = path_for_operation ~config operation in
   with_keeper_inventory_lock
     ~access:Write
@@ -642,6 +705,7 @@ let same_identity
 ;;
 
 let replace ~config ~expected_revision operation =
+  let* () = validate_operation operation in
   let* operation_path = path_for_operation ~config operation in
   with_keeper_inventory_lock
     ~access:Write
@@ -676,6 +740,7 @@ let replace ~config ~expected_revision operation =
 ;;
 
 let persist_blocked_latest ~config ~identity ~failure ~updated_at =
+  let* () = validate_operation identity in
   let* operation_path = path_for_operation ~config identity in
   with_keeper_inventory_lock
     ~access:Write

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -693,17 +693,6 @@ let persist_new ~config operation =
            |> Result.map_error (fun detail -> Io_error detail)))
 ;;
 
-let same_identity
-    (left : Keeper_shutdown_types.t)
-    (right : Keeper_shutdown_types.t)
-  =
-  Operation_id.equal left.operation_id right.operation_id
-  && String.equal left.keeper_name right.keeper_name
-  && Keeper_lane.Id.equal left.lane_id right.lane_id
-  && Keeper_id.Trace_id.equal left.trace_id right.trace_id
-  && Int.equal left.generation right.generation
-;;
-
 let replace ~config ~expected_revision operation =
   let* () = validate_operation operation in
   let* operation_path = path_for_operation ~config operation in
@@ -730,7 +719,7 @@ let replace ~config ~expected_revision operation =
                 { expected = expected_revision + 1
                 ; actual = operation.revision
                 })
-         | Ok existing when same_identity existing operation ->
+         | Ok existing when Keeper_shutdown_types.immutable_fields_equal existing operation ->
            Keeper_fs.save_json_atomic operation_path (to_json operation)
            |> Result.map_error (fun detail -> Io_error detail)
          | Ok _ ->
@@ -755,7 +744,9 @@ let persist_blocked_latest ~config ~identity ~failure ~updated_at =
              ~operation_id:identity.operation_id
          with
          | Error _ as error -> error
-         | Ok existing when not (same_identity existing identity) ->
+         | Ok existing
+           when not
+                  (Keeper_shutdown_types.immutable_fields_equal existing identity) ->
            Error (Identity_mismatch (Operation_id.to_string identity.operation_id))
          | Ok existing ->
            (match existing.phase with

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -9,6 +9,7 @@ type error =
   | Not_found of string
   | Io_error of string
   | Decode_error of string
+  | Invalid_operation of Keeper_shutdown_types.invariant_error
   | Identity_mismatch of string
   | Revision_conflict of
       { expected : int

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -259,6 +259,67 @@ let validate operation =
     | Blocked _ -> Ok ()
 ;;
 
+let option_equal equal left right =
+  match left, right with
+  | None, None -> true
+  | Some left, Some right -> equal left right
+  | None, Some _
+  | Some _, None -> false
+;;
+
+let admission_lane_equal left right =
+  match left, right with
+  | Autonomous, Autonomous
+  | Chat, Chat -> true
+  | Autonomous, Chat
+  | Chat, Autonomous -> false
+;;
+
+let active_turn_equal left right =
+  option_equal admission_lane_equal left.lane right.lane
+  && option_equal Float.equal left.admitted_at right.admitted_at
+  && option_equal Int.equal left.observed_turn_id right.observed_turn_id
+  && option_equal Float.equal left.observation_started_at right.observation_started_at
+;;
+
+let turn_disposition_equal left right =
+  match left, right with
+  | No_inflight_turn, No_inflight_turn -> true
+  | Inflight_effect_unknown left, Inflight_effect_unknown right ->
+    active_turn_equal left right
+  | No_inflight_turn, Inflight_effect_unknown _
+  | Inflight_effect_unknown _, No_inflight_turn -> false
+;;
+
+let meta_disposition_equal left right =
+  match left, right with
+  | Retain_operator_pause, Retain_operator_pause
+  | Retain_dead_tombstone, Retain_dead_tombstone
+  | Remove_meta, Remove_meta -> true
+  | Retain_operator_pause, (Retain_dead_tombstone | Remove_meta)
+  | Retain_dead_tombstone, (Retain_operator_pause | Remove_meta)
+  | Remove_meta, (Retain_operator_pause | Retain_dead_tombstone) -> false
+;;
+
+let cleanup_intent_equal left right =
+  meta_disposition_equal left.meta_disposition right.meta_disposition
+  && Bool.equal left.remove_session right.remove_session
+;;
+
+let immutable_fields_equal left right =
+  Int.equal left.schema_version right.schema_version
+  && Operation_id.equal left.operation_id right.operation_id
+  && String.equal left.keeper_name right.keeper_name
+  && Keeper_lane.Id.equal left.lane_id right.lane_id
+  && Keeper_id.Trace_id.equal left.trace_id right.trace_id
+  && Int.equal left.generation right.generation
+  && String.equal left.actor right.actor
+  && cleanup_intent_equal left.cleanup_intent right.cleanup_intent
+  && turn_disposition_equal left.turn_disposition right.turn_disposition
+  && List.equal Keeper_id.Task_id.equal left.owned_task_ids right.owned_task_ids
+  && String.equal left.created_at right.created_at
+;;
+
 let admission_lane_to_string = function
   | Autonomous -> "autonomous"
   | Chat -> "chat"

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -28,8 +28,20 @@ module Operation_id = struct
   let equal = String.equal
 end
 
+type meta_disposition =
+  | Retain_operator_pause
+  | Retain_dead_tombstone
+  | Remove_meta
+
+type completion_action = Dead_tombstone_reaped
+
+type completion_receipt =
+  | Completion_not_requested
+  | Completion_pending of completion_action
+  | Completion_delivered of completion_action
+
 type cleanup_intent =
-  { remove_meta : bool
+  { meta_disposition : meta_disposition
   ; remove_session : bool
   }
 
@@ -94,6 +106,7 @@ type finalization_evidence =
   ; meta_removed : bool
   ; session_removed : bool
   ; registry_unregistered : bool
+  ; completion : completion_receipt
   }
 
 type phase =
@@ -124,7 +137,127 @@ type t =
   ; updated_at : string
   }
 
-let schema_version = 2
+type invariant_error =
+  | Schema_version_mismatch of
+      { expected_schema_version : int
+      ; actual_schema_version : int
+      }
+  | Finalized_meta_removed_mismatch of
+      { expected_meta_removed : bool
+      ; actual_meta_removed : bool
+      }
+  | Finalized_session_removed_mismatch of
+      { expected_session_removed : bool
+      ; actual_session_removed : bool
+      }
+  | Finalized_completion_mismatch of meta_disposition * completion_receipt
+
+let schema_version = 3
+
+let meta_disposition_to_string = function
+  | Retain_operator_pause -> "retain_operator_pause"
+  | Retain_dead_tombstone -> "retain_dead_tombstone"
+  | Remove_meta -> "remove_meta"
+;;
+
+let meta_disposition_of_string = function
+  | "retain_operator_pause" -> Ok Retain_operator_pause
+  | "retain_dead_tombstone" -> Ok Retain_dead_tombstone
+  | "remove_meta" -> Ok Remove_meta
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown meta disposition: %S" value)
+;;
+
+let completion_action_to_string = function
+  | Dead_tombstone_reaped -> "dead_tombstone_reaped"
+;;
+
+let completion_action_of_string = function
+  | "dead_tombstone_reaped" -> Ok Dead_tombstone_reaped
+  | value -> Error (Printf.sprintf "unknown Keeper shutdown completion action: %S" value)
+;;
+
+let completion_receipt_kind = function
+  | Completion_not_requested -> "not_requested"
+  | Completion_pending _ -> "pending"
+  | Completion_delivered _ -> "delivered"
+;;
+
+let invariant_error_to_string = function
+  | Schema_version_mismatch
+      { expected_schema_version; actual_schema_version } ->
+    Printf.sprintf
+      "shutdown schema version mismatch: expected %d, actual %d"
+      expected_schema_version
+      actual_schema_version
+  | Finalized_meta_removed_mismatch
+      { expected_meta_removed; actual_meta_removed } ->
+    Printf.sprintf
+      "shutdown finalized meta evidence mismatch: expected removed=%b, actual=%b"
+      expected_meta_removed
+      actual_meta_removed
+  | Finalized_session_removed_mismatch
+      { expected_session_removed; actual_session_removed } ->
+    Printf.sprintf
+      "shutdown finalized session evidence mismatch: expected removed=%b, actual=%b"
+      expected_session_removed
+      actual_session_removed
+  | Finalized_completion_mismatch (meta_disposition, completion) ->
+    Printf.sprintf
+      "shutdown finalized completion mismatch: meta_disposition=%s, completion=%s"
+      (meta_disposition_to_string meta_disposition)
+      (completion_receipt_kind completion)
+;;
+
+let validate operation =
+  if not (Int.equal operation.schema_version schema_version)
+  then
+    Error
+      (Schema_version_mismatch
+         { expected_schema_version = schema_version
+         ; actual_schema_version = operation.schema_version
+         })
+  else
+    match operation.phase with
+    | Finalized evidence ->
+      let expected_meta_removed =
+        match operation.cleanup_intent.meta_disposition with
+        | Remove_meta -> true
+        | Retain_operator_pause
+        | Retain_dead_tombstone -> false
+      in
+      if not (Bool.equal evidence.meta_removed expected_meta_removed)
+      then
+        Error
+          (Finalized_meta_removed_mismatch
+             { expected_meta_removed
+             ; actual_meta_removed = evidence.meta_removed
+             })
+      else if
+        not
+          (Bool.equal
+             evidence.session_removed
+             operation.cleanup_intent.remove_session)
+      then
+        Error
+          (Finalized_session_removed_mismatch
+             { expected_session_removed = operation.cleanup_intent.remove_session
+             ; actual_session_removed = evidence.session_removed
+             })
+      else
+        (match operation.cleanup_intent.meta_disposition, evidence.completion with
+         | Retain_dead_tombstone,
+           (Completion_pending Dead_tombstone_reaped
+           | Completion_delivered Dead_tombstone_reaped)
+         | (Retain_operator_pause | Remove_meta), Completion_not_requested -> Ok ()
+         | meta_disposition, completion ->
+           Error (Finalized_completion_mismatch (meta_disposition, completion)))
+    | Prepared
+    | Joined_idle
+    | Finalizing_tasks _
+    | Cleanup_ready _
+    | Reconciliation_required _
+    | Blocked _ -> Ok ()
+;;
 
 let admission_lane_to_string = function
   | Autonomous -> "autonomous"

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -11,8 +11,20 @@ module Operation_id : sig
   val equal : t -> t -> bool
 end
 
+type meta_disposition =
+  | Retain_operator_pause
+  | Retain_dead_tombstone
+  | Remove_meta
+
+type completion_action = Dead_tombstone_reaped
+
+type completion_receipt =
+  | Completion_not_requested
+  | Completion_pending of completion_action
+  | Completion_delivered of completion_action
+
 type cleanup_intent =
-  { remove_meta : bool
+  { meta_disposition : meta_disposition
   ; remove_session : bool
   }
 
@@ -77,6 +89,7 @@ type finalization_evidence =
   ; meta_removed : bool
   ; session_removed : bool
   ; registry_unregistered : bool
+  ; completion : completion_receipt
   }
 
 type phase =
@@ -107,7 +120,28 @@ type t =
   ; updated_at : string
   }
 
+type invariant_error =
+  | Schema_version_mismatch of
+      { expected_schema_version : int
+      ; actual_schema_version : int
+      }
+  | Finalized_meta_removed_mismatch of
+      { expected_meta_removed : bool
+      ; actual_meta_removed : bool
+      }
+  | Finalized_session_removed_mismatch of
+      { expected_session_removed : bool
+      ; actual_session_removed : bool
+      }
+  | Finalized_completion_mismatch of meta_disposition * completion_receipt
+
 val schema_version : int
+val meta_disposition_to_string : meta_disposition -> string
+val meta_disposition_of_string : string -> (meta_disposition, string) result
+val completion_action_to_string : completion_action -> string
+val completion_action_of_string : string -> (completion_action, string) result
+val invariant_error_to_string : invariant_error -> string
+val validate : t -> (unit, invariant_error) result
 val admission_lane_to_string : admission_lane -> string
 val admission_lane_of_string : string -> (admission_lane, string) result
 val failure_stage_to_string : failure_stage -> string

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -142,6 +142,10 @@ val completion_action_to_string : completion_action -> string
 val completion_action_of_string : string -> (completion_action, string) result
 val invariant_error_to_string : invariant_error -> string
 val validate : t -> (unit, invariant_error) result
+val immutable_fields_equal : t -> t -> bool
+(** Compare every operation field that must remain fixed across revision
+    replacement. Progress fields ([revision], backlog version, join/finalization
+    evidence, phase, and [updated_at]) are intentionally excluded. *)
 val admission_lane_to_string : admission_lane -> string
 val admission_lane_of_string : string -> (admission_lane, string) result
 val failure_stage_to_string : failure_stage -> string

--- a/lib/keeper/keeper_subprocess_registry.ml
+++ b/lib/keeper/keeper_subprocess_registry.ml
@@ -152,6 +152,8 @@ let register_default_cleanup_hook () =
   if Atomic.compare_and_set registered false true then
     Keeper_lifecycle_hooks.register default_hook
 
+let default_cleanup_hook_registered () = Atomic.get registered
+
 let reset_for_testing () =
   with_lock (fun () -> Hashtbl.clear registry);
   Atomic.set registered false

--- a/lib/keeper/keeper_subprocess_registry.mli
+++ b/lib/keeper/keeper_subprocess_registry.mli
@@ -69,6 +69,11 @@ val drain : keeper_id:string -> grace_ms:int -> drain_result
     bootstrap. *)
 val register_default_cleanup_hook : unit -> unit
 
+(** Exact process-local readiness of the mandatory default tombstone cleanup
+    hook. Durable completion recovery uses this to avoid acknowledging a
+    receipt before the cleanup subscriber is installed. *)
+val default_cleanup_hook_registered : unit -> bool
+
 (** Test-only escape hatch: clear the registry. Production code should
     never call this. *)
 val reset_for_testing : unit -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -772,16 +772,11 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
          msg
          entry.restart_count))
     final_acc.to_mark_dead;
-  (* RFC-0036 Phase A.2: fire Tombstone_reaped after cleanup completes.
-     Hook is exception-safe; supervisor never observes failure. *)
+  (* Submit exact-lane durable finalization. [Dead_cleaned] and
+     [Tombstone_reaped] are emitted only by the completion receipt handler. *)
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-       cleanup_dead_tombstone ctx entry;
-       Keeper_lifecycle_hooks.run
-         ~base_dir:(Workspace.masc_root_dir ctx.config)
-         ~meta:entry.meta
-         ~keeper_id:entry.name
-         Keeper_lifecycle_hooks.Tombstone_reaped)
+       cleanup_dead_tombstone ctx entry)
     final_acc.to_cleanup_dead;
   let active_count =
     Keeper_registry.all ~base_path () |> active_supervision_keeper_count

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -1,173 +1,107 @@
-(** Dead-tombstone cleanup for the keeper supervisor, extracted from
-    [keeper_supervisor.ml]. The cleanup CASes [paused = true] (merging
-    heartbeat-owned fields), unregisters the keeper, drops its tool
-    emission accumulator, and emits the [Dead_cleaned] lifecycle event.
+(** Dead-tombstone cleanup admission and completion delivery.
 
-    [publish_lifecycle] is injected explicitly so the sibling does not
-    reach back into the supervisor godfile (mirrors the pattern already
-    used by [Keeper_supervisor_self_preservation.apply]). *)
+    The supervisor only submits an exact-lane durable shutdown operation.
+    Meta mutation, lane join, registry removal, and accumulator removal are
+    owned by [Keeper_shutdown_finalize]. [Dead_cleaned] and
+    [Tombstone_reaped] are delivered from the durable completion receipt after
+    finalization, never from the sweep that observed the old entry. *)
 
-open Keeper_types
-open Keeper_meta_contract
-open Keeper_meta_store
-open Keeper_types_profile
-open Keeper_execution
+open Keeper_shutdown_types
 
-let unregister_exact_dead_entry (entry : Keeper_registry.registry_entry) =
-  match Keeper_registry.unregister_exact entry with
-  | Keeper_registry.Exact_unregistered ->
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    true
-  | Keeper_registry.Exact_entry_missing -> false
-  | Keeper_registry.Exact_entry_replaced ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string SupervisorCleanupFailures)
-      ~labels:[ "keeper", entry.name; "site", "dead_tombstone_entry_replaced" ]
-      ();
-    Log.Keeper.warn
-      "%s: dead tombstone cleanup retained a newer same-name lane"
-      entry.name;
-    false
+let cleanup_intent : Keeper_shutdown_types.cleanup_intent =
+  { meta_disposition = Retain_dead_tombstone
+  ; remove_session = false
+  }
+;;
+
+let record_submission_failure keeper_name =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string SupervisorCleanupFailures)
+    ~labels:
+      [ "keeper", keeper_name
+      ; ( "site"
+        , Keeper_supervisor_cleanup_failure_site.(
+            to_label Dead_tombstone_submission) )
+      ]
+    ()
 ;;
 
 let cleanup_dead_tombstone
-      ~publish_lifecycle
-      (ctx : _ context)
-      (entry : Keeper_registry.registry_entry)
+    (ctx : _ Keeper_types_profile.context)
+    (entry : Keeper_registry.registry_entry)
   =
-  match read_meta ctx.config entry.name with
-  | Ok (Some meta) ->
-    let dead_tombstone_terminal_persisted =
-      meta.paused
-      &&
-      match meta.latched_reason with
-      | Some Keeper_latched_reason.Dead_tombstone ->
-        Option.is_none meta.auto_resume_after_sec
-        && Option.is_none meta.runtime.last_blocker
-      | Some _
-      | None -> false
-    in
-    let persisted_paused =
-      if dead_tombstone_terminal_persisted
-      then true
-      else (
-        (* #9733: dead tombstone cleanup writes [paused = true] —
-             cycle-owned field — while heartbeat fibers can still
-             update the same record's heartbeat-owned fields.  Use
-             the same merged-CAS retry as the resume + overflow-pause
-             paths so a parallel heartbeat write doesn't make this
-             write fail and leave the keeper unpaused on disk while
-             the supervisor proceeds to unregister it.
+  let request : Keeper_shutdown_prepare_join.request =
+    { actor = ctx.agent_name; cleanup_intent }
+  in
+  match Keeper_shutdown_runtime.submit ~config:ctx.config ~entry ~request with
+  | Ok operation ->
+    Log.Keeper.info
+      "%s: dead tombstone finalization accepted operation=%s"
+      entry.name
+      (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+  | Error error ->
+    record_submission_failure entry.name;
+    Log.Keeper.error
+      "%s: dead tombstone finalization submission failed: %s"
+      entry.name
+      (Keeper_shutdown_runtime.submit_error_to_string error)
+;;
 
-             The cleanup owns [paused]/[latched_reason] here, so use
-             [dead_tombstone_cleanup_from_disk] rather than the
-             heartbeat merge: on a CAS retry that re-reads an operator
-             pause, the heartbeat merge would copy the operator reason
-             back over [Dead_tombstone] and still return [Ok ()]. *)
-        match
-          write_meta_with_merge
-            ~merge:Keeper_meta_merge.dead_tombstone_cleanup_from_disk
-            ctx.config
-            { meta with
-              paused = true
-            ; (* Record {i why} this meta is paused on disk: a dead-keeper
-                 tombstone, distinct from an operator pause or runtime latch.
-                 Observability only — the unregister/pause behavior below is
-                 unchanged. *)
-              latched_reason = Some Keeper_latched_reason.Dead_tombstone
-            ; auto_resume_after_sec = None
-            ; updated_at = now_iso ()
-            ; runtime = { meta.runtime with last_blocker = None }
-            }
-        with
-        | Ok () -> true
-        | Error err when is_version_conflict_error err ->
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string WriteMetaFailures)
-            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup_cas_race" ]
-            ();
-          Log.Keeper.warn
-            "%s: dead tombstone cleanup paused/reason write lost CAS race after retries: %s"
-            entry.name
-            err;
-          false
-        | Error err ->
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string WriteMetaFailures)
-            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup" ]
-            ();
-          Log.Keeper.warn
-            "%s: dead tombstone cleanup paused/reason write failed: %s"
-            entry.name
-            err;
-          false)
-    in
-    if not (unregister_exact_dead_entry entry)
-    then ()
-    else if persisted_paused
-    then (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        "paused meta persisted"
-        ();
-      Log.Keeper.info "%s: dead tombstone cleaned up" entry.name)
-    else (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        "meta write failed, unregistered anyway"
-        ();
-      Log.Keeper.warn
-        "%s: dead tombstone unregistered despite meta write failure"
-        entry.name;
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string SupervisorCleanupFailures)
-        ~labels:
-          [ "keeper", entry.name
-          ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write))
-          ]
-        ())
+let completion_meta_for_coverage config operation =
+  match Keeper_meta_store.read_meta config operation.Keeper_shutdown_types.keeper_name with
+  | Ok (Some meta)
+    when Keeper_id.Trace_id.equal meta.runtime.trace_id operation.trace_id
+         && Int.equal meta.runtime.generation operation.generation -> Some meta
+  | Ok (Some _) ->
+    Log.Keeper.warn
+      "%s: dead tombstone completion coverage meta identity changed"
+      operation.keeper_name;
+    None
   | Ok None ->
-    if unregister_exact_dead_entry entry
-    then (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        "meta missing"
-        ();
-      Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string SupervisorCleanupFailures)
-        ~labels:
-          [ "keeper", entry.name
-          ; ( "site"
-            , Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing) )
-          ]
-        ())
-  | Error err ->
-    if unregister_exact_dead_entry entry
-    then (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        (Printf.sprintf "meta read error: %s" err)
-        ();
-      Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string SupervisorCleanupFailures)
-        ~labels:
-          [ "keeper", entry.name
-          ; ( "site"
-            , Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error) )
-          ]
-        ())
+    Log.Keeper.warn
+      "%s: dead tombstone completion coverage meta is absent"
+      operation.keeper_name;
+    None
+  | Error detail ->
+    Log.Keeper.warn
+      "%s: dead tombstone completion coverage meta read failed: %s"
+      operation.keeper_name
+      detail;
+    None
+;;
+
+let completion_sinks_ready () =
+  match Masc_event_bus.get () with
+  | None -> Error "MASC lifecycle event bus is not installed"
+  | Some _ when not (Keeper_subprocess_registry.default_cleanup_hook_registered ()) ->
+    Error "default Keeper subprocess cleanup hook is not registered"
+  | Some _ -> Ok ()
+;;
+
+let handle_completion config operation = function
+  | Keeper_shutdown_types.Dead_tombstone_reaped ->
+    (match completion_sinks_ready () with
+     | Error _ as error -> error
+     | Ok () ->
+       let operation_id =
+         Keeper_shutdown_types.Operation_id.to_string operation.operation_id
+       in
+       Keeper_supervisor_publish_lifecycle.publish_lifecycle
+         ~event:
+           (Keeper_lifecycle_events.Custom_event
+              { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+         operation.keeper_name
+         ("shutdown_operation=" ^ operation_id)
+         ();
+       let meta = completion_meta_for_coverage config operation in
+       Keeper_lifecycle_hooks.run
+         ~base_dir:(Workspace.masc_root_dir config)
+         ?meta
+         ~keeper_id:operation.keeper_name
+         Keeper_lifecycle_hooks.Tombstone_reaped;
+       Log.Keeper.info
+         "%s: dead tombstone finalization delivered operation=%s"
+         operation.keeper_name
+         operation_id;
+       Ok ())
 ;;

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.mli
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.mli
@@ -1,8 +1,14 @@
-(** Dead-tombstone cleanup helper for the keeper supervisor. *)
+(** Submit exact-lane dead-tombstone finalization without blocking the
+    supervisor sweep. *)
+val cleanup_dead_tombstone :
+  'a Keeper_types_profile.context ->
+  Keeper_registry.registry_entry ->
+  unit
 
-val cleanup_dead_tombstone
-  :  publish_lifecycle:
-       (event:Keeper_lifecycle_events.lifecycle_event -> string -> string -> unit -> unit)
-  -> 'a Keeper_types_profile.context
-  -> Keeper_registry.registry_entry
-  -> unit
+(** Deliver the typed post-finalization event/hook. Registered by server boot
+    before shutdown recovery starts. *)
+val handle_completion :
+  Workspace.config ->
+  Keeper_shutdown_types.t ->
+  Keeper_shutdown_types.completion_action ->
+  (unit, string) result

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -674,14 +674,10 @@ let reconcile_keepalive_keepers ~load_or_materialize_keeper_meta (ctx : _ contex
     ctx
 ;;
 
-(* Dead-tombstone cleanup extracted to
-   [Keeper_supervisor_cleanup_tombstone] (godfile decomp). publish_lifecycle is
-   injected explicitly to avoid sibling -> parent cycle. *)
+(* Dead-tombstone cleanup submits a durable exact-lane finalization operation;
+   completion events/hooks are delivered from its durable receipt. *)
 let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_entry) =
-  Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone
-    ~publish_lifecycle
-    ctx
-    entry
+  Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone ctx entry
 ;;
 
 (** Cohort key from structured failure_reason ADT.

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -44,9 +44,8 @@ let publish_lifecycle = Keeper_supervisor_publish_lifecycle.publish_lifecycle
 let publish_phase_lifecycle = Keeper_supervisor_publish_lifecycle.publish_phase_lifecycle
 (* ── Supervised fiber launch ─────────────────────────────── *)
 
-let global_switch : Eio.Switch.t option Atomic.t = Atomic.make None
-let set_global_switch sw = Atomic.set global_switch (Some sw)
-let get_global_switch () = Atomic.get global_switch
+let set_global_switch = Keeper_process_switch.set
+let get_global_switch = Keeper_process_switch.get
 
 let set_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.set
 let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enabled
@@ -109,7 +108,7 @@ let launch_supervised_fiber_body
           meta.name;
       (* determinism-contract: allow — ctx.sw fallback is the same deterministic
          default used before the ref -> Atomic conversion. *)
-      let sw = Option.value (Atomic.get global_switch) ~default:ctx.sw in
+      let sw = Option.value (Keeper_process_switch.get ()) ~default:ctx.sw in
       match
         Keeper_lane.fork
           ~sw

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -106,12 +106,9 @@ let launch_supervised_fiber_body
           "keeper supervise domain pool ignored: keepalive body requires the owning \
            Eio domain (first_keeper=%s)"
           meta.name;
-      (* determinism-contract: allow — ctx.sw fallback is the same deterministic
-         default used before the ref -> Atomic conversion. *)
-      let sw = Option.value (Keeper_process_switch.get ()) ~default:ctx.sw in
       match
         Keeper_lane.fork
-          ~sw
+          ~sw:ctx.sw
           reg.lane
           ~run:body
           ~cleanup:(fun _ -> Ok ())

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -86,7 +86,10 @@ let handle_keeper_down (ctx : _ context) args : tool_result =
       let request : Keeper_shutdown_prepare_join.request =
         { actor = ctx.agent_name
         ; cleanup_intent =
-            { remove_meta = get_bool args "remove_meta" false
+            { meta_disposition =
+                (if get_bool args "remove_meta" false
+                 then Keeper_shutdown_types.Remove_meta
+                 else Keeper_shutdown_types.Retain_operator_pause)
             ; remove_session = get_bool args "remove_session" false
             }
         }

--- a/lib/keeper_failure_taxonomy/keeper_supervisor_cleanup_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_supervisor_cleanup_failure_site.ml
@@ -1,18 +1,14 @@
 type t =
   | Fiber_start_rejected
   | Reconcile_gate_rejected
-  | Dead_tombstone_meta_write
-  | Dead_tombstone_meta_missing
-  | Dead_tombstone_meta_error
+  | Dead_tombstone_submission
   | Force_watchdog_crash
   | Paused_meta_prune
 
 let to_label = function
   | Fiber_start_rejected -> "fiber_start_rejected"
   | Reconcile_gate_rejected -> "reconcile_gate_rejected"
-  | Dead_tombstone_meta_write -> "dead_tombstone_meta_write"
-  | Dead_tombstone_meta_missing -> "dead_tombstone_meta_missing"
-  | Dead_tombstone_meta_error -> "dead_tombstone_meta_error"
+  | Dead_tombstone_submission -> "dead_tombstone_submission"
   | Force_watchdog_crash -> "force_watchdog_crash"
   | Paused_meta_prune -> "paused_meta_prune"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_supervisor_cleanup_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_supervisor_cleanup_failure_site.mli
@@ -1,13 +1,10 @@
 (** Keeper_supervisor_cleanup_failure_site — closed sum for [site] label on
-    [metric_keeper_supervisor_cleanup_failures] (7 sites in
-    keeper_supervisor.ml). *)
+    [metric_keeper_supervisor_cleanup_failures]. *)
 
 type t =
   | Fiber_start_rejected
   | Reconcile_gate_rejected
-  | Dead_tombstone_meta_write
-  | Dead_tombstone_meta_missing
-  | Dead_tombstone_meta_error
+  | Dead_tombstone_submission
   | Force_watchdog_crash
   | Paused_meta_prune
 

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -37,7 +37,7 @@ type t =
   | Dead_tombstone
       (** The supervisor reaped a dead keeper and left [paused = true] on
           disk as a tombstone (see
-          [Keeper_supervisor_cleanup_tombstone]). Carries no payload:
+          [Keeper_shutdown_finalize]). Carries no payload:
           the fact that the paused meta is a dead-keeper tombstone — not
           an operator pause or a runtime latch — is the whole
           observability signal. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -335,54 +335,12 @@ let start_keeper_loops
   in
   let shutdown_inventory_p, shutdown_inventory_r = Eio.Promise.create () in
   let config = Mcp_server.workspace_config state in
-  fork_subsystem "keeper_shutdown_recovery" (fun () ->
-    let inventory =
-      match Keeper_shutdown_store.scan_inventory ~config with
-      | Error error -> Error (Keeper_shutdown_store.error_to_string error)
-      | Ok entries ->
-        Keeper_shutdown_runtime.restore_inventory_admission ~config entries
-    in
-    Eio.Promise.resolve shutdown_inventory_r inventory;
-    match inventory with
-    | Error detail ->
-      Log.Keeper.error "shutdown recovery inventory failed: %s" detail;
-      failwith detail
-    | Ok restored ->
-      List.iter
-        (fun corrupt ->
-           Log.Keeper.error
-             "corrupt shutdown operation retained under an exact Keeper admission fence: keeper=%s operation=%s path=%s error=%s"
-             corrupt.Keeper_shutdown_store.keeper_name
-             (Keeper_shutdown_types.Operation_id.to_string corrupt.operation_id)
-             corrupt.path
-             (Keeper_shutdown_store.error_to_string corrupt.error))
-        restored.corrupt_records;
-      Eio.Switch.run (fun recovery_sw ->
-        List.iter
-          (fun operation ->
-             Eio.Fiber.fork ~sw:recovery_sw (fun () ->
-               try
-                 match Keeper_shutdown_runtime.recover_operation ~config operation with
-                 | Ok recovered ->
-                   Log.Keeper.info
-                     "recovered shutdown operation keeper=%s operation=%s"
-                     recovered.Keeper_shutdown_types.keeper_name
-                     (Keeper_shutdown_types.Operation_id.to_string recovered.operation_id)
-                 | Error detail ->
-                   Log.Keeper.error
-                     "shutdown recovery failed keeper=%s operation=%s error=%s"
-                     operation.Keeper_shutdown_types.keeper_name
-                     (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
-                     detail
-               with
-               | Eio.Cancel.Cancelled _ as exn -> raise exn
-               | exn ->
-                 Log.Keeper.error
-                   "shutdown recovery crashed keeper=%s operation=%s error=%s"
-                   operation.Keeper_shutdown_types.keeper_name
-                   (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
-                   (Printexc.to_string exn)))
-          restored.operations));
+  (* Completion recovery can publish [Dead_cleaned] and invoke
+     [Tombstone_reaped]. Install the production hook before any durable
+     receipt is replayed. *)
+  Keeper_subprocess_registry.register_default_cleanup_hook ();
+  Keeper_shutdown_finalize.register_completion_handler
+    Keeper_supervisor_cleanup_tombstone.handle_completion;
   let wait_for_lazy_startup () =
     (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
        a per-task boot guard.  The diagnostic surface stays as #10854
@@ -531,6 +489,58 @@ let start_keeper_loops
   in
   Eio.Switch.on_release sw (fun () ->
     Agent_sdk_metrics_bridge.unsubscribe masc_event_bus keeper_lifecycle_sub);
+  (* Replay durable completion receipts only after the MASC event bus has its
+     SSE/metrics subscribers and lifecycle hooks are installed. Otherwise a
+     boot-time [Dead_cleaned] publish can return successfully while every
+     process-local sink is still absent. *)
+  fork_subsystem "keeper_shutdown_recovery" (fun () ->
+    let inventory =
+      match Keeper_shutdown_store.scan_inventory ~config with
+      | Error error -> Error (Keeper_shutdown_store.error_to_string error)
+      | Ok entries ->
+        Keeper_shutdown_runtime.restore_inventory_admission ~config entries
+    in
+    Eio.Promise.resolve shutdown_inventory_r inventory;
+    match inventory with
+    | Error detail ->
+      Log.Keeper.error "shutdown recovery inventory failed: %s" detail;
+      failwith detail
+    | Ok restored ->
+      List.iter
+        (fun corrupt ->
+           Log.Keeper.error
+             "corrupt shutdown operation retained under an exact Keeper admission fence: keeper=%s operation=%s path=%s error=%s"
+             corrupt.Keeper_shutdown_store.keeper_name
+             (Keeper_shutdown_types.Operation_id.to_string corrupt.operation_id)
+             corrupt.path
+             (Keeper_shutdown_store.error_to_string corrupt.error))
+        restored.corrupt_records;
+      Eio.Switch.run (fun recovery_sw ->
+        List.iter
+          (fun operation ->
+             Eio.Fiber.fork ~sw:recovery_sw (fun () ->
+               try
+                 match Keeper_shutdown_runtime.recover_operation ~config operation with
+                 | Ok recovered ->
+                   Log.Keeper.info
+                     "recovered shutdown operation keeper=%s operation=%s"
+                     recovered.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string recovered.operation_id)
+                 | Error detail ->
+                   Log.Keeper.error
+                     "shutdown recovery failed keeper=%s operation=%s error=%s"
+                     operation.Keeper_shutdown_types.keeper_name
+                     (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                     detail
+               with
+               | Eio.Cancel.Cancelled _ as exn -> raise exn
+               | exn ->
+                 Log.Keeper.error
+                   "shutdown recovery crashed keeper=%s operation=%s error=%s"
+                   operation.Keeper_shutdown_types.keeper_name
+                   (Keeper_shutdown_types.Operation_id.to_string operation.operation_id)
+                   (Printexc.to_string exn)))
+          restored.operations));
   (* Spawn the OAS bus depth sampler so warnings surface on stdout
      even when no external telemetry backend is attached.
 
@@ -730,10 +740,6 @@ let start_keeper_loops
      Log.Server.error
        "subsystem orchestrator failed to start: %s"
        (Printexc.to_string exn));
-  (* RFC-0036 Phase A.3: register default keeper-lifecycle cleanup hooks
-     once during bootstrap. The call is Atomic-guarded and idempotent so
-     re-bootstrapping (e.g. tests) is safe. *)
-  Keeper_subprocess_registry.register_default_cleanup_hook ();
   (* Build read-only tool surface shared by both judges. *)
   let judge_tool_names =
     [ "masc_status"

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -31,6 +31,9 @@ module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Keeper_meta_store = Masc.Keeper_meta_store
+module Lifecycle_hooks = Masc.Keeper_lifecycle_hooks
+module Subprocess_registry = Masc.Keeper_subprocess_registry
+module Tombstone_cleanup = Masc.Keeper_supervisor_cleanup_tombstone
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -104,6 +107,18 @@ let make_meta name =
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+
+let retain_operator_cleanup : Shutdown_types.cleanup_intent =
+  { meta_disposition = Shutdown_types.Retain_operator_pause
+  ; remove_session = false
+  }
+;;
+
+let remove_meta_cleanup : Shutdown_types.cleanup_intent =
+  { meta_disposition = Shutdown_types.Remove_meta
+  ; remove_session = false
+  }
+;;
 
 let resolve_done_for_test reg value =
   ignore (R.resolve_done reg ~source:"test_fixture" value);
@@ -767,7 +782,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         ; trace_id = meta.runtime.trace_id
         ; generation = meta.runtime.generation
         ; actor = "tester"
-        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; cleanup_intent = retain_operator_cleanup
         ; turn_disposition = Shutdown_types.No_inflight_turn
         ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
@@ -784,6 +799,28 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Error (Shutdown_store.Already_exists _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "duplicate shutdown operation overwrote its record");
+      let invalid_completion_operation =
+        { operation with
+          operation_id = Shutdown_types.Operation_id.generate ()
+        ; phase =
+            Shutdown_types.Finalized
+              { cleanup =
+                  { settled_task_ids = []; pending_confirms_removed = 0 }
+              ; meta_removed = false
+              ; session_removed = false
+              ; registry_unregistered = false
+              ; completion =
+                  Shutdown_types.Completion_pending
+                    Shutdown_types.Dead_tombstone_reaped
+              }
+        }
+      in
+      (match Shutdown_store.persist_new ~config invalid_completion_operation with
+       | Error
+           (Shutdown_store.Invalid_operation
+             (Shutdown_types.Finalized_completion_mismatch _)) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "store accepted completion outside dead-tombstone intent");
       let loaded =
         match Shutdown_store.load ~config ~keeper_name:meta.name operation_id with
         | Ok loaded -> loaded
@@ -963,7 +1000,7 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
           ; trace_id = meta.runtime.trace_id
           ; generation = meta.runtime.generation
           ; actor = "tester"
-          ; cleanup_intent = { remove_meta = false; remove_session = false }
+          ; cleanup_intent = retain_operator_cleanup
           ; turn_disposition = Shutdown_types.No_inflight_turn
           ; expected_backlog_version = backlog_version
           ; owned_task_ids = []
@@ -1130,7 +1167,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
             ~entry
             ~request:
               { actor = "operator"
-              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              ; cleanup_intent = retain_operator_cleanup
               }
         with
         | Ok operation -> operation
@@ -1185,7 +1222,7 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
             ~entry
             ~request:
               { actor = "operator"
-              ; cleanup_intent = { remove_meta = false; remove_session = false }
+              ; cleanup_intent = retain_operator_cleanup
               }
         with
         | Ok operation -> operation
@@ -1238,7 +1275,7 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
            ~entry
            ~request:
              { actor = "operator"
-             ; cleanup_intent = { remove_meta = false; remove_session = false }
+             ; cleanup_intent = retain_operator_cleanup
              }
        with
        | Error (Shutdown_prepare_join.Prepare_persist_failed _) -> ()
@@ -1289,7 +1326,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
         ; trace_id = meta.runtime.trace_id
         ; generation = meta.runtime.generation
         ; actor = "operator"
-        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; cleanup_intent = retain_operator_cleanup
         ; turn_disposition = Shutdown_types.No_inflight_turn
         ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
@@ -1353,6 +1390,257 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       | Ok None -> fail "retained Keeper metadata disappeared"
       | Error detail -> fail detail)
 
+let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-dead-tombstone-completion" in
+  let completion_bus =
+    Agent_sdk.Event_bus.create
+      ~policy:Agent_sdk.Event_bus.Drop_oldest
+      ()
+  in
+  let completion_subscription =
+    Agent_sdk.Event_bus.subscribe
+      ~purpose:"dead-tombstone-completion-test"
+      completion_bus
+  in
+  Masc_event_bus.set completion_bus;
+  Fun.protect
+    ~finally:(fun () ->
+      Agent_sdk.Event_bus.unsubscribe completion_bus completion_subscription;
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Shutdown_finalize.For_testing.reset_completion_handler ();
+      Lifecycle_hooks.reset_for_testing ();
+      Subprocess_registry.reset_for_testing ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "supervisor")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let meta = make_meta "shutdown-dead-tombstone-keeper" in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let entry = R.register ~base_path:config.base_path meta.name meta in
+      let hook_deliveries = ref 0 in
+      Subprocess_registry.register_default_cleanup_hook ();
+      Lifecycle_hooks.register (fun ~keeper_id event ->
+        match event with
+        | Lifecycle_hooks.Tombstone_reaped ->
+          check string "completion hook Keeper" meta.name keeper_id;
+          incr hook_deliveries
+        | Lifecycle_hooks.Phase_transition _ -> ());
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      Shutdown_finalize.register_completion_handler
+        (fun _config _operation _action -> Error "synthetic completion outage");
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id entry.lane
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "supervisor"
+        ; cleanup_intent =
+            { meta_disposition = Shutdown_types.Retain_dead_tombstone
+            ; remove_session = false
+            }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "fresh dead-tombstone fixture was already reserved");
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_finalize.run ~config ~entry:(Some entry) operation with
+       | Error (Shutdown_finalize.Completion_failed (_, detail)) ->
+         check string
+           "completion outage remains explicit"
+           "synthetic completion outage"
+           detail
+       | Error error -> fail (Shutdown_finalize.error_to_string error)
+       | Ok _ -> fail "completion outage was reported as delivered");
+      let pending =
+        match
+          Shutdown_store.load
+            ~config
+            ~keeper_name:meta.name
+            operation_id
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match pending.phase with
+       | Shutdown_types.Finalized
+           { completion =
+               Shutdown_types.Completion_pending
+                 Shutdown_types.Dead_tombstone_reaped
+           ; registry_unregistered
+           ; _
+           } -> check bool "exact dead lane unregistered" true registry_unregistered
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Finalized _ ->
+         fail "completion outage did not retain a pending durable receipt");
+      check int "pending receipt did not fire hook" 0 !hook_deliveries;
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (fun () -> ())
+       with
+       | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
+         check bool "pending receipt retains exact admission owner" true
+           (Shutdown_types.Operation_id.equal operation_id reserved)
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+       | `Ran () -> fail "pending completion reopened admission");
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      let boot_inventory =
+        match Shutdown_store.scan_inventory ~config with
+        | Ok inventory -> inventory
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      let restored =
+        match
+          Shutdown_runtime.restore_inventory_admission ~config boot_inventory
+        with
+        | Ok restored -> restored
+        | Error detail -> fail detail
+      in
+      check
+        (list string)
+        "boot restores pending completion owner fence"
+        [ meta.name ]
+        restored.blocked_keeper_names;
+      (match
+         Masc.Keeper_turn_admission.run_if_free
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           (fun () -> ())
+       with
+       | `Busy (Masc.Keeper_turn_admission.Shutdown_requested reserved) ->
+         check bool "boot-restored fence keeps exact completion owner" true
+           (Shutdown_types.Operation_id.equal operation_id reserved)
+       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+       | `Ran () -> fail "boot recovery reopened pending completion admission");
+      Shutdown_finalize.register_completion_handler
+        Tombstone_cleanup.handle_completion;
+      let finalized =
+        match Shutdown_finalize.run ~config ~entry:None pending with
+        | Ok finalized -> finalized
+        | Error error -> fail (Shutdown_finalize.error_to_string error)
+      in
+      (match finalized.phase with
+       | Shutdown_types.Finalized
+           { completion =
+               Shutdown_types.Completion_delivered
+                 Shutdown_types.Dead_tombstone_reaped
+           ; registry_unregistered
+           ; meta_removed
+           ; _
+           } ->
+         check bool "delivered receipt preserves unregister evidence" true
+           registry_unregistered;
+         check bool "dead tombstone meta retained" false meta_removed
+       | Shutdown_types.Prepared
+       | Shutdown_types.Joined_idle
+       | Shutdown_types.Finalizing_tasks _
+       | Shutdown_types.Cleanup_ready _
+       | Shutdown_types.Reconciliation_required _
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Finalized _ ->
+          fail "dead tombstone completion receipt was not delivered");
+      check int "Tombstone_reaped delivered once" 1 !hook_deliveries;
+      (match Agent_sdk.Event_bus.drain completion_subscription with
+       | [ event ] ->
+         (match event.Agent_sdk.Event_bus.payload with
+          | Agent_sdk.Event_bus.Custom
+              ("masc.keeper.lifecycle", `Assoc fields) ->
+            (match List.assoc_opt "event" fields, List.assoc_opt "detail" fields with
+             | Some (`String event_name), Some (`String detail) ->
+               check string "durable completion lifecycle event" "dead_cleaned" event_name;
+               check string
+                 "durable completion event identity"
+                 ("shutdown_operation="
+                  ^ Shutdown_types.Operation_id.to_string operation_id)
+                 detail
+             | _ -> fail "dead completion event payload lost typed fields")
+          | Agent_sdk.Event_bus.Custom (topic, _) ->
+            fail ("unexpected completion event topic: " ^ topic)
+          | _ -> fail "dead completion did not publish a custom lifecycle event")
+       | events ->
+         fail
+           (Printf.sprintf
+              "expected one durable completion event, got %d"
+              (List.length events)));
+      let reloaded =
+        match
+          Shutdown_store.load
+            ~config
+            ~keeper_name:meta.name
+            operation_id
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check bool "delivered completion receipt survives store round-trip" true
+        (reloaded.phase = finalized.phase);
+      check bool "dead Keeper removed from registry" false
+        (R.is_registered ~base_path:config.base_path meta.name);
+      (match Keeper_meta_store.read_meta config meta.name with
+       | Ok (Some retained) ->
+         check bool "retained dead meta paused" true retained.paused;
+         (match retained.latched_reason with
+          | Some Keeper_latched_reason.Dead_tombstone -> ()
+          | Some _ | None -> fail "retained meta lost Dead_tombstone reason")
+       | Ok None -> fail "dead tombstone meta was removed"
+       | Error detail -> fail detail);
+      (match Shutdown_finalize.run ~config ~entry:None finalized with
+       | Ok _ -> ()
+       | Error error -> fail (Shutdown_finalize.error_to_string error));
+      check int "delivered receipt prevents duplicate hook" 1 !hook_deliveries;
+      check int
+        "delivered receipt prevents duplicate lifecycle event"
+        0
+        (List.length (Agent_sdk.Event_bus.drain completion_subscription));
+      match
+        Masc.Keeper_turn_admission.run_if_free
+          ~base_path:config.base_path
+          ~keeper_name:meta.name
+          (fun () -> ())
+      with
+      | `Ran () -> ()
+      | `Busy _ -> fail "delivered dead completion left admission fenced")
+
 let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1389,7 +1677,7 @@ let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
         ; trace_id = meta.runtime.trace_id
         ; generation = meta.runtime.generation
         ; actor = "operator"
-        ; cleanup_intent = { remove_meta = true; remove_session = false }
+        ; cleanup_intent = remove_meta_cleanup
         ; turn_disposition = Shutdown_types.No_inflight_turn
         ; expected_backlog_version = backlog_version
         ; owned_task_ids = []
@@ -1478,7 +1766,7 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
         ; trace_id = meta.runtime.trace_id
         ; generation = meta.runtime.generation
         ; actor = "operator"
-        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; cleanup_intent = retain_operator_cleanup
         ; turn_disposition = Shutdown_types.No_inflight_turn
         ; expected_backlog_version = backlog_version
         ; owned_task_ids = [ task_id ]
@@ -1956,6 +2244,8 @@ let () =
         test_keeper_shutdown_prepare_failure_rolls_back_fence;
       test_case "shutdown finalizes idle operation" `Quick
         test_keeper_shutdown_finalizes_idle_operation;
+      test_case "shutdown delivers dead tombstone completion after receipt" `Quick
+        test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt;
       test_case "shutdown cleanup replays after meta removal" `Quick
         test_keeper_shutdown_cleanup_replays_after_meta_removal;
       test_case "shutdown recovers committed task receipt" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -861,6 +861,21 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Error (Shutdown_store.Identity_mismatch _) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
        | Ok () -> fail "shutdown store accepted a different lane identity");
+      let mutated_cleanup =
+        { joined with
+          revision = joined.revision + 1
+        ; cleanup_intent = remove_meta_cleanup
+        }
+      in
+      (match
+         Shutdown_store.replace
+           ~config
+           ~expected_revision:joined.revision
+           mutated_cleanup
+       with
+       | Error (Shutdown_store.Identity_mismatch _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "shutdown store accepted a changed cleanup intent");
       let worker_failure = Failure "worker exploded after durable join" in
       let holder_locked_p, holder_locked_r = Eio.Promise.create () in
       let release_holder_p, release_holder_r = Eio.Promise.create () in

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -8,8 +8,8 @@
       -> [directive_paused_meta]) -> [Operator_paused {grpc_directive}]
     - keeper_down retain ([Keeper_shutdown_finalize.For_testing.paused_meta],
       remove_meta=false) -> [Operator_paused {keeper_down}]
-    - dead-tombstone cleanup
-      ([Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone])
+    - durable dead-tombstone final meta
+      ([Keeper_shutdown_finalize.For_testing.dead_tombstone_meta])
       -> [Dead_tombstone]
 
     Observability only: these tests assert the {i reason} annotation, not
@@ -20,15 +20,12 @@ open Alcotest
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_json = Masc.Keeper_meta_json
 module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
-module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_meta_merge = Masc.Keeper_meta_merge
 module Keeper_registry = Masc.Keeper_registry
 module Keeper_keepalive = Masc.Keeper_keepalive
 module Keeper_turn_lifecycle = Masc.Keeper_turn_lifecycle
 module Keeper_status_bridge = Masc.Keeper_status_bridge
-module Keeper_supervisor_cleanup_tombstone = Masc.Keeper_supervisor_cleanup_tombstone
 module Keeper_supervisor_types = Masc.Keeper_supervisor_types
-module Keeper_types_profile = Masc.Keeper_types_profile
 
 let base_json name =
   `Assoc
@@ -200,135 +197,39 @@ let test_keeper_down_retain_records_reason () =
 
 (* ── Site 1: dead-tombstone cleanup ─────────────────────────── *)
 
-let run_dead_tombstone_cleanup_records_reason
-      ?(paused = false)
-      ?latched_reason
-      ?auto_resume_after_sec
-      ?last_blocker
-      ?updated_at
-      keeper_name
-  =
-  Eio_main.run
-  @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Eio.Switch.run
-  @@ fun sw ->
-  let base_path = Masc_test_deps.setup_test_workspace () in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.clear ();
-      Masc_test_deps.cleanup_test_workspace base_path)
-    (fun () ->
-       let config = Masc.Workspace.default_config base_path in
-       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta =
-         let base =
-           { (make_meta keeper_name) with
-             paused
-           ; latched_reason
-           ; auto_resume_after_sec
-           }
-         in
-         let base =
-           match updated_at with
-           | Some updated_at -> { base with updated_at }
-           | None -> base
-         in
-         { base with runtime = { base.runtime with last_blocker } }
-       in
-       Keeper_registry.clear ();
-       (match Keeper_meta_store.write_meta config meta with
-        | Ok () -> ()
-        | Error err -> failf "seed meta write: %s" err);
-       let entry =
-         Keeper_registry.register ~base_path:config.base_path keeper_name meta
-       in
-       let ctx : _ Keeper_types_profile.context =
-         { config
-         ; agent_name = "supervisor"
-         ; sw
-         ; clock = Eio.Stdenv.clock env
-         ; proc_mgr = None
-         ; net = None
-         }
-       in
-       let events = ref [] in
-       let publish_lifecycle ~event:_ name detail () =
-         events := (name, detail) :: !events
-       in
-       Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone
-         ~publish_lifecycle
-         ctx
-         entry;
-       check bool "dead-cleaned lifecycle event published" true (!events <> []);
-       match Keeper_meta_store.read_meta config keeper_name with
-       | Ok (Some persisted) ->
-         check bool "dead tombstone persists paused=true" true persisted.paused;
-         check
-           (option string)
-           "dead tombstone records the Dead_tombstone reason"
-           (Some wire_dead_tombstone)
-           (latched_reason_wire persisted);
-         check
-           bool
-           "dead tombstone clears stale auto-resume policy"
-           true
-           (Option.is_none persisted.auto_resume_after_sec);
-         check
-           bool
-           "dead tombstone clears stale blocker"
-           true
-           (Option.is_none persisted.runtime.last_blocker);
-         check
-           bool
-           "dead tombstone pause is not auto-resume due"
-           false
-           (Keeper_supervisor_types.paused_meta_auto_resume_due
-              ~now:(Unix.time () +. 7200.0)
-              persisted)
-       | Ok None -> fail "expected tombstone meta to remain on disk after cleanup"
-       | Error err -> failf "read persisted meta: %s" err)
-
-let test_dead_tombstone_cleanup_records_reason () =
-  run_dead_tombstone_cleanup_records_reason "dead-tombstone-keeper"
-
-let test_dead_tombstone_cleanup_overwrites_existing_pause_reason () =
-  run_dead_tombstone_cleanup_records_reason
-    ~paused:true
-    ~latched_reason:
-      (Keeper_latched_reason.Operator_paused
-         { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
-    "dead-tombstone-paused-keeper"
-
-let test_dead_tombstone_cleanup_clears_auto_resume_state () =
+let test_dead_tombstone_final_meta_records_reason () =
   let timeout_blocker =
     Keeper_meta_contract.blocker_info_of_class
-      ~detail:"stale auto-pause before dead cleanup"
+      ~detail:"stale pause before durable dead finalization"
       Keeper_meta_contract.Turn_timeout
   in
-  run_dead_tombstone_cleanup_records_reason
-    ~paused:true
-    ~latched_reason:
-      (Keeper_latched_reason.Operator_paused
-         { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
-    ~auto_resume_after_sec:1.0
-    ~last_blocker:timeout_blocker
-    ~updated_at:"1970-01-01T00:00:00Z"
-    "dead-tombstone-auto-resume-keeper"
-
-let test_dead_tombstone_cleanup_repairs_stale_terminal_state () =
-  let timeout_blocker =
-    Keeper_meta_contract.blocker_info_of_class
-      ~detail:"stale dead tombstone auto-resume state"
-      Keeper_meta_contract.Turn_timeout
+  let input =
+    { (make_meta "dead-tombstone-final-meta") with
+      paused = true
+    ; latched_reason =
+        Some
+          (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+    ; auto_resume_after_sec = Some 1.0
+    ; runtime =
+        { (make_meta "dead-tombstone-final-meta").runtime with
+          last_blocker = Some timeout_blocker
+        }
+    }
   in
-  run_dead_tombstone_cleanup_records_reason
-    ~paused:true
-    ~latched_reason:Keeper_latched_reason.Dead_tombstone
-    ~auto_resume_after_sec:1.0
-    ~last_blocker:timeout_blocker
-    ~updated_at:"1970-01-01T00:00:00Z"
-    "dead-tombstone-stale-terminal-keeper"
+  let finalized =
+    Masc.Keeper_shutdown_finalize.For_testing.dead_tombstone_meta input
+  in
+  check bool "dead final meta remains paused" true finalized.paused;
+  check
+    (option string)
+    "dead final meta records Dead_tombstone"
+    (Some wire_dead_tombstone)
+    (latched_reason_wire finalized);
+  check bool "dead final meta clears auto-resume" true
+    (Option.is_none finalized.auto_resume_after_sec);
+  check bool "dead final meta clears stale blocker" true
+    (Option.is_none finalized.runtime.last_blocker)
 
 let test_dead_tombstone_latch_blocks_legacy_auto_resume () =
   let timeout_blocker =
@@ -397,89 +298,6 @@ let test_heartbeat_merge_preserves_only_typed_operator_pause () =
     None
     (latched_reason_wire not_preserved)
 
-(* Reviewer P1 (2026-07-03): the overwrite test above only exercises the
-   no-conflict write, where the merge never runs. On a CAS retry the cleanup
-   re-reads disk; if that snapshot is an operator pause, reusing
-   [heartbeat_fields_from_disk] copied the operator reason back over
-   [Dead_tombstone] and returned [Ok ()], silently persisting the wrong reason.
-   This drives the retry path deterministically without a concurrent writer: the
-   caller carries a stale [meta_version] so its first write loses the CAS race
-   against a seeded operator-pause snapshot, forcing the merge to run. *)
-let test_dead_tombstone_cleanup_cas_retry_preserves_reason () =
-  Eio_main.run
-  @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base_path = Masc_test_deps.setup_test_workspace () in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.clear ();
-      Masc_test_deps.cleanup_test_workspace base_path)
-    (fun () ->
-       let config = Masc.Workspace.default_config base_path in
-       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let keeper_name = "dead-tombstone-cas-keeper" in
-       (* Disk snapshot the retry re-reads: an operator pause with a higher turn
-          count than the caller's stale snapshot. The typed
-          [Operator_paused] latch is what lets the heartbeat merge preserve the
-          disk pause; dead-tombstone cleanup must keep ownership with the
-          caller instead. *)
-       let disk_meta =
-         let base =
-           { (make_meta keeper_name) with
-             paused = true
-           ; latched_reason =
-               Some
-                 (Keeper_latched_reason.Operator_paused
-                    { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
-           }
-         in
-         { base with
-           runtime =
-             { base.runtime with
-               usage = { base.runtime.usage with total_turns = 7 }
-             }
-         }
-       in
-       (match Keeper_meta_store.write_meta config disk_meta with
-        | Ok () -> ()
-        | Error err -> failf "seed disk meta: %s" err);
-       (* Caller: the cleanup's stale in-hand snapshot. [meta_version = 0] loses
-          the CAS race against the seeded version, forcing the retry + merge. *)
-       let caller =
-         { disk_meta with
-           meta_version = 0
-         ; paused = true
-         ; latched_reason = Some Keeper_latched_reason.Dead_tombstone
-         ; runtime =
-             { disk_meta.runtime with
-               usage = { disk_meta.runtime.usage with total_turns = 3 }
-             }
-         }
-       in
-       (match
-          Keeper_meta_store.write_meta_with_merge
-            ~merge:Keeper_meta_merge.dead_tombstone_cleanup_from_disk
-            config
-            caller
-        with
-        | Ok () -> ()
-        | Error err -> failf "write_meta_with_merge after CAS retry: %s" err);
-       match Keeper_meta_store.read_meta config keeper_name with
-       | Ok (Some persisted) ->
-         check bool "CAS retry keeps paused=true" true persisted.paused;
-         check
-           (option string)
-           "CAS retry persists Dead_tombstone, not the operator reason"
-           (Some wire_dead_tombstone)
-           (latched_reason_wire persisted);
-         check
-           int
-           "CAS retry preserves heartbeat-owned turn count monotonically"
-           7
-           persisted.runtime.usage.total_turns
-       | Ok None -> fail "expected meta on disk after CAS retry"
-       | Error err -> failf "read persisted meta: %s" err)
-
 let () =
   run
     "keeper_latched_reason_wiring"
@@ -498,19 +316,11 @@ let () =
             test_grpc_pause_directive_records_reason
         ; test_case "keeper_down retain records keeper_down reason" `Quick
             test_keeper_down_retain_records_reason
-        ; test_case "dead-tombstone cleanup records Dead_tombstone reason" `Quick
-            test_dead_tombstone_cleanup_records_reason
-        ; test_case "dead-tombstone cleanup overwrites existing pause reason" `Quick
-            test_dead_tombstone_cleanup_overwrites_existing_pause_reason
-        ; test_case "dead-tombstone cleanup clears auto-resume state" `Quick
-            test_dead_tombstone_cleanup_clears_auto_resume_state
-        ; test_case "dead-tombstone cleanup repairs stale terminal state" `Quick
-            test_dead_tombstone_cleanup_repairs_stale_terminal_state
+        ; test_case "dead final meta records terminal tombstone reason" `Quick
+            test_dead_tombstone_final_meta_records_reason
         ; test_case "dead-tombstone latch blocks legacy auto-resume" `Quick
             test_dead_tombstone_latch_blocks_legacy_auto_resume
         ; test_case "heartbeat merge uses typed operator latch, not pause shape" `Quick
             test_heartbeat_merge_preserves_only_typed_operator_pause
-        ; test_case "dead-tombstone cleanup CAS retry preserves Dead_tombstone" `Quick
-            test_dead_tombstone_cleanup_cas_retry_preserves_reason
         ] )
     ]


### PR DESCRIPTION
## Summary

- route dead-tombstone cleanup through the durable exact-Keeper shutdown lane instead of name-only meta/register side effects in the supervisor sweep
- persist a typed meta disposition and post-finalization completion receipt, retaining the exact admission fence until completion is delivered
- restore pending-completion fences at boot and start recovery only after the MASC lifecycle bus subscribers and mandatory subprocess cleanup hook are installed
- reject durable records whose cleanup intent, removal evidence, and completion receipt contradict one another
- keep Dead_cleaned and Tombstone_reaped repeat-safe with the shutdown operation id as the projection identity

## Failure model

- a completion handler outage leaves Finalized + Completion_pending durable and keeps only that Keeper lane fenced
- boot restores that exact operation owner before attempting delivery
- a delivered receipt releases admission and does not duplicate the lifecycle event or hook on replay
- unrelated Keepers remain independent

## Verification

- ocamlformat --check on every changed OCaml file
- ocamlc -stop-after parsing on every changed .ml/.mli
- git diff --check
- no local Dune build or runtest; GitHub CI is the build authority

## Stack

- base: #24195
- issue: #24113
- Draft / do-not-merge until the lifecycle stack and exact-head CI are green
