### PR TITLE
fix(keeper): mitigate shutdown inventory fleet-block (WORKAROUND)

### DIFF
--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -587,27 +587,50 @@ let list_unlocked ~config =
   then Ok []
   else
     try
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.sort String.compare
-      |> List.fold_left
-           (fun result filename ->
-              let* operations = result in
-              if not (Filename.check_suffix filename ".json")
-              then
-                Error
-                  (Decode_error
-                     (Printf.sprintf "unexpected shutdown store entry: %s" filename))
-              else
-                let raw_id = Filename.chop_suffix filename ".json" in
-                let* operation_id =
-                  Operation_id.of_string raw_id
-                  |> Result.map_error (fun e -> Decode_error e)
-                in
-                let* operation = load ~config operation_id in
-                Ok (operation :: operations))
-           (Ok [])
-      |> Result.map List.rev
+      (* WORKAROUND: fleet-wide autoboot block 완화. 근본 해결은 #24195
+         (per-owner path + typed [Corrupt_record] fence). flat 레이아웃에서는
+         payload가 손상되면 그 안의 keeper_name을 복원할 수 없어 admission
+         fence를 세울 수 없다. 그래서 손상 항목을 per-record로 skip 한다 —
+         손상 1건이 전 fleet autoboot를 0으로 만드는 것(현재 동작)보다 blast
+         radius가 작다(해당 keeper만 fence 없이 재개). 모든 skip은 WARN 으로
+         관측 가능하므로 silent failure 는 아니다. dir-level I/O 실패만 여전히
+         [Error] 로 escalate 한다.
+         removal target: #24195 (per-owner fence) 머지 시 이 skip 경로 제거. *)
+      let operations =
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.sort String.compare
+        |> List.filter_map (fun filename ->
+             if Fs_compat.is_atomic_orphan_name filename
+             then (
+               (* crash-during-write 로 남은 atomic-write orphan: 유효 record가
+                  아니라 reclaimable 잔여물이므로 fleet 를 막지 않는다. *)
+               Log.Keeper.warn
+                 "shutdown store: skipping atomic-write orphan %s" filename;
+               None)
+             else if not (Filename.check_suffix filename ".json")
+             then (
+               Log.Keeper.warn
+                 "shutdown store: skipping non-json entry %s" filename;
+               None)
+             else
+               let raw_id = Filename.chop_suffix filename ".json" in
+               match Operation_id.of_string raw_id with
+               | Error e ->
+                 Log.Keeper.warn
+                   "shutdown store: skipping undecodable operation id %s: %s"
+                   filename e;
+                 None
+               | Ok operation_id ->
+                 (match load ~config operation_id with
+                  | Error e ->
+                    Log.Keeper.warn
+                      "shutdown store: skipping unreadable record %s: %s"
+                      filename (error_to_string e);
+                    None
+                  | Ok operation -> Some operation))
+      in
+      Ok operations
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn -> Error (Io_error (Printexc.to_string exn))

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -339,31 +339,33 @@ let start_keeper_loops
       match Keeper_shutdown_store.list_all ~config with
       | Error error -> Error (Keeper_shutdown_store.error_to_string error)
       | Ok operations ->
-        List.fold_left
-          (fun restored operation ->
-             match restored with
-             | Error _ as error -> error
-             | Ok () when not (operation_requires_fence operation) -> Ok ()
-             | Ok () ->
-               (match
-                  Keeper_turn_admission.restore_shutdown
-                    ~base_path:config.base_path
-                    ~keeper_name:operation.keeper_name
-                    ~operation_id:operation.operation_id
-                with
-                | Keeper_turn_admission.Shutdown_restored
-                | Keeper_turn_admission.Shutdown_already_restored -> Ok ()
-                | Keeper_turn_admission.Shutdown_restore_conflict existing ->
-                  Error
-                    (Printf.sprintf
-                       "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
-                       operation.keeper_name
-                       (Keeper_shutdown_types.Operation_id.to_string
-                          operation.operation_id)
-                       (Keeper_shutdown_types.Operation_id.to_string existing))))
-          (Ok ())
-          operations
-        |> Result.map (fun () -> operations)
+        (* Per-operation isolation: a restore conflict on one keeper must not
+           abort the remaining fence restores, which would leave the whole
+           fleet unbooted. Each conflict is logged (observable, not silent)
+           and that keeper is skipped; the healthy keepers still restore.
+           근본 정합: #24195 (per-owner fence)가 conflict 를 typed 로 격리. *)
+        List.iter
+          (fun operation ->
+             if operation_requires_fence operation
+             then (
+               match
+                 Keeper_turn_admission.restore_shutdown
+                   ~base_path:config.base_path
+                   ~keeper_name:operation.keeper_name
+                   ~operation_id:operation.operation_id
+               with
+               | Keeper_turn_admission.Shutdown_restored
+               | Keeper_turn_admission.Shutdown_already_restored -> ()
+               | Keeper_turn_admission.Shutdown_restore_conflict existing ->
+                 Log.Keeper.warn
+                   "shutdown admission restore conflict (isolated): keeper=%s \
+                    durable=%s existing=%s"
+                   operation.keeper_name
+                   (Keeper_shutdown_types.Operation_id.to_string
+                      operation.operation_id)
+                   (Keeper_shutdown_types.Operation_id.to_string existing)))
+          operations;
+        Ok operations
     in
     Eio.Promise.resolve shutdown_inventory_r inventory;
     match inventory with

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -934,6 +934,90 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
       | Error error -> fail (Shutdown_store.error_to_string error)
       | Ok _ -> fail "unsupported shutdown schema was accepted")
 
+let test_shutdown_store_list_all_isolates_malformed_records () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-store-isolation" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let persist name =
+        let meta = make_meta name in
+        let operation_id = Shutdown_types.Operation_id.generate () in
+        let lane = Lane.create () in
+        let now = Masc_domain.now_iso () in
+        let operation : Shutdown_types.t =
+          { schema_version = Shutdown_types.schema_version
+          ; revision = 0
+          ; operation_id
+          ; keeper_name = meta.name
+          ; lane_id = Lane.id lane
+          ; trace_id = meta.runtime.trace_id
+          ; generation = meta.runtime.generation
+          ; actor = "tester"
+          ; cleanup_intent = { remove_meta = false; remove_session = false }
+          ; turn_disposition = Shutdown_types.No_inflight_turn
+          ; expected_backlog_version = backlog_version
+          ; owned_task_ids = []
+          ; join_evidence = None
+          ; phase = Shutdown_types.Prepared
+          ; created_at = now
+          ; updated_at = now
+          }
+        in
+        (match Shutdown_store.persist_new ~config operation with
+         | Ok () -> ()
+         | Error error -> fail (Shutdown_store.error_to_string error));
+        meta.name
+      in
+      let name_a = persist "healthy-a" in
+      let name_b = persist "healthy-b" in
+      let records_dir =
+        Filename.dirname
+          (Shutdown_store.path ~config (Shutdown_types.Operation_id.generate ()))
+      in
+      let write path content =
+        let oc = open_out path in
+        output_string oc content;
+        close_out oc
+      in
+      (* Malformed neighbors that must NOT sink the healthy records (pre-fix the
+         fold collapsed the whole inventory to Error and blocked every keeper's
+         autoboot): a crash-during-write atomic orphan, a stray non-json file,
+         and a corrupt .json payload. *)
+      let orphan_name = ".atomic_crash_leftover.tmp" in
+      check
+        bool
+        "fixture name is a recognized atomic-write orphan"
+        true
+        (Fs_compat.is_atomic_orphan_name orphan_name);
+      write (Filename.concat records_dir orphan_name) "partial write";
+      write (Filename.concat records_dir "not-a-record.txt") "garbage";
+      write (Filename.concat records_dir "corrupt.json") "{ not valid json";
+      match Shutdown_store.list_all ~config with
+      | Error error ->
+        fail
+          (Printf.sprintf
+             "list_all must isolate malformed entries, not fail wholesale: %s"
+             (Shutdown_store.error_to_string error))
+      | Ok operations ->
+        let names =
+          List.map (fun (o : Shutdown_types.t) -> o.keeper_name) operations
+        in
+        check int "healthy records survive malformed neighbors" 2
+          (List.length operations);
+        check bool "healthy-a retained" true (List.mem name_a names);
+        check bool "healthy-b retained" true (List.mem name_b names))
+
 let test_keeper_shutdown_prepare_joins_idle_lane () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1793,6 +1877,8 @@ let () =
         test_keeper_lane_cancel_is_lane_local_and_joinable;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "shutdown store list_all isolates malformed records" `Quick
+        test_shutdown_store_list_all_isolates_malformed_records;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown prepare joins not-started lane" `Quick


