### PR TITLE
fix(test): pass request_authority to make_health_json (main compile fix)

### DIFF
--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1815,7 +1815,11 @@ let test_health_json_surfaces_typed_keeper_config_error () =
   write_file keeper_path
     "[keeper]\nbase = \"missing-base.toml\"\ngoal = \"test\"\n";
   let request = Httpun.Request.create `GET "/health" in
-  let json = Runtime.make_health_json request in
+  let json =
+    Runtime.make_health_json
+      ~request_authority:(request_authority_exn request)
+      request
+  in
   let open Yojson.Safe.Util in
   check int "config error count" 1
     (json |> member "keeper_config_error_count" |> to_int);


### PR DESCRIPTION
## 목적
main 컴파일 에러 수정 (CI 기아로 숨겨져 있던 깨짐 — 로컬 `dune build .`로 발견).

## 원인
`make_health_json`가 권한 중앙화 변경으로 `~request_authority`를 **필수**로 받게 됐으나, `test/test_keeper_toml.ml:1818` call site 하나만 갱신 누락(N-of-M). `json`이 부분 적용 함수가 되어 파일 컴파일 실패 → main 빌드 broken.

## 수정
인접한 2개 call site(1763, 1845)와 동일하게 `~request_authority:(request_authority_exn request)` 추가.

## 범위 확인 (N-of-M 완료)
- `test_server_runtime_bootstrap.ml`(22 site): local module wrapper(line 13-22)가 자동 주입 → 정상.
- `test_server_hibernation.ml`: 명시적 전달 → 정상.
- 누락은 본 1곳만.

| 등급 | 상태 |
|------|------|
| P0 | main 컴파일 에러 — 이 PR로 해소 (CI green 확정 필요) |
| 병합 가능성 | trivial main-fix, CI green 후 즉시 |
