### PR TITLE
fix(keeper): preserve verified v1 receipt success

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -95,6 +95,38 @@ let operator_disposition_kind_of_string = function
   | _ -> None
 ;;
 
+let terminal_disposition_of_persisted_json json =
+  match Json_util.assoc_string_opt "terminal_reason_code" json with
+  | None -> None
+  | Some terminal_reason_code ->
+    let parsed = Keeper_turn_disposition.of_wire terminal_reason_code in
+    (match parsed with
+     | Keeper_turn_disposition.Unknown _ ->
+       let is_v1_success =
+         match
+           ( Json_util.assoc_string_opt "schema" json
+           , Option.bind
+               (Json_util.assoc_string_opt "operator_disposition" json)
+               operator_disposition_kind_of_string
+           , Option.bind
+               (Json_util.assoc_string_opt "outcome" json)
+               outcome_kind_of_string )
+         with
+         | ( Some schema
+           , Some Disp_pass
+           , Some `Ok )
+           when String.equal
+                  schema
+                  Keeper_types_support.execution_receipt_v1_schema ->
+           true
+         | _ -> false
+       in
+       if is_v1_success
+       then Some Keeper_turn_disposition.Success
+       else Some parsed
+     | _ -> Some parsed)
+;;
+
 type operator_disposition_reason =
   | Reason_healthy
   | Reason_runtime_exhausted

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -245,6 +245,16 @@ type operator_disposition_kind =
 val operator_disposition_kind_to_string : operator_disposition_kind -> string
 val operator_disposition_kind_of_string : string -> operator_disposition_kind option
 
+val terminal_disposition_of_persisted_json :
+  Yojson.Safe.t -> Keeper_turn_disposition.t option
+(** Project a persisted receipt into the typed terminal-disposition SSOT.
+    Canonical terminal wires are parsed directly.  A v1 row whose terminal
+    wire is unknown is projected to [Success] only when the same record carries
+    both typed [Disp_pass] and terminal [`Ok] evidence.  This preserves already
+    persisted normal-completion rows without adding a global
+    ["completed" -> Success] string alias.  Missing or contradictory evidence
+    remains [Unknown] (or [None] when the terminal field is absent). *)
+
 (** Reason paired with [operator_disposition_kind]. Closed set; the wire
     form is byte-compatible with the pre-typing string. *)
 type operator_disposition_reason =

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -75,7 +75,9 @@ let terminal_reason_from_decision json =
         (json_string_opt_member "terminal_reason_code" json)
 
 let terminal_reason_from_receipt receipt =
-  let terminal_reason_code = json_string_opt_member "terminal_reason_code" receipt in
+  let terminal_disposition =
+    Keeper_execution_receipt.terminal_disposition_of_persisted_json receipt
+  in
   let operator_disposition_reason =
     json_string_opt_member "operator_disposition_reason" receipt
     |> Option.map String.lowercase_ascii
@@ -87,16 +89,19 @@ let terminal_reason_from_receipt receipt =
     | _, Some result -> Completion_contract_result.requires_attention result
     | _ -> false
   in
-  match terminal_reason_code with
-  | Some code when receipt_requires_tool_attention
-                   && Keeper_turn_disposition.is_success
-                        (Keeper_turn_disposition.of_wire code) ->
+  match terminal_disposition with
+  | Some disposition
+    when receipt_requires_tool_attention
+         && Keeper_turn_disposition.is_success disposition ->
       Some
         (Keeper_turn_terminal.of_disposition
            ~source:"execution_receipt"
            Keeper_turn_disposition.Completion_contract_unsatisfied)
-  | Some code ->
-      Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
+  | Some disposition ->
+      Some
+        (Keeper_turn_terminal.of_disposition
+           ~source:"execution_receipt"
+           disposition)
   | None when receipt_requires_tool_attention ->
       Some
         (Keeper_turn_terminal.of_disposition

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -50,7 +50,8 @@ let execution_receipt_store_cache : (string, Dated_jsonl.t) Hashtbl.t =
 
 let execution_receipt_store_mu = Eio.Mutex.create ()
 
-let execution_receipt_schema = "keeper.execution_receipt.v1"
+let execution_receipt_v1_schema = "keeper.execution_receipt.v1"
+let execution_receipt_schema = execution_receipt_v1_schema
 let execution_receipts_dirname = "execution-receipts"
 
 let keeper_execution_receipt_store config name : Dated_jsonl.t =

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -29,6 +29,11 @@ val execution_receipts_dirname : string
 (** Runtime subdirectory under each keeper directory for date-split execution
     receipt JSONL. *)
 
+val execution_receipt_v1_schema : string
+(** Stable schema tag for persisted v1 receipts.  Kept separately from the
+    current writer tag so record-level compatibility remains explicit after a
+    future schema bump. *)
+
 val execution_receipt_schema : string
 (** JSONL schema tag for execution receipt rows. *)
 

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -440,12 +440,12 @@ let composite_execution_blocked execution =
   || composite_execution_contract_blocked execution
   || Option.is_some (composite_execution_completion_unsatisfied_reason execution)
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
-  || (match json_string "terminal_reason_code" execution with
-      | Some terminal ->
-        not (String.equal terminal "")
-        && not
-             (Keeper_turn_disposition.is_success
-                (Keeper_turn_disposition.of_wire terminal))
+  || (match
+        Keeper_execution_receipt.terminal_disposition_of_persisted_json
+          execution
+      with
+      | Some terminal_disposition ->
+        not (Keeper_turn_disposition.is_success terminal_disposition)
         && not (composite_execution_budget_exhausted_pass execution)
       | None -> false)
   ||

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -421,6 +421,53 @@ let test_passive_only_no_work_receipt_does_not_mark_attention () =
           | _ -> false))
 ;;
 
