### PR TITLE
feat(keeper): make dashboard purge durable

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -59,13 +59,26 @@ export async function claimTask(taskId: string): Promise<void> {
   await callMcpTool('masc_transition', { task_id: taskId, action: 'claim' })
 }
 
-export interface PurgeAgentResponse {
-  ok: boolean
-  target_kind: 'agent' | 'keeper' | string
-  agent_name: string
-  keeper_name?: string
-  removed_keeper_toml?: boolean
-}
+export type PurgeAgentResponse =
+  | {
+      ok: true
+      accepted: true
+      target_kind: 'keeper'
+      agent_name: string
+      keeper_name: string
+      operation_id: string
+    }
+  | {
+      ok: true
+      accepted: false
+      target_kind: 'agent'
+      agent_name: string
+      cleanup_results: Array<{
+        agent_name: string
+        heartbeats_stopped: number
+        workspace_unbound: boolean
+      }>
+    }
 
 export async function purgeAgent(agentName: string): Promise<PurgeAgentResponse> {
   return post<PurgeAgentResponse>('/api/v1/dashboard/agents/purge', {

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -214,20 +214,22 @@ export function AgentDetailOverlay() {
       const targetLabel = keeper ? `${displayName} 키퍼` : displayName
       const confirmed = await requestConfirm({
         title: '에이전트 완전 삭제',
-        message: `${targetLabel}를 완전 삭제합니다.\n런타임 상태, 인증, metrics가 제거되고 keeper면 config/keepers TOML도 함께 삭제됩니다.`,
+        message: keeper
+          ? `${targetLabel}의 안전한 삭제 작업을 접수합니다.\n현재 작업이 정리된 뒤 세션, 인증, metrics와 Keeper 설정이 삭제됩니다.`
+          : `${targetLabel}를 완전 삭제합니다.\n런타임 상태, 인증, metrics가 제거됩니다.`,
         tone: 'danger',
-        confirmText: '완전 삭제',
+        confirmText: keeper ? '삭제 작업 접수' : '완전 삭제',
       })
       if (!confirmed) return
       purgePending.value = true
       try {
-        const result = await purgeAgent(agentName)
+        const result = await purgeAgent(keeper?.name ?? agentName)
         closeAgentDetail()
         invalidateDashboardCache()
         await refreshDashboard({ force: true })
         showToast(
           result.target_kind === 'keeper'
-            ? `${displayName} 완전 삭제됨`
+            ? `${displayName} 삭제 작업 접수됨 (${result.operation_id})`
             : `${agentName} 삭제됨`,
           'success',
         )

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -316,16 +316,19 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
     void (async () => {
       const confirmed = await requestConfirm({
         title: '키퍼 완전 삭제',
-        message: `${keeper.name}를 완전 삭제합니다.\n런타임 상태, 세션 trace, 인증, metrics와 config/keepers/${keeper.name}.toml까지 함께 제거됩니다.`,
+        message: `${keeper.name}의 안전한 삭제 작업을 접수합니다.\n현재 작업이 정리된 뒤 세션 trace, 인증, metrics와 Keeper 설정이 삭제됩니다.`,
         tone: 'danger',
-        confirmText: '완전 삭제',
+        confirmText: '삭제 작업 접수',
       })
       if (!confirmed) return
       setPurgePending(true)
       try {
-        await purgeAgent(keeper.name)
+        const result = await purgeAgent(keeper.name)
+        if (result.target_kind !== 'keeper') {
+          throw new Error('Keeper 삭제 요청이 agent 즉시 삭제로 처리되었습니다')
+        }
         closeKeeperDetail()
-        showToast(`${keeper.name} 완전 삭제됨`, 'success')
+        showToast(`${keeper.name} 삭제 작업 접수됨 (${result.operation_id})`, 'success')
         await refreshAfterRuntimeAction()
       } catch (err) {
         showToast(err instanceof Error ? err.message : '키퍼 삭제 실패', 'error')

--- a/dashboard/src/components/keeper-lifecycle-timeline.test.ts
+++ b/dashboard/src/components/keeper-lifecycle-timeline.test.ts
@@ -45,6 +45,10 @@ describe('lifecycleEventTone', () => {
     expect(lifecycleEventTone('dead_cleaned')).toBe('bad')
   })
 
+  it('purged returns info', () => {
+    expect(lifecycleEventTone('purged')).toBe('info')
+  })
+
   it('unknown events return info', () => {
     expect(lifecycleEventTone('unknown_event')).toBe('info')
     expect(lifecycleEventTone('')).toBe('info')
@@ -71,6 +75,10 @@ describe('lifecycleEventLabel', () => {
 
   it('maps auto_resumed to Korean label', () => {
     expect(lifecycleEventLabel('auto_resumed')).toBe('자동 재개됨')
+  })
+
+  it('maps purged to Korean label', () => {
+    expect(lifecycleEventLabel('purged')).toBe('완전 삭제됨')
   })
 
   it('falls back to underscore-replaced string for unknown events', () => {

--- a/dashboard/src/components/keeper-lifecycle-timeline.ts
+++ b/dashboard/src/components/keeper-lifecycle-timeline.ts
@@ -39,6 +39,7 @@ export function lifecycleEventTone(event: string): EventTone {
   if (e === 'started' || e === 'reconciled' || e === 'auto_resumed') return 'ok'
   if (e === 'restarted') return 'warn'
   if (e === 'dead_cleaned') return 'bad'
+  if (e === 'purged') return 'info'
   if (e === 'paused_pruned' || e === 'self_preservation') return 'warn'
   return 'info'
 }
@@ -62,6 +63,7 @@ export function lifecycleEventLabel(event: string): string {
     case 'dead_cleaned':      return '종료 정리됨'
     case 'self_preservation': return '자기보존'
     case 'paused_pruned':     return '일시정지 정리됨'
+    case 'purged':            return '완전 삭제됨'
     case 'auto_resumed':      return '자동 재개됨'
     default:                  return event.replace(/_/g, ' ')
   }

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -497,6 +497,7 @@ let persist_raw_token config ~agent_name raw_token =
 (** Delete agent credential *)
 let delete_credential config agent_name =
   let file = credential_file config agent_name in
+  let raw_token = raw_token_file config agent_name in
   let redirect_target = load_redirect_target config file in
   let credential_target =
     match load_credential config agent_name with
@@ -504,6 +505,7 @@ let delete_credential config agent_name =
     | _ -> None
   in
   remove_file_if_exists file;
+  remove_file_if_exists raw_token;
   Option.iter remove_file_if_exists redirect_target;
   Option.iter remove_file_if_exists credential_target;
   !credential_cache_invalidator_ref config

--- a/lib/keeper/keeper_dashboard_purge.ml
+++ b/lib/keeper/keeper_dashboard_purge.ml
@@ -1,0 +1,169 @@
+type target =
+  { requested_name : string
+  ; keeper_name : string
+  ; meta : Keeper_meta_contract.keeper_meta
+  }
+
+type resolve_error =
+  | Empty_requested_name
+  | Invalid_requested_name of
+      { requested_name : string
+      ; detail : string
+      }
+  | Keeper_metadata_unreadable of
+      { keeper_name : string
+      ; metadata_path : string
+      ; detail : string
+      }
+  | Keeper_metadata_required of
+      { keeper_name : string
+      ; configuration_path : string
+      }
+  | Keeper_metadata_name_mismatch of
+      { expected_keeper_name : string
+      ; persisted_keeper_name : string
+      }
+  | Keeper_agent_name_invalid of
+      { keeper_name : string
+      ; agent_name : string
+      ; detail : string
+      }
+  | Keeper_operation_unreadable of
+      { keeper_name : string
+      ; operation_id : Keeper_shutdown_types.Operation_id.t
+      ; detail : string
+      }
+
+let resolve_error_to_string = function
+  | Empty_requested_name -> "dashboard Keeper purge requires a non-empty target name"
+  | Invalid_requested_name { requested_name; detail } ->
+    Printf.sprintf
+      "dashboard purge target name is invalid: target=%S error=%s"
+      requested_name
+      detail
+  | Keeper_metadata_unreadable { keeper_name; metadata_path; detail } ->
+    Printf.sprintf
+      "dashboard Keeper purge cannot read exact owner metadata: keeper=%s path=%s error=%s"
+      keeper_name
+      metadata_path
+      detail
+  | Keeper_metadata_required { keeper_name; configuration_path } ->
+    Printf.sprintf
+      "dashboard Keeper purge requires persisted owner metadata before removing a configured Keeper: keeper=%s config=%s"
+      keeper_name
+      configuration_path
+  | Keeper_metadata_name_mismatch
+      { expected_keeper_name; persisted_keeper_name } ->
+    Printf.sprintf
+      "dashboard Keeper purge metadata owner mismatch: expected=%s persisted=%s"
+      expected_keeper_name
+      persisted_keeper_name
+  | Keeper_agent_name_invalid { keeper_name; agent_name; detail } ->
+    Printf.sprintf
+      "dashboard Keeper purge metadata has an invalid agent owner: keeper=%s agent=%S error=%s"
+      keeper_name
+      agent_name
+      detail
+  | Keeper_operation_unreadable { keeper_name; operation_id; detail } ->
+    Printf.sprintf
+      "dashboard Keeper purge cannot load the operation owning admission: keeper=%s operation=%s error=%s"
+      keeper_name
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+      detail
+;;
+
+let canonical_requested_name requested_name =
+  let requested_name = String.trim requested_name in
+  if String.equal requested_name ""
+  then Error Empty_requested_name
+  else
+    match Workspace.validate_agent_name requested_name with
+    | Error detail -> Error (Invalid_requested_name { requested_name; detail })
+    | Ok _ -> Ok (requested_name, Keeper_identity.canonical_keeper_name requested_name)
+;;
+
+let resolve (config : Workspace.config) requested_name =
+  match canonical_requested_name requested_name with
+  | Error _ as error -> error
+  | Ok (requested_name, canonical_name) ->
+    match canonical_name with
+    | None -> Ok None
+    | Some keeper_name ->
+      let metadata_path = Keeper_types_profile.keeper_meta_path config keeper_name in
+      let configuration_path =
+        Config_dir_resolver.keeper_toml_path_opt_for_base_path
+          ~base_path:config.base_path
+          keeper_name
+      in
+      (match Keeper_meta_store.read_meta config keeper_name with
+       | Error detail ->
+         Error
+           (Keeper_metadata_unreadable { keeper_name; metadata_path; detail })
+       | Ok (Some meta) when String.equal meta.name keeper_name ->
+         (match Workspace.validate_agent_name meta.agent_name with
+          | Ok _ -> Ok (Some { requested_name; keeper_name; meta })
+          | Error detail ->
+            Error
+              (Keeper_agent_name_invalid
+                 { keeper_name; agent_name = meta.agent_name; detail }))
+       | Ok (Some meta) ->
+         Error
+           (Keeper_metadata_name_mismatch
+              { expected_keeper_name = keeper_name
+              ; persisted_keeper_name = meta.name
+              })
+       | Ok None ->
+         (match configuration_path with
+          | Some configuration_path ->
+            Error
+              (Keeper_metadata_required { keeper_name; configuration_path })
+          | None -> Ok None))
+;;
+
+let existing_operation (config : Workspace.config) requested_name =
+  match canonical_requested_name requested_name with
+  | Error _ as error -> error
+  | Ok (_, None) -> Ok None
+  | Ok (_, Some keeper_name) ->
+    let snapshot =
+      Keeper_turn_admission.snapshot_for
+        ~base_path:config.base_path
+        ~keeper_name
+    in
+    (match snapshot.snapshot_shutdown_operation_id with
+     | None -> Ok None
+     | Some operation_id ->
+       (match Keeper_shutdown_store.load ~config ~keeper_name operation_id with
+        | Error error ->
+          Error
+            (Keeper_operation_unreadable
+               { keeper_name
+               ; operation_id
+               ; detail = Keeper_shutdown_store.error_to_string error
+               })
+        | Ok operation ->
+          Ok
+            (match operation.cleanup_intent.reason with
+             | Keeper_shutdown_types.Dashboard_keeper_purge _ -> Some operation
+             | Operator_stop_retain_meta
+             | Operator_stop_remove_meta
+             | Dead_tombstone_cleanup
+             | Stale_paused_prune _ -> None)))
+;;
+
+let submit ~config ~actor ({ requested_name; keeper_name; meta } : target) =
+  let context : Keeper_shutdown_types.dashboard_purge_context =
+    { requested_name; agent_name = meta.agent_name; meta_version = meta.meta_version }
+  in
+  let request : Keeper_shutdown_prepare_join.request =
+    { actor
+    ; cleanup_intent =
+        { reason = Keeper_shutdown_types.Dashboard_keeper_purge context
+        ; remove_session = true
+        }
+    }
+  in
+  match Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name with
+  | Some entry -> Keeper_shutdown_runtime.submit ~config ~entry ~request
+  | None -> Keeper_shutdown_runtime.submit_dormant ~config ~meta ~request
+;;

--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -1,0 +1,69 @@
+(** Typed admission boundary for dashboard-initiated Keeper purge operations.
+
+    Resolution never guesses a Keeper from filesystem side effects. The
+    request is normalized once through {!Keeper_identity}; a Keeper target is
+    admitted only when its canonical persisted metadata can be read. A
+    configuration-only or unreadable Keeper remains explicit and cannot fall
+    through to the plain-agent purge path. *)
+
+type target =
+  { requested_name : string
+  ; keeper_name : string
+  ; meta : Keeper_meta_contract.keeper_meta
+  }
+
+type resolve_error =
+  | Empty_requested_name
+  | Invalid_requested_name of
+      { requested_name : string
+      ; detail : string
+      }
+  | Keeper_metadata_unreadable of
+      { keeper_name : string
+      ; metadata_path : string
+      ; detail : string
+      }
+  | Keeper_metadata_required of
+      { keeper_name : string
+      ; configuration_path : string
+      }
+  | Keeper_metadata_name_mismatch of
+      { expected_keeper_name : string
+      ; persisted_keeper_name : string
+      }
+  | Keeper_agent_name_invalid of
+      { keeper_name : string
+      ; agent_name : string
+      ; detail : string
+      }
+  | Keeper_operation_unreadable of
+      { keeper_name : string
+      ; operation_id : Keeper_shutdown_types.Operation_id.t
+      ; detail : string
+      }
+
+val resolve_error_to_string : resolve_error -> string
+
+(** [resolve config requested_name] returns [Ok (Some target)] only for a
+    canonical Keeper backed by readable persisted metadata. [Ok None] means
+    the request has no Keeper metadata/configuration ownership and may be
+    considered by the separate plain-agent boundary. *)
+val resolve :
+  Workspace.config -> string -> (target option, resolve_error) result
+
+(** Return the exact dashboard purge operation that currently owns the
+    canonical Keeper's admission fence. This makes an HTTP retry idempotent
+    even after finalization removed metadata but completion delivery is still
+    pending. An unrelated lifecycle operation is not reclassified as purge. *)
+val existing_operation :
+  Workspace.config ->
+  string ->
+  (Keeper_shutdown_types.t option, resolve_error) result
+
+(** Persist and asynchronously start an exact-owner dashboard purge. The
+    returned operation id is durable before [submit] returns. *)
+val submit :
+  config:Workspace.config ->
+  actor:string ->
+  target ->
+  (Keeper_shutdown_types.t, Keeper_shutdown_runtime.submit_error) result

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -349,6 +349,18 @@ let read_operation_meta ~config operation =
      | Ok _ ->
        Error
          "stale paused Keeper metadata state changed while lifecycle cleanup owned admission")
+  | Dashboard_keeper_purge context ->
+    (match
+       Keeper_meta_store.read_meta_if_exact_identity
+         config
+         ~name:operation.keeper_name
+         ~trace_id:operation.trace_id
+         ~generation:operation.generation
+         ~meta_version:context.meta_version
+     with
+     | Ok meta -> Ok meta
+     | Error error ->
+       Error (Keeper_meta_store.exact_identity_error_to_string error))
   | Operator_stop_retain_meta
   | Operator_stop_remove_meta
   | Dead_tombstone_cleanup ->
@@ -415,14 +427,16 @@ let validate_registry_owner_exact ~config operation =
               (Keeper_state_machine.phase_to_string phase))
        | ( Operator_stop_retain_meta
          | Operator_stop_remove_meta
-         | Dead_tombstone_cleanup )
+         | Dead_tombstone_cleanup
+         | Dashboard_keeper_purge _ )
          , _ -> Ok ())
 ;;
 
 let prepare_cleanup ~config ~entry operation settled_task_ids =
   let meta_prepare_result =
     match operation.cleanup_intent.reason with
-    | Stale_paused_prune _ ->
+    | Stale_paused_prune _
+    | Dashboard_keeper_purge _ ->
       (match read_operation_meta ~config operation with
        | Error _ as error -> error
        | Ok _ -> validate_registry_owner_exact ~config operation)
@@ -478,35 +492,38 @@ let prepare_cleanup ~config ~entry operation settled_task_ids =
              | Error _ as error -> error)))
 ;;
 
-let rec remove_tree path =
-  if not (Fs_compat.file_exists path)
-  then Ok ()
-  else
-    try
-      match (Unix.lstat path).Unix.st_kind with
-      | Unix.S_DIR ->
-        let entries = Sys.readdir path |> Array.to_list in
-        let rec remove_entries = function
-          | [] ->
-            Unix.rmdir path;
-            Ok ()
-          | entry :: rest ->
-            (match remove_tree (Filename.concat path entry) with
-             | Error _ as error -> error
-             | Ok () -> remove_entries rest)
-        in
-        remove_entries entries
-      | Unix.S_REG
-      | Unix.S_LNK
-      | Unix.S_CHR
-      | Unix.S_BLK
-      | Unix.S_FIFO
-      | Unix.S_SOCK ->
-        Unix.unlink path;
-        Ok ()
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Printexc.to_string exn)
+let rec remove_tree_blocking path =
+  try
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_DIR ->
+      let entries = Sys.readdir path |> Array.to_list |> List.sort String.compare in
+      let rec remove_entries = function
+        | [] ->
+          Unix.rmdir path;
+          Ok ()
+        | entry :: rest ->
+          (match remove_tree_blocking (Filename.concat path entry) with
+           | Error _ as error -> error
+           | Ok () -> remove_entries rest)
+      in
+      remove_entries entries
+    | Unix.S_REG
+    | Unix.S_LNK
+    | Unix.S_CHR
+    | Unix.S_BLK
+    | Unix.S_FIFO
+    | Unix.S_SOCK ->
+      Unix.unlink path;
+      Ok ()
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok ()
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let remove_tree path =
+  try Eio_guard.run_in_systhread (fun () -> remove_tree_blocking path) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
 ;;
 
 let remove_meta_file ~config operation =
@@ -524,6 +541,23 @@ let remove_meta_file ~config operation =
      | Error Keeper_meta_store.Exact_identity_missing ->
        Log.Keeper.warn
          "%s: exact stale-paused metadata already absent during cleanup replay"
+         operation.keeper_name;
+       Ok ()
+     | Error error ->
+       Error (Keeper_meta_store.exact_identity_error_to_string error))
+  | Dashboard_keeper_purge context ->
+    (match
+       Keeper_meta_store.remove_meta_if_exact_identity
+         config
+         ~name:operation.keeper_name
+         ~trace_id:operation.trace_id
+         ~generation:operation.generation
+         ~meta_version:context.meta_version
+     with
+     | Ok () -> Ok ()
+     | Error Keeper_meta_store.Exact_identity_missing ->
+       Log.Keeper.warn
+         "%s: exact dashboard-purge metadata already absent during cleanup replay"
          operation.keeper_name;
        Ok ()
      | Error error ->

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -142,6 +142,13 @@ let validate_cleanup_reason reason (meta : Keeper_meta_contract.keeper_meta) =
            context.latched_reason
     then Ok ()
     else Error Stale_prune_meta_changed
+  | Dashboard_keeper_purge context ->
+    if Int.equal meta.meta_version context.meta_version
+    then Ok ()
+    else
+      Error
+        (Meta_snapshot_version_changed
+           { expected = context.meta_version; actual = meta.meta_version })
 ;;
 
 let read_guarded_meta
@@ -232,7 +239,8 @@ let prepare ~config ~(entry : Keeper_registry.registry_entry) ~request =
          | Stale_paused_prune _, phase -> Some (Stale_prune_lane_not_paused phase)
          | ( Operator_stop_retain_meta
            | Operator_stop_remove_meta
-           | Dead_tombstone_cleanup )
+           | Dead_tombstone_cleanup
+           | Dashboard_keeper_purge _ )
            , _ -> None
        in
        (match stale_prune_phase_error with

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -4,6 +4,7 @@ type submit_error =
   | Prepare_error of Keeper_shutdown_prepare_join.error
   | Existing_operation_load_error of Keeper_shutdown_store.error
   | Existing_operation_lane_mismatch of Keeper_shutdown_types.t
+  | Existing_operation_intent_mismatch of Keeper_shutdown_types.t
   | Worker_start_error of worker_start_error
 
 and worker_start_error =
@@ -23,6 +24,11 @@ let submit_error_to_string = function
   | Existing_operation_lane_mismatch operation ->
     Printf.sprintf
       "existing shutdown operation has incompatible lane ownership: keeper=%s operation=%s"
+      operation.keeper_name
+      (Operation_id.to_string operation.operation_id)
+  | Existing_operation_intent_mismatch operation ->
+    Printf.sprintf
+      "existing shutdown operation has incompatible cleanup intent: keeper=%s operation=%s"
       operation.keeper_name
       (Operation_id.to_string operation.operation_id)
   | Worker_start_error Worker_supervisor_unavailable ->
@@ -274,6 +280,15 @@ let start_or_error ~config ~entry operation =
   | Worker_start_rejected error -> Error (Worker_start_error error)
 ;;
 
+let existing_operation_intent ~request operation =
+  if
+    Keeper_shutdown_types.cleanup_intent_equal
+      request.Keeper_shutdown_prepare_join.cleanup_intent
+      operation.cleanup_intent
+  then Ok operation
+  else Error (Existing_operation_intent_mismatch operation)
+;;
+
 let submit ~config ~entry ~request =
   match Keeper_shutdown_prepare_join.prepare ~config ~entry ~request with
   | Ok operation ->
@@ -281,7 +296,13 @@ let submit ~config ~entry ~request =
   | Error (Keeper_shutdown_prepare_join.Existing_operation operation_id) ->
     (match Keeper_shutdown_store.load ~config ~keeper_name:entry.name operation_id with
      | Error error -> Error (Existing_operation_load_error error)
-     | Ok operation -> start_or_error ~config ~entry:(Some entry) operation)
+     | Ok operation ->
+       (match existing_operation_intent ~request operation with
+        | Error _ as error -> error
+        | Ok ({ lane_ownership = Registered_lane lane_id; _ } as operation)
+          when Keeper_lane.Id.equal lane_id (Keeper_lane.id entry.lane) ->
+          start_or_error ~config ~entry:(Some entry) operation
+        | Ok operation -> Error (Existing_operation_lane_mismatch operation)))
   | Error error -> Error (Prepare_error error)
 ;;
 
@@ -292,7 +313,9 @@ let submit_dormant ~config ~meta ~request =
     (match Keeper_shutdown_store.load ~config ~keeper_name:meta.name operation_id with
      | Error error -> Error (Existing_operation_load_error error)
      | Ok ({ lane_ownership = Dormant_meta; _ } as operation) ->
-       start_or_error ~config ~entry:None operation
+       (match existing_operation_intent ~request operation with
+        | Error _ as error -> error
+        | Ok operation -> start_or_error ~config ~entry:None operation)
      | Ok operation -> Error (Existing_operation_lane_mismatch operation))
   | Error error -> Error (Prepare_error error)
 ;;

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -4,6 +4,7 @@ type submit_error =
   | Prepare_error of Keeper_shutdown_prepare_join.error
   | Existing_operation_load_error of Keeper_shutdown_store.error
   | Existing_operation_lane_mismatch of Keeper_shutdown_types.t
+  | Existing_operation_intent_mismatch of Keeper_shutdown_types.t
   | Worker_start_error of worker_start_error
 
 and worker_start_error =

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -266,6 +266,13 @@ let cleanup_reason_to_json = function
           | None -> `Null
           | Some reason -> Keeper_latched_reason.Stable.to_yojson reason )
       ]
+  | Dashboard_keeper_purge context ->
+    `Assoc
+      [ "kind", `String "dashboard_keeper_purge"
+      ; "requested_name", `String context.requested_name
+      ; "agent_name", `String context.agent_name
+      ; "meta_version", `Int context.meta_version
+      ]
 ;;
 
 let phase_to_json = function
@@ -512,18 +519,60 @@ let completion_receipt_of_json json =
          (Printf.sprintf "unknown shutdown completion receipt: %S" value))
 ;;
 
-let previous_schema_version = 3
+type wire_schema =
+  | Current_schema
+  | Lifecycle_schema_v4
+  | Shutdown_schema_v3
 
-let finalization_evidence_of_json ~decoded_schema_version json =
+let lifecycle_schema_v4 = 4
+let shutdown_schema_v3 = 3
+
+let wire_schema_of_version = function
+  | version when Int.equal version schema_version -> Ok Current_schema
+  | version when Int.equal version lifecycle_schema_v4 -> Ok Lifecycle_schema_v4
+  | version when Int.equal version shutdown_schema_v3 -> Ok Shutdown_schema_v3
+  | version ->
+    Error
+      (Decode_error
+         (Printf.sprintf "unsupported shutdown schema version: %d" version))
+;;
+
+let completion_action_supported_by_wire_schema wire_schema action =
+  match wire_schema, action with
+  | Current_schema,
+    (Dead_tombstone_reaped | Paused_meta_pruned | Dashboard_keeper_purged) ->
+    true
+  | Lifecycle_schema_v4, (Dead_tombstone_reaped | Paused_meta_pruned) -> true
+  | Shutdown_schema_v3, Dead_tombstone_reaped -> true
+  | Lifecycle_schema_v4, Dashboard_keeper_purged
+  | Shutdown_schema_v3, (Paused_meta_pruned | Dashboard_keeper_purged) -> false
+;;
+
+let validate_completion_receipt_wire_schema wire_schema = function
+  | Completion_not_requested -> Ok ()
+  | Completion_pending action
+  | Completion_delivered action ->
+    if completion_action_supported_by_wire_schema wire_schema action
+    then Ok ()
+    else
+      Error
+        (Decode_error
+           (Printf.sprintf
+              "shutdown completion action %S is not valid in the persisted wire schema"
+              (completion_action_to_string action)))
+;;
+
+let finalization_evidence_of_json ~wire_schema json =
   let* cleanup_json = assoc "cleanup" json in
   let* cleanup = cleanup_evidence_of_json cleanup_json in
   let* meta_removed = bool "meta_removed" json in
   let* session_removed = bool "session_removed" json in
   let* registry_unregistered = bool "registry_unregistered" json in
   let* accumulator_dropped =
-    if Int.equal decoded_schema_version schema_version
-    then bool "accumulator_dropped" json
-    else
+    match wire_schema with
+    | Current_schema
+    | Lifecycle_schema_v4 -> bool "accumulator_dropped" json
+    | Shutdown_schema_v3 ->
       (* Schema 3 dropped the in-memory accumulator exactly when its
          registered lane was unregistered. The old receipt persisted that
          lane effect but had no duplicate accumulator field. *)
@@ -531,6 +580,7 @@ let finalization_evidence_of_json ~decoded_schema_version json =
   in
   let* completion_json = assoc "completion" json in
   let* completion = completion_receipt_of_json completion_json in
+  let* () = validate_completion_receipt_wire_schema wire_schema completion in
   Ok
     { cleanup
     ; meta_removed
@@ -541,7 +591,7 @@ let finalization_evidence_of_json ~decoded_schema_version json =
     }
 ;;
 
-let phase_of_json ~decoded_schema_version json =
+let phase_of_json ~wire_schema json =
   let* kind = string "kind" json in
   match kind with
   | "prepared" -> Ok Prepared
@@ -560,7 +610,7 @@ let phase_of_json ~decoded_schema_version json =
   | "finalized" ->
     let* evidence_json = assoc "evidence" json in
     let* evidence =
-      finalization_evidence_of_json ~decoded_schema_version evidence_json
+      finalization_evidence_of_json ~wire_schema evidence_json
     in
     Ok (Finalized evidence)
   | "blocked" ->
@@ -644,29 +694,47 @@ let cleanup_reason_of_json json =
       | Error _ as error -> error
     in
     Ok (Stale_paused_prune { meta_version; last_updated; latched_reason })
+  | "dashboard_keeper_purge" ->
+    let* requested_name = string "requested_name" json in
+    let* agent_name = string "agent_name" json in
+    let* meta_version = int "meta_version" json in
+    Ok (Dashboard_keeper_purge { requested_name; agent_name; meta_version })
   | value ->
     Error
       (Decode_error (Printf.sprintf "unknown shutdown cleanup reason: %S" value))
 ;;
 
-let lane_ownership_of_versioned_json ~decoded_schema_version json =
-  if Int.equal decoded_schema_version schema_version
-  then
+let lane_ownership_of_versioned_json ~wire_schema json =
+  match wire_schema with
+  | Current_schema
+  | Lifecycle_schema_v4 ->
     let* lane_ownership_json = assoc "lane_ownership" json in
     lane_ownership_of_json lane_ownership_json
-  else
+  | Shutdown_schema_v3 ->
     let* lane_id_wire = string "lane_id" json in
     Keeper_lane.Id.of_string lane_id_wire
     |> Result.map (fun lane_id -> Registered_lane lane_id)
     |> Result.map_error (fun detail -> Decode_error detail)
 ;;
 
-let cleanup_reason_of_versioned_json ~decoded_schema_version cleanup_json =
-  if Int.equal decoded_schema_version schema_version
-  then
+let cleanup_reason_of_versioned_json ~wire_schema cleanup_json =
+  match wire_schema with
+  | Current_schema ->
     let* cleanup_reason_json = assoc "reason" cleanup_json in
     cleanup_reason_of_json cleanup_reason_json
-  else
+  | Lifecycle_schema_v4 ->
+    let* cleanup_reason_json = assoc "reason" cleanup_json in
+    let* reason = cleanup_reason_of_json cleanup_reason_json in
+    (match reason with
+     | Operator_stop_retain_meta
+     | Operator_stop_remove_meta
+     | Dead_tombstone_cleanup
+     | Stale_paused_prune _ -> Ok reason
+     | Dashboard_keeper_purge _ ->
+       Error
+         (Decode_error
+            "dashboard Keeper purge cleanup is not valid in shutdown schema 4"))
+  | Shutdown_schema_v3 ->
     let* disposition_wire = string "meta_disposition" cleanup_json in
     let* disposition =
       meta_disposition_of_string disposition_wire
@@ -681,16 +749,7 @@ let cleanup_reason_of_versioned_json ~decoded_schema_version cleanup_json =
 
 let of_json json =
   let* decoded_schema_version = int "schema_version" json in
-  if
-    (not (Int.equal decoded_schema_version schema_version))
-    && not (Int.equal decoded_schema_version previous_schema_version)
-  then
-    Error
-      (Decode_error
-         (Printf.sprintf
-            "unsupported shutdown schema version: %d"
-            decoded_schema_version))
-  else
+  let* wire_schema = wire_schema_of_version decoded_schema_version in
     let* operation_id_wire = string "operation_id" json in
     let* revision = int "revision" json in
     let* operation_id =
@@ -699,7 +758,7 @@ let of_json json =
     in
     let* keeper_name = string "keeper_name" json in
     let* lane_ownership =
-      lane_ownership_of_versioned_json ~decoded_schema_version json
+      lane_ownership_of_versioned_json ~wire_schema json
     in
     let* trace_id_wire = string "trace_id" json in
     let* trace_id =
@@ -710,7 +769,7 @@ let of_json json =
     let* actor = string "actor" json in
     let* cleanup_json = assoc "cleanup_intent" json in
     let* reason =
-      cleanup_reason_of_versioned_json ~decoded_schema_version cleanup_json
+      cleanup_reason_of_versioned_json ~wire_schema cleanup_json
     in
     let* remove_session = bool "remove_session" cleanup_json in
     let* turn_json = assoc "turn_disposition" json in
@@ -719,7 +778,7 @@ let of_json json =
     let* owned_task_ids = task_ids_field_of_json "owned_task_ids" json in
     let* join_evidence = optional_join_evidence_of_json json in
     let* phase_json = assoc "phase" json in
-    let* phase = phase_of_json ~decoded_schema_version phase_json in
+    let* phase = phase_of_json ~wire_schema phase_json in
     let* created_at = string "created_at" json in
     let* updated_at = string "updated_at" json in
     let operation =

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -40,8 +40,8 @@ val path :
   (string, error) result
 
 val to_json : Keeper_shutdown_types.t -> Yojson.Safe.t
-(** Decode the current schema and deterministically upgrade schema 3 records
-    emitted by the immediately preceding durable-shutdown implementation.
+(** Decode the current schema and deterministically upgrade schema 4 lifecycle
+    records and schema 3 shutdown records emitted by preceding deployments.
     Unknown versions remain explicit decode failures. *)
 val of_json : Yojson.Safe.t -> (Keeper_shutdown_types.t, error) result
 

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -393,13 +393,19 @@ let turn_disposition_equal left right =
   | Inflight_effect_unknown _, No_inflight_turn -> false
 ;;
 
-let stale_paused_context_equal left right =
+let stale_paused_context_equal
+    (left : stale_paused_context)
+    (right : stale_paused_context)
+  =
   Int.equal left.meta_version right.meta_version
   && String.equal left.last_updated right.last_updated
   && option_equal Keeper_latched_reason.equal left.latched_reason right.latched_reason
 ;;
 
-let dashboard_purge_context_equal left right =
+let dashboard_purge_context_equal
+    (left : dashboard_purge_context)
+    (right : dashboard_purge_context)
+  =
   String.equal left.requested_name right.requested_name
   && String.equal left.agent_name right.agent_name
   && Int.equal left.meta_version right.meta_version

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -39,15 +39,35 @@ type stale_paused_context =
   ; latched_reason : Keeper_latched_reason.t option
   }
 
+type dashboard_purge_context =
+  { requested_name : string
+  ; agent_name : string
+  ; meta_version : int
+  }
+
 type cleanup_reason =
   | Operator_stop_retain_meta
   | Operator_stop_remove_meta
   | Dead_tombstone_cleanup
   | Stale_paused_prune of stale_paused_context
+  | Dashboard_keeper_purge of dashboard_purge_context
 
 type completion_action =
   | Dead_tombstone_reaped
   | Paused_meta_pruned
+  | Dashboard_keeper_purged
+
+type dashboard_purge_artifact =
+  | Keeper_metrics_artifact
+  | Keeper_memory_bank_artifact
+  | Keeper_generation_index_artifact
+  | Keeper_policy_log_artifact
+  | Keeper_decision_log_artifact
+  | Keeper_feedback_log_artifact
+  | Keeper_dataset_export_artifact
+  | Keeper_runtime_directory_artifact
+  | Keeper_configuration_artifact
+  | Agent_artifact_bundle of string list
 
 type completion_receipt =
   | Completion_not_requested
@@ -173,7 +193,7 @@ type invariant_error =
   | Required_accumulator_not_dropped
   | Finalized_completion_mismatch of cleanup_reason * completion_receipt
 
-let schema_version = 4
+let schema_version = 5
 
 let meta_disposition_to_string = function
   | Retain_operator_pause -> "retain_operator_pause"
@@ -193,37 +213,47 @@ let cleanup_reason_label = function
   | Operator_stop_remove_meta -> "operator_stop_remove_meta"
   | Dead_tombstone_cleanup -> "dead_tombstone_cleanup"
   | Stale_paused_prune _ -> "stale_paused_prune"
+  | Dashboard_keeper_purge _ -> "dashboard_keeper_purge"
 ;;
 
 let meta_disposition_of_cleanup_reason = function
   | Operator_stop_retain_meta -> Retain_operator_pause
   | Dead_tombstone_cleanup -> Retain_dead_tombstone
   | Operator_stop_remove_meta
-  | Stale_paused_prune _ -> Remove_meta
+  | Stale_paused_prune _
+  | Dashboard_keeper_purge _ -> Remove_meta
 ;;
 
 let completion_action_to_string = function
   | Dead_tombstone_reaped -> "dead_tombstone_reaped"
   | Paused_meta_pruned -> "paused_meta_pruned"
+  | Dashboard_keeper_purged -> "dashboard_keeper_purged"
 ;;
 
 let completion_action_of_string = function
   | "dead_tombstone_reaped" -> Ok Dead_tombstone_reaped
   | "paused_meta_pruned" -> Ok Paused_meta_pruned
+  | "dashboard_keeper_purged" -> Ok Dashboard_keeper_purged
   | value -> Error (Printf.sprintf "unknown Keeper shutdown completion action: %S" value)
 ;;
 
 let completion_action_equal left right =
   match left, right with
   | Dead_tombstone_reaped, Dead_tombstone_reaped
-  | Paused_meta_pruned, Paused_meta_pruned -> true
+  | Paused_meta_pruned, Paused_meta_pruned
+  | Dashboard_keeper_purged, Dashboard_keeper_purged -> true
   | Dead_tombstone_reaped, Paused_meta_pruned
-  | Paused_meta_pruned, Dead_tombstone_reaped -> false
+  | Dead_tombstone_reaped, Dashboard_keeper_purged
+  | Paused_meta_pruned, Dead_tombstone_reaped
+  | Paused_meta_pruned, Dashboard_keeper_purged
+  | Dashboard_keeper_purged, Dead_tombstone_reaped
+  | Dashboard_keeper_purged, Paused_meta_pruned -> false
 ;;
 
 let completion_action_of_cleanup_reason = function
   | Dead_tombstone_cleanup -> Some Dead_tombstone_reaped
   | Stale_paused_prune _ -> Some Paused_meta_pruned
+  | Dashboard_keeper_purge _ -> Some Dashboard_keeper_purged
   | Operator_stop_retain_meta
   | Operator_stop_remove_meta -> None
 ;;
@@ -301,7 +331,8 @@ let validate operation =
         let accumulator_drop_required =
           match operation.lane_ownership, operation.cleanup_intent.reason with
           | Dormant_meta, _
-          | Registered_lane _, Stale_paused_prune _ -> true
+          | Registered_lane _, (Stale_paused_prune _ | Dashboard_keeper_purge _) ->
+            true
           | Registered_lane _,
             ( Operator_stop_retain_meta
             | Operator_stop_remove_meta
@@ -368,6 +399,12 @@ let stale_paused_context_equal left right =
   && option_equal Keeper_latched_reason.equal left.latched_reason right.latched_reason
 ;;
 
+let dashboard_purge_context_equal left right =
+  String.equal left.requested_name right.requested_name
+  && String.equal left.agent_name right.agent_name
+  && Int.equal left.meta_version right.meta_version
+;;
+
 let cleanup_reason_equal left right =
   match left, right with
   | Operator_stop_retain_meta, Operator_stop_retain_meta
@@ -375,15 +412,53 @@ let cleanup_reason_equal left right =
   | Dead_tombstone_cleanup, Dead_tombstone_cleanup -> true
   | Stale_paused_prune left, Stale_paused_prune right ->
     stale_paused_context_equal left right
+  | Dashboard_keeper_purge left, Dashboard_keeper_purge right ->
+    dashboard_purge_context_equal left right
   | Operator_stop_retain_meta,
-    (Operator_stop_remove_meta | Dead_tombstone_cleanup | Stale_paused_prune _)
+    ( Operator_stop_remove_meta
+    | Dead_tombstone_cleanup
+    | Stale_paused_prune _
+    | Dashboard_keeper_purge _ )
   | Operator_stop_remove_meta,
-    (Operator_stop_retain_meta | Dead_tombstone_cleanup | Stale_paused_prune _)
+    ( Operator_stop_retain_meta
+    | Dead_tombstone_cleanup
+    | Stale_paused_prune _
+    | Dashboard_keeper_purge _ )
   | Dead_tombstone_cleanup,
-    (Operator_stop_retain_meta | Operator_stop_remove_meta | Stale_paused_prune _)
+    ( Operator_stop_retain_meta
+    | Operator_stop_remove_meta
+    | Stale_paused_prune _
+    | Dashboard_keeper_purge _ )
   | Stale_paused_prune _,
-    (Operator_stop_retain_meta | Operator_stop_remove_meta | Dead_tombstone_cleanup) ->
+    ( Operator_stop_retain_meta
+    | Operator_stop_remove_meta
+    | Dead_tombstone_cleanup
+    | Dashboard_keeper_purge _ )
+  | Dashboard_keeper_purge _,
+    ( Operator_stop_retain_meta
+    | Operator_stop_remove_meta
+    | Dead_tombstone_cleanup
+    | Stale_paused_prune _ ) ->
     false
+;;
+
+let dashboard_purge_artifact_plan ~keeper_name context =
+  let agent_aliases =
+    [ context.requested_name; keeper_name; context.agent_name ]
+    |> List.filter_map String_util.trim_to_option
+    |> List.sort_uniq String.compare
+  in
+  [ Keeper_metrics_artifact
+  ; Keeper_memory_bank_artifact
+  ; Keeper_generation_index_artifact
+  ; Keeper_policy_log_artifact
+  ; Keeper_decision_log_artifact
+  ; Keeper_feedback_log_artifact
+  ; Keeper_dataset_export_artifact
+  ; Keeper_runtime_directory_artifact
+  ; Keeper_configuration_artifact
+  ; Agent_artifact_bundle agent_aliases
+  ]
 ;;
 
 let cleanup_intent_equal left right =

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -22,15 +22,35 @@ type stale_paused_context =
   ; latched_reason : Keeper_latched_reason.t option
   }
 
+type dashboard_purge_context =
+  { requested_name : string
+  ; agent_name : string
+  ; meta_version : int
+  }
+
 type cleanup_reason =
   | Operator_stop_retain_meta
   | Operator_stop_remove_meta
   | Dead_tombstone_cleanup
   | Stale_paused_prune of stale_paused_context
+  | Dashboard_keeper_purge of dashboard_purge_context
 
 type completion_action =
   | Dead_tombstone_reaped
   | Paused_meta_pruned
+  | Dashboard_keeper_purged
+
+type dashboard_purge_artifact =
+  | Keeper_metrics_artifact
+  | Keeper_memory_bank_artifact
+  | Keeper_generation_index_artifact
+  | Keeper_policy_log_artifact
+  | Keeper_decision_log_artifact
+  | Keeper_feedback_log_artifact
+  | Keeper_dataset_export_artifact
+  | Keeper_runtime_directory_artifact
+  | Keeper_configuration_artifact
+  | Agent_artifact_bundle of string list
 
 type completion_receipt =
   | Completion_not_requested
@@ -163,6 +183,11 @@ val meta_disposition_of_cleanup_reason : cleanup_reason -> meta_disposition
 val completion_action_to_string : completion_action -> string
 val completion_action_of_string : string -> (completion_action, string) result
 val completion_action_of_cleanup_reason : cleanup_reason -> completion_action option
+val cleanup_intent_equal : cleanup_intent -> cleanup_intent -> bool
+val dashboard_purge_artifact_plan :
+  keeper_name:string ->
+  dashboard_purge_context ->
+  dashboard_purge_artifact list
 val invariant_error_to_string : invariant_error -> string
 val validate : t -> (unit, invariant_error) result
 val immutable_fields_equal : t -> t -> bool

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -133,7 +133,8 @@ let handle_completion config operation = function
               { verb = Keeper_lifecycle_events.Paused_pruned; phase = None })
          operation.keeper_name
          (Printf.sprintf
-            "last_updated=%s%s shutdown_operation=%s"
+            "meta_version=%d last_updated=%s%s shutdown_operation=%s"
+            context.meta_version
             context.last_updated
             latched_reason_detail
             operation_id)
@@ -146,6 +147,9 @@ let handle_completion config operation = function
      | Ok (),
        ( Operator_stop_retain_meta
        | Operator_stop_remove_meta
-       | Dead_tombstone_cleanup ) ->
+       | Dead_tombstone_cleanup
+       | Dashboard_keeper_purge _ ) ->
        Error "paused-meta completion does not belong to a stale-prune operation")
+  | Keeper_shutdown_types.Dashboard_keeper_purged ->
+    Error "dashboard Keeper purge completion requires the server artifact boundary"
 ;;

--- a/lib/keeper_registry/keeper_lifecycle_events.ml
+++ b/lib/keeper_registry/keeper_lifecycle_events.ml
@@ -1,8 +1,8 @@
 (** Issue #8575: SSOT for the [event] string emitted by
     {!Keeper_event_publisher.publish_keeper_lifecycle}.
 
-    The supervisor and keepalive together emit twelve distinct event
-    names through that function. The docstring on
+    The supervisor, keepalive, and durable dashboard cleanup boundary emit
+    thirteen distinct event names through that function. The docstring on
     [Keeper_event_publisher.publish_keeper_lifecycle] previously listed only five
     of them, so operators reading the doc subscribed to the
     phase-derived events ([started] / [stopped] / [crashed] /
@@ -36,6 +36,7 @@
     - [Dead_cleaned]       : tombstone cleanup after restart budget exhaustion
     - [Self_preservation]  : supervisor refused a runtime-wide action to protect itself
     - [Paused_pruned]      : paused keeper removed from registry after timeout
+    - [Purged]             : dashboard purge completed all durable artifacts
     - [Auto_resumed]       : supervisor auto-resumed a keeper after circuit-breaker back-off
     - [Admission_denied]   : spawn/admission guard refused to launch a keeper *)
 type t =
@@ -45,6 +46,7 @@ type t =
   | Dead_cleaned
   | Self_preservation
   | Paused_pruned
+  | Purged
   | Auto_resumed
   | Admission_denied
 
@@ -55,6 +57,7 @@ let to_string = function
   | Dead_cleaned -> "dead_cleaned"
   | Self_preservation -> "self_preservation"
   | Paused_pruned -> "paused_pruned"
+  | Purged -> "purged"
   | Auto_resumed -> "auto_resumed"
   | Admission_denied -> "admission_denied"
 
@@ -70,13 +73,14 @@ let event_of_string = function
   | "dead_cleaned" -> Some Dead_cleaned
   | "self_preservation" -> Some Self_preservation
   | "paused_pruned" -> Some Paused_pruned
+  | "purged" -> Some Purged
   | "auto_resumed" -> Some Auto_resumed
   | "admission_denied" -> Some Admission_denied
   | _ -> None
 
 let all_custom_events : t list =
   [ Started; Reconciled; Restarted; Dead_cleaned;
-    Self_preservation; Paused_pruned; Auto_resumed; Admission_denied ]
+    Self_preservation; Paused_pruned; Purged; Auto_resumed; Admission_denied ]
 
 let valid_custom_event_strings : string list =
   List.map to_string all_custom_events

--- a/lib/keeper_registry/keeper_lifecycle_events.mli
+++ b/lib/keeper_registry/keeper_lifecycle_events.mli
@@ -9,6 +9,7 @@ type t =
   | Dead_cleaned
   | Self_preservation
   | Paused_pruned
+  | Purged
   | Auto_resumed
   | Admission_denied
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -329,7 +329,7 @@ let start_keeper_loops
      receipt is replayed. *)
   Keeper_subprocess_registry.register_default_cleanup_hook ();
   Keeper_shutdown_finalize.register_completion_handler
