### PR TITLE
fix(exec): add gh graphql top-level subcommand to gh_family enum

### DIFF
--- a/lib/exec/gh_capability_policy.ml
+++ b/lib/exec/gh_capability_policy.ml
@@ -60,7 +60,8 @@ let creates_durable_remote_surface (v : Gh_verb.t) : bool =
   | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Release | Gh_verb.Secret
       | Gh_verb.Ssh_key | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist
       | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run | Gh_verb.Cache
-      | Gh_verb.Project | Gh_verb.Api | Gh_verb.Other _ )
+      | Gh_verb.Project | Gh_verb.Api | Gh_verb.Graphql
+      | Gh_verb.Other _ )
     , _ ) ->
     false
 ;;
@@ -107,7 +108,11 @@ let disposition_of_words (words : string list) (v : Gh_verb.t) : disposition =
   match v.Gh_verb.family with
   | Gh_verb.Api when Shell_ir_risk.gh_api_graphql_creates_durable_remote words ->
     Requires_approval
-  | Gh_verb.Api | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
+  | Gh_verb.Graphql
+    when Shell_ir_risk.gh_api_graphql_creates_durable_remote words ->
+    Requires_approval
+  | Gh_verb.Api | Gh_verb.Graphql | Gh_verb.Pr | Gh_verb.Issue
+  | Gh_verb.Repo | Gh_verb.Discussion
   | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
   | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label | Gh_verb.Run
   | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ ->
@@ -589,10 +594,12 @@ let is_graphql_api (v : Gh_verb.t) : bool =
   match v.Gh_verb.family, v.Gh_verb.action with
   | Gh_verb.Api, Some action -> String.equal (String.lowercase_ascii action) "graphql"
   | Gh_verb.Api, None -> false
+  | Gh_verb.Graphql, _ -> true
   | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
     | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
     | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
-    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ )
+    | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project
+    | Gh_verb.Other _ )
     , _ -> false
 ;;
 
@@ -728,10 +735,12 @@ let graphql_query_body_is_opaque (args : Shell_ir.arg list) : bool =
 let is_rest_api (v : Gh_verb.t) : bool =
   match v.Gh_verb.family with
   | Gh_verb.Api -> not (is_graphql_api v)
+  | Gh_verb.Graphql -> false
   | Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
   | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
   | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
-  | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project | Gh_verb.Other _ -> false
+  | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project
+  | Gh_verb.Other _ -> false
 ;;
 
 let is_method_flag = function

--- a/lib/exec/gh_verb.ml
+++ b/lib/exec/gh_verb.ml
@@ -110,9 +110,14 @@ let classify (words : string list) : t =
   | subcommand :: after ->
     let family = family_of_token subcommand in
     let action =
-      match drop_flags after with
-      | [] -> None
-      | act :: _ -> Some act
+      match family with
+      | Graphql -> None
+      | ( Pr | Issue | Repo | Discussion | Release | Secret | Ssh_key
+        | Workflow | Auth | Gist | Ruleset | Label | Run | Cache | Project
+        | Api | Other _ ) ->
+        (match drop_flags after with
+         | [] -> None
+         | act :: _ -> Some act)
     in
     { family; action }
 ;;

--- a/lib/exec/gh_verb.ml
+++ b/lib/exec/gh_verb.ml
@@ -18,6 +18,7 @@ type gh_family =
   | Cache
   | Project
   | Api
+  | Graphql
   | Other of string
 
 type t =
@@ -42,13 +43,15 @@ let family_token : gh_family -> string = function
   | Cache -> "cache"
   | Project -> "project"
   | Api -> "api"
+  | Graphql -> "graphql"
   | Other s -> s
 ;;
 
 let string_of_family = function
   | Other s -> "other:" ^ s
   | ( Pr | Issue | Repo | Discussion | Release | Secret | Ssh_key | Workflow
-    | Auth | Gist | Ruleset | Label | Run | Cache | Project | Api ) as fam ->
+    | Auth | Gist | Ruleset | Label | Run | Cache | Project | Api
+    | Graphql ) as fam ->
     family_token fam
 ;;
 
@@ -73,6 +76,7 @@ let family_of_token (token : string) : gh_family =
   | "cache" -> Cache
   | "project" -> Project
   | "api" -> Api
+  | "graphql" -> Graphql
   | other -> Other other
 ;;
 

