### PR TITLE
fix(auth): bind Origin to trusted request authority

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -338,7 +338,7 @@ let respond_request_authority_bad_request ~error_code ~message reqd =
 ;;
 
 (** Extended router to handle OPTIONS *)
-let make_extended_handler routes =
+let make_extended_handler ~trust_policy routes =
   fun client_addr gluten_reqd ->
     let reqd = gluten_reqd.Gluten.Reqd.reqd in
     (* Gluten upgrade capability — only available here at the connection
@@ -347,7 +347,9 @@ let make_extended_handler routes =
        RFC-0281. *)
     let upgrade = gluten_reqd.Gluten.Reqd.upgrade in
     let request = Httpun.Reqd.request reqd in
-    match Server_request_authority.classify_http1_request request with
+    match
+      Server_request_authority.classify_http1_request ~trust_policy request
+    with
     | Server_request_authority.Missing ->
       respond_request_authority_bad_request
         ~error_code:"request_authority_missing"
@@ -363,10 +365,28 @@ let make_extended_handler routes =
         ~error_code:"request_authority_malformed"
         ~message:"request Host authority is malformed"
         reqd
+    | Server_request_authority.Untrusted ->
+      respond_request_authority_bad_request
+        ~error_code:"request_authority_untrusted"
+        ~message:"request Host is not a configured server identity"
+        reqd
     | Server_request_authority.Single request_authority ->
-      Server_request_authority.with_current request_authority (fun () ->
+      (match classify_request_origin ~request_authority request with
+       | Multiple_origins ->
+         respond_request_authority_bad_request
+           ~error_code:"request_origin_multiple"
+           ~message:"request contains more than one Origin field"
+           reqd
+       | Malformed_origin ->
+         respond_request_authority_bad_request
+           ~error_code:"request_origin_malformed"
+           ~message:"request Origin is not one complete HTTP(S) serialized origin"
+           reqd
+       | Missing_origin | Single_origin _ ->
+         Server_request_authority.with_current request_authority (fun () ->
         (* Authority admission precedes rate limiting, auth, and routing so no
-           credential I/O or URL projection can observe ambiguous Host input. *)
+           credential I/O or URL projection can observe an untrusted Host or
+           an ambiguous/malformed Origin field set. *)
         let path = Http.Request.path request in
         if try_rate_limit_block ~path ~client_addr ~request reqd
         then ()
@@ -401,7 +421,7 @@ let make_extended_handler routes =
                log_late_response_failure
                  ~context:"main_eio request handler"
                  failure_msg
-             | None -> try_internal_error_response reqd msg))
+             | None -> try_internal_error_response reqd msg)))
 
 (** Main server loop *)
 let run_server ~sw ~env ~host ~port ~base_path =

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -330,11 +330,14 @@ Sse.subscribe_external ~id:"ws-123"
 
 라우팅, 인증, credential I/O보다 먼저 `Server_request_authority`가 요청의
 authority를 한 번만 분류한다. HTTP/1.1은 case-insensitive `Host` 필드 전체를
-읽어 `Missing | Single authority | Multiple | Malformed`로 닫고, `Single`만
-request fiber에 바인딩한다. HTTP/2는 `:authority`만 authority 원천으로 쓰며
-`Host`가 함께 있으면 정규화한 host와 scheme 기본 port가 같은지 교차 검증한다.
+읽어 `Missing | Single authority | Multiple | Malformed | Untrusted`로 닫고,
+configured bind identity 또는 명시된 `MASC_HTTP_BASE_URL` identity와 일치하는
+`Single`만 request fiber에 바인딩한다. 바인딩 값은 `(scheme, authority,
+trust_class)`를 함께 보존한다. HTTP/2는 `:authority`만 authority 원천으로 쓰며
+`Host`가 함께 있으면 정규화한 host와 typed `:scheme` 기본 port가 같은지 교차
+검증한다.
 반복 `:authority`, 반복 `Host`, userinfo, 불완전 IPv6/port, 두 authority의
-불일치는 모두 route projection 전에 400이다. H2의 authority 없는
+불일치와 미신뢰 Host는 모두 route projection 전에 400이다. H2의 authority 없는
 `OPTIONS *`는 일반 missing authority와 합치지 않고 지원하지 않는 request
 target으로 명시적으로 거부한다.
 
@@ -465,11 +468,13 @@ Access-Control-Allow-Credentials: true
 
 HTTP/1.1과 HTTP/2 모두 MCP 경로(`/mcp`, `/mcp/managed`,
 `/mcp/operator`, `/sse`, `POST /`)에서 같은 typed request authority를 기준으로
-Origin을 비교한다. HTTP(S)가 아닌 scheme, userinfo, host/port 불일치는
-`403 Forbidden`이며, `http://localhost.attacker` 같은 prefix 혼동은 허용하지
-않는다. Origin이 없는 native client는 허용한다. 로컬 Vite cross-port는
-명시된 loopback dev-origin 목록에 속하고 request authority도 같은 정규화된
-loopback host일 때만 허용한다.
+Origin을 비교한다. `Origin`은 `get_multi`로 정확히 한 필드만 허용하고, path,
+query, fragment, trailing bytes 없이 HTTP(S) serialized-origin 문법 전체를
+소비한다. scheme/host/effective-port가 모두 같아야 `Same_origin`이며,
+HTTP(S)가 아닌 scheme, userinfo, 부분 파싱 값은 거부한다. Origin이 없는 native
+client는 허용한다. 로컬 Vite cross-port는 명시된 loopback dev-origin 목록의
+정확한 typed 값일 때만 별도 `Allowed_dev_origin`으로 허용하며 loopback alias를
+`Same_origin`으로 합치지 않는다.
 
 ---
 

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -295,8 +295,8 @@ let rec masc_http_base_url () =
   | Error msg -> raise (Config_error msg)
 
 and masc_http_base_url_result () =
-  match raw_value_opt http_base_url_env_key |> trim_opt with
-  | Some base -> Ok (strip_trailing_slashes base)
+  match masc_http_base_url_opt () with
+  | Some base -> Ok base
   | None ->
       let host =
         match masc_host_opt () with
@@ -308,6 +308,11 @@ and masc_http_base_url_result () =
       Result.map
         (fun host -> Printf.sprintf "http://%s:%s" host (masc_http_port ()))
         host
+
+and masc_http_base_url_opt () =
+  raw_value_opt http_base_url_env_key
+  |> trim_opt
+  |> Option.map strip_trailing_slashes
 
 (** {1 Additional Helpers} *)
 

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -120,6 +120,13 @@ val cluster_name : unit -> string
 
 val http_base_url_env_key : string
 val mcp_url_env_key : string
+val masc_http_base_url_opt : unit -> string option
+(** Return only an explicitly configured [MASC_HTTP_BASE_URL], normalized by
+    trimming surrounding whitespace and trailing slashes.  Unlike
+    {!masc_http_base_url_result}, this never derives an identity from
+    [MASC_HOST]/[MASC_HTTP_PORT]; listener admission must use the actual bind
+    configuration instead of re-reading potentially stale environment input. *)
+
 val masc_http_base_url : unit -> string
 val masc_http_base_url_result : unit -> (string, string) result
 

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -418,55 +418,22 @@ let sanitized_dashboard_actor_for_request ~base_path request =
       if String.equal sanitized "" then None else Some sanitized
   | None -> None
 
-(** Extract host and explicit port only.
-    Host header carries no scheme, so inferring a default port from scheme
-    (80 for http, 443 for https) causes mismatches when the browser Origin
-    uses https (port 443) but we parse Host with a synthetic "http://" prefix
-    (port 80).  Comparing explicit ports avoids this class of bug. *)
-
-type browser_scheme =
-  | Http
-  | Https
-
-let browser_scheme_of_uri uri =
-  match Uri.scheme uri |> Option.map String.lowercase_ascii with
-  | Some "http" -> Some Http
-  | Some "https" -> Some Https
-  | Some _ | None -> None
-;;
-
-let default_port_of_scheme = function Http -> Some 80 | Https -> Some 443
-
-let normalize_loopback_host host =
-  match String.lowercase_ascii (String.trim host) with
-  | "127.0.0.1" -> "localhost"
-  | "::1" | "0:0:0:0:0:0:0:1" -> "localhost"
-  | other -> other
-
-
 let split_csv_nonempty raw =
   raw |> String.split_on_char ',' |> List.filter_map String_util.trim_nonempty
 
-(** Returns [(host, explicit_port, scheme)] for an HTTP(S) origin or
-    referrer.  Userinfo is never part of a browser origin and accepting it
-    would make the displayed authority differ from the authenticated one. *)
-let host_port_scheme_of_origin origin =
-  try
-    let uri = Uri.of_string origin in
-    match browser_scheme_of_uri uri, Uri.userinfo uri, Uri.host uri with
-    | Some scheme, None, Some host ->
-      String_util.trim_nonempty host
-      |> Option.map (fun host ->
-        String.lowercase_ascii host, Uri.port uri, scheme)
-    | Some _, Some _, _ | Some _, None, None | None, _, _ -> None
-  with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    Log.Auth.debug "host_port_scheme_of_origin: parse failed for %S: %s"
-      origin (Printexc.to_string exn);
-    None
+type browser_origin_admission =
+  | Same_origin
+  | Allowed_dev_origin
+  | Rejected
 
-let host_port_of_authority authority =
-  ( Server_request_authority.host authority
-  , Server_request_authority.port authority )
+type request_origin_admission =
+  | Missing_origin
+  | Single_origin of
+      { origin : string
+      ; admission : browser_origin_admission
+      }
+  | Multiple_origins
+  | Malformed_origin
 
 (* Re-reads the env var on each call so MASC_ALLOW_ANONYMOUS_MUTATIONS
    can be toggled without restarting the server process. *)
@@ -483,76 +450,129 @@ let configured_loopback_dev_mutation_origins () =
   | Some raw -> split_csv_nonempty raw
   | None -> default_loopback_dev_mutation_origins
 
