### PR TITLE
fix(keeper): make event queue lease outcomes durable

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -301,8 +301,8 @@ let receipt_outcome_kind_of_sdk_error err =
   | Provider_wall_clock_timeout
   | Oas_agent_execution_timeout
   | Oas_turn_budget_exhausted
-  | Oas_idle_budget_exhausted
   | Oas_exit_condition_reached -> `Cancelled
+  | Oas_idle_budget_exhausted -> `Error
   | Oas_input_required -> `Cancelled
   | Oas_token_budget_exhausted
   | Oas_cost_budget_exhausted

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -63,9 +63,10 @@ val api_error_terminal_reason_code_typed
   :  Agent_sdk.Error.api_error
   -> Keeper_turn_terminal_code.t
 
-(** Receipt outcome for terminal SDK errors.  Provider timeouts map to
-    [`Cancelled] to match [KeeperTurnFSM.tla] [ProviderTimeout], while
-    all other SDK errors remain ordinary failed receipts. *)
+(** Receipt outcome for terminal SDK errors.  Provider/time-budget stop
+    semantics retain their existing [`Cancelled] mapping.  Behavioral
+    [IdleDetected] is an ordinary failed receipt: it is not evidence of a
+    user or supervisor cancellation. *)
 val receipt_outcome_kind_of_sdk_error
   :  Agent_sdk.Error.sdk_error
   -> Keeper_execution_receipt.outcome_kind

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -317,23 +317,27 @@ let settlement_of_failure ~settled_at ~lease failure =
       ; successor = None
       }
   else
-    match failure.Keeper_unified_turn.route with
-    | Keeper_runtime_failure_route.Retry_after_pacing _ ->
-      Keeper_registry_event_queue.Requeue
-        Keeper_registry_event_queue.Retry_after_pacing
-    | Keeper_runtime_failure_route.Rotate_now _ ->
-      Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
-    | Keeper_runtime_failure_route.Escalate_judgment { judgment; detail } ->
-      Keeper_registry_event_queue.Escalate
-        { reason = Keeper_registry_event_queue.Failure_judgment_requested
-        ; successor =
-            Some
-              (failure_judgment_successor
-                 ~arrived_at:settled_at
-                 failure
-                 judgment
-                 detail)
-        }
+    match failure.Keeper_unified_turn.source_lease_disposition with
+    | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
+      Keeper_registry_event_queue.Ack
+    | Keeper_unified_turn.Follow_failure_route ->
+      (match failure.Keeper_unified_turn.route with
+       | Keeper_runtime_failure_route.Retry_after_pacing _ ->
+         Keeper_registry_event_queue.Requeue
+           Keeper_registry_event_queue.Retry_after_pacing
+       | Keeper_runtime_failure_route.Rotate_now _ ->
+         Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
+       | Keeper_runtime_failure_route.Escalate_judgment { judgment; detail } ->
+         Keeper_registry_event_queue.Escalate
+           { reason = Keeper_registry_event_queue.Failure_judgment_requested
+           ; successor =
+               Some
+                 (failure_judgment_successor
+                    ~arrived_at:settled_at
+                    failure
+                    judgment
+                    detail)
+           })
 ;;
 
 let settlement_of_cycle_outcome ~settled_at ~stop_requested ~lease = function

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -62,6 +62,8 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  claimed_lease : Keeper_registry_event_queue.lease option;
+  event_queue_claim_error : string option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -147,18 +149,21 @@ let run_keeper_cycle = Cycle.run_keeper_cycle
 
 (* T6 audit: outcome of one keepalive cycle evaluation.
 
-   [cycle_crashed = true] means the catch-all in
+   [cycle_crashed = true] means either the catch-all in
    [run_keepalive_unified_turn] swallowed an exception to keep the
-   keeper fiber alive. The failure has already been recorded via
+   keeper fiber alive, or the durable event-queue claim/settlement did
+   not commit. The failure has already been recorded via
    [Keeper_registry.increment_turn_failures] (the same counter the
    unified-turn failure path in [Keeper_unified_turn_failure] uses),
    so the caller reads a non-zero [turn_fail_count] and dispatches
-   [Turn_failed] instead of [Turn_succeeded]. A crashed cycle must
-   also NOT refresh the work-as-heartbeat lease. *)
+   [Turn_failed] instead of [Turn_succeeded]. Such a cycle must also
+   NOT refresh the work-as-heartbeat lease. *)
 type keepalive_turn_outcome = {
   meta : keeper_meta;
   cycle_crashed : bool;
 }
+
+exception Event_queue_settlement_failed of string
 
 let connector_attention_event_ids_of_stimuli stimuli =
   List.filter_map
@@ -269,6 +274,105 @@ let record_crashed_cycle_failure ~base_path ~keeper_name exn =
     (if String.equal backtrace "" then "" else "\n" ^ backtrace)
 ;;
 
+let lease_contains_failure_judgment lease =
+  Keeper_registry_event_queue.lease_stimuli lease
+  |> List.exists (fun (stimulus : Keeper_event_queue.stimulus) ->
+    match stimulus.payload with
+    | Keeper_event_queue.Failure_judgment _ -> true
+    | Keeper_event_queue.Board_signal _
+    | Keeper_event_queue.Fusion_completed _
+    | Keeper_event_queue.Bg_completed _
+    | Keeper_event_queue.Schedule_due _
+    | Keeper_event_queue.Bootstrap
+    | Keeper_event_queue.No_progress_recovery
+    | Keeper_event_queue.Connector_attention _
+    | Keeper_event_queue.Hitl_resolved _
+    | Keeper_event_queue.Goal_verification_failed _
+    | Keeper_event_queue.Goal_assigned _
+    | Keeper_event_queue.Goal_stagnation _ ->
+      false)
+;;
+
+let failure_judgment_successor
+      ~arrived_at
+      (failure : Keeper_unified_turn.turn_failure)
+      judgment
+      detail
+  =
+  let payload : Keeper_event_queue.failure_judgment =
+    { fj_runtime_id = failure.runtime_id; fj_judgment = judgment; fj_detail = detail }
+  in
+  { Keeper_event_queue.post_id = Keeper_event_queue.failure_judgment_post_id payload
+  ; urgency = Keeper_event_queue.Normal
+  ; arrived_at
+  ; payload = Keeper_event_queue.Failure_judgment payload
+  }
+;;
+
+let settlement_of_failure ~settled_at ~lease failure =
+  if lease_contains_failure_judgment lease
+  then
+    Keeper_registry_event_queue.Escalate
+      { reason = Keeper_registry_event_queue.Failure_judgment_failed
+      ; successor = None
+      }
+  else
+    match failure.Keeper_unified_turn.route with
+    | Keeper_runtime_failure_route.Retry_after_pacing _ ->
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Retry_after_pacing
+    | Keeper_runtime_failure_route.Rotate_now _ ->
+      Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
+    | Keeper_runtime_failure_route.Escalate_judgment { judgment; detail } ->
+      Keeper_registry_event_queue.Escalate
+        { reason = Keeper_registry_event_queue.Failure_judgment_requested
+        ; successor =
+            Some
+              (failure_judgment_successor
+                 ~arrived_at:settled_at
+                 failure
+                 judgment
+                 detail)
+        }
+;;
+
+let settlement_of_cycle_outcome ~settled_at ~stop_requested ~lease = function
+  | Some (Cycle.Completed _) -> Keeper_registry_event_queue.Ack
+  | Some (Cycle.Busy _) ->
+    Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cycle_busy
+  | Some (Cycle.Failed { failure; _ }) ->
+    settlement_of_failure ~settled_at ~lease failure
+  | None ->
+    if stop_requested
+    then Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Cancelled
+    else
+      Keeper_registry_event_queue.Requeue
+        Keeper_registry_event_queue.Turn_not_scheduled
+;;
+
+let settle_claimed_lease
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~settlement
+  =
+  Eio.Cancel.protect (fun () ->
+    Keeper_registry_event_queue.settle_result
+      ~base_path
+      keeper_name
+      ~settled_at
+      ~lease
+      ~settlement)
+;;
+
+let settlement_is_ack = function
+  | Keeper_registry_event_queue.Ack -> true
+  | Keeper_registry_event_queue.Requeue _
+  | Keeper_registry_event_queue.Escalate _ ->
+    false
+;;
+
 (* Pure: post-turn status event derived from the registry turn-failure
    counter. Extracted from the loop body so the crashed-cycle ->
    [Turn_failed] mapping is unit-testable. *)
@@ -292,7 +396,46 @@ let run_keepalive_unified_turn
   then { meta = meta_after_triage; cycle_crashed = false }
   else (
     let consumed_stimuli = ref [] in
-    let consumed_stimuli_turn_completed = ref false in
+    let claimed_lease = ref None in
+    let cycle_outcome_ref = ref None in
+    let lease_settled = ref false in
+    let settlement_failed = ref false in
+    let record_settlement_failure message =
+      settlement_failed := true;
+      match !cycle_outcome_ref with
+      | Some (Cycle.Failed _) ->
+        (* The failed turn already recorded its failure counter.  The queue
+           error remains explicit in the log and active durable lease. *)
+        ()
+      | Some (Cycle.Completed _ | Cycle.Busy _) | None ->
+        record_crashed_cycle_failure
+          ~base_path:ctx.config.base_path
+          ~keeper_name:meta_after_triage.name
+          (Event_queue_settlement_failed message)
+    in
+    let requeue_unsettled reason =
+      match !claimed_lease with
+      | None -> ()
+      | Some _ when !lease_settled -> ()
+      | Some lease ->
+        (match
+           settle_claimed_lease
+             ~base_path:ctx.config.base_path
+             ~keeper_name:meta_after_triage.name
+             ~settled_at:(Time_compat.now ())
+             ~lease
+             ~settlement:(Keeper_registry_event_queue.Requeue reason)
+         with
+         | Ok
+             ( Keeper_registry_event_queue.Settled _
+             | Keeper_registry_event_queue.Already_settled _ ) ->
+           lease_settled := true
+         | Error message ->
+           Log.Keeper.error
+             "registry: failed to requeue unsettled lease keeper=%s: %s"
+             meta_after_triage.name
+             message)
+    in
     try
       (* RFC-0310 §3.3: before intake, surface any live goal that has gone
          stale as a Goal_stagnation stimulus so it flows through the normal
@@ -316,6 +459,10 @@ let run_keepalive_unified_turn
         heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events
       in
       consumed_stimuli := event_intake.consumed_stimuli;
+      claimed_lease := event_intake.claimed_lease;
+      (match event_intake.event_queue_claim_error with
+       | None -> ()
+       | Some message -> record_settlement_failure message);
       let pending_board_events = event_intake.pending_board_events in
       let obs =
         Keeper_world_observation.observe
@@ -554,60 +701,92 @@ let run_keepalive_unified_turn
               ~wake
               ()
           in
-          (match cycle_outcome with
-           | Cycle.Completed _ -> consumed_stimuli_turn_completed := true
-           | Cycle.Failed _ | Cycle.Busy _ -> ());
+          cycle_outcome_ref := Some cycle_outcome;
           Cycle.meta cycle_outcome)
         else meta_after_triage
       in
-      (* The caller has already admitted intake before this dequeue. Downstream
-         scheduling can still decide not to run (for example provider cooldown
-         or keeper health), so acknowledge only after [run_keeper_cycle]
-         actually returns; otherwise put the lease back rather than dropping
-         the stimulus. *)
-      if !consumed_stimuli <> []
-      then
-        if !consumed_stimuli_turn_completed
-        then (
-          (match
-             Keeper_registry_event_queue.ack_consumed_result
-               ~base_path:ctx.config.base_path
-               meta_after_triage.name
-               !consumed_stimuli
-           with
-           | Ok () ->
-             record_schedule_due_event_queue_ack_reactions
-               ~ctx
-               ~keeper_name:meta_after_triage.name
-               !consumed_stimuli
-           | Error msg ->
-             Log.Keeper.warn
-               "registry: ack_consumed failed name=%s: %s"
-               meta_after_triage.name
-               msg);
-          (*
-             Connector post-turn handling preserves the existing behavior:
-             it is an external-attention lifecycle update, while
-             [event_queue_ack] evidence above is emitted only after durable
-             event-queue acknowledgement succeeds. *)
-          mark_connector_attention_ignored_after_turn
-            ~base_path:ctx.config.base_path
-            ~keeper_name:meta_after_triage.name
-            (connector_attention_event_ids_of_stimuli !consumed_stimuli))
-        else
-          Keeper_registry_event_queue.requeue_front
-            ~base_path:ctx.config.base_path
-            meta_after_triage.name
-            !consumed_stimuli;
-      { meta = meta_after_cycle; cycle_crashed = false }
+      (* Queue ownership follows the typed cycle outcome.  Pending removal,
+         lease removal, an optional judgment successor, and the transition
+         outbox receipt commit in one event-queue.json rename. *)
+      (match !claimed_lease with
+       | None ->
+         (match !cycle_outcome_ref with
+          | Some (Cycle.Failed { failure; _ }) ->
+            (match failure.Keeper_unified_turn.route with
+             | Keeper_runtime_failure_route.Escalate_judgment { judgment; detail } ->
+               let successor =
+                 failure_judgment_successor
+                   ~arrived_at:(Time_compat.now ())
+                   failure
+                   judgment
+                   detail
+               in
+               (match
+                  Keeper_registry_event_queue.enqueue_durable_result
+                    ~base_path:ctx.config.base_path
+                    meta_after_triage.name
+                    successor
+                with
+                | Ok () -> ()
+                | Error message ->
+                  Log.Keeper.error
+                    "registry: unleased failure judgment enqueue failed keeper=%s: %s"
+                    meta_after_triage.name
+                    message;
+                  record_settlement_failure message)
+             | Keeper_runtime_failure_route.Retry_after_pacing _
+             | Keeper_runtime_failure_route.Rotate_now _ ->
+               ())
+          | Some (Cycle.Completed _ | Cycle.Busy _) | None -> ())
+       | Some lease ->
+         let settled_at = Time_compat.now () in
+         let settlement =
+           settlement_of_cycle_outcome
+             ~settled_at
+             ~stop_requested:(Atomic.get stop)
+             ~lease
+             !cycle_outcome_ref
+         in
+         (match
+            settle_claimed_lease
+              ~base_path:ctx.config.base_path
+              ~keeper_name:meta_after_triage.name
+              ~settled_at
+              ~lease
+              ~settlement
+          with
+          | Error message ->
+            Log.Keeper.error
+              "registry: durable lease settlement failed keeper=%s: %s"
+              meta_after_triage.name
+              message;
+            record_settlement_failure message
+          | Ok
+              ( Keeper_registry_event_queue.Settled _
+              | Keeper_registry_event_queue.Already_settled _ ) ->
+            lease_settled := true;
+            if settlement_is_ack settlement
+            then (
+              record_schedule_due_event_queue_ack_reactions
+                ~ctx
+                ~keeper_name:meta_after_triage.name
+                !consumed_stimuli;
+              mark_connector_attention_ignored_after_turn
+                ~base_path:ctx.config.base_path
+                ~keeper_name:meta_after_triage.name
+                (connector_attention_event_ids_of_stimuli !consumed_stimuli))));
+      { meta = meta_after_cycle; cycle_crashed = !settlement_failed }
     with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | Keeper_registry.Keeper_fiber_crash as e -> raise e
+    | Eio.Cancel.Cancelled _ as e ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      requeue_unsettled Keeper_registry_event_queue.Cancelled;
+      Printexc.raise_with_backtrace e backtrace
+    | Keeper_registry.Keeper_fiber_crash as e ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
+      Printexc.raise_with_backtrace e backtrace
     | exn ->
-      Keeper_registry_event_queue.requeue_front
-        ~base_path:ctx.config.base_path
-        meta_after_triage.name
-        !consumed_stimuli;
+      requeue_unsettled Keeper_registry_event_queue.Cycle_crashed;
       (* T6 audit: keep the fiber alive, but surface the crash as a
          turn failure so the caller does not dispatch
          [Turn_succeeded] for a cycle that never completed. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -54,10 +54,6 @@ let record_event_queue_stimulus_turn_started =
   Stimulus_intake.record_event_queue_stimulus_turn_started
 ;;
 
-let record_event_queue_stimulus_ack =
-  Stimulus_intake.record_event_queue_stimulus_ack
-;;
-
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
@@ -205,26 +201,6 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
     stimuli
 ;;
 
-let record_schedule_due_event_queue_ack_reactions ~ctx ~keeper_name stimuli =
-  List.iter
-    (fun (stimulus : Keeper_event_queue.stimulus) ->
-       match stimulus.payload with
-       | Keeper_event_queue.Schedule_due _ ->
-         record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus
-       | Keeper_event_queue.Board_signal _
-       | Keeper_event_queue.Fusion_completed _
-       | Keeper_event_queue.Bg_completed _
-       | Keeper_event_queue.Bootstrap
-       | Keeper_event_queue.No_progress_recovery
-       | Keeper_event_queue.Connector_attention _
-       | Keeper_event_queue.Hitl_resolved _
-       | Keeper_event_queue.Goal_verification_failed _
-       | Keeper_event_queue.Failure_judgment _
-       | Keeper_event_queue.Goal_assigned _
-       | Keeper_event_queue.Goal_stagnation _ -> ())
-    stimuli
-;;
-
 let mark_connector_attention_ignored_after_turn ~base_path ~keeper_name event_ids =
   match event_ids with
   | [] -> ()
@@ -354,6 +330,45 @@ let settlement_of_cycle_outcome ~settled_at ~stop_requested ~lease = function
         Keeper_registry_event_queue.Turn_not_scheduled
 ;;
 
+let reaction_kind_of_settlement = function
+  | Keeper_registry_event_queue.Ack -> Keeper_reaction_ledger.Event_queue_ack
+  | Keeper_registry_event_queue.Requeue _ ->
+    Keeper_reaction_ledger.Event_queue_requeued
+  | Keeper_registry_event_queue.Escalate _ ->
+    Keeper_reaction_ledger.Event_queue_escalated
+;;
+
+let project_transition_outbox ~base_path ~keeper_name =
+  let rec project_stimuli ~reaction_kind ~receipt = function
+    | [] -> Ok ()
+    | stimulus :: rest ->
+      (match
+         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+           ~base_path
+           ~keeper_name
+           ~reaction_kind
+           ~receipt
+           stimulus
+       with
+       | Error _ as error -> error
+       | Ok () -> project_stimuli ~reaction_kind ~receipt rest)
+  in
+  match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
+  | Error _ as error -> error
+  | Ok [] -> Ok ()
+  | Ok [ (entry : Keeper_registry_event_queue.outbox_entry) ] ->
+    let receipt = entry.receipt in
+    let reaction_kind = reaction_kind_of_settlement receipt.settlement in
+    (match project_stimuli ~reaction_kind ~receipt entry.stimuli with
+     | Error _ as error -> error
+     | Ok () ->
+       Keeper_registry_event_queue.mark_transition_projected_result
+         ~base_path
+         keeper_name
+         ~transition_id:receipt.transition_id)
+  | Ok (_ :: _ :: _) -> Error "event queue state has multiple unprojected transitions"
+;;
+
 let settle_claimed_lease
       ~base_path
       ~keeper_name
@@ -441,6 +456,13 @@ let run_keepalive_unified_turn
              message)
     in
     try
+      (match
+         project_transition_outbox
+           ~base_path:ctx.config.base_path
+           ~keeper_name:meta_after_triage.name
+       with
+       | Ok () -> ()
+       | Error message -> raise (Event_queue_settlement_failed message));
       (* RFC-0310 §3.3: before intake, surface any live goal that has gone
          stale as a Goal_stagnation stimulus so it flows through the normal
          event-queue intake below and drives this turn. The producer is
@@ -769,16 +791,19 @@ let run_keepalive_unified_turn
               ( Keeper_registry_event_queue.Settled _
               | Keeper_registry_event_queue.Already_settled _ ) ->
             lease_settled := true;
+            (match
+               project_transition_outbox
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:meta_after_triage.name
+             with
+             | Error message -> raise (Event_queue_settlement_failed message)
+             | Ok () -> ());
             if settlement_is_ack settlement
-            then (
-              record_schedule_due_event_queue_ack_reactions
-                ~ctx
-                ~keeper_name:meta_after_triage.name
-                !consumed_stimuli;
+            then
               mark_connector_attention_ignored_after_turn
                 ~base_path:ctx.config.base_path
                 ~keeper_name:meta_after_triage.name
-                (connector_attention_event_ids_of_stimuli !consumed_stimuli))));
+                (connector_attention_event_ids_of_stimuli !consumed_stimuli)));
       { meta = meta_after_cycle; cycle_crashed = !settlement_failed }
     with
     | Eio.Cancel.Cancelled _ as e ->

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -13,6 +13,7 @@ open Keeper_memory
 open Keeper_execution
 open Keeper_keepalive_signal
 module Observations = Keeper_heartbeat_loop_observations
+module Cycle = Keeper_heartbeat_loop_cycle
 
 (* Presence/identity sync extracted to
    [Keeper_heartbeat_loop_presence] (godfile decomp). *)
@@ -142,7 +143,7 @@ let provider_timeout_metric_outcome =
 ;;
 
 (** Run keeper cycle with holder diagnostics. *)
-let run_keeper_cycle = Keeper_heartbeat_loop_cycle.run_keeper_cycle
+let run_keeper_cycle = Cycle.run_keeper_cycle
 
 (* T6 audit: outcome of one keepalive cycle evaluation.
 
@@ -540,7 +541,7 @@ let run_keepalive_unified_turn
                    !consumed_stimuli)
             else Keeper_registry.Proactive_tick
           in
-          let meta_after_cycle =
+          let cycle_outcome =
             run_keeper_cycle
               ?event_bus
               ?hitl_resolution
@@ -553,8 +554,10 @@ let run_keepalive_unified_turn
               ~wake
               ()
           in
-          consumed_stimuli_turn_completed := true;
-          meta_after_cycle)
+          (match cycle_outcome with
+           | Cycle.Completed _ -> consumed_stimuli_turn_completed := true
+           | Cycle.Failed _ | Cycle.Busy _ -> ());
+          Cycle.meta cycle_outcome)
         else meta_after_triage
       in
       (* The caller has already admitted intake before this dequeue. Downstream

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -55,6 +55,8 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  claimed_lease : Keeper_registry_event_queue.lease option;
+  event_queue_claim_error : string option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -113,11 +115,12 @@ val provider_timeout_policy_decision :
 (** Outcome of one keepalive cycle evaluation.
 
     [cycle_crashed = true] means the cycle's catch-all swallowed an
-    exception to keep the keeper fiber alive (T6 audit). The failure
-    has already been recorded via
+    exception to keep the keeper fiber alive (T6 audit), or a durable
+    event-queue claim/settlement did not commit. The failure has
+    already been recorded via
     [Keeper_registry.increment_turn_failures] — the same counter the
     unified-turn failure path uses — so the caller dispatches
-    [Turn_failed]. A crashed cycle must not refresh the
+    [Turn_failed]. Such a cycle must not refresh the
     work-as-heartbeat lease. *)
 type keepalive_turn_outcome = {
   meta : keeper_meta;
@@ -130,6 +133,16 @@ type keepalive_turn_outcome = {
     and logs at ERROR. Does not raise. *)
 val record_crashed_cycle_failure :
   base_path:string -> keeper_name:string -> exn -> unit
+
+val settlement_of_failure :
+  settled_at:float ->
+  lease:Keeper_registry_event_queue.lease ->
+  Keeper_unified_turn.turn_failure ->
+  Keeper_registry_event_queue.settlement
+(** Pure queue disposition for a failed cycle.  Retry/rotation requeue;
+    deterministic failure creates one judgment successor; failure of an
+    already-leased judgment emits an operator-visible escalation with no
+    recursive successor. *)
 
 (** Pure: post-turn status event derived from the registry
     turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -144,6 +144,12 @@ val settlement_of_failure :
     already-leased judgment emits an operator-visible escalation with no
     recursive successor. *)
 
+val project_transition_outbox :
+  base_path:string -> keeper_name:string -> (unit, string) result
+(** Idempotently materialize the lane's single durable transition into the
+    reaction ledger, then retire the outbox entry. New claims remain blocked
+    while this projection is incomplete. *)
+
 (** Pure: post-turn status event derived from the registry
     turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];
     [0] maps to [Turn_succeeded]. *)

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -39,6 +39,21 @@ open Keeper_types_profile
 module In_turn_pulse = Keeper_heartbeat_loop_in_turn_pulse
 module Observations = Keeper_heartbeat_loop_observations
 
+type cycle_outcome =
+  | Completed of keeper_meta
+  | Failed of
+      { meta : keeper_meta
+      ; error : Agent_sdk.Error.sdk_error
+      }
+  | Busy of
+      { meta : keeper_meta
+      ; block : Keeper_turn_admission.autonomous_block
+      }
+
+let meta = function
+  | Completed meta | Failed { meta; _ } | Busy { meta; _ } -> meta
+;;
+
 (* Body of [run_keeper_cycle], runnable only while holding the keeper's
    turn slot ([Keeper_turn_admission]). The post-failure meta re-reads stay
    inside the slot for the same reason as the chat lane: a concurrent turn
@@ -103,35 +118,38 @@ let run_keeper_cycle_admitted
         "%s: provider_timeout observed; preserving original turn \
          failure without Provider_timeout_loop latch"
         keeper_name);
-    (match read_effective_meta ctx.config meta_after_triage.name with
-     | Ok (Some latest) -> latest
-     | Ok None ->
-       Log.Keeper.error
-         "keeper:%s read_effective_meta returned None after turn failure, using stale meta"
-         meta_after_triage.name;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string MetaReadFailures)
-         ~labels:
-           [ "keeper", meta_after_triage.name; "site", "none_after_failure" ]
-         ();
-       meta_after_triage
-     | Error e ->
-       Log.Keeper.error
-         "keeper:%s read_effective_meta failed after turn failure (%s), using stale meta"
-         meta_after_triage.name
-         e;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string MetaReadFailures)
-         ~labels:
-           [ "keeper", meta_after_triage.name; "site", "error_after_failure" ]
-         ();
-       meta_after_triage)
+    let meta =
+      match read_effective_meta ctx.config meta_after_triage.name with
+      | Ok (Some latest) -> latest
+      | Ok None ->
+        Log.Keeper.error
+          "keeper:%s read_effective_meta returned None after turn failure, using stale meta"
+          meta_after_triage.name;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string MetaReadFailures)
+          ~labels:
+            [ "keeper", meta_after_triage.name; "site", "none_after_failure" ]
+          ();
+        meta_after_triage
+      | Error e ->
+        Log.Keeper.error
+          "keeper:%s read_effective_meta failed after turn failure (%s), using stale meta"
+          meta_after_triage.name
+          e;
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string MetaReadFailures)
+          ~labels:
+            [ "keeper", meta_after_triage.name; "site", "error_after_failure" ]
+          ();
+        meta_after_triage
+    in
+    Failed { meta; error = err }
   | Ok updated ->
     Keeper_turn_holders.reset_budget_exhaustion ~keeper_name:meta_after_triage.name;
     Observations.clear_provider_timeout_failure_reason
       ~base_path:ctx.config.base_path
       ~keeper_name:meta_after_triage.name;
-    updated
+    Completed updated
 ;;
 
 let run_keeper_cycle
@@ -161,14 +179,14 @@ let run_keeper_cycle
          ?event_bus
          ?hitl_resolution)
   with
-  | `Ran updated -> updated
-  | `Busy (Keeper_turn_admission.Shutdown_requested operation_id) ->
+  | `Ran outcome -> outcome
+  | `Busy ((Keeper_turn_admission.Shutdown_requested operation_id) as block) ->
     Log.Keeper.info
       "%s: autonomous turn admission closed by shutdown operation %s"
       meta_after_triage.name
       (Keeper_shutdown_types.Operation_id.to_string operation_id);
-    meta_after_triage
-  | `Busy (Keeper_turn_admission.Turn_busy in_flight) ->
+    Busy { meta = meta_after_triage; block }
+  | `Busy ((Keeper_turn_admission.Turn_busy in_flight) as block) ->
     (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
        cycle and return the pre-cycle meta unchanged. The next heartbeat
        retries naturally — same shape as the pre-existing skip decisions. *)
@@ -186,5 +204,5 @@ let run_keeper_cycle
       "%s: turn slot busy (%s); skipping autonomous cycle until next heartbeat"
       meta_after_triage.name
       holder;
-    meta_after_triage
+    Busy { meta = meta_after_triage; block }
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -43,7 +43,7 @@ type cycle_outcome =
   | Completed of keeper_meta
   | Failed of
       { meta : keeper_meta
-      ; error : Agent_sdk.Error.sdk_error
+      ; failure : Keeper_unified_turn.turn_failure
       }
   | Busy of
       { meta : keeper_meta
@@ -87,7 +87,8 @@ let run_keeper_cycle_admitted
         ?event_bus
         ())
   with
-  | Error err ->
+  | Error failure ->
+    let err = failure.Keeper_unified_turn.error in
     let e_str = Agent_sdk.Error.to_string err in
     Log.Keeper.debug "%s: keeper cycle failed: %s" meta_after_triage.name e_str;
     (* Classify on the typed [Config (InvalidConfig { field = "eio_context" })]
@@ -143,7 +144,7 @@ let run_keeper_cycle_admitted
           ();
         meta_after_triage
     in
-    Failed { meta; error = err }
+    Failed { meta; failure }
   | Ok updated ->
     Keeper_turn_holders.reset_budget_exhaustion ~keeper_name:meta_after_triage.name;
     Observations.clear_provider_timeout_failure_reason

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -4,7 +4,7 @@ type cycle_outcome =
   | Completed of Keeper_meta_contract.keeper_meta
   | Failed of
       { meta : Keeper_meta_contract.keeper_meta
-      ; error : Agent_sdk.Error.sdk_error
+      ; failure : Keeper_unified_turn.turn_failure
       }
   | Busy of
       { meta : Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -1,5 +1,22 @@
 (** Keeper cycle execution with error-class handling. *)
 
+type cycle_outcome =
+  | Completed of Keeper_meta_contract.keeper_meta
+  | Failed of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; error : Agent_sdk.Error.sdk_error
+      }
+  | Busy of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; block : Keeper_turn_admission.autonomous_block
+      }
+
+val meta : cycle_outcome -> Keeper_meta_contract.keeper_meta
+(** Metadata projection for callers that must continue the heartbeat state
+    machine independently of whether the turn completed, failed, or was not
+    admitted.  Queue ownership must inspect the full {!cycle_outcome}; this
+    projection alone is never completion evidence. *)
+
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
@@ -11,4 +28,4 @@ val run_keeper_cycle
   -> shared_context:Agent_sdk.Context.t
   -> wake:Keeper_registry.wake_reason
   -> unit
-  -> Keeper_meta_contract.keeper_meta
+  -> cycle_outcome

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -75,6 +75,8 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  claimed_lease : Keeper_registry_event_queue.lease option;
+  event_queue_claim_error : string option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
@@ -346,23 +348,55 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
      signal is consumed as one batch ({!Keeper_event_queue.drain_board_all},
      RFC-0334 W2 — arrival-window batching is retired), and the non-board
      fallback below stays a single stimulus. *)
-  let board_batch =
-    Keeper_registry_event_queue.drain_board
-      ~base_path:ctx.config.base_path
-      meta_after_triage.name
+  let base_path = ctx.config.base_path in
+  let keeper_name = meta_after_triage.name in
+  let claim_new () =
+    match
+      Keeper_registry_event_queue.claim_board_result
+        ~base_path
+        keeper_name
+        ~claimed_at:(Time_compat.now ())
+    with
+    | Error _ as error -> error
+    | Ok (Some _ as lease) -> Ok lease
+    | Ok None ->
+      Keeper_registry_event_queue.claim_when_result
+        ~base_path
+        keeper_name
+        ~claimed_at:(Time_compat.now ())
+        ~ready:stimulus_ready_for_intake
   in
-  let queued_observations, consumed_stimuli =
-    match board_batch with
-    | [] ->
-      (match
-         Keeper_registry_event_queue.dequeue_when
-           ~base_path:ctx.config.base_path
-           meta_after_triage.name
-           ~ready:stimulus_ready_for_intake
-       with
-       | None -> [], []
-       | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, [ stim ])
-    | batch -> consume_board_stimulus_batch ~meta_after_triage batch, batch
+  let claimed_lease =
+    match Keeper_registry_event_queue.active_lease_result ~base_path keeper_name with
+    | Error _ as error -> error
+    | Ok (Some _ as lease) -> Ok lease
+    | Ok None -> claim_new ()
+  in
+  let queued_observations, consumed_stimuli, claimed_lease, event_queue_claim_error =
+    match claimed_lease with
+    | Error message ->
+      Log.Keeper.error
+        "turn entry: event queue claim failed keeper=%s: %s"
+        keeper_name
+        message;
+      [], [], None, Some message
+    | Ok None -> [], [], None, None
+    | Ok (Some lease) ->
+      let stimuli = Keeper_registry_event_queue.lease_stimuli lease in
+      let observations =
+        match Keeper_registry_event_queue.lease_kind lease, stimuli with
+        | Keeper_event_queue_persistence.Board_batch, batch ->
+          consume_board_stimulus_batch ~meta_after_triage batch
+        | ( Keeper_event_queue_persistence.Single
+          | Keeper_event_queue_persistence.Legacy_inflight ), [ stimulus ] ->
+          consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stimulus
+        | ( Keeper_event_queue_persistence.Single
+          | Keeper_event_queue_persistence.Legacy_inflight ), stimuli ->
+          List.concat_map
+            (consume_single_heartbeat_stimulus ~ctx ~meta_after_triage)
+            stimuli
+      in
+      observations, stimuli, Some lease, None
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
   let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in
@@ -386,5 +420,11 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
       pending_board_events
       (List.rev queued_observations)
   in
-  { pending_board_events; consumed_stimulus_count; consumed_stimuli; event_queue_triggers }
+  { pending_board_events
+  ; consumed_stimulus_count
+  ; consumed_stimuli
+  ; claimed_lease
+  ; event_queue_claim_error
+  ; event_queue_triggers
+  }
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -59,14 +59,6 @@ let record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus =
     stimulus
 ;;
 
-let record_event_queue_stimulus_ack ~ctx ~keeper_name stimulus =
-  record_event_queue_stimulus_reaction
-    ~ctx
-    ~keeper_name
-    ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
-    stimulus
-;;
-
 let record_recovery_stimulus_turn_started ~ctx ~keeper_name stimulus =
   record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -56,6 +56,8 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  claimed_lease : Keeper_registry_event_queue.lease option;
+  event_queue_claim_error : string option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -40,16 +40,6 @@ val record_event_queue_stimulus_turn_started
   -> Keeper_event_queue.stimulus
   -> unit
 
-(** [record_event_queue_stimulus_ack ~ctx ~keeper_name stim] writes a durable
-    [Event_queue_ack] reaction only after the caller has confirmed
-    [ack_consumed] persisted. Logs and swallows errors except
-    [Eio.Cancel.Cancelled]. *)
-val record_event_queue_stimulus_ack
-  :  ctx:_ context
-  -> keeper_name:string
-  -> Keeper_event_queue.stimulus
-  -> unit
-
 (** Result of one heartbeat intake — accumulated pending board events
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -906,6 +906,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
            "start_keepalive: registry validation rejected %s: %s"
            m.name
            (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+       | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
+         Log.Keeper.error
+           "start_keepalive: registry event queue unavailable keeper=%s: %s"
+           keeper_name
+           detail
        | Ok reg ->
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -25,12 +25,16 @@ type stimulus_kind =
 type reaction_kind =
   | Turn_started
   | Event_queue_ack
+  | Event_queue_requeued
+  | Event_queue_escalated
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
   | Operator_escalation
   | Supervisor_recovery_requested
   | Unknown_reaction of string
+
+module Event_id_set = Set.Make (String)
 
 let schema = "keeper.reaction_ledger.v1"
 
@@ -72,6 +76,8 @@ let stimulus_kind_of_string = function
 let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
   | Event_queue_ack -> "event_queue_ack"
+  | Event_queue_requeued -> "event_queue_requeued"
+  | Event_queue_escalated -> "event_queue_escalated"
   | Execution_receipt -> "execution_receipt"
   | Terminal_reason -> "terminal_reason"
   | Cursor_ack -> "cursor_ack"
@@ -87,6 +93,8 @@ let reaction_kind_to_string = function
 let reaction_kind_of_string = function
   | "turn_started" -> Turn_started
   | "event_queue_ack" -> Event_queue_ack
+  | "event_queue_requeued" -> Event_queue_requeued
+  | "event_queue_escalated" -> Event_queue_escalated
   | "execution_receipt" -> Execution_receipt
   | "terminal_reason" -> Terminal_reason
   | "cursor_ack" -> Cursor_ack
@@ -314,6 +322,62 @@ let record_event_queue_reaction ~base_path ~keeper_name ~reaction_kind stimulus 
     (event_queue_reaction_json ~keeper_name ~reaction_kind stimulus)
 ;;
 
+let event_queue_transition_reaction_json
+      ~keeper_name
+      ~reaction_kind
+      (receipt : Keeper_event_queue_state.transition_receipt)
+      stimulus
+  =
+  let stimulus_id = stimulus_id_of_event_queue stimulus in
+  `Assoc
+    (base_fields
+       ~record_kind:"reaction"
+       ~event_id:(digest_id "krl" (receipt.event_id ^ "|" ^ stimulus_id))
+       ~keeper_name
+       ~recorded_at:receipt.settled_at
+     @ [ "stimulus_id", `String stimulus_id
+       ; ( "reaction"
+         , `Assoc
+             [ "kind", `String (reaction_kind_to_string reaction_kind)
+             ; "source", `String "keeper_event_queue_transition_outbox"
+             ; "post_id", `String stimulus.post_id
+             ; ( "stimulus_kind"
+               , `String
+                   (stimulus_kind_to_string (stimulus_kind_of_event_queue stimulus)) )
+             ; "transition_id", `String receipt.transition_id
+             ; ( "transition_receipt"
+               , Keeper_event_queue_state.transition_receipt_to_yojson receipt )
+             ] )
+       ])
+;;
+
+let record_event_queue_transition_reaction_result
+      ~base_path
+      ~keeper_name
+      ~reaction_kind
+      ~receipt
+      stimulus
+  =
+  try
+    Dated_jsonl.append
+      (store_for_base_path ~base_path ~keeper_name)
+      (event_queue_transition_reaction_json
+         ~keeper_name
+         ~reaction_kind
+         receipt
+         stimulus);
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "event queue transition ledger append failed keeper=%s transition=%s: %s"
+         keeper_name
+         receipt.Keeper_event_queue_state.transition_id
+         (Printexc.to_string exn))
+;;
+
 let cursor_json { cursor_ts; post_id } =
   `Assoc
     [ "scope", `String "board"
@@ -515,6 +579,8 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
             event_queue_ack_seen := true;
             event_queue_ack_recorded_at
               := max_recorded_at !event_queue_ack_recorded_at recorded_at
+          | Some Event_queue_requeued
+          | Some Event_queue_escalated -> ()
           | Some Execution_receipt
           | Some Terminal_reason
           | Some Cursor_ack
@@ -780,12 +846,28 @@ let board_stimulus_token row =
   | _ -> None
 ;;
 
+let dedupe_rows_by_event_id rows =
+  let rec loop seen kept = function
+    | [] -> List.rev kept
+    | row :: rest ->
+      (match string_field "event_id" row with
+       | Some event_id when Event_id_set.mem event_id seen -> loop seen kept rest
+       | Some event_id ->
+         loop (Event_id_set.add event_id seen) (row :: kept) rest
+       | None -> loop seen (row :: kept) rest)
+  in
+  loop Event_id_set.empty [] rows
+;;
+
 let summarize_rows ~keeper_name ~limit rows =
+  let rows = dedupe_rows_by_event_id rows in
   let row_count = List.length rows in
   let stimulus_count = ref 0 in
   let reaction_count = ref 0 in
   let turn_started_count = ref 0 in
   let event_queue_ack_count = ref 0 in
+  let event_queue_requeue_count = ref 0 in
+  let event_queue_escalation_count = ref 0 in
   let cursor_ack_count = ref 0 in
   let execution_receipt_count = ref 0 in
   let terminal_reason_count = ref 0 in
@@ -877,6 +959,8 @@ let summarize_rows ~keeper_name ~limit rows =
       (match reaction_kind_of_string raw with
        | Turn_started -> incr turn_started_count
        | Event_queue_ack -> incr event_queue_ack_count
+       | Event_queue_requeued -> incr event_queue_requeue_count
+       | Event_queue_escalated -> incr event_queue_escalation_count
        | Cursor_ack -> incr cursor_ack_count
        | Execution_receipt -> incr execution_receipt_count
        | Terminal_reason -> incr terminal_reason_count
@@ -1058,6 +1142,8 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "reaction_count", `Int !reaction_count
     ; "turn_started_count", `Int !turn_started_count
     ; "event_queue_ack_count", `Int !event_queue_ack_count
+    ; "event_queue_requeue_count", `Int !event_queue_requeue_count
+    ; "event_queue_escalation_count", `Int !event_queue_escalation_count
     ; "cursor_ack_count", `Int !cursor_ack_count
     ; "execution_receipt_count", `Int !execution_receipt_count
     ; "terminal_reason_count", `Int !terminal_reason_count
@@ -1430,6 +1516,9 @@ let fleet_summary_json ~base_path ~keeper_names ~limit_per_keeper =
     ; "reaction_count", `Int (total_int "reaction_count")
     ; "turn_started_count", `Int (total_int "turn_started_count")
     ; "event_queue_ack_count", `Int (total_int "event_queue_ack_count")
+    ; "event_queue_requeue_count", `Int (total_int "event_queue_requeue_count")
+    ; ( "event_queue_escalation_count"
+      , `Int (total_int "event_queue_escalation_count") )
     ; "cursor_ack_count", `Int (total_int "cursor_ack_count")
     ; "execution_receipt_count", `Int (total_int "execution_receipt_count")
     ; "terminal_reason_count", `Int (total_int "terminal_reason_count")

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -32,6 +32,8 @@ type stimulus_kind =
 type reaction_kind =
   | Turn_started
   | Event_queue_ack
+  | Event_queue_requeued
+  | Event_queue_escalated
   | Execution_receipt
   | Terminal_reason
   | Cursor_ack
@@ -69,6 +71,17 @@ val record_event_queue_reaction :
   Keeper_event_queue.stimulus ->
   unit
 (** Append a [record_kind="reaction"] row tied to an event queue stimulus. *)
+
+val record_event_queue_transition_reaction_result :
+  base_path:string ->
+  keeper_name:string ->
+  reaction_kind:reaction_kind ->
+  receipt:Keeper_event_queue_state.transition_receipt ->
+  Keeper_event_queue.stimulus ->
+  (unit, string) result
+(** Append the outbox-owned terminal transition with a stable event id.  A
+    retry may append the same id after a crash, so readers treat [event_id] as
+    the idempotency identity.  Persistence failures remain explicit [Error]. *)
 
 type event_queue_reaction_evidence =
   { keeper_name : string

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -39,6 +39,10 @@ val register_offline : base_path:string -> string -> keeper_meta -> registry_ent
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
   | Registration_invalid of registry_entry_validation_error
+  | Registration_event_queue_unavailable of
+      { keeper_name : string
+      ; detail : string
+      }
 
 (** Production registration gate: the final registry CAS is serialized with
     Keeper shutdown reservation. Event-queue loading remains outside the
@@ -57,6 +61,10 @@ val register_offline_if_admitted :
 type register_restarting_error =
   | Budget_already_exhausted of { name : string }
   | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Restart_event_queue_unavailable of
+      { keeper_name : string
+      ; detail : string
+      }
 
 (** Register a keeper that is about to relaunch after a crash.
     The entry starts in [Restarting] and must receive [Fiber_started] when the

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -11,6 +11,7 @@ type lease = Keeper_event_queue_persistence.lease
 
 type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -36,6 +37,16 @@ type settle_result = Keeper_event_queue_persistence.settle_result =
   | Already_settled of transition_receipt
 
 let lease_stimuli = Keeper_event_queue_persistence.lease_stimuli
+let lease_kind = Keeper_event_queue_persistence.lease_kind
+
+let active_lease_result ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" name)
+  | Some _ ->
+    Keeper_event_queue_persistence.active_lease_result
+      ~base_path
+      ~keeper_name:name
+;;
 
 let rec queue_contains queue stimulus =
   match Keeper_event_queue.dequeue queue with
@@ -220,64 +231,76 @@ let snapshot ~base_path name =
 ;;
 
 let dequeue_when ~base_path name ~ready =
-  match
-    Keeper_event_queue_persistence.claim_when_result
-      ~base_path
-      ~keeper_name:name
-      ~claimed_at:(Time_compat.now ())
-      ~ready
-      ~after_commit:(publish_pending ~base_path name)
-      ()
-  with
-  | Error message ->
-    Log.Keeper.error "registry: durable claim failed name=%s: %s" name message;
-    None
-  | Ok None -> None
-  | Ok (Some lease) ->
-    (match lease_stimuli lease with
-     | [ stimulus ] -> Some stimulus
-     | [] | _ :: _ :: _ ->
-       Log.Keeper.error
-         "registry: single claim returned invalid cardinality name=%s"
-         name;
-       None)
+  match Keeper_registry.get ~base_path name with
+  | None -> None
+  | Some _ ->
+    (match
+       Keeper_event_queue_persistence.claim_when_result
+         ~base_path
+         ~keeper_name:name
+         ~claimed_at:(Time_compat.now ())
+         ~ready
+         ~after_commit:(publish_pending ~base_path name)
+         ()
+     with
+     | Error message ->
+       Log.Keeper.error "registry: durable claim failed name=%s: %s" name message;
+       None
+     | Ok None -> None
+     | Ok (Some lease) ->
+       (match lease_stimuli lease with
+        | [ stimulus ] -> Some stimulus
+        | [] | _ :: _ :: _ ->
+          Log.Keeper.error
+            "registry: single claim returned invalid cardinality name=%s"
+            name;
+          None))
 ;;
 
 let dequeue ~base_path name = dequeue_when ~base_path name ~ready:(fun _ -> true)
 
 let drain_board ~base_path name =
-  match
-    Keeper_event_queue_persistence.claim_board_result
-      ~base_path
-      ~keeper_name:name
-      ~claimed_at:(Time_compat.now ())
-      ~after_commit:(publish_pending ~base_path name)
-      ()
-  with
-  | Error message ->
-    Log.Keeper.error "registry: durable board claim failed name=%s: %s" name message;
-    []
-  | Ok None -> []
-  | Ok (Some lease) -> lease_stimuli lease
+  match Keeper_registry.get ~base_path name with
+  | None -> []
+  | Some _ ->
+    (match
+       Keeper_event_queue_persistence.claim_board_result
+         ~base_path
+         ~keeper_name:name
+         ~claimed_at:(Time_compat.now ())
+         ~after_commit:(publish_pending ~base_path name)
+         ()
+     with
+     | Error message ->
+       Log.Keeper.error "registry: durable board claim failed name=%s: %s" name message;
+       []
+     | Ok None -> []
+     | Ok (Some lease) -> lease_stimuli lease)
 ;;
 
 let claim_when_result ~base_path name ~claimed_at ~ready =
-  Keeper_event_queue_persistence.claim_when_result
-    ~base_path
-    ~keeper_name:name
-    ~claimed_at
-    ~ready
-    ~after_commit:(publish_pending ~base_path name)
-    ()
+  match Keeper_registry.get ~base_path name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" name)
+  | Some _ ->
+    Keeper_event_queue_persistence.claim_when_result
+      ~base_path
+      ~keeper_name:name
+      ~claimed_at
+      ~ready
+      ~after_commit:(publish_pending ~base_path name)
+      ()
 ;;
 
 let claim_board_result ~base_path name ~claimed_at =
-  Keeper_event_queue_persistence.claim_board_result
-    ~base_path
-    ~keeper_name:name
-    ~claimed_at
-    ~after_commit:(publish_pending ~base_path name)
-    ()
+  match Keeper_registry.get ~base_path name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" name)
+  | Some _ ->
+    Keeper_event_queue_persistence.claim_board_result
+      ~base_path
+      ~keeper_name:name
+      ~claimed_at
+      ~after_commit:(publish_pending ~base_path name)
+      ()
 ;;
 
 let settle_result ~base_path name ~settled_at ~lease ~settlement =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -31,6 +31,7 @@ type settlement = Keeper_event_queue_persistence.settlement =
       }
 
 type transition_receipt = Keeper_event_queue_persistence.transition_receipt
+type outbox_entry = Keeper_event_queue_persistence.outbox_entry
 
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
@@ -46,6 +47,19 @@ let active_lease_result ~base_path name =
     Keeper_event_queue_persistence.active_lease_result
       ~base_path
       ~keeper_name:name
+;;
+
+let transition_outbox_result ~base_path name =
+  Keeper_event_queue_persistence.transition_outbox_result
+    ~base_path
+    ~keeper_name:name
+;;
+
+let mark_transition_projected_result ~base_path name ~transition_id =
+  Keeper_event_queue_persistence.mark_transition_projected_result
+    ~base_path
+    ~keeper_name:name
+    ~transition_id
 ;;
 
 let rec queue_contains queue stimulus =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -2,13 +2,40 @@
 
     Extracted from keeper_registry.ml (lines 1854-1900) as part of the
     godfile decomp campaign. Each [registry_entry] carries its own
-    [event_queue : Keeper_event_queue.t Atomic.t] — these wrappers do
-    CAS on that per-entry atomic after locating the entry via the
-    central registry's public [get]. No coupling to the central
-    Atomic state primitive. CAS-successful mutations are mirrored to
-    [Keeper_event_queue_persistence] for restart replay. *)
+    [event_queue : Keeper_event_queue.t Atomic.t].  The durable v2 envelope is
+    the mutation authority; these wrappers publish its pending projection to
+    that per-entry Atomic only after commit.  No coupling to the central
+    registry Atomic state primitive. *)
 
-open Keeper_registry_types
+type lease = Keeper_event_queue_persistence.lease
+
+type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement = Keeper_event_queue_persistence.settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type transition_receipt = Keeper_event_queue_persistence.transition_receipt
+
+type settle_result = Keeper_event_queue_persistence.settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+let lease_stimuli = Keeper_event_queue_persistence.lease_stimuli
 
 let rec queue_contains queue stimulus =
   match Keeper_event_queue.dequeue queue with
@@ -51,61 +78,41 @@ let requeue_missing_front queue stimuli =
   Keeper_event_queue.prepend_list missing queue
 ;;
 
-let persist_live_queue ~base_path (entry : Keeper_registry.registry_entry) name =
-  Keeper_event_queue_persistence.persist_snapshot
-    ~base_path
-    ~keeper_name:name
-    (fun () -> Atomic.get entry.event_queue)
-;;
-
-let enqueue_live_if_missing (entry : Keeper_registry.registry_entry) stimulus =
-  let rec loop () =
-    let cur = Atomic.get entry.event_queue in
-    let next = enqueue_if_missing cur stimulus in
-    if next = cur
-    then ()
-    else if Atomic.compare_and_set entry.event_queue cur next
-    then ()
-    else loop ()
-  in
-  loop ()
+let publish_pending ~base_path name pending =
+  match Keeper_registry.get ~base_path name with
+  | None -> ()
+  | Some entry -> Atomic.set entry.event_queue pending
 ;;
 
 let enqueue ~base_path name stimulus =
-  match Keeper_registry.get ~base_path name with
-  | None ->
+  if Option.is_none (Keeper_registry.get ~base_path name)
+  then
     Log.Keeper.warn
       "registry: enqueue_event name=%s base_path=%s: keeper not registered; persisting stimulus for replay"
       name
       base_path;
-    Keeper_event_queue_persistence.update
+  let committed_pending = ref None in
+  match
+    Keeper_event_queue_persistence.update_checked_result
       ~base_path
       ~keeper_name:name
-      (fun cur -> enqueue_if_missing cur stimulus);
-    (match Keeper_registry.get ~base_path name with
-     | None -> ()
-     | Some entry ->
-       let rec loop () =
-         let cur = Atomic.get entry.event_queue in
-         let next = enqueue_if_missing cur stimulus in
-         if next = cur
-         then ()
-         else if Atomic.compare_and_set entry.event_queue cur next
-         then persist_live_queue ~base_path entry name
-         else loop ()
-       in
-       loop ())
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      let next = enqueue_if_missing cur stimulus in
-      if next = cur
-      then ()
-      else if Atomic.compare_and_set entry.event_queue cur next
-      then persist_live_queue ~base_path entry name
-      else loop ()
-    in
-    loop ()
+      ~after_commit:(fun () ->
+        match !committed_pending with
+        | None -> ()
+        | Some pending -> publish_pending ~base_path name pending)
+      (fun current ->
+         let pending = enqueue_if_missing current stimulus in
+         committed_pending := Some pending;
+         Ok pending)
+  with
+  | Ok () -> ()
+  | Error message ->
+    Log.Keeper.error
+      "registry: durable enqueue failed name=%s base_path=%s post_id=%s: %s"
+      name
+      base_path
+      stimulus.Keeper_event_queue.post_id
+      message
 ;;
 
 let enqueue_durable_result ~base_path name stimulus =
@@ -113,16 +120,20 @@ let enqueue_durable_result ~base_path name stimulus =
      delivery result. This path is intentionally separate from [enqueue]: most
      stimuli already have an upstream replay source, while HITL resolution is
      the sole carrier of an operator decision and must fail closed. *)
-  let after_commit =
-    match Keeper_registry.get ~base_path name with
-    | None -> fun () -> ()
-    | Some entry -> fun () -> enqueue_live_if_missing entry stimulus
-  in
+  let committed_pending = ref None in
   Keeper_event_queue_persistence.update_checked_result
     ~base_path
     ~keeper_name:name
-    ~after_commit
-    (fun queue -> enqueue_external_decision queue stimulus)
+    ~after_commit:(fun () ->
+      match !committed_pending with
+      | None -> ()
+      | Some pending -> publish_pending ~base_path name pending)
+    (fun queue ->
+       match enqueue_external_decision queue stimulus with
+       | Error _ as error -> error
+       | Ok pending ->
+         committed_pending := Some pending;
+         Ok pending)
 ;;
 
 let enqueue_hitl_resolution_durable_result
@@ -149,26 +160,27 @@ let requeue_front ~base_path name stimuli =
   match stimuli with
   | [] -> ()
   | _ ->
-    (match Keeper_registry.get ~base_path name with
-     | None ->
-       Keeper_event_queue_persistence.update
+    let committed_pending = ref None in
+    (match
+       Keeper_event_queue_persistence.update_checked_result
          ~base_path
          ~keeper_name:name
-         (fun cur -> requeue_missing_front cur stimuli);
-       Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli
-     | Some entry ->
-       let rec loop () =
-         let cur = Atomic.get entry.event_queue in
-         let next = requeue_missing_front cur stimuli in
-         if next = cur
-         then Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli
-         else if Atomic.compare_and_set entry.event_queue cur next
-         then (
-           persist_live_queue ~base_path entry name;
-           Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli)
-         else loop ()
-       in
-       loop ())
+         ~after_commit:(fun () ->
+           match !committed_pending with
+           | None -> ()
+           | Some pending -> publish_pending ~base_path name pending)
+         (fun current ->
+            let pending = requeue_missing_front current stimuli in
+            committed_pending := Some pending;
+            Ok pending)
+     with
+     | Error message ->
+       Log.Keeper.error "registry: durable requeue failed name=%s: %s" name message
+     | Ok () ->
+       Keeper_event_queue_persistence.ack_inflight
+         ~base_path
+         ~keeper_name:name
+         stimuli)
 ;;
 
 let ack_consumed_result ~base_path name stimuli =
@@ -183,25 +195,13 @@ let ack_consumed ~base_path name stimuli =
 ;;
 
 let drop_by_post_id ~base_path name ~post_id =
-  let remove_live (entry : Keeper_registry.registry_entry) =
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      let removed, next = Keeper_event_queue.remove_by_post_id post_id cur in
-      if removed = []
-      then removed
-      else if Atomic.compare_and_set entry.event_queue cur next
-      then (
-        persist_live_queue ~base_path entry name;
-        removed)
-      else loop ()
-    in
-    loop ()
-  in
   match
     Keeper_event_queue_persistence.drop_by_post_id
       ~base_path
       ~keeper_name:name
       ~post_id
+      ~after_commit:(publish_pending ~base_path name)
+      ()
   with
   | Error msg ->
     Log.Keeper.warn
@@ -210,13 +210,7 @@ let drop_by_post_id ~base_path name ~post_id =
       post_id
       msg;
     Error msg
-  | Ok persisted_removed ->
-    let live_removed =
-      match Keeper_registry.get ~base_path name with
-      | None -> []
-      | Some entry -> remove_live entry
-    in
-    Ok (Keeper_event_queue.uniq_stimuli (live_removed @ persisted_removed))
+  | Ok persisted_removed -> Ok persisted_removed
 ;;
 
 let snapshot ~base_path name =
@@ -226,43 +220,73 @@ let snapshot ~base_path name =
 ;;
 
 let dequeue_when ~base_path name ~ready =
-  match Keeper_registry.get ~base_path name with
-  | None -> None
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      match Keeper_event_queue.dequeue cur with
-      | None -> None
-      | Some (stim, _) when not (ready stim) -> None
-      | Some (stim, rest) ->
-        Keeper_event_queue_persistence.record_inflight
-          ~base_path
-          ~keeper_name:name
-          [ stim ];
-        if Atomic.compare_and_set entry.event_queue cur rest
-        then (
-          persist_live_queue ~base_path entry name;
-          Some stim)
-        else loop ()
-    in
-    loop ()
+  match
+    Keeper_event_queue_persistence.claim_when_result
+      ~base_path
+      ~keeper_name:name
+      ~claimed_at:(Time_compat.now ())
+      ~ready
+      ~after_commit:(publish_pending ~base_path name)
+      ()
+  with
+  | Error message ->
+    Log.Keeper.error "registry: durable claim failed name=%s: %s" name message;
+    None
+  | Ok None -> None
+  | Ok (Some lease) ->
+    (match lease_stimuli lease with
+     | [ stimulus ] -> Some stimulus
+     | [] | _ :: _ :: _ ->
+       Log.Keeper.error
+         "registry: single claim returned invalid cardinality name=%s"
+         name;
+       None)
 ;;
 
 let dequeue ~base_path name = dequeue_when ~base_path name ~ready:(fun _ -> true)
 
 let drain_board ~base_path name =
-  match Keeper_registry.get ~base_path name with
-  | None -> []
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      let board, rest = Keeper_event_queue.drain_board_all cur in
-      Keeper_event_queue_persistence.record_inflight ~base_path ~keeper_name:name board;
-      if Atomic.compare_and_set entry.event_queue cur rest
-      then (
-        persist_live_queue ~base_path entry name;
-        board)
-      else loop ()
-    in
-    loop ()
+  match
+    Keeper_event_queue_persistence.claim_board_result
+      ~base_path
+      ~keeper_name:name
+      ~claimed_at:(Time_compat.now ())
+      ~after_commit:(publish_pending ~base_path name)
+      ()
+  with
+  | Error message ->
+    Log.Keeper.error "registry: durable board claim failed name=%s: %s" name message;
+    []
+  | Ok None -> []
+  | Ok (Some lease) -> lease_stimuli lease
+;;
+
+let claim_when_result ~base_path name ~claimed_at ~ready =
+  Keeper_event_queue_persistence.claim_when_result
+    ~base_path
+    ~keeper_name:name
+    ~claimed_at
+    ~ready
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let claim_board_result ~base_path name ~claimed_at =
+  Keeper_event_queue_persistence.claim_board_result
+    ~base_path
+    ~keeper_name:name
+    ~claimed_at
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let settle_result ~base_path name ~settled_at ~lease ~settlement =
+  Keeper_event_queue_persistence.settle_result
+    ~base_path
+    ~keeper_name:name
+    ~settled_at
+    ~lease
+    ~settlement
+    ~after_commit:(publish_pending ~base_path name)
+    ()
 ;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -30,6 +30,7 @@ type settlement = Keeper_event_queue_persistence.settlement =
       }
 
 type transition_receipt = Keeper_event_queue_persistence.transition_receipt
+type outbox_entry = Keeper_event_queue_persistence.outbox_entry
 
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
@@ -40,6 +41,12 @@ val lease_kind : lease -> Keeper_event_queue_persistence.lease_kind
 
 val active_lease_result :
   base_path:string -> string -> (lease option, string) result
+
+val transition_outbox_result :
+  base_path:string -> string -> (outbox_entry list, string) result
+
+val mark_transition_projected_result :
+  base_path:string -> string -> transition_id:string -> (unit, string) result
 
 val claim_when_result :
   base_path:string ->

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -1,11 +1,58 @@
 (** Per-keeper event-queue access.
 
     SSOT for enqueueing / draining the per-keeper stimulus queue.
-    Internal CAS retry on the entry-owned
-    [event_queue : Keeper_event_queue.t Atomic.t] field; no central
-    registry Atomic touched. Successful mutations are mirrored to the
-    MASC-owned durable queue snapshot so a keeper restart can replay
-    pending stimuli. *)
+    The MASC-owned v2 envelope is authoritative.  Mutations commit that one
+    durable state first, then publish its pending projection into the
+    entry-owned [event_queue : Keeper_event_queue.t Atomic.t].  No central
+    registry Atomic is touched. *)
+
+type lease = Keeper_event_queue_persistence.lease
+
+type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason = Keeper_event_queue_persistence.escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement = Keeper_event_queue_persistence.settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type transition_receipt = Keeper_event_queue_persistence.transition_receipt
+
+type settle_result = Keeper_event_queue_persistence.settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+val lease_stimuli : lease -> Keeper_event_queue.stimulus list
+
+val claim_when_result :
+  base_path:string ->
+  string ->
+  claimed_at:float ->
+  ready:(Keeper_event_queue.stimulus -> bool) ->
+  (lease option, string) result
+
+val claim_board_result :
+  base_path:string -> string -> claimed_at:float -> (lease option, string) result
+
+val settle_result :
+  base_path:string ->
+  string ->
+  settled_at:float ->
+  lease:lease ->
+  settlement:settlement ->
+  (settle_result, string) result
 
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -10,6 +10,7 @@ type lease = Keeper_event_queue_persistence.lease
 
 type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -35,6 +36,10 @@ type settle_result = Keeper_event_queue_persistence.settle_result =
   | Already_settled of transition_receipt
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
+val lease_kind : lease -> Keeper_event_queue_persistence.lease_kind
+
+val active_lease_result :
+  base_path:string -> string -> (lease option, string) result
 
 val claim_when_result :
   base_path:string ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -352,48 +352,13 @@ let update_entry_if_registered_unit ~base_path name f =
   ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 
-let rec queue_contains_stimulus queue stimulus =
-  match Keeper_event_queue.dequeue queue with
-  | None -> false
-  | Some (head, rest) -> head = stimulus || queue_contains_stimulus rest stimulus
-;;
-
-let enqueue_missing_stimulus queue stimulus =
-  if queue_contains_stimulus queue stimulus
-  then queue
-  else Keeper_event_queue.enqueue queue stimulus
-;;
-
-let merge_event_queues ~durable ~live =
-  let rec loop acc queue =
-    match Keeper_event_queue.dequeue queue with
-    | None -> acc
-    | Some (stimulus, rest) -> loop (enqueue_missing_stimulus acc stimulus) rest
-  in
-  loop durable live
-;;
-
-let refresh_entry_event_queue_from_persistence ~base_path name entry =
-  let durable = Keeper_event_queue_persistence.load ~base_path ~keeper_name:name in
-  let rec loop () =
-    let live = Atomic.get entry.event_queue in
-    let merged = merge_event_queues ~durable ~live in
-    if merged = live
-    then ()
-    else if Atomic.compare_and_set entry.event_queue live merged
-    then
-      Keeper_event_queue_persistence.persist_snapshot
-        ~base_path
-        ~keeper_name:name
-        (fun () -> Atomic.get entry.event_queue)
-    else loop ()
-  in
-  loop ()
-;;
-
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
   | Registration_invalid of registry_entry_validation_error
+  | Registration_event_queue_unavailable of
+      { keeper_name : string
+      ; detail : string
+      }
 
 let register_with_state_result
       ~respect_shutdown_fence
@@ -412,9 +377,15 @@ let register_with_state_result
     (Keeper_state_machine.phase_to_string phase);
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
-  let initial_event_queue =
-    Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
-  in
+  match
+    Keeper_event_queue_persistence.prepare_registration_result
+      ~base_path
+      ~keeper_name:name
+      ~settled_at:(Time_compat.now ())
+      ()
+  with
+  | Error detail -> Error (Registration_event_queue_unavailable { keeper_name = name; detail })
+  | Ok initial_event_queue ->
   let entry =
     { base_path
     ; name
@@ -492,7 +463,6 @@ let register_with_state_result
       "registry: keeper registered name=%s running_count=%d"
       name
       (Atomic.get running_count_atomic);
-    refresh_entry_event_queue_from_persistence ~base_path name entry;
     Ok entry
 ;;
 
@@ -509,6 +479,12 @@ let register_with_state ~base_path name meta ~phase ~conditions =
   | Ok entry -> entry
   | Error (Registration_invalid error) ->
     invalid_arg (registry_entry_validation_error_to_string error)
+  | Error (Registration_event_queue_unavailable { keeper_name; detail }) ->
+    invalid_arg
+      (Printf.sprintf
+         "keeper registration event queue unavailable keeper=%s: %s"
+         keeper_name
+         detail)
   | Error (Registration_shutdown_reserved _) ->
     invalid_arg "unchecked registry registration observed a shutdown fence"
 ;;
@@ -556,6 +532,10 @@ let register_offline_if_admitted ~base_path name meta =
 type register_restarting_error =
   | Budget_already_exhausted of { name : string }
   | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Restart_event_queue_unavailable of
+      { keeper_name : string
+      ; detail : string
+      }
 
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
@@ -577,9 +557,15 @@ let register_restarting ~base_path name meta
      re-allocating. Pending Event Layer stimuli are restored from the durable
      queue snapshot instead of being reset across restart. *)
   let done_p, done_r = Eio.Promise.create () in
-  let initial_event_queue =
-    Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
-  in
+  match
+    Keeper_event_queue_persistence.prepare_registration_result
+      ~base_path
+      ~keeper_name:name
+      ~settled_at:(Time_compat.now ())
+      ()
+  with
+  | Error detail -> Error (Restart_event_queue_unavailable { keeper_name = name; detail })
+  | Ok initial_event_queue ->
   let new_entry =
     { base_path
     ; name
@@ -645,7 +631,6 @@ let register_restarting ~base_path name meta
       name
       base_path
       (Keeper_state_machine.phase_to_string phase);
-    refresh_entry_event_queue_from_persistence ~base_path name registered;
     Ok registered
 ;;
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -842,6 +842,15 @@ let sweep_and_recover ~load_or_materialize_keeper_meta ~pacing_enforced (ctx : _
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
               ()
+          | Error (Keeper_registry.Restart_event_queue_unavailable { keeper_name; detail }) ->
+            Log.Keeper.error
+              "%s: restart refused because durable event queue is unavailable: %s"
+              keeper_name
+              detail;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", keeper_name; "outcome", "event_queue_unavailable" ]
+              ()
           | Ok reg ->
             Keeper_registry.restore_supervisor_state
               ~base_path

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -84,6 +84,11 @@ let supervise_keepalive
          "supervisor registry validation rejected %s: %s"
          meta.name
          (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+     | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
+       Log.Keeper.error
+         "supervisor registry event queue unavailable keeper=%s: %s"
+         keeper_name
+         detail
      | Ok reg ->
     (* Workspace initialization *)
     (try

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -20,6 +20,12 @@ include Keeper_unified_turn_types
 
 include Keeper_unified_turn_phase_plan
 
+type turn_failure =
+  { error : Agent_sdk.Error.sdk_error
+  ; runtime_id : string
+  ; route : Keeper_runtime_failure_route.route
+  }
+
 let run_keeper_cycle
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -32,7 +38,7 @@ let run_keeper_cycle
       ?event_bus
       ?hitl_resolution
       ()
-  : (keeper_meta, Agent_sdk.Error.sdk_error) result
+  : (keeper_meta, turn_failure) result
   =
   (* Spec navigation: see specs/keeper-state-machine/KeeperTaskAcquisition.tla
      (Cycle 8/Tier B2, PR #11412).  Action mapping:
@@ -48,6 +54,7 @@ let run_keeper_cycle
      so dashboards/tests can inspect the same routing contract for blocked
      phases like Overflowed. *)
   let registry_base_path = config.base_path in
+  let exact_failure_execution = ref None in
   let hitl_delivery_channel =
     Option.map
       (fun (resolution : Keeper_event_queue.hitl_resolution) -> resolution.channel)
@@ -958,17 +965,15 @@ dominant source of the observed CAS race exhaustion after
                       (String.concat ", " committed_tools)
                       turn_event_summary.event_count
                       (String.concat ", " turn_event_summary.payload_kinds));
-                  (* RFC-0313 W2: route the failure (total over sdk_error) and
-                     record alongside the legacy machinery. The route is
-                     observe-only until the W3 flip: pacing shadow takes the
-                     typed retry_after hint, the route counter feeds Grafana,
-                     and Escalate_judgment enqueues a judgment stimulus
-                     ([enqueue_if_missing] identity-dedups repeats; no
-                     dedicated turn_reason, so scheduling cooldowns are
-                     unchanged). Placed before the escalate call, which may
-                     raise [Keeper_fiber_crash] and must not skip the
-                     observations. *)
+                  (* RFC-0313: route the failure (total over sdk_error), retain
+                     the exact final execution identity, and record pacing plus
+                     telemetry here. Queue ownership lives one boundary out:
+                     the heartbeat settles the current lease and, for
+                     [Escalate_judgment], enqueues its typed successor in the
+                     same durable event-queue transaction. *)
                   let failure_route = Keeper_runtime_failure_route.route_of_error err in
+                  exact_failure_execution :=
+                    Some (final_execution.runtime_id, failure_route);
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string FailureRoute)
                     ~labels:
@@ -984,24 +989,6 @@ dominant source of the observed CAS race exhaustion after
                     ~runtime_id:final_execution.runtime_id
                     ~retry_after:
                       (Keeper_runtime_failure_route.retry_after_of_route failure_route);
-                  (match failure_route with
-                   | Keeper_runtime_failure_route.Escalate_judgment { judgment; detail } ->
-                     let fj : Keeper_event_queue.failure_judgment =
-                       { fj_runtime_id = final_execution.runtime_id
-                       ; fj_judgment = judgment
-                       ; fj_detail = detail
-                       }
-                     in
-                     Keeper_registry_event_queue.enqueue
-                       ~base_path:config.base_path
-                       meta.name
-                       { post_id = Keeper_event_queue.failure_judgment_post_id fj
-                       ; urgency = Keeper_event_queue.Normal
-                       ; arrived_at = Time_compat.now ()
-                       ; payload = Keeper_event_queue.Failure_judgment fj
-                       }
-                   | Keeper_runtime_failure_route.Retry_after_pacing _
-                   | Keeper_runtime_failure_route.Rotate_now _ -> ());
                   Keeper_unified_turn_failure.record_failure_and_maybe_escalate
                     ~config
                     ~meta
@@ -1041,7 +1028,7 @@ dominant source of the observed CAS race exhaustion after
                      (Streaming -> Completing -> Done) are emitted once inside
                      [Keeper_unified_turn_success.handle]. Do not duplicate them
                      here; this is the sole caller of that function. *)
-                  let updated_meta =
+                  let success =
                     Keeper_unified_turn_success.handle
                       ~config
                       ~base_dir
@@ -1058,12 +1045,29 @@ dominant source of the observed CAS race exhaustion after
                       ~keeper_turn_id
                       result
                   in
-                  (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
-                  let turn_state =
-                    { turn_state with cycle_completed = true }
-                  in
-                  post_turn_complete_task ~cycle_completed:turn_state.cycle_completed;
-                  Ok updated_meta, turn_state)))))
+                  (match success.failure_judgment with
+                   | Some judgment ->
+                     let route =
+                       Keeper_runtime_failure_route.Escalate_judgment
+                         { judgment = judgment.fj_judgment
+                         ; detail = judgment.fj_detail
+                         }
+                     in
+                     exact_failure_execution :=
+                       Some (final_execution.runtime_id, route);
+                     let error =
+                       Keeper_internal_error.sdk_error_of_masc_internal_error
+                         (Keeper_internal_error.Internal_contract_rejected
+                            { reason = judgment.fj_detail })
+                     in
+                     Error error, turn_state
+                   | None ->
+                     (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
+                     let turn_state =
+                       { turn_state with cycle_completed = true }
+                     in
+                     post_turn_complete_task ~cycle_completed:turn_state.cycle_completed;
+                     Ok success.meta, turn_state))))))
   in
   let append_phase_gate_decision_for_gate turn_plan turn_state =
     Keeper_unified_turn_manifest.append_phase_gate_decision
@@ -1083,10 +1087,20 @@ dominant source of the observed CAS race exhaustion after
       ~turn_state
       ~registry_base_path
   in
+  let failure_of_error error =
+    match !exact_failure_execution with
+    | Some (runtime_id, route) -> { error; runtime_id; route }
+    | None ->
+      { error
+      ; runtime_id = Keeper_meta_contract.runtime_id_of_meta meta
+      ; route = Keeper_runtime_failure_route.route_of_error error
+      }
+  in
   match phase_gate_outcome with
   | Keeper_unified_turn_phase_gate.Phase_gate_terminal_ok meta -> Ok meta
-  | Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err -> Error err
+  | Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err ->
+    Error (failure_of_error err)
   | Keeper_unified_turn_phase_gate.Phase_gate_proceed phase_opt ->
     let result, _turn_state = main_path turn_state phase_opt in
-    result
+    Result.map_error failure_of_error result
 ;;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -20,10 +20,15 @@ include Keeper_unified_turn_types
 
 include Keeper_unified_turn_phase_plan
 
+type source_lease_disposition =
+  | Follow_failure_route
+  | Acknowledge_after_in_turn_handling
+
 type turn_failure =
   { error : Agent_sdk.Error.sdk_error
   ; runtime_id : string
   ; route : Keeper_runtime_failure_route.route
+  ; source_lease_disposition : source_lease_disposition
   }
 
 let run_keeper_cycle
@@ -973,7 +978,10 @@ dominant source of the observed CAS race exhaustion after
                      same durable event-queue transaction. *)
                   let failure_route = Keeper_runtime_failure_route.route_of_error err in
                   exact_failure_execution :=
-                    Some (final_execution.runtime_id, failure_route);
+                    Some
+                      ( final_execution.runtime_id
+                      , failure_route
+                      , Follow_failure_route );
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string FailureRoute)
                     ~labels:
@@ -1045,29 +1053,43 @@ dominant source of the observed CAS race exhaustion after
                       ~keeper_turn_id
                       result
                   in
-                  (match success.failure_judgment with
-                   | Some judgment ->
+                  (match success with
+                   | Keeper_unified_turn_success.Failed_completion_contract
+                       { failure_judgment = judgment
+                       ; judgment_delivery
+                       ; _
+                       } ->
                      let route =
                        Keeper_runtime_failure_route.Escalate_judgment
                          { judgment = judgment.fj_judgment
                          ; detail = judgment.fj_detail
                          }
                      in
+                     let source_lease_disposition =
+                       match judgment_delivery with
+                       | Keeper_unified_turn_success.Queue_successor ->
+                         Follow_failure_route
+                       | Keeper_unified_turn_success.Handled_in_turn ->
+                         Acknowledge_after_in_turn_handling
+                     in
                      exact_failure_execution :=
-                       Some (final_execution.runtime_id, route);
+                       Some
+                         ( final_execution.runtime_id
+                         , route
+                         , source_lease_disposition );
                      let error =
                        Keeper_internal_error.sdk_error_of_masc_internal_error
                          (Keeper_internal_error.Internal_contract_rejected
                             { reason = judgment.fj_detail })
                      in
                      Error error, turn_state
-                   | None ->
+                   | Keeper_unified_turn_success.Completed updated_meta ->
                      (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
                      let turn_state =
                        { turn_state with cycle_completed = true }
                      in
                      post_turn_complete_task ~cycle_completed:turn_state.cycle_completed;
-                     Ok success.meta, turn_state))))))
+                     Ok updated_meta, turn_state))))))
   in
   let append_phase_gate_decision_for_gate turn_plan turn_state =
     Keeper_unified_turn_manifest.append_phase_gate_decision
@@ -1089,11 +1111,13 @@ dominant source of the observed CAS race exhaustion after
   in
   let failure_of_error error =
     match !exact_failure_execution with
-    | Some (runtime_id, route) -> { error; runtime_id; route }
+    | Some (runtime_id, route, source_lease_disposition) ->
+      { error; runtime_id; route; source_lease_disposition }
     | None ->
       { error
       ; runtime_id = Keeper_meta_contract.runtime_id_of_meta meta
       ; route = Keeper_runtime_failure_route.route_of_error error
+      ; source_lease_disposition = Follow_failure_route
       }
   in
   match phase_gate_outcome with

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -196,10 +196,19 @@ val record_streaming_cancelled_observation
   -> unit
   -> unit
 
+type source_lease_disposition =
+  | Follow_failure_route
+  | Acknowledge_after_in_turn_handling
+(** A failed turn normally follows its typed retry/rotate/escalate route.
+    [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
+    the configured in-turn policy already handled the terminal failure; the
+    cycle remains failed for receipts, counters, and heartbeat freshness. *)
+
 type turn_failure =
   { error : Agent_sdk.Error.sdk_error
   ; runtime_id : string
   ; route : Keeper_runtime_failure_route.route
+  ; source_lease_disposition : source_lease_disposition
   }
 (** Exact execution identity and typed disposition route for a failed turn.
     The heartbeat queue settles from this value; it must not reconstruct a

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -196,6 +196,15 @@ val record_streaming_cancelled_observation
   -> unit
   -> unit
 
+type turn_failure =
+  { error : Agent_sdk.Error.sdk_error
+  ; runtime_id : string
+  ; route : Keeper_runtime_failure_route.route
+  }
+(** Exact execution identity and typed disposition route for a failed turn.
+    The heartbeat queue settles from this value; it must not reconstruct a
+    possibly rotated runtime from Keeper meta. *)
+
 val run_keeper_cycle
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
@@ -208,7 +217,7 @@ val run_keeper_cycle
   -> ?event_bus:Agent_sdk.Event_bus.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> unit
-  -> (Keeper_meta_contract.keeper_meta, Agent_sdk.Error.sdk_error) result
+  -> (Keeper_meta_contract.keeper_meta, turn_failure) result
 
 (** Run a unified keeper turn.
 

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -75,8 +75,8 @@ let record_failure_and_maybe_escalate
       (Some (Keeper_registry.Turn_consecutive_failures count));
   (* RFC-0313 W3: with [pacing.mode = enforce] a turn failure never writes
      [paused=true] — the failure was already recorded as pacing (revisit
-     widening) and, for judgment classes, as a [Failure_judgment] stimulus at
-     the routing site in [Keeper_unified_turn]. The three auto-pause flags
+     widening) and, for judgment classes, as a [Failure_judgment] successor in
+     the heartbeat lease settlement transaction. The three auto-pause flags
      below stay reachable only in shadow mode (kill-switch, removed in W4).
      [pacing_enforced] is injected by the caller (production wires
      [Keeper_pacing_shadow.pacing_enforced ()]) so the mode is an explicit

--- a/lib/keeper/keeper_unified_turn_failure.mli
+++ b/lib/keeper/keeper_unified_turn_failure.mli
@@ -12,6 +12,6 @@ val record_failure_and_maybe_escalate
 (** [pacing_enforced] is the RFC-0313 W3 mode, read once by the caller
     (production wires [Keeper_pacing_shadow.pacing_enforced ()]).  When
     [true] (default runtime config), the three legacy auto-pause flags are
-    inert — the failure is expressed as pacing plus a judgment stimulus at
-    the routing site; when [false] (shadow kill-switch, removed in W4), the
+    inert — the failure is expressed as pacing plus a judgment successor in
+    the heartbeat lease settlement; when [false] (shadow kill-switch, removed in W4), the
     legacy [paused=true] writes run. *)

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -735,6 +735,7 @@ let completion_contract_attention_detail ~reason_code =
 let record_completion_contract_attention_failure
       ~(config : Workspace.config)
       ~(updated_meta : Keeper_meta_contract.keeper_meta)
+      ~runtime_id
       ~reason_code
   =
   let base_path = config.Workspace.base_path in
@@ -754,31 +755,22 @@ let record_completion_contract_attention_failure
   let count = Keeper_registry.get_turn_failures ~base_path updated_meta.name in
   if Keeper_pacing_shadow.pacing_enforced ()
   then (
-    (* RFC-0313 W3: contract attention after a runtime success is a judgment
-       stimulus, not a pause. The keeper keeps running; its own next turn
-       receives the typed [Failure_judgment] as input (identity-deduped in
-       the queue, no dedicated turn_reason, scheduling cadence unchanged). *)
+    (* Return the typed successor to the owning heartbeat lease transaction.
+       Enqueueing here would commit the successor separately from acknowledging
+       the stimulus that caused this turn. *)
     let fj : Keeper_event_queue.failure_judgment =
-      { fj_runtime_id = Keeper_meta_contract.runtime_id_of_meta updated_meta
+      { fj_runtime_id = runtime_id
       ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
       ; fj_detail = detail
       }
     in
-    Keeper_registry_event_queue.enqueue
-      ~base_path
-      updated_meta.name
-      { post_id = Keeper_event_queue.failure_judgment_post_id fj
-      ; urgency = Keeper_event_queue.Normal
-      ; arrived_at = Time_compat.now ()
-      ; payload = Keeper_event_queue.Failure_judgment fj
-      };
     Log.Keeper.warn
       "%s: completion contract attention (streak=%d, reason=%s) escalated as \
-       judgment stimulus; keeper keeps running (RFC-0313 W3)"
+       an atomic judgment successor (RFC-0313 W3)"
       updated_meta.name
       count
       reason_code;
-    updated_meta)
+    updated_meta, Some fj)
   else (
     let pause_threshold = Runtime.pause_threshold () in
     let turn_fail_streak_threshold =
@@ -819,7 +811,7 @@ let record_completion_contract_attention_failure
           count
           turn_fail_streak_threshold
           reason_code;
-        paused_meta
+        paused_meta, None
       | Error sync_err ->
         Log.Keeper.error
           "%s: completion contract attention auto-pause sync failed: %s \
@@ -833,8 +825,8 @@ let record_completion_contract_attention_failure
             ; "site", "completion_contract_attention_auto_pause"
             ]
           ();
-        pause_meta)
-    else updated_meta)
+        pause_meta, None)
+    else updated_meta, None)
 ;;
 
 let emit_terminal_fsm
@@ -842,6 +834,7 @@ let emit_terminal_fsm
       ~meta
       ~keeper_turn_id
       ~updated_meta
+      ~runtime_id
       ~terminal_outcome
       result
   =
@@ -856,6 +849,7 @@ let emit_terminal_fsm
       record_completion_contract_attention_failure
         ~config
         ~updated_meta
+        ~runtime_id
         ~reason_code
     in
     Keeper_turn_fsm.emit_transition
@@ -872,8 +866,13 @@ let emit_terminal_fsm
       ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Completing
       Keeper_turn_fsm.Done;
-    updated_meta
+    updated_meta, None
 ;;
+
+type handle_result =
+  { meta : Keeper_meta_contract.keeper_meta
+  ; failure_judgment : Keeper_event_queue.failure_judgment option
+  }
 
 let handle
       ~config
@@ -1010,11 +1009,15 @@ let handle
      computed before side effects, so metrics, decision records, activity graph,
      meta writes, health/failure accounting, and FSM emission cannot disagree
      on whether this turn completed or failed its completion contract. *)
-  emit_terminal_fsm
+  let meta, failure_judgment =
+    emit_terminal_fsm
     ~config
     ~meta
     ~keeper_turn_id
     ~updated_meta
+    ~runtime_id:final_execution.runtime_id
     ~terminal_outcome
     result
+  in
+  { meta; failure_judgment }
 ;;

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -189,6 +189,18 @@ type terminal_outcome =
   | Terminal_checkpoint
   | Terminal_failed_completion_contract of { reason_code : string }
 
+type failure_judgment_delivery =
+  | Queue_successor
+  | Handled_in_turn
+
+type handle_result =
+  | Completed of Keeper_meta_contract.keeper_meta
+  | Failed_completion_contract of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; failure_judgment : Keeper_event_queue.failure_judgment
+      ; judgment_delivery : failure_judgment_delivery
+      }
+
 let completion_contract_attention_reason_code result =
   match result with
   | Keeper_execution_receipt.Contract_passive_only ->
@@ -753,24 +765,24 @@ let record_completion_contract_attention_failure
     ~agent_name:updated_meta.name
     ~reason:(Keeper_types_profile.short_preview detail);
   let count = Keeper_registry.get_turn_failures ~base_path updated_meta.name in
+  let fj : Keeper_event_queue.failure_judgment =
+    { fj_runtime_id = runtime_id
+    ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
+    ; fj_detail = detail
+    }
+  in
   if Keeper_pacing_shadow.pacing_enforced ()
   then (
     (* Return the typed successor to the owning heartbeat lease transaction.
        Enqueueing here would commit the successor separately from acknowledging
        the stimulus that caused this turn. *)
-    let fj : Keeper_event_queue.failure_judgment =
-      { fj_runtime_id = runtime_id
-      ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
-      ; fj_detail = detail
-      }
-    in
     Log.Keeper.warn
       "%s: completion contract attention (streak=%d, reason=%s) escalated as \
        an atomic judgment successor (RFC-0313 W3)"
       updated_meta.name
       count
       reason_code;
-    updated_meta, Some fj)
+    updated_meta, fj, Queue_successor)
   else (
     let pause_threshold = Runtime.pause_threshold () in
     let turn_fail_streak_threshold =
@@ -811,7 +823,7 @@ let record_completion_contract_attention_failure
           count
           turn_fail_streak_threshold
           reason_code;
-        paused_meta, None
+        paused_meta, fj, Handled_in_turn
       | Error sync_err ->
         Log.Keeper.error
           "%s: completion contract attention auto-pause sync failed: %s \
@@ -825,8 +837,8 @@ let record_completion_contract_attention_failure
             ; "site", "completion_contract_attention_auto_pause"
             ]
           ();
-        pause_meta, None)
-    else updated_meta, None)
+        pause_meta, fj, Handled_in_turn)
+    else updated_meta, fj, Handled_in_turn)
 ;;
 
 let emit_terminal_fsm
@@ -845,7 +857,7 @@ let emit_terminal_fsm
     Keeper_turn_fsm.Completing;
   match terminal_outcome with
   | Terminal_failed_completion_contract { reason_code } ->
-    let updated_meta =
+    let updated_meta, failure_judgment, judgment_delivery =
       record_completion_contract_attention_failure
         ~config
         ~updated_meta
@@ -858,7 +870,8 @@ let emit_terminal_fsm
       ~prev:Keeper_turn_fsm.Completing
       (Keeper_turn_fsm.Failed
          (Keeper_turn_fsm.Failure_completion_contract_violation { reason_code }));
-    updated_meta
+    Failed_completion_contract
+      { meta = updated_meta; failure_judgment; judgment_delivery }
   | Terminal_done | Terminal_checkpoint ->
     reset_turn_failures_for_stop_reason ~config ~updated_meta result;
     Keeper_turn_fsm.emit_transition
@@ -866,13 +879,8 @@ let emit_terminal_fsm
       ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Completing
       Keeper_turn_fsm.Done;
-    updated_meta, None
+    Completed updated_meta
 ;;
-
-type handle_result =
-  { meta : Keeper_meta_contract.keeper_meta
-  ; failure_judgment : Keeper_event_queue.failure_judgment option
-  }
 
 let handle
       ~config
@@ -1009,8 +1017,7 @@ let handle
      computed before side effects, so metrics, decision records, activity graph,
      meta writes, health/failure accounting, and FSM emission cannot disagree
      on whether this turn completed or failed its completion contract. *)
-  let meta, failure_judgment =
-    emit_terminal_fsm
+  emit_terminal_fsm
     ~config
     ~meta
     ~keeper_turn_id
@@ -1018,6 +1025,4 @@ let handle
     ~runtime_id:final_execution.runtime_id
     ~terminal_outcome
     result
-  in
-  { meta; failure_judgment }
 ;;

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -79,10 +79,23 @@ module For_testing : sig
     -> unit
 end
 
+type failure_judgment_delivery =
+  | Queue_successor
+  | Handled_in_turn
+(** Whether the heartbeat must atomically append the judgment as the source
+    lease successor, or the configured in-turn failure policy already handled
+    the terminal failure.  This does not change the failure into success. *)
+
 type handle_result =
-  { meta : Keeper_meta_contract.keeper_meta
-  ; failure_judgment : Keeper_event_queue.failure_judgment option
-  }
+  | Completed of Keeper_meta_contract.keeper_meta
+  | Failed_completion_contract of
+      { meta : Keeper_meta_contract.keeper_meta
+      ; failure_judgment : Keeper_event_queue.failure_judgment
+      ; judgment_delivery : failure_judgment_delivery
+      }
+(** Final typed turn disposition from the authoritative receipt/operator
+    verdict.  Runtime completion with a failed completion contract is never
+    represented as [Completed]. *)
 
 val handle
   :  config:Workspace.config

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -79,6 +79,11 @@ module For_testing : sig
     -> unit
 end
 
+type handle_result =
+  { meta : Keeper_meta_contract.keeper_meta
+  ; failure_judgment : Keeper_event_queue.failure_judgment option
+  }
+
 val handle
   :  config:Workspace.config
   -> base_dir:string
@@ -95,4 +100,4 @@ val handle
   -> current_turn_blocker_info:Keeper_meta_contract.blocker_info option
   -> keeper_turn_id:int
   -> Keeper_agent_run.run_result
-  -> Keeper_meta_contract.keeper_meta
+  -> handle_result

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -24,6 +24,7 @@
   keeper_runtime_failure_route
   keeper_latched_reason
   keeper_event_queue
+  keeper_event_queue_state
   keeper_event_queue_owner_lock
   keeper_event_queue_persistence
   keeper_continuation_channel)

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
@@ -95,7 +95,7 @@ type 'a lock_outcome =
    poisons the gate when the callback raises. The gate carries no mutable
    resource state of its own, and the shared Stdlib mutex is released by the
    [Fun.protect] finalizer before any callback exception is propagated. *)
-let with_eio_lock owner f =
+let with_eio_lock ~check_after owner f =
   let outcome =
     match
       Eio.Mutex.use_ro owner.eio_gate (fun () ->
@@ -112,7 +112,7 @@ let with_eio_lock owner f =
      transaction. Re-check the parent context after both owner locks have been
      released on every outcome so an ordinary exception cannot mask pending
      cancellation. *)
-  Eio.Fiber.check ();
+  if check_after then Eio.Fiber.check ();
   match outcome with
   | Returned value -> value
   | Raised (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
@@ -120,6 +120,12 @@ let with_eio_lock owner f =
 
 let with_lock owner f =
   match execution_context () with
-  | Eio_fiber -> with_eio_lock owner f
+  | Eio_fiber -> with_eio_lock ~check_after:true owner f
+  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+;;
+
+let with_durable_lock owner f =
+  match execution_context () with
+  | Eio_fiber -> with_eio_lock ~check_after:false owner f
   | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.mli
@@ -38,3 +38,10 @@ val with_lock : t -> (unit -> 'a) -> 'a
     locks are released; cancellation is checked again before a value or an
     ordinary exception can leave the lock boundary.
     Non-Eio callers use the same Stdlib mutex directly. *)
+
+val with_durable_lock : t -> (unit -> 'a) -> 'a
+(** Transaction lock for durable state changes.  Lock acquisition remains
+    cancellable.  Once acquired, [f] and lock release are cancellation
+    protected, and pending cancellation is deliberately not re-raised at this
+    boundary.  This lets the caller receive a committed lease/receipt and
+    settle it before cancellation propagates at the next cancellation point. *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -297,29 +297,38 @@ let replay_queue state =
 ;;
 
 let load_with_projection ~projection ~base_path ~keeper_name =
-  match load_state_result ~base_path ~keeper_name with
-  | Ok state -> projection state
-  | Error message ->
-    Log.Keeper.error
-      "event_queue_snapshot: refusing unreadable state keeper=%s: %s"
-      keeper_name
-      message;
-    Keeper_event_queue.empty
+  load_state_result ~base_path ~keeper_name |> Result.map projection
+;;
+
+let load_result ~base_path ~keeper_name =
+  load_with_projection ~projection:replay_queue ~base_path ~keeper_name
+;;
+
+let unavailable_projection_exn ~keeper_name message =
+  Failure
+    (Printf.sprintf
+       "event queue state unavailable keeper=%s: %s"
+       keeper_name
+       message)
 ;;
 
 let load ~base_path ~keeper_name =
-  let queue = load_with_projection ~projection:replay_queue ~base_path ~keeper_name in
-  if not (Keeper_event_queue.is_empty queue)
-  then
-    Log.Keeper.info
-      "event_queue_snapshot: restored %s for keeper=%s"
-      (Keeper_event_queue.summary queue)
-      keeper_name;
-  queue
+  match load_result ~base_path ~keeper_name with
+  | Error message -> raise (unavailable_projection_exn ~keeper_name message)
+  | Ok queue ->
+    if not (Keeper_event_queue.is_empty queue)
+    then
+      Log.Keeper.info
+        "event_queue_snapshot: restored %s for keeper=%s"
+        (Keeper_event_queue.summary queue)
+        keeper_name;
+    queue
 ;;
 
 let load_pending ~base_path ~keeper_name =
-  load_with_projection ~projection:State.pending ~base_path ~keeper_name
+  match load_with_projection ~projection:State.pending ~base_path ~keeper_name with
+  | Ok queue -> queue
+  | Error message -> raise (unavailable_projection_exn ~keeper_name message)
 ;;
 
 let load_pending_result ~base_path ~keeper_name =
@@ -567,7 +576,7 @@ let settle_result
     State.settle ~settled_at ~lease ~settlement state)
 ;;
 
-let recover_leases_result
+let prepare_registration_result
       ?(after_commit = fun _ -> ())
       ~base_path
       ~keeper_name
@@ -577,7 +586,7 @@ let recover_leases_result
   commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
     match State.recover_leases ~settled_at state with
     | Error _ as error -> error
-    | Ok state -> Ok (state, ()))
+    | Ok state -> Ok (state, State.pending state))
 ;;
 
 let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -8,6 +8,7 @@ type lease_kind = State.lease_kind =
 
 type requeue_reason = State.requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -35,6 +36,7 @@ type settle_result = State.settle_result =
   | Already_settled of transition_receipt
 
 let lease_stimuli (lease : lease) = lease.stimuli
+let lease_kind = State.lease_kind
 
 let snapshot_filename = "event-queue.json"
 let legacy_inflight_filename = "event-queue-inflight.json"
@@ -249,6 +251,10 @@ let load_state_result ~base_path ~keeper_name =
             (Printexc.to_string exn)))
 ;;
 
+let active_lease_result ~base_path ~keeper_name =
+  load_state_result ~base_path ~keeper_name |> Result.map State.active_lease
+;;
+
 let queue_of_stimuli stimuli =
   List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty stimuli
 ;;
@@ -308,6 +314,46 @@ type snapshot_pair_with_errors =
   ; read_errors : snapshot_read_error list
   }
 
+let diagnose_snapshot_read_error ~base_path ~keeper_name message =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error invalid -> [ { kind = Invalid_path; path = None; message = invalid } ]
+  | Ok owner ->
+    let primary = snapshot_path_of_owner owner in
+    let legacy = legacy_inflight_path_of_owner owner in
+    let inspect path =
+      try
+        if not (Sys.file_exists path)
+        then None
+        else
+          match Safe_ops.read_json_file_safe path with
+          | Error read_message ->
+            Some { kind = Read_failed; path = Some path; message = read_message }
+          | Ok _ -> Some { kind = Parse_failed; path = Some path; message }
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        Some
+          { kind = Read_failed
+          ; path = Some path
+          ; message = Printexc.to_string exn
+          }
+    in
+    (match inspect primary with
+     | Some ({ kind = Read_failed; _ } as error) -> [ error ]
+     | Some ({ kind = Parse_failed; _ } as primary_error) ->
+       (match inspect legacy with
+        | Some ({ kind = Read_failed; _ } as error) -> [ error ]
+        | Some ({ kind = Parse_failed; _ } as error) -> [ error ]
+        | Some { kind = Invalid_path; _ } -> [ primary_error ]
+        | None -> [ primary_error ])
+     | Some { kind = Invalid_path; _ } ->
+       [ { kind = Invalid_path; path = None; message } ]
+     | None ->
+       (match inspect legacy with
+        | Some error -> [ error ]
+        | None -> [ { kind = Parse_failed; path = None; message } ]))
+;;
+
 let load_snapshot_pair_with_errors ~base_path ~keeper_name =
   match load_state_result ~base_path ~keeper_name with
   | Ok state ->
@@ -315,7 +361,7 @@ let load_snapshot_pair_with_errors ~base_path ~keeper_name =
   | Error message ->
     { pending = Keeper_event_queue.empty
     ; inflight = Keeper_event_queue.empty
-    ; read_errors = [ { kind = Parse_failed; path = None; message } ]
+    ; read_errors = diagnose_snapshot_read_error ~base_path ~keeper_name message
     }
 ;;
 
@@ -509,6 +555,17 @@ let recover_leases_result
     match State.recover_leases ~settled_at state with
     | Error _ as error -> error
     | Ok state -> Ok (state, ()))
+;;
+
+let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =
+  commit_transform
+    ~base_path
+    ~keeper_name
+    ~after_commit:(fun _ -> ())
+    (fun state ->
+       match State.mark_transition_projected ~transition_id state with
+       | Error _ as error -> error
+       | Ok state -> Ok (state, ()))
 ;;
 
 let record_inflight ~base_path ~keeper_name stimuli =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -1,21 +1,45 @@
-(** Durable snapshot store for per-keeper Event Layer queues.
-
-    The registry keeps the live queue in [registry_entry.event_queue]. This
-    module mirrors the post-CAS queue snapshot to disk so a keeper restart can
-    replay pending stimuli instead of resetting to [Keeper_event_queue.empty].
-
-    Reads and writes over one keeper's pending/inflight snapshot pair are
-    serialized by [Keeper_event_queue_owner_lock]. Distinct keeper owners do
-    not share an I/O lock, while Eio and non-Eio callers for the same canonical
-    [(base_path, keeper_name)] identity use one cross-context mutex. *)
-
 module Owner_lock = Keeper_event_queue_owner_lock
+module State = Keeper_event_queue_state
+
+type lease_kind = State.lease_kind =
+  | Single
+  | Board_batch
+  | Legacy_inflight
+
+type requeue_reason = State.requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason = State.escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement = State.settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type lease = State.lease
+type transition_receipt = State.transition_receipt
+type outbox_entry = State.outbox_entry
+
+type settle_result = State.settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+let lease_stimuli (lease : lease) = lease.stimuli
+
+let snapshot_filename = "event-queue.json"
+let legacy_inflight_filename = "event-queue-inflight.json"
 
 let owner_error_to_string = Owner_lock.resolve_error_to_string
-
-let keeper_name_of_owner owner =
-  Owner_lock.keeper_name owner |> Keeper_id.Keeper_name.to_string
-;;
 
 let resolve_owner ~base_path ~keeper_name =
   match Owner_lock.resolve ~base_path ~keeper_name with
@@ -23,28 +47,9 @@ let resolve_owner ~base_path ~keeper_name =
   | Error error -> Error (owner_error_to_string error)
 ;;
 
-let snapshot_filename = "event-queue.json"
-let inflight_snapshot_filename = "event-queue-inflight.json"
-
-(* [Fs_compat.mkdir_p] raises (Sys_error / Unix_error) on ENOSPC/EROFS/ENOTDIR
-   instead of returning a result, so route it through the same [(unit, string)
-   result] channel as [save_file_atomic]. This keeps [save_json_atomic] total:
-   it never raises for a disk failure, so the enclosing owner-lock critical
-   section returns normally.
-   [Eio.Cancel.Cancelled] is re-raised so cancellation is not flattened into a
-   string error. *)
-let save_json_atomic path json =
-  match
-    (try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn -> Error (Printexc.to_string exn))
-  with
-  | Error _ as err -> err
-  | Ok () ->
-    json
-    |> Safe_ops.sanitize_json_utf8
-    |> Yojson.Safe.pretty_to_string
-    |> Fs_compat.save_file_atomic path
+let keeper_name_of_owner owner =
+  Owner_lock.keeper_name owner |> Keeper_id.Keeper_name.to_string
+;;
 
 let keeper_runtime_dir_of_owner owner =
   Filename.concat
@@ -56,128 +61,37 @@ let snapshot_path_of_owner owner =
   Filename.concat (keeper_runtime_dir_of_owner owner) snapshot_filename
 ;;
 
-let inflight_path_of_owner owner =
-  Filename.concat (keeper_runtime_dir_of_owner owner) inflight_snapshot_filename
+let legacy_inflight_path_of_owner owner =
+  Filename.concat (keeper_runtime_dir_of_owner owner) legacy_inflight_filename
 ;;
 
-type dir_state =
-  | Missing
-  | Directory
-  | Not_directory
-
-let dir_state path =
-  try
-    if not (Sys.file_exists path)
-    then Ok Missing
-    else if Sys.is_directory path
-    then Ok Directory
-    else Ok Not_directory
+let save_json_atomic path json =
+  match
+    try Ok (Fs_compat.mkdir_p (Filename.dirname path)) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
   with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "failed to inspect directory %s: %s" path (Printexc.to_string exn))
+  | Error _ as error -> error
+  | Ok () ->
+    json
+    |> Safe_ops.sanitize_json_utf8
+    |> Yojson.Safe.pretty_to_string
+    |> Fs_compat.save_file_atomic path
+;;
 
-let file_exists_safe path =
-  try Ok (Sys.file_exists path) with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "failed to inspect file %s: %s" path (Printexc.to_string exn))
-
-type snapshot_discovery =
-  { keeper_names : string list
-  ; read_error : string option
-  }
-
-let discover_keeper_names_with_snapshots ~base_path =
-  match Owner_lock.canonical_base_path base_path with
-  | Error error ->
-    { keeper_names = []; read_error = Some (owner_error_to_string error) }
-  | Ok base_path ->
-    let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-    (match dir_state keepers_dir with
-     | Error msg -> { keeper_names = []; read_error = Some msg }
-     | Ok Missing -> { keeper_names = []; read_error = None }
-     | Ok Not_directory ->
-       { keeper_names = []
-       ; read_error =
-           Some
-             (Printf.sprintf
-                "keepers runtime path is not a directory: %s"
-                keepers_dir)
-       }
-     | Ok Directory ->
-       (match Safe_ops.list_dir_safe keepers_dir with
-        | Error msg -> { keeper_names = []; read_error = Some msg }
-        | Ok entries ->
-          let names, errors =
-            List.fold_left
-              (fun (names, errors) name ->
-                 let keeper_dir = Filename.concat keepers_dir name in
-                 match dir_state keeper_dir with
-                 | Error msg -> names, msg :: errors
-                 | Ok Missing | Ok Not_directory -> names, errors
-                 | Ok Directory ->
-                   let pending_path = Filename.concat keeper_dir snapshot_filename in
-                   let inflight_path =
-                     Filename.concat keeper_dir inflight_snapshot_filename
-                   in
-                   (match file_exists_safe pending_path, file_exists_safe inflight_path with
-                    | Error msg, _ | _, Error msg -> names, msg :: errors
-                    | Ok false, Ok false -> names, errors
-                    | Ok true, _ | _, Ok true ->
-                      (match Keeper_id.Keeper_name.of_string name with
-                       | Ok keeper_name ->
-                         Keeper_id.Keeper_name.to_string keeper_name :: names, errors
-                       | Error reason ->
-                         ( names
-                         , Printf.sprintf
-                             "invalid keeper name with durable event queue snapshot: %s"
-                             reason
-                           :: errors ))))
-              ([], [])
-              entries
-          in
-          { keeper_names = List.sort_uniq String.compare names
-          ; read_error =
-              (match List.rev errors with
-               | [] -> None
-               | errors -> Some (String.concat "; " errors))
-          }))
-
-let rec queue_contains queue stimulus =
-  match Keeper_event_queue.dequeue queue with
-  | None -> false
-  | Some (head, rest) ->
-    Keeper_event_queue.stimulus_identity_equal head stimulus
-    || queue_contains rest stimulus
-
-let append_missing queue stimuli =
-  List.fold_left
-    (fun acc stimulus ->
-       if queue_contains acc stimulus then acc else Keeper_event_queue.enqueue acc stimulus)
-    queue
-    stimuli
-
-let prepend_missing queue stimuli =
-  let missing =
-    List.filter (fun stimulus -> not (queue_contains queue stimulus)) stimuli
-  in
-  Keeper_event_queue.prepend_list missing queue
-
-let queue_of_list stimuli =
-  List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty stimuli
-
-let remove_stimuli queue stimuli =
-  match stimuli with
-  | [] -> queue
-  | _ ->
-    let remove stimulus =
-      List.exists
-        (fun target -> Keeper_event_queue.stimulus_identity_equal target stimulus)
-        stimuli
-    in
-    queue
-    |> Keeper_event_queue.to_list
-    |> List.filter (fun stimulus -> not (remove stimulus))
-    |> queue_of_list
+let save_state_unlocked owner state =
+  let keeper_name = keeper_name_of_owner owner in
+  let path = snapshot_path_of_owner owner in
+  match save_json_atomic path (State.to_yojson state) with
+  | Ok () -> Ok ()
+  | Error message ->
+    Error
+      (Printf.sprintf
+         "failed to persist keeper=%s path=%s: %s"
+         keeper_name
+         path
+         message)
+;;
 
 type snapshot_read_error_kind =
   | Invalid_path
@@ -190,70 +104,197 @@ type snapshot_read_error =
   ; message : string
   }
 
-type snapshot_pair_with_errors =
-  { pending : Keeper_event_queue.t
-  ; inflight : Keeper_event_queue.t
-  ; read_errors : snapshot_read_error list
-  }
-
 let snapshot_read_error_kind_to_string = function
   | Invalid_path -> "invalid_path"
   | Read_failed -> "read_failed"
   | Parse_failed -> "parse_failed"
 ;;
 
-(* [log_restore] gates the "restored N pending" info line. It is a genuine
-   restore signal only on the live hydration path ([load]); the operator
-   health surfaces ([load_snapshot_pair*]) call this on every dashboard poll,
-   where the same line is pure read-on-log noise (~1000 lines / 5000 in the
-   2026-07-07 fleet log). Default off so only [load] announces a restore. *)
-let load_from_path_with_errors ?(log_restore = false) ~keeper_name path =
-  if not (Sys.file_exists path)
-  then Keeper_event_queue.empty, []
-  else (
-    match Safe_ops.read_json_file_safe path with
-    | Error msg ->
-      Log.Keeper.warn
-        "event_queue_snapshot: failed to read keeper=%s path=%s: %s"
-        keeper_name
-        path
-        msg;
-      ( Keeper_event_queue.empty
-      , [ { kind = Read_failed; path = Some path; message = msg } ] )
-    | Ok json ->
-      (match Keeper_event_queue.queue_of_yojson json with
-       | Error msg ->
-         Log.Keeper.warn
-           "event_queue_snapshot: failed to parse keeper=%s path=%s: %s"
-           keeper_name
-           path
-           msg;
-         ( Keeper_event_queue.empty
-         , [ { kind = Parse_failed; path = Some path; message = msg } ] )
-       | Ok queue ->
-         let deduped = Keeper_event_queue.dedup_by_identity queue in
-         let dropped =
-           Keeper_event_queue.length queue - Keeper_event_queue.length deduped
-         in
-         if dropped > 0
-         then
-           Log.Keeper.warn
-             "event_queue_snapshot: dropped %d duplicate stimulus identity rows for keeper=%s path=%s"
-             dropped
-             keeper_name
-             path;
-         if log_restore && not (Keeper_event_queue.is_empty deduped)
-         then
-           Log.Keeper.info
-             "event_queue_snapshot: restored %s for keeper=%s"
-             (Keeper_event_queue.summary deduped)
-             keeper_name;
-         deduped, []))
+let read_json_if_present path =
+  try
+    if Sys.file_exists path
+    then
+      (match Safe_ops.read_json_file_safe path with
+       | Ok json -> Ok (Some json)
+       | Error message ->
+         Error (Printf.sprintf "failed to read %s: %s" path message))
+    else Ok None
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error (Printf.sprintf "failed to inspect %s: %s" path (Printexc.to_string exn))
 ;;
 
-let load_from_path ?(log_restore = false) ~keeper_name path =
-  let queue, _read_errors = load_from_path_with_errors ~log_restore ~keeper_name path in
+let schema_field = function
+  | `Assoc fields ->
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema) -> Ok schema
+     | Some _ -> Error "snapshot schema must be a string"
+     | None -> Error "snapshot missing required field schema")
+  | _ -> Error "snapshot must be a JSON object"
+;;
+
+type primary_snapshot =
+  | Primary_missing
+  | Primary_v1 of Keeper_event_queue.t
+  | Primary_v2 of State.t
+
+let read_primary_unlocked owner =
+  let path = snapshot_path_of_owner owner in
+  match read_json_if_present path with
+  | Error _ as error -> error
+  | Ok None -> Ok Primary_missing
+  | Ok (Some json) ->
+    (match schema_field json with
+     | Error message -> Error (Printf.sprintf "%s: %s" path message)
+     | Ok schema when String.equal schema State.schema ->
+       (match State.of_yojson json with
+        | Ok state -> Ok (Primary_v2 state)
+        | Error message -> Error (Printf.sprintf "%s: %s" path message))
+     | Ok schema when String.equal schema "keeper.event_queue.v1" ->
+       (match Keeper_event_queue.queue_of_yojson json with
+        | Ok queue -> Ok (Primary_v1 queue)
+        | Error message -> Error (Printf.sprintf "%s: %s" path message))
+     | Ok schema ->
+       Error (Printf.sprintf "%s: unsupported snapshot schema %s" path schema))
+;;
+
+let read_legacy_inflight_unlocked owner =
+  let path = legacy_inflight_path_of_owner owner in
+  match read_json_if_present path with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some json) ->
+    (match Keeper_event_queue.queue_of_yojson json with
+     | Ok queue -> Ok (Some queue)
+     | Error message -> Error (Printf.sprintf "%s: %s" path message))
+;;
+
+let remove_legacy_inflight_unlocked owner =
+  let path = legacy_inflight_path_of_owner owner in
+  try
+    if Sys.file_exists path then Sys.remove path;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "v2 state committed but failed to remove legacy inflight input %s: %s"
+         path
+         (Printexc.to_string exn))
+;;
+
+let migrate_unlocked owner pending legacy_inflight =
+  let state = State.with_pending pending State.empty in
+  let migration =
+    match legacy_inflight with
+    | None -> Ok (state, None)
+    | Some queue -> State.add_legacy_inflight (Keeper_event_queue.to_list queue) state
+  in
+  match migration with
+  | Error _ as error -> error
+  | Ok (state, _lease) ->
+    let state =
+      match State.recover_leases ~settled_at:(Time_compat.now ()) state with
+      | Ok state -> Ok state
+      | Error _ as error -> error
+    in
+    (match state with
+     | Error _ as error -> error
+     | Ok state ->
+    (match save_state_unlocked owner state with
+     | Error _ as error -> error
+     | Ok () ->
+       remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)))
+;;
+
+let load_state_unlocked owner =
+  match read_primary_unlocked owner with
+  | Error _ as error -> error
+  | Ok (Primary_v2 state) ->
+    let legacy_path = legacy_inflight_path_of_owner owner in
+    (match read_json_if_present legacy_path with
+     | Error _ as error -> error
+     | Ok None -> Ok state
+     | Ok (Some _) ->
+       Error
+         (Printf.sprintf
+            "v2 event queue has forbidden legacy inflight residue: %s"
+            legacy_path))
+  | Ok Primary_missing ->
+    (match read_legacy_inflight_unlocked owner with
+     | Error _ as error -> error
+     | Ok None -> Ok State.empty
+     | Ok (Some legacy) ->
+       migrate_unlocked owner Keeper_event_queue.empty (Some legacy))
+  | Ok (Primary_v1 pending) ->
+    (match read_legacy_inflight_unlocked owner with
+     | Error _ as error -> error
+     | Ok legacy -> migrate_unlocked owner pending legacy)
+;;
+
+let load_state_result ~base_path ~keeper_name =
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try Owner_lock.with_durable_lock owner (fun () -> load_state_unlocked owner) with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue state load raised keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            (snapshot_path_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let queue_of_stimuli stimuli =
+  List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty stimuli
+;;
+
+let inflight_queue state =
+  State.leases state
+  |> List.concat_map (fun (lease : lease) -> lease.stimuli)
+  |> Keeper_event_queue.uniq_stimuli
+  |> queue_of_stimuli
+;;
+
+let replay_queue state =
+  Keeper_event_queue.prepend_list
+    (Keeper_event_queue.to_list (inflight_queue state))
+    (State.pending state)
+  |> Keeper_event_queue.dedup_by_identity
+;;
+
+let load_with_projection ~projection ~base_path ~keeper_name =
+  match load_state_result ~base_path ~keeper_name with
+  | Ok state -> projection state
+  | Error message ->
+    Log.Keeper.error
+      "event_queue_snapshot: refusing unreadable state keeper=%s: %s"
+      keeper_name
+      message;
+    Keeper_event_queue.empty
+;;
+
+let load ~base_path ~keeper_name =
+  let queue = load_with_projection ~projection:replay_queue ~base_path ~keeper_name in
+  if not (Keeper_event_queue.is_empty queue)
+  then
+    Log.Keeper.info
+      "event_queue_snapshot: restored %s for keeper=%s"
+      (Keeper_event_queue.summary queue)
+      keeper_name;
   queue
+;;
+
+let load_pending ~base_path ~keeper_name =
+  load_with_projection ~projection:State.pending ~base_path ~keeper_name
+;;
+
+let load_pending_result ~base_path ~keeper_name =
+  load_state_result ~base_path ~keeper_name |> Result.map State.pending
 ;;
 
 type snapshot_pair =
@@ -261,497 +302,457 @@ type snapshot_pair =
   ; inflight : Keeper_event_queue.t
   }
 