+let test_persisted_v1_completed_pass_receipt_uses_record_evidence () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       init_runtime_default_for_tests ();
+       let keeper_name = "runtime-trust-v1-completed-pass" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "schema", `String Masc.Keeper_types_support.execution_receipt_v1_schema
+             ; "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "outcome", `String "receipt_done"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "completed"
+             ; "completion_contract_result", `String "passive_only"
+             ; "current_task_id", `Null
+             ; "goal_ids", `List []
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       let terminal = snapshot |> member "latest_terminal_reason" in
+       Alcotest.(check bool)
+         "v1 record-level success does not require attention"
+         false
+         (snapshot |> member "needs_attention" |> to_bool);
+       Alcotest.(check string)
+         "v1 record-level evidence projects canonical success"
+         "success"
+         (terminal |> member "disposition" |> to_string);
+       Alcotest.(check string)
+         "v1 compatibility stays inside the execution receipt boundary"
+         "execution_receipt"
+         (terminal |> member "source" |> to_string))
+;;
+
 let test_passive_only_active_receipt_does_not_mark_attention () =
   Eio_main.run
   @@ fun env ->
@@ -820,6 +867,10 @@ let () =
             "passive-only no-work receipt does not mark attention"
             `Quick
             test_passive_only_no_work_receipt_does_not_mark_attention
+        ; Alcotest.test_case
+            "persisted v1 completed pass uses record evidence"
+            `Quick
+            test_persisted_v1_completed_pass_receipt_uses_record_evidence
         ; Alcotest.test_case
             "passive-only active receipt does not mark attention"
             `Quick

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -101,6 +101,36 @@ let legacy_completed_passive_execution =
   passive_execution_with_terminal_reason "completed"
 ;;
 
+let persisted_v1_completed_pass_execution =
+  match legacy_completed_passive_execution with
+  | `Assoc fields ->
+    `Assoc
+      ([ "schema", `String Masc.Keeper_types_support.execution_receipt_v1_schema
+       ; "outcome", `String "receipt_done"
+       ]
+       @ fields)
+  | _ -> assert false
+;;
+
+let replace_assoc_field key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | _ -> assert false
+;;
+
+let persisted_v1_completed_error_execution =
+  replace_assoc_field
+    "outcome"
+    (`String "receipt_failed")
+    persisted_v1_completed_pass_execution
+;;
+
+let foreign_schema_completed_pass_execution =
+  replace_assoc_field
+    "schema"
+    (`String "keeper.execution_receipt.v2")
+    persisted_v1_completed_pass_execution
+;;
+
 let canonical_success_passive_execution =
   passive_execution_with_terminal_reason "success"
 ;;
@@ -260,6 +290,40 @@ let test_legacy_completed_receipt_is_blocked () =
   check string "state" "blocked" attention.cra_state
 ;;
 
+let test_persisted_v1_completed_pass_receipt_is_not_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:persisted_v1_completed_pass_execution
+  in
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
+;;
+
+let test_persisted_v1_completed_error_receipt_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:persisted_v1_completed_error_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state
+;;
+
+let test_foreign_schema_completed_pass_receipt_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:foreign_schema_completed_pass_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state
+;;
+
 let test_canonical_success_receipt_is_not_blocked () =
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
@@ -353,6 +417,18 @@ let () =
             "legacy completed receipt is blocked"
             `Quick
             test_legacy_completed_receipt_is_blocked
+        ; test_case
+            "persisted v1 completed pass receipt is not blocked"
+            `Quick
+            test_persisted_v1_completed_pass_receipt_is_not_blocked
+        ; test_case
+            "persisted v1 completed error receipt stays blocked"
+            `Quick
+            test_persisted_v1_completed_error_receipt_is_blocked
+        ; test_case
+            "foreign schema completed pass receipt stays blocked"
+            `Quick
+            test_foreign_schema_completed_pass_receipt_is_blocked
         ; test_case
             "canonical success receipt is not blocked"
             `Quick


### PR DESCRIPTION
## Summary

- publish the persisted v1 receipt schema as the canonical compatibility boundary
- recover success only when the terminal wire is unknown, the schema is exactly v1, and typed operator/outcome evidence is Pass plus Ok
- keep incomplete, failed, malformed, and foreign-schema receipts blocked

## Why

PR #24196 correctly separated terminal disposition from runtime completion, but previously persisted v1 records may still carry the legacy completion wire while retaining complete typed success evidence. Treating every such row as unknown creates a false runtime/dashboard blocker.

This follow-up restores only the structurally proven v1 case. It does not add a global completed-string alias or schema-version heuristic.

## Verification

- base: 2c48beb99a02b0afe69c82cd3618efe6529c7d2a
- head: bde745a990650fe141fcc0da81326e77deb226a9
- scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_runtime_trust_snapshot.exe test/test_server_dashboard_composite_attention.exe
- test_keeper_runtime_trust_snapshot: 18/18
- test_server_dashboard_composite_attention: 15/15
- git diff --check origin/main...HEAD

## Merge gate

Draft only. Keep do-not-merge until exact-head CI and review are green.

Refs #24196