### PR TITLE
fix(keeper): require typed delivery evidence

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -7,7 +7,7 @@ let poll_interval_sec =
   | None -> 1.0
 
 type turn_outcome =
-  | Delivered of { outcome_ref : string }
+  | Delivered of { outcome_ref : Ids.Turn_ref.t }
   | Failed of
       { kind : Keeper_chat_queue.failure_kind
       ; detail : string
@@ -197,17 +197,8 @@ let canonical_failure_detail detail =
   else detail
 
 let finalization_of_delivered ~clock ~outcome_ref =
-  match canonical_turn_ref_string outcome_ref with
-  | Some outcome_ref ->
-    Keeper_chat_queue.Mark_delivered
-      { completed_at = Eio.Time.now clock; outcome_ref = Some outcome_ref }
-  | None ->
-    Keeper_chat_queue.Mark_failed
-      { completed_at = Eio.Time.now clock
-      ; kind = Keeper_chat_queue.Internal_error
-      ; detail = "queued turn claimed delivery with an invalid turn_ref"
-      ; outcome_ref = None
-      }
+  Keeper_chat_queue.Mark_delivered
+    { completed_at = Eio.Time.now clock; outcome_ref }
 
 let finalization_of_failed ~clock ~kind ~detail ~outcome_ref =
   let outcome_ref, invalid_outcome_ref =

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -12,10 +12,11 @@
 (** A typed outcome from the whole queued-turn delivery boundary. Connector
     adapters must be joined before returning [Delivered]; a persisted failure,
     missing connector, or outbound error returns [Failed]. [Delivered]'s
-    [outcome_ref] is required and must be a canonical [Ids.Turn_ref] string;
-    the consumer fails closed as [Internal_error] if that invariant is broken. *)
+    [outcome_ref] is a required [Ids.Turn_ref.t], so absent and raw-string
+    success evidence is not representable at the write boundary; the queue
+    validates its canonical wire form before persistence. *)
 type turn_outcome =