-let normalized_origin_key origin =
-  match host_port_scheme_of_origin origin with
-  | Some (host, port, scheme) ->
-      let default = default_port_of_scheme scheme in
-      Some
-        ( normalize_loopback_host host,
-          (match port with Some _ -> port | None -> default),
-          scheme )
-  | None -> None
-
-let is_allowlisted_loopback_dev_origin origin =
-  match normalized_origin_key origin with
-  | Some ((host, _, _) as candidate) when is_loopback_host host ->
-      configured_loopback_dev_mutation_origins ()
-      |> List.filter_map normalized_origin_key
-      |> List.exists (fun allowed -> allowed = candidate)
-  | _ -> false
-
-let origin_matches_request_authority ~request_authority origin =
-  match host_port_scheme_of_origin origin with
-  | Some (origin_host, origin_port, scheme) ->
-    let request_host, request_port =
-      host_port_of_authority request_authority
-    in
-    if
-      String.equal
-        (normalize_loopback_host origin_host)
-        (normalize_loopback_host request_host)
-    then
-      let default = default_port_of_scheme scheme in
-      let normalize_port = function
-        | Some _ as explicit -> explicit
-        | None -> default
-      in
-      normalize_port origin_port = normalize_port request_port
-    else false
-  | None -> false
+let parse_configured_dev_origins () =
+  let rec parse_all parsed = function
+    | [] -> Ok (List.rev parsed)
+    | raw :: rest ->
+      (match Server_request_authority.parse_serialized_origin raw with
+       | Ok origin -> parse_all (origin :: parsed) rest
+       | Error `Malformed -> Error raw)
+  in
+  parse_all [] (configured_loopback_dev_mutation_origins ())
 ;;
 
 let allowlisted_dev_origin_matches_request ~request_authority origin =
-  match host_port_scheme_of_origin origin with
-  | Some (origin_host, _, _) ->
-    let request_host = Server_request_authority.host request_authority in
-    String.equal
-      (normalize_loopback_host origin_host)
-      (normalize_loopback_host request_host)
-    && is_loopback_host (normalize_loopback_host origin_host)
-    && is_allowlisted_loopback_dev_origin origin
-  | None -> false
+  let request_host = Server_request_authority.host request_authority in
+  let origin_host = Server_request_authority.serialized_origin_host origin in
+  if not (is_loopback_host request_host && is_loopback_host origin_host)
+  then false
+  else
+    match parse_configured_dev_origins () with
+    | Ok configured ->
+      List.exists
+        (Server_request_authority.serialized_origin_equal origin)
+        configured
+    | Error malformed ->
+      Log.Auth.warn
+        "rejecting dev Origin because MASC_HTTP_DEV_MUTATION_ORIGINS contains a malformed serialized origin: %S"
+        malformed;
+      false
+;;
+
+let admission_of_serialized_origin ~request_authority origin =
+  if
+    Server_request_authority.serialized_origin_matches_authority
+      origin
+      request_authority
+  then Same_origin
+  else if allowlisted_dev_origin_matches_request ~request_authority origin
+  then Allowed_dev_origin
+  else Rejected
+;;
+
+let classify_request_origin ~request_authority request =
+  match Httpun.Headers.get_multi request.Httpun.Request.headers "origin" with
+  | [] -> Missing_origin
+  | [ raw ] ->
+    (match Server_request_authority.parse_serialized_origin raw with
+     | Error `Malformed -> Malformed_origin
+     | Ok parsed ->
+       Single_origin
+         { origin = raw
+         ; admission =
+             admission_of_serialized_origin ~request_authority parsed
+         })
+  | _ -> Multiple_origins
 ;;
 
 let browser_origin_matches_request_authority ~request_authority origin =
-  origin_matches_request_authority ~request_authority origin
-  || allowlisted_dev_origin_matches_request ~request_authority origin
+  match Server_request_authority.parse_serialized_origin origin with
+  | Error `Malformed -> false
+  | Ok parsed ->
+    (match admission_of_serialized_origin ~request_authority parsed with
+     | Same_origin | Allowed_dev_origin -> true
+     | Rejected -> false)
 ;;
 
-(* Browsers omit Origin for same-origin requests per the Fetch spec, but
-   always include Referer.  The admitted request authority is already parsed
-   at the request entry; this path never re-reads Host. *)
+let ascii_is_whitespace = function
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+;;
+
+let serialized_origin_of_referer referer =
+  if
+    String.equal referer ""
+    || not (String.equal referer (String.trim referer))
+    || String.exists ascii_is_whitespace referer
+  then None
+  else
+    let uri = Uri.of_string referer in
+    match
+      Uri.scheme uri |> Option.map String.lowercase_ascii,
+      Uri.userinfo uri,
+      Uri.host uri,
+      Uri.fragment uri
+    with
+    | Some ("http" | "https" as scheme), None, Some host, None ->
+      let rendered_host =
+        match Ipaddr.V6.of_string host with
+        | Ok _ -> "[" ^ host ^ "]"
+        | Error _ -> host
+      in
+      let rendered_port =
+        Option.fold ~none:"" ~some:(Printf.sprintf ":%d") (Uri.port uri)
+      in
+      (match
+         Server_request_authority.parse_serialized_origin
+           (Printf.sprintf "%s://%s%s" scheme rendered_host rendered_port)
+       with
+       | Ok origin -> Some origin
+       | Error `Malformed -> None)
+    | Some _, _, _, _ | None, _, _, _ -> None
+;;
+
+let referer_matches_request_authority ~request_authority referer =
+  match serialized_origin_of_referer referer with
+  | Some origin ->
+    Server_request_authority.serialized_origin_matches_authority
+      origin
+      request_authority
+  | None -> false
+;;
+
+(* Browsers omit Origin for some same-origin requests. Referer is parsed by a
+   separate URL parser because it legitimately carries a path/query; it never
+   goes through the serialized-Origin grammar. The admitted request authority
+   is already parsed at request entry, so this path never re-reads Host. *)
 let ensure_same_origin_browser_request ~request_authority request :
     (unit, Masc_domain.masc_error) result =
-  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
-  | None ->
-    (* Same-origin browser requests don't send Origin.  Check Referer
-       as a fallback — browsers always include it even for same-origin. *)
-    (match Httpun.Headers.get request.Httpun.Request.headers "referer" with
-     | Some referer
-       when origin_matches_request_authority ~request_authority referer ->
+  match classify_request_origin ~request_authority request with
+  | Missing_origin ->
+    (match Httpun.Headers.get_multi request.Httpun.Request.headers "referer" with
+     | [ referer ]
+       when referer_matches_request_authority ~request_authority referer ->
        Ok ()
-     | _ ->
+     | [] | [ _ ] | _ :: _ :: _ ->
        if allow_anonymous_mutations () then Ok ()
        else
          Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized
@@ -560,18 +580,29 @@ let ensure_same_origin_browser_request ~request_authority request :
            ; message = "Authentication required: provide a bearer token or Origin header. \
                         Set MASC_ALLOW_ANONYMOUS_MUTATIONS=true for local development."
            })))
-  | Some origin ->
-    if browser_origin_matches_request_authority ~request_authority origin
-    then Ok ()
-    else (
-      Log.Auth.debug
-        "same-origin check failed: origin=%S authority=%S"
-        origin
-        (Server_request_authority.rendered request_authority);
-      Error
-        (Masc_domain.Auth
-           (Masc_domain.Auth_error.Forbidden
-              { agent = "browser"; action = "cross-origin HTTP mutation" })))
+  | Single_origin
+      { admission = (Same_origin | Allowed_dev_origin); _ } ->
+    Ok ()
+  | Single_origin { origin; admission = Rejected } ->
+    Log.Auth.debug
+      "same-origin check failed: origin=%S scheme=%s authority=%S trust=%s"
+      origin
+      (Server_request_authority.scheme request_authority
+       |> Server_request_authority.scheme_to_string)
+      (Server_request_authority.rendered request_authority)
+      (match Server_request_authority.trust_class request_authority with
+       | Server_request_authority.Configured_bind -> "configured_bind"
+       | Server_request_authority.Explicit_trusted_host ->
+         "explicit_trusted_host");
+    Error
+      (Masc_domain.Auth
+         (Masc_domain.Auth_error.Forbidden
+            { agent = "browser"; action = "cross-origin HTTP mutation" }))
+  | Multiple_origins | Malformed_origin ->
+    Error
+      (Masc_domain.Auth
+         (Masc_domain.Auth_error.Forbidden
+            { agent = "browser"; action = "malformed Origin header" }))
 
 (* Mirrors [Masc_error.code] (the typed SSOT in lib/types/masc_error.ml).
    Previously the catch-all [_ -> `Internal_server_error] silently demoted
@@ -607,17 +638,27 @@ let http_status_of_auth_error = function
 let server_state : Mcp_server.server_state option ref = ref None
 
 (** CORS origin *)
+exception Invalid_origin_header
+
 let get_origin (request : Httpun.Request.t) =
-  Httpun.Headers.get request.headers "origin"
-  |> Option.value ~default:"*"
+  match Httpun.Headers.get_multi request.headers "origin" with
+  | [] -> "*"
+  | [ origin ] ->
+    (match Server_request_authority.parse_serialized_origin origin with
+     | Ok _ -> origin
+     | Error `Malformed -> raise Invalid_origin_header)
+  | _ -> raise Invalid_origin_header
 
 let public_read_cors_origin_opt ~request_authority (request : Httpun.Request.t) =
-  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
-  | None -> None
-  | Some origin ->
-    if browser_origin_matches_request_authority ~request_authority origin
-    then Some origin
-    else None
+  match classify_request_origin ~request_authority request with
+  | Single_origin
+      { origin; admission = (Same_origin | Allowed_dev_origin) } ->
+    Some origin
+  | Missing_origin
+  | Single_origin { admission = Rejected; _ }
+  | Multiple_origins
+  | Malformed_origin ->
+    None
 
 (** CORS headers *)
 let cors_allow_headers_value =
@@ -653,13 +694,14 @@ let respond_json_value_with_cors ?(status = `OK) request reqd value =
     ~extra_headers:(cors_headers origin) value reqd
 
 let public_read_cors_headers request =
-  match Httpun.Headers.get request.Httpun.Request.headers "origin" with
-  | None -> [ ("vary", "Origin") ]
-  | Some _ ->
+  match Httpun.Headers.get_multi request.Httpun.Request.headers "origin" with
+  | [] -> [ ("vary", "Origin") ]
+  | [ _ ] ->
     let request_authority = Server_request_authority.current_exn () in
     (match public_read_cors_origin_opt ~request_authority request with
      | Some origin -> cors_headers origin
      | None -> [ ("vary", "Origin") ])
+  | _ -> raise Invalid_origin_header
 
 let respond_public_read_json ?(status = `OK) request reqd body =
   Http_server_eio.Response.json ~status

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -159,6 +159,28 @@ val allow_anonymous_mutations : unit -> bool
 (** Re-reads [MASC_ALLOW_ANONYMOUS_MUTATIONS] on each call.
     When [true] non-loopback mutations skip auth (test fixtures only). *)
 
+type browser_origin_admission =
+  | Same_origin
+  | Allowed_dev_origin
+  | Rejected
+
+type request_origin_admission =
+  | Missing_origin
+  | Single_origin of
+      { origin : string
+      ; admission : browser_origin_admission
+      }
+  | Multiple_origins
+  | Malformed_origin
+
+val classify_request_origin :
+  request_authority:Server_request_authority.authority ->
+  Httpun.Request.t ->
+  request_origin_admission
+(** Classify the full case-insensitive [Origin] field set.  Exactly one field
+    is parsed as one complete HTTP(S) serialized origin; repeated fields and
+    partially consumed values are distinct fail-closed outcomes. *)
+
 val browser_origin_matches_request_authority :
   request_authority:Server_request_authority.authority -> string -> bool
 (** Compare an HTTP(S) browser origin with the admitted request authority.
@@ -195,8 +217,11 @@ val server_state : Mcp_server.server_state option ref
     state is threaded through. *)
 
 val get_origin : Httpun.Request.t -> Httpun.Headers.value
-(** Resolve the request's [Origin] header value (empty string when
-    missing). *)
+(** Return the one syntactically valid serialized [Origin], or ["*"] when the
+    field is absent.  Raises [Invalid_origin_header] for repeated or malformed
+    fields; live request entry points reject those cases before routing. *)
+
+exception Invalid_origin_header
 
 val public_read_cors_origin_opt :
   request_authority:Server_request_authority.authority ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -30,7 +30,7 @@ let make_error_handler () =
 
   h2_error_handler
 
-let make_request_handler ~sw ~clock ~server_start_time:_ =
+let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
   let mcp_eio_profile_of_transport_profile = function
     | Server_mcp_transport_http.Full -> Mcp_eio.Full
     | Server_mcp_transport_http.Managed_agent -> Mcp_eio.Managed_agent
