### PR TITLE
fix(keeper): repair canonical schema projections

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -420,8 +420,6 @@ let phase6_specs : tool_spec list =
   ; masc_gc_spec
   ; masc_tool_stats_spec
   ; masc_cleanup_zombies_spec
-  ; masc_pause_spec
-  ; masc_resume_spec
     (* PR-2: plan group *)
   ; masc_plan_init_spec
   ; masc_plan_update_spec
@@ -558,7 +556,7 @@ let format_behavior_contract = function
     "\n\nUsage rules:\n" ^ String.concat "\n" bullets
 ;;
 
-let emit_tool_schema buf spec =
+let emit_tool_schema_record buf spec =
   Buffer.add_string buf "  {\n";
   buf_addf buf "    name = %S;\n" spec.name;
   buf_addf
@@ -576,7 +574,18 @@ let emit_tool_schema buf spec =
   emit_required buf spec.parameters;
   buf_addf buf "      (\"additionalProperties\", `Bool %b);\n" spec.additional_properties;
   Buffer.add_string buf "    ];\n";
-  Buffer.add_string buf "  };\n"
+  Buffer.add_string buf "  }"
+;;
+
+let emit_tool_schema buf spec =
+  emit_tool_schema_record buf spec;
+  Buffer.add_string buf ";\n"
+;;
+
+let emit_named_tool_schema buf binding spec =
+  buf_addf buf "let %s : tool_schema =\n" binding;
+  emit_tool_schema_record buf spec;
+  Buffer.add_string buf "\n;;\n\n"
 ;;
 
 let emit_schemas_list buf specs =
@@ -590,6 +599,8 @@ let emit_schemas_list buf specs =
 let () =
   let buf = Buffer.create 4096 in
   emit_header buf;
+  emit_named_tool_schema buf "masc_pause_schema" masc_pause_spec;
+  emit_named_tool_schema buf "masc_resume_schema" masc_resume_spec;
   emit_schemas_list buf phase6_specs;
   print_string (Buffer.contents buf)
 ;;

--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -90,6 +90,8 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_sandbox_containment.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_control.ml` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_control.mli` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_control_contract.ml` - sandbox-runtime
+- `lib/keeper/keeper_sandbox_control_contract.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_docker_container_name.ml` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_docker_container_name.mli` - sandbox-runtime
 - `lib/keeper/keeper_sandbox_docker_nested_runtime.ml` - sandbox-runtime

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -10,31 +10,18 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-let managed_kind = "managed"
-let turn_kind = "turn"
-let all_kind = "all"
+module Contract = Keeper_sandbox_control_contract
 
-type stop_scope =
+type stop_scope = Contract.stop_scope =
   | Stop_managed
   | Stop_turn
   | Stop_all
 
-let stop_scope_to_string = function
-  | Stop_managed -> managed_kind
-  | Stop_turn -> turn_kind
-  | Stop_all -> all_kind
-
-let parse_stop_scope raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "" -> Ok Stop_managed
-  | kind when String.equal kind managed_kind -> Ok Stop_managed
-  | kind when String.equal kind turn_kind -> Ok Stop_turn
-  | kind when String.equal kind all_kind -> Ok Stop_all
-  | other ->
-      Error
-        (Printf.sprintf
-           "invalid container_kind %S; expected managed, turn, or all"
-           other)
+let stop_scope_to_string = Contract.stop_scope_to_string
+let parse_stop_scope = Contract.parse_stop_scope
+let managed_kind = stop_scope_to_string Stop_managed
+let turn_kind = stop_scope_to_string Stop_turn
+let all_kind = stop_scope_to_string Stop_all
 
 let now_ms () =
   int_of_float (Unix.gettimeofday () *. 1000.0)

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -8,7 +8,7 @@ val turn_kind : string
 
 val all_kind : string
 
-type stop_scope =
+type stop_scope = Keeper_sandbox_control_contract.stop_scope =
   | Stop_managed
   | Stop_turn
   | Stop_all

--- a/lib/keeper/keeper_sandbox_control_contract.ml
+++ b/lib/keeper/keeper_sandbox_control_contract.ml
@@ -1,0 +1,54 @@
+(** Typed input contract shared by keeper sandbox schemas and handlers. *)
+
+type bounded_float =
+  { minimum : float
+  ; maximum : float
+  ; default : float
+  }
+
+let managed_ttl_sec =
+  { minimum = 1.0; maximum = 86_400.0; default = 1_800.0 }
+;;
+
+let operation_timeout_sec =
+  { minimum = 1.0; maximum = 30.0; default = 10.0 }
+;;
+
+let clamp bounds value =
+  Stdlib.Float.min bounds.maximum (Stdlib.Float.max bounds.minimum value)
+;;
+
+type stop_scope =
+  | Stop_managed
+  | Stop_turn
+  | Stop_all
+
+let all_stop_scopes = [ Stop_managed; Stop_turn; Stop_all ]
+let default_stop_scope = Stop_managed
+
+let stop_scope_to_string = function
+  | Stop_managed -> "managed"
+  | Stop_turn -> "turn"
+  | Stop_all -> "all"
+;;
+
+let stop_scope_strings = List.map stop_scope_to_string all_stop_scopes
+
+let parse_stop_scope raw =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  if String.equal normalized ""
+  then Ok default_stop_scope
+  else
+    match
+      List.find_opt
+        (fun scope -> String.equal normalized (stop_scope_to_string scope))
+        all_stop_scopes
+    with
+    | Some scope -> Ok scope
+    | None ->
+      Error
+        (Printf.sprintf
+           "invalid container_kind %S; expected %s"
+           normalized
+           (String.concat ", " stop_scope_strings))
+;;

