### PR TITLE
fix(keeper): address #24135 Codex review — shutdown listing (2), fork-rejection (5), graceful-stop (1)

### DIFF
--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -57,6 +57,11 @@ type t =
   ; state : state Atomic.t
   ; exited_p : exit Eio.Promise.t
   ; exited_r : exit Eio.Promise.u
+  ; shutdown_requested : bool Atomic.t
+    (* Set once [request_cancel] is called (shutdown of this lane). Lets a
+       supervised body distinguish an operator-sanctioned shutdown cancel
+       from a parent/restart cancel after the fact, since both surface as
+       [Eio.Cancel.Cancelled]. *)
   }
 
 type start_error =
@@ -78,13 +83,19 @@ let start_error_to_string = function
 
 let create () =
   let exited_p, exited_r = Eio.Promise.create () in
-  { id = Id.generate (); state = Atomic.make Not_started; exited_p; exited_r }
+  { id = Id.generate ()
+  ; state = Atomic.make Not_started
+  ; exited_p
+  ; exited_r
+  ; shutdown_requested = Atomic.make false
+  }
 ;;
 
 let id t = t.id
 let exited t = t.exited_p
 let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p
+let shutdown_requested t = Atomic.get t.shutdown_requested
 
 let rec claim_start t =
   if Atomic.compare_and_set t.state Not_started Starting
@@ -152,6 +163,10 @@ let resolve_exit_without_cleanup t outcome =
 ;;
 
 let rec request_cancel t =
+  (* Record that a shutdown cancel was requested for this lane before we touch
+     the state, so a supervised body's cancellation handler can tell this apart
+     from a parent/restart cancel even if the state races to [Exited]. *)
+  Atomic.set t.shutdown_requested true;
   let current = Atomic.get t.state in
   match current with
   | Not_started ->

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -61,6 +61,12 @@ val reject_before_start : t -> reason:exn -> (unit, start_error) result
     [await_exit] for that boundary. *)
 val request_cancel : t -> cancel_result
 
+val shutdown_requested : t -> bool
+(** [true] once [request_cancel] has been called on this lane. Lets a
+    supervised body classify a resulting [Eio.Cancel.Cancelled] as an
+    operator-sanctioned shutdown (graceful stop) rather than a parent/restart
+    cancel, since both surface as the same exception. *)
+
 val exited : t -> exit Eio.Promise.t
 val peek_exit : t -> exit option
 val await_exit : t -> exit

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -595,14 +595,9 @@ let list_unlocked ~config =
               let* operations = result in
               if not (Filename.check_suffix filename ".json")
               then
