### PR TITLE
fix(shutdown): fail closed on invalid deadline setup

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -651,10 +651,6 @@ let run_cmd host port cli_base_path =
             let watchdog =
               Masc.Shutdown.start_process_deadline_watchdog_or_exit
                 ~timeout_s:force_timeout
-                ~on_error:(fun error ->
-                  Log.Server.error
-                    "[FATAL] Unable to arm graceful shutdown deadline: %s"
-                    (Masc.Shutdown.deadline_error_to_string error))
             in
             Atomic.set shutdown_watchdog (Some watchdog);
             Log.Server.info

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -557,6 +557,14 @@ let run_cmd host port cli_base_path =
   acquire_pid_lock port;
   acquire_base_path_lock normalized_base_path;
   Log.init_from_env ();
+  let shutdown_cfg =
+    match Masc.Shutdown.config_from_env () with
+    | Ok config -> config
+    | Error error ->
+        Log.Server.error "[FATAL] Invalid shutdown configuration: %s"
+          (Masc.Shutdown.config_error_to_string error);
+        exit 1
+  in
   (* Decouple console mirror writes from the Eio domain before any keeper
      boots: with fd 2 on a pty, a full pty buffer (scrollback/copy-mode)
      blocks write(2) outside the scheduler and halts the whole fleet
@@ -637,24 +645,21 @@ let run_cmd host port cli_base_path =
             Eio.Time.sleep clock 0.05;
             await_shutdown_signal ()
         | Some signal ->
-            let shutdown_cfg = Masc.Shutdown.config_from_env () in
             let force_timeout = shutdown_cfg.force_timeout_s in
             let t_shutdown_start = Unix.gettimeofday () in
             let signal_name = shutdown_signal_name signal in
-            (match
-               Masc.Shutdown.start_process_deadline_watchdog
-                 ~timeout_s:force_timeout
-             with
-             | Ok watchdog ->
-                 Atomic.set shutdown_watchdog (Some watchdog);
-                 Log.Server.info
-                   "[MASC] Received %s, shutting down gracefully (timeout=%.0fs, hard_exit=%d)..."
-                   signal_name force_timeout Masc.Shutdown.process_deadline_exit_code
-             | Error error ->
-                 Log.Server.error
-                   "[MASC] Invalid graceful shutdown deadline: %s"
-                   (Masc.Shutdown.deadline_error_to_string error);
-                 exit 1);
+            let watchdog =
+              Masc.Shutdown.start_process_deadline_watchdog_or_exit
+                ~timeout_s:force_timeout
+                ~on_error:(fun error ->
+                  Log.Server.error
+                    "[FATAL] Unable to arm graceful shutdown deadline: %s"
+                    (Masc.Shutdown.deadline_error_to_string error))
+            in
+            Atomic.set shutdown_watchdog (Some watchdog);
+            Log.Server.info
+              "[MASC] Received %s, shutting down gracefully (timeout=%.0fs, hard_exit=%d)..."
+              signal_name force_timeout Masc.Shutdown.process_deadline_exit_code;
             (* Phase 1: Notify SSE clients *)
             let t_phase = Unix.gettimeofday () in
             let shutdown_data =

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -558,7 +558,7 @@ let run_cmd host port cli_base_path =
   acquire_base_path_lock normalized_base_path;
   Log.init_from_env ();
   let shutdown_cfg =
-    match Masc.Shutdown.config_from_env () with
+    match Masc.Shutdown.config_from_env_result () with
     | Ok config -> config
     | Error error ->
         Log.Server.error "[FATAL] Invalid shutdown configuration: %s"

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -28,24 +28,78 @@ let default_config = {
   force_timeout_s = 10.0;
 }
 
+type config_field =
+  | Notify_delay
+  | Drain_timeout
+  | Cleanup_timeout
+  | Force_timeout
+
+let config_field_env_name = function
+  | Notify_delay -> "MASC_SHUTDOWN_NOTIFY_DELAY"
+  | Drain_timeout -> "MASC_SHUTDOWN_DRAIN_TIMEOUT"
+  | Cleanup_timeout -> "MASC_SHUTDOWN_CLEANUP_TIMEOUT"
+  | Force_timeout -> "MASC_SHUTDOWN_FORCE_TIMEOUT"
+
+type config_error =
+  | Invalid_config_number of { field : config_field; raw_value : string }
+  | Non_finite_config_duration of { field : config_field; value : float }
+  | Negative_config_duration of { field : config_field; value : float }
+  | Non_positive_config_duration of { field : config_field; value : float }
+
+let config_error_to_string = function
+  | Invalid_config_number { field; raw_value } ->
+      Printf.sprintf "%s must be a number (received %S)"
+        (config_field_env_name field) raw_value
+  | Non_finite_config_duration { field; value } ->
+      Printf.sprintf "%s must be finite (received %g)"
+        (config_field_env_name field) value
+  | Negative_config_duration { field; value } ->
+      Printf.sprintf "%s must be non-negative (received %g)"
+        (config_field_env_name field) value
+  | Non_positive_config_duration { field; value } ->
+      Printf.sprintf "%s must be greater than zero (received %g)"
+        (config_field_env_name field) value
+
 let config_from_env () =
-  let get_float name default =
-    match Sys.getenv_opt name with
-    | Some s -> Option.value ~default (float_of_string_opt s)
-    | None -> default
+  let get_duration field ~default ~positive =
+    match Sys.getenv_opt (config_field_env_name field) with
+    | None -> Ok default
+    | Some raw_value ->
+        (match float_of_string_opt raw_value with
+         | None -> Error (Invalid_config_number { field; raw_value })
+         | Some value when not (Float.is_finite value) ->
+             Error (Non_finite_config_duration { field; value })
+         | Some value when positive && value <= 0.0 ->
+             Error (Non_positive_config_duration { field; value })
+         | Some value when value < 0.0 ->
+             Error (Negative_config_duration { field; value })
+         | Some value -> Ok value)
   in
-  {
-    notify_delay_s = get_float "MASC_SHUTDOWN_NOTIFY_DELAY" 0.2;
-    drain_timeout_s = get_float "MASC_SHUTDOWN_DRAIN_TIMEOUT" 5.0;
-    cleanup_timeout_s = get_float "MASC_SHUTDOWN_CLEANUP_TIMEOUT" 3.0;
-    force_timeout_s = get_float "MASC_SHUTDOWN_FORCE_TIMEOUT" 10.0;
-  }
+  let ( let* ) = Result.bind in
+  let* notify_delay_s =
+    get_duration Notify_delay ~default:default_config.notify_delay_s
+      ~positive:false
+  in
+  let* drain_timeout_s =
+    get_duration Drain_timeout ~default:default_config.drain_timeout_s
+      ~positive:false
+  in
+  let* cleanup_timeout_s =
+    get_duration Cleanup_timeout ~default:default_config.cleanup_timeout_s
+      ~positive:false
+  in
+  let* force_timeout_s =
+    get_duration Force_timeout ~default:default_config.force_timeout_s
+      ~positive:true
+  in
+  Ok { notify_delay_s; drain_timeout_s; cleanup_timeout_s; force_timeout_s }
 
 (** {1 Process deadline supervision} *)
 
 type deadline_error =
   | Non_finite_deadline_timeout of float
   | Non_positive_deadline_timeout of float
+  | Watchdog_thread_start_failed of string
 
 let deadline_error_to_string = function
   | Non_finite_deadline_timeout value ->
@@ -54,6 +108,8 @@ let deadline_error_to_string = function
       Printf.sprintf
         "deadline timeout must be greater than zero (received %g)"
         value
+  | Watchdog_thread_start_failed reason ->
+      Printf.sprintf "deadline watchdog thread failed to start: %s" reason
 
 type watchdog_state =
   | Armed
@@ -71,6 +127,14 @@ type disarm_result =
   | Already_fired
 
 let process_deadline_exit_code = 124
+let process_deadline_start_failure_exit_code = 125
+
+let default_deadline_thread_create f = Thread.create f ()
+let deadline_thread_create = Atomic.make default_deadline_thread_create
+
+let set_deadline_thread_create_for_testing f = Atomic.set deadline_thread_create f
+let reset_deadline_thread_create_for_testing () =
+  Atomic.set deadline_thread_create default_deadline_thread_create
 
 let start_process_deadline_watchdog ~timeout_s =
   if not (Float.is_finite timeout_s) then
@@ -79,15 +143,26 @@ let start_process_deadline_watchdog ~timeout_s =
     Error (Non_positive_deadline_timeout timeout_s)
   else
     let state = Atomic.make Armed in
-    let thread =
-      Thread.create
-        (fun () ->
-          Thread.delay timeout_s;
-          if Atomic.compare_and_set state Armed Fired then
-            Unix._exit process_deadline_exit_code)
-        ()
-    in
-    Ok { state; thread }
+    (match
+       try
+         Ok
+           ((Atomic.get deadline_thread_create) (fun () ->
+                Thread.delay timeout_s;
+                if Atomic.compare_and_set state Armed Fired then
+                  Unix._exit process_deadline_exit_code))
+       with exn -> Error (Watchdog_thread_start_failed (Printexc.to_string exn))
+     with
+     | Ok thread -> Ok { state; thread }
+     | Error _ as error -> error)
+
+let start_process_deadline_watchdog_or_exit ~timeout_s ~on_error =
+  match start_process_deadline_watchdog ~timeout_s with
+  | Ok watchdog -> watchdog
+  | Error error ->
+      Fun.protect
+        ~finally:(fun () -> Unix._exit process_deadline_start_failure_exit_code)
+        (fun () -> on_error error);
+      assert false
 
 let rec disarm_deadline_watchdog watchdog =
   if Atomic.compare_and_set watchdog.state Armed Disarmed_state then
@@ -132,13 +207,22 @@ type state = {
   config : config;
 }
 
-let create ?(config = config_from_env ()) () = {
-  phase = Running;
-  started_at = 0.0;
-  reason = "";
-  entered = Atomic.make false;
-  config;
-}
+let create ?config () =
+  let config =
+    match config with
+    | Some config -> config
+    | None ->
+        (match config_from_env () with
+         | Ok config -> config
+         | Error error -> invalid_arg (config_error_to_string error))
+  in
+  {
+    phase = Running;
+    started_at = 0.0;
+    reason = "";
+    entered = Atomic.make false;
+    config;
+  }
 
 (** {1 Hook Registry} *)
 

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -135,13 +135,6 @@ type disarm_result =
 let process_deadline_exit_code = 124
 let process_deadline_start_failure_exit_code = 125
 
-let default_deadline_thread_create f = Thread.create f ()
-let deadline_thread_create = Atomic.make default_deadline_thread_create
-
-let set_deadline_thread_create_for_testing f = Atomic.set deadline_thread_create f
-let reset_deadline_thread_create_for_testing () =
-  Atomic.set deadline_thread_create default_deadline_thread_create
-
 let start_process_deadline_watchdog ~timeout_s =
   if not (Float.is_finite timeout_s) then
     Error (Non_finite_deadline_timeout timeout_s)
@@ -152,27 +145,25 @@ let start_process_deadline_watchdog ~timeout_s =
     (match
        try
          Ok
-           ((Atomic.get deadline_thread_create) (fun () ->
+           (Thread.create
+              (fun () ->
                 try
                   Thread.delay timeout_s;
                   if Atomic.compare_and_set state Armed Fired then
                     Unix._exit process_deadline_exit_code
                 with _ ->
                   if Atomic.compare_and_set state Armed Fired then
-                    Unix._exit process_deadline_start_failure_exit_code))
+                    Unix._exit process_deadline_start_failure_exit_code)
+              ())
        with exn -> Error (Watchdog_thread_start_failed (Printexc.to_string exn))
      with
      | Ok thread -> Ok { state; thread }
      | Error _ as error -> error)
 
-let start_process_deadline_watchdog_or_exit ~timeout_s ~on_error =
+let start_process_deadline_watchdog_or_exit ~timeout_s =
   match start_process_deadline_watchdog ~timeout_s with
   | Ok watchdog -> watchdog
-  | Error error ->
-      Fun.protect
-        ~finally:(fun () -> Unix._exit process_deadline_start_failure_exit_code)
-        (fun () -> on_error error);
-      assert false
+  | Error _ -> Unix._exit process_deadline_start_failure_exit_code
 
 let rec disarm_deadline_watchdog watchdog =
   if Atomic.compare_and_set watchdog.state Armed Disarmed_state then

--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -60,7 +60,7 @@ let config_error_to_string = function
       Printf.sprintf "%s must be greater than zero (received %g)"
         (config_field_env_name field) value
 
-let config_from_env () =
+let config_from_env_result () =
   let get_duration field ~default ~positive =
     match Sys.getenv_opt (config_field_env_name field) with
     | None -> Ok default
@@ -93,6 +93,12 @@ let config_from_env () =
       ~positive:true
   in
   Ok { notify_delay_s; drain_timeout_s; cleanup_timeout_s; force_timeout_s }
+
+let config_from_env () =
+  match config_from_env_result () with
+  | Ok config -> config
+  | Error error -> invalid_arg (config_error_to_string error)
+;;
 
 (** {1 Process deadline supervision} *)
 
@@ -147,9 +153,13 @@ let start_process_deadline_watchdog ~timeout_s =
        try
          Ok
            ((Atomic.get deadline_thread_create) (fun () ->
-                Thread.delay timeout_s;
-                if Atomic.compare_and_set state Armed Fired then
-                  Unix._exit process_deadline_exit_code))
+                try
+                  Thread.delay timeout_s;
+                  if Atomic.compare_and_set state Armed Fired then
+                    Unix._exit process_deadline_exit_code
+                with _ ->
+                  if Atomic.compare_and_set state Armed Fired then
+                    Unix._exit process_deadline_start_failure_exit_code))
        with exn -> Error (Watchdog_thread_start_failed (Printexc.to_string exn))
      with
      | Ok thread -> Ok { state; thread }
