### PR TITLE
fix(keeper): fail closed across profile projections

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -43,8 +43,15 @@ let keeper_names (config : Workspace.config) =
 let keeper_count (config : Workspace.config) : int =
   List.length (keeper_names config)
 
+let configured_runtime_keeper_names config =
+  Keeper_meta_store.configured_keeper_names config
+  |> List.filter (fun name ->
+       Keeper_types_profile.keeper_profile_defaults_materializable_for_name
+         ~base_path:config.Workspace.base_path
+         name)
+
 let configured_keeper_count (config : Workspace.config) : int =
-  List.length (Keeper_meta_store.configured_keeper_names config)
+  List.length (configured_runtime_keeper_names config)
 
 let non_empty_trimmed_string_opt value =
   let trimmed = String.trim value in

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -161,9 +161,31 @@ let keeper_toml_path_opt name =
 let keeper_toml_path_opt_for_base_path ~base_path name =
   Config_dir_resolver.keeper_toml_path_opt_for_base_path ~base_path name
 
-let load_keeper_profile_defaults_from_persona_dirs ~persona_dirs name
-    : keeper_profile_defaults =
+let persona_load_error_to_profile_error
+    ?keeper_path
+    (error : Keeper_types_profile_persona_defaults.load_error) =
+  let kind =
+    match error.kind with
+    | Keeper_types_profile_persona_defaults.Persona_read_error -> Read_error
+    | Keeper_types_profile_persona_defaults.Persona_parse_error -> Parse_error
+  in
+  let keeper_path =
+    match keeper_path with
+    | Some keeper_path -> keeper_path
+    | None -> error.path
+  in
+  { keeper_path
+  ; failing_path = error.path
+  ; kind
+  ; detail = error.detail
+  }
+
+let load_keeper_profile_defaults_from_persona_dirs
+    ?keeper_path
+    ~persona_dirs
+    name =
   Keeper_types_profile_persona_defaults.load_from_dirs ~persona_dirs ~name
+  |> Result.map_error (persona_load_error_to_profile_error ?keeper_path)
 
 let safe_persona_dirs ?base_path () =
   try
@@ -204,18 +226,21 @@ let load_keeper_profile_defaults_result_uncached_with_paths
        | Ok (_name, defaults) -> (
            match defaults.persona_name with
            | Some persona_name ->
-               let persona_defaults =
-                 load_keeper_profile_defaults_from_persona_dirs
-                   ~persona_dirs
-                   persona_name
-               in
-               Ok
-                 (merge_keeper_profile_defaults ~agent_name:name
-                    ~base:persona_defaults ~overlay:defaults)
+               (match
+                  load_keeper_profile_defaults_from_persona_dirs
+                    ~keeper_path:toml_path
+                    ~persona_dirs
+                    persona_name
+                with
+                | Error _ as error -> error
+                | Ok persona_defaults ->
+                  Ok
+                    (merge_keeper_profile_defaults ~agent_name:name
+                       ~base:persona_defaults ~overlay:defaults))
            | None -> Ok defaults)
        | Error e -> Error e)
     | None ->
-      Ok (load_keeper_profile_defaults_from_persona_dirs ~persona_dirs name)
+      load_keeper_profile_defaults_from_persona_dirs ~persona_dirs name
   in
   result
 
@@ -591,15 +616,21 @@ let keeper_default_source_snapshot ~base_path name : keeper_default_source_snaps
           ; config_error = Some e
           })
   | None ->
-      let defaults =
-        load_keeper_profile_defaults_from_persona_dirs
-          ~persona_dirs:(safe_persona_dirs ~base_path ())
-          name
-      in
-      let source_kind =
-        if Option.is_some defaults.manifest_path then Some "persona" else None
-      in
-      { source_kind; defaults; config_error = None }
+      (match
+         load_keeper_profile_defaults_from_persona_dirs
+           ~persona_dirs:(safe_persona_dirs ~base_path ())
+           name
+       with
+       | Error config_error ->
+         { source_kind = None
+         ; defaults = empty_keeper_profile_defaults
+         ; config_error = Some config_error
+         }
+       | Ok defaults ->
+         let source_kind =
+           if Option.is_some defaults.manifest_path then Some "persona" else None
+         in
+         { source_kind; defaults; config_error = None })
 
 let persona_description_max_chars =
   Keeper_types_profile_persona.persona_description_max_chars