-let empty_snapshot_pair =
-  { pending = Keeper_event_queue.empty; inflight = Keeper_event_queue.empty }
-;;
-
-let empty_snapshot_pair_with_errors =
-  { pending = Keeper_event_queue.empty
-  ; inflight = Keeper_event_queue.empty
-  ; read_errors = []
+type snapshot_pair_with_errors =
+  { pending : Keeper_event_queue.t
+  ; inflight : Keeper_event_queue.t
+  ; read_errors : snapshot_read_error list
   }
-;;
 
-let load_snapshot_pair_unlocked ~log_restore owner =
-  let keeper_name = keeper_name_of_owner owner in
-  let pending =
-    load_from_path ~log_restore ~keeper_name (snapshot_path_of_owner owner)
-  in
-  let inflight =
-    load_from_path ~log_restore ~keeper_name (inflight_path_of_owner owner)
-  in
-  { pending; inflight }
-;;
-
-let load_snapshot_pair_with_errors_unlocked owner =
-  let keeper_name = keeper_name_of_owner owner in
-  let pending, pending_errors =
-    load_from_path_with_errors ~keeper_name (snapshot_path_of_owner owner)
-  in
-  let inflight, inflight_errors =
-    load_from_path_with_errors ~keeper_name (inflight_path_of_owner owner)
-  in
-  { pending; inflight; read_errors = pending_errors @ inflight_errors }
-;;
-
-let load_unlocked owner =
-  (* The live hydration path: announce the restore once. *)
-  let pair = load_snapshot_pair_unlocked ~log_restore:true owner in
-  prepend_missing pair.pending (Keeper_event_queue.to_list pair.inflight)
+let load_snapshot_pair_with_errors ~base_path ~keeper_name =
+  match load_state_result ~base_path ~keeper_name with
+  | Ok state ->
+    { pending = State.pending state; inflight = inflight_queue state; read_errors = [] }
+  | Error message ->
+    { pending = Keeper_event_queue.empty
+    ; inflight = Keeper_event_queue.empty
+    ; read_errors = [ { kind = Parse_failed; path = None; message } ]
+    }
 ;;
 
 let load_snapshot_pair ~base_path ~keeper_name =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg ->
-    Log.Keeper.warn "event_queue_snapshot: %s" msg;
-    empty_snapshot_pair
-  | Ok owner ->
-    Owner_lock.with_lock owner (fun () ->
-      load_snapshot_pair_unlocked ~log_restore:false owner)
+  let snapshot = load_snapshot_pair_with_errors ~base_path ~keeper_name in
+  { pending = snapshot.pending; inflight = snapshot.inflight }
 ;;
 
-let load_snapshot_pair_with_errors ~base_path ~keeper_name =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg ->
-    Log.Keeper.warn "event_queue_snapshot: %s" msg;
-    { empty_snapshot_pair_with_errors with
-      read_errors = [ { kind = Invalid_path; path = None; message = msg } ]
-    }
-  | Ok owner ->
-    Owner_lock.with_lock owner (fun () ->
-      load_snapshot_pair_with_errors_unlocked owner)
+type snapshot_discovery =
+  { keeper_names : string list
+  ; read_error : string option
+  }
+
+let discover_keeper_names_with_snapshots ~base_path =
+  match Owner_lock.canonical_base_path base_path with
+  | Error error ->
+    { keeper_names = []; read_error = Some (owner_error_to_string error) }
+  | Ok base_path ->
+    let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+    (try
+       if not (Sys.file_exists keepers_dir)
+       then { keeper_names = []; read_error = None }
+       else if not (Sys.is_directory keepers_dir)
+       then
+         { keeper_names = []
+         ; read_error = Some ("keepers runtime path is not a directory: " ^ keepers_dir)
+         }
+       else
+         let names, errors =
+           Sys.readdir keepers_dir
+           |> Array.fold_left
+                (fun (names, errors) name ->
+                   let keeper_dir = Filename.concat keepers_dir name in
+                   let primary = Filename.concat keeper_dir snapshot_filename in
+                   let legacy = Filename.concat keeper_dir legacy_inflight_filename in
+                   if
+                     not (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir)
+                     || not (Sys.file_exists primary || Sys.file_exists legacy)
+                   then names, errors
+                   else
+                     match Keeper_id.Keeper_name.of_string name with
+                     | Ok keeper_name ->
+                       Keeper_id.Keeper_name.to_string keeper_name :: names, errors
+                     | Error reason ->
+                       names,
+                       Printf.sprintf
+                         "invalid keeper name with durable event queue snapshot: %s"
+                         reason
+                       :: errors)
+                ([], [])
+         in
+         { keeper_names = List.sort_uniq String.compare names
+         ; read_error =
+             (match List.rev errors with
+              | [] -> None
+              | errors -> Some (String.concat "; " errors))
+         }
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       { keeper_names = []
+       ; read_error =
+           Some
+             (Printf.sprintf
+                "failed to discover event queue snapshots under %s: %s"
+                keepers_dir
+                (Printexc.to_string exn))
+       })
 ;;
 
-let load ~base_path ~keeper_name =
+let bump_revision state =
+  if Int64.equal (State.revision state) Int64.max_int
+  then Error "event queue revision exhausted"
+  else Ok (State.with_revision (Int64.succ (State.revision state)) state)
+;;
+
+let commit_transform_unlocked owner ~after_commit transform =
+  match load_state_unlocked owner with
+  | Error _ as error -> error
+  | Ok current ->
+    (match transform current with
+     | Error _ as error -> error
+     | Ok (next, value) when next == current -> Ok value
+     | Ok (next, value) ->
+       (match bump_revision next with
+        | Error _ as error -> error
+        | Ok next ->
+          (match save_state_unlocked owner next with
+           | Error _ as error -> error
+           | Ok () ->
+             after_commit (State.pending next);
+             Ok value)))
+;;
+
+let commit_transform ~base_path ~keeper_name ~after_commit transform =
   match resolve_owner ~base_path ~keeper_name with
-  | Error msg ->
-    Log.Keeper.warn "event_queue_snapshot: %s" msg;
-    Keeper_event_queue.empty
-  | Ok owner -> Owner_lock.with_lock owner (fun () -> load_unlocked owner)
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         commit_transform_unlocked owner ~after_commit transform)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue transaction raised keeper=%s path=%s: %s"
+            (keeper_name_of_owner owner)
+            (snapshot_path_of_owner owner)
+            (Printexc.to_string exn)))
+;;
+
+let update_checked_result ?(after_commit = fun () -> ()) ~base_path ~keeper_name f =
+  commit_transform
+    ~base_path
+    ~keeper_name
+    ~after_commit:(fun _pending -> after_commit ())
+    (fun state ->
+       match f (State.pending state) with
+       | Error _ as error -> error
+       | Ok pending -> Ok (State.with_pending pending state, ()))
+;;
+
+let update_result ?after_commit ~base_path ~keeper_name f =
+  update_checked_result ?after_commit ~base_path ~keeper_name (fun queue -> Ok (f queue))
+;;
+
+let update ~base_path ~keeper_name f =
+  match update_result ~base_path ~keeper_name f with
+  | Ok () -> ()
+  | Error message ->
+    Log.Keeper.error "event_queue_snapshot: update failed keeper=%s: %s" keeper_name message
+;;
+
+let persist ~base_path ~keeper_name queue =
+  update ~base_path ~keeper_name (fun _ -> queue)
+;;
+
+let persist_snapshot ~base_path ~keeper_name snapshot =
+  update ~base_path ~keeper_name (fun _ -> snapshot ())
+;;
+
+let claim_when_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~claimed_at
+      ~ready
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    match State.claim_when ~claimed_at ~ready state with
+    | Error _ as error -> error
+    | Ok (state, lease) -> Ok (state, lease))
+;;
+
+let claim_board_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~claimed_at
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    match State.claim_board ~claimed_at state with
+    | Error _ as error -> error
+    | Ok (state, lease) -> Ok (state, lease))
+;;
+
+let settle_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~settlement
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    State.settle ~settled_at ~lease ~settlement state)
+;;
+
+let recover_leases_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    match State.recover_leases ~settled_at state with
+    | Error _ as error -> error
+    | Ok state -> Ok (state, ()))
+;;
+
+let record_inflight ~base_path ~keeper_name stimuli =
+  match stimuli with
+  | [] -> ()
+  | _ ->
+    (match
+       commit_transform
+         ~base_path
+         ~keeper_name
+         ~after_commit:(fun _ -> ())
+         (fun state ->
+            match State.add_legacy_inflight stimuli state with
+            | Error _ as error -> error
+            | Ok (state, _lease) -> Ok (state, ()))
+     with
+     | Ok () -> ()
+     | Error message ->
+       Log.Keeper.error
+         "event_queue_snapshot: record legacy inflight failed keeper=%s: %s"
+         keeper_name
+         message)
+;;
+
+let ack_inflight ~base_path ~keeper_name stimuli =
+  match
+    commit_transform
+      ~base_path
+      ~keeper_name
+      ~after_commit:(fun _ -> ())
+      (fun state ->
+         Ok (State.release_legacy_inflight stimuli state, ()))
+  with
+  | Ok () -> ()
+  | Error message ->
+    Log.Keeper.error "event_queue_snapshot: ack_inflight failed keeper=%s: %s" keeper_name message
+;;
+
+let remove_post_ids stimuli state =
+  List.fold_left
+    (fun (removed, state) (stimulus : Keeper_event_queue.stimulus) ->
+       let newly_removed, state = State.remove_by_post_id stimulus.post_id state in
+       Keeper_event_queue.uniq_stimuli (removed @ newly_removed), state)
+    ([], state)
+    stimuli
+;;
+
+let ack_consumed ~base_path ~keeper_name stimuli =
+  commit_transform
+    ~base_path
+    ~keeper_name
+    ~after_commit:(fun _ -> ())
+    (fun state ->
+       let _removed, state = remove_post_ids stimuli state in
+       Ok (state, ()))
+;;
+
+let drop_by_post_id
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~post_id
+      ()
+  =
+  commit_transform
+    ~base_path
+    ~keeper_name
+    ~after_commit
+    (fun state ->
+       let removed, state = State.remove_by_post_id post_id state in
+       Ok (state, removed))
+;;
 
 let queue_oldest_arrived_at queue =
   queue
   |> Keeper_event_queue.to_list
   |> List.fold_left
