### PR TITLE
fix(keeper): isolate durable event queue owner locks

### DIFF
--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -24,14 +24,17 @@
   keeper_runtime_failure_route
   keeper_latched_reason
   keeper_event_queue
+  keeper_event_queue_owner_lock
   keeper_event_queue_persistence
   keeper_continuation_channel)
+ (private_modules keeper_event_queue_owner_lock)
  (libraries
   agent_sdk
   agent_sdk.llm_provider
   eio
   masc_eio_context
   masc.config
+  masc.keeper_registry
   masc.keeper_toml
   masc.config_dir_resolver
   masc.fs_compat

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
@@ -1,0 +1,137 @@
+(** Per-owner synchronization for durable Keeper event queues. *)
+
+type resolve_error =
+  | Invalid_base_path of string
+  | Invalid_keeper_name of string
+
+module Owner_key = struct
+  type nonrec t = string * Keeper_id.Keeper_name.t
+
+  let equal (left_base, left_name) (right_base, right_name) =
+    String.equal left_base right_base
+    && Keeper_id.Keeper_name.equal left_name right_name
+  ;;
+
+  let hash (base_path, keeper_name) =
+    Hashtbl.hash (base_path, Keeper_id.Keeper_name.to_string keeper_name)
+  ;;
+end
+
+type t =
+  { owner_key : Owner_key.t
+  ; eio_gate : Eio.Mutex.t
+  ; cross_context_mutex : Stdlib.Mutex.t
+  }
+
+module Owner_table = Ephemeron.K1.Make (Owner_key)
+
+(* No fleet-size estimate belongs at this boundary; the table grows from its
+   implementation-defined minimum as canonical owners are resolved. Ephemeron
+   keys let inactive owners disappear without an arbitrary eviction policy;
+   every active caller keeps [owner_key] strongly reachable through [t]. *)
+let owners : t Owner_table.t = Owner_table.create 0
+let owners_mutex = Stdlib.Mutex.create ()
+
+let resolve_error_to_string = function
+  | Invalid_base_path reason -> "invalid event-queue base path: " ^ reason
+  | Invalid_keeper_name reason -> reason
+;;
+
+let canonical_base_path raw =
+  let normalized = Env_config_core.normalize_masc_base_path_input raw in
+  if String.equal normalized ""
+  then Error (Invalid_base_path "path is empty after normalization")
+  else
+    let absolute =
+      if Filename.is_relative normalized
+      then Filename.concat (Config_dir_resolver.current_working_dir ()) normalized
+      else normalized
+    in
+    let canonical = Env_config_core.normalize_masc_base_path_input absolute in
+    if String.equal canonical "" || Filename.is_relative canonical
+    then
+      Error
+        (Invalid_base_path
+           (Printf.sprintf "could not derive an absolute path from %S" raw))
+    else Ok canonical
+;;
+
+let resolve ~base_path ~keeper_name =
+  match canonical_base_path base_path, Keeper_id.Keeper_name.of_string keeper_name with
+  | Error error, _ -> Error error
+  | Ok _, Error reason -> Error (Invalid_keeper_name reason)
+  | Ok base_path, Ok keeper_name ->
+    let key = base_path, keeper_name in
+    Ok
+      (Stdlib.Mutex.protect owners_mutex (fun () ->
+         match Owner_table.find_opt owners key with
+         | Some owner -> owner
+         | None ->
+           Owner_table.clean owners;
+           let owner =
+             { owner_key = key
+             ; eio_gate = Eio.Mutex.create ()
+             ; cross_context_mutex = Stdlib.Mutex.create ()
+             }
+           in
+           Owner_table.add owners key owner;
+           owner))
+;;
+
+let base_path owner = fst owner.owner_key
+let keeper_name owner = snd owner.owner_key
+
+type execution_context =
+  | Eio_fiber
+  | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.check () with
+  | () -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
+let rec lock_cross_context_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_cross_context_cooperatively mutex)
+;;
+
+type 'a lock_outcome =
+  | Returned of 'a
+  | Raised of exn * Printexc.raw_backtrace
+
+(* Eio [use_ro] is still exclusive; unlike [use_rw], it releases rather than
+   poisons the gate when the callback raises. The gate carries no mutable
+   resource state of its own, and the shared Stdlib mutex is released by the
+   [Fun.protect] finalizer before any callback exception is propagated. *)
+let with_eio_lock owner f =
+  let outcome =
+    match
+      Eio.Mutex.use_ro owner.eio_gate (fun () ->
+        lock_cross_context_cooperatively owner.cross_context_mutex;
+        Eio.Cancel.protect (fun () ->
+          Fun.protect
+            ~finally:(fun () -> Stdlib.Mutex.unlock owner.cross_context_mutex)
+            f))
+    with
+    | value -> Returned value
+    | exception exn -> Raised (exn, Printexc.get_raw_backtrace ())
+  in
+  (* [Cancel.protect] deliberately finishes an acquired persistence
+     transaction. Re-check the parent context after both owner locks have been
+     released on every outcome so an ordinary exception cannot mask pending
+     cancellation. *)
+  Eio.Fiber.check ();
+  match outcome with
+  | Returned value -> value
+  | Raised (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+;;
+
+let with_lock owner f =
+  match execution_context () with
+  | Eio_fiber -> with_eio_lock owner f
+  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+;;

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
@@ -1,0 +1,40 @@
+(** Per-owner synchronization for durable Keeper event queues.
+
+    One owner is identified by the canonical MASC [base_path] and a parsed
+    {!Keeper_id.Keeper_name}.  The process-wide ephemeron registry mutex
+    protects only owner lookup/creation; inactive entries are collectible
+    without an eviction heuristic.  Every owner carries its own cooperative
+    Eio gate and a shared Stdlib mutex, so unrelated Keeper lanes never
+    serialize on queue I/O while Eio and non-Eio callers still exclude each
+    other. *)
+
+type resolve_error =
+  | Invalid_base_path of string
+  | Invalid_keeper_name of string
+
+type t
+
+val resolve_error_to_string : resolve_error -> string
+
+val canonical_base_path : string -> (string, resolve_error) result
+(** Normalize through {!Env_config_core.normalize_masc_base_path_input}, then
+    anchor relative inputs at {!Config_dir_resolver.current_working_dir}.  The
+    returned path is absolute and lexically canonical. *)
+
+val resolve :
+  base_path:string -> keeper_name:string -> (t, resolve_error) result
+(** Resolve or create the unique in-process owner for this canonical
+    [(base_path, keeper_name)] identity. *)
+
+val base_path : t -> string
+val keeper_name : t -> Keeper_id.Keeper_name.t
+
+val with_lock : t -> (unit -> 'a) -> 'a
+(** Serialize [f] with every Eio and non-Eio caller for this owner.
+
+    Eio callers wait cooperatively: one fiber waits on the Eio gate and polls
+    the shared Stdlib mutex with [Mutex.try_lock] plus [Fiber.yield].  Once both
+    locks are held, cancellation is protected until [f] finishes and both
+    locks are released; cancellation is checked again before a value or an
+    ordinary exception can leave the lock boundary.
+    Non-Eio callers use the same Stdlib mutex directly. *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -4,46 +4,24 @@
     module mirrors the post-CAS queue snapshot to disk so a keeper restart can
     replay pending stimuli instead of resetting to [Keeper_event_queue.empty].
 
-    Reads and writes over the pending/inflight snapshot pair are serialized with
-    an Eio mutex in runtime fibers. Setup/tests that reach this module without
-    an Eio context fall back to a Stdlib mutex. *)
+    Reads and writes over one keeper's pending/inflight snapshot pair are
+    serialized by [Keeper_event_queue_owner_lock]. Distinct keeper owners do
+    not share an I/O lock, while Eio and non-Eio callers for the same canonical
+    [(base_path, keeper_name)] identity use one cross-context mutex. *)
 
-let eio_write_mu = Eio.Mutex.create ()
-let fallback_write_mu = Stdlib.Mutex.create ()
+module Owner_lock = Keeper_event_queue_owner_lock
 
-(* [eio_write_mu] is process-global, so a poisoned mutex blocks durable
-   event-queue snapshots for EVERY keeper for the lifetime of the process
-   (audit 2026-06-29). [Eio.Mutex.use_rw] poisons the mutex permanently if the
-   critical section raises, so the failure must never cross the [use_rw]
-   boundary: a non-cancellation exception is captured inside the critical
-   section and re-raised — with its original backtrace — only after the lock is
-   released, leaving the mutex usable for the next keeper. [Eio.Cancel.Cancelled]
-   is re-raised in place so cancellation/shutdown is honoured and never swallowed
-   (CancelledNeverAbsorbed). The external contract is unchanged: [with_write_lock]
-   still returns [f ()] or re-raises its exception. *)
-let with_write_lock : type a. (unit -> a) -> a =
- fun f ->
-  let guarded () =
-    match f () with
-    | v -> Ok v
-    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-    | exception exn -> Error (exn, Printexc.get_raw_backtrace ())
-  in
-  let outcome =
-    match Eio_context.get_switch_opt () with
-    | Some _ -> Eio.Mutex.use_rw ~protect:true eio_write_mu guarded
-    | None -> Stdlib.Mutex.protect fallback_write_mu guarded
-  in
-  match outcome with
-  | Ok v -> v
-  | Error (exn, bt) -> Printexc.raise_with_backtrace exn bt
+let owner_error_to_string = Owner_lock.resolve_error_to_string
 
-let valid_keeper_name name =
-  let valid_char = function
-    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
-    | _ -> false
-  in
-  (not (String.equal name "")) && String.for_all valid_char name
+let keeper_name_of_owner owner =
+  Owner_lock.keeper_name owner |> Keeper_id.Keeper_name.to_string
+;;
+
+let resolve_owner ~base_path ~keeper_name =
+  match Owner_lock.resolve ~base_path ~keeper_name with
+  | Ok owner -> Ok owner
+  | Error error -> Error (owner_error_to_string error)
+;;
 
 let snapshot_filename = "event-queue.json"
 let inflight_snapshot_filename = "event-queue-inflight.json"
@@ -51,8 +29,8 @@ let inflight_snapshot_filename = "event-queue-inflight.json"
 (* [Fs_compat.mkdir_p] raises (Sys_error / Unix_error) on ENOSPC/EROFS/ENOTDIR
    instead of returning a result, so route it through the same [(unit, string)
    result] channel as [save_file_atomic]. This keeps [save_json_atomic] total:
-   it never raises for a disk failure, so the enclosing [with_write_lock]
-   critical section returns normally and the shared mutex is not poisoned.
+   it never raises for a disk failure, so the enclosing owner-lock critical
+   section returns normally.
    [Eio.Cancel.Cancelled] is re-raised so cancellation is not flattened into a
    string error. *)
 let save_json_atomic path json =
@@ -68,23 +46,19 @@ let save_json_atomic path json =
     |> Yojson.Safe.pretty_to_string
     |> Fs_compat.save_file_atomic path
 
-let snapshot_path ~base_path ~keeper_name =
-  if valid_keeper_name keeper_name
-  then
-    Ok
-      (Filename.concat
-         (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-         snapshot_filename)
-  else Error (Printf.sprintf "invalid keeper name for event queue snapshot: %s" keeper_name)
+let keeper_runtime_dir_of_owner owner =
+  Filename.concat
+    (Common.keepers_runtime_dir_of_base ~base_path:(Owner_lock.base_path owner))
+    (keeper_name_of_owner owner)
+;;
 
-let inflight_path ~base_path ~keeper_name =
-  if valid_keeper_name keeper_name
-  then
-    Ok
-      (Filename.concat
-         (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-         inflight_snapshot_filename)
-  else Error (Printf.sprintf "invalid keeper name for event queue inflight: %s" keeper_name)
+let snapshot_path_of_owner owner =
+  Filename.concat (keeper_runtime_dir_of_owner owner) snapshot_filename
+;;
+
+let inflight_path_of_owner owner =
+  Filename.concat (keeper_runtime_dir_of_owner owner) inflight_snapshot_filename
+;;
 
 type dir_state =
   | Missing
@@ -113,49 +87,60 @@ type snapshot_discovery =
   }
 
 let discover_keeper_names_with_snapshots ~base_path =
-  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-  match dir_state keepers_dir with
-  | Error msg -> { keeper_names = []; read_error = Some msg }
-  | Ok Missing -> { keeper_names = []; read_error = None }
-  | Ok Not_directory ->
-    { keeper_names = []
-    ; read_error = Some (Printf.sprintf "keepers runtime path is not a directory: %s" keepers_dir)
-    }
-  | Ok Directory ->
-    (match Safe_ops.list_dir_safe keepers_dir with
+  match Owner_lock.canonical_base_path base_path with
+  | Error error ->
+    { keeper_names = []; read_error = Some (owner_error_to_string error) }
+  | Ok base_path ->
+    let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+    (match dir_state keepers_dir with
      | Error msg -> { keeper_names = []; read_error = Some msg }
-     | Ok entries ->
-       let names, errors =
-         List.fold_left
-           (fun (names, errors) name ->
-              let keeper_dir = Filename.concat keepers_dir name in
-              match dir_state keeper_dir with
-              | Error msg -> names, msg :: errors
-              | Ok Missing | Ok Not_directory -> names, errors
-              | Ok Directory ->
-                let pending_path = Filename.concat keeper_dir snapshot_filename in
-                let inflight_path = Filename.concat keeper_dir inflight_snapshot_filename in
-                (match file_exists_safe pending_path, file_exists_safe inflight_path with
-                 | Error msg, _ | _, Error msg -> names, msg :: errors
-                 | Ok false, Ok false -> names, errors
-                 | Ok true, _ | _, Ok true ->
-                   if valid_keeper_name name
-                   then name :: names, errors
-                   else
-                     ( names
-                     , Printf.sprintf
-                         "invalid keeper name with durable event queue snapshot: %s"
-                         name
-                       :: errors )))
-           ([], [])
-           entries
-       in
-       { keeper_names = List.sort_uniq String.compare names
+     | Ok Missing -> { keeper_names = []; read_error = None }
+     | Ok Not_directory ->
+       { keeper_names = []
        ; read_error =
-           (match List.rev errors with
-            | [] -> None
-            | errors -> Some (String.concat "; " errors))
-       })
+           Some
+             (Printf.sprintf
+                "keepers runtime path is not a directory: %s"
+                keepers_dir)
+       }
+     | Ok Directory ->
+       (match Safe_ops.list_dir_safe keepers_dir with
+        | Error msg -> { keeper_names = []; read_error = Some msg }
+        | Ok entries ->
+          let names, errors =
+            List.fold_left
+              (fun (names, errors) name ->
+                 let keeper_dir = Filename.concat keepers_dir name in
+                 match dir_state keeper_dir with
+                 | Error msg -> names, msg :: errors
+                 | Ok Missing | Ok Not_directory -> names, errors
+                 | Ok Directory ->
+                   let pending_path = Filename.concat keeper_dir snapshot_filename in
+                   let inflight_path =
+                     Filename.concat keeper_dir inflight_snapshot_filename
+                   in
+                   (match file_exists_safe pending_path, file_exists_safe inflight_path with
+                    | Error msg, _ | _, Error msg -> names, msg :: errors
+                    | Ok false, Ok false -> names, errors
+                    | Ok true, _ | _, Ok true ->
+                      (match Keeper_id.Keeper_name.of_string name with
+                       | Ok keeper_name ->
+                         Keeper_id.Keeper_name.to_string keeper_name :: names, errors
+                       | Error reason ->
+                         ( names
+                         , Printf.sprintf
+                             "invalid keeper name with durable event queue snapshot: %s"
+                             reason
+                           :: errors ))))
+              ([], [])
+              entries
+          in
+          { keeper_names = List.sort_uniq String.compare names
+          ; read_error =
+              (match List.rev errors with
+               | [] -> None
+               | errors -> Some (String.concat "; " errors))
+          }))
 
 let rec queue_contains queue stimulus =
   match Keeper_event_queue.dequeue queue with
@@ -287,47 +272,62 @@ let empty_snapshot_pair_with_errors =
   }
 ;;
 
-let load_snapshot_pair_unlocked ~log_restore ~base_path ~keeper_name =
-  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
-  | Error msg, _ | _, Error msg ->
-    Log.Keeper.warn "event_queue_snapshot: %s" msg;
-    empty_snapshot_pair
-  | Ok pending_path, Ok inflight_path ->
-    let pending = load_from_path ~log_restore ~keeper_name pending_path in
-    let inflight = load_from_path ~log_restore ~keeper_name inflight_path in
-    { pending; inflight }
+let load_snapshot_pair_unlocked ~log_restore owner =
+  let keeper_name = keeper_name_of_owner owner in
+  let pending =
+    load_from_path ~log_restore ~keeper_name (snapshot_path_of_owner owner)
+  in
+  let inflight =
+    load_from_path ~log_restore ~keeper_name (inflight_path_of_owner owner)
+  in
+  { pending; inflight }
 ;;
 
-let load_snapshot_pair_with_errors_unlocked ~base_path ~keeper_name =
-  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
-  | Error msg, _ | _, Error msg ->
-    Log.Keeper.warn "event_queue_snapshot: %s" msg;
-    { empty_snapshot_pair_with_errors with
-      read_errors = [ { kind = Invalid_path; path = None; message = msg } ]
-    }
-  | Ok pending_path, Ok inflight_path ->
-    let pending, pending_errors = load_from_path_with_errors ~keeper_name pending_path in
-    let inflight, inflight_errors = load_from_path_with_errors ~keeper_name inflight_path in
-    { pending; inflight; read_errors = pending_errors @ inflight_errors }
+let load_snapshot_pair_with_errors_unlocked owner =
+  let keeper_name = keeper_name_of_owner owner in
+  let pending, pending_errors =
+    load_from_path_with_errors ~keeper_name (snapshot_path_of_owner owner)
+  in
+  let inflight, inflight_errors =
+    load_from_path_with_errors ~keeper_name (inflight_path_of_owner owner)
+  in
+  { pending; inflight; read_errors = pending_errors @ inflight_errors }
 ;;
 
-let load_unlocked ~base_path ~keeper_name =
+let load_unlocked owner =
   (* The live hydration path: announce the restore once. *)
-  let pair = load_snapshot_pair_unlocked ~log_restore:true ~base_path ~keeper_name in
+  let pair = load_snapshot_pair_unlocked ~log_restore:true owner in
   prepend_missing pair.pending (Keeper_event_queue.to_list pair.inflight)
 ;;
 
 let load_snapshot_pair ~base_path ~keeper_name =
-  with_write_lock (fun () ->
-    load_snapshot_pair_unlocked ~log_restore:false ~base_path ~keeper_name)
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg ->
+    Log.Keeper.warn "event_queue_snapshot: %s" msg;
+    empty_snapshot_pair
+  | Ok owner ->
+    Owner_lock.with_lock owner (fun () ->
+      load_snapshot_pair_unlocked ~log_restore:false owner)
 ;;
 
 let load_snapshot_pair_with_errors ~base_path ~keeper_name =
-  with_write_lock (fun () -> load_snapshot_pair_with_errors_unlocked ~base_path ~keeper_name)
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg ->
+    Log.Keeper.warn "event_queue_snapshot: %s" msg;
+    { empty_snapshot_pair_with_errors with
+      read_errors = [ { kind = Invalid_path; path = None; message = msg } ]
+    }
+  | Ok owner ->
+    Owner_lock.with_lock owner (fun () ->
+      load_snapshot_pair_with_errors_unlocked owner)
 ;;
 
 let load ~base_path ~keeper_name =
-  with_write_lock (fun () -> load_unlocked ~base_path ~keeper_name)
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg ->
+    Log.Keeper.warn "event_queue_snapshot: %s" msg;
+    Keeper_event_queue.empty
+  | Ok owner -> Owner_lock.with_lock owner (fun () -> load_unlocked owner)
 
 let queue_oldest_arrived_at queue =
   queue
@@ -370,15 +370,28 @@ let read_queue_for_summary ~keeper_name path =
               keeper_name
               msg))
 