--- a/lib/keeper/keeper_types_profile_persona_defaults.ml
+++ b/lib/keeper/keeper_types_profile_persona_defaults.ml
@@ -1,14 +1,28 @@
 open Keeper_types_profile_defaults
 module Normalizers = Keeper_types_profile_toml_normalizers
 
-let load_from_path ~name path : keeper_profile_defaults =
-  match Safe_ops.read_json_file_logged ~label:"load_keeper_profile_defaults" path with
-  | None -> empty_keeper_profile_defaults
-  | Some json ->
+type load_error_kind =
+  | Persona_read_error
+  | Persona_parse_error
+
+type load_error =
+  { path : string
+  ; kind : load_error_kind
+  ; detail : string
+  }
+
+let load_from_path ~name path : (keeper_profile_defaults, load_error) result =
+  let error kind detail = Error { path; kind; detail } in
+  match Safe_ops.read_file_safe path with
+  | Error detail -> error Persona_read_error detail
+  | Ok content ->
+    (match Safe_ops.parse_json_safe ~context:path content with
+     | Error detail -> error Persona_parse_error detail
+     | Ok json ->
       if
         Keeper_types_profile_persona.reject_placeholder_persona_profile
           ~label:"load_keeper_profile_defaults" ~path json
-      then empty_keeper_profile_defaults
+      then Ok empty_keeper_profile_defaults
       else
         let keeper_json =
           match Json_util.assoc_member_opt "keeper" json with
@@ -33,7 +47,8 @@ let load_from_path ~name path : keeper_profile_defaults =
          | None -> ());
         match keeper_json with
         | `Assoc _ ->
-            {
+            Ok
+              {
               id = Some (Ids.Keeper_id.generate ~name ~path);
               manifest_path = Some path;
               persona_name = Some name;
@@ -67,12 +82,12 @@ let load_from_path ~name path : keeper_profile_defaults =
               always_approve = Safe_ops.json_bool_opt "always_approve" keeper_json;
               oas_env = [];
               unknown_toml_keys = [];
-            }
-        | _ -> { empty_keeper_profile_defaults with manifest_path = Some path }
+              }
+        | _ -> Ok { empty_keeper_profile_defaults with manifest_path = Some path })
 
-let load_from_dirs ~persona_dirs ~name : keeper_profile_defaults =
+let load_from_dirs ~persona_dirs ~name : (keeper_profile_defaults, load_error) result =
   match
     Keeper_types_profile_persona.persona_profile_path_opt_in_dirs persona_dirs name
   with
-  | None -> empty_keeper_profile_defaults
+  | None -> Ok empty_keeper_profile_defaults
   | Some path -> load_from_path ~name path

--- a/lib/keeper/keeper_types_profile_persona_defaults.mli
+++ b/lib/keeper/keeper_types_profile_persona_defaults.mli
@@ -4,7 +4,17 @@
     remains outside persona profiles. Persona prompt fields are loaded as
     defaults and may be overridden by keeper TOML overlays. *)
 
+type load_error_kind =
+  | Persona_read_error
+  | Persona_parse_error
+
+type load_error =
+  { path : string
+  ; kind : load_error_kind
+  ; detail : string
+  }
+
 val load_from_dirs :
   persona_dirs:string list ->
   name:string ->
-  Keeper_types_profile_defaults.keeper_profile_defaults
+  (Keeper_types_profile_defaults.keeper_profile_defaults, load_error) result

--- a/lib/keeper/keeper_types_profile_toml_io.ml
+++ b/lib/keeper/keeper_types_profile_toml_io.ml
@@ -25,7 +25,7 @@ let keeper_toml_load_error_to_string error =
   then Printf.sprintf "%s: %s" error.failing_path error.detail
   else
     Printf.sprintf
-      "%s: keeper.base %s failed: %s"
+      "%s: profile dependency %s failed: %s"
       error.keeper_path
       error.failing_path
       error.detail

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1013,6 +1013,47 @@ let test_persona_without_keeper_toml_remains_valid () =
     check (option string) "persona manifest" (Some profile_path)
       defaults.manifest_path
 
+let test_persona_parse_failure_is_typed_profile_error () =
+  with_profile_base @@ fun ~base_path ~config_dir ~keepers_dir ->
+  let persona_dir = Filename.concat (Filename.concat config_dir "personas") "analyst" in
+  mkdir_p persona_dir;
+  let profile_path = Filename.concat persona_dir "profile.json" in
+  write_file profile_path "{invalid-json";
+  let keeper_path = Filename.concat keepers_dir "reviewer.toml" in
+  write_file keeper_path
+    "[keeper]\npersona_name = \"analyst\"\nautoboot_enabled = true\n";
+  match
+    KTP.load_keeper_profile_defaults_result_for_base_path
+      ~base_path
+      "reviewer"
+  with
+  | Ok _ -> fail "malformed persona profile must fail before defaults projection"
+  | Error error ->
+    check bool "persona parse error kind" true (error.kind = KTP.Parse_error);
+    check string "keeper TOML retains dependency owner" keeper_path error.keeper_path;
+    check string "persona profile is the failing path" profile_path error.failing_path;
+    check bool "error reports profile dependency" true
+      (contains_substring
+         (KTP.keeper_toml_load_error_to_string error)
+         "profile dependency")
+
+let test_persona_read_failure_is_typed_profile_error () =
+  with_profile_base @@ fun ~base_path ~config_dir ~keepers_dir:_ ->
+  let persona_dir = Filename.concat (Filename.concat config_dir "personas") "analyst" in
+  mkdir_p persona_dir;
+  let profile_path = Filename.concat persona_dir "profile.json" in
+  Unix.mkdir profile_path 0o755;
+  match
+    KTP.load_keeper_profile_defaults_result_for_base_path
+      ~base_path
+      "analyst"
+  with
+  | Ok _ -> fail "unreadable persona profile must fail before defaults projection"
+  | Error error ->
+    check bool "persona read error kind" true (error.kind = KTP.Read_error);
+    check string "standalone persona owns load" profile_path error.keeper_path;
+    check string "unreadable persona is the failing path" profile_path error.failing_path
+
 let test_keeper_config_directory_probe_is_typed () =
   let path = Filename.temp_file "keeper-config-not-dir" ".toml" in
   Fun.protect
@@ -2064,6 +2105,10 @@ let () =
             test_absent_profile_is_legitimate_empty_defaults;
           test_case "persona without keeper TOML remains valid" `Quick
             test_persona_without_keeper_toml_remains_valid;