@@ -1005,11 +1005,25 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
           ~status:`Internal_server_error
           ~extra_headers:cors
     in
-    match Server_request_authority.classify_h2_request h2_req with
+    match
+      Server_request_authority.classify_h2_request ~trust_policy h2_req
+    with
     | Server_request_authority.H2_authority
         (Server_request_authority.Single request_authority) ->
-      Server_request_authority.with_current request_authority (fun () ->
-        handle_admitted_request request_authority)
+      (match classify_request_origin ~request_authority httpun_request with
+       | Multiple_origins ->
+         h2_request_authority_bad_request
+           ~error_code:"request_origin_multiple"
+           ~message:"request contains more than one Origin field"
+           h2_reqd
+       | Malformed_origin ->
+         h2_request_authority_bad_request
+           ~error_code:"request_origin_malformed"
+           ~message:"request Origin is not one complete HTTP(S) serialized origin"
+           h2_reqd
+       | Missing_origin | Single_origin _ ->
+         Server_request_authority.with_current request_authority (fun () ->
+           handle_admitted_request request_authority))
     | Server_request_authority.H2_authority Server_request_authority.Missing ->
       h2_request_authority_bad_request
         ~error_code:"request_authority_missing"
@@ -1024,6 +1038,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       h2_request_authority_bad_request
         ~error_code:"request_authority_malformed"
         ~message:"request authority is malformed"
+        h2_reqd
+    | Server_request_authority.H2_authority Server_request_authority.Untrusted ->
+      h2_request_authority_bad_request
+        ~error_code:"request_authority_untrusted"
+        ~message:"request authority is not a configured server identity"
         h2_reqd
     | Server_request_authority.Unsupported_asterisk_form_options ->
       h2_request_authority_bad_request

--- a/lib/server/server_h2_gateway.mli
+++ b/lib/server/server_h2_gateway.mli
@@ -12,6 +12,7 @@ val make_error_handler :
   unit
 
 val make_request_handler :
+  trust_policy:Server_request_authority.trust_policy ->
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   server_start_time:float ->

--- a/lib/server/server_request_authority.ml
+++ b/lib/server/server_request_authority.ml
@@ -1,19 +1,77 @@
-type authority =
+type scheme =
+  | Http
+  | Https
+
+type trust_class =
+  | Configured_bind
+  | Explicit_trusted_host
+
+type host_port =
   { host : string
   ; port : int option
   }
 
+type authority =
+  { host : string
+  ; port : int option
+  ; scheme : scheme
+  ; trust_class : trust_class
+  }
+
+type request_context = authority
+
+type trusted_identity =
+  { authority : host_port
+  ; scheme : scheme
+  }
+
+type trust_policy =
+  { configured_bind : trusted_identity
+  ; explicit_trusted_host : trusted_identity option
+  }
+
+type trust_policy_error =
+  | Malformed_bind_authority
+  | Malformed_explicit_base_url
+
 type classification =
   | Missing
-  | Single of authority
+  | Single of request_context
   | Multiple
   | Malformed
+  | Untrusted
 
 type h2_classification =
   | H2_authority of classification
   | Unsupported_asterisk_form_options
 
 exception Unbound_request_authority
+
+type serialized_origin =
+  { authority : host_port
+  ; scheme : scheme
+  }
+
+let scheme_to_string = function
+  | Http -> "http"
+  | Https -> "https"
+;;
+
+let scheme_of_string raw =
+  if not (String.equal raw (String.trim raw))
+  then None
+  else
+    match String.lowercase_ascii raw with
+    | "http" -> Some Http
+    | "https" -> Some Https
+    | _ -> None
+;;
+
+let trust_policy_error_to_string = function
+  | Malformed_bind_authority -> "configured HTTP bind authority is malformed"
+  | Malformed_explicit_base_url ->
+    "configured HTTP base URL is not a valid HTTP(S) trusted identity"
+;;
 
 let ascii_is_digit c = c >= '0' && c <= '9'
 
@@ -114,30 +172,34 @@ let parse_h2 raw =
   if String.equal raw (String.trim raw) then parse raw else None
 ;;
 
-let classify_values ~multiple values =
-  match values with
-  | [] -> Missing
-  | [ raw ] -> Option.fold ~none:Malformed ~some:(fun value -> Single value) (parse raw)
-  | _ -> multiple
+let rendered_host host =
+  match Ipaddr.V6.of_string host with
+  | Ok _ -> "[" ^ host ^ "]"
+  | Error _ -> host
 ;;
 
-let classify_http1_request request =
-  classify_values
-    ~multiple:Multiple
-    (Httpun.Headers.get_multi request.Httpun.Request.headers "host")
+let host_port_of_parts ~host ~port =
+  let suffix = Option.fold ~none:"" ~some:(Printf.sprintf ":%d") port in
+  parse_h2 (rendered_host host ^ suffix)
 ;;
 
-let default_port_for_scheme scheme =
-  match String.lowercase_ascii scheme with
-  | "http" -> Some 80
-  | "https" -> Some 443
-  | _ -> None
+let default_port_for_scheme = function
+  | Http -> Some 80
+  | Https -> Some 443
 ;;
 
-let effective_port ~scheme authority =
-  match authority.port with
+let effective_port_value ~scheme port =
+  match port with
   | Some _ as explicit -> explicit
   | None -> default_port_for_scheme scheme
+;;
+
+let effective_port ~scheme (authority : authority) =
+  effective_port_value ~scheme authority.port
+;;
+
+let effective_host_port ~scheme (authority : host_port) =
+  effective_port_value ~scheme authority.port
 ;;
 
 let equivalent_for_scheme ~scheme left right =
@@ -147,11 +209,175 @@ let equivalent_for_scheme ~scheme left right =
        (effective_port ~scheme right)
 ;;
 
-let classify_h2_request request =
+let host_port_equivalent_for_scheme ~scheme (left : host_port)
+    (right : host_port) =
+  String.equal left.host right.host
+  && Option.equal Int.equal
+       (effective_host_port ~scheme left)
+       (effective_host_port ~scheme right)
+;;
+
+let trusted_host_port_matches ~scheme (trusted : host_port)
+    (candidate : host_port) =
+  Option.equal Int.equal
+    (effective_host_port ~scheme trusted)
+    (effective_host_port ~scheme candidate)
+  && (String.equal trusted.host candidate.host
+      || (Masc_network_defaults.is_loopback_host trusted.host
+          && Masc_network_defaults.is_loopback_host candidate.host))
+;;
+
+let host_is_unspecified host =
+  match Ipaddr.of_string host with
+  | Ok (Ipaddr.V4 address) -> Ipaddr.V4.compare address Ipaddr.V4.any = 0
+  | Ok (Ipaddr.V6 address) -> Ipaddr.V6.compare address Ipaddr.V6.unspecified = 0
+  | Error _ -> false
+;;
+
+let configured_bind_matches configured request_authority =
+  let same_port =
+    Option.equal Int.equal
+      (effective_host_port ~scheme:Http configured.authority)
+      (effective_host_port ~scheme:Http request_authority)
+  in
+  not (host_is_unspecified configured.authority.host)
+  && same_port
+  && (String.equal configured.authority.host request_authority.host
+      || (Masc_network_defaults.is_loopback_host configured.authority.host
+          && Masc_network_defaults.is_loopback_host request_authority.host))
+;;
+
+let explicit_identity_of_base_url raw =
+  if not (String.equal raw (String.trim raw))
+  then None
+  else
+    let uri = Uri.of_string raw in
+    match
+      Option.bind (Uri.scheme uri) scheme_of_string,
+      Uri.userinfo uri,
+      Uri.host uri,
+      Uri.fragment uri,
+      Uri.query uri
+    with
+    | Some scheme, None, Some host, None, [] ->
+      Option.map
+        (fun authority -> ({ authority; scheme } : trusted_identity))
+        (host_port_of_parts ~host ~port:(Uri.port uri))
+    | Some _, None, Some _, None, _ :: _
+    | Some _, None, Some _, Some _, _
+    | Some _, Some _, _, _, _
+    | Some _, None, None, _, _
+    | None, _, _, _, _ ->
+      None
+;;
+
+let make_trust_policy ~bind_host ~bind_port ~explicit_base_url =
+  match host_port_of_parts ~host:bind_host ~port:(Some bind_port) with
+  | None -> Error Malformed_bind_authority
+  | Some bind_authority ->
+    let configured_bind = { authority = bind_authority; scheme = Http } in
+    (match explicit_base_url with
+     | None -> Ok { configured_bind; explicit_trusted_host = None }
+     | Some raw ->
+       (match explicit_identity_of_base_url raw with
+        | None -> Error Malformed_explicit_base_url
+        | Some explicit_trusted_host ->
+          Ok
+            { configured_bind
+            ; explicit_trusted_host = Some explicit_trusted_host
+            }))
+;;
+
+let admit_authority ~trust_policy ~wire_scheme parsed =
+  let explicit_match () =
+    match trust_policy.explicit_trusted_host with
+    | Some trusted
+      when trusted.scheme = wire_scheme
+           && trusted_host_port_matches
+                ~scheme:wire_scheme
+                trusted.authority
+                parsed ->
+      Some
+        { host = parsed.host
+        ; port = parsed.port
+        ; scheme = wire_scheme
+        ; trust_class = Explicit_trusted_host
+        }
+    | Some _ | None -> None
+  in
+  let configured_match () =
+    if wire_scheme = Http
+       && configured_bind_matches trust_policy.configured_bind parsed
+    then
+      Some
+        { host = parsed.host
+        ; port = parsed.port
+        ; scheme = Http
+        ; trust_class = Configured_bind
+        }
+    else None
+  in
+  match wire_scheme with
+  | Https -> explicit_match ()
+  | Http ->
+    (match configured_match () with
+     | Some _ as admitted -> admitted
+     | None -> explicit_match ())
+;;
+
+let admit_http1_authority ~trust_policy parsed =
+  match trust_policy.explicit_trusted_host with
+  | Some trusted
+    when trusted.scheme = Https
+         && trusted_host_port_matches
+              ~scheme:Https
+              trusted.authority
+              parsed ->
+    Some
+      { host = parsed.host
+      ; port = parsed.port
+      ; scheme = Https
+      ; trust_class = Explicit_trusted_host
+      }
+  | Some _ | None ->
+    (match admit_authority ~trust_policy ~wire_scheme:Http parsed with
+     | Some _ as admitted -> admitted
+     | None ->
+       (match trust_policy.explicit_trusted_host with
+        | Some trusted
+          when trusted_host_port_matches
+                 ~scheme:trusted.scheme
+                 trusted.authority
+                 parsed ->
+          Some
+            { host = parsed.host
+            ; port = parsed.port
+            ; scheme = trusted.scheme
+            ; trust_class = Explicit_trusted_host
+            }
+        | Some _ | None -> None))
+;;
+
+let classify_http1_request ~trust_policy request =
+  match Httpun.Headers.get_multi request.Httpun.Request.headers "host" with
+  | [] -> Missing
+  | [ raw ] ->
+    (match parse raw with
+     | None -> Malformed
+     | Some parsed ->
+       Option.fold
+         ~none:Untrusted
+         ~some:(fun admitted -> Single admitted)
+         (admit_http1_authority ~trust_policy parsed))
+  | _ -> Multiple
+;;
+
+let classify_h2_request ~trust_policy request =
   let authorities = H2.Headers.get_multi request.H2.Request.headers ":authority" in
   let hosts = H2.Headers.get_multi request.H2.Request.headers "host" in
-  match authorities with
-  | []
+  match scheme_of_string request.H2.Request.scheme, authorities with
+  | None, _ -> H2_authority Malformed
+  | Some _, []
     when request.H2.Request.meth = `OPTIONS
          && String.equal request.H2.Request.target "*" ->
     (match hosts with
@@ -161,57 +387,101 @@ let classify_h2_request request =
         | Some _ -> Unsupported_asterisk_form_options
         | None -> H2_authority Malformed)
      | _ -> H2_authority Malformed)