-type queue_summary = {
-  queue : Keeper_event_queue.t;
-  read_error : string option;
-}
+type queue_summary =
+  { queue : Keeper_event_queue.t
+  ; read_error : string option
+  }
 
 let queue_summary ~keeper_name path =
   match read_queue_for_summary ~keeper_name path with
   | Ok queue -> { queue; read_error = None }
   | Error msg -> { queue = Keeper_event_queue.empty; read_error = Some msg }
+
+let snapshot_read_error_to_string (error : snapshot_read_error) =
+  let location =
+    match error.path with
+    | None -> ""
+    | Some path -> " path=" ^ path
+  in
+  Printf.sprintf
+    "%s%s: %s"
+    (snapshot_read_error_kind_to_string error.kind)
+    location
+    error.message
+;;
 
 type keeper_queue_summary = {
   keeper_name : string;
@@ -395,8 +408,8 @@ let keeper_oldest_arrived_at summary =
   min_float_opt summary.pending_oldest_arrived_at summary.inflight_oldest_arrived_at
 
 let keeper_queue_summary ~base_path ~keeper_name =
-  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
-  | Error msg, _ | _, Error msg ->
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg ->
     { keeper_name
     ; pending_count = 0
     ; inflight_count = 0
@@ -404,17 +417,21 @@ let keeper_queue_summary ~base_path ~keeper_name =
     ; inflight_oldest_arrived_at = None
     ; read_errors = [ msg ]
     }
-  | Ok pending_path, Ok inflight_path ->
-    let pending = queue_summary ~keeper_name pending_path in
-    let inflight = queue_summary ~keeper_name inflight_path in
-    { keeper_name
-    ; pending_count = Keeper_event_queue.length pending.queue
-    ; inflight_count = Keeper_event_queue.length inflight.queue
-    ; pending_oldest_arrived_at = queue_oldest_arrived_at pending.queue
-    ; inflight_oldest_arrived_at = queue_oldest_arrived_at inflight.queue
-    ; read_errors =
-        List.filter_map (fun value -> value) [ pending.read_error; inflight.read_error ]
-    }
+  | Ok owner ->
+    Owner_lock.with_lock owner (fun () ->
+      let keeper_name = keeper_name_of_owner owner in
+      let pending = queue_summary ~keeper_name (snapshot_path_of_owner owner) in
+      let inflight = queue_summary ~keeper_name (inflight_path_of_owner owner) in
+      { keeper_name
+      ; pending_count = Keeper_event_queue.length pending.queue
+      ; inflight_count = Keeper_event_queue.length inflight.queue
+      ; pending_oldest_arrived_at = queue_oldest_arrived_at pending.queue
+      ; inflight_oldest_arrived_at = queue_oldest_arrived_at inflight.queue
+      ; read_errors =
+          List.filter_map
+            (fun value -> value)
+            [ pending.read_error; inflight.read_error ]
+      })
 
 let keeper_queue_summary_json ~now summary =
   let oldest_arrived_at = keeper_oldest_arrived_at summary in
@@ -449,8 +466,19 @@ let queue_count_by_keeper_json ~now kind summary =
     ]
 
 let fleet_summary_json ~now ~base_path =
