### PR TITLE
feat(task): add OperatorBlocked task status (task-2185)

### DIFF
--- a/lib/dashboard/dashboard.ml
+++ b/lib/dashboard/dashboard.ml
@@ -136,7 +136,8 @@ let split_tasks (tasks : Masc_domain.task list) =
     List.filter (fun task ->
       match task.Masc_domain.task_status with
       | Masc_domain.InProgress _ | Masc_domain.Claimed _ | Masc_domain.AwaitingVerification _ -> true
-      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
+      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _
+      | Masc_domain.OperatorBlocked _ -> false
     ) tasks
   in
   let pending = List.filter (fun task -> (=) task.Masc_domain.task_status Masc_domain.Todo) tasks in
@@ -152,7 +153,8 @@ let task_lines (tasks : Masc_domain.task list) =
         | Masc_domain.InProgress { assignee; _ } -> assignee
         | Masc_domain.Claimed { assignee; _ } -> assignee
         | Masc_domain.AwaitingVerification { assignee; _ } -> assignee
-        | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> "?"
+        | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _
+        | Masc_domain.OperatorBlocked _ -> "?"
       in
       Printf.sprintf "[P%d] %s (@%s)" task.priority task.title assignee
     ) active)
@@ -478,7 +480,8 @@ let generate_compact ?(scope = All) (config : Workspace_utils.config) : string =
       match t.task_status with
       | Masc_domain.Claimed _ -> true (* claimed but not in-progress = potentially blocked *)
       | Masc_domain.Todo | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
