### PR TITLE
fix(keeper): suppress capacity pacing operator pages

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -102,6 +102,7 @@ type operator_disposition_reason =
   | Reason_degraded_retry
   | Reason_runtime_fallback
   | Reason_transient_runtime_retry
+  | Reason_capacity_backpressure
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
@@ -127,6 +128,7 @@ let operator_disposition_reason_to_string = function
   | Reason_degraded_retry -> "degraded_retry"
   | Reason_runtime_fallback -> "runtime_fallback"
   | Reason_transient_runtime_retry -> "transient_runtime_retry"
+  | Reason_capacity_backpressure -> Keeper_internal_error.capacity_backpressure_kind
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
   | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
@@ -256,6 +258,13 @@ let operator_disposition (receipt : t)
   match terminal_reason with
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_alert_exhausted, Reason_runtime_exhausted
+  | Keeper_terminal_reason.Capacity_backpressure _ ->
+    (* The typed runtime route treats provider-capacity cooldown as pacing and
+       continues with another eligible runtime.  This receipt is written for
+       the failed pre-dispatch attempt before that rotation is reflected in
+       [runtime_fallback_applied], so it must neither claim a completed
+       fallback nor page a human. *)
+    Disp_fail_open_next_runtime, Reason_capacity_backpressure
   | _ when preflight_config_failure ->
     Disp_pause_human, Reason_preflight_config_error
   | _
@@ -352,6 +361,7 @@ let operator_disposition (receipt : t)
       match terminal_reason with
       | Keeper_terminal_reason.Turn_budget_exhausted _ -> true
       | Runtime_exhausted _
+      | Capacity_backpressure _
       | Config_or_auth _
       | Provider_runtime_failure _
       | Completion_contract_violation _
@@ -401,6 +411,7 @@ let operator_disposition (receipt : t)
       (match terminal_reason with
        | Keeper_terminal_reason.Pre_dispatch_success _ -> true
        | Runtime_exhausted _
+       | Capacity_backpressure _
        | Config_or_auth _
        | Provider_runtime_failure _
        | Completion_contract_violation _

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -261,6 +261,11 @@ type operator_disposition_reason =
       [Disp_fail_open_next_runtime]; suppresses the operator page that the
       pre-fix [Reason_provider_runtime_error] / [Disp_pause_human]
       fall-through emitted. *)
+  | Reason_capacity_backpressure
+  (** Typed provider-capacity pacing before a retry/rotation has completed.
+      Paired with [Disp_fail_open_next_runtime]: the keeper keeps moving and
+      no operator broadcast is emitted, while the receipt does not falsely
+      claim [Reason_runtime_fallback]. *)
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -19,6 +19,11 @@
    key the dashboard still parses). *)
 let runtime_id_to_string (s : string) = s
 
+(* Canonical wire kind for the typed [Capacity_backpressure] envelope.  The
+   producer codec, receipt terminal projection, and consumer decoder share
+   this value so recoverability cannot drift through duplicated literals. *)
+let capacity_backpressure_kind = "capacity_backpressure"
+
 type provider_rejection = {
   provider_label : string;
   reason : string;
@@ -488,7 +493,7 @@ let masc_internal_error_to_json = function
     in
     `Assoc
       ([
-         ("kind", `String "capacity_backpressure");
+         ("kind", `String capacity_backpressure_kind);
          ("runtime_id", `String runtime_id);
          ("source", `String (capacity_backpressure_source_to_string source));
          ("detail", `String detail);
@@ -823,7 +828,7 @@ let summary_of_masc_internal_error = function
 
 let kind_of_masc_internal_error = function
   | Runtime_exhausted _ -> "runtime_exhausted"
-  | Capacity_backpressure _ -> "capacity_backpressure"
+  | Capacity_backpressure _ -> capacity_backpressure_kind
   | Resumable_cli_session _ -> "resumable_cli_session"
   | Accept_rejected _ -> "accept_rejected"
   | Admission_queue_timeout _ -> "admission_queue_timeout"
