### PR TITLE
fix(keeper): rotate on unavailable models

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -160,7 +160,7 @@ let api_error_terminal_reason_code (err : Agent_sdk.Error.api_error) : string =
   | Agent_sdk.Retry.AuthError _ -> "api_error_auth"
   | Agent_sdk.Retry.PaymentRequired _ -> "api_error_payment_required"
   | Agent_sdk.Retry.InvalidRequest _ -> "api_error_invalid_request"
-  | Agent_sdk.Retry.NotFound _ -> "api_error_not_found"
+  | Agent_sdk.Retry.NotFound _ -> Keeper_terminal_reason.wire_api_error_not_found
   | Agent_sdk.Retry.ContextOverflow _ -> "api_error_context_overflow"
   (* SSOT: the two transient wire codes are owned by [Keeper_terminal_reason]
      so the consumer-side disposition classifier
@@ -261,7 +261,8 @@ let provider_error_terminal_reason_code = function
   | Llm_provider.Error.Timeout { timeout_phase; _ } ->
     "provider_error_timeout" ^ provider_timeout_suffix timeout_phase
   | Llm_provider.Error.InvalidRequest _ -> "provider_error_invalid_request"
-  | Llm_provider.Error.NotFound _ -> "provider_error_not_found"
+  | Llm_provider.Error.NotFound _ ->
+    Keeper_terminal_reason.wire_provider_error_not_found
   | Llm_provider.Error.ProviderTerminal { reason; _ } ->
     Printf.sprintf "provider_error_terminal:%s" reason
 ;;

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -351,6 +351,7 @@ type degraded_retry_reason =
   | Runtime_candidates_filtered
   | Runtime_exhausted
   | Capacity_backpressure
+  | Model_unavailable
   | Rate_limit
   | Server_error
   | Auth_error
@@ -367,6 +368,9 @@ let degraded_retry_reason_to_string = function
   | Runtime_candidates_filtered -> "runtime_candidates_filtered"
   | Runtime_exhausted -> "runtime_exhausted"
   | Capacity_backpressure -> "capacity_backpressure"
+  | Model_unavailable ->
+    Keeper_runtime_failure_route.rotate_class_label
+      Keeper_runtime_failure_route.Model_unavailable
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
@@ -560,6 +564,8 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Rate_limit
          | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
              Some Capacity_backpressure
+         | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _) ->
+             Some Model_unavailable
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when is_gateway_backpressure_status status ->
              Some Capacity_backpressure
@@ -573,6 +579,8 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
              Some Capacity_backpressure
+         | Agent_sdk.Error.Provider (Llm_provider.Error.NotFound _) ->
+             Some Model_unavailable
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
@@ -590,7 +598,6 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              (Llm_provider.Error.ServerError _
              | Llm_provider.Error.InvalidConfig _
              | Llm_provider.Error.InvalidRequest _
-             | Llm_provider.Error.NotFound _
              | Llm_provider.Error.NetworkError _
              | Llm_provider.Error.Timeout _
              | Llm_provider.Error.ParseError _
@@ -602,7 +609,6 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.PaymentRequired _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
-         | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) -> None
@@ -665,6 +671,7 @@ let default_degraded_rotation_candidates
     dedupe_keep_order (default_candidates @ tool_capable)
   | Some
       ( Capacity_backpressure
+      | Model_unavailable
       | Provider_timeout
       | Server_error
       | Auth_error
@@ -773,6 +780,7 @@ let degraded_reason_allows_candidate_cycle = function
      Cap rotation here; the keeper pauses after candidates are exhausted and
      retries on a later turn once the provider actually recovers. *)
   | Capacity_backpressure
+  | Model_unavailable
   | Read_only_no_progress
   | Empty_no_progress
   | Thinking_only_no_progress -> false
@@ -830,6 +838,7 @@ let degraded_rotation_after_recoverable_error
         | Runtime_candidates_filtered
         | Runtime_exhausted
         | Capacity_backpressure
+        | Model_unavailable
         | Server_error
         | Auth_error -> candidates
       in

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -494,10 +494,20 @@ let degraded_retry_after_recoverable_error
         None
 
 let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
