### PR TITLE
fix(keeper): persist connector failures as typed rows

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -289,12 +289,51 @@ export function extractApiError(err: unknown, fallbackMessage: string): ApiError
   return { message: fallbackMessage, status: null, path: null, timeout: false }
 }
 
-async function fetchAndConsumeWithTimeout<T>(
+export async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController()
+  const upstreamSignal = init.signal
+  const abortFromUpstream = () => controller.abort()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort()
+    } else {
+      upstreamSignal.addEventListener('abort', abortFromUpstream, { once: true })
+    }
+  }
+
+  try {
+    return await fetch(path, {
+      ...init,
+      cache: init.cache ?? 'no-store',
+      signal: controller.signal,
+    })
+  } catch (err) {
+    if (isAbortError(err)) {
+      if (upstreamSignal?.aborted) {
+        throw err
+      }
+      const method = typeof init.method === 'string' ? init.method.toUpperCase() : 'GET'
+      throw new ApiRequestError({
+        method,
+        path,
+        timeout: true,
+        timeoutMs,
+      })
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+    upstreamSignal?.removeEventListener('abort', abortFromUpstream)
+  }
+}
+
+export async function fetchJsonWithTimeout(
   path: string,
   init: RequestInit,
   timeoutMs: number,
-  consume: (response: Response) => Promise<T>,
-): Promise<T> {
+): Promise<{ response: Response; data: unknown | null }> {
   const controller = new AbortController()
   const upstreamSignal = init.signal
   let rejectBoundary: (reason: unknown) => void = () => undefined
@@ -320,45 +359,29 @@ async function fetchAndConsumeWithTimeout<T>(
   }
 
   try {
-    const request = fetch(path, {
-      ...init,
-      cache: init.cache ?? 'no-store',
-      signal: controller.signal,
-    }).then(consume)
+    const request = (async () => {
+      const response = await fetch(path, {
+        ...init,
+        cache: init.cache ?? 'no-store',
+        signal: controller.signal,
+      })
+      return {
+        response,
+        data: response.ok ? await response.json() : null,
+      }
+    })()
     return await Promise.race([request, boundary])
   } catch (err) {
     if (isAbortError(err)) {
-      if (upstreamSignal?.aborted) {
-        throw err
-      }
+      if (upstreamSignal?.aborted) throw err
       const method = typeof init.method === 'string' ? init.method.toUpperCase() : 'GET'
-      throw new ApiRequestError({
-        method,
-        path,
-        timeout: true,
-        timeoutMs,
-      })
+      throw new ApiRequestError({ method, path, timeout: true, timeoutMs })
     }
     throw err
   } finally {
     clearTimeout(timer)
     upstreamSignal?.removeEventListener('abort', abortFromUpstream)
   }
-}
-
-export async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
-  return fetchAndConsumeWithTimeout(path, init, timeoutMs, async response => response)
-}
-
-export async function fetchJsonWithTimeout(
-  path: string,
-  init: RequestInit,
-  timeoutMs: number,
-): Promise<{ response: Response; data: unknown | null }> {
-  return fetchAndConsumeWithTimeout(path, init, timeoutMs, async response => ({
-    response,
-    data: response.ok ? await response.json() : null,
-  }))
 }
 
 const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -289,11 +289,27 @@ export function extractApiError(err: unknown, fallbackMessage: string): ApiError
   return { message: fallbackMessage, status: null, path: null, timeout: false }
 }
 
-export async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+async function fetchAndConsumeWithTimeout<T>(
+  path: string,
+  init: RequestInit,
+  timeoutMs: number,
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController()
   const upstreamSignal = init.signal
-  const abortFromUpstream = () => controller.abort()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  let rejectBoundary: (reason: unknown) => void = () => undefined
+  const boundary = new Promise<never>((_resolve, reject) => {
+    rejectBoundary = reject
+  })
+  const abortFromUpstream = () => {
+    controller.abort()
+    rejectBoundary(upstreamSignal?.reason ?? new DOMException('Aborted', 'AbortError'))
+  }
+  const timer = setTimeout(() => {
+    controller.abort()
+    const method = typeof init.method === 'string' ? init.method.toUpperCase() : 'GET'
+    rejectBoundary(new ApiRequestError({ method, path, timeout: true, timeoutMs }))
+  }, timeoutMs)
 
   if (upstreamSignal) {
     if (upstreamSignal.aborted) {
@@ -304,11 +320,12 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
   }
 
   try {
-    return await fetch(path, {
+    const request = fetch(path, {
       ...init,
       cache: init.cache ?? 'no-store',
       signal: controller.signal,
-    })
+    }).then(consume)
+    return await Promise.race([request, boundary])
   } catch (err) {
     if (isAbortError(err)) {
       if (upstreamSignal?.aborted) {
@@ -327,6 +344,21 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
     clearTimeout(timer)
     upstreamSignal?.removeEventListener('abort', abortFromUpstream)
   }
+}
+
+export async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  return fetchAndConsumeWithTimeout(path, init, timeoutMs, async response => response)
+}
+
+export async function fetchJsonWithTimeout(
+  path: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<{ response: Response; data: unknown | null }> {
+  return fetchAndConsumeWithTimeout(path, init, timeoutMs, async response => ({
+    response,
+    data: response.ok ? await response.json() : null,
+  }))
 }
 
 const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([

--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -271,9 +271,25 @@ export interface DashboardScheduledAutomation {
   requests: DashboardScheduledAutomationRequest[]
 }
 
+export type DashboardKeeperWaitingSource =
+  | 'event_queue_pending'
+  | 'event_queue_inflight'
+  | 'chat_queue_pending'
+  | 'chat_queue_inflight'
+  | 'hitl_pending'
+  | 'external_attention'
+  | 'fusion_running'
+  | 'background_task'
+  | 'schedule_waiting'
+  | 'turn_admission_waiting'
+  | 'operator_pending_confirm'
+  | 'read_error'
+
+export type DashboardKeeperWaitingState = 'idle' | 'busy' | 'waiting' | 'deferred'
+
 export interface DashboardKeeperWaitingRow {
   keeper_name?: string | null
-  source: string
+  source: DashboardKeeperWaitingSource
   waiting_on: string
   wake_producer?: string | null
   since?: number | null
@@ -286,7 +302,7 @@ export interface DashboardKeeperWaitingRow {
 
 export interface DashboardKeeperWaitingKeeper {
   keeper_name: string
-  state: 'idle' | 'busy' | 'waiting' | 'deferred' | string
+  state: DashboardKeeperWaitingState
   waiting_on: DashboardKeeperWaitingRow[]
   waiting_count: number
   waiting_count_truncated?: boolean

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -219,6 +219,8 @@ export type {
   DashboardScheduledAutomationPayloadSupport,
   DashboardScheduledAutomationLiveSupportedNonTerminalEvidence,
   DashboardScheduledAutomation,
+  DashboardKeeperWaitingSource,
+  DashboardKeeperWaitingState,
   DashboardKeeperWaitingRow,
   DashboardKeeperWaitingKeeper,
   DashboardKeeperWaitingInventory,

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -19,11 +19,13 @@ import {
   bulkKeeperDirective,
   clearKeeper,
   deleteKeeperHistorySnapshots,
+  fetchKeeperChatReceipt,
   fetchKeeperCheckpoints,
   fetchQueuedKeeperMessageResult,
   fetchKeeperRuntimeTrace,
   pauseKeeper,
   parseKeeperRuntimeTrace,
+  parseKeeperChatReceipt,
   queuedKeeperMessageError,
   queuedKeeperMessageToReply,
   resumeKeeper,
@@ -85,6 +87,78 @@ describe('keeper API module split compatibility', () => {
     expect(fetchKeeperCheckpoints).toBe(fetchKeeperCheckpointsFromLifecycle)
     expect(deleteKeeperHistorySnapshots).toBe(deleteKeeperHistorySnapshotsFromLifecycle)
     expect(bulkKeeperDirective).toBe(bulkKeeperDirectiveFromLifecycle)
+  })
+})
+
+describe('Keeper chat durable receipt API', () => {
+  it('parses the closed terminal failure state', () => {
+    expect(parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 7,
+      state: {
+        kind: 'failed',
+        failure_kind: 'delivery_failed',
+        detail: 'Slack API rejected the message',
+        completed_at: 42,
+        outcome_ref: null,
+      },
+    })).toEqual({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 7,
+      state: {
+        kind: 'failed',
+        failureKind: 'delivery_failed',
+        detail: 'Slack API rejected the message',
+        completedAt: 42,
+        outcomeRef: null,
+      },
+    })
+  })
+
+  it('rejects an unknown receipt lifecycle instead of guessing', () => {
+    expect(() => parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 1,
+      state: { kind: 'lost_somewhere' },
+    })).toThrow('unknown state')
+  })
+
+  it('rejects a non-canonical receipt identity', () => {
+    expect(() => parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'receipt-echo-1',
+      revision: 1,
+      state: { kind: 'pending' },
+    })).toThrow('missing identity')
+  })
+
+  it('fetches the exact encoded Keeper receipt route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        schema: 'keeper_chat_queue.receipt.v1',
+        keeper_name: 'keeper sangsu',
+        receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+        revision: 2,
+        state: { kind: 'pending' },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchKeeperChatReceipt(
+      'keeper sangsu',
+      'chatq_00000000-0000-4000-8000-000000000001',
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/keepers/keeper%20sangsu/chat/receipts/chatq_00000000-0000-4000-8000-000000000001',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    )
   })
 })
 

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -138,6 +138,32 @@ describe('Keeper chat durable receipt API', () => {
     })).toThrow('missing identity')
   })
 
+  it('rejects malformed nullable outcome refs instead of coercing schema drift', () => {
+    expect(() => parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 2,
+      state: { kind: 'delivered', completed_at: 42, outcome_ref: 7 },
+    })).toThrow('outcome_ref must be a string or null')
+  })
+
+  it('rejects whitespace-only failure detail', () => {
+    expect(() => parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 2,
+      state: {
+        kind: 'failed',
+        failure_kind: 'delivery_failed',
+        detail: '   ',
+        completed_at: 42,
+        outcome_ref: null,
+      },
+    })).toThrow('invalid failure metadata')
+  })
+
   it('fetches the exact encoded Keeper receipt route', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -19,6 +19,7 @@ import {
   bulkKeeperDirective,
   clearKeeper,
   deleteKeeperHistorySnapshots,
+  fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
   fetchKeeperCheckpoints,
   fetchQueuedKeeperMessageResult,
@@ -53,8 +54,10 @@ import {
   parseKeeperRuntimeTrace as parseKeeperRuntimeTraceFromRuntimeTrace,
 } from './keeper-runtime-trace'
 import { resetDevTokenBootstrap } from './dev-token'
+import { DEFAULT_GET_TIMEOUT_MS } from '../config/constants'
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.clearAllMocks()
   vi.unstubAllGlobals()
   try {
@@ -185,6 +188,27 @@ describe('Keeper chat durable receipt API', () => {
       '/api/v1/keepers/keeper%20sangsu/chat/receipts/chatq_00000000-0000-4000-8000-000000000001',
       expect.objectContaining({ headers: expect.any(Object) }),
     )
+  })
+
+  it('bounds chat history response-body consumption after headers arrive', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: vi.fn(() => new Promise<never>(() => undefined)),
+    } satisfies Partial<Response>)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const historyPromise = fetchKeeperChatHistory('echo')
+    const rejection = expect(historyPromise).rejects.toMatchObject({ timeout: true })
+    await vi.advanceTimersByTimeAsync(DEFAULT_GET_TIMEOUT_MS)
+    await rejection
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }))
   })
 })
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -741,6 +741,17 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
     throw new Error('Keeper chat receipt response is missing identity or state')
   }
   let state: KeeperChatReceiptState
+  const nullableString = (fieldName: string, fieldValue: unknown): string | null => {
+    if (fieldValue === null || fieldValue === undefined) return null
+    if (typeof fieldValue !== 'string') {
+      throw new Error(`Keeper chat receipt ${fieldName} must be a string or null`)
+    }
+    const trimmed = fieldValue.trim()
+    if (!trimmed) {
+      throw new Error(`Keeper chat receipt ${fieldName} must not be empty`)
+    }
+    return trimmed
+  }
   switch (kind) {
     case 'pending':
       state = { kind }
@@ -762,13 +773,13 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
       state = {
         kind,
         completedAt,
-        outcomeRef: asString(rawState.outcome_ref) ?? null,
+        outcomeRef: nullableString('outcome_ref', rawState.outcome_ref),
       }
       break
     }
     case 'failed': {
       const failureKind = asString(rawState.failure_kind, '') as KeeperChatReceiptFailureKind
-      const detail = asString(rawState.detail, '')
+      const detail = asString(rawState.detail, '').trim()
       const completedAt = asNumber(rawState.completed_at)
       if (!KEEPER_CHAT_RECEIPT_FAILURE_KINDS.has(failureKind) || !detail || typeof completedAt !== 'number') {
         throw new Error('Keeper chat failed receipt has invalid failure metadata')
@@ -778,7 +789,7 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
         failureKind,
         detail,
         completedAt,
-        outcomeRef: asString(rawState.outcome_ref) ?? null,
+        outcomeRef: nullableString('outcome_ref', rawState.outcome_ref),
       }
       break
     }

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -1,12 +1,16 @@
 // MASC Dashboard — Keeper messaging (operator-mediated queue, SSE streaming)
 
-import { asString, isRecord } from '../components/common/normalize'
+import { asNumber, asString, isRecord } from '../components/common/normalize'
 import {
   formatKeeperVisibleReply,
   keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
 } from '../keeper-message'
-import type { KeeperConversationDetails, KeeperUserInputBlock } from '../types'
+import type {
+  KeeperConversationDetails,
+  KeeperQueueReceiptFailureKind,
+  KeeperUserInputBlock,
+} from '../types'
 import type { DashboardAuthErrorCode } from '../types/dashboard-execution'
 import {
   currentDashboardActor,
@@ -23,6 +27,7 @@ import {
   DEFAULT_POST_TIMEOUT_MS,
 } from './core'
 import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
+import { isKeeperChatReceiptId } from '../lib/keeper-chat-receipt'
 import type {
   KeeperCompositeSnapshot,
   FleetCompositeSnapshot,
@@ -683,6 +688,120 @@ export async function streamKeeperMessage(
 }
 
 // --- Chat history ---
+
+export type KeeperChatReceiptFailureKind = KeeperQueueReceiptFailureKind
+
+export type KeeperChatReceiptState =
+  | { kind: 'pending' }
+  | { kind: 'inflight'; leaseId: string; startedAt: number }
+  | { kind: 'delivered'; completedAt: number; outcomeRef: string | null }
+  | {
+      kind: 'failed'
+      failureKind: KeeperChatReceiptFailureKind
+      detail: string
+      completedAt: number
+      outcomeRef: string | null
+    }
+
+export interface KeeperChatReceipt {
+  keeperName: string
+  receiptId: string
+  revision: number
+  state: KeeperChatReceiptState
+}
+
+const KEEPER_CHAT_RECEIPT_FAILURE_KINDS = new Set<KeeperChatReceiptFailureKind>([
+  'turn_failed',
+  'timed_out',
+  'no_visible_reply',
+  'transcript_persist_failed',
+  'connector_unavailable',
+  'delivery_failed',
+  'cancelled',
+  'internal_error',
+])
+
+export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
+  if (!isRecord(value) || value.schema !== 'keeper_chat_queue.receipt.v1') {
+    throw new Error('Keeper chat receipt response has an unsupported schema')
+  }
+  const keeperName = asString(value.keeper_name, '').trim()
+  const receiptId = asString(value.receipt_id, '').trim()
+  const revision = asNumber(value.revision)
+  const rawState = isRecord(value.state) ? value.state : null
+  const kind = asString(rawState?.kind, '').trim()
+  if (
+    !keeperName
+    || !isKeeperChatReceiptId(receiptId)
+    || !rawState
+    || typeof revision !== 'number'
+    || !Number.isSafeInteger(revision)
+    || revision < 0
+  ) {
+    throw new Error('Keeper chat receipt response is missing identity or state')
+  }
+  let state: KeeperChatReceiptState
+  switch (kind) {
+    case 'pending':
+      state = { kind }
+      break
+    case 'inflight': {
+      const leaseId = asString(rawState.lease_id, '').trim()
+      const startedAt = asNumber(rawState.started_at)
+      if (!leaseId || typeof startedAt !== 'number') {
+        throw new Error('Keeper chat inflight receipt is missing lease metadata')
+      }
+      state = { kind, leaseId, startedAt }
+      break
+    }
+    case 'delivered': {
+      const completedAt = asNumber(rawState.completed_at)
+      if (typeof completedAt !== 'number') {
+        throw new Error('Keeper chat delivered receipt is missing completion time')
+      }
+      state = {
+        kind,
+        completedAt,
+        outcomeRef: asString(rawState.outcome_ref) ?? null,
+      }
+      break
+    }
+    case 'failed': {
+      const failureKind = asString(rawState.failure_kind, '') as KeeperChatReceiptFailureKind
+      const detail = asString(rawState.detail, '')
+      const completedAt = asNumber(rawState.completed_at)
+      if (!KEEPER_CHAT_RECEIPT_FAILURE_KINDS.has(failureKind) || !detail || typeof completedAt !== 'number') {
+        throw new Error('Keeper chat failed receipt has invalid failure metadata')
+      }
+      state = {
+        kind,
+        failureKind,
+        detail,
+        completedAt,
+        outcomeRef: asString(rawState.outcome_ref) ?? null,
+      }
+      break
+    }
+    default:
+      throw new Error(`Keeper chat receipt has unknown state: ${kind || '<empty>'}`)
+  }
+  return { keeperName, receiptId, revision, state }
+}
+
+export async function fetchKeeperChatReceipt(
+  keeperName: string,
+  receiptId: string,
+): Promise<KeeperChatReceipt> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/receipts/${encodeURIComponent(receiptId)}`,
+    { headers: jsonHeaders() },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) {
+    throw new Error(`fetchKeeperChatReceipt: HTTP ${resp.status} ${resp.statusText}`)
+  }
+  return parseKeeperChatReceipt(await resp.json())
+}
 
 export async function fetchKeeperChatHistory(
   name: string,

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -23,6 +23,7 @@ import {
   post,
   runOperatorAction,
   fetchWithTimeout,
+  fetchJsonWithTimeout,
   DEFAULT_GET_TIMEOUT_MS,
   DEFAULT_POST_TIMEOUT_MS,
 } from './core'
@@ -803,7 +804,7 @@ export async function fetchKeeperChatReceipt(
   keeperName: string,
   receiptId: string,
 ): Promise<KeeperChatReceipt> {
-  const resp = await fetchWithTimeout(
+  const { response: resp, data } = await fetchJsonWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/receipts/${encodeURIComponent(receiptId)}`,
     { headers: jsonHeaders() },
     DEFAULT_GET_TIMEOUT_MS,
@@ -811,7 +812,7 @@ export async function fetchKeeperChatReceipt(
   if (!resp.ok) {
     throw new Error(`fetchKeeperChatReceipt: HTTP ${resp.status} ${resp.statusText}`)
   }
-  return parseKeeperChatReceipt(await resp.json())
+  return parseKeeperChatReceipt(data)
 }
 
 export async function fetchKeeperChatHistory(
@@ -824,7 +825,7 @@ export async function fetchKeeperChatHistory(
   // keeper-actions.ts) is responsible for surfacing the failure to
   // the operator.  Per-item safeParse drift remains
   // tolerant — only network / HTTP / shape errors throw.
-  const resp = await fetchWithTimeout(
+  const { response: resp, data } = await fetchJsonWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
     { headers: jsonHeaders() },
     DEFAULT_GET_TIMEOUT_MS,
@@ -832,7 +833,6 @@ export async function fetchKeeperChatHistory(
   if (!resp.ok) {
     throw new Error(`fetchKeeperChatHistory: HTTP ${resp.status} ${resp.statusText}`)
   }
-  const data: unknown = await resp.json()
   if (!Array.isArray(data)) {
     throw new Error('fetchKeeperChatHistory: response is not an array')
   }

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -824,9 +824,10 @@ export async function fetchKeeperChatHistory(
   // keeper-actions.ts) is responsible for surfacing the failure to
   // the operator.  Per-item safeParse drift remains
   // tolerant — only network / HTTP / shape errors throw.
-  const resp = await fetch(
+  const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/chat/history`,
     { headers: jsonHeaders() },
+    DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) {
     throw new Error(`fetchKeeperChatHistory: HTTP ${resp.status} ${resp.statusText}`)

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -580,6 +580,12 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
     typeof details.usage?.totalTokens === 'number' ? { label: '토큰', value: `${details.usage.totalTokens}` } : null,
     formatCurrency(details.costUsd) ? { label: '비용', value: formatCurrency(details.costUsd)! } : null,
     details.traceId ? { label: '트레이스', value: details.traceId } : null,
+    details.queueReceiptId ? { label: '큐 receipt', value: details.queueReceiptId } : null,
+    details.queueState ? { label: '큐 상태', value: details.queueState } : null,
+    details.queueFailureKind ? { label: '큐 실패', value: details.queueFailureKind } : null,
+    typeof details.queueRevision === 'number' ? { label: '큐 revision', value: `${details.queueRevision}` } : null,
+    typeof details.queuePendingCount === 'number' ? { label: '접수 시 pending', value: `${details.queuePendingCount}` } : null,
+    typeof details.queueInflightCount === 'number' ? { label: '접수 시 inflight', value: `${details.queueInflightCount}` } : null,
     typeof details.generation === 'number' ? { label: '세대', value: `${details.generation}` } : null,
   ].filter((row): row is { label: string; value: string } => Boolean(row))
 }
@@ -2458,6 +2464,11 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
       data-chat-speaker-name=${entry.speakerName ?? undefined}
       data-chat-speaker-authority=${entry.speakerAuthority ?? undefined}
       data-chat-turn-ref=${entry.turnRef ?? undefined}
+      data-chat-queue-receipt-id=${entry.details?.queueReceiptId ?? undefined}
+      data-chat-queue-state=${entry.details?.queueState ?? undefined}
+      data-chat-queue-revision=${entry.details?.queueRevision ?? undefined}
+      data-chat-queue-pending-count=${entry.details?.queuePendingCount ?? undefined}
+      data-chat-queue-inflight-count=${entry.details?.queueInflightCount ?? undefined}
       data-chat-attachment-count=${attachments.length}
       data-chat-server-attach-block-count=${attachBlocks.length}
       data-chat-multimodal-sources=${multimodalSources.length > 0 ? multimodalSources.join(',') : undefined}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -446,6 +446,31 @@ function showDeliveryBadge(entry: KeeperConversationEntry, variant: ChatTranscri
   return entry.delivery !== 'history' && entry.delivery !== 'delivered'
 }
 
+function QueueReceiptBadge({ entry }: { entry: KeeperConversationEntry }) {
+  const receiptId = entry.details?.queueReceiptId?.trim()
+  const queueState = entry.details?.queueState
+  if (!receiptId || !queueState) return null
+  const label = (() => {
+    switch (queueState) {
+      case 'pending': return '서버 대기'
+      case 'inflight': return 'Keeper 처리 중'
+      case 'delivered': return '처리 완료'
+      case 'failed': return '처리 실패'
+      default: return '상태 확인 필요'
+    }
+  })()
+  return html`
+    <span
+      class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-fg-secondary)]"
+      title=${`receipt ${receiptId} · ${label}`}
+      data-chat-queue-state-badge=${queueState}
+      data-chat-queue-receipt=${receiptId}
+    >
+      ${label}
+    </span>
+  `
+}
+
 function avatarLabel(entry: KeeperConversationEntry): string {
   if (entry.role === 'user') return '사용자'
   if (entry.label.trim()) return entry.label.trim()
@@ -2506,6 +2531,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${QueueReceiptBadge} entry=${entry} />
                     <${StreamContractBadge} badge=${streamContractBadge} compact=${true} />
                     <${ChatMetaChip} info=${surfaceInfo} compact=${true} />
                     <${ChatMetaChip} info=${speakerInfo} compact=${true} />
@@ -2529,6 +2555,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
+                    <${QueueReceiptBadge} entry=${entry} />
                     ${timestamp
                       ? html`
                           <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2.5 py-1 text-2xs font-medium tabular-nums text-[var(--color-fg-secondary)]">

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -17,8 +17,10 @@ const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
 // above `let` declarations, so the shared state must itself be created inside
 // `vi.hoisted` to avoid the temporal dead zone. Tests inject a
 // `keeper_waiting_inventory` by setting `mockedToolsData.value` before render.
-const { mockedToolsData } = vi.hoisted(() => ({
+const { mockedToolsData, mockedToolsError, subscribeToolsAutoRefresh } = vi.hoisted(() => ({
   mockedToolsData: { value: null as unknown },
+  mockedToolsError: { value: null as string | null },
+  subscribeToolsAutoRefresh: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('../keeper-actions', () => ({
@@ -96,7 +98,9 @@ vi.mock('../store', async (importOriginal) => {
 vi.mock('../components/tools/tool-state', () => ({
   toolsData: mockedToolsData,
   toolsLoading: { value: false },
-  toolsError: { value: null },
+  toolsError: mockedToolsError,
+  KEEPER_WAITING_INVENTORY_REFRESH_MS: 15_000,
+  subscribeToolsAutoRefresh,
   loadTools: vi.fn(),
 }))
 
@@ -201,6 +205,8 @@ describe('KeeperConversationPanel', () => {
     keeperStreamStartedAt.value = {}
     shellAuthSummary.value = null
     mockedToolsData.value = null
+    mockedToolsError.value = null
+    subscribeToolsAutoRefresh.mockClear()
     _resetChatStoreForTests()
     vi.mocked(sendKeeperThreadMessage).mockReset()
     vi.mocked(sendKeeperThreadMessage).mockResolvedValue(undefined)
@@ -944,6 +950,74 @@ describe('KeeperConversationPanel', () => {
       expect(status?.getAttribute('data-server-chat-queue-read-errors')).toBe('1')
       expect(status?.textContent).toContain('대기열 조회 실패 1')
       expect(status?.textContent).toContain('repair_keeper_chat_queue_snapshot')
+    })
+  })
+
+  it('surfaces a failed tools refresh even when stale queue counts remain cached', async () => {
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [
+          {
+            keeper_name: 'sangsu',
+            state: 'waiting',
+            waiting_on: [],
+            waiting_count: 1,
+            sources: { chat_queue_pending: 1 },
+          },
+        ],
+      },
+    }
+    mockedToolsError.value = 'HTTP 502 Bad Gateway'
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      const status = container.querySelector('[data-server-chat-queue]') as HTMLElement | null
+      expect(status?.getAttribute('data-server-chat-queue-projection')).toBe('read-failed')
+      expect(status?.textContent).toContain('서버 대기열 갱신 실패')
+      expect(status?.textContent).toContain('표시 수치는 이전 snapshot일 수 있습니다')
+    })
+  })
+
+  it('shows each durable receipt lifecycle in messenger mode with receipt identity', async () => {
+    const receiptStates = ['pending', 'inflight', 'delivered', 'failed'] as const
+    keeperThreads.value = {
+      sangsu: receiptStates.map((queueState, index) => ({
+        id: `receipt-${queueState}`,
+        role: 'assistant' as const,
+        source: 'direct_assistant' as const,
+        label: 'sangsu',
+        text: `receipt ${queueState}`,
+        timestamp: null,
+        delivery: queueState === 'failed' ? 'error' as const : queueState === 'delivered' ? 'delivered' as const : 'queued' as const,
+        streamState: null,
+        details: {
+          queueReceiptId: `chatq_00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+          queueRevision: index + 1,
+          queueState,
+        },
+      })),
+    }
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [{ keeper_name: 'sangsu', state: 'waiting', waiting_on: [], waiting_count: 0 }],
+      },
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-chat-queue-state-badge="pending"]')?.textContent).toContain('서버 대기')
+      expect(container.querySelector('[data-chat-queue-state-badge="inflight"]')?.textContent).toContain('Keeper 처리 중')
+      expect(container.querySelector('[data-chat-queue-state-badge="delivered"]')?.textContent).toContain('처리 완료')
+      expect(container.querySelector('[data-chat-queue-state-badge="failed"]')?.textContent).toContain('처리 실패')
+      expect(container.querySelector('[data-chat-queue-state-badge="delivered"]')?.getAttribute('title')).toContain('chatq_')
     })
   })
 

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -27,6 +27,7 @@ vi.mock('../keeper-actions', () => ({
   hydrateKeeperChatHistory: vi.fn(async () => undefined),
   loadFullKeeperHistory: vi.fn(async () => null),
   probeKeeperRuntime: vi.fn(),
+  reconcileKeeperChatReceipts: vi.fn(async () => undefined),
   recoverKeeperRuntime: vi.fn(),
   resumePendingKeeperChatRequests: vi.fn(async () => undefined),
   sendKeeperThreadMessage: vi.fn(async () => null),
@@ -867,7 +868,7 @@ describe('KeeperConversationPanel', () => {
     expect(container.textContent).toContain('Snapshot says the keeper heartbeat is stale.')
   })
 
-  it('shows a busy chip when the keeper waiting inventory reports busy', async () => {
+  it('shows an explicit running-turn state when the keeper waiting inventory reports busy', async () => {
     mockedToolsData.value = {
       keeper_waiting_inventory: {
         keepers: [
@@ -880,7 +881,69 @@ describe('KeeperConversationPanel', () => {
       container,
     )
     await waitFor(() => {
-      expect(container.textContent).toContain('busy')
+      expect(container.textContent).toContain('Keeper 턴 실행 중')
+      expect(container.textContent).toContain('다른 턴 실행 중')
+    })
+  })
+
+  it('separates durable server pending/inflight counts from browser-local drafts', async () => {
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [
+          {
+            keeper_name: 'sangsu',
+            state: 'busy',
+            waiting_on: [],
+            waiting_count: 3,
+            sources: {
+              chat_queue_pending: 2,
+              chat_queue_inflight: 1,
+            },
+            next_action: 'keeper_chat_consumer_drain',
+          },
+        ],
+      },
+    }
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      const status = container.querySelector('[data-server-chat-queue]') as HTMLElement | null
+      expect(status?.getAttribute('data-server-chat-queue-pending')).toBe('2')
+      expect(status?.getAttribute('data-server-chat-queue-inflight')).toBe('1')
+      expect(status?.textContent).toContain('서버 대기 2')
+      expect(status?.textContent).toContain('처리 중 1')
+      expect(container.textContent).not.toContain('브라우저 초안 · 서버 미접수')
+    })
+  })
+
+  it('surfaces a server queue snapshot read failure instead of showing an empty queue', async () => {
+    mockedToolsData.value = {
+      keeper_waiting_inventory: {
+        keepers: [
+          {
+            keeper_name: 'sangsu',
+            state: 'waiting',
+            waiting_on: [],
+            waiting_count: 1,
+            sources: { read_error: 1 },
+            next_action: 'repair_keeper_chat_queue_snapshot',
+          },
+        ],
+      },
+    }
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="Say something" layout="primary" />`,
+      container,
+    )
+
+    await waitFor(() => {
+      const status = container.querySelector('[data-server-chat-queue]') as HTMLElement | null
+      expect(status?.getAttribute('data-server-chat-queue-read-errors')).toBe('1')
+      expect(status?.textContent).toContain('대기열 조회 실패 1')
+      expect(status?.textContent).toContain('repair_keeper_chat_queue_snapshot')
     })
   })
 
@@ -897,7 +960,7 @@ describe('KeeperConversationPanel', () => {
       container,
     )
     await waitFor(() => {
-      expect(container.textContent).toContain('busy')
+      expect(container.textContent).toContain('Keeper 턴 실행 중')
     })
 
     const interruptButton = Array.from(container.querySelectorAll('button'))

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -74,14 +74,19 @@ import {
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
 } from '../tool-call-output-store'
-import { loadTools, toolsData, toolsLoading } from './tools/tool-state'
+import {
+  KEEPER_WAITING_INVENTORY_REFRESH_MS,
+  subscribeToolsAutoRefresh,
+  toolsData,
+  toolsError,
+} from './tools/tool-state'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
 
 // Mirrors `LANE_REFRESH_MS` in keeper-workspace/keeper-lane-strip.ts. That
 // const is module-local there, so we keep the same 15 s cadence here rather
 // than exporting it cross-file for a single consumer.
-const BUSY_REFRESH_MS = 15_000
+const BUSY_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
 
 
 function GhostButton({
@@ -526,15 +531,28 @@ function ServerQueueStatus({
   pendingCount,
   inflightCount,
   readErrorCount,
+  projectionError,
+  projectionReady,
+  projectionPresent,
   nextAction,
 }: {
   busy: boolean
   pendingCount: number
   inflightCount: number
   readErrorCount: number
+  projectionError?: string | null
+  projectionReady: boolean
+  projectionPresent: boolean
   nextAction?: string | null
 }) {
-  if (!busy && pendingCount === 0 && inflightCount === 0 && readErrorCount === 0) return null
+  const projectionUnavailable = Boolean(projectionError) || !projectionReady || !projectionPresent
+  if (
+    !projectionUnavailable
+    && !busy
+    && pendingCount === 0
+    && inflightCount === 0
+    && readErrorCount === 0
+  ) return null
   return html`
     <div
       class="mb-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2.5 text-xs text-[var(--color-fg-secondary)] v2-monitoring-panel"
@@ -542,6 +560,13 @@ function ServerQueueStatus({
       data-server-chat-queue-pending=${pendingCount}
       data-server-chat-queue-inflight=${inflightCount}
       data-server-chat-queue-read-errors=${readErrorCount}
+      data-server-chat-queue-projection=${projectionError
+        ? 'read-failed'
+        : !projectionReady
+          ? 'loading'
+          : !projectionPresent
+            ? 'missing'
+            : 'ready'}
     >
       <div class="flex flex-wrap items-center gap-2 v2-monitoring-row">
         <span class="font-semibold text-[var(--color-fg-primary)]">Keeper 서버 대기열</span>
@@ -554,12 +579,20 @@ function ServerQueueStatus({
         ${readErrorCount > 0
           ? html`<span class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-[var(--color-status-err)]" data-server-chat-queue-state="read-error">대기열 조회 실패 ${readErrorCount}</span>`
           : null}
+        ${projectionError
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-[var(--color-status-err)]">서버 대기열 갱신 실패</span>`
+          : !projectionReady
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--info-20)] bg-[var(--info-10)] px-2 py-0.5">서버 대기열 불러오는 중</span>`
+            : !projectionPresent
+              ? html`<span class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-[var(--color-status-err)]">Keeper 대기열 투영 없음</span>`
+              : null}
         ${busy && inflightCount === 0
           ? html`<span class="rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5">다른 턴 실행 중</span>`
           : null}
       </div>
       <div class="mt-1.5 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
         이 값은 브라우저 초안이 아니라 서버의 durable receipt 투영입니다.
+        ${projectionError ? html` 최근 갱신 오류: <code>${projectionError}</code>. 표시 수치는 이전 snapshot일 수 있습니다.` : null}
         ${nextAction ? html` 다음 서버 동작: <code>${nextAction}</code>` : null}
       </div>
     </div>
@@ -602,12 +635,15 @@ export function KeeperConversationPanel({
   // is hidden, refresh immediately on focus/return, and return the cleanup so
   // the busy chip / interrupt button cannot freeze on a stale snapshot.
   useEffect(() => {
-    if (!toolsData.value && !toolsLoading.value) void loadTools()
+    const unsubscribeToolsRefresh = subscribeToolsAutoRefresh()
     void reconcileKeeperChatReceipts(keeperName)
-    return setupVisibleAutoRefresh(() => {
-      void loadTools()
+    const stopReceiptRefresh = setupVisibleAutoRefresh(() => {
       void reconcileKeeperChatReceipts(keeperName)
     }, BUSY_REFRESH_MS)
+    return () => {
+      stopReceiptRefresh()
+      unsubscribeToolsRefresh()
+    }
   }, [keeperName])
 
   const inventoryEntry = useMemo(() => {
@@ -654,6 +690,11 @@ export function KeeperConversationPanel({
   const serverPendingCount = Math.max(0, inventoryEntry?.sources?.chat_queue_pending ?? 0)
   const serverInflightCount = Math.max(0, inventoryEntry?.sources?.chat_queue_inflight ?? 0)
   const serverQueueReadErrorCount = Math.max(0, inventoryEntry?.sources?.read_error ?? 0)
+  const toolsProjectionError = toolsError.value
+  const toolsProjectionReady = toolsData.value !== null
+  const toolsProjectionPresent = Boolean(
+    toolsData.value?.keeper_waiting_inventory && inventoryEntry,
+  )
   const visibleThread = useMemo(
     () =>
       sending && !thread.some(isActiveAssistantEntry)
@@ -887,6 +928,9 @@ export function KeeperConversationPanel({
       pendingCount=${serverPendingCount}
       inflightCount=${serverInflightCount}
       readErrorCount=${serverQueueReadErrorCount}
+      projectionError=${toolsProjectionError}
+      projectionReady=${toolsProjectionReady}
+      projectionPresent=${toolsProjectionPresent}
       nextAction=${inventoryEntry?.next_action}
     />
   `

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -22,6 +22,7 @@ import {
   interruptKeeperTurn,
   isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
+  reconcileKeeperChatReceipts,
   recoverKeeperRuntime,
   resumePendingKeeperChatRequests,
   sendKeeperThreadMessage,
@@ -513,9 +514,54 @@ function BusyToolbar({
       data-keeper-name=${keeperName}
     >
       <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 font-medium text-[var(--color-status-warn)]">
-        busy
+        Keeper 턴 실행 중
       </span>
       <${GhostButton} onClick=${onInterrupt}>현재 턴 중단<//>
+    </div>
+  `
+}
+
+function ServerQueueStatus({
+  busy,
+  pendingCount,
+  inflightCount,
+  readErrorCount,
+  nextAction,
+}: {
+  busy: boolean
+  pendingCount: number
+  inflightCount: number
+  readErrorCount: number
+  nextAction?: string | null
+}) {
+  if (!busy && pendingCount === 0 && inflightCount === 0 && readErrorCount === 0) return null
+  return html`
+    <div
+      class="mb-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2.5 text-xs text-[var(--color-fg-secondary)] v2-monitoring-panel"
+      data-server-chat-queue
+      data-server-chat-queue-pending=${pendingCount}
+      data-server-chat-queue-inflight=${inflightCount}
+      data-server-chat-queue-read-errors=${readErrorCount}
+    >
+      <div class="flex flex-wrap items-center gap-2 v2-monitoring-row">
+        <span class="font-semibold text-[var(--color-fg-primary)]">Keeper 서버 대기열</span>
+        ${inflightCount > 0
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--info-20)] bg-[var(--info-10)] px-2 py-0.5" data-server-chat-queue-state="inflight">처리 중 ${inflightCount}</span>`
+          : null}
+        ${pendingCount > 0
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5" data-server-chat-queue-state="pending">서버 대기 ${pendingCount}</span>`
+          : null}
+        ${readErrorCount > 0
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-[var(--color-status-err)]" data-server-chat-queue-state="read-error">대기열 조회 실패 ${readErrorCount}</span>`
+          : null}
+        ${busy && inflightCount === 0
+          ? html`<span class="rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5">다른 턴 실행 중</span>`
+          : null}
+      </div>
+      <div class="mt-1.5 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+        이 값은 브라우저 초안이 아니라 서버의 durable receipt 투영입니다.
+        ${nextAction ? html` 다음 서버 동작: <code>${nextAction}</code>` : null}
+      </div>
     </div>
   `
 }
@@ -557,10 +603,12 @@ export function KeeperConversationPanel({
   // the busy chip / interrupt button cannot freeze on a stale snapshot.
   useEffect(() => {
     if (!toolsData.value && !toolsLoading.value) void loadTools()
+    void reconcileKeeperChatReceipts(keeperName)
     return setupVisibleAutoRefresh(() => {
       void loadTools()
+      void reconcileKeeperChatReceipts(keeperName)
     }, BUSY_REFRESH_MS)
-  }, [])
+  }, [keeperName])
 
   const inventoryEntry = useMemo(() => {
     const inv = toolsData.value?.keeper_waiting_inventory
@@ -601,7 +649,11 @@ export function KeeperConversationPanel({
   )
   const hiddenCount = rawThread.length - thread.length
   const sending = keeperSending.value[keeperName] ?? false
-  const isKeeperBusy = Boolean(inventoryEntry?.state === 'busy' && !sending)
+  const serverBusy = inventoryEntry?.state === 'busy'
+  const isKeeperBusy = Boolean(serverBusy && !sending)
+  const serverPendingCount = Math.max(0, inventoryEntry?.sources?.chat_queue_pending ?? 0)
+  const serverInflightCount = Math.max(0, inventoryEntry?.sources?.chat_queue_inflight ?? 0)
+  const serverQueueReadErrorCount = Math.max(0, inventoryEntry?.sources?.read_error ?? 0)
   const visibleThread = useMemo(
     () =>
       sending && !thread.some(isActiveAssistantEntry)
@@ -829,6 +881,16 @@ export function KeeperConversationPanel({
     />
   `
 
+  const serverQueueStatus = html`
+    <${ServerQueueStatus}
+      busy=${serverBusy}
+      pendingCount=${serverPendingCount}
+      inflightCount=${serverInflightCount}
+      readErrorCount=${serverQueueReadErrorCount}
+      nextAction=${inventoryEntry?.next_action}
+    />
+  `
+
   if (layout === 'workspace') {
     // 3-pane workspace: identity + lifecycle live in the ChatHeader above
     // this panel, so the workspace layout drops the panel's own header and
@@ -919,11 +981,12 @@ export function KeeperConversationPanel({
 
         <div class="kw-composer-wrap v2-monitoring-panel">
           <div class="kw-composer-inner v2-monitoring-panel">
+            ${serverQueueStatus}
             ${queueCount > 0
               ? html`
                   <div class="mb-3 flex flex-col gap-2" data-chat-queue-list>
                     <div class="flex items-center justify-between gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                      <span>${queueCount}개 메시지 대기 중</span>
+                      <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
                       <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
                     </div>
                     ${queuedMessages.map(msg => html`
@@ -1046,10 +1109,11 @@ export function KeeperConversationPanel({
           : null}
 
         <div class="shrink-0 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 shadow-none v2-monitoring-panel">
-          ${queueCount > 0
+        ${serverQueueStatus}
+        ${queueCount > 0
             ? html`
                 <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                  <span>${queueCount}개 메시지 대기 중</span>
+                  <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
                   <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
                 </div>
               `
@@ -1159,10 +1223,11 @@ export function KeeperConversationPanel({
           : null}
 
         <div class="border-t border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-4 v2-monitoring-panel">
-          ${queueCount > 0
+        ${serverQueueStatus}
+        ${queueCount > 0
             ? html`
                 <div class="mb-2 flex items-center gap-2 text-2xs text-[var(--color-fg-muted)] v2-monitoring-row" data-chat-queue-row>
-                  <span>${queueCount}개 메시지 대기 중</span>
+                  <span>${queueCount}개 브라우저 초안 · 서버 미접수</span>
                   <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
                 </div>
               `

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.test.ts
@@ -16,7 +16,7 @@ function keeperFixture(overrides: Partial<Keeper> = {}): Keeper {
 
 function inventoryFixture(): DashboardKeeperWaitingInventory {
   return {
-    schema: 'masc.dashboard.keeper_waiting_inventory.v1',
+    schema: 'masc.dashboard.keeper_waiting_inventory.v2',
     source: 'server_keeper_waiting_inventory',
     generated_at: '2026-07-07T09:00:00Z',
     supported_states: ['idle', 'busy', 'waiting', 'deferred'],

--- a/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-strip.ts
@@ -15,7 +15,13 @@ import type {
   DashboardKeeperWaitingKeeper,
   DashboardKeeperWaitingRow,
 } from '../../api'
-import { loadTools, toolsData, toolsError, toolsLoading } from '../tools/tool-state'
+import {
+  KEEPER_WAITING_INVENTORY_REFRESH_MS,
+  subscribeToolsAutoRefresh,
+  toolsData,
+  toolsError,
+  toolsLoading,
+} from '../tools/tool-state'
 import { StatusChip } from '../common/status-chip'
 import {
   enumLabel,
@@ -23,7 +29,7 @@ import {
   stateTone,
 } from '../tools/keeper-waiting-inventory-panel'
 import { formatDateTimeKo } from '../../lib/format-time'
-import { setupVisibleAutoRefresh, formatAutoRefreshLabel } from '../../lib/auto-refresh'
+import { formatAutoRefreshLabel } from '../../lib/auto-refresh'
 import { CountBadge } from '../v2/primitives-v2'
 
 const LANE_ROW_LIMIT = 3
@@ -35,7 +41,7 @@ const LANE_ROW_LIMIT = 3
 // 30s shared panel default because this is the live "what is this keeper
 // waiting on right now" surface; setupVisibleAutoRefresh still pauses when the
 // tab is hidden and refreshes immediately on focus/return.
-const LANE_REFRESH_MS = 15_000
+const LANE_REFRESH_MS = KEEPER_WAITING_INVENTORY_REFRESH_MS
 
 function inventoryEntry(
   inventory: DashboardKeeperWaitingInventory | null | undefined,
@@ -150,10 +156,7 @@ export function KeeperLaneStrip({
  *  inventory in place without flashing a loading gap. */
 export function KeeperLaneSection({ keeper }: { keeper: Keeper }): VNode {
   useEffect(() => {
-    if (!toolsData.value && !toolsLoading.value) void loadTools()
-    return setupVisibleAutoRefresh(() => {
-      void loadTools()
-    }, LANE_REFRESH_MS)
+    return subscribeToolsAutoRefresh()
   }, [])
   return html`
     <${KeeperLaneStrip}

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -94,7 +94,7 @@ function sampleAutomation(): DashboardScheduledAutomation {
 
 function sampleWaitingInventory(): DashboardKeeperWaitingInventory {
   return {
-    schema: 'masc.dashboard.keeper_waiting_inventory.v1',
+    schema: 'masc.dashboard.keeper_waiting_inventory.v2',
     source: 'server_keeper_waiting_inventory',
     keeper_count_known: true,
     keeper_count: 1,

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
@@ -7,20 +7,21 @@ import { KeeperLaneInventoryPanel, KeeperWaitingInventoryPanel } from './keeper-
 
 function inventoryFixture(): DashboardKeeperWaitingInventory {
   return {
-    schema: 'masc.dashboard.keeper_waiting_inventory.v1',
+    schema: 'masc.dashboard.keeper_waiting_inventory.v2',
     source: 'server_keeper_waiting_inventory',
     generated_at: '2026-07-04T00:00:00Z',
     supported_states: ['idle', 'busy', 'waiting', 'deferred'],
     keeper_count_known: true,
     keeper_count: 3,
     waiting_keeper_count: 2,
-    row_count: 3,
+    row_count: 4,
     global_row_count: 1,
     global_pending_confirm_count_known: true,
     global_pending_confirm_count: 1,
     source_counts: {
       event_queue_pending: 1,
       event_queue_inflight: 1,
+      chat_queue_inflight: 1,
       schedule_waiting: 1,
       turn_admission_waiting: 1,
     },
@@ -28,10 +29,11 @@ function inventoryFixture(): DashboardKeeperWaitingInventory {
       {
         keeper_name: 'sangsu',
         state: 'waiting',
-        waiting_count: 2,
+        waiting_count: 3,
         sources: {
           event_queue_pending: 1,
           event_queue_inflight: 1,
+          chat_queue_inflight: 1,
         },
         waiting_on: [
           {
@@ -49,6 +51,23 @@ function inventoryFixture(): DashboardKeeperWaitingInventory {
             wake_producer: 'keeper_no_progress_recovery',
             since_iso: '2026-07-04T00:01:00Z',
             next_action: 'recover_inflight_turn',
+          },
+          {
+            keeper_name: 'sangsu',
+            source: 'chat_queue_inflight',
+            waiting_on: 'dashboard',
+            wake_producer: 'keeper_chat_queue_store',
+            since_iso: '2026-07-04T00:02:00Z',
+            next_action: 'keeper_chat_turn_terminal_receipt',
+            detail: {
+              queue_index: 0,
+              receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+              lifecycle: {
+                state: 'inflight',
+                lease_id: 'lease_00000000-0000-4000-8000-000000000002',
+                started_at_iso: '2026-07-04T00:02:30Z',
+              },
+            },
           },
         ],
       },
@@ -117,6 +136,9 @@ describe('KeeperWaitingInventoryPanel', () => {
     expect(container.textContent).toContain('producer keeper supervisor')
     expect(container.textContent).toContain('producer keeper no progress recovery')
     expect(container.textContent).toContain('no_progress_recovery')
+    expect(container.textContent).toContain('chatq_00000000-0000-4000-8000-000000000001')
+    expect(container.textContent).toContain('lease_00000000-0000-4000-8000-000000000002')
+    expect(container.textContent).toContain('state inflight')
     expect(container.textContent).toContain('Global waiting')
     expect(container.textContent).toContain('masc.board_post')
     expect(container.textContent).not.toContain('idle-one')
@@ -204,7 +226,7 @@ describe('KeeperLaneInventoryPanel', () => {
         waiting_on: [
           {
             keeper_name: 'partial-lane',
-            source: 'external_message',
+            source: 'external_attention',
             waiting_on: 'discord:ops',
             wake_producer: null,
             next_action: '',

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.test.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { DashboardKeeperWaitingInventory } from '../../api'
@@ -148,6 +149,32 @@ describe('KeeperWaitingInventoryPanel', () => {
     render(html`<${KeeperWaitingInventoryPanel} inventory=${null} />`, container)
 
     expect(container.textContent).toContain('waiting inventory unavailable')
+  })
+
+  it('expands the active receipt rows instead of hiding reload correlation ids', () => {
+    const inventory = inventoryFixture()
+    const keeper = inventory.keepers[0]
+    if (!keeper) throw new Error('fixture keeper missing')
+    keeper.waiting_on = Array.from({ length: 7 }, (_, index) => ({
+      keeper_name: keeper.keeper_name,
+      source: 'chat_queue_pending',
+      waiting_on: 'slack',
+      wake_producer: 'keeper_chat_queue',
+      next_action: 'keeper_chat_consumer_drain',
+      detail: {
+        queue_index: index,
+        receipt_id: `chatq_00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+        lifecycle: { state: 'pending' },
+      },
+    }))
+    keeper.waiting_count = keeper.waiting_on.length
+
+    render(html`<${KeeperWaitingInventoryPanel} inventory=${inventory} />`, container)
+
+    expect(container.textContent).not.toContain('chatq_00000000-0000-4000-8000-000000000006')
+    fireEvent.click(container.querySelector('[data-expand-waiting-rows]') as HTMLButtonElement)
+    expect(container.textContent).toContain('chatq_00000000-0000-4000-8000-000000000006')
+    expect(container.querySelector('[data-collapse-waiting-rows]')).not.toBeNull()
   })
 
   it('renders unknown pending-confirm count when the store read failed', () => {

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import type {
   DashboardKeeperWaitingInventory,
   DashboardKeeperWaitingKeeper,
@@ -140,7 +141,9 @@ function WaitingRow({ row }: { row: DashboardKeeperWaitingRow }) {
 }
 
 function KeeperRow({ keeper }: { keeper: DashboardKeeperWaitingKeeper }) {
-  const rows = (keeper.waiting_on ?? []).slice(0, 4)
+  const [expanded, setExpanded] = useState(false)
+  const allRows = keeper.waiting_on ?? []
+  const rows = expanded ? allRows : allRows.slice(0, 4)
   const truncatedSources = Object.entries(keeper.truncated_sources ?? {})
     .filter(([, truncated]) => truncated)
     .map(([source]) => enumLabel(source))
@@ -163,8 +166,13 @@ function KeeperRow({ keeper }: { keeper: DashboardKeeperWaitingKeeper }) {
         : null}
       <div class="mt-2">
         ${rows.map((row, index) => html`<${WaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />`)}
-        ${keeper.waiting_count > rows.length
-          ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]">+${keeper.waiting_count - rows.length} more</div>`
+        ${allRows.length > rows.length
+          ? html`<button type="button" class="pt-1 text-2xs font-medium text-[var(--color-accent-fg)]" onClick=${() => setExpanded(true)} data-expand-waiting-rows>+${allRows.length - rows.length} more · 전체 보기</button>`
+          : expanded && allRows.length > 4
+            ? html`<button type="button" class="pt-1 text-2xs font-medium text-[var(--color-accent-fg)]" onClick=${() => setExpanded(false)} data-collapse-waiting-rows>접기</button>`
+          : null}
+        ${keeper.waiting_count > allRows.length
+          ? html`<div class="pt-1 text-2xs text-[var(--color-status-warn)]">서버 projection에서 ${keeper.waiting_count - allRows.length}행이 추가로 생략되었습니다.</div>`
           : null}
       </div>
     </div>
@@ -236,7 +244,9 @@ function laneSummary(keeper: DashboardKeeperWaitingKeeper): string {
 }
 
 function LaneEvidenceCard({ keeper }: { keeper: DashboardKeeperWaitingKeeper }) {
-  const rows = (keeper.waiting_on ?? []).slice(0, 6)
+  const [expanded, setExpanded] = useState(false)
+  const allRows = keeper.waiting_on ?? []
+  const rows = expanded ? allRows : allRows.slice(0, 6)
   const truncatedSources = Object.entries(keeper.truncated_sources ?? {})
     .filter(([, truncated]) => truncated)
     .map(([source]) => enumLabel(source))
@@ -279,8 +289,13 @@ function LaneEvidenceCard({ keeper }: { keeper: DashboardKeeperWaitingKeeper }) 
         ${rows.length > 0
           ? rows.map((row, index) => html`<${WaitingRow} key=${`${row.source}:${row.waiting_on}:${index}`} row=${row} />`)
           : html`<div class="border-t border-[var(--color-border-subtle)] pt-2 text-xs text-[var(--color-fg-muted)]">no keeper-specific waiting rows</div>`}
-        ${keeper.waiting_count > rows.length
-          ? html`<div class="pt-1 text-2xs text-[var(--color-fg-muted)]">+${keeper.waiting_count - rows.length} more</div>`
+        ${allRows.length > rows.length
+          ? html`<button type="button" class="pt-1 text-2xs font-medium text-[var(--color-accent-fg)]" onClick=${() => setExpanded(true)} data-expand-lane-rows>+${allRows.length - rows.length} more · 전체 보기</button>`
+          : expanded && allRows.length > 6
+            ? html`<button type="button" class="pt-1 text-2xs font-medium text-[var(--color-accent-fg)]" onClick=${() => setExpanded(false)} data-collapse-lane-rows>접기</button>`
+          : null}
+        ${keeper.waiting_count > allRows.length
+          ? html`<div class="pt-1 text-2xs text-[var(--color-status-warn)]">서버 projection에서 ${keeper.waiting_count - allRows.length}행이 추가로 생략되었습니다.</div>`
           : null}
       </div>
     </article>

--- a/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
+++ b/dashboard/src/components/tools/keeper-waiting-inventory-panel.ts
@@ -88,6 +88,37 @@ function SourceCounts({ counts }: { counts: Record<string, number> | null | unde
   `
 }
 
+function asDetailRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function WaitingRowReceiptDetail({ row }: { row: DashboardKeeperWaitingRow }) {
+  const detail = asDetailRecord(row.detail)
+  const lifecycle = asDetailRecord(detail?.lifecycle)
+  const receiptId = typeof detail?.receipt_id === 'string' ? detail.receipt_id : null
+  if (!receiptId) return null
+  const queueIndex = typeof detail?.queue_index === 'number' ? detail.queue_index : null
+  const state = typeof lifecycle?.state === 'string' ? lifecycle.state : null
+  const leaseId = typeof lifecycle?.lease_id === 'string' ? lifecycle.lease_id : null
+  const startedAt = typeof lifecycle?.started_at_iso === 'string'
+    ? lifecycle.started_at_iso
+    : null
+  return html`
+    <div
+      class="flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-2xs text-[var(--color-fg-muted)]"
+      data-keeper-chat-receipt=${receiptId}
+    >
+      <span class="min-w-0 break-all font-mono">receipt ${receiptId}</span>
+      ${queueIndex === null ? null : html`<span class="font-mono">queue index ${queueIndex}</span>`}
+      ${state ? html`<span class="font-mono">state ${enumLabel(state)}</span>` : null}
+      ${leaseId ? html`<span class="min-w-0 break-all font-mono">lease ${leaseId}</span>` : null}
+      ${startedAt ? html`<span>started ${timeLabel(startedAt)}</span>` : null}
+    </div>
+  `
+}
+
 function WaitingRow({ row }: { row: DashboardKeeperWaitingRow }) {
   const wakeProducer = evidenceLabel(row.wake_producer, 'wake producer missing')
   const nextAction = evidenceLabel(row.next_action, 'next action missing')
@@ -103,6 +134,7 @@ function WaitingRow({ row }: { row: DashboardKeeperWaitingRow }) {
         <span class="font-mono">producer ${wakeProducer}</span>
         <span class="font-mono">${nextAction}</span>
       </div>
+      <${WaitingRowReceiptDetail} row=${row} />
     </div>
   `
 }

--- a/dashboard/src/components/tools/tool-state-refresh.test.ts
+++ b/dashboard/src/components/tools/tool-state-refresh.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { fetchDashboardTools, setupVisibleAutoRefresh, stopRefresh } = vi.hoisted(() => ({
+  fetchDashboardTools: vi.fn(async () => ({
+    tools: [],
+    keeper_waiting_inventory: { keepers: [] },
+  })),
+  setupVisibleAutoRefresh: vi.fn(),
+  stopRefresh: vi.fn(),
+}))
+
+setupVisibleAutoRefresh.mockReturnValue(stopRefresh)
+
+vi.mock('../../api', () => ({ fetchDashboardTools }))
+vi.mock('../../lib/auto-refresh', () => ({ setupVisibleAutoRefresh }))
+vi.mock('../../sse-store', () => ({ registerKeeperChatQueueRefresh: vi.fn() }))
+
+import { subscribeToolsAutoRefresh } from './tool-state'
+
+let disposers: Array<() => void> = []
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) dispose()
+  vi.clearAllMocks()
+  setupVisibleAutoRefresh.mockReturnValue(stopRefresh)
+})
+
+describe('subscribeToolsAutoRefresh', () => {
+  it('shares one polling owner across multiple mounted consumers', () => {
+    const first = subscribeToolsAutoRefresh()
+    const second = subscribeToolsAutoRefresh()
+    disposers = [first, second]
+
+    expect(setupVisibleAutoRefresh).toHaveBeenCalledTimes(1)
+
+    first()
+    disposers = [second]
+    expect(stopRefresh).not.toHaveBeenCalled()
+
+    second()
+    disposers = []
+    expect(stopRefresh).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
 import { fetchDashboardTools, type DashboardToolsResponse, type DashboardToolInventoryItem } from '../../api'
 import { createManagedAsyncResource } from '../../lib/async-state'
+import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
 import { registerKeeperChatQueueRefresh } from '../../sse-store'
 
 // Managed (stale-while-revalidate): the previously loaded response stays
@@ -42,6 +43,31 @@ export const SURFACE_LABELS: Record<SurfaceFilter, string> = {
 
 export async function loadTools() {
   await toolsResource.load(signal => fetchDashboardTools({ signal }))
+}
+
+export const KEEPER_WAITING_INVENTORY_REFRESH_MS = 15_000
+let toolsRefreshSubscriberCount = 0
+let stopToolsRefresh: (() => void) | null = null
+
+/** Share one visibility-aware tools poller across every mounted Keeper lane
+ * and conversation surface. The managed resource deduplicates fetch state;
+ * this subscription also deduplicates the timer and global visibility/focus
+ * listeners that trigger it. */
+export function subscribeToolsAutoRefresh(): () => void {
+  toolsRefreshSubscriberCount += 1
+  if (toolsRefreshSubscriberCount === 1) {
+    if (!toolsData.value && !toolsLoading.value) void loadTools()
+    stopToolsRefresh = setupVisibleAutoRefresh(() => {
+      void loadTools()
+    }, KEEPER_WAITING_INVENTORY_REFRESH_MS)
+  }
+  return () => {
+    toolsRefreshSubscriberCount = Math.max(0, toolsRefreshSubscriberCount - 1)
+    if (toolsRefreshSubscriberCount === 0) {
+      stopToolsRefresh?.()
+      stopToolsRefresh = null
+    }
+  }
 }
 
 registerKeeperChatQueueRefresh(() => {

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { signal, computed } from '@preact/signals'
 import { fetchDashboardTools, type DashboardToolsResponse, type DashboardToolInventoryItem } from '../../api'
 import { createManagedAsyncResource } from '../../lib/async-state'
+import { registerKeeperChatQueueRefresh } from '../../sse-store'
 
 // Managed (stale-while-revalidate): the previously loaded response stays
 // readable while a refetch is in flight. Panel-level polling — the keeper
@@ -42,6 +43,10 @@ export const SURFACE_LABELS: Record<SurfaceFilter, string> = {
 export async function loadTools() {
   await toolsResource.load(signal => fetchDashboardTools({ signal }))
 }
+
+registerKeeperChatQueueRefresh(() => {
+  void loadTools()
+})
 
 export function hasSurface(item: DashboardToolInventoryItem, surface: string): boolean {
   return (item.surfaces ?? []).includes(surface)

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -63,7 +63,7 @@ import { Tools } from './tools-main'
 
 function waitingInventoryFixture(): DashboardKeeperWaitingInventory {
   return {
-    schema: 'masc.dashboard.keeper_waiting_inventory.v1',
+    schema: 'masc.dashboard.keeper_waiting_inventory.v2',
     source: 'server_keeper_waiting_inventory',
     keeper_count_known: true,
     keeper_count: 1,

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -219,6 +219,9 @@ describe('reconcileKeeperChatReceipts', () => {
       ],
     }
     keeperActionErrors.value = {}
+    _resetChatHydrationForTests()
+    fetchKeeperChatHistory.mockReset()
+    fetchKeeperChatHistory.mockResolvedValue([])
     fetchKeeperChatReceipt.mockReset()
   })
 
@@ -240,6 +243,28 @@ describe('reconcileKeeperChatReceipts', () => {
       status: 'queue_poll_result',
       deliveryReceipt: 'server_durable_receipt',
     })
+  })
+
+  it('forces transcript convergence when only the terminal queue receipt is observed', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+    })
+    fetchKeeperChatHistory.mockResolvedValue([
+      { role: 'assistant', content: 'reply recovered without append SSE', ts: 1_780_000_001 },
+    ])
+
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(fetchKeeperChatHistory).toHaveBeenCalledWith('echo')
+    expect(keeperThreads.value.echo?.some(entry => (
+      entry.text === 'reply recovered without append SSE'
+    ))).toBe(true)
+    expect(keeperThreads.value.echo?.some(entry => (
+      entry.details?.queueState === 'delivered'
+    ))).toBe(true)
   })
 
   it('surfaces a durable failed receipt on the queued chat row', async () => {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -267,6 +267,37 @@ describe('reconcileKeeperChatReceipts', () => {
     ))).toBe(true)
   })
 
+  it('retries terminal transcript convergence on the next poll after a failed fetch', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+    })
+    fetchKeeperChatHistory
+      .mockRejectedValueOnce(new Error('temporary history timeout'))
+      .mockResolvedValueOnce([
+        { role: 'assistant', content: 'reply recovered on retry', ts: 1_780_000_002 },
+      ])
+
+    await reconcileKeeperChatReceipts('echo')
+
+    const receiptEntry = keeperThreads.value.echo?.find(entry => (
+      entry.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))
+    expect(receiptEntry?.delivery).toBe('delivered')
+    expect(keeperActionErrors.value.echo).toContain('transcript convergence')
+
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(fetchKeeperChatReceipt).toHaveBeenCalledTimes(1)
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+    expect(keeperThreads.value.echo?.some(entry => (
+      entry.text === 'reply recovered on retry'
+    ))).toBe(true)
+    expect(keeperActionErrors.value.echo).toBeFalsy()
+  })
+
   it('surfaces a durable failed receipt on the queued chat row', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
@@ -353,6 +384,9 @@ describe('reconcileKeeperChatReceipts', () => {
   })
 
   it('ignores an older rejected lookup after a newer terminal success', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([
+      { role: 'assistant', content: 'authoritative terminal reply', ts: 1_780_000_003 },
+    ])
     let rejectOlder!: (reason: Error) => void
     let resolveNewer!: (value: {
       keeperName: string
@@ -382,7 +416,10 @@ describe('reconcileKeeperChatReceipts', () => {
     rejectOlder(new Error('stale network failure'))
     await olderReconciliation
 
-    expect(keeperThreads.value.echo?.[0]?.delivery).toBe('delivered')
+    const receiptEntry = keeperThreads.value.echo?.find(entry => (
+      entry.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))
+    expect(receiptEntry?.delivery).toBe('delivered')
     expect(keeperActionErrors.value.echo).toBeFalsy()
   })
 

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -252,6 +252,29 @@ describe('reconcileKeeperChatReceipts', () => {
     })
   })
 
+  it('fails closed instead of retrying forever when Delivered lacks outcome_ref', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+    })
+
+    await reconcileKeeperChatReceipts('echo')
+
+    const entry = keeperThreads.value.echo?.find(candidate => (
+      candidate.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))
+    expect(entry?.delivery).toBe('error')
+    expect(entry?.details?.queueCorrelationError).toBe('missing_outcome_ref')
+    expect(entry?.error).toContain('outcome_ref')
+    expect(keeperActionErrors.value.echo).toContain('outcome_ref')
+    expect(fetchKeeperChatHistory).not.toHaveBeenCalled()
+
+    await reconcileKeeperChatReceipts('echo')
+    expect(fetchKeeperChatHistory).not.toHaveBeenCalled()
+  })
+
   it('forces transcript convergence when only the terminal queue receipt is observed', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -9,6 +9,7 @@ const { invalidateDashboardCache, refreshDashboard } = vi.hoisted(() => ({
 const {
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
+  fetchKeeperChatReceipt,
   fetchQueuedKeeperMessageResult,
   isTerminalQueuedKeeperMessage,
   queuedKeeperMessageError,
@@ -17,6 +18,7 @@ const {
 } = vi.hoisted(() => ({
   cancelQueuedKeeperMessage: vi.fn(async () => undefined),
   fetchKeeperChatHistory: vi.fn(),
+  fetchKeeperChatReceipt: vi.fn(),
   fetchQueuedKeeperMessageResult: vi.fn(),
   isTerminalQueuedKeeperMessage: vi.fn((result: { status: string }) => (
     result.status === 'done'
@@ -40,6 +42,7 @@ vi.mock('./api/core', () => ({ runOperatorAction }))
 vi.mock('./api/keeper', () => ({
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
+  fetchKeeperChatReceipt,
   fetchQueuedKeeperMessageResult,
   isTerminalQueuedKeeperMessage,
   queuedKeeperMessageError,
@@ -76,6 +79,7 @@ import {
   loadFullKeeperHistory,
   noteKeeperChatAppended,
   probeKeeperRuntime,
+  reconcileKeeperChatReceipts,
   recoverKeeperRuntime,
   refreshActiveKeeperChatHistory,
   resumePendingKeeperChatRequests,
@@ -188,6 +192,188 @@ describe('noteKeeperChatAppended', () => {
     await vi.runAllTimersAsync()
 
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('reconcileKeeperChatReceipts', () => {
+  beforeEach(() => {
+    keeperThreads.value = {
+      echo: [
+        {
+          id: 'queued-reply-1',
+          role: 'assistant',
+          source: 'direct_assistant',
+          label: 'echo',
+          text: 'echo is busy; your message is queued.',
+          timestamp: null,
+          delivery: 'queued',
+          streamState: null,
+          details: {
+            queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+            queueRevision: 1,
+            queuePendingCount: 1,
+            queueInflightCount: 0,
+            queueState: 'pending',
+          },
+        },
+      ],
+    }
+    keeperActionErrors.value = {}
+    fetchKeeperChatReceipt.mockReset()
+  })
+
+  it('moves a busy ACK to delivered only after the durable terminal receipt', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+    })
+
+    await reconcileKeeperChatReceipts('echo')
+
+    const entry = keeperThreads.value.echo?.[0]
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.details?.queueState).toBe('delivered')
+    expect(entry?.streamContract).toMatchObject({
+      source: 'queue_poll',
+      status: 'queue_poll_result',
+      deliveryReceipt: 'server_durable_receipt',
+    })
+  })
+
+  it('surfaces a durable failed receipt on the queued chat row', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 5,
+      state: {
+        kind: 'failed',
+        failureKind: 'delivery_failed',
+        detail: 'Slack API rejected the terminal message',
+        completedAt: 43,
+        outcomeRef: null,
+      },
+    })
+
+    await reconcileKeeperChatReceipts('echo')
+
+    const entry = keeperThreads.value.echo?.[0]
+    expect(entry?.delivery).toBe('error')
+    expect(entry?.details?.queueState).toBe('failed')
+    expect(entry?.details?.queueFailureKind).toBe('delivery_failed')
+    expect(entry?.error).toContain('Slack API rejected')
+  })
+
+  it('does not let an older concurrent lookup regress a terminal receipt', async () => {
+    let resolveOlder!: (value: {
+      keeperName: string
+      receiptId: string
+      revision: number
+      state: { kind: 'pending' }
+    }) => void
+    let resolveNewer!: (value: {
+      keeperName: string
+      receiptId: string
+      revision: number
+      state: { kind: 'delivered'; completedAt: number; outcomeRef: null }
+    }) => void
+    const older = new Promise<Parameters<typeof resolveOlder>[0]>(resolve => {
+      resolveOlder = resolve
+    })
+    const newer = new Promise<Parameters<typeof resolveNewer>[0]>(resolve => {
+      resolveNewer = resolve
+    })
+    fetchKeeperChatReceipt
+      .mockReturnValueOnce(older)
+      .mockReturnValueOnce(newer)
+
+    const olderReconciliation = reconcileKeeperChatReceipts('echo')
+    const newerReconciliation = reconcileKeeperChatReceipts('echo')
+    resolveNewer({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 6,
+      state: { kind: 'delivered', completedAt: 44, outcomeRef: null },
+    })
+    await newerReconciliation
+    resolveOlder({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 5,
+      state: { kind: 'pending' },
+    })
+    await olderReconciliation
+
+    const entry = keeperThreads.value.echo?.[0]
+    expect(entry?.delivery).toBe('delivered')
+    expect(entry?.details?.queueRevision).toBe(6)
+    expect(entry?.details?.queueState).toBe('delivered')
+  })
+
+  it('clears a receipt lookup error after authoritative recovery', async () => {
+    fetchKeeperChatReceipt.mockRejectedValueOnce(new Error('temporary disconnect'))
+    await reconcileKeeperChatReceipts('echo')
+    expect(keeperActionErrors.value.echo).toContain('큐 receipt 조회 실패')
+
+    fetchKeeperChatReceipt.mockResolvedValueOnce({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 2,
+      state: { kind: 'pending' },
+    })
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(keeperActionErrors.value.echo).toBeFalsy()
+  })
+
+  it('ignores an older rejected lookup after a newer terminal success', async () => {
+    let rejectOlder!: (reason: Error) => void
+    let resolveNewer!: (value: {
+      keeperName: string
+      receiptId: string
+      revision: number
+      state: { kind: 'delivered'; completedAt: number; outcomeRef: null }
+    }) => void
+    const older = new Promise<never>((_resolve, reject) => {
+      rejectOlder = reject
+    })
+    const newer = new Promise<Parameters<typeof resolveNewer>[0]>(resolve => {
+      resolveNewer = resolve
+    })
+    fetchKeeperChatReceipt
+      .mockReturnValueOnce(older)
+      .mockReturnValueOnce(newer)
+
+    const olderReconciliation = reconcileKeeperChatReceipts('echo')
+    const newerReconciliation = reconcileKeeperChatReceipts('echo')
+    resolveNewer({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 7,
+      state: { kind: 'delivered', completedAt: 46, outcomeRef: null },
+    })
+    await newerReconciliation
+    rejectOlder(new Error('stale network failure'))
+    await olderReconciliation
+
+    expect(keeperThreads.value.echo?.[0]?.delivery).toBe('delivered')
+    expect(keeperActionErrors.value.echo).toBeFalsy()
+  })
+
+  it('reconciles visible receipts after reconnect history hydration', async () => {
+    _resetChatHydrationForTests()
+    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 3,
+      state: { kind: 'delivered', completedAt: 45, outcomeRef: null },
+    })
+
+    await hydrateKeeperChatHistory('echo', { force: true })
+
+    expect(keeperThreads.value.echo?.[0]?.delivery).toBe('delivered')
   })
 })
 
@@ -1035,6 +1221,92 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     // whole dashboard after every chat send (user-visible "refresh").
     expect(refreshDashboard).not.toHaveBeenCalled()
     expect(invalidateDashboardCache).not.toHaveBeenCalled()
+  })
+
+  it('keeps a busy server-accepted message queued after RUN_FINISHED', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'pending' },
+    })
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TEXT_MESSAGE_START' },
+      { type: 'TEXT_MESSAGE_CONTENT', delta: 'echo is busy; your message is queued.' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_CHAT_QUEUED',
+        value: {
+          keeper_name: 'echo',
+          status: 'queued',
+          receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+          queue_revision: 4,
+          pending_count: 1,
+          inflight_count: 0,
+        },
+      },
+      { type: 'TEXT_MESSAGE_END' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('queued')
+    expect(reply?.text).toContain('message is queued')
+    expect(reply?.details).toMatchObject({
+      queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      queueRevision: 4,
+      queuePendingCount: 1,
+      queueInflightCount: 0,
+    })
+    expect(fetchKeeperChatReceipt).toHaveBeenCalledWith(
+      'echo',
+      'chatq_00000000-0000-4000-8000-000000000001',
+    )
+  })
+
+  it('does not let the short ACK RUN_FINISHED overwrite a durable failed receipt', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000002',
+      revision: 5,
+      state: {
+        kind: 'failed',
+        failureKind: 'turn_failed',
+        detail: 'provider rejected the queued turn',
+        completedAt: 47,
+        outcomeRef: null,
+      },
+    })
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TEXT_MESSAGE_START' },
+      { type: 'TEXT_MESSAGE_CONTENT', delta: 'echo accepted the durable message.' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_CHAT_QUEUED',
+        value: {
+          keeper_name: 'echo',
+          status: 'queued',
+          receipt_id: 'chatq_00000000-0000-4000-8000-000000000002',
+          queue_revision: 4,
+          pending_count: 1,
+          inflight_count: 0,
+        },
+      },
+      { type: 'TEXT_MESSAGE_END' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+    await vi.waitFor(() => {
+      const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+      expect(reply?.delivery).toBe('error')
+      expect(reply?.details?.queueState).toBe('failed')
+      expect(reply?.error).toContain('provider rejected')
+    })
   })
 
   it('throttles stream heartbeat signal updates during dense event bursts', async () => {

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -195,6 +195,8 @@ describe('noteKeeperChatAppended', () => {
   })
 })
 
+const RECEIPT_TURN_REF = 'trace-queue#42'
+
 describe('reconcileKeeperChatReceipts', () => {
   beforeEach(() => {
     keeperThreads.value = {
@@ -230,12 +232,17 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 4,
-      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
+    fetchKeeperChatHistory.mockResolvedValue([
+      { role: 'assistant', content: 'delivered reply', ts: 1_780_000_000, turn_ref: RECEIPT_TURN_REF },
+    ])
 
     await reconcileKeeperChatReceipts('echo')
 
-    const entry = keeperThreads.value.echo?.[0]
+    const entry = keeperThreads.value.echo?.find(candidate => (
+      candidate.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))
     expect(entry?.delivery).toBe('delivered')
     expect(entry?.details?.queueState).toBe('delivered')
     expect(entry?.streamContract).toMatchObject({
@@ -250,10 +257,15 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 4,
-      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory.mockResolvedValue([
-      { role: 'assistant', content: 'reply recovered without append SSE', ts: 1_780_000_001 },
+      {
+        role: 'assistant',
+        content: 'reply recovered without append SSE',
+        ts: 1_780_000_001,
+        turn_ref: RECEIPT_TURN_REF,
+      },
     ])
 
     await reconcileKeeperChatReceipts('echo')
@@ -272,12 +284,17 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 4,
-      state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory
       .mockRejectedValueOnce(new Error('temporary history timeout'))
       .mockResolvedValueOnce([
-        { role: 'assistant', content: 'reply recovered on retry', ts: 1_780_000_002 },
+        {
+          role: 'assistant',
+          content: 'reply recovered on retry',
+          ts: 1_780_000_002,
+          turn_ref: RECEIPT_TURN_REF,
+        },
       ])
 
     await reconcileKeeperChatReceipts('echo')
@@ -295,6 +312,78 @@ describe('reconcileKeeperChatReceipts', () => {
     expect(keeperThreads.value.echo?.some(entry => (
       entry.text === 'reply recovered on retry'
     ))).toBe(true)
+    expect(keeperActionErrors.value.echo).toBeFalsy()
+  })
+
+  it('does not accept stale non-empty history for a newer terminal receipt', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
+    })
+    fetchKeeperChatHistory
+      .mockResolvedValueOnce([
+        { role: 'assistant', content: 'older reply', ts: 1_779_999_999, turn_ref: 'trace-old#41' },
+      ])
+      .mockResolvedValueOnce([
+        {
+          role: 'assistant',
+          content: 'exact terminal reply',
+          ts: 1_780_000_005,
+          turn_ref: RECEIPT_TURN_REF,
+        },
+      ])
+
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(keeperActionErrors.value.echo).toContain(`did not find turn_ref ${RECEIPT_TURN_REF}`)
+
+    await reconcileKeeperChatReceipts('echo')
+
+    expect(fetchKeeperChatReceipt).toHaveBeenCalledTimes(1)
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(2)
+    expect(keeperThreads.value.echo?.some(entry => (
+      entry.turnRef === RECEIPT_TURN_REF && entry.text === 'exact terminal reply'
+    ))).toBe(true)
+    expect(keeperActionErrors.value.echo).toBeFalsy()
+  })
+
+  it('shares one terminal transcript convergence fetch across overlapping polls', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 4,
+      state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
+    })
+    let resolveHistory!: (history: Array<{
+      role: string
+      content: string
+      ts: number
+      turn_ref: string
+    }>) => void
+    fetchKeeperChatHistory.mockReturnValue(new Promise(resolve => {
+      resolveHistory = resolve
+    }))
+
+    const firstPoll = reconcileKeeperChatReceipts('echo')
+    await vi.waitFor(() => expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1))
+    const overlappingPoll = reconcileKeeperChatReceipts('echo')
+    await Promise.resolve()
+
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
+
+    resolveHistory([
+      {
+        role: 'assistant',
+        content: 'one bounded convergence result',
+        ts: 1_780_000_006,
+        turn_ref: RECEIPT_TURN_REF,
+      },
+    ])
+    await Promise.all([firstPoll, overlappingPoll])
+
+    expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
     expect(keeperActionErrors.value.echo).toBeFalsy()
   })
 
@@ -332,7 +421,7 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: string
       receiptId: string
       revision: number
-      state: { kind: 'delivered'; completedAt: number; outcomeRef: null }
+      state: { kind: 'delivered'; completedAt: number; outcomeRef: string }
     }) => void
     const older = new Promise<Parameters<typeof resolveOlder>[0]>(resolve => {
       resolveOlder = resolve
@@ -350,7 +439,7 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 6,
-      state: { kind: 'delivered', completedAt: 44, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 44, outcomeRef: RECEIPT_TURN_REF },
     })
     await newerReconciliation
     resolveOlder({
@@ -385,14 +474,19 @@ describe('reconcileKeeperChatReceipts', () => {
 
   it('ignores an older rejected lookup after a newer terminal success', async () => {
     fetchKeeperChatHistory.mockResolvedValue([
-      { role: 'assistant', content: 'authoritative terminal reply', ts: 1_780_000_003 },
+      {
+        role: 'assistant',
+        content: 'authoritative terminal reply',
+        ts: 1_780_000_003,
+        turn_ref: RECEIPT_TURN_REF,
+      },
     ])
     let rejectOlder!: (reason: Error) => void
     let resolveNewer!: (value: {
       keeperName: string
       receiptId: string
       revision: number
-      state: { kind: 'delivered'; completedAt: number; outcomeRef: null }
+      state: { kind: 'delivered'; completedAt: number; outcomeRef: string }
     }) => void
     const older = new Promise<never>((_resolve, reject) => {
       rejectOlder = reject
@@ -410,7 +504,7 @@ describe('reconcileKeeperChatReceipts', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 7,
-      state: { kind: 'delivered', completedAt: 46, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 46, outcomeRef: RECEIPT_TURN_REF },
     })
     await newerReconciliation
     rejectOlder(new Error('stale network failure'))
@@ -425,17 +519,26 @@ describe('reconcileKeeperChatReceipts', () => {
 
   it('reconciles visible receipts after reconnect history hydration', async () => {
     _resetChatHydrationForTests()
-    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'assistant',
+        content: 'reconnected terminal reply',
+        ts: 1_780_000_004,
+        turn_ref: RECEIPT_TURN_REF,
+      },
+    ])
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 3,
-      state: { kind: 'delivered', completedAt: 45, outcomeRef: null },
+      state: { kind: 'delivered', completedAt: 45, outcomeRef: RECEIPT_TURN_REF },
     })
 
     await hydrateKeeperChatHistory('echo', { force: true })
 
-    expect(keeperThreads.value.echo?.[0]?.delivery).toBe('delivered')
+    expect(keeperThreads.value.echo?.find(entry => (
+      entry.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))?.delivery).toBe('delivered')
   })
 })
 

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -3,6 +3,7 @@ import { runOperatorAction } from './api/core'
 import {
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
+  fetchKeeperChatReceipt,
   fetchQueuedKeeperMessageResult,
   interruptKeeperTurn as apiInterruptKeeperTurn,
   isTerminalQueuedKeeperMessage,
@@ -299,10 +300,12 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
 // the merge are the fresher copy, and re-merging mid-session would
 // race the in-flight stream entries.
 const hydratedChatKeepers = new Set<string>()
+const keeperReceiptReconciliationGeneration = new Map<string, number>()
 
 /** Test-only: reset the once-per-keeper hydration guard. */
 export function _resetChatHydrationForTests(): void {
   hydratedChatKeepers.clear()
+  keeperReceiptReconciliationGeneration.clear()
 }
 
 /** Merge the server-persisted chat transcript
@@ -326,8 +329,9 @@ export async function hydrateKeeperChatHistory(
     // when chat history is empty so a keeper panel can still join recently
     // fetched tool rows from the rail/inspector.
     void hydrateKeeperToolOutputs(keeperName)
-    if (history.length === 0) return
-    mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
+    if (history.length > 0) {
+      mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
+    }
   } catch (err) {
     // Allow a later mount to retry instead of caching the failure.
     hydratedChatKeepers.delete(keeperName)
@@ -337,6 +341,7 @@ export async function hydrateKeeperChatHistory(
   } finally {
     setRecordValue(keeperHydrating, keeperName, false)
   }
+  await reconcileKeeperChatReceipts(keeperName)
 }
 
 // Match the visible chat history window. A keeper that calls many tools can
@@ -728,6 +733,127 @@ export async function resumePendingKeeperChatRequests(name: string): Promise<voi
   await Promise.all(pendingKeeperChatRequestsForKeeper(keeperName).map(resumePendingKeeperChatRequest))
 }
 
+/** Reconcile locally visible busy-ACK rows against the server's durable queue
+ * receipt ledger. Queue-change SSE is only an invalidation signal; this GET is
+ * the lifecycle truth for the exact receipt. */
+export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
+  const keeperName = name.trim()
+  if (!keeperName) return
+  const generation = (keeperReceiptReconciliationGeneration.get(keeperName) ?? 0) + 1
+  keeperReceiptReconciliationGeneration.set(keeperName, generation)
+  const queuedEntries = (keeperThreads.value[keeperName] ?? []).filter(entry => (
+    entry.role === 'assistant'
+    && entry.delivery === 'queued'
+    && Boolean(entry.details?.queueReceiptId)
+  ))
+  if (queuedEntries.length === 0) {
+    if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
+      setRecordValue(keeperActionErrors, keeperName, null)
+    }
+    return
+  }
+  const failures: string[] = []
+  await Promise.all(queuedEntries.map(async (entry) => {
+    const receiptId = entry.details?.queueReceiptId?.trim() ?? ''
+    if (!receiptId) return
+    try {
+      const receipt = await fetchKeeperChatReceipt(keeperName, receiptId)
+      if (receipt.keeperName !== keeperName || receipt.receiptId !== receiptId) {
+        throw new Error('receipt identity mismatch')
+      }
+      const currentEntry = (keeperThreads.value[keeperName] ?? [])
+        .find(candidate => candidate.id === entry.id)
+      if (!currentEntry || currentEntry.details?.queueReceiptId !== receiptId) return
+      const currentRevision = currentEntry.details.queueRevision
+      const currentState = currentEntry.details.queueState
+      if (typeof currentRevision === 'number' && receipt.revision < currentRevision) {
+        return
+      }
+      if (
+        typeof currentRevision === 'number'
+        && receipt.revision === currentRevision
+        && currentState
+        && currentState !== receipt.state.kind
+      ) {
+        throw new Error(
+          `receipt lifecycle conflict at revision ${receipt.revision}: ${currentState} -> ${receipt.state.kind}`,
+        )
+      }
+      if (
+        (currentState === 'delivered' || currentState === 'failed')
+        && currentState !== receipt.state.kind
+      ) {
+        throw new Error(
+          `terminal receipt lifecycle regressed at revision ${receipt.revision}: ${currentState} -> ${receipt.state.kind}`,
+        )
+      }
+      const details = {
+        ...(entry.details ?? {}),
+        queueRevision: receipt.revision,
+        queueState: receipt.state.kind,
+        queueFailureKind:
+          receipt.state.kind === 'failed' ? receipt.state.failureKind : null,
+      }
+      const streamContract = keeperStreamContract('queue_poll', 'queue_poll_result', {
+        deliveryReceipt: 'server_durable_receipt',
+        reason: `receipt ${receiptId} is ${receipt.state.kind}`,
+      })
+      switch (receipt.state.kind) {
+        case 'pending':
+        case 'inflight':
+          finalizeAssistantEntry(keeperName, entry.id, {
+            delivery: 'queued',
+            streamState: null,
+            details,
+            streamContract,
+          })
+          break
+        case 'delivered':
+          finalizeAssistantEntry(keeperName, entry.id, {
+            delivery: 'delivered',
+            streamState: null,
+            details,
+            error: null,
+            streamContract,
+          })
+          break
+        case 'failed':
+          finalizeAssistantEntry(keeperName, entry.id, {
+            delivery: 'error',
+            streamState: null,
+            details,
+            error: `큐 처리 실패 (${receipt.state.failureKind}): ${receipt.state.detail}`,
+            streamContract,
+          })
+          break
+      }
+    } catch (err) {
+      failures.push(
+        `${receiptId}: ${err instanceof Error ? err.message : 'receipt lookup failed'}`,
+      )
+    }
+  }))
+  const stillQueued = (keeperThreads.value[keeperName] ?? []).some(entry => (
+    entry.role === 'assistant'
+    && entry.delivery === 'queued'
+    && Boolean(entry.details?.queueReceiptId)
+  ))
+  if (!stillQueued) {
+    if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
+      setRecordValue(keeperActionErrors, keeperName, null)
+    }
+    return
+  }
+  if (keeperReceiptReconciliationGeneration.get(keeperName) !== generation) return
+  if (failures.length > 0) {
+    const message = `큐 receipt 조회 실패: ${failures.join('; ')}`
+    setRecordValue(keeperActionErrors, keeperName, message)
+    console.warn(`[keeper] ${message}`)
+  } else if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
+    setRecordValue(keeperActionErrors, keeperName, null)
+  }
+}
+
 /** React to a server `keeper_chat_appended` push: re-merge the
  *  persisted transcript so messages arriving through other connectors
  *  (Discord, Slack, agent MCP) appear without a page reload.
@@ -775,7 +901,9 @@ export function noteKeeperChatAppended(name: string, audio?: unknown, _blocks?: 
   if (pending) clearTimeout(pending)
   chatRefreshTimers.set(keeperName, setTimeout(() => {
     chatRefreshTimers.delete(keeperName)
-    void hydrateKeeperChatHistory(keeperName, { force: true })
+    void (async () => {
+      await hydrateKeeperChatHistory(keeperName, { force: true })
+    })()
   }, CHAT_APPENDED_REFRESH_DELAY_MS))
 }
 
@@ -1069,7 +1197,7 @@ export async function sendKeeperThreadMessage(
     }
 
     const finalDelivery =
-      !finalText && finalEntry?.delivery === 'queued'
+      finalEntry?.delivery === 'queued'
         ? 'queued' as KeeperConversationDelivery
         : 'delivered' as KeeperConversationDelivery
     if (!finalText && finalDelivery !== 'queued' && !toolCallEnded) {
@@ -1111,6 +1239,9 @@ export async function sendKeeperThreadMessage(
     if (requestId) {
       removePendingKeeperChatRequest(requestId)
       releaseActiveStreamRequestId(requestId)
+    }
+    if (finalDelivery === 'queued') {
+      void reconcileKeeperChatReceipts(keeperName)
     }
   } catch (err) {
     flushPendingKeeperStreamDeltas(keeperName, assistantId)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -753,6 +753,7 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
     return
   }
   const failures: string[] = []
+  let terminalReceiptObserved = false
   await Promise.all(queuedEntries.map(async (entry) => {
     const receiptId = entry.details?.queueReceiptId?.trim() ?? ''
     if (!receiptId) return
@@ -809,6 +810,8 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'delivered':
+          terminalReceiptObserved = terminalReceiptObserved
+            || (currentState !== 'delivered' && currentState !== 'failed')
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'delivered',
             streamState: null,
@@ -818,6 +821,8 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'failed':
+          terminalReceiptObserved = terminalReceiptObserved
+            || (currentState !== 'delivered' && currentState !== 'failed')
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'error',
             streamState: null,
@@ -833,6 +838,15 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
       )
     }
   }))
+  if (
+    terminalReceiptObserved
+    && keeperReceiptReconciliationGeneration.get(keeperName) === generation
+  ) {
+    // Receipt settlement and transcript persistence are separate projections.
+    // Force one merge here so a dropped keeper_chat_appended invalidation cannot
+    // leave the terminal ACK visible without the final assistant message.
+    await hydrateKeeperChatHistory(keeperName, { force: true })
+  }
   const stillQueued = (keeperThreads.value[keeperName] ?? []).some(entry => (
     entry.role === 'assistant'
     && entry.delivery === 'queued'

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -301,21 +301,66 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
 // race the in-flight stream entries.
 const hydratedChatKeepers = new Set<string>()
 const keeperReceiptReconciliationGeneration = new Map<string, number>()
-const pendingTerminalTranscriptConvergence = new Map<string, Set<string>>()
+const pendingTerminalTranscriptConvergence = new Map<string, Map<string, string | null>>()
+const terminalTranscriptConvergenceFlights = new Map<string, Promise<string[]>>()
 
 /** Test-only: reset the once-per-keeper hydration guard. */
 export function _resetChatHydrationForTests(): void {
   hydratedChatKeepers.clear()
   keeperReceiptReconciliationGeneration.clear()
   pendingTerminalTranscriptConvergence.clear()
+  terminalTranscriptConvergenceFlights.clear()
 }
 
-async function fetchAndMergeKeeperChatHistory(keeperName: string): Promise<number> {
+async function fetchAndMergeKeeperChatHistory(keeperName: string): Promise<Set<string>> {
   const history = await fetchKeeperChatHistory(keeperName)
   if (history.length > 0) {
     mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
   }
-  return history.filter(message => message.role === 'assistant').length
+  return new Set(history.flatMap(message => (
+    message.role === 'assistant' && message.turn_ref?.trim()
+      ? [message.turn_ref.trim()]
+      : []
+  )))
+}
+
+async function convergeTerminalTranscript(keeperName: string): Promise<string[]> {
+  const existing = terminalTranscriptConvergenceFlights.get(keeperName)
+  if (existing) return existing
+  const flight = (async (): Promise<string[]> => {
+    const targets = new Map(pendingTerminalTranscriptConvergence.get(keeperName) ?? [])
+    if (targets.size === 0) return []
+    try {
+      const assistantTurnRefs = await fetchAndMergeKeeperChatHistory(keeperName)
+      const current = pendingTerminalTranscriptConvergence.get(keeperName)
+      const failures: string[] = []
+      for (const [receiptId, outcomeRef] of targets) {
+        if (outcomeRef && assistantTurnRefs.has(outcomeRef)) {
+          current?.delete(receiptId)
+        } else if (!outcomeRef) {
+          failures.push(`transcript convergence for ${receiptId} has no outcome_ref`)
+        } else {
+          failures.push(
+            `transcript convergence for ${receiptId} did not find turn_ref ${outcomeRef}`,
+          )
+        }
+      }
+      if (current?.size === 0) pendingTerminalTranscriptConvergence.delete(keeperName)
+      return failures
+    } catch (err) {
+      return [
+        `transcript convergence for ${[...targets.keys()].join(', ')}: ${err instanceof Error ? err.message : 'history lookup failed'}`,
+      ]
+    }
+  })()
+  terminalTranscriptConvergenceFlights.set(keeperName, flight)
+  try {
+    return await flight
+  } finally {
+    if (terminalTranscriptConvergenceFlights.get(keeperName) === flight) {
+      terminalTranscriptConvergenceFlights.delete(keeperName)
+    }
+  }
 }
 
 /** Merge the server-persisted chat transcript
@@ -818,10 +863,10 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           break
         case 'delivered':
           if (currentState !== 'delivered' && currentState !== 'failed') {
-            const receiptIds = pendingTerminalTranscriptConvergence.get(keeperName)
-              ?? new Set<string>()
-            receiptIds.add(receiptId)
-            pendingTerminalTranscriptConvergence.set(keeperName, receiptIds)
+            const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
+              ?? new Map<string, string | null>()
+            receiptTargets.set(receiptId, receipt.state.outcomeRef)
+            pendingTerminalTranscriptConvergence.set(keeperName, receiptTargets)
           }
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'delivered',
@@ -832,6 +877,16 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'failed':
+          if (
+            receipt.state.outcomeRef
+            && currentState !== 'delivered'
+            && currentState !== 'failed'
+          ) {
+            const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
+              ?? new Map<string, string | null>()
+            receiptTargets.set(receiptId, receipt.state.outcomeRef)
+            pendingTerminalTranscriptConvergence.set(keeperName, receiptTargets)
+          }
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'error',
             streamState: null,
@@ -847,32 +902,18 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
       )
     }
   }))
-  const receiptIdsAwaitingTranscript = pendingTerminalTranscriptConvergence.get(keeperName)
+  const receiptsAwaitingTranscript = pendingTerminalTranscriptConvergence.get(keeperName)
   if (
-    receiptIdsAwaitingTranscript
-    && receiptIdsAwaitingTranscript.size > 0
+    receiptsAwaitingTranscript
+    && receiptsAwaitingTranscript.size > 0
     && keeperReceiptReconciliationGeneration.get(keeperName) === generation
   ) {
     // Receipt settlement and transcript persistence are separate projections.
-    // Keep this work pending until a bounded, authoritative history fetch sees
-    // an assistant row. A failed/empty fetch is retried by the next visible
-    // receipt poll even though the local ACK row is already terminal.
-    try {
-      const assistantCount = await fetchAndMergeKeeperChatHistory(keeperName)
-      if (assistantCount > 0) {
-        if (keeperReceiptReconciliationGeneration.get(keeperName) === generation) {
-          pendingTerminalTranscriptConvergence.delete(keeperName)
-        }
-      } else {
-        failures.push(
-          `transcript convergence for ${[...receiptIdsAwaitingTranscript].join(', ')} returned no assistant rows`,
-        )
-      }
-    } catch (err) {
-      failures.push(
-        `transcript convergence for ${[...receiptIdsAwaitingTranscript].join(', ')}: ${err instanceof Error ? err.message : 'history lookup failed'}`,
-      )
-    }
+    // The receipt outcome_ref is the exact turn_ref persisted on the assistant
+    // row. Keep retrying until that identity appears; old non-empty history can
+    // never satisfy a newer receipt. One in-flight fetch per Keeper prevents a
+    // stalled response body from multiplying on each visible poll.
+    failures.push(...await convergeTerminalTranscript(keeperName))
   }
   const stillQueued = (keeperThreads.value[keeperName] ?? []).some(entry => (
     entry.role === 'assistant'

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -301,11 +301,21 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
 // race the in-flight stream entries.
 const hydratedChatKeepers = new Set<string>()
 const keeperReceiptReconciliationGeneration = new Map<string, number>()
+const pendingTerminalTranscriptConvergence = new Map<string, Set<string>>()
 
 /** Test-only: reset the once-per-keeper hydration guard. */
 export function _resetChatHydrationForTests(): void {
   hydratedChatKeepers.clear()
   keeperReceiptReconciliationGeneration.clear()
+  pendingTerminalTranscriptConvergence.clear()
+}
+
+async function fetchAndMergeKeeperChatHistory(keeperName: string): Promise<number> {
+  const history = await fetchKeeperChatHistory(keeperName)
+  if (history.length > 0) {
+    mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
+  }
+  return history.filter(message => message.role === 'assistant').length
 }
 
 /** Merge the server-persisted chat transcript
@@ -324,14 +334,11 @@ export async function hydrateKeeperChatHistory(
   hydratedChatKeepers.add(keeperName)
   setRecordValue(keeperHydrating, keeperName, true)
   try {
-    const history = await fetchKeeperChatHistory(keeperName)
+    await fetchAndMergeKeeperChatHistory(keeperName)
     // Tool outputs are stored on a separate durable endpoint. Hydrate even
     // when chat history is empty so a keeper panel can still join recently
     // fetched tool rows from the rail/inspector.
     void hydrateKeeperToolOutputs(keeperName)
-    if (history.length > 0) {
-      mergeServerHistoryEntries(keeperName, chatHistoryEntriesFromRest(keeperName, history))
-    }
   } catch (err) {
     // Allow a later mount to retry instead of caching the failure.
     hydratedChatKeepers.delete(keeperName)
@@ -746,14 +753,14 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
     && entry.delivery === 'queued'
     && Boolean(entry.details?.queueReceiptId)
   ))
-  if (queuedEntries.length === 0) {
+  const pendingConvergence = pendingTerminalTranscriptConvergence.get(keeperName)
+  if (queuedEntries.length === 0 && (!pendingConvergence || pendingConvergence.size === 0)) {
     if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
       setRecordValue(keeperActionErrors, keeperName, null)
     }
     return
   }
   const failures: string[] = []
-  let terminalReceiptObserved = false
   await Promise.all(queuedEntries.map(async (entry) => {
     const receiptId = entry.details?.queueReceiptId?.trim() ?? ''
     if (!receiptId) return
@@ -810,8 +817,12 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'delivered':
-          terminalReceiptObserved = terminalReceiptObserved
-            || (currentState !== 'delivered' && currentState !== 'failed')
+          if (currentState !== 'delivered' && currentState !== 'failed') {
+            const receiptIds = pendingTerminalTranscriptConvergence.get(keeperName)
+              ?? new Set<string>()
+            receiptIds.add(receiptId)
+            pendingTerminalTranscriptConvergence.set(keeperName, receiptIds)
+          }
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'delivered',
             streamState: null,
@@ -821,8 +832,6 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'failed':
-          terminalReceiptObserved = terminalReceiptObserved
-            || (currentState !== 'delivered' && currentState !== 'failed')
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'error',
             streamState: null,
@@ -838,21 +847,42 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
       )
     }
   }))
+  const receiptIdsAwaitingTranscript = pendingTerminalTranscriptConvergence.get(keeperName)
   if (
-    terminalReceiptObserved
+    receiptIdsAwaitingTranscript
+    && receiptIdsAwaitingTranscript.size > 0
     && keeperReceiptReconciliationGeneration.get(keeperName) === generation
   ) {
     // Receipt settlement and transcript persistence are separate projections.
-    // Force one merge here so a dropped keeper_chat_appended invalidation cannot
-    // leave the terminal ACK visible without the final assistant message.
-    await hydrateKeeperChatHistory(keeperName, { force: true })
+    // Keep this work pending until a bounded, authoritative history fetch sees
+    // an assistant row. A failed/empty fetch is retried by the next visible
+    // receipt poll even though the local ACK row is already terminal.
+    try {
+      const assistantCount = await fetchAndMergeKeeperChatHistory(keeperName)
+      if (assistantCount > 0) {
+        if (keeperReceiptReconciliationGeneration.get(keeperName) === generation) {
+          pendingTerminalTranscriptConvergence.delete(keeperName)
+        }
+      } else {
+        failures.push(
+          `transcript convergence for ${[...receiptIdsAwaitingTranscript].join(', ')} returned no assistant rows`,
+        )
+      }
+    } catch (err) {
+      failures.push(
+        `transcript convergence for ${[...receiptIdsAwaitingTranscript].join(', ')}: ${err instanceof Error ? err.message : 'history lookup failed'}`,
+      )
+    }
   }
   const stillQueued = (keeperThreads.value[keeperName] ?? []).some(entry => (
     entry.role === 'assistant'
     && entry.delivery === 'queued'
     && Boolean(entry.details?.queueReceiptId)
   ))
-  if (!stillQueued) {
+  const stillAwaitingTranscript = (
+    pendingTerminalTranscriptConvergence.get(keeperName)?.size ?? 0
+  ) > 0
+  if (!stillQueued && !stillAwaitingTranscript) {
     if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
       setRecordValue(keeperActionErrors, keeperName, null)
     }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -862,11 +862,35 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
           })
           break
         case 'delivered':
-          if (currentState !== 'delivered' && currentState !== 'failed') {
-            const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
-              ?? new Map<string, string | null>()
-            receiptTargets.set(receiptId, receipt.state.outcomeRef)
-            pendingTerminalTranscriptConvergence.set(keeperName, receiptTargets)
+          {
+            const outcomeRef = receipt.state.outcomeRef?.trim() ?? ''
+            if (!outcomeRef) {
+              const correlationError =
+                '큐 처리 결과 무결성 오류: Delivered receipt에 outcome_ref가 없습니다.'
+              const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
+              receiptTargets?.delete(receiptId)
+              if (receiptTargets?.size === 0) {
+                pendingTerminalTranscriptConvergence.delete(keeperName)
+              }
+              setRecordValue(keeperActionErrors, keeperName, correlationError)
+              finalizeAssistantEntry(keeperName, entry.id, {
+                delivery: 'error',
+                streamState: null,
+                details: {
+                  ...details,
+                  queueCorrelationError: 'missing_outcome_ref',
+                },
+                error: correlationError,
+                streamContract,
+              })
+              break
+            }
+            if (currentState !== 'delivered' && currentState !== 'failed') {
+              const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
+                ?? new Map<string, string | null>()
+              receiptTargets.set(receiptId, outcomeRef)
+              pendingTerminalTranscriptConvergence.set(keeperName, receiptTargets)
+            }
           }
           finalizeAssistantEntry(keeperName, entry.id, {
             delivery: 'delivered',

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -28,5 +28,6 @@ export {
   sendKeeperThreadMessage,
   isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
+  reconcileKeeperChatReceipts,
   recoverKeeperRuntime,
 } from './keeper-actions'

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1368,7 +1368,13 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
       // must survive history merges until they finalize. Otherwise a queued
       // assistant with empty text can be mistaken for an older empty-text
       // history row and dropped, making the queued reply look like an error.
-      const shouldKeepLocalEntry = isInFlightDelivery(entry.delivery) || !coveredByHistory
+      // A terminal durable-receipt observation is also operator evidence, not
+      // a duplicate assistant reply: keep it alongside the canonical history
+      // row so its Pending/Inflight/Delivered/Failed lifecycle remains visible.
+      const isReceiptObservation = Boolean(entry.details?.queueReceiptId)
+      const shouldKeepLocalEntry = isInFlightDelivery(entry.delivery)
+        || isReceiptObservation
+        || !coveredByHistory
       return entry.delivery !== 'history' && !isCoveredToolRow && shouldKeepLocalEntry
     },
   )

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -91,6 +91,70 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamContract?.deliveryReceipt).toBe('client_observed_sse_event')
   })
 
+  it('retains the durable receipt when a busy chat message enters the server queue', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: {
+        keeper_name: 'sangsu',
+        status: 'queued',
+        receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
+        queue_revision: 12,
+        pending_count: 3,
+        inflight_count: 1,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.delivery).toBe('queued')
+    expect(entry?.streamState).toBeNull()
+    expect(entry?.details).toMatchObject({
+      queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000007',
+      queueRevision: 12,
+      queuePendingCount: 3,
+      queueInflightCount: 1,
+    })
+    expect(entry?.streamContract).toMatchObject({
+      source: 'queue_event',
+      eventName: 'KEEPER_CHAT_QUEUED',
+      deliveryReceipt: 'client_observed_sse_event',
+    })
+  })
+
+  it('rejects a busy queue acceptance event without a durable receipt', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: { status: 'queued', pending_count: 1, inflight_count: 0 },
+    })).toBe('Keeper queue acceptance is missing its durable receipt metadata.')
+  })
+
+  it('rejects malformed or partial durable queue acceptance metadata', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: {
+        receipt_id: 'not-a-chat-receipt',
+        queue_revision: 1,
+        pending_count: 1,
+        inflight_count: 0,
+      },
+    })).toBe('Keeper queue acceptance is missing its durable receipt metadata.')
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: {
+        receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
+        pending_count: 1,
+        inflight_count: 0,
+      },
+    })).toBe('Keeper queue acceptance is missing its durable receipt metadata.')
+  })
+
   it('surfaces failed request terminal events before stream error close', () => {
     assistantEntry()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -34,6 +34,7 @@ import { isRecord, asNumber, asString } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
 import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
 import { updatePendingKeeperChatAssistantDraft } from './keeper-chat-pending'
+import { isKeeperChatReceiptId } from './lib/keeper-chat-receipt'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
@@ -647,6 +648,46 @@ export function applyKeeperStreamEvent(
           'queued',
           keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', { eventName: 'KEEPER_QUEUE_REQUEST' }),
         )
+        return null
+      }
+      if (event.name === 'KEEPER_CHAT_QUEUED') {
+        flushPendingThinkingDeltas(keeperName, assistantEntryId)
+        const queued = isRecord(event.value) ? event.value : null
+        const receiptId = asString(queued?.receipt_id, '').trim()
+        const revision = asNumber(queued?.queue_revision)
+        const pendingCount = asNumber(queued?.pending_count)
+        const inflightCount = asNumber(queued?.inflight_count)
+        if (
+          !isKeeperChatReceiptId(receiptId)
+          || typeof revision !== 'number'
+          || !Number.isSafeInteger(revision)
+          || revision < 0
+          || typeof pendingCount !== 'number'
+          || !Number.isSafeInteger(pendingCount)
+          || pendingCount < 1
+          || typeof inflightCount !== 'number'
+          || !Number.isSafeInteger(inflightCount)
+          || inflightCount < 0
+        ) {
+          return 'Keeper queue acceptance is missing its durable receipt metadata.'
+        }
+        updateThreadEntry(keeperName, assistantEntryId, entry => ({
+          ...entry,
+          delivery: 'queued',
+          streamState: null,
+          details: {
+            ...(entry.details ?? {}),
+            queueReceiptId: receiptId,
+            queueRevision: revision,
+            queuePendingCount: pendingCount,
+            queueInflightCount: inflightCount,
+            queueState: 'pending',
+          },
+          streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
+            eventName: 'KEEPER_CHAT_QUEUED',
+            reason: `durable receipt ${receiptId}`,
+          }),
+        }))
         return null
       }
       if (event.name === 'KEEPER_CONTINUATION_CHECKPOINT') {

--- a/dashboard/src/lib/keeper-chat-receipt.ts
+++ b/dashboard/src/lib/keeper-chat-receipt.ts
@@ -1,0 +1,6 @@
+const KEEPER_CHAT_RECEIPT_ID_PATTERN =
+  /^chatq_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function isKeeperChatReceiptId(value: string): boolean {
+  return KEEPER_CHAT_RECEIPT_ID_PATTERN.test(value)
+}

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -208,6 +208,30 @@ describe('SSEMessageSchema', () => {
     })
     expect(r.success).toBe(false)
   })
+
+  it('accepts a typed Keeper chat-queue projection invalidation', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'keeper_chat_queue_changed',
+      keeper_name: 'keeper-1',
+      revision: 7,
+      ts_unix: 1_712_000_000,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it.each([
+    { type: 'keeper_chat_queue_changed', revision: 7 },
+    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1' },
+    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1', revision: -1 },
+    { type: 'keeper_chat_queue_changed', keeper_name: 'keeper-1', revision: 1.5 },
+    {
+      type: 'keeper_chat_queue_changed',
+      keeper_name: 'keeper-1',
+      revision: Number.MAX_SAFE_INTEGER + 1,
+    },
+  ])('rejects an incomplete Keeper chat-queue invalidation: %o', value => {
+    expect(SSEMessageSchema.safeParse(value).success).toBe(false)
+  })
 })
 
 describe('parseSSEMessage', () => {

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -57,6 +57,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'keeper_phase_changed',
   'keeper_composite_changed',
   'keeper_chat_appended',
+  'keeper_chat_queue_changed',
   'keeper_tool_call',
   'masc/keeper_tool_call',
   'keeper_tool_skipped',
@@ -143,6 +144,7 @@ const NUMBER_FIELDS = new Set([
   'before_tokens',
   'after_tokens',
   'saved_tokens',
+  'revision',
   'duration_ms',
   'turn',
   'input_tokens',
@@ -312,6 +314,15 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
   }
   if (value.audio != null && !isSSEAudioClip(value.audio)) {
     return fail('audio', 'Expected audio clip object')
+  }
+
+  if (value.type === 'keeper_chat_queue_changed') {
+    if (typeof value.keeper_name !== 'string' || value.keeper_name.trim() === '') {
+      return fail('keeper_name', 'Expected non-empty keeper_name')
+    }
+    if (!Number.isSafeInteger(value.revision) || (value.revision as number) < 0) {
+      return fail('revision', 'Expected exact non-negative integer revision')
+    }
   }
 
   return ok(value as unknown as SSEMessage)

--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -37,6 +37,7 @@ const BACKEND_EMITTED: Record<string, string> = {
   execution_snapshot: '../lib/server/server_dashboard_http_execution_surfaces.ml',
   governance_param_changed: '../lib/server/server_routes_http_routes_activity.ml',
   keeper_chat_appended: '../lib/keeper/keeper_chat_broadcast.ml',
+  keeper_chat_queue_changed: '../lib/keeper/keeper_chat_broadcast.ml',
   keeper_composite_changed: '../lib/server/server_mcp_transport_ws.ml',
   keeper_heartbeat: '../lib/keeper/keeper_heartbeat_snapshot.ml',
   keeper_turn_complete: '../lib/keeper/keeper_hooks_oas.ml',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -46,6 +46,7 @@ const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
 const hydrateGoalLoopSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
 const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown, blocks?: unknown) => void>()
 const refreshActiveKeeperChatHistory = vi.fn<(opts?: { force?: boolean }) => void>()
+const reconcileKeeperChatReceipts = vi.fn<(name: string) => Promise<void>>(async () => {})
 
 async function flushAsyncWork(): Promise<void> {
   await vi.dynamicImportSettled()
@@ -102,6 +103,7 @@ async function loadSseStore() {
   }))
   vi.doMock('./keeper-runtime', () => ({
     noteKeeperChatAppended,
+    reconcileKeeperChatReceipts,
     refreshActiveKeeperChatHistory,
   }))
   vi.doMock('./router', () => ({ route }))
@@ -134,6 +136,8 @@ describe('setupSSEReaction reconnect hydration', () => {
     replayOasRuntimeTelemetry.mockClear()
     replayOasRuntimeTelemetry.mockResolvedValue(undefined)
     refreshActiveKeeperChatHistory.mockReset()
+    reconcileKeeperChatReceipts.mockReset()
+    reconcileKeeperChatReceipts.mockResolvedValue(undefined)
     hydrateFleetCompositeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockReturnValue(true)
@@ -530,6 +534,29 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(noteKeeperChatAppended).toHaveBeenCalledWith('echo', undefined, undefined)
+  })
+
+  it('invalidates the authoritative Keeper chat-queue projection once per burst', async () => {
+    const { sseStore } = await loadSseStore()
+    const refreshQueue = vi.fn()
+    sseStore.registerKeeperChatQueueRefresh(refreshQueue)
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_chat_queue_changed',
+      keeper_name: 'echo',
+      revision: 4,
+    })
+    sseStore.routeServerPushEvent({
+      type: 'keeper_chat_queue_changed',
+      keeper_name: 'echo',
+      revision: 5,
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshQueue).toHaveBeenCalledTimes(1)
+    expect(reconcileKeeperChatReceipts).toHaveBeenCalledTimes(1)
+    expect(reconcileKeeperChatReceipts).toHaveBeenCalledWith('echo')
   })
 
   it('forwards RFC-0235 audio clips on keeper_chat_appended to the chat handler', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -98,6 +98,16 @@ export function registerKeeperTurnRefresh(fn: (keeperName: string) => void): voi
   _keeperTurnRefreshFn = fn
 }
 
+// The tools payload owns the Keeper waiting/receipt projection. Queue SSE is
+// deliberately an invalidation signal, so the tools resource registers its
+// authoritative re-read here instead of this transport layer importing a UI
+// store or reconstructing Pending/Inflight state from event deltas.
+let _refreshKeeperChatQueueFn: (() => void) | null = null
+const pendingKeeperChatQueueRefreshNames = new Set<string>()
+export function registerKeeperChatQueueRefresh(fn: () => void): void {
+  _refreshKeeperChatQueueFn = fn
+}
+
 const _refreshActivityFns = new Set<() => void>()
 export function registerActivityRefresh(fn: () => void): () => void {
   _refreshActivityFns.add(fn)
@@ -646,6 +656,31 @@ export function hydrateServerPushEvent(event: SSEEvent): boolean {
           console.debug('[SSE] keeper chat refresh unavailable', err instanceof Error ? err.message : '')
         })
     }
+    return true
+  }
+
+  if (event.type === 'keeper_chat_queue_changed') {
+    const keeperName = event.keeper_name?.trim() ?? ''
+    if (keeperName) pendingKeeperChatQueueRefreshNames.add(keeperName)
+    scheduleRefresh(
+      'keeper_chat_queue',
+      () => {
+        const keeperNames = Array.from(pendingKeeperChatQueueRefreshNames)
+        pendingKeeperChatQueueRefreshNames.clear()
+        _refreshKeeperChatQueueFn?.()
+        void import('./keeper-runtime')
+          .then(mod => Promise.all(
+            keeperNames.map(name => mod.reconcileKeeperChatReceipts(name)),
+          ))
+          .catch(err => {
+            console.warn(
+              '[SSE] keeper chat receipt reconciliation unavailable',
+              err instanceof Error ? err.message : err,
+            )
+          })
+      },
+      SSE_KEEPER_THREAD_DEBOUNCE_MS,
+    )
     return true
   }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -806,6 +806,7 @@ export interface KeeperConversationDetails {
   queueInflightCount?: number | null
   queueState?: KeeperQueueReceiptLifecycle | null
   queueFailureKind?: KeeperQueueReceiptFailureKind | null
+  queueCorrelationError?: 'missing_outcome_ref' | null
   rawPayload?: unknown
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -768,6 +768,22 @@ export type KeeperTurnOutcome =
   | 'continuation_checkpoint'
   | 'no_visible_reply'
 
+export type KeeperQueueReceiptLifecycle =
+  | 'pending'
+  | 'inflight'
+  | 'delivered'
+  | 'failed'
+
+export type KeeperQueueReceiptFailureKind =
+  | 'turn_failed'
+  | 'timed_out'
+  | 'no_visible_reply'
+  | 'transcript_persist_failed'
+  | 'connector_unavailable'
+  | 'delivery_failed'
+  | 'cancelled'
+  | 'internal_error'
+
 export interface KeeperConversationDetails {
   traceId?: string | null
   turnRef?: string | null
@@ -782,6 +798,14 @@ export interface KeeperConversationDetails {
   skillReason?: string | null
   replyText?: string | null
   turnOutcome?: KeeperTurnOutcome | null
+  /** Durable server receipt for a busy chat message accepted into the Keeper
+   * queue. This is distinct from the browser-local draft queue. */
+  queueReceiptId?: string | null
+  queueRevision?: number | null
+  queuePendingCount?: number | null
+  queueInflightCount?: number | null
+  queueState?: KeeperQueueReceiptLifecycle | null
+  queueFailureKind?: KeeperQueueReceiptFailureKind | null
   rawPayload?: unknown
 }
 
@@ -959,6 +983,7 @@ export type KeeperConversationStreamContractStatus =
 
 export type KeeperConversationStreamDeliveryReceipt =
   | 'client_observed_sse_event'
+  | 'server_durable_receipt'
   | 'server_lifecycle_replay_only'
   | 'no_delivery_receipt'
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -33,6 +33,7 @@ export type SSEEventType =
   | 'keeper_phase_changed'
   | 'keeper_composite_changed'
   | 'keeper_chat_appended'
+  | 'keeper_chat_queue_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
   | 'keeper_tool_skipped'
@@ -178,6 +179,10 @@ export interface SSEEvent {
   before_tokens?: number
   after_tokens?: number
   saved_tokens?: number
+  // Durable Keeper chat-queue projection invalidation. The event does not
+  // carry lifecycle truth; consumers re-read the receipt projection at this
+  // exact revision instead of reconstructing queue state from deltas.
+  revision?: number
   trigger?: string
   runtime?: string
   reason?: string

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -205,6 +205,14 @@ reconnect hydration, and a visible-panel safety poll provide catch-up when the
 queue invalidation arrives before the stream acknowledgement or is missed during
 a disconnect.
 
+A delivered receipt's `outcome_ref` is the exact `turn_ref` persisted on its
+assistant transcript row. Terminal transcript convergence is complete only when
+the bounded history read contains that identity; an older non-empty history
+window is not success. The history and receipt deadlines cover response-body
+parsing as well as response headers, and the Dashboard permits only one terminal
+convergence read per Keeper at a time. Failed, empty, stale, or timed-out reads
+remain pending for the next visible-panel poll.
+
 ### 6.2 Authoritative queue projection
 
 `Server_keeper_waiting_inventory` exposes separate

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0203", "0217", "0223", "0225", "0226", "0232", "masc#23925"]
-implementation_prs: []
+implementation_prs: [24139]
 ---
 
 # RFC: Durable Keeper chat receipts and connector delivery settlement

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -171,6 +171,13 @@ The autonomous lane yields while the Keeper has either pending or inflight chat
 receipts. Leasing must not create a race window in which an autonomous turn can
 overtake the queued chat turn.
 
+Direct Dashboard and connector turns use non-blocking admission. Route-level
+queue observations are only fast paths: after acquiring the Keeper turn slot,
+the admission boundary rereads parked waiters and active durable receipts before
+running the turn. A receipt committed or leased before that post-lock read wins
+FIFO priority; queue read errors fail closed and route the message through the
+durable enqueue/error path.
+
 Queue state and finalization state are per Keeper. Different Keepers may drain
 concurrently. A corrupt snapshot, connector failure, or stuck finalization for
 one Keeper must not block another Keeper lane.
@@ -213,6 +220,14 @@ parsing as well as response headers, and the Dashboard permits only one terminal
 convergence read per Keeper at a time. Failed, empty, stale, or timed-out reads
 remain pending for the next visible-panel poll.
 
+`Delivered.outcome_ref` is non-optional at the queued-turn boundary. If a
+successful-looking provider reply omits or malforms `turn_ref`, the transcript
+row is retained for diagnosis but the receipt terminates as typed
+`Missing_turn_ref`/`Internal_error`; the server never fabricates a join key or
+emits `Delivered` without one. If a legacy or corrupt snapshot still projects a
+`Delivered` receipt without a nonblank key, the Dashboard surfaces a correlation
+invariant error and stops terminal-convergence retries for that receipt.
+
 ### 6.2 Authoritative queue projection
 
 `Server_keeper_waiting_inventory` exposes separate
@@ -244,10 +259,13 @@ Focused regression coverage must prove:
 - cancellation nacks, while unexpected exceptions become terminal failures;
 - failed finalization persistence retries without redelivering the turn;
 - different Keeper queues dispatch concurrently;
+- a receipt committed after a stale outer peek still blocks direct admission,
+  both while Pending and Inflight;
 - connector ACK receipt matches the durable snapshot;
 - Discord/Slack terminal callback failures remain visible;
 - Dashboard busy ACK rows remain `queued` after `RUN_FINISHED`;
 - pending/inflight/read-error rows reach the Dashboard projection; and
+- missing or malformed queued-turn `turn_ref` never reaches `Delivered`; and
 - queue-change SSE triggers an authoritative refresh.
 
 Full Dune remains CI authority. Local validation uses focused repo wrapper

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -227,6 +227,12 @@ row is retained for diagnosis but the receipt terminates as typed
 emits `Delivered` without one. If a legacy or corrupt snapshot still projects a
 `Delivered` receipt without a nonblank key, the Dashboard surfaces a correlation
 invariant error and stops terminal-convergence retries for that receipt.
+The queue consumer repeats this invariant at its final typed boundary:
+`Delivered` carries a required canonical `turn_ref` string, and an invalid value
+is finalized as `Internal_error`, never as `Delivered` with a missing key. A
+`Failed` outcome may omit correlation, but a supplied value must be the same
+canonical key; invalid values are omitted with explicit failure detail rather
+than sanitized into a different identity.
 
 ### 6.2 Authoritative queue projection
 

--- a/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
+++ b/docs/rfc/RFC-connector-deferred-reply-via-chat-queue.md
@@ -1,274 +1,256 @@
 ---
 rfc: "connector-deferred-reply-via-chat-queue"
-title: "Connector deferred reply: busy-path messages must drain through the chat queue, not a poll-only async store"
-status: Draft
+title: "Durable Keeper chat receipts and connector delivery settlement"
+status: Active
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-11
 author: vincent
 supersedes: []
 superseded_by: null
-related: ["0203", "0217", "0223", "0225", "0226", "0232"]
+related: ["0203", "0217", "0223", "0225", "0226", "0232", "masc#23925"]
 implementation_prs: []
 ---
 
-# RFC: Connector deferred reply via the chat queue
+# RFC: Durable Keeper chat receipts and connector delivery settlement
 
 ## 1. Problem
 
-A keeper in autonomous / `Busy` state receives a connector (Discord) message,
-emits a "busy, I'll answer later" ACK, finishes its in-flight work — and never
-answers the queued connector message. The deferred reply is generated but never
-delivered back to the channel.
+A busy Keeper can accept a Dashboard, Discord, or Slack message after returning
+the acknowledgement “your message is queued”. Acceptance used to mean only that
+an in-memory or partially persisted payload existed. It did not prove that:
 
-### 1.1 Observed mechanism (verified, file:line)
+- the individual message had a durable identity;
+- a restart would replay the same message;
+- an active lease remained observable as work in progress;
+- the turn persisted a reply or failure marker;
+- the originating connector delivered the terminal response; or
+- the Dashboard invalidated and reread the authoritative queue projection.
 
-The non-busy and busy gate paths diverge in `gate_keeper_backend.ml`:
+The old public destructive dequeue and a second consumer watchdog made the gap
+worse. A payload could disappear before its terminal outcome was known, and a
+watchdog could settle a lease while the underlying turn continued.
 
-- **Inbound recording (both paths):** `dispatch_core` records the connector user
-  line at the gate boundary — `Keeper_chat_store.append_user_message`
-  (`lib/gate_keeper_backend.ml:299`), per RFC-0226 ("the gate inbound boundary is
-  the sole recorder of connector user lines").
-- **Busy branch:** when `Keeper_turn_admission.in_flight = Some info`
-  (`lib/gate_keeper_backend.ml:359`), it returns `` `Async_ack `` and calls
-  `Keeper_tool_surface.dispatch ~name:"masc_keeper_msg" ~args`
-  (`lib/gate_keeper_backend.ml:367-370`). It builds a busy ACK reply
-  (`busy_ack_reply_text`, `:133`) with `message_request = Some request` and the
-  original Discord fiber sends the ACK and **returns**.
-- `masc_keeper_msg` resolves to `Keeper_msg_async.submit`
-  (`lib/keeper/keeper_tool_surface_ops.ml:103`), which forks a background daemon
-  fiber. That fiber runs `Turn.handle_keeper_msg`
-  (`lib/keeper/keeper_turn.ml:1320`) → `Keeper_turn_admission.run_serialized`,
-  which **waits fiber-cooperatively** for the in-flight turn to release, then runs
-  a genuine keeper turn (`keeper_turn_admission.mli:56`). So the deferred turn
-  **does** execute — the drain is not the break.
-- **The break is outbound routing.** The busy turn's success callback,
-  `append_direct_chat_pair_if_reply` (`lib/keeper/keeper_tool_surface_ops.ml:583`),
-  writes the assistant reply only to `Keeper_chat_store` + `Keeper_chat_broadcast`
-  (dashboard SSE; `keeper_chat_broadcast.mli` — "the dashboard uses it to re-merge
-  the server transcript live"). It has **no connector outbound**.
-  `keeper_msg_async.ml` contains zero references to discord / send_message /
-  adapter_loop / chat_queue.
+## 2. Required invariant
 
-### 1.2 The only Discord-outbound path is never fed
+Every accepted message has one stable `Receipt_id` and follows this closed
+lifecycle:
 
-The single code path that forks a Discord delivery adapter
-(`Keeper_chat_discord.adapter_loop`, `lib/server/server_bootstrap_loops.ml:1050`)
-is `Keeper_chat_consumer`'s `handle_turn`, which drains a **different** store:
-`Keeper_chat_queue`. But `Keeper_chat_queue.enqueue`
-(`lib/keeper/keeper_chat_queue.ml:275`) has **zero production callers** —
-repo-wide it is invoked only by tests (`test/test_keeper_chat_coalescing.ml`,
-`test/test_keeper_effective_meta_overlay.ml`). The drain + outbound half of the
-pipeline is wired (`Keeper_chat_consumer.start`,
-`server_bootstrap_loops.ml:989`); the producer half is not.
-
-Result: busy connector messages flow into `Keeper_msg_async` (poll-only, no
-outbound), while the outbound-capable `Keeper_chat_queue` is never populated. Two
-disjoint async subsystems.
-
-### 1.3 This completes RFC-0225 §3.1, which was only half-implemented
-
-RFC-0225 §3.1 specifies: "The `fork_daemon`-per-request pattern in
-`keeper_msg_async.ml` is replaced by a per-keeper serial consumer fiber draining
-the queued chat requests through the same admission point." Rollout Phase 1:
-"Admission primitive + chat lane serial consumer (3.1)."
-
-What shipped: the admission primitive (`run_serialized` / `in_flight`),
-`Keeper_chat_consumer`, `Keeper_chat_queue` (typed source + outbound adapter).
-What did **not** ship: routing the busy connector path off `Keeper_msg_async`
-(fork-per-request, poll-only) onto `Keeper_chat_queue`. This RFC finishes that
-migration for the connector lane.
-
-### 1.4 History (not a regression)
-
-The user-described behaviour — busy ACK now, automatic answer later — was never
-built in any version. The Python sidecar's only deferred mechanism was an
-**operator-triggered** emoji-reaction re-submission (`_drain_pending`), dropped on
-the in-process gateway migration (the `Reaction_add` "drain pending messages …
-dropped" comment, `lib/server/server_discord_in_process_gateway.ml:544`). This is
-a missing feature, not a regression.
-
-## 2. Non-goals
-
-- **External-attention wake gate (separate axis).** `Keeper_external_attention`
-  records connector urgency (`Mention | Direct_message | Ambient`) but is consumed
-  only by `operator_digest.ml:287` (digest/dashboard); the reactive-wake gate keys
-  on `Keeper_approval_queue.has_pending_for_keeper`, a different queue. Making the
-  connector backlog drive a wake belongs to the RFC-0020 data-channel frame and is
-  out of scope here. The user's scenario is a message that already entered the chat
-  lane (it was dispatched and got a busy ACK), so this RFC closes it without the
-  wake-gate change.
-- Not a turn-admission redesign; RFC-0225's `run_serialized` stays as-is.
-- Not removing `Keeper_msg_async` wholesale. Keeper→keeper messaging and operator
-  `masc_keeper_msg` retain their poll/`masc_keeper_msg_result` semantics. Only the
-  **gate connector** busy branch is rerouted.
-
-## 3. Design
-
-### 3.1 Route the busy connector branch into `Keeper_chat_queue`
-
-In `gate_keeper_backend.dispatch_core`, replace the busy-branch
-`Keeper_msg_async.submit` call with `Keeper_chat_queue.enqueue` carrying a typed
-`message_source`. The already-wired `Keeper_chat_consumer` then drains it once the
-slot frees (coalescing same-source batches via `dequeue_batch` / `merge_batch`)
-and `handle_turn` forks `Keeper_chat_discord.adapter_loop ~channel_id` to deliver
-the reply to the channel. The non-busy branch keeps streaming the immediate reply
-unchanged.
-
-### 3.2 Typed source mapping — no string match (key boundary decision)
-
-`gate_keeper_backend` is connector-neutral by design (RFC-0226): `dispatch_core`
-sees only a string `lane = channel` (`"discord"`, …), `channel_workspace_id`
-(= Discord channel_id snowflake), and `channel_user_id`. But
-`Keeper_chat_queue.message_source` is a typed sum
-(`Dashboard | Discord {channel_id; user_id} | Slack {channel; user_id}`).
-
-Mapping `lane` → `message_source` by `match lane with "discord" -> …` is a
-string classifier — forbidden (CLAUDE.md "노 스트링 매치"; AI anti-pattern #2/#4).
-
-#### Layering constraint (discovered during implementation)
-
-The first instinct — thread a typed `Surface_ref.t` or `message_source` through
-the `Channel_gate.dispatch_fn` type — does **not** type-check: `channel_gate` lives
-in the `masc_gate` library, which `masc` (where `Surface_ref` / `message_source` /
-`gate_keeper_backend` live) **depends on**. Putting a `masc`-level type on a
-`masc_gate` function signature is a dependency cycle (`masc_gate → masc`).
-
-**Resolution — `connector_kind` injected at dispatch construction (not per
-message):** the connector type (Discord vs Slack vs sidecar) is a property of the
-*connector*, not of each message; the per-message varying data (channel_id,
-user_id) already arrives as `channel_workspace_id` / `channel_user_id`. So:
-
-- Define a leaf variant in `masc` (next to the routing site):
-  `type connector_kind = Discord | Slack | Generic`.
-- Add `?connector_kind` to `Gate_keeper_backend.dispatch` /
-  `dispatch_with_text_snapshot` (functions in `masc`, **not** the `masc_gate`
-  `dispatch_fn` type). The Discord gateway bakes `~connector_kind:Discord` in at
-  partial-application time, when it constructs its `dispatch`; the remaining
-  signature still matches `streaming_dispatch_fn`, so `masc_gate` is untouched and
-  no cycle is introduced. Default `Generic` preserves today's behaviour for every
-  caller that does not opt in (HTTP gate-route sidecars, tests).
-- `dispatch_core`'s busy branch maps `connector_kind` + channel_id + user_id →
-  `message_source` via an **exhaustive** match (a new `connector_kind` variant
-  fails to compile until handled). No string match; the typed discrimination
-  happens where the type is known (the connector), threaded as a typed value.
-
-The pure decision is `route_busy_connector` (§4.0), exhaustive over
-`connector_kind`.
-
-### 3.3 message_source coverage gap (honest constraint)
-
-`message_source` is a closed 3-variant sum. HTTP gate-route sidecars
-(imessage-bot, cli-connector) also POST to `/api/v1/gate/message` and converge on
-`dispatch_core` (RFC-0226 §3.3 amendment) with a generic `channel` label that is
-neither `discord` nor `slack` nor `dashboard`. Two admissible resolutions, to be
-decided in review:
-
-- **(a) Scope deferred-queue delivery to connectors with an in-process outbound
-  adapter** (Discord, Slack). Sidecars that POST-and-await keep their current
-  synchronous/poll semantics; the typed map returns `None` for them and the busy
-  branch falls back to today's `Keeper_msg_async` path. Smallest blast radius.
-- **(b) Widen `message_source`** with a generic `Gate {label; channel_id;
-  user_id}` variant and a matching outbound delivery adapter. Larger, but unifies
-  every gate connector under the serial consumer (full RFC-0225 §3.1 intent).
-
-This RFC recommends **(a)** first (surgical, closes the reported Discord bug),
-with **(b)** as a follow-up once a generic gate outbound adapter exists.
-
-### 3.4 Recording ownership — source-keyed user-line write
-
-`Keeper_chat_consumer.handle_turn` invokes `process_single_turn`
-(`lib/server/server_routes_http_keeper_stream.ml:669`), which records the user
-line itself (`persist_user_message_only`, `:736`; `append_turn`, `:755`). That is
-correct for **dashboard** stream messages (no gate inbound recorder) but would
-**double-record** a connector user line, since the gate inbound already recorded
-it (`gate_keeper_backend.ml:299`, RFC-0226's sole-recorder invariant).
-
-**Resolution (typed, exhaustive):** the consumer-driven turn records the user line
-only when there is no upstream recorder, keyed on the typed `message_source`:
-
-```ocaml
-match queued_message.source with
-| Dashboard            -> record user line   (* no gate inbound recorder *)
-| Discord _ | Slack _  -> assistant-only     (* gate inbound owns the user line *)
+```text
+Pending -> Inflight -> Delivered
+                    \-> Failed
 ```
 
-This preserves RFC-0226's ownership split (gate inbound = connector user line;
-reply path = assistant) under the unified consumer, with no dedup and no
-string-keyed branch. A new source variant forces a compile-time decision.
+`Delivered` means the complete delivery boundary succeeded:
 
-## 4. Verification
+1. the Keeper turn produced a visible terminal result;
+2. the transcript write committed; and
+3. for Discord or Slack, the connector's primary terminal send committed.
 
-### 4.0 The fix must introduce a testable routing seam (harness-first)
+`Failed` is also terminal and carries a typed failure kind plus detail. It is
+not silently converted into success. Structured process cancellation is the one
+non-terminal exit: it nacks the lease back to `Pending` with the same receipt ID.
 
-Today the busy branch hard-calls `Keeper_tool_surface.dispatch ~name:"masc_keeper_msg"`
-inline (`lib/gate_keeper_backend.ml:367-370`), and `test/test_gate_keeper_backend.ml`
-exercises only `Gate_keeper_backend`'s pure helpers — there is **no harness that
-drives `dispatch_core`'s busy branch end-to-end**, and no injection point for the
-routing decision. A deterministic "red now, green after" reproduction therefore
-cannot be written against the current code without standing up a full runtime
-(proc_mgr / net / a live keeper turn).
+Messages from the same source may be coalesced into one Keeper turn, but the
+lease retains every constituent receipt and finalizes them atomically.
 
-The fix extracts the busy-connector routing decision into a pure, injectable
-function whose effect is observable — e.g.
+## 3. Durable queue contract
 
-```ocaml
-type connector_kind = Discord | Slack | Generic
+### 3.1 Snapshot schema
 
-(* pure, exhaustive over connector_kind: decide where a busy connector
-   message goes, building the typed message_source from per-message ids *)
-val route_busy_connector
-  :  connector_kind
-  -> channel_id:string
-  -> user_id:string
-  -> [ `Enqueue_chat_queue of Keeper_chat_queue.message_source
-     | `Async_poll (* §3.3 fallback: Generic has no in-process outbound adapter *) ]
+The on-disk SSOT is the BasePath-owned file:
+
+```text
+<base>/.masc/keepers/<keeper>/chat-queue.json
 ```
 
-The enqueue side effect (`Keeper_chat_queue.length` / `dequeue`) is the
-deterministic seam the test asserts against. This is the harness-first part of the
-fix, not an afterthought: the routing decision becomes a total function over the
-typed source, and the test pins it.
+Schema `keeper_chat_queue.v2` contains:
 
-### 4.1 Tests
+- a monotonic `revision`;
+- every receipt ID;
+- `Pending` and `Inflight` message payloads;
+- lease ID and start time for `Inflight`; and
+- terminal completion/failure metadata without message bodies or attachments.
 
-- **Routing decision (pure, deterministic):** `route_busy_connector
-  ~source:(Some (Discord {channel_id; user_id}))` → `` `Enqueue_chat_queue (Discord …) ``;
-  a source with no chat-queue projection (§3.3) → `` `Async_poll ``. Exhaustive over
-  `message_source`.
-- **Reproduction test (failing-first), `test/test_keeper_busy_connector_deferred.ml`:**
-  hold the turn slot busy (the proven `Keeper_turn_admission.For_testing.reset` +
-  forked `run_serialized` blocking on a `release` promise pattern from
-  `test_keeper_turn_admission.ml`), dispatch a Discord-source gate message, and
-  assert `Keeper_chat_queue.length ~keeper_name ≥ 1` with `source = Discord
-  {channel_id; _}`. Pre-fix the busy branch routes into `Keeper_msg_async`, so
-  `length = 0` — **red**. Post-fix — **green**.
-- **Ownership regression guard:** assert the gate inbound records the user line
-  exactly once and the consumer-driven turn records it zero additional times for a
-  `Discord` source (no double-record).
-- **Drain/coalesce:** reuse the existing `test_keeper_chat_coalescing.ml` harness
-  to assert same-source coalescing of multiple busy-arrival connector messages into
-  one follow-up turn.
-- **TLA+ bug model (CLAUDE.md pattern), optional:** `BugAction` = busy connector
-  message routed to a store with no outbound; `Invariant` = every accepted
-  connector message eventually has an outbound delivery attempt. Clean spec passes;
-  buggy spec violates.
+The revision domain is capped at JavaScript's exact JSON integer boundary
+(`2^53 - 1`) because the same value crosses the Dashboard JSON/SSE boundary.
+The next mutation fails explicitly with `Revision_exhausted`; it never wraps a
+signed `int64` into a corrupt negative snapshot.
 
-## 5. Rollout
+Every mutation is written atomically before the API reports success. A failed
+write rolls the in-memory mutation and revision back. Corrupt or unreadable
+snapshots remain untouched, make that Keeper queue unavailable, and surface an
+explicit load error. They are never interpreted as an empty queue.
 
-1. Typed `connector_source` threaded through gate dispatch + busy-branch enqueue
-   into `Keeper_chat_queue` (§3.1–3.3 option (a)).
-2. Source-keyed user-line ownership in the consumer turn (§3.4).
-3. Failing reproduction test flips to green; coalescing + ownership guards added.
-4. Follow-up (separate RFC/PR): generic gate outbound adapter (§3.3 option (b))
-   and the external-attention wake gate (§2, RFC-0020 frame).
+### 3.2 Version-1 migration
 
-## 6. Workaround self-check (CLAUDE.md gate)
+Production snapshots existed as `keeper_chat_queue.v1` before this contract.
+Startup therefore performs one explicit migration transaction:
 
-- Telemetry-as-fix: no — this routes the message to a store that delivers, it does
-  not merely count the drop.
-- String/substring classifier: no — §3.2 explicitly replaces a would-be string
-  match with a typed `Surface_ref → message_source` exhaustive mapping.
-- N-of-M: no — the migration is the producer half of RFC-0225 §3.1, completed for
-  the connector lane in one place; §3.3 names the remaining coverage decision
-  rather than silently patching one site.
-- Cap/cooldown/dedup/repair: none introduced.
+1. strictly decode the v1 shape;
+2. mint one receipt for each legacy inflight/pending payload;
+3. replay legacy inflight payloads ahead of pending payloads; and
+4. atomically replace the file with strict v2.
+
+After that transaction there is no v1 runtime fallback or dual-write path. A
+malformed v1/v2 file is a load error, not a compatibility success.
+
+### 3.3 Restart recovery
+
+An `Inflight` snapshot means the previous process did not durably settle the
+lease. Startup atomically moves those receipts back to `Pending`, preserving
+their IDs and FIFO order, and increments the revision. Delivery is therefore
+at-least-once; connector and transcript effects must remain idempotent where
+their downstream contracts permit it.
+
+Reconfiguring BasePath first clears the in-memory registry and then loads the
+new workspace. Receipts from one BasePath must never appear in another.
+
+### 3.4 Mutation surface
+
+The public queue API is intentionally narrow:
+
+- `enqueue` returns the durable receipt, revision, pending count, and inflight
+  count only after commit;
+- `lease_batch` changes a same-source pending run to `Inflight` atomically;
+- `finalize` commits `Delivered` or `Failed` for the exact lease;
+- `nack` returns the exact lease to `Pending`; and
+- `snapshot` / `lookup_receipt` are read-only diagnostics; exact lookup returns
+  the receipt and revision from one locked observation.
+
+There is no public unleased `dequeue`, `clear`, `remove_matching`, or untyped
+`ack` path.
+
+## 4. Turn and connector settlement
+
+### 4.1 One timeout owner
+
+The Keeper turn runtime owns timeout and cancellation. The queue consumer does
+not race it with a second wall-clock watchdog. The turn returns a typed terminal
+outcome, and the consumer persists that exact decision before allowing another
+queued turn for the Keeper.
+
+If finalization persistence fails, the consumer retains the decision in memory
+and retries the same finalization. It does not rerun the Keeper turn and does
+not release the Keeper dispatch gate until settlement succeeds.
+
+### 4.2 Connector join
+
+For Discord and Slack, the consumer starts the outbound adapter before the turn
+and joins its terminal callback after the turn finishes. The callback reports
+exactly one result for the primary final reply or error reply.
+
+- preview edits and rich side messages do not settle the receipt;
+- an interim stream-protocol diagnostic cannot mask a later final-send failure;
+- a missing connector credential becomes `Connector_unavailable`;
+- a terminal HTTP/API failure becomes `Delivery_failed`; and
+- empty terminal connector output is a failure, not implicit success.
+
+When both the turn and connector delivery fail, the durable receipt records the
+connector delivery failure and retains the typed turn failure in its detail.
+The transcript already contains the turn-side failure marker.
+
+Dashboard-originated queued turns have no external adapter. Their event stream
+is still drained so backpressure cannot stall the turn, and transcript commit is
+their delivery boundary.
+
+### 4.3 Recording ownership
+
+The source variant fixes transcript ownership without string classification:
+
+```ocaml
+match source with
+| Dashboard -> turn records user and assistant rows
+| Discord _ | Slack _ -> gate records the user row; turn records assistant only
+```
+
+This preserves the single connector-inbound recorder defined by RFC-0226.
+
+## 5. Admission and lane isolation
+
+The autonomous lane yields while the Keeper has either pending or inflight chat
+receipts. Leasing must not create a race window in which an autonomous turn can
+overtake the queued chat turn.
+
+Queue state and finalization state are per Keeper. Different Keepers may drain
+concurrently. A corrupt snapshot, connector failure, or stuck finalization for
+one Keeper must not block another Keeper lane.
+
+## 6. Dashboard and acknowledgement wiring
+
+### 6.1 Busy acknowledgement
+
+A successful busy acknowledgement includes:
+
+- `receipt_id`;
+- committed `queue_revision`;
+- pending and inflight counts; and
+- a typed queued status source.
+
+If durable enqueue fails, the route returns an explicit error and must not claim
+the message is queued.
+
+The Dashboard handles `KEEPER_CHAT_QUEUED` as a server acceptance receipt. It
+keeps the chat row in `queued` state after the short acknowledgement stream ends
+and preserves the receipt ID, revision, and queue position in message details.
+Browser-local unsent drafts are labelled separately as “server not accepted”.
+
+The exact lifecycle and its atomic snapshot revision are queryable at
+`GET /api/v1/keepers/<name>/chat/receipts/<receipt_id>`. Queue-change SSE remains
+an invalidation rather than lifecycle truth: the Dashboard rereads this endpoint
+for every visible busy-ACK receipt and moves that chat row to
+`pending`, `inflight`, `delivered`, or `failed`. A receipt-query failure is
+operator-visible and never guessed as success. Revision comparison prevents an
+older concurrent GET from regressing a newer terminal row. Receipt observation,
+reconnect hydration, and a visible-panel safety poll provide catch-up when the
+queue invalidation arrives before the stream acknowledgement or is missed during
+a disconnect.
+
+### 6.2 Authoritative queue projection
+
+`Server_keeper_waiting_inventory` exposes separate
+`chat_queue_pending` and `chat_queue_inflight` rows. Each row includes receipt
+ID, source, timestamp, and lifecycle detail. Snapshot load failures appear as
+explicit `read_error` rows.
+
+Every committed mutation invokes one post-commit transition observer outside
+queue locks. The server emits `keeper_chat_queue_changed` with Keeper name and
+revision. This event is an invalidation signal: the Dashboard debounces it and
+rereads the authoritative waiting inventory instead of reconstructing state
+from deltas.
+
+The chat composer renders server pending/inflight/read-error counts independently
+from browser-local drafts and from the Keeper's active turn state. The waiting
+inventory renders each active receipt ID, lifecycle, lease ID, and inflight start
+time so a reloaded Dashboard still has a correlation path.
+
+## 7. Verification
+
+Focused regression coverage must prove:
+
+- `Pending -> Inflight -> Delivered|Failed` and exact receipt lookup;
+- coalescing preserves all receipt identities;
+- nack and restart preserve receipt IDs;
+- enqueue, lease, finalize, and nack persistence failures roll back;
+- v1 migration happens once and malformed snapshots fail closed;
+- BasePath reconfiguration does not leak the registry;
+- cancellation nacks, while unexpected exceptions become terminal failures;
+- failed finalization persistence retries without redelivering the turn;
+- different Keeper queues dispatch concurrently;
+- connector ACK receipt matches the durable snapshot;
+- Discord/Slack terminal callback failures remain visible;
+- Dashboard busy ACK rows remain `queued` after `RUN_FINISHED`;
+- pending/inflight/read-error rows reach the Dashboard projection; and
+- queue-change SSE triggers an authoritative refresh.
+
+Full Dune remains CI authority. Local validation uses focused repo wrapper
+targets plus the relevant Dashboard typecheck and Vitest suites.
+
+## 8. Non-goals
+
+- Generic sidecar connectors without an in-process outbound adapter retain the
+  async-poll path.
+- This RFC does not redesign the general Keeper event queue.
+- Connector-specific rich formatting is a separate transport contract; this
+  RFC only requires its terminal delivery result to settle truthfully.
+- Terminal receipt retention/archival policy may move to a separate append-only
+  ledger, but active receipts must never be pruned or hidden by that work.

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -134,13 +134,21 @@ let register () =
   let handler ~name ~args = Some (handle_tool name args) in
   let make_spec (s : Masc_domain.tool_schema) =
     let ro = List.mem s.name tool_spec_read_only in
+    let metadata = Tool_catalog.metadata s.name in
     Tool_spec.create
       ~name:s.name
       ~description:s.description
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
       ~handler_binding:(Shared handler)
-      ~visibility:(Tool_catalog.metadata s.name).visibility
+      ~visibility:metadata.visibility
+      ~implementation_status:metadata.implementation_status
+      ?canonical_name:metadata.canonical_name
+      ?replacement:metadata.replacement
+      ?reason:metadata.reason
+      ~allow_direct_call_when_hidden:metadata.allow_direct_call_when_hidden
+      ?effect_domain:metadata.effect_domain
+      ?requires_actor_binding:metadata.requires_actor_binding
       ~is_read_only:ro
       ~is_idempotent:ro
       ~is_destructive:(is_destructive_board_tool s.name)

--- a/lib/board_tool_adapter/board_tool_dispatch.ml
+++ b/lib/board_tool_adapter/board_tool_dispatch.ml
@@ -140,6 +140,7 @@ let register () =
       ~module_tag:Tool_dispatch.Mod_inline
       ~input_schema:s.input_schema
       ~handler_binding:(Shared handler)
+      ~visibility:(Tool_catalog.metadata s.name).visibility
       ~is_read_only:ro
       ~is_idempotent:ro
       ~is_destructive:(is_destructive_board_tool s.name)

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -99,11 +99,12 @@ let parse_empty_response ~status ~body =
   if status >= 200 && status < 300 then Ok ()
   else Error (error_of_non2xx ~status ~body)
 
-let send_message ~token ~channel_id ~content ?reply_to_message_id () =
+let send_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel_id ~content ?reply_to_message_id () =
   let (url, headers, body) =
     build_request ~token ~channel_id ~content ?reply_to_message_id ()
   in
-  match Masc_http_client.post_sync ~url ~headers ~body () with
+  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
 
@@ -171,17 +172,19 @@ let build_edit_request ~token ~channel_id ~message_id ~content () =
   in
   (url, headers, body)
 
-let edit_message ~token ~channel_id ~message_id ~content () =
+let edit_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel_id ~message_id ~content () =
   let (url, headers, body) =
     build_edit_request ~token ~channel_id ~message_id ~content ()
   in
-  match Masc_http_client.patch_sync ~url ~headers ~body () with
+  match Masc_http_client.patch_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_empty_response ~status ~body
 
-let trigger_typing ~token ~channel_id () =
+let trigger_typing ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel_id () =
   let url, headers, body = build_typing_request ~token ~channel_id () in
-  match Masc_http_client.post_sync ~url ~headers ~body () with
+  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_empty_response ~status ~body
 
@@ -313,18 +316,22 @@ let build_edit_embed_request ~token ~channel_id ~message_id
   let body = Yojson.Safe.to_string (`Assoc fields) in
   (url, headers, body)
 
-let send_embed_message ~token ~channel_id ~content ?embeds () =
+let send_embed_message ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel_id ~content ?embeds () =
   let (url, headers, body) =
     build_embed_request ~token ~channel_id ~content ?embeds ()
   in
-  match Masc_http_client.post_sync ~url ~headers ~body () with
+  match Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_response ~status ~body
 
-let edit_embed_message ~token ~channel_id ~message_id ~content ?embeds () =
+let edit_embed_message ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ~token ~channel_id ~message_id ~content ?embeds () =
   let (url, headers, body) =
     build_edit_embed_request ~token ~channel_id ~message_id ~content ?embeds ()
   in
-  match Masc_http_client.patch_sync ~url ~headers ~body () with
+  match Masc_http_client.patch_sync ?clock ~timeout_sec ~url ~headers ~body () with
   | Error msg -> Error (Network msg)
   | Ok (status, body) -> parse_empty_response ~status ~body

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -52,6 +52,8 @@ type error =
 val pp_error : Format.formatter -> error -> unit
 
 val send_message :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
   token:string ->
   channel_id:string ->
   content:string ->
@@ -69,6 +71,8 @@ val send_message :
     @raise nothing — failures are surfaced as typed {!error}. *)
 
 val edit_message :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
   token:string ->
   channel_id:string ->
   message_id:string ->
@@ -85,6 +89,8 @@ val edit_message :
     @raise nothing — failures are surfaced as typed {!error}. *)
 
 val trigger_typing :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
   token:string ->
   channel_id:string ->
   unit ->
@@ -133,6 +139,8 @@ val image_embed : url:string -> caption:string option -> embed
 (** Build an image embed with optional caption as the description. *)
 
 val send_embed_message :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
   token:string ->
   channel_id:string ->
   content:string ->
@@ -143,6 +151,8 @@ val send_embed_message :
     Returns the created message id on [Ok]. *)
 
 val edit_embed_message :
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
   token:string ->
   channel_id:string ->
   message_id:string ->

--- a/lib/gate/slack_rest_client.ml
+++ b/lib/gate/slack_rest_client.ml
@@ -40,7 +40,7 @@ let streaming_update_min_interval_sec = 3.0
    gateway does); clock-less callers keep the prior unbounded behavior. Matches
    the socket client's [fetch_wss_url] default so all Slack HTTP shares one
    ceiling. *)
-let default_http_timeout_sec = 10.0
+let default_http_timeout_sec = Masc_http_client.default_request_timeout_sec
 
 let user_agent = "masc-slack-bot/0.1 (https://github.com/jeong-sik/masc)"
 

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -38,14 +38,15 @@ type connector_kind =
    frees and delivers the reply through the connector's outbound adapter
    ([Keeper_chat_discord.adapter_loop]); [Generic] has no such adapter and falls
    back to the async poll store. *)
-let route_busy_connector (kind : connector_kind) ~channel_id ~user_id :
+let route_busy_connector (kind : connector_kind) ~channel_id ~user_id ~user_name
+    ~team_id ~thread_ts :
     [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ] =
   match kind with
   | Discord -> `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id })
   | Slack ->
-    (* [Keeper_chat_queue.Slack] names the channel field [channel], not
-       [channel_id]; the busy Slack message carries the same conversation id. *)
-    `Enqueue_chat_queue (Keeper_chat_queue.Slack { channel = channel_id; user_id })
+    `Enqueue_chat_queue
+      (Keeper_chat_queue.Slack
+         { channel_id; user_id; user_name; team_id; thread_ts })
   | Generic -> `Async_poll
 
 (* ── Keeper response parsing ─────────────────────────────────── *)
@@ -589,12 +590,29 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
       ~base_path:config.Workspace.base_path
       ~keeper_name
   in
+  let active_chat_queue = Keeper_chat_queue.has_active_receipts ~keeper_name in
+  let should_defer_to_existing_work =
+    match busy_in_flight, active_chat_queue with
+    | Some _, _ -> true
+    | None, Ok active -> active
+    | None, Error error ->
+      Log.Server.error
+        "channel gate chat queue admission unavailable (keeper=%s, lane=%s): %s"
+        keeper_name lane (Keeper_chat_queue.mutation_error_to_string error);
+      true
+  in
+  let slack_reply_thread_ts =
+    match slack_thread_ts metadata with
+    | Some thread_ts -> Some thread_ts
+    | None -> metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
+  in
   let dispatch_result =
-    match busy_in_flight with
-    | Some info ->
+    if should_defer_to_existing_work then
         (match
            route_busy_connector connector_kind
              ~channel_id:channel_workspace_id ~user_id:channel_user_id
+             ~user_name:channel_user_name ~team_id:(slack_team_id metadata)
+             ~thread_ts:slack_reply_thread_ts
          with
          | `Enqueue_chat_queue source ->
              (* RFC-connector-deferred-reply-via-chat-queue: the keeper already holds an in-flight turn. Route the
@@ -615,7 +633,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
                   ; source
                   }
               with
-              | Ok receipt -> `Queued_to_chat_lane (info, receipt)
+              | Ok receipt -> `Queued_to_chat_lane (busy_in_flight, receipt)
               | Error error ->
                 Log.Server.error
                   "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
@@ -624,10 +642,10 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
                 `Chat_queue_error error)
          | `Async_poll ->
              `Async_ack
-               ( info
+               ( busy_in_flight
                , Keeper_tool_surface.dispatch keeper_ctx
                    ~name:"masc_keeper_msg" ~args ))
-    | None ->
+    else
         (* Channel gate needs the final keeper reply when the keeper can run it
            now, not the async request ACK that plain dispatch returns. *)
         `Streaming
@@ -644,14 +662,14 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
       in
       let ack_with_in_flight =
         extract_message_request_ack ~channel ~channel_user_id ~keeper_name
-          ~metadata:(metadata @ in_flight_metadata (Some in_flight))
+          ~metadata:(metadata @ in_flight_metadata in_flight)
           body
       in
       let message_request, reply =
         match ack_with_in_flight with
         | Ok request ->
             ( Some request
-            , busy_ack_reply_text ~in_flight request )
+            , busy_ack_reply_text ?in_flight request )
         | Error failure ->
             (* Backend drift: the keeper accepted the message into its
                async queue but the wire envelope we expected is missing or
@@ -705,7 +723,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
       in
       let reply =
         redact_text
-          (busy_ack_reply_text_queued ~in_flight:(Some in_flight) ~keeper_name
+          (busy_ack_reply_text_queued ~in_flight ~keeper_name
              ~receipt_id:message_request.request_id)
       in
       let stats =

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -585,72 +585,55 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
                  "channel gate text snapshot callback failed (keeper=%s): %s"
                  keeper_name (Printexc.to_string exn))
   in
-  let busy_in_flight =
-    Keeper_turn_admission.in_flight
-      ~base_path:config.Workspace.base_path
-      ~keeper_name
-  in
-  let active_chat_queue = Keeper_chat_queue.has_active_receipts ~keeper_name in
-  let should_defer_to_existing_work =
-    match busy_in_flight, active_chat_queue with
-    | Some _, _ -> true
-    | None, Ok active -> active
-    | None, Error error ->
-      Log.Server.error
-        "channel gate chat queue admission unavailable (keeper=%s, lane=%s): %s"
-        keeper_name lane (Keeper_chat_queue.mutation_error_to_string error);
-      true
-  in
   let slack_reply_thread_ts =
     match slack_thread_ts metadata with
     | Some thread_ts -> Some thread_ts
     | None -> metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
   in
+  let defer_to_existing_work in_flight =
+    match
+      route_busy_connector connector_kind
+        ~channel_id:channel_workspace_id ~user_id:channel_user_id
+        ~user_name:channel_user_name ~team_id:(slack_team_id metadata)
+        ~thread_ts:slack_reply_thread_ts
+    with
+    | `Enqueue_chat_queue source ->
+      (* RFC-connector-deferred-reply-via-chat-queue: route accepted connector
+         input onto the durable queue whenever the authoritative if-free
+         admission reports Busy. This includes a receipt committed or leased
+         after any outer observation but before the turn slot was acquired. *)
+      (match
+         Keeper_chat_queue.enqueue ~keeper_name
+           { Keeper_chat_queue.content = String.trim content
+           ; user_blocks = []
+           ; attachments = []
+           ; timestamp = Eio.Time.now clock
+           ; source
+           }
+       with
+       | Ok receipt -> `Queued_to_chat_lane (in_flight, receipt)
+       | Error error ->
+         Log.Server.error
+           "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
+           keeper_name lane
+           (Keeper_chat_queue.mutation_error_to_string error);
+         `Chat_queue_error error)
+    | `Async_poll ->
+      `Async_ack
+        ( in_flight
+        , Keeper_tool_surface.dispatch keeper_ctx
+            ~name:"masc_keeper_msg" ~args )
+  in
   let dispatch_result =
-    if should_defer_to_existing_work then
-        (match
-           route_busy_connector connector_kind
-             ~channel_id:channel_workspace_id ~user_id:channel_user_id
-             ~user_name:channel_user_name ~team_id:(slack_team_id metadata)
-             ~thread_ts:slack_reply_thread_ts
-         with
-         | `Enqueue_chat_queue source ->
-             (* RFC-connector-deferred-reply-via-chat-queue: the keeper already holds an in-flight turn. Route the
-                connector message onto [Keeper_chat_queue] so the serial
-                [Keeper_chat_consumer] drains it once the slot frees and delivers
-                the deferred reply through the connector's outbound adapter
-                ([Keeper_chat_discord.adapter_loop]). The async [masc_keeper_msg]
-                store ([Keeper_msg_async]) has no outbound path, so a busy
-                connector message routed there is answered into the dashboard
-                transcript only and never reaches the channel — the RFC-connector-deferred-reply-via-chat-queue
-                root cause. *)
-             (match
-                Keeper_chat_queue.enqueue ~keeper_name
-                  { Keeper_chat_queue.content = String.trim content
-                  ; user_blocks = []
-                  ; attachments = []
-                  ; timestamp = Eio.Time.now clock
-                  ; source
-                  }
-              with
-              | Ok receipt -> `Queued_to_chat_lane (busy_in_flight, receipt)
-              | Error error ->
-                Log.Server.error
-                  "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
-                  keeper_name lane
-                  (Keeper_chat_queue.mutation_error_to_string error);
-                `Chat_queue_error error)
-         | `Async_poll ->
-             `Async_ack
-               ( busy_in_flight
-               , Keeper_tool_surface.dispatch keeper_ctx
-                   ~name:"masc_keeper_msg" ~args ))
-    else
-        (* Channel gate needs the final keeper reply when the keeper can run it
-           now, not the async request ACK that plain dispatch returns. *)
-        `Streaming
-          (Keeper_tool_surface.dispatch_stream ~on_text_delta keeper_ctx
-             ~name:"masc_keeper_msg" ~args)
+    (* The admission boundary, not a route-level peek, owns the FIFO decision.
+       It rechecks the durable queue after acquiring the Keeper turn slot. *)
+    match
+      Keeper_tool_surface.dispatch_stream_if_free ~on_text_delta keeper_ctx
+        ~name:"masc_keeper_msg" ~args
+    with
+    | `Ran result -> `Streaming result
+    | `Busy { Keeper_turn_admission.in_flight; _ } ->
+      defer_to_existing_work in_flight
   in
   match dispatch_result with
   | `Async_ack (in_flight, Some result) when Tool_result.is_success result ->

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -194,12 +194,12 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
     request.request_id
     in_flight_text
 
-(* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. Unlike
-   [busy_ack_reply_text], there is no [Keeper_msg_async] request envelope: the
-   message was enqueued onto [Keeper_chat_queue], so the durable handle is the
-   queue position, not a poll request_id. The reply is delivered later by the
-   serial consumer through the connector's outbound adapter. *)
-let busy_ack_reply_text_queued ~in_flight ~keeper_name =
+(* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. The
+   message was durably enqueued onto [Keeper_chat_queue], so its receipt id is
+   the correlation handle instead of a [Keeper_msg_async] poll request id. The
+   reply is delivered later by the serial consumer through the connector's
+   outbound adapter. *)
+let busy_ack_reply_text_queued ~in_flight ~keeper_name ~receipt_id =
   let in_flight_text =
     match in_flight with
     | None -> ""
@@ -210,9 +210,32 @@ let busy_ack_reply_text_queued ~in_flight ~keeper_name =
   in
   Printf.sprintf
     "%s is busy; your message is queued and will be answered once the current \
-     turn finishes.%s"
-    keeper_name
+     turn finishes (receipt_id=%s).%s"
+    keeper_name receipt_id
     in_flight_text
+
+let chat_queue_message_request ~channel ~channel_user_id ~keeper_name ~metadata
+    (receipt : Keeper_chat_queue.enqueue_receipt) =
+  let receipt_id =
+    Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id
+  in
+  { Gate_protocol.request_id = receipt_id
+  ; destination_type = "keeper"
+  ; destination_id = keeper_name
+  ; channel
+  ; actor_id = non_empty_opt channel_user_id
+  ; status = Gate_protocol.Queued
+  ; modalities = [ "text" ]
+  ; transport = non_empty_opt channel
+  ; metadata =
+      [ "status_source", "keeper_chat_queue"
+      ; "receipt_id", receipt_id
+      ; "queue_revision", Int64.to_string receipt.revision
+      ; "pending_count", string_of_int receipt.pending_count
+      ; "inflight_count", string_of_int receipt.inflight_count
+      ]
+      @ metadata
+  }
 
 (* ── Dispatch ────────────────────────────────────────────────── *)
 
@@ -583,22 +606,22 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
                 connector message routed there is answered into the dashboard
                 transcript only and never reaches the channel — the RFC-connector-deferred-reply-via-chat-queue
                 root cause. *)
-             (* [receipt_id] is not surfaced on this path — unlike the
-                dashboard busy-ack (RFC-connector-deferred-reply-via-chat-queue), the connector reply
-                has no request envelope to carry a correlation token in (see
-                [`Queued_to_chat_lane]'s comment below) — the queue position
-                is the only durable handle a connector gets today. *)
-             (* fire-and-forget: receipt_id has no consumer on this path. *)
-             ignore (Keeper_chat_queue.enqueue ~keeper_name
-               { Keeper_chat_queue.content = String.trim content
-               ; user_blocks = []
-               ; attachments = []
-               ; timestamp = Eio.Time.now clock
-               ; source }
-               : string);
-             Keeper_chat_broadcast.queue_changed ~keeper_name
-               ~depth:(Keeper_chat_queue.length ~keeper_name) ();
-             `Queued_to_chat_lane info
+             (match
+                Keeper_chat_queue.enqueue ~keeper_name
+                  { Keeper_chat_queue.content = String.trim content
+                  ; user_blocks = []
+                  ; attachments = []
+                  ; timestamp = Eio.Time.now clock
+                  ; source
+                  }
+              with
+              | Ok receipt -> `Queued_to_chat_lane (info, receipt)
+              | Error error ->
+                Log.Server.error
+                  "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
+                  keeper_name lane
+                  (Keeper_chat_queue.mutation_error_to_string error);
+                `Chat_queue_error error)
          | `Async_poll ->
              `Async_ack
                ( info
@@ -665,25 +688,42 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~sw ~clock
           }
       in
       Gate_protocol.Reply { content = reply; structured; stats; message_request }
-  | `Queued_to_chat_lane in_flight ->
+  | `Queued_to_chat_lane (in_flight, receipt) ->
       (* RFC-connector-deferred-reply-via-chat-queue: the message was enqueued onto [Keeper_chat_queue]; the
          connector gets a busy ACK now and the deferred reply later via the
-         serial consumer's outbound adapter. There is no [Keeper_msg_async]
-         request envelope, so [message_request] is [None] — the queue position is
-         the durable handle, not a poll request_id. *)
+         serial consumer's outbound adapter. The existing [message_request]
+         envelope carries the durable receipt id and queue revision so the
+         connector can correlate that later delivery. *)
       let duration_ms =
         Mtime.Span.to_uint64_ns (Mtime.span (Mtime_clock.now ()) start_mtime)
         |> Int64.div 1_000_000L
         |> Int64.to_int
       in
+      let message_request =
+        chat_queue_message_request ~channel ~channel_user_id ~keeper_name
+          ~metadata receipt
+      in
       let reply =
-        redact_text (busy_ack_reply_text_queued ~in_flight:(Some in_flight) ~keeper_name)
+        redact_text
+          (busy_ack_reply_text_queued ~in_flight:(Some in_flight) ~keeper_name
+             ~receipt_id:message_request.request_id)
       in
       let stats =
         Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
       in
       Gate_protocol.Reply
-        { content = reply; structured = None; stats; message_request = None }
+        { content = reply
+        ; structured = None
+        ; stats
+        ; message_request = Some message_request
+        }
+  | `Chat_queue_error error ->
+      Gate_protocol.Keeper_error_result
+        (redact_text
+           (Printf.sprintf
+              "%s is busy; your message was not queued because the durable chat queue rejected it: %s"
+              keeper_name
+              (Keeper_chat_queue.mutation_error_to_string error)))
   | `Streaming (Some result) when Tool_result.is_success result ->
       let body = Tool_result.message result in
       let duration_ms =

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -55,9 +55,13 @@ val dispatch :
     When the target keeper already has an admitted turn in flight, the busy
     message is routed per {!route_busy_connector}: a [Discord]/[Slack]
     [connector_kind] enqueues onto [Keeper_chat_queue] for deferred delivery via
-    the serial consumer's outbound adapter (RFC-connector-deferred-reply-via-chat-queue); [Generic] (the default)
+    the serial consumer's outbound adapter
+    (RFC-connector-deferred-reply-via-chat-queue). The enqueue is acknowledged
+    only after its durable snapshot commits; the reply's [message_request]
+    carries the queue receipt id and revision. Persistence failure returns an
+    explicit [Keeper_error_result], never a queued ACK. [Generic] (the default)
     returns an accepted async request envelope ([Keeper_msg_async]) instead of
-    blocking the connector request behind that turn.  The [channel] and
+    blocking the connector request behind that turn. The [channel] and
     [channel_user_id] are used to construct the agent name
     ([gate:<channel>:<workspace_id>:<user_id>]).  The other connector fields are
     injected into the keeper-visible message body so external user identity

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -27,6 +27,9 @@ val route_busy_connector :
   connector_kind ->
   channel_id:string ->
   user_id:string ->
+  user_name:string ->
+  team_id:string option ->
+  thread_ts:string option ->
   [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ]
 (** Pure routing decision for a connector message that arrives while the keeper
     has an in-flight turn. Exhaustive over {!connector_kind}: [Discord] and

--- a/lib/keeper/keeper_chat_broadcast.ml
+++ b/lib/keeper/keeper_chat_broadcast.ml
@@ -106,13 +106,13 @@ let chat_appended ~keeper_name ~source ?content () =
 let chat_appended_with_audio ~keeper_name ~source ~audio ?content () =
   do_broadcast ~keeper_name ~source ~audio:(Some audio) ?content ()
 
-let queue_changed ~keeper_name ~depth () =
+let queue_changed ~keeper_name ~revision () =
   try
     Sse.broadcast
       (`Assoc
         [ ("type", `String "keeper_chat_queue_changed");
-          ("name", `String keeper_name);
-          ("depth", `Int depth);
+          ("keeper_name", `String keeper_name);
+          ("revision", `Intlit (Int64.to_string revision));
           ("ts_unix", `Float (Time_compat.now ()));
         ])
   with
@@ -126,4 +126,3 @@ let queue_changed ~keeper_name ~depth () =
       "keeper_chat_broadcast: queue_changed name=%s failed: %s"
       keeper_name
       (Printexc.to_string exn)
-

--- a/lib/keeper/keeper_chat_broadcast.mli
+++ b/lib/keeper/keeper_chat_broadcast.mli
@@ -43,15 +43,13 @@ val chat_appended :
 val chat_appended_with_audio :
   keeper_name:string -> source:string -> audio:audio_clip -> ?content:string -> unit -> unit
 
-(** Broadcast a [keeper_chat_queue_changed] SSE event whenever a keeper's
-    still-queued (not leased) message count changes: enqueue, lease, ack, or
-    nack. [depth] is the count {!Keeper_chat_queue.length} would report right
-    after the mutation. The busy-ack HTTP response already carries a
-    one-shot [queue_length] at enqueue time (RFC-connector-deferred-reply-via-chat-queue); this event is
-    what keeps that number live for a dashboard session that is already
-    open and watching a keeper it did not just send a message to.
+(** Broadcast a [keeper_chat_queue_changed] invalidation whenever a durable
+    receipt transition commits. [revision] is the exact queue projection
+    revision after that transition. Lifecycle truth is intentionally absent
+    from this event: dashboards re-read the authoritative receipt projection
+    instead of guessing Pending/Inflight/Delivered/Failed from deltas.
 
     Same failure contract as {!chat_appended}: exceptions from
     [Sse.broadcast] are counted and logged at WARN, {!Eio.Cancel.Cancelled}
     propagates. *)
-val queue_changed : keeper_name:string -> depth:int -> unit -> unit
+val queue_changed : keeper_name:string -> revision:int64 -> unit -> unit

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -101,14 +101,7 @@ let settle_lease state ~keeper_name ~lease_id action =
             lease=%s: %s; finalization will retry"
            keeper_name
            lease_id
-           (match error with
-            | Keeper_chat_queue.Persistence_not_configured ->
-                "persistence_not_configured"
-            | Keeper_chat_queue.Revision_exhausted ->
-                "revision_exhausted"
-            | Keeper_chat_queue.Persist_failed message -> message
-            | Keeper_chat_queue.Snapshot_unavailable load_error ->
-                load_error.message);
+           (Keeper_chat_queue.mutation_error_to_string error);
          `Pending)
     | Nack ->
       (match Keeper_chat_queue.nack ~keeper_name ~lease_id with
@@ -130,14 +123,7 @@ let settle_lease state ~keeper_name ~lease_id action =
             finalization will retry"
            keeper_name
            lease_id
-           (match error with
-            | Keeper_chat_queue.Persistence_not_configured ->
-                "persistence_not_configured"
-            | Keeper_chat_queue.Revision_exhausted ->
-                "revision_exhausted"
-            | Keeper_chat_queue.Persist_failed message -> message
-            | Keeper_chat_queue.Snapshot_unavailable load_error ->
-                load_error.message);
+           (Keeper_chat_queue.mutation_error_to_string error);
          `Pending)
   in
   result
@@ -263,14 +249,7 @@ let start ~sw ~clock ~base_path ~handle_turn =
                        "keeper_chat_consumer: lease_batch persist failed for keeper=%s: \
                         %s; retrying next poll"
                        keeper_name
-                       (match error with
-                        | Keeper_chat_queue.Persistence_not_configured ->
-                            "persistence_not_configured"
-                        | Keeper_chat_queue.Revision_exhausted ->
-                            "revision_exhausted"
-                        | Keeper_chat_queue.Persist_failed message -> message
-                        | Keeper_chat_queue.Snapshot_unavailable load_error ->
-                            load_error.message);
+                       (Keeper_chat_queue.mutation_error_to_string error);
                      clear_dispatching dispatch_state keeper_name
                  | `Leased { Keeper_chat_queue.lease_id; items } ->
                      (match items with

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -78,31 +78,56 @@ end
 (* A finalization persist failure is recoverable: queue-core keeps the lease
    unchanged. Retain the exact typed decision and retry it before dispatching
    another turn for this Keeper. *)
+let invalid_finalization_fallback message =
+  let completed_at = Time_compat.now () in
+  let completed_at = if Float.is_finite completed_at then completed_at else 0.0 in
+  Keeper_chat_queue.Mark_failed
+    { completed_at
+    ; kind = Keeper_chat_queue.Internal_error
+    ; detail =
+        Safe_ops.sanitize_text_utf8
+          ("queued turn produced an invalid terminal outcome: " ^ message)
+    ; outcome_ref = None
+    }
+
 let settle_lease state ~keeper_name ~lease_id action =
   let result =
     match action with
     | Finalize outcome ->
-      (match Keeper_chat_queue.finalize ~keeper_name ~lease_id ~outcome with
-       | `Finalized _ ->
-         clear_pending_finalization state ~keeper_name ~lease_id;
-         `Settled
-       | `Unknown_lease ->
-         clear_pending_finalization state ~keeper_name ~lease_id;
-         Log.Keeper.warn
-           "keeper_chat_consumer: finalize found no matching lease=%s for \
-            keeper=%s (already finalized/nacked?)"
-           lease_id
-           keeper_name;
-         `Settled
-       | `Error error ->
-         remember_pending_finalization state ~keeper_name ~lease_id ~action;
-         Log.Keeper.error
-           "keeper_chat_consumer: finalize persist failed for keeper=%s \
-            lease=%s: %s; finalization will retry"
-           keeper_name
-           lease_id
-           (Keeper_chat_queue.mutation_error_to_string error);
-         `Pending)
+      let rec finalize ~allow_invalid_fallback outcome =
+        match Keeper_chat_queue.finalize ~keeper_name ~lease_id ~outcome with
+        | `Finalized _ ->
+          clear_pending_finalization state ~keeper_name ~lease_id;
+          `Settled
+        | `Unknown_lease ->
+          clear_pending_finalization state ~keeper_name ~lease_id;
+          Log.Keeper.warn
+            "keeper_chat_consumer: finalize found no matching lease=%s for \
+             keeper=%s (already finalized/nacked?)"
+            lease_id
+            keeper_name;
+          `Settled
+        | `Error (Keeper_chat_queue.Invalid_input message)
+          when allow_invalid_fallback ->
+          let fallback = invalid_finalization_fallback message in
+          Log.Keeper.error
+            "keeper_chat_consumer: rejected invalid terminal outcome for \
+             keeper=%s lease=%s: %s; replacing it with a typed internal_error"
+            keeper_name lease_id message;
+          finalize ~allow_invalid_fallback:false fallback
+        | `Error error ->
+          let retry_action = Finalize outcome in
+          remember_pending_finalization state ~keeper_name ~lease_id
+            ~action:retry_action;
+          Log.Keeper.error
+            "keeper_chat_consumer: finalize persist failed for keeper=%s \
+             lease=%s: %s; finalization will retry"
+            keeper_name
+            lease_id
+            (Keeper_chat_queue.mutation_error_to_string error);
+          `Pending
+      in
+      finalize ~allow_invalid_fallback:true outcome
     | Nack ->
       (match Keeper_chat_queue.nack ~keeper_name ~lease_id with
        | `Requeued _ ->
@@ -148,16 +173,30 @@ let retry_pending_finalization state ~keeper_name =
     | `Settled | `Pending -> ());
     true
 
+let canonical_optional_outcome_ref = function
+  | None -> None
+  | Some value ->
+    let value = Safe_ops.sanitize_text_utf8 value |> String.trim in
+    if String.equal value "" then None else Some value
+
+let canonical_failure_detail detail =
+  let detail = Safe_ops.sanitize_text_utf8 detail |> String.trim in
+  if String.equal detail ""
+  then "queued turn failed without diagnostic detail"
+  else detail
+
 let finalization_of_turn_outcome ~clock = function
   | Delivered { outcome_ref } ->
       Keeper_chat_queue.Mark_delivered
-        { completed_at = Eio.Time.now clock; outcome_ref }
+        { completed_at = Eio.Time.now clock
+        ; outcome_ref = canonical_optional_outcome_ref outcome_ref
+        }
   | Failed { kind; detail; outcome_ref } ->
       Keeper_chat_queue.Mark_failed
         { completed_at = Eio.Time.now clock
         ; kind
-        ; detail
-        ; outcome_ref
+        ; detail = canonical_failure_detail detail
+        ; outcome_ref = canonical_optional_outcome_ref outcome_ref
         }
 
 let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id ~queued =

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -7,7 +7,7 @@ let poll_interval_sec =
   | None -> 1.0
 
 type turn_outcome =
-  | Delivered of { outcome_ref : string option }
+  | Delivered of { outcome_ref : string }
   | Failed of
       { kind : Keeper_chat_queue.failure_kind
       ; detail : string
@@ -173,11 +173,21 @@ let retry_pending_finalization state ~keeper_name =
     | `Settled | `Pending -> ());
     true
 
+let canonical_turn_ref_string value =
+  if not (String.is_valid_utf_8 value) then None
+  else
+    match Ids.Turn_ref.of_string value with
+    | Some turn_ref
+      when String.equal (Ids.Turn_ref.to_string turn_ref) value ->
+      Some value
+    | Some _ | None -> None
+
 let canonical_optional_outcome_ref = function
-  | None -> None
+  | None -> None, false
   | Some value ->
-    let value = Safe_ops.sanitize_text_utf8 value |> String.trim in
-    if String.equal value "" then None else Some value
+    (match canonical_turn_ref_string value with
+     | Some value -> Some value, false
+     | None -> None, true)
 
 let canonical_failure_detail detail =
   let detail = Safe_ops.sanitize_text_utf8 detail |> String.trim in
@@ -187,16 +197,35 @@ let canonical_failure_detail detail =
 
 let finalization_of_turn_outcome ~clock = function
   | Delivered { outcome_ref } ->
-      Keeper_chat_queue.Mark_delivered
-        { completed_at = Eio.Time.now clock
-        ; outcome_ref = canonical_optional_outcome_ref outcome_ref
-        }
+      (match canonical_turn_ref_string outcome_ref with
+       | Some outcome_ref ->
+         Keeper_chat_queue.Mark_delivered
+           { completed_at = Eio.Time.now clock
+           ; outcome_ref = Some outcome_ref
+           }
+       | None ->
+         Keeper_chat_queue.Mark_failed
+           { completed_at = Eio.Time.now clock
+           ; kind = Keeper_chat_queue.Internal_error
+           ; detail =
+               "queued turn claimed delivery with an invalid turn_ref"
+           ; outcome_ref = None
+           })
   | Failed { kind; detail; outcome_ref } ->
+      let outcome_ref, invalid_outcome_ref =
+        canonical_optional_outcome_ref outcome_ref
+      in
+      let detail = canonical_failure_detail detail in
+      let detail =
+        if invalid_outcome_ref
+        then detail ^ "; invalid turn_ref omitted from terminal correlation"
+        else detail
+      in
       Keeper_chat_queue.Mark_failed
         { completed_at = Eio.Time.now clock
         ; kind
-        ; detail = canonical_failure_detail detail
-        ; outcome_ref = canonical_optional_outcome_ref outcome_ref
+        ; detail
+        ; outcome_ref
         }
 
 let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id ~queued =

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -6,8 +6,16 @@ let poll_interval_sec =
       try float_of_string s with Failure _ -> 1.0)
   | None -> 1.0
 
+type turn_outcome =
+  | Delivered of { outcome_ref : string option }
+  | Failed of
+      { kind : Keeper_chat_queue.failure_kind
+      ; detail : string
+      ; outcome_ref : string option
+      }
+
 type lease_finalization =
-  | Ack
+  | Finalize of Keeper_chat_queue.finalization
   | Nack
 
 type dispatch_state = {
@@ -46,11 +54,11 @@ let pending_finalization state keeper_name =
   with_dispatch_state state (fun () ->
       Hashtbl.find_opt state.pending_finalizations keeper_name)
 
-let clear_pending_finalization state ~keeper_name ~lease_id ~action =
+let clear_pending_finalization state ~keeper_name ~lease_id =
   with_dispatch_state state (fun () ->
       match Hashtbl.find_opt state.pending_finalizations keeper_name with
-      | Some (pending_lease_id, pending_action)
-        when String.equal pending_lease_id lease_id && pending_action = action ->
+      | Some (pending_lease_id, _)
+        when String.equal pending_lease_id lease_id ->
         Hashtbl.remove state.pending_finalizations keeper_name
       | Some _ | None -> ())
 
@@ -67,79 +75,77 @@ module For_testing = struct
   let clear_dispatching = clear_dispatching
 end
 
-(* Single broadcast site for every queue-depth-affecting mutation this module
-   performs (lease/ack/nack — [enqueue]'s callers broadcast their own, since
-   they already have the post-enqueue length in hand). Keeping it here rather
-   than scattered across each [`Leased]/[`Acked]/[`Requeued] call site avoids
-   an N-of-M gap where a future new call site forgets to broadcast. *)
-let broadcast_queue_changed ~keeper_name =
-  Keeper_chat_broadcast.queue_changed ~keeper_name
-    ~depth:(Keeper_chat_queue.length ~keeper_name)
-    ()
-
-(* A finalization persist failure is recoverable: the queue deliberately rolls
-   the lease mutation back, so the same lease remains outstanding in memory.
-   Keep the typed decision and retry it from the next poll; otherwise the
-   consumer would observe [Already_leased] forever and permanently wedge this
-   Keeper lane. The decision is not persisted separately because a process
-   restart requeues the outstanding lease, after which the pending decision is
-   intentionally discarded. *)
+(* A finalization persist failure is recoverable: queue-core keeps the lease
+   unchanged. Retain the exact typed decision and retry it before dispatching
+   another turn for this Keeper. *)
 let settle_lease state ~keeper_name ~lease_id action =
   let result =
     match action with
-    | Ack ->
-      (match Keeper_chat_queue.ack ~keeper_name ~lease_id with
-       | `Acked ->
-         clear_pending_finalization state ~keeper_name ~lease_id ~action;
-         broadcast_queue_changed ~keeper_name;
+    | Finalize outcome ->
+      (match Keeper_chat_queue.finalize ~keeper_name ~lease_id ~outcome with
+       | `Finalized _ ->
+         clear_pending_finalization state ~keeper_name ~lease_id;
          `Settled
        | `Unknown_lease ->
-         clear_pending_finalization state ~keeper_name ~lease_id ~action;
+         clear_pending_finalization state ~keeper_name ~lease_id;
          Log.Keeper.warn
-           "keeper_chat_consumer: ack found no matching lease=%s for keeper=%s \
-            (already acked/nacked?)"
+           "keeper_chat_consumer: finalize found no matching lease=%s for \
+            keeper=%s (already finalized/nacked?)"
            lease_id
            keeper_name;
          `Settled
-       | `Persist_failed msg ->
+       | `Error error ->
          remember_pending_finalization state ~keeper_name ~lease_id ~action;
          Log.Keeper.error
-           "keeper_chat_consumer: ack persist failed for keeper=%s lease=%s: %s; \
-            finalization will retry"
+           "keeper_chat_consumer: finalize persist failed for keeper=%s \
+            lease=%s: %s; finalization will retry"
            keeper_name
            lease_id
-           msg;
+           (match error with
+            | Keeper_chat_queue.Persistence_not_configured ->
+                "persistence_not_configured"
+            | Keeper_chat_queue.Revision_exhausted ->
+                "revision_exhausted"
+            | Keeper_chat_queue.Persist_failed message -> message
+            | Keeper_chat_queue.Snapshot_unavailable load_error ->
+                load_error.message);
          `Pending)
     | Nack ->
       (match Keeper_chat_queue.nack ~keeper_name ~lease_id with
-       | `Requeued ->
-         clear_pending_finalization state ~keeper_name ~lease_id ~action;
-         broadcast_queue_changed ~keeper_name;
+       | `Requeued _ ->
+         clear_pending_finalization state ~keeper_name ~lease_id;
          `Settled
        | `Unknown_lease ->
-         clear_pending_finalization state ~keeper_name ~lease_id ~action;
+         clear_pending_finalization state ~keeper_name ~lease_id;
          Log.Keeper.warn
            "keeper_chat_consumer: nack found no matching lease=%s for keeper=%s \
             (already acked/nacked?)"
            lease_id
            keeper_name;
          `Settled
-       | `Persist_failed msg ->
+       | `Error error ->
          remember_pending_finalization state ~keeper_name ~lease_id ~action;
          Log.Keeper.error
            "keeper_chat_consumer: nack persist failed for keeper=%s lease=%s: %s; \
             finalization will retry"
            keeper_name
            lease_id
-           msg;
+           (match error with
+            | Keeper_chat_queue.Persistence_not_configured ->
+                "persistence_not_configured"
+            | Keeper_chat_queue.Revision_exhausted ->
+                "revision_exhausted"
+            | Keeper_chat_queue.Persist_failed message -> message
+            | Keeper_chat_queue.Snapshot_unavailable load_error ->
+                load_error.message);
          `Pending)
   in
   result
 
 (* Keep these names at the call sites readable: they now retain the decision
    when persistence is temporarily unavailable instead of silently giving up. *)
-let ack_or_warn state ~keeper_name ~lease_id =
-  match settle_lease state ~keeper_name ~lease_id Ack with
+let finalize_or_warn state ~keeper_name ~lease_id outcome =
+  match settle_lease state ~keeper_name ~lease_id (Finalize outcome) with
   | `Settled | `Pending -> ()
 
 let nack_or_warn state ~keeper_name ~lease_id =
@@ -156,44 +162,44 @@ let retry_pending_finalization state ~keeper_name =
     | `Settled | `Pending -> ());
     true
 
-(* Races [handle_turn] against [dispatch_deadline_sec] so one wedged turn
-   cannot permanently starve this keeper's queue: [handle_turn] normally
-   blocks until the turn's terminal status is observed (see
-   [Server_routes_http_keeper_stream.process_single_turn]), and if the
-   underlying async execution is cancelled mid-turn by its own internal
-   timeout, nothing ever wakes that wait. [dispatch_deadline_sec] is set well
-   above that internal timeout (see the .mli) so by the time it fires here,
-   the turn's own machinery has already given up. *)
-let run_leased_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn ~on_stalled
-    ~keeper_name ~lease_id ~queued =
-  match
-    Eio.Fiber.first
-      (fun () ->
-        handle_turn ~sw ~keeper_name ~queued_message:queued;
-        `Completed)
-      (fun () ->
-        Eio.Time.sleep clock dispatch_deadline_sec;
-        `Stalled)
-  with
-  | `Completed -> ack_or_warn state ~keeper_name ~lease_id
-  | `Stalled -> (
-      match on_stalled ~keeper_name ~queued_message:queued with
-      | () -> ack_or_warn state ~keeper_name ~lease_id
-      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-      | exception exn ->
-          Log.Keeper.warn
-            "keeper_chat_consumer: on_stalled failed for keeper=%s: %s; nacking \
-             instead of acking so the batch is retried"
-            keeper_name
-            (Printexc.to_string exn);
-          nack_or_warn state ~keeper_name ~lease_id)
+let finalization_of_turn_outcome ~clock = function
+  | Delivered { outcome_ref } ->
+      Keeper_chat_queue.Mark_delivered
+        { completed_at = Eio.Time.now clock; outcome_ref }
+  | Failed { kind; detail; outcome_ref } ->
+      Keeper_chat_queue.Mark_failed
+        { completed_at = Eio.Time.now clock
+        ; kind
+        ; detail
+        ; outcome_ref
+        }
 
-let dispatch_queued_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn ~on_stalled
-    ~keeper_name ~lease_id ~queued =
+let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id ~queued =
+  match handle_turn ~sw ~keeper_name ~queued_message:queued with
+  | outcome ->
+      finalize_or_warn state ~keeper_name ~lease_id
+        (finalization_of_turn_outcome ~clock outcome)
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+  | exception exn ->
+      let detail = Printexc.to_string exn in
+      Log.Keeper.error
+        "keeper_chat_consumer: handle_turn raised for keeper=%s: %s; recording \
+         a terminal internal_error receipt"
+        keeper_name detail;
+      finalize_or_warn state ~keeper_name ~lease_id
+        (Keeper_chat_queue.Mark_failed
+           { completed_at = Eio.Time.now clock
+           ; kind = Keeper_chat_queue.Internal_error
+           ; detail
+           ; outcome_ref = None
+           })
+
+let dispatch_queued_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
+    ~queued =
   Eio.Fiber.fork ~sw (fun () ->
       try
-        run_leased_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn ~on_stalled
-          ~keeper_name ~lease_id ~queued;
+        run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
+          ~queued;
         clear_dispatching state keeper_name
       with
       | Eio.Cancel.Cancelled _ as e ->
@@ -203,12 +209,13 @@ let dispatch_queued_turn state ~sw ~clock ~dispatch_deadline_sec ~handle_turn ~o
       | exn ->
           nack_or_warn state ~keeper_name ~lease_id;
           clear_dispatching state keeper_name;
-          Log.Keeper.warn
-            "keeper_chat_consumer: handle_turn failed for keeper=%s: %s"
+          Log.Keeper.error
+            "keeper_chat_consumer: dispatch finalization failed unexpectedly \
+             for keeper=%s: %s"
             keeper_name
             (Printexc.to_string exn))
 
-let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled =
+let start ~sw ~clock ~base_path ~handle_turn =
   let dispatch_state = create_dispatch_state () in
   let rec poll_loop () =
     let keeper_names = Keeper_chat_queue.all_keeper_names () in
@@ -251,24 +258,30 @@ let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled 
                        lease_id
                        keeper_name;
                      clear_dispatching dispatch_state keeper_name
-                 | `Persist_failed msg ->
+                 | `Error error ->
                      Log.Keeper.warn
                        "keeper_chat_consumer: lease_batch persist failed for keeper=%s: \
                         %s; retrying next poll"
                        keeper_name
-                       msg;
+                       (match error with
+                        | Keeper_chat_queue.Persistence_not_configured ->
+                            "persistence_not_configured"
+                        | Keeper_chat_queue.Revision_exhausted ->
+                            "revision_exhausted"
+                        | Keeper_chat_queue.Persist_failed message -> message
+                        | Keeper_chat_queue.Snapshot_unavailable load_error ->
+                            load_error.message);
                      clear_dispatching dispatch_state keeper_name
-                 | `Leased { Keeper_chat_queue.lease_id; messages } ->
-                     broadcast_queue_changed ~keeper_name;
-                     (match messages with
+                 | `Leased { Keeper_chat_queue.lease_id; items } ->
+                     (match items with
                       | _ :: _ :: _ ->
                           Log.Keeper.info
                             "keeper_chat_consumer: coalesced %d queued messages \
                              into one turn for keeper=%s"
-                            (List.length messages)
+                            (List.length items)
                             keeper_name
                       | [] | [ _ ] -> ());
-                     (match Keeper_chat_queue.merge_batch messages with
+                     (match Keeper_chat_queue.merge_batch items with
                       | None ->
                           (* Unreachable in practice: [lease_batch] only returns
                              [`Leased] with a non-empty [messages]. Nack rather
@@ -284,8 +297,7 @@ let start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn ~on_stalled 
                       | Some queued ->
                           (try
                              dispatch_queued_turn dispatch_state ~sw ~clock
-                               ~dispatch_deadline_sec ~handle_turn ~on_stalled
-                               ~keeper_name ~lease_id ~queued
+                               ~handle_turn ~keeper_name ~lease_id ~queued
                            with
                            | Eio.Cancel.Cancelled _ as e ->
                                Eio.Cancel.protect (fun () ->

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -9,8 +9,18 @@
 
     @since 2.145.0 *)
 
-(** [start ~sw ~clock ~base_path ~dispatch_deadline_sec ~handle_turn
-    ~on_stalled] begins a background fiber that polls [Keeper_chat_queue]
+(** A typed outcome from the whole queued-turn delivery boundary. Connector
+    adapters must be joined before returning [Delivered]; a persisted failure,
+    missing connector, or outbound error returns [Failed]. *)
+type turn_outcome =
+  | Delivered of { outcome_ref : string option }
+  | Failed of
+      { kind : Keeper_chat_queue.failure_kind
+      ; detail : string
+      ; outcome_ref : string option
+      }
+
+(** [start ~sw ~clock ~base_path ~handle_turn] begins a background fiber that polls [Keeper_chat_queue]
     every [MASC_KEEPER_QUEUE_POLL_SEC] seconds (default 1.0).
 
     Per keeper and per tick: when a turn is in flight
@@ -23,23 +33,16 @@
     keeper-local dispatch gate preserves the single follow-up turn contract
     for messages sent during an existing queued turn.
 
-    Delivery is at-least-once: the lease is acked only once [handle_turn]
-    returns without raising, nacked (returned to the head of the queue) on
-    any other exception including {!Eio.Cancel.Cancelled} from outside this
-    fiber. [handle_turn] is raced against [dispatch_deadline_sec]; if it has
-    not returned by then, [handle_turn]'s fiber is cancelled, [on_stalled] is
-    called to durably record that the queued message was never answered
-    (its own failure does not raise — a failed [on_stalled] still nacks so
-    the batch is retried instead of silently vanishing), and the lease is
-    acked (the stall itself is now the durable, visible answer, so retrying
-    would re-run a turn [Keeper_msg_async]'s own internal timeout has
-    already given up on). [dispatch_deadline_sec] should exceed the turn
-    execution timeout [handle_turn] itself enforces, with margin: it exists
-    to bound how long a *misbehaving* [handle_turn] can wedge this keeper's
-    queue, not to race the turn's own timeout. If the durable ack/nack rewrite
-    fails, the typed finalization decision is retained for the next poll and
-    retried before another turn starts; a transient persistence error therefore
-    cannot leave this keeper permanently stuck behind [Already_leased].
+    Delivery is at-least-once. [handle_turn]'s typed outcome is durably
+    finalized as [Delivered] or [Failed]; only structured cancellation nacks
+    the unchanged receipt back to [Pending]. An unexpected handler exception
+    becomes a durable [Internal_error] failure instead of a poison-message
+    retry loop. There is deliberately no second wall-clock watchdog: the turn
+    runtime owns timeout/cancellation and must return the typed outcome.
+
+    If finalization persistence fails, the exact decision is retained and
+    retried before another turn starts; a transient filesystem error cannot
+    leave the lane stuck behind an outstanding lease.
 
     The fiber runs until [sw] is released.
 
@@ -50,9 +53,7 @@ val start :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   base_path:string ->
-  dispatch_deadline_sec:float ->
-  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
-  on_stalled:(keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> unit) ->
+  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> turn_outcome) ->
   unit
 
 module For_testing : sig

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -42,7 +42,10 @@ type turn_outcome =
 
     If finalization persistence fails, the exact decision is retained and
     retried before another turn starts; a transient filesystem error cannot
-    leave the lane stuck behind an outstanding lease.
+    leave the lane stuck behind an outstanding lease. External diagnostic text
+    is normalized at this terminal boundary. If queue validation still rejects
+    the decision, the consumer replaces it with a typed [Internal_error]
+    terminal outcome instead of retrying a permanently invalid action forever.
 
     The fiber runs until [sw] is released.
 

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -11,9 +11,11 @@
 
 (** A typed outcome from the whole queued-turn delivery boundary. Connector
     adapters must be joined before returning [Delivered]; a persisted failure,
-    missing connector, or outbound error returns [Failed]. *)
+    missing connector, or outbound error returns [Failed]. [Delivered]'s
+    [outcome_ref] is required and must be a canonical [Ids.Turn_ref] string;
+    the consumer fails closed as [Internal_error] if that invariant is broken. *)
 type turn_outcome =
-  | Delivered of { outcome_ref : string option }
+  | Delivered of { outcome_ref : string }
   | Failed of
       { kind : Keeper_chat_queue.failure_kind
       ; detail : string

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -272,7 +272,10 @@ let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
   let content =
     Printf.sprintf "🔊 %s%s\n%s" duration_prefix message_text url
   in
-  ignore (send_message ~token ~channel_id ~content : (unit, error) result)
+  (* Rich audio is a side message, not the primary terminal delivery receipt.
+     [send_message] already logs the concrete transport error. *)
+  match send_message ~token ~channel_id ~content with
+  | Ok () | Error _ -> ()
 
 let truncate_embed_desc s =
   let max_len = 3900 in

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -13,23 +13,31 @@
    1.0 s is 80 % of that budget, leaving headroom for the final edit. *)
 let min_edit_interval_s = 1.0
 
+type error = Discord_rest_client.error
+
+let pp_error = Discord_rest_client.pp_error
+
 (* ── Text chunking helpers ────────────────────────────────────────── *)
 
 let send_message ~token ~channel_id ~content =
   let content = Observability_redact.redact_text content in
   let limit = Discord_rest_client.message_content_limit in
   let len = String.length content in
-  if len = 0 then ()
+  if len = 0 then Ok ()
   else if len <= limit then
     match Discord_rest_client.send_message ~token ~channel_id ~content () with
-    | Ok _msg_id -> ()
+    | Ok _msg_id -> Ok ()
     | Error err ->
         let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
         Log.Keeper.warn
-          "keeper_chat_discord: send_message failed: %s" err_str
+          "keeper_chat_discord: send_message failed: %s" err_str;
+        Error err
   else
-    let rec send_chunks rest =
-      if String.length rest = 0 then ()
+    let rec send_chunks first_error rest =
+      if String.length rest = 0 then
+        match first_error with
+        | None -> Ok ()
+        | Some err -> Error err
       else
         (* Split on a codepoint boundary: Discord measures the limit in
            Unicode scalar values, and a mid-codepoint byte cut produces
@@ -38,16 +46,22 @@ let send_message ~token ~channel_id ~content =
           Discord_rest_client.split_at_codepoint rest ~limit
         in
         (match Discord_rest_client.send_message ~token ~channel_id ~content:chunk () with
-         | Ok _msg_id -> send_chunks remaining
+         | Ok _msg_id -> send_chunks first_error remaining
          | Error err ->
              let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
              Log.Keeper.warn
                "keeper_chat_discord: send_message chunk failed: %s" err_str;
-             (* Continue sending remaining chunks despite error — partial
-                delivery is better than silent truncation. *)
-             send_chunks remaining)
+             (* Preserve the existing best-effort overflow behavior, but return
+                the first failure after all remaining chunks are attempted so
+                the terminal delivery receipt cannot claim success. *)
+             let first_error =
+               match first_error with
+               | None -> Some err
+               | Some _ -> first_error
+             in
+             send_chunks first_error remaining)
     in
-    send_chunks content
+    send_chunks None content
 
 (* Truncate to Discord message limit for PATCH edits, with redaction.
    Cuts on a codepoint boundary so the PATCH body stays valid UTF-8. *)
@@ -92,16 +106,17 @@ let final_head_and_overflow content =
   let overflow = if overflow_str = "" then None else Some overflow_str in
   (head, overflow)
 
-let edit_message_silent ~token ~channel_id ~message_id ~content =
+let edit_message ~token ~channel_id ~message_id ~content =
   match Discord_rest_client.edit_message
           ~token ~channel_id ~message_id ~content ()
   with
-  | Ok () -> ()
+  | Ok () -> Ok ()
   | Error err ->
       let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
       Log.Keeper.warn
         "keeper_chat_discord: edit_message failed (msg=%s): %s"
-        message_id err_str
+        message_id err_str;
+      Error err
 
 (* ── Tool embed helpers ──────────────────────────────────────────── *)
 
@@ -257,7 +272,7 @@ let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
   let content =
     Printf.sprintf "🔊 %s%s\n%s" duration_prefix message_text url
   in
-  send_message ~token ~channel_id ~content
+  ignore (send_message ~token ~channel_id ~content : (unit, error) result)
 
 let truncate_embed_desc s =
   let max_len = 3900 in
@@ -349,7 +364,13 @@ let send_text_rich_embeds ~token ~channel_id text =
    not for deterministic policy or state transitions. *)
 let now () = Unix.gettimeofday ()
 
-let adapter_loop ~token ~channel_id ~events ?base_url () =
+let combine_delivery_results primary overflow =
+  match primary with
+  | Error _ -> primary
+  | Ok () -> overflow
+
+let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
+    ~edit_message ~send_message ?base_url ?(on_send_result = fun _ -> ()) () =
   let base_url =
     match base_url with
     | Some b -> Some (Masc_network_defaults.normalize_loopback_base_url b)
@@ -374,8 +395,7 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
                loop ~acc_text ~msg_id:None ~last_edit_time
                  ~last_edited_text ~base_url ~tool_msgs
              else
-               (match Discord_rest_client.send_message
-                       ~token ~channel_id ~content:patch_content ()
+               (match post_message ~content:patch_content
                with
                 | Ok created_id ->
                     loop ~acc_text
@@ -398,12 +418,23 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
                loop ~acc_text ~msg_id ~last_edit_time
                  ~last_edited_text ~base_url ~tool_msgs
              else if elapsed >= min_edit_interval_s then begin
-               edit_message_silent ~token ~channel_id
-                 ~message_id:mid ~content:patch_content;
-               loop ~acc_text ~msg_id
-                 ~last_edit_time:(now ())
-                 ~last_edited_text:patch_content
-                 ~base_url ~tool_msgs
+               match edit_message ~message_id:mid ~content:patch_content with
+               | Ok () ->
+                   loop ~acc_text ~msg_id
+                     ~last_edit_time:(now ())
+                     ~last_edited_text:patch_content
+                     ~base_url ~tool_msgs
+               | Error err ->
+                   let err_str =
+                     Format.asprintf "%a" Discord_rest_client.pp_error err
+                   in
+                   Log.Keeper.warn
+                     "keeper_chat_discord: streaming PATCH failed (msg=%s): %s"
+                     mid err_str;
+                   (* Keep the last successful edit state so a later delta or
+                      the terminal PATCH retries the unsent content. *)
+                   loop ~acc_text ~msg_id ~last_edit_time
+                     ~last_edited_text ~base_url ~tool_msgs
              end else
                (* Rate limited — skip this PATCH. *)
                loop ~acc_text ~msg_id ~last_edit_time
@@ -413,39 +444,53 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
         let final_content = truncate acc_text in
         (match msg_id with
          | Some mid when final_content <> last_edited_text ->
-             edit_message_silent ~token ~channel_id
-               ~message_id:mid ~content:final_content;
-             loop ~acc_text ~msg_id
-               ~last_edit_time:(now ())
-               ~last_edited_text:final_content
-               ~base_url ~tool_msgs
+             (match edit_message ~message_id:mid ~content:final_content with
+              | Ok () ->
+                  loop ~acc_text ~msg_id
+                    ~last_edit_time:(now ())
+                    ~last_edited_text:final_content
+                    ~base_url ~tool_msgs
+              | Error err ->
+                  let err_str =
+                    Format.asprintf "%a" Discord_rest_client.pp_error err
+                  in
+                  Log.Keeper.warn
+                    "keeper_chat_discord: text-end PATCH failed (msg=%s): %s"
+                    mid err_str;
+                  loop ~acc_text ~msg_id ~last_edit_time
+                    ~last_edited_text ~base_url ~tool_msgs)
          | _ ->
              loop ~acc_text ~msg_id ~last_edit_time
                ~last_edited_text ~base_url ~tool_msgs)
     | Run_finished { run_id = _ } ->
-        (match msg_id with
-         | None ->
-             (* No deltas received — fall back to single send (chunks). *)
-             if String.length acc_text > 0 then
-               send_message ~token ~channel_id ~content:acc_text
-         | Some mid ->
-             let head, overflow = final_head_and_overflow acc_text in
-             (* Final PATCH with the head (first 2000 chars). *)
-             edit_message_silent ~token ~channel_id
-               ~message_id:mid ~content:head;
-             (* Send overflow as follow-up messages, matching the original
-                chunking behavior. send_message handles further splitting. *)
-             (match overflow with
-              | None -> ()
-              | Some overflow ->
-               send_message ~token ~channel_id ~content:overflow
-             ));
+        let final_result =
+          match msg_id with
+          | None ->
+              (* No stable streaming segment was posted. The terminal fallback
+                 is the primary delivery and its result owns the receipt. *)
+              if String.length acc_text = 0 then
+                Error
+                  (Discord_rest_client.Other
+                     "primary final Discord reply contained no text")
+              else send_message ~content:acc_text
+          | Some mid ->
+              let head, overflow = final_head_and_overflow acc_text in
+              let patch_result = edit_message ~message_id:mid ~content:head in
+              let overflow_result =
+                match overflow with
+                | None -> Ok ()
+                | Some overflow -> send_message ~content:overflow
+              in
+              (* Overflow is attempted even after a failed PATCH. The first
+                 primary failure remains the terminal result. *)
+              combine_delivery_results patch_result overflow_result
+        in
+        on_send_result final_result;
         send_text_rich_embeds ~token ~channel_id acc_text;
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->
-        send_message ~token ~channel_id
-          ~content:("Keeper error: " ^ message);
+        on_send_result (send_message ~content:("Keeper error: " ^ message));
         (* Loop exits after error. *)
         ()
     | Run_started { run_id = _; thread_id = _ } ->
@@ -469,10 +514,12 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
     | Oas_media_delta _ ->
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Oas_stream_protocol_error error ->
-        send_message ~token ~channel_id
-          ~content:
-            ("Keeper stream protocol: "
-             ^ Keeper_chat_events.stream_protocol_error_summary error);
+        ignore
+          (send_message
+             ~content:
+               ("Keeper stream protocol: "
+                ^ Keeper_chat_events.stream_protocol_error_summary error)
+            : (unit, error) result);
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_call_start { tool_call_id; tool_call_name } ->
         let tool_msgs =
@@ -536,9 +583,20 @@ let adapter_loop ~token ~channel_id ~events ?base_url () =
   loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
     ~last_edited_text:"" ~base_url ~tool_msgs:[]
 
+let adapter_loop ~token ~channel_id ~events ?base_url
+    ?(on_send_result = fun _ -> ()) () =
+  adapter_loop_with_transport ~token ~channel_id ~events
+    ~post_message:(fun ~content ->
+      Discord_rest_client.send_message ~token ~channel_id ~content ())
+    ~edit_message:(fun ~message_id ~content ->
+      edit_message ~token ~channel_id ~message_id ~content)
+    ~send_message:(fun ~content -> send_message ~token ~channel_id ~content)
+    ?base_url ~on_send_result ()
+
 module For_testing = struct
   let streaming_patch_content = streaming_patch_content
   let final_head_and_overflow = final_head_and_overflow
   let public_voice_audio_url = public_voice_audio_url
   let rich_embeds_of_text = rich_embeds_of_text
+  let adapter_loop = adapter_loop_with_transport
 end

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -19,13 +19,13 @@ let pp_error = Discord_rest_client.pp_error
 
 (* ── Text chunking helpers ────────────────────────────────────────── *)
 
-let send_message ~token ~channel_id ~content =
+let send_message ?clock ~token ~channel_id ~content () =
   let content = Observability_redact.redact_text content in
   let limit = Discord_rest_client.message_content_limit in
   let len = String.length content in
   if len = 0 then Ok ()
   else if len <= limit then
-    match Discord_rest_client.send_message ~token ~channel_id ~content () with
+    match Discord_rest_client.send_message ?clock ~token ~channel_id ~content () with
     | Ok _msg_id -> Ok ()
     | Error err ->
         let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
@@ -45,7 +45,7 @@ let send_message ~token ~channel_id ~content =
         let chunk, remaining =
           Discord_rest_client.split_at_codepoint rest ~limit
         in
-        (match Discord_rest_client.send_message ~token ~channel_id ~content:chunk () with
+        (match Discord_rest_client.send_message ?clock ~token ~channel_id ~content:chunk () with
          | Ok _msg_id -> send_chunks first_error remaining
          | Error err ->
              let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
@@ -106,9 +106,9 @@ let final_head_and_overflow content =
   let overflow = if overflow_str = "" then None else Some overflow_str in
   (head, overflow)
 
-let edit_message ~token ~channel_id ~message_id ~content =
+let edit_message ?clock ~token ~channel_id ~message_id ~content () =
   match Discord_rest_client.edit_message
-          ~token ~channel_id ~message_id ~content ()
+          ?clock ~token ~channel_id ~message_id ~content ()
   with
   | Ok () -> Ok ()
   | Error err ->
@@ -170,7 +170,7 @@ let tool_embed_title ~tool_name =
 
 (* Send a "running" embed for a tool call. Returns the Discord message
    id so we can edit it to "done" later. *)
-let send_tool_running ~token ~channel_id ~tool_call_name =
+let send_tool_running ?clock ~token ~channel_id ~tool_call_name () =
   let embed =
     { Discord_rest_client.title = tool_embed_title ~tool_name:tool_call_name
     ; description = Some "Running…"
@@ -181,7 +181,7 @@ let send_tool_running ~token ~channel_id ~tool_call_name =
     }
   in
   match Discord_rest_client.send_embed_message
-          ~token ~channel_id ~content:"" ~embeds:[embed] () with
+          ?clock ~token ~channel_id ~content:"" ~embeds:[embed] () with
   | Ok msg_id -> Some msg_id
   | Error err ->
       let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
@@ -191,8 +191,8 @@ let send_tool_running ~token ~channel_id ~tool_call_name =
 
 (* Edit a "running" embed to "done", preserving the original tool name and
    enriching it with optional argument and result summaries. *)
-let send_tool_done ~token ~channel_id ~message_id ~tool_call_name
-    ~args_summary ~result_summary =
+let send_tool_done ?clock ~token ~channel_id ~message_id ~tool_call_name
+    ~args_summary ~result_summary () =
   let fields =
     [ ( "args"
       , truncate_to ~max_len:Discord_rest_client.embed_field_value_limit
@@ -220,7 +220,7 @@ let send_tool_done ~token ~channel_id ~message_id ~tool_call_name
     }
   in
   match Discord_rest_client.edit_embed_message
-          ~token ~channel_id ~message_id ~content:"" ~embeds:[embed] () with
+          ?clock ~token ~channel_id ~message_id ~content:"" ~embeds:[embed] () with
   | Ok () -> ()
   | Error err ->
       let err_str = Format.asprintf "%a" Discord_rest_client.pp_error err in
@@ -237,12 +237,12 @@ let public_voice_audio_url ?base_url token =
   in
   base ^ "/api/v1/voice/audio/" ^ token
 
-let send_link_block ~token ~channel_id ~url ~title ~description ~image =
+let send_link_block ?clock ~token ~channel_id ~url ~title ~description ~image () =
   let embed =
     Discord_rest_client.link_embed ~url ~title ~description ~image
   in
   match Discord_rest_client.send_embed_message
-          ~token ~channel_id ~content:"" ~embeds:[embed] ()
+          ?clock ~token ~channel_id ~content:"" ~embeds:[embed] ()
   with
   | Ok _msg_id -> ()
   | Error err ->
@@ -250,10 +250,10 @@ let send_link_block ~token ~channel_id ~url ~title ~description ~image =
       Log.Keeper.warn
         "keeper_chat_discord: send_link_block failed: %s" err_str
 
-let send_image_block ~token ~channel_id ~url ~caption =
+let send_image_block ?clock ~token ~channel_id ~url ~caption () =
   let embed = Discord_rest_client.image_embed ~url ~caption in
   match Discord_rest_client.send_embed_message
-          ~token ~channel_id ~content:"" ~embeds:[embed] ()
+          ?clock ~token ~channel_id ~content:"" ~embeds:[embed] ()
   with
   | Ok _msg_id -> ()
   | Error err ->
@@ -261,8 +261,8 @@ let send_image_block ~token ~channel_id ~url ~caption =
       Log.Keeper.warn
         "keeper_chat_discord: send_image_block failed: %s" err_str
 
-let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
-    ~duration_sec =
+let send_audio_block ?clock ~token ~channel_id ~base_url ~audio_token ~message_text
+    ~duration_sec () =
   let url = public_voice_audio_url ?base_url audio_token in
   let duration_prefix =
     match duration_sec with
@@ -274,7 +274,7 @@ let send_audio_block ~token ~channel_id ~base_url ~audio_token ~message_text
   in
   (* Rich audio is a side message, not the primary terminal delivery receipt.
      [send_message] already logs the concrete transport error. *)
-  match send_message ~token ~channel_id ~content with
+  match send_message ?clock ~token ~channel_id ~content () with
   | Ok () | Error _ -> ()
 
 let truncate_embed_desc s =
@@ -346,12 +346,12 @@ let rich_embeds_of_text text =
   |> Keeper_chat_blocks.parse_text_to_blocks
   |> List.filter_map rich_embed_of_chat_block
 
-let send_text_rich_embeds ~token ~channel_id text =
+let send_text_rich_embeds ?clock ~token ~channel_id text =
   rich_embeds_of_text text
   |> List.iter (fun embed ->
          match
            Discord_rest_client.send_embed_message ~token ~channel_id
-             ~content:"" ~embeds:[ embed ] ()
+             ?clock ~content:"" ~embeds:[ embed ] ()
          with
          | Ok _msg_id -> ()
          | Error err ->
@@ -373,7 +373,8 @@ let combine_delivery_results primary overflow =
   | Ok () -> overflow
 
 let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
-    ~edit_message ~send_message ?base_url ?(on_send_result = fun _ -> ()) () =
+    ~edit_message ~send_message ?clock ?base_url
+    ?(on_send_result = fun _ -> ()) () =
   let base_url =
     match base_url with
     | Some b -> Some (Masc_network_defaults.normalize_loopback_base_url b)
@@ -489,7 +490,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
               combine_delivery_results patch_result overflow_result
         in
         on_send_result final_result;
-        send_text_rich_embeds ~token ~channel_id acc_text;
+        send_text_rich_embeds ?clock ~token ~channel_id acc_text;
         (* Loop exits after one turn. *)
         ()
     | Event_error { message } ->
@@ -526,7 +527,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_call_start { tool_call_id; tool_call_name } ->
         let tool_msgs =
-          match send_tool_running ~token ~channel_id ~tool_call_name with
+          match send_tool_running ?clock ~token ~channel_id ~tool_call_name () with
           | Some discord_msg_id ->
               let entry =
                 { discord_message_id = discord_msg_id
@@ -549,24 +550,24 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         (match find_tool_msg tool_msgs tool_call_id with
          | Some entry ->
              let args_summary = Option.value entry.args_summary ~default:"" in
-             send_tool_done ~token ~channel_id
+             send_tool_done ?clock ~token ~channel_id
                ~message_id:entry.discord_message_id
                ~tool_call_name:entry.tool_call_name ~args_summary
-               ~result_summary:entry.result_summary;
+               ~result_summary:entry.result_summary ();
              let tool_msgs = remove_tool_msg tool_msgs tool_call_id in
              loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
          | None ->
              (* No running embed was created (send failed earlier). *)
              loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs)
     | Link_block { url; title; description; image } ->
-        send_link_block ~token ~channel_id ~url ~title ~description ~image;
+        send_link_block ?clock ~token ~channel_id ~url ~title ~description ~image ();
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Image_block { url; caption } ->
-        send_image_block ~token ~channel_id ~url ~caption;
+        send_image_block ?clock ~token ~channel_id ~url ~caption ();
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Audio_block { token; mime = _; message_text; duration_sec } ->
-        send_audio_block ~token ~channel_id ~base_url ~audio_token:token
-          ~message_text ~duration_sec;
+        send_audio_block ?clock ~token ~channel_id ~base_url ~audio_token:token
+          ~message_text ~duration_sec ();
         loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text ~base_url ~tool_msgs
     | Tool_context_block { tool_call_id; name = _; args_summary; result_summary }
       ->
@@ -586,15 +587,15 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
   loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
     ~last_edited_text:"" ~base_url ~tool_msgs:[]
 
-let adapter_loop ~token ~channel_id ~events ?base_url
+let adapter_loop ~clock ~token ~channel_id ~events ?base_url
     ?(on_send_result = fun _ -> ()) () =
   adapter_loop_with_transport ~token ~channel_id ~events
     ~post_message:(fun ~content ->
-      Discord_rest_client.send_message ~token ~channel_id ~content ())
+      Discord_rest_client.send_message ~clock ~token ~channel_id ~content ())
     ~edit_message:(fun ~message_id ~content ->
-      edit_message ~token ~channel_id ~message_id ~content)
-    ~send_message:(fun ~content -> send_message ~token ~channel_id ~content)
-    ?base_url ~on_send_result ()
+      edit_message ~clock ~token ~channel_id ~message_id ~content ())
+    ~send_message:(fun ~content -> send_message ~clock ~token ~channel_id ~content ())
+    ~clock ?base_url ~on_send_result ()
 
 module For_testing = struct
   let streaming_patch_content = streaming_patch_content

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -19,7 +19,8 @@ type error = Discord_rest_client.error
 val pp_error : Format.formatter -> error -> unit
 
 val send_message :
-  token:string -> channel_id:string -> content:string -> (unit, error) result
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  token:string -> channel_id:string -> content:string -> unit -> (unit, error) result
 (** [send_message ~token ~channel_id ~content] posts to Discord.
     Errors are logged as warnings and returned to the caller.
     Content exceeding Discord's 2000-character limit is split into
@@ -27,6 +28,7 @@ val send_message :
     returned after the remaining chunks have been attempted. *)
 
 val adapter_loop :
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   token:string ->
   channel_id:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
@@ -94,6 +96,7 @@ module For_testing : sig
     post_message:(content:string -> (string, error) result) ->
     edit_message:(message_id:string -> content:string -> (unit, error) result) ->
     send_message:(content:string -> (unit, error) result) ->
+    ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
     ?base_url:string ->
     ?on_send_result:((unit, error) result -> unit) ->
     unit ->

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -14,21 +14,28 @@
 val min_edit_interval_s : float
 (** Minimum seconds between PATCH edits (default 1.0). *)
 
+type error = Discord_rest_client.error
+
+val pp_error : Format.formatter -> error -> unit
+
 val send_message :
-  token:string -> channel_id:string -> content:string -> unit
+  token:string -> channel_id:string -> content:string -> (unit, error) result
 (** [send_message ~token ~channel_id ~content] posts to Discord.
-    Errors are logged as warnings but never raised.
+    Errors are logged as warnings and returned to the caller.
     Content exceeding Discord's 2000-character limit is split into
-    multiple messages. *)
+    multiple messages. All chunks are attempted; the first failure is
+    returned after the remaining chunks have been attempted. *)
 
 val adapter_loop :
   token:string ->
   channel_id:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   ?base_url:string ->
+  ?on_send_result:((unit, error) result -> unit) ->
   unit ->
   unit
-(** [adapter_loop ~token ~channel_id ~events ?base_url ()] subscribes to the
+(** [adapter_loop ~token ~channel_id ~events ?base_url ?on_send_result ()]
+    subscribes to the
     event stream and delivers text to Discord in real time:
     - [Text_delta] (first stable segment): POST creates the message,
       stores its id.
@@ -49,6 +56,13 @@ val adapter_loop :
     configured {!Env_config_core.masc_http_base_url} is used.
 
     Falls back to a single POST if no deltas arrive before [Run_finished].
+
+    [on_send_result] is invoked exactly once when the turn terminates through
+    [Run_finished] or [Event_error]. The result reports whether the primary
+    final text/error reply was actually delivered: the final PATCH plus every
+    overflow POST must succeed. Streaming previews, tool embeds, and other rich
+    side messages do not produce terminal callback invocations. The callback
+    defaults to a no-op.
 
     The loop exits after one turn; the caller must restart it for
     subsequent turns. *)
@@ -72,4 +86,20 @@ module For_testing : sig
       the text message already carries the reply. Image/link/audio/fusion
       cards use existing channel-native projection paths; code and Mermaid
       are rendered into embeds for richer Discord delivery. *)
+
+  val adapter_loop :
+    token:string ->
+    channel_id:string ->
+    events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+    post_message:(content:string -> (string, error) result) ->
+    edit_message:(message_id:string -> content:string -> (unit, error) result) ->
+    send_message:(content:string -> (unit, error) result) ->
+    ?base_url:string ->
+    ?on_send_result:((unit, error) result -> unit) ->
+    unit ->
+    unit
+  (** Test seam for the text-delivery transport. Production uses
+      {!Discord_rest_client}; tests can inject exact POST/PATCH outcomes while
+      exercising the real event-loop state machine. Rich side-message helpers
+      remain production-backed and should not be emitted by transport tests. *)
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1,17 +1,4 @@
-(** Keeper_chat_queue — thread-safe per-keeper message queue.
-
-    Each keeper owns an in-memory FIFO queue for chat messages that
-    arrive while the keeper is already processing a previous message.
-    When a stream finishes, the queue is drained automatically.
-
-    Queue contents can be mirrored to a per-keeper durable snapshot once
-    [configure_persistence] is called from server bootstrap.  This keeps
-    queued connector/dashboard follow-up messages replayable across restart,
-    and (RFC-connector-deferred-reply-via-chat-queue lease/ack/nack) makes
-    delivery at-least-once: a leased-but-unacknowledged batch survives a
-    crash and is redelivered on the next [configure_persistence].
-
-    @since 2.145.0 *)
+(** Durable per-Keeper chat receipt queue. *)
 
 type message_source =
   | Dashboard
@@ -26,25 +13,199 @@ type queued_message = {
   source : message_source;
 }
 
+module Receipt_id = struct
+  type t = string
+
+  let prefix = "chatq_"
+  let rng = Random.State.make_self_init ()
+  let rng_mutex = Stdlib.Mutex.create ()
+
+  let generate () =
+    let uuid =
+      Stdlib.Mutex.protect rng_mutex (fun () -> Uuidm.v4_gen rng ())
+    in
+    prefix ^ Uuidm.to_string uuid
+
+  let of_string raw =
+    let prefix_len = String.length prefix in
+    if String.length raw <= prefix_len
+       || not (String.equal (String.sub raw 0 prefix_len) prefix)
+    then Error "chat queue receipt id must start with chatq_"
+    else
+      let uuid = String.sub raw prefix_len (String.length raw - prefix_len) in
+      match Uuidm.of_string uuid with
+      | Some _ -> Ok raw
+      | None -> Error "chat queue receipt id must contain a UUID"
+
+  let to_string id = id
+  let equal = String.equal
+end
+
+type completion = {
+  completed_at : float;
+  outcome_ref : string option;
+}
+
+type failure_kind =
+  | Turn_failed
+  | Timed_out
+  | No_visible_reply
+  | Transcript_persist_failed
+  | Connector_unavailable
+  | Delivery_failed
+  | Cancelled
+  | Internal_error
+
+type failure = {
+  completed_at : float;
+  kind : failure_kind;
+  detail : string;
+  outcome_ref : string option;
+}
+
+type receipt_state =
+  | Pending
+  | Inflight of { lease_id : string; started_at : float }
+  | Delivered of completion
+  | Failed of failure
+
+type leased_message = {
+  receipt_id : Receipt_id.t;
+  message : queued_message;
+}
+
 type lease = {
   lease_id : string;
-  messages : queued_message list;
+  items : leased_message list;
 }
+
+type finalization =
+  | Mark_delivered of completion
+  | Mark_failed of failure
+
+type snapshot_load_error_kind =
+  | Invalid_path
+  | Read_failed
+  | Parse_failed
+  | Migration_failed
+  | Recovery_failed
+
+type snapshot_load_error = {
+  kind : snapshot_load_error_kind;
+  path : string option;
+  message : string;
+}
+
+type mutation_error =
+  | Persistence_not_configured
+  | Snapshot_unavailable of snapshot_load_error
+  | Revision_exhausted
+  | Persist_failed of string
+
+let snapshot_load_error_kind_to_string = function
+  | Invalid_path -> "invalid_path"
+  | Read_failed -> "read_failed"
+  | Parse_failed -> "parse_failed"
+  | Migration_failed -> "migration_failed"
+  | Recovery_failed -> "recovery_failed"
+
+let mutation_error_to_string = function
+  | Persistence_not_configured -> "chat queue persistence is not configured"
+  | Revision_exhausted -> "chat queue revision domain is exhausted"
+  | Persist_failed message -> "chat queue persistence failed: " ^ message
+  | Snapshot_unavailable error ->
+    Printf.sprintf
+      "chat queue snapshot unavailable (%s): %s"
+      (snapshot_load_error_kind_to_string error.kind)
+      error.message
+
+type active_receipt = {
+  receipt_id : Receipt_id.t;
+  message : queued_message;
+  state : receipt_state;
+}
+
+type receipt_view = {
+  receipt_id : Receipt_id.t;
+  state : receipt_state;
+}
+
+type receipt_lookup = {
+  revision : int64;
+  receipt : receipt_view option;
+}
+
+type diagnostic_snapshot = {
+  revision : int64;
+  pending : active_receipt list;
+  inflight : active_receipt list;
+  terminal : receipt_view list;
+  load_errors : snapshot_load_error list;
+}
+
+type enqueue_receipt = {
+  receipt_id : Receipt_id.t;
+  revision : int64;
+  pending_count : int;
+  inflight_count : int;
+}
+
+type configure_report = {
+  restored_keeper_count : int;
+  migrated_keeper_count : int;
+  recovered_receipt_count : int;
+  load_errors : (string option * snapshot_load_error) list;
+}
+
+type transition_observer = keeper_name:string -> revision:int64 -> unit
+
+type stored_state =
+  | Stored_pending of queued_message
+  | Stored_inflight of
+      { lease_id : string
+      ; started_at : float
+      ; message : queued_message
+      }
+  | Stored_delivered of completion
+  | Stored_failed of failure
+
+type stored_receipt = {
+  receipt_id : Receipt_id.t;
+  state : stored_state;
+}
+
+type queue_entry = {
+  mutex : Eio.Mutex.t;
+  mutable revision : int64;
+  mutable receipts : stored_receipt list;
+  mutable load_errors : snapshot_load_error list;
+}
+
+let schema_v1 = "keeper_chat_queue.v1"
+let schema_v2 = "keeper_chat_queue.v2"
+(* Revisions cross the JSON/JavaScript dashboard boundary as numbers. Keep the
+   persisted domain within IEEE-754's exact integer range instead of accepting
+   all int64 values and silently losing identity in the browser. *)
+let max_revision = 9_007_199_254_740_991L
+let persistence_file = "chat-queue.json"
+let persistence_base_path : string option Atomic.t = Atomic.make None
+let global_load_errors : snapshot_load_error list Atomic.t = Atomic.make []
+let fail_next_persist_for_testing = Atomic.make false
+let transition_observer : transition_observer option Atomic.t = Atomic.make None
+
+let registry_mutex = Eio.Mutex.create ()
+let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
 
 let dashboard_queue_default_thread_id = "dashboard"
 
 let dashboard_thread_id_or_default = function
   | Some thread_id -> thread_id
-  | None ->
-    (* DET-OK: queued dashboard messages without AG-UI thread metadata are routed
-       to the documented singleton dashboard lane, not inferred from runtime
-       state. *)
-    dashboard_queue_default_thread_id
+  | None -> dashboard_queue_default_thread_id
 
 let continuation_channel_of_message_source ?dashboard_thread_id = function
   | Dashboard ->
-    let thread_id = dashboard_thread_id_or_default dashboard_thread_id in
-    Keeper_continuation_channel.Dashboard { thread_id }
+    Keeper_continuation_channel.Dashboard
+      { thread_id = dashboard_thread_id_or_default dashboard_thread_id }
   | Discord { channel_id; user_id } ->
     Keeper_continuation_channel.Discord
       { guild_id = None
@@ -57,58 +218,27 @@ let continuation_channel_of_message_source ?dashboard_thread_id = function
     Keeper_continuation_channel.Slack
       { team_id = None; channel_id = channel; thread_ts = None; user_id }
 
-type queue_entry = {
-  mutex : Eio.Mutex.t;
-  q : queued_message Queue.t;
-  mutable inflight : lease option;
-}
+let set_transition_observer observer = Atomic.set transition_observer observer
 
-let schema = "keeper_chat_queue.v1"
-let persistence_file = "chat-queue.json"
-let persistence_base_path : string option Atomic.t = Atomic.make None
-let fail_next_persist_for_testing = Atomic.make false
-let lease_counter = Atomic.make 0
-let receipt_counter = Atomic.make 0
-
-exception Persistence_failed of string
-
-(** Global registry protected by a single mutex.
-    Per-keeper queues have their own mutex for independent enqueue/dequeue
-    parallelism; the global mutex is only for lookup/insertion into the
-    registry. *)
-let registry_mutex = Eio.Mutex.create ()
-let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
+let notify_transition ~keeper_name ~revision =
+  match Atomic.get transition_observer with
+  | None -> ()
+  | Some observer ->
+    (try observer ~keeper_name ~revision with
+     | exn ->
+       Log.Keeper.warn
+         "chat_queue_transition_observer: keeper=%s revision=%Ld failed: %s"
+         keeper_name revision (Printexc.to_string exn))
 
 let valid_keeper_name name =
   let valid_char = function
     | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
     | _ -> false
   in
-  (not (String.equal name "")) && String.for_all valid_char name
-
-(* [generate_lease_id]/[generate_receipt_id] follow the same
-   counter+keeper+epoch-ms shape as [Keeper_msg_async.generate_request_id] —
-   unique within a process without a UUID dependency. Neither needs to be
-   globally unique across restarts: a lease_id only has to distinguish the
-   single outstanding lease from a stale one within one process lifetime, and
-   a receipt_id is an ephemeral enqueue-time echo token, not a durable key. *)
-let generate_lease_id ~keeper_name =
-  let n = Atomic.fetch_and_add lease_counter 1 in
-  let safe_keeper_name =
-    Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name
-  in
-  (* DET-OK: epoch-ms is an id uniqueness salt, not a branch input. *)
-  Printf.sprintf "lease_%s_%d_%d" safe_keeper_name n
-    (int_of_float (Unix.gettimeofday () *. 1000.0))
-
-let generate_receipt_id ~keeper_name =
-  let n = Atomic.fetch_and_add receipt_counter 1 in
-  let safe_keeper_name =
-    Workspace_utils_backend_setup.sanitize_namespace_segment keeper_name
-  in
-  (* DET-OK: see generate_lease_id above — epoch-ms is a uniqueness salt. *)
-  Printf.sprintf "chatq_%s_%d_%d" safe_keeper_name n
-    (int_of_float (Unix.gettimeofday () *. 1000.0))
+  (not (String.equal name ""))
+  && not (String.equal name ".")
+  && not (String.equal name "..")
+  && String.for_all valid_char name
 
 let snapshot_path ~base_path ~keeper_name =
   if valid_keeper_name keeper_name
@@ -120,152 +250,235 @@ let snapshot_path ~base_path ~keeper_name =
   else Error (Printf.sprintf "invalid keeper name for chat queue snapshot: %s" keeper_name)
 
 let source_to_yojson = function
-  | Dashboard -> `Assoc [ ("kind", `String "dashboard") ]
+  | Dashboard -> `Assoc [ "kind", `String "dashboard" ]
   | Discord { channel_id; user_id } ->
     `Assoc
-      [ ("kind", `String "discord")
-      ; ("channel_id", `String channel_id)
-      ; ("user_id", `String user_id)
+      [ "kind", `String "discord"
+      ; "channel_id", `String channel_id
+      ; "user_id", `String user_id
       ]
   | Slack { channel; user_id } ->
     `Assoc
-      [ ("kind", `String "slack")
-      ; ("channel", `String channel)
-      ; ("user_id", `String user_id)
+      [ "kind", `String "slack"
+      ; "channel", `String channel
+      ; "user_id", `String user_id
       ]
 
-let source_of_yojson json =
-  match Json_util.get_string json "kind" with
-  | Some "dashboard" -> Ok Dashboard
-  | Some "discord" ->
-    let channel_id =
-      Json_util.get_string_with_default json ~key:"channel_id" ~default:""
-    in
-    let user_id = Json_util.get_string_with_default json ~key:"user_id" ~default:"" in
-    if String.trim channel_id = "" || String.trim user_id = ""
-    then Error "discord chat queue source requires channel_id and user_id"
-    else Ok (Discord { channel_id; user_id })
-  | Some "slack" ->
-    let channel = Json_util.get_string_with_default json ~key:"channel" ~default:"" in
-    let user_id = Json_util.get_string_with_default json ~key:"user_id" ~default:"" in
-    if String.trim channel = "" || String.trim user_id = ""
-    then Error "slack chat queue source requires channel and user_id"
-    else Ok (Slack { channel; user_id })
-  | Some kind -> Error (Printf.sprintf "unsupported chat queue source kind: %s" kind)
-  | None -> Error "chat queue source requires kind"
+let required_member json key =
+  match Json_util.assoc_member_opt key json with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "chat queue JSON requires %s" key)
 
-let queued_message_to_yojson (msg : queued_message) =
+let required_string json key =
+  match required_member json key with
+  | Ok (`String value) -> Ok value
+  | Ok _ -> Error (Printf.sprintf "chat queue JSON field %s must be a string" key)
+  | Error _ as error -> error
+
+let required_float json key =
+  match required_member json key with
+  | Ok (`Float value) when Float.is_finite value -> Ok value
+  | Ok (`Float _) ->
+    Error (Printf.sprintf "chat queue JSON field %s must be finite" key)
+  | Ok (`Int value) -> Ok (Float.of_int value)
+  | Ok _ -> Error (Printf.sprintf "chat queue JSON field %s must be a number" key)
+  | Error _ as error -> error
+
+let required_nonnegative_int json key =
+  match required_member json key with
+  | Ok (`Int value) when value >= 0 -> Ok value
+  | Ok _ ->
+    Error
+      (Printf.sprintf
+         "chat queue JSON field %s must be a non-negative integer"
+         key)
+  | Error _ as error -> error
+
+let optional_string json key =
+  match Json_util.assoc_member_opt key json with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error (Printf.sprintf "chat queue JSON field %s must be string or null" key)
+
+let source_of_yojson json =
+  match required_string json "kind" with
+  | Error _ as error -> error
+  | Ok "dashboard" -> Ok Dashboard
+  | Ok "discord" ->
+    (match required_string json "channel_id", required_string json "user_id" with
+     | Ok channel_id, Ok user_id
+       when String.trim channel_id <> "" && String.trim user_id <> "" ->
+       Ok (Discord { channel_id; user_id })
+     | Ok _, Ok _ -> Error "discord chat queue source requires non-empty ids"
+     | Error error, _ | _, Error error -> Error error)
+  | Ok "slack" ->
+    (match required_string json "channel", required_string json "user_id" with
+     | Ok channel, Ok user_id
+       when String.trim channel <> "" && String.trim user_id <> "" ->
+       Ok (Slack { channel; user_id })
+     | Ok _, Ok _ -> Error "slack chat queue source requires non-empty ids"
+     | Error error, _ | _, Error error -> Error error)
+  | Ok kind -> Error (Printf.sprintf "unsupported chat queue source kind: %s" kind)
+
+let same_source left right =
+  match left, right with
+  | Dashboard, Dashboard -> true
+  | Discord left, Discord right ->
+    String.equal left.channel_id right.channel_id
+    && String.equal left.user_id right.user_id
+  | Slack left, Slack right ->
+    String.equal left.channel right.channel
+    && String.equal left.user_id right.user_id
+  | Dashboard, (Discord _ | Slack _)
+  | Discord _, (Dashboard | Slack _)
+  | Slack _, (Dashboard | Discord _) -> false
+
+let queued_message_to_yojson (message : queued_message) =
   `Assoc
-    [ ("content", `String msg.content)
-    ; ("user_blocks", Keeper_multimodal_input.user_blocks_to_yojson msg.user_blocks)
-    ; ("attachments", Keeper_multimodal_input.attachments_to_yojson msg.attachments)
-    ; ("timestamp", `Float msg.timestamp)
-    ; ("source", source_to_yojson msg.source)
+    [ "content", `String message.content
+    ; "user_blocks", Keeper_multimodal_input.user_blocks_to_yojson message.user_blocks
+    ; "attachments", Keeper_multimodal_input.attachments_to_yojson message.attachments
+    ; "timestamp", `Float message.timestamp
+    ; "source", source_to_yojson message.source
     ]
+
+let attachment_of_yojson json =
+  match json with
+  | `Assoc _ ->
+    (match
+       required_string json "id",
+       required_string json "type",
+       required_string json "name",
+       required_nonnegative_int json "size",
+       required_string json "mime_type",
+       required_string json "data"
+     with
+     | Ok id, Ok att_type, Ok name, Ok size, Ok mime_type, Ok data
+       when String.trim id <> "" && data <> "" ->
+       Ok
+         { Keeper_chat_store.id
+         ; att_type
+         ; name
+         ; size
+         ; mime_type
+         ; data
+         }
+     | Ok _, Ok _, Ok _, Ok _, Ok _, Ok _ ->
+       Error "chat queue attachment requires non-empty id and data"
+     | Error error, _, _, _, _, _
+     | _, Error error, _, _, _, _
+     | _, _, Error error, _, _, _
+     | _, _, _, Error error, _, _
+     | _, _, _, _, Error error, _
+     | _, _, _, _, _, Error error -> Error error)
+  | _ -> Error "chat queue attachment must be a JSON object"
+
+let attachments_of_yojson = function
+  | `List values ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        (match attachment_of_yojson value with
+         | Ok attachment -> loop (attachment :: acc) rest
+         | Error _ as error -> error)
+    in
+    loop [] values
+  | _ -> Error "chat queue attachments must be an array"
 
 let queued_message_of_yojson json =
   match json with
   | `Assoc _ ->
-    let content = Json_util.get_string_with_default json ~key:"content" ~default:"" in
-    (match Json_util.get_float json "timestamp" with
-     | None -> Error "chat queue message requires timestamp"
-     | Some timestamp ->
-       let attachments = Keeper_multimodal_input.parse_attachments json in
-       (match Keeper_multimodal_input.parse_user_blocks json with
-        | Error err -> Error err
-        | Ok user_blocks ->
-          (match Json_util.assoc_member_opt "source" json with
-           | None -> Error "chat queue message requires source"
-           | Some source_json ->
-             (match source_of_yojson source_json with
-              | Error err -> Error err
-              | Ok source -> Ok { content; user_blocks; attachments; timestamp; source }))))
+    (match
+       required_string json "content",
+       required_float json "timestamp",
+       required_member json "user_blocks",
+       required_member json "attachments",
+       required_member json "source"
+     with
+     | Ok content, Ok timestamp, Ok _, Ok attachments_json, Ok source_json ->
+       (match
+          Keeper_multimodal_input.parse_user_blocks json,
+          attachments_of_yojson attachments_json,
+          source_of_yojson source_json
+        with
+        | Ok user_blocks, Ok attachments, Ok source ->
+          Ok { content; user_blocks; attachments; timestamp; source }
+        | Error error, _, _ | _, Error error, _ | _, _, Error error ->
+          Error error)
+     | Error error, _, _, _, _
+     | _, Error error, _, _, _
+     | _, _, Error error, _, _
+     | _, _, _, Error error, _
+     | _, _, _, _, Error error -> Error error)
   | _ -> Error "chat queue message must be a JSON object"
 
-let queue_to_list q =
-  let acc = ref [] in
-  Queue.iter (fun item -> acc := item :: !acc) q;
-  List.rev !acc
+let failure_kind_to_string = function
+  | Turn_failed -> "turn_failed"
+  | Timed_out -> "timed_out"
+  | No_visible_reply -> "no_visible_reply"
+  | Transcript_persist_failed -> "transcript_persist_failed"
+  | Connector_unavailable -> "connector_unavailable"
+  | Delivery_failed -> "delivery_failed"
+  | Cancelled -> "cancelled"
+  | Internal_error -> "internal_error"
 
-let queue_of_list items =
-  let q = Queue.create () in
-  List.iter (fun item -> Queue.push item q) items;
-  q
+let failure_kind_of_string = function
+  | "turn_failed" -> Ok Turn_failed
+  | "timed_out" -> Ok Timed_out
+  | "no_visible_reply" -> Ok No_visible_reply
+  | "transcript_persist_failed" -> Ok Transcript_persist_failed
+  | "connector_unavailable" -> Ok Connector_unavailable
+  | "delivery_failed" -> Ok Delivery_failed
+  | "cancelled" -> Ok Cancelled
+  | "internal_error" -> Ok Internal_error
+  | value -> Error (Printf.sprintf "unknown chat queue failure kind: %s" value)
 
-let replace_queue q items =
-  Queue.clear q;
-  List.iter (fun item -> Queue.push item q) items
+let completion_fields (completion : completion) =
+  [ "completed_at", `Float completion.completed_at
+  ; ( "outcome_ref"
+    , match completion.outcome_ref with
+      | None -> `Null
+      | Some value -> `String value )
+  ]
 
-let messages_of_yojson items_json =
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | item :: rest ->
-      (match queued_message_of_yojson item with
-       | Ok parsed -> loop (parsed :: acc) rest
-       | Error err -> Error err)
-  in
-  match items_json with
-  | `List items -> loop [] items
-  | _ -> Error "chat queue expects an items array"
-
-let inflight_to_yojson = function
-  | None -> `Null
-  | Some { lease_id; messages } ->
+let state_to_yojson = function
+  | Stored_pending _ -> `Assoc [ "kind", `String "pending" ]
+  | Stored_inflight { lease_id; started_at; _ } ->
     `Assoc
-      [ ("lease_id", `String lease_id)
-      ; ("items", `List (List.map queued_message_to_yojson messages))
+      [ "kind", `String "inflight"
+      ; "lease_id", `String lease_id
+      ; "started_at", `Float started_at
       ]
+  | Stored_delivered completion ->
+    `Assoc (("kind", `String "delivered") :: completion_fields completion)
+  | Stored_failed failure ->
+    `Assoc
+      (("kind", `String "failed")
+       :: ("failure_kind", `String (failure_kind_to_string failure.kind))
+       :: ("detail", `String failure.detail)
+       :: completion_fields
+            { completed_at = failure.completed_at; outcome_ref = failure.outcome_ref })
 
-let inflight_of_yojson json =
-  match json with
-  | `Null -> Ok None
-  | `Assoc _ -> (
-    match Json_util.get_string json "lease_id" with
-    | None -> Error "chat queue inflight lease requires lease_id"
-    | Some lease_id -> (
-      match Json_util.assoc_member_opt "items" json with
-      | None -> Error "chat queue inflight lease requires items array"
-      | Some items_json -> (
-        match messages_of_yojson items_json with
-        | Error err -> Error err
-        | Ok [] -> Error "chat queue inflight lease requires at least one message"
-        | Ok messages -> Ok (Some { lease_id; messages }))))
-  | _ -> Error "chat queue inflight lease must be null or an object"
-
-(* Snapshot envelope: the still-queued messages plus the (at most one)
-   outstanding lease, so a crash between [lease_batch] and [ack]/[nack]
-   leaves the leased batch durably recorded instead of vanishing — see the
-   [configure_persistence] mli comment for the boot-time requeue this
-   enables. The schema string is intentionally unchanged from the
-   pre-lease/ack/nack format: [inflight] is a new optional field, absent in
-   every file written before this change, and its absence has exactly one
-   meaning ("no lease was outstanding when this was written") — not an
-   unknown value being defaulted, so no schema bump is needed. *)
-let entry_state_to_yojson ~items ~inflight =
-  `Assoc
-    [ ("schema", `String schema)
-    ; ("items", `List (List.map queued_message_to_yojson items))
-    ; ("inflight", inflight_to_yojson inflight)
+let stored_receipt_to_yojson receipt =
+  let fields =
+    [ "receipt_id", `String (Receipt_id.to_string receipt.receipt_id)
+    ; "state", state_to_yojson receipt.state
     ]
+  in
+  let fields =
+    match receipt.state with
+    | Stored_pending message | Stored_inflight { message; _ } ->
+      fields @ [ "message", queued_message_to_yojson message ]
+    | Stored_delivered _ | Stored_failed _ -> fields
+  in
+  `Assoc fields
 
-let entry_state_of_yojson json =
-  match (Json_util.get_string json "schema", Json_util.assoc_member_opt "items" json) with
-  | Some s, _ when not (String.equal s schema) ->
-    Error (Printf.sprintf "unexpected chat queue snapshot schema: %s" s)
-  | None, _ -> Error "chat queue snapshot requires schema"
-  | Some _, None -> Error "chat queue snapshot requires items array"
-  | Some _, Some items_json -> (
-    match messages_of_yojson items_json with
-    | Error err -> Error err
-    | Ok items -> (
-      let inflight_json =
-        match Json_util.assoc_member_opt "inflight" json with
-        | None -> `Null
-        | Some j -> j
-      in
-      match inflight_of_yojson inflight_json with
-      | Error err -> Error err
-      | Ok inflight -> Ok (items, inflight)))
+let snapshot_to_yojson ~revision receipts =
+  `Assoc
+    [ "schema", `String schema_v2
+    ; "revision", `Intlit (Int64.to_string revision)
+    ; "receipts", `List (List.map stored_receipt_to_yojson receipts)
+    ]
 
 let save_json_atomic path json =
   Fs_compat.mkdir_p (Filename.dirname path);
@@ -274,431 +487,754 @@ let save_json_atomic path json =
   |> Yojson.Safe.pretty_to_string
   |> Fs_compat.save_file_atomic path
 
-let load_snapshot ~base_path ~keeper_name =
-  match snapshot_path ~base_path ~keeper_name with
-  | Error msg ->
-    Log.Keeper.warn "chat_queue_snapshot: %s" msg;
-    (Queue.create (), None)
-  | Ok path ->
-    if not (Sys.file_exists path)
-    then (Queue.create (), None)
-    else (
-      match Safe_ops.read_json_file_safe path with
-      | Error msg ->
-        Log.Keeper.warn
-          "chat_queue_snapshot: failed to read keeper=%s path=%s: %s"
-          keeper_name
-          path
-          msg;
-        (Queue.create (), None)
-      | Ok json ->
-        (match entry_state_of_yojson json with
-         | Ok (items, inflight) ->
-           if items <> [] || inflight <> None
-           then
-             Log.Keeper.info
-               "chat_queue_snapshot: restored %d queued message(s) (inflight \
-                lease=%s) for keeper=%s"
-               (List.length items)
-               (match inflight with
-                | Some { lease_id; _ } -> lease_id
-                | None -> "none")
-               keeper_name;
-           (queue_of_list items, inflight)
-         | Error msg ->
-           Log.Keeper.warn
-             "chat_queue_snapshot: failed to parse keeper=%s path=%s: %s"
-             keeper_name
-             path
-             msg;
-           (Queue.create (), None)))
-
-let persist_snapshot ~base_path ~keeper_name ~items ~inflight =
+let persist_snapshot_to_path path ~revision receipts =
   if Atomic.exchange fail_next_persist_for_testing false
   then Error "injected chat queue persist failure"
-  else match snapshot_path ~base_path ~keeper_name with
-  | Error msg -> Error msg
-  | Ok path ->
+  else
+    try save_json_atomic path (snapshot_to_yojson ~revision receipts) with
+    | Eio.Cancel.Cancelled _ as exception_ -> raise exception_
+    | exception_ -> Error (Printexc.to_string exception_)
+
+let revision_in_domain revision =
+  Int64.compare revision 0L >= 0 && Int64.compare revision max_revision <= 0
+
+let parse_revision json =
+  match required_member json "revision" with
+  | Ok (`Int value) when revision_in_domain (Int64.of_int value) ->
+    Ok (Int64.of_int value)
+  | Ok (`Intlit value) ->
     (try
-       match save_json_atomic path (entry_state_to_yojson ~items ~inflight) with
-       | Ok () -> Ok ()
-       | Error msg ->
-         Error
-           (Printf.sprintf
-              "failed to persist keeper=%s path=%s: %s"
-              keeper_name
-              path
-              msg)
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Error
-         (Printf.sprintf
-            "persist raised keeper=%s path=%s: %s"
-            keeper_name
-            path
-            (Printexc.to_string exn)))
+       let revision = Int64.of_string value in
+       if revision_in_domain revision then Ok revision
+       else Error "chat queue revision exceeds the exact non-negative JSON integer domain"
+     with Failure _ -> Error "chat queue revision must be an int64")
+  | Ok _ ->
+    Error "chat queue revision must be an exact non-negative JSON integer"
+  | Error _ as error -> error
 
-let persist_if_configured ~keeper_name (entry : queue_entry) =
-  match Atomic.get persistence_base_path with
-  | None -> ()
-  | Some base_path ->
-    let items = queue_to_list entry.q in
-    (match persist_snapshot ~base_path ~keeper_name ~items ~inflight:entry.inflight with
-     | Ok () -> ()
-     | Error msg -> raise (Persistence_failed msg))
+let parse_receipt_id json =
+  match required_string json "receipt_id" with
+  | Error _ as error -> error
+  | Ok value -> Receipt_id.of_string value
 
-(* [before_items]/[before_inflight] are the pre-mutation state to restore if
-   the durable rewrite fails, keeping in-memory state and the last-known-good
-   snapshot aligned (never acknowledge a mutation the snapshot doesn't
-   reflect). Every mutator captures both, even ones that only ever touch one
-   of the two fields, because the persisted file always encodes the full
-   entry — a rollback that only restored [q] would silently commit an
-   unrelated, already-applied [inflight] change (or vice versa) on the next
-   successful write. *)
-let persist_or_rollback ~keeper_name (entry : queue_entry) ~before_items ~before_inflight =
-  try persist_if_configured ~keeper_name entry with
-  | Eio.Cancel.Cancelled _ as exn ->
-    replace_queue entry.q before_items;
-    entry.inflight <- before_inflight;
-    raise exn
-  | exn ->
-    replace_queue entry.q before_items;
-    entry.inflight <- before_inflight;
-    raise exn
+let reject_terminal_message json =
+  match Json_util.assoc_member_opt "message" json with
+  | None -> Ok ()
+  | Some _ -> Error "terminal chat queue receipts must not retain message bodies"
 
-let persistence_configured () =
-  match Atomic.get persistence_base_path with
-  | None -> false
-  | Some _ -> true
+let stored_receipt_of_v2_yojson json =
+  match json with
+  | `Assoc _ ->
+    (match parse_receipt_id json, required_member json "state" with
+     | Error error, _ | _, Error error -> Error error
+     | Ok receipt_id, Ok state_json ->
+       (match required_string state_json "kind" with
+        | Error _ as error -> error
+        | Ok "pending" ->
+          (match required_member json "message" with
+           | Error _ as error -> error
+           | Ok message_json ->
+             Result.map
+               (fun message -> { receipt_id; state = Stored_pending message })
+               (queued_message_of_yojson message_json))
+        | Ok "inflight" ->
+          (match
+             required_string state_json "lease_id",
+             required_float state_json "started_at",
+             required_member json "message"
+           with
+           | Ok lease_id, Ok started_at, Ok message_json
+             when String.trim lease_id <> "" ->
+             Result.map
+               (fun message ->
+                  { receipt_id
+                  ; state = Stored_inflight { lease_id; started_at; message }
+                  })
+               (queued_message_of_yojson message_json)
+           | Ok _, Ok _, Ok _ ->
+             Error "chat queue inflight lease_id must be non-empty"
+           | Error error, _, _ | _, Error error, _ | _, _, Error error -> Error error)
+        | Ok "delivered" ->
+          (match
+             required_float state_json "completed_at",
+             optional_string state_json "outcome_ref",
+             reject_terminal_message json
+           with
+           | Ok completed_at, Ok outcome_ref, Ok () ->
+             Ok { receipt_id; state = Stored_delivered { completed_at; outcome_ref } }
+           | Error error, _, _ | _, Error error, _ | _, _, Error error -> Error error)
+        | Ok "failed" ->
+          (match
+             required_float state_json "completed_at",
+             required_string state_json "failure_kind",
+             required_string state_json "detail",
+             optional_string state_json "outcome_ref",
+             reject_terminal_message json
+           with
+           | Ok completed_at, Ok kind, Ok detail, Ok outcome_ref, Ok ()
+             when String.trim detail <> "" ->
+             Result.map
+               (fun kind ->
+                  { receipt_id
+                  ; state = Stored_failed { completed_at; kind; detail; outcome_ref }
+                  })
+               (failure_kind_of_string kind)
+           | Ok _, Ok _, Ok _, Ok _, Ok () ->
+             Error "failed chat queue receipt detail must be non-empty"
+           | Error error, _, _, _, _
+           | _, Error error, _, _, _
+           | _, _, Error error, _, _
+           | _, _, _, Error error, _
+           | _, _, _, _, Error error -> Error error)
+        | Ok kind -> Error (Printf.sprintf "unknown chat queue receipt state: %s" kind)))
+  | _ -> Error "chat queue receipt must be an object"
 
-let get_or_create_entry keeper_name =
-  match Hashtbl.find_opt registry keeper_name with
-  | Some entry -> entry
-  | None ->
-      let entry = { mutex = Eio.Mutex.create (); q = Queue.create (); inflight = None } in
-      Hashtbl.add registry keeper_name entry;
-      entry
+let parse_receipt_list json =
+  match json with
+  | `List values ->
+    let seen = Hashtbl.create (List.length values) in
+    let rec loop seen acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        (match stored_receipt_of_v2_yojson value with
+         | Error _ as error -> error
+         | Ok receipt ->
+           let id = Receipt_id.to_string receipt.receipt_id in
+           if Hashtbl.mem seen id
+           then Error (Printf.sprintf "duplicate chat queue receipt_id: %s" id)
+           else (
+             Hashtbl.add seen id ();
+             loop seen (receipt :: acc) rest))
+    in
+    loop seen [] values
+  | _ -> Error "chat queue receipts must be an array"
 
-let get_or_create_entry_locked keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      get_or_create_entry keeper_name)
+let parse_v2 json =
+  match parse_revision json, required_member json "receipts" with
+  | Ok revision, Ok receipts_json ->
+    (match parse_receipt_list receipts_json with
+     | Error _ as error -> error
+     | Ok receipts ->
+       let inflight =
+         List.filter_map
+           (fun receipt ->
+              match receipt.state with
+              | Stored_inflight { lease_id; message; _ } ->
+                Some (lease_id, message)
+              | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> None)
+           receipts
+       in
+       (match inflight with
+        | [] -> Ok (revision, receipts)
+        | (first_lease_id, first_message) :: rest ->
+          if
+            List.for_all
+              (fun (lease_id, message) ->
+                 String.equal lease_id first_lease_id
+                 && same_source message.source first_message.source)
+              rest
+          then Ok (revision, receipts)
+          else
+            Error
+              "chat queue v2 permits at most one same-source inflight lease per keeper"))
+  | Error error, _ | _, Error error -> Error error
+
+let parse_message_list json =
+  match json with
+  | `List values ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        (match queued_message_of_yojson value with
+         | Error _ as error -> error
+         | Ok message -> loop (message :: acc) rest)
+    in
+    loop [] values
+  | _ -> Error "legacy chat queue items must be an array"
+
+let parse_v1_inflight json =
+  match Json_util.assoc_member_opt "inflight" json with
+  | None | Some `Null -> Ok []
+  | Some (`Assoc _ as inflight) ->
+    (match required_string inflight "lease_id", required_member inflight "items" with
+     | Ok lease_id, Ok items_json when String.trim lease_id <> "" -> parse_message_list items_json
+     | Ok _, Ok _ -> Error "legacy inflight lease_id must be non-empty"
+     | Error error, _ | _, Error error -> Error error)
+  | Some _ -> Error "legacy chat queue inflight must be null or an object"
+
+let parse_v1_for_migration json =
+  match required_member json "items", parse_v1_inflight json with
+  | Ok items_json, Ok inflight ->
+    Result.map (fun pending -> inflight @ pending) (parse_message_list items_json)
+  | Error error, _ | _, Error error -> Error error
+
+let migrate_v1_to_v2 path json =
+  match parse_v1_for_migration json with
+  | Error error -> Error (`Parse error)
+  | Ok messages ->
+    let receipts =
+      List.map
+        (fun message ->
+           { receipt_id = Receipt_id.generate (); state = Stored_pending message })
+        messages
+    in
+    let revision = 1L in
+    (match persist_snapshot_to_path path ~revision receipts with
+     | Ok () -> Ok (revision, receipts)
+     | Error error -> Error (`Persist error))
+
+type loaded_snapshot = {
+  revision : int64;
+  receipts : stored_receipt list;
+  migrated : bool;
+  recovered_count : int;
+}
+
+let load_error kind ?path message = { kind; path; message }
+
+let recover_inflight path ~revision receipts =
+  let recovered_count =
+    List.fold_left
+      (fun count receipt ->
+         match receipt.state with
+         | Stored_inflight _ -> count + 1
+         | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> count)
+      0 receipts
+  in
+  if recovered_count = 0
+  then Ok { revision; receipts; migrated = false; recovered_count = 0 }
+  else
+    let receipts =
+      List.map
+        (fun receipt ->
+           match receipt.state with
+           | Stored_inflight { message; _ } ->
+             { receipt with state = Stored_pending message }
+           | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> receipt)
+        receipts
+    in
+    if Int64.compare revision max_revision >= 0
+    then
+      Error
+        (load_error Recovery_failed ~path
+           "cannot persist restart recovery: chat queue revision domain is exhausted")
+    else
+      let revision = Int64.succ revision in
+      match persist_snapshot_to_path path ~revision receipts with
+      | Ok () -> Ok { revision; receipts; migrated = false; recovered_count }
+      | Error error ->
+        Error
+          (load_error Recovery_failed ~path
+             ("failed to persist restart recovery: " ^ error))
+
+let load_snapshot ~base_path ~keeper_name =
+  match snapshot_path ~base_path ~keeper_name with
+  | Error message -> Error (load_error Invalid_path message)
+  | Ok path ->
+    if not (Sys.file_exists path)
+    then Ok None
+    else
+      match Safe_ops.read_json_file_safe path with
+      | Error message -> Error (load_error Read_failed ~path message)
+      | Ok json ->
+        (match required_string json "schema" with
+         | Error message -> Error (load_error Parse_failed ~path message)
+         | Ok schema when String.equal schema schema_v2 ->
+           (match parse_v2 json with
+            | Error message -> Error (load_error Parse_failed ~path message)
+            | Ok (revision, receipts) ->
+              Result.map Option.some (recover_inflight path ~revision receipts))
+         | Ok schema when String.equal schema schema_v1 ->
+           (match migrate_v1_to_v2 path json with
+            | Ok (revision, receipts) ->
+              Ok (Some { revision; receipts; migrated = true; recovered_count = 0 })
+            | Error (`Parse message) ->
+              Error (load_error Parse_failed ~path message)
+            | Error (`Persist message) ->
+              Error
+                (load_error Migration_failed ~path
+                   ("failed to persist v1 migration: " ^ message)))
+         | Ok schema ->
+           Error
+             (load_error Parse_failed ~path
+                (Printf.sprintf "unsupported chat queue schema: %s" schema)))
+
+let create_entry ?(revision = 0L) ?(receipts = []) ?(load_errors = []) () =
+  { mutex = Eio.Mutex.create (); revision; receipts; load_errors }
+
+let with_registry_rw f = Eio.Mutex.use_rw ~protect:true registry_mutex f
 
 let find_entry keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.find_opt registry keeper_name)
+  with_registry_rw (fun () -> Hashtbl.find_opt registry keeper_name)
+
+let get_or_create_entry keeper_name =
+  with_registry_rw (fun () ->
+      match Hashtbl.find_opt registry keeper_name with
+      | Some entry -> entry
+      | None ->
+        let entry = create_entry () in
+        Hashtbl.add registry keeper_name entry;
+        entry)
 
 let with_entry_lock entry f =
   match
     Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
         try Ok (f ()) with
-        | exn -> Error (exn, Printexc.get_raw_backtrace ()))
+        | exception_ -> Error (exception_, Printexc.get_raw_backtrace ()))
   with
   | Ok value -> value
-  | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
+  | Error (exception_, backtrace) ->
+    Printexc.raise_with_backtrace exception_ backtrace
 
-let enqueue ~keeper_name msg =
-  let entry = get_or_create_entry_locked keeper_name in
-  with_entry_lock entry (fun () ->
-      let before_items = queue_to_list entry.q in
-      let before_inflight = entry.inflight in
-      Queue.push msg entry.q;
-      persist_or_rollback ~keeper_name entry ~before_items ~before_inflight;
-      generate_receipt_id ~keeper_name)
+let persistence_configured () = Option.is_some (Atomic.get persistence_base_path)
 
-let dequeue ~keeper_name =
-  match find_entry keeper_name with
-  | None -> None
-  | Some entry ->
+let first_snapshot_error entry =
+  match entry.load_errors with
+  | error :: _ -> Some error
+  | [] ->
+    (match Atomic.get global_load_errors with
+     | error :: _ -> Some error
+     | [] -> None)
+
+let mutation_entry ~keeper_name ~create =
+  match Atomic.get persistence_base_path with
+  | None -> Error Persistence_not_configured
+  | Some base_path ->
+    (match snapshot_path ~base_path ~keeper_name with
+     | Error message ->
+       Error (Snapshot_unavailable (load_error Invalid_path message))
+     | Ok path ->
+       let entry =
+         match find_entry keeper_name, create with
+         | Some entry, _ -> Some entry
+         | None, true -> Some (get_or_create_entry keeper_name)
+         | None, false -> None
+       in
+       match entry with
+       | None -> Ok (base_path, path, None)
+       | Some entry ->
+         (match first_snapshot_error entry with
+          | Some error -> Error (Snapshot_unavailable error)
+          | None -> Ok (base_path, path, Some entry)))
+
+let pending_receipts receipts =
+  List.filter_map
+    (fun receipt ->
+       match receipt.state with
+       | Stored_pending message -> Some { receipt_id = receipt.receipt_id; message }
+       | Stored_inflight _ | Stored_delivered _ | Stored_failed _ -> None)
+    receipts
+
+let inflight_receipts receipts =
+  List.filter_map
+    (fun receipt ->
+       match receipt.state with
+       | Stored_inflight { message; _ } ->
+         Some { receipt_id = receipt.receipt_id; message }
+       | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> None)
+    receipts
+
+let commit (entry : queue_entry) ~path receipts =
+  let before_receipts = entry.receipts in
+  let before_revision = entry.revision in
+  if Int64.compare before_revision max_revision >= 0
+  then Error Revision_exhausted
+  else
+    let revision = Int64.succ before_revision in
+    entry.receipts <- receipts;
+    entry.revision <- revision;
+    match persist_snapshot_to_path path ~revision receipts with
+    | Ok () -> Ok revision
+    | Error message ->
+      entry.receipts <- before_receipts;
+      entry.revision <- before_revision;
+      Error (Persist_failed message)
+    | exception (Eio.Cancel.Cancelled _ as exception_) ->
+      entry.receipts <- before_receipts;
+      entry.revision <- before_revision;
+      raise exception_
+
+let enqueue ~keeper_name message =
+  let receipt_id = Receipt_id.generate () in
+  match mutation_entry ~keeper_name ~create:true with
+  | Error _ as error -> error
+  | Ok (_, _, None) ->
+    Error (Persist_failed "chat queue entry creation did not produce an entry")
+  | Ok (_, path, Some entry) ->
+    let result =
       with_entry_lock entry (fun () ->
-          if Queue.is_empty entry.q
-          then None
-          else (
-            let before_items = queue_to_list entry.q in
-            let before_inflight = entry.inflight in
-            let msg = Queue.pop entry.q in
-            persist_or_rollback ~keeper_name entry ~before_items ~before_inflight;
-            Some msg))
+          let receipt = { receipt_id; state = Stored_pending message } in
+          let receipts = entry.receipts @ [ receipt ] in
+          match commit entry ~path receipts with
+          | Error _ as error -> error
+          | Ok revision ->
+            Ok
+              { receipt_id
+              ; revision
+              ; pending_count = List.length (pending_receipts receipts)
+              ; inflight_count = List.length (inflight_receipts receipts)
+              })
+    in
+    (match result with
+     | Ok receipt ->
+       notify_transition ~keeper_name ~revision:receipt.revision;
+       Ok receipt
+     | Error _ as error -> error)
 
-let same_source a b =
-  match (a, b) with
-  | Dashboard, Dashboard -> true
-  | ( Discord { channel_id = c1; user_id = u1 },
-      Discord { channel_id = c2; user_id = u2 } ) ->
-      String.equal c1 c2 && String.equal u1 u2
-  | Slack { channel = c1; user_id = u1 }, Slack { channel = c2; user_id = u2 }
-    ->
-      String.equal c1 c2 && String.equal u1 u2
-  | Dashboard, (Discord _ | Slack _)
-  | Discord _, (Dashboard | Slack _)
-  | Slack _, (Dashboard | Discord _) ->
-      false
+let lease_id () =
+  "lease_"
+  ^ Uuidm.to_string
+      (Stdlib.Mutex.protect Receipt_id.rng_mutex (fun () ->
+           Uuidm.v4_gen Receipt_id.rng ()))
+
+let take_same_source_run (items : leased_message list) =
+  match items with
+  | [] -> []
+  | first :: rest ->
+    let rec loop (acc : leased_message list) (remaining : leased_message list) =
+      match remaining with
+      | next :: tail when same_source first.message.source next.message.source ->
+        loop (next :: acc) tail
+      | _ -> List.rev acc
+    in
+    first :: loop [] rest
 
 let lease_batch ~keeper_name =
-  match find_entry keeper_name with
-  | None -> `Empty
-  | Some entry ->
+  match mutation_entry ~keeper_name ~create:false with
+  | Error error -> `Error error
+  | Ok (_, _, None) -> `Empty
+  | Ok (_, path, Some entry) ->
+    let result =
       with_entry_lock entry (fun () ->
-          match entry.inflight with
-          | Some { lease_id; _ } -> `Already_leased lease_id
-          | None -> (
-              let before_items = queue_to_list entry.q in
-              match Queue.take_opt entry.q with
-              | None -> `Empty
-              | Some first ->
-                  let rec drain acc =
-                    match Queue.peek_opt entry.q with
-                    | Some next when same_source first.source next.source ->
-                        let next = Queue.pop entry.q in
-                        drain (next :: acc)
-                    | Some _ | None -> List.rev acc
-                  in
-                  let messages = first :: drain [] in
-                  let lease_id = generate_lease_id ~keeper_name in
-                  entry.inflight <- Some { lease_id; messages };
-                  (try
-                     persist_or_rollback ~keeper_name entry ~before_items
-                       ~before_inflight:None;
-                     `Leased { lease_id; messages }
-                   with
-                   | Persistence_failed msg -> `Persist_failed msg)))
+          match inflight_receipts entry.receipts with
+          | { receipt_id = _; message = _ } :: _ ->
+            let outstanding =
+              List.find_map
+                (fun receipt ->
+                   match receipt.state with
+                   | Stored_inflight { lease_id; _ } -> Some lease_id
+                   | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> None)
+                entry.receipts
+            in
+            (match outstanding with
+             | Some lease_id -> `Already_leased lease_id
+             | None ->
+               `Error
+                 (Persist_failed
+                    "inflight receipt exists without a lease id"))
+          | [] ->
+            let items = take_same_source_run (pending_receipts entry.receipts) in
+            if items = []
+            then `Empty
+            else
+              let lease_id = lease_id () in
+              let started_at = Time_compat.now () in
+              let leased_ids =
+                List.map
+                  (fun (item : leased_message) ->
+                     Receipt_id.to_string item.receipt_id)
+                  items
+              in
+              let receipts =
+                List.map
+                  (fun receipt ->
+                     match receipt.state with
+                     | Stored_pending message
+                       when List.mem
+                              (Receipt_id.to_string receipt.receipt_id)
+                              leased_ids ->
+                       { receipt with
+                         state = Stored_inflight { lease_id; started_at; message }
+                       }
+                     | Stored_pending _ | Stored_inflight _
+                     | Stored_delivered _ | Stored_failed _ -> receipt)
+                  entry.receipts
+              in
+              match commit entry ~path receipts with
+              | Error error -> `Error error
+              | Ok revision -> `Leased ({ lease_id; items }, revision))
+    in
+    (match result with
+     | `Leased (lease, revision) ->
+       notify_transition ~keeper_name ~revision;
+       `Leased lease
+     | `Empty -> `Empty
+     | `Already_leased lease_id -> `Already_leased lease_id
+     | `Error error -> `Error error)
 
-let ack ~keeper_name ~lease_id =
-  match find_entry keeper_name with
-  | None -> `Unknown_lease
-  | Some entry ->
+let terminal_state = function
+  | Mark_delivered completion -> Stored_delivered completion
+  | Mark_failed failure -> Stored_failed failure
+
+let finalize ~keeper_name ~lease_id ~outcome =
+  match mutation_entry ~keeper_name ~create:false with
+  | Error error -> `Error error
+  | Ok (_, _, None) -> `Unknown_lease
+  | Ok (_, path, Some entry) ->
+    let result =
       with_entry_lock entry (fun () ->
-          match entry.inflight with
-          | Some { lease_id = current; _ } when String.equal current lease_id ->
-              let before_items = queue_to_list entry.q in
-              let before_inflight = entry.inflight in
-              entry.inflight <- None;
-              (try
-                 persist_or_rollback ~keeper_name entry ~before_items ~before_inflight;
-                 `Acked
-               with
-               | Persistence_failed msg -> `Persist_failed msg)
-          | Some _ | None -> `Unknown_lease)
+          let matched =
+            List.filter_map
+              (fun receipt ->
+                 match receipt.state with
+                 | Stored_inflight current when String.equal current.lease_id lease_id ->
+                   Some receipt.receipt_id
+                 | Stored_pending _ | Stored_inflight _
+                 | Stored_delivered _ | Stored_failed _ -> None)
+              entry.receipts
+          in
+          if matched = []
+          then `Unknown_lease
+          else
+            let receipts =
+              List.map
+                (fun receipt ->
+                   match receipt.state with
+                   | Stored_inflight current when String.equal current.lease_id lease_id ->
+                     { receipt with state = terminal_state outcome }
+                   | Stored_pending _ | Stored_inflight _
+                   | Stored_delivered _ | Stored_failed _ -> receipt)
+                entry.receipts
+            in
+            match commit entry ~path receipts with
+            | Error error -> `Error error
+            | Ok revision -> `Finalized (matched, revision))
+    in
+    (match result with
+     | `Finalized (receipts, revision) ->
+       notify_transition ~keeper_name ~revision;
+       `Finalized receipts
+     | `Unknown_lease -> `Unknown_lease
+     | `Error error -> `Error error)
 
 let nack ~keeper_name ~lease_id =
-  match find_entry keeper_name with
-  | None -> `Unknown_lease
-  | Some entry ->
+  match mutation_entry ~keeper_name ~create:false with
+  | Error error -> `Error error
+  | Ok (_, _, None) -> `Unknown_lease
+  | Ok (_, path, Some entry) ->
+    let result =
       with_entry_lock entry (fun () ->
-          match entry.inflight with
-          | Some { lease_id = current; messages } when String.equal current lease_id ->
-              let before_items = queue_to_list entry.q in
-              let before_inflight = entry.inflight in
-              (* Requeue ahead of anything that arrived while the lease was
-                 outstanding: the leased batch was already the head run, so
-                 retrying it before newer arrivals preserves FIFO order. *)
-              replace_queue entry.q (messages @ before_items);
-              entry.inflight <- None;
-              (try
-                 persist_or_rollback ~keeper_name entry ~before_items ~before_inflight;
-                 `Requeued
-               with
-               | Persistence_failed msg -> `Persist_failed msg)
-          | Some _ | None -> `Unknown_lease)
+          let matched =
+            List.filter_map
+              (fun receipt ->
+                 match receipt.state with
+                 | Stored_inflight current when String.equal current.lease_id lease_id ->
+                   Some receipt.receipt_id
+                 | Stored_pending _ | Stored_inflight _
+                 | Stored_delivered _ | Stored_failed _ -> None)
+              entry.receipts
+          in
+          if matched = []
+          then `Unknown_lease
+          else
+            let receipts =
+              List.map
+                (fun receipt ->
+                   match receipt.state with
+                   | Stored_inflight current when String.equal current.lease_id lease_id ->
+                     { receipt with state = Stored_pending current.message }
+                   | Stored_pending _ | Stored_inflight _
+                   | Stored_delivered _ | Stored_failed _ -> receipt)
+                entry.receipts
+            in
+            match commit entry ~path receipts with
+            | Error error -> `Error error
+            | Ok revision -> `Requeued (matched, revision))
+    in
+    (match result with
+     | `Requeued (receipts, revision) ->
+       notify_transition ~keeper_name ~revision;
+       `Requeued receipts
+     | `Unknown_lease -> `Unknown_lease
+     | `Error error -> `Error error)
 
-let merge_batch batch =
-  match batch with
-  | [] -> None
-  | [ msg ] -> Some msg
-  | first :: _ ->
-      Some
-        {
-          content = String.concat "\n\n" (List.map (fun m -> m.content) batch);
-          user_blocks = List.concat_map (fun m -> m.user_blocks) batch;
-          attachments = List.concat_map (fun m -> m.attachments) batch;
-          timestamp = first.timestamp;
-          source = first.source;
-        }
-
-let rec list_equal equal xs ys =
-  match xs, ys with
-  | [], [] -> true
-  | x :: xs, y :: ys -> equal x y && list_equal equal xs ys
-  | [], _ :: _ | _ :: _, [] -> false
-
-let option_equal equal a b =
-  match a, b with
-  | None, None -> true
-  | Some a, Some b -> equal a b
-  | None, Some _ | Some _, None -> false
-
-let user_media_block_equal
-      (a : Keeper_multimodal_input.user_media_block)
-      (b : Keeper_multimodal_input.user_media_block)
-  =
-  String.equal a.attachment_id b.attachment_id
-  && String.equal a.name b.name
-  && String.equal a.mime_type b.mime_type
-  && option_equal Int.equal a.size b.size
-
-let user_input_block_equal a b =
-  match a, b with
-  | Keeper_multimodal_input.User_text a, Keeper_multimodal_input.User_text b ->
-      String.equal a b
-  | Keeper_multimodal_input.User_image a, Keeper_multimodal_input.User_image b ->
-      user_media_block_equal a b
-  | Keeper_multimodal_input.User_document a, Keeper_multimodal_input.User_document b ->
-      user_media_block_equal a b
-  | Keeper_multimodal_input.User_audio a, Keeper_multimodal_input.User_audio b ->
-      user_media_block_equal a b
-  | ( Keeper_multimodal_input.User_text _,
-      ( Keeper_multimodal_input.User_image _
-      | Keeper_multimodal_input.User_document _
-      | Keeper_multimodal_input.User_audio _ ) )
-  | ( Keeper_multimodal_input.User_image _,
-      ( Keeper_multimodal_input.User_text _
-      | Keeper_multimodal_input.User_document _
-      | Keeper_multimodal_input.User_audio _ ) )
-  | ( Keeper_multimodal_input.User_document _,
-      ( Keeper_multimodal_input.User_text _
-      | Keeper_multimodal_input.User_image _
-      | Keeper_multimodal_input.User_audio _ ) )
-  | ( Keeper_multimodal_input.User_audio _,
-      ( Keeper_multimodal_input.User_text _
-      | Keeper_multimodal_input.User_image _
-      | Keeper_multimodal_input.User_document _ ) ) ->
-      false
-
-let attachment_equal (a : Keeper_chat_store.attachment) (b : Keeper_chat_store.attachment) =
-  String.equal a.id b.id
-  && String.equal a.att_type b.att_type
-  && String.equal a.name b.name
-  && Int.equal a.size b.size
-  && String.equal a.mime_type b.mime_type
-  && String.equal a.data b.data
-
-let message_source_equal a b =
-  match a, b with
-  | Dashboard, Dashboard -> true
-  | Discord { channel_id = c1; user_id = u1 }, Discord { channel_id = c2; user_id = u2 } ->
-      String.equal c1 c2 && String.equal u1 u2
-  | Slack { channel = c1; user_id = u1 }, Slack { channel = c2; user_id = u2 } ->
-      String.equal c1 c2 && String.equal u1 u2
-  | Dashboard, (Discord _ | Slack _)
-  | Discord _, (Dashboard | Slack _)
-  | Slack _, (Dashboard | Discord _) ->
-      false
-
-let queued_message_equal (a : queued_message) (b : queued_message) =
-  String.equal a.content b.content
-  && list_equal user_input_block_equal a.user_blocks b.user_blocks
-  && list_equal attachment_equal a.attachments b.attachments
-  && Float.equal a.timestamp b.timestamp
-  && message_source_equal a.source b.source
-
-(* Remove the first message structurally equal to [target] from the head run —
-   the leading messages sharing the head message's source, i.e. the exact set
-   [lease_batch] coalesces into one turn. Returns the item list with that one
-   message dropped, or [None] when no head-run message matches. Confining the
-   search to the head run keeps [remove_matching] and [lease_batch] acting on
-   the same region under the shared per-keeper mutex, so a still-queued
-   message is answered by at most one of them. *)
-let remove_first_in_head_run items target =
+let merge_batch (items : leased_message list) =
   match items with
   | [] -> None
-  | head :: _ ->
-      let rec loop acc = function
-        | [] -> None
-        | msg :: rest ->
-            if not (same_source head.source msg.source)
-            then None
-            else if queued_message_equal msg target
-            then Some (List.rev_append acc rest)
-            else loop (msg :: acc) rest
-      in
-      loop [] items
+  | [ item ] -> Some item.message
+  | first :: _ ->
+    Some
+      { content =
+          String.concat "\n\n"
+            (List.map
+               (fun (item : leased_message) -> item.message.content)
+               items)
+      ; user_blocks =
+          List.concat_map
+            (fun (item : leased_message) -> item.message.user_blocks)
+            items
+      ; attachments =
+          List.concat_map
+            (fun (item : leased_message) -> item.message.attachments)
+            items
+      ; timestamp = first.message.timestamp
+      ; source = first.message.source
+      }
 
-let remove_matching ~keeper_name target =
-  match find_entry keeper_name with
-  | None -> `Not_found
-  | Some entry ->
-      with_entry_lock entry (fun () ->
-          let before_items = queue_to_list entry.q in
-          let before_inflight = entry.inflight in
-          match remove_first_in_head_run before_items target with
-          | None -> `Not_found
-          | Some remaining ->
-              replace_queue entry.q remaining;
-              (* Reuse the persist-abort idiom: on snapshot rewrite failure
-                 [persist_or_rollback] restores [before_items]/[before_inflight]
-                 and re-raises, so the removal is aborted (queue unchanged)
-                 before it is reported. Only [Persistence_failed] becomes a
-                 typed result; [Cancelled] and any other exception still
-                 propagate. *)
-              (try
-                 persist_or_rollback ~keeper_name entry ~before_items ~before_inflight;
-                 `Removed
-               with Persistence_failed msg -> `Persist_failed msg))
+let pending_count ~keeper_name =
+  match mutation_entry ~keeper_name ~create:false with
+  | Error _ as error -> error
+  | Ok (_, _, None) -> Ok 0
+  | Ok (_, _, Some entry) ->
+    with_entry_lock entry (fun () -> Ok (List.length (pending_receipts entry.receipts)))
 
-let length ~keeper_name =
-  match find_entry keeper_name with
-  | None -> 0
-  | Some entry ->
-      with_entry_lock entry (fun () -> Queue.length entry.q)
+let inflight_count ~keeper_name =
+  match mutation_entry ~keeper_name ~create:false with
+  | Error _ as error -> error
+  | Ok (_, _, None) -> Ok 0
+  | Ok (_, _, Some entry) ->
+    with_entry_lock entry (fun () -> Ok (List.length (inflight_receipts entry.receipts)))
+
+let receipt_state_of_stored = function
+  | Stored_pending _ -> Pending
+  | Stored_inflight { lease_id; started_at; _ } -> Inflight { lease_id; started_at }
+  | Stored_delivered completion -> Delivered completion
+  | Stored_failed failure -> Failed failure
 
 let snapshot ~keeper_name =
   match find_entry keeper_name with
-  | None -> []
+  | None ->
+    { revision = 0L
+    ; pending = []
+    ; inflight = []
+    ; terminal = []
+    ; load_errors = Atomic.get global_load_errors
+    }
   | Some entry ->
-      with_entry_lock entry (fun () -> queue_to_list entry.q)
+    with_entry_lock entry (fun () ->
+        let pending, inflight, terminal =
+          List.fold_left
+            (fun (pending, inflight, terminal) receipt ->
+               match receipt.state with
+               | Stored_pending message ->
+                 ( { receipt_id = receipt.receipt_id; message; state = Pending } :: pending
+                 , inflight
+                 , terminal )
+               | Stored_inflight ({ message; _ } as state) ->
+                 ( pending
+                 , { receipt_id = receipt.receipt_id
+                   ; message
+                   ; state = receipt_state_of_stored (Stored_inflight state)
+                   }
+                   :: inflight
+                 , terminal )
+               | Stored_delivered _ | Stored_failed _ ->
+                 ( pending
+                 , inflight
+                 , ({ receipt_id = receipt.receipt_id
+                    ; state = receipt_state_of_stored receipt.state
+                    } : receipt_view)
+                   :: terminal ))
+            ([], [], []) entry.receipts
+        in
+        { revision = entry.revision
+        ; pending = List.rev pending
+        ; inflight = List.rev inflight
+        ; terminal = List.rev terminal
+        ; load_errors = entry.load_errors @ Atomic.get global_load_errors
+        })
 
-let clear ~keeper_name =
-  match find_entry keeper_name with
-  | None -> ()
-  | Some entry ->
-      with_entry_lock entry (fun () ->
-          let before_items = queue_to_list entry.q in
-          let before_inflight = entry.inflight in
-          Queue.clear entry.q;
-          persist_or_rollback ~keeper_name entry ~before_items ~before_inflight)
+let lookup_receipt ~keeper_name ~receipt_id =
+  match mutation_entry ~keeper_name ~create:false with
+  | Error _ as error -> error
+  | Ok (_, _, None) -> Ok { revision = 0L; receipt = None }
+  | Ok (_, _, Some entry) ->
+    with_entry_lock entry (fun () ->
+        let receipt =
+          List.find_map
+            (fun receipt ->
+               if Receipt_id.equal receipt.receipt_id receipt_id
+               then
+                 Some
+                   ({ receipt_id = receipt.receipt_id
+                    ; state = receipt_state_of_stored receipt.state
+                    } : receipt_view)
+               else None)
+            entry.receipts
+        in
+        Ok { revision = entry.revision; receipt })
 
 let all_keeper_names () =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
+  with_registry_rw (fun () ->
+      Hashtbl.fold (fun keeper_name _ names -> keeper_name :: names) registry [])
 
 let configure_persistence ~base_path =
-  Atomic.set persistence_base_path (Some base_path);
+  Atomic.set persistence_base_path None;
+  Atomic.set global_load_errors [];
+  (* BasePath is the queue ownership boundary. A reconfiguration must not make
+     an in-memory entry from the previous workspace appear in the new one. *)
+  with_registry_rw (fun () -> Hashtbl.clear registry);
+  let restored_keeper_count = ref 0 in
+  let migrated_keeper_count = ref 0 in
+  let recovered_receipt_count = ref 0 in
+  let load_errors = ref [] in
+  let restored_mutations = ref [] in
   let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-  if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir
-  then
-    Sys.readdir keepers_dir
-    |> Array.iter (fun keeper_name ->
-      if valid_keeper_name keeper_name
-      then
-        let loaded_q, loaded_inflight = load_snapshot ~base_path ~keeper_name in
-        let inflight_items =
-          match loaded_inflight with
-          | None -> []
-          | Some { lease_id; messages } ->
-            Log.Keeper.warn
-              "chat_queue_snapshot: requeuing %d message(s) from unacknowledged \
-               lease=%s for keeper=%s after restart (at-least-once redelivery)"
-              (List.length messages)
-              lease_id
-              keeper_name;
-            messages
+  let keeper_names =
+    if not (Sys.file_exists keepers_dir)
+    then []
+    else
+      try Array.to_list (Sys.readdir keepers_dir) with
+      | exception_ ->
+        let error =
+          load_error Read_failed ~path:keepers_dir
+            ("failed to discover keeper chat queue snapshots: "
+             ^ Printexc.to_string exception_)
         in
-        let snapshot_items = inflight_items @ queue_to_list loaded_q in
-        if snapshot_items <> []
-        then
-          let entry = get_or_create_entry_locked keeper_name in
-          with_entry_lock entry (fun () ->
-              let before_items = queue_to_list entry.q in
-              let before_inflight = entry.inflight in
-              replace_queue entry.q (snapshot_items @ before_items);
-              entry.inflight <- None;
-              persist_or_rollback ~keeper_name entry ~before_items ~before_inflight))
+        load_errors := (None, error) :: !load_errors;
+        Atomic.set global_load_errors [ error ];
+        []
+  in
+  List.iter
+    (fun keeper_name ->
+       let path = Filename.concat (Filename.concat keepers_dir keeper_name) persistence_file in
+       if Sys.file_exists path
+       then if not (valid_keeper_name keeper_name)
+         then
+           let error =
+             load_error Invalid_path ~path
+               (Printf.sprintf "invalid snapshot-bearing keeper name: %s" keeper_name)
+           in
+           load_errors := (Some keeper_name, error) :: !load_errors
+         else
+           match load_snapshot ~base_path ~keeper_name with
+           | Ok None -> ()
+           | Ok (Some loaded) ->
+             incr restored_keeper_count;
+             if loaded.migrated then incr migrated_keeper_count;
+             recovered_receipt_count :=
+               !recovered_receipt_count + loaded.recovered_count;
+             with_registry_rw (fun () ->
+                 Hashtbl.replace registry keeper_name
+                   (create_entry ~revision:loaded.revision
+                      ~receipts:loaded.receipts ()));
+             if loaded.migrated || loaded.recovered_count > 0
+             then
+               restored_mutations :=
+                 (keeper_name, loaded.revision) :: !restored_mutations
+           | Error error ->
+             load_errors := (Some keeper_name, error) :: !load_errors;
+             with_registry_rw (fun () ->
+                 Hashtbl.replace registry keeper_name
+                   (create_entry ~load_errors:[ error ] ())))
+    keeper_names;
+  Atomic.set persistence_base_path (Some base_path);
+  List.rev !restored_mutations
+  |> List.iter (fun (keeper_name, revision) ->
+         notify_transition ~keeper_name ~revision);
+  { restored_keeper_count = !restored_keeper_count
+  ; migrated_keeper_count = !migrated_keeper_count
+  ; recovered_receipt_count = !recovered_receipt_count
+  ; load_errors = List.rev !load_errors
+  }
 
 module For_testing = struct
   let reset () =
     Atomic.set fail_next_persist_for_testing false;
     Atomic.set persistence_base_path None;
-    Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)
+    Atomic.set global_load_errors [];
+    Atomic.set transition_observer None;
+    with_registry_rw (fun () -> Hashtbl.clear registry)
 
   let fail_next_persist () = Atomic.set fail_next_persist_for_testing true
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -17,6 +17,9 @@ module Receipt_id = struct
   type t = string
 
   let prefix = "chatq_"
+  (* Random UUID bits are an opaque durable identity salt. They are persisted
+     before acceptance and never choose lifecycle policy or control flow. *)
+  (* NDT-OK: identity entropy only; never a lifecycle decision input. *)
   let rng = Random.State.make_self_init ()
   let rng_mutex = Stdlib.Mutex.create ()
 

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -3,7 +3,13 @@
 type message_source =
   | Dashboard
   | Discord of { channel_id : string; user_id : string }
-  | Slack of { channel : string; user_id : string }
+  | Slack of {
+      channel_id : string;
+      user_id : string;
+      user_name : string;
+      team_id : string option;
+      thread_ts : string option;
+    }
 
 type queued_message = {
   content : string;
@@ -102,6 +108,7 @@ type snapshot_load_error = {
 type mutation_error =
   | Persistence_not_configured
   | Snapshot_unavailable of snapshot_load_error
+  | Invalid_input of string
   | Revision_exhausted
   | Persist_failed of string
 
@@ -114,6 +121,7 @@ let snapshot_load_error_kind_to_string = function
 
 let mutation_error_to_string = function
   | Persistence_not_configured -> "chat queue persistence is not configured"
+  | Invalid_input message -> "chat queue input is invalid: " ^ message
   | Revision_exhausted -> "chat queue revision domain is exhausted"
   | Persist_failed message -> "chat queue persistence failed: " ^ message
   | Snapshot_unavailable error ->
@@ -217,9 +225,9 @@ let continuation_channel_of_message_source ?dashboard_thread_id = function
       ; thread_id = None
       ; user_id
       }
-  | Slack { channel; user_id } ->
+  | Slack { channel_id; user_id; team_id; thread_ts; _ } ->
     Keeper_continuation_channel.Slack
-      { team_id = None; channel_id = channel; thread_ts = None; user_id }
+      { team_id; channel_id; thread_ts; user_id }
 
 let set_transition_observer observer = Atomic.set transition_observer observer
 
@@ -260,11 +268,14 @@ let source_to_yojson = function
       ; "channel_id", `String channel_id
       ; "user_id", `String user_id
       ]
-  | Slack { channel; user_id } ->
+  | Slack { channel_id; user_id; user_name; team_id; thread_ts } ->
     `Assoc
       [ "kind", `String "slack"
-      ; "channel", `String channel
+      ; "channel_id", `String channel_id
       ; "user_id", `String user_id
+      ; "user_name", `String user_name
+      ; ("team_id", Option.fold ~none:`Null ~some:(fun value -> `String value) team_id)
+      ; ("thread_ts", Option.fold ~none:`Null ~some:(fun value -> `String value) thread_ts)
       ]
 
 let required_member json key =
@@ -300,7 +311,11 @@ let required_nonnegative_int json key =
 let optional_string json key =
   match Json_util.assoc_member_opt key json with
   | None | Some `Null -> Ok None
-  | Some (`String value) -> Ok (Some value)
+  | Some (`String value) ->
+    let value = String.trim value in
+    if value = ""
+    then Error (Printf.sprintf "chat queue JSON field %s must be non-empty when present" key)
+    else Ok (Some value)
   | Some _ -> Error (Printf.sprintf "chat queue JSON field %s must be string or null" key)
 
 let source_of_yojson json =
@@ -315,12 +330,25 @@ let source_of_yojson json =
      | Ok _, Ok _ -> Error "discord chat queue source requires non-empty ids"
      | Error error, _ | _, Error error -> Error error)
   | Ok "slack" ->
-    (match required_string json "channel", required_string json "user_id" with
-     | Ok channel, Ok user_id
-       when String.trim channel <> "" && String.trim user_id <> "" ->
-       Ok (Slack { channel; user_id })
-     | Ok _, Ok _ -> Error "slack chat queue source requires non-empty ids"
-     | Error error, _ | _, Error error -> Error error)
+    (match
+       required_string json "channel_id",
+       required_string json "user_id",
+       required_string json "user_name",
+       optional_string json "team_id",
+       optional_string json "thread_ts"
+     with
+     | Ok channel_id, Ok user_id, Ok user_name, Ok team_id, Ok thread_ts
+       when String.trim channel_id <> ""
+            && String.trim user_id <> ""
+            && String.trim user_name <> "" ->
+       Ok (Slack { channel_id; user_id; user_name; team_id; thread_ts })
+     | Ok _, Ok _, Ok _, Ok _, Ok _ ->
+       Error "slack chat queue source requires non-empty channel/user identity"
+     | Error error, _, _, _, _
+     | _, Error error, _, _, _
+     | _, _, Error error, _, _
+     | _, _, _, Error error, _
+     | _, _, _, _, Error error -> Error error)
   | Ok kind -> Error (Printf.sprintf "unsupported chat queue source kind: %s" kind)
 
 let same_source left right =
@@ -330,8 +358,10 @@ let same_source left right =
     String.equal left.channel_id right.channel_id
     && String.equal left.user_id right.user_id
   | Slack left, Slack right ->
-    String.equal left.channel right.channel
+    String.equal left.channel_id right.channel_id
     && String.equal left.user_id right.user_id
+    && Option.equal String.equal left.team_id right.team_id
+    && Option.equal String.equal left.thread_ts right.thread_ts
   | Dashboard, (Discord _ | Slack _)
   | Discord _, (Dashboard | Slack _)
   | Slack _, (Dashboard | Discord _) -> false
@@ -388,7 +418,7 @@ let attachments_of_yojson = function
     loop [] values
   | _ -> Error "chat queue attachments must be an array"
 
-let queued_message_of_yojson json =
+let queued_message_of_yojson_with_source source_parser json =
   match json with
   | `Assoc _ ->
     (match
@@ -402,7 +432,7 @@ let queued_message_of_yojson json =
        (match
           Keeper_multimodal_input.parse_user_blocks json,
           attachments_of_yojson attachments_json,
-          source_of_yojson source_json
+          source_parser source_json
         with
         | Ok user_blocks, Ok attachments, Ok source ->
           Ok { content; user_blocks; attachments; timestamp; source }
@@ -414,6 +444,57 @@ let queued_message_of_yojson json =
      | _, _, _, Error error, _
      | _, _, _, _, Error error -> Error error)
   | _ -> Error "chat queue message must be a JSON object"
+
+let queued_message_of_yojson json =
+  queued_message_of_yojson_with_source source_of_yojson json
+
+let source_of_v1_yojson json =
+  match required_string json "kind" with
+  | Ok "slack" ->
+    (match required_string json "channel", required_string json "user_id" with
+     | Ok channel_id, Ok user_id
+       when String.trim channel_id <> "" && String.trim user_id <> "" ->
+       (* Version 1 predates typed Slack thread/team/name persistence. Preserve
+          its known channel/user identity explicitly; absent fields remain
+          absent rather than being inferred from unrelated values. *)
+       Ok
+         (Slack
+            { channel_id
+            ; user_id
+            ; user_name = user_id
+            ; team_id = None
+            ; thread_ts = None
+            })
+     | Ok _, Ok _ -> Error "legacy slack chat queue source requires non-empty ids"
+     | Error error, _ | _, Error error -> Error error)
+  | Ok _ | Error _ -> source_of_yojson json
+
+let rec validate_json_utf8 path = function
+  | `String value when String.is_valid_utf_8 value -> Ok ()
+  | `String _ -> Error (path ^ " contains malformed UTF-8")
+  | `Assoc fields ->
+    List.fold_left
+      (fun result (key, value) ->
+         Result.bind result (fun () ->
+             if not (String.is_valid_utf_8 key)
+             then Error (path ^ " contains a malformed UTF-8 field name")
+             else validate_json_utf8 (path ^ "." ^ key) value))
+      (Ok ()) fields
+  | `List values | `Tuple values ->
+    List.fold_left
+      (fun result value ->
+         Result.bind result (fun () -> validate_json_utf8 path value))
+      (Ok ()) values
+  | `Variant (name, value) ->
+    if not (String.is_valid_utf_8 name)
+    then Error (path ^ " contains a malformed UTF-8 variant name")
+    else Option.fold ~none:(Ok ()) ~some:(validate_json_utf8 path) value
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ -> Ok ()
+
+let canonical_queued_message message =
+  let json = queued_message_to_yojson message in
+  Result.bind (validate_json_utf8 "message" json) (fun () ->
+      queued_message_of_yojson json)
 
 let failure_kind_to_string = function
   | Turn_failed -> "turn_failed"
@@ -486,7 +567,6 @@ let snapshot_to_yojson ~revision receipts =
 let save_json_atomic path json =
   Fs_compat.mkdir_p (Filename.dirname path);
   json
-  |> Safe_ops.sanitize_json_utf8
   |> Yojson.Safe.pretty_to_string
   |> Fs_compat.save_file_atomic path
 
@@ -648,7 +728,7 @@ let parse_message_list json =
     let rec loop acc = function
       | [] -> Ok (List.rev acc)
       | value :: rest ->
-        (match queued_message_of_yojson value with
+        (match queued_message_of_yojson_with_source source_of_v1_yojson value with
          | Error _ as error -> error
          | Ok message -> loop (message :: acc) rest)
     in
@@ -859,6 +939,9 @@ let commit (entry : queue_entry) ~path receipts =
 
 let enqueue ~keeper_name message =
   let receipt_id = Receipt_id.generate () in
+  match canonical_queued_message message with
+  | Error message -> Error (Invalid_input message)
+  | Ok message ->
   match mutation_entry ~keeper_name ~create:true with
   | Error _ as error -> error
   | Ok (_, _, None) ->
@@ -965,11 +1048,35 @@ let lease_batch ~keeper_name =
      | `Already_leased lease_id -> `Already_leased lease_id
      | `Error error -> `Error error)
 
-let terminal_state = function
-  | Mark_delivered completion -> Stored_delivered completion
-  | Mark_failed failure -> Stored_failed failure
+let canonical_optional_ref = function
+  | None -> Ok None
+  | Some value ->
+    let value = String.trim value in
+    if value = "" then Error "terminal outcome_ref must be non-empty when present"
+    else if not (String.is_valid_utf_8 value) then Error "terminal outcome_ref contains malformed UTF-8"
+    else Ok (Some value)
+
+let canonical_terminal_state = function
+  | Mark_delivered completion when Float.is_finite completion.completed_at ->
+    Result.map
+      (fun outcome_ref -> Stored_delivered { completion with outcome_ref })
+      (canonical_optional_ref completion.outcome_ref)
+  | Mark_delivered _ -> Error "terminal completed_at must be finite"
+  | Mark_failed failure when not (Float.is_finite failure.completed_at) ->
+    Error "terminal completed_at must be finite"
+  | Mark_failed failure ->
+    let detail = String.trim failure.detail in
+    if detail = "" then Error "terminal failure detail must be non-empty"
+    else if not (String.is_valid_utf_8 detail) then Error "terminal failure detail contains malformed UTF-8"
+    else
+      Result.map
+        (fun outcome_ref -> Stored_failed { failure with detail; outcome_ref })
+        (canonical_optional_ref failure.outcome_ref)
 
 let finalize ~keeper_name ~lease_id ~outcome =
+  match canonical_terminal_state outcome with
+  | Error message -> `Error (Invalid_input message)
+  | Ok terminal_state ->
   match mutation_entry ~keeper_name ~create:false with
   | Error error -> `Error error
   | Ok (_, _, None) -> `Unknown_lease
@@ -994,7 +1101,7 @@ let finalize ~keeper_name ~lease_id ~outcome =
                 (fun receipt ->
                    match receipt.state with
                    | Stored_inflight current when String.equal current.lease_id lease_id ->
-                     { receipt with state = terminal_state outcome }
+                     { receipt with state = terminal_state }
                    | Stored_pending _ | Stored_inflight _
                    | Stored_delivered _ | Stored_failed _ -> receipt)
                 entry.receipts
@@ -1087,6 +1194,20 @@ let inflight_count ~keeper_name =
   | Ok (_, _, None) -> Ok 0
   | Ok (_, _, Some entry) ->
     with_entry_lock entry (fun () -> Ok (List.length (inflight_receipts entry.receipts)))
+
+let has_active_receipts ~keeper_name =
+  match mutation_entry ~keeper_name ~create:false with
+  | Error _ as error -> error
+  | Ok (_, _, None) -> Ok false
+  | Ok (_, _, Some entry) ->
+    with_entry_lock entry (fun () ->
+        Ok
+          (List.exists
+             (fun receipt ->
+                match receipt.state with
+                | Stored_pending _ | Stored_inflight _ -> true
+                | Stored_delivered _ | Stored_failed _ -> false)
+             entry.receipts))
 
 let receipt_state_of_stored = function
   | Stored_pending _ -> Pending

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -1,32 +1,15 @@
-(** Keeper_chat_queue — thread-safe per-keeper message queue.
+(** Durable per-Keeper chat receipt queue.
 
-    Each keeper owns an in-memory FIFO queue for chat messages that
-    arrive while the keeper is already processing a previous message.
-    When a stream finishes, the queue is drained automatically.
+    Every accepted message receives a stable receipt before the first durable
+    write.  The receipt then follows exactly one closed lifecycle:
+    [Pending -> Inflight -> Delivered | Failed].  A process restart moves an
+    unfinalized [Inflight] receipt back to [Pending] without changing its id.
 
-    Once [configure_persistence] is called from server bootstrap, queue
-    mutations are mirrored to a per-keeper durable snapshot and replayed on
-    restart. Snapshot rewrite failure aborts the mutation before it is
-    acknowledged, keeping in-memory state and durable replay aligned.
-
-    Delivery is at-least-once, not at-most-once: {!lease_batch} moves a
-    same-source run out of the live queue into a durably-persisted inflight
-    slot instead of deleting it outright. The caller must call {!ack} once a
-    reply (or failure marker) has actually been persisted for the batch, or
-    {!nack} to return the batch to the head of the queue for retry. A lease
-    that is never acked or nacked (process crash, unhandled cancellation)
-    survives in the durable snapshot and is requeued the next time
-    {!configure_persistence} runs — see its doc comment.
-
-    Queue drain is handled by [Keeper_chat_consumer], started from
-    server bootstrap.  The [source] field preserves connector context
-    so queued dashboard, Discord, and Slack messages can be projected
-    into the same keeper-chat execution path without losing reply
-    routing metadata.
+    Queue delivery is at-least-once.  Same-source receipts may share one turn,
+    but their identities are never merged: a lease and its terminal transition
+    always carry every constituent receipt.
 
     @since 2.145.0 *)
-
-(** {1 Types} *)
 
 type message_source =
   | Dashboard
@@ -41,142 +24,188 @@ type queued_message = {
   source : message_source;
 }
 
-(** A same-source run leased out of the live queue by {!lease_batch}.
-    [lease_id] identifies this specific lease for {!ack}/{!nack}; it is
-    unrelated to the per-message [receipt_id] {!enqueue} returns. *)
-type lease = {
-  lease_id : string;
-  messages : queued_message list;
+module Receipt_id : sig
+  type t
+
+  val of_string : string -> (t, string) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
+type completion = {
+  completed_at : float;
+  outcome_ref : string option;
 }
 
-(** [continuation_channel_of_message_source source] converts queued chat
-    provenance into the RFC-0320 continuation-channel type. Dashboard queue
-    sources may supply [dashboard_thread_id] from the local AG-UI thread; when
-    omitted the dashboard surface is preserved as a single route. *)
+type failure_kind =
+  | Turn_failed
+  | Timed_out
+  | No_visible_reply
+  | Transcript_persist_failed
+  | Connector_unavailable
+  | Delivery_failed
+  | Cancelled
+  | Internal_error
+
+val failure_kind_to_string : failure_kind -> string
+
+type failure = {
+  completed_at : float;
+  kind : failure_kind;
+  detail : string;
+  outcome_ref : string option;
+}
+
+type receipt_state =
+  | Pending
+  | Inflight of { lease_id : string; started_at : float }
+  | Delivered of completion
+  | Failed of failure
+
+type leased_message = {
+  receipt_id : Receipt_id.t;
+  message : queued_message;
+}
+
+type lease = {
+  lease_id : string;
+  items : leased_message list;
+}
+
+type finalization =
+  | Mark_delivered of completion
+  | Mark_failed of failure
+
+type snapshot_load_error_kind =
+  | Invalid_path
+  | Read_failed
+  | Parse_failed
+  | Migration_failed
+  | Recovery_failed
+
+type snapshot_load_error = {
+  kind : snapshot_load_error_kind;
+  path : string option;
+  message : string;
+}
+
+type mutation_error =
+  | Persistence_not_configured
+  | Snapshot_unavailable of snapshot_load_error
+  | Revision_exhausted
+  | Persist_failed of string
+
+val snapshot_load_error_kind_to_string : snapshot_load_error_kind -> string
+val mutation_error_to_string : mutation_error -> string
+
+type active_receipt = {
+  receipt_id : Receipt_id.t;
+  message : queued_message;
+  state : receipt_state;
+}
+
+type receipt_view = {
+  receipt_id : Receipt_id.t;
+  state : receipt_state;
+}
+
+type receipt_lookup = {
+  revision : int64;
+  receipt : receipt_view option;
+}
+
+type diagnostic_snapshot = {
+  revision : int64;
+  pending : active_receipt list;
+  inflight : active_receipt list;
+  terminal : receipt_view list;
+  load_errors : snapshot_load_error list;
+}
+
+type enqueue_receipt = {
+  receipt_id : Receipt_id.t;
+  revision : int64;
+  pending_count : int;
+  inflight_count : int;
+}
+
+type configure_report = {
+  restored_keeper_count : int;
+  migrated_keeper_count : int;
+  recovered_receipt_count : int;
+  load_errors : (string option * snapshot_load_error) list;
+}
+
+type transition_observer = keeper_name:string -> revision:int64 -> unit
+
+(** Install the single post-commit invalidation observer.  It is invoked after
+    every successful queue mutation and always outside queue mutexes.  Observer
+    failures are logged and never roll back or disguise a committed mutation. *)
+val set_transition_observer : transition_observer option -> unit
+
 val continuation_channel_of_message_source :
   ?dashboard_thread_id:string -> message_source -> Keeper_continuation_channel.t
 
-(** {1 Queue operations} *)
+(** Enable persistence and restore every per-Keeper snapshot.  Version-1 files
+    are decoded only by the explicit one-time migration, atomically rewritten
+    as strict version 2, and never treated as a version-2 fallback.  A malformed
+    snapshot is retained, registered as unavailable, and reported here; it is
+    never replaced by an empty queue. Reconfiguration clears the prior
+    in-memory registry before loading the new BasePath ownership boundary. *)
+val configure_persistence : base_path:string -> configure_report
 
-(** [configure_persistence base_path] enables durable per-keeper queue
-    snapshots under the runtime keeper directory and loads any non-empty
-    snapshots into memory for queue-consumer replay.
-
-    A snapshot recorded while a lease was outstanding (the process crashed or
-    was killed between {!lease_batch} and the matching {!ack}/{!nack}) has its
-    leased messages requeued ahead of the still-queued messages, and the
-    stale lease is dropped: nothing survives as "leased" across a restart,
-    so a booted process always starts with every keeper's inflight slot free.
-    This is the at-least-once guarantee — a message answered but not yet
-    acked when the process died is redelivered and may be answered twice. *)
-val configure_persistence : base_path:string -> unit
-
-(** [persistence_configured ()] reports whether durable snapshots are enabled
-    in this process. *)
 val persistence_configured : unit -> bool
 
-(** [enqueue keeper_name msg] adds [msg] to the tail of [keeper_name]'s
-    queue.  Creates the queue lazily if it does not yet exist. Returns a
-    freshly minted [receipt_id] correlation token for this specific message
-    (not persisted, not required to be unique across process restarts) so a
-    caller such as the dashboard busy-ack can echo it back to the sender. *)
-val enqueue : keeper_name:string -> queued_message -> string
+(** Enqueue only after the receipt-bearing version-2 snapshot commits. *)
+val enqueue :
+  keeper_name:string -> queued_message -> (enqueue_receipt, mutation_error) result
 
-(** [dequeue keeper_name] removes and returns the head message, or
-    [None] if the queue is empty or does not exist. Unlike {!lease_batch}
-    this is an immediate, unleased pop — it does not participate in the
-    ack/nack lifecycle. *)
-val dequeue : keeper_name:string -> queued_message option
-
-(** [same_source a b] is true when two messages share a reply route:
-    the dashboard surface, the same Discord channel+user, or the same
-    Slack channel+user. Coalescing across different routes would lose
-    reply routing. *)
 val same_source : message_source -> message_source -> bool
 
-(** [lease_batch keeper_name] leases the head run of messages sharing the
-    same source ([same_source]) out of the live queue, preserving FIFO
-    order, and durably records the lease so a crash before {!ack}/{!nack}
-    redelivers it (see {!configure_persistence}). Stops at the first message
-    with a different source so each coalesced turn answers one reply route.
-
-    - [Leased lease] — the run was leased; the caller must eventually call
-      {!ack} or {!nack} with [lease.lease_id].
-    - [Empty] — the queue is empty or absent.
-    - [Already_leased lease_id] — a previous lease for this keeper is
-      still outstanding (the caller has not yet acked/nacked it); the queue
-      is unchanged. At most one lease is outstanding per keeper at a time.
-    - [Persist_failed msg] — the snapshot rewrite failed; the queue is
-      unchanged (rolled back before this is returned). *)
 val lease_batch :
   keeper_name:string ->
   [ `Leased of lease
   | `Empty
   | `Already_leased of string
-  | `Persist_failed of string
+  | `Error of mutation_error
   ]
 
-(** [ack keeper_name lease_id] permanently removes a leased batch after its
-    reply (or failure marker) has been durably persisted by the caller.
-    [`Unknown_lease] when [lease_id] does not match the keeper's current
-    outstanding lease (already acked/nacked, or never leased). *)
-val ack :
+(** Atomically finalize every receipt in the matching lease.  Terminal records
+    retain correlation metadata but discard message bodies and attachments. *)
+val finalize :
   keeper_name:string ->
   lease_id:string ->
-  [ `Acked | `Unknown_lease | `Persist_failed of string ]
+  outcome:finalization ->
+  [ `Finalized of Receipt_id.t list
+  | `Unknown_lease
+  | `Error of mutation_error
+  ]
 
-(** [nack keeper_name lease_id] returns a leased batch to the head of the
-    queue, ahead of any messages that arrived while the lease was
-    outstanding, so it is retried on the next {!lease_batch}. [`Unknown_lease]
-    when [lease_id] does not match the keeper's current outstanding lease. *)
+(** Return every receipt in the matching lease to [Pending], preserving ids and
+    FIFO order. *)
 val nack :
   keeper_name:string ->
   lease_id:string ->
-  [ `Requeued | `Unknown_lease | `Persist_failed of string ]
+  [ `Requeued of Receipt_id.t list
+  | `Unknown_lease
+  | `Error of mutation_error
+  ]
 
-(** [merge_batch batch] coalesces a same-source batch into one message:
-    contents joined in arrival order with a blank line, semantic user blocks
-    and attachments concatenated, the first message's timestamp (queueing
-    latency stays measurable), the shared source. [None] on [[]]; a singleton
-    is returned unchanged. *)
-val merge_batch : queued_message list -> queued_message option
+(** Coalesce a leased same-source run into one turn payload without erasing the
+    receipt list carried by the lease. *)
+val merge_batch : leased_message list -> queued_message option
 
-(** [remove_matching keeper_name msg] removes exactly one message structurally
-    equal to [msg] from the head run of [keeper_name]'s still-queued messages
-    — the leading same-source messages {!lease_batch} would coalesce into one
-    turn. A message already moved into the inflight lease by {!lease_batch}
-    is out of scope: it is being answered, not merely queued, so it is not a
-    candidate for removal here. Duplicates in the head run leave all but the
-    first match in place, and a match past the head-run boundary is not
-    removed. Returns [`Not_found] when the queue is empty or absent, or when
-    no head-run message matches. On a match the durable snapshot is rewritten
-    before the removal is reported [`Removed]; a snapshot rewrite failure
-    aborts the removal (queue unchanged) and returns [`Persist_failed msg],
-    mirroring the persist-abort contract of {!lease_batch}. Serialized on the
-    same per-keeper mutex as {!lease_batch}, so a still-queued message is
-    answered by at most one of them. *)
-val remove_matching :
+val pending_count : keeper_name:string -> (int, mutation_error) result
+val inflight_count : keeper_name:string -> (int, mutation_error) result
+val snapshot : keeper_name:string -> diagnostic_snapshot
+
+val lookup_receipt :
   keeper_name:string ->
-  queued_message ->
-  [ `Removed | `Not_found | `Persist_failed of string ]
+  receipt_id:Receipt_id.t ->
+  (receipt_lookup, mutation_error) result
+(** Atomically return the receipt observation with the queue revision that
+    produced it. *)
 
-(** [length keeper_name] returns the number of still-queued messages — it
-    excludes a message currently held by an outstanding lease, which is
-    being answered rather than waiting. *)
-val length : keeper_name:string -> int
-
-(** [snapshot keeper_name] returns the still-queued messages in FIFO order
-    without mutating the queue (excludes an outstanding lease's messages, see
-    {!length}). Intended for diagnostic projections that need source
-    metadata; consumers must still use {!lease_batch} for delivery. *)
-val snapshot : keeper_name:string -> queued_message list
-
-(** [clear keeper_name] empties the still-queued messages. Does not affect an
-    outstanding lease — {!ack} or {!nack} it explicitly. *)
-val clear : keeper_name:string -> unit
-
-(** [all_keeper_names ()] returns a snapshot list of all keeper names
-    that currently have a queue in the registry. *)
 val all_keeper_names : unit -> string list
 
 module For_testing : sig

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -14,7 +14,13 @@
 type message_source =
   | Dashboard
   | Discord of { channel_id : string; user_id : string }
-  | Slack of { channel : string; user_id : string }
+  | Slack of {
+      channel_id : string;
+      user_id : string;
+      user_name : string;
+      team_id : string option;
+      thread_ts : string option;
+    }
 
 type queued_message = {
   content : string;
@@ -92,6 +98,7 @@ type snapshot_load_error = {
 type mutation_error =
   | Persistence_not_configured
   | Snapshot_unavailable of snapshot_load_error
+  | Invalid_input of string
   | Revision_exhausted
   | Persist_failed of string
 
@@ -197,6 +204,7 @@ val merge_batch : leased_message list -> queued_message option
 
 val pending_count : keeper_name:string -> (int, mutation_error) result
 val inflight_count : keeper_name:string -> (int, mutation_error) result
+val has_active_receipts : keeper_name:string -> (bool, mutation_error) result
 val snapshot : keeper_name:string -> diagnostic_snapshot
 
 val lookup_receipt :

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -273,7 +273,12 @@ let send_message ~token ~channel ~content =
 
 let add_block acc block = block :: acc
 
-let adapter_loop ~token ~channel ~events ?base_url
+let adapter_loop_with_transport
+    ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t)
+    ~(send_plain : content:string -> (unit, error) result)
+    ~(send_blocks :
+       content:string -> blocks:Yojson.Safe.t list -> (unit, error) result)
+    ?base_url
     ?(on_send_result = fun _ -> ()) () =
   let rec loop ~acc_text ~acc_blocks ~run_id_opt =
     match Keeper_chat_events.subscribe events with
@@ -286,13 +291,14 @@ let adapter_loop ~token ~channel ~events ?base_url
           final_message_blocks ~content:acc_text
             ~event_blocks:(List.rev acc_blocks)
         in
-        if String.length acc_text > 0 || List.length blocks > 0 then
+        if String.length acc_text > 0 || List.length blocks > 0
+        then on_send_result (send_blocks ~content:acc_text ~blocks)
+        else
           on_send_result
-            (send_message_with_blocks ~token ~channel ~content:acc_text ~blocks);
+            (Error (Other "Slack terminal reply contained no text or blocks"));
         ()
     | Event_error { message } ->
-        on_send_result
-          (send_message ~token ~channel ~content:("Keeper error: " ^ message));
+        on_send_result (send_plain ~content:("Keeper error: " ^ message));
         ()
     | Run_started { run_id; thread_id = _ } ->
         loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:(Some run_id)
@@ -313,11 +319,20 @@ let adapter_loop ~token ~channel ~events ?base_url
     | Oas_media_delta _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Oas_stream_protocol_error error ->
-        on_send_result
-          (send_message ~token ~channel
+        (* This is an interim diagnostic, not the terminal queued-message
+           delivery receipt. Reporting it through [on_send_result] could let a
+           successful diagnostic mask a later final-send failure. *)
+        (match
+           send_plain
              ~content:
                ("Keeper stream protocol: "
-                ^ Keeper_chat_events.stream_protocol_error_summary error));
+                ^ Keeper_chat_events.stream_protocol_error_summary error)
+         with
+         | Ok () -> ()
+         | Error error ->
+           Log.Keeper.warn
+             "keeper_chat_slack: protocol diagnostic delivery failed: %s"
+             (Format.asprintf "%a" pp_error error));
         loop ~acc_text ~acc_blocks ~run_id_opt
     | Tool_call_start _ | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _ ->
         loop ~acc_text ~acc_blocks ~run_id_opt
@@ -339,6 +354,13 @@ let adapter_loop ~token ~channel ~events ?base_url
   in
   loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None
 
+let adapter_loop ~token ~channel ~events ?base_url ?on_send_result () =
+  adapter_loop_with_transport
+    ~send_plain:(fun ~content -> send_message ~token ~channel ~content)
+    ~send_blocks:(fun ~content ~blocks ->
+      send_message_with_blocks ~token ~channel ~content ~blocks)
+    ~events ?base_url ?on_send_result ()
+
 module For_testing = struct
   let escape_mrkdwn_text = escape_mrkdwn_text
   let truncate_to_limit = truncate_to_limit
@@ -350,4 +372,6 @@ module For_testing = struct
   let tool_context_block_json = tool_context_block_json
   let content_blocks_of_text = content_blocks_of_text
   let final_message_blocks = final_message_blocks
+
+  let adapter_loop = adapter_loop_with_transport
 end

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -215,23 +215,32 @@ let limit_blocks_for_slack blocks =
     let keep = max 0 (slack_max_blocks - 1) in
     take keep blocks @ [ omitted_blocks_notice (count - keep) ]
 
-let send_message_with_blocks ~token ~channel ~content ~blocks =
-  let content =
-    redact content |> escape_mrkdwn_text |> fun s ->
-    truncate_to_limit s slack_message_limit
-  in
-  let blocks = limit_blocks_for_slack blocks in
-  let fields =
-    [ ("channel", `String channel); ("text", `String content) ]
-  in
+let build_message_body ~channel ~content ~blocks ?thread_ts () =
+  let fields = [ ("channel", `String channel); ("text", `String content) ] in
   let fields =
     match blocks with
     | [] -> fields
     | _ -> fields @ [ ("blocks", `List blocks) ]
   in
-  let body_json = `Assoc fields |> Yojson.Safe.to_string in
+  let fields =
+    match thread_ts with
+    | None -> fields
+    | Some thread_ts -> fields @ [ "thread_ts", `String thread_ts ]
+  in
+  `Assoc fields |> Yojson.Safe.to_string
+
+let send_message_with_blocks ?clock
+    ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
+    ?thread_ts ~token ~channel ~content ~blocks () =
+  let content =
+    redact content |> escape_mrkdwn_text |> fun s ->
+    truncate_to_limit s slack_message_limit
+  in
+  let blocks = limit_blocks_for_slack blocks in
+  let body_json = build_message_body ~channel ~content ~blocks ?thread_ts () in
   match
-    Masc_http_client.post_sync ~url:"https://slack.com/api/chat.postMessage"
+    Masc_http_client.post_sync ?clock ~timeout_sec
+      ~url:"https://slack.com/api/chat.postMessage"
       ~headers:
         [ ("Authorization", "Bearer " ^ token)
         ; ("Content-Type", "application/json")
@@ -266,8 +275,9 @@ let send_message_with_blocks ~token ~channel ~content ~blocks =
             Log.Keeper.warn "keeper_chat_slack: JSON parse error: %s" msg;
             Error (Other ("JSON parse error: " ^ msg))
 
-let send_message ~token ~channel ~content =
-  send_message_with_blocks ~token ~channel ~content ~blocks:[]
+let send_message ?clock ?timeout_sec ?thread_ts ~token ~channel ~content () =
+  send_message_with_blocks ?clock ?timeout_sec ?thread_ts
+    ~token ~channel ~content ~blocks:[] ()
 
 (* ── Adapter loop ────────────────────────────────────────────────── *)
 
@@ -354,11 +364,13 @@ let adapter_loop_with_transport
   in
   loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:None
 
-let adapter_loop ~token ~channel ~events ?base_url ?on_send_result () =
+let adapter_loop ~clock ~token ~channel ?thread_ts ~events ?base_url
+    ?on_send_result () =
   adapter_loop_with_transport
-    ~send_plain:(fun ~content -> send_message ~token ~channel ~content)
+    ~send_plain:(fun ~content ->
+      send_message ~clock ?thread_ts ~token ~channel ~content ())
     ~send_blocks:(fun ~content ~blocks ->
-      send_message_with_blocks ~token ~channel ~content ~blocks)
+      send_message_with_blocks ~clock ?thread_ts ~token ~channel ~content ~blocks ())
     ~events ?base_url ?on_send_result ()
 
 module For_testing = struct
@@ -372,6 +384,7 @@ module For_testing = struct
   let tool_context_block_json = tool_context_block_json
   let content_blocks_of_text = content_blocks_of_text
   let final_message_blocks = final_message_blocks
+  let build_message_body = build_message_body
 
   let adapter_loop = adapter_loop_with_transport
 end

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -15,13 +15,19 @@ type error =
 val pp_error : Format.formatter -> error -> unit
 
 val send_message :
-  token:string -> channel:string -> content:string -> (unit, error) result
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  ?thread_ts:string ->
+  token:string -> channel:string -> content:string -> unit -> (unit, error) result
 (** [send_message ~token ~channel ~content] posts to
     [chat.postMessage]. Logs errors via [Log.Keeper.warn] and returns the
     outcome. *)
 
 val send_message_with_blocks :
-  token:string -> channel:string -> content:string -> blocks:Yojson.Safe.t list -> (unit, error) result
+  ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  ?timeout_sec:float ->
+  ?thread_ts:string ->
+  token:string -> channel:string -> content:string -> blocks:Yojson.Safe.t list -> unit -> (unit, error) result
 (** [send_message_with_blocks ~token ~channel ~content ~blocks] posts to
     [chat.postMessage] with the given Block Kit [blocks]. Logs errors via
     [Log.Keeper.warn] and returns the outcome. *)
@@ -38,8 +44,10 @@ val content_blocks_of_text : string -> Yojson.Safe.t list
     Slack-native projection yet. *)
 
 val adapter_loop :
+  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   token:string ->
   channel:string ->
+  ?thread_ts:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
   ?base_url:string ->
   ?on_send_result:((unit, error) result -> unit) ->
@@ -95,6 +103,16 @@ module For_testing : sig
     content:string -> event_blocks:Yojson.Safe.t list -> Yojson.Safe.t list
   (** Merge text-derived blocks with explicitly emitted rich event blocks in
       final delivery order. *)
+
+  val build_message_body :
+    channel:string ->
+    content:string ->
+    blocks:Yojson.Safe.t list ->
+    ?thread_ts:string ->
+    unit ->
+    string
+  (** Pure chat.postMessage JSON builder used to prove deferred replies retain
+      the originating Slack thread. *)
 
   val adapter_loop :
     events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -58,10 +58,11 @@ val adapter_loop :
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.
 
-    [on_send_result] is invoked once per outbound attempt with the send
-    outcome, so callers (e.g. the connector gateway) can record delivery
-    observability without this adapter depending on any metric sink. It
-    defaults to a no-op to preserve existing behavior.
+    [on_send_result] is invoked exactly once for the terminal
+    [Run_finished]/[Event_error] delivery. Interim protocol diagnostics do not
+    settle the callback, so an earlier diagnostic cannot hide a later final
+    send failure. Empty terminal output reports a typed [Other] error. The
+    callback defaults to a no-op.
 
     The loop exits after one turn. *)
 
@@ -94,4 +95,15 @@ module For_testing : sig
     content:string -> event_blocks:Yojson.Safe.t list -> Yojson.Safe.t list
   (** Merge text-derived blocks with explicitly emitted rich event blocks in
       final delivery order. *)
+
+  val adapter_loop :
+    events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
+    send_plain:(content:string -> (unit, error) result) ->
+    send_blocks:(content:string -> blocks:Yojson.Safe.t list -> (unit, error) result) ->
+    ?base_url:string ->
+    ?on_send_result:((unit, error) result -> unit) ->
+    unit ->
+    unit
+  (** Test seam for the outbound transport. It runs the production terminal
+      settlement state machine with injected Slack sends. *)
 end

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -699,7 +699,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
 let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
+    ?surface ?conversation_id ?audio ?blocks ?(kind = Row_kind.Utterance)
+    ?turn_ref ?stream_lifecycle () :
     (unit, string) result =
   try
     ensure_dir_once ~base_dir;
@@ -711,7 +712,7 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let ts = Time_compat.now () in
     let line =
       encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
-        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+        ?audio ?blocks ~kind ?turn_ref ?stream_lifecycle ()
     in
     Fs_compat.append_file path (line ^ "\n");
     Ok ()
@@ -730,10 +731,11 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
    failure is already counted + logged inside the [_result] variant). New callers
    that must surface the failure call [append_assistant_message_result] directly. *)
 let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () =
+    ?surface ?conversation_id ?audio ?blocks ?(kind = Row_kind.Utterance)
+    ?turn_ref ?stream_lifecycle () =
   ignore
     (append_assistant_message_result ~base_dir ~keeper_name ~content ?surface
-       ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+       ?conversation_id ?audio ?blocks ~kind ?turn_ref ?stream_lifecycle ()
       : (unit, string) result)
 
 (* RFC-0226: inbound user line recorded at delivery time, before (and

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -610,7 +610,7 @@ let user_line_mentions ~extra_mentions content =
   Keeper_lane_mentions.mention_ids_of_content content @ extra_mentions
   |> List.sort_uniq Keeper_identity.Keeper_id.compare
 
-let append_turn ~base_dir ~keeper_name ~(user_content : string)
+let append_turn_result ~base_dir ~keeper_name ~(user_content : string)
     ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
     ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
     ?(assistant_kind = Row_kind.Utterance)
@@ -665,7 +665,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
     in
-    Fs_compat.append_file path payload
+    Fs_compat.append_file path payload;
+    Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -673,8 +674,22 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
       Keeper_metrics.(to_string ChatStoreFailures)
       ~labels:[("operation", Keeper_chat_store_operation.(to_label Append))]
       ();
+    let message = Printexc.to_string exn in
     Log.Keeper.warn "keeper_chat_store: append failed for %s: %s"
-      (sanitize_name keeper_name) (Printexc.to_string exn)
+      (sanitize_name keeper_name) message;
+    Error message
+
+let append_turn ~base_dir ~keeper_name ~(user_content : string)
+    ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
+    ?conversation_id ?external_message_id ?speaker ?(extra_mentions = [])
+    ?(assistant_kind = Row_kind.Utterance) ?blocks ?turn_ref ?stream_lifecycle
+    ~(assistant_content : string) () =
+  ignore
+    (append_turn_result ~base_dir ~keeper_name ~user_content ~user_attachments
+       ~tool_calls ?surface ?conversation_id ?external_message_id ?speaker
+       ~extra_mentions ~assistant_kind ?blocks ?turn_ref ?stream_lifecycle
+       ~assistant_content ()
+      : (unit, string) result)
 
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
    assistant line — there is no user turn to pair it with.

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -206,6 +206,28 @@ type chat_message = {
     the assistant line is (default [Utterance]); the failed-request
     persistence path passes [Transport_failure]. Failures are logged but
     never raised except for {!Eio.Cancel.Cancelled}. *)
+(** [append_turn_result] is {!append_turn} with an explicit persistence
+    result. Queue consumers use it so a durable delivery receipt cannot become
+    [Delivered] after the transcript write actually failed. *)
+val append_turn_result :
+  base_dir:string ->
+  keeper_name:string ->
+  user_content:string ->
+  user_attachments:attachment list ->
+  ?tool_calls:tool_call list ->
+  ?surface:Surface_ref.t ->
+  ?conversation_id:string ->
+  ?external_message_id:string ->
+  ?speaker:speaker ->
+  ?extra_mentions:Keeper_identity.Keeper_id.t list ->
+  ?assistant_kind:Row_kind.t ->
+  ?blocks:chat_block list ->
+  ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
+  assistant_content:string ->
+  unit ->
+  (unit, string) result
+
 val append_turn :
   base_dir:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -250,7 +250,9 @@ val append_turn :
 (** [append_assistant_message_result] is {!append_assistant_message} that
     returns [Error msg] on a write failure instead of swallowing it (the failure
     is still counted + warn-logged). For callers whose own contract requires
-    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}. *)
+    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}.
+    [kind] declares whether the row is a keeper utterance or a typed transport
+    failure; it defaults to [Utterance]. *)
 val append_assistant_message_result :
   base_dir:string ->
   keeper_name:string ->
@@ -259,6 +261,7 @@ val append_assistant_message_result :
   ?conversation_id:string ->
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
+  ?kind:Row_kind.t ->
   ?turn_ref:Ids.Turn_ref.t ->
   ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
@@ -268,7 +271,8 @@ val append_assistant_message_result :
     ?conversation_id ()]
     appends one keeper-initiated assistant line with no paired user
     turn (RFC-0223 P4 [keeper_surface_post]). Same failure policy as
-    {!append_turn} (failure is counted + logged, not raised). *)
+    {!append_turn} (failure is counted + logged, not raised). [kind] defaults
+    to [Utterance]. *)
 val append_assistant_message :
   base_dir:string ->
   keeper_name:string ->
@@ -277,6 +281,7 @@ val append_assistant_message :
   ?conversation_id:string ->
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
+  ?kind:Row_kind.t ->
   ?turn_ref:Ids.Turn_ref.t ->
   ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -245,10 +245,84 @@ let effective_meta_overlay_hash (meta : keeper_meta) =
   |> Digest.string
   |> Digest.to_hex
 
-let hash_status_args _config resolved_name (meta : keeper_meta) args =
+type chat_queue_status_observation =
+  | Chat_queue_snapshot of Keeper_chat_queue.diagnostic_snapshot
+  | Chat_queue_unavailable of string
+
+let observe_chat_queue ~keeper_name =
+  if Eio_guard.is_ready ()
+  then Chat_queue_snapshot (Keeper_chat_queue.snapshot ~keeper_name)
+  else Chat_queue_unavailable "eio_guard_not_ready"
+
+let chat_queue_load_error_fingerprint
+    (error : Keeper_chat_queue.snapshot_load_error) =
+  String.concat ":"
+    [ Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind
+    ; Option.value error.path ~default:""
+    ; error.message
+    ]
+
+let chat_queue_observation_fingerprint observation =
+  let persistence =
+    string_of_bool (Keeper_chat_queue.persistence_configured ())
+  in
+  match observation with
+  | Chat_queue_unavailable reason ->
+    String.concat ":" [ persistence; "unavailable"; reason ]
+  | Chat_queue_snapshot snapshot ->
+    String.concat ":"
+      [ persistence
+      ; Int64.to_string snapshot.revision
+      ; string_of_int (List.length snapshot.pending)
+      ; string_of_int (List.length snapshot.inflight)
+      ; snapshot.load_errors
+        |> List.map chat_queue_load_error_fingerprint
+        |> String.concat ","
+      ]
+
+let chat_queue_load_error_to_json
+    (error : Keeper_chat_queue.snapshot_load_error) =
+  `Assoc
+    [ ( "kind"
+      , `String
+          (Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind) )
+    ; "path", Json_util.string_opt_to_json error.path
+    ; "message", `String error.message
+    ]
+
+let chat_queue_status_to_json observation =
+  let durable_replay_enabled =
+    Keeper_chat_queue.persistence_configured ()
+  in
+  match observation with
+  | Chat_queue_unavailable reason ->
+    `Assoc
+      [ "pending_messages", `Null
+      ; "inflight_messages", `Null
+      ; "revision", `Null
+      ; "load_errors", `Null
+      ; "snapshot_available", `Bool false
+      ; "read_error", `String reason
+      ; "durable_replay_enabled", `Bool durable_replay_enabled
+      ]
+  | Chat_queue_snapshot snapshot ->
+    `Assoc
+      [ "pending_messages", `Int (List.length snapshot.pending)
+      ; "inflight_messages", `Int (List.length snapshot.inflight)
+      ; "revision", `Intlit (Int64.to_string snapshot.revision)
+      ; ( "load_errors"
+        , `List (List.map chat_queue_load_error_to_json snapshot.load_errors) )
+      ; "snapshot_available", `Bool true
+      ; "read_error", `Null
+      ; "durable_replay_enabled", `Bool durable_replay_enabled
+      ]
+
+let hash_status_args _config resolved_name (meta : keeper_meta)
+    ~chat_queue_fingerprint args =
   let parts = [
     resolved_name;
     effective_meta_overlay_hash meta;
+    chat_queue_fingerprint;
     (* Keeper_manual_reconcile.cache_key removed with reconcile system. *)
     string_of_bool (get_bool args "fast" false);
     string_of_bool (get_bool args "include_context" false);
@@ -275,7 +349,13 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
   | Error err -> tool_result_error err
   | Ok (name, m) ->
       let cache_key = status_cache_key ~base_path:config.base_path ~name in
-      let args_hash = hash_status_args config name m args in
+      let chat_queue_observation = observe_chat_queue ~keeper_name:m.name in
+      let args_hash =
+        hash_status_args config name m
+          ~chat_queue_fingerprint:
+            (chat_queue_observation_fingerprint chat_queue_observation)
+          args
+      in
       (* Cache hit: same updated_at + same args/effective-meta hash → return cached response.
          The read is taken under [cache_mu] so it cannot interleave with
          an eviction from [invalidate_status_cache_{for,all}]. *)
@@ -767,24 +847,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            | other -> other
          in
          let chat_queue =
-           (* [Keeper_chat_queue.length] reads behind a raw [Eio.Mutex], which
-              performs effects and raises [Effect.Unhandled] when no Eio scheduler
-              is running.  Production dispatch runs under [Eio_main.run] with
-              [Eio_guard.enable ()] (bin/main_eio.ml, bin/main_stdio_eio.ml,
-              bin/masc_worker_run.ml), so the depth is read there.  Pre-Eio /
-              non-Eio init paths (and unit tests that do not enable the guard)
-              report [`Null] instead of probing the scheduler via a side-effecting
-              [Eio.Fiber.yield] + [Effect.Unhandled] catch. *)
-           let pending_messages =
-             if Eio_guard.is_ready ()
-             then `Int (Keeper_chat_queue.length ~keeper_name:m.name)
-             else `Null
-           in
-           `Assoc
-             [
-               ("pending_messages", pending_messages);
-               ("durable_replay_enabled", `Bool (Keeper_chat_queue.persistence_configured ()));
-             ]
+           chat_queue_status_to_json chat_queue_observation
          in
 
          let json = `Assoc ([

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -256,9 +256,14 @@ let observe_chat_queue ~keeper_name =
 
 let chat_queue_load_error_fingerprint
     (error : Keeper_chat_queue.snapshot_load_error) =
+  let path =
+    match error.path with
+    | Some path -> path
+    | None -> "<no-path>"
+  in
   String.concat ":"
     [ Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind
-    ; Option.value error.path ~default:""
+    ; path
     ; error.message
     ]
 

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -241,7 +241,7 @@ let handle_surface_post ~config ~(meta : keeper_meta) ~args =
         | Some token ->
             match
               Keeper_chat_slack.send_message_with_blocks ~token
-                ~channel:channel_id ~content:safe_content ~blocks:slack_blocks
+                ~channel:channel_id ~content:safe_content ~blocks:slack_blocks ()
             with
             | Error err ->
                 Keeper_surface_post.error_json

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -716,6 +716,33 @@ let dispatch_stream
               args))
   | _ -> None
 
+let dispatch_stream_if_free
+      ?on_text_delta
+      ?on_event
+      ?continuation_channel
+      ctx
+      ~name
+      ~args
+  =
+  maybe_bootstrap_existing_keepalives ctx ~name ~args;
+  let ctx = resolve_ctx ctx ~name args in
+  match name with
+  | "masc_keeper_msg" ->
+      (match
+         handle_keeper_msg_stream_if_free
+           ?on_text_delta
+           ?on_event
+           ?continuation_channel
+           ctx
+           args
+       with
+       | `Busy rejection -> `Busy rejection
+       | `Ran result ->
+         `Ran
+           (Some
+              (tool_result_with_tool_name ~tool_name:name result)))
+  | _ -> `Ran None
+
 (* ================================================================ *)
 (* Tool_spec registration                                           *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -36,3 +36,15 @@ val dispatch_stream :
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+
+(** Non-blocking streaming dispatch for direct chat admission. The Keeper turn
+    slot performs the authoritative post-lock durable-queue recheck; [`Busy]
+    callers must route the accepted message to their deferred transport. *)
+val dispatch_stream_if_free :
+  ?on_text_delta:(string -> unit) ->
+  ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
+  _ context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  [ `Ran of tool_result option | `Busy of Keeper_turn_admission.rejection ]

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -804,6 +804,18 @@ let keeper_msg_queue_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_msg_queue ctx args : tool_result =
   keeper_msg_queue_body ~config:ctx.config args
 
+let complete_keeper_msg_stream_result ~name result =
+  if not (tool_result_success result) then result
+  else begin
+    let body = tool_result_body result in
+    invalidate_keeper_list_cache ();
+    invalidate_status_cache name;
+    let json = json_of_body body in
+    tool_result_ok
+      (Yojson.Safe.pretty_to_string
+         (annotate_keeper_json ~runtime_class:"keeper" json))
+  end
+
 let handle_keeper_msg_stream
       ?on_text_delta
       ?on_event
@@ -828,21 +840,63 @@ let handle_keeper_msg_stream
         ctx
         resolved_args
     in
-    if not (tool_result_success result) then
-      Ok result
-    else begin
-      let body = tool_result_body result in
-      invalidate_keeper_list_cache ();
-      invalidate_status_cache name;
-      let json = json_of_body body in
-      Ok
-        (tool_result_ok
-           (Yojson.Safe.pretty_to_string
-              (annotate_keeper_json ~runtime_class:"keeper" json)))
-    end
+    Ok (complete_keeper_msg_stream_result ~name result)
   with
   | Ok result -> result
   | Error err -> tool_result_error err
+
+let handle_keeper_msg_stream_if_free
+      ?on_text_delta
+      ?on_event
+      ?continuation_channel
+      ctx
+      args
+  =
+  match resolve_keeper_name ctx args with
+  | Error err ->
+    let raw_name = String.trim (get_string args "name" "") in
+    if not (Keeper_config.validate_name raw_name)
+    then `Ran (tool_result_error err)
+    else
+      (* A connector message already accepted for a live/raw Keeper identity
+         must remain queueable even if metadata resolution is temporarily
+         unavailable. This is a failure-path observation only: successfully
+         resolved requests still use the post-lock queue recheck in
+         [run_chat_if_free] as the authoritative admission boundary. *)
+      let slot =
+        Keeper_turn_admission.snapshot_for
+          ~base_path:ctx.config.base_path
+          ~keeper_name:raw_name
+      in
+      let queue_busy =
+        match Keeper_chat_queue.has_active_receipts ~keeper_name:raw_name with
+        | Ok active -> active
+        | Error _ -> true
+      in
+      if Option.is_some slot.snapshot_in_flight
+         || slot.snapshot_waiting > 0
+         || queue_busy
+      then
+        `Busy
+          { Keeper_turn_admission.waiting = slot.snapshot_waiting
+          ; in_flight = slot.snapshot_in_flight
+          }
+      else `Ran (tool_result_error err)
+  | Ok name ->
+    let resolved_args = with_keeper_name args name in
+    let event_bus = Keeper_event_bus.get () in
+    (match
+       Turn.handle_keeper_msg_if_free
+         ?on_text_delta
+         ?on_event
+         ?event_bus
+         ?continuation_channel
+         ctx
+         resolved_args
+     with
+     | `Busy rejection -> `Busy rejection
+     | `Ran result ->
+       `Ran (complete_keeper_msg_stream_result ~name result))
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let resolve_keeper_meta_config ~(config : Workspace.config) args =
   let name = String.trim (get_string args "name" "") in

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -860,28 +860,14 @@ let handle_keeper_msg_stream_if_free
     else
       (* A connector message already accepted for a live/raw Keeper identity
          must remain queueable even if metadata resolution is temporarily
-         unavailable. This is a failure-path observation only: successfully
-         resolved requests still use the post-lock queue recheck in
-         [run_chat_if_free] as the authoritative admission boundary. *)
-      let slot =
-        Keeper_turn_admission.snapshot_for
+         unavailable. Run the resolution error itself through the same
+         post-lock admission boundary: a held slot, parked waiter, active
+         receipt, or queue read error returns Busy; only an atomically free
+         lane returns the original metadata error. *)
+      Keeper_turn_admission.run_chat_if_free
           ~base_path:ctx.config.base_path
           ~keeper_name:raw_name
-      in
-      let queue_busy =
-        match Keeper_chat_queue.has_active_receipts ~keeper_name:raw_name with
-        | Ok active -> active
-        | Error _ -> true
-      in
-      if Option.is_some slot.snapshot_in_flight
-         || slot.snapshot_waiting > 0
-         || queue_busy
-      then
-        `Busy
-          { Keeper_turn_admission.waiting = slot.snapshot_waiting
-          ; in_flight = slot.snapshot_in_flight
-          }
-      else `Ran (tool_result_error err)
+          (fun () -> tool_result_error err)
   | Ok name ->
     let resolved_args = with_keeper_name args name in
     let event_bus = Keeper_event_bus.get () in

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -210,7 +210,28 @@ let run_chat_if_free ~base_path ~keeper_name f =
   if waiting_count slot > 0
   then `Busy (rejection_snapshot slot)
   else if Eio.Mutex.try_lock slot.turn_mu
-  then run_locked slot ~lane:Chat f
+  then
+    let active_receipts =
+      try Keeper_chat_queue.has_active_receipts ~keeper_name with
+      | exn ->
+        Eio.Mutex.unlock slot.turn_mu;
+        raise exn
+    in
+    (* The outer route's queue peek is only a fast path. Recheck after the
+       turn slot is acquired so a receipt committed or leased between that
+       peek and admission cannot be overtaken. The queue entry lock makes a
+       commit already in progress finish before this read returns; a commit
+       that starts after the read is ordered after this admitted turn. The
+       waiter recheck closes the equivalent increment-before-lock window for
+       [run_serialized]. Queue read errors fail closed and are surfaced by the
+       caller's durable-enqueue path. *)
+    if waiting_count slot > 0
+       || match active_receipts with Ok active -> active | Error _ -> true
+    then (
+      let rejection = rejection_snapshot slot in
+      Eio.Mutex.unlock slot.turn_mu;
+      `Busy rejection)
+    else run_locked slot ~lane:Chat f
   else `Busy (rejection_snapshot slot)
 ;;
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -147,10 +147,19 @@ let run_if_free ~base_path ~keeper_name f =
      lock-only, non-suspending peek and is the SSOT signal that closes the
      gap: the autonomous lane cooperates on the same backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
-     deterministically instead of racing the next autonomous cycle. *)
+     deterministically instead of racing the next autonomous cycle. A leased
+     receipt remains active until its terminal decision commits, so the
+     autonomous lane must also yield during the short lease-to-admission and
+     admission-to-finalization windows. *)
   if waiting_count slot > 0
   then `Busy (peek_info slot)
-  else if Keeper_chat_queue.length ~keeper_name > 0
+  else if not (Keeper_chat_queue.persistence_configured ())
+  then `Busy (peek_info slot)
+  else if
+    let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+    snapshot.load_errors <> []
+    || snapshot.pending <> []
+    || snapshot.inflight <> []
   then `Busy (peek_info slot)
   else if Eio.Mutex.try_lock slot.turn_mu
   then run_locked slot ~lane:Autonomous f

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -405,6 +405,9 @@ module For_testing = struct
   let with_unpublished_turn_lock ~base_path ~keeper_name f =
     let slot = slot_for ~base_path ~keeper_name in
     Eio.Mutex.lock slot.turn_mu;
+    (* fun-protect-finally-ok: Eio.Mutex.unlock is non-suspending; this helper
+       acquired the raw test-only lock immediately above and the finalizer
+       releases exactly that lock on normal return, exception, or cancellation. *)
     Fun.protect ~finally:(fun () -> Eio.Mutex.unlock slot.turn_mu) f
   ;;
 

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -402,6 +402,12 @@ let fleet_health_json ~base_path ~keeper_names =
 module For_testing = struct
   let reset () = Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.reset slots)
 
+  let with_unpublished_turn_lock ~base_path ~keeper_name f =
+    let slot = slot_for ~base_path ~keeper_name in
+    Eio.Mutex.lock slot.turn_mu;
+    Fun.protect ~finally:(fun () -> Eio.Mutex.unlock slot.turn_mu) f
+  ;;
+
   let peek ~base_path ~keeper_name =
     let key = Keeper_registry_types.registry_key ~base_path keeper_name in
     Stdlib.Mutex.protect slots_mu (fun () -> Hashtbl.find_opt slots key)

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -131,7 +131,11 @@ val run_chat_if_free
     in-flight turn. Dashboard direct-stream callers use this to preserve live
     streaming for idle keepers while atomically routing busy keepers to the
     durable chat queue. Existing parked chat waiters have priority: when
-    [chat_waiting] is true this returns [`Busy] without attempting the lock. *)
+    [chat_waiting] is true this returns [`Busy] without attempting the lock.
+    After acquiring the turn slot it rechecks both parked waiters and active
+    durable receipts. This post-lock check is the direct-admission
+    linearization point: a receipt committed or leased after an outer route
+    peek cannot be overtaken, and queue read errors fail closed as [`Busy]. *)
 
 val in_flight
   :  base_path:string

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -172,6 +172,12 @@ module For_testing : sig
   val reset : unit -> unit
   (** Drop every slot. Only safe when no turn is in flight. *)
 
+  val with_unpublished_turn_lock :
+    base_path:string -> keeper_name:string -> (unit -> 'a) -> 'a
+  (** Hold the raw turn mutex without publishing [in_flight_info]. Constructs
+      the documented lock-to-observability window for deterministic admission
+      regression tests. *)
+
   val peek
     :  base_path:string
     -> keeper_name:string

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -74,8 +74,8 @@ val run_if_free
 
     Also returns [`Busy] without attempting the lock when a chat request is
     already parked on this slot ([chat_waiting] is true), or when a busy
-    connector/dashboard message is deferred in [Keeper_chat_queue] for this
-    keeper ([Keeper_chat_queue.length] > 0). Eio.Mutex hands a released slot
+    connector/dashboard receipt is active in [Keeper_chat_queue] for this
+    keeper (pending or inflight). Eio.Mutex hands a released slot
     directly to the next parked waiter, so a new autonomous cycle would not
     overtake a queued chat regardless; these pre-checks make the yield
     explicit and keep a heartbeat-scheduled cycle from competing for a slot
@@ -84,7 +84,8 @@ val run_if_free
     back-to-back autonomous turn could otherwise busy-ACK a connector
     forever: the autonomous lane yields on the same backlog the consumer
     drains, so the consumer's [in_flight = None] window opens
-    deterministically. *)
+    deterministically. Queue persistence/read errors fail closed rather than
+    being mistaken for an empty queue. *)
 
 val chat_waiting : base_path:string -> keeper_name:string -> bool
 (** [true] when at least one chat request is parked on this keeper's slot

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -29,7 +29,9 @@ type retry_loop_input =
 let autonomous_yield_request ~base_path ~keeper_name ~channel =
   if
     Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
-    || Keeper_chat_queue.length ~keeper_name > 0
+    || (match Keeper_chat_queue.pending_count ~keeper_name with
+        | Ok count -> count > 0
+        | Error _ -> true)
   then
     let boundary =
       match channel with

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -34,6 +34,8 @@ type response = {
   body : string;
 }
 
+let default_request_timeout_sec = 10.0
+
 (** Apply an optional Eio wall-clock timeout around a request. When both
     [clock] and [timeout_sec] are supplied, a sleep fiber races the request
     fiber; whichever finishes first wins and the loser is cancelled. On
@@ -137,6 +139,11 @@ let get_sync ?clock ?timeout_sec ~url ~headers () =
   match get_response_sync ?clock ?timeout_sec ~url ~headers () with
   | Ok response -> Ok (response.status, response.body)
   | Error _ as error -> error
+
+module For_testing = struct
+  let with_request_timeout ~clock ~timeout_sec f =
+    with_optional_timeout ~clock ~timeout_sec f
+end
 
 (* ── Observability ────────────────────────────────────────────────── *)
 

--- a/lib/masc_http_client/masc_http_client.mli
+++ b/lib/masc_http_client/masc_http_client.mli
@@ -17,6 +17,11 @@ type response = {
   headers : (string * string) list;
   body : string;
 }
+
+val default_request_timeout_sec : float
+(** Shared outbound HTTP request deadline used by connector delivery clients.
+    This bounds the full request/response exchange, unlike the pool's separate
+    connection-establishment timeout. *)
 (** Structured response returned by {!get_response_sync}.  Body is
     fully read into memory; size capped at 8 MB
     (see {!post_sync} / {!get_response_sync} for the cap details). *)
@@ -108,3 +113,13 @@ val all_domain_pools : unit -> (int * Pool.t) list
     [(domain_id, pool)] pairs.  Used by [Pool_metrics] to aggregate
     counters across all OCaml Domains.  Thread-safe; acquires an
     internal [Stdlib.Mutex] for the duration of the snapshot. *)
+
+module For_testing : sig
+  val with_request_timeout :
+    clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+    timeout_sec:float ->
+    (unit -> ('a, string) result) ->
+    ('a, string) result
+  (** Transport-independent proof seam for the exact deadline race used by
+      [post_sync]/[patch_sync]. *)
+end

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1221,7 +1221,7 @@ let start_keeper_loops
              match turn_outcome, delivery_outcome with
              | Some (Delivered { outcome_ref }), Ok () ->
                  Keeper_chat_consumer.Delivered
-                   { outcome_ref = Some outcome_ref }
+                   { outcome_ref }
              | Some (Delivered { outcome_ref }), Error (kind, detail) ->
                  Keeper_chat_consumer.Failed
                    { kind; detail; outcome_ref = Some outcome_ref }

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -190,16 +190,16 @@ let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
           ~channel_workspace_id:channel_id
           ~channel_user_id:user_id;
     }
-  | Keeper_chat_queue.Slack { channel; user_id } ->
+  | Keeper_chat_queue.Slack { channel_id; user_id; user_name; _ } ->
     {
-      payload_channel = channel;
+      payload_channel = "slack";
       payload_channel_user_id = user_id;
-      payload_channel_user_name = "";
-      payload_channel_workspace_id = "";
+      payload_channel_user_name = user_name;
+      payload_channel_workspace_id = channel_id;
       agent_name =
         Gate_keeper_backend.agent_name_for_channel_actor
-          ~channel
-          ~channel_workspace_id:""
+          ~channel:"slack"
+          ~channel_workspace_id:channel_id
           ~channel_user_id:user_id;
     }
 
@@ -1125,7 +1125,7 @@ let start_keeper_loops
                    | Some token ->
                        fork_delivery_adapter ~label:"Discord"
                          ~run:(fun settle ->
-                           Keeper_chat_discord.adapter_loop ~token
+                           Keeper_chat_discord.adapter_loop ~clock ~token
                              ~channel_id ~events
                              ~on_send_result:(fun result ->
                                settle
@@ -1148,7 +1148,7 @@ let start_keeper_loops
                           DISCORD_BOT_TOKEN not set, \
                           skipping Discord delivery for keeper=%s"
                          keeper_name)
-              | Keeper_chat_queue.Slack { channel; _ } ->
+              | Keeper_chat_queue.Slack { channel_id; thread_ts; _ } ->
                   Log.Keeper.info
                     "keeper_chat_consumer: forking Slack adapter \
                      for keeper=%s"
@@ -1157,8 +1157,8 @@ let start_keeper_loops
                    | Some token ->
                        fork_delivery_adapter ~label:"Slack"
                          ~run:(fun settle ->
-                           Keeper_chat_slack.adapter_loop ~token
-                             ~channel ~events
+                           Keeper_chat_slack.adapter_loop ~clock ~token
+                             ~channel:channel_id ?thread_ts ~events
                              ~on_send_result:(fun result ->
                                Slack_observability.record_reply
                                  (match result with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1219,11 +1219,11 @@ let start_keeper_loops
              in
              let delivery_outcome = Eio.Promise.await delivery in
              match turn_outcome, delivery_outcome with
-             | Some Delivered, Ok () ->
-                 Keeper_chat_consumer.Delivered { outcome_ref = None }
-             | Some Delivered, Error (kind, detail) ->
+             | Some (Delivered { outcome_ref }), Ok () ->
+                 Keeper_chat_consumer.Delivered { outcome_ref }
+             | Some (Delivered { outcome_ref }), Error (kind, detail) ->
                  Keeper_chat_consumer.Failed
-                   { kind; detail; outcome_ref = None }
+                   { kind; detail; outcome_ref }
              | Some (Failed { kind = turn_kind; detail = turn_detail }),
                Error (delivery_kind, delivery_detail) ->
                  Keeper_chat_consumer.Failed

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -203,8 +203,7 @@ let queued_chat_projection (queued_message : Keeper_chat_queue.queued_message) =
           ~channel_user_id:user_id;
     }
 
-(* Shared by both the queue consumer's [handle_turn] and [on_stalled]
-   wiring below: both need the same synthetic
+(* Queue-consumer turns need the same synthetic
    [Server_routes_http_keeper_stream.keeper_chat_stream_request] built from
    a dequeued/leased [Keeper_chat_queue.queued_message], and a duplicated
    copy would silently drift out of sync with [queued_chat_projection] the
@@ -282,16 +281,6 @@ let log_dashboard_fiber_crash =
 let filteri_with_fair_yield =
   Server_bootstrap_loops_fiber.filteri_with_fair_yield
 let iteri_with_fair_yield = Server_bootstrap_loops_fiber.iteri_with_fair_yield
-
-(* [Keeper_chat_consumer]'s per-turn dispatch watchdog margin, added on top
-   of [Keeper_runtime_resolved.turn_timeout_sec] to bound [handle_turn]. It
-   exists only to unwedge the consumer's dispatch gate if [handle_turn]
-   itself never returns (see [Keeper_chat_consumer.start]'s .mli); it is not
-   meant to race the turn's own internal timeout, so it must stay
-   comfortably larger than that timeout — 30s covers
-   [Keeper_msg_async.submit]'s own [Eio.Time.with_timeout_exn] race plus its
-   status-write cleanup (Hashtbl/Atomic updates, no I/O) finishing. *)
-let queue_dispatch_watchdog_margin_sec = 30.0
 
 let start_keeper_loops
       ~sw
@@ -1033,19 +1022,21 @@ let start_keeper_loops
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
          let base_path = (Mcp_server.workspace_config state).base_path in
-         Keeper_chat_queue.configure_persistence ~base_path;
+         Keeper_chat_queue.set_transition_observer
+           (Some
+              (fun ~keeper_name ~revision ->
+                 Keeper_chat_broadcast.queue_changed ~keeper_name
+                   ~revision ()));
+         let queue_report = Keeper_chat_queue.configure_persistence ~base_path in
+         List.iter
+           (fun (keeper_name, (error : Keeper_chat_queue.snapshot_load_error)) ->
+              Log.Keeper.error
+                "keeper_chat_queue: snapshot unavailable keeper=%s: %s"
+                (Option.value keeper_name ~default:"<registry>")
+                error.Keeper_chat_queue.message)
+           queue_report.load_errors;
          Keeper_chat_consumer.start ~sw ~clock
            ~base_path
-           ~dispatch_deadline_sec:
-             (Keeper_runtime_resolved.turn_timeout_sec ()
-              +. queue_dispatch_watchdog_margin_sec)
-           ~on_stalled:(fun ~keeper_name ~queued_message ->
-             let payload = payload_of_queued_message ~keeper_name queued_message in
-             let connector_user_line_recorded_upstream =
-               connector_user_line_recorded_upstream_of_source queued_message.source
-             in
-             Server_routes_http_keeper_stream.persist_queued_turn_stalled ~base_path
-               ~connector_user_line_recorded_upstream ~payload)
            ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in
@@ -1062,12 +1053,64 @@ let start_keeper_loops
              let events = Keeper_chat_events.create () in
              let closed = ref false in
              let thread_id = "keeper-consumer:" ^ keeper_name in
+             let delivery, delivery_resolver = Eio.Promise.create () in
+             let resolve_delivery result =
+               ignore
+                 (Eio.Promise.try_resolve delivery_resolver result : bool)
+             in
+             let drain_events () =
+               let rec loop () =
+                 match Keeper_chat_events.subscribe events with
+                 | Keeper_chat_events.Run_finished _
+                 | Keeper_chat_events.Event_error _ -> ()
+                 | _ -> loop ()
+               in
+               loop ()
+             in
+             let fork_delivery_adapter ~label ~run =
+               fork_logged_fiber ~sw
+                 ~on_error:(fun exn ->
+                   let detail =
+                     Printf.sprintf "%s adapter crashed for keeper=%s: %s"
+                       label keeper_name (Printexc.to_string exn)
+                   in
+                   resolve_delivery
+                     (Error (Keeper_chat_queue.Delivery_failed, detail));
+                   Log.Keeper.error "keeper_chat_consumer: %s" detail;
+                   (* Keep consuming the bounded event stream after an
+                      unexpected adapter crash so producer backpressure cannot
+                      deadlock the turn before it emits its terminal outcome. *)
+                   drain_events ())
+                 (fun () ->
+                   let callback_observed = ref false in
+                   run (fun result ->
+                     callback_observed := true;
+                     resolve_delivery result);
+                   if not !callback_observed then
+                     resolve_delivery
+                       (Error
+                          ( Keeper_chat_queue.Delivery_failed,
+                            Printf.sprintf
+                              "%s adapter terminated without a terminal delivery receipt"
+                              label )))
+             in
              (match queued_message.source with
               | Keeper_chat_queue.Dashboard ->
                   Log.Keeper.info
                     "keeper_chat_consumer: processing dashboard queue \
                      message for keeper=%s"
-                    keeper_name
+                    keeper_name;
+                  fork_logged_fiber ~sw
+                    ~on_error:(fun exn ->
+                      resolve_delivery
+                        (Error
+                           ( Keeper_chat_queue.Internal_error,
+                             Printf.sprintf
+                               "dashboard event drain crashed for keeper=%s: %s"
+                               keeper_name (Printexc.to_string exn) )))
+                    (fun () ->
+                      drain_events ();
+                      resolve_delivery (Ok ()))
               | Keeper_chat_queue.Discord { channel_id; _ } ->
                   Log.Keeper.info
                     "keeper_chat_consumer: forking Discord adapter \
@@ -1075,24 +1118,26 @@ let start_keeper_loops
                     keeper_name;
                   (match discord_bot_token_opt () with
                    | Some token ->
-                       (* fork_logged_fiber, not bare Eio.Fiber.fork: the
-                          adapter body runs after this synchronous frame
-                          returns, so the enclosing try/with cannot catch an
-                          exception it raises later. A bare fork would fail
-                          the shared [sw] and cancel every sibling fiber under
-                          it. [on_error] contains non-Cancelled exceptions;
-                          [fork_logged_fiber] re-raises Cancelled to preserve
-                          structured teardown. *)
-                       fork_logged_fiber ~sw
-                         ~on_error:(fun exn ->
-                           Log.Keeper.error
-                             "keeper_chat_consumer: Discord adapter fiber \
-                              crashed for keeper=%s: %s"
-                             keeper_name (Printexc.to_string exn))
-                         (fun () ->
+                       fork_delivery_adapter ~label:"Discord"
+                         ~run:(fun settle ->
                            Keeper_chat_discord.adapter_loop ~token
-                             ~channel_id ~events ())
+                             ~channel_id ~events
+                             ~on_send_result:(fun result ->
+                               settle
+                                 (Result.map_error
+                                    (fun error ->
+                                      ( Keeper_chat_queue.Delivery_failed,
+                                        Format.asprintf "%a"
+                                          Keeper_chat_discord.pp_error error ))
+                                    result))
+                             ())
                    | None ->
+                       resolve_delivery
+                         (Error
+                            ( Keeper_chat_queue.Connector_unavailable,
+                              "DISCORD_BOT_TOKEN is not configured" ));
+                       fork_logged_fiber ~sw
+                         ~on_error:(fun _ -> ()) drain_events;
                        Log.Keeper.warn
                          "keeper_chat_consumer: \
                           DISCORD_BOT_TOKEN not set, \
@@ -1105,16 +1150,8 @@ let start_keeper_loops
                     keeper_name;
                   (match Env_config_slack.bot_token_opt () with
                    | Some token ->
-                       (* Isolate from the shared [sw] like the Discord arm
-                          above; a bare fork would cancel sibling fibers if
-                          the adapter raises a non-Cancelled exception. *)
-                       fork_logged_fiber ~sw
-                         ~on_error:(fun exn ->
-                           Log.Keeper.error
-                             "keeper_chat_consumer: Slack adapter fiber \
-                              crashed for keeper=%s: %s"
-                             keeper_name (Printexc.to_string exn))
-                         (fun () ->
+                       fork_delivery_adapter ~label:"Slack"
+                         ~run:(fun settle ->
                            Keeper_chat_slack.adapter_loop ~token
                              ~channel ~events
                              ~on_send_result:(fun result ->
@@ -1122,9 +1159,22 @@ let start_keeper_loops
                                  (match result with
                                   | Ok () -> Slack_observability.Reply_send_ok
                                   | Error _ ->
-                                      Slack_observability.Reply_send_failed))
+                                      Slack_observability.Reply_send_failed);
+                               settle
+                                 (Result.map_error
+                                    (fun error ->
+                                      ( Keeper_chat_queue.Delivery_failed,
+                                        Format.asprintf "%a"
+                                          Keeper_chat_slack.pp_error error ))
+                                    result))
                              ())
                    | None ->
+                       resolve_delivery
+                         (Error
+                            ( Keeper_chat_queue.Connector_unavailable,
+                              "SLACK_BOT_TOKEN is not configured" ));
+                       fork_logged_fiber ~sw
+                         ~on_error:(fun _ -> ()) drain_events;
                        Log.Keeper.error
                          "keeper_chat_consumer: \
                           SLACK_BOT_TOKEN not set; \
@@ -1144,11 +1194,65 @@ let start_keeper_loops
                  ~dashboard_thread_id:thread_id
                  queued_message.source
              in
-             process_single_turn ~connector_user_line_recorded_upstream
-               ~queued_turn:true
-               ~state ~clock ~sw ~auth_token:None
-               ~thread_id ~continuation_channel ~closed ~client_disconnects:None
-               ~payload ~run_id ~message_id ~agent_name ~events)
+             let turn_outcome =
+               match
+                 process_single_turn ~connector_user_line_recorded_upstream
+                   ~queued_turn:true
+                   ~state ~clock ~sw ~auth_token:None
+                   ~thread_id ~continuation_channel ~closed
+                   ~client_disconnects:None
+                   ~payload ~run_id ~message_id ~agent_name ~events
+               with
+               | outcome -> outcome
+               | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+               | exception exn ->
+                   Keeper_chat_events.publish events
+                     (Keeper_chat_events.Event_error
+                        { message = Printexc.to_string exn });
+                   ignore (Eio.Promise.await delivery);
+                   raise exn
+             in
+             let delivery_outcome = Eio.Promise.await delivery in
+             match turn_outcome, delivery_outcome with
+             | Some Delivered, Ok () ->
+                 Keeper_chat_consumer.Delivered { outcome_ref = None }
+             | Some Delivered, Error (kind, detail) ->
+                 Keeper_chat_consumer.Failed
+                   { kind; detail; outcome_ref = None }
+             | Some (Failed { kind = turn_kind; detail = turn_detail }),
+               Error (delivery_kind, delivery_detail) ->
+                 Keeper_chat_consumer.Failed
+                   { kind = delivery_kind
+                   ; detail =
+                       Printf.sprintf
+                         "turn failed (%s): %s; terminal connector delivery also failed: %s"
+                         (queued_turn_failure_kind_to_string turn_kind)
+                         turn_detail delivery_detail
+                   ; outcome_ref = None
+                   }
+             | Some (Failed { kind; detail }), Ok () ->
+                 let kind =
+                   match kind with
+                   | Turn_failed -> Keeper_chat_queue.Turn_failed
+                   | Turn_timed_out -> Keeper_chat_queue.Timed_out
+                   | Turn_cancelled -> Keeper_chat_queue.Cancelled
+                   | No_visible_reply
+                   | Continuation_checkpoint_without_reply ->
+                       Keeper_chat_queue.No_visible_reply
+                   | Transcript_persist_failed ->
+                       Keeper_chat_queue.Transcript_persist_failed
+                   | Stream_projection_failed ->
+                       Keeper_chat_queue.Internal_error
+                 in
+                 Keeper_chat_consumer.Failed
+                   { kind; detail; outcome_ref = None }
+             | None, _ ->
+                 Keeper_chat_consumer.Failed
+                   { kind = Keeper_chat_queue.Internal_error
+                   ; detail =
+                       "queued turn returned no terminal outcome (invariant violation)"
+                   ; outcome_ref = None
+                   })
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1220,10 +1220,11 @@ let start_keeper_loops
              let delivery_outcome = Eio.Promise.await delivery in
              match turn_outcome, delivery_outcome with
              | Some (Delivered { outcome_ref }), Ok () ->
-                 Keeper_chat_consumer.Delivered { outcome_ref }
+                 Keeper_chat_consumer.Delivered
+                   { outcome_ref = Some outcome_ref }
              | Some (Delivered { outcome_ref }), Error (kind, detail) ->
                  Keeper_chat_consumer.Failed
-                   { kind; detail; outcome_ref }
+                   { kind; detail; outcome_ref = Some outcome_ref }
              | Some (Failed { kind = turn_kind; detail = turn_detail }),
                Error (delivery_kind, delivery_detail) ->
                  Keeper_chat_consumer.Failed
@@ -1244,6 +1245,7 @@ let start_keeper_loops
                    | No_visible_reply
                    | Continuation_checkpoint_without_reply ->
                        Keeper_chat_queue.No_visible_reply
+                   | Missing_turn_ref -> Keeper_chat_queue.Internal_error
                    | Transcript_persist_failed ->
                        Keeper_chat_queue.Transcript_persist_failed
                    | Stream_projection_failed ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1030,9 +1030,14 @@ let start_keeper_loops
          let queue_report = Keeper_chat_queue.configure_persistence ~base_path in
          List.iter
            (fun (keeper_name, (error : Keeper_chat_queue.snapshot_load_error)) ->
+              let keeper_label =
+                match keeper_name with
+                | Some keeper_name -> keeper_name
+                | None -> "<registry>"
+              in
               Log.Keeper.error
                 "keeper_chat_queue: snapshot unavailable keeper=%s: %s"
-                (Option.value keeper_name ~default:"<registry>")
+                keeper_label
                 error.Keeper_chat_queue.message)
            queue_report.load_errors;
          Keeper_chat_consumer.start ~sw ~clock
@@ -1209,7 +1214,7 @@ let start_keeper_loops
                    Keeper_chat_events.publish events
                      (Keeper_chat_events.Event_error
                         { message = Printexc.to_string exn });
-                   ignore (Eio.Promise.await delivery);
+                   let _delivery_outcome = Eio.Promise.await delivery in
                    raise exn
              in
              let delivery_outcome = Eio.Promise.await delivery in

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1112,6 +1112,61 @@ let user_model_dashboard_json ~keeper_id =
       ]
 ;;
 
+let keeper_chat_receipt_state_json = function
+  | Keeper_chat_queue.Pending ->
+    `Assoc [ "kind", `String "pending" ]
+  | Keeper_chat_queue.Inflight { lease_id; started_at } ->
+    `Assoc
+      [ "kind", `String "inflight"
+      ; "lease_id", `String lease_id
+      ; "started_at", `Float started_at
+      ]
+  | Keeper_chat_queue.Delivered completion ->
+    `Assoc
+      [ "kind", `String "delivered"
+      ; "completed_at", `Float completion.completed_at
+      ; "outcome_ref", json_string_opt completion.outcome_ref
+      ]
+  | Keeper_chat_queue.Failed failure ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; ( "failure_kind"
+        , `String (Keeper_chat_queue.failure_kind_to_string failure.kind) )
+      ; ( "detail"
+        , `String (Observability_redact.redact_text failure.detail) )
+      ; "completed_at", `Float failure.completed_at
+      ; "outcome_ref", json_string_opt failure.outcome_ref
+      ]
+;;
+
+let keeper_chat_receipt_json ~keeper_name ~revision
+    (receipt : Keeper_chat_queue.receipt_view) =
+  `Assoc
+    [ "schema", `String "keeper_chat_queue.receipt.v1"
+    ; "keeper_name", `String keeper_name
+    ; ( "receipt_id"
+      , `String
+          (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
+    ; "revision", `Intlit (Int64.to_string revision)
+    ; "state", keeper_chat_receipt_state_json receipt.state
+    ]
+;;
+
+let keeper_chat_receipt_route req_path =
+  if not (String.starts_with ~prefix:keeper_api_prefix req_path)
+  then None
+  else
+    let rest =
+      String.sub req_path (String.length keeper_api_prefix)
+        (String.length req_path - String.length keeper_api_prefix)
+    in
+    match String.split_on_char '/' rest with
+    | [ keeper_name; "chat"; "receipts"; receipt_id ]
+      when keeper_name <> "" && receipt_id <> "" ->
+      Some (keeper_name, receipt_id)
+    | _ -> None
+;;
+
 let handle_keeper_get_subroutes state req request reqd =
   let req_path = Http.Request.path req in
   let prefix = keeper_api_prefix in
@@ -1126,6 +1181,30 @@ let handle_keeper_get_subroutes state req request reqd =
     let slen = String.length suffix in
     String.trim (String.sub req_path plen (tlen - plen - slen))
   in
+  match keeper_chat_receipt_route req_path with
+  | Some (name, raw_receipt_id) ->
+    if not (Keeper_config.validate_name name)
+    then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json (Printf.sprintf "invalid keeper name: %s" name))
+    else
+      (match Keeper_chat_queue.Receipt_id.of_string raw_receipt_id with
+       | Error message ->
+         Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+           (error_json message)
+       | Ok receipt_id ->
+         (match Keeper_chat_queue.lookup_receipt ~keeper_name:name ~receipt_id with
+          | Error error ->
+            Server_auth.respond_json_value_with_cors ~status:`Service_unavailable
+              request reqd
+              (error_json (Keeper_chat_queue.mutation_error_to_string error))
+          | Ok { receipt = None; _ } ->
+            Server_auth.respond_json_value_with_cors ~status:`Not_found request reqd
+              (error_json "keeper chat receipt not found")
+          | Ok { revision; receipt = Some receipt } ->
+            Server_auth.respond_json_value_with_cors ~status:`OK request reqd
+              (keeper_chat_receipt_json ~keeper_name:name ~revision receipt)))
+  | None ->
   if ends_with "/digest" then (
     (* Keeper catch-up digest (since-last-seen). Inherits the enclosing
        prefix_get "/api/v1/keepers/" + with_public_read gating, same as the

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -223,6 +223,17 @@ val handle_keeper_get_subroutes :
 (** Dispatch [GET /api/v1/keepers/<name>/<sub>] sub-routes
     (status / tools / checkpoints listing / etc.). *)
 
+val keeper_chat_receipt_route : string -> (string * string) option
+(** Parse the exact
+    [/api/v1/keepers/<name>/chat/receipts/<receipt_id>] read route. *)
+
+val keeper_chat_receipt_json :
+  keeper_name:string ->
+  revision:int64 ->
+  Keeper_chat_queue.receipt_view ->
+  Yojson.Safe.t
+(** Read-only typed receipt projection returned by the route above. *)
+
 (** {1 Memory-OS dashboard JSON} *)
 
 val memory_os_fact_json :

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1250,6 +1250,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
          ~keeper_name:payload.name
          ~content:(persisted_error_reply err)
          ~surface:chat_surface
+         ~kind:Keeper_chat_store.Row_kind.Transport_failure
          ~stream_lifecycle:errored_stream_lifecycle
          ()
       else

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1060,7 +1060,7 @@ and queued_turn_failure_kind =
   | Stream_projection_failed
 
 and queued_turn_outcome =
-  | Delivered
+  | Delivered of { outcome_ref : string option }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string
@@ -1464,7 +1464,14 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                    | Ok () ->
                        Keeper_chat_broadcast.chat_appended
                          ~keeper_name:payload.name ~source:chat_source ?content ();
-                       if queued_turn then Some Delivered else None
+                       if queued_turn
+                       then
+                         Some
+                           (Delivered
+                              { outcome_ref =
+                                  Option.map Ids.Turn_ref.to_string turn_ref
+                              })
+                       else None
                    | Error persist_error ->
                        if queued_turn
                        then
@@ -1536,7 +1543,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                            ; queued_outcome
                            });
                       Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
-                  | Some Delivered | None ->
+                  | Some (Delivered _) | None ->
                       push_worker_event
                         (Stream_terminal
                            { ok = true

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1056,11 +1056,12 @@ and queued_turn_failure_kind =
   | Turn_cancelled
   | No_visible_reply
   | Continuation_checkpoint_without_reply
+  | Missing_turn_ref
   | Transcript_persist_failed
   | Stream_projection_failed
 
 and queued_turn_outcome =
-  | Delivered of { outcome_ref : string option }
+  | Delivered of { outcome_ref : string }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string
@@ -1073,8 +1074,19 @@ let queued_turn_failure_kind_to_string = function
   | No_visible_reply -> "no_visible_reply"
   | Continuation_checkpoint_without_reply ->
       "continuation_checkpoint_without_reply"
+  | Missing_turn_ref -> "missing_turn_ref"
   | Transcript_persist_failed -> "transcript_persist_failed"
   | Stream_projection_failed -> "stream_projection_failed"
+
+let queued_delivery_outcome_of_turn_ref = function
+  | Some turn_ref ->
+      Delivered { outcome_ref = Ids.Turn_ref.to_string turn_ref }
+  | None ->
+      Failed
+        { kind = Missing_turn_ref
+        ; detail =
+            "queued turn persisted a reply but the reply payload had no valid turn_ref"
+        }
 
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
@@ -1388,8 +1400,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             in
             (* RFC-0233 §7: the keeper minted this turn's join key into the
                reply payload (keeper_turn.ml). Decode it via the shared
-               reply-payload parser — never repair: a malformed or absent
-               value reads as None and the row simply carries no turn_ref. *)
+               reply-payload parser — never repair. A direct turn may retain
+               an uncorrelated row for diagnostics; a queued turn fails closed
+               below because Delivered requires the exact join key. *)
             let turn_ref =
               Keeper_turn_outcome.turn_ref_of_reply_payload payload_json_opt
             in
@@ -1466,11 +1479,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                          ~keeper_name:payload.name ~source:chat_source ?content ();
                        if queued_turn
                        then
-                         Some
-                           (Delivered
-                              { outcome_ref =
-                                  Option.map Ids.Turn_ref.to_string turn_ref
-                              })
+                         Some (queued_delivery_outcome_of_turn_ref turn_ref)
                        else None
                    | Error persist_error ->
                        if queued_turn
@@ -2171,6 +2180,8 @@ module For_testing = struct
 
   let extract_visible_reply = extract_visible_reply
   let direct_reply_terminal_error = direct_reply_terminal_error
+  let queued_delivery_outcome_of_turn_ref =
+    queued_delivery_outcome_of_turn_ref
   let visible_reply_with_stream_fallback = visible_reply_with_stream_fallback
   let redacted_visible_reply_with_stream_fallback =
     redacted_visible_reply_with_stream_fallback

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -185,14 +185,24 @@ let modalities_for_request payload =
 type dashboard_deferred_chat =
   { in_flight : Keeper_turn_admission.in_flight_info option
   ; chat_waiting : bool
-  ; queue_length : int
+  ; pending_count : int
+  ; inflight_count : int
   ; receipt_id : string
+  ; queue_revision : int64
   }
 
 let dashboard_busy_queue_state ~base_path ~keeper_name =
   let in_flight = Keeper_turn_admission.in_flight ~base_path ~keeper_name in
   let chat_waiting = Keeper_turn_admission.chat_waiting ~base_path ~keeper_name in
-  let queue_waiting = Keeper_chat_queue.length ~keeper_name > 0 in
+  let queue_waiting =
+    if not (Keeper_chat_queue.persistence_configured ())
+    then true
+    else
+      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+      snapshot.load_errors <> []
+      || snapshot.pending <> []
+      || snapshot.inflight <> []
+  in
   match in_flight, chat_waiting, queue_waiting with
   | None, false, false -> None
   | None, false, true -> Some (None, false)
@@ -200,14 +210,16 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
   | Some info, false, _ -> Some (Some info, false)
   | Some info, true, _ -> Some (Some info, true)
 
-let dashboard_deferred_ack_text ~keeper_name =
+let dashboard_deferred_ack_text ~keeper_name
+    ({ receipt_id; pending_count; inflight_count; _ } : dashboard_deferred_chat) =
   Printf.sprintf
-    "%s is busy; your message is queued and will be answered after the current \
-     turn finishes."
-    keeper_name
+    "%s is busy; your message was durably accepted (receipt_id=%s, \
+     pending_count=%d, inflight_count=%d). The Dashboard will track it through \
+     Pending, Inflight, and a terminal Delivered or Failed state."
+    keeper_name receipt_id pending_count inflight_count
 
 let dashboard_deferred_chat_to_json ~keeper_name
-    ({ in_flight; chat_waiting; queue_length; receipt_id } : dashboard_deferred_chat) =
+    ({ in_flight; chat_waiting; pending_count; inflight_count; receipt_id; queue_revision } : dashboard_deferred_chat) =
   let in_flight_fields =
     match in_flight with
     | None -> []
@@ -222,14 +234,16 @@ let dashboard_deferred_chat_to_json ~keeper_name
     ([ ("keeper_name", `String keeper_name)
      ; ("status", `String "queued")
      ; ("queue", `String "keeper_chat_queue")
-     ; ("queue_length", `Int queue_length)
+     ; ("pending_count", `Int pending_count)
+     ; ("inflight_count", `Int inflight_count)
      ; ("chat_waiting", `Bool chat_waiting)
      ; ("receipt_id", `String receipt_id)
+     ; ("queue_revision", `Intlit (Int64.to_string queue_revision))
      ]
      @ in_flight_fields)
 
 let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
-  let receipt_id =
+  match
     Keeper_chat_queue.enqueue ~keeper_name:payload.name
       { Keeper_chat_queue.content = payload.message
       ; user_blocks = payload.user_blocks
@@ -237,10 +251,17 @@ let enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting =
       ; timestamp = Eio.Time.now clock
       ; source = Keeper_chat_queue.Dashboard
       }
-  in
-  let queue_length = Keeper_chat_queue.length ~keeper_name:payload.name in
-  Keeper_chat_broadcast.queue_changed ~keeper_name:payload.name ~depth:queue_length ();
-  { in_flight; chat_waiting; queue_length; receipt_id }
+  with
+  | Error error -> Error (Keeper_chat_queue.mutation_error_to_string error)
+  | Ok receipt ->
+      Ok
+        { in_flight
+        ; chat_waiting
+        ; pending_count = receipt.pending_count
+        ; inflight_count = receipt.inflight_count
+        ; receipt_id = Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id
+        ; queue_revision = receipt.revision
+        }
 
 let dashboard_deferred_chat_of_rejection ~clock payload
     ({ Keeper_turn_admission.waiting; in_flight } : Keeper_turn_admission.rejection) =
@@ -250,7 +271,9 @@ let defer_dashboard_payload_if_busy ~base_path ~clock payload =
   match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
   | None -> `Not_busy
   | Some (in_flight, chat_waiting) ->
-      `Queued (enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting)
+      (match enqueue_dashboard_payload ~clock payload ~in_flight ~chat_waiting with
+       | Ok queued -> `Queued queued
+       | Error message -> `Queue_error message)
 
 let keeper_chat_request_prefixes =
   [
@@ -1024,7 +1047,34 @@ type keeper_stream_worker_event =
       { ok : bool
       ; status : string
       ; body : string
+      ; queued_outcome : queued_turn_outcome option
       }
+
+and queued_turn_failure_kind =
+  | Turn_failed
+  | Turn_timed_out
+  | Turn_cancelled
+  | No_visible_reply
+  | Continuation_checkpoint_without_reply
+  | Transcript_persist_failed
+  | Stream_projection_failed
+
+and queued_turn_outcome =
+  | Delivered
+  | Failed of
+      { kind : queued_turn_failure_kind
+      ; detail : string
+      }
+
+let queued_turn_failure_kind_to_string = function
+  | Turn_failed -> "turn_failed"
+  | Turn_timed_out -> "turn_timed_out"
+  | Turn_cancelled -> "turn_cancelled"
+  | No_visible_reply -> "no_visible_reply"
+  | Continuation_checkpoint_without_reply ->
+      "continuation_checkpoint_without_reply"
+  | Transcript_persist_failed -> "transcript_persist_failed"
+  | Stream_projection_failed -> "stream_projection_failed"
 
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
@@ -1181,16 +1231,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
          [append_turn] would double-record that user line, so persist an
          assistant-only durable failure marker instead — the failure survives a
          restart and stays joined to the already-pending user line. *)
-    (if connector_user_line_recorded_upstream then
-       Keeper_chat_store.append_assistant_message
+    let persisted =
+      if connector_user_line_recorded_upstream then
+       Keeper_chat_store.append_assistant_message_result
          ~base_dir:base_path
          ~keeper_name:payload.name
          ~content:(persisted_error_reply err)
          ~surface:chat_surface
          ~stream_lifecycle:errored_stream_lifecycle
          ()
-     else
-       Keeper_chat_store.append_turn
+      else
+       Keeper_chat_store.append_turn_result
          ~base_dir:base_path
          ~keeper_name:payload.name
          ~user_content:payload.message
@@ -1200,15 +1251,22 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
          ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
          ~assistant_content:(persisted_error_reply err)
          ~stream_lifecycle:errored_stream_lifecycle
-         ());
-    Keeper_chat_broadcast.chat_appended
-      ~keeper_name:payload.name ~source:chat_source
-      ~content:(persisted_error_reply err)
-      ()
+         ()
+    in
+    (match persisted with
+     | Ok () ->
+         Keeper_chat_broadcast.chat_appended
+           ~keeper_name:payload.name ~source:chat_source
+           ~content:(persisted_error_reply err)
+           ()
+     | Error _ -> ());
+    persisted
   in
   let timeout_sec = Option.map float_of_int payload.timeout_sec in
   let dashboard_direct_stream =
-    (not connector_user_line_recorded_upstream) && not (has_external_speaker payload)
+    (not queued_turn)
+    && (not connector_user_line_recorded_upstream)
+    && not (has_external_speaker payload)
   in
   (* masc#23924: [f] below pushes its own [Stream_terminal] once it reaches a
      completion arm, but a timeout/cancellation cuts [f] off before any of
@@ -1218,20 +1276,35 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
      sites (never inside the cancelled [f]) so this turn still gets exactly
      one terminal event via the same serialized [push_worker_event]. *)
   let on_worker_aborted (reason : Keeper_msg_async.worker_abort_reason) =
-    let status, body =
+    let status, body, failure_kind =
       match reason with
       | Keeper_msg_async.Timeout { timeout_sec } ->
           ( "timeout"
           , Printf.sprintf
               "keeper_msg request exceeded timeout_sec=%.3f before completion"
-              timeout_sec )
+              timeout_sec
+          , Turn_timed_out )
       | Keeper_msg_async.Worker_cancelled { cancelled_by; reason } ->
           let cancelled_by =
             Keeper_msg_async.worker_cancel_source_to_string cancelled_by
           in
-          "cancelled", Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
+          ( "cancelled"
+          , Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
+          , Turn_cancelled )
     in
-    push_worker_event (Stream_terminal { ok = false; status; body })
+    let queued_outcome =
+      if not queued_turn then None
+      else
+        match persist_failure_reply body with
+        | Ok () -> Some (Failed { kind = failure_kind; detail = body })
+        | Error persist_error ->
+            Some
+              (Failed
+                 { kind = Transcript_persist_failed
+                 ; detail = persist_error
+                 })
+    in
+    push_worker_event (Stream_terminal { ok = false; status; body; queued_outcome })
   in
   let request_id =
     Keeper_msg_async.submit ?timeout_sec ~clock ~sw ~on_worker_aborted
@@ -1251,11 +1324,13 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               with
               | `Ran result -> Ok (`Ran result)
               | `Busy rejection ->
-                  let queued =
-                    dashboard_deferred_chat_of_rejection ~clock payload rejection
-                  in
-                  push_worker_event (Stream_dashboard_queued queued);
-                  Ok (`Queued queued)
+                  (match
+                     dashboard_deferred_chat_of_rejection ~clock payload rejection
+                   with
+                   | Ok queued ->
+                       push_worker_event (Stream_dashboard_queued queued);
+                       Ok (`Queued queued)
+                   | Error message -> Error message)
             else
               Ok
                 (`Ran
@@ -1337,14 +1412,31 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  visible_reply
              with
              | Some err ->
-                 persist_failure_reply err;
+                 let queued_outcome =
+                   if not queued_turn then None
+                   else
+                     match persist_failure_reply err with
+                     | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
+                     | Error persist_error ->
+                         Some
+                           (Failed
+                              { kind = Transcript_persist_failed
+                              ; detail = persist_error
+                              })
+                 in
+                 if not queued_turn then ignore (persist_failure_reply err : (unit, string) result);
                  push_worker_event
-                   (Stream_terminal { ok = false; status = "error"; body = err });
+                   (Stream_terminal
+                      { ok = false
+                      ; status = "error"
+                      ; body = err
+                      ; queued_outcome
+                      });
                  Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
              | None ->
                  let persist_assistant_reply ~assistant_content =
                    if connector_user_line_recorded_upstream then
-                     Keeper_chat_store.append_assistant_message
+                     Keeper_chat_store.append_assistant_message_result
                        ~base_dir:base_path
                        ~keeper_name:payload.name
                        ~content:assistant_content
@@ -1354,7 +1446,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                        ~stream_lifecycle:completed_stream_lifecycle
                        ()
                    else
-                     Keeper_chat_store.append_turn
+                     Keeper_chat_store.append_turn_result
                        ~base_dir:base_path
                        ~keeper_name:payload.name
                        ~user_content:payload.message
@@ -1367,53 +1459,127 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                        ~stream_lifecycle:completed_stream_lifecycle
                        ()
                  in
-                 let broadcast_chat_appended ?content () =
-                   Keeper_chat_broadcast.chat_appended
-                     ~keeper_name:payload.name ~source:chat_source ?content ()
+                 let delivered_after_persist ?content persisted =
+                   match persisted with
+                   | Ok () ->
+                       Keeper_chat_broadcast.chat_appended
+                         ~keeper_name:payload.name ~source:chat_source ?content ();
+                       if queued_turn then Some Delivered else None
+                   | Error persist_error ->
+                       if queued_turn
+                       then
+                         Some
+                           (Failed
+                              { kind = Transcript_persist_failed
+                              ; detail = persist_error
+                              })
+                       else None
                  in
-                 (match
-                    ( Keeper_turn_outcome.of_reply_payload payload_json_opt,
-                      String_util.trim_to_option visible_reply )
-                  with
-                 | Keeper_turn_outcome.Continuation_checkpoint, _ ->
-                     persist_user_message_only ()
-                 | Keeper_turn_outcome.No_visible_reply, _
-                 | Keeper_turn_outcome.Visible_reply, None ->
-                     if has_visible_blocks then (
-                       persist_assistant_reply ~assistant_content:"";
-                       broadcast_chat_appended ())
-                     else if queued_turn then
-                       (* RFC-connector-deferred-reply-via-chat-queue: a queued message was already
-                          dequeued off [Keeper_chat_queue] before this turn ran,
-                          so [persist_user_message_only]'s "the keeper answers on
-                          its next turn" contract does not hold here — there is
-                          no next turn this message rides along with. Record a
-                          typed failure row instead of leaving the queued
-                          message permanently unanswered. The interactive HTTP
-                          stream ([queued_turn = false]) keeps the original
-                          behaviour: that user line is still live in the
-                          conversation and legitimately may be answered later. *)
-                       persist_failure_reply
-                         "no visible reply was produced for this queued message"
-                     else persist_user_message_only ()
-                 | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
-                     (* RFC-connector-deferred-reply-via-chat-queue §3.4: gate-recorded connector message → the user
-                        line is already persisted at the gate inbound boundary,
-                        so pair the reply by appending the assistant line only
-                        (mirrors [append_direct_chat_pair_if_reply]'s connector
-                        arm). The dashboard route records the full pair. *)
-                     persist_assistant_reply ~assistant_content:visible_reply;
-                     broadcast_chat_appended ~content:visible_reply ());
-                 push_worker_event
-                   (Stream_terminal { ok = true; status = "done"; body });
-                 Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body)
+                 let turn_outcome =
+                   Keeper_turn_outcome.of_reply_payload payload_json_opt
+                 in
+                 let queued_outcome =
+                   match turn_outcome, String_util.trim_to_option visible_reply with
+                   | Keeper_turn_outcome.Continuation_checkpoint, _ when queued_turn ->
+                       let detail =
+                         "queued turn ended with a continuation checkpoint and no delivered reply"
+                       in
+                       (match persist_failure_reply detail with
+                        | Ok () ->
+                            Some
+                              (Failed
+                                 { kind = Continuation_checkpoint_without_reply
+                                 ; detail
+                                 })
+                        | Error persist_error ->
+                            Some
+                              (Failed
+                                 { kind = Transcript_persist_failed
+                                 ; detail = persist_error
+                                 }))
+                   | Keeper_turn_outcome.Continuation_checkpoint, _ ->
+                       persist_user_message_only ();
+                       None
+                   | Keeper_turn_outcome.No_visible_reply, _
+                   | Keeper_turn_outcome.Visible_reply, None ->
+                       if has_visible_blocks
+                       then
+                         persist_assistant_reply ~assistant_content:""
+                         |> delivered_after_persist
+                       else if queued_turn
+                       then
+                         let detail =
+                           "no visible reply was produced for this queued message"
+                         in
+                         (match persist_failure_reply detail with
+                          | Ok () -> Some (Failed { kind = No_visible_reply; detail })
+                          | Error persist_error ->
+                              Some
+                                (Failed
+                                   { kind = Transcript_persist_failed
+                                   ; detail = persist_error
+                                   }))
+                       else (
+                         persist_user_message_only ();
+                         None)
+                   | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
+                       persist_assistant_reply ~assistant_content:visible_reply
+                       |> delivered_after_persist ~content:visible_reply
+                 in
+                 (match queued_outcome with
+                  | Some (Failed { detail; _ }) ->
+                      push_worker_event
+                        (Stream_terminal
+                           { ok = false
+                           ; status = "error"
+                           ; body = detail
+                           ; queued_outcome
+                           });
+                      Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail
+                  | Some Delivered | None ->
+                      push_worker_event
+                        (Stream_terminal
+                           { ok = true
+                           ; status = "done"
+                           ; body
+                           ; queued_outcome
+                           });
+                      Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body))
         | Ok (`Ran (false, err)) ->
-            persist_failure_reply err;
-            push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
+            let persisted = persist_failure_reply err in
+            let queued_outcome =
+              if not queued_turn then None
+              else
+                match persisted with
+                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
+                | Error persist_error ->
+                    Some
+                      (Failed
+                         { kind = Transcript_persist_failed
+                         ; detail = persist_error
+                         })
+            in
+            push_worker_event
+              (Stream_terminal
+                 { ok = false; status = "error"; body = err; queued_outcome });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | Error err ->
-            persist_failure_reply err;
-            push_worker_event (Stream_terminal { ok = false; status = "error"; body = err });
+            let persisted = persist_failure_reply err in
+            let queued_outcome =
+              if not queued_turn then None
+              else
+                match persisted with
+                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
+                | Error persist_error ->
+                    Some
+                      (Failed
+                         { kind = Transcript_persist_failed
+                         ; detail = persist_error
+                         })
+            in
+            push_worker_event
+              (Stream_terminal
+                 { ok = false; status = "error"; body = err; queued_outcome });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err)
       ()
   in
@@ -1483,9 +1649,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         (Custom { name = "KEEPER_REQUEST_TERMINAL"; value = payload_json })
   in
   let rec consume_worker_events bridge_state =
-    if Atomic.get client_disconnected then ()
+    if Atomic.get client_disconnected then None
     else match Eio.Stream.take worker_events with
-    | Stream_client_disconnected -> ()
+    | Stream_client_disconnected -> None
     | Stream_event evt ->
         let translated =
           translate_oas_stream_event ~redact_text
@@ -1496,7 +1662,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         List.iter (Keeper_chat_events.publish events) translated.chat_events;
         consume_worker_events translated.bridge_state
     | Stream_dashboard_queued queued ->
-        let message = dashboard_deferred_ack_text ~keeper_name:payload.name in
+        let message =
+          dashboard_deferred_ack_text ~keeper_name:payload.name queued
+        in
         publish_terminal ~status:"queued" ~ok:true ~message ();
         Keeper_chat_events.publish events (Text_delta message);
         Keeper_chat_events.publish events
@@ -1505,18 +1673,26 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                value = dashboard_deferred_chat_to_json ~keeper_name:payload.name queued
              });
         Keeper_chat_events.publish events Text_message_end;
-        Keeper_chat_events.publish events (Run_finished { run_id })
-    | Stream_terminal { ok = false; status = "cancelled"; body = message } ->
+        Keeper_chat_events.publish events (Run_finished { run_id });
+        None
+    | Stream_terminal
+        { ok = false
+        ; status = "cancelled"
+        ; body = message
+        ; queued_outcome
+        } ->
         let message = redact_text message in
         publish_terminal ~status:"cancelled" ~ok:false ~message ();
         Keeper_chat_events.publish events Text_message_end;
-        Keeper_chat_events.publish events (Run_finished { run_id })
-    | Stream_terminal { ok = false; status; body = err } ->
+        Keeper_chat_events.publish events (Run_finished { run_id });
+        queued_outcome
+    | Stream_terminal { ok = false; status; body = err; queued_outcome } ->
         let err = redact_text err in
         publish_terminal ~status ~ok:false ~message:err ();
         Keeper_chat_events.publish events Text_message_end;
-        Keeper_chat_events.publish events (Event_error { message = err })
-    | Stream_terminal { ok = true; body; _ } -> (
+        Keeper_chat_events.publish events (Event_error { message = err });
+        queued_outcome
+    | Stream_terminal { ok = true; body; queued_outcome; _ } -> (
         try
           let payload_json_opt, visible_reply = extract_visible_reply body in
           let visible_reply =
@@ -1567,7 +1743,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  });
           publish_terminal ~status:"done" ~ok:true ();
           Keeper_chat_events.publish events Text_message_end;
-          Keeper_chat_events.publish events (Run_finished { run_id })
+          Keeper_chat_events.publish events (Run_finished { run_id });
+          queued_outcome
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
@@ -1575,72 +1752,18 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             publish_terminal ~status:"error" ~ok:false ~message ();
             Keeper_chat_events.publish events Text_message_end;
             Keeper_chat_events.publish events
-              (Event_error { message }))
+              (Event_error { message });
+            if queued_turn
+            then Some (Failed { kind = Stream_projection_failed; detail = message })
+            else None)
   in
   match consume_worker_events empty_keeper_stream_bridge_state with
-  | () -> signal_stream_projection_done ()
+  | outcome ->
+      signal_stream_projection_done ();
+      outcome
   | exception exn ->
       signal_stream_projection_done ();
       raise exn
-
-(* Failure-lifecycle shape for a turn that never reached a normal terminal
-   event — mirrors the [errored_stream_lifecycle] local binding inside
-   [process_single_turn] (Run_error in place of Run_finished). Small enough,
-   and different enough in scope (this fires with no live event stream to
-   have derived it from), that duplicating the 4-element list here reads
-   clearer than threading it out as a shared value. *)
-let stalled_stream_lifecycle =
-  [ Keeper_chat_store.Run_started
-  ; Keeper_chat_store.Text_message_start
-  ; Keeper_chat_store.Text_message_end
-  ; Keeper_chat_store.Run_error
-  ]
-
-(* [Keeper_chat_consumer]'s dispatch watchdog calls this — via
-   [Server_bootstrap_loops]'s [on_stalled] wiring — when a queued turn's
-   [handle_turn] (== [process_single_turn]) never reaches a terminal
-   outcome within [dispatch_deadline_sec]. That happens when the turn's own
-   [Keeper_msg_async.submit] cancels the in-flight work on ITS internal
-   timeout: the cancelled fiber never reaches the [persist_assistant_reply]/
-   [persist_failure_reply] calls inside [process_single_turn], so nothing is
-   ever durably recorded for the message — L1/L2 of the busy-queue root
-   cause. This mirrors [persist_failure_reply]'s dashboard/connector split
-   without a live [payload]/closure to call into (the turn's own closures
-   died with the cancelled fiber), so [payload] and
-   [connector_user_line_recorded_upstream] are passed in directly instead. *)
-let persist_queued_turn_stalled ~base_path ~connector_user_line_recorded_upstream ~payload =
-  let chat_surface = chat_surface_of_request payload in
-  let chat_source = Surface_ref.lane_label chat_surface in
-  let chat_speaker = chat_speaker_of_request payload in
-  let content =
-    persisted_error_reply
-      "queued turn did not complete within the dispatch watchdog deadline"
-  in
-  Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string ChatTransportFailures)
-    ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
-    ();
-  (if connector_user_line_recorded_upstream then
-     Keeper_chat_store.append_assistant_message
-       ~base_dir:base_path
-       ~keeper_name:payload.name
-       ~content
-       ~surface:chat_surface
-       ~stream_lifecycle:stalled_stream_lifecycle
-       ()
-   else
-     Keeper_chat_store.append_turn
-       ~base_dir:base_path
-       ~keeper_name:payload.name
-       ~user_content:payload.message
-       ~user_attachments:payload.attachments
-       ~surface:chat_surface
-       ~speaker:chat_speaker
-       ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
-       ~assistant_content:content
-       ~stream_lifecycle:stalled_stream_lifecycle
-       ());
-  Keeper_chat_broadcast.chat_appended ~keeper_name:payload.name ~source:chat_source ~content ()
 
 let keeper_chat_stream_headers origin =
   Httpun.Headers.of_list
@@ -1961,13 +2084,15 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
            let run_now () =
              (* Dashboard stream route: no gate inbound boundary recorded this
                 user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
-	             process_single_turn ~connector_user_line_recorded_upstream:false
-	               ~queued_turn:false
-	               ~state ~clock ~sw
-	               ~auth_token:(auth_token_from_request request)
-	               ~thread_id ~continuation_channel ~closed
-	               ~client_disconnects:(Some (stream_sw, client_disconnects))
-	               ~payload ~run_id ~message_id ~agent_name ~events;
+             ignore
+               (process_single_turn ~connector_user_line_recorded_upstream:false
+                  ~queued_turn:false
+                  ~state ~clock ~sw
+                  ~auth_token:(auth_token_from_request request)
+                  ~thread_id ~continuation_channel ~closed
+                  ~client_disconnects:(Some (stream_sw, client_disconnects))
+                  ~payload ~run_id ~message_id ~agent_name ~events
+                : queued_turn_outcome option);
              wait_for_adapter_finished ()
            in
            if has_external_speaker payload then run_now ()
@@ -1981,8 +2106,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
              | `Not_busy -> run_now ()
              | `Queued queued ->
                  Log.Keeper.info
-                   "keeper_stream: deferred busy dashboard message keeper=%s queue_length=%d"
-                   payload.name queued.queue_length;
+                   "keeper_stream: deferred busy dashboard message keeper=%s pending_count=%d inflight_count=%d"
+                   payload.name queued.pending_count queued.inflight_count;
                  Keeper_chat_events.publish events
                    (Run_started { run_id; thread_id });
                  Keeper_chat_events.publish events
@@ -1990,7 +2115,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                       { message_id; role = Keeper_chat_events.Assistant });
                  Keeper_chat_events.publish events
                    (Text_delta
-                      (dashboard_deferred_ack_text ~keeper_name:payload.name));
+                      (dashboard_deferred_ack_text ~keeper_name:payload.name
+                         queued));
                  Keeper_chat_events.publish events
                    (Custom
                       { name = "KEEPER_CHAT_QUEUED";
@@ -2033,7 +2159,8 @@ module For_testing = struct
   let defer_dashboard_payload_if_busy ~base_path ~clock payload =
     match defer_dashboard_payload_if_busy ~base_path ~clock payload with
     | `Not_busy -> `Not_busy
-    | `Queued queued -> `Queued queued.queue_length
+    | `Queued queued -> `Queued queued.pending_count
+    | `Queue_error message -> `Queue_error message
 
   let extract_visible_reply = extract_visible_reply
   let direct_reply_terminal_error = direct_reply_terminal_error

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -163,11 +163,12 @@ type queued_turn_failure_kind =
   | Turn_cancelled
   | No_visible_reply
   | Continuation_checkpoint_without_reply
+  | Missing_turn_ref
   | Transcript_persist_failed
   | Stream_projection_failed
 
 type queued_turn_outcome =
-  | Delivered of { outcome_ref : string option }
+  | Delivered of { outcome_ref : string }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string
@@ -254,6 +255,8 @@ module For_testing : sig
   val extract_visible_reply : string -> Yojson.Safe.t option * string
   val direct_reply_terminal_error :
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option
+  val queued_delivery_outcome_of_turn_ref :
+    Ids.Turn_ref.t option -> queued_turn_outcome
   val visible_reply_with_stream_fallback :
     streamed_text:string -> string -> string
   val redacted_visible_reply_with_stream_fallback :

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -157,6 +157,24 @@ val handle_keeper_chat_stream :
 
 (** {1 Turn execution (shared between HTTP handler and queue consumer)} *)
 
+type queued_turn_failure_kind =
+  | Turn_failed
+  | Turn_timed_out
+  | Turn_cancelled
+  | No_visible_reply
+  | Continuation_checkpoint_without_reply
+  | Transcript_persist_failed
+  | Stream_projection_failed
+
+type queued_turn_outcome =
+  | Delivered
+  | Failed of
+      { kind : queued_turn_failure_kind
+      ; detail : string
+      }
+
+val queued_turn_failure_kind_to_string : queued_turn_failure_kind -> string
+
 val process_single_turn :
   connector_user_line_recorded_upstream:bool ->
   queued_turn:bool ->
@@ -173,7 +191,7 @@ val process_single_turn :
   message_id:string ->
   agent_name:string ->
   events:Keeper_chat_events.keeper_chat_event Eio.Stream.t ->
-  unit
+  queued_turn_outcome option
 (** Execute a single keeper turn, publishing events to the provided
     event stream. [sw] owns the async keeper_msg worker and must outlive
     a single HTTP stream when resumable dashboard requests are used.
@@ -200,22 +218,9 @@ val process_single_turn :
     ([persist_user_message_only]), matching its existing "the keeper will
     answer on the next turn" semantics; a queued turn instead persists a
     typed failure row via [persist_failure_reply]. A queued message was
-    already dequeued off [Keeper_chat_queue] — there is no "next turn" for
+    already leased from [Keeper_chat_queue] — there is no "next turn" for
     it to ride along with, so silence here is terminal, not merely
     deferred. *)
-
-val persist_queued_turn_stalled :
-  base_path:string ->
-  connector_user_line_recorded_upstream:bool ->
-  payload:keeper_chat_stream_request ->
-  unit
-(** Durably records that a queued turn never reached a terminal outcome
-    within [Keeper_chat_consumer]'s dispatch watchdog deadline: a typed
-    failure row (mirroring [persist_failure_reply]'s dashboard/connector
-    split), a [ChatTransportFailures] counter increment, and a
-    [Keeper_chat_broadcast.chat_appended] broadcast. Called from
-    [Server_bootstrap_loops]'s [on_stalled] wiring — see
-    [Keeper_chat_consumer.start] for when this fires and why. *)
 
 (** {1 Testing helpers} *)
 
@@ -245,7 +250,7 @@ module For_testing : sig
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
     keeper_chat_stream_request ->
-    [ `Not_busy | `Queued of int ]
+    [ `Not_busy | `Queued of int | `Queue_error of string ]
   val extract_visible_reply : string -> Yojson.Safe.t option * string
   val direct_reply_terminal_error :
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -167,7 +167,7 @@ type queued_turn_failure_kind =
   | Stream_projection_failed
 
 type queued_turn_outcome =
-  | Delivered
+  | Delivered of { outcome_ref : string option }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -2,6 +2,7 @@ type waiting_source =
   | Event_queue_pending
   | Event_queue_inflight
   | Chat_queue_pending
+  | Chat_queue_inflight
   | Hitl_pending
   | External_attention
   | Fusion_running
@@ -54,6 +55,7 @@ let source_to_string = function
   | Event_queue_pending -> "event_queue_pending"
   | Event_queue_inflight -> "event_queue_inflight"
   | Chat_queue_pending -> "chat_queue_pending"
+  | Chat_queue_inflight -> "chat_queue_inflight"
   | Hitl_pending -> "hitl_pending"
   | External_attention -> "external_attention"
   | Fusion_running -> "fusion_running"
@@ -68,6 +70,7 @@ let all_waiting_sources =
   [ Event_queue_pending
   ; Event_queue_inflight
   ; Chat_queue_pending
+  ; Chat_queue_inflight
   ; Hitl_pending
   ; External_attention
   ; Fusion_running
@@ -255,26 +258,103 @@ let chat_queue_source_json = function
       ]
 ;;
 
-let chat_queue_rows keeper_name =
-  Keeper_chat_queue.snapshot ~keeper_name
-  |> List.mapi (fun queue_index (msg : Keeper_chat_queue.queued_message) ->
-    let source_label = chat_queue_source_label msg.source in
-    { keeper_name = Some keeper_name
-    ; source = Chat_queue_pending
+let chat_queue_active_row ~source ~next_action ~lifecycle_fields keeper_name queue_index
+    (receipt : Keeper_chat_queue.active_receipt) =
+  let msg = receipt.message in
+  let source_label = chat_queue_source_label msg.source in
+  { keeper_name = Some keeper_name
+    ; source
     ; waiting_on = source_label
     ; wake_producer = Keeper_chat_queue_store
     ; since = Some msg.timestamp
     ; due_at = None
-    ; next_action = "keeper_chat_consumer_drain"
+    ; next_action
     ; detail =
         `Assoc
           [ "queue_index", `Int queue_index
+          ; ( "receipt_id"
+            , `String
+                (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
           ; "message_source", chat_queue_source_json msg.source
           ; "content_length", `Int (String.length msg.content)
           ; "user_block_count", `Int (List.length msg.user_blocks)
           ; "attachment_count", `Int (List.length msg.attachments)
+          ; "lifecycle", `Assoc lifecycle_fields
           ]
-    })
+    }
+;;
+
+let chat_queue_invariant_error_row keeper_name queue_index
+    (receipt : Keeper_chat_queue.active_receipt) expected_state =
+  read_error_row ~keeper_name ~waiting_on:"chat_queue_snapshot_invariant"
+    ~next_action:"repair_keeper_chat_queue_snapshot"
+    (`Assoc
+      [ "expected_state", `String expected_state
+      ; ( "receipt_id"
+        , `String
+            (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
+      ; "queue_index", `Int queue_index
+      ])
+;;
+
+let chat_queue_load_error_row keeper_name
+    (error : Keeper_chat_queue.snapshot_load_error) =
+  let kind =
+    match error.kind with
+    | Keeper_chat_queue.Invalid_path -> "invalid_path"
+    | Keeper_chat_queue.Read_failed -> "read_failed"
+    | Keeper_chat_queue.Parse_failed -> "parse_failed"
+    | Keeper_chat_queue.Migration_failed -> "migration_failed"
+    | Keeper_chat_queue.Recovery_failed -> "recovery_failed"
+  in
+  read_error_row ~keeper_name ~waiting_on:"chat_queue_snapshot"
+    ~next_action:"repair_keeper_chat_queue_snapshot"
+    (`Assoc
+      [ "kind", `String kind
+      ; "path", Json_util.string_opt_to_json error.path
+      ; "message", `String error.message
+      ])
+;;
+
+let chat_queue_rows keeper_name =
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  let pending =
+    snapshot.pending
+    |> List.mapi (fun queue_index
+                       (receipt : Keeper_chat_queue.active_receipt) ->
+           match receipt.Keeper_chat_queue.state with
+           | Keeper_chat_queue.Pending ->
+               chat_queue_active_row ~source:Chat_queue_pending
+                 ~next_action:"keeper_chat_consumer_drain"
+                 ~lifecycle_fields:[ "state", `String "pending" ] keeper_name
+                 queue_index receipt
+           | Keeper_chat_queue.Inflight _ | Keeper_chat_queue.Delivered _
+           | Keeper_chat_queue.Failed _ ->
+               chat_queue_invariant_error_row keeper_name queue_index receipt
+                 "pending")
+  in
+  let inflight =
+    snapshot.inflight
+    |> List.mapi (fun queue_index
+                       (receipt : Keeper_chat_queue.active_receipt) ->
+           match receipt.Keeper_chat_queue.state with
+           | Keeper_chat_queue.Inflight { lease_id; started_at } ->
+               chat_queue_active_row ~source:Chat_queue_inflight
+                 ~next_action:"keeper_chat_turn_terminal_receipt"
+                 ~lifecycle_fields:
+                   [ "state", `String "inflight"
+                   ; "lease_id", `String lease_id
+                   ; "started_at", `Float started_at
+                   ; "started_at_iso", unix_iso_json (Some started_at)
+                   ]
+                 keeper_name queue_index receipt
+           | Keeper_chat_queue.Pending | Keeper_chat_queue.Delivered _
+           | Keeper_chat_queue.Failed _ ->
+               chat_queue_invariant_error_row keeper_name queue_index receipt
+                 "inflight")
+  in
+  pending @ inflight
+  @ List.map (chat_queue_load_error_row keeper_name) snapshot.load_errors
 ;;
 
 let turn_admission_rows ~base_path keeper_name =
@@ -800,7 +880,7 @@ let dashboard_json config =
   in
   record_metrics ~now ~per_keeper ~global_rows;
   `Assoc
-    [ "schema", `String "masc.dashboard.keeper_waiting_inventory.v1"
+    [ "schema", `String "masc.dashboard.keeper_waiting_inventory.v2"
     ; "source", `String "server_keeper_waiting_inventory"
     ; "generated_at", `String (Masc_domain.now_iso ())
     ; "supported_states", `List (List.map (fun value -> `String value) [ "idle"; "busy"; "waiting"; "deferred" ])

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -250,11 +250,13 @@ let chat_queue_source_json = function
       ; "channel_id", `String channel_id
       ; "user_id", `String user_id
       ]
-  | Keeper_chat_queue.Slack { channel; user_id } ->
+  | Keeper_chat_queue.Slack { channel_id; user_id; team_id; thread_ts; _ } ->
     `Assoc
       [ "kind", `String "slack"
-      ; "channel", `String channel
+      ; "channel_id", `String channel_id
       ; "user_id", `String user_id
+      ; "team_id", Json_util.string_opt_to_json team_id
+      ; "thread_ts", Json_util.string_opt_to_json thread_ts
       ]
 ;;
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -4,6 +4,7 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 module Lib = Masc
 module Auth = Masc.Auth
+module Keeper_chat_queue = Masc.Keeper_chat_queue
 module Workspace = Masc.Workspace
 
 open Alcotest
@@ -148,6 +149,52 @@ let test_keeper_post_route_classifies_catchup_judge () =
   check string "keeper name extracted" "idealist"
     (Server_dashboard_http_keeper_api.extract_keeper_name_for_suffix path
        Server_dashboard_http_keeper_api.keeper_suffix_catchup_judge)
+
+let test_keeper_chat_receipt_route_and_json () =
+  let receipt_id =
+    match
+      Keeper_chat_queue.Receipt_id.of_string
+        "chatq_00000000-0000-4000-8000-000000000123"
+    with
+    | Ok receipt_id -> receipt_id
+    | Error error -> fail error
+  in
+  let path =
+    "/api/v1/keepers/idealist/chat/receipts/"
+    ^ Keeper_chat_queue.Receipt_id.to_string receipt_id
+  in
+  check (option (pair string string)) "receipt route is exact"
+    (Some ("idealist", Keeper_chat_queue.Receipt_id.to_string receipt_id))
+    (Server_dashboard_http_keeper_api.keeper_chat_receipt_route path);
+  check (option (pair string string)) "receipt route rejects extra segments" None
+    (Server_dashboard_http_keeper_api.keeper_chat_receipt_route (path ^ "/extra"));
+  let json =
+    Server_dashboard_http_keeper_api.keeper_chat_receipt_json
+      ~keeper_name:"idealist" ~revision:7L
+      { Keeper_chat_queue.receipt_id
+      ; state =
+          Keeper_chat_queue.Failed
+            { completed_at = 42.0
+            ; kind = Keeper_chat_queue.Delivery_failed
+            ; detail = "Slack rejected sk-proj-abcdefghijklmnopqrstuvwxyz"
+            ; outcome_ref = Some "chat-row-7"
+            }
+      }
+  in
+  let open Yojson.Safe.Util in
+  check string "receipt JSON state" "failed"
+    (json |> member "state" |> member "kind" |> to_string);
+  check string "receipt JSON revision" "7"
+    (match json |> member "revision" with
+     | `Int revision -> string_of_int revision
+     | `Intlit revision -> revision
+     | _ -> "invalid");
+  check string "receipt JSON failure kind" "delivery_failed"
+    (json |> member "state" |> member "failure_kind" |> to_string);
+  check bool "receipt JSON redacts failure detail" false
+    (contains_substring
+       (json |> member "state" |> member "detail" |> to_string)
+       "sk-proj-abcdefghijklmnopqrstuvwxyz")
 
 let with_test_env f =
   let dir = test_dir () in
@@ -1760,6 +1807,8 @@ let () =
             test_state_diagram_runtime_projection_missing_meta_stays_empty;
           test_case "keeper catch-up judge route is classified" `Quick
             test_keeper_post_route_classifies_catchup_judge;
+          test_case "keeper chat receipt route is typed" `Quick
+            test_keeper_chat_receipt_route_and_json;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -183,6 +183,38 @@ let test_discord_queue_projection_matches_gateway_context () =
     "gate:discord:discord-channel-1:discord-user-9"
     projection.agent_name
 
+let test_slack_queue_projection_matches_gateway_context () =
+  let queued : Chat_queue.queued_message =
+    { content = "hello"
+    ; user_blocks = []
+    ; attachments = []
+    ; timestamp = 0.0
+    ; source =
+        Chat_queue.Slack
+          { channel_id = "C-SLACK"
+          ; user_id = "U-SLACK"
+          ; user_name = "Slack User"
+          ; team_id = Some "T-SLACK"
+          ; thread_ts = Some "171.001"
+          }
+    }
+  in
+  let projection = Boot.queued_chat_projection queued in
+  check string "connector label" "slack" projection.payload_channel;
+  check string "actor id" "U-SLACK" projection.payload_channel_user_id;
+  check string "actor name" "Slack User" projection.payload_channel_user_name;
+  check string "workspace id uses Slack channel id" "C-SLACK"
+    projection.payload_channel_workspace_id;
+  check string "agent identity matches gate channel actor"
+    "gate:slack:C-SLACK:U-SLACK" projection.agent_name;
+  match Chat_queue.continuation_channel_of_message_source queued.source with
+  | Keeper_continuation_channel.Slack { team_id; channel_id; thread_ts; user_id } ->
+    check (option string) "team retained" (Some "T-SLACK") team_id;
+    check string "channel retained" "C-SLACK" channel_id;
+    check (option string) "thread retained" (Some "171.001") thread_ts;
+    check string "user retained" "U-SLACK" user_id
+  | _ -> fail "Slack source must project to a Slack continuation"
+
 let () =
   run "env_config_keeper_bootstrap_intervals"
     [
@@ -218,5 +250,7 @@ let () =
         [
           test_case "Discord queue source keeps connector context" `Quick
             test_discord_queue_projection_matches_gateway_context;
+          test_case "Slack queue source keeps connector context" `Quick
+            test_slack_queue_projection_matches_gateway_context;
         ] );
     ]

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2725,6 +2725,7 @@ let test_route_busy_discord_enqueues () =
   match
     Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Discord
       ~channel_id:"123456789" ~user_id:"u-42"
+      ~user_name:"discord-user" ~team_id:None ~thread_ts:None
   with
   | `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id }) ->
       check string "discord channel_id threaded" "123456789" channel_id;
@@ -2738,10 +2739,17 @@ let test_route_busy_slack_enqueues () =
   match
     Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Slack
       ~channel_id:"C0SLACK" ~user_id:"U-99"
+      ~user_name:"slack-user" ~team_id:(Some "T0SLACK")
+      ~thread_ts:(Some "171.001")
   with
-  | `Enqueue_chat_queue (Keeper_chat_queue.Slack { channel; user_id }) ->
-      check string "slack channel threaded" "C0SLACK" channel;
-      check string "slack user_id threaded" "U-99" user_id
+  | `Enqueue_chat_queue
+      (Keeper_chat_queue.Slack
+         { channel_id; user_id; user_name; team_id; thread_ts }) ->
+      check string "slack channel threaded" "C0SLACK" channel_id;
+      check string "slack user_id threaded" "U-99" user_id;
+      check string "slack user name threaded" "slack-user" user_name;
+      check (option string) "slack team threaded" (Some "T0SLACK") team_id;
+      check (option string) "slack reply thread threaded" (Some "171.001") thread_ts
   | `Enqueue_chat_queue _ ->
       fail "Slack must map to a Slack message_source, not another variant"
   | `Async_poll -> fail "Slack has an outbound adapter; must enqueue, not poll"
@@ -2750,6 +2758,7 @@ let test_route_busy_generic_falls_back () =
   match
     Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Generic
       ~channel_id:"x" ~user_id:"y"
+      ~user_name:"generic-user" ~team_id:None ~thread_ts:None
   with
   | `Async_poll -> check bool "generic falls back to async poll" true true
   | `Enqueue_chat_queue _ ->

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -207,9 +207,113 @@ let test_busy_discord_persist_failure_is_explicit () =
         check "failed enqueue does not advance queue revision"
           (snapshot.revision = 0L)))
 
+let test_pending_receipt_prevents_direct_overtake () =
+  Printf.printf "Test: active receipt queues a later connector turn without a live slot\n%!";
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-pending-conn-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      configure_queue ~base;
+      ignore
+        (Keeper_chat_queue.enqueue ~keeper_name
+           { content = "first"
+           ; user_blocks = []
+           ; attachments = []
+           ; timestamp = Eio.Time.now clock
+           ; source =
+               Keeper_chat_queue.Discord
+                 { channel_id = "chan-777"; user_id = "user-42" }
+           });
+      Eio.Switch.run @@ fun sw ->
+      let reply =
+        Gate_keeper_backend.dispatch
+          ~connector_kind:Gate_keeper_backend.Discord
+          ~sw ~clock ~proc_mgr:None ~net:None ~config
+          ~channel:"discord" ~channel_user_id:"user-42"
+          ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
+          ~keeper_name ~idempotency_key:"discord-msg-778"
+          ~metadata:[] ~content:"second"
+      in
+      (match reply with
+       | Gate_protocol.Reply { message_request = Some request; _ } ->
+         check "later connector input is queued" (request.status = Gate_protocol.Queued)
+       | _ -> check "later connector input is queued" false);
+      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+      check "FIFO keeps both accepted receipts pending"
+        (List.map (fun item -> item.Keeper_chat_queue.message.content) snapshot.pending
+         = [ "first"; "second" ]))
+
+let test_busy_slack_preserves_thread_context () =
+  Printf.printf "Test: busy Slack dispatch preserves reply-thread identity\n%!";
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-busy-slack-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      configure_queue ~base;
+      Eio.Switch.run @@ fun sw ->
+      let reply =
+        with_busy_slot ~base ~sw (fun () ->
+          Gate_keeper_backend.dispatch
+            ~connector_kind:Gate_keeper_backend.Slack
+            ~sw ~clock ~proc_mgr:None ~net:None ~config
+            ~channel:"slack" ~channel_user_id:"U-42"
+            ~channel_user_name:"Slack User" ~channel_workspace_id:"C-777"
+            ~keeper_name ~idempotency_key:"slack-msg-171.001"
+            ~metadata:
+              [ "slack.message_ts", "171.001"
+              ; "slack.team_id", "T-777"
+              ]
+            ~content:"threaded question")
+      in
+      (match reply with
+       | Gate_protocol.Reply { message_request = Some request; _ } ->
+         check "Slack busy input is queued" (request.status = Gate_protocol.Queued)
+       | _ -> check "Slack busy input is queued" false);
+      match (Keeper_chat_queue.snapshot ~keeper_name).pending with
+      | [ { message =
+              { source =
+                  Keeper_chat_queue.Slack
+                    { channel_id; user_id; user_name; team_id; thread_ts }
+              ; _
+              }
+          ; _
+          } ] ->
+        check "Slack channel retained" (channel_id = "C-777");
+        check "Slack user retained" (user_id = "U-42" && user_name = "Slack User");
+        check "Slack team retained" (team_id = Some "T-777");
+        check "top-level message roots deferred reply thread"
+          (thread_ts = Some "171.001")
+      | _ -> check "one typed Slack receipt is pending" false)
+
 let () =
   test_busy_discord_enqueues ();
   test_busy_discord_persist_failure_is_explicit ();
+  test_pending_receipt_prevents_direct_overtake ();
+  test_busy_slack_preserves_thread_context ();
   if !failures > 0 then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
     exit 1)

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -52,6 +52,12 @@ let count_user_lines ~base =
           match m.role with Keeper_chat_store.Role.User -> true | _ -> false)
        (Keeper_chat_store.load ~base_dir:base ~keeper_name))
 
+let configure_queue ~base =
+  Keeper_chat_queue.For_testing.reset ();
+  let report = Keeper_chat_queue.configure_persistence ~base_path:base in
+  check "chat queue persistence configured without load errors"
+    (report.load_errors = [])
+
 let test_busy_discord_enqueues () =
   Printf.printf
     "Test: busy Discord dispatch enqueues onto Keeper_chat_queue (not async poll)\n%!";
@@ -62,7 +68,8 @@ let test_busy_discord_enqueues () =
   in
   Unix.mkdir base 0o755;
   Fun.protect
-    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -70,8 +77,9 @@ let test_busy_discord_enqueues () =
       let config = Workspace.default_config base in
       ignore (Workspace.init config ~agent_name:(Some keeper_name));
       Keeper_turn_admission.For_testing.reset ();
-      Keeper_chat_queue.clear ~keeper_name;
+      configure_queue ~base;
       Eio.Switch.run (fun sw ->
+        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
         let reply =
           with_busy_slot ~base ~sw (fun () ->
             Gate_keeper_backend.dispatch
@@ -83,42 +91,125 @@ let test_busy_discord_enqueues () =
               ~metadata:[] ~content:"are you there?")
         in
         (* The connector receives a busy ACK now; the deferred reply arrives
-           later via the consumer, so there is no async-poll request_id. *)
+           later via the consumer. The existing message-request envelope carries
+           the durable queue receipt instead of an async-poll request id. *)
+        let ack_receipt_id = ref None in
         (match reply with
-         | Gate_protocol.Reply { message_request; content; _ } ->
-             check "busy connector reply carries no async-poll request_id"
-               (message_request = None);
+         | Gate_protocol.Reply
+             { message_request = Some request; content; _ } ->
+             ack_receipt_id := Some request.request_id;
+             check "busy connector ACK is queued"
+               (request.status = Gate_protocol.Queued);
+             check "busy connector ACK carries queue status source"
+               (List.assoc_opt "status_source" request.metadata
+                = Some "keeper_chat_queue");
+             check "busy connector ACK carries queue revision"
+               (List.assoc_opt "queue_revision" request.metadata <> None);
              check "busy ACK text is non-empty" (String.length content > 0)
+         | Gate_protocol.Reply { message_request = None; _ } ->
+             check "busy connector ACK carries durable receipt" false
          | Gate_protocol.Keeper_error_result _
          | Gate_protocol.Unavailable_result ->
              check "busy Discord dispatch returns a Reply (not error/unavailable)"
                false);
         (* The message lands on the chat queue with the typed Discord source so
            the serial consumer can drain it and route the reply to the channel. *)
-        check "exactly one message enqueued"
-          (Keeper_chat_queue.length ~keeper_name = 1);
-        (match Keeper_chat_queue.dequeue ~keeper_name with
-         | Some
-             { Keeper_chat_queue.source =
-                 Keeper_chat_queue.Discord { channel_id; user_id }
-             ; content
+        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+        check "exactly one durable receipt is pending"
+          (List.length snapshot.pending = 1);
+        check "no durable receipt is inflight yet"
+          (snapshot.inflight = []);
+        check "queue snapshot has no load errors" (snapshot.load_errors = []);
+        (match snapshot.pending with
+         | [ { Keeper_chat_queue.receipt_id; message =
+                 { Keeper_chat_queue.source =
+                     Keeper_chat_queue.Discord { channel_id; user_id }
+                 ; content
+                 ; _
+                 }
              ; _
-             } ->
+             } ] ->
+             check "ACK and pending receipt ids match"
+               (Some (Keeper_chat_queue.Receipt_id.to_string receipt_id)
+                = !ack_receipt_id);
              check "queued source is the Discord channel_id"
                (channel_id = "chan-777");
              check "queued source carries the user_id" (user_id = "user-42");
              check "queued content is the user's message"
                (content = "are you there?")
-         | Some _ -> check "queued source is Discord" false
-         | None -> check "queue holds the busy message" false);
+         | _ -> check "queue holds one Discord receipt" false);
+        (match Keeper_chat_queue.lease_batch ~keeper_name with
+         | `Leased lease ->
+             check "lease carries the pending receipt"
+               (List.length lease.items = 1);
+             (match
+                Keeper_chat_queue.finalize ~keeper_name
+                  ~lease_id:lease.lease_id
+                  ~outcome:
+                    (Keeper_chat_queue.Mark_delivered
+                       { completed_at = Time_compat.now (); outcome_ref = None })
+              with
+              | `Finalized receipt_ids ->
+                  check "finalize records the delivered receipt"
+                    (List.length receipt_ids = 1)
+              | `Unknown_lease | `Error _ ->
+                  check "leased receipt finalizes" false)
+         | `Empty | `Already_leased _ | `Error _ ->
+             check "pending receipt leases" false);
         (* Ownership invariant (RFC §3.4): the gate inbound boundary recorded the
            user line exactly once; no paired assistant row exists yet because the
            turn has not been drained. *)
         check "gate inbound recorded the connector user line exactly once"
           (count_user_lines ~base = 1)))
 
+let test_busy_discord_persist_failure_is_explicit () =
+  Printf.printf
+    "Test: busy Discord dispatch fails closed when durable enqueue fails\n%!";
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-busy-conn-fail-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      configure_queue ~base;
+      Eio.Switch.run (fun sw ->
+        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
+        let reply =
+          with_busy_slot ~base ~sw (fun () ->
+            Keeper_chat_queue.For_testing.fail_next_persist ();
+            Gate_keeper_backend.dispatch
+              ~connector_kind:Gate_keeper_backend.Discord
+              ~sw ~clock ~proc_mgr:None ~net:None ~config
+              ~channel:"discord" ~channel_user_id:"user-42"
+              ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
+              ~keeper_name ~idempotency_key:"discord-msg-persist-fail"
+              ~metadata:[] ~content:"do not lose me")
+        in
+        (match reply with
+         | Gate_protocol.Keeper_error_result message ->
+             check "persistence failure is returned explicitly"
+               (String.length message > 0)
+         | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
+             check "persistence failure never claims queued" false);
+        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+        check "failed enqueue leaves no pending receipt"
+          (snapshot.pending = []);
+        check "failed enqueue does not advance queue revision"
+          (snapshot.revision = 0L)))
+
 let () =
   test_busy_discord_enqueues ();
+  test_busy_discord_persist_failure_is_explicit ();
   if !failures > 0 then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
     exit 1)

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -42,6 +42,19 @@ let with_busy_slot ~base ~sw f =
   Eio.Promise.resolve set_release ();
   result
 
+let with_unpublished_busy_slot ~base ~sw f =
+  let started, set_started = Eio.Promise.create () in
+  let release, set_release = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Keeper_turn_admission.For_testing.with_unpublished_turn_lock
+      ~base_path:base ~keeper_name (fun () ->
+        Eio.Promise.resolve set_started ();
+        Eio.Promise.await release));
+  Eio.Promise.await started;
+  let result = f () in
+  Eio.Promise.resolve set_release ();
+  result
+
 let count_user_lines ~base =
   (* The gate inbound boundary records the connector user line as a pending
      (assistant-less) row. Count those rows for the keeper to assert exactly-once
@@ -161,6 +174,52 @@ let test_busy_discord_enqueues () =
            turn has not been drained. *)
         check "gate inbound recorded the connector user line exactly once"
           (count_user_lines ~base = 1)))
+
+let test_unpublished_busy_slot_queues_without_resolved_meta () =
+  Printf.printf
+    "Test: unresolved-meta Gate queues during the lock-before-in-flight window\n%!";
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-unpublished-conn-%d-%d" (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock = Eio.Stdenv.clock env in
+      let config = Workspace.default_config base in
+      ignore (Workspace.init config ~agent_name:(Some keeper_name));
+      Keeper_turn_admission.For_testing.reset ();
+      configure_queue ~base;
+      Eio.Switch.run (fun sw ->
+        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
+        let reply =
+          with_unpublished_busy_slot ~base ~sw (fun () ->
+            check "raw lock has no published in-flight metadata"
+              (Keeper_turn_admission.in_flight ~base_path:base ~keeper_name = None);
+            Gate_keeper_backend.dispatch
+              ~connector_kind:Gate_keeper_backend.Discord
+              ~sw ~clock ~proc_mgr:None ~net:None ~config
+              ~channel:"discord" ~channel_user_id:"user-unpublished"
+              ~channel_user_name:"Tester" ~channel_workspace_id:"chan-unpublished"
+              ~keeper_name ~idempotency_key:"discord-msg-unpublished"
+              ~metadata:[] ~content:"queue me during admission")
+        in
+        (match reply with
+         | Gate_protocol.Reply { message_request = Some request; _ } ->
+           check "unpublished busy slot returns a queued ACK"
+             (request.status = Gate_protocol.Queued)
+         | Gate_protocol.Reply { message_request = None; _ }
+         | Gate_protocol.Keeper_error_result _
+         | Gate_protocol.Unavailable_result ->
+           check "unpublished busy slot returns a queued ACK" false);
+        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+        check "unpublished busy slot durably preserves the connector message"
+          (List.length snapshot.pending = 1 && snapshot.inflight = [])))
 
 let test_busy_discord_persist_failure_is_explicit () =
   Printf.printf
@@ -311,6 +370,7 @@ let test_busy_slack_preserves_thread_context () =
 
 let () =
   test_busy_discord_enqueues ();
+  test_unpublished_busy_slot_queues_without_resolved_meta ();
   test_busy_discord_persist_failure_is_explicit ();
   test_pending_receipt_prevents_direct_overtake ();
   test_busy_slack_preserves_thread_context ();

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -56,7 +56,12 @@ let with_env body =
       ignore (Workspace.init config ~agent_name:(Some keeper_name));
       Keeper_turn_admission.For_testing.reset ();
       Keeper_chat_queue.For_testing.reset ();
-      body ~base ~clock)
+      let report = Keeper_chat_queue.configure_persistence ~base_path:base in
+      check "chat queue persistence configured without load errors"
+        (report.load_errors = []);
+      Eio.Switch.run (fun sw ->
+        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
+        body ~base ~clock))
 ;;
 
 let with_busy_slot ~base ~sw ?(keeper_name = keeper_name) f =
@@ -110,13 +115,19 @@ let test_busy_dashboard_enqueues () =
        (payload ())
    with
    | `Queued len -> check "queue length is reported" (len = 1)
-   | `Not_busy -> check "busy keeper was deferred" false);
-  check "exactly one dashboard message enqueued" (Keeper_chat_queue.length ~keeper_name = 1);
-  (match Keeper_chat_queue.dequeue ~keeper_name with
-   | Some { Keeper_chat_queue.content; source = Dashboard; _ } ->
+   | `Not_busy | `Queue_error _ -> check "busy keeper was deferred" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "exactly one dashboard receipt is pending"
+    (List.length snapshot.pending = 1);
+  check "dashboard queue has no inflight receipt" (snapshot.inflight = []);
+  check "dashboard queue revision advances" (snapshot.revision = 1L);
+  (match snapshot.pending with
+   | [ { Keeper_chat_queue.message =
+           { Keeper_chat_queue.content; source = Dashboard; _ }
+       ; _
+       } ] ->
      check "queued content is the user's message" (String.equal content "are you there?")
-   | Some _ -> check "queued source is dashboard" false
-   | None -> check "queue holds the dashboard message" false)
+   | _ -> check "queue holds one dashboard receipt" false)
 ;;
 
 let test_free_dashboard_not_enqueued () =
@@ -130,23 +141,28 @@ let test_free_dashboard_not_enqueued () =
        (payload ~content:"run now" ())
    with
    | `Not_busy -> check "free keeper stays on direct stream path" true
-   | `Queued _ -> check "free keeper must not enqueue" false);
-  check "queue remains empty" (Keeper_chat_queue.length ~keeper_name = 0)
+   | `Queued _ | `Queue_error _ -> check "free keeper must not enqueue" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "queue remains empty" (snapshot.pending = [] && snapshot.inflight = [])
 ;;
 
 let test_existing_backlog_defers_new_dashboard_message () =
   Printf.printf "Test: existing dashboard backlog keeps newer messages queued\n%!";
   with_env
   @@ fun ~base ~clock ->
-  ignore
-    (Keeper_chat_queue.enqueue ~keeper_name
+  (match
+     Keeper_chat_queue.enqueue ~keeper_name
        { Keeper_chat_queue.content = "older queued message"
        ; user_blocks = []
        ; attachments = []
        ; timestamp = Eio.Time.now clock
        ; source = Dashboard
        }
-      : string);
+   with
+   | Ok receipt ->
+     check "older message receives the first durable revision"
+       (receipt.revision = 1L)
+   | Error _ -> check "older message enqueue succeeds" false);
   (match
      Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
        ~base_path:base
@@ -154,15 +170,17 @@ let test_existing_backlog_defers_new_dashboard_message () =
        (payload ~content:"newer dashboard message" ())
    with
    | `Queued len -> check "newer message joins existing backlog" (len = 2)
-   | `Not_busy -> check "existing backlog should force queue path" false);
-  (match Keeper_chat_queue.dequeue ~keeper_name with
-   | Some { Keeper_chat_queue.content; _ } ->
-     check "older queued message stays first" (String.equal content "older queued message")
-   | None -> check "older queued message is present" false);
-  (match Keeper_chat_queue.dequeue ~keeper_name with
-   | Some { Keeper_chat_queue.content; _ } ->
-     check "newer dashboard message stays second" (String.equal content "newer dashboard message")
-   | None -> check "newer queued message is present" false)
+   | `Not_busy | `Queue_error _ ->
+     check "existing backlog should force queue path" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  let pending_contents =
+    List.map
+      (fun (receipt : Keeper_chat_queue.active_receipt) ->
+         receipt.message.content)
+      snapshot.pending
+  in
+  check "durable snapshot preserves FIFO order"
+    (pending_contents = [ "older queued message"; "newer dashboard message" ])
 ;;
 
 let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
@@ -205,7 +223,7 @@ let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
     | Some (`Queued 1) ->
       check
         (Printf.sprintf "keeper %s queued exactly one message" keeper_name)
-        (Keeper_chat_queue.length ~keeper_name = 1)
+        (List.length (Keeper_chat_queue.snapshot ~keeper_name).pending = 1)
     | Some (`Queued n) ->
       check
         (Printf.sprintf "keeper %s queued exactly one message (got %d)" keeper_name n)
@@ -214,6 +232,10 @@ let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
       check
         (Printf.sprintf "keeper %s was busy and should defer" keeper_name)
         false
+    | Some (`Queue_error message) ->
+      check
+        (Printf.sprintf "keeper %s enqueue succeeded: %s" keeper_name message)
+        false
     | None ->
       check
         (Printf.sprintf "keeper %s defer fiber completed" keeper_name)
@@ -221,10 +243,37 @@ let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
   let total_queued =
     keeper_names
     |> List.fold_left
-         (fun acc keeper_name -> acc + Keeper_chat_queue.length ~keeper_name)
+         (fun acc keeper_name ->
+            acc + List.length (Keeper_chat_queue.snapshot ~keeper_name).pending)
          0
   in
   check "all busy dashboard messages are preserved" (total_queued = 8)
+;;
+
+let test_busy_dashboard_persist_failure_is_explicit () =
+  Printf.printf "Test: busy dashboard durable enqueue failure is explicit\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Eio.Switch.run
+  @@ fun sw ->
+  with_busy_slot ~base ~sw
+  @@ fun () ->
+  Keeper_chat_queue.For_testing.fail_next_persist ();
+  (match
+     Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
+       ~base_path:base
+       ~clock
+       (payload ~content:"do not acknowledge this as queued" ())
+   with
+   | `Queue_error message ->
+     check "dashboard receives the persistence error" (String.length message > 0)
+   | `Queued _ | `Not_busy ->
+     check "dashboard persistence failure never claims queued" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "dashboard failed enqueue leaves no pending receipt"
+    (snapshot.pending = []);
+  check "dashboard failed enqueue leaves revision unchanged"
+    (snapshot.revision = 0L)
 ;;
 
 let test_stream_headers_close_per_turn_response () =
@@ -243,6 +292,7 @@ let () =
   test_free_dashboard_not_enqueued ();
   test_existing_backlog_defers_new_dashboard_message ();
   test_concurrent_busy_dashboard_enqueues_are_per_keeper ();
+  test_busy_dashboard_persist_failure_is_explicit ();
   test_stream_headers_close_per_turn_response ();
   if !failures > 0
   then (

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -333,13 +333,13 @@ let test_persist_failures_roll_back () =
     "failed nack leaves original lease inflight"
     ((Keeper_chat_queue.snapshot ~keeper_name).inflight <> [])
 
-let v1_message_json content =
+let v1_message_json ?(source = `Assoc [ "kind", `String "dashboard" ]) content =
   `Assoc
     [ "content", `String content
     ; "user_blocks", `List []
     ; "attachments", `List []
     ; "timestamp", `Float 1.0
-    ; "source", `Assoc [ "kind", `String "dashboard" ]
+    ; "source", source
     ]
 
 let test_v1_atomic_migration () =
@@ -350,7 +350,18 @@ let test_v1_atomic_migration () =
   let v1 =
     `Assoc
       [ "schema", `String "keeper_chat_queue.v1"
-      ; "items", `List [ v1_message_json "legacy pending" ]
+      ; "items",
+        `List
+          [ v1_message_json "legacy pending"
+          ; v1_message_json
+              ~source:
+                (`Assoc
+                   [ "kind", `String "slack"
+                   ; "channel", `String "C-legacy"
+                   ; "user_id", `String "U-legacy"
+                   ])
+              "legacy slack"
+          ]
       ; ( "inflight"
         , `Assoc
             [ "lease_id", `String "legacy-lease"
@@ -362,7 +373,23 @@ let test_v1_atomic_migration () =
   let report = Keeper_chat_queue.configure_persistence ~base_path in
   check "migration is reported once" (report.migrated_keeper_count = 1);
   let migrated = Keeper_chat_queue.snapshot ~keeper_name in
-  check "legacy inflight is replayed ahead of pending" (List.length migrated.pending = 2);
+  check "legacy inflight is replayed ahead of pending" (List.length migrated.pending = 3);
+  (match List.nth_opt migrated.pending 2 with
+   | Some
+       { message =
+           { source =
+               Keeper_chat_queue.Slack
+                 { channel_id; user_id; user_name; team_id; thread_ts }
+           ; _
+           }
+       ; _
+       } ->
+     check "legacy Slack channel survives migration" (channel_id = "C-legacy");
+     check "legacy Slack user survives migration"
+       (user_id = "U-legacy" && user_name = "U-legacy");
+     check "legacy absent Slack context remains absent"
+       (team_id = None && thread_ts = None)
+   | _ -> check "legacy Slack source migrates explicitly" false);
   let migrated_ids = active_ids migrated.pending in
   check "migration mints durable ids" (List.for_all (( <> ) "") migrated_ids);
   Keeper_chat_queue.For_testing.reset ();
@@ -643,6 +670,80 @@ let test_snapshot_path_rejects_parent_segments () =
                 (Common.keepers_runtime_dir_of_base ~base_path))
              "chat-queue.json")))
 
+let test_writer_rejects_unloadable_values_before_commit () =
+  Printf.printf "Test: writer accepts only values the strict loader can replay\n%!";
+  with_base "keeper-chat-writer-schema" @@ fun base_path ->
+  let keeper_name = "writer-schema" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  (match
+     Keeper_chat_queue.enqueue ~keeper_name
+       (message
+          ~source:
+            (Keeper_chat_queue.Slack
+               { channel_id = ""
+               ; user_id = "U1"
+               ; user_name = "User"
+               ; team_id = None
+               ; thread_ts = Some "171.001"
+               })
+          "invalid source")
+   with
+   | Error (Keeper_chat_queue.Invalid_input _) ->
+     check "invalid source is rejected before acknowledgement" true
+   | Ok _ | Error _ -> check "invalid source is rejected before acknowledgement" false);
+  check "invalid source leaves the queue unchanged"
+    ((Keeper_chat_queue.snapshot ~keeper_name).pending = []);
+  ignore (enqueue_exn ~keeper_name (message "valid") : Keeper_chat_queue.enqueue_receipt);
+  let lease = lease_exn ~keeper_name in
+  (match
+     Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+       ~outcome:
+         (Mark_failed
+            { completed_at = 3.0
+            ; kind = Delivery_failed
+            ; detail = "   "
+            ; outcome_ref = None
+            })
+   with
+   | `Error (Keeper_chat_queue.Invalid_input _) ->
+     check "invalid terminal detail is rejected" true
+   | `Finalized _ | `Unknown_lease | `Error _ ->
+     check "invalid terminal detail is rejected" false);
+  check "rejected terminal update leaves receipt inflight"
+    (List.length (Keeper_chat_queue.snapshot ~keeper_name).inflight = 1)
+
+let test_control_bearing_prompt_roundtrips_byte_for_byte () =
+  Printf.printf "Test: JSON persistence does not sanitize prompt strings\n%!";
+  with_base "keeper-chat-control-text" @@ fun base_path ->
+  let keeper_name = "control-text" in
+  let content = "[STATE] Grep\nNEXT\tConstraints BDI\000tail" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  ignore (enqueue_exn ~keeper_name (message content) : Keeper_chat_queue.enqueue_receipt);
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "control-bearing prompt reload has no schema errors" (report.load_errors = []);
+  match (Keeper_chat_queue.snapshot ~keeper_name).pending with
+  | [ { message; _ } ] ->
+    check "prompt bytes are identical before and after restart"
+      (String.equal content message.content)
+  | _ -> check "one prompt receipt reloads" false
+
+let test_slack_threads_are_distinct_fifo_sources () =
+  Printf.printf "Test: Slack thread identity is a coalescing boundary\n%!";
+  let source thread_ts =
+    Keeper_chat_queue.Slack
+      { channel_id = "C1"
+      ; user_id = "U1"
+      ; user_name = "User"
+      ; team_id = Some "T1"
+      ; thread_ts = Some thread_ts
+      }
+  in
+  check "same actor in different Slack threads does not coalesce"
+    (not
+       (Keeper_chat_queue.same_source
+          (source "171.001")
+          (source "171.002")))
+
 let () =
   Eio_main.run @@ fun _environment ->
   test_durable_receipt_lifecycle ();
@@ -660,6 +761,9 @@ let () =
   test_post_commit_observer_is_central_and_unlocked ();
   test_reconfigure_does_not_leak_receipts_across_base_paths ();
   test_snapshot_path_rejects_parent_segments ();
+  test_writer_rejects_unloadable_values_before_commit ();
+  test_control_bearing_prompt_roundtrips_byte_for_byte ();
+  test_slack_threads_are_distinct_fifo_sources ();
   if !failures > 0
   then begin
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -1,45 +1,47 @@
-(* test_keeper_chat_coalescing.ml — chat queue coalescing (task-759) +
-   lease/ack/nack delivery semantics (PR-4a, 38-bug campaign #1).
-
-   Messages that accumulate while a keeper's turn is in flight must
-   drain as ONE same-source FIFO batch and merge into a single message;
-   different reply routes (dashboard vs Discord vs Slack, or different
-   channel/user) must never merge. Also covers the read-only
-   [Keeper_turn_admission.in_flight] accessor the consumer gates on, and
-   [Keeper_chat_queue]'s at-least-once lease/ack/nack contract: a leased
-   batch is durably recorded as inflight until it is acked (answered) or
-   nacked (retried), and a lease outstanding across a crash is requeued the
-   next time [configure_persistence] runs. *)
+(* Durable Keeper chat receipt lifecycle regression suite. *)
 
 open Masc
 
 let failures = ref 0
 
+let check name condition =
+  if condition
+  then Printf.printf "  ✓ %s\n%!" name
+  else begin
+    incr failures;
+    Printf.printf "  ✗ %s\n%!" name
+  end
+
 let temp_dir prefix = Filename.temp_dir prefix ""
 
 let rec rm_rf path =
   if Sys.file_exists path
-  then
-    if Sys.is_directory path
-    then (
-      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-      Unix.rmdir path)
+  then if Sys.is_directory path
+    then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
     else Unix.unlink path
-;;
 
-let check name cond =
-  if cond
-  then Printf.printf "  ✓ %s\n%!" name
-  else (
-    incr failures;
-    Printf.printf "  ✗ %s\n%!" name)
-;;
+let with_base prefix body =
+  let base_path = temp_dir prefix in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () -> body base_path)
 
-let msg ?(attachments = []) ~content ~ts source =
-  { Keeper_chat_queue.content; user_blocks = []; attachments; timestamp = ts; source }
-;;
+let message ?(source = Keeper_chat_queue.Dashboard) ?(timestamp = 1.0)
+    ?(user_blocks = []) ?(attachments = []) content =
+  { Keeper_chat_queue.content
+  ; user_blocks
+  ; attachments
+  ; timestamp
+  ; source
+  }
 
-let attachment ~id =
+let attachment id =
   { Keeper_chat_store.id
   ; att_type = "file"
   ; name = id ^ ".txt"
@@ -47,598 +49,620 @@ let attachment ~id =
   ; mime_type = "text/plain"
   ; data = "d"
   }
-;;
 
-let image_block ~attachment_id =
+let image_block attachment_id =
   Keeper_multimodal_input.User_image
-    { attachment_id; name = attachment_id ^ ".png"; mime_type = "image/png"; size = None }
-;;
+    { attachment_id
+    ; name = attachment_id ^ ".png"
+    ; mime_type = "image/png"
+    ; size = None
+    }
 
-let contents batch = List.map (fun m -> m.Keeper_chat_queue.content) batch
+let configure base_path =
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "persistence configure has no load errors" (report.load_errors = []);
+  report
 
-(* [enqueue]'s receipt_id is an ephemeral enqueue-time correlation token
-   (see keeper_chat_queue.mli), not part of the stored message — most tests
-   below don't need it and enqueue as a statement. *)
-let enqueue_ ~keeper_name m = ignore (Keeper_chat_queue.enqueue ~keeper_name m : string)
+let enqueue_exn ~keeper_name message =
+  match Keeper_chat_queue.enqueue ~keeper_name message with
+  | Ok receipt -> receipt
+  | Error error ->
+    check
+      ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
+      false;
+    failwith "enqueue failed"
 
-let chat_snapshot_path ~base_path ~keeper_name =
+let lease_exn ~keeper_name =
+  match Keeper_chat_queue.lease_batch ~keeper_name with
+  | `Leased lease -> lease
+  | `Empty ->
+    check "lease is non-empty" false;
+    failwith "empty lease"
+  | `Already_leased lease_id ->
+    check ("no outstanding lease: " ^ lease_id) false;
+    failwith "already leased"
+  | `Error error ->
+    check
+      ("lease succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
+      false;
+    failwith "lease failed"
+
+let ids items =
+  List.map
+    (fun (item : Keeper_chat_queue.leased_message) ->
+       Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
+    items
+
+let active_ids items =
+  List.map
+    (fun (item : Keeper_chat_queue.active_receipt) ->
+       Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
+    items
+
+let terminal_ids items =
+  List.map
+    (fun (item : Keeper_chat_queue.receipt_view) ->
+       Keeper_chat_queue.Receipt_id.to_string item.receipt_id)
+    items
+
+let snapshot_path ~base_path ~keeper_name =
   Filename.concat
     (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
     "chat-queue.json"
-;;
 
-let test_same_source () =
-  Printf.printf "Test 1: same_source pairs reply routes correctly\n%!";
-  let open Keeper_chat_queue in
-  check "dashboard ~ dashboard" (same_source Dashboard Dashboard);
-  check
-    "same Discord channel+user"
-    (same_source
-       (Discord { channel_id = "c1"; user_id = "u1" })
-       (Discord { channel_id = "c1"; user_id = "u1" }));
-  check
-    "different Discord user does not merge"
-    (not
-       (same_source
-          (Discord { channel_id = "c1"; user_id = "u1" })
-          (Discord { channel_id = "c1"; user_id = "u2" })));
-  check
-    "different Slack channel does not merge"
-    (not
-       (same_source
-          (Slack { channel = "a"; user_id = "u" })
-          (Slack { channel = "b"; user_id = "u" })));
-  check
-    "dashboard does not merge with Discord"
-    (not (same_source Dashboard (Discord { channel_id = "c"; user_id = "u" })))
-;;
+let save_raw path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error error -> failwith error
 
-(* [lease_batch] the head run, check its content, then [ack] it before
-   leasing the next run — a second [lease_batch] call while a lease is
-   outstanding returns [`Already_leased], it does not drain further. *)
-let lease_and_ack ~keeper_name =
-  match Keeper_chat_queue.lease_batch ~keeper_name with
-  | `Empty -> []
-  | `Already_leased lease_id ->
-    check
-      (Printf.sprintf "lease_and_ack: unexpected outstanding lease=%s" lease_id)
-      false;
-    []
-  | `Persist_failed msg ->
-    check (Printf.sprintf "lease_and_ack: unexpected persist failure: %s" msg) false;
-    []
-  | `Leased { lease_id; messages } ->
-    (match Keeper_chat_queue.ack ~keeper_name ~lease_id with
-     | `Acked -> ()
-     | `Unknown_lease -> check "lease_and_ack: ack found the lease it just took" false
-     | `Persist_failed msg ->
-       check (Printf.sprintf "lease_and_ack: ack persist failed: %s" msg) false);
-    messages
-;;
+let read_raw path =
+  let channel = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
 
-let test_lease_batch_runs () =
-  Printf.printf "Test 2: lease_batch drains same-source runs in FIFO order\n%!";
-  let keeper_name = "coalesce-runs" in
-  Keeper_chat_queue.clear ~keeper_name;
-  let discord = Keeper_chat_queue.Discord { channel_id = "c"; user_id = "u" } in
-  List.iter
-    (enqueue_ ~keeper_name)
-    [ msg ~content:"d1" ~ts:1.0 Keeper_chat_queue.Dashboard
-    ; msg ~content:"d2" ~ts:2.0 Keeper_chat_queue.Dashboard
-    ; msg ~content:"x1" ~ts:3.0 discord
-    ; msg ~content:"d3" ~ts:4.0 Keeper_chat_queue.Dashboard
-    ];
-  let first = lease_and_ack ~keeper_name in
-  check "first batch is the dashboard run" (contents first = [ "d1"; "d2" ]);
-  check "queue depth after first lease" (Keeper_chat_queue.length ~keeper_name = 2);
-  let second = lease_and_ack ~keeper_name in
-  check "second batch stops at the route boundary" (contents second = [ "x1" ]);
-  let third = lease_and_ack ~keeper_name in
-  check "third batch picks up the trailing dashboard message"
-    (contents third = [ "d3" ]);
-  check "queue is drained" (Keeper_chat_queue.lease_batch ~keeper_name = `Empty);
-  check "length is zero after drain" (Keeper_chat_queue.length ~keeper_name = 0)
-;;
+let test_durable_receipt_lifecycle () =
+  Printf.printf "Test: durable per-message Pending -> Inflight -> Delivered\n%!";
+  with_base "keeper-chat-receipt" @@ fun base_path ->
+  let keeper_name = "receipt-lifecycle" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  let enqueued = enqueue_exn ~keeper_name (message "keep this message") in
+  let receipt_id = Keeper_chat_queue.Receipt_id.to_string enqueued.receipt_id in
+  check "receipt is minted before committed enqueue returns" (receipt_id <> "");
+  check "enqueue revision is one" (Int64.equal enqueued.revision 1L);
+  let pending = Keeper_chat_queue.snapshot ~keeper_name in
+  check "receipt starts pending" (active_ids pending.pending = [ receipt_id ]);
+  let lease = lease_exn ~keeper_name in
+  check "lease carries the exact receipt" (ids lease.items = [ receipt_id ]);
+  let inflight = Keeper_chat_queue.snapshot ~keeper_name in
+  check "pending is empty while receipt is inflight" (inflight.pending = []);
+  check "diagnostic snapshot exposes inflight" (active_ids inflight.inflight = [ receipt_id ]);
+  (match
+     Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+       ~outcome:
+         (Keeper_chat_queue.Mark_delivered
+            { completed_at = 3.0; outcome_ref = Some "chat-row-1" })
+   with
+   | `Finalized receipt_ids ->
+     check
+       "finalize reports every receipt"
+       (List.map Keeper_chat_queue.Receipt_id.to_string receipt_ids = [ receipt_id ])
+   | `Unknown_lease | `Error _ -> check "finalize succeeds" false);
+  let terminal = Keeper_chat_queue.snapshot ~keeper_name in
+  check "terminal receipt leaves active queue" (terminal.pending = [] && terminal.inflight = []);
+  check "terminal receipt remains queryable" (terminal_ids terminal.terminal = [ receipt_id ]);
+  (match terminal.terminal with
+   | [ { state = Delivered { outcome_ref = Some "chat-row-1"; _ }; _ } ] ->
+     check "delivered outcome ref is durable" true
+   | _ -> check "delivered outcome ref is durable" false);
+  (match
+     Keeper_chat_queue.lookup_receipt ~keeper_name
+       ~receipt_id:enqueued.receipt_id
+   with
+   | Ok { revision; receipt = Some { state = Delivered _; _ } } ->
+     check "receipt lookup returns terminal state" true;
+     check "receipt lookup returns its atomic snapshot revision"
+       (Int64.equal revision terminal.revision)
+   | Ok { receipt = Some _; _ } | Ok { receipt = None; _ } | Error _ ->
+     check "receipt lookup returns terminal state" false;
+     check "receipt lookup returns its atomic snapshot revision" false);
+  let persisted =
+    Safe_ops.read_json_file_safe (snapshot_path ~base_path ~keeper_name)
+  in
+  (match persisted with
+   | Error _ -> check "terminal snapshot is readable" false
+   | Ok (`Assoc fields) ->
+     (match List.assoc_opt "receipts" fields with
+      | Some (`List [ `Assoc receipt_fields ]) ->
+        check
+          "terminal record discards message body"
+          (not (List.mem_assoc "message" receipt_fields))
+      | _ -> check "terminal record is present" false)
+   | Ok _ -> check "terminal snapshot is an object" false)
 
-let test_merge_batch () =
-  Printf.printf "Test 3: merge_batch coalesces content and attachments\n%!";
-  let single = msg ~content:"only" ~ts:5.0 Keeper_chat_queue.Dashboard in
-  (match Keeper_chat_queue.merge_batch [ single ] with
-   | Some m -> check "singleton is returned unchanged" (m = single)
-   | None -> check "singleton is returned unchanged" false);
-  check "empty batch merges to None" (Keeper_chat_queue.merge_batch [] = None);
-  let batch =
-    [ msg ~content:"first" ~ts:1.0 ~attachments:[ attachment ~id:"a" ]
-        Keeper_chat_queue.Dashboard
-    ; { (msg ~content:"second" ~ts:2.0 Keeper_chat_queue.Dashboard) with
-        Keeper_chat_queue.user_blocks = [ image_block ~attachment_id:"att-img" ] }
-    ; msg ~content:"third" ~ts:3.0 ~attachments:[ attachment ~id:"b" ]
-        Keeper_chat_queue.Dashboard
+let test_coalesced_finalize_preserves_all_receipts () =
+  Printf.printf "Test: coalescing never erases per-message receipts\n%!";
+  with_base "keeper-chat-coalesce-receipts" @@ fun base_path ->
+  let keeper_name = "coalesced-receipts" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  let first =
+    enqueue_exn ~keeper_name
+      (message ~timestamp:1.0 ~attachments:[ attachment "first" ] "first")
+  in
+  let second =
+    enqueue_exn ~keeper_name
+      (message ~timestamp:2.0 ~user_blocks:[ image_block "second-image" ]
+         ~attachments:[ attachment "second" ] "second")
+  in
+  let expected =
+    [ Keeper_chat_queue.Receipt_id.to_string first.receipt_id
+    ; Keeper_chat_queue.Receipt_id.to_string second.receipt_id
     ]
   in
-  match Keeper_chat_queue.merge_batch batch with
-  | None -> check "merged batch exists" false
-  | Some m ->
-    check
-      "contents join in arrival order with blank lines"
-      (String.equal m.Keeper_chat_queue.content "first\n\nsecond\n\nthird");
-    check
-      "attachments concatenate in order"
-      (List.map
-         (fun (a : Keeper_chat_store.attachment) -> a.Keeper_chat_store.id)
-         m.Keeper_chat_queue.attachments
-       = [ "a"; "b" ]);
-    check
-      "semantic user blocks concatenate in order"
-      (Keeper_multimodal_input.modalities m.Keeper_chat_queue.user_blocks
-       = [ "image" ]);
-    check "timestamp is the first message's" (m.Keeper_chat_queue.timestamp = 1.0);
-    check
-      "source is the shared route"
-      (Keeper_chat_queue.same_source m.Keeper_chat_queue.source
-         Keeper_chat_queue.Dashboard)
-;;
+  let lease = lease_exn ~keeper_name in
+  check "one lease carries both receipt ids" (ids lease.items = expected);
+  (match Keeper_chat_queue.merge_batch lease.items with
+   | Some merged ->
+     check "coalesced content remains FIFO" (merged.content = "first\n\nsecond");
+     check "coalesced attachments remain FIFO"
+       (List.map
+          (fun (item : Keeper_chat_store.attachment) -> item.id)
+          merged.attachments
+        = [ "first"; "second" ]);
+     check "coalesced semantic blocks remain visible"
+       (Keeper_multimodal_input.modalities merged.user_blocks = [ "image" ]);
+     check "coalesced timestamp belongs to the head receipt"
+       (Float.equal merged.timestamp 1.0)
+   | None -> check "coalesced payload exists" false);
+  (match
+     Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+       ~outcome:
+         (Mark_failed
+            { completed_at = 4.0
+            ; kind = Turn_failed
+            ; detail = "provider returned a terminal error"
+            ; outcome_ref = Some "failure-row-1"
+            })
+   with
+   | `Finalized receipt_ids ->
+     check
+       "failed coalesced turn finalizes each receipt"
+       (List.map Keeper_chat_queue.Receipt_id.to_string receipt_ids = expected)
+   | `Unknown_lease | `Error _ -> check "coalesced finalization succeeds" false);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "both failed receipts remain queryable" (terminal_ids snapshot.terminal = expected)
 
-let test_in_flight_accessor () =
-  Printf.printf "Test 4: in_flight reflects the slot the consumer gates on\n%!";
-  Keeper_turn_admission.For_testing.reset ();
-  let base_path = "/tmp/masc_test_chat_coalescing" in
-  let keeper_name = "coalesce-keeper" in
-  check
-    "unknown keeper reads as free"
-    (Keeper_turn_admission.in_flight ~base_path ~keeper_name = None);
-  Eio.Switch.run (fun sw ->
-    let started, set_started = Eio.Promise.create () in
-    let release, set_release = Eio.Promise.create () in
-    Eio.Fiber.fork ~sw (fun () ->
-      ignore
-        (Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () ->
-           Eio.Promise.resolve set_started ();
-           Eio.Promise.await release)));
-    Eio.Promise.await started;
-    (match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
-     | Some { Keeper_turn_admission.lane = Chat; _ } ->
-       check "in-flight chat turn is visible" true
-     | Some _ | None -> check "in-flight chat turn is visible" false);
-    Eio.Promise.resolve set_release ());
-  check
-    "slot reads as free again after release"
-    (Keeper_turn_admission.in_flight ~base_path ~keeper_name = None)
-;;
-
-let test_persistence_replay () =
-  Printf.printf "Test 5: queued chat messages persist and replay after restart\n%!";
-  let base_path = temp_dir "keeper-chat-queue-persistence" in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_chat_queue.For_testing.reset ();
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "chat-queue-persistence" in
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      enqueue_ ~keeper_name
-        { (msg ~content:"persist-1" ~ts:1.0 ~attachments:[ attachment ~id:"persist-a" ]
-             Keeper_chat_queue.Dashboard)
-          with
-          Keeper_chat_queue.user_blocks = [ image_block ~attachment_id:"persist-a" ]
-        };
-      enqueue_ ~keeper_name (msg ~content:"persist-2" ~ts:2.0 Keeper_chat_queue.Dashboard);
-      check
-        "snapshot file is written"
-        (Sys.file_exists (chat_snapshot_path ~base_path ~keeper_name));
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      check
-        "restored keeper name is visible to consumer"
-        (List.mem keeper_name (Keeper_chat_queue.all_keeper_names ()));
-      let batch = lease_and_ack ~keeper_name in
-      check "replayed batch preserves FIFO content" (contents batch = [ "persist-1"; "persist-2" ]);
-      check "queue is empty after replay drain" (Keeper_chat_queue.length ~keeper_name = 0);
-      (match batch with
-       | first :: _ ->
-         check
-           "replayed source route is preserved"
-           (Keeper_chat_queue.same_source
-              first.Keeper_chat_queue.source
-              Keeper_chat_queue.Dashboard);
-         check
-           "replayed attachment survives"
-           (List.map
-              (fun (a : Keeper_chat_store.attachment) -> a.Keeper_chat_store.id)
-              first.Keeper_chat_queue.attachments
-            = [ "persist-a" ]);
-         check
-           "replayed semantic user block survives"
-           (Keeper_multimodal_input.modalities first.Keeper_chat_queue.user_blocks
-            = [ "image" ])
-       | [] -> check "replayed batch is non-empty" false);
-      (* The batch above was leased AND acked, so a third restart — with no
-         inflight lease and an empty queue on disk — finds nothing to
-         replay. *)
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      check
-        "empty persisted queue does not replay after drain"
-        (Keeper_chat_queue.lease_batch ~keeper_name = `Empty))
-;;
-
-let test_lease_persist_failure_does_not_acknowledge () =
-  Printf.printf
-    "Test 6: a failed lease persist reports Persist_failed and leaves the \
-     queue intact\n%!";
-  let base_path = temp_dir "keeper-chat-queue-persist-failure" in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_chat_queue.For_testing.reset ();
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "chat-queue-persist-failure" in
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      enqueue_ ~keeper_name (msg ~content:"must-not-ack" ~ts:1.0 Keeper_chat_queue.Dashboard);
-      Keeper_chat_queue.For_testing.fail_next_persist ();
-      (match Keeper_chat_queue.lease_batch ~keeper_name with
-       | `Persist_failed _ ->
-         check "lease_batch reports Persist_failed instead of raising" true
-       | `Leased _ | `Empty | `Already_leased _ ->
-         check "lease_batch reports Persist_failed instead of raising" false);
-      check
-        "in-memory queue rolls back after failed lease persist"
-        (Keeper_chat_queue.length ~keeper_name = 1);
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      check
-        "stale snapshot replays the unleased message exactly once"
-        (contents (lease_and_ack ~keeper_name) = [ "must-not-ack" ]))
-;;
-
-let test_configure_persistence_prepends_snapshot_to_live_queue () =
-  Printf.printf "Test 7: restart snapshot prepends ahead of live bootstrap messages\n%!";
-  let base_path = temp_dir "keeper-chat-queue-prepend" in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_chat_queue.For_testing.reset ();
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "chat-queue-prepend" in
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      enqueue_ ~keeper_name
-        (msg ~content:"snapshot-before-restart" ~ts:1.0 Keeper_chat_queue.Dashboard);
-      Keeper_chat_queue.For_testing.reset ();
-      enqueue_ ~keeper_name
-        (msg ~content:"live-during-bootstrap" ~ts:2.0 Keeper_chat_queue.Dashboard);
-      Keeper_chat_queue.configure_persistence ~base_path;
-      check
-        "snapshot messages are not dropped when live queue is non-empty"
-        (contents (lease_and_ack ~keeper_name)
-         = [ "snapshot-before-restart"; "live-during-bootstrap" ]))
-;;
-
-let test_remove_matching_single_from_head_run () =
-  Printf.printf "Test 8: remove_matching drops exactly one head-run match\n%!";
-  let keeper_name = "remove-matching-single" in
-  Keeper_chat_queue.clear ~keeper_name;
-  let dash content ts = msg ~content ~ts Keeper_chat_queue.Dashboard in
-  (* Two structurally identical dashboard messages plus a same-source tail, all
-     inside one head run. Removing the duplicate target drops exactly one copy. *)
-  let dup = dash "dup" 1.0 in
-  List.iter (enqueue_ ~keeper_name) [ dup; dup; dash "tail" 3.0 ];
-  (match Keeper_chat_queue.remove_matching ~keeper_name dup with
-   | `Removed -> check "duplicate head-run message reports Removed" true
-   | `Not_found | `Persist_failed _ ->
-     check "duplicate head-run message reports Removed" false);
-  check "exactly one duplicate is removed" (Keeper_chat_queue.length ~keeper_name = 2);
-  check
-    "the other duplicate and tail survive in FIFO order"
-    (contents (lease_and_ack ~keeper_name) = [ "dup"; "tail" ]);
-  (* A match in the middle of the head run is removed without touching the
-     messages before it. *)
-  Keeper_chat_queue.clear ~keeper_name;
-  let mid = dash "mid" 2.0 in
+let test_source_boundaries_preserve_fifo_runs () =
+  Printf.printf "Test: lease batches stop at typed connector source boundaries\n%!";
+  with_base "keeper-chat-source-boundary" @@ fun base_path ->
+  let keeper_name = "source-boundary" in
+  let discord =
+    Keeper_chat_queue.Discord { channel_id = "channel"; user_id = "user" }
+  in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
   List.iter
-    (enqueue_ ~keeper_name)
-    [ dash "head" 1.0; mid; dash "after" 3.0 ];
-  (match Keeper_chat_queue.remove_matching ~keeper_name mid with
-   | `Removed -> check "mid-run match reports Removed" true
-   | `Not_found | `Persist_failed _ -> check "mid-run match reports Removed" false);
-  check
-    "mid-run removal keeps the surrounding messages"
-    (contents (lease_and_ack ~keeper_name) = [ "head"; "after" ])
-;;
-
-let test_remove_matching_not_found () =
-  Printf.printf "Test 9: remove_matching reports Not_found off the head run\n%!";
-  let absent = msg ~content:"anything" ~ts:1.0 Keeper_chat_queue.Dashboard in
-  check
-    "absent keeper reports Not_found"
-    (Keeper_chat_queue.remove_matching ~keeper_name:"remove-matching-absent" absent
-     = `Not_found);
-  let keeper_name = "remove-matching-notfound" in
-  Keeper_chat_queue.clear ~keeper_name;
-  check
-    "empty queue reports Not_found"
-    (Keeper_chat_queue.remove_matching ~keeper_name absent = `Not_found);
-  (* A dashboard head run followed by a Discord message: the Discord target is
-     past the head-run boundary, so it is not removed and the queue is intact. *)
-  let discord = Keeper_chat_queue.Discord { channel_id = "c"; user_id = "u" } in
-  let beyond = msg ~content:"x1" ~ts:2.0 discord in
-  List.iter
-    (enqueue_ ~keeper_name)
-    [ msg ~content:"d1" ~ts:1.0 Keeper_chat_queue.Dashboard; beyond ];
-  check
-    "match beyond the head-run boundary reports Not_found"
-    (Keeper_chat_queue.remove_matching ~keeper_name beyond = `Not_found);
-  check "queue is unchanged after Not_found" (Keeper_chat_queue.length ~keeper_name = 2);
-  check
-    "an unqueued target reports Not_found"
-    (Keeper_chat_queue.remove_matching ~keeper_name
-       (msg ~content:"nope" ~ts:9.0 Keeper_chat_queue.Dashboard)
-     = `Not_found);
-  Keeper_chat_queue.clear ~keeper_name;
-  let with_block =
-    { (msg ~content:"same-text" ~ts:3.0 Keeper_chat_queue.Dashboard) with
-      Keeper_chat_queue.user_blocks = [ image_block ~attachment_id:"img-1" ] }
-  in
-  let without_block = msg ~content:"same-text" ~ts:3.0 Keeper_chat_queue.Dashboard in
-  enqueue_ ~keeper_name with_block;
-  check
-    "same text/source/timestamp but different user_blocks reports Not_found"
-    (Keeper_chat_queue.remove_matching ~keeper_name without_block = `Not_found);
-  check
-    "near-match payload stays queued"
-    (match lease_and_ack ~keeper_name with
-     | [ msg ] ->
-       Keeper_multimodal_input.modalities msg.Keeper_chat_queue.user_blocks = [ "image" ]
-     | _ -> false)
-;;
-
-let test_remove_matching_persist_failure_aborts () =
-  Printf.printf "Test 10: failed remove_matching persist leaves the queue intact\n%!";
-  let base_path = temp_dir "keeper-chat-queue-remove-persist-failure" in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_chat_queue.For_testing.reset ();
-      rm_rf base_path)
-    (fun () ->
-      let keeper_name = "chat-queue-remove-persist-failure" in
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      let target = msg ~content:"keep-me" ~ts:1.0 Keeper_chat_queue.Dashboard in
-      List.iter
-        (enqueue_ ~keeper_name)
-        [ target; msg ~content:"keep-me-too" ~ts:2.0 Keeper_chat_queue.Dashboard ];
-      Keeper_chat_queue.For_testing.fail_next_persist ();
-      (match Keeper_chat_queue.remove_matching ~keeper_name target with
-       | `Persist_failed _ ->
-         check "snapshot rewrite failure reports Persist_failed" true
-       | `Removed | `Not_found ->
-         check "snapshot rewrite failure reports Persist_failed" false);
-      check
-        "in-memory queue rolls back after failed remove persist"
-        (Keeper_chat_queue.length ~keeper_name = 2);
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      check
-        "stale snapshot still replays both messages exactly once"
-        (contents (lease_and_ack ~keeper_name)
-         = [ "keep-me"; "keep-me-too" ]))
-;;
-
-let test_remove_matching_lease_batch_exactly_once () =
-  Printf.printf
-    "Test 11: lease_batch and remove_matching answer each message once\n%!";
-  (* Single-domain Eio serializes remove_matching and lease_batch through the
-     shared per-keeper mutex; the two argument orders below enumerate the two
-     possible linearizations. In each, the target must be answered by exactly
-     one path — removed XOR present in the leased batch, never both, never
-     neither — and the queue must drain fully (no outstanding lease left
-     behind: the winning side's lease is acked immediately in this test). *)
-  let discord = Keeper_chat_queue.Discord { channel_id = "c"; user_id = "u" } in
-  let m1 = msg ~content:"m1" ~ts:1.0 discord in
-  let m2 = msg ~content:"m2" ~ts:2.0 discord in
-  let in_batch content batch =
-    List.exists (fun m -> String.equal m.Keeper_chat_queue.content content) batch
-  in
-  let run_race label ~remove_first =
-    let keeper_name = "remove-race-" ^ label in
-    Keeper_chat_queue.clear ~keeper_name;
-    List.iter (enqueue_ ~keeper_name) [ m1; m2 ];
-    let removed = ref `Not_found in
-    let batch = ref [] in
-    let do_remove () =
-      removed := Keeper_chat_queue.remove_matching ~keeper_name m1
-    in
-    let do_dequeue () = batch := lease_and_ack ~keeper_name in
-    if remove_first
-    then Eio.Fiber.both do_remove do_dequeue
-    else Eio.Fiber.both do_dequeue do_remove;
-    let m1_removed = !removed = `Removed in
-    let m1_dequeued = in_batch "m1" !batch in
-    check (label ^ ": m1 is answered by exactly one path") (m1_removed <> m1_dequeued);
-    check (label ^ ": m2 ends up in the leased batch") (in_batch "m2" !batch);
-    check (label ^ ": queue is fully drained") (Keeper_chat_queue.length ~keeper_name = 0)
-  in
-  run_race "remove-first" ~remove_first:true;
-  run_race "dequeue-first" ~remove_first:false
-;;
-
-let test_receipt_id_round_trip () =
-  Printf.printf
-    "Test 12: enqueue mints a distinct receipt_id per message\n%!";
-  let keeper_name = "receipt-id-keeper" in
-  Keeper_chat_queue.clear ~keeper_name;
-  let r1 =
-    Keeper_chat_queue.enqueue ~keeper_name
-      (msg ~content:"one" ~ts:1.0 Keeper_chat_queue.Dashboard)
-  in
-  let r2 =
-    Keeper_chat_queue.enqueue ~keeper_name
-      (msg ~content:"two" ~ts:2.0 Keeper_chat_queue.Dashboard)
-  in
-  check "receipt_id is non-empty" (String.length r1 > 0 && String.length r2 > 0);
-  check "successive receipt_ids are distinct" (not (String.equal r1 r2));
-  ignore (lease_and_ack ~keeper_name : Keeper_chat_queue.queued_message list)
-;;
-
-let test_lease_ack_nack_lifecycle () =
-  Printf.printf
-    "Test 13: ack removes a lease permanently, nack requeues it for retry\n%!";
-  let ack_keeper = "lease-ack-keeper" in
-  Keeper_chat_queue.clear ~keeper_name:ack_keeper;
-  enqueue_ ~keeper_name:ack_keeper (msg ~content:"answered" ~ts:1.0 Keeper_chat_queue.Dashboard);
-  (match Keeper_chat_queue.lease_batch ~keeper_name:ack_keeper with
-   | `Leased { lease_id; messages } ->
-     check "leased batch carries the queued message" (contents messages = [ "answered" ]);
-     check "leased message no longer counts toward length"
-       (Keeper_chat_queue.length ~keeper_name:ack_keeper = 0);
-     (match Keeper_chat_queue.ack ~keeper_name:ack_keeper ~lease_id with
-      | `Acked -> check "ack succeeds for the current lease" true
-      | `Unknown_lease | `Persist_failed _ -> check "ack succeeds for the current lease" false)
-   | `Empty | `Already_leased _ | `Persist_failed _ ->
-     check "lease_batch leases the enqueued message" false);
-  check "acked message never returns"
-    (Keeper_chat_queue.lease_batch ~keeper_name:ack_keeper = `Empty);
-  let nack_keeper = "lease-nack-keeper" in
-  Keeper_chat_queue.clear ~keeper_name:nack_keeper;
-  enqueue_ ~keeper_name:nack_keeper (msg ~content:"retry-me" ~ts:1.0 Keeper_chat_queue.Dashboard);
-  (match Keeper_chat_queue.lease_batch ~keeper_name:nack_keeper with
-   | `Leased { lease_id; _ } -> (
-     (* A message arrives while the lease is outstanding — it must land
-        behind the nacked (retried) batch, not in front of it, when the
-        lease is returned to the queue. *)
-     enqueue_ ~keeper_name:nack_keeper
-       (msg ~content:"arrived-during-lease" ~ts:2.0 Keeper_chat_queue.Dashboard);
-     match Keeper_chat_queue.nack ~keeper_name:nack_keeper ~lease_id with
-     | `Requeued -> check "nack succeeds for the current lease" true
-     | `Unknown_lease | `Persist_failed _ -> check "nack succeeds for the current lease" false)
-   | `Empty | `Already_leased _ | `Persist_failed _ ->
-     check "lease_batch leases the enqueued message" false);
-  check "nacked message is queued again ahead of newer arrivals"
-    (Keeper_chat_queue.length ~keeper_name:nack_keeper = 2);
-  (match Keeper_chat_queue.lease_batch ~keeper_name:nack_keeper with
-   | `Leased { messages; _ } ->
-     check "retry preserves FIFO order across the nack"
-       (contents messages = [ "retry-me"; "arrived-during-lease" ])
-   | `Empty | `Already_leased _ | `Persist_failed _ ->
-     check "the requeued batch is leaseable again" false)
-;;
-
-let test_lease_already_leased_blocks_second_lease () =
-  Printf.printf
-    "Test 14: a second lease_batch call while one is outstanding reports \
-     Already_leased and does not touch the queue\n%!";
-  let keeper_name = "double-lease-keeper" in
-  Keeper_chat_queue.clear ~keeper_name;
-  List.iter
-    (enqueue_ ~keeper_name)
-    [ msg ~content:"a" ~ts:1.0 Keeper_chat_queue.Dashboard
-    ; msg ~content:"b" ~ts:2.0 Keeper_chat_queue.Dashboard
+    (fun queued -> ignore (enqueue_exn ~keeper_name queued : Keeper_chat_queue.enqueue_receipt))
+    [ message ~timestamp:1.0 "dashboard-1"
+    ; message ~timestamp:2.0 "dashboard-2"
+    ; message ~source:discord ~timestamp:3.0 "discord"
+    ; message ~timestamp:4.0 "dashboard-3"
     ];
-  match Keeper_chat_queue.lease_batch ~keeper_name with
-  | `Leased { lease_id = first_lease_id; _ } -> (
-    match Keeper_chat_queue.lease_batch ~keeper_name with
-    | `Already_leased lease_id ->
-      check "second lease reports the same outstanding lease_id"
-        (String.equal lease_id first_lease_id)
-    | `Leased _ | `Empty | `Persist_failed _ ->
-      check "a second lease_batch call is refused while one is outstanding" false)
-  | `Empty | `Already_leased _ | `Persist_failed _ ->
-    check "lease_batch leases the enqueued run" false
-;;
+  let take expected =
+    let lease = lease_exn ~keeper_name in
+    check "lease keeps one same-source FIFO run"
+      (List.map
+         (fun (item : Keeper_chat_queue.leased_message) -> item.message.content)
+         lease.items
+       = expected);
+    ignore
+      (Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+         ~outcome:
+           (Mark_delivered { completed_at = 4.0; outcome_ref = None }))
+  in
+  take [ "dashboard-1"; "dashboard-2" ];
+  take [ "discord" ];
+  take [ "dashboard-3" ];
+  check "all typed source runs drain without reordering"
+    (match Keeper_chat_queue.lease_batch ~keeper_name with
+     | `Empty -> true
+     | `Leased _ | `Already_leased _ | `Error _ -> false)
 
-let test_ack_nack_unknown_lease () =
-  Printf.printf
-    "Test 15: ack/nack with a stale or absent lease_id report Unknown_lease\n%!";
-  let keeper_name = "unknown-lease-keeper" in
-  Keeper_chat_queue.clear ~keeper_name;
+let test_nack_and_restart_preserve_receipt () =
+  Printf.printf "Test: nack and restart replay preserve receipt identity\n%!";
+  with_base "keeper-chat-replay-receipt" @@ fun base_path ->
+  let keeper_name = "replay-receipt" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  let enqueued = enqueue_exn ~keeper_name (message "retry me") in
+  let expected = Keeper_chat_queue.Receipt_id.to_string enqueued.receipt_id in
+  let first_lease = lease_exn ~keeper_name in
+  (match Keeper_chat_queue.nack ~keeper_name ~lease_id:first_lease.lease_id with
+   | `Requeued receipt_ids ->
+     check
+       "nack reports original receipt"
+       (List.map Keeper_chat_queue.Receipt_id.to_string receipt_ids = [ expected ])
+   | `Unknown_lease | `Error _ -> check "nack succeeds" false);
   check
-    "ack on an absent keeper reports Unknown_lease"
-    (Keeper_chat_queue.ack ~keeper_name:"never-existed" ~lease_id:"lease_x" = `Unknown_lease);
+    "nack returns same receipt to pending"
+    (active_ids (Keeper_chat_queue.snapshot ~keeper_name).pending = [ expected ]);
+  let crash_lease = lease_exn ~keeper_name in
+  check "receipt is inflight before simulated crash" (ids crash_lease.items = [ expected ]);
+  Keeper_chat_queue.For_testing.reset ();
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "restart recovery is reported" (report.recovered_receipt_count = 1);
+  let replay = Keeper_chat_queue.snapshot ~keeper_name in
+  check "restart moves inflight back to pending" (replay.inflight = []);
+  check "restart preserves receipt id" (active_ids replay.pending = [ expected ])
+
+let test_persist_failures_roll_back () =
+  Printf.printf "Test: every lifecycle persistence failure rolls back\n%!";
+  with_base "keeper-chat-rollback" @@ fun base_path ->
+  let keeper_name = "receipt-rollback" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  let first = enqueue_exn ~keeper_name (message "first") in
+  Keeper_chat_queue.For_testing.fail_next_persist ();
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must roll back") with
+   | Error (Persist_failed _) -> check "failed enqueue is typed" true
+   | Ok _ | Error _ -> check "failed enqueue is typed" false);
   check
-    "nack on an absent keeper reports Unknown_lease"
-    (Keeper_chat_queue.nack ~keeper_name:"never-existed" ~lease_id:"lease_x" = `Unknown_lease);
-  enqueue_ ~keeper_name (msg ~content:"solo" ~ts:1.0 Keeper_chat_queue.Dashboard);
+    "failed enqueue leaves prior pending receipt unchanged"
+    (active_ids (Keeper_chat_queue.snapshot ~keeper_name).pending
+     = [ Keeper_chat_queue.Receipt_id.to_string first.receipt_id ]);
+  Keeper_chat_queue.For_testing.fail_next_persist ();
   (match Keeper_chat_queue.lease_batch ~keeper_name with
-   | `Leased { lease_id; _ } ->
-     check
-       "ack with the wrong lease_id reports Unknown_lease"
-       (Keeper_chat_queue.ack ~keeper_name ~lease_id:(lease_id ^ "-stale") = `Unknown_lease);
-     (match Keeper_chat_queue.ack ~keeper_name ~lease_id with
-      | `Acked -> ()
-      | `Unknown_lease | `Persist_failed _ -> check "ack the real lease to clean up" false);
-     check
-       "acking an already-acked lease reports Unknown_lease"
-       (Keeper_chat_queue.ack ~keeper_name ~lease_id = `Unknown_lease);
-     check
-       "nacking an already-acked lease reports Unknown_lease"
-       (Keeper_chat_queue.nack ~keeper_name ~lease_id = `Unknown_lease)
-   | `Empty | `Already_leased _ | `Persist_failed _ ->
-     check "lease_batch leases the enqueued message" false)
-;;
+   | `Error (Persist_failed _) -> check "failed lease is typed" true
+   | `Leased _ | `Empty | `Already_leased _ | `Error _ -> check "failed lease is typed" false);
+  check "failed lease leaves receipt pending" ((Keeper_chat_queue.snapshot ~keeper_name).inflight = []);
+  let lease = lease_exn ~keeper_name in
+  Keeper_chat_queue.For_testing.fail_next_persist ();
+  (match
+     Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+       ~outcome:(Mark_delivered { completed_at = 5.0; outcome_ref = None })
+   with
+   | `Error (Persist_failed _) -> check "failed finalize is typed" true
+   | `Finalized _ | `Unknown_lease | `Error _ -> check "failed finalize is typed" false);
+  check
+    "failed finalize leaves original lease inflight"
+    (active_ids (Keeper_chat_queue.snapshot ~keeper_name).inflight
+     = [ Keeper_chat_queue.Receipt_id.to_string first.receipt_id ]);
+  Keeper_chat_queue.For_testing.fail_next_persist ();
+  (match Keeper_chat_queue.nack ~keeper_name ~lease_id:lease.lease_id with
+   | `Error (Persist_failed _) -> check "failed nack is typed" true
+   | `Requeued _ | `Unknown_lease | `Error _ -> check "failed nack is typed" false);
+  check
+    "failed nack leaves original lease inflight"
+    ((Keeper_chat_queue.snapshot ~keeper_name).inflight <> [])
 
-let test_inflight_lease_requeued_on_restart () =
-  Printf.printf
-    "Test 16: a lease outstanding when the process dies is requeued on the \
-     next configure_persistence (at-least-once redelivery)\n%!";
-  let base_path = temp_dir "keeper-chat-queue-inflight-crash" in
+let v1_message_json content =
+  `Assoc
+    [ "content", `String content
+    ; "user_blocks", `List []
+    ; "attachments", `List []
+    ; "timestamp", `Float 1.0
+    ; "source", `Assoc [ "kind", `String "dashboard" ]
+    ]
+
+let test_v1_atomic_migration () =
+  Printf.printf "Test: v1 has one explicit atomic migration to strict v2\n%!";
+  with_base "keeper-chat-v1-migration" @@ fun base_path ->
+  let keeper_name = "v1-migration" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let v1 =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v1"
+      ; "items", `List [ v1_message_json "legacy pending" ]
+      ; ( "inflight"
+        , `Assoc
+            [ "lease_id", `String "legacy-lease"
+            ; "items", `List [ v1_message_json "legacy inflight" ]
+            ] )
+      ]
+  in
+  save_raw path (Yojson.Safe.pretty_to_string v1);
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "migration is reported once" (report.migrated_keeper_count = 1);
+  let migrated = Keeper_chat_queue.snapshot ~keeper_name in
+  check "legacy inflight is replayed ahead of pending" (List.length migrated.pending = 2);
+  let migrated_ids = active_ids migrated.pending in
+  check "migration mints durable ids" (List.for_all (( <> ) "") migrated_ids);
+  Keeper_chat_queue.For_testing.reset ();
+  let second_report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "v2 is not migrated again" (second_report.migrated_keeper_count = 0);
+  check
+    "migrated ids survive another restart"
+    (active_ids (Keeper_chat_queue.snapshot ~keeper_name).pending = migrated_ids);
+  (match Safe_ops.read_json_file_safe path with
+   | Ok json ->
+     check
+       "migration atomically rewrites strict v2 schema"
+       (Json_util.get_string json "schema" = Some "keeper_chat_queue.v2")
+   | Error _ -> check "migrated snapshot is readable" false)
+
+let test_corrupt_snapshot_is_quarantined () =
+  Printf.printf "Test: corrupt snapshot is explicit and never overwritten as empty\n%!";
+  with_base "keeper-chat-corrupt" @@ fun base_path ->
+  let keeper_name = "corrupt-snapshot" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let corrupt = "{ definitely-not-json" in
+  save_raw path corrupt;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "configure reports corrupt keeper" (List.length report.load_errors = 1);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "diagnostic snapshot carries load error" (List.length snapshot.load_errors = 1);
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must not overwrite") with
+   | Error (Snapshot_unavailable { kind = Read_failed; _ }) ->
+     check "enqueue fails closed on unreadable snapshot" true
+   | Error (Snapshot_unavailable { kind = Parse_failed; _ }) ->
+     check "enqueue fails closed on malformed snapshot" true
+   | Ok _ | Error _ -> check "enqueue fails closed on corrupt snapshot" false);
+  let unknown_id =
+    match
+      Keeper_chat_queue.Receipt_id.of_string
+        "chatq_00000000-0000-4000-8000-000000000001"
+    with
+    | Ok receipt_id -> receipt_id
+    | Error error -> failwith error
+  in
+  (match Keeper_chat_queue.lookup_receipt ~keeper_name ~receipt_id:unknown_id with
+   | Error (Snapshot_unavailable _) ->
+     check "receipt lookup does not collapse unreadable into absent" true
+   | Ok _ | Error _ ->
+     check "receipt lookup does not collapse unreadable into absent" false);
+  check "corrupt bytes remain untouched" (String.equal (read_raw path) corrupt)
+
+let test_invalid_v2_is_not_a_compatibility_fallback () =
+  Printf.printf "Test: malformed v2 is a parse error, never an empty fallback\n%!";
+  with_base "keeper-chat-invalid-v2" @@ fun base_path ->
+  let keeper_name = "invalid-v2" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let invalid_v2 =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v2"
+      ; "revision", `Int 9
+      ; "receipts",
+        `List
+          [ `Assoc
+              [ "receipt_id",
+                `String "chatq_00000000-0000-4000-8000-000000000009"
+              ; "state", `Assoc [ "kind", `String "inflight" ]
+              ]
+          ]
+      ]
+    |> Yojson.Safe.pretty_to_string
+  in
+  save_raw path invalid_v2;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  (match report.load_errors with
+   | [ (Some name, { kind = Parse_failed; _ }) ] ->
+     check "strict v2 parse failure names the keeper" (name = keeper_name)
+   | _ -> check "strict v2 parse failure is explicit" false);
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must not replace v2") with
+   | Error (Snapshot_unavailable { kind = Parse_failed; _ }) ->
+     check "malformed v2 keeper is quarantined" true
+   | Ok _ | Error _ -> check "malformed v2 keeper is quarantined" false);
+  check "malformed v2 bytes remain untouched" (String.equal (read_raw path) invalid_v2)
+
+let test_invalid_v2_attachment_is_not_silently_dropped () =
+  Printf.printf "Test: malformed v2 attachments fail instead of disappearing\n%!";
+  with_base "keeper-chat-invalid-attachment" @@ fun base_path ->
+  let keeper_name = "invalid-attachment" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let invalid =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v2"
+      ; "revision", `Int 1
+      ; ( "receipts"
+        , `List
+            [ `Assoc
+                [ ( "receipt_id"
+                  , `String
+                      "chatq_00000000-0000-4000-8000-000000000010" )
+                ; "state", `Assoc [ "kind", `String "pending" ]
+                ; ( "message"
+                  , `Assoc
+                      [ "content", `String "attachment must survive"
+                      ; "user_blocks", `List []
+                      ; ( "attachments"
+                        , `List
+                            [ `Assoc
+                                [ "id", `String ""
+                                ; "type", `String "file"
+                                ; "name", `String "broken.txt"
+                                ; "size", `Int 1
+                                ; "mime_type", `String "text/plain"
+                                ; "data", `String "payload"
+                                ]
+                            ] )
+                      ; "timestamp", `Float 1.0
+                      ; "source", `Assoc [ "kind", `String "dashboard" ]
+                      ] )
+                ]
+            ] )
+      ]
+    |> Yojson.Safe.pretty_to_string
+  in
+  save_raw path invalid;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  (match report.load_errors with
+   | [ (Some name, { kind = Parse_failed; _ }) ] ->
+     check "malformed attachment quarantines its keeper"
+       (String.equal name keeper_name)
+   | _ -> check "malformed attachment is an explicit parse failure" false);
+  check "malformed attachment bytes remain untouched"
+    (String.equal (read_raw path) invalid)
+
+let test_revision_domain_does_not_wrap () =
+  Printf.printf "Test: revision exhaustion fails closed without int64 wrap\n%!";
+  with_base "keeper-chat-revision-domain" @@ fun base_path ->
+  let keeper_name = "revision-domain" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let at_limit =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v2"
+      ; "revision", `Intlit "9007199254740991"
+      ; "receipts", `List []
+      ]
+    |> Yojson.Safe.pretty_to_string
+  in
+  save_raw path at_limit;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "maximum exact JSON revision remains readable" (report.load_errors = []);
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must not wrap") with
+   | Error Keeper_chat_queue.Revision_exhausted ->
+     check "next mutation reports revision exhaustion" true
+   | Ok _ | Error _ -> check "next mutation reports revision exhaustion" false);
+  check "revision exhaustion leaves the snapshot untouched"
+    (String.equal (read_raw path) at_limit)
+
+let test_revision_outside_json_domain_is_rejected () =
+  Printf.printf "Test: revision above the exact JSON domain is quarantined\n%!";
+  with_base "keeper-chat-revision-too-large" @@ fun base_path ->
+  let keeper_name = "revision-too-large" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let too_large =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v2"
+      ; "revision", `Intlit "9007199254740992"
+      ; "receipts", `List []
+      ]
+    |> Yojson.Safe.pretty_to_string
+  in
+  save_raw path too_large;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  (match report.load_errors with
+   | [ (Some name, { kind = Parse_failed; _ }) ] ->
+     check "unsafe JSON revision names the quarantined keeper"
+       (String.equal name keeper_name)
+   | _ -> check "unsafe JSON revision is an explicit parse failure" false);
+  check "unsafe revision bytes remain untouched"
+    (String.equal (read_raw path) too_large)
+
+let test_revision_recovery_exhaustion_is_quarantined () =
+  Printf.printf "Test: max-revision inflight recovery fails without overwrite\n%!";
+  with_base "keeper-chat-recovery-exhausted" @@ fun base_path ->
+  let keeper_name = "recovery-exhausted" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let at_limit_inflight =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v2"
+      ; "revision", `Intlit "9007199254740991"
+      ; ( "receipts"
+        , `List
+            [ `Assoc
+                [ ( "receipt_id"
+                  , `String
+                      "chatq_00000000-0000-4000-8000-000000000099" )
+                ; ( "state"
+                  , `Assoc
+                      [ "kind", `String "inflight"
+                      ; "lease_id", `String "lease-before-restart"
+                      ; "started_at", `Float 1.0
+                      ] )
+                ; "message", v1_message_json "replay me"
+                ]
+            ] )
+      ]
+    |> Yojson.Safe.pretty_to_string
+  in
+  save_raw path at_limit_inflight;
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  (match report.load_errors with
+   | [ (Some name, { kind = Recovery_failed; _ }) ] ->
+     check "recovery exhaustion names the quarantined keeper"
+       (String.equal name keeper_name)
+   | _ -> check "recovery exhaustion is explicit" false);
+  check "failed recovery preserves the inflight snapshot bytes"
+    (String.equal (read_raw path) at_limit_inflight)
+
+let test_post_commit_observer_is_central_and_unlocked () =
+  Printf.printf "Test: one post-commit observer sees every mutation outside locks\n%!";
+  with_base "keeper-chat-observer" @@ fun base_path ->
+  let keeper_name = "transition-observer" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  let revisions = ref [] in
+  Keeper_chat_queue.set_transition_observer
+    (Some
+       (fun ~keeper_name:observed ~revision ->
+          (* Re-entering snapshot would deadlock if the callback ran under the
+             entry mutex. *)
+          ignore (Keeper_chat_queue.snapshot ~keeper_name:observed : Keeper_chat_queue.diagnostic_snapshot);
+          revisions := revision :: !revisions));
+  ignore (enqueue_exn ~keeper_name (message "observe") : Keeper_chat_queue.enqueue_receipt);
+  let first = lease_exn ~keeper_name in
+  ignore (Keeper_chat_queue.nack ~keeper_name ~lease_id:first.lease_id);
+  let second = lease_exn ~keeper_name in
+  ignore
+    (Keeper_chat_queue.finalize ~keeper_name ~lease_id:second.lease_id
+       ~outcome:(Mark_delivered { completed_at = 6.0; outcome_ref = None }));
+  check
+    "observer sees enqueue, lease, nack, lease, finalize exactly once"
+    (List.rev !revisions = [ 1L; 2L; 3L; 4L; 5L ])
+
+let test_reconfigure_does_not_leak_receipts_across_base_paths () =
+  Printf.printf "Test: BasePath reconfiguration clears the in-memory registry\n%!";
+  with_base "keeper-chat-base-a" @@ fun first_base ->
+  let second_base = temp_dir "keeper-chat-base-b" in
   Fun.protect
-    ~finally:(fun () ->
-      Keeper_chat_queue.For_testing.reset ();
-      rm_rf base_path)
+    ~finally:(fun () -> rm_rf second_base)
     (fun () ->
-      let keeper_name = "inflight-crash-keeper" in
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
-      List.iter
-        (enqueue_ ~keeper_name)
-        [ msg ~content:"leased-1" ~ts:1.0 Keeper_chat_queue.Dashboard
-        ; msg ~content:"leased-2" ~ts:2.0 Keeper_chat_queue.Dashboard
-        ];
-      (match Keeper_chat_queue.lease_batch ~keeper_name with
-       | `Leased { messages; _ } ->
-         check "both messages coalesce into the outstanding lease"
-           (contents messages = [ "leased-1"; "leased-2" ])
-       | `Empty | `Already_leased _ | `Persist_failed _ ->
-         check "lease_batch leases both messages" false);
-      (* Crash: the process dies with the lease neither acked nor nacked.
-         [For_testing.reset] drops in-memory state but not the durable
-         snapshot [lease_batch] already wrote before returning. *)
-      Keeper_chat_queue.For_testing.reset ();
-      Keeper_chat_queue.configure_persistence ~base_path;
+      let keeper_name = "base-boundary" in
+      ignore (configure first_base : Keeper_chat_queue.configure_report);
+      let first_receipt = enqueue_exn ~keeper_name (message "first workspace") in
       check
-        "the crashed keeper's queue is visible again after restart"
-        (List.mem keeper_name (Keeper_chat_queue.all_keeper_names ()));
-      (match Keeper_chat_queue.lease_batch ~keeper_name with
-       | `Leased { messages; _ } ->
-         check "the unacknowledged lease is redelivered whole after restart"
-           (contents messages = [ "leased-1"; "leased-2" ])
-       | `Empty | `Already_leased _ | `Persist_failed _ ->
-         check "the redelivered batch is leaseable" false))
-;;
+        "first BasePath has one receipt"
+        (active_ids (Keeper_chat_queue.snapshot ~keeper_name).pending
+         = [ Keeper_chat_queue.Receipt_id.to_string first_receipt.receipt_id ]);
+      let first_path = snapshot_path ~base_path:first_base ~keeper_name in
+      let first_snapshot_bytes = read_raw first_path in
+      ignore
+        (Keeper_chat_queue.configure_persistence ~base_path:second_base
+          : Keeper_chat_queue.configure_report);
+      let second_snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+      check
+        "second BasePath does not inherit the first registry"
+        (second_snapshot.pending = [] && second_snapshot.inflight = []
+         && second_snapshot.terminal = []);
+      ignore (enqueue_exn ~keeper_name (message "second workspace"));
+      check
+        "mutating the second BasePath leaves the first snapshot untouched"
+        (String.equal (read_raw first_path) first_snapshot_bytes))
+
+let test_snapshot_path_rejects_parent_segments () =
+  Printf.printf "Test: queue snapshot paths reject parent-directory segments\n%!";
+  with_base "keeper-chat-invalid-path" @@ fun base_path ->
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  (match Keeper_chat_queue.enqueue ~keeper_name:".." (message "escape") with
+   | Error (Snapshot_unavailable { kind = Invalid_path; _ }) ->
+     check "parent segment is a typed invalid path" true
+   | Ok _ | Error _ -> check "parent segment is a typed invalid path" false);
+  check "invalid Keeper path creates no queue snapshot outside its lane"
+    (not
+       (Sys.file_exists
+          (Filename.concat
+             (Filename.dirname
+                (Common.keepers_runtime_dir_of_base ~base_path))
+             "chat-queue.json")))
 
 let () =
-  Eio_main.run @@ fun _env ->
-  test_same_source ();
-  test_lease_batch_runs ();
-  test_merge_batch ();
-  test_in_flight_accessor ();
-  test_persistence_replay ();
-  test_lease_persist_failure_does_not_acknowledge ();
-  test_configure_persistence_prepends_snapshot_to_live_queue ();
-  test_remove_matching_single_from_head_run ();
-  test_remove_matching_not_found ();
-  test_remove_matching_persist_failure_aborts ();
-  test_remove_matching_lease_batch_exactly_once ();
-  test_receipt_id_round_trip ();
-  test_lease_ack_nack_lifecycle ();
-  test_lease_already_leased_blocks_second_lease ();
-  test_ack_nack_unknown_lease ();
-  test_inflight_lease_requeued_on_restart ();
+  Eio_main.run @@ fun _environment ->
+  test_durable_receipt_lifecycle ();
+  test_coalesced_finalize_preserves_all_receipts ();
+  test_source_boundaries_preserve_fifo_runs ();
+  test_nack_and_restart_preserve_receipt ();
+  test_persist_failures_roll_back ();
+  test_v1_atomic_migration ();
+  test_corrupt_snapshot_is_quarantined ();
+  test_invalid_v2_is_not_a_compatibility_fallback ();
+  test_invalid_v2_attachment_is_not_silently_dropped ();
+  test_revision_domain_does_not_wrap ();
+  test_revision_outside_json_domain_is_rejected ();
+  test_revision_recovery_exhaustion_is_quarantined ();
+  test_post_commit_observer_is_central_and_unlocked ();
+  test_reconfigure_does_not_leak_receipts_across_base_paths ();
+  test_snapshot_path_rejects_parent_segments ();
   if !failures > 0
-  then (
+  then begin
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
-    exit 1)
+    exit 1
+  end
   else Printf.printf "All keeper_chat_coalescing checks passed\n%!"
-;;

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -159,7 +159,7 @@ let test_delivery_finalizes_terminal_receipt () =
       let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message =
         captured := Some (dispatched_keeper, queued_message);
         Keeper_chat_consumer.Delivered
-          { outcome_ref = Some "turn:delivered-1" }
+          { outcome_ref = "trace-delivered#1" }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -172,7 +172,7 @@ let test_delivery_finalizes_terminal_receipt () =
           (match receipt.state with
            | Keeper_chat_queue.Delivered completion ->
              check "delivery stores the typed outcome reference"
-               (completion.outcome_ref = Some "turn:delivered-1")
+               (completion.outcome_ref = Some "trace-delivered#1")
            | Pending | Inflight _ | Failed _ ->
              check "delivery state is Delivered" false));
       (match !captured with
@@ -206,7 +206,7 @@ let test_explicit_failure_finalizes_failed_receipt () =
         Keeper_chat_consumer.Failed
           { kind = Keeper_chat_queue.Delivery_failed
           ; detail = "connector rejected outbound delivery"
-          ; outcome_ref = Some "delivery:failed-1"
+          ; outcome_ref = Some "trace-delivery-failed#1"
           }
       in
       with_consumer_switch (fun sw ->
@@ -225,7 +225,7 @@ let test_explicit_failure_finalizes_failed_receipt () =
                (String.equal failure.detail
                   "connector rejected outbound delivery");
              check "failure outcome reference is preserved"
-               (failure.outcome_ref = Some "delivery:failed-1")
+               (failure.outcome_ref = Some "trace-delivery-failed#1")
            | Pending | Inflight _ | Delivered _ ->
              check "explicit failure state is Failed" false));
       check_terminal_snapshot ~label:"explicit failure" ~keeper_name
@@ -312,7 +312,7 @@ let test_dispatch_is_concurrent_per_keeper () =
           Eio.Promise.resolve resolve_first_started ();
           Eio.Promise.await release_first;
           Keeper_chat_consumer.Delivered
-            { outcome_ref = Some ("turn:" ^ dispatched_keeper) }
+            { outcome_ref = "trace-" ^ dispatched_keeper ^ "#2" }
         | Some first when String.equal first dispatched_keeper ->
           check "one keeper is not dispatched twice concurrently" false;
           Keeper_chat_consumer.Failed
@@ -324,7 +324,7 @@ let test_dispatch_is_concurrent_per_keeper () =
           second_keeper := Some dispatched_keeper;
           Eio.Promise.resolve resolve_second_started ();
           Keeper_chat_consumer.Delivered
-            { outcome_ref = Some ("turn:" ^ dispatched_keeper) }
+            { outcome_ref = "trace-" ^ dispatched_keeper ^ "#2" }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -379,7 +379,7 @@ let test_finalization_persistence_retry_does_not_redeliver () =
         incr calls;
         Keeper_chat_queue.For_testing.fail_next_persist ();
         Keeper_chat_consumer.Delivered
-          { outcome_ref = Some "turn:finalized-after-retry" }
+          { outcome_ref = "trace-finalized-after-retry#3" }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -392,11 +392,44 @@ let test_finalization_persistence_retry_does_not_redeliver () =
           (match receipt.state with
            | Keeper_chat_queue.Delivered completion ->
              check "retried finalization preserves the outcome reference"
-               (completion.outcome_ref = Some "turn:finalized-after-retry")
+               (completion.outcome_ref = Some "trace-finalized-after-retry#3")
            | Pending | Inflight _ | Failed _ ->
              check "retried finalization reaches Delivered" false));
       check "finalization retry does not re-run handle_turn" (!calls = 1);
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
+        ~receipt_id:accepted.receipt_id)
+
+let test_invalid_delivered_turn_ref_fails_closed () =
+  Printf.printf
+    "Test: Delivered with an invalid turn_ref becomes a terminal failure\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"invalid turn_ref enqueue" ~keeper_name
+        (discord_msg ~content:"invalid delivered ref"
+           ~channel_id:"channel-invalid-ref" ~user_id:"user-invalid-ref"
+           ~timestamp:6.5)
+    with
+    | None -> ()
+    | Some accepted ->
+      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+        Keeper_chat_consumer.Delivered { outcome_ref = "trace#0042" }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        match
+          await_receipt ~clock ~seconds:5.0 ~keeper_name
+            ~receipt_id:accepted.receipt_id ~accept:is_failed
+        with
+        | Some { state = Keeper_chat_queue.Failed failure; _ } ->
+          check "invalid Delivered ref is an internal failure"
+            (failure.kind = Keeper_chat_queue.Internal_error);
+          check "invalid Delivered ref is not persisted as a join key"
+            (failure.outcome_ref = None);
+          check "invalid Delivered ref has diagnostic detail"
+            (String.trim failure.detail <> "")
+        | Some { state = Pending | Inflight _ | Delivered _; _ } | None ->
+          check "invalid Delivered ref never reaches Delivered" false);
+      check_terminal_snapshot ~label:"invalid delivered ref" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
 let test_invalid_delivery_diagnostic_does_not_block_lane () =
@@ -425,7 +458,7 @@ let test_invalid_delivery_diagnostic_does_not_block_lane () =
             ; detail = "HTTP response body: \255"
             ; outcome_ref = Some " delivery:\255 "
             })
-        else Keeper_chat_consumer.Delivered { outcome_ref = Some "turn:next" }
+        else Keeper_chat_consumer.Delivered { outcome_ref = "trace-next#4" }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -447,7 +480,9 @@ let test_invalid_delivery_diagnostic_does_not_block_lane () =
              check "malformed diagnostic is repaired to valid UTF-8"
                (String.is_valid_utf_8 failure.detail);
              check "original failure kind is preserved"
-               (failure.kind = Keeper_chat_queue.Delivery_failed)
+               (failure.kind = Keeper_chat_queue.Delivery_failed);
+             check "invalid failure turn_ref is omitted, never repaired"
+               (failure.outcome_ref = None)
            | Some { state = Pending | Inflight _ | Delivered _; _ } | None ->
              check "malformed diagnostic reaches terminal Failed" false);
           check "next queued turn dispatches after repaired terminal outcome"
@@ -467,6 +502,7 @@ let () =
   test_structured_cancellation_nacks_and_preserves_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
+  test_invalid_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   if !failures > 0
   then (

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -1,366 +1,412 @@
-(* test_keeper_chat_consumer_delivery.ml — the back half of the connector
-   deferred-reply pipeline (RFC-connector-deferred-reply-via-chat-queue).
+(* Durable receipt lifecycle tests for Keeper_chat_consumer.
 
-   The merged fix enqueues a busy connector message onto Keeper_chat_queue; the
-   front half (enqueue + queued ACK) is covered by
-   test_keeper_busy_connector_deferred. This pins the back half:
-   Keeper_chat_consumer drains the queue once the keeper's turn slot frees, routes
-   each same-source run as ONE coalesced turn, and hands handle_turn the typed
-   Discord source carrying the channel_id — the routing key the Discord delivery
-   adapter (Keeper_chat_discord.adapter_loop -> Discord_rest_client) posts to.
-
-   handle_turn is the consumer's injection seam, so this is deterministic with no
-   provider and no Discord REST call: a capturing handle_turn records what the
-   consumer would have delivered. The literal HTTP POST is Discord_rest_client's
-   transport responsibility and is out of scope for this unit (no DI seam). *)
+   These tests exercise the consumer through Keeper_chat_queue's public durable
+   API.  They intentionally assert receipt states instead of transient queue
+   depth so delivery, typed failure, cancellation, and finalization retry remain
+   observable across the persistence boundary. *)
 
 open Masc
 
 let failures = ref 0
 
-let check name cond =
-  if cond then Printf.printf "  \xe2\x9c\x93 %s\n%!" name
+let check name condition =
+  if condition
+  then Printf.printf "  ✓ %s\n%!" name
   else (
     incr failures;
-    Printf.printf "  \xe2\x9c\x97 %s\n%!" name)
+    Printf.printf "  ✗ %s\n%!" name)
 
-let keeper_name = "consumer-delivery-keeper"
+let check_failure name detail =
+  incr failures;
+  Printf.printf "  ✗ %s: %s\n%!" name detail
 
-let discord_msg ~content ~channel_id ~user_id ~ts =
+let keeper_name = "consumer-receipt-keeper"
+
+let discord_msg ~content ~channel_id ~user_id ~timestamp =
   { Keeper_chat_queue.content
   ; user_blocks = []
   ; attachments = []
-  ; timestamp = ts
+  ; timestamp
   ; source = Keeper_chat_queue.Discord { channel_id; user_id }
   }
 
-(* Run [body] with a fresh temp base path, an Eio env, and a clean queue +
-   admission slot. *)
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+
 let with_env body =
   let base =
     Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-consumer-deliv-%d-%d" (Unix.getpid ())
+      (Printf.sprintf "masc-consumer-receipt-%d-%d" (Unix.getpid ())
          (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
   in
   Unix.mkdir base 0o755;
   Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
+    ~finally:(fun () -> rm_rf base)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let clock = Eio.Stdenv.clock env in
       let config = Workspace.default_config base in
       ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      (* Full registry reset, not just [clear ~keeper_name]: several tests
-         below use derived names ([keeper_name ^ "-a"/"-b"]) that a prior
-         test's dispatch fiber can leave with a message requeued by
-         [Keeper_chat_consumer]'s at-least-once nack-on-cancel path (the
-         switch teardown between tests can race a fiber that was mid-ack).
-         [Keeper_chat_queue.all_keeper_names] is process-global, so the next
-         test's consumer would otherwise pick up and dispatch that leaked
-         entry too. *)
       Keeper_chat_queue.For_testing.reset ();
-      body ~base ~clock)
-
-(* Generously above every [await_or_timeout] window this suite uses (longest
-   is 5.0s), so the dispatch watchdog never preempts a [handle_turn] fake that
-   is only waiting on a test-controlled promise. *)
-let test_dispatch_deadline_sec = 10.0
-
-(* None of these tests exercise a [handle_turn] that outlives
-   [test_dispatch_deadline_sec] — that path is [test_dispatch_stall] below.
-   Failing loudly here turns a silent hang into a clear assertion if a future
-   change makes a fake [handle_turn] block longer than intended. *)
-let unexpected_on_stalled ~keeper_name ~queued_message:_ =
-  check
-    (Printf.sprintf "on_stalled must not fire for keeper=%s in this test" keeper_name)
-    false
-
-(* Capture handle_turn calls; resolve [first] on the first call so the test can
-   wait without polling. The queue is emptied by the first drain, so the consumer
-   does not call handle_turn again. *)
-let capturing () =
-  let captured = ref [] in
-  let resolved = ref false in
-  let first, set_first = Eio.Promise.create () in
-  let handle_turn ~sw:_ ~keeper_name:kn ~queued_message =
-    captured := (kn, queued_message) :: !captured;
-    if not !resolved then (
-      resolved := true;
-      Eio.Promise.resolve set_first ())
-  in
-  (captured, first, handle_turn)
-
-(* Await [p] but never hang the suite: lose to a timeout and report it. *)
-let await_or_timeout ~clock ~secs p =
-  Eio.Fiber.first
-    (fun () ->
-      Eio.Promise.await p;
-      `Got)
-    (fun () ->
-      Eio.Time.sleep clock secs;
-      `Timeout)
-
-let await_queue_depth_or_timeout ~clock ~keeper_name ~expected ~secs =
-  Eio.Fiber.first
-    (fun () ->
-      let rec wait () =
-        if Keeper_chat_queue.length ~keeper_name = expected
-        then `Got
-        else (
-          Eio.Time.sleep clock 0.05;
-          wait ())
+      Keeper_turn_admission.For_testing.reset ();
+      let report : Keeper_chat_queue.configure_report =
+        Keeper_chat_queue.configure_persistence ~base_path:base
       in
-      wait ())
+      check "persistence configured without load errors" (report.load_errors = []);
+      Fun.protect
+        ~finally:(fun () ->
+          Keeper_chat_queue.For_testing.reset ();
+          Keeper_turn_admission.For_testing.reset ())
+        (fun () -> body ~base ~clock))
+
+let enqueue_checked ~label ~keeper_name message =
+  match Keeper_chat_queue.enqueue ~keeper_name message with
+  | Ok receipt -> Some receipt
+  | Error error ->
+    check_failure label (Keeper_chat_queue.mutation_error_to_string error);
+    None
+
+let await_promise ~clock ~seconds promise =
+  Eio.Fiber.first
     (fun () ->
-      Eio.Time.sleep clock secs;
-      `Timeout)
+      Eio.Promise.await promise;
+      true)
+    (fun () ->
+      Eio.Time.sleep clock seconds;
+      false)
 
-(* [Keeper_chat_consumer.start] forks a non-daemon poll fiber that never returns,
-   so a normal [Switch.run] would wait on it forever (in production the
-   server-wide switch lives for the process lifetime). Force teardown by raising
-   inside the switch body, which cancels the poll fiber. *)
-exception Stop
+let await_receipt ~clock ~seconds ~keeper_name ~receipt_id ~accept =
+  Eio.Fiber.first
+    (fun () ->
+      let rec loop () =
+        match Keeper_chat_queue.lookup_receipt ~keeper_name ~receipt_id with
+        | Ok { receipt = Some ({ state; _ } as receipt); _ } when accept state ->
+          Some receipt
+        | Ok { receipt = Some _ | None; _ } ->
+          Eio.Time.sleep clock 0.02;
+          loop ()
+        | Error error ->
+          check_failure "receipt lookup"
+            (Keeper_chat_queue.mutation_error_to_string error);
+          None
+      in
+      loop ())
+    (fun () ->
+      Eio.Time.sleep clock seconds;
+      None)
 
-let with_consumer_switch f =
-  try Eio.Switch.run (fun sw -> f sw; raise Stop) with Stop -> ()
+let is_delivered = function
+  | Keeper_chat_queue.Delivered _ -> true
+  | Pending | Inflight _ | Failed _ -> false
 
-let test_drains_discord_to_handle_turn () =
-  Printf.printf "Test: consumer drains a Discord queue entry to handle_turn\n%!";
+let is_failed = function
+  | Keeper_chat_queue.Failed _ -> true
+  | Pending | Inflight _ | Delivered _ -> false
+
+let is_inflight = function
+  | Keeper_chat_queue.Inflight _ -> true
+  | Pending | Delivered _ | Failed _ -> false
+
+let receipt_id_in_active receipt_id receipts =
+  List.exists
+    (fun (receipt : Keeper_chat_queue.active_receipt) ->
+       Keeper_chat_queue.Receipt_id.equal receipt.receipt_id receipt_id)
+    receipts
+
+let receipt_id_in_terminal receipt_id receipts =
+  List.exists
+    (fun (receipt : Keeper_chat_queue.receipt_view) ->
+       Keeper_chat_queue.Receipt_id.equal receipt.receipt_id receipt_id)
+    receipts
+
+let check_terminal_snapshot ~label ~keeper_name ~receipt_id =
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check (label ^ " has no pending receipt")
+    (not (receipt_id_in_active receipt_id snapshot.pending));
+  check (label ^ " has no inflight receipt")
+    (not (receipt_id_in_active receipt_id snapshot.inflight));
+  check (label ^ " retains terminal receipt")
+    (receipt_id_in_terminal receipt_id snapshot.terminal)
+
+(* [Keeper_chat_consumer.start] owns a process-lifetime polling fiber.  Raising
+   from the switch body gives each test a structured teardown and, when a turn
+   is active, exercises the same cancellation path as server shutdown. *)
+exception Stop_consumer
+
+let with_consumer_switch body =
+  try Eio.Switch.run (fun sw -> body sw; raise Stop_consumer) with
+  | Stop_consumer -> ()
+
+let test_delivery_finalizes_terminal_receipt () =
+  Printf.printf "Test: delivery finalizes a durable terminal receipt\n%!";
   with_env (fun ~base ~clock ->
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"are you free now?" ~channel_id:"chan-1"
-            ~user_id:"u-1" ~ts:1.0)
-        : string);
-    let captured, first, handle_turn = capturing () in
-    with_consumer_switch (fun sw ->
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:test_dispatch_deadline_sec
-        ~on_stalled:unexpected_on_stalled ~handle_turn;
-      (match await_or_timeout ~clock ~secs:5.0 first with
-       | `Got -> ()
-       | `Timeout -> check "consumer drained within timeout" false));
-    match !captured with
-    | [ (kn, qm) ] ->
-        check "delivered to the bound keeper" (kn = keeper_name);
-        (match qm.Keeper_chat_queue.source with
-         | Keeper_chat_queue.Discord { channel_id; user_id } ->
-             check "routing key is the Discord channel_id" (channel_id = "chan-1");
-             check "routing key carries the user_id" (user_id = "u-1")
-         | _ -> check "delivered source is Discord" false);
-        check "delivered the user's content" (qm.content = "are you free now?")
-    | _ -> check "exactly one handle_turn call" false)
+    match
+      enqueue_checked ~label:"delivery enqueue" ~keeper_name
+        (discord_msg ~content:"deliver me" ~channel_id:"channel-delivered"
+           ~user_id:"user-delivered" ~timestamp:1.0)
+    with
+    | None -> ()
+    | Some accepted ->
+      let captured = ref None in
+      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message =
+        captured := Some (dispatched_keeper, queued_message);
+        Keeper_chat_consumer.Delivered
+          { outcome_ref = Some "turn:delivered-1" }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        match
+          await_receipt ~clock ~seconds:5.0 ~keeper_name
+            ~receipt_id:accepted.receipt_id ~accept:is_delivered
+        with
+        | None -> check "delivery reaches terminal state" false
+        | Some receipt ->
+          (match receipt.state with
+           | Keeper_chat_queue.Delivered completion ->
+             check "delivery stores the typed outcome reference"
+               (completion.outcome_ref = Some "turn:delivered-1")
+           | Pending | Inflight _ | Failed _ ->
+             check "delivery state is Delivered" false));
+      (match !captured with
+       | Some (dispatched_keeper, queued_message) ->
+         check "delivery dispatches to the accepted keeper"
+           (String.equal dispatched_keeper keeper_name);
+         check "delivery preserves queued content"
+           (String.equal queued_message.content "deliver me");
+         (match queued_message.source with
+          | Keeper_chat_queue.Discord { channel_id; user_id } ->
+            check "delivery preserves Discord channel"
+              (String.equal channel_id "channel-delivered");
+            check "delivery preserves Discord user"
+              (String.equal user_id "user-delivered")
+          | Dashboard | Slack _ -> check "delivery source is Discord" false)
+       | None -> check "delivery invokes handle_turn" false);
+      check_terminal_snapshot ~label:"delivery" ~keeper_name
+        ~receipt_id:accepted.receipt_id)
 
-let test_coalesces_same_source_run () =
-  Printf.printf
-    "Test: same-source messages coalesce into one delivered turn\n%!";
+let test_explicit_failure_finalizes_failed_receipt () =
+  Printf.printf "Test: explicit turn failure finalizes a Failed receipt\n%!";
   with_env (fun ~base ~clock ->
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"first" ~channel_id:"chan-9" ~user_id:"u-9" ~ts:1.0)
-        : string);
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"second" ~channel_id:"chan-9" ~user_id:"u-9" ~ts:2.0)
-        : string);
-    let captured, first, handle_turn = capturing () in
-    with_consumer_switch (fun sw ->
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:test_dispatch_deadline_sec
-        ~on_stalled:unexpected_on_stalled ~handle_turn;
-      ignore (await_or_timeout ~clock ~secs:5.0 first));
-    match !captured with
-    | [ (_, qm) ] ->
-        check "two same-source messages became one turn"
-          (Keeper_chat_queue.length ~keeper_name = 0);
-        check "coalesced content keeps the first message"
-          (String_util.string_contains_substring ~needle:"first" qm.content);
-        check "coalesced content keeps the second message"
-          (String_util.string_contains_substring ~needle:"second" qm.content)
-    | _ -> check "exactly one coalesced handle_turn call" false)
+    match
+      enqueue_checked ~label:"failure enqueue" ~keeper_name
+        (discord_msg ~content:"fail explicitly" ~channel_id:"channel-failed"
+           ~user_id:"user-failed" ~timestamp:2.0)
+    with
+    | None -> ()
+    | Some accepted ->
+      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+        Keeper_chat_consumer.Failed
+          { kind = Keeper_chat_queue.Delivery_failed
+          ; detail = "connector rejected outbound delivery"
+          ; outcome_ref = Some "delivery:failed-1"
+          }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        match
+          await_receipt ~clock ~seconds:5.0 ~keeper_name
+            ~receipt_id:accepted.receipt_id ~accept:is_failed
+        with
+        | None -> check "explicit failure reaches terminal state" false
+        | Some receipt ->
+          (match receipt.state with
+           | Keeper_chat_queue.Failed failure ->
+             check "failure kind is preserved"
+               (failure.kind = Keeper_chat_queue.Delivery_failed);
+             check "failure detail is preserved"
+               (String.equal failure.detail
+                  "connector rejected outbound delivery");
+             check "failure outcome reference is preserved"
+               (failure.outcome_ref = Some "delivery:failed-1")
+           | Pending | Inflight _ | Delivered _ ->
+             check "explicit failure state is Failed" false));
+      check_terminal_snapshot ~label:"explicit failure" ~keeper_name
+        ~receipt_id:accepted.receipt_id)
 
-let test_gates_while_turn_in_flight () =
-  Printf.printf "Test: queue is not drained while a turn is in flight\n%!";
+let test_structured_cancellation_nacks_and_preserves_receipt () =
+  Printf.printf "Test: structured cancellation nacks the unchanged receipt\n%!";
   with_env (fun ~base ~clock ->
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"during busy" ~channel_id:"chan-5" ~user_id:"u-5"
-            ~ts:1.0)
-        : string);
-    let captured, first, handle_turn = capturing () in
-    with_consumer_switch (fun sw ->
-      (* Hold the admission slot busy in a sibling fiber. *)
-      let started, set_started = Eio.Promise.create () in
-      let release, set_release = Eio.Promise.create () in
-      Eio.Fiber.fork ~sw (fun () ->
-        ignore
-          (Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
-             (fun () ->
-               Eio.Promise.resolve set_started ();
-               Eio.Promise.await release)));
-      Eio.Promise.await started;
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:test_dispatch_deadline_sec
-        ~on_stalled:unexpected_on_stalled ~handle_turn;
-      (* The first poll runs immediately; if the consumer ignored the in-flight
-         gate it would drain within this window. *)
-      (match await_or_timeout ~clock ~secs:0.3 first with
-       | `Got -> check "consumer must not drain while a turn is in flight" false
-       | `Timeout ->
-           check "queue stayed put while the turn was in flight"
-             (Keeper_chat_queue.length ~keeper_name = 1));
-      (* Release the slot; the next poll drains. *)
-      Eio.Promise.resolve set_release ();
-      (match await_or_timeout ~clock ~secs:5.0 first with
-       | `Got -> ()
-       | `Timeout -> check "consumer drains once the slot frees" false));
-    check "delivered exactly once after release" (List.length !captured = 1))
+    match
+      enqueue_checked ~label:"cancellation enqueue" ~keeper_name
+        (discord_msg ~content:"cancel this turn" ~channel_id:"channel-cancel"
+           ~user_id:"user-cancel" ~timestamp:3.0)
+    with
+    | None -> ()
+    | Some accepted ->
+      let started, resolve_started = Eio.Promise.create () in
+      let never, _resolve_never = Eio.Promise.create () in
+      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+        Eio.Promise.resolve resolve_started ();
+        Eio.Promise.await never
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        check "cancellable turn starts"
+          (await_promise ~clock ~seconds:5.0 started);
+        check "receipt is inflight before cancellation"
+          (match
+             await_receipt ~clock ~seconds:1.0 ~keeper_name
+               ~receipt_id:accepted.receipt_id ~accept:is_inflight
+           with
+           | Some _ -> true
+           | None -> false));
+      (match
+         Keeper_chat_queue.lookup_receipt ~keeper_name
+           ~receipt_id:accepted.receipt_id
+       with
+       | Ok
+           { receipt = Some { state = Keeper_chat_queue.Pending; receipt_id }
+           ; _
+           } ->
+         check "cancellation preserves the accepted receipt id"
+           (Keeper_chat_queue.Receipt_id.equal receipt_id accepted.receipt_id)
+       | Ok
+           { receipt =
+               Some { state = Inflight _ | Delivered _ | Failed _; _ }
+             | None
+           ; _
+           }
+       | Error _ ->
+         check "cancellation returns the receipt to Pending" false);
+      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+      check "cancelled receipt remains pending"
+        (receipt_id_in_active accepted.receipt_id snapshot.pending);
+      check "cancelled receipt is not left inflight"
+        (not (receipt_id_in_active accepted.receipt_id snapshot.inflight));
+      check "cancelled receipt is not terminal"
+        (not (receipt_id_in_terminal accepted.receipt_id snapshot.terminal)))
 
-let test_queued_dispatch_is_per_keeper () =
-  Printf.printf "Test: queued dispatch is independent per keeper\n%!";
+let test_dispatch_is_concurrent_per_keeper () =
+  Printf.printf "Test: queued turns dispatch concurrently across keepers\n%!";
   with_env (fun ~base ~clock ->
     let keeper_a = keeper_name ^ "-a" in
     let keeper_b = keeper_name ^ "-b" in
-    Keeper_chat_queue.clear ~keeper_name:keeper_a;
-    Keeper_chat_queue.clear ~keeper_name:keeper_b;
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name:keeper_a
-         (discord_msg ~content:"alpha waits" ~channel_id:"chan-a" ~user_id:"u-a"
-            ~ts:1.0)
-        : string);
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name:keeper_b
-         (discord_msg ~content:"beta should pass" ~channel_id:"chan-b"
-            ~user_id:"u-b" ~ts:2.0)
-        : string);
-    let first_keeper = ref None in
-    let second_keeper = ref None in
-    let first_started, set_first_started = Eio.Promise.create () in
-    let release_first, set_release_first = Eio.Promise.create () in
-    let second_seen, set_second_seen = Eio.Promise.create () in
-    let first_resolved = ref false in
-    let second_resolved = ref false in
-    let handle_turn ~sw:_ ~keeper_name:kn ~queued_message:_ =
-      match !first_keeper with
-      | None ->
-          first_keeper := Some kn;
-          if not !first_resolved then (
-            first_resolved := true;
-            Eio.Promise.resolve set_first_started ());
-          Eio.Promise.await release_first
-      | Some first when String.equal first kn ->
-          check "same keeper is not dispatched again while its queued turn runs"
-            false
-      | Some _ ->
-          second_keeper := Some kn;
-          if not !second_resolved then (
-            second_resolved := true;
-            Eio.Promise.resolve set_second_seen ())
-    in
-    with_consumer_switch (fun sw ->
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:test_dispatch_deadline_sec
-        ~on_stalled:unexpected_on_stalled ~handle_turn;
-      (match await_or_timeout ~clock ~secs:5.0 first_started with
-       | `Got -> ()
-       | `Timeout -> check "first queued keeper dispatch started" false);
-      (match await_or_timeout ~clock ~secs:0.5 second_seen with
-       | `Got ->
-           check "another keeper dispatches while first handler is blocked" true
-       | `Timeout ->
-           check "another keeper dispatches while first handler is blocked" false);
-      Eio.Promise.resolve set_release_first);
-    match (!first_keeper, !second_keeper) with
-    | Some first, Some second ->
-        check "second dispatch uses the other keeper"
-          ((String.equal first keeper_a && String.equal second keeper_b)
-          || (String.equal first keeper_b && String.equal second keeper_a))
-    | _ -> check "both keeper dispatches were observed" false)
+    match
+      ( enqueue_checked ~label:"keeper A enqueue" ~keeper_name:keeper_a
+          (discord_msg ~content:"alpha waits" ~channel_id:"channel-a"
+             ~user_id:"user-a" ~timestamp:4.0)
+      , enqueue_checked ~label:"keeper B enqueue" ~keeper_name:keeper_b
+          (discord_msg ~content:"beta proceeds" ~channel_id:"channel-b"
+             ~user_id:"user-b" ~timestamp:5.0) )
+    with
+    | Some accepted_a, Some accepted_b ->
+      let first_keeper = ref None in
+      let second_keeper = ref None in
+      let calls = ref 0 in
+      let first_started, resolve_first_started = Eio.Promise.create () in
+      let release_first, resolve_release_first = Eio.Promise.create () in
+      let second_started, resolve_second_started = Eio.Promise.create () in
+      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message:_ =
+        incr calls;
+        match !first_keeper with
+        | None ->
+          first_keeper := Some dispatched_keeper;
+          Eio.Promise.resolve resolve_first_started ();
+          Eio.Promise.await release_first;
+          Keeper_chat_consumer.Delivered
+            { outcome_ref = Some ("turn:" ^ dispatched_keeper) }
+        | Some first when String.equal first dispatched_keeper ->
+          check "one keeper is not dispatched twice concurrently" false;
+          Keeper_chat_consumer.Failed
+            { kind = Keeper_chat_queue.Internal_error
+            ; detail = "duplicate concurrent dispatch in test"
+            ; outcome_ref = None
+            }
+        | Some _ ->
+          second_keeper := Some dispatched_keeper;
+          Eio.Promise.resolve resolve_second_started ();
+          Keeper_chat_consumer.Delivered
+            { outcome_ref = Some ("turn:" ^ dispatched_keeper) }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        check "first keeper dispatch starts"
+          (await_promise ~clock ~seconds:5.0 first_started);
+        check "other keeper starts while first keeper is blocked"
+          (await_promise ~clock ~seconds:2.0 second_started);
+        Eio.Promise.resolve resolve_release_first ();
+        check "keeper A receipt reaches Delivered"
+          (match
+             await_receipt ~clock ~seconds:5.0 ~keeper_name:keeper_a
+               ~receipt_id:accepted_a.receipt_id ~accept:is_delivered
+           with
+           | Some _ -> true
+           | None -> false);
+        check "keeper B receipt reaches Delivered"
+          (match
+             await_receipt ~clock ~seconds:5.0 ~keeper_name:keeper_b
+               ~receipt_id:accepted_b.receipt_id ~accept:is_delivered
+           with
+           | Some _ -> true
+           | None -> false));
+      (match (!first_keeper, !second_keeper) with
+       | Some first, Some second ->
+         check "the concurrent dispatches use different keepers"
+           (not (String.equal first second));
+         check "both accepted keepers were dispatched"
+           ((String.equal first keeper_a && String.equal second keeper_b)
+            || (String.equal first keeper_b && String.equal second keeper_a))
+       | None, _ | _, None -> check "both keeper dispatches are observed" false);
+      check "each keeper turn is handled exactly once" (!calls = 2);
+      check_terminal_snapshot ~label:"keeper A delivery" ~keeper_name:keeper_a
+        ~receipt_id:accepted_a.receipt_id;
+      check_terminal_snapshot ~label:"keeper B delivery" ~keeper_name:keeper_b
+        ~receipt_id:accepted_b.receipt_id
+    | None, _ | _, None -> ())
 
-(* PR-4a (busy-queue lease/ack/nack): a [handle_turn] that never returns must
-   not wedge this keeper's queue forever (the L1/L2 root cause — see
-   Keeper_chat_queue.mli and Keeper_chat_consumer.mli). The dispatch
-   watchdog races [handle_turn] against [dispatch_deadline_sec]; on timeout
-   it calls [on_stalled] then acks (not nacks) the lease, since retrying a
-   turn [Keeper_msg_async]'s own timeout has already abandoned would not
-   help. *)
-let test_dispatch_stall_calls_on_stalled_and_acks () =
+let test_finalization_persistence_retry_does_not_redeliver () =
   Printf.printf
-    "Test: a handle_turn that never returns triggers on_stalled and acks \
-     (not nacks)\n%!";
+    "Test: failed terminal persistence retries without re-running the turn\n%!";
   with_env (fun ~base ~clock ->
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"stuck turn" ~channel_id:"chan-stall"
-            ~user_id:"u-stall" ~ts:1.0)
-        : string);
-    let never, _never_resolve = Eio.Promise.create () in
-    let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ = Eio.Promise.await never in
-    let stalled, set_stalled = Eio.Promise.create () in
-    let stalled_call = ref None in
-    let on_stalled ~keeper_name:kn ~queued_message:qm =
-      stalled_call := Some (kn, qm);
-      Eio.Promise.resolve set_stalled ()
-    in
-    with_consumer_switch (fun sw ->
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:0.2 ~on_stalled ~handle_turn;
-      (match await_or_timeout ~clock ~secs:5.0 stalled with
-       | `Got -> ()
-       | `Timeout -> check "on_stalled fires once the dispatch deadline elapses" false);
-      (* Let the synchronous ack that follows on_stalled land. *)
-      Eio.Time.sleep clock 0.3);
-    (match !stalled_call with
-     | Some (kn, qm) ->
-         check "on_stalled sees the bound keeper" (kn = keeper_name);
-         check "on_stalled sees the stuck message"
-           (String.equal qm.Keeper_chat_queue.content "stuck turn")
-     | None -> check "on_stalled was called" false);
-    check "the stalled lease is acked, not requeued"
-      (Keeper_chat_queue.length ~keeper_name = 0))
-
-let test_failed_nack_persist_retries_without_wedging_keeper () =
-  Printf.printf
-    "Test: failed nack persistence is retried instead of wedging the keeper\n%!";
-  with_env (fun ~base ~clock ->
-    Keeper_chat_queue.configure_persistence ~base_path:base;
-    ignore
-      (Keeper_chat_queue.enqueue ~keeper_name
-         (discord_msg ~content:"retry after nack persist" ~channel_id:"chan-retry"
-            ~user_id:"u-retry" ~ts:1.0)
-        : string);
-    let never, _never_resolve = Eio.Promise.create () in
-    let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ = Eio.Promise.await never in
-    let stalled, set_stalled = Eio.Promise.create () in
-    let on_stalled ~keeper_name:_ ~queued_message:_ =
-      Keeper_chat_queue.For_testing.fail_next_persist ();
-      Eio.Promise.resolve set_stalled ();
-      failwith "force nack path"
-    in
-    with_consumer_switch (fun sw ->
-      Keeper_chat_consumer.start ~sw ~clock ~base_path:base
-        ~dispatch_deadline_sec:0.2 ~on_stalled ~handle_turn;
-      (match await_or_timeout ~clock ~secs:5.0 stalled with
-       | `Got -> ()
-       | `Timeout -> check "stalled callback fires before nack retry" false);
-      match
-        await_queue_depth_or_timeout ~clock ~keeper_name ~expected:1 ~secs:3.0
-      with
-      | `Got -> check "failed nack persistence is retried and requeues" true
-      | `Timeout ->
-        check "failed nack persistence is retried and requeues" false))
+    match
+      enqueue_checked ~label:"finalization retry enqueue" ~keeper_name
+        (discord_msg ~content:"finalize after retry"
+           ~channel_id:"channel-finalize-retry" ~user_id:"user-finalize-retry"
+           ~timestamp:6.0)
+    with
+    | None -> ()
+    | Some accepted ->
+      let calls = ref 0 in
+      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+        incr calls;
+        Keeper_chat_queue.For_testing.fail_next_persist ();
+        Keeper_chat_consumer.Delivered
+          { outcome_ref = Some "turn:finalized-after-retry" }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        match
+          await_receipt ~clock ~seconds:5.0 ~keeper_name
+            ~receipt_id:accepted.receipt_id ~accept:is_delivered
+        with
+        | None -> check "terminal persistence is retried" false
+        | Some receipt ->
+          (match receipt.state with
+           | Keeper_chat_queue.Delivered completion ->
+             check "retried finalization preserves the outcome reference"
+               (completion.outcome_ref = Some "turn:finalized-after-retry")
+           | Pending | Inflight _ | Failed _ ->
+             check "retried finalization reaches Delivered" false));
+      check "finalization retry does not re-run handle_turn" (!calls = 1);
+      check_terminal_snapshot ~label:"retried finalization" ~keeper_name
+        ~receipt_id:accepted.receipt_id)
 
 let () =
-  test_drains_discord_to_handle_turn ();
-  test_coalesces_same_source_run ();
-  test_gates_while_turn_in_flight ();
-  test_queued_dispatch_is_per_keeper ();
-  test_dispatch_stall_calls_on_stalled_and_acks ();
-  test_failed_nack_persist_retries_without_wedging_keeper ();
-  if !failures > 0 then (
+  test_delivery_finalizes_terminal_receipt ();
+  test_explicit_failure_finalizes_failed_receipt ();
+  test_structured_cancellation_nacks_and_preserves_receipt ();
+  test_dispatch_is_concurrent_per_keeper ();
+  test_finalization_persistence_retry_does_not_redeliver ();
+  if !failures > 0
+  then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
     exit 1)
-  else Printf.printf "All keeper_chat_consumer_delivery checks passed\n%!"
+  else Printf.printf "All keeper_chat_consumer receipt checks passed\n%!"

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -399,12 +399,75 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
+let test_invalid_delivery_diagnostic_does_not_block_lane () =
+  Printf.printf
+    "Test: malformed delivery diagnostics terminate and release the Keeper lane\n%!";
+  with_env (fun ~base ~clock ->
+    match
+      enqueue_checked ~label:"invalid diagnostic enqueue" ~keeper_name
+        (discord_msg ~content:"invalid diagnostic" ~channel_id:"channel-invalid"
+           ~user_id:"user-invalid" ~timestamp:7.0)
+    with
+    | None -> ()
+    | Some first ->
+      let calls = ref 0 in
+      let first_started, resolve_first_started = Eio.Promise.create () in
+      let release_first, resolve_release_first = Eio.Promise.create () in
+      let handle_turn ~sw:_ ~keeper_name:_
+          ~(queued_message : Keeper_chat_queue.queued_message) =
+        incr calls;
+        if String.equal queued_message.content "invalid diagnostic"
+        then (
+          Eio.Promise.resolve resolve_first_started ();
+          Eio.Promise.await release_first;
+          Keeper_chat_consumer.Failed
+            { kind = Keeper_chat_queue.Delivery_failed
+            ; detail = "HTTP response body: \255"
+            ; outcome_ref = Some " delivery:\255 "
+            })
+        else Keeper_chat_consumer.Delivered { outcome_ref = Some "turn:next" }
+      in
+      with_consumer_switch (fun sw ->
+        Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
+        check "invalid diagnostic turn starts"
+          (await_promise ~clock ~seconds:5.0 first_started);
+        match
+          enqueue_checked ~label:"next lane message enqueue" ~keeper_name
+            (discord_msg ~content:"next lane message" ~channel_id:"channel-next"
+               ~user_id:"user-next" ~timestamp:8.0)
+        with
+        | None -> Eio.Promise.resolve resolve_release_first ()
+        | Some second ->
+          Eio.Promise.resolve resolve_release_first ();
+          (match
+             await_receipt ~clock ~seconds:5.0 ~keeper_name
+               ~receipt_id:first.receipt_id ~accept:is_failed
+           with
+           | Some { state = Keeper_chat_queue.Failed failure; _ } ->
+             check "malformed diagnostic is repaired to valid UTF-8"
+               (String.is_valid_utf_8 failure.detail);
+             check "original failure kind is preserved"
+               (failure.kind = Keeper_chat_queue.Delivery_failed)
+           | Some { state = Pending | Inflight _ | Delivered _; _ } | None ->
+             check "malformed diagnostic reaches terminal Failed" false);
+          check "next queued turn dispatches after repaired terminal outcome"
+            (match
+               await_receipt ~clock ~seconds:5.0 ~keeper_name
+                 ~receipt_id:second.receipt_id ~accept:is_delivered
+             with
+             | Some _ -> true
+             | None -> false));
+      check "each lane turn is handled exactly once" (!calls = 2);
+      check_terminal_snapshot ~label:"invalid diagnostic" ~keeper_name
+        ~receipt_id:first.receipt_id)
+
 let () =
   test_delivery_finalizes_terminal_receipt ();
   test_explicit_failure_finalizes_failed_receipt ();
   test_structured_cancellation_nacks_and_preserves_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
+  test_invalid_delivery_diagnostic_does_not_block_lane ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -5,6 +5,30 @@ module D = Masc.Keeper_chat_discord.For_testing
 let contains haystack needle =
   String_util.contains_substring haystack needle
 
+let run_adapter events ~post_message ~edit_message ~send_message =
+  Eio_main.run
+  @@ fun _env ->
+  let stream = Masc.Keeper_chat_events.create () in
+  List.iter (Masc.Keeper_chat_events.publish stream) events;
+  let outcomes = ref [] in
+  D.adapter_loop ~token:"test-token" ~channel_id:"test-channel"
+    ~events:stream ~post_message ~edit_message ~send_message
+    ~on_send_result:(fun result -> outcomes := result :: !outcomes) ();
+  List.rev !outcomes
+
+let check_single_ok label = function
+  | [ Ok () ] -> ()
+  | outcomes ->
+      failf "%s: expected one Ok callback, got %d callback(s)" label
+        (List.length outcomes)
+
+let check_single_network_error label expected = function
+  | [ Error (Discord_rest_client.Network actual) ] ->
+      check string label expected actual
+  | outcomes ->
+      failf "%s: expected one Network error callback, got %d callback(s)"
+        label (List.length outcomes)
+
 let test_streaming_holds_back_trailing_token () =
   let content =
     D.streaming_patch_content "prefix sk-proj-abcdefghijklmnop"
@@ -124,6 +148,93 @@ let test_rich_embeds_includes_code_and_mermaid () =
   check bool "mermaid body" true
     (contains mermaid_json "```mermaid\\nflowchart TD\\nA-->B\\n```")
 
+let test_terminal_callback_once_for_fallback_post () =
+  let final_posts = ref [] in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-fallback"; thread_id = "thread-fallback" }
+      ; Masc.Keeper_chat_events.Text_delta "hello"
+      ; Masc.Keeper_chat_events.Text_message_end
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-fallback" }
+      ]
+      ~post_message:(fun ~content:_ -> fail "stable prefix should not POST")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        fail "fallback delivery should not PATCH")
+      ~send_message:(fun ~content ->
+        final_posts := content :: !final_posts;
+        Ok ())
+  in
+  check_single_ok "fallback terminal result" outcomes;
+  check (list string) "one final POST" [ "hello" ] (List.rev !final_posts)
+
+let test_terminal_callback_reports_final_patch_failure () =
+  let patch_calls = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-patch"; thread_id = "thread-patch" }
+      ; Masc.Keeper_chat_events.Text_delta "hello "
+      ; Masc.Keeper_chat_events.Text_message_end
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-patch" }
+      ]
+      ~post_message:(fun ~content ->
+        check string "streaming POST content" "hello " content;
+        Ok "discord-message-1")
+      ~edit_message:(fun ~message_id ~content ->
+        incr patch_calls;
+        check string "final PATCH message" "discord-message-1" message_id;
+        check string "final PATCH content" "hello " content;
+        Error (Discord_rest_client.Network "final patch failed"))
+      ~send_message:(fun ~content:_ -> fail "no overflow expected")
+  in
+  check int "one final PATCH" 1 !patch_calls;
+  check_single_network_error "final PATCH failure" "final patch failed" outcomes
+
+let test_terminal_callback_reports_overflow_failure () =
+  let content = String.make 2100 'x' ^ " " in
+  let overflow_posts = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-overflow"; thread_id = "thread-overflow" }
+      ; Masc.Keeper_chat_events.Text_delta content
+      ; Masc.Keeper_chat_events.Text_message_end
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-overflow" }
+      ]
+      ~post_message:(fun ~content ->
+        check int "streaming head length" 2000 (String.length content);
+        Ok "discord-message-2")
+      ~edit_message:(fun ~message_id:_ ~content ->
+        check int "final head length" 2000 (String.length content);
+        Ok ())
+      ~send_message:(fun ~content ->
+        incr overflow_posts;
+        check int "overflow length" 101 (String.length content);
+        Error (Discord_rest_client.Network "overflow failed"))
+  in
+  check int "one overflow POST" 1 !overflow_posts;
+  check_single_network_error "overflow failure" "overflow failed" outcomes
+
+let test_error_reply_callback_once () =
+  let sends = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-error"; thread_id = "thread-error" }
+      ; Masc.Keeper_chat_events.Event_error { message = "provider failed" }
+      ]
+      ~post_message:(fun ~content:_ -> fail "error reply should use final sender")
+      ~edit_message:(fun ~message_id:_ ~content:_ ->
+        fail "error reply should not PATCH")
+      ~send_message:(fun ~content ->
+        incr sends;
+        check string "error reply" "Keeper error: provider failed" content;
+        Error (Discord_rest_client.Network "error post failed"))
+  in
+  check int "one error POST" 1 !sends;
+  check_single_network_error "error POST failure" "error post failed" outcomes
+
 let () =
   run "keeper_chat_discord"
     [ ( "streaming-redaction"
@@ -139,6 +250,14 @@ let () =
             test_final_split_preserves_overflow
         ; test_case "redacts before chunking" `Quick
             test_final_split_redacts_before_chunking
+        ; test_case "callback once for fallback POST" `Quick
+            test_terminal_callback_once_for_fallback_post
+        ; test_case "callback reports final PATCH failure" `Quick
+            test_terminal_callback_reports_final_patch_failure
+        ; test_case "callback reports overflow failure" `Quick
+            test_terminal_callback_reports_overflow_failure
+        ; test_case "error reply callback exactly once" `Quick
+            test_error_reply_callback_once
         ] )
     ; ( "rich-blocks"
       , [ test_case "audio URL uses base URL" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -210,6 +210,81 @@ let test_final_message_blocks_merges_text_and_event_blocks () =
   check bool "event block preserved" true
     (contains second "https://event.example.com")
 
+let run_adapter events ~send_plain ~send_blocks =
+  Eio_main.run @@ fun _env ->
+  let stream = Masc.Keeper_chat_events.create () in
+  List.iter (Masc.Keeper_chat_events.publish stream) events;
+  let outcomes = ref [] in
+  S.adapter_loop ~events:stream ~send_plain ~send_blocks
+    ~on_send_result:(fun result -> outcomes := result :: !outcomes)
+    ();
+  List.rev !outcomes
+
+let test_adapter_terminal_success_once () =
+  let sends = ref [] in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_started
+          { run_id = "run-1"; thread_id = "thread-1" }
+      ; Masc.Keeper_chat_events.Text_delta "done"
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-1" }
+      ]
+      ~send_plain:(fun ~content ->
+        sends := ("plain", content) :: !sends;
+        Ok ())
+      ~send_blocks:(fun ~content ~blocks:_ ->
+        sends := ("blocks", content) :: !sends;
+        Ok ())
+  in
+  check int "one terminal callback" 1 (List.length outcomes);
+  check bool "terminal callback succeeds" true (outcomes = [ Ok () ]);
+  check (list (pair string string)) "one final blocks send"
+    [ "blocks", "done" ] (List.rev !sends)
+
+let test_protocol_diagnostic_cannot_mask_final_failure () =
+  let protocol_error : Masc.Keeper_chat_events.stream_protocol_error =
+    { kind = Masc.Keeper_chat_events.Sse_error
+    ; index = None
+    ; tool_call_id = None
+    ; event_type = Some "error"
+    ; reason = Some "upstream warning"
+    ; raw_bytes = None
+    }
+  in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Oas_stream_protocol_error protocol_error
+      ; Masc.Keeper_chat_events.Text_delta "final"
+      ; Masc.Keeper_chat_events.Run_finished { run_id = "run-2" }
+      ]
+      ~send_plain:(fun ~content:_ -> Ok ())
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        Error (Masc.Keeper_chat_slack.Other "final send failed"))
+  in
+  match outcomes with
+  | [ Error (Masc.Keeper_chat_slack.Other message) ] ->
+    check string "final error wins" "final send failed" message
+  | _ -> fail "only the terminal final-send failure settles the callback"
+
+let test_adapter_empty_terminal_is_error () =
+  let sends = ref 0 in
+  let outcomes =
+    run_adapter
+      [ Masc.Keeper_chat_events.Run_finished { run_id = "run-empty" } ]
+      ~send_plain:(fun ~content:_ ->
+        incr sends;
+        Ok ())
+      ~send_blocks:(fun ~content:_ ~blocks:_ ->
+        incr sends;
+        Ok ())
+  in
+  check int "empty terminal makes no Slack call" 0 !sends;
+  match outcomes with
+  | [ Error (Masc.Keeper_chat_slack.Other message) ] ->
+    check bool "empty terminal failure is explicit" true
+      (contains message "no text or blocks")
+  | _ -> fail "empty terminal must settle exactly once with an error"
+
 let () =
   run "keeper_chat_slack"
     [
@@ -257,5 +332,13 @@ let () =
             test_content_blocks_suppresses_credential_url
         ; test_case "final delivery merges text and event blocks" `Quick
             test_final_message_blocks_merges_text_and_event_blocks
+        ] )
+    ; ( "terminal-receipt"
+      , [ test_case "terminal success settles once" `Quick
+            test_adapter_terminal_success_once
+        ; test_case "protocol diagnostic cannot mask final failure" `Quick
+            test_protocol_diagnostic_cannot_mask_final_failure
+        ; test_case "empty terminal is explicit failure" `Quick
+            test_adapter_empty_terminal_is_error
         ] )
     ]

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -285,6 +285,18 @@ let test_adapter_empty_terminal_is_error () =
       (contains message "no text or blocks")
   | _ -> fail "empty terminal must settle exactly once with an error"
 
+let test_message_body_preserves_reply_thread () =
+  let body =
+    Masc.Keeper_chat_slack.For_testing.build_message_body
+      ~channel:"C-thread" ~content:"deferred reply" ~blocks:[]
+      ~thread_ts:"1710000000.123456" ()
+    |> Yojson.Safe.from_string
+  in
+  let open Yojson.Safe.Util in
+  check string "channel retained" "C-thread" (body |> member "channel" |> to_string);
+  check string "reply thread retained" "1710000000.123456"
+    (body |> member "thread_ts" |> to_string)
+
 let () =
   run "keeper_chat_slack"
     [
@@ -340,5 +352,9 @@ let () =
             test_protocol_diagnostic_cannot_mask_final_failure
         ; test_case "empty terminal is explicit failure" `Quick
             test_adapter_empty_terminal_is_error
+        ] )
+    ; ( "thread-routing"
+      , [ test_case "deferred reply keeps thread_ts" `Quick
+            test_message_body_preserves_reply_thread
         ] )
     ]

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -53,6 +53,27 @@ let test_error_when_path_under_a_file () =
         "append under a non-directory path is Error" true
         (Result.is_error result))
 
+let test_persists_typed_transport_failure () =
+  let base_dir = temp_base_path "keeper-chat-store-kind" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let result =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"upstream request failed"
+          ~kind:S.Row_kind.Transport_failure
+          ()
+      in
+      Alcotest.(check bool) "typed append succeeds" true (Result.is_ok result);
+      match S.load ~base_dir ~keeper_name with
+      | [ message ] ->
+          Alcotest.(check bool)
+            "assistant-only failure is not persisted as keeper speech" true
+            (S.Row_kind.equal message.kind S.Row_kind.Transport_failure)
+      | messages ->
+          Alcotest.failf "expected one persisted row, got %d"
+            (List.length messages))
+
 let () =
   Alcotest.run "keeper_chat_store_append_result"
     [
@@ -61,5 +82,7 @@ let () =
           Alcotest.test_case "writable dir -> Ok" `Quick test_ok_on_writable_dir;
           Alcotest.test_case "path under a file -> Error" `Quick
             test_error_when_path_under_a_file;
+          Alcotest.test_case "typed transport failure" `Quick
+            test_persists_typed_transport_failure;
         ] );
     ]

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -630,9 +630,15 @@ let test_status_surfaces_chat_queue_runtime () =
       Masc.Keeper_chat_queue.For_testing.reset ();
       Eio_guard.disable ())
     (fun () ->
-      Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path;
-      ignore
-        (Masc.Keeper_chat_queue.enqueue
+      let report =
+        Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path
+      in
+      Alcotest.(check int)
+        "queue persistence config has no load errors"
+        0
+        (List.length report.load_errors);
+      (match
+         Masc.Keeper_chat_queue.enqueue
            ~keeper_name:name
            {
              Masc.Keeper_chat_queue.content = "queued status probe";
@@ -641,7 +647,11 @@ let test_status_surfaces_chat_queue_runtime () =
              timestamp = 1.0;
              source = Masc.Keeper_chat_queue.Dashboard;
            }
-          : string);
+       with
+       | Ok _receipt -> ()
+       | Error err ->
+           Alcotest.failf "queue enqueue failed: %s"
+             (Masc.Keeper_chat_queue.mutation_error_to_string err));
       let status_json = status_json_with ~name config in
       let chat_queue = json_assoc_field "chat_queue" status_json in
       Alcotest.(check (option int))

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -621,7 +621,7 @@ let test_status_surfaces_chat_queue_runtime () =
   ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
   Eio_main.run @@ fun _env ->
   (* Mirror production: the status handler runs under [Eio_main.run] with the
-     guard enabled (bin/main_eio.ml), so [Keeper_chat_queue.length] is read.
+     guard enabled (bin/main_eio.ml), so the durable queue snapshot is read.
      Disable on exit so other (non-Eio) cases keep reporting [`Null]. *)
   Eio_guard.enable ();
   Masc.Keeper_chat_queue.For_testing.reset ();

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1070,13 +1070,16 @@ let () =
     Fun.protect
       ~finally:(fun () ->
         Masc.Keeper_registry.clear ();
-        Masc.Keeper_chat_queue.clear ~keeper_name:"keeper-event-queue-yield-test";
+        Masc.Keeper_chat_queue.For_testing.reset ();
         rm_rf base_path)
       (fun () ->
         let keeper_name = "keeper-event-queue-yield-test" in
         let meta = meta_for_keeper keeper_name "trace-event-queue-yield-test" in
         Masc.Keeper_registry.clear ();
-        Masc.Keeper_chat_queue.clear ~keeper_name;
+        Masc.Keeper_chat_queue.For_testing.reset ();
+        ignore
+          (Masc.Keeper_chat_queue.configure_persistence ~base_path
+            : Masc.Keeper_chat_queue.configure_report);
         ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
         (match
            Masc.Keeper_unified_turn_execution.autonomous_yield_request

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -638,7 +638,36 @@ let test_masc_board_descriptions_disambiguate_post_id_flow () =
 ;;
 
 let test_masc_board_registry_has_descriptor_projection () =
+  let post_update_name =
+    Tool_name.Board_name.(to_string Board_post_update)
+  in
+  let expected_post_update = Tool_catalog.metadata post_update_name in
+  Alcotest.(check bool)
+    "post-update precondition is hidden"
+    true
+    (expected_post_update.visibility = Tool_catalog.Hidden);
+  Alcotest.(check bool)
+    "post-update precondition allows direct hidden calls"
+    true
+    expected_post_update.allow_direct_call_when_hidden;
+  Alcotest.(check bool)
+    "post-update precondition explains hidden status"
+    true
+    (Option.is_some expected_post_update.reason);
   Board_tool_dispatch.register ();
+  let actual_post_update = Tool_catalog.metadata post_update_name in
+  Alcotest.(check bool)
+    "post-update visibility preserved"
+    true
+    (actual_post_update.visibility = expected_post_update.visibility);
+  Alcotest.(check bool)
+    "post-update hidden direct-call allowance preserved"
+    expected_post_update.allow_direct_call_when_hidden
+    actual_post_update.allow_direct_call_when_hidden;
+  Alcotest.(check (option string))
+    "post-update hidden reason preserved"
+    expected_post_update.reason
+    actual_post_update.reason;
   let wire_names =
     List.map Tool_name.Board_name.to_string Tool_name.Board_name.all
   in

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -638,6 +638,7 @@ let test_masc_board_descriptions_disambiguate_post_id_flow () =
 ;;
 
 let test_masc_board_registry_has_descriptor_projection () =
+  Board_tool_dispatch.register ();
   let wire_names =
     List.map Tool_name.Board_name.to_string Tool_name.Board_name.all
   in

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -21,7 +21,12 @@ let check name cond =
 
 let base_path = "/tmp/masc_test_turn_admission"
 let keeper_name = "admission-keeper"
-let reset () = Keeper_turn_admission.For_testing.reset ()
+let reset () =
+  Keeper_turn_admission.For_testing.reset ();
+  Keeper_chat_queue.For_testing.reset ();
+  ignore
+    (Keeper_chat_queue.configure_persistence ~base_path
+      : Keeper_chat_queue.configure_report)
 
 let test_free_slot_admits () =
   reset ();
@@ -395,7 +400,6 @@ let test_idle_loop_yields_to_parked_chat () =
 
 let test_autonomous_yields_to_queued_connector_message () =
   reset ();
-  Keeper_chat_queue.clear ~keeper_name;
   Printf.printf
     "Test 10: autonomous lane yields while a connector/dashboard message is queued\n%!";
   (* Sanity: an empty queue lets the autonomous lane run. *)
@@ -406,16 +410,22 @@ let test_autonomous_yields_to_queued_connector_message () =
      without parking on the admission slot, so [chat_waiting] stays false. The
      autonomous lane must still yield, or a long/back-to-back autonomous turn
      busy-ACKs the connector forever (the starvation this pins). *)
-  ignore
-    (Keeper_chat_queue.enqueue ~keeper_name
+  (match
+     Keeper_chat_queue.enqueue ~keeper_name
        { Keeper_chat_queue.content = "deferred slack mention"
        ; user_blocks = []
        ; attachments = []
        ; timestamp = 1.0
        ; source = Keeper_chat_queue.Slack { channel = "C-test"; user_id = "U-test" }
        }
-      : string);
-  check "queue depth is 1 after enqueue" (Keeper_chat_queue.length ~keeper_name = 1);
+   with
+   | Ok _ -> ()
+   | Error error ->
+     check
+       ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
+       false);
+  let queued = Keeper_chat_queue.snapshot ~keeper_name in
+  check "queue depth is 1 after enqueue" (List.length queued.pending = 1);
   check
     "a queued connector message is not a parked chat"
     (not (Keeper_turn_admission.chat_waiting ~base_path ~keeper_name));
@@ -424,15 +434,36 @@ let test_autonomous_yields_to_queued_connector_message () =
      check "run_if_free yields (Busy) while a connector message is queued" true
    | `Ran () ->
      check "run_if_free must not admit while a connector message is queued" false);
-  (* Draining the queue (what the consumer does in the yielded window) lets the
-     autonomous lane run again. [length] excludes a leased-but-unacked batch
-     just like it excluded a dequeued one, so leasing alone (no ack needed)
-     is enough to reproduce that window here. *)
-  (match Keeper_chat_queue.lease_batch ~keeper_name with
-   | `Leased _ -> ()
-   | `Empty | `Already_leased _ | `Persist_failed _ ->
-     check "lease_batch drains the queued connector message" false);
-  check "queue empty after drain" (Keeper_chat_queue.length ~keeper_name = 0);
+  (* Leasing changes the receipt to Inflight but does not make it disappear.
+     The autonomous lane keeps yielding until the terminal decision commits. *)
+  let lease =
+    match Keeper_chat_queue.lease_batch ~keeper_name with
+    | `Leased lease -> Some lease
+    | `Empty | `Already_leased _ | `Error _ ->
+      check "lease_batch leases the queued connector message" false;
+      None
+  in
+  let inflight = Keeper_chat_queue.snapshot ~keeper_name in
+  check "leased receipt remains visible" (List.length inflight.inflight = 1);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy _ -> check "run_if_free yields while the receipt is inflight" true
+   | `Ran () -> check "run_if_free must not overtake an inflight receipt" false);
+  (match lease with
+   | None -> ()
+   | Some lease ->
+     (match
+        Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+          ~outcome:
+            (Keeper_chat_queue.Mark_delivered
+               { completed_at = 2.0; outcome_ref = None })
+      with
+      | `Finalized _ -> ()
+      | `Unknown_lease | `Error _ ->
+        check "finalize commits the terminal receipt" false));
+  let settled = Keeper_chat_queue.snapshot ~keeper_name in
+  check
+    "queue has no active receipts after finalization"
+    (settled.pending = [] && settled.inflight = []);
   match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "ok") with
   | `Ran "ok" -> check "run_if_free admits again once the queue is drained" true
   | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -416,7 +416,14 @@ let test_autonomous_yields_to_queued_connector_message () =
        ; user_blocks = []
        ; attachments = []
        ; timestamp = 1.0
-       ; source = Keeper_chat_queue.Slack { channel = "C-test"; user_id = "U-test" }
+       ; source =
+           Keeper_chat_queue.Slack
+             { channel_id = "C-test"
+             ; user_id = "U-test"
+             ; user_name = "slack-user"
+             ; team_id = Some "T-test"
+             ; thread_ts = Some "171.001"
+             }
        }
    with
    | Ok _ -> ()

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -76,6 +76,62 @@ let test_chat_if_free_never_parks () =
     Eio.Promise.resolve set_release ())
 ;;
 
+let test_chat_if_free_rechecks_durable_queue_after_stale_peek () =
+  reset ();
+  Printf.printf
+    "Test 1c: run_chat_if_free rechecks durable receipts after a stale outer peek\n%!";
+  check
+    "outer precheck initially observes no active receipt"
+    (Keeper_chat_queue.has_active_receipts ~keeper_name = Ok false);
+  let message : Keeper_chat_queue.queued_message =
+    { content = "queued first"
+    ; user_blocks = []
+    ; attachments = []
+    ; timestamp = Time_compat.now ()
+    ; source = Keeper_chat_queue.Dashboard
+    }
+  in
+  let receipt = Keeper_chat_queue.enqueue ~keeper_name message in
+  check "receipt commits after the stale outer peek" (Result.is_ok receipt);
+  let direct_ran = ref false in
+  (match
+     Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () ->
+       direct_ran := true)
+   with
+   | `Busy { Keeper_turn_admission.waiting = 0; in_flight = None } ->
+     check "pending receipt blocks direct admission" true
+   | `Busy _ | `Ran () -> check "pending receipt blocks direct admission" false);
+  check "pending receipt is not overtaken" (not !direct_ran);
+  let lease =
+    match Keeper_chat_queue.lease_batch ~keeper_name with
+    | `Leased lease -> lease
+    | `Empty | `Already_leased _ | `Error _ ->
+      failwith "expected the committed receipt to lease"
+  in
+  (match
+     Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () ->
+       direct_ran := true)
+   with
+   | `Busy _ -> check "inflight receipt blocks direct admission" true
+   | `Ran () -> check "inflight receipt blocks direct admission" false);
+  check "inflight receipt is not overtaken" (not !direct_ran);
+  (match
+     Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
+       ~outcome:
+         (Keeper_chat_queue.Mark_delivered
+            { completed_at = Time_compat.now (); outcome_ref = Some "turn#1" })
+   with
+   | `Finalized _ -> ()
+   | `Unknown_lease | `Error _ -> failwith "expected the lease to finalize");
+  (match
+     Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () ->
+       direct_ran := true)
+   with
+   | `Ran () -> check "terminal receipt no longer blocks direct admission" true
+   | `Busy _ -> check "terminal receipt no longer blocks direct admission" false);
+  check "direct turn runs only after receipt terminalizes" !direct_ran
+;;
+
 let test_autonomous_skips_in_flight_chat () =
   reset ();
   Printf.printf "Test 2: autonomous lane skips while a chat turn is in flight\n%!";
@@ -480,6 +536,7 @@ let () =
   Eio_main.run @@ fun _env ->
   test_free_slot_admits ();
   test_chat_if_free_never_parks ();
+  test_chat_if_free_rechecks_durable_queue_after_stale_peek ();
   test_autonomous_skips_in_flight_chat ();
   test_chat_turns_serialize ();
   test_distinct_keepers_do_not_block_each_other ();

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -15,6 +15,7 @@ open Alcotest
 
 module TO = Masc.Keeper_turn_outcome
 module Ops = Masc.Keeper_tool_surface_ops
+module Stream = Server_routes_http_keeper_stream
 
 let outcome : TO.t testable =
   testable
@@ -199,6 +200,42 @@ let test_turn_ref_payload_decode () =
   check (option turn_ref_t) "non-string field -> None" None
     (TO.turn_ref_of_reply_payload (payload [ (TO.turn_ref_wire_key, `Int 5) ]))
 
+let test_queued_delivery_requires_exact_turn_ref () =
+  let check_failed label payload_json =
+    match
+      payload_json
+      |> TO.turn_ref_of_reply_payload
+      |> Stream.For_testing.queued_delivery_outcome_of_turn_ref
+    with
+    | Stream.Failed { kind = Stream.Missing_turn_ref; detail } ->
+        check bool (label ^ " has diagnostic detail") true
+          (String.trim detail <> "")
+    | Stream.Failed _ | Stream.Delivered _ ->
+        fail (label ^ " must fail with Missing_turn_ref")
+  in
+  check_failed "missing turn_ref"
+    (payload [ ("reply", `String "hi") ]);
+  check_failed "malformed turn_ref"
+    (payload
+       [ ("reply", `String "hi")
+       ; (TO.turn_ref_wire_key, `String "not-a-turn-ref")
+       ]);
+  let valid =
+    payload
+      [ ("reply", `String "hi")
+      ; (TO.turn_ref_wire_key, `String "trace-queued#42")
+      ]
+  in
+  match
+    valid
+    |> TO.turn_ref_of_reply_payload
+    |> Stream.For_testing.queued_delivery_outcome_of_turn_ref
+  with
+  | Stream.Delivered { outcome_ref } ->
+      check string "valid turn_ref is preserved exactly"
+        "trace-queued#42" outcome_ref
+  | Stream.Failed _ -> fail "valid turn_ref must produce Delivered"
+
 let body fields = Yojson.Safe.to_string (`Assoc fields)
 
 let test_direct_reply_visible_text () =
@@ -252,6 +289,8 @@ let () =
           test_case "prefix is dead" `Quick test_prefix_is_dead;
           test_case "turn_ref decode (parse, don't repair)" `Quick
             test_turn_ref_payload_decode;
+          test_case "queued delivery requires exact turn_ref" `Quick
+            test_queued_delivery_requires_exact_turn_ref;
         ] );
       ( "direct_reply",
         [

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -48,9 +48,15 @@ let with_workspace f =
   let dir = temp_dir () in
   Eio.Switch.run
   @@ fun sw ->
-  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  Eio.Switch.on_release sw (fun () ->
+    Keeper_chat_queue.For_testing.reset ();
+    rm_rf dir);
   let config = Workspace_core.default_config dir in
   ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  Keeper_chat_queue.For_testing.reset ();
+  let queue_report = Keeper_chat_queue.configure_persistence ~base_path:dir in
+  check int "chat queue persistence starts clean" 0
+    (List.length queue_report.load_errors);
   f config
 ;;
 
@@ -212,7 +218,7 @@ let test_event_queue_pending_and_inflight_are_visible () =
        Otel_metric_store.metric_keeper_waiting_age_seconds
        ~labels:[ "scope", "keeper"; "source", "event_queue_pending" ]
      > 0.0);
-  check string "schema" "masc.dashboard.keeper_waiting_inventory.v1"
+  check string "schema" "masc.dashboard.keeper_waiting_inventory.v2"
     (json_string_member "schema" json);
   check int "one keeper" 1 (json_int_member "keeper_count" json);
   check int "one waiting keeper" 1 (json_int_member "waiting_keeper_count" json);
@@ -238,7 +244,6 @@ let test_chat_queue_pending_rows_are_visible () =
   @@ fun config ->
   let keeper_name = "queued-chat-keeper" in
   ensure_keeper config keeper_name;
-  Keeper_chat_queue.For_testing.reset ();
   let message : Keeper_chat_queue.queued_message =
     { content = "queued while busy"
     ; user_blocks = []
@@ -247,7 +252,14 @@ let test_chat_queue_pending_rows_are_visible () =
     ; source = Keeper_chat_queue.Discord { channel_id = "chan-42"; user_id = "user-7" }
     }
   in
-  ignore (Keeper_chat_queue.enqueue ~keeper_name message : string);
+  let receipt =
+    match Keeper_chat_queue.enqueue ~keeper_name message with
+    | Ok receipt -> receipt
+    | Error error ->
+      fail
+        ("chat queue enqueue failed: "
+         ^ Keeper_chat_queue.mutation_error_to_string error)
+  in
   let json = Server_keeper_waiting_inventory.dashboard_json config in
   check_metric_float "chat queue metric"
     Otel_metric_store.metric_keeper_waiting_count
@@ -278,8 +290,41 @@ let test_chat_queue_pending_rows_are_visible () =
             row |> member "detail" |> member "message_source" |> member "channel_id"
             |> to_string);
         check int "chat queue content length" (String.length message.content)
-          U.(row |> member "detail" |> member "content_length" |> to_int)
+          U.(row |> member "detail" |> member "content_length" |> to_int);
+        check string "pending receipt is correlated"
+          (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id)
+          U.(row |> member "detail" |> member "receipt_id" |> to_string);
+        check string "pending lifecycle is explicit" "pending"
+          U.(row |> member "detail" |> member "lifecycle" |> member "state"
+             |> to_string)
       | rows -> failf "expected one chat queue row, got %d" (List.length rows)))
+  ;
+  let lease =
+    match Keeper_chat_queue.lease_batch ~keeper_name with
+    | `Leased lease -> lease
+    | `Empty | `Already_leased _ | `Error _ ->
+      fail "pending chat receipt should lease"
+  in
+  let inflight_json = Server_keeper_waiting_inventory.dashboard_json config in
+  match find_keeper inflight_json keeper_name with
+  | None -> fail "inflight keeper row missing"
+  | Some keeper ->
+    check int "pending source clears after lease" 0
+      U.(keeper |> member "sources" |> member "chat_queue_pending" |> to_int_option
+         |> Option.value ~default:0);
+    check int "inflight source is visible" 1
+      U.(keeper |> member "sources" |> member "chat_queue_inflight" |> to_int);
+    (match U.(keeper |> member "waiting_on" |> to_list) with
+     | [ row ] ->
+       check string "inflight row source" "chat_queue_inflight"
+         (json_string_member "source" row);
+       check string "inflight lifecycle is explicit" "inflight"
+         U.(row |> member "detail" |> member "lifecycle" |> member "state"
+            |> to_string);
+       check string "inflight lease is correlated" lease.lease_id
+         U.(row |> member "detail" |> member "lifecycle" |> member "lease_id"
+            |> to_string)
+     | rows -> failf "expected one inflight chat row, got %d" (List.length rows))
 ;;
 
 let test_turn_admission_waiting_row_is_visible () =
@@ -449,6 +494,39 @@ let save_text path text =
   match Fs_compat.save_file_atomic path text with
   | Ok () -> ()
   | Error err -> fail ("save_file_atomic failed: " ^ err)
+;;
+
+let test_corrupt_chat_queue_snapshot_is_read_error () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "corrupt-chat-queue-keeper" in
+  ensure_keeper config keeper_name;
+  let base_path = config.Workspace_utils_backend_setup.base_path in
+  let path =
+    Filename.concat
+      (Filename.concat
+         (Common.keepers_runtime_dir_of_base ~base_path)
+         keeper_name)
+      "chat-queue.json"
+  in
+  save_text path "{not-json";
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check int "corrupt chat queue is reported at configure" 1
+    (List.length report.load_errors);
+  let json = Server_keeper_waiting_inventory.dashboard_json config in
+  match find_keeper json keeper_name with
+  | None -> fail "corrupt chat queue keeper row missing"
+  | Some keeper ->
+    check int "corrupt queue projects one read error" 1
+      U.(keeper |> member "sources" |> member "read_error" |> to_int);
+    (match U.(keeper |> member "waiting_on" |> to_list) with
+     | [ row ] ->
+       check string "corrupt queue waiting_on" "chat_queue_snapshot"
+         (json_string_member "waiting_on" row);
+       check string "corrupt queue repair action"
+         "repair_keeper_chat_queue_snapshot"
+         (json_string_member "next_action" row)
+     | rows -> failf "expected one corrupt chat queue row, got %d" (List.length rows))
 ;;
 
 let pending_confirm_fixture ?(target_type = "goal") ?target_id ()
@@ -700,6 +778,8 @@ let () =
             test_live_turn_keeper_is_busy_without_waiting_rows
         ; test_case "corrupt schedule ledger is read_error" `Quick
             test_corrupt_schedule_ledger_is_read_error
+        ; test_case "corrupt chat queue is read_error" `Quick
+            test_corrupt_chat_queue_snapshot_is_read_error
         ; test_case "keeper name discovery failure is read_error" `Quick
             test_keeper_name_discovery_failure_is_read_error
         ; test_case "corrupt external attention is read_error" `Quick

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -296,6 +296,26 @@ let test_close_unreleased_client_swallows_release_error () =
   Alcotest.(check int) "release attempted once" 1 !calls;
   Alcotest.(check bool) "marked released before failing" true !released
 
+let test_request_timeout_bounds_never_returning_transport () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let started = Eio.Time.now clock in
+  let result =
+    Masc_http_client.For_testing.with_request_timeout ~clock ~timeout_sec:0.02
+      (fun () ->
+         Eio.Time.sleep clock 60.0;
+         Ok ())
+  in
+  let elapsed = Eio.Time.now clock -. started in
+  (match result with
+   | Error message ->
+     Alcotest.(check bool)
+       "timeout is explicit"
+       true
+       (Astring.String.is_prefix ~affix:"timeout after" message)
+   | Ok () -> Alcotest.fail "never-returning transport must time out");
+  Alcotest.(check bool) "deadline settles promptly" true (elapsed < 0.5)
+
 (* ── Runner ──────────────────────────────────────────────────── *)
 
 let () =
@@ -362,5 +382,10 @@ let () =
             test_close_unreleased_client_closes_once;
           Alcotest.test_case "swallows release failure" `Quick
             test_close_unreleased_client_swallows_release_error;
+        ] );
+      ( "request deadline",
+        [
+          Alcotest.test_case "never-returning transport is bounded" `Quick
+            test_request_timeout_bounds_never_returning_transport;
         ] );
     ]

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -160,7 +160,7 @@ let () = test "dispatch_keeper_waiting_inventory" (fun () ->
       assert
         (String.equal
            (json_string_member "schema" data)
-           "masc.dashboard.keeper_waiting_inventory.v1");
+           "masc.dashboard.keeper_waiting_inventory.v2");
       assert
         (String.equal
            (json_string_member "source" data)


### PR DESCRIPTION
## Summary

- extend assistant-only chat persistence with the existing typed `Row_kind`
- persist connector-side upstream failures as `Transport_failure`, not keeper `Utterance`
- cover the assistant-only typed row with a storage regression test

## Why

MASC #24152 taught the dashboard to render `transport_failure` rows, while its connector failure producer still used `append_assistant_message_result` without a kind. That API defaulted to `Utterance`, so a Discord/Slack upstream failure could survive durably as something the keeper supposedly said, advance the wrong projection semantics, and never render as the new failure card.

This child is stacked on #24139 because that PR already makes transcript write failure explicit to the queue consumer. This patch only closes the remaining producer/type boundary and does not duplicate the durability work.

## Validation

- `scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_chat_store_append_result.exe test/test_keeper_busy_connector_deferred.exe`
- `_build/default/test/test_keeper_chat_store_append_result.exe` — 3/3 pass
- `_build/default/test/test_keeper_busy_connector_deferred.exe` — all checks pass
- `scripts/dune-local.sh build @check`
- `git diff --check`

## Stack / merge condition

- base: #24139 (`agent/keeper-chat-receipts-dashboard` at `23df1c1dbd`)
- audit origin: merged #24152
- keep Draft / `status:do-not-merge` until #24139 is terminal-green and this exact head receives CI/review evidence