@@ -978,7 +983,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                Some (Runtime_exhausted { runtime_id; reason })
              | None -> None)
           | None -> None)
-      | Some (`String "capacity_backpressure") -> (
+      | Some (`String kind) when String.equal kind capacity_backpressure_kind -> (
           match
             string_opt_of_assoc "runtime_id" json,
             string_opt_of_assoc "source" json,

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -1,6 +1,10 @@
 (** Structured keeper-internal error envelopes carried through
     [Agent_sdk.Error.Internal]. *)
 
+(** Canonical wire kind emitted for {!Capacity_backpressure}.  Receipt
+    terminal projection and decoding consume this same value. *)
+val capacity_backpressure_kind : string
+
 type provider_rejection = {
   provider_label : string;
   reason : string;

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -70,7 +70,9 @@ let contains_config_or_auth lowered =
    order of the pre-typing [operator_disposition] string predicates, with the
    exact canonical [Capacity_backpressure] policy bucket inserted before the
    opaque internal-error fall-through;
-   [of_wire] returns the FIRST matching bucket. The original
+   [of_wire] returns the FIRST matching bucket. Capacity backpressure is an
+   exact producer-owned wire kind; casing variants remain opaque rather than
+   inheriting its non-pageable policy. The original
    (case-preserving) [wire] is carried in payload-bearing variants so
    [to_wire] reproduces it byte-for-byte; classification is done on a
    lowercased copy to match [operator_disposition], which lowercased
@@ -79,7 +81,7 @@ let of_wire wire =
   let lowered = String.lowercase_ascii wire in
   if String.equal lowered "runtime_exhausted"
   then Runtime_exhausted wire
-  else if String.equal lowered Keeper_internal_error.capacity_backpressure_kind
+  else if String.equal wire Keeper_internal_error.capacity_backpressure_kind
   then Capacity_backpressure wire
   else if contains_config_or_auth lowered
   then Config_or_auth wire

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -50,6 +50,7 @@ let is_auto_recoverable_turn_budget_terminal terminal_reason =
 
 type t =
   | Runtime_exhausted of string
+  | Capacity_backpressure of string
   | Config_or_auth of string
   | Provider_runtime_failure of string
   | Completion_contract_violation of string
@@ -66,7 +67,9 @@ let contains_config_or_auth lowered =
 ;;
 
 (* Priority-ranked partition. The bucket order replicates the [if/else]
-   order of the pre-typing [operator_disposition] string predicates;
+   order of the pre-typing [operator_disposition] string predicates, with the
+   exact canonical [Capacity_backpressure] policy bucket inserted before the
+   opaque internal-error fall-through;
    [of_wire] returns the FIRST matching bucket. The original
    (case-preserving) [wire] is carried in payload-bearing variants so
    [to_wire] reproduces it byte-for-byte; classification is done on a
@@ -76,6 +79,8 @@ let of_wire wire =
   let lowered = String.lowercase_ascii wire in
   if String.equal lowered "runtime_exhausted"
   then Runtime_exhausted wire
+  else if String.equal lowered Keeper_internal_error.capacity_backpressure_kind
+  then Capacity_backpressure wire
   else if contains_config_or_auth lowered
   then Config_or_auth wire
   else if
@@ -104,6 +109,7 @@ let of_wire wire =
    round-trip fidelity; [operator_disposition] ignores it. *)
 let to_wire = function
   | Runtime_exhausted wire -> wire
+  | Capacity_backpressure wire -> wire
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
   | Completion_contract_violation wire -> wire
@@ -139,6 +145,7 @@ let is_transient_provider_runtime_failure = function
     || String.equal lowered "provider_error_network:timeout"
     || String.starts_with ~prefix:"provider_error_network:timeout:" lowered
   | Runtime_exhausted _
+  | Capacity_backpressure _
   | Config_or_auth _
   | Completion_contract_violation _
   | Turn_livelock _

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -28,8 +28,9 @@
 
     [of_wire] is a {e priority-ranked partition}: it tests the buckets in
     the same order the old [operator_disposition] [if/else] chain tested
-    its string predicates and returns the first match. This is a faithful
-    re-encoding of the [if/else] order — pathological overlaps (a contract
+    its string predicates, plus the exact canonical
+    [Capacity_backpressure] policy bucket, and returns the first match.
+    Pathological overlaps (a contract
     id containing ["auth"], a budget string that also matches a later
     bucket) resolve identically to the pre-typing code. The order is
     load-bearing; see the [.ml] for the ranked list.
@@ -54,6 +55,11 @@ type t =
   (** Exact wire ["runtime_exhausted"] (modulo case). Payload is the
           original string, carried only so [to_wire] is a byte-identical
           inverse; the disposition classifier ignores it. *)
+  | Capacity_backpressure of string
+  (** Exact canonical wire kind
+          {!Keeper_internal_error.capacity_backpressure_kind}.  This is a
+          typed provider/infrastructure pacing condition, not an opaque
+          internal failure.  Payload preserves the original bytes. *)
   | Config_or_auth of string
   (** Wire string contains ["config"] or ["auth"] (case-insensitive).
           Ranked above the provider family so [api_error_auth],

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -689,6 +689,20 @@ let () =
     (got = want);
   check
     "opaque internal lookalike still emits operator broadcast"
+    (R.needs_operator_broadcast (fst got));
+  let noncanonical_case =
+    { receipt with terminal_reason_code = String.uppercase_ascii code }
+  in
+  let got = R.operator_disposition noncanonical_case in
+  let want = R.Disp_pause_human, R.Reason_internal_error in
+  check
+    (Printf.sprintf
+       "noncanonical capacity casing stays opaque want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  check
+    "noncanonical capacity casing still emits operator broadcast"
     (R.needs_operator_broadcast (fst got))
 ;;
 

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -9,8 +9,8 @@
 
    2. The NEW [Keeper_execution_receipt.operator_disposition] (which now
       parses [terminal_reason_code] once via [Keeper_terminal_reason.of_wire]
-      and exhaustive-matches) returns the SAME (disposition, reason) pair as
-      the frozen independent oracle over the cartesian product of
+      and exhaustive-matches) returns the same pair as the independent oracle,
+      including focused policy updates, over the cartesian product of
       (producer-string corpus) x (the small finite field matrix the
       classifier branches on). The oracle is intentionally NOT refactored to
       share code with production, so a priority-order regression in production
@@ -72,6 +72,7 @@ let read_meta_exn config keeper_name =
 let roundtrip_corpus =
   [ (* exact-match buckets *)
     "runtime_exhausted"
+  ; Keeper_internal_error.capacity_backpressure_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -254,6 +255,9 @@ let frozen_operator_disposition (receipt : R.t)
   in
   if String.equal terminal_reason "runtime_exhausted"
   then R.Disp_alert_exhausted, R.Reason_runtime_exhausted
+  else if
+    String.equal terminal_reason Keeper_internal_error.capacity_backpressure_kind
+  then R.Disp_fail_open_next_runtime, R.Reason_capacity_backpressure
   else if preflight_config_failure
   then R.Disp_pause_human, R.Reason_preflight_config_error
   else if
@@ -628,6 +632,64 @@ let () =
     "test_keeper_terminal_reason_typed: matrix cases=%d mismatches=%d\n"
     !count
     !mismatches
+;;
+
+let () =
+  let internal_error =
+    Keeper_internal_error.Capacity_backpressure
+      { runtime_id = "runtime-capacity"
+      ; source = Keeper_internal_error.Provider_capacity
+      ; detail = "provider health cooldown active before dispatch"
+      ; retry_after = Keeper_internal_error.No_retry_hint
+      ; cooldown_cause = None
+      }
+  in
+  let code =
+    internal_error
+    |> Keeper_internal_error.sdk_error_of_masc_internal_error
+    |> Masc.Keeper_agent_error.terminal_reason_code_of_sdk_error
+  in
+  check
+    "capacity producer uses canonical terminal kind"
+    (String.equal code Keeper_internal_error.capacity_backpressure_kind);
+  check
+    "capacity terminal kind decodes to closed variant"
+    (match Tr.of_wire code with
+     | Tr.Capacity_backpressure wire -> String.equal wire code
+     | _ -> false);
+  let receipt =
+    { base_receipt with
+      terminal_reason_code = code
+    ; error_kind = Some (R.error_kind_of_string "internal")
+    ; outcome = `Error
+    ; runtime_outcome = R.Runtime_not_observed
+    }
+  in
+  let got = R.operator_disposition receipt in
+  let want = R.Disp_fail_open_next_runtime, R.Reason_capacity_backpressure in
+  check
+    (Printf.sprintf
+       "capacity disposition want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  check
+    "capacity pacing does not emit operator broadcast"
+    (not (R.needs_operator_broadcast (fst got)));
+  let opaque_internal =
+    { receipt with terminal_reason_code = code ^ "_unexpected" }
+  in
+  let got = R.operator_disposition opaque_internal in
+  let want = R.Disp_pause_human, R.Reason_internal_error in
+  check
+    (Printf.sprintf
+       "capacity lookalike remains opaque internal want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  check
+    "opaque internal lookalike still emits operator broadcast"
+    (R.needs_operator_broadcast (fst got))
 ;;
 
 let () =


### PR DESCRIPTION
## Summary

- decode the canonical keeper capacity-backpressure terminal into a closed `Keeper_terminal_reason` variant
- classify that pre-rotation receipt as `fail_open_next_runtime/capacity_backpressure` instead of `pause_human/internal_error`
- keep fallback truth exact: the failed attempt does not claim that a runtime fallback already completed
- preserve fail-closed paging for opaque internal failures and capacity-like unknown strings

## Runtime evidence

Live receipts on 2026-07-11 UTC showed the same false page repeatedly:

- idealist: 176 matches in the latest 500 receipts
- taskmaster: 196 matches in the latest 500 receipts
- tuple: `terminal_reason_code=capacity_backpressure`, `operator_disposition=pause_human`, `operator_disposition_reason=internal_error`
- the adjacent runtime path continued with a recoverable rotation

The failed attempt has `runtime_fallback_applied=false` and `runtime_outcome=not_observed`, so reordering fallback flags cannot fix the classification. The canonical terminal kind must survive the receipt boundary as a typed case.

## Design

- `Keeper_internal_error.capacity_backpressure_kind` is the wire SSOT for codec, terminal projection, and decoder.
- `Keeper_terminal_reason.Capacity_backpressure` is an exact boundary decode, not a substring heuristic.
- `Reason_capacity_backpressure` is explicit operator telemetry.
- `Disp_fail_open_next_runtime` remains non-pageable and does not assert completed fallback.

## Verification

- OCaml parser pass for all touched `.ml`/`.mli` files
- `ocamlformat --check`
- `git diff --check`
- OCaml structure ratchet
- stringly-boundary ratchet
- MASC/OAS boundary ratchet
- keeper tool boundary matrix
- silent-failure ratchet
- keeper cwd leak gate
- full Dune build/test intentionally delegated to PR CI

Focused regression coverage pins producer/decoder SSOT, the live internal-error receipt shape, broadcast suppression, and an exact-match lookalike that must still page.

[근거] OCaml 5.4 official manual: https://ocaml.org/manual/5.4/index.html and https://ocaml.org/manual/5.4/comp.html — 확인일시 2026-07-12 KST — 신뢰도 High

Closes #24236
