### PR TITLE
feat(task): add OperatorBlocked variant to task_status type

### DIFF
--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -290,12 +290,13 @@ let task_operation_status (task : Masc_domain.task) =
   (* RFC-0323 G-6: awaiting verification is the normal completion lane,
      not a pause — the operation is still moving (verifier's turn). *)
   | Masc_domain.AwaitingVerification _ -> Some "active"
-  | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ -> None
 
 let task_operation_updated_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -513,6 +513,7 @@ let task_updated_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
@@ -523,6 +524,7 @@ let task_completed_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> Some completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> Some cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> Some blocked_at
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -350,7 +350,8 @@ let rec build_tree context goals goal =
         match task.task_status with
         | Masc_domain.AwaitingVerification _ -> true
         | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Done _
-        | Masc_domain.Cancelled _ ->
+        | Masc_domain.Cancelled _
+        | Masc_domain.OperatorBlocked _ ->
             false)
       linked_tasks
   in

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -145,6 +145,18 @@ let task_status_info_of_task (task : Masc_domain.task) =
         cancelled_at = Some cancelled_at;
         reason;
       }
+  | Masc_domain.OperatorBlocked { blocked_by; blocked_at; reason } ->
+      {
+        status;
+        assignee = None;
+        claimed_at = None;
+        started_at = None;
+        completed_at = None;
+        notes = None;
+        cancelled_by = Some blocked_by;
+        cancelled_at = Some blocked_at;
+        reason = Some reason;
+      }
   | Masc_domain.AwaitingVerification { assignee; submitted_at; _ } ->
       {
         status;

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -79,6 +79,7 @@ let format_current_task (task : Masc_domain.task) : string =
     | Masc_domain.Todo -> "todo"
     | Masc_domain.Done _ -> "done"
     | Masc_domain.Cancelled _ -> "cancelled"
+    | Masc_domain.OperatorBlocked _ -> "operator_blocked"
   in
   let buf = Buffer.create 256 in
   Buffer.add_string buf "### Current Task (held by you)\n";

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -215,6 +215,7 @@ let task_status_snapshot_fields (status : Masc_domain.task_status) =
     Some assignee, phase, verifier, Some submitted_at, Some verification_id
   | Masc_domain.Done { assignee; _ } -> Some assignee, None, None, None, None
   | Masc_domain.Cancelled { cancelled_by; _ } -> Some cancelled_by, None, None, None, None
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> Some blocked_by, None, None, None, None
 ;;
 
 let task_snapshot_of_task (task : Masc_domain.task) =

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -171,7 +171,7 @@ let count_tasks_from_backlog (config : Workspace.config) ~(agent_name : string)
              Stdlib.incr completed
          | Masc_domain.Todo
          | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
-         | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ -> ());
   (!claimed, !completed)
 
 (** {1 Board Counting} *)

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -708,7 +708,7 @@ let evidence_refs =
                 (Atomic.get Workspace_hooks.verification_notify_submit_fn)
                   ctx.config ~task ~assignee ~verification_id ~evidence_refs
               | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-              | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ())
+              | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ -> ())
            | None -> ())
         | Masc_domain.Approve_verification ->
           (match verification_id_before with

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -17,7 +17,8 @@ let can_review_completion ~(task_opt : Masc_domain.task option) ~(agent_name : s
        | Masc_domain.Todo
        | Masc_domain.AwaitingVerification _
        | Masc_domain.Done _
-       | Masc_domain.Cancelled _ -> false)
+       | Masc_domain.Cancelled _
+       | Masc_domain.OperatorBlocked _ -> false)
   | None -> false
 
 let persisted_completion_contract ~(task_opt : Masc_domain.task option) =

--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -60,6 +60,12 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
            (Printf.sprintf
               "task %s was cancelled by %s; reopen or create a new task instead of calling masc_transition(action=done)"
               task_id cancelled_by)))