-  | [] ->
+  | Some _, [] ->
     H2_authority
       (match hosts with
        | [] | [ _ ] -> Missing
        | _ -> Malformed)
-  | [ raw_authority ] ->
+  | Some scheme, [ raw_authority ] ->
     let classification =
       match parse_h2 raw_authority with
       | None -> Malformed
-      | Some authority ->
-        (match hosts with
-         | [] -> Single authority
+      | Some parsed ->
+        let host_cross_check =
+          match hosts with
+          | [] -> true
          | [ raw_host ] ->
            (match parse_h2 raw_host with
-            | Some host
-              when equivalent_for_scheme
-                     ~scheme:request.H2.Request.scheme
-                     authority
-                     host ->
-              Single authority
-            | Some _ | None -> Malformed)
-         | _ -> Malformed)
+            | Some host ->
+              host_port_equivalent_for_scheme ~scheme parsed host
+            | None -> false)
+          | _ -> false
+        in
+        if not host_cross_check
+        then Malformed
+        else
+          Option.fold
+            ~none:Untrusted
+            ~some:(fun admitted -> Single admitted)
+            (admit_authority ~trust_policy ~wire_scheme:scheme parsed)
     in
     H2_authority classification
-  | _ -> H2_authority Malformed
+  | Some _, _ -> H2_authority Malformed
 ;;
 
 let host authority = authority.host
 let port authority = authority.port
-
-let rendered_host authority =
-  match Ipaddr.V6.of_string authority.host with
-  | Ok _ -> "[" ^ authority.host ^ "]"
-  | Error _ -> authority.host
-;;
+let scheme (authority : authority) = authority.scheme
+let trust_class authority = authority.trust_class
 
 let rendered authority =
   match authority.port with
-  | None -> rendered_host authority
-  | Some port -> Printf.sprintf "%s:%d" (rendered_host authority) port
+  | None -> rendered_host authority.host
+  | Some port -> Printf.sprintf "%s:%d" (rendered_host authority.host) port
 ;;
 
 let of_host_port ~host ~port =
-  let raw_host =
-    match Ipaddr.V6.of_string host with
-    | Ok _ -> "[" ^ host ^ "]"
-    | Error _ -> host
-  in
-  match parse (Printf.sprintf "%s:%d" raw_host port) with
-  | Some authority -> Ok authority
+  match host_port_of_parts ~host ~port:(Some port) with
+  | Some authority ->
+    Ok
+      { host = authority.host
+      ; port = authority.port
+      ; scheme = Http
+      ; trust_class = Configured_bind
+      }
   | None -> Error `Malformed
+;;
+
+let parse_serialized_origin raw =
+  if String.equal raw "" || not (String.equal raw (String.trim raw))
+  then Error `Malformed
+  else
+    match String.index_opt raw ':' with
+    | None | Some 0 -> Error `Malformed
+    | Some scheme_end ->
+      let scheme_raw = String.sub raw 0 scheme_end in
+      let authority_start = scheme_end + 3 in
+      if authority_start > String.length raw
+         || scheme_end + 2 >= String.length raw
+         || not (Char.equal raw.[scheme_end + 1] '/')
+         || not (Char.equal raw.[scheme_end + 2] '/')
+      then Error `Malformed
+      else
+        let authority_raw =
+          String.sub raw authority_start (String.length raw - authority_start)
+        in
+        (match scheme_of_string scheme_raw, parse_h2 authority_raw with
+         | Some scheme, Some authority -> Ok { authority; scheme }
+         | Some _, None | None, _ -> Error `Malformed)
+;;
+
+let serialized_origin_host origin = origin.authority.host
+let serialized_origin_scheme origin = origin.scheme
+
+let serialized_origin_equal left right =
+  left.scheme = right.scheme
+  && host_port_equivalent_for_scheme
+       ~scheme:left.scheme
+       left.authority
+       right.authority
+;;
+
+let serialized_origin_matches_authority origin authority =
+  origin.scheme = authority.scheme
+  && String.equal origin.authority.host authority.host
+  && Option.equal Int.equal
+       (effective_host_port ~scheme:origin.scheme origin.authority)
+       (effective_port ~scheme:authority.scheme authority)
 ;;
 
 let current_key : authority Eio.Fiber.key = Eio.Fiber.create_key ()

--- a/lib/server/server_request_authority.ml
+++ b/lib/server/server_request_authority.ml
@@ -234,7 +234,7 @@ let host_is_unspecified host =
   | Error _ -> false
 ;;
 
-let configured_bind_matches configured request_authority =
+let configured_bind_matches (configured : trusted_identity) request_authority =
   let same_port =
     Option.equal Int.equal
       (effective_host_port ~scheme:Http configured.authority)
@@ -271,11 +271,14 @@ let explicit_identity_of_base_url raw =
       None
 ;;
 
-let make_trust_policy ~bind_host ~bind_port ~explicit_base_url =
+let make_trust_policy ~bind_host ~bind_port ~explicit_base_url :
+    (trust_policy, trust_policy_error) result =
   match host_port_of_parts ~host:bind_host ~port:(Some bind_port) with
   | None -> Error Malformed_bind_authority
   | Some bind_authority ->
-    let configured_bind = { authority = bind_authority; scheme = Http } in
+    let configured_bind : trusted_identity =
+      { authority = bind_authority; scheme = Http }
+    in
     (match explicit_base_url with
      | None -> Ok { configured_bind; explicit_trusted_host = None }
      | Some raw ->
@@ -288,7 +291,23 @@ let make_trust_policy ~bind_host ~bind_port ~explicit_base_url =
             }))
 ;;
 
-let admit_authority ~trust_policy ~wire_scheme parsed =
+let projection_context (trust_policy : trust_policy) : request_context =
+  let identity, trust_class =
+    match trust_policy.explicit_trusted_host with
+    | Some identity -> identity, Explicit_trusted_host
+    | None -> trust_policy.configured_bind, Configured_bind
+  in
+  { host = identity.authority.host
+  ; port = identity.authority.port
+  ; scheme = identity.scheme
+  ; trust_class
+  }
+;;
+
+let admit_authority
+    ~(trust_policy : trust_policy)
+    ~(wire_scheme : scheme)
+    (parsed : host_port) : authority option =
   let explicit_match () =
     match trust_policy.explicit_trusted_host with
     | Some trusted
@@ -325,7 +344,9 @@ let admit_authority ~trust_policy ~wire_scheme parsed =
      | None -> explicit_match ())
 ;;
 
-let admit_http1_authority ~trust_policy parsed =
+let admit_http1_authority
+    ~(trust_policy : trust_policy)
+    (parsed : host_port) : authority option =
   match trust_policy.explicit_trusted_host with
   | Some trusted
     when trusted.scheme = Https
@@ -358,7 +379,7 @@ let admit_http1_authority ~trust_policy parsed =
         | Some _ | None -> None))
 ;;
 
-let classify_http1_request ~trust_policy request =
+let classify_http1_request ~(trust_policy : trust_policy) request =
   match Httpun.Headers.get_multi request.Httpun.Request.headers "host" with
   | [] -> Missing
   | [ raw ] ->
@@ -372,7 +393,7 @@ let classify_http1_request ~trust_policy request =
   | _ -> Multiple
 ;;
 
-let classify_h2_request ~trust_policy request =
+let classify_h2_request ~(trust_policy : trust_policy) request =
   let authorities = H2.Headers.get_multi request.H2.Request.headers ":authority" in
   let hosts = H2.Headers.get_multi request.H2.Request.headers "host" in
   match scheme_of_string request.H2.Request.scheme, authorities with
@@ -419,12 +440,21 @@ let classify_h2_request ~trust_policy request =
   | Some _, _ -> H2_authority Malformed
 ;;
 
-let host authority = authority.host
-let port authority = authority.port
+let host (authority : authority) = authority.host
+let port (authority : authority) = authority.port
 let scheme (authority : authority) = authority.scheme
-let trust_class authority = authority.trust_class
+let trust_class (authority : authority) = authority.trust_class
 
-let rendered authority =
+let port_or_default (authority : authority) =
+  match authority.port with
+  | Some port -> port
+  | None ->
+    (match authority.scheme with
+     | Http -> 80
+     | Https -> 443)
+;;
+
+let rendered (authority : authority) =
   match authority.port with
   | None -> rendered_host authority.host
   | Some port -> Printf.sprintf "%s:%d" (rendered_host authority.host) port
@@ -434,11 +464,12 @@ let of_host_port ~host ~port =
   match host_port_of_parts ~host ~port:(Some port) with
   | Some authority ->
     Ok
-      { host = authority.host
-      ; port = authority.port
-      ; scheme = Http
-      ; trust_class = Configured_bind
-      }
+      ({ host = authority.host
+       ; port = authority.port
+       ; scheme = Http
+       ; trust_class = Configured_bind
+       }
+        : authority)
   | None -> Error `Malformed
 ;;
 
@@ -461,14 +492,17 @@ let parse_serialized_origin raw =
           String.sub raw authority_start (String.length raw - authority_start)
         in
         (match scheme_of_string scheme_raw, parse_h2 authority_raw with
-         | Some scheme, Some authority -> Ok { authority; scheme }
+         | Some scheme, Some authority ->
+           Ok ({ authority; scheme } : serialized_origin)
          | Some _, None | None, _ -> Error `Malformed)
 ;;
 
-let serialized_origin_host origin = origin.authority.host
-let serialized_origin_scheme origin = origin.scheme
+let serialized_origin_host (origin : serialized_origin) = origin.authority.host
+let serialized_origin_scheme (origin : serialized_origin) = origin.scheme
 
-let serialized_origin_equal left right =
+let serialized_origin_equal
+    (left : serialized_origin)
+    (right : serialized_origin) =
   left.scheme = right.scheme
   && host_port_equivalent_for_scheme
        ~scheme:left.scheme
@@ -476,7 +510,9 @@ let serialized_origin_equal left right =
        right.authority
 ;;
 
-let serialized_origin_matches_authority origin authority =
+let serialized_origin_matches_authority
+    (origin : serialized_origin)
+    (authority : authority) =
   origin.scheme = authority.scheme
   && String.equal origin.authority.host authority.host
   && Option.equal Int.equal

--- a/lib/server/server_request_authority.mli
+++ b/lib/server/server_request_authority.mli
@@ -41,6 +41,12 @@ val make_trust_policy :
 
 val trust_policy_error_to_string : trust_policy_error -> string
 
+val projection_context : trust_policy -> request_context
+(** Return the policy-owned context for background projections that have no
+    wire request to classify.  The explicit public identity wins when present;
+    otherwise the effective listener identity is used.  Consumers must not
+    reconstruct this context from environment variables. *)
+
 type classification =
   | Missing
   | Single of request_context
@@ -75,6 +81,11 @@ val of_host_port : host:string -> port:int -> (authority, [ `Malformed ]) result
 
 val host : authority -> string
 val port : authority -> int option
+val port_or_default : authority -> int
+(** Return the admitted explicit port or the typed scheme default (80/443).
+    This is the only projection for consumers that require a concrete port;
+    they must not re-read listener environment after admission. *)
+
 val scheme : authority -> scheme
 val scheme_to_string : scheme -> string
 val trust_class : authority -> trust_class

