### PR TITLE
fix(dashboard): close MCP auth retry races

### DIFF
--- a/dashboard/src/api/mcp.test.ts
+++ b/dashboard/src/api/mcp.test.ts
@@ -94,10 +94,12 @@ function setupMcpSessionMocks(sessionId: string) {
 
 function deferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise
+    reject = rejectPromise
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 /** Find a fetchWithTimeout call by matching the JSON body's "method" field. */
@@ -186,6 +188,51 @@ describe('mcpHeaders auth integration', () => {
     await callMcpTool('masc_status', {})
 
     expect(callsByMethod('initialize')).toHaveLength(2)
+    const latestToolCall = callsByMethod('tools/call').at(-1)
+    expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
+      .toBe('sess-token-b')
+  }, 60_000)
+
+  it('does not replay a delayed unknown-session response after the token changes', async () => {
+    let tokenRevision = 0
+    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
+    setupMcpSessionMocks('sess-token-a')
+
+    const { callMcpTool } = await import('./mcp')
+    await callMcpTool('masc_status', {})
+
+    const finishOldErrorBody = deferred<void>()
+    apiRequestErrorFromResponse.mockImplementationOnce(async (_method, _path, res) => {
+      await finishOldErrorBody.promise
+      return new Error(`POST /mcp: ${res.status} stale transport session`)
+    })
+    fetchWithTimeout.mockResolvedValueOnce(new Response('{}', {
+      status: 404,
+      statusText: 'Not Found',
+      headers: { 'Mcp-Session-Id': 'sess-uninitialized-replacement' },
+    }))
+    const oldCall = callMcpTool('masc_status', {})
+    await vi.waitFor(() => {
+      expect(callsByMethod('tools/call')).toHaveLength(2)
+    })
+
+    tokenRevision = 1
+    setupMcpSessionMocks('sess-token-b')
+    await callMcpTool('masc_status', {})
+
+    finishOldErrorBody.resolve(undefined)
+    await expect(oldCall).rejects.toThrow('MCP authentication changed during request')
+
+    expect(callsByMethod('initialize')).toHaveLength(2)
+    expect(callsByMethod('tools/call')).toHaveLength(3)
+
+    fetchWithTimeout.mockResolvedValueOnce(
+      new Response('data: {"result":{"content":[{"type":"text","text":"still-b"}]}}\n', { status: 200 }),
+    )
+    await callMcpTool('masc_status', {})
+
+    expect(callsByMethod('initialize')).toHaveLength(2)
+    expect(callsByMethod('tools/call')).toHaveLength(4)
     const latestToolCall = callsByMethod('tools/call').at(-1)
     expect((latestToolCall?.[1].headers as Record<string, string>)['Mcp-Session-Id'])
       .toBe('sess-token-b')
@@ -502,6 +549,44 @@ describe('callMcpTool', () => {
     )
   })
 
+  it('attributes a delayed failure to the binding that sent the request', async () => {
+    let tokenRevision = 0
+    currentStoredTokenRevision.mockImplementation(() => tokenRevision)
+    const delayedOldFailure = deferred<Response>()
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-telemetry-a' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('', { status: 202 }))
+      .mockImplementationOnce(() => delayedOldFailure.promise)
+
+    const { callMcpTool } = await import('./mcp')
+    const oldCall = callMcpTool('masc_keeper_msg', { name: 'sangsu', message: 'old' })
+    const oldFailure = expect(oldCall).rejects.toThrow('POST /mcp: timeout after 30000ms')
+    await vi.waitFor(() => {
+      expect(callsByMethod('tools/call')).toHaveLength(1)
+    })
+
+    tokenRevision = 1
+    setupMcpSessionMocks('sess-telemetry-b')
+    await callMcpTool('masc_status', {})
+
+    delayedOldFailure.reject(new Error('POST /mcp: timeout after 30000ms'))
+    await oldFailure
+
+    expect(reportToolHostFailure).toHaveBeenCalledTimes(1)
+    expect(reportToolHostFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool_name: 'masc_keeper_msg',
+        phase: 'tools/call',
+        session_id: 'sess-telemetry-a',
+      }),
+    )
+  }, 60_000)
+
   it('does not retry implicit actor mismatches', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(
@@ -563,7 +648,7 @@ describe('callMcpTool', () => {
             jsonrpc: '2.0',
             error: {
               code: -32600,
-              message: 'Unknown Mcp-Session-Id. Re-initialize to obtain a fresh session.',
+              message: 'transport session is no longer available',
             },
             id: null,
           }),
@@ -646,6 +731,29 @@ describe('callMcpTool', () => {
       'POST /mcp initialize: 500',
     )
     expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed when the initialized notification returns non-2xx', async () => {
+    fetchWithTimeout
+      .mockResolvedValueOnce(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'sess-notification-failed' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error',
+        }),
+      )
+
+    const { callMcpTool } = await import('./mcp')
+
+    await expect(callMcpTool('masc_status', {})).rejects.toThrow(
+      'POST /mcp notifications/initialized: 500',
+    )
+    expect(callsByMethod('tools/call')).toHaveLength(0)
   })
 
   it('blocks subsequent calls after initialize returns 403', async () => {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -23,7 +23,6 @@ import { errorToString } from '../lib/format-string'
 // --- MCP Session Management ---
 
 const MCP_BLOCKED_MESSAGE = 'MCP 연결이 차단되었습니다.'
-const MCP_UNKNOWN_SESSION_MESSAGE = 'Unknown Mcp-Session-Id'
 const MCP_AUTH_CHANGED_MESSAGE = 'MCP authentication changed during request'
 
 interface McpSessionBinding {
@@ -41,22 +40,25 @@ interface McpInitAttempt {
   cooldownTimer: ReturnType<typeof setTimeout> | null
 }
 
+interface McpRequestTrace {
+  binding: McpSessionBinding | null
+}
+
+type McpErrorResponseContract =
+  | { readonly kind: 'unknown_session'; readonly replacementSessionId: string }
+  | { readonly kind: 'other' }
+
 let mcpSessionState: McpSessionState | null = null
 let observedTokenRevision = currentStoredTokenRevision()
 let initGeneration = 0
 let initAttempt: McpInitAttempt | null = null
-
-function activeSessionId(): string | null {
-  return mcpSessionState?.kind === 'ready'
-    ? mcpSessionState.binding.sessionId
-    : null
-}
 
 async function bestEffortReportToolHostFailure(payload: {
   toolName: string
   message: string
   phase: string
   requestId?: string
+  sessionId?: string
   timeoutMs?: number
 }) {
   try {
@@ -67,7 +69,7 @@ async function bestEffortReportToolHostFailure(payload: {
       phase: payload.phase,
       message: payload.message,
       request_id: payload.requestId,
-      session_id: activeSessionId() ?? undefined,
+      session_id: payload.sessionId,
       timeout_ms: payload.timeoutMs,
     })
   } catch {
@@ -180,12 +182,24 @@ function canRetryUnknownSession(body: unknown): boolean {
     && method !== 'server/discover'
 }
 
-async function responseTextSnippet(res: Response): Promise<string> {
-  try {
-    return await res.clone().text()
-  } catch {
-    return ''
+function classifyMcpErrorResponse(
+  res: Response,
+  body: unknown,
+): McpErrorResponseContract {
+  const replacementSessionId = res.headers.get('Mcp-Session-Id')
+  if (
+    res.status === 404
+    && replacementSessionId
+    && canRetryUnknownSession(body)
+  ) {
+    return { kind: 'unknown_session', replacementSessionId }
   }
+  return { kind: 'other' }
+}
+
+function invalidatePublishedBinding(binding: McpSessionBinding): void {
+  assertPublishedBinding(binding)
+  resetMcpSessionOnly()
 }
 
 async function mcpPost(
@@ -194,8 +208,10 @@ async function mcpPost(
   timeoutMs = DEFAULT_MCP_TIMEOUT_MS,
   actorName?: string | null,
   retryUnknownSession = true,
+  requestTrace?: McpRequestTrace,
 ): Promise<string> {
   assertPublishedBinding(binding)
+  if (requestTrace) requestTrace.binding = binding
   const res = await fetchWithTimeout('/mcp', {
     method: 'POST',
     headers: mcpHeadersForActor(binding, actorName),
@@ -210,18 +226,15 @@ async function mcpPost(
       }
       throw new Error(MCP_BLOCKED_MESSAGE)
     }
-    const bodyText = res.status === 404 ? await responseTextSnippet(res) : ''
+    const responseContract = classifyMcpErrorResponse(res, body)
     const err = await apiRequestErrorFromResponse('POST', '/mcp', res)
-    const message = `${bodyText}\n${errorToString(err)}`
     if (
       retryUnknownSession
-      && res.status === 404
-      && canRetryUnknownSession(body)
-      && message.includes(MCP_UNKNOWN_SESSION_MESSAGE)
+      && responseContract.kind === 'unknown_session'
     ) {
-      resetMcpSessionOnly()
+      invalidatePublishedBinding(binding)
       const freshBinding = await ensureSession()
-      return mcpPost(body, freshBinding, timeoutMs, actorName, false)
+      return mcpPost(body, freshBinding, timeoutMs, actorName, false, requestTrace)
     }
     throw err
   }
@@ -291,7 +304,7 @@ async function initializeSession(
   }
   if (binding.sessionId) {
     try {
-      await fetchWithTimeout('/mcp', {
+      const initializedRes = await fetchWithTimeout('/mcp', {
         method: 'POST',
         headers: mcpHeadersForActor(binding),
         body: JSON.stringify({
@@ -300,9 +313,17 @@ async function initializeSession(
         }),
       }, MCP_INITIALIZED_NOTIFY_TIMEOUT_MS)
       assertCurrentInitAttempt(attempt, authRevision)
+      if (!initializedRes.ok) {
+        throw await apiRequestErrorFromResponse(
+          'POST',
+          '/mcp notifications/initialized',
+          initializedRes,
+        )
+      }
     } catch (err) {
       assertCurrentInitAttempt(attempt, authRevision)
       console.warn('[mcp] initialized notification failed:', err)
+      throw err
     }
   }
   assertCurrentInitAttempt(attempt, authRevision)
@@ -392,6 +413,7 @@ async function callMcpToolInternal(
   const requestId = String(Math.floor(Date.now() % 1000000))
   synchronizeMcpAuthRevision()
   let phase = mcpSessionState?.kind === 'ready' ? 'tools/call' : 'initialize'
+  const requestTrace: McpRequestTrace = { binding: null }
   try {
     const binding = await ensureSession()
     phase = 'tools/call'
@@ -409,7 +431,7 @@ async function callMcpToolInternal(
         arguments: toolArgs,
       },
       id: Number.parseInt(requestId, 10),
-    }, binding, DEFAULT_MCP_TIMEOUT_MS, actor)
+    }, binding, DEFAULT_MCP_TIMEOUT_MS, actor, true, requestTrace)
     const parsed = parseMcpHttpResponse(text)
     return extractMcpText(parsed)
   } catch (err) {
@@ -420,6 +442,7 @@ async function callMcpToolInternal(
         message,
         phase,
         requestId: phase === 'tools/call' ? requestId : undefined,
+        sessionId: requestTrace.binding?.sessionId ?? undefined,
         timeoutMs: phase === 'initialize' ? MCP_INITIALIZE_TIMEOUT_MS : DEFAULT_MCP_TIMEOUT_MS,
       })
     }


### PR DESCRIPTION
## Summary

- classify unknown MCP sessions structurally from the 404 plus replacement session header instead of server-message matching
- re-check the immutable auth/session binding after asynchronous error decoding before clearing or retrying
- attribute failure telemetry to the binding that actually sent the request
- fail closed when notifications/initialized is rejected instead of publishing a ready session
- add delayed-404 token-switch, binding-owned telemetry, and initialized non-2xx regressions

## Why

#24213 merged to main 53 seconds after an exact-head P1 block comment while p1 and status:do-not-merge remained. A token-A 404 could wait on its body while token B published a new session, then clear B and replay A's mutating request under B credentials. The same path matched an OCaml error string, reported failures using mutable global session state, and published ready after initialized notification failure.

Follow-up to #24213 and https://github.com/jeong-sik/masc/pull/24213#issuecomment-4946981719.

## Verification

- exact base: 2c48beb99a02b0afe69c82cd3618efe6529c7d2a
- exact head: a802692253efced3440ed8d0638c931079e00f6e
- pnpm typecheck: PASS
- focused dashboard/src/api/mcp.test.ts Vitest: 25/25 PASS
- git diff --check: PASS
- fresh applicable exact-head CI: terminal green
- reviewThreads: 0
- merge state: CLEAN

## Gate

Exact-head source review and applicable CI are terminal green. Blocking labels are removed; Draft is retained for operator merge sequencing.