--- a/lib/keeper/keeper_sandbox_control_contract.mli
+++ b/lib/keeper/keeper_sandbox_control_contract.mli
@@ -1,0 +1,31 @@
+(** Typed input contract shared by keeper sandbox schemas and handlers. *)
+
+type bounded_float =
+  { minimum : float
+  ; maximum : float
+  ; default : float
+  }
+
+val managed_ttl_sec : bounded_float
+(** Bounds for the lifetime of a managed sandbox container. *)
+
+val operation_timeout_sec : bounded_float
+(** Bounds for sandbox start and stop operation timeouts. *)
+
+val clamp : bounded_float -> float -> float
+(** [clamp bounds value] applies the same inclusive bounds advertised by the
+    JSON schema. *)
+
+type stop_scope =
+  | Stop_managed
+  | Stop_turn
+  | Stop_all
+
+val all_stop_scopes : stop_scope list
+(** Exhaustive ordered set exposed by the sandbox-stop schema. *)
+
+val default_stop_scope : stop_scope
+
+val stop_scope_to_string : stop_scope -> string
+val stop_scope_strings : string list
+val parse_stop_scope : string -> (stop_scope, string) result

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -5,12 +5,22 @@ open Masc_domain
 (** Network mode strings exposed only by explicit sandbox-management tools.
     Keeper creation/update no longer accepts sandbox posture knobs. *)
 let network_mode_enum_strings =
-  [ "none"; "inherit" ]
+  Keeper_types_profile_sandbox.valid_network_mode_strings
+;;
 