--- a/lib/server/server_request_authority.mli
+++ b/lib/server/server_request_authority.mli
@@ -1,17 +1,52 @@
 (** Typed request-authority admission shared by HTTP/1.1 and HTTP/2.
 
-    A request entry point classifies its authority exactly once, rejects every
-    non-[Single] result, and binds the admitted value for the lifetime of the
-    request fiber.  Downstream auth and projection code consumes [authority]
-    rather than re-reading wire headers. *)
+    A request entry point classifies its authority exactly once against the
+    configured listener/base-URL identities, rejects every non-[Single]
+    result, and binds the admitted value for the lifetime of the request
+    fiber.  The abstract [authority] is the admitted request context: it keeps
+    the typed scheme and trust provenance alongside host/port so downstream
+    origin/auth code cannot reconstruct either from raw headers. *)
+
+type scheme =
+  | Http
+  | Https
+
+type trust_class =
+  | Configured_bind
+  | Explicit_trusted_host
 
 type authority
+(** Backward-compatible name for the admitted host/port projection. *)
+
+type request_context = authority
+(** The live request context: typed scheme + admitted authority + trust class.
+    The alias keeps existing projection APIs source-compatible while making
+    the security boundary explicit at classifiers and fiber binding sites. *)
+
+type trust_policy
+
+type trust_policy_error =
+  | Malformed_bind_authority
+  | Malformed_explicit_base_url
+
+val make_trust_policy :
+  bind_host:string ->
+  bind_port:int ->
+  explicit_base_url:string option ->
+  (trust_policy, trust_policy_error) result
+(** Build the only live-request Host trust policy.  [bind_host]/[bind_port]
+    are the actual listener identity and [explicit_base_url] is the configured
+    public identity (normally [MASC_HTTP_BASE_URL]).  No request header is a
+    trust-policy input. *)
+
+val trust_policy_error_to_string : trust_policy_error -> string
 
 type classification =
   | Missing
-  | Single of authority
+  | Single of request_context
   | Multiple
   | Malformed
+  | Untrusted
 
 type h2_classification =
   | H2_authority of classification
@@ -19,15 +54,20 @@ type h2_classification =
 
 exception Unbound_request_authority
 
-val classify_http1_request : Httpun.Request.t -> classification
-(** Classify the case-insensitive HTTP/1.1 [Host] field set. *)
+val classify_http1_request :
+  trust_policy:trust_policy -> Httpun.Request.t -> classification
+(** Classify the case-insensitive HTTP/1.1 [Host] field set, then admit it only
+    when it is the configured bind identity (HTTP) or the explicit base-URL
+    identity (whose HTTP(S) scheme is preserved). *)
 
-val classify_h2_request : H2.Request.t -> h2_classification
+val classify_h2_request :
+  trust_policy:trust_policy -> H2.Request.t -> h2_classification
 (** Classify HTTP/2 [:authority].  A same-authority [Host] field is accepted
     only as a cross-check; it is never used as the authority source.  Repeated
-    [:authority], repeated [Host], or a scheme-normalized mismatch is
-    [Malformed].  Authority-free [OPTIONS *] is reported separately because
-    MASC does not implement asterisk-form routing. *)
+    [:authority], repeated [Host], an unsupported [:scheme], or a
+    scheme-normalized mismatch is [Malformed].  A syntactically valid but
+    unconfigured identity is [Untrusted].  Authority-free [OPTIONS *] is
+    reported separately because MASC does not implement asterisk-form routing. *)
 
 val of_host_port : host:string -> port:int -> (authority, [ `Malformed ]) result
 (** Validate a trusted configured host/port through the same authority parser.
@@ -35,19 +75,42 @@ val of_host_port : host:string -> port:int -> (authority, [ `Malformed ]) result
 
 val host : authority -> string
 val port : authority -> int option
+val scheme : authority -> scheme
+val scheme_to_string : scheme -> string
+val trust_class : authority -> trust_class
 val rendered : authority -> string
 
 val equivalent_for_scheme :
-  scheme:string -> authority -> authority -> bool
+  scheme:scheme -> authority -> authority -> bool
 (** Compare normalized host and effective port.  [http] and [https] apply
     their standard default ports; IPv4/IPv6 textual aliases are canonicalized
     during parsing. *)
 
-val with_current : authority -> (unit -> 'a) -> 'a
+type serialized_origin
+
+val parse_serialized_origin :
+  string -> (serialized_origin, [ `Malformed ]) result
+(** Parse exactly one RFC 6454 HTTP(S) serialized origin.  The parser consumes
+    the complete field value and rejects OWS, userinfo, path, query, fragment,
+    trailing bytes, and non-HTTP(S) schemes. *)
+
+val serialized_origin_host : serialized_origin -> string
+val serialized_origin_scheme : serialized_origin -> scheme
+
+val serialized_origin_equal :
+  serialized_origin -> serialized_origin -> bool
+(** Exact scheme/normalized-host/effective-port equality. *)
+
+val serialized_origin_matches_authority :
+  serialized_origin -> authority -> bool
+(** Exact scheme/normalized-host/effective-port equality against the admitted
+    request context.  Loopback aliases are deliberately not collapsed. *)
+
+val with_current : request_context -> (unit -> 'a) -> 'a
 (** Bind an admitted authority to the current Eio request fiber. *)
 
-val current : unit -> authority option
-val current_exn : unit -> authority
+val current : unit -> request_context option
+val current_exn : unit -> request_context
 (** Return the request-fiber authority or raise
     {!Unbound_request_authority}.  There is intentionally no raw-header or
     configured-host fallback. *)

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -116,10 +116,13 @@ let is_mcp_transport_request (request : Httpun.Request.t) =
 (** Validate an HTTP(S) Origin against the authority admitted at request entry.
     Native clients without an Origin remain valid. *)
 let validate_origin ~request_authority (request : Httpun.Request.t) =
-  match Httpun.Headers.get request.headers "origin" with
-  | None -> true
-  | Some origin ->
-    browser_origin_matches_request_authority ~request_authority origin
+  match classify_request_origin ~request_authority request with
+  | Missing_origin -> true
+  | Single_origin { admission = (Same_origin | Allowed_dev_origin); _ } -> true
+  | Single_origin { admission = Rejected; _ }
+  | Multiple_origins
+  | Malformed_origin ->
+    false
 
 (** Check if client accepts SSE *)
 let accepts_sse (request : Httpun.Request.t) =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -72,22 +72,14 @@ let authority_of_host_port host port =
   Printf.sprintf "%s:%d" (authority_host host) port
 
 let advertised_host_port_authority ~request_authority =
-  let default_port = configured_http_port () in
   let request_host = Server_request_authority.host request_authority in
   let port_opt = Server_request_authority.port request_authority in
-  let port =
-    match port_opt with
-    | Some explicit_port -> explicit_port
-    | None -> default_port
-  in
+  let port = Server_request_authority.port_or_default request_authority in
   let host = Transport_read_model.normalize_advertised_host request_host in
   let authority =
     match port_opt with
     | Some _ -> authority_of_host_port host port
-    | None ->
-      if String.equal host request_host
-      then authority_host host
-      else authority_of_host_port host port
+    | None -> authority_host host
   in
   host, port, authority
 
@@ -1186,18 +1178,8 @@ let make_cached_full_health_json ?(listener = "http/1.1") ~request_authority
              ~refresh_started_at ~refresh_requested snapshot );
        ])
 
-let start_full_health_snapshot_refresh_loop ~sw ~clock =
+let start_full_health_snapshot_refresh_loop ~sw ~clock ~request_authority =
   let request = Httpun.Request.create `GET "/health?full=1" in
-  let request_authority =
-    match
-      Server_request_authority.of_host_port
-        ~host:(configured_http_host ())
-        ~port:(configured_http_port ())
-    with
-    | Ok authority -> authority
-    | Error `Malformed ->
-      invalid_arg "configured HTTP host/port is not a valid authority"
-  in
   Proactive_refresh.start
     ~sw
     ~clock

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -97,57 +97,15 @@ let advertised_host_port ~request_authority =
   in
   (host, port)
 
-let normalize_forwarded_proto raw =
-  let value =
-    raw
-    |> String.trim
-    |> String.lowercase_ascii
-    |> fun value ->
-    let len = String.length value in
-    if len >= 2 && value.[0] = '"' && value.[len - 1] = '"'
-    then String.sub value 1 (len - 2)
-    else value
-  in
-  match value with
-  | "http" | "https" -> Some value
-  | _ -> None
-
-let first_forwarded_proto raw =
-  raw
-  |> String.split_on_char ','
-  |> List.find_map (fun element ->
-       element
-       |> String.split_on_char ';'
-       |> List.find_map (fun part ->
-            match String.split_on_char '=' (String.trim part) with
-            | [ key; value ] when String.equal (String.lowercase_ascii (String.trim key)) "proto" ->
-              normalize_forwarded_proto value
-            | _ -> None))
-
-let advertised_scheme request =
-  let headers = request.Httpun.Request.headers in
-  match Httpun.Headers.get headers "x-forwarded-proto" with
-  | Some raw -> (
-      match
-        raw
-        |> String.split_on_char ','
-        |> List.find_map normalize_forwarded_proto
-      with
-      | Some scheme -> scheme
-      | None -> (
-          match Httpun.Headers.get headers "forwarded" with
-          | Some raw -> Option.value ~default:"http" (first_forwarded_proto raw)
-          | None -> "http"))
-  | None -> (
-      match Httpun.Headers.get headers "forwarded" with
-      | Some raw -> Option.value ~default:"http" (first_forwarded_proto raw)
-      | None -> "http")
-
-let advertised_base_url ~request_authority request =
+let advertised_base_url ~request_authority _request =
   let _host, _port, authority =
     advertised_host_port_authority ~request_authority
   in
-  Printf.sprintf "%s://%s" (advertised_scheme request) authority
+  Printf.sprintf
+    "%s://%s"
+    (Server_request_authority.scheme request_authority
+     |> Server_request_authority.scheme_to_string)
+    authority
 
 let websocket_discovery_json ~request_authority request =
   let host, _port = advertised_host_port ~request_authority in

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -243,10 +243,13 @@ val make_health_response_json :
 val start_full_health_snapshot_refresh_loop :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  request_authority:Server_request_authority.request_context ->
   unit
 (** Starts the Eio background refresh loop for cached [/health?full=1]
     diagnostics.  The loop keeps heavy durable scans out of the HTTP request
-    path and stores stale/error metadata when refreshes fail or time out. *)
+    path and stores stale/error metadata when refreshes fail or time out.  Its
+    projection context comes from the bootstrap trust policy, never a second
+    read of listener environment. *)
 
 module For_testing : sig
   val reset_full_health_snapshot : unit -> unit

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -78,10 +78,9 @@ val advertised_base_url :
   Httpun.Request.t ->
   string
 (** [advertised_base_url ~request_authority request] returns the
-    browser-visible HTTP(S) base URL.  It derives the authority from the typed
-    request-entry value and the scheme from
-    [X-Forwarded-Proto] / [Forwarded: proto=...] when present, falling back to
-    local [http]. *)
+    browser-visible HTTP(S) base URL.  Both scheme and authority come from the
+    typed trusted request-entry value; untrusted forwarded headers are not
+    scheme inputs. *)
 
 (** {1 Discovery / status JSON} *)
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -740,11 +740,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     loop ());
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = Server_bootstrap_http.make_http_config ~host ~port in
-  let explicit_base_url =
-    match Env_config_core.masc_http_base_url_result () with
-    | Ok base_url -> Some base_url
-    | Error message -> raise (Env_config_core.Config_error message)
-  in
+  (* The listener identity comes only from the effective CLI/bootstrap config
+     above.  A public identity is additional trust only when the operator
+     explicitly configured MASC_HTTP_BASE_URL; deriving it again from env
+     MASC_HOST/MASC_HTTP_PORT would diverge from CLI overrides and could admit
+     a host/port on which this process is not listening. *)
+  let explicit_base_url = Env_config_core.masc_http_base_url_opt () in
   let request_trust_policy =
     match
       Server_request_authority.make_trust_policy
@@ -757,6 +758,9 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       raise
         (Env_config_core.Config_error
            (Server_request_authority.trust_policy_error_to_string error))
+  in
+  let background_request_authority =
+    Server_request_authority.projection_context request_trust_policy
   in
   let routes = make_routes ~port:config.port ~host:config.host ~sw ~clock in
   let request_handler = make_request_handler ~trust_policy:request_trust_policy routes in
@@ -1389,7 +1393,10 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         (* Full-health scans are heavier than the probe path. Start them after
            shell prewarm has either succeeded or exhausted its own budget so
            cold-start diagnostics do not contend with the shell's first render. *)
-        Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock);
+        Server_routes_http_runtime.start_full_health_snapshot_refresh_loop
+          ~sw
+          ~clock
+          ~request_authority:background_request_authority);
       start_lazy_startup state;
       (* RFC-0206: runtime catalog startup validation removed; Runtime.init_default
          already fail-fasts on an invalid runtime config at boot. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -740,10 +740,32 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
     loop ());
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = Server_bootstrap_http.make_http_config ~host ~port in
+  let explicit_base_url =
+    match Env_config_core.masc_http_base_url_result () with
+    | Ok base_url -> Some base_url
+    | Error message -> raise (Env_config_core.Config_error message)
+  in
+  let request_trust_policy =
+    match
+      Server_request_authority.make_trust_policy
+        ~bind_host:config.host
+        ~bind_port:config.port
+        ~explicit_base_url
+    with
+    | Ok policy -> policy
+    | Error error ->
+      raise
+        (Env_config_core.Config_error
+           (Server_request_authority.trust_policy_error_to_string error))
+  in
   let routes = make_routes ~port:config.port ~host:config.host ~sw ~clock in
-  let request_handler = make_request_handler routes in
+  let request_handler = make_request_handler ~trust_policy:request_trust_policy routes in
   let h2_request_handler =
-    make_h2_request_handler ~sw ~clock ~server_start_time
+    make_h2_request_handler
+      ~trust_policy:request_trust_policy
+      ~sw
+      ~clock
+      ~server_start_time
   in
   let h2_error_handler = make_h2_error_handler () in
   let http_mode =

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -163,10 +163,12 @@ val run :
   base_path:string ->
   make_routes:(port:int -> host:string -> sw:Eio.Switch.t ->
                clock:float Eio.Time.clock_ty Eio.Resource.t -> 'a) ->
-  make_request_handler:('a ->
+  make_request_handler:(trust_policy:Server_request_authority.trust_policy ->
+                        'a ->
                         Eio.Net.Sockaddr.stream ->
                         Httpun.Reqd.t Gluten.Reqd.t -> unit) ->
-  make_h2_request_handler:(sw:Eio.Switch.t ->
+  make_h2_request_handler:(trust_policy:Server_request_authority.trust_policy ->
+                           sw:Eio.Switch.t ->
                            clock:float Eio.Time.clock_ty Eio.Resource.t ->
                            server_start_time:float ->
                            Eio.Net.Sockaddr.stream ->

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -9,11 +9,25 @@ let authority_exn raw =
       `GET
       "/api/v1/dashboard/dev-token"
   in
-  match Server_request_authority.classify_http1_request request with
+  let trust_policy =
+    match
+      Server_request_authority.make_trust_policy
+        ~bind_host:"attacker.example"
+        ~bind_port:8935
+        ~explicit_base_url:None
+    with
+    | Ok policy -> policy
+    | Error error ->
+      fail (Server_request_authority.trust_policy_error_to_string error)
+  in
+  match
+    Server_request_authority.classify_http1_request ~trust_policy request
+  with
   | Server_request_authority.Single authority -> authority
   | ( Server_request_authority.Missing
     | Server_request_authority.Multiple
-    | Server_request_authority.Malformed ) ->
+    | Server_request_authority.Malformed
+    | Server_request_authority.Untrusted ) ->
     failf "expected valid authority %S" raw
 ;;
 

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -868,11 +868,25 @@ let test_dashboard_shell_auth_json_reports_missing_token () =
       ]
   in
   let request_authority =
-    match Server_request_authority.classify_http1_request request with
+    let trust_policy =
+      match
+        Server_request_authority.make_trust_policy
+          ~bind_host:"127.0.0.1"
+          ~bind_port:5173
+          ~explicit_base_url:None
+      with
+      | Ok policy -> policy
+      | Error error ->
+        fail (Server_request_authority.trust_policy_error_to_string error)
+    in
+    match
+      Server_request_authority.classify_http1_request ~trust_policy request
+    with
     | Server_request_authority.Single authority -> authority
     | ( Server_request_authority.Missing
       | Server_request_authority.Multiple
-      | Server_request_authority.Malformed ) ->
+      | Server_request_authority.Malformed
+      | Server_request_authority.Untrusted ) ->
       fail "expected valid authority"
   in
   let json =

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -5,12 +5,29 @@
 
 open Masc.Http_server_eio
 