+          test_case "persona parse failure is typed" `Quick
+            test_persona_parse_failure_is_typed_profile_error;
+          test_case "persona read failure is typed" `Quick
+            test_persona_read_failure_is_typed_profile_error;
           test_case "config directory probe is typed" `Quick
             test_keeper_config_directory_probe_is_typed;
         ] );


### PR DESCRIPTION
## Summary

- restore `configured_keepers` counting to the existing materializable Keeper profile SSOT so disabled base profiles are excluded
- replace persona profile JSON read/parse failure to empty defaults with typed `Persona_read_error` and `Persona_parse_error`
- preserve both the Keeper TOML dependency owner and the actual failing persona path in the existing profile-load error
- keep standalone persona absence as legitimate empty defaults while malformed or unreadable present files fail closed

## Why

#24144 merged to main with Build/Test and CI Gate red plus p2 and status:do-not-merge. Exact review already found that present corrupt persona JSON became empty defaults and was later misreported as missing `sandbox_profile`. Its integrated head also replaced materializable profile filtering with raw `configured_keeper_names`, producing expected 2 / got 3 by counting disabled `base.toml`.

## Verification

- exact base: main `199cbd3f040c2d229f01a6f7dad96695fa90a128`
- exact remote head: `9d5583a295cc41872b9244c9da6d5815534f2675`
- exact tree: `60b27363a4f506114dff868ec4bdf53d10fd94ec` (byte-identical to the locally tested rebased tree)
- `ocamlformat --check`: PASS
- OCaml parse checks: 6/6 changed files PASS
- focused `test/test_keeper_toml.exe`: 99/99 PASS
- `git diff --check`: PASS
- fresh PR CI is the merge authority

## Gate

Draft + p2 + status:do-not-merge until exact-head adversarial review and required CI are terminal green.

Follow-up to #24144.