-    Keeper_supervisor_cleanup_tombstone.handle_completion;
+    Server_dashboard_http_delete_actions.handle_keeper_lifecycle_completion;
   let wait_for_lazy_startup () =
     (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
        a per-task boot guard.  The diagnostic surface stays as #10854

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -122,7 +122,7 @@ let rec remove_paths_strict = function
     (match remove_path_strict path with
      | Error _ as error -> error
      | Ok outcome ->
-       Log.Misc.info
+       Log.Misc.debug
          "[dashboard_purge] artifact path=%s outcome=%s"
          path
          (match outcome with Path_absent -> "absent" | Path_removed -> "removed");
@@ -428,7 +428,7 @@ let purge_dashboard_keeper_artifacts config operation =
                | Keeper_dataset_export_artifact
                | Keeper_configuration_artifact
                | Agent_artifact_bundle _ -> ());
-              Log.Keeper.info
+              Log.Keeper.debug
                 "dashboard Keeper purge artifact: keeper=%s path=%s outcome=%s"
                 operation.keeper_name
                 path

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -3,35 +3,25 @@
     Extracted from server_routes_http_routes_dashboard.ml.
     Contains POST handler logic for /api/v1/dashboard/board/delete,
     /api/v1/dashboard/tasks/delete, /api/v1/dashboard/goals/delete,
-    /api/v1/dashboard/goals/sweep, /api/v1/dashboard/agents/purge. *)
+    /api/v1/dashboard/goals/sweep, /api/v1/dashboard/agents/purge.
+    Keeper purge is durable and asynchronous; plain-agent purge remains an
+    exact synchronous cleanup. *)
 
 module Http = Http_server_eio
 
 open Server_auth
 