@@ -211,10 +221,7 @@ let create ?config () =
   let config =
     match config with
     | Some config -> config
-    | None ->
-        (match config_from_env () with
-         | Ok config -> config
-         | Error error -> invalid_arg (config_error_to_string error))
+    | None -> config_from_env ()
   in
   {
     phase = Running;

--- a/lib/shutdown.mli
+++ b/lib/shutdown.mli
@@ -86,18 +86,11 @@ val start_process_deadline_watchdog :
     disarm it only after the supervised switch has actually returned. *)
 
 val start_process_deadline_watchdog_or_exit :
-  timeout_s:float -> on_error:(deadline_error -> unit) -> watchdog
+  timeout_s:float -> watchdog
 (** Start the watchdog or terminate immediately via {!Unix._exit} with
-    {!process_deadline_start_failure_exit_code}. The error observer is
-    best-effort and cannot prevent the fail-closed terminal action. *)
-
-val set_deadline_thread_create_for_testing :
-  ((unit -> unit) -> Thread.t) -> unit
-(** Install the process-local deadline thread starter. Intended only for
-    focused tests of thread-start failure. *)
-
-val reset_deadline_thread_create_for_testing : unit -> unit
-(** Restore the default [Thread.create]-backed deadline starter. *)
+    {!process_deadline_start_failure_exit_code}. No callback runs before the
+    terminal action, so logging or another observer cannot block fail-closed
+    process termination. *)
 
 val disarm_deadline_watchdog : watchdog -> disarm_result
 (** Atomically disarm an armed watchdog. The result distinguishes a successful

--- a/lib/shutdown.mli
+++ b/lib/shutdown.mli
@@ -21,13 +21,33 @@ type config = {
 }
 
 val default_config : config
-val config_from_env : unit -> config
+
+type config_field =
+  | Notify_delay
+  | Drain_timeout
+  | Cleanup_timeout
+  | Force_timeout
+
+val config_field_env_name : config_field -> string
+
+type config_error =
+  | Invalid_config_number of { field : config_field; raw_value : string }
+  | Non_finite_config_duration of { field : config_field; value : float }
+  | Negative_config_duration of { field : config_field; value : float }
+  | Non_positive_config_duration of { field : config_field; value : float }
+
+val config_error_to_string : config_error -> string
+val config_from_env : unit -> (config, config_error) result
+(** Read and validate the shutdown duration environment variables. A present
+    malformed, non-finite, or out-of-range value is an explicit error; it is
+    never replaced with a default. *)
 
 (** {1 Process deadline supervision} *)
 
 type deadline_error =
   | Non_finite_deadline_timeout of float
   | Non_positive_deadline_timeout of float
+  | Watchdog_thread_start_failed of string
 
 val deadline_error_to_string : deadline_error -> string
 
@@ -37,6 +57,10 @@ val process_deadline_exit_code : int
 (** Dedicated non-zero process status for a fired shutdown deadline. Process
     supervisors and runtime telemetry may use this SSOT to distinguish a hard
     deadline from generic exit status [1]. *)
+
+val process_deadline_start_failure_exit_code : int
+(** Dedicated terminal status used when the process cannot arm its hard
+    shutdown deadline authority. *)
 
 type disarm_result =
   | Disarmed
@@ -55,6 +79,20 @@ val start_process_deadline_watchdog :
     cooperative cancellation, or a stalled Eio domain cannot cancel its own
     process deadline. The process entrypoint must own the returned handle and
     disarm it only after the supervised switch has actually returned. *)