### PR DESCRIPTION
## 요약

손상된 shutdown record 1개가 **모든 keeper의 autoboot를 막아요**(부팅 복구 fold가 전체 인벤토리를 Error로 붕괴 → "inventory is uncertain" → autoboot 0대). main(`1b7ec0ec12`)에 실재하는 프로덕션 fleet-block P0예요.

## 변경 (`eb606f142c`)

- `list_unlocked`: atomic-write orphan(`is_atomic_orphan_name`, crash-during-write 잔여물) + stray non-json + undecodable/unreadable record를 per-record로 skip. 각 skip은 WARN 로깅(관측 가능, silent 아님). dir-level I/O 실패만 Error escalate.
- `server_bootstrap_loops` restore fold: `Shutdown_restore_conflict`를 해당 keeper만 로깅+skip(전체 abort 대신).

## WORKAROUND

WORKAROUND: production fleet-block(손상 1개→전체 autoboot 0대) 즉시 완화. flat layout에선 corrupt payload의 keeper_name을 복원 못 해 fence 불가라, corrupt record는 fence 대신 skip해요. fleet-wide 0대보다 blast radius가 명백히 작아요(그 keeper만 영향).
RFC/대체: #24195 (per-owner path + typed Corrupt_record fence)가 skip을 fence로 대체.
removal target: #24195 merge 시 skip 경로 제거.

## P0/P1/P2/P3

- **P0 완화**: fleet-wide coupling 제거(무관한 1건이 전체 인질). 근본은 #24195.
- P1/P2/P3: 없음.

## 검증

- 로컬 dune build 미실행, CI가 빌드 권위.
- ocamlformat --check 3파일 pass.
- 회귀 테스트 `test_shutdown_store_list_all_isolates_malformed_records`: atomic orphan + stray + corrupt.json 옆에서 healthy 2개 생존(전체 Error 아님). fixture는 `is_atomic_orphan_name`으로 형식 검증(SSOT 방어).