+let request_trust_policy =
+  match
+    Server_request_authority.make_trust_policy
+      ~bind_host:"127.0.0.1"
+      ~bind_port:8935
+      ~explicit_base_url:None
+  with
+  | Ok policy -> policy
+  | Error error ->
+    Alcotest.fail (Server_request_authority.trust_policy_error_to_string error)
+;;
+
 let request_authority_exn request =
-  match Server_request_authority.classify_http1_request request with
+  match
+    Server_request_authority.classify_http1_request
+      ~trust_policy:request_trust_policy
+      request
+  with
   | Server_request_authority.Single authority -> authority
   | ( Server_request_authority.Missing
     | Server_request_authority.Multiple
-    | Server_request_authority.Malformed ) ->
+    | Server_request_authority.Malformed
+    | Server_request_authority.Untrusted ) ->
     Alcotest.fail "expected one valid request authority"
 ;;
 

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -5,6 +5,18 @@ module KTP = Masc.Keeper_types_profile
 module KEP = Masc.Keeper_tool_persona_runtime
 module Runtime = Server_routes_http_runtime
 
+let request_trust_policy =
+  match
+    Server_request_authority.make_trust_policy
+      ~bind_host:"127.0.0.1"
+      ~bind_port:8935
+      ~explicit_base_url:None
+  with
+  | Ok policy -> policy
+  | Error error ->
+    fail (Server_request_authority.trust_policy_error_to_string error)
+;;
+
 let health_request () =
   Httpun.Request.create
     ~headers:(Httpun.Headers.of_list [ "host", "localhost:8935" ])
@@ -13,11 +25,16 @@ let health_request () =
 ;;
 
 let request_authority_exn request =
-  match Server_request_authority.classify_http1_request request with
+  match
+    Server_request_authority.classify_http1_request
+      ~trust_policy:request_trust_policy
+      request
+  with
   | Server_request_authority.Single authority -> authority
   | ( Server_request_authority.Missing
     | Server_request_authority.Multiple
-    | Server_request_authority.Malformed ) ->
+    | Server_request_authority.Malformed
+    | Server_request_authority.Untrusted ) ->
     fail "expected valid authority"
 ;;
 

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -7,6 +7,18 @@ module Negotiation = Mcp_transport_protocol.Http_negotiation
 module Mcp_store = Masc.Session.McpSessionStore
 module Auth = Masc.Auth
 
+let request_trust_policy =
+  match
+    Server_request_authority.make_trust_policy
+      ~bind_host:"127.0.0.1"
+      ~bind_port:8935
+      ~explicit_base_url:None
+  with
+  | Ok policy -> policy
+  | Error error ->
+    fail (Server_request_authority.trust_policy_error_to_string error)
+;;
+
 let source_root () =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with
   | Some root when Sys.file_exists (Filename.concat root "dune-project") -> root
@@ -455,11 +467,16 @@ let ws_upgrade_request headers =
 let ws_gate_on ~base_path headers =
   let request = ws_upgrade_request headers in
   let request_authority =
-    match Server_request_authority.classify_http1_request request with
+    match
+      Server_request_authority.classify_http1_request
+        ~trust_policy:request_trust_policy
+        request
+    with
     | Server_request_authority.Single authority -> authority
     | ( Server_request_authority.Missing
       | Server_request_authority.Multiple
-      | Server_request_authority.Malformed ) ->
+      | Server_request_authority.Malformed
+      | Server_request_authority.Untrusted ) ->
       fail "expected valid authority"
   in
   Server_routes_http_routes_frontend.websocket_upgrade_authorized

--- a/test/test_server_hibernation.ml
+++ b/test/test_server_hibernation.ml
@@ -20,6 +20,18 @@ let bool_field name json =
   | _ -> failf "field %s is not a bool" name
 ;;
 
+let request_trust_policy =
+  match
+    Server_request_authority.make_trust_policy
+      ~bind_host:"127.0.0.1"
+      ~bind_port:8935
+      ~explicit_base_url:None
+  with
+  | Ok policy -> policy
+  | Error error ->
+    fail (Server_request_authority.trust_policy_error_to_string error)
+;;
+
 let test_status_contract () =
   let json = Server_hibernation.status_json () in
   check string "schema" "masc.server_hibernation.v1" (string_field "schema" json);
@@ -39,11 +51,16 @@ let test_health_exposes_status () =
   let headers = Httpun.Headers.of_list [ "host", "localhost:8935" ] in
   let request = Httpun.Request.create ~headers `GET "/health" in
   let request_authority =
-    match Server_request_authority.classify_http1_request request with
+    match
+      Server_request_authority.classify_http1_request
+        ~trust_policy:request_trust_policy
+        request
+    with
     | Server_request_authority.Single authority -> authority
     | ( Server_request_authority.Missing
       | Server_request_authority.Multiple
-      | Server_request_authority.Malformed ) ->
+      | Server_request_authority.Malformed
+      | Server_request_authority.Untrusted ) ->
       fail "expected valid authority"
   in
   let json =

--- a/test/test_server_request_authority.ml
+++ b/test/test_server_request_authority.ml
@@ -2,6 +2,18 @@ open Alcotest
 
 module Authority = Server_request_authority
 
+let trust_policy ?(bind_host = "127.0.0.1") ?(bind_port = 8935)
+    ?explicit_base_url () =
+  match
+    Authority.make_trust_policy ~bind_host ~bind_port ~explicit_base_url
+  with
+  | Ok policy -> policy
+  | Error error -> fail (Authority.trust_policy_error_to_string error)
+;;
+
+let loopback_policy = trust_policy ()
+let example_https_policy = trust_policy ~explicit_base_url:"https://example.com" ()
+
 let http1_request ?(headers = []) path =
   Httpun.Request.create
     ~headers:(Httpun.Headers.of_list headers)
@@ -17,10 +29,17 @@ let h2_request ?(scheme = "https") ?(meth = `GET) ?(headers = []) target =
     target
 ;;
 
-let admitted_http1 headers =
-  match Authority.classify_http1_request (http1_request ~headers "/") with
+let admitted_http1 ?(policy = loopback_policy) headers =
+  match
+    Authority.classify_http1_request
+      ~trust_policy:policy
+      (http1_request ~headers "/")
+  with
   | Authority.Single authority -> authority