-type keeper_purge_target =
-  { keeper_name : string
-  ; agent_name : string
-  ; trace_id : string option
-  ; toml_path : string option
-  }
-
 type agent_purge_cleanup_result =
   { agent_name : string
-  ; pending_confirms_removed : int
   ; heartbeats_stopped : int
-  ; workspace_unbind_result : string
+  ; workspace_unbound : bool
   }
 
-type agent_purge_cleanup_target =
-  { agent_name : string
-  ; aliases : string list
-  }
+type path_removal = Path_absent | Path_removed
 
-type keeper_purge_cleanup_result =
-  { keeper_pending_confirms_removed : int
-  ; agent_cleanup_results : agent_purge_cleanup_result list
-  }
+type plain_agent_resolve_error =
+  | Invalid_plain_agent_name of string
+  | Plain_agent_artifact_read_failed of string
 
 let invalid_request field =
   Printf.sprintf "invalid request: requires {\"%s\":\"...\"}" field
@@ -56,66 +46,110 @@ let respond_error ?(status = `Bad_request) ~request reqd message =
     reqd
 ;;
 
-let sum_pending_confirm_removals config ~target_type target_ids =
-  target_ids
-  |> List.fold_left
-       (fun acc target_id ->
-         match acc with
-         | Error _ -> acc
-         | Ok total -> (
-           match
-             Operator_pending_confirm.remove_pending_confirms_by_target
-               config
-               ~target_type
-               ~target_id:(Some target_id)
-           with
-           | Ok removed -> Ok (total + removed)
-           | Error msg ->
-             Error
-               (Printf.sprintf
-                  "pending-confirm cleanup failed for %s %s: %s"
-                  target_type
-                  target_id
-                  msg)))
-       (Ok 0)
+let path_error operation path exn =
+  Printf.sprintf "%s failed for %s: %s" operation path (Printexc.to_string exn)
 ;;
 
-let rec rm_rf path =
-  if Fs_compat.file_exists path
-  then if Sys.is_directory path
-  then (
-    Sys.readdir path
-    |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
-    (try Fs_compat.rmdir path with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Log.Misc.warn "[agent_purge] failed to remove directory %s: %s"
-         path (Printexc.to_string exn)))
-  else Safe_ops.remove_file_logged ~context:"agent_purge" path
+let lstat_path_blocking path =
+  try Ok (Some (Unix.lstat path)) with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+  | exn -> Error (path_error "lstat" path exn)
 ;;
 
-let remove_path_if_exists ~context path =
-  if Fs_compat.file_exists path
-  then if Sys.is_directory path
-  then rm_rf path
-  else Safe_ops.remove_file_logged ~context path
+let lstat_path path =
+  try Eio_guard.run_in_systhread (fun () -> lstat_path_blocking path) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (path_error "systhread lstat" path exn)
 ;;
 
-let credential_aliases agent_name =
-  let trimmed = String.trim agent_name in
+let unlink_path_blocking path =
+  try
+    Unix.unlink path;
+    Ok Path_removed
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Path_absent
+  | exn -> Error (path_error "unlink" path exn)
+;;
+
+let rmdir_path_blocking path =
+  try
+    Unix.rmdir path;
+    Ok Path_removed
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Path_absent
+  | exn -> Error (path_error "rmdir" path exn)
+;;
+
+let rec remove_path_strict_blocking path =
+  match lstat_path_blocking path with
+  | Error _ as error -> error
+  | Ok None -> Ok Path_absent
+  | Ok (Some stat) ->
+    (match stat.Unix.st_kind with
+     | Unix.S_DIR ->
+       let entries =
+         try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
+         | exn -> Error (path_error "readdir" path exn)
+       in
+       (match entries with
+        | Error _ as error -> error
+        | Ok entries ->
+          let rec remove_entries = function
+            | [] -> rmdir_path_blocking path
+            | entry :: rest ->
+              (match remove_path_strict_blocking (Filename.concat path entry) with
+               | Error _ as error -> error
+               | Ok (Path_absent | Path_removed) -> remove_entries rest)
+          in
+          remove_entries entries)
+     | Unix.S_REG
+     | Unix.S_LNK
+     | Unix.S_CHR
+     | Unix.S_BLK
+     | Unix.S_FIFO
+     | Unix.S_SOCK -> unlink_path_blocking path)
+;;
+
+let remove_path_strict path =
+  try Eio_guard.run_in_systhread (fun () -> remove_path_strict_blocking path) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (path_error "systhread recursive removal" path exn)
+;;
+
+let rec remove_paths_strict = function
+  | [] -> Ok ()
+  | path :: rest ->
+    (match remove_path_strict path with
+     | Error _ as error -> error
+     | Ok outcome ->
+       Log.Misc.info
+         "[dashboard_purge] artifact path=%s outcome=%s"
+         path
+         (match outcome with Path_absent -> "absent" | Path_removed -> "removed");
+       remove_paths_strict rest)
+;;
+
+let validate_agent_alias alias =
+  match Workspace.validate_agent_name alias with
+  | Ok _ -> Ok alias
+  | Error detail ->
+    Error (Printf.sprintf "invalid exact agent purge owner %S: %s" alias detail)
+;;
+
+let exact_agent_aliases agent_names =
   let aliases =
-    [
-      Some trimmed;
-      (if Nickname.is_generated_nickname trimmed
-       then Nickname.extract_agent_type trimmed
-       else None);
-    ]
+    agent_names
+    |> List.filter_map String_util.trim_to_option
+    |> List.sort_uniq String.compare
   in
-  aliases
-  |> List.filter_map (function
-       | Some value when value <> "" -> Some value
-       | _ -> None)
-  |> Json_util.dedupe_keep_order
+  let rec validate acc = function
+    | [] -> Ok (List.rev acc)
+    | alias :: rest ->
+      (match validate_agent_alias alias with
+       | Error _ as error -> error
+       | Ok alias -> validate (alias :: acc) rest)
+  in
+  validate [] aliases
 ;;
 
 let agent_file_path config agent_name =
@@ -123,232 +157,387 @@ let agent_file_path config agent_name =
     (Workspace.safe_filename agent_name ^ ".json")
 ;;
 
-let resolve_keeper_purge_target config requested_name =
+let plain_agent_candidate_names requested_name =
   let trimmed = String.trim requested_name in
-  let candidates =
-    [
-      Some trimmed;
-      Keeper_identity.canonical_keeper_name_from_agent_name trimmed;
-      Keeper_identity.canonical_keeper_name trimmed;
-    ]
-    |> List.filter_map (function
-         | Some value when value <> "" -> Some value
-         | _ -> None)
-    |> Json_util.dedupe_keep_order
-  in
-  let rec loop = function
-    | [] -> None
-    | candidate :: rest -> (
-      let candidate_meta_path = Keeper_types_profile.keeper_meta_path config candidate in
-      let candidate_toml_path = Config_dir_resolver.keeper_toml_path_opt candidate in
-      match Keeper_meta_store.read_meta_resolved config candidate with
-      | Ok (Some (resolved_name, meta)) ->
-        Some
-          {
-            keeper_name = resolved_name;
-            agent_name = meta.agent_name;
-            trace_id =
-              Some (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
-            toml_path = Config_dir_resolver.keeper_toml_path_opt resolved_name;
-          }
-      | Ok None ->
-        if Fs_compat.file_exists candidate_meta_path
-           || Option.is_some candidate_toml_path
-        then
-          Some
-            {
-              keeper_name = candidate;
-              agent_name = Keeper_identity.keeper_agent_name candidate;
-              trace_id = None;
-              toml_path = candidate_toml_path;
-            }
-        else loop rest
-      | Error err ->
-        if Fs_compat.file_exists candidate_meta_path
-           || Option.is_some candidate_toml_path
-        then (
-          Log.Keeper.warn
-            "agent purge: continuing despite keeper meta read failure for %s: %s"
-            candidate err;
-          Some
-            {
-              keeper_name = candidate;
-              agent_name = Keeper_identity.keeper_agent_name candidate;
-              trace_id = None;
-              toml_path = candidate_toml_path;
-            })
-        else loop rest)
-  in
-  loop candidates
-;;
-
-let plain_agent_candidate_names config requested_name =
-  let trimmed = String.trim requested_name in
-  let resolved = Workspace.resolve_agent_name config trimmed in
-  [ trimmed; resolved ]
+  [ trimmed ]
   |> List.filter (fun value -> value <> "")
-  |> Json_util.dedupe_keep_order
 ;;
 
 let plain_agent_artifacts_exist config agent_name =
-  let agent_exists = Fs_compat.file_exists (agent_file_path config agent_name) in
-  let metrics_exists =
-    Fs_compat.file_exists (Metrics_store_eio.agent_metrics_dir config agent_name)
+  let rec any_path_exists = function
+    | [] -> Ok false
+    | path :: rest ->
+      (match lstat_path path with
+       | Error _ as error -> error
+       | Ok (Some _) -> Ok true
+       | Ok None -> any_path_exists rest)
   in
-  let credential_exists =
-    credential_aliases agent_name
-    |> List.exists (fun alias ->
-         Fs_compat.file_exists
-           (Auth.credential_file config.base_path alias))
-  in
-  agent_exists || metrics_exists || credential_exists
+  any_path_exists
+    [ agent_file_path config agent_name
+    ; Metrics_store_eio.agent_metrics_dir config agent_name
+    ; Auth.credential_file config.base_path agent_name
+    ]
 ;;
 
 let resolve_plain_agent_target config requested_name =
-  plain_agent_candidate_names config requested_name
-  |> List.find_opt (plain_agent_artifacts_exist config)
+  match exact_agent_aliases (plain_agent_candidate_names requested_name) with
+  | Error detail -> Error (Invalid_plain_agent_name detail)
+  | Ok [] -> Ok None
+  | Ok (agent_name :: _) ->
+    (match plain_agent_artifacts_exist config agent_name with
+     | Error detail -> Error (Plain_agent_artifact_read_failed detail)
+     | Ok true -> Ok (Some agent_name)
+     | Ok false -> Ok None)
+;;
+
+let plain_agent_resolve_error_to_string = function
+  | Invalid_plain_agent_name detail -> detail
+  | Plain_agent_artifact_read_failed detail -> detail
+;;
+
+let plain_agent_resolve_status = function
+  | Invalid_plain_agent_name _ -> `Bad_request
+  | Plain_agent_artifact_read_failed _ -> `Internal_server_error
 ;;
 
 let agent_purge_cleanup_result_to_json
     { agent_name
-    ; pending_confirms_removed
     ; heartbeats_stopped
-    ; workspace_unbind_result
+    ; workspace_unbound
     } =
   `Assoc
     [ ("agent_name", `String agent_name)
-    ; ("pending_confirms_removed", `Int pending_confirms_removed)
     ; ("heartbeats_stopped", `Int heartbeats_stopped)
-    ; ("workspace_unbind_result", `String workspace_unbind_result)
+    ; ("workspace_unbound", `Bool workspace_unbound)
     ]
 ;;
 
-let resolve_agent_purge_targets config agent_names =
-  let aliases_by_agent = Hashtbl.create (List.length agent_names) in
-  let order = ref [] in
-  let add_alias ~agent_name alias =
-    let aliases =
-      match Hashtbl.find_opt aliases_by_agent agent_name with
-      | Some existing -> existing
-      | None ->
-        order := agent_name :: !order;
-        []
-    in
-    Hashtbl.replace aliases_by_agent agent_name
-      (aliases @ [ alias; agent_name ] |> Json_util.dedupe_keep_order)
+type credential_plan =
+  { aliases : string list
+  ; credential_paths : string list
+  }
+;;
+
+let credential_plan config aliases =
+  let owner_matches (credential : Masc_domain.agent_credential) =
+    List.exists (String.equal credential.agent_name) aliases
   in
-  agent_names
-  |> List.iter (fun requested_name ->
-       let alias = String.trim requested_name in
-       if alias <> ""
-       then (
-         let agent_name = Workspace.resolve_agent_name config alias |> String.trim in
-         if agent_name <> "" then add_alias ~agent_name alias));
-  !order
-  |> List.rev
-  |> List.map (fun agent_name ->
-       let aliases =
-         Hashtbl.find_opt aliases_by_agent agent_name
-         |> Option.value ~default:[ agent_name ]
-         |> List.rev
-         |> Json_util.dedupe_keep_order
-         |> List.rev
-       in
-       { agent_name; aliases })
+  let rec collect credential_paths = function
+    | [] ->
+      Ok
+        { aliases
+        ; credential_paths = List.sort_uniq String.compare credential_paths
+        }
+    | alias :: rest ->
+      let alias_path = Auth.credential_file config.Workspace.base_path alias in
+      (match lstat_path alias_path with
+       | Error _ as error -> error
+       | Ok None -> collect credential_paths rest
+       | Ok (Some _) ->
+         let loaded =
+           try Ok (Auth.load_credential config.base_path alias) with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn -> Error (path_error "credential read" alias_path exn)
+         in
+         (match loaded with
+          | Error _ as error -> error
+          | Ok None ->
+            Error
+              (Printf.sprintf
+                 "credential artifact is present but unreadable: owner=%s path=%s"
+                 alias
+                 alias_path)
+          | Ok (Some credential) when owner_matches credential ->
+            let credential_paths =
+              match credential.id with
+              | None -> alias_path :: credential_paths
+              | Some credential_id ->
+                Auth.credential_file
+                  config.base_path
+                  (Masc_domain.Credential_id.to_string credential_id)
+                :: alias_path
+                :: credential_paths
+            in
+            collect credential_paths rest
+          | Ok (Some credential) ->
+            Error
+              (Printf.sprintf
+                 "credential artifact owner mismatch: requested=%s persisted=%s path=%s"
+                 alias
+                 credential.agent_name
+                 alias_path)))
+  in
+  collect [] aliases
+;;
+
+let delete_credentials config ({ aliases; credential_paths } : credential_plan) =
+  let rec delete_aliases = function
+    | [] -> remove_paths_strict credential_paths
+    | alias :: rest ->
+      (try
+         Auth.delete_credential config.Workspace.base_path alias;
+         delete_aliases rest
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Error
+           (Printf.sprintf
+              "credential deletion failed for exact owner %s: %s"
+              alias
+              (Printexc.to_string exn)))
+  in
+  delete_aliases aliases
+;;
+
+let unbind_exact_workspace_agents config aliases =
+  try
+    let state = Workspace.read_state config in
+    let unbound =
+      List.filter
+        (fun alias -> List.exists (String.equal alias) state.active_agents)
+        aliases
+    in
+    if unbound <> []
+    then
+      ignore
+        (Workspace.update_state config (fun current ->
+           { current with
+             active_agents =
+               List.filter
+                 (fun active -> not (List.exists (String.equal active) aliases))
+                 current.active_agents
+           }));
+    Ok unbound
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "exact workspace agent unbind failed for [%s]: %s"
+         (String.concat "," aliases)
+         (Printexc.to_string exn))
 ;;
 
 let purge_agent_filesystem_artifacts config agent_names =
-  agent_names
-  |> resolve_agent_purge_targets config
-  |> List.fold_left
-       (fun acc { agent_name; aliases } ->
-         match acc with
-         | Error _ -> acc
-         | Ok results -> (
-           match sum_pending_confirm_removals config ~target_type:"agent" aliases with
-           | Error msg -> Error msg
-           | Ok pending_confirms_removed ->
-             let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
-             let workspace_unbind_result =
-               Workspace.end_session ~stop_heartbeats:false config ~agent_name
-             in
-             let aliases_label = String.concat "," aliases in
-             Log.Misc.info
-               "[agent_purge] cleanup agent=%s aliases=%s pending_confirms_removed=%d heartbeats_stopped=%d workspace_unbind=%S"
-               agent_name aliases_label pending_confirms_removed heartbeats_stopped
-               workspace_unbind_result;
-             aliases
-             |> List.iter (fun alias ->
-                  remove_path_if_exists ~context:"agent_purge"
-                    (agent_file_path config alias);
-                  remove_path_if_exists ~context:"agent_purge"
-                    (Metrics_store_eio.agent_metrics_dir config alias);
-                  Tool_shard.remove_agent_shards alias;
-                  credential_aliases alias
-                  |> List.iter (Auth.delete_credential config.base_path));
-             Ok
-               ({ agent_name
-                ; pending_confirms_removed
-                ; heartbeats_stopped
-                ; workspace_unbind_result
-                }
-                :: results)))
-       (Ok [])
-  |> Result.map List.rev
+  match exact_agent_aliases agent_names with
+  | Error _ as error -> error
+  | Ok aliases ->
+    (match credential_plan config aliases with
+     | Error _ as error -> error
+     | Ok credential_plan ->
+       (match unbind_exact_workspace_agents config aliases with
+        | Error _ as error -> error
+        | Ok unbound ->
+          let cleanup_results =
+            List.map
+              (fun agent_name ->
+                 let heartbeats_stopped = Heartbeat.stop_by_agent ~agent_name in
+                 Tool_shard.remove_agent_shards agent_name;
+                 { agent_name
+                 ; heartbeats_stopped
+                 ; workspace_unbound =
+                     List.exists (String.equal agent_name) unbound
+                 })
+              aliases
+          in
+          let filesystem_paths =
+            aliases
+            |> List.concat_map (fun alias ->
+                 [ agent_file_path config alias
+                 ; Metrics_store_eio.agent_metrics_dir config alias
+                 ])
+            |> List.sort_uniq String.compare
+          in
+          (match remove_paths_strict filesystem_paths with
+           | Error _ as error -> error
+           | Ok () ->
+             (match delete_credentials config credential_plan with
+              | Error _ as error -> error
+              | Ok () ->
+                List.iter
+                  (fun result ->
+                     Log.Misc.info
+                       "[agent_purge] exact owner=%s heartbeats_stopped=%d workspace_unbound=%b"
+                       result.agent_name
+                       result.heartbeats_stopped
+                       result.workspace_unbound)
+                  cleanup_results;
+                Ok cleanup_results))))
 ;;
 
-let purge_keeper_artifacts config requested_name
-    ({ keeper_name; agent_name; trace_id; toml_path } : keeper_purge_target) =
-  let keeper_dir = Keeper_fs.keeper_dir config in
-  let keeper_runtime_dir = Filename.concat keeper_dir keeper_name in
-  let cleanup_names =
-    [ requested_name; keeper_name; agent_name ]
-    |> List.filter_map String_util.trim_to_option
-    |> Json_util.dedupe_keep_order
-  in
-  cleanup_names
-  |> List.iter (fun name ->
-       Keeper_keepalive.stop_keepalive ~base_path:config.base_path name);
-  match
-    Operator_pending_confirm.remove_pending_confirms_by_target
-      config
-      ~target_type:"keeper"
-      ~target_id:(Some keeper_name)
-  with
-  | Error msg ->
-    Error
-      (Printf.sprintf
-         "pending-confirm cleanup failed for keeper %s: %s"
-         keeper_name
-         msg)
-  | Ok keeper_pending_confirms_removed ->
-  Log.Misc.info
-    "[keeper_purge] cleanup keeper=%s pending_confirms_removed=%d"
-    keeper_name keeper_pending_confirms_removed;
-  Keeper_registry.unregister ~base_path:config.base_path keeper_name;
-  (match purge_agent_filesystem_artifacts config [ agent_name; keeper_name ] with
-   | Error _ as err -> err
-   | Ok agent_cleanup_results ->
-  List.iter
-    (remove_path_if_exists ~context:"keeper_purge")
-    [
-      Keeper_types_profile.keeper_meta_path config keeper_name;
-      Keeper_types_support.keeper_metrics_path config keeper_name;
-      Keeper_types_support.keeper_memory_bank_path config keeper_name;
-      Keeper_types_support.keeper_generation_index_path config keeper_name;
-      Keeper_types_support.keeper_policy_log_path config keeper_name;
-      Keeper_types_support.keeper_decision_log_path config keeper_name;
-      Keeper_types_support.keeper_feedback_log_path config keeper_name;
-      Keeper_types_support.keeper_dataset_export_path config keeper_name;
-    ];
-  remove_path_if_exists ~context:"keeper_purge" keeper_runtime_dir;
-  Option.iter
-    (fun keeper_trace_id ->
-       remove_path_if_exists ~context:"keeper_purge"
-         (Keeper_types_support.keeper_session_dir config keeper_trace_id))
-    trace_id;
-  Option.iter (remove_path_if_exists ~context:"keeper_purge") toml_path;
-  Ok { keeper_pending_confirms_removed; agent_cleanup_results })
+let keeper_artifact_path config keeper_name artifact =
+  let open Keeper_shutdown_types in
+  match artifact with
+  | Keeper_metrics_artifact ->
+    Some (Keeper_types_support.keeper_metrics_path config keeper_name)
+  | Keeper_memory_bank_artifact ->
+    Some (Keeper_types_support.keeper_memory_bank_path config keeper_name)
+  | Keeper_generation_index_artifact ->
+    Some (Keeper_types_support.keeper_generation_index_path config keeper_name)
+  | Keeper_policy_log_artifact ->
+    Some (Keeper_types_support.keeper_policy_log_path config keeper_name)
+  | Keeper_decision_log_artifact ->
+    Some (Keeper_types_support.keeper_decision_log_path config keeper_name)
+  | Keeper_feedback_log_artifact ->
+    Some (Keeper_types_support.keeper_feedback_log_path config keeper_name)
+  | Keeper_dataset_export_artifact ->
+    Some (Keeper_types_support.keeper_dataset_export_path config keeper_name)
+  | Keeper_runtime_directory_artifact ->
+    Some (Filename.concat (Keeper_fs.keeper_dir config) keeper_name)
+  | Keeper_configuration_artifact ->
+    Some
+      (Filename.concat
+         (Config_dir_resolver.keepers_dir_for_base_path
+            ~base_path:config.Workspace.base_path)
+         (keeper_name ^ ".toml"))
+  | Agent_artifact_bundle _ -> None
+;;
+
+let purge_dashboard_keeper_artifacts config operation =
+  let open Keeper_shutdown_types in
+  match operation.Keeper_shutdown_types.cleanup_intent.reason with
+  | Dashboard_keeper_purge context ->
+    let artifacts =
+      Keeper_shutdown_types.dashboard_purge_artifact_plan
+        ~keeper_name:operation.keeper_name
+        context
+    in
+    let rec remove = function
+      | [] -> Ok ()
+      | Agent_artifact_bundle aliases :: rest ->
+        (match purge_agent_filesystem_artifacts config aliases with
+         | Error _ as error -> error
+         | Ok _ -> remove rest)
+      | artifact :: rest ->
+        (match keeper_artifact_path config operation.keeper_name artifact with
+         | None ->
+           Error "dashboard Keeper purge artifact plan lost its typed projection"
+         | Some path ->
+           (match remove_path_strict path with
+            | Error _ as error -> error
+            | Ok outcome ->
+              (match artifact with
+               | Keeper_runtime_directory_artifact ->
+                 Keeper_fs.invalidate_dir path
+               | Keeper_metrics_artifact
+               | Keeper_memory_bank_artifact
+               | Keeper_generation_index_artifact
+               | Keeper_policy_log_artifact
+               | Keeper_decision_log_artifact
+               | Keeper_feedback_log_artifact
+               | Keeper_dataset_export_artifact
+               | Keeper_configuration_artifact
+               | Agent_artifact_bundle _ -> ());
+              Log.Keeper.info
+                "dashboard Keeper purge artifact: keeper=%s path=%s outcome=%s"
+                operation.keeper_name
+                path
+                (match outcome with
+                 | Path_absent -> "absent"
+                 | Path_removed -> "removed");
+              remove rest))
+    in
+    remove artifacts
+  | Operator_stop_retain_meta
+  | Operator_stop_remove_meta
+  | Dead_tombstone_cleanup
+  | Stale_paused_prune _ ->
+    Error "dashboard Keeper purge artifacts require a dashboard purge operation"
+;;
+
+let handle_dashboard_keeper_purge_completion config operation =
+  match Masc_event_bus.get () with
+  | None -> Error "MASC lifecycle event bus is not installed"
+  | Some _ ->
+    (match operation.Keeper_shutdown_types.cleanup_intent.reason with
+     | Keeper_shutdown_types.Dashboard_keeper_purge context ->
+       (match purge_dashboard_keeper_artifacts config operation with
+        | Error _ as error -> error
+        | Ok () ->
+          let operation_id =
+            Keeper_shutdown_types.Operation_id.to_string operation.operation_id
+          in
+          Keeper_supervisor_publish_lifecycle.publish_lifecycle
+            ~event:
+              (Keeper_lifecycle_events.Custom_event
+                 { verb = Keeper_lifecycle_events.Purged; phase = None })
+            operation.keeper_name
+            (Printf.sprintf
+               "requested_name=%s agent_name=%s shutdown_operation=%s"
+               context.requested_name
+               context.agent_name
+               operation_id)
+            ();
+          Log.Keeper.info
+            "dashboard Keeper purge completion delivered: keeper=%s operation=%s"
+            operation.keeper_name
+            operation_id;
+          Ok ())
+     | Operator_stop_retain_meta
+     | Operator_stop_remove_meta
+     | Dead_tombstone_cleanup
+     | Stale_paused_prune _ ->
+       Error "dashboard purge completion does not belong to a dashboard purge operation")
+;;
+
+let handle_keeper_lifecycle_completion config operation = function
+  | Keeper_shutdown_types.Dashboard_keeper_purged ->
+    handle_dashboard_keeper_purge_completion config operation
+  | Dead_tombstone_reaped
+  | Paused_meta_pruned as action ->
+    Keeper_supervisor_cleanup_tombstone.handle_completion config operation action
+;;
+
+let keeper_purge_resolve_status = function
+  | Keeper_dashboard_purge.Empty_requested_name -> `Bad_request
+  | Invalid_requested_name _ -> `Bad_request
+  | Keeper_metadata_unreadable _ -> `Internal_server_error
+  | Keeper_metadata_required _
+  | Keeper_metadata_name_mismatch _
+  | Keeper_agent_name_invalid _ -> `Conflict
+  | Keeper_operation_unreadable _ -> `Internal_server_error
+;;
+
+let keeper_purge_submit_status = function
+  | Keeper_shutdown_runtime.Worker_start_error _ -> `Service_unavailable
+  | Existing_operation_load_error _ -> `Internal_server_error
+  | Prepare_error _
+  | Existing_operation_lane_mismatch _
+  | Existing_operation_intent_mismatch _ -> `Conflict
+;;
+
+module For_testing = struct
+  let purge_dashboard_keeper_artifacts = purge_dashboard_keeper_artifacts
+end
+
+let respond_keeper_purge_operation_accepted ~request reqd operation =
+  match operation.Keeper_shutdown_types.cleanup_intent.reason with
+  | Keeper_shutdown_types.Dashboard_keeper_purge context ->
+    Http.Response.json_value
+      ~status:`Accepted
+      ~compress:true
+      ~request
+      (`Assoc
+         [ ("ok", `Bool true)
+         ; ("accepted", `Bool true)
+         ; ("target_kind", `String "keeper")
+         ; ("agent_name", `String context.agent_name)
+         ; ("keeper_name", `String operation.keeper_name)
+         ; ( "operation_id"
+           , `String
+               (Keeper_shutdown_types.Operation_id.to_string
+                  operation.operation_id) )
+         ])
+      reqd
+  | Operator_stop_retain_meta
+  | Operator_stop_remove_meta
+  | Dead_tombstone_cleanup
+  | Stale_paused_prune _ ->
+    respond_error
+      ~status:`Internal_server_error
+      ~request
+      reqd
+      "dashboard purge acceptance received a non-dashboard lifecycle operation"
 ;;
 
 let add_delete_action_routes router =
@@ -483,7 +672,7 @@ let add_delete_action_routes router =
 
   |> Http.Router.post "/api/v1/dashboard/agents/purge" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun state _agent_name req reqd ->
+         (fun state actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -492,62 +681,84 @@ let add_delete_action_routes router =
                respond_error ~request:req reqd (invalid_request "agent_name")
              | Some requested_name ->
                let config = (Mcp_server.workspace_config state) in
-               (match resolve_keeper_purge_target config requested_name with
-                | Some keeper_target ->
-                  let toml_deleted = Option.is_some keeper_target.toml_path in
-                  (match purge_keeper_artifacts config requested_name keeper_target with
-                   | Error msg ->
+               (match
+                  Keeper_dashboard_purge.existing_operation
+                    config
+                    requested_name
+                with
+                | Error error ->
+                  respond_error
+                    ~status:(keeper_purge_resolve_status error)
+                    ~request:req
+                    reqd
+                    (Keeper_dashboard_purge.resolve_error_to_string error)
+                | Ok (Some operation) ->
+                  respond_keeper_purge_operation_accepted
+                    ~request:req
+                    reqd
+                    operation
+                | Ok None ->
+                  (match Keeper_dashboard_purge.resolve config requested_name with
+                  | Error error ->
+                    respond_error
+                      ~status:(keeper_purge_resolve_status error)
+                      ~request:req
+                      reqd
+                      (Keeper_dashboard_purge.resolve_error_to_string error)
+                  | Ok (Some keeper_target) ->
+                  (match
+                     Keeper_dashboard_purge.submit
+                       ~config
+                       ~actor
+                       keeper_target
+                   with
+                   | Error error ->
                      respond_error
-                       ~status:`Internal_server_error
+                       ~status:(keeper_purge_submit_status error)
                        ~request:req
                        reqd
-                       msg
-                   | Ok purge_result ->
-                  Http.Response.json_value ~compress:true ~request:req
-                    (`Assoc
-                       [
-                         ("ok", `Bool true);
-                         ("target_kind", `String "keeper");
-                         ("agent_name", `String keeper_target.agent_name);
-                         ("keeper_name", `String keeper_target.keeper_name);
-                         ("removed_keeper_toml", `Bool toml_deleted);
-                         ( "keeper_pending_confirms_removed",
-                           `Int purge_result.keeper_pending_confirms_removed );
-                         ( "cleanup_results",
-                           `List
-                             (List.map agent_purge_cleanup_result_to_json
-                                purge_result.agent_cleanup_results) );
-                       ])
-                    reqd)
-                | None -> (
-                  match resolve_plain_agent_target config requested_name with
-                  | Some agent_name ->
-                    (match
-                       purge_agent_filesystem_artifacts config
-                         [ requested_name; agent_name ]
-                     with
-                     | Error msg ->
-                       respond_error
-                         ~status:`Internal_server_error
-                         ~request:req
-                         reqd
-                         msg
-                     | Ok cleanup_results ->
-                    Http.Response.json_value ~compress:true ~request:req
-                      (`Assoc
-                         [
-                           ("ok", `Bool true);
-                           ("target_kind", `String "agent");
-                           ("agent_name", `String agent_name);
-                           ( "cleanup_results",
-                             `List
-                               (List.map agent_purge_cleanup_result_to_json
-                                  cleanup_results) );
-                         ])
-                      reqd)
-                  | None ->
-                    respond_error ~status:`Not_found ~request:req reqd
-                      "agent or keeper not found"))
+                       (Keeper_shutdown_runtime.submit_error_to_string error)
+                   | Ok operation ->
+                     respond_keeper_purge_operation_accepted
+                       ~request:req
+                       reqd
+                       operation)
+                  | Ok None ->
+                    (match resolve_plain_agent_target config requested_name with
+                    | Error error ->
+                      respond_error
+                        ~status:(plain_agent_resolve_status error)
+                        ~request:req
+                        reqd
+                        (plain_agent_resolve_error_to_string error)
+                    | Ok (Some agent_name) ->
+                      (match
+                         purge_agent_filesystem_artifacts config
+                           [ agent_name ]
+                       with
+                       | Error msg ->
+                         respond_error
+                           ~status:`Internal_server_error
+                           ~request:req
+                           reqd
+                           msg
+                       | Ok cleanup_results ->
+                      Http.Response.json_value ~compress:true ~request:req
+                        (`Assoc
+                           [
+                             ("ok", `Bool true);
+                             ("accepted", `Bool false);
+                             ("target_kind", `String "agent");
+                             ("agent_name", `String agent_name);
+                             ( "cleanup_results",
+                               `List
+                                 (List.map agent_purge_cleanup_result_to_json
+                                    cleanup_results) );
+                           ])
+                        reqd)
+                    | Ok None ->
+                      respond_error ~status:`Not_found ~request:req reqd
+                        "agent or keeper not found")))
            with Yojson.Json_error _ ->
              respond_error ~request:req reqd (invalid_request "agent_name")
          )

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -6,7 +6,8 @@
     - [/api/v1/dashboard/board/delete] — delete one board post
     - [/api/v1/dashboard/tasks/delete] — delete one task
     - [/api/v1/dashboard/goals/delete] — delete one goal
-    - [/api/v1/dashboard/agents/purge] — hard-delete one agent/keeper
+    - [/api/v1/dashboard/agents/purge] — delete an exact agent or accept a
+      durable Keeper purge operation
 
     Board moderation routes (Phase 2):
     - [POST /api/v1/dashboard/board/moderation/flag] — flag a post for review
@@ -19,3 +20,18 @@
     [Server_auth.with_token_permission_auth]. *)
 val add_delete_action_routes :
   Http_server_eio.Router.t -> Http_server_eio.Router.t
+
+(** Process-boundary completion handler for durable Keeper lifecycle
+    operations. Dashboard purge artifacts are removed strictly and
+    repeat-safely; non-dashboard actions delegate to the supervisor cleanup
+    handler. *)
+val handle_keeper_lifecycle_completion :
+  Workspace.config ->
+  Keeper_shutdown_types.t ->
+  Keeper_shutdown_types.completion_action ->
+  (unit, string) result
+
+module For_testing : sig
+  val purge_dashboard_keeper_artifacts :
+    Workspace.config -> Keeper_shutdown_types.t -> (unit, string) result
+end

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -496,6 +496,8 @@ let display_of_custom_event (verb : Keeper_lifecycle_events.t) : lifecycle_displ
   | Paused_pruned ->
     (* prune == removed from supervision *)
     { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = true }
+  | Purged ->
+    { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = false }
   | Admission_denied ->
     (* admission guard refused to launch a fiber *)
     { ld_keepalive_running = false; ld_phase = "offline"; ld_pipeline_stage = "offline"; ld_paused = false }

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1734,6 +1734,7 @@ let test_lifecycle_event_display_values () =
       ("resumed", true, "running", "idle", false);
       ("paused", true, "paused", "paused", true);
       ("paused_pruned", false, "stopped", "offline", true);
+      ("purged", false, "stopped", "offline", false);
       ("admission_denied", false, "offline", "offline", false);
       ("dead_cleaned", false, "dead", "offline", false);
       ("stopped", false, "stopped", "offline", true);

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -32,6 +32,7 @@ module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_runtime = Masc.Keeper_shutdown_runtime
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_store = Masc.Keeper_meta_store
+module Keeper_types_support = Masc.Keeper_types_support
 module Lifecycle_hooks = Masc.Keeper_lifecycle_hooks
 module Subprocess_registry = Masc.Keeper_subprocess_registry
 module Tombstone_cleanup = Masc.Keeper_supervisor_cleanup_tombstone
@@ -185,6 +186,8 @@ let shutdown_schema3_fixture (operation : Shutdown_types.t) =
     | Shutdown_types.Dead_tombstone_cleanup -> "retain_dead_tombstone"
     | Shutdown_types.Stale_paused_prune _ ->
       fail "schema 3 fixture cannot encode stale paused cleanup"
+    | Shutdown_types.Dashboard_keeper_purge _ ->
+      fail "schema 3 fixture cannot encode dashboard Keeper purge"
   in
   match Shutdown_store.to_json operation with
   | `Assoc fields ->

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -47,17 +47,8 @@ let temp_dir prefix =
   Unix.mkdir dir 0o755;
   dir
 
-let rec mkdir_p path =
-  if Sys.file_exists path
-  then ()
-  else (
-    let parent = Filename.dirname path in
-    if not (String.equal parent path) then mkdir_p parent;
-    Unix.mkdir path 0o755)
-;;
-
 let write_file path content =
-  mkdir_p (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let oc = open_out_bin path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -35,6 +35,8 @@ module Keeper_meta_store = Masc.Keeper_meta_store
 module Lifecycle_hooks = Masc.Keeper_lifecycle_hooks
 module Subprocess_registry = Masc.Keeper_subprocess_registry
 module Tombstone_cleanup = Masc.Keeper_supervisor_cleanup_tombstone
+module Dashboard_purge = Masc.Keeper_dashboard_purge
+module Dashboard_delete = Server_dashboard_http_delete_actions
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -43,6 +45,23 @@ let temp_dir prefix =
   Unix.unlink dir;
   Unix.mkdir dir 0o755;
   dir
+
+let rec mkdir_p path =
+  if Sys.file_exists path
+  then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
 
 (* The autonomous keeper_cycle_decision path resolves a runtime id
    (Keeper_meta_contract.runtime_id_of_meta -> Runtime.get_default_runtime_id),
@@ -134,6 +153,20 @@ let stale_paused_cleanup (meta : Keeper_meta_contract.keeper_meta)
   }
 ;;
 
+let dashboard_purge_cleanup requested_name
+    (meta : Keeper_meta_contract.keeper_meta)
+    : Shutdown_types.cleanup_intent
+  =
+  { reason =
+      Shutdown_types.Dashboard_keeper_purge
+        { requested_name
+        ; agent_name = meta.agent_name
+        ; meta_version = meta.meta_version
+        }
+  ; remove_session = true
+  }
+;;
+
 let replace_assoc_field key value fields =
   (key, value) :: List.remove_assoc key fields
 ;;
@@ -184,6 +217,13 @@ let shutdown_schema3_fixture (operation : Shutdown_types.t) =
               ; "remove_session", `Bool operation.cleanup_intent.remove_session
               ])
        |> replace_assoc_field "phase" phase)
+  | _ -> fail "shutdown JSON codec did not return an object"
+;;
+
+let shutdown_schema4_fixture (operation : Shutdown_types.t) =
+  match Shutdown_store.to_json operation with
+  | `Assoc fields ->
+    `Assoc (replace_assoc_field "schema_version" (`Int 4) fields)
   | _ -> fail "shutdown JSON codec did not return an object"
 ;;
 
@@ -953,6 +993,39 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Shutdown_types.Finalized _ ->
          fail "schema 3 unregister receipt did not restore accumulator evidence"
        | _ -> fail "schema 3 finalized phase changed during migration");
+      let migrated_schema4 =
+        match
+          operation
+          |> shutdown_schema4_fixture
+          |> Shutdown_store.of_json
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "schema 4 lifecycle record migrates to current schema"
+        Shutdown_types.schema_version
+        migrated_schema4.schema_version;
+      check bool
+        "schema 4 immutable intent survives migration"
+        true
+        (Shutdown_types.cleanup_intent_equal
+           operation.cleanup_intent
+           migrated_schema4.cleanup_intent);
+      let dashboard_v5_operation =
+        { operation with
+          operation_id = Shutdown_types.Operation_id.generate ()
+        ; cleanup_intent = dashboard_purge_cleanup meta.name meta
+        }
+      in
+      (match
+         dashboard_v5_operation
+         |> shutdown_schema4_fixture
+         |> Shutdown_store.of_json
+       with
+       | Error (Shutdown_store.Decode_error _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok _ -> fail "schema 4 accepted a schema 5 dashboard cleanup reason");
       let loaded =
         match Shutdown_store.load ~config ~keeper_name:meta.name operation_id with
         | Ok loaded -> loaded
@@ -1297,6 +1370,120 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
           true
           (recovered.phase = recoverable_operation.phase)
       | Error detail -> fail detail)
+
+let test_dashboard_purge_resolution_is_fail_closed () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "dashboard-purge-resolution" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      (match Dashboard_purge.resolve config "plain-agent" with
+       | Ok None -> ()
+       | Ok (Some _) -> fail "plain agent was classified as a Keeper"
+       | Error error -> fail (Dashboard_purge.resolve_error_to_string error));
+      let persisted = make_meta "dashboard-purge-persisted" in
+      (match Keeper_meta_store.write_meta config persisted with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let persisted =
+        match Keeper_meta_store.read_meta config persisted.name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "persisted dashboard purge metadata disappeared"
+        | Error detail -> fail detail
+      in
+      let target =
+        match Dashboard_purge.resolve config persisted.name with
+        | Ok (Some target) -> target
+        | Ok None -> fail "persisted Keeper fell through to plain-agent purge"
+        | Error error -> fail (Dashboard_purge.resolve_error_to_string error)
+      in
+      check string "resolved exact Keeper name" persisted.name target.keeper_name;
+      check int
+        "resolved exact metadata version"
+        persisted.meta_version
+        target.meta.meta_version;
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let existing_operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id = Shutdown_types.Operation_id.generate ()
+        ; keeper_name = persisted.name
+        ; lane_ownership = Shutdown_types.Dormant_meta
+        ; trace_id = persisted.runtime.trace_id
+        ; generation = persisted.runtime.generation
+        ; actor = "supervisor"
+        ; cleanup_intent = retain_operator_cleanup
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase = Shutdown_types.Joined_idle
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config existing_operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match
+         Masc.Keeper_turn_admission.restore_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:persisted.name
+           ~operation_id:existing_operation.operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_restored -> ()
+       | Shutdown_already_restored
+       | Shutdown_restore_conflict _ ->
+         fail "existing cleanup fixture could not restore admission");
+      (match Dashboard_purge.submit ~config ~actor:"operator" target with
+       | Error (Shutdown_runtime.Existing_operation_intent_mismatch operation) ->
+         check bool
+           "mismatched operation identity is surfaced"
+           true
+           (Shutdown_types.Operation_id.equal
+              existing_operation.operation_id
+              operation.operation_id)
+       | Error error -> fail (Shutdown_runtime.submit_error_to_string error)
+       | Ok _ -> fail "dashboard purge reused an unrelated cleanup operation");
+      let corrupt_name = "dashboard-purge-corrupt" in
+      write_file
+        (Keeper_types_profile.keeper_meta_path config corrupt_name)
+        "{not-json";
+      (match Dashboard_purge.resolve config corrupt_name with
+       | Error (Dashboard_purge.Keeper_metadata_unreadable _) -> ()
+       | Error error -> fail (Dashboard_purge.resolve_error_to_string error)
+       | Ok _ -> fail "corrupt Keeper metadata fell through to agent purge");
+      let configured_name = "dashboard-purge-configured" in
+      let configured_path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path
+             ~base_path:config.base_path)
+          (configured_name ^ ".toml")
+      in
+      write_file configured_path "[keeper]\nautoboot = false\n";
+      match Dashboard_purge.resolve config configured_name with
+      | Error
+          (Dashboard_purge.Keeper_metadata_required
+            { configuration_path; _ }) ->
+        check string
+          "configuration-only Keeper path stays explicit"
+          configured_path
+          configuration_path
+      | Error error -> fail (Dashboard_purge.resolve_error_to_string error)
+      | Ok _ -> fail "configuration-only Keeper fell through to agent purge")
+;;
 
 let test_stale_prune_dormant_prepare_rejects_version_change () =
   Eio_main.run @@ fun env ->
@@ -2083,6 +2270,266 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
               ~keeper_name:meta.name)
              .snapshot_shutdown_operation_id))
 
+let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "dashboard-purge-finalization" in
+  let completion_bus =
+    Agent_sdk.Event_bus.create
+      ~policy:Agent_sdk.Event_bus.Drop_oldest
+      ()
+  in
+  let completion_subscription =
+    Agent_sdk.Event_bus.subscribe
+      ~purpose:"dashboard-purge-completion-test"
+      completion_bus
+  in
+  Masc_event_bus.set completion_bus;
+  Fun.protect
+    ~finally:(fun () ->
+      Agent_sdk.Event_bus.unsubscribe completion_bus completion_subscription;
+      Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Shutdown_finalize.For_testing.reset_completion_handler ();
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      R.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let initial = make_meta "dashboard-purge-finalize" in
+      (match Keeper_meta_store.write_meta config initial with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let meta =
+        match Keeper_meta_store.read_meta config initial.name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "dashboard purge metadata disappeared"
+        | Error detail -> fail detail
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let sidecar_paths =
+        [ Keeper_types_support.keeper_metrics_path config meta.name
+        ; Keeper_types_support.keeper_memory_bank_path config meta.name
+        ; Keeper_types_support.keeper_generation_index_path config meta.name
+        ; Keeper_types_support.keeper_policy_log_path config meta.name
+        ; Keeper_types_support.keeper_decision_log_path config meta.name
+        ; Keeper_types_support.keeper_feedback_log_path config meta.name
+        ; Keeper_types_support.keeper_dataset_export_path config meta.name
+        ]
+      in
+      List.iter (fun path -> write_file path "fixture") sidecar_paths;
+      let runtime_dir = Filename.concat (Keeper_fs.keeper_dir config) meta.name in
+      write_file (Filename.concat runtime_dir "runtime.json") "{}";
+      let session_dir =
+        Keeper_types_support.keeper_session_dir
+          config
+          (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      in
+      write_file (Filename.concat session_dir "history.jsonl") "{}\n";
+      let configuration_path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path
+             ~base_path:config.base_path)
+          (meta.name ^ ".toml")
+      in
+      write_file configuration_path "[keeper]\nautoboot = false\n";
+      let agent_path =
+        Filename.concat
+          (Workspace.agents_dir config)
+          (Workspace.safe_filename meta.agent_name ^ ".json")
+      in
+      write_file agent_path "{}";
+      let agent_metrics_dir =
+        Metrics_store_eio.agent_metrics_dir config meta.agent_name
+      in
+      write_file (Filename.concat agent_metrics_dir "fixture.jsonl") "{}\n";
+      let unrelated_path =
+        Filename.concat (Workspace.agents_dir config) "unrelated.json"
+      in
+      write_file unrelated_path "{}";
+      Masc.Auth.save_credential
+        config.base_path
+        { id = None
+        ; agent_id = None
+        ; agent_name = meta.agent_name
+        ; token = Masc.Auth.sha256_hash "dashboard-purge-token"
+        ; role = Masc_domain.Worker
+        ; created_at = Masc_domain.now_iso ()
+        ; expires_at = None
+        };
+      ignore
+        (Workspace.update_state config (fun state ->
+           { state with
+             active_agents = meta.agent_name :: state.active_agents
+           }));
+      ignore
+        (Heartbeat.start
+           ~agent_name:meta.agent_name
+           ~interval:30
+           ~message:"dashboard purge fixture");
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_ownership = Shutdown_types.Dormant_meta
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "operator"
+        ; cleanup_intent = dashboard_purge_cleanup meta.name meta
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase =
+            Shutdown_types.Cleanup_ready
+              { settled_task_ids = []; pending_confirms_removed = 0 }
+        ; created_at = Masc_domain.now_iso ()
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match
+         Masc.Keeper_turn_admission.restore_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_restored -> ()
+       | Shutdown_already_restored
+       | Shutdown_restore_conflict _ ->
+         fail "dashboard purge fixture could not restore admission");
+      Shutdown_finalize.register_remove_pending_confirms_by_target
+        (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+      Shutdown_finalize.register_completion_handler
+        (fun _config _operation _action -> Error "synthetic dashboard completion outage");
+      (match Shutdown_finalize.run ~config ~entry:None operation with
+       | Error (Shutdown_finalize.Completion_failed (_, detail)) ->
+         check string
+           "dashboard completion outage remains explicit"
+           "synthetic dashboard completion outage"
+           detail
+       | Error error -> fail (Shutdown_finalize.error_to_string error)
+       | Ok _ -> fail "dashboard completion outage was reported as delivered");
+      let pending =
+        match Shutdown_store.load ~config ~keeper_name:meta.name operation_id with
+        | Ok pending -> pending
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check bool
+        "pending dashboard completion already removed exact metadata"
+        false
+        (Sys.file_exists (Keeper_types_profile.keeper_meta_path config meta.name));
+      check bool
+        "pending dashboard completion already removed exact session"
+        false
+        (Sys.file_exists session_dir);
+      check bool
+        "pending dashboard completion retains server artifacts for retry"
+        true
+        (Sys.file_exists configuration_path);
+      (match Dashboard_purge.existing_operation config meta.name with
+       | Ok (Some existing) ->
+         check bool
+           "HTTP retry recovers the exact pending dashboard operation"
+           true
+           (Shutdown_types.Operation_id.equal
+              operation_id
+              existing.operation_id)
+       | Ok None -> fail "pending dashboard operation was not discoverable"
+       | Error error -> fail (Dashboard_purge.resolve_error_to_string error));
+      Shutdown_finalize.register_completion_handler
+        Dashboard_delete.handle_keeper_lifecycle_completion;
+      let finalized =
+        match Shutdown_finalize.run ~config ~entry:None pending with
+        | Ok finalized -> finalized
+        | Error error -> fail (Shutdown_finalize.error_to_string error)
+      in
+      (match finalized.phase with
+       | Shutdown_types.Finalized
+           { meta_removed = true
+           ; session_removed = true
+           ; completion =
+               Shutdown_types.Completion_delivered
+                 Shutdown_types.Dashboard_keeper_purged
+           ; _
+           } -> ()
+       | _ -> fail "dashboard purge did not persist its delivered receipt");
+      let removed_paths =
+        [ Keeper_types_profile.keeper_meta_path config meta.name
+        ; runtime_dir
+        ; session_dir
+        ; configuration_path
+        ; agent_path
+        ; agent_metrics_dir
+        ; Masc.Auth.credential_file config.base_path meta.agent_name
+        ]
+        @ sidecar_paths
+      in
+      List.iter
+        (fun path ->
+           check bool ("artifact removed: " ^ path) false (Sys.file_exists path))
+        removed_paths;
+      check bool "unrelated agent artifact preserved" true
+        (Sys.file_exists unrelated_path);
+      check bool
+        "exact workspace owner unbound"
+        false
+        (List.exists
+           (String.equal meta.agent_name)
+           (Workspace.read_state config).active_agents);
+      check int
+        "exact agent heartbeats stopped"
+        0
+        (List.length
+           (List.filter
+              (fun (heartbeat : Heartbeat.t) ->
+                 String.equal heartbeat.agent_name meta.agent_name)
+              (Heartbeat.list ())));
+      (match Agent_sdk.Event_bus.drain completion_subscription with
+       | [ event ] ->
+         (match event.Agent_sdk.Event_bus.payload with
+          | Agent_sdk.Event_bus.Custom
+              ("masc.keeper.lifecycle", `Assoc fields) ->
+            check string
+              "dashboard purge lifecycle event"
+              "purged"
+              (match List.assoc_opt "event" fields with
+               | Some (`String event_name) -> event_name
+               | _ -> fail "dashboard purge event omitted event name")
+          | _ -> fail "dashboard purge did not publish a lifecycle event")
+       | events ->
+         fail
+           (Printf.sprintf
+              "expected one dashboard purge lifecycle event, got %d"
+              (List.length events)));
+      (match Shutdown_finalize.run ~config ~entry:None finalized with
+       | Ok replayed -> check bool "finalized replay is stable" true
+                          (replayed.phase = finalized.phase)
+       | Error error -> fail (Shutdown_finalize.error_to_string error));
+      check int
+        "delivered dashboard purge receipt prevents duplicate event"
+        0
+        (List.length (Agent_sdk.Event_bus.drain completion_subscription));
+      match
+        Masc.Keeper_turn_admission.run_if_free
+          ~base_path:config.base_path
+          ~keeper_name:meta.name
+          (fun () -> ())
+      with
+      | `Ran () -> ()
+      | `Busy _ -> fail "delivered dashboard purge left admission fenced")
+;;
+
 let test_keeper_shutdown_cleanup_replays_after_meta_removal () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2682,6 +3129,8 @@ let () =
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
+      test_case "dashboard purge resolution is fail closed" `Quick
+        test_dashboard_purge_resolution_is_fail_closed;
       test_case "stale dormant prepare rejects a newer meta version" `Quick
         test_stale_prune_dormant_prepare_rejects_version_change;
       test_case "stale registered prepare requires a paused lane" `Quick
@@ -2698,6 +3147,8 @@ let () =
         test_keeper_shutdown_finalizes_idle_operation;
       test_case "shutdown delivers dead tombstone completion after receipt" `Quick
         test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt;
+      test_case "dashboard purge finalizes artifacts and receipt" `Quick
+        test_dashboard_keeper_purge_finalizes_artifacts_and_receipt;
       test_case "shutdown cleanup replays after meta removal" `Quick
         test_keeper_shutdown_cleanup_replays_after_meta_removal;
       test_case "shutdown recovers committed task receipt" `Quick


### PR DESCRIPTION
## Why

The dashboard Keeper purge route synchronously guessed ownership from names/files, could fail open on unreadable metadata, unregistered the Keeper before strict artifact cleanup, and reported deletion complete before cleanup actually finished. Its nested agent cleanup also called an unsupported pending-confirm target type.

## What

- resolve Keeper ownership from canonical persisted metadata and reject corrupt or config-only ownership explicitly
- submit exact registered/dormant owners through the durable lifecycle lane and return HTTP 202 with the durable operation id
- recover the same in-flight dashboard purge operation on request retry, including after metadata removal while completion is pending
- add schema 5 typed dashboard purge intent, artifact plan, completion receipt, and schema 3/4 closed migrations
- run session/artifact tree deletion through a systhread with explicit repeat-safe errors
- deliver strict server artifact cleanup only after durable finalization, then publish the typed purged lifecycle event
- make plain-agent cleanup exact-name based and remove the invalid stringly agent pending-confirm call
- make the dashboard distinguish accepted Keeper deletion from completed agent deletion
- reuse Fs_compat.mkdir_p in integration fixtures instead of maintaining a second recursive directory implementation

## Credential boundary

RFC-WAIVED: the auth_credential_base.ml change does not introduce or alter credential providers, storage resolution, repository identity, or dispatch. Purge already owns credential removal; this patch removes the raw-token sibling under the same canonical credential boundary so purge cannot leave an orphan. RFC-0019 is withdrawn and its repository credential-unification model is explicitly not an active design target.

## Verification

- exact head: 1e654d1f5a398400f8534d308b4e090ab1fbe117
- exact stack base: #24212 at a66dde50b948d6bbe2db0ebe7004c5d791652ce9
- OCaml parser passed for every changed .ml/.mli file
- ocamlformat --check passed for every changed .ml/.mli file
- git diff --check passed
- Dashboard pnpm typecheck: pass
- keeper-lifecycle-timeline Vitest: 17/17 pass
- targeted ESLint: repo allowlist ignored these files; no lint-pass claim
- focused Dune cannot start because the machine-wide agent_sdk pin is 492de324 while this checkout SSOT requires ca4dbb19; guard was not bypassed or mutated
- full Dune build/test authority: GitHub CI

## Stack

- base branch: #24212 durable stale-paused cleanup
- #24212 is rewritten directly on current main and no longer depends on #24202
- Draft / do not merge until the stack and this PR are green