-  if Keeper_turn_driver.sdk_error_is_hard_quota err then
-    Some Hard_quota
-  else
-    match Keeper_turn_driver.classify_masc_internal_error err with
+  (* RFC-0313 keeps the broader legacy rotation ladder until its W3 flip, but
+     model availability already has an authoritative closed route. Consume
+     that route here instead of independently matching OAS [NotFound] again. *)
+  match Keeper_runtime_failure_route.route_of_error err with
+  | Keeper_runtime_failure_route.Rotate_now
+      { rotate = Keeper_runtime_failure_route.Model_unavailable } ->
+    Some Model_unavailable
+  | Keeper_runtime_failure_route.Retry_after_pacing _
+  | Keeper_runtime_failure_route.Rotate_now _
+  | Keeper_runtime_failure_route.Escalate_judgment _ ->
+    if Keeper_turn_driver.sdk_error_is_hard_quota err then
+      Some Hard_quota
+    else
+      match Keeper_turn_driver.classify_masc_internal_error err with
     | Some (Keeper_turn_driver.Resumable_cli_session _) ->
         Some Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
@@ -564,8 +574,6 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Rate_limit
          | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
              Some Capacity_backpressure
-         | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _) ->
-             Some Model_unavailable
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when is_gateway_backpressure_status status ->
              Some Capacity_backpressure
@@ -579,8 +587,6 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
              Some Capacity_backpressure
-         | Agent_sdk.Error.Provider (Llm_provider.Error.NotFound _) ->
-             Some Model_unavailable
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
@@ -598,6 +604,7 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
              (Llm_provider.Error.ServerError _
              | Llm_provider.Error.InvalidConfig _
              | Llm_provider.Error.InvalidRequest _
+             | Llm_provider.Error.NotFound _
              | Llm_provider.Error.NetworkError _
              | Llm_provider.Error.Timeout _
              | Llm_provider.Error.ParseError _
@@ -609,6 +616,7 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.PaymentRequired _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) -> None

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -121,6 +121,7 @@ type degraded_retry_reason =
   | Runtime_candidates_filtered
   | Runtime_exhausted
   | Capacity_backpressure
+  | Model_unavailable
   | Rate_limit
   | Server_error
   | Auth_error
@@ -165,6 +166,7 @@ val fallback_runtime_for_unavailable_profile :
     - [RateLimited] soft provider throttles → ["rate_limit"] (rotation filters
       candidates sharing the same credential pool)
     - [Overloaded] and Cloudflare 524 → ["capacity_backpressure"]
+    - [NotFound] → ["model_unavailable"]
     - [ServerError] with status >= 500 → ["server_error"]
     - [AuthError] → ["auth_error"]
 
@@ -224,8 +226,9 @@ val degraded_rotation_after_recoverable_error :
   degraded_retry option
 
 (** [true] when [reason] permits re-cycling the candidate pool after every
-    candidate has been attempted. [Capacity_backpressure] returns [false]
-    (see {!degraded_rotation_after_recoverable_error}). *)
+    candidate has been attempted. [Capacity_backpressure] and
+    [Model_unavailable] return [false] in shadow mode (see
+    {!degraded_rotation_after_recoverable_error}). *)
 val degraded_reason_allows_candidate_cycle :
   degraded_retry_reason -> bool
 

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -166,7 +166,8 @@ val fallback_runtime_for_unavailable_profile :
     - [RateLimited] soft provider throttles → ["rate_limit"] (rotation filters
       candidates sharing the same credential pool)
     - [Overloaded] and Cloudflare 524 → ["capacity_backpressure"]
-    - [NotFound] → ["model_unavailable"]
+    - authoritative [Keeper_runtime_failure_route.Model_unavailable] →
+      ["model_unavailable"]
     - [ServerError] with status >= 500 → ["server_error"]
     - [AuthError] → ["auth_error"]
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -103,6 +103,7 @@ type operator_disposition_reason =
   | Reason_runtime_fallback
   | Reason_transient_runtime_retry
   | Reason_capacity_backpressure
+  | Reason_model_unavailable
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
@@ -129,6 +130,9 @@ let operator_disposition_reason_to_string = function
   | Reason_runtime_fallback -> "runtime_fallback"
   | Reason_transient_runtime_retry -> "transient_runtime_retry"
   | Reason_capacity_backpressure -> Keeper_internal_error.capacity_backpressure_kind
+  | Reason_model_unavailable ->
+    Keeper_runtime_failure_route.rotate_class_label
+      Keeper_runtime_failure_route.Model_unavailable
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
   | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
@@ -265,6 +269,12 @@ let operator_disposition (receipt : t)
        [runtime_fallback_applied], so it must neither claim a completed
        fallback nor page a human. *)
     Disp_fail_open_next_runtime, Reason_capacity_backpressure