-       (fun acc (stimulus : Keeper_event_queue.stimulus) ->
-          match acc with
+       (fun oldest (stimulus : Keeper_event_queue.stimulus) ->
+          match oldest with
           | None -> Some stimulus.arrived_at
-          | Some ts -> Some (Float.min ts stimulus.arrived_at))
+          | Some value -> Some (Float.min value stimulus.arrived_at))
        None
+;;
 
 let min_float_opt left right =
   match left, right with
   | None, None -> None
   | Some value, None | None, Some value -> Some value
-  | Some a, Some b -> Some (Float.min a b)
+  | Some left, Some right -> Some (Float.min left right)
+;;
 
 let json_of_float_opt = function
   | None -> `Null
   | Some value -> `Float value
+;;
 
 let age_seconds_json ~now = function
   | None -> `Null
-  | Some ts -> `Float (Float.max 0.0 (now -. ts))
-
-let read_queue_for_summary ~keeper_name path =
-  if not (Sys.file_exists path)
-  then Ok Keeper_event_queue.empty
-  else
-    match Safe_ops.read_json_file_safe path with
-    | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
-    | Ok json ->
-      (match Keeper_event_queue.queue_of_yojson json with
-       | Ok queue -> Ok queue
-       | Error msg ->
-         Error
-           (Printf.sprintf
-              "%s: failed to parse keeper=%s event queue: %s"
-              path
-              keeper_name
-              msg))
-
-type queue_summary =
-  { queue : Keeper_event_queue.t
-  ; read_error : string option
-  }
-
-let queue_summary ~keeper_name path =
-  match read_queue_for_summary ~keeper_name path with
-  | Ok queue -> { queue; read_error = None }
-  | Error msg -> { queue = Keeper_event_queue.empty; read_error = Some msg }
-
-let snapshot_read_error_to_string (error : snapshot_read_error) =
-  let location =
-    match error.path with
-    | None -> ""
-    | Some path -> " path=" ^ path
-  in
-  Printf.sprintf
-    "%s%s: %s"
-    (snapshot_read_error_kind_to_string error.kind)
-    location
-    error.message
+  | Some timestamp -> `Float (Float.max 0.0 (now -. timestamp))
 ;;
 
-type keeper_queue_summary = {
-  keeper_name : string;
-  pending_count : int;
-  inflight_count : int;
-  pending_oldest_arrived_at : float option;
-  inflight_oldest_arrived_at : float option;
-  read_errors : string list;
-}
-
-let keeper_total_count summary = summary.pending_count + summary.inflight_count
-
-let keeper_oldest_arrived_at summary =
-  min_float_opt summary.pending_oldest_arrived_at summary.inflight_oldest_arrived_at
-
-let keeper_queue_summary ~base_path ~keeper_name =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg ->
-    { keeper_name
-    ; pending_count = 0
-    ; inflight_count = 0
-    ; pending_oldest_arrived_at = None
-    ; inflight_oldest_arrived_at = None
-    ; read_errors = [ msg ]
-    }
-  | Ok owner ->
-    Owner_lock.with_lock owner (fun () ->
-      let keeper_name = keeper_name_of_owner owner in
-      let pending = queue_summary ~keeper_name (snapshot_path_of_owner owner) in
-      let inflight = queue_summary ~keeper_name (inflight_path_of_owner owner) in
-      { keeper_name
-      ; pending_count = Keeper_event_queue.length pending.queue
-      ; inflight_count = Keeper_event_queue.length inflight.queue
-      ; pending_oldest_arrived_at = queue_oldest_arrived_at pending.queue
-      ; inflight_oldest_arrived_at = queue_oldest_arrived_at inflight.queue
-      ; read_errors =
-          List.filter_map
-            (fun value -> value)
-            [ pending.read_error; inflight.read_error ]
-      })
-
-let keeper_queue_summary_json ~now summary =
-  let oldest_arrived_at = keeper_oldest_arrived_at summary in
-  `Assoc
-    [ "keeper_name", `String summary.keeper_name
-    ; "pending_count", `Int summary.pending_count
-    ; "inflight_count", `Int summary.inflight_count
-    ; "total_count", `Int (keeper_total_count summary)
-    ; "oldest_arrived_at_unix", json_of_float_opt oldest_arrived_at
-    ; "oldest_age_seconds", age_seconds_json ~now oldest_arrived_at
-    ; "pending_oldest_arrived_at_unix", json_of_float_opt summary.pending_oldest_arrived_at
-    ; "pending_oldest_age_seconds", age_seconds_json ~now summary.pending_oldest_arrived_at
-    ; "inflight_oldest_arrived_at_unix", json_of_float_opt summary.inflight_oldest_arrived_at
-    ; "inflight_oldest_age_seconds", age_seconds_json ~now summary.inflight_oldest_arrived_at
-    ; "read_errors", `List (List.map (fun msg -> `String msg) summary.read_errors)
-    ]
-
-type queue_kind =
-  | Pending
-  | Inflight
-
-let queue_count_by_keeper_json ~now kind summary =
-  let field, count, oldest_arrived_at =
-    match kind with
-    | Pending -> "pending_count", summary.pending_count, summary.pending_oldest_arrived_at
-    | Inflight -> "inflight_count", summary.inflight_count, summary.inflight_oldest_arrived_at
+let keeper_summary_json ~now ~base_path keeper_name =
+  let snapshot = load_snapshot_pair_with_errors ~base_path ~keeper_name in
+  let pending_count = Keeper_event_queue.length snapshot.pending in
+  let inflight_count = Keeper_event_queue.length snapshot.inflight in
+  let pending_oldest = queue_oldest_arrived_at snapshot.pending in
+  let inflight_oldest = queue_oldest_arrived_at snapshot.inflight in
+  let oldest = min_float_opt pending_oldest inflight_oldest in
+  let state = load_state_result ~base_path ~keeper_name in
+  let outbox_count, unprojected_outbox_count =
+    match state with
+    | Error _ -> 0, 0
+    | Ok state ->
+      let outbox = State.transition_outbox state in
+      ( List.length outbox
+      , List.fold_left
+          (fun count (entry : outbox_entry) ->
+             if entry.projected_to_reaction_ledger then count else count + 1)
+          0
+          outbox )
   in