-(** Hand-mirrored from [Keeper_sandbox_control]'s typed stop scope. Keeper_schema
-    is upstream of the runtime control module; the descriptor integrity test
-    keeps this JSON Schema enum aligned with the parser constants. *)
-let sandbox_stop_scope_enum_strings = [ "managed"; "turn"; "all" ]
+module Sandbox_contract = Keeper_sandbox_control_contract
+
+let sandbox_stop_scope_enum_strings = Sandbox_contract.stop_scope_strings
+
+let bounded_number_schema (bounds : Sandbox_contract.bounded_float) description =
+  `Assoc
+    [ "type", `String "number"
+    ; "minimum", `Float bounds.minimum
+    ; "maximum", `Float bounds.maximum
+    ; "default", `Float bounds.default
+    ; "description", `String description
+    ]
+;;
 
 (** Issue #8486: hand-mirrored from
     [Keeper_status_detail.valid_tail_order_strings].  Same cycle
@@ -51,20 +61,14 @@ let keeper_schemas : tool_schema list = [
           ("enum", `List (List.map (fun value -> `String value) network_mode_enum_strings));
           ("description", `String "Optional sandbox network mode. Defaults to the keeper's configured network mode.");
         ]);
-        ("ttl_sec", `Assoc [
-          ("type", `String "number");
-          ("minimum", `Float 1.0);
-          ("maximum", `Float 86400.0);
-          ("default", `Float 1800.0);
-          ("description", `String "Managed sandbox lifetime in seconds (default: 1800; clamped to 1-86400).");
-        ]);
-        ("timeout_sec", `Assoc [
-          ("type", `String "number");
-          ("minimum", `Float 1.0);
-          ("maximum", `Float 30.0);
-          ("default", `Float 10.0);
-          ("description", `String "Sandbox start timeout in seconds (default: 10; clamped to 1-30).");
-        ]);
+        ( "ttl_sec",
+          bounded_number_schema
+            Sandbox_contract.managed_ttl_sec
+            "Managed sandbox lifetime in seconds." );
+        ( "timeout_sec",
+          bounded_number_schema
+            Sandbox_contract.operation_timeout_sec
+            "Sandbox start timeout in seconds." );
       ]);
       ("required", `List [`String "name"]);
       ("additionalProperties", `Bool false);
@@ -83,16 +87,16 @@ let keeper_schemas : tool_schema list = [
         ("container_kind", `Assoc [
           ("type", `String "string");
           ("enum", `List (List.map (fun value -> `String value) sandbox_stop_scope_enum_strings));
-          ("default", `String "managed");
+          ( "default",
+            `String
+              (Sandbox_contract.stop_scope_to_string
+                 Sandbox_contract.default_stop_scope) );
           ("description", `String "Container scope to stop: managed, turn, or all (default: managed).");
         ]);
-        ("timeout_sec", `Assoc [
-          ("type", `String "number");
-          ("minimum", `Float 1.0);
-          ("maximum", `Float 30.0);
-          ("default", `Float 10.0);
-          ("description", `String "Sandbox stop timeout in seconds (default: 10; clamped to 1-30).");
-        ]);
+        ( "timeout_sec",
+          bounded_number_schema
+            Sandbox_contract.operation_timeout_sec
+            "Sandbox stop timeout in seconds." );
         ("prune_stale", `Assoc [
           ("type", `String "boolean");
           ("default", `Bool false);

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -6,6 +6,12 @@ open Masc_domain
     Keeper creation/update no longer accepts sandbox posture knobs. *)
 let network_mode_enum_strings =
   [ "none"; "inherit" ]
+
+(** Hand-mirrored from [Keeper_sandbox_control]'s typed stop scope. Keeper_schema
+    is upstream of the runtime control module; the descriptor integrity test
+    keeps this JSON Schema enum aligned with the parser constants. *)
+let sandbox_stop_scope_enum_strings = [ "managed"; "turn"; "all" ]
+
 (** Issue #8486: hand-mirrored from
     [Keeper_status_detail.valid_tail_order_strings].  Same cycle
     constraint — Keeper_schema is upstream of Keeper_status_detail.
@@ -30,6 +36,72 @@ let tool_access_schema description =
   ]
 
 let keeper_schemas : tool_schema list = [
+  {
+    name = "masc_keeper_sandbox_start";
+    description = "Start the managed sandbox container for a keeper.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle whose managed sandbox should be started.");
+        ]);
+        ("network_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List (List.map (fun value -> `String value) network_mode_enum_strings));
+          ("description", `String "Optional sandbox network mode. Defaults to the keeper's configured network mode.");
+        ]);
+        ("ttl_sec", `Assoc [
+          ("type", `String "number");
+          ("minimum", `Float 1.0);
+          ("maximum", `Float 86400.0);
+          ("default", `Float 1800.0);
+          ("description", `String "Managed sandbox lifetime in seconds (default: 1800; clamped to 1-86400).");
+        ]);
+        ("timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("minimum", `Float 1.0);
+          ("maximum", `Float 30.0);
+          ("default", `Float 10.0);
+          ("description", `String "Sandbox start timeout in seconds (default: 10; clamped to 1-30).");
+        ]);
+      ]);
+      ("required", `List [`String "name"]);
+      ("additionalProperties", `Bool false);
+    ];
+  };
+  {
+    name = "masc_keeper_sandbox_stop";
+    description = "Stop the managed sandbox container(s) for a keeper or fleet.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional keeper handle. When omitted, stop matching containers across the active fleet.");
+        ]);
+        ("container_kind", `Assoc [
+          ("type", `String "string");
+          ("enum", `List (List.map (fun value -> `String value) sandbox_stop_scope_enum_strings));
+          ("default", `String "managed");
+          ("description", `String "Container scope to stop: managed, turn, or all (default: managed).");
+        ]);
+        ("timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("minimum", `Float 1.0);
+          ("maximum", `Float 30.0);
+          ("default", `Float 10.0);
+          ("description", `String "Sandbox stop timeout in seconds (default: 10; clamped to 1-30).");
+        ]);
+        ("prune_stale", `Assoc [
+          ("type", `String "boolean");
+          ("default", `Bool false);
+          ("description", `String "Also remove stale managed sandbox containers after the targeted stop.");
+        ]);
+      ]);
+      ("additionalProperties", `Bool false);
+    ];
+  };
   {
     name = "masc_persona_list";
     description = "List available persona profiles that can be used to create keepers via masc_keeper_create_from_persona.";

--- a/lib/keeper/keeper_schema.mli
+++ b/lib/keeper/keeper_schema.mli
@@ -6,6 +6,9 @@
 val network_mode_enum_strings : string list
 (** Allowed values for explicit sandbox-management tool inputs. *)
 
+val sandbox_stop_scope_enum_strings : string list
+(** Allowed container scopes for the explicit sandbox-stop tool. *)
+
 
 val tail_order_enum_strings : string list
 (** Allowed values for log-tail ordering options. *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -976,11 +976,10 @@ let find_masc_schema_opt name =
 let find_cluster_schema_opt name =
   (* Priority preserves the historical hidden keeper namespace ownership:
      keeper taskboard wrappers first, then typed board wrappers, voice,
-     the generated misc/control registry, then public masc_* aggregates.
+     the generated misc registry, then public masc_* aggregates.
      The namespaces are expected to be disjoint; this order is not a conflict
-     resolver. [masc_pause]/[masc_resume] deliberately stay out of Config's
-     public schema list, so their canonical Tool_schemas_misc definitions must
-     be read directly rather than replaced by a permissive placeholder. *)
+     resolver. Control descriptors use their dedicated typed schema projection
+     and do not enter this name-based lookup. *)
   match find_taskboard_schema_opt name with
   | Some _ as schema -> schema
   | None ->
@@ -1518,14 +1517,17 @@ let masc_misc_descriptor id name description ~readonly =
     ()
 ;;
 
-let masc_control_descriptor id name description ~readonly =
-  cluster_descriptor
+let masc_control_descriptor operation =
+  let schema = Tool_schemas_misc.control_schema operation in
+  cluster_descriptor_with_schema_source
     ~keeper_model_projection:Dispatch_only
-    ~id:("masc.control." ^ id)
-    ~name
-    ~description
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:("masc.control." ^ Tool_schemas_misc.control_operation_id operation)
+    ~name:schema.name
+    ~description:schema.description
     ~handler:Tool_masc_control_dispatch
-    ~readonly
+    ~readonly:false
     ~inline_safe:false
     ~maintenance_only:false
     ()
@@ -2070,10 +2072,8 @@ let internal_descriptors : t list =
      duplicate internal descriptors here; that would make runtime receipt
      projection depend on list order. *)
   (* ── RFC-0182 §3.1 — masc_control_* cluster (2 entries) ──────── *)
-  ; masc_control_descriptor "pause" "masc_pause"
-      "Pause a paused/runnable agent." ~readonly:false
-  ; masc_control_descriptor "resume" "masc_resume"
-      "Resume a paused agent." ~readonly:false
+  ; masc_control_descriptor Tool_schemas_misc.Pause
+  ; masc_control_descriptor Tool_schemas_misc.Resume
   (* ── RFC-0182 §3.1 — masc_agent_timeline singleton (1 entry) ── *)
   ; masc_agent_timeline_descriptor "masc_agent_timeline"
       "Read agent timeline events." ~readonly:true

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -2115,11 +2115,14 @@ let internal_descriptors : t list =
   ; masc_keeper_descriptor "up" "masc_keeper_up"
       "Bring a keeper online (create new or update existing)." ~readonly:false
   (* ── RFC-0182 §3.1 — masc_surface_audit singleton ────────────── *)
-  ; cluster_descriptor
+  ; let schema = Tool_schemas_misc.surface_audit_schema ~remote:false in
+    cluster_descriptor_with_schema_source
       ~keeper_model_projection:Internal_name
+      ~input_schema_source:Canonical_registry
+      ~input_schema:schema.input_schema
       ~id:"masc.surface.audit"
-      ~name:"masc_surface_audit"
-      ~description:"Read dashboard surface readiness snapshot (optionally for a single surface)."
+      ~name:schema.name
+      ~description:schema.description
       ~handler:Tool_masc_surface_audit
       ~readonly:true
       ~inline_safe:false

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -250,8 +250,17 @@ let keeper_sandbox_start_body ~(config : Workspace.config) args : tool_result =
   match resolve_keeper_meta_config ~config args with
   | Error err -> tool_result_error err
   | Ok meta ->
-      let timeout_sec = Stdlib.Float.min 30.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 10.0)) in
-      let ttl_sec = Stdlib.Float.min 86_400.0 (Stdlib.Float.max 1.0 (get_float args "ttl_sec" 1800.0)) in
+      let module Contract = Keeper_sandbox_control_contract in
+      let timeout_sec =
+        Contract.clamp
+          Contract.operation_timeout_sec
+          (get_float args "timeout_sec" Contract.operation_timeout_sec.default)
+      in
+      let ttl_sec =
+        Contract.clamp
+          Contract.managed_ttl_sec
+          (get_float args "ttl_sec" Contract.managed_ttl_sec.default)
+      in
       let network_mode_raw =
         String.trim
           (get_string args "network_mode"
@@ -281,7 +290,12 @@ let handle_keeper_sandbox_start ctx args : tool_result =
 
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_sandbox_stop_body ~(config : Workspace.config) args : tool_result =
-  let timeout_sec = Stdlib.Float.min 30.0 (Stdlib.Float.max 1.0 (get_float args "timeout_sec" 10.0)) in
+  let module Contract = Keeper_sandbox_control_contract in
+  let timeout_sec =
+    Contract.clamp
+      Contract.operation_timeout_sec
+      (get_float args "timeout_sec" Contract.operation_timeout_sec.default)
+  in
   let prune_stale = get_bool args "prune_stale" false in
   let container_kind_raw =
     get_string args "container_kind" Keeper_sandbox_control.managed_kind

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -143,23 +143,7 @@ let digest_schema ~remote =
         ];
   }
 
