### PR TITLE
fix(dashboard): make MCP auth generations atomic

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -92,6 +92,14 @@ function setupMcpSessionMocks(sessionId: string) {
     )
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 /** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
 function findCallByMethod(method: string) {
   return callsByMethod(method)[0]
@@ -141,10 +149,94 @@ describe('mcpHeaders auth integration', () => {
 
     const { callMcpTool } = await import('./mcp')
     await expect(callMcpTool('masc_status', {}))
-      .rejects.toThrow('MCP authentication changed during session initialization')
+      .rejects.toThrow('MCP authentication changed during request')
 
     expect(callsByMethod('notifications/initialized')).toHaveLength(0)
     expect(callsByMethod('tools/call')).toHaveLength(0)
+  }, 60_000)
+
+  it('does not let a delayed old-token tool response replace the current session', async () => {
+    let tokenRevision = 0
+    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
+    setupMcpSessionMocks('sess-token-a')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    const delayedOldResponse = deferred<Response>()
+    fetchWithTimeout.mockImplementationOnce(() => delayedOldResponse.promise)
+    const oldCall = callMcpTool('masc_status', {})
+    await vi.waitFor(() => {
+      expect(callsByMethod('tools/call')).toHaveLength(2)
+    })
+
+    tokenRevision = 1
+    setupMcpSessionMocks('sess-token-b')
+    await callMcpTool('masc_status', {})
+
+    delayedOldResponse.resolve(new Response(
+      'data: {"result":{"content":[{"type":"text","text":"stale"}]}}\n',
+      { status: 200, headers: { 'Mcp-Session-Id': 'sess-token-a' } },
+    ))
+    await expect(oldCall).rejects.toThrow('MCP authentication changed during request')
+
+    fetchWithTimeout.mockResolvedValueOnce(
+      new Response('data: {"result":{"content":[{"type":"text","text":"fresh"}]}}\n', { status: 200 }),
+    )
+    await callMcpTool('masc_status', {})
+
+    expect(callsByMethod('initialize')).toHaveLength(2)
+    const latestToolCall = callsByMethod('tools/call').at(-1)
+    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-token-b')
+  }, 60_000)
+
+  it('keeps a newer initializer authoritative when an older initializer finishes last', async () => {
+    let tokenRevision = 0
+    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
+    const initializeA = deferred<Response>()
+    const initializeB = deferred<Response>()
+    fetchWithTimeout.mockImplementationOnce(() => initializeA.promise)
+
+    const { callMcpTool } = await import('./mcp')
+    const callA = callMcpTool('masc_status', {})
+    await vi.waitFor(() => {
+      expect(callsByMethod('initialize')).toHaveLength(1)
+    })
+
+    tokenRevision = 1
+    fetchWithTimeout
+      .mockImplementationOnce(() => initializeB.promise)
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockResolvedValueOnce(
+        new Response('data: {"result":{"content":[{"type":"text","text":"b"}]}}\n', { status: 200 }),
+      )
+    const callB = callMcpTool('masc_status', {})
+    await vi.waitFor(() => {
+      expect(callsByMethod('initialize')).toHaveLength(2)
+    })
+
+    initializeB.resolve(new Response('{}', {
+      status: 200,
+      headers: { 'Mcp-Session-Id': 'sess-init-b' },
+    }))
+    await expect(callB).resolves.toBe('b')
+
+    initializeA.resolve(new Response('{}', {
+      status: 200,
+      headers: { 'Mcp-Session-Id': 'sess-init-a' },
+    }))
+    await expect(callA).rejects.toThrow('MCP authentication changed during request')
+
+    fetchWithTimeout.mockResolvedValueOnce(
+      new Response('data: {"result":{"content":[{"type":"text","text":"still-b"}]}}\n', { status: 200 }),
+    )
+    await callMcpTool('masc_status', {})
+
+    expect(callsByMethod('initialize')).toHaveLength(2)
+    const latestToolCall = callsByMethod('tools/call').at(-1)
+    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-init-b')
   }, 60_000)
 
   it('includes Authorization header from authHeaders in MCP initialize request', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -23,13 +23,34 @@ import { errorToString } from '../lib/format-string'
 // --- MCP Session Management ---
 
 const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
-const MCP_SESSION_BLOCKED = '__blocked__'
 const MCP_UNKNOWN_SESSION_MESSAGE = 'Unknown Mcp-Session-Id'
+const MCP_AUTH_CHANGED_MESSAGE = 'MCP authentication changed during request'
 
-let mcpSessionId: string | null = null
+interface McpSessionBinding {
+  readonly sessionId: string | null
+  readonly authRevision: number
+}
+
+type McpSessionState =
+  | { readonly kind: 'ready'; readonly binding: McpSessionBinding }
+  | { readonly kind: 'blocked'; readonly authRevision: number }
+
+interface McpInitAttempt {
+  readonly generation: number
+  readonly promise: Promise<McpSessionBinding>
+  cooldownTimer: ReturnType<typeof setTimeout> | null
+}
+
+let mcpSessionState: McpSessionState | null = null
 let observedTokenRevision = currentStoredTokenRevision()
-let initPromise: Promise<void> | null = null
-let initCooldownTimer: ReturnType<typeof setTimeout> | null = null
+let initGeneration = 0
+let initAttempt: McpInitAttempt | null = null
+
+function activeSessionId(): string | null {
+  return mcpSessionState?.kind === 'ready'
+    ? mcpSessionState.binding.sessionId
+    : null
+}
 
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
@@ -46,7 +67,7 @@ async function bestEffortReportToolHostFailure(payload: {
       phase: payload.phase,
       message: payload.message,
       request_id: payload.requestId,
-      session_id: mcpSessionId ?? undefined,
+      session_id: activeSessionId() ?? undefined,
       timeout_ms: payload.timeoutMs,
     })
   } catch {
@@ -64,19 +85,6 @@ function shouldReportToolHostFailure(message: string): boolean {
     || normalized.includes('load failed')
     || normalized.includes('error decoding response body')
   )
-}
-
-function mcpHeaders(extra?: Record<string, string>): Record<string, string> {
-  const headers: Record<string, string> = {
-    ...authHeaders(),
-    'Content-Type': 'application/json',
-    Accept: 'application/json, text/event-stream',
-    ...(extra ?? {}),
-  }
-  if (mcpSessionId) {
-    headers['Mcp-Session-Id'] = mcpSessionId
-  }
-  return headers
 }
 
 function explicitToolActor(args: Record<string, unknown>): string | null {
@@ -101,28 +109,52 @@ function implicitToolActor(): string | null {
 }
 
 function mcpHeadersForActor(
+  binding: McpSessionBinding,
   actorName?: string | null,
   extra?: Record<string, string>,
 ): Record<string, string> {
+  assertAuthRevision(binding.authRevision)
   const headers: Record<string, string> = {
     ...authHeaders({ actorName }),
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
     ...(extra ?? {}),
   }
-  if (mcpSessionId) {
-    headers['Mcp-Session-Id'] = mcpSessionId
+  assertAuthRevision(binding.authRevision)
+  if (binding.sessionId) {
+    headers['Mcp-Session-Id'] = binding.sessionId
   }
   return headers
 }
 
-function resetMcpSessionOnly(): void {
-  mcpSessionId = null
-  initPromise = null
-  if (initCooldownTimer) {
-    clearTimeout(initCooldownTimer)
-    initCooldownTimer = null
+function authChangedError(): Error {
+  return new Error(MCP_AUTH_CHANGED_MESSAGE)
+}
+
+function assertAuthRevision(expectedRevision: number): void {
+  if (currentStoredTokenRevision() !== expectedRevision) {
+    throw authChangedError()
   }
+}
+
+function assertPublishedBinding(binding: McpSessionBinding): void {
+  assertAuthRevision(binding.authRevision)
+  if (mcpSessionState?.kind !== 'ready' || mcpSessionState.binding !== binding) {
+    throw authChangedError()
+  }
+}
+
+function invalidateInitAttempt(): void {
+  initGeneration += 1
+  if (initAttempt?.cooldownTimer) {
+    clearTimeout(initAttempt.cooldownTimer)
+  }
+  initAttempt = null
+}
+
+function resetMcpSessionOnly(): void {
+  mcpSessionState = null
+  invalidateInitAttempt()
 }
 
 function synchronizeMcpAuthRevision(): void {
@@ -158,18 +190,24 @@ async function responseTextSnippet(res: Response): Promise<string> {
 
 async function mcpPost(
   body: unknown,
+  binding: McpSessionBinding,
   timeoutMs = DEFAULT_MCP_TIMEOUT_MS,
   actorName?: string | null,
   retryUnknownSession = true,
 ): Promise<string> {
+  assertPublishedBinding(binding)
   const res = await fetchWithTimeout('/mcp', {
     method: 'POST',
-    headers: mcpHeadersForActor(actorName),
+    headers: mcpHeadersForActor(binding, actorName),
     body: JSON.stringify(body),
   }, timeoutMs)
+  assertPublishedBinding(binding)
   if (!res.ok) {
     if (res.status === 403) {
-      mcpSessionId = MCP_SESSION_BLOCKED
+      mcpSessionState = {
+        kind: 'blocked',
+        authRevision: binding.authRevision,
+      }
       throw new Error(MCP_BLOCKED_MESSAGE)
     }
     const bodyText = res.status === 404 ? await responseTextSnippet(res) : ''
@@ -182,23 +220,121 @@ async function mcpPost(
       && message.includes(MCP_UNKNOWN_SESSION_MESSAGE)
     ) {
       resetMcpSessionOnly()
-      await ensureSession()
-      return mcpPost(body, timeoutMs, actorName, false)
+      const freshBinding = await ensureSession()
+      return mcpPost(body, freshBinding, timeoutMs, actorName, false)
     }
     throw err
   }
   // Capture session ID only after successful responses. A stale-session 404
   // may include a fresh header, but that header is not initialized yet.
   const sid = res.headers.get('Mcp-Session-Id')
-  if (sid) mcpSessionId = sid
-  return res.text()
+  const text = await res.text()
+  assertPublishedBinding(binding)
+  if (sid && sid !== binding.sessionId) {
+    mcpSessionState = {
+      kind: 'ready',
+      binding: { sessionId: sid, authRevision: binding.authRevision },
+    }
+  }
+  return text
 }
 
 let blockedToastShown = false
 
-async function ensureSession(): Promise<void> {
+function assertCurrentInitAttempt(
+  attempt: McpInitAttempt,
+  authRevision?: number,
+): void {
+  if (initAttempt !== attempt || attempt.generation !== initGeneration) {
+    throw authChangedError()
+  }
+  if (authRevision !== undefined) assertAuthRevision(authRevision)
+}
+
+async function initializeSession(
+  attempt: McpInitAttempt,
+): Promise<McpSessionBinding> {
+  await ensureDevToken()
+  assertCurrentInitAttempt(attempt)
+  const authRevision = currentStoredTokenRevision()
+  observedTokenRevision = authRevision
+  const initializingBinding: McpSessionBinding = {
+    sessionId: null,
+    authRevision,
+  }
+  const res = await fetchWithTimeout('/mcp', {
+    method: 'POST',
+    headers: mcpHeadersForActor(initializingBinding),
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'masc-dashboard', version: '1.0.0' },
+      },
+      id: 0,
+    }),
+  }, MCP_INITIALIZE_TIMEOUT_MS)
+  assertCurrentInitAttempt(attempt, authRevision)
+  if (!res.ok) {
+    if (res.status === 403) {
+      mcpSessionState = { kind: 'blocked', authRevision }
+      initAttempt = null
+      throw new Error(MCP_BLOCKED_MESSAGE)
+    }
+    throw await apiRequestErrorFromResponse('POST', '/mcp initialize', res)
+  }
+  const binding: McpSessionBinding = {
+    sessionId: res.headers.get('Mcp-Session-Id'),
+    authRevision,
+  }
+  if (binding.sessionId) {
+    try {
+      await fetchWithTimeout('/mcp', {
+        method: 'POST',
+        headers: mcpHeadersForActor(binding),
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'notifications/initialized',
+        }),
+      }, MCP_INITIALIZED_NOTIFY_TIMEOUT_MS)
+      assertCurrentInitAttempt(attempt, authRevision)
+    } catch (err) {
+      assertCurrentInitAttempt(attempt, authRevision)
+      console.warn('[mcp] initialized notification failed:', err)
+    }
+  }
+  assertCurrentInitAttempt(attempt, authRevision)
+  mcpSessionState = { kind: 'ready', binding }
+  initAttempt = null
+  return binding
+}
+
+function startSessionInitialization(): Promise<McpSessionBinding> {
+  const generation = initGeneration + 1
+  initGeneration = generation
+  let attempt!: McpInitAttempt
+  const promise = Promise.resolve()
+    .then(() => initializeSession(attempt))
+    .catch((err: unknown) => {
+      if (initAttempt === attempt) {
+        if (attempt.cooldownTimer) clearTimeout(attempt.cooldownTimer)
+        attempt.cooldownTimer = setTimeout(() => {
+          if (initAttempt === attempt) initAttempt = null
+          attempt.cooldownTimer = null
+        }, MCP_INIT_COOLDOWN_MS)
+      }
+      throw err
+    })
+  attempt = { generation, promise, cooldownTimer: null }
+  initAttempt = attempt
+  return promise
+}
+
+async function ensureSession(): Promise<McpSessionBinding> {
   synchronizeMcpAuthRevision()
-  if (mcpSessionId === MCP_SESSION_BLOCKED) {
+  if (mcpSessionState?.kind === 'blocked') {
     if (!blockedToastShown) {
       blockedToastShown = true
       showActionToast(
@@ -210,66 +346,12 @@ async function ensureSession(): Promise<void> {
     }
     throw new Error(MCP_BLOCKED_MESSAGE)
   }
-  if (mcpSessionId) return
-  if (initPromise) return initPromise
-  initPromise = (async () => {
-    await ensureDevToken()
-    const tokenRevision = currentStoredTokenRevision()
-    observedTokenRevision = tokenRevision
-    try {
-      const res = await fetchWithTimeout('/mcp', {
-        method: 'POST',
-        headers: mcpHeaders(),
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'initialize',
-          params: {
-            protocolVersion: '2025-03-26',
-            capabilities: {},
-            clientInfo: { name: 'masc-dashboard', version: '1.0.0' },
-          },
-          id: 0,
-        }),
-      }, MCP_INITIALIZE_TIMEOUT_MS)
-      if (currentStoredTokenRevision() !== tokenRevision) {
-        throw new Error('MCP authentication changed during session initialization')
-      }
-      if (!res.ok) {
-        if (res.status === 403) {
-          mcpSessionId = MCP_SESSION_BLOCKED
-          throw new Error(MCP_BLOCKED_MESSAGE)
-        }
-        throw await apiRequestErrorFromResponse('POST', '/mcp initialize', res)
-      }
-      const sid = res.headers.get('Mcp-Session-Id')
-      if (sid) {
-        mcpSessionId = sid
-      }
-      // Send initialized notification
-      if (mcpSessionId) {
-        await fetchWithTimeout('/mcp', {
-          method: 'POST',
-          headers: mcpHeaders(),
-          body: JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'notifications/initialized',
-          }),
-        }, MCP_INITIALIZED_NOTIFY_TIMEOUT_MS).catch(err => console.warn('[mcp] initialized notification failed:', err))
-      }
-      initPromise = null
-    } catch (err) {
-      // Keep initPromise alive briefly to prevent retry storms
-      if (initCooldownTimer) {
-        clearTimeout(initCooldownTimer)
-      }
-      initCooldownTimer = setTimeout(() => {
-        initPromise = null
-        initCooldownTimer = null
-      }, MCP_INIT_COOLDOWN_MS)
-      throw err
-    }
-  })()
-  return initPromise
+  if (mcpSessionState?.kind === 'ready') {
+    assertAuthRevision(mcpSessionState.binding.authRevision)
+    return mcpSessionState.binding
+  }
+  if (initAttempt) return initAttempt.promise
+  return startSessionInitialization()
 }
 
 export function resetMcpClientState(): void {
@@ -309,9 +391,9 @@ async function callMcpToolInternal(
 ): Promise<string> {
   const requestId = String(Math.floor(Date.now() % 1000000))
   synchronizeMcpAuthRevision()
-  let phase = mcpSessionId ? 'tools/call' : 'initialize'
+  let phase = mcpSessionState?.kind === 'ready' ? 'tools/call' : 'initialize'
   try {
-    await ensureSession()
+    const binding = await ensureSession()
     phase = 'tools/call'
     const explicitActor = explicitToolActor(args)
     const actor = explicitActor ?? implicitToolActor()
@@ -327,7 +409,7 @@ async function callMcpToolInternal(
         arguments: toolArgs,
       },
       id: Number.parseInt(requestId, 10),
-    }, DEFAULT_MCP_TIMEOUT_MS, actor)
+    }, binding, DEFAULT_MCP_TIMEOUT_MS, actor)
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
@@ -377,13 +459,13 @@ function parseMcpListResponse(raw: string): McpListResponse {
 }
 
 async function listMcpTools(cursor?: string): Promise<McpToolsListResult> {
-  await ensureSession()
+  const binding = await ensureSession()
   const text = await mcpPost({
     jsonrpc: '2.0',
     method: 'tools/list',
     params: cursor ? { cursor } : {},
     id: Date.now(),
-  })
+  }, binding)
   const parsed = parseMcpListResponse(text)
   if (parsed.error) {
     const message = parsed.error.message || 'tools/list: 서버가 message 없이 error 반환'


### PR DESCRIPTION
## Summary

- bind every MCP request to one immutable sessionId/authRevision value
- give each initializer its own monotonic generation, promise, and cooldown-timer ownership
- compare auth revision plus binding/generation identity before any async response publishes or clears global state
- cover a delayed old-token tool response and an older initializer completing after a newer session

## Why

Merged #24201 reset the global session when the stored-token revision changed, but asynchronous completions were still unowned. A delayed token-A response could arrive after token B initialized and overwrite the B session or publish a global blocked state. Likewise an old initializer could clear or schedule clearing of the newer initializer shared promise/timer.

The same exact #24201 head carried a valid P1 blocker describing this race, then a contradictory pass comment without a code change. It moved Ready and merged three seconds later while p1 and status:do-not-merge remained.

## Design

- ready and blocked MCP state are typed variants; the blocked sentinel string is removed
- request headers and response completion use the same captured binding
- a token change or replacement binding fails closed before send and again after response-body completion
- stale initializer catch/finally paths can mutate only their own generation
- initialized notification completes under the same revision before the session is published

## Validation

- current base: main@5449256130
- current head: 96cfac313e
- TypeScript noEmit: pass
- focused core + MCP Vitest: 56/56 pass
- git diff check: pass
- the focused ESLint inventory does not include src/api/mcp.ts or its test; Dashboard CI remains required
- fresh exact-head PR CI is authoritative before merge

## Gate

Draft + p1 + status:do-not-merge until exact-head Dashboard CI and adversarial concurrency review are terminal.

Follow-up to #24201.