+  let read_errors = List.map (fun error -> error.message) snapshot.read_errors in
   `Assoc
-    [ "keeper_name", `String summary.keeper_name
-    ; field, `Int count
-    ; "oldest_age_seconds", age_seconds_json ~now oldest_arrived_at
+    [ "keeper_name", `String keeper_name
+    ; "pending_count", `Int pending_count
+    ; "inflight_count", `Int inflight_count
+    ; "total_count", `Int (pending_count + inflight_count)
+    ; "oldest_arrived_at_unix", json_of_float_opt oldest
+    ; "oldest_age_seconds", age_seconds_json ~now oldest
+    ; "pending_oldest_arrived_at_unix", json_of_float_opt pending_oldest
+    ; "pending_oldest_age_seconds", age_seconds_json ~now pending_oldest
+    ; "inflight_oldest_arrived_at_unix", json_of_float_opt inflight_oldest
+    ; "inflight_oldest_age_seconds", age_seconds_json ~now inflight_oldest
+    ; "transition_outbox_count", `Int outbox_count
+    ; "unprojected_transition_outbox_count", `Int unprojected_outbox_count
+    ; "read_errors", `List (List.map (fun message -> `String message) read_errors)
     ]
+;;
+
+let int_field name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`Int value) -> value
+     | _ -> 0)
+  | _ -> 0
+;;
+
+let float_option_field name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`Float value) -> Some value
+     | Some (`Int value) -> Some (float_of_int value)
+     | _ -> None)
+  | _ -> None
+;;
+
+let list_field_json name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`List values) -> values
+     | _ -> [])
+  | _ -> []
+;;
 
 let fleet_summary_json ~now ~base_path =
-  let projection_base_path, discovery =
-    match Owner_lock.canonical_base_path base_path with
-    | Ok canonical ->
-      canonical, discover_keeper_names_with_snapshots ~base_path:canonical
-    | Error error ->
-      ( base_path
-      , { keeper_names = []
-        ; read_error = Some (owner_error_to_string error)
-        } )
-  in
-  let keepers_dir =
-    Common.keepers_runtime_dir_of_base ~base_path:projection_base_path
-  in
-  let keeper_names = discovery.keeper_names in
-  let scan_errors =
-    match discovery.read_error with
-    | None -> []
-    | Some msg -> [ msg ]
-  in
+  let discovery = discover_keeper_names_with_snapshots ~base_path in
   let keepers =
-    List.map (fun keeper_name -> keeper_queue_summary ~base_path ~keeper_name) keeper_names
+    List.map (keeper_summary_json ~now ~base_path) discovery.keeper_names
   in
   let pending_count =
-    List.fold_left (fun acc summary -> acc + summary.pending_count) 0 keepers
+    List.fold_left (fun total json -> total + int_field "pending_count" json) 0 keepers
   in
   let inflight_count =
-    List.fold_left (fun acc summary -> acc + summary.inflight_count) 0 keepers
+    List.fold_left (fun total json -> total + int_field "inflight_count" json) 0 keepers
   in
-  let oldest_arrived_at =
+  let outbox_count =
     List.fold_left
-      (fun acc summary -> min_float_opt acc (keeper_oldest_arrived_at summary))
+      (fun total json -> total + int_field "transition_outbox_count" json)
+      0
+      keepers
+  in
+  let unprojected_outbox_count =
+    List.fold_left
+      (fun total json -> total + int_field "unprojected_transition_outbox_count" json)
+      0
+      keepers
+  in
+  let oldest =
+    List.fold_left
+      (fun oldest json ->
+         min_float_opt oldest (float_option_field "oldest_arrived_at_unix" json))
       None
       keepers
   in
   let read_errors =
-    scan_errors @ List.concat (List.map (fun summary -> summary.read_errors) keepers)
+    (match discovery.read_error with None -> [] | Some error -> [ `String error ])
+    @ List.concat_map (list_field_json "read_errors") keepers
   in