-let surface_audit_schema ~remote =
-  {
-    name = "masc_surface_audit";
-    description =
-      if remote then
-        "Read dashboard surface readiness, exposure policy, and evidence references. Use this before pointing operators to an experimental surface."
-      else
-        "Read dashboard surface readiness, exposure policy, and evidence references. Use this to decide whether a surface belongs in main navigation, Lab, or should stay hidden.";
-    input_schema =
-      `Assoc
-        [
-          ("type", `String "object");
-          ( "properties",
-            schema_properties
-              [ ("surface_id", `Assoc [ ("type", `String "string") ]) ] );
-        ];
-  }
+let surface_audit_schema = Tool_schemas_misc.surface_audit_schema
 
 let action_schema ~remote =
   {

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -146,8 +146,8 @@ let handle_pause_status ~tool_name ~start_time ctx _args : Tool_result.result =
   text_ok ~tool_name ~start_time (Yojson.Safe.to_string payload)
 ;;
 
-(* schemas removed in RFC-0057 PR-1 — masc_pause / masc_resume are emitted
-   via Tool_descriptors_gen (Tool_schemas_misc.schemas chain). *)
+(* Schemas are generated from the RFC-0057 specs and projected through
+   [Tool_schemas_misc.control_schemas]. *)
 
 (* Dispatch function *)
 let dispatch ctx ~name ~args : Tool_result.result option =
@@ -166,23 +166,18 @@ let dispatch ctx ~name ~args : Tool_result.result option =
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-(* RFC-0057 PR-1: control tool schemas now come from
-   Tool_descriptors_gen via Tool_schemas_misc.schemas. Filter to the
-   two control tools so they register with Mod_control. *)
+(* Control schemas have a dedicated typed projection because they must remain
+   registered with [Mod_control] while staying outside Config's public/front-door
+   inventory. *)
 let () =
-  let is_control = function
-    | "masc_pause" | "masc_resume" -> true
-    | _ -> false
-  in
   List.iter
     (fun (s : Masc_domain.tool_schema) ->
-      if is_control s.name then
-        Tool_spec.register
-          (Tool_spec.create
-             ~name:s.name
-             ~description:s.description
-             ~module_tag:Tool_dispatch.Mod_control
-             ~input_schema:s.input_schema
-             ~handler_binding:Tag_dispatch
-             ()))
-    Tool_schemas_misc.schemas
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:s.name
+           ~description:s.description
+           ~module_tag:Tool_dispatch.Mod_control
+           ~input_schema:s.input_schema
+           ~handler_binding:Tag_dispatch
+           ()))
+    Tool_schemas_misc.control_schemas

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -37,7 +37,27 @@ let config_category_enum_strings =
   ]
 ;;
 
