### PR TITLE
fix(keeper): restore deprecated fail-open helper API

### DIFF
--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -28,6 +28,16 @@ let resolved_tool_lane_label ~effective_tools ~runtime_mcp_policy =
   | false, false, Some _ -> "runtime_mcp_connect_only"
   | false, false, None -> "none"
 
+(* Compatibility-only public API: RFC-0206 removed every production caller,
+   but downstream users may still compile against the installed helper module. *)
+let fail_open_health_filtered_candidates
+    ~(tool_filtered_candidates : 'a list)
+    ~(health_filtered_candidates : 'a list)
+  : 'a list * bool =
+  match health_filtered_candidates with
+  | [] when tool_filtered_candidates <> [] -> tool_filtered_candidates, true
+  | _ -> health_filtered_candidates, false
+
 (* RFC-0206: provider_rejections_for_no_tool_error deleted — multi-candidate
    tool-filter rejection lists have no meaning under single-runtime dispatch. *)
 

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -8,6 +8,19 @@ val resolved_tool_lane_label :
   runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
   string
 
+val fail_open_health_filtered_candidates :
+  tool_filtered_candidates:'a list ->
+  health_filtered_candidates:'a list ->
+  'a list * bool
+[@@deprecated
+  "Compatibility-only legacy helper; RFC-0206 removed its production path. Do not use in new runtime dispatch code."]
+(** [fail_open_health_filtered_candidates ~tool_filtered_candidates
+    ~health_filtered_candidates] preserves health-filtered candidates unless
+    the health/cooldown filter would empty an otherwise tool-capable candidate
+    set. In that all-cooldown case it returns the pre-health-filter candidates
+    plus [true], preserving the pre-RFC-0206 public API for downstream source
+    compatibility. *)
+
 val apply_stream_idle_timeout_default : float option -> float option
 
 val checkpoint_after_attempt :

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1,5 +1,9 @@
 module Runtime_manifest = Masc.Keeper_runtime_manifest
 module Driver = Masc.Keeper_turn_driver
+module Helpers = Masc.Keeper_turn_driver_helpers
+
+let legacy_fail_open_health_filtered_candidates =
+  (Helpers.fail_open_health_filtered_candidates [@alert "-deprecated"])
 
 let contains ~needle haystack =
   let needle_len = String.length needle in
@@ -916,6 +920,28 @@ let test_attempt_loop_preserves_last_sdk_error () =
        | _ -> false)
      |> List.map decision_runtime_id)
 
+let test_legacy_fail_open_helper_compatibility () =
+  let candidates, failed_open =
+    legacy_fail_open_health_filtered_candidates
+      ~tool_filtered_candidates:[ "primary"; "fallback" ]
+      ~health_filtered_candidates:[]
+  in
+  Alcotest.(check (list string))
+    "empty health result preserves tool-filtered candidates"
+    [ "primary"; "fallback" ]
+    candidates;
+  Alcotest.(check bool) "fallback is explicit" true failed_open;
+  let candidates, failed_open =
+    legacy_fail_open_health_filtered_candidates
+      ~tool_filtered_candidates:[ "primary"; "fallback" ]
+      ~health_filtered_candidates:[ "fallback" ]
+  in
+  Alcotest.(check (list string))
+    "non-empty health result remains authoritative"
+    [ "fallback" ]
+    candidates;
+  Alcotest.(check bool) "no fallback occurred" false failed_open
+
 let () =
   Alcotest.run
     "keeper_turn_driver_failover"
@@ -990,5 +1016,9 @@ let () =
             "attempt loop preserves last SDK error"
             `Quick
             test_attempt_loop_preserves_last_sdk_error;
+          Alcotest.test_case
+            "legacy fail-open helper remains source-compatible"
+            `Quick
+            test_legacy_fail_open_helper_compatibility;
         ] );
     ]


### PR DESCRIPTION
## 문제

#24186 계열 변경이 더 이상 production에서 사용하지 않는 deprecated fail-open helper까지 public API에서 제거했습니다. 외부/하위 호환 호출자는 컴파일 단계에서 깨지지만, production 경로를 되살릴 필요는 없습니다.

## 변경

- `fail_open_health_filtered_candidates`의 기존 public signature를 복구합니다.
- 반환값은 `(candidates, fallback_occurred)`로 명시해 fallback 여부를 숨기지 않습니다.
- production caller는 추가하지 않습니다. deprecated compatibility surface만 복구합니다.
- health 후보가 비었을 때의 fallback과 비어 있지 않을 때의 authoritative path를 focused test로 고정합니다.

## 현재 기준

- base: `4f388535e5b242243f3ed663142cf07665c21df3`
- head: `4cd1f6e3fbe692cf15ec7b68bec241811b8f5e07`
- merge-base: base와 동일

## 검증

- `scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_turn_driver_failover.exe` PASS (직전 main `2c48beb9`)
- 이후 main 변경 #24235는 `dashboard/src/api/mcp.ts`, `dashboard/src/api/mcp.test.ts` 두 파일뿐임을 확인
- 새 main으로 rebase 후 `test_keeper_turn_driver_failover.exe`: 18/18 PASS
- `git diff --check origin/main...HEAD`: PASS

Draft 및 `status:do-not-merge`는 fresh CI가 끝날 때까지 유지합니다.