-  let read_error_count = List.length read_errors in
-  let keepers_with_pending =
-    keepers |> List.filter (fun summary -> summary.pending_count > 0)
+  let keepers_with field =
+    List.filter (fun json -> int_field field json > 0) keepers
   in
-  let keepers_with_inflight =
-    keepers |> List.filter (fun summary -> summary.inflight_count > 0)
+  let compact_count field json =
+    match json with
+    | `Assoc fields ->
+      let keeper_name = Option.value ~default:`Null (List.assoc_opt "keeper_name" fields) in
+      let count = Option.value ~default:(`Int 0) (List.assoc_opt field fields) in
+      let oldest_age =
+        let age_field =
+          if String.equal field "pending_count"
+          then "pending_oldest_age_seconds"
+          else "inflight_oldest_age_seconds"
+        in
+        Option.value ~default:`Null (List.assoc_opt age_field fields)
+      in
+      `Assoc [ "keeper_name", keeper_name; field, count; "oldest_age_seconds", oldest_age ]
+    | _ -> `Assoc []
+  in
+  let projection_base_path =
+    match Owner_lock.canonical_base_path base_path with
+    | Ok path -> path
+    | Error _ -> base_path
   in
   `Assoc
     [ "schema", `String "masc.keeper_event_queue.fleet_summary.v1"
-    ; "status", `String (if read_error_count = 0 then "ok" else "degraded")
-    ; "operator_action_required", `Bool (read_error_count > 0)
+    ; "status", `String (if read_errors = [] then "ok" else "degraded")
+    ; "operator_action_required", `Bool (read_errors <> [] || unprojected_outbox_count > 0)
     ; "base_path", `String projection_base_path
-    ; "keepers_runtime_dir", `String keepers_dir
-    ; "keeper_count", `Int (List.length keeper_names)
-    ; "keeper_names", `List (List.map (fun name -> `String name) keeper_names)
+    ; ( "keepers_runtime_dir"
+      , `String (Common.keepers_runtime_dir_of_base ~base_path:projection_base_path) )
+    ; "keeper_count", `Int (List.length discovery.keeper_names)
+    ; "keeper_names", `List (List.map (fun name -> `String name) discovery.keeper_names)
     ; "pending_count", `Int pending_count
     ; "inflight_count", `Int inflight_count
     ; "total_count", `Int (pending_count + inflight_count)
-    ; "oldest_arrived_at_unix", json_of_float_opt oldest_arrived_at
-    ; "oldest_age_seconds", age_seconds_json ~now oldest_arrived_at
-    ; "pending_by_keeper",
-      `List
-        (List.map
-           (queue_count_by_keeper_json ~now Pending)
-           keepers_with_pending)
-    ; "inflight_by_keeper",
-      `List
-        (List.map
-           (queue_count_by_keeper_json ~now Inflight)
-           keepers_with_inflight)
-    ; "read_error_count", `Int read_error_count
-    ; "read_errors", `List (List.map (fun msg -> `String msg) read_errors)
-    ; "keepers", `List (List.map (keeper_queue_summary_json ~now) keepers)
+    ; "transition_outbox_count", `Int outbox_count
+    ; "unprojected_transition_outbox_count", `Int unprojected_outbox_count
+    ; "oldest_arrived_at_unix", json_of_float_opt oldest
+    ; "oldest_age_seconds", age_seconds_json ~now oldest
+    ; ( "pending_by_keeper"
+      , `List (List.map (compact_count "pending_count") (keepers_with "pending_count")) )
+    ; ( "inflight_by_keeper"
+      , `List (List.map (compact_count "inflight_count") (keepers_with "inflight_count")) )
+    ; "read_error_count", `Int (List.length read_errors)
+    ; "read_errors", `List read_errors
+    ; "keepers", `List keepers
     ]
-
-let persist_to_path_result ~keeper_name path queue =
-  match save_json_atomic path (Keeper_event_queue.queue_to_yojson queue) with
-  | Ok () -> Ok ()
-  | Error msg ->
-    Error
-      (Printf.sprintf
-         "failed to persist keeper=%s path=%s: %s"
-         keeper_name
-         path
-         msg)
-
-let persist_to_path ~keeper_name path queue =
-  match persist_to_path_result ~keeper_name path queue with
-  | Ok () -> ()
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-
-let persist ~base_path ~keeper_name queue =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let path = snapshot_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         persist_to_path ~keeper_name path queue)
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Log.Keeper.warn
-         "event_queue_snapshot: persist raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn))
-
-let persist_snapshot ~base_path ~keeper_name snapshot =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let path = snapshot_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         persist_to_path ~keeper_name path (snapshot ()))
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Log.Keeper.warn
-         "event_queue_snapshot: persist_snapshot raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn))
-
-let update_checked_result ?(after_commit = fun () -> ()) ~base_path ~keeper_name f =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Error msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let path = snapshot_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         let cur, read_errors = load_from_path_with_errors ~keeper_name path in
-         match read_errors with
-         | _ :: _ ->
-           Error
-             (Printf.sprintf
-                "refusing to overwrite unreadable event queue keeper=%s: %s"
-                keeper_name
-                (String.concat
-                   "; "
-                   (List.map snapshot_read_error_to_string read_errors)))
-         | [] ->
-           (match f cur with
-            | Error _ as err -> err
-            | Ok next ->
-              (match persist_to_path_result ~keeper_name path next with
-               | Error _ as err -> err
-               | Ok () ->
-                 (* Keep the persistence lock through the live publication. Any
-                    ordinary CAS writer can advance the in-memory queue, but its
-                    snapshot is serialized after this callback and therefore
-                    observes the committed stimulus instead of overwriting it. *)
-                 after_commit ();
-                 Ok ())))
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Error
-         (Printf.sprintf
-            "update raised keeper=%s path=%s: %s"
-            keeper_name
-            path
-            (Printexc.to_string exn)))
-
-let update_result ?after_commit ~base_path ~keeper_name f =
-  update_checked_result
-    ?after_commit
-    ~base_path
-    ~keeper_name
-    (fun queue -> Ok (f queue))
-
-let update ~base_path ~keeper_name f =
-  match update_result ~base_path ~keeper_name f with
-  | Ok () -> ()
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-
-let record_inflight ~base_path ~keeper_name stimuli =
-  match stimuli with
-  | [] -> ()
-  | _ -> (
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let path = inflight_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         let cur = load_from_path ~keeper_name path in
-         persist_to_path ~keeper_name path (append_missing cur stimuli))
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Log.Keeper.warn
-         "event_queue_snapshot: record_inflight raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn)))
-
-let ack_inflight ~base_path ~keeper_name stimuli =
-  (* [ack_inflight] clears the inflight file ONLY. It is used after
-     [requeue_front] has put the lease back into the pending snapshot, so the
-     stimulus MUST remain pending. Genuine consumed-ack uses [ack_consumed],
-     which updates pending and inflight under one lock. *)
-  match stimuli with
-  | [] -> ()
-  | _ -> (
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let path = inflight_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         let cur = load_from_path ~keeper_name path in
-         persist_to_path ~keeper_name path (remove_stimuli cur stimuli))
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Log.Keeper.warn
-         "event_queue_snapshot: ack_inflight raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn)))
-
-let ack_consumed ~base_path ~keeper_name stimuli =
-  (* Genuine consumed-ack must remove stimuli from both durable snapshots as one
-     synchronized transition. Public [load] takes the same lock, so it cannot
-     observe "inflight cleared, pending not drained" or the reverse. *)
-  match stimuli with
-  | [] -> Ok ()
-  | _ -> (
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Error msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let pending_path = snapshot_path_of_owner owner in
-    let inflight_path = inflight_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         let pending = load_from_path ~keeper_name pending_path in
-         let inflight = load_from_path ~keeper_name inflight_path in
-         let pending' = remove_stimuli pending stimuli in
-         let inflight' = remove_stimuli inflight stimuli in
-         match persist_to_path_result ~keeper_name pending_path pending' with
-         | Error _ as err -> err
-         | Ok () -> persist_to_path_result ~keeper_name inflight_path inflight')
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Error
-         (Printf.sprintf
-            "ack_consumed raised keeper=%s pending=%s inflight=%s: %s"
-            keeper_name
-            pending_path
-            inflight_path
-            (Printexc.to_string exn))))
-
-let drop_by_post_id ~base_path ~keeper_name ~post_id =
-  match resolve_owner ~base_path ~keeper_name with
-  | Error msg -> Error msg
-  | Ok owner ->
-    let keeper_name = keeper_name_of_owner owner in
-    let pending_path = snapshot_path_of_owner owner in
-    let inflight_path = inflight_path_of_owner owner in
-    (try
-       Owner_lock.with_lock owner (fun () ->
-         let pending = load_from_path ~keeper_name pending_path in
-         let inflight = load_from_path ~keeper_name inflight_path in
-         let removed, pending', inflight' =
-           Keeper_event_queue.remove_by_post_id_pair post_id pending inflight
-         in
-         match persist_to_path_result ~keeper_name pending_path pending' with
-         | Error _ as err -> err
-         | Ok () ->
-           (match persist_to_path_result ~keeper_name inflight_path inflight' with
-            | Error _ as err -> err
-            | Ok () -> Ok removed))
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Error
-         (Printf.sprintf
-            "drop_by_post_id raised keeper=%s pending=%s inflight=%s post_id=%s: %s"
-            keeper_name
-            pending_path
-            inflight_path
-            post_id
-            (Printexc.to_string exn)))
+;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -211,19 +211,38 @@ let migrate_unlocked owner pending legacy_inflight =
        remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)))
 ;;
 
+let state_accounts_for_stimulus state stimulus =
+  let same candidate =
+    Keeper_event_queue.stimulus_identity_equal candidate stimulus
+  in
+  List.exists same (Keeper_event_queue.to_list (State.pending state))
+  || List.exists
+       (fun (lease : lease) -> List.exists same lease.stimuli)
+       (State.leases state)
+  || List.exists
+       (fun (entry : outbox_entry) -> List.exists same entry.stimuli)
+       (State.transition_outbox state)
+;;
+
+let reconcile_v2_legacy_residue_unlocked owner state legacy =
+  let legacy_stimuli = Keeper_event_queue.to_list legacy in
+  if List.for_all (state_accounts_for_stimulus state) legacy_stimuli
+  then remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)
+  else
+    Error
+      (Printf.sprintf
+         "v2 event queue conflicts with legacy inflight residue: %s"
+         (legacy_inflight_path_of_owner owner))
+;;
+
 let load_state_unlocked owner =
   match read_primary_unlocked owner with
   | Error _ as error -> error
   | Ok (Primary_v2 state) ->
-    let legacy_path = legacy_inflight_path_of_owner owner in
-    (match read_json_if_present legacy_path with
+    (match read_legacy_inflight_unlocked owner with
      | Error _ as error -> error
      | Ok None -> Ok state
-     | Ok (Some _) ->
-       Error
-         (Printf.sprintf
-            "v2 event queue has forbidden legacy inflight residue: %s"
-            legacy_path))
+     | Ok (Some legacy) -> reconcile_v2_legacy_residue_unlocked owner state legacy)
   | Ok Primary_missing ->
     (match read_legacy_inflight_unlocked owner with
      | Error _ as error -> error
@@ -253,6 +272,10 @@ let load_state_result ~base_path ~keeper_name =
 
 let active_lease_result ~base_path ~keeper_name =
   load_state_result ~base_path ~keeper_name |> Result.map State.active_lease
+;;
+
+let transition_outbox_result ~base_path ~keeper_name =
+  load_state_result ~base_path ~keeper_name |> Result.map State.transition_outbox
 ;;
 
 let queue_of_stimuli stimuli =
@@ -675,7 +698,6 @@ type keeper_summary =
   ; inflight_oldest : float option
   ; oldest : float option
   ; outbox_count : int
-  ; unprojected_outbox_count : int
   ; counts_complete : bool
   ; read_errors : string list
   }
@@ -695,12 +717,6 @@ let keeper_summary ~base_path keeper_name =
     ; inflight_oldest
     ; oldest = min_float_opt pending_oldest inflight_oldest
     ; outbox_count = List.length outbox
-    ; unprojected_outbox_count =
-        List.fold_left
-          (fun count (entry : outbox_entry) ->
-             if entry.projected_to_reaction_ledger then count else count + 1)
-          0
-          outbox
     ; counts_complete = true
     ; read_errors = []
     }
@@ -716,7 +732,6 @@ let keeper_summary ~base_path keeper_name =
     ; inflight_oldest = None
     ; oldest = None
     ; outbox_count = 0
-    ; unprojected_outbox_count = 0
     ; counts_complete = false
     ; read_errors
     }
@@ -735,7 +750,6 @@ let keeper_summary_json ~now (summary : keeper_summary) =
     ; "inflight_oldest_arrived_at_unix", json_of_float_opt summary.inflight_oldest
     ; "inflight_oldest_age_seconds", age_seconds_json ~now summary.inflight_oldest
     ; "transition_outbox_count", `Int summary.outbox_count
-    ; "unprojected_transition_outbox_count", `Int summary.unprojected_outbox_count
     ; "counts_complete", `Bool summary.counts_complete
     ; "read_errors", `List (List.map (fun message -> `String message) summary.read_errors)
     ]
@@ -778,13 +792,6 @@ let fleet_summary_json ~now ~base_path =
       0
       summaries
   in
-  let unprojected_outbox_count =
-    List.fold_left
-      (fun total (summary : keeper_summary) ->
-         total + summary.unprojected_outbox_count)
-      0
-      summaries
-  in
   let oldest =
     List.fold_left
       (fun oldest (summary : keeper_summary) -> min_float_opt oldest summary.oldest)
@@ -810,7 +817,7 @@ let fleet_summary_json ~now ~base_path =
   `Assoc
     [ "schema", `String "masc.keeper_event_queue.fleet_summary.v1"
     ; "status", `String (if read_errors = [] then "ok" else "degraded")
-    ; "operator_action_required", `Bool (read_errors <> [] || unprojected_outbox_count > 0)
+    ; "operator_action_required", `Bool (read_errors <> [] || outbox_count > 0)
     ; "base_path", `String projection_base_path
     ; ( "keepers_runtime_dir"
       , `String (Common.keepers_runtime_dir_of_base ~base_path:projection_base_path) )
@@ -820,7 +827,6 @@ let fleet_summary_json ~now ~base_path =
     ; "inflight_count", `Int inflight_count
     ; "total_count", `Int (pending_count + inflight_count)
     ; "transition_outbox_count", `Int outbox_count
-    ; "unprojected_transition_outbox_count", `Int unprojected_outbox_count
     ; "counts_complete", `Bool counts_complete
     ; "oldest_arrived_at_unix", json_of_float_opt oldest
     ; "oldest_age_seconds", age_seconds_json ~now oldest

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -667,121 +667,140 @@ let age_seconds_json ~now = function
   | Some timestamp -> `Float (Float.max 0.0 (now -. timestamp))
 ;;
 
-let keeper_summary_json ~now ~base_path keeper_name =
-  let snapshot = load_snapshot_pair_with_errors ~base_path ~keeper_name in
-  let pending_count = Keeper_event_queue.length snapshot.pending in
-  let inflight_count = Keeper_event_queue.length snapshot.inflight in
-  let pending_oldest = queue_oldest_arrived_at snapshot.pending in
-  let inflight_oldest = queue_oldest_arrived_at snapshot.inflight in
-  let oldest = min_float_opt pending_oldest inflight_oldest in
-  let state = load_state_result ~base_path ~keeper_name in
-  let outbox_count, unprojected_outbox_count =
-    match state with
-    | Error _ -> 0, 0
-    | Ok state ->
-      let outbox = State.transition_outbox state in
-      ( List.length outbox
-      , List.fold_left
+type keeper_summary =
+  { keeper_name : string
+  ; pending_count : int
+  ; inflight_count : int
+  ; pending_oldest : float option
+  ; inflight_oldest : float option
+  ; oldest : float option
+  ; outbox_count : int
+  ; unprojected_outbox_count : int
+  ; counts_complete : bool
+  ; read_errors : string list
+  }
+
+let keeper_summary ~base_path keeper_name =
+  match load_state_result ~base_path ~keeper_name with
+  | Ok state ->
+    let pending = State.pending state in
+    let inflight = inflight_queue state in
+    let pending_oldest = queue_oldest_arrived_at pending in
+    let inflight_oldest = queue_oldest_arrived_at inflight in
+    let outbox = State.transition_outbox state in
+    { keeper_name
+    ; pending_count = Keeper_event_queue.length pending
+    ; inflight_count = Keeper_event_queue.length inflight
+    ; pending_oldest
+    ; inflight_oldest
+    ; oldest = min_float_opt pending_oldest inflight_oldest
+    ; outbox_count = List.length outbox
+    ; unprojected_outbox_count =
+        List.fold_left
           (fun count (entry : outbox_entry) ->
              if entry.projected_to_reaction_ledger then count else count + 1)
           0
-          outbox )
-  in
-  let read_errors = List.map (fun error -> error.message) snapshot.read_errors in
+          outbox
+    ; counts_complete = true
+    ; read_errors = []
+    }
+  | Error message ->
+    let read_errors =
+      diagnose_snapshot_read_error ~base_path ~keeper_name message
+      |> List.map (fun error -> error.message)
+    in
+    { keeper_name
+    ; pending_count = 0
+    ; inflight_count = 0
+    ; pending_oldest = None
+    ; inflight_oldest = None
+    ; oldest = None
+    ; outbox_count = 0
+    ; unprojected_outbox_count = 0
+    ; counts_complete = false
+    ; read_errors
+    }
+;;
+
+let keeper_summary_json ~now (summary : keeper_summary) =
   `Assoc
-    [ "keeper_name", `String keeper_name
-    ; "pending_count", `Int pending_count
-    ; "inflight_count", `Int inflight_count
-    ; "total_count", `Int (pending_count + inflight_count)
-    ; "oldest_arrived_at_unix", json_of_float_opt oldest
-    ; "oldest_age_seconds", age_seconds_json ~now oldest
-    ; "pending_oldest_arrived_at_unix", json_of_float_opt pending_oldest
-    ; "pending_oldest_age_seconds", age_seconds_json ~now pending_oldest
-    ; "inflight_oldest_arrived_at_unix", json_of_float_opt inflight_oldest
-    ; "inflight_oldest_age_seconds", age_seconds_json ~now inflight_oldest
-    ; "transition_outbox_count", `Int outbox_count
-    ; "unprojected_transition_outbox_count", `Int unprojected_outbox_count
-    ; "read_errors", `List (List.map (fun message -> `String message) read_errors)
+    [ "keeper_name", `String summary.keeper_name
+    ; "pending_count", `Int summary.pending_count
+    ; "inflight_count", `Int summary.inflight_count
+    ; "total_count", `Int (summary.pending_count + summary.inflight_count)
+    ; "oldest_arrived_at_unix", json_of_float_opt summary.oldest
+    ; "oldest_age_seconds", age_seconds_json ~now summary.oldest
+    ; "pending_oldest_arrived_at_unix", json_of_float_opt summary.pending_oldest
+    ; "pending_oldest_age_seconds", age_seconds_json ~now summary.pending_oldest
+    ; "inflight_oldest_arrived_at_unix", json_of_float_opt summary.inflight_oldest
+    ; "inflight_oldest_age_seconds", age_seconds_json ~now summary.inflight_oldest
+    ; "transition_outbox_count", `Int summary.outbox_count
+    ; "unprojected_transition_outbox_count", `Int summary.unprojected_outbox_count
+    ; "counts_complete", `Bool summary.counts_complete
+    ; "read_errors", `List (List.map (fun message -> `String message) summary.read_errors)
     ]
 ;;
 
-let int_field name = function
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some (`Int value) -> value
-     | _ -> 0)
-  | _ -> 0
+let compact_pending_count_json ~now (summary : keeper_summary) =
+  `Assoc
+    [ "keeper_name", `String summary.keeper_name
+    ; "pending_count", `Int summary.pending_count
+    ; "oldest_age_seconds", age_seconds_json ~now summary.pending_oldest
+    ]
 ;;
 
-let float_option_field name = function
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some (`Float value) -> Some value
-     | Some (`Int value) -> Some (float_of_int value)
-     | _ -> None)
-  | _ -> None
-;;
-
-let list_field_json name = function
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some (`List values) -> values
-     | _ -> [])
-  | _ -> []
+let compact_inflight_count_json ~now (summary : keeper_summary) =
+  `Assoc
+    [ "keeper_name", `String summary.keeper_name
+    ; "inflight_count", `Int summary.inflight_count
+    ; "oldest_age_seconds", age_seconds_json ~now summary.inflight_oldest
+    ]
 ;;
 
 let fleet_summary_json ~now ~base_path =
   let discovery = discover_keeper_names_with_snapshots ~base_path in
-  let keepers =
-    List.map (keeper_summary_json ~now ~base_path) discovery.keeper_names
-  in
+  let summaries = List.map (keeper_summary ~base_path) discovery.keeper_names in
   let pending_count =
-    List.fold_left (fun total json -> total + int_field "pending_count" json) 0 keepers
+    List.fold_left
+      (fun total (summary : keeper_summary) -> total + summary.pending_count)
+      0
+      summaries
   in
   let inflight_count =
-    List.fold_left (fun total json -> total + int_field "inflight_count" json) 0 keepers
+    List.fold_left
+      (fun total (summary : keeper_summary) -> total + summary.inflight_count)
+      0
+      summaries
   in
   let outbox_count =
     List.fold_left
-      (fun total json -> total + int_field "transition_outbox_count" json)
+      (fun total (summary : keeper_summary) -> total + summary.outbox_count)
       0
-      keepers
+      summaries
   in
   let unprojected_outbox_count =
     List.fold_left
-      (fun total json -> total + int_field "unprojected_transition_outbox_count" json)
+      (fun total (summary : keeper_summary) ->
+         total + summary.unprojected_outbox_count)
       0
-      keepers
+      summaries
   in
   let oldest =
     List.fold_left
-      (fun oldest json ->
-         min_float_opt oldest (float_option_field "oldest_arrived_at_unix" json))
+      (fun oldest (summary : keeper_summary) -> min_float_opt oldest summary.oldest)
       None
-      keepers
+      summaries
   in
   let read_errors =
     (match discovery.read_error with None -> [] | Some error -> [ `String error ])
