### PR TITLE
fix(test): make reqd-swallow source guard whitespace-robust

### DIFF
--- a/test/test_reqd_invalid_state_swallow.ml
+++ b/test/test_reqd_invalid_state_swallow.ml
@@ -49,7 +49,30 @@ let read_file path =
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> In_channel.input_all ic)
 
+let normalize_ws s =
+  (* Collapse every run of whitespace (including the newlines ocamlformat
+     inserts when it wraps a comment across lines) into a single space, so a
+     source-presence assertion checks the defensive pattern's *content*, not
+     its incidental line breaks.  Without this, reformatting a present-and-
+     correct guard could turn CI red purely on layout. *)
+  let buf = Buffer.create (String.length s) in
+  let in_ws = ref false in
+  String.iter
+    (fun c ->
+       match c with
+       | ' ' | '\t' | '\n' | '\r' ->
+         if not !in_ws then Buffer.add_char buf ' ';
+         in_ws := true
+       | _ ->
+         Buffer.add_char buf c;
+         in_ws := false)
+    s;
+  Buffer.contents buf
+;;
+
 let assert_contains ~label haystack needle =
+  let haystack = normalize_ws haystack in
+  let needle = normalize_ws needle in
   let n = String.length needle in
   let h = String.length haystack in
   let rec scan i =


### PR DESCRIPTION
## 요약

main이 `test_reqd_invalid_state_swallow`의 **M2 anchor**로 red예요(main `199cbd3f04`에서 재현). 실제 회귀가 아니라 **drift-guard의 취약점**이에요.

## 원인 (`920897b79c`)

- M2 anchor는 `make_extended_handler`(bin/main_eio.ml) source에 Cancelled re-raise 주석 "Re-raise cancellation so Eio structured concurrency propagates cleanly"가 있는지 검사해요.
- `assert_contains`가 **raw substring scan**이라, ocamlformat이 그 주석을 `propagates` / `cleanly` 두 줄로 wrap하면 needle과 매치 실패 → CI red.
- **실제 방어 코드/주석은 bin/main_eio.ml에 정상 존재**해요(`| Eio.Cancel.Cancelled _ as exn -> raise exn` + 주석). 레이아웃만으로 false red가 나서 main-based PR을 전부 base-collateral로 막고 있어요.

## 변경

- `normalize_ws`로 공백 run을 단일 스페이스로 collapse한 뒤 presence 검사. formatter 줄바꿈에 robust해져요.
- `assert_not_contains`는 raw 유지(나쁜-패턴 탐지는 완화하면 안 됨).

## P0/P1/P2/P3

- **P0(main 안정성) 해소**: false-red drift-guard로 인한 main-red 제거.
- P1/P2/P3: 없음. 실제 Cancelled 삼킴 회귀 아님(코드 무변경).

## 검증

- 로컬 dune build 미실행, CI가 빌드 권위. ocamlformat --check pass.
- test 전용 변경(production 무변경).
