### PR TITLE
fix(keeper): isolate malformed shutdown records from fleet autoboot

### DIFF
--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -587,27 +587,39 @@ let list_unlocked ~config =
   then Ok []
   else
     try
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.sort String.compare
-      |> List.fold_left
-           (fun result filename ->
-              let* operations = result in
-              if not (Filename.check_suffix filename ".json")
-              then
-                Error
-                  (Decode_error
-                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
-              else
-                let raw_id = Filename.chop_suffix filename ".json" in
-                let* operation_id =
-                  Operation_id.of_string raw_id
-                  |> Result.map_error (fun e -> Decode_error e)
-                in
-                let* operation = load ~config operation_id in
-                Ok (operation :: operations))
-           (Ok [])
-      |> Result.map List.rev
+      (* Per-record isolation: one malformed entry must not sink the whole
+         inventory, which would block every keeper's autoboot recovery.  Each
+         bad record is quarantined with a WARN so the loss stays observable
+         (not silent), while the healthy records are still returned.  Only a
+         directory-level I/O failure escapes as [Error]. *)
+      let operations =
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.sort String.compare
+        |> List.filter_map (fun filename ->
+             if not (Filename.check_suffix filename ".json")
+             then (
+               Log.Keeper.warn
+                 "shutdown store: skipping non-json entry %s" filename;
+               None)
+             else
+               let raw_id = Filename.chop_suffix filename ".json" in
+               match Operation_id.of_string raw_id with
+               | Error e ->
+                 Log.Keeper.warn
+                   "shutdown store: skipping undecodable operation id %s: %s"
+                   filename e;
+                 None
+               | Ok operation_id ->
+                 (match load ~config operation_id with
+                  | Error e ->
+                    Log.Keeper.warn
+                      "shutdown store: skipping unreadable record %s: %s"
+                      filename (error_to_string e);
+                    None
+                  | Ok operation -> Some operation))
+      in
+      Ok operations
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Io_error (Printexc.to_string exn))

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -350,31 +350,32 @@ let start_keeper_loops
       match Keeper_shutdown_store.list_all ~config with
       | Error error -> Error (Keeper_shutdown_store.error_to_string error)
       | Ok operations ->
-        List.fold_left
-          (fun restored operation ->
-             match restored with
-             | Error _ as error -> error
-             | Ok () when not (operation_requires_fence operation) -> Ok ()
-             | Ok () ->
-               (match
-                  Keeper_turn_admission.restore_shutdown
-                    ~base_path:config.base_path
-                    ~keeper_name:operation.keeper_name
-                    ~operation_id:operation.operation_id
-                with
-                | Keeper_turn_admission.Shutdown_restored
-                | Keeper_turn_admission.Shutdown_already_restored -> Ok ()
-                | Keeper_turn_admission.Shutdown_restore_conflict existing ->
-                  Error
-                    (Printf.sprintf
-                       "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
-                       operation.keeper_name
-                       (Keeper_shutdown_types.Operation_id.to_string
-                          operation.operation_id)
-                       (Keeper_shutdown_types.Operation_id.to_string existing))))
-          (Ok ())
-          operations
-        |> Result.map (fun () -> operations)
+        (* Per-operation isolation: a restore conflict on one keeper must not
+           abort the remaining fence restores, which would leave the whole
+           fleet unbooted.  Each conflict is logged (observable, not silent)
+           and that keeper is skipped; the healthy keepers still restore. *)
+        List.iter
+          (fun operation ->
+             if operation_requires_fence operation
+             then (
+               match
+                 Keeper_turn_admission.restore_shutdown
+                   ~base_path:config.base_path
+                   ~keeper_name:operation.keeper_name
+                   ~operation_id:operation.operation_id
+               with
+               | Keeper_turn_admission.Shutdown_restored
+               | Keeper_turn_admission.Shutdown_already_restored -> ()
+               | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+                 Log.Keeper.warn
+                   "shutdown admission restore conflict (isolated): keeper=%s \
+                    durable=%s existing=%s"
+                   operation.keeper_name
+                   (Keeper_shutdown_types.Operation_id.to_string
+                      operation.operation_id)
+                   (Keeper_shutdown_types.Operation_id.to_string existing)))
+          operations;
+        Ok operations
     in
     Eio.Promise.resolve shutdown_inventory_r inventory;
     match inventory with

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -915,6 +915,82 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
       | Error error -> fail (Shutdown_store.error_to_string error)
       | Ok _ -> fail "unsupported shutdown schema was accepted")
 