-  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-  let discovery = discover_keeper_names_with_snapshots ~base_path in
+  let projection_base_path, discovery =
+    match Owner_lock.canonical_base_path base_path with
+    | Ok canonical ->
+      canonical, discover_keeper_names_with_snapshots ~base_path:canonical
+    | Error error ->
+      ( base_path
+      , { keeper_names = []
+        ; read_error = Some (owner_error_to_string error)
+        } )
+  in
+  let keepers_dir =
+    Common.keepers_runtime_dir_of_base ~base_path:projection_base_path
+  in
   let keeper_names = discovery.keeper_names in
   let scan_errors =
     match discovery.read_error with
@@ -486,7 +514,7 @@ let fleet_summary_json ~now ~base_path =
     [ "schema", `String "masc.keeper_event_queue.fleet_summary.v1"
     ; "status", `String (if read_error_count = 0 then "ok" else "degraded")
     ; "operator_action_required", `Bool (read_error_count > 0)
-    ; "base_path", `String base_path
+    ; "base_path", `String projection_base_path
     ; "keepers_runtime_dir", `String keepers_dir
     ; "keeper_count", `Int (List.length keeper_names)
     ; "keeper_names", `List (List.map (fun name -> `String name) keeper_names)
@@ -527,11 +555,14 @@ let persist_to_path ~keeper_name path queue =
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
 
 let persist ~base_path ~keeper_name queue =
-  match snapshot_path ~base_path ~keeper_name with
+  match resolve_owner ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok path ->
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let path = snapshot_path_of_owner owner in
     (try
-       with_write_lock (fun () -> persist_to_path ~keeper_name path queue)
+       Owner_lock.with_lock owner (fun () ->
+         persist_to_path ~keeper_name path queue)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -542,11 +573,14 @@ let persist ~base_path ~keeper_name queue =
          (Printexc.to_string exn))
 
 let persist_snapshot ~base_path ~keeper_name snapshot =
-  match snapshot_path ~base_path ~keeper_name with
+  match resolve_owner ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok path ->
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let path = snapshot_path_of_owner owner in
     (try
-       with_write_lock (fun () -> persist_to_path ~keeper_name path (snapshot ()))
+       Owner_lock.with_lock owner (fun () ->
+         persist_to_path ~keeper_name path (snapshot ()))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -556,24 +590,14 @@ let persist_snapshot ~base_path ~keeper_name snapshot =
          path
          (Printexc.to_string exn))
 
-let snapshot_read_error_to_string (error : snapshot_read_error) =
-  let location =
-    match error.path with
-    | None -> ""
-    | Some path -> " path=" ^ path
-  in
-  Printf.sprintf
-    "%s%s: %s"
-    (snapshot_read_error_kind_to_string error.kind)
-    location
-    error.message
-
 let update_checked_result ?(after_commit = fun () -> ()) ~base_path ~keeper_name f =
-  match snapshot_path ~base_path ~keeper_name with
+  match resolve_owner ~base_path ~keeper_name with
   | Error msg -> Error msg
-  | Ok path ->
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let path = snapshot_path_of_owner owner in
     (try
-       with_write_lock (fun () ->
+       Owner_lock.with_lock owner (fun () ->
          let cur, read_errors = load_from_path_with_errors ~keeper_name path in
          match read_errors with
          | _ :: _ ->
@@ -623,11 +647,13 @@ let record_inflight ~base_path ~keeper_name stimuli =
   match stimuli with
   | [] -> ()
   | _ -> (
-  match inflight_path ~base_path ~keeper_name with
+  match resolve_owner ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok path ->
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let path = inflight_path_of_owner owner in
     (try
-       with_write_lock (fun () ->
+       Owner_lock.with_lock owner (fun () ->
          let cur = load_from_path ~keeper_name path in
          persist_to_path ~keeper_name path (append_missing cur stimuli))
      with
@@ -647,11 +673,13 @@ let ack_inflight ~base_path ~keeper_name stimuli =
   match stimuli with
   | [] -> ()
   | _ -> (
-  match inflight_path ~base_path ~keeper_name with
+  match resolve_owner ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok path ->
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let path = inflight_path_of_owner owner in
     (try
-       with_write_lock (fun () ->
+       Owner_lock.with_lock owner (fun () ->
          let cur = load_from_path ~keeper_name path in
          persist_to_path ~keeper_name path (remove_stimuli cur stimuli))
      with
@@ -670,11 +698,14 @@ let ack_consumed ~base_path ~keeper_name stimuli =
   match stimuli with
   | [] -> Ok ()
   | _ -> (
-  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
-  | Error msg, _ | _, Error msg -> Error msg
-  | Ok pending_path, Ok inflight_path ->
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg -> Error msg
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let pending_path = snapshot_path_of_owner owner in
+    let inflight_path = inflight_path_of_owner owner in
     (try
-       with_write_lock (fun () ->
+       Owner_lock.with_lock owner (fun () ->
          let pending = load_from_path ~keeper_name pending_path in
          let inflight = load_from_path ~keeper_name inflight_path in
          let pending' = remove_stimuli pending stimuli in
@@ -694,11 +725,14 @@ let ack_consumed ~base_path ~keeper_name stimuli =
             (Printexc.to_string exn))))
 
 let drop_by_post_id ~base_path ~keeper_name ~post_id =
-  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
-  | Error msg, _ | _, Error msg -> Error msg
-  | Ok pending_path, Ok inflight_path ->
+  match resolve_owner ~base_path ~keeper_name with
+  | Error msg -> Error msg
+  | Ok owner ->
+    let keeper_name = keeper_name_of_owner owner in
+    let pending_path = snapshot_path_of_owner owner in
+    let inflight_path = inflight_path_of_owner owner in
     (try
-       with_write_lock (fun () ->
+       Owner_lock.with_lock owner (fun () ->
          let pending = load_from_path ~keeper_name pending_path in
          let inflight = load_from_path ~keeper_name inflight_path in
          let removed, pending', inflight' =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -6,8 +6,8 @@
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Restore a keeper queue snapshot, returning [Keeper_event_queue.empty] when
     no snapshot exists or the snapshot cannot be parsed. [load] is synchronized
-    with pending/inflight writes so callers cannot observe a split snapshot
-    transition. *)
+    by the canonical per-owner lock shared with pending/inflight writes, so
+    callers cannot observe a split snapshot transition. *)
 
 type snapshot_pair =
   { pending : Keeper_event_queue.t
@@ -62,7 +62,9 @@ val load_snapshot_pair_with_errors :
 val persist :
   base_path:string -> keeper_name:string -> Keeper_event_queue.t -> unit
 (** Atomically write the latest queue snapshot. Runtime fibers use a yielding
-    Eio mutex; non-Eio setup/test callers use a Stdlib fallback mutex.
+    per-owner Eio gate; non-Eio setup/test callers synchronize through the same
+    owner's cross-context Stdlib mutex. Different keeper owners do not share an
+    I/O lock.
     Persistence failures are logged and do not roll back the already-applied
     in-memory registry CAS update. *)
 
@@ -131,7 +133,8 @@ val drop_by_post_id :
 
 val fleet_summary_json : now:float -> base_path:string -> Yojson.Safe.t
 (** Diagnostic fleet summary of durable pending and in-flight queue snapshots.
-    This is read-only and does not mutate or de-duplicate files. Parse/read
-    failures are surfaced in the JSON instead of being collapsed to an empty
-    queue, so health probes cannot report a false green while durable queue
-    state is unreadable. *)
+    Each pending/in-flight pair is read under that keeper's owner lock; the
+    fleet is not globally serialized. This is read-only and does not mutate or
+    de-duplicate files. Parse/read failures are surfaced in the JSON instead of
+    being collapsed to an empty queue, so health probes cannot report a false
+    green while durable queue state is unreadable. *)

--- a/test/dune
+++ b/test/dune
@@ -369,6 +369,7 @@
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
+  test_keeper_event_queue_owner_lock
   test_keeper_event_queue_persist_poison
   test_keeper_goal_stagnation_wake
   test_workspace_routes_keeper
@@ -738,6 +739,7 @@
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
+  test_keeper_event_queue_owner_lock
   test_keeper_event_queue_persist_poison
   test_keeper_goal_stagnation_wake
   test_actionable_path_action

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -1,0 +1,369 @@
+(** Deterministic concurrency contracts for durable event-queue owner locks.
+
+    Every interleaving below is controlled by an explicit [Atomic] barrier.
+    There are no timing thresholds: a participant either reaches the protected
+    transition or remains blocked until the owning Keeper lane releases it. *)
+
+module Persistence = Keeper_event_queue_persistence
+module Queue = Keeper_event_queue
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
+let with_temp_dir prefix f =
+  let base_path = Filename.temp_dir prefix "" in
+  Fun.protect ~finally:(fun () -> rm_rf base_path) (fun () -> f base_path)
+;;
+
+let require_ok label = function
+  | Ok value -> value
+  | Error message -> Alcotest.failf "%s: %s" label message
+;;
+
+let require_some label = function
+  | Some value -> value
+  | None -> Alcotest.failf "%s: missing result" label
+;;
+
+let rec await_atomic flag =
+  if Atomic.get flag
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    await_atomic flag)
+;;
+
+let await_atomic_in_domain flag =
+  while not (Atomic.get flag) do
+    Domain.cpu_relax ()
+  done
+;;
+
+let stimulus ~post_id ~arrived_at : Queue.stimulus =
+  { post_id; urgency = Queue.Normal; arrived_at; payload = Queue.Bootstrap }
+;;
+
+let post_ids queue =
+  Queue.to_list queue
+  |> List.map (fun (item : Queue.stimulus) -> item.post_id)
+;;
+
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+;;
+
+let inflight_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue-inflight.json"
+;;
+
+let persist_queue_file path queue =
+  Queue.queue_to_yojson queue
+  |> Yojson.Safe.pretty_to_string
+  |> Fs_compat.save_file_atomic path
+  |> require_ok ("write split-state fixture " ^ path)
+;;
+
+let json_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let int_field name json =
+  match json_field name json with
+  | Some (`Int value) -> value
+  | _ -> Alcotest.failf "expected int field %S" name
+;;
+
+let list_field name json =
+  match json_field name json with
+  | Some (`List values) -> values
+  | _ -> Alcotest.failf "expected list field %S" name
+;;
+
+let string_field name json =
+  match json_field name json with
+  | Some (`String value) -> value
+  | _ -> Alcotest.failf "expected string field %S" name
+;;
+
+let keeper_summary keeper_name json =
+  match
+    list_field "keepers" json
+    |> List.find_opt (fun item ->
+      String.equal keeper_name (string_field "keeper_name" item))
+  with
+  | Some summary -> summary
+  | None -> Alcotest.failf "missing fleet summary for keeper %S" keeper_name
+;;
+
+let test_canonical_owner_and_cross_context_isolation () =
+  with_temp_dir "event-queue-owner-a" (fun base_a ->
+    with_temp_dir "event-queue-owner-b" (fun base_b ->
+      let keeper_a = "owner_a" in
+      let keeper_b = "owner_b" in
+      let base_a_masc = Filename.concat base_a Common.masc_dirname in
+      (match
+         Persistence.update_result
+           ~base_path:base_a
+           ~keeper_name:"owner.with.untyped-separator"
+           (fun queue -> queue)
+       with
+       | Error _ -> ()
+       | Ok () -> Alcotest.fail "invalid Keeper identity resolved an owner lock");
+
+      let held = Atomic.make false in
+      let release = Atomic.make false in
+      let holder_result = ref None in
+      let holder =
+        Domain.spawn (fun () ->
+          Persistence.update_result
+            ~base_path:base_a_masc
+            ~keeper_name:keeper_a
+            (fun queue ->
+               Atomic.set held true;
+               await_atomic_in_domain release;
+               Queue.enqueue queue (stimulus ~post_id:"domain-a" ~arrived_at:1.0)))
+      in
+      Fun.protect
+        ~finally:(fun () ->
+          Atomic.set release true;
+          holder_result := Some (Domain.join holder))
+        (fun () ->
+           await_atomic held;
+           Eio.Switch.run (fun sw ->
+             let same_attempted = Atomic.make false in
+             let same_entered = Atomic.make false in
+             let same_done, resolve_same_done = Eio.Promise.create () in
+             Eio.Fiber.fork ~sw (fun () ->
+               Atomic.set same_attempted true;
+               let result =
+                 Persistence.update_result
+                   ~base_path:base_a
+                   ~keeper_name:keeper_a
+                   (fun queue ->
+                      Atomic.set same_entered true;
+                      Queue.enqueue
+                        queue
+                        (stimulus ~post_id:"fiber-a" ~arrived_at:2.0))
+               in
+               Eio.Promise.resolve resolve_same_done result);
+             await_atomic same_attempted;
+             Eio.Fiber.yield ();
+             Alcotest.(check bool)
+               "same owner cannot enter while Domain owns it"
+               false
+               (Atomic.get same_entered);
+
+             Persistence.update_result
+               ~base_path:base_a
+               ~keeper_name:keeper_b
+               (fun queue ->
+                  Queue.enqueue queue (stimulus ~post_id:"other-keeper" ~arrived_at:3.0))
+             |> require_ok "different keeper proceeds while owner A is held";
+             Persistence.update_result
+               ~base_path:base_b
+               ~keeper_name:keeper_a
+               (fun queue ->
+                  Queue.enqueue queue (stimulus ~post_id:"other-base" ~arrived_at:4.0))
+             |> require_ok "different BasePath proceeds while owner A is held";
+
+             Atomic.set release true;
+             Eio.Promise.await same_done
+             |> require_ok "same-owner fiber completes after release"));
+      require_some "Domain holder join" !holder_result
+      |> require_ok "Domain holder update";
+
+      Alcotest.(check (list string))
+        "BasePath aliases preserve both serialized updates exactly once"
+        [ "domain-a"; "fiber-a" ]
+        (Persistence.load ~base_path:base_a ~keeper_name:keeper_a |> post_ids);
+      Alcotest.(check (list string))
+        "different keeper persisted independently"
+        [ "other-keeper" ]
+        (Persistence.load ~base_path:base_a ~keeper_name:keeper_b |> post_ids);
+      Alcotest.(check (list string))
+        "different BasePath persisted independently"
+        [ "other-base" ]
+        (Persistence.load ~base_path:base_b ~keeper_name:keeper_a |> post_ids)))
+;;
+
+let test_cancelled_waiter_does_not_leak_owner_lock () =
+  with_temp_dir "event-queue-owner-cancel" (fun base_path ->
+    let keeper_name = "cancel_owner" in
+    let peer_name = "cancel_peer" in
+    let held = Atomic.make false in
+    let release = Atomic.make false in
+    let holder_result = ref None in
+    let holder =
+      Domain.spawn (fun () ->
+        Persistence.update_result ~base_path ~keeper_name (fun queue ->
+          Atomic.set held true;
+          await_atomic_in_domain release;
+          queue))
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        Atomic.set release true;
+        holder_result := Some (Domain.join holder))
+      (fun () ->
+         await_atomic held;
+         let waiter_started = Atomic.make false in
+         let waiter_entered = Atomic.make false in
+         let first_result =
+           Eio.Fiber.first
+             (fun () ->
+                Atomic.set waiter_started true;
+                (match
+                   Persistence.update_result ~base_path ~keeper_name (fun queue ->
+                     Atomic.set waiter_entered true;
+                     Queue.enqueue
+                       queue
+                       (stimulus ~post_id:"cancelled" ~arrived_at:5.0))
+                 with
+                 | Ok () -> `Waiter_committed
+                 | Error message -> `Waiter_failed message))
+             (fun () ->
+                await_atomic waiter_started;
+                `Cancel_waiter)
+         in
+         (match first_result with
+          | `Cancel_waiter -> ()
+          | `Waiter_committed ->
+            Alcotest.fail "same-owner waiter committed before its owner released"
+          | `Waiter_failed message ->
+            Alcotest.failf
+              "same-owner waiter failed instead of remaining blocked: %s"
+              message);
+         Alcotest.(check bool)
+           "cancelled waiter never entered persistence transform"
+           false
+           (Atomic.get waiter_entered);
+         Persistence.update_result ~base_path ~keeper_name:peer_name (fun queue ->
+           Queue.enqueue
+             queue
+             (stimulus ~post_id:"peer-during-cancel" ~arrived_at:5.5))
+         |> require_ok "peer owner proceeds while cancelled owner remains held";
+         Atomic.set release true);
+    require_some "cancel holder join" !holder_result
+    |> require_ok "cancel holder update";
+
+    Persistence.update_result ~base_path ~keeper_name (fun queue ->
+      Queue.enqueue queue (stimulus ~post_id:"survivor" ~arrived_at:6.0))
+    |> require_ok "owner remains usable after waiter cancellation";
+    Alcotest.(check (list string))
+      "cancelled waiter committed no durable stimulus"
+      [ "survivor" ]
+      (Persistence.load ~base_path ~keeper_name |> post_ids);
+    Alcotest.(check (list string))
+      "peer owner persisted during cancellation"
+      [ "peer-during-cancel" ]
+      (Persistence.load ~base_path ~keeper_name:peer_name |> post_ids))
+;;
+
+let test_exception_does_not_poison_owner_or_other_lane () =
+  with_temp_dir "event-queue-owner-exception" (fun base_path ->
+    let keeper_a = "exception_owner" in
+    let keeper_b = "exception_peer" in
+    (match
+       Persistence.update_result ~base_path ~keeper_name:keeper_a (fun _queue ->
+         raise Exit)
+     with
+     | Error _ -> ()
+     | Ok () -> Alcotest.fail "raising transform was reported as committed");
+    Persistence.update_result ~base_path ~keeper_name:keeper_a (fun queue ->
+      Queue.enqueue queue (stimulus ~post_id:"same-owner" ~arrived_at:7.0))
+    |> require_ok "same owner remains usable after exception";
+    Persistence.update_result ~base_path ~keeper_name:keeper_b (fun queue ->
+      Queue.enqueue queue (stimulus ~post_id:"peer-owner" ~arrived_at:8.0))
+    |> require_ok "peer owner remains independent after exception";
+    Alcotest.(check (list string))
+      "same owner durable state after exception"
+      [ "same-owner" ]
+      (Persistence.load ~base_path ~keeper_name:keeper_a |> post_ids);
+    Alcotest.(check (list string))
+      "peer owner durable state after exception"
+      [ "peer-owner" ]
+      (Persistence.load ~base_path ~keeper_name:keeper_b |> post_ids))
+;;
+
+let test_fleet_summary_never_observes_split_owner_pair () =
+  with_temp_dir "event-queue-owner-summary" (fun base_path ->
+    let keeper_name = "summary_owner" in
+    let pending = stimulus ~post_id:"pending" ~arrived_at:9.0 in
+    let inflight = stimulus ~post_id:"inflight" ~arrived_at:10.0 in
+    Persistence.persist
+      ~base_path
+      ~keeper_name
+      (Queue.enqueue Queue.empty pending);
+    Persistence.record_inflight ~base_path ~keeper_name [ inflight ];
+    let pending_path = snapshot_path ~base_path ~keeper_name in
+    let inflight_path = inflight_path ~base_path ~keeper_name in
+    let split_ready = Atomic.make false in
+    let release = Atomic.make false in
+    let writer_result = ref None in
+    let writer =
+      Domain.spawn (fun () ->
+        Persistence.update_result ~base_path ~keeper_name (fun _queue ->
+          persist_queue_file pending_path Queue.empty;
+          Atomic.set split_ready true;
+          await_atomic_in_domain release;
+          persist_queue_file inflight_path Queue.empty;
+          Queue.empty))
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        Atomic.set release true;
+        writer_result := Some (Domain.join writer))
+      (fun () ->
+         await_atomic split_ready;
+         Eio.Switch.run (fun sw ->
+           let summary_started = Atomic.make false in
+           let summary_done = Atomic.make false in
+           let summary, resolve_summary = Eio.Promise.create () in
+           Eio.Fiber.fork ~sw (fun () ->
+             Atomic.set summary_started true;
+             let json =
+               Persistence.fleet_summary_json ~now:20.0 ~base_path
+             in
+             Atomic.set summary_done true;
+             Eio.Promise.resolve resolve_summary json);
+           await_atomic summary_started;
+           Eio.Fiber.yield ();
+           Alcotest.(check bool)
+             "summary blocks while one owner pair is split"
+             false
+             (Atomic.get summary_done);
+           Atomic.set release true;
+           let json = Eio.Promise.await summary in
+           let keeper = keeper_summary keeper_name json in
+           Alcotest.(check int)
+             "summary pending count comes from completed pair"
+             0
+             (int_field "pending_count" keeper);
+           Alcotest.(check int)
+             "summary inflight count comes from completed pair"
+             0
+             (int_field "inflight_count" keeper)));
+    require_some "split writer join" !writer_result
+    |> require_ok "split writer update")
+;;
+
+let () =
+  Eio_main.run (fun _env ->
+    test_canonical_owner_and_cross_context_isolation ();
+    test_cancelled_waiter_does_not_leak_owner_lock ();
+    test_exception_does_not_poison_owner_or_other_lane ();
+    test_fleet_summary_never_observes_split_owner_pair ());
+  print_endline "test_keeper_event_queue_owner_lock: OK"
+;;