+  | Keeper_terminal_reason.Model_unavailable _ ->
+    (* [NotFound] identifies the selected runtime's model/endpoint, not a
+       fleet-wide terminal. The typed runtime route rotates immediately, but
+       this failed-attempt receipt is emitted before that rotation is visible
+       in the fallback fields. Preserve liveness without claiming completion. *)
+    Disp_fail_open_next_runtime, Reason_model_unavailable
   | _ when preflight_config_failure ->
     Disp_pause_human, Reason_preflight_config_error
   | _

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -372,6 +372,7 @@ let operator_disposition (receipt : t)
       | Keeper_terminal_reason.Turn_budget_exhausted _ -> true
       | Runtime_exhausted _
       | Capacity_backpressure _
+      | Model_unavailable _
       | Config_or_auth _
       | Provider_runtime_failure _
       | Completion_contract_violation _
@@ -422,6 +423,7 @@ let operator_disposition (receipt : t)
        | Keeper_terminal_reason.Pre_dispatch_success _ -> true
        | Runtime_exhausted _
        | Capacity_backpressure _
+       | Model_unavailable _
        | Config_or_auth _
        | Provider_runtime_failure _
        | Completion_contract_violation _

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -266,6 +266,11 @@ type operator_disposition_reason =
       Paired with [Disp_fail_open_next_runtime]: the keeper keeps moving and
       no operator broadcast is emitted, while the receipt does not falsely
       claim [Reason_runtime_fallback]. *)
+  | Reason_model_unavailable
+  (** The selected runtime returned a typed API/provider [NotFound]. Paired
+      with [Disp_fail_open_next_runtime]: another configured runtime may serve
+      the request, and the pre-rotation receipt must not page a human or claim
+      that fallback already completed. *)
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -42,6 +42,12 @@ let terminal_prefix_turn_budget_exhausted = "turn_budget_exhausted"
 let wire_api_error_timeout = "api_error_timeout"
 let wire_api_error_network = "api_error_network"
 
+(* Exact producer/consumer wire SSOT for typed model availability failures.
+   These are deliberately separate from the transient set above: [NotFound]
+   rotates immediately, but is not a same-runtime transient retry. *)
+let wire_api_error_not_found = "api_error_not_found"
+let wire_provider_error_not_found = "provider_error_not_found"
+
 let is_auto_recoverable_turn_budget_terminal terminal_reason =
   String.starts_with ~prefix:terminal_prefix_max_turns_exceeded terminal_reason
   || String.starts_with ~prefix:terminal_prefix_execution_timeout terminal_reason
@@ -51,6 +57,7 @@ let is_auto_recoverable_turn_budget_terminal terminal_reason =
 type t =
   | Runtime_exhausted of string
   | Capacity_backpressure of string
+  | Model_unavailable of string
   | Config_or_auth of string
   | Provider_runtime_failure of string
   | Completion_contract_violation of string
@@ -81,6 +88,10 @@ let of_wire wire =
   then Runtime_exhausted wire
   else if String.equal lowered Keeper_internal_error.capacity_backpressure_kind
   then Capacity_backpressure wire
+  else if
+    String.equal lowered wire_api_error_not_found
+    || String.equal lowered wire_provider_error_not_found
+  then Model_unavailable wire
   else if contains_config_or_auth lowered
   then Config_or_auth wire
   else if
@@ -110,6 +121,7 @@ let of_wire wire =
 let to_wire = function
   | Runtime_exhausted wire -> wire
   | Capacity_backpressure wire -> wire
+  | Model_unavailable wire -> wire
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
   | Completion_contract_violation wire -> wire
@@ -146,6 +158,7 @@ let is_transient_provider_runtime_failure = function
     || String.starts_with ~prefix:"provider_error_network:timeout:" lowered
   | Runtime_exhausted _
   | Capacity_backpressure _
+  | Model_unavailable _
   | Config_or_auth _
   | Completion_contract_violation _
   | Turn_livelock _

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -60,6 +60,12 @@ type t =
           {!Keeper_internal_error.capacity_backpressure_kind}.  This is a
           typed provider/infrastructure pacing condition, not an opaque
           internal failure.  Payload preserves the original bytes. *)