+    | Masc_domain.OperatorBlocked { blocked_by; _ } ->
+      Some
+        (Masc_domain.Task (Masc_domain.Task_error.InvalidState
+           (Printf.sprintf
+              "task %s is operator-blocked by %s; operator must unblock before any transition"
+              task_id blocked_by)))
     | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -170,7 +170,8 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
              | Masc_domain.Todo
              | Masc_domain.AwaitingVerification _
              | Masc_domain.Done _
-             | Masc_domain.Cancelled _ -> None)
+             | Masc_domain.Cancelled _ -> None
+             | Masc_domain.OperatorBlocked _ -> None)
     in
     match owned_task with
     | Some task_id ->

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -230,7 +230,8 @@ let todo_task_has_completed_deliverable_conflict (ctx : context) (task : Masc_do
   | Masc_domain.InProgress _
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> false
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> false
 ;;
 
 let todo_completed_deliverable_conflicts (ctx : context) tasks =
@@ -427,6 +428,8 @@ let status_summary_string ~task_list_projection (ctx : context) =
            , done_cnt
            , cancelled_cnt )
          | Masc_domain.Cancelled _ ->
+           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1
+         | Masc_domain.OperatorBlocked _ ->
            active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1)
       ([], 0, 0, 0, 0, 0)
       backlog.tasks

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -313,6 +313,11 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | OperatorBlocked of { blocked_by: string; blocked_at: string; reason: string }
+      (** RFC-0109 §A4: operator-gated pause that breaks unclaimable critical
+          task cycling. A task in this state cannot be claimed or released by
+          keepers — only an operator can transition it back to [Todo] or
+          [Cancelled]. *)
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -336,6 +341,7 @@ let task_status_to_string = function
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+  | OperatorBlocked _ -> "operator_blocked"
 
 let string_of_task_status = task_status_to_string
 
@@ -347,6 +353,7 @@ let task_status_icon = function
   | AwaitingVerification _ -> "🔍"
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"
+  | OperatorBlocked _ -> "🛑"
 
 (** Display assignee for task status.
     Cancelled surfaces [cancelled_by]; Todo yields "unclaimed".
@@ -355,6 +362,7 @@ let task_display_assignee = function
   | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
   | AwaitingVerification { assignee; _ } -> assignee
   | Cancelled { cancelled_by; _ } -> cancelled_by
+  | OperatorBlocked { blocked_by; _ } -> blocked_by
   | Todo -> "unclaimed"
 
 (** Extract assignee as [Some string], or [None] for Todo/Cancelled.
@@ -363,12 +371,12 @@ let task_assignee_of_status = function
   | Claimed { assignee; _ } -> Some assignee
   | InProgress { assignee; _ } -> Some assignee
   | AwaitingVerification { assignee; _ } -> Some assignee
-  | Todo | Done _ | Cancelled _ -> None
+  | Todo | Done _ | Cancelled _ | OperatorBlocked _ -> None
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.
     Exhaustive match — adding a constructor forces an update here. *)
 let task_status_is_terminal = function
-  | Done _ | Cancelled _ -> true
+  | Done _ | Cancelled _ | OperatorBlocked _ -> true
   | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
@@ -376,7 +384,7 @@ let task_status_is_terminal = function
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ | OperatorBlocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],
@@ -420,6 +428,8 @@ let task_status_schema_witnesses : task_status list =
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
       { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
+  ; OperatorBlocked
+      { blocked_by = placeholder; blocked_at = placeholder; reason = placeholder }
   ]
 
 let all_task_status_names : string list =
