### PR TITLE
fix(keeper): clear latched_reason on operator resume

### DIFF
--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -213,6 +213,14 @@ let update_keeper ?(preserve_prompt_defaults = false)
     autoboot_enabled;
     active_goal_ids;
     paused = if resume_paused_keeper then false else old.paused;
+    (* Operator-sanctioned resume clears the terminal latch (Dead_tombstone
+       included) so a sanctioned keeper_up revives a latched keeper.  Without
+       this [latched_reason] survives a paused-clearing resume and every
+       latch-keyed gate (auto-resume / stale-paused prune / lifecycle
+       admission) keeps denying revival forever even after [paused] is
+       cleared. *)
+    latched_reason =
+      if resume_paused_keeper then None else source_meta.latched_reason;
     auto_resume_after_sec =
       if resume_paused_keeper then None else old.auto_resume_after_sec;
     runtime =

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -384,6 +384,35 @@ let test_dead_tombstone_latch_blocks_legacy_auto_resume () =
        ~now:(Unix.time () +. 7200.0)
        meta)
 
+(* Regression for the "permanent zombie" bug: operator [masc_keeper_up]
+   ([Keeper_turn_up_update] resume branch) must clear [latched_reason], not
+   only [paused].  A [Dead_tombstone] latch that survives a paused-clearing
+   resume keeps [paused_meta_auto_resume_due] false forever, so the keeper can
+   never recover.  This pins that clearing the latch re-enables recovery. *)
+let test_operator_resume_clears_dead_tombstone_latch () =
+  let base = make_meta "revive-after-operator-up" in
+  let paused_due =
+    { base with
+      paused = true
+    ; auto_resume_after_sec = Some 1.0
+    ; updated_at = "1970-01-01T00:00:00Z"
+    }
+  in
+  check
+    bool
+    "Dead_tombstone latch blocks auto-resume"
+    false
+    (Keeper_supervisor_types.paused_meta_auto_resume_due
+       ~now:(Unix.time () +. 7200.0)
+       { paused_due with latched_reason = Some Keeper_latched_reason.Dead_tombstone });
+  check
+    bool
+    "operator-cleared latch re-enables auto-resume"
+    true
+    (Keeper_supervisor_types.paused_meta_auto_resume_due
+       ~now:(Unix.time () +. 7200.0)
+       { paused_due with latched_reason = None })
+
 let test_heartbeat_merge_preserves_only_typed_operator_pause () =
   let caller =
     { (make_meta "typed-operator-pause-merge-caller") with
@@ -536,6 +565,8 @@ let () =
             test_dead_tombstone_cleanup_repairs_stale_terminal_state
         ; test_case "dead-tombstone latch blocks legacy auto-resume" `Quick
             test_dead_tombstone_latch_blocks_legacy_auto_resume
+        ; test_case "operator resume clears dead-tombstone latch to re-enable recovery"
+            `Quick test_operator_resume_clears_dead_tombstone_latch
         ; test_case "heartbeat merge uses typed operator latch, not pause shape" `Quick
             test_heartbeat_merge_preserves_only_typed_operator_pause
         ; test_case "dead-tombstone cleanup CAS retry preserves Dead_tombstone" `Quick


### PR DESCRIPTION
## 요약

`update_keeper`(운영자 `masc_keeper_up`)의 resume 브랜치가 `paused`·`last_blocker`는 지웠지만 `latched_reason`을 남겼어용. 그래서 `Dead_tombstone` latch가 paused-clearing resume 후에도 살아남아, latch-키 게이트(`paused_meta_auto_resume_due` / stale-paused prune / lifecycle admission)가 stale reason을 계속 읽고 복구를 영구 거부했어요 — 운영자의 복구 명령이 prunable tombstone을 **영구 좀비**로 만들었어요.

## 변경 (`112e4a0c21`)

- `keeper_turn_up_update.ml` resume 브랜치에 `latched_reason = None` 추가. latch의 자동 효과(자동 재부팅 방지)는 보존하고, **명시적 운영자 resume만** 해제해요.
- 회귀 테스트: cleared latch가 `paused_meta_auto_resume_due`를 재활성화, 살아있는 `Dead_tombstone` latch는 여전히 차단.

## 근거

라이브에서 dead_tombstone latch된 keeper가 `keeper_up`으로 안 살아나는 문제가 실재해요(rondo: `auto_resume_after_sec=None`). #24155(lifecycle admission 중앙화)가 이 latch를 terminal admission 게이트로 승격하면 문제가 더 심각(9 keeper/14 latch 즉시 복구불능)해서, main 선반영으로 예방해요. #24155가 rebase하면 이 fix를 흡수해요.

## P0/P1/P2/P3

- **P1 해소**: 운영자 복구 영구차단(영구 좀비) → resume이 latch clear로 복구 대칭성 회복.
- P0/P2/P3: 없음.

## 검증

- 로컬 dune build 미실행, CI가 빌드 권위.
- 회귀 테스트 `test_operator_resume_clears_dead_tombstone_latch` 추가.

## 테스트 한계 (투명)

`update_keeper`는 dashboard context 의존 통합 함수라 직접 통합 테스트 하네스가 없어요. fix 라인(resume→latched clear)은 CI 컴파일/회귀로 보호하고, 회귀 테스트는 `Keeper_supervisor_types` 레벨에서 복구 불변식(latch cleared → auto_resume 가능)을 pin해요.

RFC-WAIVED: keeper lifecycle 복구 버그 수정(`latched_reason` clear)이고 신규 credential/identity/auth 아키텍처가 아니에요. credential_*/operator_control* 미접촉.
