### PR TITLE
fix(test): pass request_authority to make_health_json (main-red unblock)

### DIFF
--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1814,8 +1814,12 @@ let test_health_json_surfaces_typed_keeper_config_error () =
   let base_path = Filename.concat keepers_dir "missing-base.toml" in
   write_file keeper_path
     "[keeper]\nbase = \"missing-base.toml\"\ngoal = \"test\"\n";
-  let request = Httpun.Request.create `GET "/health" in
-  let json = Runtime.make_health_json request in
+  let request = health_request () in
+  let json =
+    Runtime.make_health_json
+      ~request_authority:(request_authority_exn request)
+      request
+  in
   let open Yojson.Safe.Util in
   check int "config error count" 1
     (json |> member "keeper_config_error_count" |> to_int);


### PR DESCRIPTION
## 무엇이 문제였소

`main`의 `Build and Test`가 여러 커밋째 red요. 유일한 컴파일 에러:

```
File "test/test_keeper_toml.ml", line 1821
Error: The value json has type ... request_authority:Server_request_authority.authority -> ...
```

`make_health_json`는 required `~request_authority` 인자를 받는데, `test_keeper_toml.ml:1817`이 그 인자 없이 호출→`json`이 `Yojson.Safe.t`가 아니라 부분적용 함수값(`~request_authority -> Yojson.Safe.t`)이 되오. 아래 `member` 사용 지점에서 타입 실패.

## 근본 원인 — rebase-race (코드 회귀 아님)

- `make_health_json`에 required `~request_authority`를 추가한 변경(#24148 계보)과,
- 그 인자 없이 호출부를 추가한 #24144

가 각자 base에서 green→rebase 없이 병합→합집합이 컴파일 red. 개별 PR이 green이어도 서로 다른 base 신호면 union은 green이 아니오.

확인 커밋: origin/main `1b7ec0ec12` (호출부 잔존), 실패 근원 `5449256130` (#24144, Build FAILURE).

## 고침

같은 파일의 형제 호출부(1763·1845)를 그대로 미러:
- `Httpun.Request.create` raw → `health_request ()` (host 헤더 보유)
- `~request_authority:(request_authority_exn request)` 전달

이 테스트는 keeper config-error 카운트를 검증하므로 유효 authority 값이 무엇이든 무관. heuristic 아닌 **동일 파일 확립 패턴 복제**라 결정론적이오.

## 반경

- 이 main-red는 모든 keeper PR의 Build/Health를 막소 (#24215, #24226 등 test_keeper_toml.ml 편집 PR 포함).
- test-only 1-hunk 변경. lib 무변경, RFC-gated subsystem 미접촉.

RFC-WAIVED: test-only fix, no credential/operator/keeper_sandbox surface touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