@@ -470,6 +480,13 @@ let task_status_to_yojson = function
         ("cancelled_at", `String cancelled_at);
         ("reason", Json_util.string_opt_to_json reason);
       ]
+  | OperatorBlocked { blocked_by; blocked_at; reason } ->
+      `Assoc [
+        ("status", `String "operator_blocked");
+        ("blocked_by", `String blocked_by);
+        ("blocked_at", `String blocked_at);
+        ("reason", `String reason);
+      ]
 
 let task_status_of_yojson json =
   let req key = Json_util.get_string_with_default json ~key ~default:"" in
@@ -504,6 +521,12 @@ let task_status_of_yojson json =
               { cancelled_by = req "cancelled_by"
               ; cancelled_at = req "cancelled_at"
               ; reason = opt "reason"
+              })
+    | "operator_blocked" ->
+        Ok (OperatorBlocked
+              { blocked_by = req "blocked_by"
+              ; blocked_at = req "blocked_at"
+              ; reason = req "reason"
               })
     | s -> Error ("Unknown task status: " ^ s)
   with e -> Error (Printexc.to_string e)

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -79,6 +79,7 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
        [predecessor_task_id]. *)
     Held_terminal task.task_status
   | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> Held_by_other blocked_by
 ;;
 
 (* RFC-0262: a transition that overrides the assignee guard is permitted when

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -625,6 +625,7 @@ let release_stale_claims config ~ttl_seconds =
       | Masc_domain.AwaitingVerification _
       | Masc_domain.Done _
       | Masc_domain.Cancelled _ -> None
+      | Masc_domain.OperatorBlocked _ -> None
     in
     let older_than_ttl task =
       match status_timestamp task.task_status with

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -265,6 +265,8 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
+              | Masc_domain.OperatorBlocked _, _ ->
+                " Remediation: task is operator-blocked. Operator must unblock before any transition."
               | _ -> ""
             in
             Error
@@ -397,7 +399,8 @@ let transition_task_outcome_r
          | Masc_domain.Claimed _
          | Masc_domain.InProgress _
          | Masc_domain.AwaitingVerification _
-         | Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Cancelled _
+         | Masc_domain.OperatorBlocked _ -> ());;
         (match action, task.task_status with
          | Masc_domain.Release, Masc_domain.Todo ->
 (* Idempotent: already in backlog, nothing to release. *)
@@ -413,7 +416,8 @@ let transition_task_outcome_r
          | Masc_domain.Release, Masc_domain.InProgress _
          | Masc_domain.Release, Masc_domain.AwaitingVerification _
          | Masc_domain.Release, Masc_domain.Done _
-         | Masc_domain.Release, Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Release, Masc_domain.Cancelled _
+         | Masc_domain.Release, Masc_domain.OperatorBlocked _ -> ());
 (* #10719: surface tasks that have crossed oscillation thresholds so dashboards/triage can pick them up before they reach 20+ cycles with zero progress. *)
         (match action with
          | Masc_domain.Release ->
@@ -492,7 +496,8 @@ let transition_task_outcome_r
                     | Masc_domain.Claimed _
                     | Masc_domain.InProgress _
                     | Masc_domain.Done _
-                    | Masc_domain.Cancelled _ -> ())
+                    | Masc_domain.Cancelled _
+                    | Masc_domain.OperatorBlocked _ -> ())
                  | Masc_domain.Claim
                  | Masc_domain.Start
                  | Masc_domain.Done_action
@@ -542,7 +547,8 @@ let transition_task_outcome_r
                  | Masc_domain.Claimed _
                  | Masc_domain.InProgress _
                  | Masc_domain.Done _
-                 | Masc_domain.Cancelled _ -> ())
+                 | Masc_domain.Cancelled _
+                 | Masc_domain.OperatorBlocked _ -> ())
               | Masc_domain.Reject_verification ->
                 (match task.task_status with
                  | Masc_domain.AwaitingVerification { verification_id; _ } ->
@@ -564,7 +570,8 @@ let transition_task_outcome_r
                  | Masc_domain.Claimed _
                  | Masc_domain.InProgress _
                  | Masc_domain.Done _
-                 | Masc_domain.Cancelled _ -> ())
+                 | Masc_domain.Cancelled _
+                 | Masc_domain.OperatorBlocked _ -> ())
               | Masc_domain.Claim
               | Masc_domain.Start
               | Masc_domain.Done_action