-      | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
+      | Masc_domain.Done _ | Masc_domain.Cancelled _
+      | Masc_domain.OperatorBlocked _ -> false
     ) all_tasks
   in
   (* Agent counts by group *)

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -290,12 +290,14 @@ let task_operation_status (task : Masc_domain.task) =
   (* RFC-0323 G-6: awaiting verification is the normal completion lane,
      not a pause — the operation is still moving (verifier's turn). *)
   | Masc_domain.AwaitingVerification _ -> Some "active"
-  | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Done _ | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> None
 
 let task_operation_updated_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -513,6 +513,7 @@ let task_updated_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
@@ -526,7 +527,8 @@ let task_completed_at (task : Masc_domain.task) =
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
-  | Masc_domain.AwaitingVerification _ -> None
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.OperatorBlocked _ -> None
 ;;
 
 let task_execution_links_json (task : Masc_domain.task) =
@@ -836,6 +838,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           (match Masc_domain.parse_iso8601_opt cancelled_at with
            | Some ts -> ts >= recent_cutoff
            | None -> false)
+        | Masc_domain.OperatorBlocked _ -> false
         | _ -> false)
       |> take 20
     in

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -364,19 +364,22 @@ let task_operation_status (task : Masc_domain.task) =
   (* RFC-0323 G-6: awaiting verification is the normal completion lane,
      not a pause — the operation is still moving (verifier's turn). *)
   | Masc_domain.AwaitingVerification _ -> Some "active"
-  | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Done _ | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> None
 
 let task_operation_severity (task : Masc_domain.task) =
   match task.task_status with
   (* RFC-0323 G-6: verification pending is not a warning tone. *)
   | Masc_domain.AwaitingVerification _ -> Tone_ok
   | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Tone_ok
-  | Masc_domain.Done _ | Masc_domain.Cancelled _ -> Tone_ok
+  | Masc_domain.Done _ | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> Tone_ok
 
 let task_operation_updated_at (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -79,6 +79,7 @@ let task_status_label (task : Masc_domain.task) : string =
   | Masc_domain.AwaitingVerification _ -> "awaiting_verification"
   | Masc_domain.Done _ -> "completed"
   | Masc_domain.Cancelled _ -> "cancelled"
+  | Masc_domain.OperatorBlocked _ -> "operator_blocked"
 
 let task_is_terminal (task : Masc_domain.task) : bool =
   Masc_domain.task_status_is_terminal task.task_status
@@ -90,6 +91,7 @@ let task_updated_at (task : Masc_domain.task) : string =
   match task.task_status with
   | Masc_domain.Done { completed_at; _ } -> completed_at
   | Masc_domain.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -350,7 +350,7 @@ let rec build_tree context goals goal =
         match task.task_status with
         | Masc_domain.AwaitingVerification _ -> true
         | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Done _
-        | Masc_domain.Cancelled _ ->
+        | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ ->
             false)
       linked_tasks
   in

--- a/lib/keeper/keeper_current_task_reconcile.ml
+++ b/lib/keeper/keeper_current_task_reconcile.ml
@@ -81,7 +81,8 @@ let owned_active_tasks_snapshot_for_names ~(config : Workspace.config)
           | Masc_domain.AwaitingVerification _
           | Masc_domain.Todo
           | Masc_domain.Done _
-          | Masc_domain.Cancelled _ -> None)
+          | Masc_domain.Cancelled _
+          | Masc_domain.OperatorBlocked _ -> None)
       in
       Ok { tasks; backlog_tasks = backlog.tasks; backlog_version = backlog.version }
   with
@@ -145,7 +146,8 @@ let active_status_rank = function
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Todo
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> 2
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> 2
 
 let current_task_rank (meta : Keeper_meta_contract.keeper_meta) task_id =
   match meta.current_task_id with

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -48,7 +48,8 @@ let task_is_unclaimed_todo (task : Masc_domain.task) =
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ ->
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ ->
     false
 
 (* Closed set of claim-scope modes. Was a bare [string] (#20674): producers
@@ -162,7 +163,8 @@ let task_is_blocked (task : Masc_domain.task) =
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ ->
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ ->
     false
 
 let goal_progress_json ~(config : Workspace.config) (meta : keeper_meta) =

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -593,7 +593,8 @@ let handle_keeper_task_tool
          match List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks with
          | Some { task_status = Masc_domain.InProgress _; _ } -> false
          | Some { task_status = Masc_domain.Done _ | Masc_domain.Cancelled _
-                 | Masc_domain.AwaitingVerification _; _ } -> false
+                 | Masc_domain.AwaitingVerification _ | Masc_domain.OperatorBlocked _
+                 ; _ } -> false
          | _ -> true
        in
        if needs_start then begin

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -79,6 +79,7 @@ let format_current_task (task : Masc_domain.task) : string =
     | Masc_domain.Todo -> "todo"
     | Masc_domain.Done _ -> "done"
     | Masc_domain.Cancelled _ -> "cancelled"
+    | Masc_domain.OperatorBlocked _ -> "operator_blocked"
   in
   let buf = Buffer.create 256 in
   Buffer.add_string buf "### Current Task (held by you)\n";

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -45,7 +45,8 @@ let task_has_actionable_verification actionable_request_ids
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> false
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> false
 ;;
 
 (** RFC-0323 G-5 readiness gate 3 audit: AwaitingVerification tasks whose

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -215,6 +215,7 @@ let task_status_snapshot_fields (status : Masc_domain.task_status) =
     Some assignee, phase, verifier, Some submitted_at, Some verification_id
   | Masc_domain.Done { assignee; _ } -> Some assignee, None, None, None, None
   | Masc_domain.Cancelled { cancelled_by; _ } -> Some cancelled_by, None, None, None, None
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> Some blocked_by, None, None, None, None
 ;;
 
 let task_snapshot_of_task (task : Masc_domain.task) =

--- a/lib/reputation.ml
+++ b/lib/reputation.ml
@@ -171,7 +171,8 @@ let count_tasks_from_backlog (config : Workspace.config) ~(agent_name : string)
              Stdlib.incr completed
          | Masc_domain.Todo
          | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
-         | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ());
+         | Masc_domain.Done _ | Masc_domain.Cancelled _
+         | Masc_domain.OperatorBlocked _ -> ());
   (!claimed, !completed)
 
 (** {1 Board Counting} *)

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -81,6 +81,7 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
         let dominated = match t.task_status with
           | Done _ -> not include_done
           | Cancelled _ -> not include_cancelled
+          | OperatorBlocked _ -> true
           | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
         in
         not dominated

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -708,7 +708,8 @@ let evidence_refs =
                 (Atomic.get Workspace_hooks.verification_notify_submit_fn)
                   ctx.config ~task ~assignee ~verification_id ~evidence_refs
               | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-              | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ())
