### PR TITLE
fix(auth): fail closed on dashboard dev-token read errors

### DIFF
--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -37,6 +37,15 @@ type dashboard_dev_token_candidate =
   | Reusable of string
   | Rotate
 
+let default_dashboard_dev_token_load path = Fs_compat.load_file path
+let dashboard_dev_token_load = Atomic.make default_dashboard_dev_token_load
+
+let set_dashboard_dev_token_load_for_testing load =
+  Atomic.set dashboard_dev_token_load load
+
+let reset_dashboard_dev_token_load_for_testing () =
+  Atomic.set dashboard_dev_token_load default_dashboard_dev_token_load
+
 let classify_dashboard_dev_token_candidate ~base_path raw :
     (dashboard_dev_token_candidate, string) result =
   let trimmed = String.trim raw in
@@ -60,17 +69,16 @@ let read_reusable_dashboard_dev_token ~base_path path :
   else
     try
       match classify_dashboard_dev_token_candidate ~base_path
-              (Fs_compat.load_file path) with
+              ((Atomic.get dashboard_dev_token_load) path) with
       | Ok (Reusable raw) -> Ok (Some raw)
       | Ok Rotate -> Ok None
       | Error msg -> Error msg
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-        Log.Server.warn
-          "dashboard dev-token read skipped for %s: %s"
-          path (Printexc.to_string exn);
-        Ok None
+        Error
+          (Printf.sprintf "read dev-token %s: %s"
+             path (Printexc.to_string exn))
 
 let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
   let token_path = dashboard_dev_token_path base_path in

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -10,6 +10,12 @@ val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result
 
+val set_dashboard_dev_token_load_for_testing : (string -> string) -> unit
+(** Replace the dev-token file reader for focused failure-path tests. *)
+
+val reset_dashboard_dev_token_load_for_testing : unit -> unit
+(** Restore the production dev-token file reader. *)
+
 val ensure_dashboard_dev_token_for_authority :
   request_authority:Server_request_authority.authority ->
   base_path:string ->

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -50,6 +50,30 @@ let test_non_loopback_rejection_precedes_token_io () =
       | Ok _ -> fail "non-loopback authority must not reach token I/O")
 ;;
 
+let test_read_failure_does_not_mint_admin_credential () =
+  let base_path = Filename.temp_file "masc-dev-token-read-" ".workspace" in
+  Sys.remove base_path;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree base_path)
+    (fun () ->
+      let token_path = Dev_token.dashboard_dev_token_path base_path in
+      Fs_compat.mkdir_p (Filename.dirname token_path);
+      Fs_compat.save_file token_path "stale";
+      Dev_token.set_dashboard_dev_token_load_for_testing (fun _ ->
+        raise (Sys_error "injected read failure"));
+      Fun.protect
+        ~finally:Dev_token.reset_dashboard_dev_token_load_for_testing
+        (fun () ->
+          match Dev_token.ensure_dashboard_dev_token base_path with
+          | Error _ ->
+              check
+                bool
+                "read failure creates no credential store"
+                false
+                (Sys.file_exists (Common.agents_dir_from_base_path ~base_path))
+          | Ok _ -> fail "unreadable dev-token path must fail closed"))
+;;
+
 let () =
   run
     "dashboard-dev-token-host-gate"
@@ -59,6 +83,10 @@ let () =
             "non-loopback rejected before token I/O"
             `Quick
             test_non_loopback_rejection_precedes_token_io
+        ; test_case
+            "read failure does not mint admin credential"
+            `Quick
+            test_read_failure_does_not_mint_admin_credential
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary\n\n- propagate dashboard.token read exceptions as an explicit error instead of converting them to Missing\n- prevent read failures from reaching Auth.create_token and minting a new Admin credential\n- add an injected read-failure regression that proves no credential store is created\n\n## Why\n\nPost-merge audit of #24148 found a fail-open credential lifecycle: any non-cancellation read error returned Ok None, so ensure_dashboard_dev_token minted Admin before dashboard.token persistence could fail. That can leave orphan Admin credentials and repeat on subsequent requests.\n\n## Scope\n\nThis is the smallest independent read-failure slice. Concurrent mint serialization/recovery, trusted Host/Origin admission, and WebSocket bearer continuity remain separate security boundaries and are not claimed fixed here.\n\n## Verification\n\n- ocamlformat --check: pass\n- ocamlc parse checks for implementation, interface, and test: pass\n- git diff --check: pass\n- focused Dune build pending: an unrelated bare dune build . PID 95049 holds the machine-wide guard; it was not killed or bypassed\n- PR CI is the build authority before merge\n\n## Gate\n\nDraft + p1 + status:do-not-merge until focused/CI build and adversarial review complete.\n\nFollow-up to #24148.