-    @ List.concat_map (list_field_json "read_errors") keepers
+    @ List.concat_map
+        (fun (summary : keeper_summary) ->
+           List.map (fun error -> `String error) summary.read_errors)
+        summaries
   in
-  let keepers_with field =
-    List.filter (fun json -> int_field field json > 0) keepers
-  in
-  let compact_count field json =
-    match json with
-    | `Assoc fields ->
-      let keeper_name = Option.value ~default:`Null (List.assoc_opt "keeper_name" fields) in
-      let count = Option.value ~default:(`Int 0) (List.assoc_opt field fields) in
-      let oldest_age =
-        let age_field =
-          if String.equal field "pending_count"
-          then "pending_oldest_age_seconds"
-          else "inflight_oldest_age_seconds"
-        in
-        Option.value ~default:`Null (List.assoc_opt age_field fields)
-      in
-      `Assoc [ "keeper_name", keeper_name; field, count; "oldest_age_seconds", oldest_age ]
-    | _ -> `Assoc []
+  let counts_complete =
+    discovery.read_error = None
+    && List.for_all (fun (summary : keeper_summary) -> summary.counts_complete) summaries
   in
   let projection_base_path =
     match Owner_lock.canonical_base_path base_path with
@@ -802,14 +821,21 @@ let fleet_summary_json ~now ~base_path =
     ; "total_count", `Int (pending_count + inflight_count)
     ; "transition_outbox_count", `Int outbox_count
     ; "unprojected_transition_outbox_count", `Int unprojected_outbox_count
+    ; "counts_complete", `Bool counts_complete
     ; "oldest_arrived_at_unix", json_of_float_opt oldest
     ; "oldest_age_seconds", age_seconds_json ~now oldest
     ; ( "pending_by_keeper"
-      , `List (List.map (compact_count "pending_count") (keepers_with "pending_count")) )
+      , `List
+          (summaries
+           |> List.filter (fun (summary : keeper_summary) -> summary.pending_count > 0)
+           |> List.map (compact_pending_count_json ~now)) )
     ; ( "inflight_by_keeper"
-      , `List (List.map (compact_count "inflight_count") (keepers_with "inflight_count")) )
+      , `List
+          (summaries
+           |> List.filter (fun (summary : keeper_summary) -> summary.inflight_count > 0)
+           |> List.map (compact_inflight_count_json ~now)) )
     ; "read_error_count", `Int (List.length read_errors)
     ; "read_errors", `List read_errors
-    ; "keepers", `List keepers
+    ; "keepers", `List (List.map (keeper_summary_json ~now) summaries)
     ]
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -12,6 +12,7 @@ type lease_kind = Keeper_event_queue_state.lease_kind =
 
 type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -39,6 +40,10 @@ type settle_result = Keeper_event_queue_state.settle_result =
   | Already_settled of transition_receipt
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
+val lease_kind : lease -> lease_kind
+
+val active_lease_result :
+  base_path:string -> keeper_name:string -> (lease option, string) result
 
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Compatibility replay projection: pending followed by active lease stimuli.
@@ -125,6 +130,12 @@ val recover_leases_result :
 (** Registration boundary for a newly-owned lane.  Requeues abandoned leases
     and records one stable [Registration_recovery] transition per lease in the
     same state write. *)
+
+val mark_transition_projected_result :
+  base_path:string ->
+  keeper_name:string ->
+  transition_id:string ->
+  (unit, string) result
 
 val persist :
   base_path:string -> keeper_name:string -> Keeper_event_queue.t -> unit

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -45,6 +45,11 @@ val lease_kind : lease -> lease_kind
 val active_lease_result :
   base_path:string -> keeper_name:string -> (lease option, string) result
 
+val transition_outbox_result :
+  base_path:string -> keeper_name:string -> (outbox_entry list, string) result
+(** Read the single pending projection entry for this Keeper lane.  The state
+    machine blocks new claims until this list is drained. *)
+
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Compatibility replay projection: pending followed by active lease stimuli.
     New live registry code should use {!load_pending} after explicitly

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -53,9 +53,17 @@ val transition_outbox_result :
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Compatibility replay projection: pending followed by active lease stimuli.
     New live registry code should use {!load_pending} after explicitly
-    recovering abandoned leases at registration. *)
+    recovering abandoned leases at registration. Raises [Failure] when the
+    durable state is unavailable; it never substitutes an empty queue. *)
+
+val load_result :
+  base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
+(** Result-returning replay projection for callers that can propagate a durable
+    read failure. *)
 
 val load_pending : base_path:string -> keeper_name:string -> Keeper_event_queue.t
+(** Compatibility pending projection. Raises [Failure] on a durable read
+    failure; use {!load_pending_result} in production control flow. *)
 
 val load_pending_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
@@ -125,16 +133,17 @@ val settle_result :
   unit ->
   (settle_result, string) result
 
-val recover_leases_result :
+val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
   base_path:string ->
   keeper_name:string ->
   settled_at:float ->
   unit ->
-  (unit, string) result
-(** Registration boundary for a newly-owned lane.  Requeues abandoned leases
-    and records one stable [Registration_recovery] transition per lease in the
-    same state write. *)
+  (Keeper_event_queue.t, string) result
+(** Registration boundary for a newly-owned lane. Requeues an abandoned lease,
+    records its stable [Registration_recovery] transition, and returns the
+    resulting pending projection from the same durable transaction. A malformed
+    state is an [Error]; registration must not substitute an empty queue. *)
 
 val mark_transition_projected_result :
   base_path:string ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,13 +1,54 @@
-(** Durable snapshot store for per-keeper Event Layer queues.
+(** Durable per-Keeper Event Layer state.
 
-    This module lives in [masc.keeper_runtime] so queue persistence stays with
-    the queue DTO/codec and does not grow the main keeper surface. *)
+    [event-queue.json] uses one v2 envelope containing pending stimuli, active
+    typed leases, the monotonic lease sequence and the transition outbox.
+    [event-queue-inflight.json] is accepted only as a one-time v1 migration
+    input; it is never a second runtime authority. *)
+
+type lease_kind = Keeper_event_queue_state.lease_kind =
+  | Single
+  | Board_batch
+  | Legacy_inflight
+
+type requeue_reason = Keeper_event_queue_state.requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason = Keeper_event_queue_state.escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement = Keeper_event_queue_state.settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type lease = Keeper_event_queue_state.lease
+type transition_receipt = Keeper_event_queue_state.transition_receipt
+type outbox_entry = Keeper_event_queue_state.outbox_entry
+
+type settle_result = Keeper_event_queue_state.settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
-(** Restore a keeper queue snapshot, returning [Keeper_event_queue.empty] when
-    no snapshot exists or the snapshot cannot be parsed. [load] is synchronized
-    by the canonical per-owner lock shared with pending/inflight writes, so
-    callers cannot observe a split snapshot transition. *)
+(** Compatibility replay projection: pending followed by active lease stimuli.
+    New live registry code should use {!load_pending} after explicitly
+    recovering abandoned leases at registration. *)
+
+val load_pending : base_path:string -> keeper_name:string -> Keeper_event_queue.t
+
+val load_pending_result :
+  base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
 
 type snapshot_pair =
   { pending : Keeper_event_queue.t
@@ -37,104 +78,97 @@ type snapshot_discovery =
   }
 
 val snapshot_read_error_kind_to_string : snapshot_read_error_kind -> string
-
 val discover_keeper_names_with_snapshots : base_path:string -> snapshot_discovery
-(** Discover keeper names that have durable pending or in-flight queue snapshot
-    files under the runtime keeper directory. Missing keeper roots are an empty
-    discovery; unreadable roots or invalid snapshot-bearing keeper directories
-    are surfaced in [read_error] so health callers do not silently report a false
-    empty backlog. *)
-
 val load_snapshot_pair : base_path:string -> keeper_name:string -> snapshot_pair
-(** Restore the pending and in-flight snapshots as separate typed queues under
-    the same lock used by {!load}. Use this for operator health surfaces that
-    must distinguish queued work from leased work without parsing file paths
-    independently. *)
-
 val load_snapshot_pair_with_errors :
   base_path:string -> keeper_name:string -> snapshot_pair_with_errors
-(** Like {!load_snapshot_pair}, but preserves read/parse/path failures for
-    operator health surfaces. Queue replay semantics remain conservative:
-    failed snapshots contribute [Keeper_event_queue.empty], while
-    [read_errors] records the exact reason so full health cannot silently
-    report a false empty backlog. *)
+
+val load_state_result :
+  base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
+(** Strict state read used by tests and operator projection.  A malformed v2
+    envelope or v2-plus-legacy residue is an [Error], never an empty queue. *)
+
+val claim_when_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  claimed_at:float ->
+  ready:(Keeper_event_queue.stimulus -> bool) ->
+  unit ->
+  (lease option, string) result
+
+val claim_board_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  claimed_at:float ->
+  unit ->
+  (lease option, string) result
+
+val settle_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  lease:lease ->
+  settlement:settlement ->
+  unit ->
+  (settle_result, string) result
+
+val recover_leases_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  unit ->
+  (unit, string) result
+(** Registration boundary for a newly-owned lane.  Requeues abandoned leases
+    and records one stable [Registration_recovery] transition per lease in the
+    same state write. *)
 
 val persist :
   base_path:string -> keeper_name:string -> Keeper_event_queue.t -> unit
-(** Atomically write the latest queue snapshot. Runtime fibers use a yielding
-    per-owner Eio gate; non-Eio setup/test callers synchronize through the same
-    owner's cross-context Stdlib mutex. Different keeper owners do not share an
-    I/O lock.
-    Persistence failures are logged and do not roll back the already-applied
-    in-memory registry CAS update. *)
 
 val update :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t -> Keeper_event_queue.t) -> unit
-(** Load, transform, and atomically write the queue snapshot while holding the
-    persistence write lock. Use this for pre-registry mutation paths that do not
-    have a live registry CAS cell yet. *)
 
 val update_result :
-  ?after_commit:(unit -> unit)
-  -> base_path:string
-  -> keeper_name:string
-  -> (Keeper_event_queue.t -> Keeper_event_queue.t)
-  -> (unit, string) result
-(** Result-returning form of {!update}. Critical delivery paths use this so a
-    failed durable write cannot be reported as a committed wake.
-    [after_commit] runs under the same write lock only after the snapshot is
-    durable, allowing a live queue publication without a generation gap. *)
+  ?after_commit:(unit -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  (Keeper_event_queue.t -> Keeper_event_queue.t) ->
+  (unit, string) result
 
 val update_checked_result :
-  ?after_commit:(unit -> unit)
-  -> base_path:string
-  -> keeper_name:string
-  -> (Keeper_event_queue.t -> (Keeper_event_queue.t, string) result)
-  -> (unit, string) result
-(** Checked transform form of {!update_result}. A transform error leaves the
-    existing durable snapshot and live queue unchanged. *)
+  ?after_commit:(unit -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  (Keeper_event_queue.t -> (Keeper_event_queue.t, string) result) ->
+  (unit, string) result
 
 val persist_snapshot :
   base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit
-(** Evaluate [snapshot] while holding the persistence write lock, then atomically
-    write it. Use this after live registry CAS mutations so an older writer
-    cannot overwrite a newer live queue snapshot after waiting on the file lock. *)
 
 val record_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
-(** Mark drained stimuli as in-flight before they are removed from the pending
-    snapshot. [load] merges these rows back in front of pending rows, giving a
-    restart at-least-once replay boundary until {!ack_inflight} acknowledges
-    them. *)
+(** Legacy source/test adapter.  Writes a typed [Legacy_inflight] lease into the
+    v2 envelope; it never creates [event-queue-inflight.json]. *)
 
 val ack_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
-(** Remove acknowledged stimuli from the in-flight lease after the heartbeat
-    stimuli have been requeued into the pending snapshot. Genuine turn-complete
-    acknowledgement uses {!ack_consumed} instead. *)
 
 val ack_consumed :
-  base_path:string
-  -> keeper_name:string
-  -> Keeper_event_queue.stimulus list
-  -> (unit, string) result
-(** Remove consumed stimuli from pending and in-flight snapshots under one
-    persistence lock. Returns [Error _] when durable acknowledgement fails so
-    the caller can avoid treating the stimuli as acknowledged. *)
+  base_path:string ->
+  keeper_name:string ->
+  Keeper_event_queue.stimulus list ->
+  (unit, string) result
 
 val drop_by_post_id :
-  base_path:string
-  -> keeper_name:string
-  -> post_id:string
-  -> (Keeper_event_queue.stimulus list, string) result
-(** Remove matching stimuli from pending and in-flight snapshots under one
-    persistence lock, returning the exact removed stimuli for ledger
-    acknowledgement. *)
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  post_id:string ->
+  unit ->
+  (Keeper_event_queue.stimulus list, string) result
 
 val fleet_summary_json : now:float -> base_path:string -> Yojson.Safe.t
-(** Diagnostic fleet summary of durable pending and in-flight queue snapshots.
-    Each pending/in-flight pair is read under that keeper's owner lock; the
-    fleet is not globally serialized. This is read-only and does not mutate or
-    de-duplicate files. Parse/read failures are surfaced in the JSON instead of
-    being collapsed to an empty queue, so health probes cannot report a false
-    green while durable queue state is unreadable. *)

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -5,6 +5,7 @@ type lease_kind =
 
 type requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -74,6 +75,36 @@ let next_lease_sequence state = state.next_lease_sequence
 let pending state = state.pending
 let leases state = state.leases
 let transition_outbox state = state.transition_outbox
+let lease_kind (lease : lease) = lease.kind
+let active_lease state =
+  match state.leases with
+  | [] -> None
+  | lease :: _ -> Some lease
+;;
+
+let mark_transition_projected ~transition_id state =
+  let found = ref false in
+  let changed = ref false in
+  let transition_outbox =
+    List.map
+      (fun entry ->
+         if String.equal entry.receipt.transition_id transition_id
+         then (
+           found := true;
+           if entry.projected_to_reaction_ledger
+           then entry
+           else (
+             changed := true;
+             { entry with projected_to_reaction_ledger = true }))
+         else entry)
+      state.transition_outbox
+  in
+  if not !found
+  then Error (Printf.sprintf "event queue transition not found: %s" transition_id)
+  else if not !changed
+  then Ok state
+  else Ok { state with transition_outbox }
+;;
 let with_pending pending state = { state with pending }
 let with_revision revision state = { state with revision }
 
@@ -168,6 +199,7 @@ let lease_kind_of_label = function
 
 let requeue_reason_label = function
   | Cycle_busy -> "cycle_busy"
+  | Turn_not_scheduled -> "turn_not_scheduled"
   | Retry_after_pacing -> "retry_after_pacing"
   | Rotate_now -> "rotate_now"
   | Cancelled -> "cancelled"
@@ -177,6 +209,7 @@ let requeue_reason_label = function
 
 let requeue_reason_of_label = function
   | "cycle_busy" -> Ok Cycle_busy
+  | "turn_not_scheduled" -> Ok Turn_not_scheduled
   | "retry_after_pacing" -> Ok Retry_after_pacing
   | "rotate_now" -> Ok Rotate_now
   | "cancelled" -> Ok Cancelled
@@ -232,6 +265,29 @@ let settlement_equal left right =
     false
 ;;
 
+let ( let* ) = Result.bind
+
+let validate_settlement = function
+  | Ack | Requeue _ -> Ok ()
+  | Escalate
+      { reason = Failure_judgment_requested
+      ; successor =
+          Some
+            { Keeper_event_queue.payload =
+                Keeper_event_queue.Failure_judgment _
+            ; _
+            }
+      } ->
+    Ok ()
+  | Escalate { reason = Failure_judgment_failed; successor = None } -> Ok ()
+  | Escalate { reason = Failure_judgment_requested; successor = None } ->
+    Error "failure judgment request settlement requires a typed successor"
+  | Escalate { reason = Failure_judgment_requested; successor = Some _ } ->
+    Error "failure judgment request successor has the wrong payload kind"
+  | Escalate { reason = Failure_judgment_failed; successor = Some _ } ->
+    Error "failed failure judgment must not enqueue a successor"
+;;
+
 let receipt_for_lease ~settled_at ~settlement (lease : lease) =
   let transition_id = transition_id lease settlement in
   { transition_id
@@ -272,6 +328,7 @@ let lease_equal (left : lease) (right : lease) =
 ;;
 
 let settle ~settled_at ~lease ~settlement state =
+  let* () = validate_settlement settlement in
   match committed_lease lease state with
   | None ->
     (match find_prior_receipt lease.lease_id state with
@@ -372,8 +429,6 @@ let release_legacy_inflight stimuli state =
   { state with leases }
 ;;
 
-let ( let* ) = Result.bind
-
 let assoc_fields ~context = function
   | `Assoc fields -> Ok fields
   | _ -> Error (context ^ " must be a JSON object")
@@ -464,8 +519,20 @@ let lease_of_yojson json =
   let* stimuli =
     list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
   in
-  if stimuli = []
+  if Int64.compare sequence 1L < 0
+  then Error "event queue lease sequence must be positive"
+  else if stimuli = []
   then Error "event queue lease must contain at least one stimulus"
+  else if kind = Single && List.length stimuli <> 1
+  then Error "single event queue lease must contain exactly one stimulus"
+  else if
+    kind = Board_batch
+    && not
+         (List.for_all
+            (fun (stimulus : Keeper_event_queue.stimulus) ->
+               Keeper_event_queue.is_board_signal stimulus.payload)
+            stimuli)
+  then Error "board event queue lease contains a non-board stimulus"
   else if not (String.equal lease_id (lease_id_of_sequence sequence))
   then Error (Printf.sprintf "event queue lease id/sequence mismatch: %s" lease_id)
   else Ok { lease_id; sequence; kind; claimed_at; stimuli }
@@ -509,7 +576,9 @@ let settlement_of_yojson json =
         let* successor = Keeper_event_queue.stimulus_of_yojson json in
         Ok (Some successor)
     in
-    Ok (Escalate { reason; successor })
+    let settlement = Escalate { reason; successor } in
+    let* () = validate_settlement settlement in
+    Ok settlement
   | kind -> Error (Printf.sprintf "unknown event queue settlement kind: %s" kind)
 ;;
 
@@ -603,7 +672,9 @@ let duplicate_by key values =
 ;;
 
 let validate_state state =
-  if Int64.compare state.next_lease_sequence 1L < 0
+  if Int64.compare state.revision 0L < 0
+  then Error "event queue revision must not be negative"
+  else if Int64.compare state.next_lease_sequence 1L < 0
   then Error "event queue next lease sequence must be positive"
   else
     match duplicate_by (fun (lease : lease) -> lease.lease_id) state.leases with

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -423,7 +423,7 @@ let release_legacy_inflight stimuli state =
          let remaining = List.filter (fun stimulus -> not (should_release stimulus)) lease.stimuli in
          match remaining with
          | [] -> None
-         | _ -> Some { lease with stimuli = remaining })
+         | _ :: _ -> Some { lease with stimuli = remaining })
       state.leases
   in
   { state with leases }

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -44,7 +44,6 @@ type transition_receipt =
 type outbox_entry =
   { receipt : transition_receipt
   ; stimuli : Keeper_event_queue.stimulus list
-  ; projected_to_reaction_ledger : bool
   }
 
 type t =
@@ -52,6 +51,7 @@ type t =
   ; next_lease_sequence : int64
   ; pending : Keeper_event_queue.t
   ; leases : lease list
+  ; last_settlement : transition_receipt option
   ; transition_outbox : outbox_entry list
   }
 
@@ -66,6 +66,7 @@ let empty =
   ; next_lease_sequence = 1L
   ; pending = Keeper_event_queue.empty
   ; leases = []
+  ; last_settlement = None
   ; transition_outbox = []
   }
 ;;
@@ -74,6 +75,7 @@ let revision state = state.revision
 let next_lease_sequence state = state.next_lease_sequence
 let pending state = state.pending
 let leases state = state.leases
+let last_settlement state = state.last_settlement
 let transition_outbox state = state.transition_outbox
 let lease_kind (lease : lease) = lease.kind
 let active_lease state =
@@ -83,27 +85,21 @@ let active_lease state =
 ;;
 
 let mark_transition_projected ~transition_id state =
-  let found = ref false in
-  let changed = ref false in
-  let transition_outbox =
-    List.map
-      (fun entry ->
-         if String.equal entry.receipt.transition_id transition_id
-         then (
-           found := true;
-           if entry.projected_to_reaction_ledger
-           then entry
-           else (
-             changed := true;
-             { entry with projected_to_reaction_ledger = true }))
-         else entry)
-      state.transition_outbox
-  in
-  if not !found
-  then Error (Printf.sprintf "event queue transition not found: %s" transition_id)
-  else if not !changed
-  then Ok state
-  else Ok { state with transition_outbox }
+  match state.transition_outbox with
+  | [ entry ] when String.equal entry.receipt.transition_id transition_id ->
+    Ok
+      { state with
+        last_settlement = Some entry.receipt
+      ; transition_outbox = []
+      }
+  | [] ->
+    (match state.last_settlement with
+     | Some receipt when String.equal receipt.transition_id transition_id -> Ok state
+     | Some _ | None ->
+       Error (Printf.sprintf "event queue transition not found: %s" transition_id))
+  | [ _ ] ->
+    Error (Printf.sprintf "event queue transition not found: %s" transition_id)
+  | _ :: _ :: _ -> Error "event queue state has multiple unprojected transitions"
 ;;
 let with_pending pending state = { state with pending }
 let with_revision revision state = { state with revision }
@@ -161,8 +157,14 @@ let make_lease ~kind ~claimed_at stimuli state =
       , Some lease )
 ;;
 
+let lease_admission_blocked state =
+  state.leases <> [] || state.transition_outbox <> []
+;;
+
 let claim_when ~claimed_at ~ready state =
-  match Keeper_event_queue.dequeue state.pending with
+  if lease_admission_blocked state
+  then Ok (state, None)
+  else match Keeper_event_queue.dequeue state.pending with
   | None -> Ok (state, None)
   | Some (stimulus, _) when not (ready stimulus) -> Ok (state, None)
   | Some (stimulus, pending) ->
@@ -174,14 +176,20 @@ let claim_when ~claimed_at ~ready state =
 ;;
 
 let claim_board ~claimed_at state =
-  let stimuli, pending = Keeper_event_queue.drain_board_all state.pending in
-  make_lease ~kind:Board_batch ~claimed_at:(Some claimed_at) stimuli { state with pending }
+  if lease_admission_blocked state
+  then Ok (state, None)
+  else (
+    let stimuli, pending = Keeper_event_queue.drain_board_all state.pending in
+    make_lease ~kind:Board_batch ~claimed_at:(Some claimed_at) stimuli { state with pending })
 ;;
 
 let add_legacy_inflight stimuli state =
-  let stimuli = Keeper_event_queue.uniq_stimuli stimuli in
-  let pending = remove_stimuli state.pending stimuli in
-  make_lease ~kind:Legacy_inflight ~claimed_at:None stimuli { state with pending }
+  if lease_admission_blocked state
+  then Error "event queue cannot migrate legacy inflight work while a lease or outbox exists"
+  else (
+    let stimuli = Keeper_event_queue.uniq_stimuli stimuli in
+    let pending = remove_stimuli state.pending stimuli in
+    make_lease ~kind:Legacy_inflight ~claimed_at:None stimuli { state with pending })
 ;;
 
 let lease_kind_label = function
@@ -300,11 +308,13 @@ let receipt_for_lease ~settled_at ~settlement (lease : lease) =
 ;;
 
 let find_prior_receipt lease_id state =
-  state.transition_outbox
-  |> List.find_map (fun entry ->
-    if String.equal entry.receipt.lease_id lease_id
-    then Some entry.receipt
-    else None)
+  match state.transition_outbox with
+  | [ entry ] when String.equal entry.receipt.lease_id lease_id -> Some entry.receipt
+  | [] | [ _ ] ->
+    (match state.last_settlement with
+     | Some receipt when String.equal receipt.lease_id lease_id -> Some receipt
+     | Some _ | None -> None)
+  | _ :: _ :: _ -> None
 ;;
 
 let remove_lease lease_id leases =
@@ -357,14 +367,13 @@ let settle ~settled_at ~lease ~settlement state =
     let outbox_entry =
       { receipt
       ; stimuli = committed.stimuli
-      ; projected_to_reaction_ledger = false
       }
     in
     Ok
       ( { state with
           pending
         ; leases = remove_lease committed.lease_id state.leases
-        ; transition_outbox = state.transition_outbox @ [ outbox_entry ]
+        ; transition_outbox = [ outbox_entry ]
         }
       , Settled receipt )
 ;;
@@ -453,13 +462,6 @@ let float_field ~context name fields =
   | `Float value -> Ok value
   | `Int value -> Ok (float_of_int value)
   | _ -> Error (Printf.sprintf "%s.%s must be a number" context name)
-;;
-
-let bool_field ~context name fields =
-  let* value = required_field ~context name fields in
-  match value with
-  | `Bool value -> Ok value
-  | _ -> Error (Printf.sprintf "%s.%s must be a boolean" context name)
 ;;
 
 let int64_field ~context name fields =
@@ -582,7 +584,7 @@ let settlement_of_yojson json =
   | kind -> Error (Printf.sprintf "unknown event queue settlement kind: %s" kind)
 ;;
 
-let receipt_to_yojson receipt =
+let transition_receipt_to_yojson receipt =
   `Assoc
     [ "transition_id", `String receipt.transition_id
     ; "event_id", `String receipt.event_id
@@ -627,9 +629,8 @@ let receipt_of_yojson json =
 
 let outbox_entry_to_yojson entry =
   `Assoc
-    [ "receipt", receipt_to_yojson entry.receipt
+    [ "receipt", transition_receipt_to_yojson entry.receipt
     ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson entry.stimuli)
-    ; "projected_to_reaction_ledger", `Bool entry.projected_to_reaction_ledger
     ]
 ;;
 
@@ -641,10 +642,7 @@ let outbox_entry_of_yojson json =
   let* stimuli =
     list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
   in
-  let* projected_to_reaction_ledger =
-    bool_field ~context "projected_to_reaction_ledger" fields
-  in
-  Ok { receipt; stimuli; projected_to_reaction_ledger }
+  Ok { receipt; stimuli }
 ;;
 
 let to_yojson state =
@@ -654,6 +652,10 @@ let to_yojson state =
     ; "next_lease_sequence", int64_json state.next_lease_sequence
     ; "pending", Keeper_event_queue.queue_to_yojson state.pending
     ; "leases", `List (List.map lease_to_yojson state.leases)
+    ; ( "last_settlement"
+      , match state.last_settlement with
+        | None -> `Null
+        | Some receipt -> transition_receipt_to_yojson receipt )
     ; ( "transition_outbox"
       , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
     ]
@@ -676,6 +678,18 @@ let validate_state state =
   then Error "event queue revision must not be negative"
   else if Int64.compare state.next_lease_sequence 1L < 0
   then Error "event queue next lease sequence must be positive"
+  else if List.length state.leases > 1
+  then Error "event queue state must contain at most one active lease"
+  else if List.length state.transition_outbox > 1
+  then Error "event queue state must contain at most one unprojected transition"
+  else if state.leases <> [] && state.transition_outbox <> []
+  then Error "event queue state cannot contain both an active lease and an outbox transition"
+  else if
+    match state.last_settlement, state.transition_outbox with
+    | Some receipt, [ entry ] ->
+      String.equal receipt.transition_id entry.receipt.transition_id
+    | None, _ | Some _, ([] | _ :: _ :: _) -> false
+  then Error "event queue last settlement duplicates the unprojected transition"
   else
     match duplicate_by (fun (lease : lease) -> lease.lease_id) state.leases with
     | Some lease_id -> Error (Printf.sprintf "duplicate event queue lease id: %s" lease_id)
@@ -700,6 +714,11 @@ let validate_state state =
              max_sequence
              state.transition_outbox
          in
+         let max_sequence =
+           match state.last_settlement with
+           | None -> max_sequence
+           | Some receipt -> Int64.max max_sequence receipt.lease_sequence
+         in
          if Int64.compare state.next_lease_sequence max_sequence <= 0
          then
            Error
@@ -719,9 +738,21 @@ let of_yojson json =
     let* pending_json = required_field ~context "pending" fields in
     let* pending = Keeper_event_queue.queue_of_yojson pending_json in
     let* leases = list_field ~context "leases" lease_of_yojson fields in