-  | Authority.Missing | Authority.Multiple | Authority.Malformed ->
+  | Authority.Missing
+  | Authority.Multiple
+  | Authority.Malformed
+  | Authority.Untrusted ->
     fail "expected one valid HTTP/1.1 authority"
 ;;
 
@@ -29,6 +48,7 @@ let check_classification expected actual =
   | `Missing, Authority.Missing
   | `Multiple, Authority.Multiple
   | `Malformed, Authority.Malformed
+  | `Untrusted, Authority.Untrusted
   | `Single, Authority.Single _ ->
     ()
   | _ -> fail "unexpected request-authority classification"
@@ -37,10 +57,13 @@ let check_classification expected actual =
 let test_http1_closed_classification () =
   check_classification
     `Missing
-    (Authority.classify_http1_request (http1_request "/"));
+    (Authority.classify_http1_request
+       ~trust_policy:loopback_policy
+       (http1_request "/"));
   check_classification
     `Multiple
     (Authority.classify_http1_request
+       ~trust_policy:loopback_policy
        (http1_request
           ~headers:[ "Host", "localhost"; "hOsT", "localhost" ]
           "/"));
@@ -49,6 +72,7 @@ let test_http1_closed_classification () =
       check_classification
         `Malformed
         (Authority.classify_http1_request
+           ~trust_policy:loopback_policy
            (http1_request ~headers:[ "host", raw ] "/")))
     [ ""
     ; "http://localhost"
@@ -66,7 +90,11 @@ let test_http1_closed_classification () =
 ;;
 
 let test_http1_normalizes_authority () =
-  let dns = admitted_http1 [ "host", " ExAmPlE.COM:443 " ] in
+  let dns =
+    admitted_http1
+      ~policy:example_https_policy
+      [ "host", " ExAmPlE.COM:443 " ]
+  in
   check string "DNS case" "example.com" (Authority.host dns);
   check (option int) "explicit port" (Some 443) (Authority.port dns);
   let ipv6 = admitted_http1 [ "host", "[0:0:0:0:0:0:0:1]:8935" ] in
@@ -75,7 +103,11 @@ let test_http1_normalizes_authority () =
 ;;
 
 let check_h2_malformed request =
-  match Authority.classify_h2_request request with
+  match
+    Authority.classify_h2_request
+      ~trust_policy:example_https_policy
+      request
+  with
   | Authority.H2_authority Authority.Malformed -> ()
   | _ -> fail "expected malformed HTTP/2 authority"
 ;;
@@ -102,9 +134,33 @@ let test_h2_authority_whitespace_is_malformed () =
        "/")
 ;;
 
+let test_h2_unknown_scheme_is_malformed () =
+  check_h2_malformed
+    (h2_request
+       ~scheme:"ftp"
+       ~headers:[ ":authority", "example.com" ]
+       "/")
+;;
+
+let test_h2_unconfigured_authority_is_untrusted () =
+  match
+    Authority.classify_h2_request
+      ~trust_policy:example_https_policy
+      (h2_request
+         ~headers:[ ":authority", "attacker.example" ]
+         "/")
+  with
+  | Authority.H2_authority Authority.Untrusted -> ()
+  | _ -> fail "unconfigured H2 authority was not rejected"
+;;
+
 let test_h2_host_is_cross_check_only () =
-  let accepted headers =
-    match Authority.classify_h2_request (h2_request ~headers "/") with
+  let accepted ?(policy = example_https_policy) ?(scheme = "https") headers =
+    match
+      Authority.classify_h2_request
+        ~trust_policy:policy
+        (h2_request ~scheme ~headers "/")
+    with
     | Authority.H2_authority (Authority.Single authority) -> authority
     | _ -> fail "expected H2 authority + equivalent Host to be admitted"
   in
@@ -112,9 +168,16 @@ let test_h2_host_is_cross_check_only () =
     accepted [ ":authority", "Example.COM"; "host", "example.com:443" ]
   in
   check string "case-normalized authority" "example.com" (Authority.host dns);
+  check bool "H2 scheme preserved" true (Authority.scheme dns = Authority.Https);
+  check bool
+    "H2 explicit trust"
+    true
+    (Authority.trust_class dns = Authority.Explicit_trusted_host);
   let ipv6 =
     accepted
-      [ ":authority", "[0:0:0:0:0:0:0:1]"; "host", "[::1]:443" ]
+      ~policy:loopback_policy
+      ~scheme:"http"
+      [ ":authority", "[0:0:0:0:0:0:0:1]:8935"; "host", "[::1]:8935" ]
   in
   check string "IPv6-normalized authority" "::1" (Authority.host ipv6);
   check_h2_malformed
@@ -131,6 +194,7 @@ let test_h2_host_is_cross_check_only () =
        "/");
   (match
      Authority.classify_h2_request
+       ~trust_policy:example_https_policy
        (h2_request ~headers:[ "host", "example.com" ] "/")
    with
    | Authority.H2_authority Authority.Missing -> ()
@@ -139,8 +203,15 @@ let test_h2_host_is_cross_check_only () =
 
 let test_h2_default_port_normalization_is_scheme_specific () =
   let accepted ~scheme authority host =
+    let policy =
+      match scheme with
+      | "http" -> trust_policy ~bind_host:"example.com" ~bind_port:80 ()
+      | "https" -> example_https_policy
+      | _ -> fail "test supplied an unsupported scheme"
+    in
     match
       Authority.classify_h2_request
+        ~trust_policy:policy
         (h2_request
            ~scheme
            ~headers:[ ":authority", authority; "host", host ]
@@ -161,6 +232,7 @@ let test_h2_default_port_normalization_is_scheme_specific () =
 let test_h2_authority_free_asterisk_is_explicitly_unsupported () =
   match
     Authority.classify_h2_request
+      ~trust_policy:example_https_policy
       (h2_request ~meth:`OPTIONS ~headers:[] "*")
   with
   | Authority.Unsupported_asterisk_form_options -> ()
@@ -198,10 +270,205 @@ let test_projection_routes_share_case_insensitive_duplicate_gate () =
           ~headers:[ "Host", "localhost:8935"; "hOsT", "localhost:8935" ]
           path
       in
-      match Authority.classify_http1_request request with
+      match
+        Authority.classify_http1_request
+          ~trust_policy:loopback_policy
+          request
+      with
       | Authority.Multiple -> ()
       | _ -> failf "%s bypassed the shared duplicate Host gate" path)
     authority_projection_routes
+;;
+
+let test_dns_rebinding_host_is_untrusted_before_origin () =
+  let request =
+    http1_request
+      ~headers:
+        [ "host", "attacker.example:8935"
+        ; "origin", "http://attacker.example:8935"
+        ]
+      "/api/v1/dashboard/shell"
+  in
+  check_classification
+    `Untrusted
+    (Authority.classify_http1_request
+       ~trust_policy:loopback_policy
+       request)
+;;
+
+let check_scheme label expected authority =
+  check bool label true (Authority.scheme authority = expected)
+;;
+
+let check_trust label expected authority =
+  check bool label true (Authority.trust_class authority = expected)
+;;
+
+let test_request_context_preserves_scheme_and_trust () =
+  let local = admitted_http1 [ "host", "localhost:8935" ] in
+  check_scheme "local scheme" Authority.Http local;
+  check_trust "local trust" Authority.Configured_bind local;
+  let external_policy =
+    trust_policy
+      ~bind_host:"0.0.0.0"
+      ~explicit_base_url:"https://masc.example.test:9443/root"
+      ()
+  in
+  let external_authority =
+    admitted_http1
+      ~policy:external_policy
+      [ "host", "masc.example.test:9443" ]
+  in
+  check_scheme "external scheme" Authority.Https external_authority;
+  check_trust
+    "external trust"
+    Authority.Explicit_trusted_host
+    external_authority
+;;
+
+let test_trust_policy_has_no_permissive_default () =
+  (match
+     Authority.make_trust_policy
+       ~bind_host:"0.0.0.0"
+       ~bind_port:8935
+       ~explicit_base_url:(Some "ftp://attacker.example")
+   with
+   | Error Authority.Malformed_explicit_base_url -> ()
+   | Error Authority.Malformed_bind_authority
+   | Ok _ ->
+     fail "malformed explicit trusted host did not fail closed");
+  let wildcard_only = trust_policy ~bind_host:"0.0.0.0" () in
+  check_classification
+    `Untrusted
+    (Authority.classify_http1_request
+       ~trust_policy:wildcard_only
+       (http1_request ~headers:[ "host", "attacker.example:8935" ] "/"))
+;;
+
+let check_origin_admission label expected request_authority headers =
+  match
+    Server_auth.classify_request_origin
+      ~request_authority
+      (http1_request ~headers "/")
+  with
+  | Server_auth.Single_origin { admission; _ } ->
+    check bool label true (admission = expected)
+  | Server_auth.Missing_origin
+  | Server_auth.Multiple_origins
+  | Server_auth.Malformed_origin ->
+    failf "%s did not produce one parsed Origin" label
+;;
+
+let test_origin_exact_grammar_and_cardinality () =
+  let request_authority = admitted_http1 [ "host", "localhost:8935" ] in
+  check_origin_admission
+    "same origin"
+    Server_auth.Same_origin
+    request_authority
+    [ "origin", "http://localhost:8935" ];
+  check_origin_admission
+    "wrong scheme"
+    Server_auth.Rejected
+    request_authority
+    [ "origin", "https://localhost:8935" ];
+  check_origin_admission
+    "loopback alias is not same origin"
+    Server_auth.Rejected
+    request_authority
+    [ "origin", "http://127.0.0.1:8935" ];
+  check_origin_admission
+    "explicit Vite origin"
+    Server_auth.Allowed_dev_origin
+    request_authority
+    [ "origin", "http://localhost:5173" ];
+  List.iter
+    (fun origin ->
+      match
+        Server_auth.classify_request_origin
+          ~request_authority
+          (http1_request ~headers:[ "origin", origin ] "/")
+      with
+      | Server_auth.Malformed_origin -> ()
+      | _ -> failf "accepted non-serialized Origin %S" origin)
+    [ "http://localhost:8935/"
+    ; "http://localhost:8935/path"
+    ; "http://localhost:8935?query=1"
+    ; "http://localhost:8935#fragment"
+    ; "http://localhost:8935 http://attacker.example"
+    ; "http://localhost:8935trailing"
+    ];
+  (match
+     Server_auth.classify_request_origin
+       ~request_authority
+       (http1_request
+          ~headers:
+            [ "Origin", "http://localhost:8935"
+            ; "oRiGiN", "http://localhost:8935"
+            ]
+          "/")
+   with
+   | Server_auth.Multiple_origins -> ()
+   | _ -> fail "duplicate Origin fields were not rejected")
+;;
+
+let test_custom_trusted_https_origin () =
+  let policy =
+    trust_policy
+      ~bind_host:"0.0.0.0"
+      ~explicit_base_url:"https://masc.example.test:9443/root"
+      ()
+  in
+  let request_authority =
+    admitted_http1
+      ~policy
+      [ "host", "masc.example.test:9443" ]
+  in
+  check_origin_admission
+    "custom trusted HTTPS"
+    Server_auth.Same_origin
+    request_authority
+    [ "origin", "https://masc.example.test:9443" ];
+  check_origin_admission
+    "custom trusted wrong HTTP scheme"
+    Server_auth.Rejected
+    request_authority
+    [ "origin", "http://masc.example.test:9443" ]
+;;
+
+let test_referer_keeps_separate_url_grammar () =
+  let request_authority = admitted_http1 [ "host", "localhost:8935" ] in
+  let request =
+    http1_request
+      ~headers:
+        [ "referer", "http://localhost:8935/dashboard/keepers?tab=active" ]
+      "/api/v1/dashboard/shell"
+  in
+  (match
+     Server_auth.ensure_same_origin_browser_request ~request_authority request
+   with
+   | Ok () -> ()
+   | Error error -> fail (Masc_domain.masc_error_to_string error))
+;;
+
+let test_wildcard_bind_keeps_explicit_loopback_aliases () =
+  let policy =
+    trust_policy
+      ~bind_host:"0.0.0.0"
+      ~explicit_base_url:"http://127.0.0.1:8935"
+      ()
+  in
+  let request_authority =
+    admitted_http1 ~policy [ "host", "localhost:8935" ]
+  in
+  check_trust
+    "loopback alias uses explicit trust"
+    Authority.Explicit_trusted_host
+    request_authority;
+  check_origin_admission
+    "preserved Host alias remains exact origin"
+    Server_auth.Same_origin
+    request_authority
+    [ "origin", "http://localhost:8935" ]
 ;;
 
 let test_auth_and_cors_consume_admitted_authority () =
@@ -212,9 +479,16 @@ let test_auth_and_cors_consume_admitted_authority () =
       "/api/v1/dashboard/shell"
   in
   let request_authority =
-    match Authority.classify_http1_request request with
+    match
+      Authority.classify_http1_request
+        ~trust_policy:loopback_policy
+        request
+    with
     | Authority.Single authority -> authority
-    | Authority.Missing | Authority.Multiple | Authority.Malformed ->
+    | Authority.Missing
+    | Authority.Multiple
+    | Authority.Malformed
+    | Authority.Untrusted ->
       fail "expected admitted authority"
   in
   (match
@@ -334,6 +608,26 @@ let () =
             `Quick
             test_projection_routes_share_case_insensitive_duplicate_gate
         ; test_case
+            "DNS rebinding Host is untrusted"
+            `Quick
+            test_dns_rebinding_host_is_untrusted_before_origin
+        ; test_case
+            "Origin grammar and cardinality are exact"
+            `Quick
+            test_origin_exact_grammar_and_cardinality
+        ; test_case
+            "custom trusted HTTPS origin"
+            `Quick
+            test_custom_trusted_https_origin
+        ; test_case
+            "wildcard bind preserves explicit loopback aliases"
+            `Quick
+            test_wildcard_bind_keeps_explicit_loopback_aliases
+        ; test_case
+            "Referer keeps separate URL grammar"
+            `Quick
+            test_referer_keeps_separate_url_grammar
+        ; test_case
             "auth and CORS consume admitted authority"
             `Quick
             test_auth_and_cors_consume_admitted_authority
@@ -353,6 +647,14 @@ let () =
             `Quick
             test_h2_authority_whitespace_is_malformed
         ; test_case
+            "unknown scheme malformed"
+            `Quick
+            test_h2_unknown_scheme_is_malformed
+        ; test_case
+            "unconfigured authority untrusted"
+            `Quick
+            test_h2_unconfigured_authority_is_untrusted
+        ; test_case
             "scheme default-port normalization"
             `Quick
             test_h2_default_port_normalization_is_scheme_specific
@@ -366,6 +668,15 @@ let () =
             test_h2_asterisk_does_not_mask_repeated_host
         ] )
     ; ( "request context"
-      , [ test_case "fiber binding has no fallback" `Quick test_fiber_binding_has_no_fallback ] )
+      , [ test_case
+            "scheme and trust provenance"
+            `Quick
+            test_request_context_preserves_scheme_and_trust
+        ; test_case "fiber binding has no fallback" `Quick test_fiber_binding_has_no_fallback
+        ; test_case
+            "trust policy has no permissive default"
+            `Quick
+            test_trust_policy_has_no_permissive_default
+        ] )
     ]
 ;;