-  | Delivered of { outcome_ref : string }
+  | Delivered of { outcome_ref : Ids.Turn_ref.t }
   | Failed of
       { kind : Keeper_chat_queue.failure_kind
       ; detail : string

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -55,6 +55,11 @@ type completion = {
   outcome_ref : string option;
 }
 
+type delivered_completion = {
+  completed_at : float;
+  outcome_ref : Ids.Turn_ref.t;
+}
+
 type failure_kind =
   | Turn_failed
   | Timed_out
@@ -89,7 +94,7 @@ type lease = {
 }
 
 type finalization =
-  | Mark_delivered of completion
+  | Mark_delivered of delivered_completion
   | Mark_failed of failure
 
 type snapshot_load_error_kind =
@@ -1056,11 +1061,24 @@ let canonical_optional_ref = function
     else if not (String.is_valid_utf_8 value) then Error "terminal outcome_ref contains malformed UTF-8"
     else Ok (Some value)
 
+let canonical_turn_ref turn_ref =
+  let wire = Ids.Turn_ref.to_string turn_ref in
+  match Ids.Turn_ref.of_string wire with
+  | Some parsed
+    when Ids.Turn_ref.equal parsed turn_ref
+         && String.equal (Ids.Turn_ref.to_string parsed) wire ->
+    Ok wire
+  | Some _ | None -> Error "terminal outcome_ref must be a canonical turn_ref"
+
 let canonical_terminal_state = function
   | Mark_delivered completion when Float.is_finite completion.completed_at ->
     Result.map
-      (fun outcome_ref -> Stored_delivered { completion with outcome_ref })
-      (canonical_optional_ref completion.outcome_ref)
+      (fun outcome_ref ->
+         Stored_delivered
+           { completed_at = completion.completed_at
+           ; outcome_ref = Some outcome_ref
+           })
+      (canonical_turn_ref completion.outcome_ref)
   | Mark_delivered _ -> Error "terminal completed_at must be finite"
   | Mark_failed failure when not (Float.is_finite failure.completed_at) ->
     Error "terminal completed_at must be finite"

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -43,6 +43,15 @@ type completion = {
   outcome_ref : string option;
 }
 
+(** Write-side delivered evidence.  Unlike legacy persisted [completion]
+    reads, a new successful finalization cannot omit the turn join key or pass
+    an arbitrary string.  The queue also round-trips the typed value through
+    the canonical [Ids.Turn_ref] codec before persistence. *)
+type delivered_completion = {
+  completed_at : float;
+  outcome_ref : Ids.Turn_ref.t;
+}
+
 type failure_kind =
   | Turn_failed
   | Timed_out
@@ -79,7 +88,7 @@ type lease = {
 }
 
 type finalization =
-  | Mark_delivered of completion
+  | Mark_delivered of delivered_completion
   | Mark_failed of failure
 
 type snapshot_load_error_kind =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1329,7 +1329,10 @@ let start_keeper_loops
                    { outcome_ref }
              | Some (Delivered { outcome_ref }), Error (kind, detail) ->
                  Keeper_chat_consumer.Failed
-                   { kind; detail; outcome_ref = Some outcome_ref }
+                   { kind
+                   ; detail
+                   ; outcome_ref = Some (Ids.Turn_ref.to_string outcome_ref)
+                   }
              | Some (Failed { kind = turn_kind; detail = turn_detail }),
                Error (delivery_kind, delivery_detail) ->
                  Keeper_chat_consumer.Failed

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1124,7 +1124,7 @@ and queued_turn_failure_kind =
   | Stream_projection_failed
 
 and queued_turn_outcome =
-  | Delivered of { outcome_ref : string }
+  | Delivered of { outcome_ref : Ids.Turn_ref.t }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string
@@ -1167,7 +1167,7 @@ let queued_turn_failure_kind_to_string = function
 
 let queued_delivery_outcome_of_turn_ref = function
   | Some turn_ref ->
-      Delivered { outcome_ref = Ids.Turn_ref.to_string turn_ref }
+      Delivered { outcome_ref = turn_ref }
   | None ->
       Failed
         { kind = Missing_turn_ref

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -168,7 +168,7 @@ type queued_turn_failure_kind =
   | Stream_projection_failed
 
 type queued_turn_outcome =
-  | Delivered of { outcome_ref : string }
+  | Delivered of { outcome_ref : Ids.Turn_ref.t }
   | Failed of
       { kind : queued_turn_failure_kind
       ; detail : string

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -26,6 +26,8 @@ let check name cond =
 let contains ~affix text = Astring.String.is_infix ~affix text
 
 let keeper_name = "busy-connector-keeper"
+let turn_ref trace_id absolute_turn =
+  Ids.Turn_ref.make ~trace_id ~absolute_turn
 
 (* Hold the keeper's admission slot busy in a forked fiber (the proven pattern
    from test_keeper_turn_admission): the body resolves [started] then blocks on
@@ -162,7 +164,9 @@ let test_busy_discord_enqueues () =
                   ~lease_id:lease.lease_id
                   ~outcome:
                     (Keeper_chat_queue.Mark_delivered
-                       { completed_at = Time_compat.now (); outcome_ref = None })
+                       { completed_at = Time_compat.now ()
+                       ; outcome_ref = turn_ref "busy-connector" 1
+                       })
               with
               | `Finalized receipt_ids ->
                   check "finalize records the delivered receipt"

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -12,6 +12,9 @@ let check name condition =
     Printf.printf "  ✗ %s\n%!" name
   end
 
+let turn_ref trace_id absolute_turn =
+  Ids.Turn_ref.make ~trace_id ~absolute_turn
+
 let temp_dir prefix = Filename.temp_dir prefix ""
 
 let rec rm_rf path =
@@ -142,7 +145,7 @@ let test_durable_receipt_lifecycle () =
      Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
        ~outcome:
          (Keeper_chat_queue.Mark_delivered
-            { completed_at = 3.0; outcome_ref = Some "chat-row-1" })
+            { completed_at = 3.0; outcome_ref = turn_ref "chat-row" 1 })
    with
    | `Finalized receipt_ids ->
      check
@@ -153,7 +156,7 @@ let test_durable_receipt_lifecycle () =
   check "terminal receipt leaves active queue" (terminal.pending = [] && terminal.inflight = []);
   check "terminal receipt remains queryable" (terminal_ids terminal.terminal = [ receipt_id ]);
   (match terminal.terminal with
-   | [ { state = Delivered { outcome_ref = Some "chat-row-1"; _ }; _ } ] ->
+   | [ { state = Delivered { outcome_ref = Some "chat-row#1"; _ }; _ } ] ->
      check "delivered outcome ref is durable" true
    | _ -> check "delivered outcome ref is durable" false);
   (match
@@ -258,7 +261,8 @@ let test_source_boundaries_preserve_fifo_runs () =
     ignore
       (Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
          ~outcome:
-           (Mark_delivered { completed_at = 4.0; outcome_ref = None }))
+           (Mark_delivered
+              { completed_at = 4.0; outcome_ref = turn_ref "source-run" 1 }))
   in
   take [ "dashboard-1"; "dashboard-2" ];
   take [ "discord" ];
@@ -317,7 +321,9 @@ let test_persist_failures_roll_back () =
   Keeper_chat_queue.For_testing.fail_next_persist ();
   (match
      Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
-       ~outcome:(Mark_delivered { completed_at = 5.0; outcome_ref = None })
+       ~outcome:
+         (Mark_delivered
+            { completed_at = 5.0; outcome_ref = turn_ref "rollback" 1 })
    with
    | `Error (Persist_failed _) -> check "failed finalize is typed" true
    | `Finalized _ | `Unknown_lease | `Error _ -> check "failed finalize is typed" false);
@@ -620,7 +626,9 @@ let test_post_commit_observer_is_central_and_unlocked () =
   let second = lease_exn ~keeper_name in
   ignore
     (Keeper_chat_queue.finalize ~keeper_name ~lease_id:second.lease_id
-       ~outcome:(Mark_delivered { completed_at = 6.0; outcome_ref = None }));
+       ~outcome:
+         (Mark_delivered
+            { completed_at = 6.0; outcome_ref = turn_ref "observer" 1 }));
   check
     "observer sees enqueue, lease, nack, lease, finalize exactly once"
     (List.rev !revisions = [ 1L; 2L; 3L; 4L; 5L ])

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -21,6 +21,8 @@ let check_failure name detail =
   Printf.printf "  ✗ %s: %s\n%!" name detail
 
 let keeper_name = "consumer-receipt-keeper"
+let turn_ref trace_id absolute_turn =
+  Ids.Turn_ref.make ~trace_id ~absolute_turn
 
 let discord_msg ~content ~channel_id ~user_id ~timestamp =
   { Keeper_chat_queue.content
@@ -163,7 +165,7 @@ let test_delivery_finalizes_terminal_receipt () =
       let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message =
         captured := Some (dispatched_keeper, queued_message);
         Keeper_chat_consumer.Delivered
-          { outcome_ref = "trace-delivered#1" }
+          { outcome_ref = turn_ref "trace-delivered" 1 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -316,7 +318,7 @@ let test_dispatch_is_concurrent_per_keeper () =
           Eio.Promise.resolve resolve_first_started ();
           Eio.Promise.await release_first;
           Keeper_chat_consumer.Delivered
-            { outcome_ref = "trace-" ^ dispatched_keeper ^ "#2" }
+            { outcome_ref = turn_ref ("trace-" ^ dispatched_keeper) 2 }
         | Some first when String.equal first dispatched_keeper ->
           check "one keeper is not dispatched twice concurrently" false;
           Keeper_chat_consumer.Failed
@@ -328,7 +330,7 @@ let test_dispatch_is_concurrent_per_keeper () =
           second_keeper := Some dispatched_keeper;
           Eio.Promise.resolve resolve_second_started ();
           Keeper_chat_consumer.Delivered
-            { outcome_ref = "trace-" ^ dispatched_keeper ^ "#2" }
+            { outcome_ref = turn_ref ("trace-" ^ dispatched_keeper) 2 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -383,7 +385,7 @@ let test_finalization_persistence_retry_does_not_redeliver () =
         incr calls;
         Keeper_chat_queue.For_testing.fail_next_persist ();
         Keeper_chat_consumer.Delivered
-          { outcome_ref = "trace-finalized-after-retry#3" }
+          { outcome_ref = turn_ref "trace-finalized-after-retry" 3 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -403,12 +405,12 @@ let test_finalization_persistence_retry_does_not_redeliver () =
       check_terminal_snapshot ~label:"retried finalization" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
-let test_invalid_delivered_turn_ref_fails_closed () =
+let test_invalid_typed_delivered_turn_ref_fails_closed () =
   Printf.printf
-    "Test: Delivered with an invalid turn_ref becomes a terminal failure\n%!";
+    "Test: non-canonical typed Delivered ref becomes a terminal failure\n%!";
   with_env (fun ~base ~clock ->
     match
-      enqueue_checked ~label:"invalid turn_ref enqueue" ~keeper_name
+      enqueue_checked ~label:"invalid typed turn ref enqueue" ~keeper_name
         (discord_msg ~content:"invalid delivered ref"
            ~channel_id:"channel-invalid-ref" ~user_id:"user-invalid-ref"
            ~timestamp:6.5)
@@ -416,7 +418,7 @@ let test_invalid_delivered_turn_ref_fails_closed () =
     | None -> ()
     | Some accepted ->
       let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
-        Keeper_chat_consumer.Delivered { outcome_ref = "trace#0042" }
+        Keeper_chat_consumer.Delivered { outcome_ref = turn_ref "" 42 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -425,15 +427,15 @@ let test_invalid_delivered_turn_ref_fails_closed () =
             ~receipt_id:accepted.receipt_id ~accept:is_failed
         with
         | Some { state = Keeper_chat_queue.Failed failure; _ } ->
-          check "invalid Delivered ref is an internal failure"
+          check "invalid typed Delivered ref is an internal failure"
             (failure.kind = Keeper_chat_queue.Internal_error);
-          check "invalid Delivered ref is not persisted as a join key"
+          check "invalid typed Delivered ref is not persisted as a join key"
             (failure.outcome_ref = None);
-          check "invalid Delivered ref has diagnostic detail"
+          check "invalid typed Delivered ref has diagnostic detail"
             (String.trim failure.detail <> "")
         | Some { state = Pending | Inflight _ | Delivered _; _ } | None ->
-          check "invalid Delivered ref never reaches Delivered" false);
-      check_terminal_snapshot ~label:"invalid delivered ref" ~keeper_name
+          check "invalid typed Delivered ref never reaches Delivered" false);
+      check_terminal_snapshot ~label:"invalid typed delivered ref" ~keeper_name
         ~receipt_id:accepted.receipt_id)
 
 let test_invalid_delivery_diagnostic_does_not_block_lane () =
@@ -462,7 +464,9 @@ let test_invalid_delivery_diagnostic_does_not_block_lane () =
             ; detail = "HTTP response body: \255"
             ; outcome_ref = Some " delivery:\255 "
             })
-        else Keeper_chat_consumer.Delivered { outcome_ref = "trace-next#4" }
+        else
+          Keeper_chat_consumer.Delivered
+            { outcome_ref = turn_ref "trace-next" 4 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -521,7 +525,7 @@ let test_shutdown_fence_keeps_receipt_pending_until_rollback () =
       let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
         incr calls;
         Keeper_chat_consumer.Delivered
-          { outcome_ref = "trace-shutdown-rollback#1" }
+          { outcome_ref = turn_ref "trace-shutdown-rollback" 1 }
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -588,7 +592,7 @@ let test_typed_admission_race_nacks_then_retries () =
           Eio.Promise.resolve resolve_second_started ();
           Eio.Promise.await release_second;
           Keeper_chat_consumer.Delivered
-            { outcome_ref = "trace-typed-deferral#2" })
+            { outcome_ref = turn_ref "trace-typed-deferral" 2 })
       in
       with_consumer_switch (fun sw ->
         Keeper_chat_consumer.start ~sw ~clock ~base_path:base ~handle_turn;
@@ -624,7 +628,7 @@ let () =
   test_structured_cancellation_nacks_and_preserves_receipt ();
   test_dispatch_is_concurrent_per_keeper ();
   test_finalization_persistence_retry_does_not_redeliver ();
-  test_invalid_delivered_turn_ref_fails_closed ();
+  test_invalid_typed_delivered_turn_ref_fails_closed ();
   test_invalid_delivery_diagnostic_does_not_block_lane ();
   test_shutdown_fence_keeps_receipt_pending_until_rollback ();
   test_typed_admission_race_nacks_then_retries ();

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -21,6 +21,9 @@ let check name cond =
 
 let base_path = "/tmp/masc_test_turn_admission"
 let keeper_name = "admission-keeper"
+let turn_ref trace_id absolute_turn =
+  Ids.Turn_ref.make ~trace_id ~absolute_turn
+
 let reset () =
   Keeper_turn_admission.For_testing.reset ();
   Keeper_chat_queue.For_testing.reset ();
@@ -119,7 +122,7 @@ let test_chat_if_free_rechecks_durable_queue_after_stale_peek () =
      Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
        ~outcome:
          (Keeper_chat_queue.Mark_delivered
-            { completed_at = Time_compat.now (); outcome_ref = Some "turn#1" })
+            { completed_at = Time_compat.now (); outcome_ref = turn_ref "turn" 1 })
    with
    | `Finalized _ -> ()
    | `Unknown_lease | `Error _ -> failwith "expected the lease to finalize");
@@ -526,7 +529,7 @@ let test_autonomous_yields_to_queued_connector_message () =
         Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
           ~outcome:
             (Keeper_chat_queue.Mark_delivered
-               { completed_at = 2.0; outcome_ref = None })
+               { completed_at = 2.0; outcome_ref = turn_ref "autonomous" 1 })
       with
       | `Finalized _ -> ()
       | `Unknown_lease | `Error _ ->

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -232,8 +232,9 @@ let test_queued_delivery_requires_exact_turn_ref () =
     |> Stream.For_testing.queued_delivery_outcome_of_turn_ref
   with
   | Stream.Delivered { outcome_ref } ->
-      check string "valid turn_ref is preserved exactly"
-        "trace-queued#42" outcome_ref
+      check turn_ref_t "valid turn_ref is preserved exactly"
+        (Ids.Turn_ref.make ~trace_id:"trace-queued" ~absolute_turn:42)
+        outcome_ref
   | Stream.Failed _ | Stream.Deferred _ ->
     fail "valid turn_ref must produce Delivered"
 


### PR DESCRIPTION
## Summary

- keep persisted legacy completion reads compatible while introducing a write-only delivered_completion that requires Ids.Turn_ref.t
- carry the typed turn reference through the queue consumer and server delivery boundary
- round-trip the typed value through the canonical Turn_ref codec before persistence
- replace even a malformed typed value with a durable Internal_error instead of storing contradictory delivery evidence

## Why

PR #24139 allowed new Mark_delivered writes with outcome_ref:string option while downstream consumers treat a missing or non-canonical turn reference as an internal failure. Backend Delivered and operator-visible error were simultaneously representable.

This follow-up makes successful raw-string or absent evidence unrepresentable at the write boundary without breaking legacy snapshot reads.

## Verification

- exact base: 2c48beb99a02b0afe69c82cd3618efe6529c7d2a
- exact head: ef8df1e2a8e90a4782399cc784a0cc70b93216ab
- focused lib plus five executable build: PASS
- test_keeper_chat_coalescing: PASS
- test_keeper_turn_admission: PASS
- test_keeper_busy_connector_deferred: PASS
- test_keeper_chat_consumer_delivery: PASS, including malformed typed ref to durable Internal_error
- test_keeper_turn_outcome: 10/10 PASS
- git diff --check: PASS

## Gate

Draft only. Keep p1 and status:do-not-merge until fresh exact-head CI and review are terminal green.

Refs #24139