### PR TITLE
fix(keeper): terminalize rejected supervisor forks

### DIFF
--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -132,6 +132,28 @@ let launch_supervised_fiber_body
           ~base_path
           meta.name
           (Some (Keeper_registry.Exception detail));
+        (match
+           Keeper_registry.dispatch_event
+             ~base_path
+             meta.name
+             (Keeper_state_machine.Fiber_terminated
+                { outcome = detail; provider_id = None; http_status = None })
+         with
+         | Ok _ -> ()
+         | Error transition_error ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string DispatchEventFailures)
+             ~labels:[ "keeper", meta.name; "event", "fiber_terminated" ]
+             ();
+           Log.Keeper.warn
+             "supervisor: fork-rejection Fiber_terminated dispatch failed: %s"
+             (Keeper_state_machine.transition_error_to_string transition_error));
+        Keeper_registry.record_crash
+          ~base_path
+          meta.name
+          (Time_compat.now ())
+          detail;
+        Keeper_registry_error_recording.record ~base_path meta.name detail;
         if
           Keeper_registry.resolve_done
             reg

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2704,17 +2704,22 @@ let test_launch_fork_rejection_does_not_announce_running () =
           net = Some (Eio.Stdenv.net env);
         }
       in
-      Sup.with_restart_launch_noop_for_test (fun () ->
-        match
-          Masc.Keeper_supervisor_launch.launch_supervised_fiber
-            ~proactive_warmup_sec:0 ctx meta reg
-        with
-        | Ok () -> fail "expected lane fork rejection to propagate as Error"
-        | Error _ -> ());
+      (match
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber
+           ~proactive_warmup_sec:0 ctx meta reg
+       with
+       | Ok () -> fail "expected lane fork rejection to propagate as Error"
+       | Error _ -> ());
       check bool
         "fork-rejected launch resolves done through the crash path"
         true
-        (Option.is_some (Eio.Promise.peek reg.done_p)))
+        (Option.is_some (Eio.Promise.peek reg.done_p));
+      check bool
+        "fork-rejected launch transitions the registry SSOT to Crashed"
+        true
+        (match Reg.get_phase ~base_path:config.base_path name with
+         | Some KSM.Crashed -> true
+         | Some _ | None -> false))
 
 let test_sweep_waits_for_lane_join_before_unregister () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

- dispatch the typed Fiber_terminated event when Keeper_lane.fork rejects after Fiber_started was accepted
- record registry crash and durable error evidence for the rejected launch
- keep the existing done-promise and Crashed lifecycle dedupe behavior
- remove the restart-launch noop from the fork-rejection regression so it exercises Keeper_lane.fork, then assert the registry SSOT is Crashed

## Why

PR #24215 first transitions the registry to Running/fiber_alive=true in prepare_fiber_launch. Its Keeper_lane.fork rejection branch returned Error and resolved done, but never terminalized the registry FSM, leaving Running with no fiber.

The new regression in #24215 also wrapped launch_supervised_fiber in with_restart_launch_noop_for_test. That helper returns Ok before Keeper_lane.fork, so the test could not exercise the path it claimed to cover.

## Verification

- exact base: 2c48beb99a02b0afe69c82cd3618efe6529c7d2a
- exact head: b9050e2c0f41d2bd8fc13c70b59ad0057a7babfe
- scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_supervisor.exe: PASS
- test_keeper_supervisor: 92/92 PASS
- ocamlformat check: PASS
- git diff --check: PASS

## Gate

Draft only. Keep p1 and status:do-not-merge until exact-head CI and review are terminal green.

Refs #24215