### PR TITLE
fix(runtime-lens): type durable manifest compatibility diagnostics

### DIFF
--- a/dashboard/src/api/keeper-runtime-trace.ts
+++ b/dashboard/src/api/keeper-runtime-trace.ts
@@ -58,6 +58,49 @@ export interface KeeperRuntimeTraceProviderAttemptsSummary {
   attempts: KeeperRuntimeTraceProviderAttempt[]
 }
 
+export interface KeeperRuntimeManifestEventCount {
+  event: string
+  count: number
+}
+
+export const KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTICS_SCHEMA =
+  'keeper.runtime_manifest_scan_diagnostics.v1' as const
+
+const KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTIC_KINDS = [
+  'retired_event',
+  'unsupported_event',
+  'invalid_manifest_row',
+  'invalid_json_row',
+] as const
+
+export type KeeperRuntimeManifestScanDiagnosticKind =
+  typeof KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTIC_KINDS[number]
+
+export interface KeeperRuntimeManifestScanDiagnostic {
+  kind: KeeperRuntimeManifestScanDiagnosticKind
+  event: string | null
+  detail: string | null
+}
+
+export type KeeperRuntimeManifestScanDiagnostics =
+  | {
+      state: 'available'
+      schema: typeof KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTICS_SCHEMA
+      retired_event_count: number
+      retired_event_counts: KeeperRuntimeManifestEventCount[]
+      unsupported_event_count: number
+      unsupported_event_counts: KeeperRuntimeManifestEventCount[]
+      unsupported_event_unattributed_count: number
+      invalid_manifest_row_count: number
+      invalid_json_row_count: number
+      samples: KeeperRuntimeManifestScanDiagnostic[]
+    }
+  | {
+      state: 'unavailable'
+      schema: string | null
+      error: string
+    }
+
 export interface KeeperRuntimeLensTurnClock {
   trace_id: string
   keeper_turn_id: number | null
@@ -263,6 +306,7 @@ export interface KeeperRuntimeTraceResponse {
   manifest_total_rows: number
   manifest_returned_rows: number
   receipt_returned_rows: number
+  manifest_scan_diagnostics: KeeperRuntimeManifestScanDiagnostics
   turn_identity: KeeperRuntimeTraceTurnIdentity
   provider_attempts: KeeperRuntimeTraceProviderAttemptsSummary
   event_bus: KeeperRuntimeTraceEventBusSummary
@@ -310,6 +354,103 @@ function stringListField(raw: Record<string, unknown>, key: string): string[] {
   const value = raw[key]
   if (!Array.isArray(value)) return []
   return value.filter((item): item is string => typeof item === 'string')
+}
+
+function nonNegativeInteger(raw: unknown): number | null {
+  return typeof raw === 'number' && Number.isInteger(raw) && raw >= 0 ? raw : null
+}
+
+function parseManifestEventCount(raw: unknown): KeeperRuntimeManifestEventCount | null {
+  if (!isRecord(raw) || typeof raw.event !== 'string' || raw.event === '') return null
+  const count = nonNegativeInteger(raw.count)
+  return count === null ? null : { event: raw.event, count }
+}
+
+function isManifestScanDiagnosticKind(
+  raw: unknown,
+): raw is KeeperRuntimeManifestScanDiagnosticKind {
+  return typeof raw === 'string'
+    && KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTIC_KINDS.some(kind => kind === raw)
+}
+
+function nullableWireString(raw: unknown): string | null | undefined {
+  if (raw === undefined || raw === null) return null
+  return typeof raw === 'string' ? raw : undefined
+}
+
+function allParsed<T>(values: (T | null)[]): values is T[] {
+  return values.every(value => value !== null)
+}
+
+function parseManifestScanDiagnostic(
+  raw: unknown,
+): KeeperRuntimeManifestScanDiagnostic | null {
+  if (!isRecord(raw) || !isManifestScanDiagnosticKind(raw.kind)) return null
+  const event = nullableWireString(raw.event)
+  const detail = nullableWireString(raw.detail)
+  if (event === undefined || detail === undefined) return null
+  return { kind: raw.kind, event, detail }
+}
+
+function parseManifestScanDiagnostics(raw: unknown): KeeperRuntimeManifestScanDiagnostics {
+  if (!isRecord(raw)) {
+    return {
+      state: 'unavailable',
+      schema: null,
+      error: 'runtime did not report manifest scan diagnostics',
+    }
+  }
+  const schema = typeof raw.schema === 'string' ? raw.schema : null
+  if (schema !== KEEPER_RUNTIME_MANIFEST_SCAN_DIAGNOSTICS_SCHEMA) {
+    return {
+      state: 'unavailable',
+      schema,
+      error: schema === null
+        ? 'manifest scan diagnostics schema is missing'
+        : `unsupported manifest scan diagnostics schema: ${schema}`,
+    }
+  }
+  if (
+    !Array.isArray(raw.retired_event_counts)
+    || !Array.isArray(raw.unsupported_event_counts)
+    || !Array.isArray(raw.samples)
+  ) {
+    return { state: 'unavailable', schema, error: 'malformed manifest scan diagnostics payload' }
+  }
+  const retiredEventCounts = raw.retired_event_counts.map(parseManifestEventCount)
+  const unsupportedEventCounts = raw.unsupported_event_counts.map(parseManifestEventCount)
+  const samples = raw.samples.map(parseManifestScanDiagnostic)
+  const retiredEventCount = nonNegativeInteger(raw.retired_event_count)
+  const unsupportedEventCount = nonNegativeInteger(raw.unsupported_event_count)
+  const unsupportedEventUnattributedCount = nonNegativeInteger(
+    raw.unsupported_event_unattributed_count,
+  )
+  const invalidManifestRowCount = nonNegativeInteger(raw.invalid_manifest_row_count)
+  const invalidJsonRowCount = nonNegativeInteger(raw.invalid_json_row_count)
+  if (
+    retiredEventCount === null
+    || unsupportedEventCount === null
+    || unsupportedEventUnattributedCount === null
+    || invalidManifestRowCount === null
+    || invalidJsonRowCount === null
+    || !allParsed(retiredEventCounts)
+    || !allParsed(unsupportedEventCounts)
+    || !allParsed(samples)
+  ) {
+    return { state: 'unavailable', schema, error: 'malformed manifest scan diagnostics payload' }
+  }
+  return {
+    state: 'available',
+    schema,
+    retired_event_count: retiredEventCount,
+    retired_event_counts: retiredEventCounts,
+    unsupported_event_count: unsupportedEventCount,
+    unsupported_event_counts: unsupportedEventCounts,
+    unsupported_event_unattributed_count: unsupportedEventUnattributedCount,
+    invalid_manifest_row_count: invalidManifestRowCount,
+    invalid_json_row_count: invalidJsonRowCount,
+    samples,
+  }
 }
 
 function recordListField(raw: Record<string, unknown>, key: string): Record<string, unknown>[] {
@@ -683,6 +824,7 @@ export function parseKeeperRuntimeTrace(raw: unknown): KeeperRuntimeTraceRespons
     manifest_total_rows: numberField(raw, 'manifest_total_rows'),
     manifest_returned_rows: numberField(raw, 'manifest_returned_rows'),
     receipt_returned_rows: numberField(raw, 'receipt_returned_rows'),
+    manifest_scan_diagnostics: parseManifestScanDiagnostics(raw.manifest_scan_diagnostics),
     turn_identity: parseRuntimeTraceTurnIdentity(raw.turn_identity),
     provider_attempts: parseRuntimeTraceProviderAttempts(raw.provider_attempts),
     event_bus: parseRuntimeTraceEventBus(raw.event_bus),

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -635,7 +635,24 @@ describe('keeper runtime trace', () => {
       manifest_total_rows: 10,
       manifest_returned_rows: 8,
       receipt_returned_rows: 1,
-	      turn_identity: {
+      manifest_scan_diagnostics: {
+        schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
+        retired_event_count: 2,
+        retired_event_counts: [
+          { event: 'state_snapshot_sidecar_saved', count: 1 },
+          { event: 'working_state_sidecar_saved', count: 1 },
+        ],
+        unsupported_event_count: 1,
+        unsupported_event_counts: [{ event: 'future_event', count: 1 }],
+        unsupported_event_unattributed_count: 0,
+        invalid_manifest_row_count: 1,
+        invalid_json_row_count: 1,
+        samples: [
+          { kind: 'retired_event', event: 'state_snapshot_sidecar_saved' },
+          { kind: 'unsupported_event', event: 'future_event' },
+        ],
+      },
+      turn_identity: {
         requested_keeper_turn_id: 7,
         manifest_keeper_turn_ids: [7],
         receipt_turn_counts: [7],
@@ -710,11 +727,30 @@ describe('keeper runtime trace', () => {
 	    expect(result.event_bus.correlation_ids).toEqual(['corr-1'])
     expect(result.memory.memory_flushed_count).toBe(0)
     expect(result.memory.episodes_flushed).toBe(2)
+    expect(result.manifest_scan_diagnostics.state).toBe('available')
+    if (result.manifest_scan_diagnostics.state !== 'available') {
+      throw new Error(result.manifest_scan_diagnostics.error)
+    }
+    expect(result.manifest_scan_diagnostics.retired_event_count).toBe(2)
+    expect(result.manifest_scan_diagnostics.unsupported_event_counts).toEqual([
+      { event: 'future_event', count: 1 },
+    ])
+    expect(result.manifest_scan_diagnostics.samples[0]?.detail).toBeNull()
     expect(result.linked_artifacts.receipts[0]?.path).toBe('/tmp/receipt.jsonl')
     expect(result.linked_artifacts.checkpoints[0]?.present).toBe(false)
     expect(result.manifest_rows[0]?.event).toBe('Turn_started')
     expect(result.receipts[0]?.terminal_reason_code).toBe('completed')
     expect(result.health).toBe('ok')
+  })
+
+  it('does not report clean diagnostics when an older runtime omits them', () => {
+    const result = parseKeeperRuntimeTrace({ keeper: 'sangsu', trace_id: 'trace-old' })
+
+    expect(result.manifest_scan_diagnostics).toEqual({
+      state: 'unavailable',
+      schema: null,
+      error: 'runtime did not report manifest scan diagnostics',
+    })
   })
 
   it('parses runtime lens evidence with safe defaults and gap codes', () => {

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -66,6 +66,18 @@ function runtimeTrace(): KeeperRuntimeTraceResponse {
     manifest_total_rows: 5,
     manifest_returned_rows: 5,
     receipt_returned_rows: 1,
+    manifest_scan_diagnostics: {
+      state: 'available',
+      schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
+      retired_event_count: 0,
+      retired_event_counts: [],
+      unsupported_event_count: 0,
+      unsupported_event_counts: [],
+      unsupported_event_unattributed_count: 0,
+      invalid_manifest_row_count: 0,
+      invalid_json_row_count: 0,
+      samples: [],
+    },
     turn_identity: {
       requested_keeper_turn_id: 1,
       manifest_keeper_turn_ids: [1],

--- a/dashboard/src/components/journey-waterfall-state.test.ts
+++ b/dashboard/src/components/journey-waterfall-state.test.ts
@@ -41,6 +41,18 @@ function runtimeTrace(overrides: Partial<KeeperRuntimeTraceResponse> = {}): Keep
     manifest_total_rows: 10,
     manifest_returned_rows: 10,
     receipt_returned_rows: 1,
+    manifest_scan_diagnostics: {
+      state: 'available',
+      schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
+      retired_event_count: 0,
+      retired_event_counts: [],
+      unsupported_event_count: 0,
+      unsupported_event_counts: [],
+      unsupported_event_unattributed_count: 0,
+      invalid_manifest_row_count: 0,
+      invalid_json_row_count: 0,
+      samples: [],
+    },
     turn_identity: {
       requested_keeper_turn_id: 2,
       manifest_keeper_turn_ids: [2],

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -503,6 +503,18 @@ describe('RuntimeLensSection', () => {
       manifest_total_rows: 6,
       manifest_returned_rows: 6,
       receipt_returned_rows: 1,
+      manifest_scan_diagnostics: {
+        state: 'available',
+        schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
+        retired_event_count: 0,
+        retired_event_counts: [],
+        unsupported_event_count: 0,
+        unsupported_event_counts: [],
+        unsupported_event_unattributed_count: 0,
+        invalid_manifest_row_count: 0,
+        invalid_json_row_count: 0,
+        samples: [],
+      },
       turn_identity: {
         requested_keeper_turn_id: 7,
         manifest_keeper_turn_ids: [7],
@@ -808,6 +820,8 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('trace-lens')).toBeInTheDocument()
     expect(screen.getByText('manifest rows')).toBeInTheDocument()
     expect(screen.getByText('6/6')).toBeInTheDocument()
+    expect(screen.getByText('manifest diagnostics')).toBeInTheDocument()
+    expect(screen.getByText('clean')).toBeInTheDocument()
     expect(screen.getByText('receipt rows')).toBeInTheDocument()
     expect(screen.getByText('manifest file')).toBeInTheDocument()
     expect(screen.getByText('manifest raw rows')).toBeInTheDocument()
@@ -835,6 +849,50 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('inj 1/1 · flush success 1 · error 0 · ep/proc ep 2 · proc 1')).toBeInTheDocument()
     expect(screen.getByText('Provider')).toBeInTheDocument()
     expect(screen.getByText('Tool Runtime')).toBeInTheDocument()
+  })
+
+  it('surfaces retired, unsupported, and invalid manifest rows', () => {
+    const trace = runtimeTraceFixture()
+    trace.manifest_scan_diagnostics = {
+      state: 'available',
+      schema: 'keeper.runtime_manifest_scan_diagnostics.v1',
+      retired_event_count: 2,
+      retired_event_counts: [
+        { event: 'state_snapshot_sidecar_saved', count: 1 },
+        { event: 'working_state_sidecar_saved', count: 1 },
+      ],
+      unsupported_event_count: 3,
+      unsupported_event_counts: [{ event: 'future_manifest_event', count: 1 }],
+      unsupported_event_unattributed_count: 2,
+      invalid_manifest_row_count: 1,
+      invalid_json_row_count: 0,
+      samples: [
+        { kind: 'unsupported_event', event: 'future_manifest_event', detail: null },
+      ],
+    }
+
+    render(h(RuntimeLensSection, { trace }))
+
+    expect(screen.getByText('retired 2 · unsupported 3 · invalid 1')).toBeInTheDocument()
+    expect(screen.getByText('manifest diagnostics').nextElementSibling).toHaveAttribute(
+      'title',
+      expect.stringContaining('unsupported rows outside identity detail bound=2'),
+    )
+  })
+
+  it('does not render an omitted diagnostics contract as clean', () => {
+    const trace = runtimeTraceFixture()
+    trace.manifest_scan_diagnostics = {
+      state: 'unavailable',
+      schema: null,
+      error: 'runtime did not report manifest scan diagnostics',
+    }
+
+    render(h(RuntimeLensSection, { trace }))
+
+    expect(screen.getByText('manifest diagnostics').nextElementSibling).toHaveTextContent(
+      'unavailable',
+    )
   })
 
   it('renders catalog-backed runtime spec for the observed live runtime id', async () => {

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -1321,6 +1321,39 @@ function runtimeTraceMemoryEvidence(trace: KeeperRuntimeTraceResponse): string {
   ].join(' · ')
 }
 
+function runtimeManifestDiagnosticsValue(trace: KeeperRuntimeTraceResponse): string {
+  const diagnostics = trace.manifest_scan_diagnostics
+  if (diagnostics.state === 'unavailable') return 'unavailable'
+  const invalid = diagnostics.invalid_manifest_row_count + diagnostics.invalid_json_row_count
+  if (
+    diagnostics.retired_event_count === 0
+    && diagnostics.unsupported_event_count === 0
+    && invalid === 0
+  ) return 'clean'
+  return [
+    `retired ${diagnostics.retired_event_count}`,
+    `unsupported ${diagnostics.unsupported_event_count}`,
+    `invalid ${invalid}`,
+  ].join(' · ')
+}
+
+function runtimeManifestDiagnosticsTitle(trace: KeeperRuntimeTraceResponse): string {
+  const diagnostics = trace.manifest_scan_diagnostics
+  if (diagnostics.state === 'unavailable') {
+    return [diagnostics.error, diagnostics.schema].filter(Boolean).join('\n')
+  }
+  const eventCounts = [
+    ...diagnostics.retired_event_counts.map(item => `retired:${item.event}=${item.count}`),
+    ...diagnostics.unsupported_event_counts.map(item => `unsupported:${item.event}=${item.count}`),
+  ]
+  const sampleDetails = diagnostics.samples.map(sample =>
+    [sample.kind, sample.event, sample.detail].filter(Boolean).join(':'))
+  const overflow = diagnostics.unsupported_event_unattributed_count === 0
+    ? []
+    : [`unsupported rows outside identity detail bound=${diagnostics.unsupported_event_unattributed_count}`]
+  return [...eventCounts, ...overflow, ...sampleDetails].join('\n') || 'no manifest scan diagnostics'
+}
+
 function artifactEvidenceLabel(artifacts: readonly { present: boolean }[]): string {
   if (artifacts.length === 0) return '0/0'
   const present = artifacts.filter(item => item.present).length
@@ -1627,6 +1660,11 @@ export function RuntimeLensSection({
           title=${trace.manifest_path}
         />
         <${SignalRow} label="manifest rows" value=${formatRatioPair({ numerator: trace.manifest_returned_rows, denominator: trace.manifest_total_rows })} />
+        <${SignalRow}
+          label="manifest diagnostics"
+          value=${runtimeManifestDiagnosticsValue(trace)}
+          title=${runtimeManifestDiagnosticsTitle(trace)}
+        />
         <${SignalRow} label="receipt rows" value=${trace.receipt_returned_rows} />
         <${SignalRow} label="manifest raw rows" value=${trace.manifest_rows.length} />
         <${SignalRow} label="receipt raw rows" value=${trace.receipts.length} />

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -570,7 +570,23 @@ let links_of_json = function
         (Printf.sprintf "field \"links\" must be an object (received %s)"
            (Json_util.kind_name other))
 
-let of_json = function
+type parsed_row = {
+  ts : string;
+  keeper_name : string;
+  agent_name : string option;
+  trace_id : string;
+  generation : int option;
+  keeper_turn_id : int option;
+  oas_turn_count : int option;
+  logical_seq : int option;
+  event_wire : string;
+  runtime_id : string option;
+  status : string;
+  decision : Yojson.Safe.t;
+  links : links;
+}
+
+let parse_row = function
   | `Assoc fields -> (
       let ( >>= ) result f =
         match result with Ok value -> f value | Error _ as err -> err
@@ -591,23 +607,14 @@ let of_json = function
             optional_int "keeper_turn_id" fields >>= fun keeper_turn_id ->
             optional_int "oas_turn_count" fields >>= fun oas_turn_count ->
             optional_int "logical_seq" fields >>= fun logical_seq ->
-            required_string "event" fields >>= fun event_string ->
-            (match event_kind_of_string event_string with
-            | None -> Error (Printf.sprintf "unknown event: %S" event_string)
-            | Some event -> Ok event)
-            >>= fun event ->
-            (match optional_string "runtime_id" fields with
-             | Ok (Some runtime_id) -> Ok (Some runtime_id)
-             | Ok None -> optional_string "runtime_id" fields
-             | Error _ as error -> error)
-            >>= fun runtime_id ->
+            required_string "event" fields >>= fun event_wire ->
+            optional_string "runtime_id" fields >>= fun runtime_id ->
             required_string "status" fields >>= fun status ->
             field "decision" fields >>= fun decision ->
             field "links" fields >>= fun links_json ->
             links_of_json links_json >>= fun links ->
             Ok
               {
-                schema_version;
                 ts;
                 keeper_name;
                 agent_name;
@@ -616,7 +623,7 @@ let of_json = function
                 keeper_turn_id;
                 oas_turn_count;
                 logical_seq;
-                event;
+                event_wire;
                 runtime_id;
                 status;
                 decision;
@@ -626,6 +633,50 @@ let of_json = function
       Error
         (Printf.sprintf "manifest row must be a JSON object (received %s)"
            (Json_util.kind_name other))
+
+let row_identity (row : parsed_row) : row_identity =
+  {
+    keeper_name = row.keeper_name;
+    trace_id = row.trace_id;
+    keeper_turn_id = row.keeper_turn_id;
+  }
+
+let active_row (row : parsed_row) event : t =
+  {
+    schema_version;
+    ts = row.ts;
+    keeper_name = row.keeper_name;
+    agent_name = row.agent_name;
+    trace_id = row.trace_id;
+    generation = row.generation;
+    keeper_turn_id = row.keeper_turn_id;
+    oas_turn_count = row.oas_turn_count;
+    logical_seq = row.logical_seq;
+    event;
+    runtime_id = row.runtime_id;
+    status = row.status;
+    decision = row.decision;
+    links = row.links;
+  }
+
+let decode_persisted_row json =
+  match parse_row json with
+  | Error _ as error -> error
+  | Ok row -> (
+      match classify_event_wire row.event_wire with
+      | Active_event event -> Ok (Active_row (active_row row event))
+      | Retired_event event -> Ok (Retired_row (row_identity row, event))
+      | Unsupported_event event -> Ok (Unsupported_row (row_identity row, event)))
+
+let of_json json =
+  match decode_persisted_row json with
+  | Ok (Active_row row) -> Ok row
+  | Ok (Retired_row (_, event)) ->
+      Error
+        (Printf.sprintf "unknown event: %S" (retired_event_kind_to_string event))
+  | Ok (Unsupported_row (_, event)) ->
+      Error (Printf.sprintf "unknown event: %S" event)
+  | Error _ as error -> error
 
 let dated_jsonl_today_path base_dir =
   let open Unix in

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -165,6 +165,9 @@ val make_for_context :
 val to_json : t -> Yojson.Safe.t
 val public_to_json : t -> Yojson.Safe.t
 val public_projection_of_decision : Yojson.Safe.t -> Yojson.Safe.t
+(** Decode and validate the common persisted envelope before classifying its
+    event as active, retired, or genuinely unsupported. *)
+val decode_persisted_row : Yojson.Safe.t -> (decoded_row, string) result
 val of_json : Yojson.Safe.t -> (t, string) result
 
 val execution_receipt_path_for_today :

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -84,24 +84,67 @@ let event_kind_of_string = function
   | "turn_finished" -> Some Turn_finished
   | _ -> None
 
+(** Event kinds that were valid in persisted schema-v1 manifests but whose
+    producers and product behavior have been retired. Keeping them outside
+    [event_kind] makes it impossible for current manifest producers to emit a
+    retired row while preserving a typed read boundary for durable history. *)
+type retired_event_kind =
+  | Memory_injected
+  | Memory_flushed
+  | Tool_lineage_recorded
+  | Tool_surface_selected
+  | Cascade_routed
+  | State_snapshot_sidecar_saved
+  | Working_state_sidecar_saved
+
+let all_retired_event_kinds =
+  [ Memory_injected
+  ; Memory_flushed
+  ; Tool_lineage_recorded
+  ; Tool_surface_selected
+  ; Cascade_routed
+  ; State_snapshot_sidecar_saved
+  ; Working_state_sidecar_saved
+  ]
+;;
+
+let retired_event_kind_to_string = function
+  | Memory_injected -> "memory_injected"
+  | Memory_flushed -> "memory_flushed"
+  | Tool_lineage_recorded -> "tool_lineage_recorded"
+  | Tool_surface_selected -> "tool_surface_selected"
+  | Cascade_routed -> "cascade_routed"
+  | State_snapshot_sidecar_saved -> "state_snapshot_sidecar_saved"
+  | Working_state_sidecar_saved -> "working_state_sidecar_saved"
+;;
+
+let retired_event_kind_of_string value =
+  List.find_opt
+    (fun event -> String.equal value (retired_event_kind_to_string event))
+    all_retired_event_kinds
+;;
+
+type event_wire_class =
+  | Active_event of event_kind
+  | Retired_event of retired_event_kind
+  | Unsupported_event of string
+
+let classify_event_wire value =
+  match event_kind_of_string value with
+  | Some event -> Active_event event
+  | None ->
+    (match retired_event_kind_of_string value with
+     | Some event -> Retired_event event
+     | None -> Unsupported_event value)
+;;
+
 type compaction_snapshot_event_class =
   | Compaction_snapshot_relevant
   | Compaction_snapshot_known_unrelated
   | Compaction_snapshot_unknown
 
 let known_unrelated_untyped_compaction_snapshot_events =
-  [ "memory_injected"
-  ; "memory_flushed"
-  ; "tool_lineage_recorded"
-  ; "tool_surface_selected"
-  ; "cascade_routed"
-  ]
-;;
-
-let is_known_unrelated_untyped_compaction_snapshot_event event =
-  List.exists
-    (String.equal event)
-    known_unrelated_untyped_compaction_snapshot_events
+  List.map retired_event_kind_to_string all_retired_event_kinds
 ;;
 
 let classify_compaction_snapshot_typed_event = function
@@ -124,12 +167,10 @@ let classify_compaction_snapshot_typed_event = function
       Compaction_snapshot_known_unrelated
 
 let classify_compaction_snapshot_event event =
-  if is_known_unrelated_untyped_compaction_snapshot_event event
-  then Compaction_snapshot_known_unrelated
-  else (
-    match event_kind_of_string event with
-    | Some typed_event -> classify_compaction_snapshot_typed_event typed_event
-    | None -> Compaction_snapshot_unknown)
+  match classify_event_wire event with
+  | Active_event typed_event -> classify_compaction_snapshot_typed_event typed_event
+  | Retired_event _ -> Compaction_snapshot_known_unrelated
+  | Unsupported_event _ -> Compaction_snapshot_unknown
 
 (* ── Record types ────────────────────────────────────────────────────── *)
 
@@ -155,6 +196,17 @@ type t = {
   decision : Yojson.Safe.t;
   links : links;
 }
+
+type row_identity = {
+  keeper_name : string;
+  trace_id : string;
+  keeper_turn_id : int option;
+}
+
+type decoded_row =
+  | Active_row of t
+  | Retired_row of row_identity * retired_event_kind
+  | Unsupported_row of row_identity * string
 
 type turn_context = {
   manifest_keeper_name : string;

--- a/lib/keeper_registry/keeper_runtime_manifest_types.mli
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.mli
@@ -20,6 +20,32 @@ val all_event_kinds : event_kind list
 val event_kind_to_string : event_kind -> string
 val event_kind_of_string : string -> event_kind option
 
+(** Persisted schema-v1 events whose producers are no longer part of the
+    active product. They are decode-only and cannot be passed to
+    [Keeper_runtime_manifest.make]. *)
+type retired_event_kind =
+  | Memory_injected
+  | Memory_flushed
+  | Tool_lineage_recorded
+  | Tool_surface_selected
+  | Cascade_routed
+  | State_snapshot_sidecar_saved
+  | Working_state_sidecar_saved
+
+val all_retired_event_kinds : retired_event_kind list
+val retired_event_kind_to_string : retired_event_kind -> string
+val retired_event_kind_of_string : string -> retired_event_kind option
+
+type event_wire_class =
+  | Active_event of event_kind
+  | Retired_event of retired_event_kind
+  | Unsupported_event of string
+
+(** Classify a manifest event wire once at the persistence boundary. Current
+    producers consume only [event_kind]; readers can observe retired and
+    genuinely unsupported wires without reintroducing their behavior. *)
+val classify_event_wire : string -> event_wire_class
+
 type compaction_snapshot_event_class =
   | Compaction_snapshot_relevant
   | Compaction_snapshot_known_unrelated
@@ -49,6 +75,23 @@ type t = {
   decision : Yojson.Safe.t;
   links : links;
 }
+
+(** Identity retained for validated persisted rows whose event is no longer
+    constructible as an active [t]. *)
+type row_identity = {
+  keeper_name : string;
+  trace_id : string;
+  keeper_turn_id : int option;
+}
+
+(** Result of decoding the durable wire envelope. All three constructors have
+    passed schema and common-field validation; only [Active_row] is accepted
+    by current producer-facing APIs. *)
+type decoded_row =
+  | Active_row of t
+  | Retired_row of row_identity * retired_event_kind
+  | Unsupported_row of row_identity * string
+
 type turn_context = {
   manifest_keeper_name : string;
   manifest_agent_name : string option;

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -399,6 +399,8 @@ let keeper_runtime_trace_json (config : Workspace.config) (name : string)
                 `Bool (manifest_scan.scanned_lines < manifest_scan.scan_line_limit) );
               ("manifest_scan_line_limit", `Int manifest_scan.scan_line_limit);
               ("manifest_scanned_lines", `Int manifest_scan.scanned_lines);
+              ( "manifest_scan_diagnostics"
+              , runtime_manifest_scan_diagnostics_json manifest_scan );
               ("manifest_returned_rows", `Int (List.length manifest_rows));
               ("receipt_returned_rows", `Int (List.length receipts));
               ( "turn_identity",

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -4,18 +4,19 @@ open Server_dashboard_http_keeper_api_types
 open Server_dashboard_http_keeper_runtime_manifest_scan
 open Server_dashboard_http_keeper_runtime_lens_swimlane
 
+type manifest_row = Keeper_runtime_manifest.t
 
 let clock_refs decision =
   match Json_util.assoc_member_opt "clock_refs" decision with
   | Some (`Assoc _ as obj) -> Some obj
   | _ -> None
 
-let clock_string row key =
+let clock_string (row : manifest_row) key =
   match clock_refs row.Keeper_runtime_manifest.decision with
   | Some refs -> Json_util.get_string refs key
   | None -> None
 
-let clock_string_non_empty row key =
+let clock_string_non_empty (row : manifest_row) key =
   match clock_string row key with
   | Some value -> String_util.trim_to_option value
   | _ -> None
@@ -32,34 +33,34 @@ let basename_opt = function
     let base = Filename.basename path in
     String_util.trim_to_option base
 
-let turn_label row =
+let turn_label (row : manifest_row) =
   match row.Keeper_runtime_manifest.keeper_turn_id with
   | Some value -> string_of_int value
   | None -> "unknown"
 
-let oas_turn_label row =
+let oas_turn_label (row : manifest_row) =
   match row.Keeper_runtime_manifest.oas_turn_count with
   | Some value -> string_of_int value
   | None -> "0"
 
-let fallback_edge_id row idx =
+let fallback_edge_id (row : manifest_row) idx =
   Printf.sprintf "%s:%s:%d" row.Keeper_runtime_manifest.trace_id
     (Keeper_runtime_manifest.event_kind_to_string row.Keeper_runtime_manifest.event)
     idx
 
-let fallback_tool_batch_id row =
+let fallback_tool_batch_id (row : manifest_row) =
   Printf.sprintf "%s:keeper-%s:tool-batch-oas-%s"
     row.Keeper_runtime_manifest.trace_id
     (turn_label row)
     (oas_turn_label row)
 
-let fallback_provider_attempt_id row attempt_index =
+let fallback_provider_attempt_id (row : manifest_row) attempt_index =
   Printf.sprintf "%s:keeper-%s:provider-attempt-%d"
     row.Keeper_runtime_manifest.trace_id
     (turn_label row)
     attempt_index
 
-let fallback_checkpoint_id row =
+let fallback_checkpoint_id (row : manifest_row) =
   let decision = row.Keeper_runtime_manifest.decision in
   first_string_opt
     [
@@ -73,13 +74,13 @@ let fallback_checkpoint_id row =
       |> Option.map (fun base -> "checkpoint:" ^ base);
     ]
 
-let fallback_compaction_id row idx =
+let fallback_compaction_id (row : manifest_row) idx =
   Printf.sprintf "%s:keeper-%s:compaction-%d"
     row.Keeper_runtime_manifest.trace_id
     (turn_label row)
     idx
 
-let event_started_at row =
+let event_started_at (row : manifest_row) =
   match row.Keeper_runtime_manifest.event with
   | Keeper_runtime_manifest.Turn_started
   | Keeper_runtime_manifest.Phase_gate_decided
@@ -101,7 +102,7 @@ let event_started_at row =
   | Keeper_runtime_manifest.Turn_finished ->
     None
 
-let event_finished_at row =
+let event_finished_at (row : manifest_row) =
   match row.Keeper_runtime_manifest.event with
   | Keeper_runtime_manifest.Runtime_completed
   | Keeper_runtime_manifest.Runtime_failed
@@ -128,7 +129,7 @@ let event_source_clock = function
     Keeper_runtime_manifest.source_clock_of_event event
     |> Keeper_runtime_manifest.source_clock_to_string
 
-let clock_edge_json ~idx ~provider_attempt_index row =
+let clock_edge_json ~idx ~provider_attempt_index (row : manifest_row) =
   let event = row.Keeper_runtime_manifest.event in
   let decision = row.Keeper_runtime_manifest.decision in
   let explicit_provider_attempt_id = clock_string row "provider_attempt_id" in

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -220,7 +220,7 @@ let max_int_opt current value =
   | None -> Some value
   | Some existing -> Some (max existing value)
 
-let update_runtime_manifest_scan scan row =
+let update_runtime_manifest_scan scan (row : Keeper_runtime_manifest.t) =
   scan.total_rows <- scan.total_rows + 1;
   push_bounded scan.returned_rows scan.limit row;
   increment_event_count scan row.Keeper_runtime_manifest.event;

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -118,7 +118,11 @@ let queue_to_list queue =
   List.rev !values
 
 let increment_count table key =
-  let current = Option.value (Hashtbl.find_opt table key) ~default:0 in
+  let current =
+    match Hashtbl.find_opt table key with
+    | Some count -> count
+    | None -> 0
+  in
   Hashtbl.replace table key (current + 1)
 ;;
 

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -5,6 +5,12 @@
 
 open Server_dashboard_http_keeper_api_types
 
+type manifest_scan_diagnostic =
+  | Retired_event_row of Keeper_runtime_manifest.retired_event_kind
+  | Unsupported_event_row of string
+  | Invalid_manifest_row of string
+  | Invalid_json_row of string
+
 type runtime_manifest_scan =
   { path : string
   ; limit : int
@@ -38,6 +44,13 @@ type runtime_manifest_scan =
   ; mutable scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
+  ; retired_event_counts : (Keeper_runtime_manifest.retired_event_kind, int) Hashtbl.t
+  ; unsupported_event_counts : (string, int) Hashtbl.t
+  ; mutable unsupported_event_count : int
+  ; mutable unsupported_event_unattributed_count : int
+  ; mutable invalid_manifest_row_count : int
+  ; mutable invalid_json_row_count : int
+  ; diagnostic_samples : manifest_scan_diagnostic Queue.t
   }
 
 let runtime_manifest_tail_scan_min_lines = 1000
@@ -85,6 +98,13 @@ let make_runtime_manifest_scan ~path ~limit ~scan_line_limit ~scan_scope =
   ; scanned_lines = 0
   ; scan_line_limit
   ; scan_scope
+  ; retired_event_counts = Hashtbl.create 7
+  ; unsupported_event_counts = Hashtbl.create 7
+  ; unsupported_event_count = 0
+  ; unsupported_event_unattributed_count = 0
+  ; invalid_manifest_row_count = 0
+  ; invalid_json_row_count = 0
+  ; diagnostic_samples = Queue.create ()
   }
 
 let push_bounded queue limit value =
@@ -96,6 +116,91 @@ let queue_to_list queue =
   let values = ref [] in
   Queue.iter (fun value -> values := value :: !values) queue;
   List.rev !values
+
+let increment_count table key =
+  let current = Option.value (Hashtbl.find_opt table key) ~default:0 in
+  Hashtbl.replace table key (current + 1)
+;;
+
+let increment_bounded_count table ~capacity key =
+  match Hashtbl.find_opt table key with
+  | Some current ->
+    Hashtbl.replace table key (current + 1);
+    true
+  | None when Hashtbl.length table < capacity ->
+    Hashtbl.add table key 1;
+    true
+  | None -> false
+;;
+
+let record_manifest_scan_diagnostic scan diagnostic =
+  (match diagnostic with
+   | Retired_event_row event -> increment_count scan.retired_event_counts event
+   | Unsupported_event_row event ->
+     scan.unsupported_event_count <- scan.unsupported_event_count + 1;
+     if not (increment_bounded_count scan.unsupported_event_counts ~capacity:scan.limit event)
+     then
+       scan.unsupported_event_unattributed_count <-
+         scan.unsupported_event_unattributed_count + 1
+   | Invalid_manifest_row _ ->
+     scan.invalid_manifest_row_count <- scan.invalid_manifest_row_count + 1
+   | Invalid_json_row _ -> scan.invalid_json_row_count <- scan.invalid_json_row_count + 1);
+  push_bounded scan.diagnostic_samples scan.limit diagnostic
+;;
+
+let sorted_count_rows table key_to_string =
+  Hashtbl.fold
+    (fun key count rows -> (key_to_string key, count) :: rows)
+    table
+    []
+  |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  |> List.map (fun (event, count) ->
+    `Assoc [ "event", `String event; "count", `Int count ])
+;;
+
+let count_total table = Hashtbl.fold (fun _ count total -> total + count) table 0
+
+let manifest_scan_diagnostic_to_json = function
+  | Retired_event_row event ->
+    `Assoc
+      [ "kind", `String "retired_event"
+      ; "event", `String (Keeper_runtime_manifest.retired_event_kind_to_string event)
+      ]
+  | Unsupported_event_row event ->
+    `Assoc [ "kind", `String "unsupported_event"; "event", `String event ]
+  | Invalid_manifest_row detail ->
+    `Assoc [ "kind", `String "invalid_manifest_row"; "detail", `String detail ]
+  | Invalid_json_row detail ->
+    `Assoc [ "kind", `String "invalid_json_row"; "detail", `String detail ]
+;;
+
+let runtime_manifest_scan_diagnostics_schema =
+  "keeper.runtime_manifest_scan_diagnostics.v1"
+;;
+
+let runtime_manifest_scan_diagnostics_json scan =
+  `Assoc
+    [ "schema", `String runtime_manifest_scan_diagnostics_schema
+    ; "retired_event_count", `Int (count_total scan.retired_event_counts)
+    ; ( "retired_event_counts"
+      , `List
+          (sorted_count_rows
+             scan.retired_event_counts
+             Keeper_runtime_manifest.retired_event_kind_to_string) )
+    ; "unsupported_event_count", `Int scan.unsupported_event_count
+    ; ( "unsupported_event_counts"
+      , `List (sorted_count_rows scan.unsupported_event_counts Fun.id) )
+    ; ( "unsupported_event_unattributed_count"
+      , `Int scan.unsupported_event_unattributed_count )
+    ; "invalid_manifest_row_count", `Int scan.invalid_manifest_row_count
+    ; "invalid_json_row_count", `Int scan.invalid_json_row_count
+    ; ( "samples"
+      , `List
+          (List.map
+             manifest_scan_diagnostic_to_json
+             (queue_to_list scan.diagnostic_samples)) )
+    ]
+;;
 
 let increment_event_count scan event =
   let key = Keeper_runtime_manifest.event_kind_to_string event in
@@ -219,6 +324,16 @@ let update_runtime_manifest_scan scan row =
      push_bounded scan.provider_attempt_rows scan.limit row
    | _ -> ())
 
+let manifest_identity_matches ?turn_id keeper_name trace_id
+    (identity : Keeper_runtime_manifest.row_identity) =
+  String.equal identity.keeper_name keeper_name
+  && String.equal identity.trace_id trace_id
+  &&
+  match turn_id with
+  | None -> true
+  | Some wanted -> identity.keeper_turn_id = Some wanted
+;;
+
 let read_runtime_manifest_scan ~config ~keeper_name ~trace_id ?turn_id ~limit () =
   let path =
     Keeper_runtime_manifest.path_for_trace config ~keeper_name ~trace_id
@@ -236,23 +351,21 @@ let read_runtime_manifest_scan ~config ~keeper_name ~trace_id ?turn_id ~limit ()
        (fun line ->
           scan.scanned_lines <- scan.scanned_lines + 1;
           try
-            match Yojson.Safe.from_string line |> Keeper_runtime_manifest.of_json with
-            | Ok row when manifest_row_matches ?turn_id keeper_name trace_id row ->
-                update_runtime_manifest_scan scan row
+            let json = Yojson.Safe.from_string line in
+            match Keeper_runtime_manifest.decode_persisted_row json with
+            | Ok (Keeper_runtime_manifest.Active_row row)
+              when manifest_row_matches ?turn_id keeper_name trace_id row ->
+              update_runtime_manifest_scan scan row
+            | Ok (Keeper_runtime_manifest.Retired_row (identity, retired))
+              when manifest_identity_matches ?turn_id keeper_name trace_id identity ->
+              record_manifest_scan_diagnostic scan (Retired_event_row retired)
+            | Ok (Keeper_runtime_manifest.Unsupported_row (identity, unsupported))
+              when manifest_identity_matches ?turn_id keeper_name trace_id identity ->
+              record_manifest_scan_diagnostic scan (Unsupported_event_row unsupported)
             | Ok _ -> ()
-            | Error msg ->
-                Log.warn
-                  ~ctx:"runtime_manifest_scan"
-                  "Runtime manifest row skipped (keeper=%s trace=%s): %s"
-                  keeper_name
-                  trace_id
-                  msg
+            | Error detail ->
+              record_manifest_scan_diagnostic scan (Invalid_manifest_row detail)
           with
           | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
-              Log.warn
-                ~ctx:"runtime_manifest_scan"
-                "Runtime manifest row JSON parse failed (keeper=%s trace=%s): %s"
-                keeper_name
-                trace_id
-                msg);
+            record_manifest_scan_diagnostic scan (Invalid_json_row msg));
   scan

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -3,6 +3,12 @@
     Split from {!Server_dashboard_http_keeper_api}; included back there so
     existing local call sites keep using the same names. *)
 
+type manifest_scan_diagnostic =
+  | Retired_event_row of Keeper_runtime_manifest.retired_event_kind
+  | Unsupported_event_row of string
+  | Invalid_manifest_row of string
+  | Invalid_json_row of string
+
 type runtime_manifest_scan =
   { path : string
   ; limit : int
@@ -36,6 +42,13 @@ type runtime_manifest_scan =
   ; mutable scanned_lines : int
   ; scan_line_limit : int
   ; scan_scope : string
+  ; retired_event_counts : (Keeper_runtime_manifest.retired_event_kind, int) Hashtbl.t
+  ; unsupported_event_counts : (string, int) Hashtbl.t
+  ; mutable unsupported_event_count : int
+  ; mutable unsupported_event_unattributed_count : int
+  ; mutable invalid_manifest_row_count : int
+  ; mutable invalid_json_row_count : int
+  ; diagnostic_samples : manifest_scan_diagnostic Queue.t
   }
 
 val make_runtime_manifest_scan :
@@ -47,6 +60,7 @@ val make_runtime_manifest_scan :
 
 val push_bounded : 'a Queue.t -> int -> 'a -> unit
 val queue_to_list : 'a Queue.t -> 'a list
+val runtime_manifest_scan_diagnostics_json : runtime_manifest_scan -> Yojson.Safe.t
 val increment_event_count : runtime_manifest_scan -> Keeper_runtime_manifest.event_kind -> unit
 
 val runtime_manifest_scan_event_count :

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1408,13 +1408,22 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
   Fun.protect
     ~finally:(fun () -> Config_dir_resolver.reset ())
     (fun () ->
+      let expected_configured_names = [ "alpha"; "base"; "beta" ] in
+      let configured_names =
+        Keeper_meta_store.configured_keeper_names config
+        |> List.sort String.compare
+      in
+      Alcotest.(check (list string))
+        "configured Keeper inventory includes every declarative TOML"
+        expected_configured_names
+        configured_names;
       let json =
         Server_dashboard_http_core.dashboard_shell_payload_json ~light:true config
       in
       let open Yojson.Safe.Util in
       Alcotest.(check int)
         "configured_keepers follows declarative runtime keeper TOML"
-        2
+        (List.length configured_names)
         (json |> member "configured_keepers" |> to_int);
       Alcotest.(check int)
         "persisted_keepers exposes durable meta count separately"
@@ -1428,12 +1437,20 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
         (Filename.concat keepers_dir "base.toml")
         "[keeper]\nautoboot_enabled = true\n";
       Config_dir_resolver.reset ();
+      let configured_names_after_autoboot_change =
+        Keeper_meta_store.configured_keeper_names config
+        |> List.sort String.compare
+      in
+      Alcotest.(check (list string))
+        "autoboot policy does not change configured inventory"
+        expected_configured_names
+        configured_names_after_autoboot_change;
       let json =
         Server_dashboard_http_core.dashboard_shell_payload_json ~light:true config
       in
       Alcotest.(check int)
-        "configured_keepers includes explicit autoboot base keeper"
-        3
+        "configured_keepers remains the TOML inventory after autoboot change"
+        (List.length configured_names_after_autoboot_change)
         (json |> member "configured_keepers" |> to_int))
 
 let test_dashboard_shell_light_counts_agents_from_summary_fields () =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1410,7 +1410,7 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
     (fun () ->
       let expected_configured_names = [ "alpha"; "base"; "beta" ] in
       let configured_names =
-        Keeper_meta_store.configured_keeper_names config
+        Masc.Keeper_meta_store.configured_keeper_names config
         |> List.sort String.compare
       in
       Alcotest.(check (list string))
@@ -1438,7 +1438,7 @@ let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
         "[keeper]\nautoboot_enabled = true\n";
       Config_dir_resolver.reset ();
       let configured_names_after_autoboot_change =
-        Keeper_meta_store.configured_keeper_names config
+        Masc.Keeper_meta_store.configured_keeper_names config
         |> List.sort String.compare
       in
       Alcotest.(check (list string))

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -221,6 +221,126 @@ let string_member key = function
   | _ -> fail "expected object"
 ;;
 
+let runtime_manifest_json_with_field row_json field replacement =
+  match row_json with
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (key, value) ->
+            if String.equal key field then key, replacement else key, value)
+         fields)
+  | _ -> fail "runtime manifest row must encode as an object"
+;;
+
+let runtime_manifest_json_with_event row_json event =
+  runtime_manifest_json_with_field row_json "event" (`String event)
+;;
+
+let runtime_manifest_json_without_field row_json field =
+  match row_json with
+  | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+  | _ -> fail "runtime manifest row must encode as an object"
+;;
+
+let test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings () =
+  with_temp_dir @@ fun dir ->
+  let config = Workspace.default_config dir in
+  let keeper_name = "manifest-diagnostic-keeper" in
+  let trace_id = "trace-manifest-diagnostics" in
+  let active_row =
+    Keeper_runtime_manifest.make
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id:1
+      ~event:Keeper_runtime_manifest.Turn_started
+      ~status:"started"
+      ()
+    |> Keeper_runtime_manifest.to_json
+  in
+  let rows =
+    [ runtime_manifest_json_with_event active_row "state_snapshot_sidecar_saved"
+    ; runtime_manifest_json_with_event active_row "working_state_sidecar_saved"
+    ; runtime_manifest_json_with_event active_row "future_manifest_event"
+    ; runtime_manifest_json_with_event active_row "future_manifest_event_2"
+    ; runtime_manifest_json_with_event active_row "future_manifest_event_3"
+    ; runtime_manifest_json_with_field
+        (runtime_manifest_json_with_event active_row "state_snapshot_sidecar_saved")
+        "schema_version"
+        (`Int 2)
+    ; runtime_manifest_json_without_field active_row "status"
+    ; active_row
+    ]
+  in
+  let path =
+    Keeper_runtime_manifest.path_for_trace config ~keeper_name ~trace_id
+  in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let channel = open_out path in
+  List.iter
+    (fun row -> Printf.fprintf channel "%s\n" (Yojson.Safe.to_string row))
+    rows;
+  Printf.fprintf channel "{not-json\n";
+  close_out channel;
+  let warnings = ref [] in
+  Console_sink.For_testing.reset ();
+  Console_sink.For_testing.set_writer (Some (fun line -> warnings := line :: !warnings));
+  let scan =
+    Fun.protect
+      ~finally:Console_sink.For_testing.reset
+      (fun () ->
+         Runtime_lens_scan.read_runtime_manifest_scan
+           ~config
+           ~keeper_name
+           ~trace_id
+           ~limit:2
+           ())
+  in
+  check int "one active row decoded" 1 scan.total_rows;
+  check int "all rows scanned" 9 scan.scanned_lines;
+  check int "reader emits no per-row warnings" 0 (List.length !warnings);
+  let diagnostics = Runtime_lens_scan.runtime_manifest_scan_diagnostics_json scan in
+  let open Yojson.Safe.Util in
+  check string
+    "diagnostic schema"
+    "keeper.runtime_manifest_scan_diagnostics.v1"
+    (diagnostics |> member "schema" |> to_string);
+  check int
+    "retired rows counted"
+    2
+    (diagnostics |> member "retired_event_count" |> to_int);
+  check int
+    "unsupported rows counted"
+    3
+    (diagnostics |> member "unsupported_event_count" |> to_int);
+  check int
+    "unsupported rows outside the identity request bound are explicit"
+    1
+    (diagnostics
+     |> member "unsupported_event_unattributed_count"
+     |> to_int);
+  check int
+    "invalid manifest rows counted"
+    2
+    (diagnostics |> member "invalid_manifest_row_count" |> to_int);
+  check int
+    "invalid json rows counted"
+    1
+    (diagnostics |> member "invalid_json_row_count" |> to_int);
+  let retired_counts = diagnostics |> member "retired_event_counts" |> to_list in
+  check int "retired kinds remain distinct" 2 (List.length retired_counts);
+  let unsupported_counts =
+    diagnostics |> member "unsupported_event_counts" |> to_list
+  in
+  check int
+    "unsupported identity aggregation obeys request bound"
+    2
+    (List.length unsupported_counts);
+  check int
+    "diagnostic samples obey request bound"
+    2
+    (diagnostics |> member "samples" |> to_list |> List.length)
+;;
+
 let test_tool_runtime_zero_event_lane_is_not_observed () =
   let scan =
     Runtime_lens_scan.make_runtime_manifest_scan
@@ -275,11 +395,17 @@ let () =
              `Quick
              test_chat_trace_block_by_turn_ref_reads_allowed_trace_history
          ] )
-     ; ( "runtime_lens_swimlane"
-       , [ test_case
-             "tool_runtime zero-event lane is not observed"
-             `Quick
-             test_tool_runtime_zero_event_lane_is_not_observed
-         ] )
-     ]
+    ; ( "runtime_lens_swimlane"
+      , [ test_case
+            "tool_runtime zero-event lane is not observed"
+            `Quick
+            test_tool_runtime_zero_event_lane_is_not_observed
+        ] )
+    ; ( "runtime_manifest_scan"
+      , [ test_case
+            "surfaces retired and unsupported rows without repeated warnings"
+            `Quick
+            test_runtime_manifest_scan_surfaces_diagnostics_without_repeat_warnings
+        ] )
+    ]
 ;;


### PR DESCRIPTION
## Root cause

Schema-v1 manifest rows outlive retired producers, but the active event sum was also the only reader decoder. Dashboard tail scans therefore flattened durable retired rows into string errors and re-emitted the same warning on every read.

## Change

- keep current producer events closed and add a separate decode-only retired event catalog
- validate the entire persisted envelope before returning Active_row, Retired_row, or Unsupported_row
- aggregate retired, unsupported, invalid-manifest, and invalid-JSON diagnostics without per-row warning replay
- bound unsupported identity detail by the request limit while preserving total and unattributed row counts
- expose a versioned runtime-trace diagnostic contract
- render old or malformed runtime payloads as unavailable instead of silently reporting clean

## Boundary

No retired constructor can be passed to Keeper_runtime_manifest.make. Current producers remain on the active event type; compatibility exists only at the durable read boundary.

## Verification

- ocamlformat --check on all touched OCaml interfaces and implementations
- ocamlc -stop-after parsing on all touched OCaml files
- dashboard TypeScript typecheck
- focused Vitest: 83 tests passed
- git diff --check
- full Dune build and tests delegated to PR CI

Closes #24114