--- a/lib/exec/gh_verb.mli
+++ b/lib/exec/gh_verb.mli
@@ -48,9 +48,10 @@ type gh_family =
 type t =
   { family : gh_family
   ; action : string option
-      (** First non-flag token after the family (e.g. ["create"] in
-          [gh repo create]). [None] when the command is bare
-          ([gh repo]). Kept as a string: see the module note. *)
+      (** First non-flag token after a family with positional actions (e.g.
+          ["create"] in [gh repo create]). [None] when the command is bare
+          ([gh repo]) or the family has no positional action grammar
+          ([gh graphql]). Kept as a string: see the module note. *)
   }
 
 val of_fields : subcommand:string -> action:string option -> t
@@ -64,7 +65,8 @@ val of_fields : subcommand:string -> action:string option -> t
 val classify : string list -> t
 (** [classify words] parses raw [gh]-style argv (["gh" :: subcommand :: rest]
     or [subcommand :: rest]) into a typed family plus its first non-flag
-    action. Flags ([-x], [--long]) are skipped with a value-less (boolean)
+    action. [Graphql] has no positional action grammar, so its action is
+    always [None]. Flags ([-x], [--long]) are skipped with a value-less (boolean)
     default, mirroring [Shell_ir_risk.classify_repo_hosting_cli]'s extraction
     so the two agree on which token is the subcommand — including agreeing on
     the known limitation that a leading {e value-taking} global flag

--- a/lib/exec/gh_verb.mli
+++ b/lib/exec/gh_verb.mli
@@ -38,6 +38,7 @@ type gh_family =
   | Cache
   | Project
   | Api
+  | Graphql
   | Other of string
       (** A top-level gh area not recognized by this closed set. Carries the
           raw token so callers can report it. Adding a new known family is a

--- a/lib/exec/shell_ir_risk.ml
+++ b/lib/exec/shell_ir_risk.ml
@@ -672,11 +672,13 @@ type gh_verb_class =
 let classify_gh_verb (v : Gh_verb.t) : gh_verb_class =
   match v.Gh_verb.family with
   | Gh_verb.Api -> Gh_string_borne
+  | Gh_verb.Graphql -> Gh_string_borne
   | Gh_verb.Other _ -> Gh_unrecognized_family
   | ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
     | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key | Gh_verb.Workflow
     | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset | Gh_verb.Label
     | Gh_verb.Run | Gh_verb.Cache | Gh_verb.Project ) as fam ->
+    (* Graphql is handled below as Gh_string_borne, like Api. *)
     (match v.Gh_verb.action with
      | None -> Gh_read (* bare family: a read *)
      | Some action ->
@@ -1223,7 +1225,7 @@ let repo_hosting_cli_floor_risk (words : string list) (simple : Shell_ir.simple)
     | Shell_ir_typed.W (Shell_ir_typed_types.Gh { subcommand; action; _ }) -> (
       let v = Gh_verb.of_fields ~subcommand ~action in
       match v.Gh_verb.family, v.Gh_verb.action with
-      | (Gh_verb.Api | Gh_verb.Other _), _ | _, None -> R0_Read
+      | (Gh_verb.Api | Gh_verb.Graphql | Gh_verb.Other _), _ | _, None -> R0_Read
       | ( ( Gh_verb.Pr | Gh_verb.Issue | Gh_verb.Repo | Gh_verb.Discussion
           | Gh_verb.Release | Gh_verb.Secret | Gh_verb.Ssh_key
           | Gh_verb.Workflow | Gh_verb.Auth | Gh_verb.Gist | Gh_verb.Ruleset

--- a/lib/exec/test/test_gh_capability_policy.ml
+++ b/lib/exec/test/test_gh_capability_policy.ml
@@ -132,6 +132,9 @@ let test_current_dispositions () =
 let graphql_words body =
   [ "gh"; "api"; "graphql"; "-f"; "query=" ^ body ]
 
+let top_level_graphql_words body =
+  [ "gh"; "graphql"; "-f"; "query=" ^ body ]
+
 let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 let var s = Shell_ir.Var (s, Shell_ir.default_meta)
 let concat parts = Shell_ir.Concat parts
@@ -311,6 +314,31 @@ let test_graphql_opaque_query_simple () =
   | None -> Alcotest.fail "expected gh disposition"
 ;;
 
+let test_top_level_graphql_keeps_graphql_safety_boundary () =
+  let durable_mutation =
+    "mutation { createRepository(input:{name:\"x\"}){ repository { id } } }"
+  in
+  let words = top_level_graphql_words durable_mutation in
+  let verb = Gh_verb.classify words in
+  (match verb.Gh_verb.family with
+   | Gh_verb.Graphql -> ()
+   | _ -> Alcotest.fail "top-level graphql must retain the Graphql family");
+  (match Pol.disposition_of_words words verb with
+   | Pol.Requires_approval -> ()
+   | disposition ->
+     Alcotest.failf "top-level durable graphql mutation must ask, got %s"
+       (dstr disposition));
+  let opaque_query =
+    gh_simple [ lit "graphql"; lit "-f"; var "QUERY" ]
+  in
+  match Pol.disposition_of_simple opaque_query with
+  | Some Pol.Requires_approval -> ()
+  | Some disposition ->
+    Alcotest.failf "opaque top-level graphql query must ask, got %s"
+      (dstr disposition)
+  | None -> Alcotest.fail "expected top-level graphql disposition"
+;;
+
 let test_pr_merge_admin_denies_simple () =
   let cases =
     [ "trailing admin", [ lit "pr"; lit "merge"; lit "123"; lit "--admin" ]
@@ -353,6 +381,8 @@ let () =
             test_graphql_durable_remote_words;
           Alcotest.test_case "graphql opaque query (simple)" `Quick
             test_graphql_opaque_query_simple;
+          Alcotest.test_case "top-level graphql keeps safety boundary" `Quick
+            test_top_level_graphql_keeps_graphql_safety_boundary;
           Alcotest.test_case "pr merge admin deny (simple)" `Quick
             test_pr_merge_admin_denies_simple;
         ] );

--- a/lib/exec/test/test_gh_verb.ml
+++ b/lib/exec/test/test_gh_verb.ml
@@ -36,6 +36,7 @@ let test_classify_family_action () =
   check "pr view 123" Gh_verb.Pr (Some "view");
   check "discussion comment 42 --body B" Gh_verb.Discussion (Some "comment");
   check "api graphql -f q=x" Gh_verb.Api (Some "graphql");
+  check "graphql -f q=x" Gh_verb.Graphql None;
   check "repo" Gh_verb.Repo None;
   check "frobnicate now" (Gh_verb.Other "frobnicate") (Some "now");
   (* Known limitation pinned: a leading value-taking global flag mis-locates
@@ -61,6 +62,7 @@ let test_of_fields () =
   check ~subcommand:"repo" ~action:(Some "create") Gh_verb.Repo;
   check ~subcommand:"discussion" ~action:(Some "comment") Gh_verb.Discussion;
   check ~subcommand:"api" ~action:(Some "graphql") Gh_verb.Api;
+  check ~subcommand:"graphql" ~action:None Gh_verb.Graphql;
   check ~subcommand:"frobnicate" ~action:None (Gh_verb.Other "frobnicate")
 ;;
 
@@ -71,7 +73,7 @@ let test_family_token_round_trip () =
     [ Gh_verb.Pr; Gh_verb.Issue; Gh_verb.Repo; Gh_verb.Discussion
     ; Gh_verb.Release; Gh_verb.Secret; Gh_verb.Ssh_key; Gh_verb.Workflow
     ; Gh_verb.Auth; Gh_verb.Gist; Gh_verb.Ruleset; Gh_verb.Label
-    ; Gh_verb.Run; Gh_verb.Cache; Gh_verb.Project; Gh_verb.Api ]
+    ; Gh_verb.Run; Gh_verb.Cache; Gh_verb.Project; Gh_verb.Api; Gh_verb.Graphql ]
   in
   List.iter
     (fun fam ->


### PR DESCRIPTION
## Problem
`gh graphql` (top-level subcommand, gh CLI 2.40+) was missing from the `gh_family` enum, causing it to fall through to `Other "graphql"` → `Gh_unrecognized_family` → R2 fail-closed denial.

Live reproduction before fix:
```
$ gh graphql --help
gh other:graphql: unrecognized family (fail-closed)
```

Estimated impact: top #9 error rank (~118 failures/24h).

## Fix
- Add `Graphql` variant to `gh_family` (gh_verb.ml/.mli)
- Classify as `Gh_string_borne` in `shell_ir_risk.ml` (same risk model as `gh api graphql`)
- Wire durable-remote mutation guard and opaque-body opacity check in `gh_capability_policy.ml`
- Update `is_graphql_api` to return `true` for `Gh_verb.Graphql` so body opacity checks apply
- Add test cases in `test_gh_verb.ml`

## Files changed (5)
- `lib/exec/gh_verb.ml` — enum variant + wiring
- `lib/exec/gh_verb.mli` — interface
- `lib/exec/shell_ir_risk.ml` — risk classification
- `lib/exec/gh_capability_policy.ml` — policy wiring
- `lib/exec/test/test_gh_verb.ml` — tests

Closes: task-1909