--- a/test/test_keeper_event_queue_persist_poison.ml
+++ b/test/test_keeper_event_queue_persist_poison.ml
@@ -1,18 +1,16 @@
-(** Regression: durable event-queue persistence must not poison its shared,
-    process-global Eio mutex on a disk write failure (audit 2026-06-29).
+(** Regression: durable event-queue persistence must not poison an owner's Eio
+    gate on a disk write failure (audit 2026-06-29, owner isolation 2026-07-11).
 
     Before the fix, [save_json_atomic] called [Fs_compat.mkdir_p] — which raises
     (Sys_error / Unix_error) on ENOTDIR/ENOSPC/EROFS — inside the
     [Eio.Mutex.use_rw] critical section. [use_rw] poisons the mutex permanently
-    on a raised exception, so a single disk error blocked durable snapshots for
-    EVERY keeper for the lifetime of the process.
+    on a raised exception, so the old process-global lock could block durable
+    snapshots for every keeper for the lifetime of the process.
 
-    This test drives the Eio path (so [Eio_context.get_switch_opt] returns
-    [Some], selecting the poison-prone [eio_write_mu]) and asserts that a failed
-    persist leaves the mutex usable for a subsequent valid persist. On the
-    unfixed code the second persist's [with_write_lock] raises
-    [Eio.Mutex.Poisoned], [persist] swallows it, the snapshot file is never
-    written, and the [Sys.file_exists] assertion fails (RED). *)
+    This test drives the Eio path and repairs the failing filesystem ancestor
+    before retrying the exact same canonical owner. The retry therefore proves
+    that the owner's cooperative gate remains usable; a different BasePath
+    cannot accidentally make the assertion pass through lock isolation. *)
 
 let rec rm_rf path =
   if Sys.file_exists path