+  | Model_unavailable of string
+  (** Exact canonical API/provider model-unavailable wire codes
+          {!wire_api_error_not_found} and {!wire_provider_error_not_found}.
+          This is a runtime-selection condition: another configured runtime
+          may serve the request, so it must not be treated as an operator-
+          pageable provider failure. Payload preserves the original bytes. *)
   | Config_or_auth of string
   (** Wire string contains ["config"] or ["auth"] (case-insensitive).
           Ranked above the provider family so [api_error_auth],
@@ -138,6 +144,14 @@ val terminal_prefix_turn_budget_exhausted : string
     part of [is_auto_recoverable_turn_budget_terminal]: it is a completed
     runtime stop reason, so receipt classification must inspect completion
     contract evidence before deciding pass vs attention. *)
+
+(** {1 Model-unavailable wire codes (SSOT)} *)
+
+val wire_api_error_not_found : string
+val wire_provider_error_not_found : string
+(** Exact wire codes emitted for typed API/provider [NotFound] errors. The
+    encoder and receipt decoder share these constants so model availability
+    cannot drift into generic provider-runtime policy. *)
 
 (** {1 Transient provider-runtime wire codes (SSOT)}
 

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -791,6 +791,53 @@ let test_server_error_classifies_as_runtime_recoverable () =
   | None -> Alcotest.fail "expected server_error recoverable reason"
 ;;
 
+let model_unavailable_errors =
+  [ ( "api"
+    , SdkE.Api (Retry.NotFound { message = "model is not deployed" }) )
+  ; ( "provider"
+    , SdkE.Provider
+        (Llm_provider.Error.NotFound
+           { provider = "runpod"; detail = "model is not deployed" }) )
+  ]
+;;
+
+let test_model_unavailable_rotates_to_another_runtime () =
+  init_rate_limit_pool_runtime ();
+  List.iter
+    (fun (label, err) ->
+       (match EC.recoverable_runtime_failure_reason err with
+        | Some EC.Model_unavailable -> ()
+        | Some reason ->
+          Alcotest.failf
+            "%s expected model_unavailable, got %s"
+            label
+            (EC.degraded_retry_reason_to_string reason)
+        | None -> Alcotest.failf "%s expected model_unavailable recovery" label);
+       match
+         EC.degraded_rotation_after_recoverable_error
+           ~pacing_enforced:false
+           ~fallback_hint:"other.c"
+           ~base_runtime:"same.a"
+           ~effective_runtime:"same.a"
+           ~attempted_runtimes:[ "same.a" ]
+           err
+       with
+       | Some { EC.next_runtime = "other.c"; fallback_reason = EC.Model_unavailable } ->
+         ()
+       | Some { next_runtime; fallback_reason } ->
+         Alcotest.failf
+           "%s expected model_unavailable -> other.c, got %s -> %s"
+           label
+           (EC.degraded_retry_reason_to_string fallback_reason)
+           next_runtime
+       | None -> Alcotest.failf "%s expected model-unavailable rotation" label)
+    model_unavailable_errors;
+  Alcotest.(check bool)
+    "model_unavailable does not recycle an exhausted candidate set in shadow mode"
+    false
+    (EC.degraded_reason_allows_candidate_cycle EC.Model_unavailable)
+;;
+
 let test_server_error_records_immediate_provider_cooldown () =
   let candidate =
     Llm_provider.Provider_config.make
@@ -1251,6 +1298,10 @@ let () =
             "500 classifies as recoverable server_error"
             `Quick
             test_server_error_classifies_as_runtime_recoverable
+        ; Alcotest.test_case
+            "model unavailable rotates to another runtime"
+            `Quick
+            test_model_unavailable_rotates_to_another_runtime
         ; Alcotest.test_case
             "500 records immediate provider cooldown"
             `Quick

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -73,6 +73,8 @@ let roundtrip_corpus =
   [ (* exact-match buckets *)
     "runtime_exhausted"
   ; Keeper_internal_error.capacity_backpressure_kind
+  ; Tr.wire_api_error_not_found
+  ; Tr.wire_provider_error_not_found
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -224,6 +226,11 @@ let frozen_is_transient_provider_runtime_failure terminal_reason =
   || String.equal terminal_reason "api_error_network"
 ;;
 
+let frozen_is_model_unavailable terminal_reason =
+  String.equal terminal_reason Tr.wire_api_error_not_found
+  || String.equal terminal_reason Tr.wire_provider_error_not_found
+;;
+
 let frozen_operator_disposition (receipt : R.t)
   : R.operator_disposition_kind * R.operator_disposition_reason
   =
@@ -258,6 +265,8 @@ let frozen_operator_disposition (receipt : R.t)
   else if
     String.equal terminal_reason Keeper_internal_error.capacity_backpressure_kind
   then R.Disp_fail_open_next_runtime, R.Reason_capacity_backpressure
+  else if frozen_is_model_unavailable terminal_reason
+  then R.Disp_fail_open_next_runtime, R.Reason_model_unavailable
   else if preflight_config_failure
   then R.Disp_pause_human, R.Reason_preflight_config_error
   else if
@@ -689,6 +698,70 @@ let () =
     (got = want);
   check
     "opaque internal lookalike still emits operator broadcast"
+    (R.needs_operator_broadcast (fst got))
+;;
+
+let () =
+  let cases =
+    [ ( "api"
+      , Agent_sdk.Error.Api
+          (Llm_provider.Retry.NotFound { message = "model is not deployed" })
+      , Tr.wire_api_error_not_found
+      , "api" )
+    ; ( "provider"
+      , Agent_sdk.Error.Provider
+          (Llm_provider.Error.NotFound
+             { provider = "runpod"; detail = "model is not deployed" })
+      , Tr.wire_provider_error_not_found
+      , "provider" )
+    ]
+  in
+  List.iter
+    (fun (label, err, expected_code, error_kind) ->
+       let code = Masc.Keeper_agent_error.terminal_reason_code_of_sdk_error err in
+       check
+         (label ^ " not-found producer uses canonical terminal code")
+         (String.equal code expected_code);
+       check
+         (label ^ " not-found decodes to model-unavailable variant")
+         (match Tr.of_wire code with
+          | Tr.Model_unavailable wire -> String.equal wire code
+          | _ -> false);
+       let receipt =
+         { base_receipt with
+           terminal_reason_code = code
+         ; error_kind = Some (R.error_kind_of_string error_kind)
+         ; outcome = `Error
+         ; runtime_outcome = R.Runtime_failed
+         }
+       in
+       let got = R.operator_disposition receipt in
+       let want = R.Disp_fail_open_next_runtime, R.Reason_model_unavailable in
+       check
+         (Printf.sprintf
+            "%s model-unavailable disposition want=%s got=%s"
+            label
+            (disp_pair_to_string want)
+            (disp_pair_to_string got))
+         (got = want);
+       check
+         (label ^ " model-unavailable does not emit operator broadcast")
+         (not (R.needs_operator_broadcast (fst got))))
+    cases;
+  let lookalike =
+    { base_receipt with
+      terminal_reason_code = Tr.wire_api_error_not_found ^ "_unexpected"
+    ; error_kind = Some (R.error_kind_of_string "api")
+    ; outcome = `Error
+    ; runtime_outcome = R.Runtime_failed
+    }
+  in
+  let got = R.operator_disposition lookalike in
+  check
+    "not-found lookalike remains a pageable provider failure"
+    (got = (R.Disp_pause_human, R.Reason_provider_runtime_error));
+  check
+    "not-found lookalike emits operator broadcast"
     (R.needs_operator_broadcast (fst got))
 ;;
 


### PR DESCRIPTION
## 변경

- typed API/provider `NotFound`를 `Model_unavailable`로 분류해 다른 configured runtime으로 즉시 회전해용.
- 판단은 `Keeper_runtime_failure_route.route_of_error`의 closed `Rotate_now Model_unavailable`만 소비하고, legacy ladder에서 OAS variant를 다시 매치하지 않아용.
- exact producer/consumer wire SSOT를 공유하고, 회전 전 실패 receipt가 operator page나 완료된 fallback을 거짓 주장하지 않게 했어용.
- invalid request, parse, unknown, lookalike wire는 fail-closed로 유지해용.

## 경계

- MASC가 OAS typed error를 소비하며 OAS에는 MASC 의존성이 없어용.
- provider 메시지 매칭이나 provider-name 하드코딩이 없어용.

## 검증

- base `#24238` head: `7daa418997`
- current head: `44b2767266`
- focused build: `lib/masc.cmxa`, typed bridge, terminal reason tests 통과
- 직접 실행: typed bridge 27/27, terminal matrix 247,680 cases / mismatch 0
- parse, ocamlformat, `git diff --check` 통과
- 전체 Dune은 current-head PR CI에서 확인해용.

## Stack

- `#24238`에 의존해용.
- Closes `#24242`.

Draft only. current-head CI와 parent가 모두 끝날 때까지 `p1`과 `status:do-not-merge`를 유지해용.