+              | Masc_domain.Done _ | Masc_domain.Cancelled _
+              | Masc_domain.OperatorBlocked _ -> ())
            | None -> ())
         | Masc_domain.Approve_verification ->
           (match verification_id_before with

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -17,7 +17,8 @@ let can_review_completion ~(task_opt : Masc_domain.task option) ~(agent_name : s
        | Masc_domain.Todo
        | Masc_domain.AwaitingVerification _
        | Masc_domain.Done _
-       | Masc_domain.Cancelled _ -> false)
+       | Masc_domain.Cancelled _
+       | Masc_domain.OperatorBlocked _ -> false)
   | None -> false
 
 let persisted_completion_contract ~(task_opt : Masc_domain.task option) =

--- a/lib/task/tool_task_contract_gate.ml
+++ b/lib/task/tool_task_contract_gate.ml
@@ -56,6 +56,8 @@ let completion_state_error ~(task_id : string) ~(agent_name : string)
               task_id assignee)))
     | Masc_domain.Cancelled { cancelled_by; _ } ->
       Some
+    | Masc_domain.OperatorBlocked { blocked_by; _ } ->
+      Some
         (Masc_domain.Task (Masc_domain.Task_error.InvalidState
            (Printf.sprintf
               "task %s was cancelled by %s; reopen or create a new task instead of calling masc_transition(action=done)"

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -170,7 +170,8 @@ let sync_planning_current_task_with_owned_task (ctx : context) =
              | Masc_domain.Todo
              | Masc_domain.AwaitingVerification _
              | Masc_domain.Done _
-             | Masc_domain.Cancelled _ -> None)
+             | Masc_domain.Cancelled _
+             | Masc_domain.OperatorBlocked _ -> None)
     in
     match owned_task with
     | Some task_id ->

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -186,7 +186,7 @@ Tip: Look for status='todo' tasks to claim.";
       ("properties", `Assoc [
         ("status", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional status filter: todo|claimed|in_progress|awaiting_verification|done|cancelled");
+          ("description", `String "Optional status filter: todo|claimed|in_progress|awaiting_verification|done|cancelled|operator_blocked");
         ]);
         ("include_done", `Assoc [
           ("type", `String "boolean");

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -230,7 +230,8 @@ let todo_task_has_completed_deliverable_conflict (ctx : context) (task : Masc_do
   | Masc_domain.InProgress _
   | Masc_domain.AwaitingVerification _
   | Masc_domain.Done _
-  | Masc_domain.Cancelled _ -> false
+  | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> false
 ;;
 
 let todo_completed_deliverable_conflicts (ctx : context) tasks =
@@ -427,7 +428,9 @@ let status_summary_string ~task_list_projection (ctx : context) =
            , done_cnt
            , cancelled_cnt )
          | Masc_domain.Cancelled _ ->
-           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1)
+           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt + 1
+         | Masc_domain.OperatorBlocked _ ->
+           active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt, cancelled_cnt)
       ([], 0, 0, 0, 0, 0)
       backlog.tasks
   in

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -313,6 +313,11 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | OperatorBlocked of {
+      blocked_by: string;
+      blocked_at: string;
+      reason: string option;
+    }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -336,6 +341,7 @@ let task_status_to_string = function
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+  | OperatorBlocked _ -> "operator_blocked"
 
 let string_of_task_status = task_status_to_string
 