@@ -35,7 +33,8 @@ let () =
   let net = Eio.Stdenv.net env in
   Eio.Switch.run @@ fun sw ->
   Eio_context.with_test_env ~net ~clock ~mono_clock ~sw @@ fun () ->
-  (* Exercise the Eio mutex (poison-prone path), not the Stdlib fallback. *)
+  (* [Eio_main.run] makes this an Eio fiber; [with_test_env] supplies the
+     existing filesystem/network test context but does not select the lock. *)
   assert (Eio_context.get_switch_opt () <> None);
 
   let keeper_name = "poison_probe" in
@@ -44,25 +43,25 @@ let () =
   (* 1) Force mkdir_p to raise inside the critical section: a base path whose
         ancestor is a regular file yields ENOTDIR. [persist] logs the failure as
         a warning and returns; pre-fix it ALSO poisoned the shared mutex. *)
-  let blocker_file = Filename.temp_file "kqp_poison_blocker" "" in
-  let bad_base = Filename.concat blocker_file "base" in
-  Keeper_event_queue_persistence.persist ~base_path:bad_base ~keeper_name queue;
+  let blocker_path = Filename.temp_file "kqp_poison_blocker" "" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists blocker_path then rm_rf blocker_path)
+    (fun () ->
+      let base_path = Filename.concat blocker_path "base" in
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name queue;
 
-  (* 2) A valid persist on a real directory. If step 1 poisoned the mutex,
-        [with_write_lock] raises [Eio.Mutex.Poisoned], [persist] swallows it, and
-        the snapshot is never written -> the assertion below fails. *)
-  let good_base = Filename.temp_dir "kqp_poison_ok" "" in
-  Keeper_event_queue_persistence.persist ~base_path:good_base ~keeper_name queue;
-  let path = snapshot_path ~base_path:good_base ~keeper_name in
-  assert (Sys.file_exists path);
+      (* 2) Replace the invalid ancestor and retry the same owner identity. *)
+      Sys.remove blocker_path;
+      Unix.mkdir blocker_path 0o755;
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name queue;
+      let path = snapshot_path ~base_path ~keeper_name in
+      assert (Sys.file_exists path);
 
