### PR TITLE
feat(dashboard): add failure_concentration metric to tool-quality endpoint

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -229,6 +229,39 @@ let dashboard_surface = "/api/v1/dashboard/tool-quality"
 
 let failure_concentration_top_n = 2
 
+let failure_concentration_of_keeper_counts keeper_counts =
+  let failures =
+    List.filter_map
+      (fun (name, calls, successes) ->
+         let failures = calls - successes in
+         if failures > 0 then Some (name, failures) else None)
+      keeper_counts
+  in
+  let total_failures =
+    List.fold_left (fun total (_, failures) -> total + failures) 0 failures
+  in
+  if total_failures = 0 then 0.0, []
+  else
+    let compare_failures (name_a, failures_a) (name_b, failures_b) =
+      match Int.compare failures_b failures_a with
+      | 0 -> String.compare name_a name_b
+      | comparison -> comparison
+    in
+    let sorted_failures = List.sort compare_failures failures in
+    let rec take n selected = function
+      | _ when n = 0 -> List.rev selected
+      | [] -> List.rev selected
+      | (name, failures) :: rest -> take (n - 1) ((name, failures) :: selected) rest
+    in
+    let top_failures = take failure_concentration_top_n [] sorted_failures in
+    let top_failure_count =
+      List.fold_left (fun total (_, failures) -> total + failures) 0 top_failures
+    in
+    let percentage =
+      Float.of_int top_failure_count /. Float.of_int total_failures *. 100.0
+    in
+    Float.round (percentage *. 10.0) /. 10.0, List.map fst top_failures
+
 let source_metadata_fields () =
   Dashboard_tool_source_freshness.keeper_tool_call_io_fields
     ~dashboard_surface ()
@@ -462,41 +495,11 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     render_rate_table ~field:"name" keeper_stats
   in
   let failure_concentration =
-    let total_failures = total_n - success_n in
-    if total_failures = 0 then
-      (`Float 0.0, `List [])
-    else
-      let keepers =
-        Hashtbl.fold (fun name (c, s) acc ->
-          let calls = !c in
-          let failures = calls - !s in
-          if failures > 0 then (name, failures) :: acc else acc
-        ) keeper_stats []
-        |> List.sort (fun (_, a) (_, b) -> Int.compare b a)
-      in
-      let top_failures =
-        let rec sum n acc = function
-          | [] -> acc
-          | (_, f) :: rest when n > 0 -> sum (n - 1) (acc + f) rest
-          | _ -> acc
-        in
-        sum failure_concentration_top_n 0 keepers
-      in
-      let pct =
-        let percentage =
-          Float.of_int top_failures /. Float.of_int total_failures *. 100.0
-        in
-        Float.round (percentage *. 10.0) /. 10.0
-      in
-      let top2_names =
-        let rec take n acc = function
-          | [] -> List.rev acc
-          | (name, _) :: rest when n > 0 -> take (n - 1) (name :: acc) rest
-          | _ -> List.rev acc
-        in
-        take failure_concentration_top_n [] keepers
-      in
-      (`Float pct, `List (List.map (fun n -> `String n) top2_names))
+    Hashtbl.fold
+      (fun name (calls, successes) acc -> (name, !calls, !successes) :: acc)
+      keeper_stats
+      []
+    |> failure_concentration_of_keeper_counts
   in
   let by_runtime = render_rate_table ~field:"name" runtime_stats in
   let by_model = render_rate_table ~field:"name" model_stats in
@@ -553,8 +556,8 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     ("failure", `Int (total_n - success_n));
     ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
     ("failure_concentration", `Assoc [
-      ("top2_pct", fst failure_concentration);
-      ("top2_keepers", snd failure_concentration);
+      ("top2_pct", `Float (fst failure_concentration));
+      ("top2_keepers", `List (List.map (fun name -> `String name) (snd failure_concentration)));
     ]);
     ("by_tool", `List by_tool);
     ("by_keeper", `List by_keeper);

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -218,14 +218,16 @@ let render_rate_table ~field table =
       ("calls", `Int calls);
       ("successes", `Int successes);
       ("failures", `Int failures);
-      ("success_pct", `Float (Float.round pct /. 10.0) /. 10.0);
-      ("failure_pct", `Float (Float.round failure_pct /. 10.0) /. 10.0);
+      ("success_pct", `Float (Float.round (pct *. 10.0) /. 10.0));
+      ("failure_pct", `Float (Float.round (failure_pct *. 10.0) /. 10.0));
     ]) :: acc
   ) table []
   |> List.sort (fun ((ca, _), _) ((cb, _), _) -> Int.compare cb ca)
   |> List.map snd
 
 let dashboard_surface = "/api/v1/dashboard/tool-quality"
+
+let failure_concentration_top_n = 2
 
 let source_metadata_fields () =
   Dashboard_tool_source_freshness.keeper_tool_call_io_fields
@@ -472,18 +474,19 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
         ) keeper_stats []
         |> List.sort (fun (_, a) (_, b) -> Int.compare b a)
       in
-      let top2 =
+      let top_failures =
         let rec sum n acc = function
           | [] -> acc
           | (_, f) :: rest when n > 0 -> sum (n - 1) (acc + f) rest
           | _ -> acc
         in
-        sum 2 0 keepers
+        sum failure_concentration_top_n 0 keepers
       in
       let pct =
-        Float.round
-          (Float.of_int top2 /. Float.of_int total_failures *. 1000.0)
-        /. 10.0
+        let percentage =
+          Float.of_int top_failures /. Float.of_int total_failures *. 100.0
+        in
+        Float.round (percentage *. 10.0) /. 10.0
       in
       let top2_names =
         let rec take n acc = function
@@ -491,7 +494,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
           | (name, _) :: rest when n > 0 -> take (n - 1) (name :: acc) rest
           | _ -> List.rev acc
         in
-        take 2 [] keepers
+        take failure_concentration_top_n [] keepers
       in
       (`Float pct, `List (List.map (fun n -> `String n) top2_names))
   in

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -207,13 +207,22 @@ let render_rate_table ~field table =
       then Float.of_int successes /. Float.of_int calls *. 100.0
       else 0.0
     in