+    let* last_settlement =
+      match List.assoc_opt "last_settlement" fields with
+      | Some `Null -> Ok None
+      | Some json -> receipt_of_yojson json |> Result.map Option.some
+      | None -> Error "keeper event queue state missing required field last_settlement"
+    in
     let* transition_outbox =
       list_field ~context "transition_outbox" outbox_entry_of_yojson fields
     in
     validate_state
-      { revision; next_lease_sequence; pending; leases; transition_outbox }
+      { revision
+      ; next_lease_sequence
+      ; pending
+      ; leases
+      ; last_settlement
+      ; transition_outbox
+      }
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -1,0 +1,656 @@
+type lease_kind =
+  | Single
+  | Board_batch
+  | Legacy_inflight
+
+type requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type lease =
+  { lease_id : string
+  ; sequence : int64
+  ; kind : lease_kind
+  ; claimed_at : float option
+  ; stimuli : Keeper_event_queue.stimulus list
+  }
+
+type transition_receipt =
+  { transition_id : string
+  ; event_id : string
+  ; lease_id : string
+  ; lease_sequence : int64
+  ; settled_at : float
+  ; settlement : settlement
+  }
+
+type outbox_entry =
+  { receipt : transition_receipt
+  ; stimuli : Keeper_event_queue.stimulus list
+  ; projected_to_reaction_ledger : bool
+  }
+
+type t =
+  { revision : int64
+  ; next_lease_sequence : int64
+  ; pending : Keeper_event_queue.t
+  ; leases : lease list
+  ; transition_outbox : outbox_entry list
+  }
+
+type settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+let schema = "keeper.event_queue.state.v2"
+
+let empty =
+  { revision = 0L
+  ; next_lease_sequence = 1L
+  ; pending = Keeper_event_queue.empty
+  ; leases = []
+  ; transition_outbox = []
+  }
+;;
+
+let revision state = state.revision
+let next_lease_sequence state = state.next_lease_sequence
+let pending state = state.pending
+let leases state = state.leases
+let transition_outbox state = state.transition_outbox
+let with_pending pending state = { state with pending }
+let with_revision revision state = { state with revision }
+
+let rec queue_contains queue stimulus =
+  match Keeper_event_queue.dequeue queue with
+  | None -> false
+  | Some (head, rest) ->
+    Keeper_event_queue.stimulus_identity_equal head stimulus
+    || queue_contains rest stimulus
+;;
+
+let enqueue_if_missing queue stimulus =
+  if queue_contains queue stimulus
+  then queue
+  else Keeper_event_queue.enqueue queue stimulus
+;;
+
+let prepend_missing stimuli queue =
+  let missing =
+    List.filter (fun stimulus -> not (queue_contains queue stimulus)) stimuli
+  in
+  Keeper_event_queue.prepend_list missing queue
+;;
+
+let remove_stimuli queue stimuli =
+  let should_remove stimulus =
+    List.exists
+      (Keeper_event_queue.stimulus_identity_equal stimulus)
+      stimuli
+  in
+  queue
+  |> Keeper_event_queue.to_list
+  |> List.filter (fun stimulus -> not (should_remove stimulus))
+  |> List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty
+;;
+
+let lease_id_of_sequence sequence = Printf.sprintf "lease:%Ld" sequence
+
+let make_lease ~kind ~claimed_at stimuli state =
+  match stimuli with
+  | [] -> Ok (state, None)
+  | _ when Int64.equal state.next_lease_sequence Int64.max_int ->
+    Error "event queue lease sequence exhausted"
+  | _ ->
+    let sequence = state.next_lease_sequence in
+    let lease =
+      { lease_id = lease_id_of_sequence sequence; sequence; kind; claimed_at; stimuli }
+    in
+    Ok
+      ( { state with
+          next_lease_sequence = Int64.succ sequence
+        ; leases = state.leases @ [ lease ]
+        }
+      , Some lease )
+;;
+
+let claim_when ~claimed_at ~ready state =
+  match Keeper_event_queue.dequeue state.pending with
+  | None -> Ok (state, None)
+  | Some (stimulus, _) when not (ready stimulus) -> Ok (state, None)
+  | Some (stimulus, pending) ->
+    make_lease
+      ~kind:Single
+      ~claimed_at:(Some claimed_at)
+      [ stimulus ]
+      { state with pending }
+;;
+
+let claim_board ~claimed_at state =
+  let stimuli, pending = Keeper_event_queue.drain_board_all state.pending in
+  make_lease ~kind:Board_batch ~claimed_at:(Some claimed_at) stimuli { state with pending }
+;;
+
+let add_legacy_inflight stimuli state =
+  let stimuli = Keeper_event_queue.uniq_stimuli stimuli in
+  let pending = remove_stimuli state.pending stimuli in
+  make_lease ~kind:Legacy_inflight ~claimed_at:None stimuli { state with pending }
+;;
+
+let lease_kind_label = function
+  | Single -> "single"
+  | Board_batch -> "board_batch"
+  | Legacy_inflight -> "legacy_inflight"
+;;
+
+let lease_kind_of_label = function
+  | "single" -> Ok Single
+  | "board_batch" -> Ok Board_batch
+  | "legacy_inflight" -> Ok Legacy_inflight
+  | label -> Error (Printf.sprintf "unknown event queue lease kind: %s" label)
+;;
+
+let requeue_reason_label = function
+  | Cycle_busy -> "cycle_busy"
+  | Retry_after_pacing -> "retry_after_pacing"
+  | Rotate_now -> "rotate_now"
+  | Cancelled -> "cancelled"
+  | Cycle_crashed -> "cycle_crashed"
+  | Registration_recovery -> "registration_recovery"
+;;
+
+let requeue_reason_of_label = function
+  | "cycle_busy" -> Ok Cycle_busy
+  | "retry_after_pacing" -> Ok Retry_after_pacing
+  | "rotate_now" -> Ok Rotate_now
+  | "cancelled" -> Ok Cancelled
+  | "cycle_crashed" -> Ok Cycle_crashed
+  | "registration_recovery" -> Ok Registration_recovery
+  | label -> Error (Printf.sprintf "unknown event queue requeue reason: %s" label)
+;;
+
+let escalation_reason_label = function
+  | Failure_judgment_requested -> "failure_judgment_requested"
+  | Failure_judgment_failed -> "failure_judgment_failed"
+;;
+
+let escalation_reason_of_label = function
+  | "failure_judgment_requested" -> Ok Failure_judgment_requested
+  | "failure_judgment_failed" -> Ok Failure_judgment_failed
+  | label -> Error (Printf.sprintf "unknown event queue escalation reason: %s" label)
+;;
+
+let settlement_kind_label = function
+  | Ack -> "ack"
+  | Requeue _ -> "requeue"
+  | Escalate _ -> "escalate"
+;;
+
+let transition_id (lease : lease) settlement =
+  Printf.sprintf "%s:%s" lease.lease_id (settlement_kind_label settlement)
+;;
+
+let event_id_of_transition transition_id =
+  "keeper-event-queue-transition:" ^ transition_id
+;;
+
+let successor_equal left right =
+  match left, right with
+  | None, None -> true
+  | Some left, Some right ->
+    Keeper_event_queue.stimulus_identity_equal left right
+  | None, Some _ | Some _, None -> false
+;;
+
+let settlement_equal left right =
+  match left, right with
+  | Ack, Ack -> true
+  | Requeue left, Requeue right -> left = right
+  | ( Escalate { reason = left_reason; successor = left_successor }
+    , Escalate { reason = right_reason; successor = right_successor } ) ->
+    left_reason = right_reason
+    && successor_equal left_successor right_successor
+  | Ack, (Requeue _ | Escalate _)
+  | Requeue _, (Ack | Escalate _)
+  | Escalate _, (Ack | Requeue _) ->
+    false
+;;
+
+let receipt_for_lease ~settled_at ~settlement (lease : lease) =
+  let transition_id = transition_id lease settlement in
+  { transition_id
+  ; event_id = event_id_of_transition transition_id
+  ; lease_id = lease.lease_id
+  ; lease_sequence = lease.sequence
+  ; settled_at
+  ; settlement
+  }
+;;
+
+let find_prior_receipt lease_id state =
+  state.transition_outbox
+  |> List.find_map (fun entry ->
+    if String.equal entry.receipt.lease_id lease_id
+    then Some entry.receipt
+    else None)
+;;
+
+let remove_lease lease_id leases =
+  List.filter
+    (fun (lease : lease) -> not (String.equal lease.lease_id lease_id))
+    leases
+;;
+
+let committed_lease (lease : lease) state =
+  List.find_opt
+    (fun (current : lease) -> String.equal current.lease_id lease.lease_id)
+    state.leases
+;;
+
+let lease_equal (left : lease) (right : lease) =
+  Int64.equal left.sequence right.sequence
+  && String.equal left.lease_id right.lease_id
+  && left.kind = right.kind
+  && List.length left.stimuli = List.length right.stimuli
+  && List.for_all2 Keeper_event_queue.stimulus_identity_equal left.stimuli right.stimuli
+;;
+
+let settle ~settled_at ~lease ~settlement state =
+  match committed_lease lease state with
+  | None ->
+    (match find_prior_receipt lease.lease_id state with
+     | Some receipt when settlement_equal receipt.settlement settlement ->
+       Ok (state, Already_settled receipt)
+     | Some receipt ->
+       Error
+         (Printf.sprintf
+            "event queue lease %s already settled as %s; refusing %s"
+            lease.lease_id
+            (settlement_kind_label receipt.settlement)
+            (settlement_kind_label settlement))
+     | None -> Error (Printf.sprintf "event queue lease not found: %s" lease.lease_id))
+  | Some committed when not (lease_equal committed lease) ->
+    Error (Printf.sprintf "event queue lease payload conflict: %s" lease.lease_id)
+  | Some committed ->
+    let pending =
+      match settlement with
+      | Ack -> state.pending
+      | Requeue _ -> prepend_missing committed.stimuli state.pending
+      | Escalate { successor = None; _ } -> state.pending
+      | Escalate { successor = Some successor; _ } ->
+        enqueue_if_missing state.pending successor
+    in
+    let receipt = receipt_for_lease ~settled_at ~settlement committed in
+    let outbox_entry =
+      { receipt
+      ; stimuli = committed.stimuli
+      ; projected_to_reaction_ledger = false
+      }
+    in
+    Ok
+      ( { state with
+          pending
+        ; leases = remove_lease committed.lease_id state.leases
+        ; transition_outbox = state.transition_outbox @ [ outbox_entry ]
+        }
+      , Settled receipt )
+;;
+
+let recover_leases ~settled_at state =
+  let rec loop state = function
+    | [] -> Ok state
+    | lease :: rest ->
+      (match
+         settle
+           ~settled_at
+           ~lease
+           ~settlement:(Requeue Registration_recovery)
+           state
+       with
+       | Error _ as error -> error
+       | Ok (state, (Settled _ | Already_settled _)) -> loop state rest)
+  in
+  loop state state.leases
+;;
+
+let remove_by_post_id post_id state =
+  let removed_pending, pending =
+    Keeper_event_queue.remove_by_post_id post_id state.pending
+  in
+  let removed_leases, leases =
+    List.fold_right
+      (fun (lease : lease) (removed, kept) ->
+         let matched, remaining =
+           List.partition
+             (fun stimulus -> String.equal stimulus.Keeper_event_queue.post_id post_id)
+             lease.stimuli
+         in
+         let kept =
+           match remaining with
+           | [] -> kept
+           | _ -> { lease with stimuli = remaining } :: kept
+         in
+         matched @ removed, kept)
+      state.leases
+      ([], [])
+  in
+  ( Keeper_event_queue.uniq_stimuli (removed_pending @ removed_leases)
+  , { state with pending; leases } )
+;;
+
+let release_legacy_inflight stimuli state =
+  let should_release stimulus =
+    List.exists
+      (Keeper_event_queue.stimulus_identity_equal stimulus)
+      stimuli
+  in
+  let leases =
+    List.filter_map
+      (fun (lease : lease) ->
+         let remaining = List.filter (fun stimulus -> not (should_release stimulus)) lease.stimuli in
+         match remaining with
+         | [] -> None
+         | _ -> Some { lease with stimuli = remaining })
+      state.leases
+  in
+  { state with leases }
+;;
+
+let ( let* ) = Result.bind
+
+let assoc_fields ~context = function
+  | `Assoc fields -> Ok fields
+  | _ -> Error (context ^ " must be a JSON object")
+;;
+
+let required_field ~context name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s missing required field %s" context name)
+;;
+
+let string_field ~context name fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "%s.%s must be a string" context name)
+;;
+
+let float_field ~context name fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `Float value -> Ok value
+  | `Int value -> Ok (float_of_int value)
+  | _ -> Error (Printf.sprintf "%s.%s must be a number" context name)
+;;
+
+let bool_field ~context name fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `Bool value -> Ok value
+  | _ -> Error (Printf.sprintf "%s.%s must be a boolean" context name)
+;;
+
+let int64_field ~context name fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `Int value -> Ok (Int64.of_int value)
+  | `Intlit value ->
+    (match Int64.of_string_opt value with
+     | Some value -> Ok value
+     | None -> Error (Printf.sprintf "%s.%s must be an int64" context name))
+  | _ -> Error (Printf.sprintf "%s.%s must be an int64" context name)
+;;
+
+let list_field ~context name parse fields =
+  let* value = required_field ~context name fields in
+  match value with
+  | `List values ->
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        let* parsed = parse value in
+        loop (parsed :: acc) rest
+    in
+    loop [] values
+  | _ -> Error (Printf.sprintf "%s.%s must be a list" context name)
+;;
+
+let int64_json value = `Intlit (Int64.to_string value)
+
+let lease_to_yojson (lease : lease) =
+  `Assoc
+    [ "lease_id", `String lease.lease_id
+    ; "sequence", int64_json lease.sequence
+    ; "kind", `String (lease_kind_label lease.kind)
+    ; ( "claimed_at_unix"
+      , match lease.claimed_at with
+        | None -> `Null
+        | Some claimed_at -> `Float claimed_at )
+    ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson lease.stimuli)
+    ]
+;;
+
+let lease_of_yojson json =
+  let context = "event queue lease" in
+  let* fields = assoc_fields ~context json in
+  let* lease_id = string_field ~context "lease_id" fields in
+  let* sequence = int64_field ~context "sequence" fields in
+  let* kind_label = string_field ~context "kind" fields in
+  let* kind = lease_kind_of_label kind_label in
+  let* claimed_at =
+    match List.assoc_opt "claimed_at_unix" fields with
+    | None | Some `Null -> Ok None
+    | Some (`Float value) -> Ok (Some value)
+    | Some (`Int value) -> Ok (Some (float_of_int value))
+    | Some _ -> Error "event queue lease.claimed_at_unix must be a number or null"
+  in
+  let* stimuli =
+    list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
+  in
+  if stimuli = []
+  then Error "event queue lease must contain at least one stimulus"
+  else if not (String.equal lease_id (lease_id_of_sequence sequence))
+  then Error (Printf.sprintf "event queue lease id/sequence mismatch: %s" lease_id)
+  else Ok { lease_id; sequence; kind; claimed_at; stimuli }
+;;
+
+let settlement_to_yojson = function
+  | Ack -> `Assoc [ "kind", `String "ack" ]
+  | Requeue reason ->
+    `Assoc
+      [ "kind", `String "requeue"
+      ; "reason", `String (requeue_reason_label reason)
+      ]
+  | Escalate { reason; successor } ->
+    `Assoc
+      [ "kind", `String "escalate"
+      ; "reason", `String (escalation_reason_label reason)
+      ; ( "successor"
+        , match successor with
+          | None -> `Null
+          | Some successor -> Keeper_event_queue.stimulus_to_yojson successor )
+      ]
+;;
+
+let settlement_of_yojson json =
+  let context = "event queue settlement" in
+  let* fields = assoc_fields ~context json in
+  let* kind = string_field ~context "kind" fields in
+  match kind with
+  | "ack" -> Ok Ack
+  | "requeue" ->
+    let* reason = string_field ~context "reason" fields in
+    let* reason = requeue_reason_of_label reason in
+    Ok (Requeue reason)
+  | "escalate" ->
+    let* reason = string_field ~context "reason" fields in
+    let* reason = escalation_reason_of_label reason in
+    let* successor =
+      match List.assoc_opt "successor" fields with
+      | None | Some `Null -> Ok None
+      | Some json ->
+        let* successor = Keeper_event_queue.stimulus_of_yojson json in
+        Ok (Some successor)
+    in
+    Ok (Escalate { reason; successor })
+  | kind -> Error (Printf.sprintf "unknown event queue settlement kind: %s" kind)
+;;
+
+let receipt_to_yojson receipt =
+  `Assoc
+    [ "transition_id", `String receipt.transition_id
+    ; "event_id", `String receipt.event_id
+    ; "lease_id", `String receipt.lease_id
+    ; "lease_sequence", int64_json receipt.lease_sequence
+    ; "settled_at_unix", `Float receipt.settled_at
+    ; "settlement", settlement_to_yojson receipt.settlement
+    ]
+;;
+
+let receipt_of_yojson json =
+  let context = "event queue transition receipt" in
+  let* fields = assoc_fields ~context json in
+  let* transition_id = string_field ~context "transition_id" fields in
+  let* event_id = string_field ~context "event_id" fields in
+  let* lease_id = string_field ~context "lease_id" fields in
+  let* lease_sequence = int64_field ~context "lease_sequence" fields in
+  let* settled_at = float_field ~context "settled_at_unix" fields in
+  let* settlement_json = required_field ~context "settlement" fields in
+  let* settlement = settlement_of_yojson settlement_json in
+  let expected_lease_id = lease_id_of_sequence lease_sequence in
+  let expected_transition_id =
+    Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
+  in
+  let expected_event_id = event_id_of_transition expected_transition_id in
+  if not (String.equal lease_id expected_lease_id)
+  then Error (Printf.sprintf "event queue receipt lease id mismatch: %s" lease_id)
+  else if not (String.equal transition_id expected_transition_id)
+  then Error (Printf.sprintf "event queue receipt transition id mismatch: %s" transition_id)
+  else if not (String.equal event_id expected_event_id)
+  then Error (Printf.sprintf "event queue receipt event id mismatch: %s" event_id)
+  else
+    Ok
+      { transition_id
+      ; event_id
+      ; lease_id
+      ; lease_sequence
+      ; settled_at
+      ; settlement
+      }
+;;
+
+let outbox_entry_to_yojson entry =
+  `Assoc
+    [ "receipt", receipt_to_yojson entry.receipt
+    ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson entry.stimuli)
+    ; "projected_to_reaction_ledger", `Bool entry.projected_to_reaction_ledger
+    ]
+;;
+
+let outbox_entry_of_yojson json =
+  let context = "event queue outbox entry" in
+  let* fields = assoc_fields ~context json in
+  let* receipt_json = required_field ~context "receipt" fields in
+  let* receipt = receipt_of_yojson receipt_json in
+  let* stimuli =
+    list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
+  in
+  let* projected_to_reaction_ledger =
+    bool_field ~context "projected_to_reaction_ledger" fields
+  in
+  Ok { receipt; stimuli; projected_to_reaction_ledger }
+;;
+
+let to_yojson state =
+  `Assoc
+    [ "schema", `String schema
+    ; "revision", int64_json state.revision
+    ; "next_lease_sequence", int64_json state.next_lease_sequence
+    ; "pending", Keeper_event_queue.queue_to_yojson state.pending
+    ; "leases", `List (List.map lease_to_yojson state.leases)
+    ; ( "transition_outbox"
+      , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
+    ]
+;;
+
+let duplicate_by key values =
+  let rec loop seen = function
+    | [] -> None
+    | value :: rest ->
+      let key = key value in
+      if List.exists (String.equal key) seen
+      then Some key
+      else loop (key :: seen) rest
+  in
+  loop [] values
+;;
+
+let validate_state state =
+  if Int64.compare state.next_lease_sequence 1L < 0
+  then Error "event queue next lease sequence must be positive"
+  else
+    match duplicate_by (fun (lease : lease) -> lease.lease_id) state.leases with
+    | Some lease_id -> Error (Printf.sprintf "duplicate event queue lease id: %s" lease_id)
+    | None ->
+      (match
+         duplicate_by
+           (fun entry -> entry.receipt.transition_id)
+           state.transition_outbox
+       with
+       | Some transition_id ->
+         Error (Printf.sprintf "duplicate event queue transition id: %s" transition_id)
+       | None ->
+         let max_sequence =
+           List.fold_left
+             (fun acc (lease : lease) -> Int64.max acc lease.sequence)
+             0L
+             state.leases
+         in
+         let max_sequence =
+           List.fold_left
+             (fun acc entry -> Int64.max acc entry.receipt.lease_sequence)
+             max_sequence
+             state.transition_outbox
+         in
+         if Int64.compare state.next_lease_sequence max_sequence <= 0
+         then
+           Error
+             "event queue next lease sequence must exceed every lease and receipt sequence"
+         else Ok state)
+;;
+
+let of_yojson json =
+  let context = "keeper event queue state" in
+  let* fields = assoc_fields ~context json in
+  let* schema_value = string_field ~context "schema" fields in
+  if not (String.equal schema_value schema)
+  then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
+  else
+    let* revision = int64_field ~context "revision" fields in
+    let* next_lease_sequence = int64_field ~context "next_lease_sequence" fields in
+    let* pending_json = required_field ~context "pending" fields in
+    let* pending = Keeper_event_queue.queue_of_yojson pending_json in
+    let* leases = list_field ~context "leases" lease_of_yojson fields in
+    let* transition_outbox =
+      list_field ~context "transition_outbox" outbox_entry_of_yojson fields
+    in
+    validate_state
+      { revision; next_lease_sequence; pending; leases; transition_outbox }
+;;

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -12,6 +12,7 @@ type lease_kind =
 
 type requeue_reason =
   | Cycle_busy
+  | Turn_not_scheduled
   | Retry_after_pacing
   | Rotate_now
   | Cancelled
@@ -65,6 +66,7 @@ val next_lease_sequence : t -> int64
 val pending : t -> Keeper_event_queue.t
 val leases : t -> lease list
 val transition_outbox : t -> outbox_entry list
+val lease_kind : lease -> lease_kind
 
 val with_pending : Keeper_event_queue.t -> t -> t
 val with_revision : int64 -> t -> t
@@ -99,6 +101,14 @@ val settle :
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim
     and stimulus order and emitting stable transition receipts. *)
+
+val active_lease : t -> lease option
+(** Oldest unsettled lease, if any.  A restarted lane resumes this lease before
+    claiming new pending work. *)
+
+val mark_transition_projected : transition_id:string -> t -> (t, string) result
+(** Idempotently mark a durable outbox entry after an external projector has
+    materialized its stable [event_id].  Unknown transition ids fail closed. *)
 
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -51,7 +51,6 @@ type transition_receipt =
 type outbox_entry =
   { receipt : transition_receipt
   ; stimuli : Keeper_event_queue.stimulus list
-  ; projected_to_reaction_ledger : bool
   }
 
 type t
@@ -65,6 +64,7 @@ val revision : t -> int64
 val next_lease_sequence : t -> int64
 val pending : t -> Keeper_event_queue.t
 val leases : t -> lease list
+val last_settlement : t -> transition_receipt option
 val transition_outbox : t -> outbox_entry list
 val lease_kind : lease -> lease_kind
 
@@ -107,8 +107,9 @@ val active_lease : t -> lease option
     claiming new pending work. *)
 
 val mark_transition_projected : transition_id:string -> t -> (t, string) result
-(** Idempotently mark a durable outbox entry after an external projector has
-    materialized its stable [event_id].  Unknown transition ids fail closed. *)
+(** Atomically retire a durable outbox entry after an external projector has
+    materialized its stable [event_id], retaining only the last receipt for an
+    immediate idempotent retry. Unknown transition ids fail closed. *)
 
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t
@@ -121,6 +122,7 @@ val release_legacy_inflight :
 
 val lease_to_yojson : lease -> Yojson.Safe.t
 val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
+val transition_receipt_to_yojson : transition_receipt -> Yojson.Safe.t
 val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -1,0 +1,118 @@
+(** Pure durable state machine for one Keeper event queue owner.
+
+    [event-queue.json] is the sole authority for pending stimuli, active
+    leases, monotonic lease identity, and settlement projection work.  This
+    module performs no I/O; persistence supplies the atomic file boundary and
+    publishes [pending] into the live registry only after a durable commit. *)
+
+type lease_kind =
+  | Single
+  | Board_batch
+  | Legacy_inflight
+
+type requeue_reason =
+  | Cycle_busy
+  | Retry_after_pacing
+  | Rotate_now
+  | Cancelled
+  | Cycle_crashed
+  | Registration_recovery
+
+type escalation_reason =
+  | Failure_judgment_requested
+  | Failure_judgment_failed
+
+type settlement =
+  | Ack
+  | Requeue of requeue_reason
+  | Escalate of
+      { reason : escalation_reason
+      ; successor : Keeper_event_queue.stimulus option
+      }
+
+type lease =
+  { lease_id : string
+  ; sequence : int64
+  ; kind : lease_kind
+  ; claimed_at : float option
+  ; stimuli : Keeper_event_queue.stimulus list
+  }
+
+type transition_receipt =
+  { transition_id : string
+  ; event_id : string
+  ; lease_id : string
+  ; lease_sequence : int64
+  ; settled_at : float
+  ; settlement : settlement
+  }
+
+type outbox_entry =
+  { receipt : transition_receipt
+  ; stimuli : Keeper_event_queue.stimulus list
+  ; projected_to_reaction_ledger : bool
+  }
+
+type t
+
+type settle_result =
+  | Settled of transition_receipt
+  | Already_settled of transition_receipt
+
+val empty : t
+val revision : t -> int64
+val next_lease_sequence : t -> int64
+val pending : t -> Keeper_event_queue.t
+val leases : t -> lease list
+val transition_outbox : t -> outbox_entry list
+
+val with_pending : Keeper_event_queue.t -> t -> t
+val with_revision : int64 -> t -> t
+
+val claim_when :
+  claimed_at:float ->
+  ready:(Keeper_event_queue.stimulus -> bool) ->
+  t ->
+  (t * lease option, string) result
+(** Lease the pending head when [ready] accepts it.  A successful claim removes
+    the stimuli from [pending] and advances the monotonic lease sequence in the
+    same returned state. *)
+
+val claim_board : claimed_at:float -> t -> (t * lease option, string) result
+(** Lease every pending board stimulus as one ordered digest. *)
+
+val add_legacy_inflight :
+  Keeper_event_queue.stimulus list -> t -> (t * lease option, string) result
+(** Migration/test compatibility boundary.  Adds one lease for legacy
+    [event-queue-inflight.json] rows and removes matching pending identities. *)
+
+val settle :
+  settled_at:float ->
+  lease:lease ->
+  settlement:settlement ->
+  t ->
+  (t * settle_result, string) result
+(** Atomically project one lease disposition into pure state.  Repeating the
+    same semantic settlement returns [Already_settled]; a different settlement
+    for an already-settled lease is an explicit conflict. *)
+
+val recover_leases : settled_at:float -> t -> (t, string) result
+(** Requeue every active lease with [Registration_recovery], preserving claim
+    and stimulus order and emitting stable transition receipts. *)
+
+val remove_by_post_id :
+  Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t
+
+val release_legacy_inflight :
+  Keeper_event_queue.stimulus list -> t -> t
+(** Compatibility-only projection for the retired split-file API.  Removes
+    matching identities from active leases while leaving pending untouched.
+    New runtime code must settle the opaque lease instead. *)
+
+val lease_to_yojson : lease -> Yojson.Safe.t
+val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, string) result
+
+val schema : string
+(** ["keeper.event_queue.state.v2"]. *)

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -164,7 +164,7 @@ let keeper_event_queue_health_json () =
       ; "inflight_count", `Int 0
       ; "total_count", `Int 0
       ; "transition_outbox_count", `Int 0
-      ; "unprojected_transition_outbox_count", `Int 0
+      ; "counts_complete", `Bool false
       ; "oldest_arrived_at_unix", `Null
       ; "oldest_age_seconds", `Null
       ; "pending_by_keeper", `List []

--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -163,6 +163,8 @@ let keeper_event_queue_health_json () =
       ; "pending_count", `Int 0
       ; "inflight_count", `Int 0
       ; "total_count", `Int 0
+      ; "transition_outbox_count", `Int 0
+      ; "unprojected_transition_outbox_count", `Int 0
       ; "oldest_arrived_at_unix", `Null
       ; "oldest_age_seconds", `Null
       ; "pending_by_keeper", `List []

--- a/test/dune
+++ b/test/dune
@@ -766,6 +766,11 @@
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.
 (test
+ (name test_keeper_event_queue_state_v2)
+ (modules test_keeper_event_queue_state_v2)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_server_request_authority)
  (modules test_server_request_authority)
  (libraries alcotest masc_test_deps eio_main h2))

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -66,6 +66,12 @@ let int_field name json =
   | _ -> Alcotest.failf "expected int field %S" name
 ;;
 
+let bool_field name json =
+  match json_field name json with
+  | Some (`Bool value) -> value
+  | _ -> Alcotest.failf "expected bool field %S" name
+;;
+
 let list_field name json =
   match json_field name json with
   | Some (`List values) -> values
@@ -324,6 +330,10 @@ let test_fleet_summary_serializes_with_owner_commit () =
            Atomic.set release true;
            let json = Eio.Promise.await summary in
            let keeper = keeper_summary keeper_name json in
+           Alcotest.(check bool)
+             "summary count projection is complete"
+             true
+             (bool_field "counts_complete" keeper);
            Alcotest.(check int)
              "summary pending count comes from completed pair"
              0

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -55,25 +55,6 @@ let post_ids queue =
   |> List.map (fun (item : Queue.stimulus) -> item.post_id)
 ;;
 
-let snapshot_path ~base_path ~keeper_name =
-  Filename.concat
-    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-    "event-queue.json"
-;;
-
-let inflight_path ~base_path ~keeper_name =
-  Filename.concat
-    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
-    "event-queue-inflight.json"
-;;
-
-let persist_queue_file path queue =
-  Queue.queue_to_yojson queue
-  |> Yojson.Safe.pretty_to_string
-  |> Fs_compat.save_file_atomic path
-  |> require_ok ("write split-state fixture " ^ path)
-;;
-
 let json_field name = function
   | `Assoc fields -> List.assoc_opt name fields
   | _ -> None
@@ -297,7 +278,7 @@ let test_exception_does_not_poison_owner_or_other_lane () =
       (Persistence.load ~base_path ~keeper_name:keeper_b |> post_ids))
 ;;
 
-let test_fleet_summary_never_observes_split_owner_pair () =
+let test_fleet_summary_serializes_with_owner_commit () =
   with_temp_dir "event-queue-owner-summary" (fun base_path ->
     let keeper_name = "summary_owner" in
     let pending = stimulus ~post_id:"pending" ~arrived_at:9.0 in
@@ -307,18 +288,14 @@ let test_fleet_summary_never_observes_split_owner_pair () =
       ~keeper_name
       (Queue.enqueue Queue.empty pending);
     Persistence.record_inflight ~base_path ~keeper_name [ inflight ];
-    let pending_path = snapshot_path ~base_path ~keeper_name in
-    let inflight_path = inflight_path ~base_path ~keeper_name in
-    let split_ready = Atomic.make false in
+    let transform_entered = Atomic.make false in
     let release = Atomic.make false in
     let writer_result = ref None in
     let writer =
       Domain.spawn (fun () ->
         Persistence.update_result ~base_path ~keeper_name (fun _queue ->
-          persist_queue_file pending_path Queue.empty;
-          Atomic.set split_ready true;
+          Atomic.set transform_entered true;
           await_atomic_in_domain release;
-          persist_queue_file inflight_path Queue.empty;
           Queue.empty))
     in
     Fun.protect
@@ -326,7 +303,7 @@ let test_fleet_summary_never_observes_split_owner_pair () =
         Atomic.set release true;
         writer_result := Some (Domain.join writer))
       (fun () ->
-         await_atomic split_ready;
+         await_atomic transform_entered;
          Eio.Switch.run (fun sw ->
            let summary_started = Atomic.make false in
            let summary_done = Atomic.make false in
@@ -341,7 +318,7 @@ let test_fleet_summary_never_observes_split_owner_pair () =
            await_atomic summary_started;
            Eio.Fiber.yield ();
            Alcotest.(check bool)
-             "summary blocks while one owner pair is split"
+             "summary blocks while the owner transaction is in progress"
              false
              (Atomic.get summary_done);
            Atomic.set release true;
@@ -352,8 +329,8 @@ let test_fleet_summary_never_observes_split_owner_pair () =
              0
              (int_field "pending_count" keeper);
            Alcotest.(check int)
-             "summary inflight count comes from completed pair"
-             0
+             "summary preserves independently leased work"
+             1
              (int_field "inflight_count" keeper)));
     require_some "split writer join" !writer_result
     |> require_ok "split writer update")
@@ -364,6 +341,6 @@ let () =
     test_canonical_owner_and_cross_context_isolation ();
     test_cancelled_waiter_does_not_leak_owner_lock ();
     test_exception_does_not_poison_owner_or_other_lane ();
-    test_fleet_summary_never_observes_split_owner_pair ());
+    test_fleet_summary_serializes_with_owner_commit ());
   print_endline "test_keeper_event_queue_owner_lock: OK"
 ;;

--- a/test/test_keeper_event_queue_owner_lock.ml
+++ b/test/test_keeper_event_queue_owner_lock.ml
@@ -336,11 +336,72 @@ let test_fleet_summary_serializes_with_owner_commit () =
     |> require_ok "split writer update")
 ;;
 
+let test_cancel_after_claim_commit_resumes_stable_lease () =
+  with_temp_dir "event-queue-owner-cancel-after-commit" (fun base_path ->
+    let keeper_name = "cancel_after_commit" in
+    let pending = stimulus ~post_id:"durable-claim" ~arrived_at:11.0 in
+    Persistence.persist
+      ~base_path
+      ~keeper_name
+      (Queue.enqueue Queue.empty pending);
+    let after_commit_entered = Atomic.make false in
+    let release_after_commit = Atomic.make false in
+    let winner =
+      Eio.Fiber.first
+        (fun () ->
+           let result =
+             Persistence.claim_when_result
+               ~base_path
+               ~keeper_name
+               ~claimed_at:12.0
+               ~ready:(fun _ -> true)
+               ~after_commit:(fun _pending ->
+                 Atomic.set after_commit_entered true;
+                 await_atomic release_after_commit)
+               ()
+           in
+           `Claim_returned result)
+        (fun () ->
+           await_atomic after_commit_entered;
+           Atomic.set release_after_commit true;
+           `Cancellation_won)
+    in
+    (match winner with
+     | `Cancellation_won -> ()
+     | `Claim_returned _ ->
+       Alcotest.fail "claim returned before deterministic cancellation won");
+    let lease =
+      Persistence.active_lease_result ~base_path ~keeper_name
+      |> require_ok "resume committed lease"
+      |> require_some "committed lease remains discoverable"
+    in
+    Alcotest.(check (list string))
+      "committed claim is absent from pending"
+      []
+      (Persistence.load_pending ~base_path ~keeper_name |> post_ids);
+    Persistence.settle_result
+      ~base_path
+      ~keeper_name
+      ~settled_at:13.0
+      ~lease
+      ~settlement:Persistence.Ack
+      ()
+    |> require_ok "settle resumed lease"
+    |> ignore;
+    Alcotest.(check bool)
+      "resumed lease settled exactly once"
+      true
+      (Persistence.active_lease_result ~base_path ~keeper_name
+       |> require_ok "read settled state"
+       |> Option.is_none))
+;;
+
 let () =
   Eio_main.run (fun _env ->
     test_canonical_owner_and_cross_context_isolation ();
     test_cancelled_waiter_does_not_leak_owner_lock ();
     test_exception_does_not_poison_owner_or_other_lane ();
-    test_fleet_summary_serializes_with_owner_commit ());
+    test_fleet_summary_serializes_with_owner_commit ();
+    test_cancel_after_claim_commit_resumes_stable_lease ());
   print_endline "test_keeper_event_queue_owner_lock: OK"
 ;;

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -70,6 +70,18 @@ let test_claim_codec_ack_idempotency () =
     "idempotent outbox cardinality"
     1
     (List.length (State.transition_outbox state));
