### PR TITLE
fix(keeper): canonicalize registry BasePath identity

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -163,6 +163,28 @@ let absolute_path path =
 let absolute_path_from ~cwd path =
   if Filename.is_relative path then Filename.concat cwd path else path
 
+type canonical_base_path_error =
+  | Empty_after_normalization
+  | Could_not_derive_absolute of { input : string }
+
+let canonical_base_path_error_to_string = function
+  | Empty_after_normalization -> "path is empty after normalization"
+  | Could_not_derive_absolute { input } ->
+    Printf.sprintf "could not derive an absolute path from %S" input
+;;
+
+let canonical_base_path raw =
+  let normalized = Env_config_core.normalize_masc_base_path_input raw in
+  if String.equal normalized ""
+  then Error Empty_after_normalization
+  else
+    let absolute = absolute_path_from ~cwd:(current_working_dir ()) normalized in
+    let canonical = Env_config_core.normalize_masc_base_path_input absolute in
+    if String.equal canonical "" || Filename.is_relative canonical
+    then Error (Could_not_derive_absolute { input = raw })
+    else Ok canonical
+;;
+
 let source_to_string = function
   | Env -> "env"
   | Local_masc -> "local_masc"

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -192,6 +192,19 @@ val current_env_base_path_opt : unit -> string option
     anchor stays the SSOT. *)
 val absolute_path : string -> string
 
+type canonical_base_path_error =
+  | Empty_after_normalization
+  | Could_not_derive_absolute of { input : string }
+
+val canonical_base_path_error_to_string : canonical_base_path_error -> string
+
+val canonical_base_path : string -> (string, canonical_base_path_error) result
+(** Canonical identity for a MASC workspace base path. Applies
+    {!Env_config_core.normalize_masc_base_path_input}, anchors relative inputs
+    at {!current_working_dir}, then normalizes once more. Thus [base_path] and
+    [base_path/.masc] resolve to the same absolute identity. Invalid input is a
+    typed error; callers must not fall back to the raw string. *)
+
 val current_env_config_dir_opt : unit -> string option
 val current_env_personas_dir_opt : unit -> string option
 

--- a/lib/keeper/keeper_heartbeat_loop_board_events.ml
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.ml
@@ -61,6 +61,7 @@ let clear_collection_failure ~base_path ~keeper_name =
 ;;
 
 let live_failure_keeper_names ~base_path =