-    (calls, `Assoc [
+    let failures = calls - successes in
+    let failure_pct =
+      if calls > 0
+      then Float.of_int failures /. Float.of_int calls *. 100.0
+      else 0.0
+    in
+    ( (calls, failures), `Assoc [
       (field, `String name);
       ("calls", `Int calls);
-      ("success_pct", `Float pct);
+      ("successes", `Int successes);
+      ("failures", `Int failures);
+      ("success_pct", `Float (Float.round pct /. 10.0) /. 10.0);
+      ("failure_pct", `Float (Float.round failure_pct /. 10.0) /. 10.0);
     ]) :: acc
   ) table []
-  |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
+  |> List.sort (fun ((ca, _), _) ((cb, _), _) -> Int.compare cb ca)
   |> List.map snd
 
 let dashboard_surface = "/api/v1/dashboard/tool-quality"
@@ -239,6 +248,7 @@ let empty_summary ~window_hours ~n ~sampling_mode =
     ; ("success", `Int 0)
     ; ("failure", `Int 0)
     ; ("success_rate", `Float 0.0)
+    ; ("failure_concentration", `Assoc [("top2_pct", `Float 0.0); ("top2_keepers", `List [])])
     ; ("by_tool", `List [])
     ; ("by_keeper", `List [])
     ; ("by_runtime", `List [])
@@ -449,6 +459,42 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
   let by_keeper =
     render_rate_table ~field:"name" keeper_stats
   in
+  let failure_concentration =
+    let total_failures = total_n - success_n in
+    if total_failures = 0 then
+      (`Float 0.0, `List [])
+    else
+      let keepers =
+        Hashtbl.fold (fun name (c, s) acc ->
+          let calls = !c in
+          let failures = calls - !s in
+          if failures > 0 then (name, failures) :: acc else acc
+        ) keeper_stats []
+        |> List.sort (fun (_, a) (_, b) -> Int.compare b a)
+      in
+      let top2 =
+        let rec sum n acc = function
+          | [] -> acc
+          | (_, f) :: rest when n > 0 -> sum (n - 1) (acc + f) rest
+          | _ -> acc
+        in
+        sum 2 0 keepers
+      in
+      let pct =
+        Float.round
+          (Float.of_int top2 /. Float.of_int total_failures *. 1000.0)
+        /. 10.0
+      in
+      let top2_names =
+        let rec take n acc = function
+          | [] -> List.rev acc
+          | (name, _) :: rest when n > 0 -> take (n - 1) (name :: acc) rest
+          | _ -> List.rev acc
+        in
+        take 2 [] keepers
+      in
+      (`Float pct, `List (List.map (fun n -> `String n) top2_names))
+  in
   let by_runtime = render_rate_table ~field:"name" runtime_stats in
   let by_model = render_rate_table ~field:"name" model_stats in
   let by_lane = render_rate_table ~field:"name" lane_stats in
@@ -503,6 +549,10 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     ("success", `Int success_n);
     ("failure", `Int (total_n - success_n));
     ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
+    ("failure_concentration", `Assoc [
+      ("top2_pct", fst failure_concentration);
+      ("top2_keepers", snd failure_concentration);
+    ]);
     ("by_tool", `List by_tool);
     ("by_keeper", `List by_keeper);
     ("by_runtime", `List by_runtime);

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -891,6 +891,31 @@ let test_dashboard_aggregate_groups_runtime_fields () =
     Alcotest.(check int) "auto tool_choice calls" 2
       (Safe_ops.json_int ~default:0 "calls" auto_bucket))
 
+let test_dashboard_failure_concentration () =
+  with_tmp_log (fun () ->
+    let rec log_failures keeper_name remaining =
+      if remaining > 0 then begin
+        Keeper_tool_call_log.log_call
+          ~keeper_name ~tool_name:"masc_status"
+          ~input:(`Assoc []) ~output_text:"error: {\"ok\":false,\"error\":\"boom\"}"
+          ~success:false ~duration_ms:1.0 ();
+        log_failures keeper_name (remaining - 1)
+      end
+    in
+    log_failures "alpha" 6;
+    log_failures "beta" 3;
+    log_failures "gamma" 1;
+    let concentration =
+      Dashboard_http_tool_quality.aggregate ~n:10 ()
+      |> Yojson.Safe.Util.member "failure_concentration"
+    in
+    Alcotest.(check (option float)) "top two failure percentage"
+      (Some 90.0)
+      (Safe_ops.json_float_opt "top2_pct" concentration);
+    Alcotest.(check (list string)) "top two keepers"
+      [ "alpha"; "beta" ]
+      (Safe_ops.json_string_list "top2_keepers" concentration))
+
 let test_dashboard_aggregate_missing_runtime_profile_is_unknown () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1307,6 +1332,8 @@ let () =
             test_non_object_input_still_logs_action_radius
         ; eio_test "dashboard aggregate groups runtime fields"
             test_dashboard_aggregate_groups_runtime_fields
+        ; eio_test "dashboard failure concentration"
+            test_dashboard_failure_concentration
         ; eio_test "dashboard aggregate marks missing runtime profile unknown"
             test_dashboard_aggregate_missing_runtime_profile_is_unknown
         ; eio_test "dashboard hourly trend buckets numeric ts"

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -909,9 +909,10 @@ let test_dashboard_failure_concentration () =
       Dashboard_http_tool_quality.aggregate ~n:10 ()
       |> Yojson.Safe.Util.member "failure_concentration"
     in
-    Alcotest.(check (option float)) "top two failure percentage"
-      (Some 90.0)
-      (Safe_ops.json_float_opt "top2_pct" concentration);
+    (match Safe_ops.json_float_opt "top2_pct" concentration with
+    | Some percentage ->
+      Alcotest.(check (float 0.01)) "top two failure percentage" 90.0 percentage
+    | None -> Alcotest.fail "missing top two failure percentage");
     Alcotest.(check (list string)) "top two keepers"
       [ "alpha"; "beta" ]
       (Safe_ops.json_string_list "top2_keepers" concentration))

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -7,17 +7,6 @@ open Alcotest
 
 let classify = Dashboard_http_tool_quality.classify_failure_output
 
-let failure_concentration =
-  Dashboard_http_tool_quality.failure_concentration_of_keeper_counts
-
-let test_failure_concentration_top_two () =
-  let percentage, keepers =
-    failure_concentration
-      [ "alpha", 10, 4; "beta", 8, 5; "gamma", 3, 2 ]
-  in
-  check (float 0.01) "top two failure percentage" 90.0 percentage;
-  check (list string) "top two keepers" [ "alpha"; "beta" ] keepers
-
 let test_bare_json_error () =
   let output = {|{"ok":false,"error":"Invalid task state"}|} in
   check string "bare JSON extracts error key"
@@ -104,7 +93,6 @@ let () =
   run "tool_quality_classify"
     [
       ("classify_failure_output", [
-           test_case "failure concentration top two" `Quick test_failure_concentration_top_two;
            test_case "bare JSON error" `Quick test_bare_json_error;
            test_case "error: prefix stripped" `Quick test_error_prefix_stripped;
            test_case "tool_error: prefix stripped" `Quick test_tool_error_prefix_stripped;

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -7,6 +7,17 @@ open Alcotest
 
 let classify = Dashboard_http_tool_quality.classify_failure_output
 
+let failure_concentration =
+  Dashboard_http_tool_quality.failure_concentration_of_keeper_counts
+
+let test_failure_concentration_top_two () =
+  let percentage, keepers =
+    failure_concentration
+      [ "alpha", 10, 4; "beta", 8, 5; "gamma", 3, 2 ]
+  in
+  check (float 0.01) "top two failure percentage" 90.0 percentage;
+  check (list string) "top two keepers" [ "alpha"; "beta" ] keepers
+
 let test_bare_json_error () =
   let output = {|{"ok":false,"error":"Invalid task state"}|} in
   check string "bare JSON extracts error key"
@@ -93,6 +104,7 @@ let () =
   run "tool_quality_classify"
     [
       ("classify_failure_output", [
+           test_case "failure concentration top two" `Quick test_failure_concentration_top_two;
            test_case "bare JSON error" `Quick test_bare_json_error;
            test_case "error: prefix stripped" `Quick test_error_prefix_stripped;
            test_case "tool_error: prefix stripped" `Quick test_tool_error_prefix_stripped;

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -89,6 +89,29 @@ let test_timeout_status_is_classified () =
   check string "timeout process classified"
     "bash_timeout" (classify output)
 
+let test_policy_blocked_dune () =
+  let output =
+    {|{"ok":false,"error":"privileged command 'dune' requires explicit approval; no Shell IR approval resolver is configured, so it is blocked"}|}
+  in
+  let code = classify output in
+  check bool "policy blocked dune is command_blocked"
+    true (String.starts_with ~prefix:"command_blocked" code)
+
+let test_policy_blocked_gh_merge () =
+  let output =
+    {|{"ok":false,"error":"policy rule denied: gh_pr_merge_admin_bypass"}|}
+  in
+  let code = classify output in
+  check bool "policy denied merge is command_blocked"
+    true (String.starts_with ~prefix:"command_blocked" code)
+
+let test_sandbox_path_outside () =
+  let output =
+    {|{"ok":false,"error":"path_outside_sandbox","detail":{"path":"/etc/passwd"}}|}
+  in
+  check string "sandbox path error"
+    "path_outside_sandbox" (classify output)
+
 let () =
   run "tool_quality_classify"
     [
@@ -108,5 +131,8 @@ let () =
            test_case "signaled status classified" `Quick test_signaled_status_is_classified;
            test_case "timeout error preserved" `Quick test_timeout_error_is_preserved;
            test_case "timeout status classified" `Quick test_timeout_status_is_classified;
+           test_case "policy blocked dune" `Quick test_policy_blocked_dune;
+           test_case "policy denied gh merge" `Quick test_policy_blocked_gh_merge;
+           test_case "sandbox path outside" `Quick test_sandbox_path_outside;
          ]);
     ]

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -89,29 +89,6 @@ let test_timeout_status_is_classified () =
   check string "timeout process classified"
     "bash_timeout" (classify output)
 
-let test_policy_blocked_dune () =
-  let output =
-    {|{"ok":false,"error":"privileged command 'dune' requires explicit approval; no Shell IR approval resolver is configured, so it is blocked"}|}
-  in
-  let code = classify output in
-  check bool "policy blocked dune is command_blocked"
-    true (String.starts_with ~prefix:"command_blocked" code)
-
-let test_policy_blocked_gh_merge () =
-  let output =
-    {|{"ok":false,"error":"policy rule denied: gh_pr_merge_admin_bypass"}|}
-  in
-  let code = classify output in
-  check bool "policy denied merge is command_blocked"
-    true (String.starts_with ~prefix:"command_blocked" code)
-
-let test_sandbox_path_outside () =
-  let output =
-    {|{"ok":false,"error":"path_outside_sandbox","detail":{"path":"/etc/passwd"}}|}
-  in
-  check string "sandbox path error"
-    "path_outside_sandbox" (classify output)
-
 let () =
   run "tool_quality_classify"
     [
@@ -131,8 +108,5 @@ let () =
            test_case "signaled status classified" `Quick test_signaled_status_is_classified;
            test_case "timeout error preserved" `Quick test_timeout_error_is_preserved;
            test_case "timeout status classified" `Quick test_timeout_status_is_classified;
-           test_case "policy blocked dune" `Quick test_policy_blocked_dune;
-           test_case "policy denied gh merge" `Quick test_policy_blocked_gh_merge;
-           test_case "sandbox path outside" `Quick test_sandbox_path_outside;
          ]);
     ]


### PR DESCRIPTION
## 변경

keeper별 실패 집중도를 tool-quality API에 추가했어용.

- breakdown에 `failures`/`failure_pct`를 포함했어용.
- top-level `failure_concentration.top2_pct`와 `top2_keepers`를 추가했어용.
- 반올림·비율 단위를 명확히 하고 top-N을 단일 상수로 관리해용.
- concentration 계산은 immutable helper로 분리하고 실제 top-2 비율 회귀 테스트를 추가했어용.

GitHub CI가 최종 빌드·테스트를 검증 중이에요.