### PR TITLE
fix(health): align effective keeper capacity

### DIFF
--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -194,10 +194,12 @@ val make_health_json :
     [running_keeper_fiber_count] / [healthy_running_keeper_fiber_count] from
     [failing_keeper_fiber_count] and [executable_keeper_fiber_count] because
     the FSM intentionally allows [Failing] keepers to finish or attempt turns.
-    It reports [blocked] when autoboot-enabled keepers exist but no executable
+    [effective_reaction_capacity_count] is the sum of healthy [Running] lanes
+    and unpaused, executable [Failing] lanes whose restart budget remains. It
+    reports [blocked] when autoboot-enabled keepers exist but no executable
     fiber remains, and [degraded] when executable fibers remain but healthy
-    running capacity is zero, below the safety margin, or below
-    [target_reaction_capacity_count].
+    running capacity is zero or below the safety margin, or effective reaction
+    capacity is below [target_reaction_capacity_count].
     [paused_autoboot_enabled_keeper_count] keeps operator-paused autoboot
     keepers visible without counting them as reaction-capacity targets.
 

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -1389,10 +1389,10 @@ let keeper_fleet_safety_health_json
     target_count > 1 && phase_counts.running < minimum_running_fibers
   in
   (* Recovering lanes are deliberately capacity-bearing for the fleet verdict:
-     they already own an executable lane and the supervisor is actively
-     restoring them. Keep that policy in one value so the advertised
-     effective count and its derived shortfall cannot diverge. Actual healthy
-     execution remains available separately as
+     [Failing] remains executable in the FSM, and restart budget marks the lane
+     eligible for heartbeat-driven recovery. Keep that policy in one value so
+     the advertised effective count and its derived shortfall cannot diverge.
+     Actual healthy execution remains available separately as
      [healthy_running_keeper_fiber_count]. *)
   let effective_reaction_capacity_count =
     phase_counts.running + phase_counts.recovering

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -1388,8 +1388,17 @@ let keeper_fleet_safety_health_json
   let low_running_fiber_margin =
     target_count > 1 && phase_counts.running < minimum_running_fibers
   in
+  (* Recovering lanes are deliberately capacity-bearing for the fleet verdict:
+     they already own an executable lane and the supervisor is actively
+     restoring them. Keep that policy in one value so the advertised
+     effective count and its derived shortfall cannot diverge. Actual healthy
+     execution remains available separately as
+     [healthy_running_keeper_fiber_count]. *)
+  let effective_reaction_capacity_count =
+    phase_counts.running + phase_counts.recovering
+  in
   let reaction_capacity_shortfall_count =
-    max 0 (target_count - phase_counts.running - phase_counts.recovering)
+    max 0 (target_count - effective_reaction_capacity_count)
   in
   let reaction_capacity_below_target =
     target_count > 0 && reaction_capacity_shortfall_count > 0
@@ -1534,7 +1543,7 @@ let keeper_fleet_safety_health_json
     ; "executable_keeper_fiber_count", `Int phase_counts.executable
     ; ( "executable_keeper_names"
       , `List (List.map (fun name -> `String name) executable_names) )
-    ; "effective_reaction_capacity_count", `Int phase_counts.running
+    ; "effective_reaction_capacity_count", `Int effective_reaction_capacity_count
     ; "executable_reaction_capacity_count", `Int phase_counts.executable
     ; "target_reaction_capacity_count", `Int target_count
     ; "minimum_running_fibers", `Int minimum_running_fibers

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2338,6 +2338,64 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
           false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
+let test_health_json_effective_capacity_includes_recovering_lanes () =
+  let previous_state = !Server_auth.server_state in
+  Fun.protect
+    ~finally:(fun () -> Server_auth.server_state := previous_state)
+    (fun () ->
+      Server_auth.server_state := None;
+      let running_names = [ "running-a"; "running-b"; "running-c" ] in
+      let recovering_names =
+        [ "recovering-a"; "recovering-b"; "recovering-c"; "recovering-d" ]
+      in
+      let target_names = running_names @ recovering_names in
+      let phase_counts :
+          Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+        { running = 3; failing = 4; recovering = 4; executable = 7 }
+      in
+      let phase_snapshot :
+          Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+        { counts = phase_counts
+        ; running_names
+        ; recovering_names
+        ; executable_names = target_names
+        ; phase_values = []
+        ; phase_details = []
+        }
+      in
+      let fleet_safety =
+        Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+          ~bootable_names:target_names
+          ~autoboot_scan:
+            { autoboot_names = target_names; read_errors = [] }
+          ~phase_snapshot
+          ~phase_counts
+          ~paused_keepers_json:(`Assoc [ ("count", `Int 0) ])
+          ()
+      in
+      let open Yojson.Safe.Util in
+      Alcotest.(check int)
+        "healthy running count remains actual running lanes"
+        3
+        (fleet_safety |> member "healthy_running_keeper_fiber_count" |> to_int);
+      Alcotest.(check int)
+        "effective capacity includes actively recovering lanes"
+        7
+        (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
+      Alcotest.(check int)
+        "effective capacity has no target shortfall"
+        0
+        (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
+      Alcotest.(check bool)
+        "capacity verdict uses the advertised effective count"
+        false
+        (fleet_safety |> member "reaction_capacity_below_target" |> to_bool);
+      Alcotest.(check string)
+        "active recovery does not request a stop/pause intervention"
+        "ok"
+        (fleet_safety |> member "status" |> to_string))
+;;
+
 let test_health_json_degrades_when_reaction_capacity_below_target () =
   with_temp_dir "health-reaction-capacity-below-target" (fun dir ->
     let config_root = make_config_root dir in
@@ -4735,6 +4793,10 @@ let () =
             "health json preserves active task owner meta read error"
             `Quick
             test_health_json_preserves_active_task_owner_meta_read_error;
+          Alcotest.test_case
+            "health json effective capacity includes recovering lanes"
+            `Quick
+            test_health_json_effective_capacity_includes_recovering_lanes;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;


### PR DESCRIPTION
## Why\n\nLive health exposed an internally inconsistent capacity projection: running 3, recovering 4, target 7, effective count 3, but shortfall 0 and below_target false. The verdict already intentionally treats actively recovering executable lanes as capacity-bearing, while the advertised effective count used running lanes only.\n\nCloses #24222.\n\n## What\n\n- derive one effective_reaction_capacity_count from running + recovering\n- derive reaction_capacity_shortfall_count from that exact SSOT value\n- keep healthy_running_keeper_fiber_count unchanged for actual healthy/running lanes\n- pin the 3 running + 4 recovering = 7 effective invariant and no-intervention verdict\n\n## Verification\n\n- OCaml parser passed for both changed files\n- ocamlformat --check passed for both changed files\n- git diff --check passed\n- OCaml structure, stringly-boundary, and silent-failure ratchets passed\n- local Dune build/test intentionally not run; CI is the build authority\n\n## Live evidence\n\nChecked 2026-07-11 23:22 KST with read-only /health?full=1. No queue mutation, Keeper restart, pause, or resume was performed.