+  let state =
+    State.mark_transition_projected ~transition_id:receipt.transition_id state
+    |> require_ok "mark transition projected"
+  in
+  let projected = List.hd (State.transition_outbox state) in
+  Alcotest.(check bool)
+    "projection acknowledgement is durable state"
+    true
+    projected.projected_to_reaction_ledger;
+  ignore
+    (State.mark_transition_projected ~transition_id:receipt.transition_id state
+     |> require_ok "projection acknowledgement is idempotent");
   (match
      State.settle
        ~settled_at:13.0
@@ -141,7 +153,112 @@ let test_requeue_and_escalation_are_total () =
     "failed judgment does not enqueue itself"
     0
     (Queue.length (State.pending state));
-  Alcotest.(check int) "both transitions visible" 3 (List.length (State.transition_outbox state))
+  Alcotest.(check int) "both transitions visible" 3 (List.length (State.transition_outbox state));
+  let open Yojson.Safe.Util in
+  let failed_judgment_settlement =
+    State.to_yojson state
+    |> member "transition_outbox"
+    |> to_list
+    |> List.rev
+    |> List.hd
+    |> member "receipt"
+    |> member "settlement"
+  in
+  Alcotest.(check string)
+    "failed judgment receipt is an escalation"
+    "escalate"
+    (failed_judgment_settlement |> member "kind" |> to_string);
+  Alcotest.(check string)
+    "failed judgment receipt preserves the typed reason"
+    "failure_judgment_failed"
+    (failed_judgment_settlement |> member "reason" |> to_string);
+  Alcotest.(check bool)
+    "failed judgment receipt explicitly stores no successor"
+    true
+    (failed_judgment_settlement
+     |> member "successor"
+     |> Yojson.Safe.equal `Null)
+;;
+
+let lease_for stimulus =
+  let state = State.with_pending (queue [ stimulus ]) State.empty in
+  let _state, lease = claim_head state in
+  require_some "fixture lease" lease
+;;
+
+let turn_failure route : Keeper_unified_turn.turn_failure =
+  { error = Agent_sdk.Error.Internal "deterministic fixture"
+  ; runtime_id = "exact-final-runtime"
+  ; route
+  }
+;;
+
+let test_failed_cycle_route_mapping () =
+  let ordinary_lease = lease_for (stimulus "ordinary" 1.0) in
+  let retry_failure =
+    turn_failure
+      (Keeper_runtime_failure_route.Retry_after_pacing
+         { pacing = Keeper_runtime_failure_route.Rate_limited
+         ; retry_after = None
+         })
+  in
+  (match
+     Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:2.0
+       ~lease:ordinary_lease
+       retry_failure
+   with
+   | Keeper_registry_event_queue.Requeue
+       Keeper_registry_event_queue.Retry_after_pacing ->
+     ()
+   | _ -> Alcotest.fail "retry route did not requeue the lease");
+  let judgment_failure =
+    turn_failure
+      (Keeper_runtime_failure_route.Escalate_judgment
+         { judgment = Keeper_runtime_failure_route.Contract_violation
+         ; detail = "fixture contract failure"
+         })
+  in
+  (match
+     Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:3.0
+       ~lease:ordinary_lease
+       judgment_failure
+   with
+   | Keeper_registry_event_queue.Escalate
+       { reason = Keeper_registry_event_queue.Failure_judgment_requested
+       ; successor = Some { Queue.payload = Queue.Failure_judgment successor; _ }
+       } ->
+     Alcotest.(check string)
+       "successor keeps exact final runtime"
+       "exact-final-runtime"
+       successor.fj_runtime_id
+   | _ -> Alcotest.fail "deterministic failure did not create one judgment successor");
+  let judgment : Queue.failure_judgment =
+    { fj_runtime_id = "source-runtime"
+    ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
+    ; fj_detail = "source failure"
+    }
+  in
+  let leased_judgment =
+    lease_for
+      (stimulus
+         ~payload:(Queue.Failure_judgment judgment)
+         (Queue.failure_judgment_post_id judgment)
+         4.0)
+  in
+  (match
+     Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:5.0
+       ~lease:leased_judgment
+       judgment_failure
+   with
+   | Keeper_registry_event_queue.Escalate
+       { reason = Keeper_registry_event_queue.Failure_judgment_failed
+       ; successor = None
+       } ->
+     ()
+   | _ -> Alcotest.fail "failed judgment recursively re-enqueued itself")
 ;;
 
 let rec remove_tree path =
@@ -250,6 +367,7 @@ let () =
     [ ( "state"
       , [ Alcotest.test_case "claim codec ack idempotency" `Quick test_claim_codec_ack_idempotency
         ; Alcotest.test_case "requeue and escalation" `Quick test_requeue_and_escalation_are_total
+        ; Alcotest.test_case "failed cycle route mapping" `Quick test_failed_cycle_route_mapping
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1,0 +1,262 @@
+module Queue = Keeper_event_queue
+module State = Keeper_event_queue_state
+module Persistence = Keeper_event_queue_persistence
+
+let require_ok label = function
+  | Ok value -> value
+  | Error message -> Alcotest.failf "%s: %s" label message
+;;
+
+let require_some label = function
+  | Some value -> value
+  | None -> Alcotest.failf "%s: expected Some" label
+;;
+
+let stimulus ?(payload = Queue.Bootstrap) post_id arrived_at : Queue.stimulus =
+  { post_id; urgency = Queue.Normal; arrived_at; payload }
+;;
+
+let queue stimuli = List.fold_left Queue.enqueue Queue.empty stimuli
+
+let post_ids queue =
+  Queue.to_list queue |> List.map (fun (stimulus : Queue.stimulus) -> stimulus.post_id)
+;;
+
+let claim_head state =
+  State.claim_when ~claimed_at:10.0 ~ready:(fun _ -> true) state
+  |> require_ok "claim head"
+;;
+
+let test_claim_codec_ack_idempotency () =
+  let first = stimulus "first" 1.0 in
+  let state = State.with_pending (queue [ first ]) State.empty in
+  let state, lease = claim_head state in
+  let lease = require_some "claimed lease" lease in
+  Alcotest.(check int64) "lease sequence" 1L lease.sequence;
+  Alcotest.(check string) "stable lease id" "lease:1" lease.lease_id;
+  Alcotest.(check int) "pending drained" 0 (Queue.length (State.pending state));
+  Alcotest.(check int64) "next sequence" 2L (State.next_lease_sequence state);
+  let state =
+    State.to_yojson state |> State.of_yojson |> require_ok "v2 codec roundtrip"
+  in
+  let state, result =
+    State.settle ~settled_at:11.0 ~lease ~settlement:State.Ack state
+    |> require_ok "ack settlement"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "first settlement was already settled"
+  in
+  Alcotest.(check string) "transition id" "lease:1:ack" receipt.transition_id;
+  Alcotest.(check string)
+    "stable projection event id"
+    "keeper-event-queue-transition:lease:1:ack"
+    receipt.event_id;
+  Alcotest.(check int) "lease removed" 0 (List.length (State.leases state));
+  Alcotest.(check int) "outbox retained" 1 (List.length (State.transition_outbox state));
+  let state, repeated =
+    State.settle ~settled_at:12.0 ~lease ~settlement:State.Ack state
+    |> require_ok "idempotent repeated ack"
+  in
+  (match repeated with
+   | State.Already_settled repeated_receipt ->
+     Alcotest.(check string)
+       "same durable receipt"
+       receipt.transition_id
+       repeated_receipt.transition_id
+   | State.Settled _ -> Alcotest.fail "repeated settlement created a second transition");
+  Alcotest.(check int)
+    "idempotent outbox cardinality"
+    1
+    (List.length (State.transition_outbox state));
+  (match
+     State.settle
+       ~settled_at:13.0
+       ~lease
+       ~settlement:(State.Requeue State.Cycle_busy)
+       state
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "conflicting second settlement was accepted")
+;;
+
+let test_requeue_and_escalation_are_total () =
+  let retry = stimulus "retry" 1.0 in
+  let state = State.with_pending (queue [ retry ]) State.empty in
+  let state, lease = claim_head state in
+  let lease = require_some "retry lease" lease in
+  let state, _ =
+    State.settle
+      ~settled_at:2.0
+      ~lease
+      ~settlement:(State.Requeue State.Retry_after_pacing)
+      state
+    |> require_ok "retry requeue"
+  in
+  Alcotest.(check (list string)) "retry restored" [ "retry" ] (post_ids (State.pending state));
+  let state, lease = claim_head state in
+  let lease = require_some "escalation lease" lease in
+  let judgment : Queue.failure_judgment =
+    { fj_runtime_id = "runtime-a"
+    ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
+    ; fj_detail = "deterministic failure"
+    }
+  in
+  let successor =
+    stimulus
+      ~payload:(Queue.Failure_judgment judgment)
+      (Queue.failure_judgment_post_id judgment)
+      3.0
+  in
+  let state, _ =
+    State.settle
+      ~settled_at:3.0
+      ~lease
+      ~settlement:
+        (State.Escalate
+           { reason = State.Failure_judgment_requested
+           ; successor = Some successor
+           })
+      state
+    |> require_ok "atomic judgment successor"
+  in
+  Alcotest.(check (list string))
+    "original consumed and successor pending"
+    [ successor.post_id ]
+    (post_ids (State.pending state));
+  let state, judgment_lease = claim_head state in
+  let judgment_lease = require_some "judgment lease" judgment_lease in
+  let state, _ =
+    State.settle
+      ~settled_at:4.0
+      ~lease:judgment_lease
+      ~settlement:
+        (State.Escalate
+           { reason = State.Failure_judgment_failed; successor = None })
+      state
+    |> require_ok "judgment failure escalation"
+  in
+  Alcotest.(check int)
+    "failed judgment does not enqueue itself"
+    0
+    (Queue.length (State.pending state));
+  Alcotest.(check int) "both transitions visible" 3 (List.length (State.transition_outbox state))
+;;
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_dir prefix f =
+  let path = Filename.temp_dir prefix "" in
+  Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
+;;
+
+let keeper_dir ~base_path ~keeper_name =
+  Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name
+;;
+
+let write_queue path queue =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Queue.queue_to_yojson queue
+  |> Yojson.Safe.pretty_to_string
+  |> Fs_compat.save_file_atomic path
+  |> require_ok ("write fixture " ^ path)
+;;
+
+let read_schema path =
+  match Safe_ops.read_json_file_safe path with
+  | Error message -> Alcotest.failf "read migrated state: %s" message
+  | Ok (`Assoc fields) ->
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema) -> schema
+     | _ -> Alcotest.fail "migrated state lacks schema")
+  | Ok _ -> Alcotest.fail "migrated state is not an object"
+;;
+
+let test_legacy_pair_migrates_once () =
+  with_temp_dir "keeper-event-queue-v2-migration" (fun base_path ->
+    let keeper_name = "migration_keeper" in
+    let dir = keeper_dir ~base_path ~keeper_name in
+    let primary = Filename.concat dir "event-queue.json" in
+    let legacy = Filename.concat dir "event-queue-inflight.json" in
+    write_queue primary (queue [ stimulus "pending" 1.0 ]);
+    write_queue legacy (queue [ stimulus "leased" 2.0 ]);
+    let state =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "migrate legacy pair"
+    in
+    Alcotest.(check string) "primary became v2" State.schema (read_schema primary);
+    Alcotest.(check bool) "legacy input removed" false (Sys.file_exists legacy);
+    Alcotest.(check (list string))
+      "legacy lease recovered before publication"
+      [ "leased"; "pending" ]
+      (post_ids (State.pending state));
+    Alcotest.(check int) "no abandoned lease survives migration" 0 (List.length (State.leases state));
+    Alcotest.(check int)
+      "migration recovery receipt retained"
+      1
+      (List.length (State.transition_outbox state));
+    write_queue legacy (queue [ stimulus "forbidden-residue" 3.0 ]);
+    (match Persistence.load_state_result ~base_path ~keeper_name with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "v2 state silently accepted legacy residue"))
+;;
+
+let test_failed_owner_write_does_not_block_peer_lane () =
+  with_temp_dir "keeper-event-queue-v2-fault" (fun base_path ->
+    let broken = "broken_lane" in
+    let peer = "peer_lane" in
+    Persistence.update_result ~base_path ~keeper_name:broken (fun queue ->
+      Queue.enqueue queue (stimulus "broken-pending" 1.0))
+    |> require_ok "seed broken lane";
+    let broken_dir = keeper_dir ~base_path ~keeper_name:broken in
+    Unix.chmod broken_dir 0o500;
+    Fun.protect
+      ~finally:(fun () -> Unix.chmod broken_dir 0o700)
+      (fun () ->
+         (match
+            Persistence.claim_when_result
+              ~base_path
+              ~keeper_name:broken
+              ~claimed_at:2.0
+              ~ready:(fun _ -> true)
+              ()
+          with
+          | Error _ -> ()
+          | Ok _ -> Alcotest.fail "unwritable owner reported a committed claim");
+         Persistence.update_result ~base_path ~keeper_name:peer (fun queue ->
+           Queue.enqueue queue (stimulus "peer-pending" 2.0))
+         |> require_ok "peer lane remains independently writable");
+    Alcotest.(check (list string))
+      "failed claim left durable pending unchanged"
+      [ "broken-pending" ]
+      (Persistence.load_pending ~base_path ~keeper_name:broken |> post_ids);
+    Alcotest.(check (list string))
+      "peer committed independently"
+      [ "peer-pending" ]
+      (Persistence.load_pending ~base_path ~keeper_name:peer |> post_ids))
+;;
+
+let () =
+  Alcotest.run
+    "keeper event queue v2"
+    [ ( "state"
+      , [ Alcotest.test_case "claim codec ack idempotency" `Quick test_claim_codec_ack_idempotency
+        ; Alcotest.test_case "requeue and escalation" `Quick test_requeue_and_escalation_are_total
+        ] )
+    ; ( "persistence"
+      , [ Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once
+        ; Alcotest.test_case
+            "lane write fault isolation"
+            `Quick
+            test_failed_owner_write_does_not_block_peer_lane
+        ] )
+    ]
+;;

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -240,7 +240,7 @@ let test_failed_cycle_route_mapping () =
          })
   in
   (match
-     Keeper_heartbeat_loop.settlement_of_failure
+     Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:2.0
        ~lease:ordinary_lease
        retry_failure
@@ -257,7 +257,7 @@ let test_failed_cycle_route_mapping () =
          })
   in
   (match
-     Keeper_heartbeat_loop.settlement_of_failure
+     Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:3.0
        ~lease:ordinary_lease
        judgment_failure
@@ -285,7 +285,7 @@ let test_failed_cycle_route_mapping () =
          4.0)
   in
   (match
-     Keeper_heartbeat_loop.settlement_of_failure
+     Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:5.0
        ~lease:leased_judgment
        judgment_failure
@@ -304,7 +304,7 @@ let test_failed_cycle_route_mapping () =
     }
   in
   (match
-     Keeper_heartbeat_loop.settlement_of_failure
+     Masc.Keeper_heartbeat_loop.settlement_of_failure
        ~settled_at:6.0
        ~lease:ordinary_lease
        handled_failure
@@ -423,7 +423,7 @@ let test_transition_outbox_projects_with_stable_identity () =
       | Persistence.Already_settled _ ->
         Alcotest.fail "first projection settlement was already settled"
     in
-    Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
     |> require_ok "project transition outbox";
     let state =
       Persistence.load_state_result ~base_path ~keeper_name
@@ -448,7 +448,7 @@ let test_transition_outbox_projects_with_stable_identity () =
       "stable event id deduplicates crash replay"
       1
       (summary |> member "event_queue_ack_count" |> to_int);
-    Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
     |> require_ok "empty outbox projection is idempotent")
 ;;
 

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -452,6 +452,84 @@ let test_transition_outbox_projects_with_stable_identity () =
     |> require_ok "empty outbox projection is idempotent")
 ;;
 
+let test_registration_preparation_is_atomic_and_fail_closed () =
+  with_temp_dir "keeper-event-queue-v2-registration" (fun base_path ->
+    let keeper_name = "registration_keeper" in
+    let source = stimulus "abandoned" 1.0 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending source)
+    |> require_ok "seed registration source";
+    ignore
+      (Persistence.claim_when_result
+         ~base_path
+         ~keeper_name
+         ~claimed_at:2.0
+         ~ready:(fun _ -> true)
+         ()
+       |> require_ok "claim registration source"
+       |> require_some "registration lease");
+    let pending =
+      Persistence.prepare_registration_result
+        ~base_path
+        ~keeper_name
+        ~settled_at:3.0
+        ()
+      |> require_ok "prepare registration"
+    in
+    Alcotest.(check (list string))
+      "abandoned lease returned to pending"
+      [ "abandoned" ]
+      (post_ids pending);
+    let prepared =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load prepared registration state"
+    in
+    Alcotest.(check int) "registration leaves no active lease" 0 (List.length (State.leases prepared));
+    Alcotest.(check int)
+      "registration records one recovery transition"
+      1
+      (List.length (State.transition_outbox prepared));
+    let prepared_revision = State.revision prepared in
+    ignore
+      (Persistence.prepare_registration_result
+         ~base_path
+         ~keeper_name
+         ~settled_at:4.0
+         ()
+       |> require_ok "repeat prepared registration");
+    let repeated =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load repeated registration state"
+    in
+    Alcotest.(check int64)
+      "repeat registration does not synthesize a transition"
+      prepared_revision
+      (State.revision repeated);
+    Alcotest.(check int)
+      "repeat registration retains one recovery transition"
+      1
+      (List.length (State.transition_outbox repeated));
+
+    let malformed_keeper = "malformed_registration_keeper" in
+    let malformed_path =
+      Filename.concat
+        (keeper_dir ~base_path ~keeper_name:malformed_keeper)
+        "event-queue.json"
+    in
+    Fs_compat.mkdir_p (Filename.dirname malformed_path);
+    Fs_compat.save_file_atomic malformed_path "{}"
+    |> require_ok "write malformed registration state";
+    (match
+       Persistence.prepare_registration_result
+         ~base_path
+         ~keeper_name:malformed_keeper
+         ~settled_at:5.0
+         ()
+     with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "malformed registration state became an empty queue"))
+;;
+
 let test_failed_owner_write_does_not_block_peer_lane () =
   with_temp_dir "keeper-event-queue-v2-fault" (fun base_path ->
     let broken = "broken_lane" in
@@ -501,6 +579,10 @@ let () =
             "transition outbox projection"
             `Quick
             test_transition_outbox_projects_with_stable_identity
+        ; Alcotest.test_case
+            "registration preparation"
+            `Quick
+            test_registration_preparation_is_atomic_and_fail_closed
         ; Alcotest.test_case
             "lane write fault isolation"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -222,11 +222,11 @@ let lease_for stimulus =
   require_some "fixture lease" lease
 ;;
 
-let turn_failure route : Keeper_unified_turn.turn_failure =
+let turn_failure route : Masc.Keeper_unified_turn.turn_failure =
   { error = Agent_sdk.Error.Internal "deterministic fixture"
   ; runtime_id = "exact-final-runtime"
   ; route
-  ; source_lease_disposition = Keeper_unified_turn.Follow_failure_route
+  ; source_lease_disposition = Masc.Keeper_unified_turn.Follow_failure_route
   }
 ;;
 
@@ -300,7 +300,7 @@ let test_failed_cycle_route_mapping () =
   let handled_failure =
     { judgment_failure with
       source_lease_disposition =
-        Keeper_unified_turn.Acknowledge_after_in_turn_handling
+        Masc.Keeper_unified_turn.Acknowledge_after_in_turn_handling
     }
   in
   (match

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -245,8 +245,8 @@ let test_failed_cycle_route_mapping () =
        ~lease:ordinary_lease
        retry_failure
    with
-   | Keeper_registry_event_queue.Requeue
-       Keeper_registry_event_queue.Retry_after_pacing ->
+   | Masc.Keeper_registry_event_queue.Requeue
+       Masc.Keeper_registry_event_queue.Retry_after_pacing ->
      ()
    | _ -> Alcotest.fail "retry route did not requeue the lease");
   let judgment_failure =
@@ -262,8 +262,8 @@ let test_failed_cycle_route_mapping () =
        ~lease:ordinary_lease
        judgment_failure
    with
-   | Keeper_registry_event_queue.Escalate
-       { reason = Keeper_registry_event_queue.Failure_judgment_requested
+   | Masc.Keeper_registry_event_queue.Escalate
+       { reason = Masc.Keeper_registry_event_queue.Failure_judgment_requested
        ; successor = Some { Queue.payload = Queue.Failure_judgment successor; _ }
        } ->
      Alcotest.(check string)
@@ -290,8 +290,8 @@ let test_failed_cycle_route_mapping () =
        ~lease:leased_judgment
        judgment_failure
    with
-   | Keeper_registry_event_queue.Escalate
-       { reason = Keeper_registry_event_queue.Failure_judgment_failed
+   | Masc.Keeper_registry_event_queue.Escalate
+       { reason = Masc.Keeper_registry_event_queue.Failure_judgment_failed
        ; successor = None
        } ->
      ()
@@ -309,7 +309,7 @@ let test_failed_cycle_route_mapping () =
        ~lease:ordinary_lease
        handled_failure
    with
-   | Keeper_registry_event_queue.Ack -> ()
+   | Masc.Keeper_registry_event_queue.Ack -> ()
    | _ -> Alcotest.fail "in-turn handled terminal failure was retried")
 ;;
 
@@ -433,15 +433,18 @@ let test_transition_outbox_projects_with_stable_identity () =
       "projection retires outbox"
       0
       (List.length (State.transition_outbox state));
-    Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+    Masc.Keeper_reaction_ledger.record_event_queue_transition_reaction_result
       ~base_path
       ~keeper_name
-      ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+      ~reaction_kind:Masc.Keeper_reaction_ledger.Event_queue_ack
       ~receipt
       source
     |> require_ok "replay stable transition reaction";
     let summary =
-      Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:20
+      Masc.Keeper_reaction_ledger.summary_for_keeper
+        ~base_path
+        ~keeper_name
+        ~limit:20
     in
     let open Yojson.Safe.Util in
     Alcotest.(check int)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -74,11 +74,15 @@ let test_claim_codec_ack_idempotency () =
     State.mark_transition_projected ~transition_id:receipt.transition_id state
     |> require_ok "mark transition projected"
   in
-  let projected = List.hd (State.transition_outbox state) in
-  Alcotest.(check bool)
-    "projection acknowledgement is durable state"
-    true
-    projected.projected_to_reaction_ledger;
+  Alcotest.(check int)
+    "projected outbox is retired"
+    0
+    (List.length (State.transition_outbox state));
+  let projected = require_some "last projected settlement" (State.last_settlement state) in
+  Alcotest.(check string)
+    "projection acknowledgement retains the last receipt"
+    receipt.transition_id
+    projected.transition_id;
   ignore
     (State.mark_transition_projected ~transition_id:receipt.transition_id state
      |> require_ok "projection acknowledgement is idempotent");
@@ -105,6 +109,26 @@ let test_requeue_and_escalation_are_total () =
       ~settlement:(State.Requeue State.Retry_after_pacing)
       state
     |> require_ok "retry requeue"
+  in
+  let retry_receipt =
+    match State.transition_outbox state with
+    | [ entry ] -> entry.receipt
+    | _ -> Alcotest.fail "retry settlement must create one outbox entry"
+  in
+  let blocked_state, blocked_lease = claim_head state in
+  Alcotest.(check bool)
+    "unprojected outbox blocks the next claim"
+    true
+    (Option.is_none blocked_lease);
+  Alcotest.(check (list string))
+    "blocked claim preserves pending work"
+    [ "retry" ]
+    (post_ids (State.pending blocked_state));
+  let state =
+    State.mark_transition_projected
+      ~transition_id:retry_receipt.transition_id
+      blocked_state
+    |> require_ok "project retry transition"
   in
   Alcotest.(check (list string)) "retry restored" [ "retry" ] (post_ids (State.pending state));
   let state, lease = claim_head state in
@@ -133,6 +157,15 @@ let test_requeue_and_escalation_are_total () =
       state
     |> require_ok "atomic judgment successor"
   in
+  let escalation_receipt =
+    match State.transition_outbox state with
+    | [ entry ] -> entry.receipt
+    | _ -> Alcotest.fail "judgment escalation must create one outbox entry"
+  in
+  let state =
+    State.mark_transition_projected ~transition_id:escalation_receipt.transition_id state
+    |> require_ok "project judgment escalation"
+  in
   Alcotest.(check (list string))
     "original consumed and successor pending"
     [ successor.post_id ]
@@ -153,7 +186,10 @@ let test_requeue_and_escalation_are_total () =
     "failed judgment does not enqueue itself"
     0
     (Queue.length (State.pending state));
-  Alcotest.(check int) "both transitions visible" 3 (List.length (State.transition_outbox state));
+  Alcotest.(check int)
+    "only the unprojected transition remains in state"
+    1
+    (List.length (State.transition_outbox state));
   let open Yojson.Safe.Util in
   let failed_judgment_settlement =
     State.to_yojson state
@@ -336,10 +372,84 @@ let test_legacy_pair_migrates_once () =
       "migration recovery receipt retained"
       1
       (List.length (State.transition_outbox state));
+    write_queue legacy (queue [ stimulus "leased" 2.0 ]);
+    let resumed =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "resume completed migration cleanup"
+    in
+    Alcotest.(check (list string))
+      "crash residue does not duplicate migrated stimulus"
+      [ "leased"; "pending" ]
+      (post_ids (State.pending resumed));
+    Alcotest.(check bool)
+      "verified crash residue removed"
+      false
+      (Sys.file_exists legacy);
     write_queue legacy (queue [ stimulus "forbidden-residue" 3.0 ]);
     (match Persistence.load_state_result ~base_path ~keeper_name with
      | Error _ -> ()
      | Ok _ -> Alcotest.fail "v2 state silently accepted legacy residue"))
+;;
+
+let test_transition_outbox_projects_with_stable_identity () =
+  with_temp_dir "keeper-event-queue-v2-outbox" (fun base_path ->
+    let keeper_name = "projection_keeper" in
+    let source = stimulus "projected-source" 1.0 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending source)
+    |> require_ok "seed projection source";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:2.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim projection source"
+      |> require_some "projection lease"
+    in
+    let receipt =
+      match
+        Persistence.settle_result
+          ~base_path
+          ~keeper_name
+          ~settled_at:3.0
+          ~lease
+          ~settlement:State.Ack
+          ()
+        |> require_ok "settle projection source"
+      with
+      | Persistence.Settled receipt -> receipt
+      | Persistence.Already_settled _ ->
+        Alcotest.fail "first projection settlement was already settled"
+    in
+    Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    |> require_ok "project transition outbox";
+    let state =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load projected state"
+    in
+    Alcotest.(check int)
+      "projection retires outbox"
+      0
+      (List.length (State.transition_outbox state));
+    Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+      ~base_path
+      ~keeper_name
+      ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+      ~receipt
+      source
+    |> require_ok "replay stable transition reaction";
+    let summary =
+      Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:20
+    in
+    let open Yojson.Safe.Util in
+    Alcotest.(check int)
+      "stable event id deduplicates crash replay"
+      1
+      (summary |> member "event_queue_ack_count" |> to_int);
+    Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    |> require_ok "empty outbox projection is idempotent")
 ;;
 
 let test_failed_owner_write_does_not_block_peer_lane () =
@@ -387,6 +497,10 @@ let () =
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once
+        ; Alcotest.test_case
+            "transition outbox projection"
+            `Quick
+            test_transition_outbox_projects_with_stable_identity
         ; Alcotest.test_case
             "lane write fault isolation"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -190,6 +190,7 @@ let turn_failure route : Keeper_unified_turn.turn_failure =
   { error = Agent_sdk.Error.Internal "deterministic fixture"
   ; runtime_id = "exact-final-runtime"
   ; route
+  ; source_lease_disposition = Keeper_unified_turn.Follow_failure_route
   }
 ;;
 
@@ -259,6 +260,21 @@ let test_failed_cycle_route_mapping () =
        } ->
      ()
    | _ -> Alcotest.fail "failed judgment recursively re-enqueued itself")
+  ;
+  let handled_failure =
+    { judgment_failure with
+      source_lease_disposition =
+        Keeper_unified_turn.Acknowledge_after_in_turn_handling
+    }
+  in
+  (match
+     Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:6.0
+       ~lease:ordinary_lease
+       handled_failure
+   with
+   | Keeper_registry_event_queue.Ack -> ()
+   | _ -> Alcotest.fail "in-turn handled terminal failure was retried")
 ;;
 
 let rec remove_tree path =

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -1319,6 +1319,8 @@ let test_reaction_kind_string_roundtrip () =
       check bool "reaction_kind round-trips through string" true (roundtrips k))
     [ Keeper_reaction_ledger.Turn_started
     ; Keeper_reaction_ledger.Event_queue_ack
+    ; Keeper_reaction_ledger.Event_queue_requeued
+    ; Keeper_reaction_ledger.Event_queue_escalated
     ; Keeper_reaction_ledger.Execution_receipt
     ; Keeper_reaction_ledger.Terminal_reason
     ; Keeper_reaction_ledger.Cursor_ack

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -117,6 +117,17 @@ let test_sdk_typed_wire () =
     sdk_cases
 ;;
 
+let test_idle_detected_receipt_is_failure () =
+  let outcome =
+    AE.receipt_outcome_kind_of_sdk_error
+      (SdkE.Agent (SdkE.IdleDetected { consecutive_idle_turns = 3 }))
+  in
+  Alcotest.(check string)
+    "IdleDetected is not cancellation"
+    "error"
+    (Masc.Keeper_execution_receipt.outcome_kind_to_string outcome)
+;;
+
 let check_parse_split label err ~provider ~model_ ~server =
   Alcotest.(check bool)
     (label ^ "/provider")
@@ -1189,6 +1200,10 @@ let () =
             "all sdk_error cases produce expected wire"
             `Quick
             test_sdk_typed_wire
+        ; Alcotest.test_case
+            "IdleDetected receipt remains a failure"
+            `Quick
+            test_idle_detected_receipt_is_failure
         ] )
     ; ( "server parse rejection split"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Scope

Foundation for #24198. This PR intentionally **does not close the issue**.

- Preserve `IdleDetected` as a typed behavioral failure rather than user cancellation.
- Replace split pending/inflight files with one per-Keeper v2 state envelope.
- Claim one lane-owned lease and settle it through typed `Ack | Requeue | Escalate` outcomes.
- Commit pending/lease/successor/outbox changes in one atomic durable transition.
- Project stable transition receipts into the reaction ledger and retire the outbox only after projection.
- Read fleet state once into typed summaries; malformed rows stay explicit and `counts_complete=false`.
- Recover abandoned leases at registration and reject unreadable queue state instead of substituting an empty queue.
- Keep owner locks per canonical `(BasePath, Keeper_name)` so one damaged lane does not serialize peers.

## Explicit remaining blocker

The `Failure_judgment` stimulus still enters the ordinary Keeper turn path. The typed settlement prevents repeated judgment failure from holding a lease forever, but this alone does not satisfy #24198's independent LLM-judgment boundary: a follow-up must execute the verdict through the configured OAS-backed structured-judge runtime with the original typed runtime/behavior provenance.

Treat this as the durable state-machine foundation, not as evidence that the full recovery loop is complete.

## Verification

- `ocamlformat --check` on every changed `.ml`/`.mli`: pass
- `ocamlc -stop-after parsing` on every changed `.ml`/`.mli`: pass
- `git diff --check`: pass
- `scripts/ci/check-determinism-contract.sh`: pass
- `scripts/ocaml-structure-ratchet.sh`: pass (`keeper_mli_missing` 15 -> 14)
- `scripts/ci/check-masc-oas-boundary.sh`: pass
- `scripts/stringly-boundary-ratchet.sh`: pass
- Full Dune build/test intentionally delegated to PR CI.

## Deterministic coverage

- Claim/settlement idempotency and conflicting settlement rejection
- Outbox claim blocking and post-projection retirement
- Stable reaction-ledger identity across crash replay
- Legacy split-file migration and crash-residue convergence
- Registration recovery, repeat-registration idempotency, and malformed-state rejection
- Per-Keeper write-fault isolation
- Typed `IdleDetected` receipt mapping

Refs #24198