+
+val start_process_deadline_watchdog_or_exit :
+  timeout_s:float -> on_error:(deadline_error -> unit) -> watchdog
+(** Start the watchdog or terminate immediately via {!Unix._exit} with
+    {!process_deadline_start_failure_exit_code}. The error observer is
+    best-effort and cannot prevent the fail-closed terminal action. *)
+
+val set_deadline_thread_create_for_testing :
+  ((unit -> unit) -> Thread.t) -> unit
+(** Install the process-local deadline thread starter. Intended only for
+    focused tests of thread-start failure. *)
+
+val reset_deadline_thread_create_for_testing : unit -> unit
+(** Restore the default [Thread.create]-backed deadline starter. *)
 
 val disarm_deadline_watchdog : watchdog -> disarm_result
 (** Atomically disarm an armed watchdog. The result distinguishes a successful

--- a/lib/shutdown.mli
+++ b/lib/shutdown.mli
@@ -37,10 +37,15 @@ type config_error =
   | Non_positive_config_duration of { field : config_field; value : float }
 
 val config_error_to_string : config_error -> string
-val config_from_env : unit -> (config, config_error) result
+val config_from_env_result : unit -> (config, config_error) result
 (** Read and validate the shutdown duration environment variables. A present
     malformed, non-finite, or out-of-range value is an explicit error; it is
     never replaced with a default. *)
+
+val config_from_env : unit -> config
+(** Source-compatible configuration front door. Invalid present values raise
+    [Invalid_argument] with {!config_error_to_string}; callers that need typed
+    startup handling should use {!config_from_env_result}. *)
 
 (** {1 Process deadline supervision} *)
 

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -169,12 +169,27 @@ let () = test "shutdown config rejects malformed present values" (fun () ->
       Unix.putenv "MASC_SHUTDOWN_DRAIN_TIMEOUT" "5";
       Unix.putenv "MASC_SHUTDOWN_CLEANUP_TIMEOUT" "3";
       Unix.putenv "MASC_SHUTDOWN_FORCE_TIMEOUT" "60s";
-      (match Shutdown.config_from_env () with
+      (match Shutdown.config_from_env_result () with
        | Error
            (Shutdown.Invalid_config_number
              { field = Shutdown.Force_timeout; raw_value = "60s" }) ->
            Unix._exit 0
        | _ -> Unix._exit 26)
+  | child_pid ->
+      let waited_pid, status = waitpid_no_intr child_pid in
+      assert (waited_pid = child_pid);
+      assert (status = Unix.WEXITED 0))
+
+let () = test "shutdown config legacy front door stays source-compatible" (fun () ->
+  match Unix.fork () with
+  | 0 ->
+      Unix.putenv "MASC_SHUTDOWN_NOTIFY_DELAY" "0.2";
+      Unix.putenv "MASC_SHUTDOWN_DRAIN_TIMEOUT" "5";
+      Unix.putenv "MASC_SHUTDOWN_CLEANUP_TIMEOUT" "3";
+      Unix.putenv "MASC_SHUTDOWN_FORCE_TIMEOUT" "11";
+      let config : Shutdown.config = Shutdown.config_from_env () in
+      if Float.equal config.force_timeout_s 11.0 then Unix._exit 0
+      else Unix._exit 27
   | child_pid ->
       let waited_pid, status = waitpid_no_intr child_pid in
       assert (waited_pid = child_pid);

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -195,14 +195,12 @@ let () = test "shutdown config legacy front door stays source-compatible" (fun (
       assert (waited_pid = child_pid);
       assert (status = Unix.WEXITED 0))
 
-let () = test "watchdog thread-start failure terminates fail-closed" (fun () ->
+let () = test "watchdog start failure terminates fail-closed" (fun () ->
   match Unix.fork () with
   | 0 ->
-      Shutdown.set_deadline_thread_create_for_testing (fun _ ->
-        raise (Failure "thread budget exhausted"));
       ignore
         (Shutdown.start_process_deadline_watchdog_or_exit
-           ~timeout_s:1.0 ~on_error:(fun _ -> ()))
+           ~timeout_s:0.0)
   | child_pid ->
       let waited_pid, status = waitpid_no_intr child_pid in
       assert (waited_pid = child_pid);

--- a/test/test_lifecycle.ml
+++ b/test/test_lifecycle.ml
@@ -97,6 +97,10 @@ let () = test "inline shutdown hooks run registered cleanup hooks" (fun () ->
 
 exception Simulated_switch_shutdown
 
+let rec waitpid_no_intr child_pid =
+  try Unix.waitpid [] child_pid with
+  | Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_no_intr child_pid
+
 let () = test "shutdown deadline outlives a stuck cancelled switch" (fun () ->
   match Unix.fork () with
   | 0 ->
@@ -118,7 +122,7 @@ let () = test "shutdown deadline outlives a stuck cancelled switch" (fun () ->
               with Simulated_switch_shutdown -> `Shutdown_escaped_switch
             with `Shutdown_escaped_switch -> Unix._exit 24))
   | child_pid ->
-      let waited_pid, status = Unix.waitpid [] child_pid in
+      let waited_pid, status = waitpid_no_intr child_pid in
       assert (waited_pid = child_pid);
       assert (status = Unix.WEXITED Shutdown.process_deadline_exit_code))
 
@@ -157,6 +161,39 @@ let () = test "shutdown deadline rejects invalid time values" (fun () ->
      with
      | Error (Shutdown.Non_positive_deadline_timeout _) -> true
      | _ -> false))
+
+let () = test "shutdown config rejects malformed present values" (fun () ->
+  match Unix.fork () with
+  | 0 ->
+      Unix.putenv "MASC_SHUTDOWN_NOTIFY_DELAY" "0.2";
+      Unix.putenv "MASC_SHUTDOWN_DRAIN_TIMEOUT" "5";
+      Unix.putenv "MASC_SHUTDOWN_CLEANUP_TIMEOUT" "3";
+      Unix.putenv "MASC_SHUTDOWN_FORCE_TIMEOUT" "60s";
+      (match Shutdown.config_from_env () with
+       | Error
+           (Shutdown.Invalid_config_number
+             { field = Shutdown.Force_timeout; raw_value = "60s" }) ->
+           Unix._exit 0
+       | _ -> Unix._exit 26)
+  | child_pid ->
+      let waited_pid, status = waitpid_no_intr child_pid in
+      assert (waited_pid = child_pid);
+      assert (status = Unix.WEXITED 0))
+
+let () = test "watchdog thread-start failure terminates fail-closed" (fun () ->
+  match Unix.fork () with
+  | 0 ->
+      Shutdown.set_deadline_thread_create_for_testing (fun _ ->
+        raise (Failure "thread budget exhausted"));
+      ignore
+        (Shutdown.start_process_deadline_watchdog_or_exit
+           ~timeout_s:1.0 ~on_error:(fun _ -> ()))
+  | child_pid ->
+      let waited_pid, status = waitpid_no_intr child_pid in
+      assert (waited_pid = child_pid);
+      assert
+        (status =
+         Unix.WEXITED Shutdown.process_deadline_start_failure_exit_code))
 
 (* ── Summary ──────────────────────────────────── *)
 


### PR DESCRIPTION
## 결과

- present한 shutdown duration이 malformed/non-finite/negative이면 default로 숨기지 않고 typed error로 거절해용.
- shutdown 설정을 signal 시점이 아니라 process startup에서 검증해용.
- hard deadline watchdog은 Eio switch 밖의 OS thread가 소유하고 timeout 시 `_exit(124)` 해용.
- watchdog 시작 실패는 callback/log 반환을 기다리지 않고 즉시 `_exit(125)` 해용.
- production API에서 watchdog thread factory를 바꾸는 테스트 setter/stub을 제거했어용.

## 검증

- exact base: `2c48beb99a02b0afe69c82cd3618efe6529c7d2a`
- exact head: `a4e2b2325e801478f83273cdad8e5a6aa9c6fd64`
- `scripts/dune-local.sh build lib/masc.cmxa bin/main_eio.exe test/test_lifecycle.exe`: PASS
- `test_lifecycle`: 10/10 PASS
- `ocamlformat`, `git diff --check`: PASS
- 전체 Dune은 exact-head CI에서 확인해용.

Draft이며 exact-head CI가 terminal green이 될 때까지 병합하지 않아용.