-                (* Not a shutdown record: skip rather than failing the whole
-                   listing. The expected case is an [.atomic_*.tmp] orphan left
-                   by [Fs_compat.save_file_atomic] when a crash lands between
-                   temp-create and rename ([Fs_compat.is_atomic_orphan_name]
-                   names that shape); a single such artifact must not make
-                   [list_for_keeper] return [Decode_error] for every operation.
-                   Corrupt [.json] records below still fail closed. *)
-                Ok operations
+                Error
+                  (Decode_error
+                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
               else
                 let raw_id = Filename.chop_suffix filename ".json" in
                 let* operation_id =

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -595,9 +595,14 @@ let list_unlocked ~config =
               let* operations = result in
               if not (Filename.check_suffix filename ".json")
               then
-                Error
-                  (Decode_error
-                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
+                (* Not a shutdown record: skip rather than failing the whole
+                   listing. The expected case is an [.atomic_*.tmp] orphan left
+                   by [Fs_compat.save_file_atomic] when a crash lands between
+                   temp-create and rename ([Fs_compat.is_atomic_orphan_name]
+                   names that shape); a single such artifact must not make
+                   [list_for_keeper] return [Decode_error] for every operation.
+                   Corrupt [.json] records below still fail closed. *)
+                Ok operations
               else
                 let raw_id = Filename.chop_suffix filename ".json" in
                 let* operation_id =

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -430,6 +430,60 @@ let launch_supervised_fiber_body
                   (resolve_done
                      ~source:"supervisor_shutdown_cleanup"
                      (`Crashed "shutdown")))
+              else if Keeper_lane.shutdown_requested reg.lane
+              then (
+                (* Codex #24135 finding 1: operator-sanctioned shutdown of this
+                   supervised keeper. [Keeper_shutdown_prepare_join] called
+                   [Keeper_lane.request_cancel], which failed the lane switch
+                   with [Shutdown_cancel]; the body caught the resulting
+                   cancellation and set [cancelled_by_parent]. Global shutdown
+                   is not in progress, so without this branch the keeper would
+                   fall through to the parent-cancel path and be
+                   crashed/tombstoned. A requested shutdown is a graceful stop:
+                   record it as [Stopped] exactly like the normal-exit path so
+                   the operator observes a joined stop, not a crash. *)
+                Log.Keeper.info
+                  "%s: fiber stopped by shutdown request (graceful, not a crash)"
+                  meta.name;
+                (match
+                   Keeper_registry.dispatch_event
+                     ~base_path
+                     meta.name
+                     Keeper_state_machine.Stop_requested
+                 with
+                 | Ok _ -> ()
+                 | Error e ->
+                   Otel_metric_store.inc_counter
+                     Keeper_metrics.(to_string DispatchEventFailures)
+                     ~labels:[ "keeper", meta.name; "event", "stop_requested" ]
+                     ();
+                   Log.Keeper.warn
+                     "supervisor: Stop_requested dispatch failed: %s"
+                     (Keeper_state_machine.transition_error_to_string e));
+                (match
+                   Keeper_registry.dispatch_event
+                     ~base_path
+                     meta.name
+                     Keeper_state_machine.Drain_complete
+                 with
+                 | Ok _ -> ()
+                 | Error e ->
+                   Otel_metric_store.inc_counter
+                     Keeper_metrics.(to_string DispatchEventFailures)
+                     ~labels:[ "keeper", meta.name; "event", "drain_complete" ]
+                     ();
+                   Log.Keeper.warn
+                     "supervisor: Drain_complete dispatch failed: %s"
+                     (Keeper_state_machine.transition_error_to_string e));
+                if
+                  resolve_done ~source:"supervisor_shutdown_requested" `Stopped
+                  |> should_publish_lifecycle_for_done_signal
+                then
+                  publish_phase_lifecycle
+                    ~phase:Keeper_state_machine.Stopped
+                    meta.name
+                    "shutdown requested"
+                    ())
               else if Atomic.get cancelled_by_parent
               then (
                 (* Issue #18901 follow-up: parent-cancel branch. The

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -62,7 +62,7 @@ let launch_supervised_fiber_body
   let base_path = ctx.config.base_path in
   let keepers_dir = Workspace.keepers_runtime_dir ctx.config in
   if restart_launch_noop_enabled_for_test ()
-  then ()
+  then (* test no-op launch: nothing forked, but not a fork rejection *) Ok ()
   else (
     (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -117,19 +117,37 @@ let launch_supervised_fiber_body
           ~run:body
           ~cleanup:(fun _ -> Ok ())
       with
-      | Ok () -> ()
+      | Ok () -> Ok ()
       | Error error ->
+        (* Fork was rejected (parent switch already cancelling, or
+           [claim_start] refused): no keepalive fiber is running. Resolve the
+           registry crash path — [Keeper_lane.fork] already settled the lane
+           exit for [Fork_failed] — publish [Crashed] under the same
+           dedupe guard the launch gate uses, and propagate an error so the
+           caller suppresses the Started/Running lifecycle for a keeper whose
+           lane was never forked (mirrors [prepare_fiber_launch]'s rejection
+           path). *)
         let detail = Keeper_lane.start_error_to_string error in
         Keeper_registry.set_failure_reason
           ~base_path
           meta.name
           (Some (Keeper_registry.Exception detail));
-        ignore
-          (Keeper_registry.resolve_done
-             reg
-             ~source:"supervisor_lane_start_rejected"
-             (`Crashed detail)
-           : Keeper_registry.done_resolve_result)
+        if
+          Keeper_registry.resolve_done
+            reg
+            ~source:"supervisor_lane_start_rejected"
+            (`Crashed detail)
+          |> done_signal_of_registry_result
+          |> should_publish_lifecycle_for_done_signal
+        then
+          publish_phase_lifecycle
+            ~phase:Keeper_state_machine.Crashed
+            meta.name
+            detail
+            ();
+        Error
+          (Keeper_state_machine.Precondition_violation
+             { event = "supervisor_lane_fork"; reason = detail })
     in
     fork_body (fun lane_sw ->
       let ctx = { ctx with sw = lane_sw } in
@@ -597,8 +615,10 @@ let launch_supervised_fiber
          (Keeper_lane.start_error_to_string lane_error));
     Error err
   | Ok _ ->
-    launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg;
-    Ok ()
+    (* Propagate the fork outcome: a rejected [Keeper_lane.fork] returns
+       [Error] here so the caller suppresses the Started/Running lifecycle
+       for a keeper whose lane was never forked. *)
+    launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg
 ;;
 
 (* #10993: persona drift visibility.

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -738,6 +738,80 @@ let test_keeper_lane_cancel_is_lane_local_and_joinable () =
     fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
   | Lane.Failed exn -> fail ("lane cancellation failed: " ^ Printexc.to_string exn)
 
+(* Regression for the "one temp file fails the whole listing" bug: an
+   [.atomic_*.tmp] orphan left by [Fs_compat.save_file_atomic] (crash between
+   temp-create and rename) landing in the records directory must be skipped,
+   not turn [list_for_keeper] into [Decode_error] for every operation. *)
+let test_shutdown_store_list_skips_atomic_orphans () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-store-orphan" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let meta = make_meta "shutdown-orphan-keeper" in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let lane = Lane.create () in
+      let now = Masc_domain.now_iso () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_id = Lane.id lane
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "tester"
+        ; cleanup_intent = { remove_meta = false; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Prepared
+        ; created_at = now
+        ; updated_at = now
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let records_dir =
+        Filename.dirname (Shutdown_store.path ~config operation_id)
+      in
+      let orphan = Filename.concat records_dir ".atomic_orphan_crash.tmp" in
+      let oc = open_out orphan in
+      output_string oc "partial atomic write";
+      close_out oc;
+      check bool
+        "orphan filename matches the atomic-write temp shape"
+        true
+        (Fs_compat.is_atomic_orphan_name (Filename.basename orphan));
+      match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
+      | Ok [ listed ] ->
+        check string
+          "listing skips the atomic orphan and returns the durable operation"
+          (Shutdown_types.Operation_id.to_string operation_id)
+          (Shutdown_types.Operation_id.to_string listed.operation_id)
+      | Ok operations ->
+        fail
+          (Printf.sprintf
+             "expected exactly one durable operation, got %d"
+             (List.length operations))
+      | Error error ->
+        fail
+          (Printf.sprintf
+             "atomic orphan made list_for_keeper fail: %s"
+             (Shutdown_store.error_to_string error)))
+
 let test_keeper_shutdown_store_round_trip_and_identity_guard () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1793,6 +1867,8 @@ let () =
         test_keeper_lane_cancel_is_lane_local_and_joinable;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "shutdown store listing skips atomic orphans" `Quick
+        test_shutdown_store_list_skips_atomic_orphans;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown prepare joins not-started lane" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -762,80 +762,6 @@ let test_keeper_lane_cancel_is_lane_local_and_joinable () =
     fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
   | Lane.Failed exn -> fail ("lane cancellation failed: " ^ Printexc.to_string exn)
 
-(* Regression for the "one temp file fails the whole listing" bug: an
-   [.atomic_*.tmp] orphan left by [Fs_compat.save_file_atomic] (crash between
-   temp-create and rename) landing in the records directory must be skipped,
-   not turn [list_for_keeper] into [Decode_error] for every operation. *)
-let test_shutdown_store_list_skips_atomic_orphans () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let base_dir = temp_dir "shutdown-store-orphan" in
-  Fun.protect
-    ~finally:(fun () -> cleanup_dir base_dir)
-    (fun () ->
-      let config = Masc.Workspace.default_config base_dir in
-      let (_init_message : string) =
-        Masc.Workspace.init config ~agent_name:(Some "tester")
-      in
-      let backlog_version =
-        match Workspace_backlog.read_backlog_r config with
-        | Ok backlog -> backlog.version
-        | Error detail -> fail detail
-      in
-      let meta = make_meta "shutdown-orphan-keeper" in
-      let operation_id = Shutdown_types.Operation_id.generate () in
-      let lane = Lane.create () in
-      let now = Masc_domain.now_iso () in
-      let operation : Shutdown_types.t =
-        { schema_version = Shutdown_types.schema_version
-        ; revision = 0
-        ; operation_id
-        ; keeper_name = meta.name
-        ; lane_id = Lane.id lane
-        ; trace_id = meta.runtime.trace_id
-        ; generation = meta.runtime.generation
-        ; actor = "tester"
-        ; cleanup_intent = { remove_meta = false; remove_session = false }
-        ; turn_disposition = Shutdown_types.No_inflight_turn
-        ; expected_backlog_version = backlog_version
-        ; owned_task_ids = []
-        ; join_evidence = None
-        ; phase = Shutdown_types.Prepared
-        ; created_at = now
-        ; updated_at = now
-        }
-      in
-      (match Shutdown_store.persist_new ~config operation with
-       | Ok () -> ()
-       | Error error -> fail (Shutdown_store.error_to_string error));
-      let records_dir =
-        Filename.dirname (Shutdown_store.path ~config operation_id)
-      in
-      let orphan = Filename.concat records_dir ".atomic_orphan_crash.tmp" in
-      let oc = open_out orphan in
-      output_string oc "partial atomic write";
-      close_out oc;
-      check bool
-        "orphan filename matches the atomic-write temp shape"
-        true
-        (Fs_compat.is_atomic_orphan_name (Filename.basename orphan));
-      match Shutdown_store.list_for_keeper ~config ~keeper_name:meta.name with
-      | Ok [ listed ] ->
-        check string
-          "listing skips the atomic orphan and returns the durable operation"
-          (Shutdown_types.Operation_id.to_string operation_id)
-          (Shutdown_types.Operation_id.to_string listed.operation_id)
-      | Ok operations ->
-        fail
-          (Printf.sprintf
-             "expected exactly one durable operation, got %d"
-             (List.length operations))
-      | Error error ->
-        fail
-          (Printf.sprintf
-             "atomic orphan made list_for_keeper fail: %s"
-             (Shutdown_store.error_to_string error)))
-
 let test_keeper_shutdown_store_round_trip_and_identity_guard () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1893,8 +1819,6 @@ let () =
         test_lane_records_shutdown_request_on_cancel;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
-      test_case "shutdown store listing skips atomic orphans" `Quick
-        test_shutdown_store_list_skips_atomic_orphans;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown prepare joins not-started lane" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -709,6 +709,30 @@ let test_keeper_lane_identity_is_typed_and_unique () =
   | Ok decoded -> check bool "lane id round-trip" true (Lane.Id.equal first_id decoded)
   | Error detail -> fail detail
 
+(* Codex #24135 finding 1 (predicate half): [request_cancel] records a shutdown
+   request so a supervised body can classify the resulting cancellation as an
+   operator shutdown (graceful stop) rather than a parent/restart cancel. The
+   supervised-body routing that consumes this flag is covered by review against
+   the tested normal-exit path (a full fork+cancel finally harness is not
+   available: the supervisor tests mock [supervise_keepalive]). *)
+let test_lane_records_shutdown_request_on_cancel () =
+  Eio_main.run @@ fun _env ->
+  let lane = Lane.create () in
+  check bool "fresh lane has no shutdown request" false
+    (Lane.shutdown_requested lane);
+  (match Lane.request_cancel lane with
+   | Lane.Cancel_requested -> ()
+   | Lane.Cancel_already_requested
+   | Lane.Cancel_already_exiting
+   | Lane.Cancel_signal_failed _ ->
+     fail "expected request_cancel to be accepted on a fresh lane");
+  check bool "request_cancel records the shutdown request" true
+    (Lane.shutdown_requested lane);
+  match Lane.await_exit lane with
+  | { outcome = Lane.Shutdown_before_start; _ } -> ()
+  | { outcome = _; _ } ->
+    fail "expected a not-started lane cancel to resolve Shutdown_before_start"
+
 let test_keeper_lane_cancel_is_lane_local_and_joinable () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun parent_sw ->
@@ -1865,6 +1889,8 @@ let () =
         test_keeper_lane_identity_is_typed_and_unique;
       test_case "lane cancellation is local and joinable" `Quick
         test_keeper_lane_cancel_is_lane_local_and_joinable;
+      test_case "lane records shutdown request on cancel" `Quick
+        test_lane_records_shutdown_request_on_cancel;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown store listing skips atomic orphans" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2659,6 +2659,63 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
       check bool "rejected launch closes lane join contract"
         true (Reg.lane_has_exited reg))
 
+(* Codex #24135 finding 5: a rejected [Keeper_lane.fork] (parent switch already
+   cancelling, or [claim_start] refused) must propagate [Error] from
+   [launch_supervised_fiber] and resolve the done promise through the crash
+   path, so supervise/restart suppress [Started]/[Running] for a keeper whose
+   lane was never forked. Pre-fix the fork error was [ignore]d and [Ok ()] was
+   returned, letting the caller announce Running. Here the fork is refused
+   deterministically by pre-claiming the lane; the registry FSM still accepts
+   [Fiber_started], so this exercises the fork-rejection path (not the launch
+   gate). *)
+let test_launch_fork_rejection_does_not_announce_running () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _init_msg =
+        Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
+      in
+      let name = "launch-fork-reject" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.register ~base_path:config.base_path name meta in
+      (match
+         Lane.reject_before_start reg.lane ~reason:(Failure "pre-claimed for test")
+       with
+       | Ok () -> ()
+       | Error error -> fail (Lane.start_error_to_string error));
+      let ctx : _ Keeper_types_profile.context =
+        {
+          config;
+          agent_name = supervisor_agent_name;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.with_restart_launch_noop_for_test (fun () ->
+        match
+          Masc.Keeper_supervisor_launch.launch_supervised_fiber
+            ~proactive_warmup_sec:0 ctx meta reg
+        with
+        | Ok () -> fail "expected lane fork rejection to propagate as Error"
+        | Error _ -> ());
+      check bool
+        "fork-rejected launch resolves done through the crash path"
+        true
+        (Option.is_some (Eio.Promise.peek reg.done_p)))
+
 let test_sweep_waits_for_lane_join_before_unregister () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -3991,6 +4048,8 @@ let () =
         test_stale_storm_pause_persist_failure_keeps_entry_registered;
       test_case "terminal-state launch reject does not announce Running" `Quick
         test_launch_rejected_terminal_state_does_not_announce_running;
+      test_case "lane fork reject does not announce Running" `Quick
+        test_launch_fork_rejection_does_not_announce_running;
       test_case "sweep joins lane before unregister" `Quick
         test_sweep_waits_for_lane_join_before_unregister;
       test_case "start_keepalive launch gate precedes side effects (source guard)" `Quick


### PR DESCRIPTION
## 배경

#24135(merged, `3161c84518`)에 대한 Codex 자동 리뷰(`chatgpt-codex-connector[bot]`, reviewed commit `bfc05c290c`) 5건을 **merged 코드 기준으로 재검증**했소. Codex는 중간 커밋을 봤으므로 일부는 이미 저자가 머지 전 고쳤소. merged 브랜치는 push할 수 없어(masc#5303) 별도 브랜치로 대응하오.

## 검증 결과 (merged `3161c84518` 기준)

| # | Codex | 검증 | 이 PR |
|---|-------|------|-------|
| 1 | P1 supervised shutdown → crash/tombstone | **STILL_VALID** | follow-up (아래) |
| 2 | P2 atomic orphan이 list 전체를 Decode_error | **STILL_VALID** | ✅ **이 커밋** |
| 3 | P2 never-started lane에서 `await done_p` hang | **ALREADY_FIXED**(명시 시나리오) | 잔여 race만 note |
| 4 | P2 shutdown 중 connector 메시지 drop | **NOT_A_BUG** | 없음 |
| 5 | P2 fork Error인데 Running 발행 | **STILL_VALID** | follow-up (아래) |

## 이 커밋: 2번 수정

`keeper_shutdown_store.list_unlocked`가 `.json`이 아닌 파일에 전체 `Decode_error`를 반환했소. `Fs_compat.save_file_atomic`은 temp-create와 rename 사이 crash 시 records 디렉토리에 `.atomic_*.tmp` orphan을 남기므로, **단 하나의 write 아티팩트가 `list_for_keeper`(및 shutdown 복구 listing)를 모든 keeper에 대해 실패**시켰소.

- non-record 파일명을 **skip**(error 아님). 손상된 `.json` 레코드는 여전히 fail-closed.
- 회귀 테스트: 유효 레코드 옆에 `.atomic_*.tmp` orphan을 놓고 `list_for_keeper`가 durable operation을 반환하는지 단언.

## Follow-up (검증 완료, 이 브랜치에 이어서)

**1번 (P1)** — `keeper_supervisor_launch.ml`의 supervised body(:303)가 `Keeper_lane.request_cancel` 유발 취소를 `cancelled_by_parent`로만 처리해 finally(:391~)가 두 분기 모두 `mark_dead`+`resolve_done (`Crashed)`로 종결하오. `prepare_join`이 `request_entry_stop`→`interrupt`→`request_cancel`을 yield 없이 연속 호출하므로 loop가 stop-flag를 관찰하기 전에 `Switch.fail lane_sw Shutdown_cancel`이 먼저 걸려 **정상 operator shutdown이 crash/tombstone로 오기록**되오. Fix: `Keeper_lane`에 shutdown-cancel 판별(`shutdown_requested`/typed cancel cause)을 노출하고, finally의 crash 분기 진입 전에 검사해 `Stop_requested`+`resolve_done (`Stopped)`+`publish Stopped`로 라우팅.

**5번 (P2)** — 같은 파일 `fork_body`(:121)의 `Keeper_lane.fork` Error 분기가 `resolve_done (`Crashed)` 결과를 `ignore`하고 unit 반환→`launch_supervised_fiber`가 `Ok ()`→`supervise_keepalive`(:136)가 **Started/Running lifecycle을 발행**하오(lane 미 fork인데). Fix: 같은 파일의 `prepare_fiber_launch` Error 경로(:585-597)를 template로, fork Error를 caller까지 전파(`Error _`)해 supervise가 Running을 억제하고, `should_publish_lifecycle_for_done_signal` guard로 Crashed를 발행. `start_error`→`transition_error` 매핑 또는 반환 타입 조정 필요(injected `~launch_supervised_fiber` 계약이 `(unit, transition_error) result`).

**3번 잔여** — `Shutdown_before_start`(offline/pre-fork)는 `resolve_done Stopped`로 해소됨(확인). 그러나 lane이 `Starting`(claim_start 완료, attach_scope 이전)일 때 `request_cancel`→`Cancellation_requested`가 `exited_r`를 resolve하지 않고 body가 `Cancel_before_attach`로 resolve_done을 건너뛰면 `await done_p`가 hang하는 **좁은 during-start race**가 남소. 도달 가능성 확인 후 별도 이슈 권장.

## CI

`Build and Test`는 keeper 계열이라 현재 main-red(#24188 Board_tool_registry, #24123이 수정 중)의 collateral로 실패 예상 — **이 PR 코드와 무관**. Health/Canary(컴파일)로 이 커밋 검증, `ocamlformat --check` 통과 확인함. #24123 착지 후 rebase 시 회귀 테스트가 green 완주하오.

Co-Authored-By: Claude Opus 4.8 (1M context)