-  (* 3) The lock still serializes correctly after recovery: load round-trips the
-        persisted (empty) queue without raising. *)
-  let restored =
-    Keeper_event_queue_persistence.load ~base_path:good_base ~keeper_name
-  in
-  assert (Keeper_event_queue.is_empty restored);
+      (* 3) The lock still serializes correctly after recovery: load round-trips
+         the persisted (empty) queue without raising. *)
+      let restored =
+        Keeper_event_queue_persistence.load ~base_path ~keeper_name
+      in
+      assert (Keeper_event_queue.is_empty restored));
 
-  rm_rf good_base;
-  (try Sys.remove blocker_file with _ -> ());
   print_endline "test_keeper_event_queue_persist_poison: OK"


### PR DESCRIPTION
## Summary

- replace the fleet-global event-queue persistence mutex and disjoint non-Eio fallback with one canonical per-owner lock
- key ownership by normalized absolute MASC BasePath plus typed Keeper name
- let Eio callers wait cooperatively while Eio and non-Eio callers for the same owner share one exclusion domain
- read each durable pending/inflight pair under the same owner lock without serializing unrelated Keeper lanes
- keep the lock implementation Dune-private and retain the existing persistence API

## Correctness contract

- same owner: Eio fiber and Domain caller serialize
- different Keeper or BasePath: no shared I/O lock
- cancellation while waiting releases the cooperative gate and commits nothing
- cancellation after acquisition is delayed through the critical section, then rechecked after both locks release
- callback and disk exceptions do not poison or leak either lock
- inactive owner locks are collectible through an Ephemeron registry; there is no fleet-size cap or eviction heuristic
- BasePath and BasePath/.masc resolve to the same owner identity