+  let base_path = Keeper_registry_types.canonical_base_path_exn base_path in
   Stdlib.Mutex.protect collection_failures_mu (fun () ->
     Hashtbl.fold
       (fun key _failure acc ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -320,6 +320,7 @@ let count_running ?base_path () =
   match base_path with
   | None -> Atomic.get running_count_atomic
   | Some expected ->
+    let expected = canonical_base_path_exn expected in
     StringMap.fold
       (fun _k v acc ->
          if String.equal expected v.base_path && v.phase = Running then acc + 1 else acc)
@@ -435,6 +436,7 @@ let wakeup_running ~base_path name =
 ;;
 
 let wakeup_all ?base_path () =
+  let base_path = Option.map canonical_base_path_exn base_path in
   StringMap.iter
     (fun _k entry ->
        match base_path with

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -42,6 +42,7 @@ let registry_entry_validation_error_to_string = function
 ;;
 
 let registry_key_parts = Keeper_registry_types.registry_key_parts
+let canonical_base_path_exn = Keeper_registry_types.canonical_base_path_exn
 
 let has_blank_tool_name names =
   List.exists (fun name -> String.equal (String.trim name) "") names
@@ -82,6 +83,7 @@ let validate_runtime_fields (runtime : agent_runtime_state) =
 ;;
 
 let validate_registry_entry ~base_path name (entry : registry_entry) =
+  let base_path = canonical_base_path_exn base_path in
   let expected_name = String.trim name in
   if not (String.equal entry.base_path base_path)
   then Error (Base_path_mismatch { expected = base_path; actual = entry.base_path })
@@ -401,6 +403,7 @@ let register_with_state_result
       ~(phase : Keeper_state_machine.phase)
       ~(conditions : Keeper_state_machine.conditions)
   =
+  let base_path = canonical_base_path_exn base_path in
   let meta = canonicalize_registry_meta ~operation:"register" ~base_path name meta in
   Log.Keeper.info
     "registry: registering keeper name=%s base_path=%s phase=%s"
@@ -557,6 +560,7 @@ type register_restarting_error =
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
   =
+  let base_path = canonical_base_path_exn base_path in
   let meta =
     canonicalize_registry_meta ~operation:"register_restarting" ~base_path name meta
   in
@@ -748,6 +752,7 @@ let get ~base_path name =
 ;;
 
 let all ?base_path () =
+  let base_path = Option.map canonical_base_path_exn base_path in
   StringMap.fold
     (fun key v acc ->
        match registry_key_parts key with
@@ -771,6 +776,7 @@ let all ?base_path () =
 ;;
 
 let update_meta ~base_path name meta =
+  let base_path = canonical_base_path_exn base_path in
   match validate_registry_meta ~base_path name meta with
   | Error reason ->
       record_invalid_registry_entry ~operation:"update_meta" ~name reason
@@ -779,6 +785,7 @@ let update_meta ~base_path name meta =
 ;;
 
 let reload_meta_from_disk ~base_path name =
+  let base_path = canonical_base_path_exn base_path in
   let config = Workspace.default_config base_path in
   match read_meta config name with
   | Error msg -> Error msg
@@ -808,6 +815,7 @@ let reload_meta_from_disk ~base_path name =
 (* Runtime-attempt cluster (runtime_attempt_merge / meta_for_runtime_attempt / record_runtime_attempt / runtime_attempt_suffix / last_runtime_attempt / runtime_attempt_freshness_threshold_sec / enrich... *)
 
 let sync_meta_if_registered ~base_path name meta =
+  let base_path = canonical_base_path_exn base_path in
   match validate_registry_meta ~base_path name meta with
   | Error reason ->
       record_invalid_registry_entry ~operation:"sync_meta_if_registered" ~name reason

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -190,9 +190,20 @@ let resolve_done entry ~source (value : done_resolution) =
 
 let lane_has_exited entry = Option.is_some (Keeper_lane.peek_exit entry.lane)
 
+let canonical_base_path_exn raw =
+  match Config_dir_resolver.canonical_base_path raw with
+  | Ok canonical -> canonical
+  | Error error ->
+    invalid_arg
+      (Printf.sprintf
+         "invalid keeper registry base path: %s"
+         (Config_dir_resolver.canonical_base_path_error_to_string error))
+;;
+
 let registry_key ~base_path name =
   if String.contains name '\x1f'
   then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
+  let base_path = canonical_base_path_exn base_path in
   base_path ^ "\x1f" ^ name
 ;;
 

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -439,6 +439,9 @@ type done_resolution = [ `Stopped | `Crashed of string ]
 
 type registry_entry = {
   base_path : string;
+      (** Canonical workspace identity from
+          {!Config_dir_resolver.canonical_base_path}; byte-equal to the
+          BasePath segment embedded by {!registry_key}. *)
   name : string;
   meta : keeper_meta;
   phase : Keeper_state_machine.phase;
@@ -610,9 +613,15 @@ val resolve_done :
 
 val lane_has_exited : registry_entry -> bool
 
-(** Internal: keeper registry key composition (base_path ^ \\x1f ^ name).
-    Exposed via mli so keeper_registry.ml's state functions can use it
-    after the intra-library split; not intended for external callers. *)
+(** Internal: canonicalize a caller-provided BasePath through the shared
+    {!Config_dir_resolver.canonical_base_path} identity. Invalid paths raise
+    [Invalid_argument]; registry APIs require a valid workspace identity. *)
+val canonical_base_path_exn : string -> string
+
+(** Internal: keeper registry key composition
+    (canonical_base_path ^ \\x1f ^ name). Exposed via mli so
+    keeper_registry.ml's state functions can use it after the intra-library
+    split; not intended for external callers. *)
 val registry_key : base_path:string -> string -> string
 
 (** Internal: inverse of [registry_key]. Returns the [base_path] and

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -105,6 +105,7 @@ let slots : (string, slot) Hashtbl.t = Hashtbl.create 16
 let slots_mu = Stdlib.Mutex.create ()
 
 let slot_for ~base_path ~keeper_name =
+  let base_path = Keeper_registry_types.canonical_base_path_exn base_path in
   let key = Keeper_registry_types.registry_key ~base_path keeper_name in
   Stdlib.Mutex.protect slots_mu (fun () ->
     match Hashtbl.find_opt slots key with
@@ -394,6 +395,7 @@ let snapshot_for ~base_path ~keeper_name =
 ;;
 
 let live_keeper_names ~base_path =
+  let base_path = Keeper_registry_types.canonical_base_path_exn base_path in
   Stdlib.Mutex.protect slots_mu (fun () ->
     Hashtbl.fold
       (fun _key slot acc ->

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
@@ -38,22 +38,10 @@ let resolve_error_to_string = function
 ;;
 
 let canonical_base_path raw =
-  let normalized = Env_config_core.normalize_masc_base_path_input raw in
-  if String.equal normalized ""
-  then Error (Invalid_base_path "path is empty after normalization")
-  else
-    let absolute =
-      if Filename.is_relative normalized
-      then Filename.concat (Config_dir_resolver.current_working_dir ()) normalized
-      else normalized
-    in
-    let canonical = Env_config_core.normalize_masc_base_path_input absolute in
-    if String.equal canonical "" || Filename.is_relative canonical
-    then
-      Error
-        (Invalid_base_path
-           (Printf.sprintf "could not derive an absolute path from %S" raw))
-    else Ok canonical
+  Config_dir_resolver.canonical_base_path raw
+  |> Result.map_error (fun error ->
+    Invalid_base_path
+      (Config_dir_resolver.canonical_base_path_error_to_string error))
 ;;
 
 let resolve ~base_path ~keeper_name =

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
@@ -17,9 +17,9 @@ type t
 val resolve_error_to_string : resolve_error -> string
 
 val canonical_base_path : string -> (string, resolve_error) result
-(** Normalize through {!Env_config_core.normalize_masc_base_path_input}, then
-    anchor relative inputs at {!Config_dir_resolver.current_working_dir}.  The
-    returned path is absolute and lexically canonical. *)
+(** Resolve through the shared {!Config_dir_resolver.canonical_base_path}
+    identity used by Keeper registry keys. The returned path is absolute and
+    lexically canonical. *)
 
 val resolve :
   base_path:string -> keeper_name:string -> (t, resolve_error) result

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -972,6 +972,90 @@ let () =
       Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name [ replayed ];
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
+  (* --- registry identity barrier: [base] and [base/.masc] must address one
+     live atomic and the same durable owner. Two registrations followed by one
+     enqueue through each alias used to leave two live entries whose snapshots
+     overwrote each other on the shared canonical file. --- *)
+  let base_path = temp_dir "keeper-event-queue-registry-base-alias" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-registry-base-alias-test" in
+      let base_path_masc = Filename.concat base_path Common.masc_dirname in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-base-alias-test" in
+      let queue_post_ids queue =
+        Keeper_event_queue.to_list queue
+        |> List.map (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.post_id)
+      in
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      ignore
+        (Masc.Keeper_registry.register
+           ~base_path:base_path_masc
+           keeper_name
+           meta);
+      let base_entry =
+        match Masc.Keeper_registry.get ~base_path keeper_name with
+        | Some entry -> entry
+        | None -> Alcotest.fail "base-path registry entry missing"
+      in
+      let masc_entry =
+        match Masc.Keeper_registry.get ~base_path:base_path_masc keeper_name with
+        | Some entry -> entry
+        | None -> Alcotest.fail "base-path/.masc registry entry missing"
+      in
+      Alcotest.(check bool)
+        "BasePath aliases resolve one live registry entry"
+        true
+        (base_entry == masc_entry);
+      Alcotest.(check string)
+        "registry stores canonical BasePath"
+        base_path
+        base_entry.base_path;
+      Alcotest.(check int)
+        "registry contains one canonical owner"
+        1
+        (List.length (Masc.Keeper_registry.all ()));
+      Alcotest.(check int)
+        "BasePath/.masc filter sees canonical owner"
+        1
+        (List.length (Masc.Keeper_registry.all ~base_path:base_path_masc ()));
+
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      Masc.Keeper_registry_event_queue.enqueue
+        ~base_path:base_path_masc
+        keeper_name
+        bootstrap_stim;
+      let expected_post_ids = [ "p1"; "bootstrap" ] in
+      Alcotest.(check (list string))
+        "both aliases publish to one live atomic"
+        expected_post_ids
+        (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name
+         |> queue_post_ids);
+      Alcotest.(check (list string))
+        "both alias stimuli share one durable snapshot"
+        expected_post_ids
+        (Keeper_event_queue_persistence.load
+           ~base_path:base_path_masc
+           ~keeper_name
+         |> queue_post_ids);
+
+      Masc.Keeper_registry.clear ();
+      ignore
+        (Masc.Keeper_registry.register
+           ~base_path:base_path_masc
+           keeper_name
+           meta);
+      Alcotest.(check (list string))
+        "restart through alias restores both stimuli"
+        expected_post_ids
+        (Masc.Keeper_registry_event_queue.snapshot
+           ~base_path
+           keeper_name
+         |> queue_post_ids));
+
   (* --- registry drain_board: turn digest consumes every queued board
      signal in one call, however spread their arrival times (RFC-0334 W2
      pin: 5 signals spread over >2 s while the keeper was busy → one


### PR DESCRIPTION
## Summary\n\n- add one canonical BasePath result boundary in Config_dir_resolver\n- make Keeper registry keys/stored entries and durable event-queue owners consume that same identity\n- canonicalize alias-sensitive admission, health, restart, meta-update, and registry filter paths\n- add a registry-level barrier proving base and base/.masc share one live atomic and one durable snapshot\n\n## Why\n\nPost-merge audit of #24205 found that durable queue ownership canonicalized base/.masc while Keeper_registry keyed entries by the raw string. Registering the same Keeper through both aliases created two independent queue atomics writing last-writer-wins snapshots to one file, losing stimuli.\n\n## Scope\n\nThis fixes only BasePath identity divergence. The Keeper-name SSOT/migration blocker and shared durable-owner lock primitive remain separate follow-ups.\n\n## Verification\n\n- OCaml parser checks on every changed ml/mli: pass\n- ocamlformat --check: pass\n- test coverage gate: pass\n- git diff --check: pass\n- registry alias regression covers single entry, two live stimuli, durable snapshot, and restart restore\n- focused Dune build pending: an unrelated interactive bare dune build . PID 28037 holds the machine-wide guard; it was not killed or bypassed\n- PR CI is the build authority before merge\n\n## Gate\n\nDraft + p1 + status:do-not-merge until focused/CI build and adversarial review complete.\n\nFollow-up to #24205.