@@ -347,6 +353,7 @@ let task_status_icon = function
   | AwaitingVerification _ -> "🔍"
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"
+  | OperatorBlocked _ -> "⛔"
 
 (** Display assignee for task status.
     Cancelled surfaces [cancelled_by]; Todo yields "unclaimed".
@@ -355,6 +362,7 @@ let task_display_assignee = function
   | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
   | AwaitingVerification { assignee; _ } -> assignee
   | Cancelled { cancelled_by; _ } -> cancelled_by
+  | OperatorBlocked { blocked_by; _ } -> blocked_by
   | Todo -> "unclaimed"
 
 (** Extract assignee as [Some string], or [None] for Todo/Cancelled.
@@ -363,20 +371,22 @@ let task_assignee_of_status = function
   | Claimed { assignee; _ } -> Some assignee
   | InProgress { assignee; _ } -> Some assignee
   | AwaitingVerification { assignee; _ } -> Some assignee
-  | Todo | Done _ | Cancelled _ -> None
+  | Todo | Done _ | Cancelled _ | OperatorBlocked _ -> None
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.
-    Exhaustive match — adding a constructor forces an update here. *)
+    Exhaustive match — adding a constructor forces an update here.
+    Note: [OperatorBlocked] is NOT terminal — the operator can unblock it. *)
 let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | OperatorBlocked _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
     also includes [Cancelled]. Use this when only successful completion
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _
+  | OperatorBlocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],
@@ -420,6 +430,8 @@ let task_status_schema_witnesses : task_status list =
   ; Done { assignee = placeholder; completed_at = placeholder; notes = None }
   ; Cancelled
       { cancelled_by = placeholder; cancelled_at = placeholder; reason = None }
+  ; OperatorBlocked
+      { blocked_by = placeholder; blocked_at = placeholder; reason = None }
   ]
 
 let all_task_status_names : string list =
@@ -470,6 +482,13 @@ let task_status_to_yojson = function
         ("cancelled_at", `String cancelled_at);
         ("reason", Json_util.string_opt_to_json reason);
       ]
+  | OperatorBlocked { blocked_by; blocked_at; reason } ->
+      `Assoc [
+        ("status", `String "operator_blocked");
+        ("blocked_by", `String blocked_by);
+        ("blocked_at", `String blocked_at);
+        ("reason", Json_util.string_opt_to_json reason);
+      ]
 
 let task_status_of_yojson json =
   let req key = Json_util.get_string_with_default json ~key ~default:"" in
@@ -503,6 +522,12 @@ let task_status_of_yojson json =
         Ok (Cancelled
               { cancelled_by = req "cancelled_by"
               ; cancelled_at = req "cancelled_at"
+              ; reason = opt "reason"
+              })
+    | "operator_blocked" ->
+        Ok (OperatorBlocked
+              { blocked_by = req "blocked_by"
+              ; blocked_at = req "blocked_at"
               ; reason = opt "reason"
               })
     | s -> Error ("Unknown task status: " ^ s)

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -181,7 +181,8 @@ let cleanup_zombies
                    ("ts", `String (now_iso ()));
                  ]))
         | Masc_domain.Claimed _ | Masc_domain.InProgress _
-        | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ()
+        | Todo | AwaitingVerification _ | Done _ | Cancelled _
+        | OperatorBlocked _ -> ()
       ) backlog.tasks;
 
       (* Phase 4: Delete files — skip agents with release failures *)

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -225,7 +225,8 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
       | Masc_domain.AwaitingVerification { assignee; _ } ->
           if is_active_agent assignee then None
           else Some (task, assignee)
-      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+      | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _
+      | Masc_domain.OperatorBlocked _ -> None
     ) backlog.tasks
 
 (* RFC-0294 PR-4: the single typed source of truth for "is this status
@@ -243,7 +244,8 @@ let orphan_status_class_of_status : Masc_domain.task_status -> string option = f
   | Masc_domain.Claimed _ -> Some "claimed"
   | Masc_domain.InProgress _ -> Some "in_progress"
   | Masc_domain.AwaitingVerification _ -> Some "awaiting_verification"
-  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _
+      | Masc_domain.OperatorBlocked _ -> None
 
 (* The fixed class set the gauge reports (0 when a class is empty, so a cleared
    class resets rather than going stale). Exactly the Some-range of

--- a/lib/workspace/workspace_task.ml
+++ b/lib/workspace/workspace_task.ml
@@ -265,7 +265,8 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_
                | Masc_domain.Claimed { assignee; _ }
                | Masc_domain.InProgress { assignee; _ }
                | Masc_domain.AwaitingVerification { assignee; _ } -> assignee = agent_name
-               | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false
+               | Masc_domain.Done _ | Masc_domain.Cancelled _
+               | Masc_domain.OperatorBlocked _ -> false
              in
              if not can_cancel
              then

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -79,6 +79,7 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
        [predecessor_task_id]. *)
     Held_terminal task.task_status
   | Masc_domain.Cancelled { cancelled_by; _ } -> Held_by_other cancelled_by
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> Held_by_other blocked_by
 ;;
 
 (* RFC-0262: a transition that overrides the assignee guard is permitted when
@@ -266,6 +267,8 @@ let decide
       | Masc_domain.Done _
       | Masc_domain.Cancelled _ ) ) ->
     if verification_enabled then Error Invalid_transition else Error Verification_disabled