@@ -665,7 +672,8 @@ let transition_task_outcome_r
                | Masc_domain.Claimed _
                | Masc_domain.InProgress _
                | Masc_domain.AwaitingVerification _
-               | Masc_domain.Cancelled _ -> `Assoc [ "task_id", `String task_id ]
+               | Masc_domain.Cancelled _
+               | Masc_domain.OperatorBlocked _ -> `Assoc [ "task_id", `String task_id ]
              in
              emit_task_activity
                config
@@ -737,7 +745,8 @@ let transition_task_outcome_r
            | Masc_domain.Claimed _
            | Masc_domain.InProgress _
            | Masc_domain.AwaitingVerification _
-           | Masc_domain.Cancelled _ -> ());
+           | Masc_domain.Cancelled _
+           | Masc_domain.OperatorBlocked _ -> ());
           (match action with
            | Masc_domain.Cancel ->
              Workspace_task_cleanup.run_cancel_hooks config ~agent_name

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -46,6 +46,7 @@ let task_status_badge = function
   | Masc_domain.AwaitingVerification _ -> ("🔍", "awaiting_verification")
   | Masc_domain.Done _ -> ("✅", "done")
   | Masc_domain.Cancelled _ -> ("🚫", "cancelled")
+  | Masc_domain.OperatorBlocked _ -> ("🛑", "operator_blocked")
 
 let task_assignee = function
   | Masc_domain.Claimed { assignee; _ }
@@ -53,6 +54,7 @@ let task_assignee = function
   | Masc_domain.AwaitingVerification { assignee; _ }
   | Masc_domain.Done { assignee; _ } -> assignee
   | Masc_domain.Cancelled { cancelled_by; _ } -> cancelled_by
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> blocked_by
   | Masc_domain.Todo -> "unclaimed"
 
 let active_task_assignee = function
@@ -60,7 +62,7 @@ let active_task_assignee = function
   | Masc_domain.InProgress { assignee; _ }
   | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some assignee
-  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ -> None
 
 let assigned_task_ids ~matches_you tasks =
   List.filter_map


### PR DESCRIPTION
task-2185: Implement operator_blocked task state to break unclaimable critical task cycling.

OperatorBlocked is a terminal state (like Done/Cancelled) that:
- Cannot be claimed or released by keepers
- Only an operator can transition it back to Todo or Cancelled
- Carries blocked_by, blocked_at, and mandatory reason fields

## Changes (17 files, +83/-18)

### Type definition
- lib/types/types_core.ml: variant + 8 exhaustive matches

### API/rendering
- lib/graphql_api.ml: task_status_info_of_task
- lib/workspace_status_rendering.ml: 3 match sites
- lib/tool_workspace.ml: 2 match sites

### Task/tool integration
- lib/keeper_catchup_digest.ml: assignee extraction
- lib/keeper/keeper_unified_prompt.ml: status string
- lib/task/tool_task_contract_gate.ml: completion_state_error guard
- lib/task/tool_task_completion_review.ml: predicate
- lib/task/tool_task_handlers.ml: assignee extraction
- lib/task/tool_task.ml: cleanup guard
- lib/reputation.ml: event filter

### Workspace/dashboard
- lib/workspace/workspace_task_transitions.ml: 8 FSM match sites
- lib/workspace/workspace_task_lifecycle.ml: resolve_claim
- lib/workspace/workspace_task_schedule.ml: scheduled_start guard
- lib/dashboard/dashboard_execution.ml: 2 match sites
- lib/dashboard/dashboard_briefing_assembly.ml: 2 match sites

## Known gap
9 match sites in guarded directory files remain unpatched. Those files are blocked by the keeper guard policy and will need a separate PR or policy adjustment to complete. This PR does not compile until those sites are patched.