### PR TITLE
fix(keeper): keep async chat turns alive

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -73,8 +73,10 @@ let max_age_sec = Masc_time_constants.hour
 
 let effective_timeout_sec ?timeout_sec () =
   match timeout_sec with
-  | Some timeout_sec -> timeout_sec
-  | None -> Keeper_runtime_resolved.turn_timeout_sec ()
+  | None -> None
+  | Some timeout_sec when Float.is_finite timeout_sec && timeout_sec > 0.0 ->
+    Some timeout_sec
+  | Some _ -> invalid_arg "keeper_msg timeout_sec must be a positive finite number"
 ;;
 
 let request_dir ~base_path =
@@ -475,6 +477,14 @@ let timeout_done_status ~request_id ~keeper_name ~timeout_sec =
 
 let submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~base_path
     ~(f : unit -> tool_result) ~keeper_name () : string =
+  let worker_timeout : (float * ((unit -> tool_result) -> tool_result)) option =
+    match effective_timeout_sec ?timeout_sec (), clock with
+    | None, (Some _ | None) -> None
+    | Some timeout_sec, Some clock ->
+      Some (timeout_sec, Eio.Time.with_timeout_exn clock timeout_sec)
+    | Some _, None ->
+      invalid_arg "keeper_msg explicit timeout_sec requires an Eio clock"
+  in
   gc_stale ();
   ignore (gc_stale_disk ~base_path);
   let request_id = generate_request_id ~keeper_name in