--- a/test/test_server_request_authority.ml
+++ b/test/test_server_request_authority.ml
@@ -323,7 +323,15 @@ let test_request_context_preserves_scheme_and_trust () =
   check_trust
     "external trust"
     Authority.Explicit_trusted_host
-    external_authority
+    external_authority;
+  let projected = Authority.projection_context external_policy in
+  check string "background projection uses public host"
+    "masc.example.test" (Authority.host projected);
+  check_scheme "background projection uses public scheme" Authority.Https projected;
+  check_trust
+    "background projection keeps public trust"
+    Authority.Explicit_trusted_host
+    projected
 ;;
 
 let test_trust_policy_has_no_permissive_default () =

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -240,21 +240,35 @@ let test_websocket_discovery_retains_same_origin_wss_diagnostic () =
       check string "primary ws_url uses same-origin wss" "wss://example.com/root/ws"
         Yojson.Safe.Util.(json |> member "ws_url" |> to_string)))
 
-let test_advertised_base_url_uses_forwarded_proto_without_internal_port () =
+let test_advertised_base_url_uses_typed_trusted_scheme () =
   let headers =
     Httpun.Headers.of_list
-      [ "host", "masc.example.com"; "x-forwarded-proto", "https" ]
+      [ "host", "masc.example.com"; "x-forwarded-proto", "http" ]
   in
   let request = Httpun.Request.create ~headers `GET "/ws" in
   let request_authority =
-    match Server_request_authority.classify_http1_request request with
+    let trust_policy =
+      match
+        Server_request_authority.make_trust_policy
+          ~bind_host:"0.0.0.0"
+          ~bind_port:8935
+          ~explicit_base_url:(Some "https://masc.example.com")
+      with
+      | Ok policy -> policy
+      | Error error ->
+        fail (Server_request_authority.trust_policy_error_to_string error)
+    in
+    match
+      Server_request_authority.classify_http1_request ~trust_policy request
+    with
     | Server_request_authority.Single authority -> authority
     | ( Server_request_authority.Missing
       | Server_request_authority.Multiple
-      | Server_request_authority.Malformed ) ->
+      | Server_request_authority.Malformed
+      | Server_request_authority.Untrusted ) ->
       fail "expected valid authority"
   in
-  check string "forwarded https base" "https://masc.example.com"
+  check string "trusted HTTPS base" "https://masc.example.com"
     (Server_routes_http_runtime.advertised_base_url
        ~request_authority
        request)
@@ -314,8 +328,8 @@ let () =
              test_websocket_discovery_waits_for_same_origin_dispatcher;
            test_case "websocket HTTPS diagnostic URL" `Quick
              test_websocket_discovery_retains_same_origin_wss_diagnostic;
-           test_case "forwarded base URL" `Quick
-             test_advertised_base_url_uses_forwarded_proto_without_internal_port;
+           test_case "typed trusted base URL" `Quick
+             test_advertised_base_url_uses_typed_trusted_scheme;
          ] );
       ( "env",
         [

--- a/test/test_transport_read_model.ml
+++ b/test/test_transport_read_model.ml
@@ -271,7 +271,13 @@ let test_advertised_base_url_uses_typed_trusted_scheme () =
   check string "trusted HTTPS base" "https://masc.example.com"
     (Server_routes_http_runtime.advertised_base_url
        ~request_authority
-       request)
+       request);
+  with_env "MASC_HTTP_PORT" (Some "9000") (fun () ->
+      let host, port =
+        Server_routes_http_runtime.advertised_host_port ~request_authority
+      in
+      check string "typed authority host" "masc.example.com" host;
+      check int "typed HTTPS default port" 443 port)
 
 let test_context_from_env_uses_default_loopback_base_url () =
   with_env "MASC_HTTP_BASE_URL" None (fun () ->
@@ -281,6 +287,27 @@ let test_context_from_env_uses_default_loopback_base_url () =
               check string "normalized host" "127.0.0.1" ctx.host;
               check string "default base_url" "http://127.0.0.1:8935"
                 ctx.base_url)))
+
+let test_explicit_base_url_opt_never_derives_from_bind_env () =
+  with_env "MASC_HTTP_BASE_URL" None (fun () ->
+      with_env "MASC_HOST" (Some "0.0.0.0") (fun () ->
+          with_env "MASC_HTTP_PORT" (Some "9000") (fun () ->
+              check
+                (option string)
+                "listener env is not an explicit public identity"
+                None
+                (Env_config_core.masc_http_base_url_opt ()))))
+
+let test_explicit_base_url_opt_normalizes_only_explicit_value () =
+  with_env
+    "MASC_HTTP_BASE_URL"
+    (Some "  https://example.com/root///  ")
+    (fun () ->
+       check
+         (option string)
+         "explicit public identity is normalized"
+         (Some "https://example.com/root")
+         (Env_config_core.masc_http_base_url_opt ()))
 
 let test_context_from_env_trims_explicit_base_url () =
   with_env "MASC_HTTP_BASE_URL" (Some "https://example.com/root/") (fun () ->
@@ -335,6 +362,10 @@ let () =
         [
           test_case "default loopback base url" `Quick
             test_context_from_env_uses_default_loopback_base_url;
+          test_case "explicit base URL does not derive bind env" `Quick
+            test_explicit_base_url_opt_never_derives_from_bind_env;
+          test_case "explicit base URL normalizes explicit value" `Quick
+            test_explicit_base_url_opt_normalizes_only_explicit_value;
           test_case "trim explicit base url" `Quick
             test_context_from_env_trims_explicit_base_url;
           test_case "normalize loopback alias base url" `Quick


### PR DESCRIPTION
## 변경

- effective listener identity와 명시된 `MASC_HTTP_BASE_URL`로 request trust policy를 한 번만 구성했어용.
- HTTP/1 `Host`와 HTTP/2 `:authority`를 typed scheme/authority/trust provenance로 분류한 뒤 routing/auth 전에 판정해용.
- missing/repeated/malformed/unconfigured authority와 H2 authority/Host 불일치를 fail-close했어용.
- `Origin` 필드 전체를 정확히 하나의 완전한 HTTP(S) serialized origin으로 파싱하고, `Referer`는 별도 URL 문법으로 유지했어용.
- `X-Forwarded-Proto`와 `Forwarded`를 scheme authority에서 제거했어용.

## 정당성

`#24148` 이후에도 구문상 유효한 미설정 Host, forwarded-header scheme 재유도, Origin cardinality/grammar 미검증이 남아 있었어용. 이 변경은 listener/public identity를 구조적 신뢰 경계로 만들고 downstream의 raw Host/env 재해석을 제거해용.

## RFC

- `docs/rfc/RFC-0340-dashboard-token-only-auth.md` §1, §2.1: DNS rebinding 경계와 auth/credential I/O 이전의 exact typed request-Host admission을 구현해용.
- `RFC-WAIVED (Origin grammar closure)`: 새 제품 정책이 아니라 기존 CSRF Origin 계층을 exact-cardinality/complete-parse로 fail-close하는 정정이며, wire 계약은 `docs/spec/09-server-transport.md` §6.0에 동기화했어용.

## 검증

- 최신 base: `4f388535e5`
- 최신 head: `5f51fa367c`
- rebase range-diff: 기존 두 커밋과 의미 동일
- rebase 전 동등 patch focused tests: authority 21/21, transport 17/17, dev-token 3/3, H1/H2 parity 14/14, dashboard HTTP 50/50, HTTP server 41/41, keeper TOML 99/99, hibernation 2/2
- current-head `git diff --check` 통과
- 전체 Dune은 current-head PR CI에서 확인해용.

## 범위

dev-token read failure는 `#24218`이 소유해용. WebSocket bearer continuity는 이 Origin/authority 수정의 완료 주장에 포함하지 않아용.

Draft only. current-head CI가 모두 끝날 때까지 `p1`과 `status:do-not-merge`를 유지해용.