+  (* ── OperatorBlocked: reject all actions ────────────────────── *)
+  | _, Masc_domain.OperatorBlocked _ -> Error Invalid_transition
 ;;
 
 (* Enumerate the actions that [decide] would accept for the given status under

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -60,7 +60,8 @@ let active_task_assignees_by_task_id backlog =
        match task.task_status with
        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
          Hashtbl.replace table task.id assignee
-       | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
+       | Todo | AwaitingVerification _ | Done _ | Cancelled _
+       | OperatorBlocked _ -> ())
     backlog.tasks;
   table
 ;;

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -265,6 +265,9 @@ let transition_task_outcome_r
               | Masc_domain.Cancelled _, _ ->
                 " Remediation: task is already cancelled. Use masc_add_task for new work \
                  or masc_tasks to find claimable items."
+              | Masc_domain.OperatorBlocked _, _ ->
+                " Remediation: task is operator-blocked. Unblocking requires operator \
+                 intervention (RFC-0323 OperatorBlocked transition)."
               | _ -> ""
             in
             Error

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -46,6 +46,7 @@ let task_status_badge = function
   | Masc_domain.AwaitingVerification _ -> ("🔍", "awaiting_verification")
   | Masc_domain.Done _ -> ("✅", "done")
   | Masc_domain.Cancelled _ -> ("🚫", "cancelled")
+  | Masc_domain.OperatorBlocked _ -> ("⛔", "operator_blocked")
 
 let task_assignee = function
   | Masc_domain.Claimed { assignee; _ }
@@ -53,6 +54,7 @@ let task_assignee = function
   | Masc_domain.AwaitingVerification { assignee; _ }
   | Masc_domain.Done { assignee; _ } -> assignee
   | Masc_domain.Cancelled { cancelled_by; _ } -> cancelled_by
+  | Masc_domain.OperatorBlocked { blocked_by; _ } -> blocked_by
   | Masc_domain.Todo -> "unclaimed"
 
 let active_task_assignee = function
@@ -60,7 +62,8 @@ let active_task_assignee = function
   | Masc_domain.InProgress { assignee; _ }
   | Masc_domain.AwaitingVerification { assignee; _ } ->
       Some assignee
-  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _
+  | Masc_domain.OperatorBlocked _ -> None
 
 let assigned_task_ids ~matches_you tasks =
   List.filter_map


### PR DESCRIPTION
## Summary
Add `OperatorBlocked` variant to `task_status` to break unclaimable critical task cycling.

When a task is stuck in a claim-release loop (keepers claim, fail, release, repeat),
the operator can now block it to prevent further claims until the root cause is addressed.

## Changes
- `lib/types/types_core.ml`: Add `OperatorBlocked` variant with `blocked_by`, `blocked_at`, `reason`
- Update all exhaustive matches (to_string, icon, assignee, is_terminal, is_done, yojson serde)
- `lib/task/task_dispatch.ml`: Filter `OperatorBlocked` from task lists by default
- `lib/task/tool_task.ml`: Handle `OperatorBlocked` in status guards
- `lib/task/tool_task_handlers.ml`: Exclude from claim eligibility
- `lib/task/tool_task_contract_gate.ml`: Reject transitions on blocked tasks
- `lib/task/tool_task_completion_review.ml`: Exclude from review eligibility
- `lib/task/tool_task_schemas.ml`: Add `operator_blocked` to status filter docs

## Note
Cannot run `dune build` in sandbox (policy-blocked). CI will validate exhaustive matches.

Closes task-2185