## Verification

Deterministic barrier tests cover:

- canonical BasePath alias + cross-context exclusion
- different Keeper/BasePath progress while another owner is held
- cancelled same-owner waiter and subsequent reuse
- transform exception and same/peer-owner reuse
- fleet summary blocking until a deliberately split pending/inflight pair finishes
- ENOTDIR recovery on the exact same canonical owner

All changed OCaml files pass parser and ocamlformat checks. Diff check plus Eio convention, OCaml structure, silent-failure, stringly-boundary, domain-boundary, and comment-trap gates pass.

Per workspace policy, local Dune was not run. GitHub CI is the build authority.

## Non-goals

This slice does **not** claim that the existing registry CAS → record-inflight → durable pending update sequence is transactional. That separate claim/ack/requeue commit problem remains tracked under #24073. Failure-judgment outcome-aware `Ack | Requeue | Escalate` remains #24198.

## Official basis

- OCaml 5.4 `Mutex.protect`: https://ocaml.org/manual/5.4/api/Mutex.html
- Eio Mutex semantics: https://ocaml-multicore.github.io/eio/eio/Eio/Mutex/index.html

[근거] source head `ca2909000b32b15ab041b536ca352575635232ca`; parser/format/static gates checked 2026-07-11 KST; confidence High.

Related: #24073