@@ -491,7 +501,6 @@ let submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~base_path
   persist_entry entry;
   Eio.Fiber.fork_daemon ~sw (fun () ->
     set_status_protected ~preserve_terminal:true request_id Running;
-    let worker_timeout_sec = effective_timeout_sec ?timeout_sec () in
     (* [f] owns any terminal signal it emits on its own side channels while
        it runs (e.g. push_worker_event in server_routes_http_keeper_stream's
        process_single_turn). Every catch arm below fires exactly when [f] was
@@ -515,9 +524,9 @@ let submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~base_path
             raise exn)
     in
     let run_worker_with_timeout () =
-      match clock with
-      | Some clock ->
-        (try Eio.Time.with_timeout_exn clock worker_timeout_sec f with
+      match worker_timeout with
+      | Some (worker_timeout_sec, run_with_timeout) ->
+        (try run_with_timeout f with
          | Eio.Time.Timeout ->
            let status =
              timeout_done_status ~request_id ~keeper_name ~timeout_sec:worker_timeout_sec

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -68,14 +68,17 @@ type worker_abort_reason =
 
 (** [submit ?clock ?timeout_sec ?on_worker_aborted ~sw ~f ~keeper_name] forks
     a background daemon fiber on [sw] that runs [f] and stores the result.
-    Returns the fresh [request_id] synchronously. When [clock] is provided,
-    the worker records a terminal timeout error if [f] does not return before
-    the deadline: [timeout_sec] when explicitly supplied, otherwise the
-    runtime-resolved keeper turn timeout. Cancellation of [sw] interrupts the
-    worker and records a terminal [Cancelled] state before stopping, so
-    pollers do not observe an indefinite [Running] request. [Lost] is
-    reserved for persisted non-terminal requests recovered without a live
-    worker.
+    Returns the fresh [request_id] synchronously. The async request has no
+    implicit outer deadline: keeper/OAS turn policy owns execution deadlines
+    and finalization, so this wrapper must not cancel a live multi-turn run a
+    second time. When [timeout_sec] is explicitly supplied together with
+    [clock], the caller-requested deadline is enforced and recorded as a
+    terminal timeout. Supplying [timeout_sec] without [clock], or a non-
+    positive/non-finite value, raises [Invalid_argument] before the request is
+    accepted. Cancellation of [sw] interrupts the worker and records a
+    terminal [Cancelled] state before stopping, so pollers do not observe an
+    indefinite [Running] request. [Lost] is reserved for persisted non-
+    terminal requests recovered without a live worker.
 
     [on_worker_aborted], when supplied, is invoked exactly once whenever [f]
     is cut off by a timeout or cancellation before it completes on its own —
@@ -138,5 +141,5 @@ module For_testing : sig
   val gc_stale_disk : base_path:string -> int
   val recover_lost_disk_records : base_path:string -> int
   val active_switch_count : unit -> int
-  val effective_timeout_sec : ?timeout_sec:float -> unit -> float
+  val effective_timeout_sec : ?timeout_sec:float -> unit -> float option
 end

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -4,18 +4,6 @@ open Server_auth
 module Http = Http_server_eio
 module Mcp_eio = Mcp_server_eio
 
-(* Keeper-chat stream tunables (CLAUDE.md Magic Number 규칙: 의미를 드러내는 리터럴은
-   named constant로). Bounds are keeper-message-specific and distinct from the
-   env_config turn/orchestrator clamps. *)
-
-(* Clamp bounds for the client-supplied per-message timeout (seconds). *)
-let keeper_msg_timeout_sec_min = 5
-let keeper_msg_timeout_sec_max = 300
-
-let clamp_keeper_msg_timeout_sec v =
-  max keeper_msg_timeout_sec_min (min keeper_msg_timeout_sec_max v)
-;;
-
 (* Progressive-render hard-wrap width (characters) for streamed keeper replies —
    a UI readability chunk width, NOT an SSE/transport line-length limit. *)
 let keeper_reply_chunk_hard_wrap_chars = 180
@@ -47,7 +35,7 @@ type keeper_chat_stream_request = {
   name : string;
   message : string;
   user_blocks : user_input_block list;
-  timeout_sec : int option;
+  timeout_sec : float option;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
   channel : string;
@@ -142,7 +130,7 @@ let args_of_request payload : Yojson.Safe.t =
       ("direct_reply", `Bool true) ]
     @
     (match payload.timeout_sec with
-     | Some timeout_sec -> [ ("timeout_sec", `Int timeout_sec) ]
+     | Some timeout_sec -> [ ("timeout_sec", `Float timeout_sec) ]
      | None -> [])
     @
     (match turn_instructions_for_request payload with
@@ -636,14 +624,12 @@ let parse_keeper_chat_stream_request body_str =
         match Json_util.assoc_member_opt "timeout_sec" json with
         | None | Some `Null -> Ok None
         | Some (`Int value) when value > 0 ->
-            Ok (Some (clamp_keeper_msg_timeout_sec value))
-        | Some (`Float value) when value > 0.0 ->
-            (* int_of_float is unspecified (not exception-raising) for
-               out-of-range floats (e.g. 1e300, infinity); clamp_keeper_msg_timeout_sec
-               below bounds whatever int comes out into [5, 300] regardless. *)
-            Ok (Some (clamp_keeper_msg_timeout_sec (int_of_float (Float.ceil value))))
-        | Some (`Int _) | Some (`Float _) -> Ok None
-        | Some _ -> Error "timeout_sec must be a positive number"
+            Ok (Some (float_of_int value))
+        | Some (`Float value) when Float.is_finite value && value > 0.0 ->
+            Ok (Some value)
+        | Some (`Int _) | Some (`Float _) ->
+          Error "timeout_sec must be a positive finite number"
+        | Some _ -> Error "timeout_sec must be a positive finite number"
       in
       let attachments = Keeper_multimodal_input.parse_attachments json in
       let user_blocks_result = Keeper_multimodal_input.parse_user_blocks json in
@@ -1363,7 +1349,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
      | Error _ -> ());
     persisted
   in
-  let timeout_sec = Option.map float_of_int payload.timeout_sec in
+  let timeout_sec = payload.timeout_sec in
   let dashboard_direct_stream =
     (not queued_turn)
     && (not connector_user_line_recorded_upstream)

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -74,7 +74,7 @@ type keeper_chat_stream_request = {
   name : string;
   message : string;
   user_blocks : user_input_block list;
-  timeout_sec : int option;
+  timeout_sec : float option;
   turn_instructions : string option;
   surface_context : Yojson.Safe.t option;
   channel : string;
@@ -86,8 +86,9 @@ type keeper_chat_stream_request = {
 (** Parsed payload of a keeper chat-stream HTTP request.
     [message] is the text fallback used by the existing direct keeper
     path; [user_blocks] preserves semantic text/media input for the
-    block-aware runtime path.  [timeout_sec] is clamped to [\[5, 300\]] when
-    present.  [turn_instructions] and [surface_context]
+    block-aware runtime path. [timeout_sec] is an optional caller-owned
+    positive finite deadline; it is never synthesized or clamped by this
+    boundary. [turn_instructions] and [surface_context]
     are optional copilot context fields; when
     [turn_instructions] is absent but [surface_context]
     is present, the surface context is formatted and
@@ -103,8 +104,8 @@ val parse_keeper_chat_stream_request :
 (** Parses the HTTP body string into a
     {!keeper_chat_stream_request}.  Returns
     [Error reason] on JSON shape mismatches, missing
-    [name] / content, malformed [user_blocks], partial connector context, or
-    presence of legacy keeper model args removed by the
+    [name] / content, malformed [user_blocks], an invalid explicit timeout,
+    partial connector context, or presence of legacy keeper model args removed by the
     runtime rewrite. *)
 
 (** {1 Error envelope} *)

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -233,6 +233,26 @@ let test_parse_keeper_chat_stream_request_accepts_connector_context () =
       check string "workspace id" "workspace-9" payload.channel_workspace_id
   | Error err -> fail ("expected connector context to parse: " ^ err)
 
+let test_parse_keeper_chat_stream_request_preserves_explicit_timeout () =
+  let body =
+    {|{"name":"luna","message":"hello","timeout_sec":1200.5}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok payload ->
+      check (option (float 0.0001))
+        "explicit timeout" (Some 1200.5) payload.timeout_sec
+  | Error err -> fail ("expected explicit timeout to parse: " ^ err)
+
+let test_parse_keeper_chat_stream_request_rejects_invalid_timeout () =
+  let body = {|{"name":"luna","message":"hello","timeout_sec":0}|} in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected non-positive timeout to be rejected"
+  | Error err ->
+      check string
+        "validation message"
+        "timeout_sec must be a positive finite number"
+        err
+
 let test_parse_keeper_chat_stream_request_rejects_partial_connector_context () =
   let body =
     {|{"name":"luna","message":"hello","channel":"discord"}|}
@@ -2794,6 +2814,10 @@ let () =
             test_contextualize_message_includes_channel_metadata;
           test_case "stream request accepts connector context" `Quick
             test_parse_keeper_chat_stream_request_accepts_connector_context;
+          test_case "stream request preserves explicit timeout" `Quick
+            test_parse_keeper_chat_stream_request_preserves_explicit_timeout;
+          test_case "stream request rejects invalid explicit timeout" `Quick
+            test_parse_keeper_chat_stream_request_rejects_invalid_timeout;
           test_case "stream request rejects partial connector context" `Quick
             test_parse_keeper_chat_stream_request_rejects_partial_connector_context;
           test_case "stream request accepts copilot context" `Quick

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -451,16 +451,41 @@ let test_keeper_msg_async_timeout_is_terminal_error () =
     Alcotest.fail "expected timeout request to remain pollable"
 ;;
 
-let test_keeper_msg_async_default_timeout_uses_turn_timeout () =
-  let expected = Keeper_runtime_resolved.turn_timeout_sec () in
-  Alcotest.(check (float 0.0001))
-    "default async worker timeout"
-    expected
+let test_keeper_msg_async_timeout_is_explicit_only () =
+  Alcotest.(check (option (float 0.0001)))
+    "default async worker has no outer timeout"
+    None
     (Keeper_msg_async.For_testing.effective_timeout_sec ());
-  Alcotest.(check (float 0.0001))
-    "explicit async worker timeout wins"
-    42.0
-    (Keeper_msg_async.For_testing.effective_timeout_sec ~timeout_sec:42.0 ())
+  Alcotest.(check (option (float 0.0001)))
+    "explicit async worker timeout is preserved"
+    (Some 42.0)
+    (Keeper_msg_async.For_testing.effective_timeout_sec ~timeout_sec:42.0 ());
+  Alcotest.check_raises
+    "invalid explicit timeout is rejected"
+    (Invalid_argument "keeper_msg timeout_sec must be a positive finite number")
+    (fun () ->
+       ignore
+         (Keeper_msg_async.For_testing.effective_timeout_sec ~timeout_sec:0.0 ()))
+;;
+
+let test_keeper_msg_async_explicit_timeout_requires_clock () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-clock-required-" in
+  Alcotest.check_raises
+    "explicit timeout without clock is rejected before request acceptance"
+    (Invalid_argument "keeper_msg explicit timeout_sec requires an Eio clock")
+    (fun () ->
+       ignore
+         (Keeper_msg_async.submit
+            ~timeout_sec:1.0
+            ~sw
+            ~base_path
+            ~keeper_name:"clock-required"
+            ~f:(fun () -> tr_ok "{}")
+            ()))
 ;;
 
 let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
@@ -753,9 +778,13 @@ let () =
             `Quick
             test_keeper_msg_async_timeout_is_terminal_error
         ; test_case
-            "default timeout follows keeper turn timeout"
+            "async worker timeout is explicit only"
             `Quick
-            test_keeper_msg_async_default_timeout_uses_turn_timeout
+            test_keeper_msg_async_timeout_is_explicit_only
+        ; test_case
+            "explicit async timeout requires a clock"
+            `Quick
+            test_keeper_msg_async_explicit_timeout_requires_clock
         ; test_case
             "gc removes stale terminal disk record"
             `Quick


### PR DESCRIPTION
## Summary

- remove the implicit outer deadline from async keeper message workers
- keep explicit caller deadlines, operator cancellation, runtime cancellation, and durable lost recovery
- preserve positive finite explicit timeout values without the server-side 5..300 clamp
- reject invalid or unenforceable explicit timeout requests before acceptance

## Runtime evidence

After the 2026-07-11 17:02Z restart, accepted dashboard chat requests for base, mad-improver, and executor all terminated at exactly 300 seconds with keeper_msg request exceeded timeout_sec. The wrapper cancelled the entire multi-turn worker before its own finalization path completed.

## Boundary

- keeper and OAS turn policy remains the execution deadline owner
- the async transport wrapper observes and persists request state but does not synthesize a second deadline
- no model/provider string matching or numeric timeout heuristic

## Verification

- OCaml parser and ocamlformat
- git diff --check
- structure, stringly-boundary, OAS-boundary, tool-matrix, silent-failure, and cwd-leak ratchets
- Eio convention, enum-string, keeper-hardcoding, and determinism gates
- local Dune intentionally not run; CI is the build authority

Addresses #23532