+let test_shutdown_store_list_all_isolates_malformed_records () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-store-isolation" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let persist name =
+        let meta = make_meta name in
+        let operation_id = Shutdown_types.Operation_id.generate () in
+        let lane = Lane.create () in
+        let now = Masc_domain.now_iso () in
+        let operation : Shutdown_types.t =
+          { schema_version = Shutdown_types.schema_version
+          ; revision = 0
+          ; operation_id
+          ; keeper_name = meta.name
+          ; lane_id = Lane.id lane
+          ; trace_id = meta.runtime.trace_id
+          ; generation = meta.runtime.generation
+          ; actor = "tester"
+          ; cleanup_intent = { remove_meta = false; remove_session = false }
+          ; turn_disposition = Shutdown_types.No_inflight_turn
+          ; expected_backlog_version = backlog_version
+          ; owned_task_ids = []
+          ; join_evidence = None
+          ; phase = Shutdown_types.Prepared
+          ; created_at = now
+          ; updated_at = now
+          }
+        in
+        (match Shutdown_store.persist_new ~config operation with
+         | Ok () -> ()
+         | Error error -> fail (Shutdown_store.error_to_string error));
+        meta.name
+      in
+      let name_a = persist "healthy-a" in
+      let name_b = persist "healthy-b" in
+      (* A malformed neighbor (stray non-json and a corrupt .json) must be
+         quarantined without sinking the healthy records — the pre-fix fold
+         collapsed the whole inventory to [Error], blocking every autoboot. *)
+      let records_dir =
+        Filename.dirname
+          (Shutdown_store.path ~config (Shutdown_types.Operation_id.generate ()))
+      in
+      let write path content =
+        let oc = open_out path in
+        output_string oc content;
+        close_out oc
+      in
+      write (Filename.concat records_dir "not-a-record.txt") "garbage";
+      write (Filename.concat records_dir "corrupt.json") "{ not valid json";
+      match Shutdown_store.list_all ~config with
+      | Error error ->
+        fail
+          (Printf.sprintf
+             "list_all must isolate malformed entries, not fail wholesale: %s"
+             (Shutdown_store.error_to_string error))
+      | Ok operations ->
+        let names =
+          List.map (fun (o : Shutdown_types.t) -> o.keeper_name) operations
+        in
+        check int "healthy records survive malformed neighbors" 2
+          (List.length operations);
+        check bool "healthy-a retained" true (List.mem name_a names);
+        check bool "healthy-b retained" true (List.mem name_b names))
+
 let test_keeper_shutdown_prepare_joins_idle_lane () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1774,6 +1850,8 @@ let () =
         test_keeper_lane_cancel_is_lane_local_and_joinable;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "shutdown store list_all isolates malformed records" `Quick
+        test_shutdown_store_list_all_isolates_malformed_records;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown prepare joins not-started lane" `Quick


### PR DESCRIPTION
## 요약

부팅 복구의 두 fold가 shutdown 인벤토리 **한 원소**가 손상되면 전체를 `Error`로 붕괴시켜, 모든 keeper의 autoboot를 막았어용("inventory is uncertain" → autoboot 0대). 무관한 1건이 전 fleet를 인질로 잡는 fleet-wide coupling이에요.

## 변경 (`f643816069`)

- `Keeper_shutdown_store.list_unlocked`: 첫 손상 항목(stray non-`.json` 파일 1개, 또는 undecodable/unreadable record 1개)에서 단락하던 걸 **per-record 격리**로. 손상은 `WARN` 로깅 후 skip, 정상 record는 그대로 반환.
- `server_bootstrap_loops` restore fold: 첫 `Shutdown_restore_conflict`에서 나머지 fence 복원을 중단하던 걸 **per-operation 격리**로. conflict는 `WARN` 로깅 후 해당 keeper만 skip, 정상 keeper는 복원+부팅.

silent 아니에요: 손상/conflict는 전부 `WARN`으로 관측 가능해요. dir-level I/O 실패만 여전히 `Error`로 escalate.

## P0/P1/P2/P3

- **P0 해소**: fleet-wide coupling(무관한 1건이 전체 autoboot를 0대로 인질) → per-record/per-operation 격리.
- P1/P2/P3: 없음.

## 근거

이 P0는 **이미 main(`3161c84518`)에 존재하는 프로덕션 버그**예요. #24146 적대 리뷰에서 지적했으나 그 브랜치가 활발히 재작업 중(diverged)이라 직접 push하면 force-push 경쟁(masc#5303)이라, main 기반 독립 fix로 분리했어요.

## 검증

- 로컬 dune build 미실행, CI가 빌드 권위.
- 회귀 테스트 `test_shutdown_store_list_all_isolates_malformed_records`: stray 파일 + corrupt `.json` 옆에서 healthy record 2개가 살아남음(전체 `Error` 아님).
- restore fold(P0-2)는 server 부팅 통합 경로라 단위 하네스 대신 같은 per-operation 원리로 적용하고 CI 회귀로 보호해요.

RFC-WAIVED: keeper shutdown 복구 버그 수정(fleet-wide coupling 격리)이고 credential/identity/operator_control 미접촉이에요.