-(* [schemas] is the generated misc schema set. Descriptor-owned web backend
+type control_operation =
+  | Pause
+  | Resume
+
+let control_operations = [ Pause; Resume ]
+
+let control_operation_id = function
+  | Pause -> "pause"
+  | Resume -> "resume"
+;;
+
+let control_schema = function
+  | Pause -> Tool_descriptors_gen.masc_pause_schema
+  | Resume -> Tool_descriptors_gen.masc_resume_schema
+;;
+
+let control_schemas = List.map control_schema control_operations
+
+(* [schemas] is the generated public misc schema set. Operator control schemas
+   use the dedicated typed projection above so they remain registered without
+   entering Config's public/front-door inventory. Descriptor-owned web backend
    names (masc_web_search / masc_web_fetch) are intentionally not generated
    here; [Config.raw_all_tool_schemas] projects them from
    [Keeper_tool_descriptor.public_descriptors] so the keeper universe still

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -55,6 +55,23 @@ let control_schema = function
 
 let control_schemas = List.map control_schema control_operations
 
+let surface_audit_schema ~remote =
+  { name = "masc_surface_audit"
+  ; description =
+      (if remote
+       then
+         "Read dashboard surface readiness, exposure policy, and evidence references. Use this before pointing operators to an experimental surface."
+       else
+         "Read dashboard surface readiness, exposure policy, and evidence references. Use this to decide whether a surface belongs in main navigation, Lab, or should stay hidden.")
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; "properties", `Assoc [ "surface_id", `Assoc [ "type", `String "string" ] ]
+        ; "additionalProperties", `Bool false
+        ]
+  }
+;;
+
 (* [schemas] is the generated public misc schema set. Operator control schemas
    use the dedicated typed projection above so they remain registered without
    entering Config's public/front-door inventory. Descriptor-owned web backend

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -54,6 +54,11 @@ val control_schemas : Masc_domain.tool_schema list
 (** Canonical control schemas used by registration. These schemas are
     intentionally excluded from {!schemas} and the Config front-door inventory. *)
 
+val surface_audit_schema : remote:bool -> Masc_domain.tool_schema
+(** Canonical surface-audit schema shared by the local operator, remote
+    operator, and keeper descriptor projections. The input contract is
+    identical on every surface; only operator guidance differs. *)
+
 val schemas : Masc_domain.tool_schema list
 (** [schemas] is the generated [Masc_domain.tool_schema list] for misc tools.
     Operator controls are intentionally available only through

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -36,8 +36,28 @@ val config_category_enum_strings : string list
 
 (** {1 Tool schema list} *)
 
+type control_operation =
+  | Pause
+  | Resume
+(** Closed set of operator control tools. *)
+
+val control_operations : control_operation list
+(** Exhaustive typed projection of operator control operations. *)
+
+val control_operation_id : control_operation -> string
+(** Stable descriptor identifier suffix for a control operation. *)
+
+val control_schema : control_operation -> Masc_domain.tool_schema
+(** Canonical generated schema for a control operation. *)
+
+val control_schemas : Masc_domain.tool_schema list
+(** Canonical control schemas used by registration. These schemas are
+    intentionally excluded from {!schemas} and the Config front-door inventory. *)
+
 val schemas : Masc_domain.tool_schema list
 (** [schemas] is the generated [Masc_domain.tool_schema list] for misc tools.
+    Operator controls are intentionally available only through
+    {!control_schemas}; they do not enter the Config front-door inventory.
     Descriptor-owned web backend names ([masc_web_search] / [masc_web_fetch])
     are intentionally projected into {!Config.raw_all_tool_schemas} from
     [Keeper_tool_descriptor.public_descriptors] instead of duplicated here.

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -590,19 +590,19 @@ let test_sandbox_control_descriptors_use_exact_canonical_schemas () =
     (schema_property_enum_strings start_schema "network_mode");
   check_json
     "sandbox start ttl default"
-    (`Float 1800.0)
+    (`Float Masc.Keeper_sandbox_control_contract.managed_ttl_sec.default)
     (schema_property_field start_schema "ttl_sec" "default");
   check_json
     "sandbox start ttl minimum"
-    (`Float 1.0)
+    (`Float Masc.Keeper_sandbox_control_contract.managed_ttl_sec.minimum)
     (schema_property_field start_schema "ttl_sec" "minimum");
   check_json
     "sandbox start ttl maximum"
-    (`Float 86400.0)
+    (`Float Masc.Keeper_sandbox_control_contract.managed_ttl_sec.maximum)
     (schema_property_field start_schema "ttl_sec" "maximum");
   check_json
     "sandbox start timeout default"
-    (`Float 10.0)
+    (`Float Masc.Keeper_sandbox_control_contract.operation_timeout_sec.default)
     (schema_property_field start_schema "timeout_sec" "default");
   let stop_schema =
     check_descriptor
@@ -611,22 +611,17 @@ let test_sandbox_control_descriptors_use_exact_canonical_schemas () =
       []
   in
   let runtime_stop_scopes =
-    [ Masc.Keeper_sandbox_control.managed_kind
-    ; Masc.Keeper_sandbox_control.turn_kind
-    ; Masc.Keeper_sandbox_control.all_kind
-    ]
+    Masc.Keeper_sandbox_control_contract.stop_scope_strings
   in
-  Alcotest.(check (list string))
-    "sandbox stop schema mirror matches the runtime parser"
-    runtime_stop_scopes
-    Masc.Keeper_schema.sandbox_stop_scope_enum_strings;
   Alcotest.(check (list string))
     "sandbox stop enum matches the runtime parser"
     runtime_stop_scopes
     (schema_property_enum_strings stop_schema "container_kind");
   check_json
     "sandbox stop scope default"
-    (`String Masc.Keeper_sandbox_control.managed_kind)
+    (`String
+      (Masc.Keeper_sandbox_control_contract.stop_scope_to_string
+         Masc.Keeper_sandbox_control_contract.default_stop_scope))
     (schema_property_field stop_schema "container_kind" "default");
   check_json
     "sandbox stop prune default"
@@ -634,7 +629,7 @@ let test_sandbox_control_descriptors_use_exact_canonical_schemas () =
     (schema_property_field stop_schema "prune_stale" "default");
   check_json
     "sandbox stop timeout default"
-    (`Float 10.0)
+    (`Float Masc.Keeper_sandbox_control_contract.operation_timeout_sec.default)
     (schema_property_field stop_schema "timeout_sec" "default")
 ;;
 

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -519,6 +519,17 @@ let schema_property_names schema =
       (Yojson.Safe.to_string other)
 ;;
 
+let schema_property_field schema property field =
+  let open Yojson.Safe.Util in
+  schema |> member "properties" |> member property |> member field
+;;
+
+let schema_property_enum_strings schema property =
+  let open Yojson.Safe.Util in
+  schema |> member "properties" |> member property |> member "enum" |> to_list
+  |> List.map to_string
+;;
+
 let schema_forbids_additional_properties schema =
   match schema with
   | `Assoc fields ->
@@ -526,6 +537,105 @@ let schema_forbids_additional_properties schema =
      | Some (`Bool false) -> true
      | _ -> false)
   | other -> Alcotest.failf "input_schema is not an object: %s" (Yojson.Safe.to_string other)
+;;
+
+let required_keeper_schema name =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
+      Masc.Keeper_schema.schemas
+  with
+  | Some schema -> schema
+  | None -> Alcotest.failf "missing keeper schema: %s" name
+;;
+
+let test_sandbox_control_descriptors_use_exact_canonical_schemas () =
+  let check_json label expected actual =
+    Alcotest.(check bool) label true (Yojson.Safe.equal expected actual)
+  in
+  let check_descriptor name expected_properties expected_required =
+    let descriptor = required_internal_descriptor name in
+    let canonical = required_keeper_schema name in
+    Alcotest.(check bool)
+      (name ^ " uses the canonical registry")
+      true
+      (descriptor.input_schema_source = Descriptor.Canonical_registry);
+    check_json
+      (name ^ " descriptor preserves the owning schema")
+      canonical.input_schema
+      descriptor.input_schema;
+    Alcotest.(check (list string))
+      (name ^ " exposes exactly the handler arguments")
+      (List.sort String.compare expected_properties)
+      (List.sort String.compare (schema_property_names descriptor.input_schema));
+    Alcotest.(check (list string))
+      (name ^ " required arguments match the handler")
+      expected_required
+      (schema_required_fields descriptor.input_schema);
+    Alcotest.(check bool)
+      (name ^ " rejects unknown arguments")
+      true
+      (schema_forbids_additional_properties descriptor.input_schema);
+    descriptor.input_schema
+  in
+  let start_schema =
+    check_descriptor
+      "masc_keeper_sandbox_start"
+      [ "name"; "network_mode"; "ttl_sec"; "timeout_sec" ]
+      [ "name" ]
+  in
+  Alcotest.(check (list string))
+    "sandbox start network modes match the owning keeper contract"
+    Masc.Keeper_schema.network_mode_enum_strings
+    (schema_property_enum_strings start_schema "network_mode");
+  check_json
+    "sandbox start ttl default"
+    (`Float 1800.0)
+    (schema_property_field start_schema "ttl_sec" "default");
+  check_json
+    "sandbox start ttl minimum"
+    (`Float 1.0)
+    (schema_property_field start_schema "ttl_sec" "minimum");
+  check_json
+    "sandbox start ttl maximum"
+    (`Float 86400.0)
+    (schema_property_field start_schema "ttl_sec" "maximum");
+  check_json
+    "sandbox start timeout default"
+    (`Float 10.0)
+    (schema_property_field start_schema "timeout_sec" "default");
+  let stop_schema =
+    check_descriptor
+      "masc_keeper_sandbox_stop"
+      [ "container_kind"; "name"; "prune_stale"; "timeout_sec" ]
+      []
+  in
+  let runtime_stop_scopes =
+    [ Masc.Keeper_sandbox_control.managed_kind
+    ; Masc.Keeper_sandbox_control.turn_kind
+    ; Masc.Keeper_sandbox_control.all_kind
+    ]
+  in
+  Alcotest.(check (list string))
+    "sandbox stop schema mirror matches the runtime parser"
+    runtime_stop_scopes
+    Masc.Keeper_schema.sandbox_stop_scope_enum_strings;
+  Alcotest.(check (list string))
+    "sandbox stop enum matches the runtime parser"
+    runtime_stop_scopes
+    (schema_property_enum_strings stop_schema "container_kind");
+  check_json
+    "sandbox stop scope default"
+    (`String Masc.Keeper_sandbox_control.managed_kind)
+    (schema_property_field stop_schema "container_kind" "default");
+  check_json
+    "sandbox stop prune default"
+    (`Bool false)
+    (schema_property_field stop_schema "prune_stale" "default");
+  check_json
+    "sandbox stop timeout default"
+    (`Float 10.0)
+    (schema_property_field stop_schema "timeout_sec" "default")
 ;;
 
 let required_board_schema name =
@@ -1519,6 +1629,10 @@ let () =
             "cluster descriptors have no missing canonical schemas"
             `Quick
             test_cluster_descriptors_have_no_missing_canonical_schemas
+        ; test_case
+            "sandbox control descriptors use exact canonical schemas"
+            `Quick
+            test_sandbox_control_descriptors_use_exact_canonical_schemas
         ; test_case
             "missing canonical schema is fail-closed"
             `Quick

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -92,17 +92,20 @@ let test_masc_board_post_resolves () =
       fail (Printf.sprintf "masc_board_post should resolve, got Unknown (tried: %s)"
               (TR.string_of_tried tried))
 
-let test_system_internal_hidden_tool_resolves () =
+let test_hidden_descriptor_precedes_system_internal_fallback () =
   (* masc_gc is a system-internal tool (tool_misc dispatch, hidden from keeper
-     surfaces). Before the System_internal source it resolved to Unknown, so the
-     prompt-token integrity scanner stripped it from continuity prose and emitted
-     ~33 false "stripped masc token masc_gc" WARNs/day for keeper taskmaster. It
-     is a real tool and must now resolve via System_internal. *)
+     surfaces). It also has a dispatch-only descriptor, which is earlier in the
+     resolution chain. Keep the current provenance explicit while asserting that
+     the System_internal fallback still independently recognizes the real tool. *)
   match TR.resolve "masc_gc" with
-  | TR.Resolved { via = TR.System_internal; canonical } ->
-      check string "canonical preserved" "masc_gc" canonical
+  | TR.Resolved { via = TR.Descriptor_registry; canonical } ->
+      check string "canonical preserved" "masc_gc" canonical;
+      check bool
+        "system-internal fallback also admits masc_gc"
+        true
+        (List.mem TR.System_internal (TR.all_admitting_sources "masc_gc"))
   | TR.Resolved { via; _ } | TR.Alias_to { via; _ } ->
-      fail (Printf.sprintf "masc_gc resolved via %s; expected System_internal"
+      fail (Printf.sprintf "masc_gc resolved via %s; expected Descriptor_registry"
               (TR.string_of_tried_source via))
   | TR.Unknown { tried; _ } ->
       fail (Printf.sprintf
@@ -335,7 +338,7 @@ let () =
         test_case "tool_execute resolves" `Quick test_tool_execute_resolves;
         test_case "masc_keeper_* cluster resolves via descriptor registry (boot guard)" `Quick test_descriptor_registry_admits_masc_keeper_cluster;
         test_case "masc_board_post resolves" `Quick test_masc_board_post_resolves;
-        test_case "system-internal hidden tool (masc_gc) resolves via System_internal" `Quick test_system_internal_hidden_tool_resolves;
+        test_case "masc_gc descriptor precedes the system-internal fallback" `Quick test_hidden_descriptor_precedes_system_internal_fallback;
       ]
     ; "policy_validation", [
         test_case "known tools resolve" `Quick test_policy_validation_known_tools_resolve;

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -191,6 +191,39 @@ let () =
       assert (Tool_control.dispatch ctx ~name:"masc_tool_disable" ~args = None))
 
 let () =
+  test "control_schema_projection_registers_without_front_door_exposure" (fun () ->
+      let raw_names =
+        List.map
+          (fun (schema : Masc_domain.tool_schema) -> schema.name)
+          Config.raw_all_tool_schemas
+      in
+      let public_names = Config.all_tool_names () in
+      List.iter
+        (fun operation ->
+           let schema = Tool_schemas_misc.control_schema operation in
+           (match Tool_dispatch.lookup_tag schema.name with
+            | Some Tool_dispatch.Mod_control -> ()
+            | Some _ ->
+              Alcotest.failf "%s registered with the wrong module tag" schema.name
+            | None -> Alcotest.failf "%s is not registered" schema.name);
+           (match Tool_dispatch.lookup_schema schema.name with
+            | Some registered ->
+              Alcotest.(check bool)
+                (schema.name ^ " registration keeps canonical input schema")
+                true
+                (Yojson.Safe.equal schema.input_schema registered)
+            | None -> Alcotest.failf "%s has no registered input schema" schema.name);
+           Alcotest.(check bool)
+             (schema.name ^ " stays out of Config.raw_all_tool_schemas")
+             false
+             (List.mem schema.name raw_names);
+           Alcotest.(check bool)
+             (schema.name ^ " stays out of Config.all_tool_names")
+             false
+             (List.mem schema.name public_names))
+        Tool_schemas_misc.control_operations)
+
+let () =
   test "get_string_present" (fun () ->
       let args = `Assoc [ ("key", `String "value") ] in
       assert (Tool_args.get_string args "key" "default" = "value"))

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -82,7 +82,7 @@ let test_masc_spawn_is_not_generated () =
     (has_schema "masc_spawn" Tool_schemas_misc.schemas)
 ;;
 
-let test_control_schemas_are_generated () =
+let test_control_schemas_use_dedicated_typed_projection () =
   let properties schema =
     match schema.input_schema with
     | `Assoc fields ->
@@ -91,8 +91,36 @@ let test_control_schemas_are_generated () =
        | _ -> Alcotest.failf "%s has no object properties" schema.name)
     | _ -> Alcotest.failf "%s has a non-object schema" schema.name
   in
-  let pause = find_by_name "masc_pause" Tool_descriptors_gen.schemas in
-  let resume = find_by_name "masc_resume" Tool_descriptors_gen.schemas in
+  let pause = Tool_schemas_misc.control_schema Tool_schemas_misc.Pause in
+  let resume = Tool_schemas_misc.control_schema Tool_schemas_misc.Resume in
+  Alcotest.check
+    yojson_testable
+    "pause projection keeps generated canonical schema"
+    Tool_descriptors_gen.masc_pause_schema.input_schema
+    pause.input_schema;
+  Alcotest.check
+    yojson_testable
+    "resume projection keeps generated canonical schema"
+    Tool_descriptors_gen.masc_resume_schema.input_schema
+    resume.input_schema;
+  Alcotest.(check (list string))
+    "typed control projection is exhaustive"
+    [ "masc_pause"; "masc_resume" ]
+    (List.map
+       (fun operation ->
+          (Tool_schemas_misc.control_schema operation).name)
+       Tool_schemas_misc.control_operations);
+  List.iter
+    (fun name ->
+       Alcotest.(check bool)
+         (name ^ " absent from generated public misc schemas")
+         false
+         (has_schema name Tool_descriptors_gen.schemas);
+       Alcotest.(check bool)
+         (name ^ " absent from effective public misc schemas")
+         false
+         (has_schema name Tool_schemas_misc.schemas))
+    [ "masc_pause"; "masc_resume" ];
   Alcotest.(check bool)
     "masc_pause has reason property"
     true
@@ -358,9 +386,9 @@ let () =
         ] )
     ; ( "control schema SSOT"
       , [ Alcotest.test_case
-            "pause and resume are generated"
+            "pause and resume use a dedicated typed projection"
             `Quick
-            test_control_schemas_are_generated
+            test_control_schemas_use_dedicated_typed_projection
         ] )
     ; ( "masc_tool_help field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_tool_help_name_matches


### PR DESCRIPTION
## Summary

- keep generated pause/resume records canonical but project them through a closed control_operation type outside the general misc schema list
- make Tool_control registration and Keeper descriptors consume that one typed control projection
- add exact canonical Keeper schemas for sandbox_start and sandbox_stop using the real handler arguments, enum values, defaults, and bounds
- update integrity tests so every cluster descriptor must resolve a real owning schema and controls remain outside Config front-door inventory

## Why

Merged #24123 entered main with Build/Test and CI Gate red. Exact failures proved two P1 boundaries: masc_keeper_sandbox_start had Missing_canonical_registry and disappeared from the Keeper model surface, while pause/resume were inserted into the broad generated aggregate and leaked into Config public inventory. The all-descriptor contract also exposed the mechanically identical missing sandbox_stop schema.

## Design

- no placeholder schema and no flag-only lie
- no raw name filter for control registration
- controls have a closed Pause/Resume projection
- sandbox start/stop schemas are owned by Keeper_schema and compared field-for-field with runtime parser constants
- masc_gc production resolution remains unchanged; its dual-authority provenance is a separate P2 follow-up

## Verification

- parser checks: 11/11 changed ml/mli files pass
- ocamlformat --check: pass
- test coverage gate: pass
- git diff/show checks and added-line hazard scan: pass
- focused Dune execution is blocked by unrelated interactive bare dune build . PID 28037; it was not killed or bypassed
- PR CI is the build/runtime authority before merge

## Gate

Draft + p1 + root-cause:SSOT + status:do-not-merge until exact-head Build/Test and adversarial review are green.

Follow-up to #24123.