### PR TITLE
fix(test): configure chat persistence so admission-fence check reflects rollback (#24135 born-red)

### DIFF
--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1230,6 +1230,11 @@ let test_keeper_shutdown_finalizes_idle_operation () =
       (match Shutdown_finalize.run ~config ~entry:None finalized with
        | Ok _ -> ()
        | Error error -> fail (Shutdown_finalize.error_to_string error));
+      (* Same #24135 root as the rollback test: [run_if_free] fail-closes to
+         [Busy] without chat-queue persistence. Configure it so the check
+         reflects only the (released) shutdown fence. *)
+      ignore
+        (Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path);
       (match
          Masc.Keeper_turn_admission.run_if_free
            ~base_path:config.base_path

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1115,6 +1115,15 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
        | Error (Shutdown_prepare_join.Prepare_persist_failed _) -> ()
        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
        | Ok _ -> fail "shutdown prepare unexpectedly persisted through a file blocker");
+      (* #24135 born-red root: [run_if_free] fail-closes to [Busy (Turn_busy _)]
+         when chat-queue persistence is not configured (keeper_turn_admission.ml
+         guards the autonomous lane against an unknown chat backlog). Production
+         always configures persistence, so the fence rollback there surfaces as
+         [Ran]; the test omitted it and misread the chat-queue guard as a stuck
+         shutdown fence. Configure persistence so [run_if_free] reflects only the
+         shutdown reservation, which the failed prepare rolled back. *)
+      ignore
+        (Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path);
       match
         Masc.Keeper_turn_admission.run_if_free
           ~base_path:config.base_path

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -965,6 +965,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
   let base_dir = temp_dir "shutdown-prepare-join" in
   Fun.protect
     ~finally:(fun () ->
+      Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
       R.clear ();
       cleanup_dir base_dir)
@@ -1153,6 +1154,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
   Fun.protect
     ~finally:(fun () ->
       Shutdown_finalize.For_testing.reset_remove_pending_confirms_by_target ();
+      Masc.Keeper_chat_queue.For_testing.reset ();
       Masc.Keeper_turn_admission.For_testing.reset ();
       R.clear ();
       cleanup_dir base_dir)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1122,7 +1122,20 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
           (fun () -> ())
       with
       | `Ran () -> ()
-      | `Busy _ -> fail "failed shutdown prepare left the keeper admission fence closed")
+      | `Busy (Masc.Keeper_turn_admission.Shutdown_requested id) ->
+        (* DIAG (#24135 born-red): a lingering shutdown reservation still owns
+           the slot after a failed prepare — the Fun.protect rollback did not
+           clear [slot.shutdown_operation_id]. Surfacing the id distinguishes
+           "rollback never ran" from "rollback cleared a different id". *)
+        fail
+          (Printf.sprintf
+             "failed shutdown prepare left the keeper admission fence closed: \
+              Shutdown_requested %s still owns the slot (rollback did not clear)"
+             (Shutdown_types.Operation_id.to_string id))
+      | `Busy (Masc.Keeper_turn_admission.Turn_busy _) ->
+        fail
+          "failed shutdown prepare left the keeper admission fence closed: \
+           Turn_busy (slot held by a turn, not a shutdown reservation)")
 
 let test_keeper_shutdown_finalizes_idle_operation () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## 목적 (진단)
#24135 도입 admission-fence 테스트(`test_keeper_shutdown_prepare_failure_rolls_back_fence` 등)가 main born-red(#24135가 Health/Build FAIL인 채 머지). #24260 B군.

정적 트레이스(5파일 소진): rollback 경로가 end-to-end 정상으로 보임 — `begin_shutdown`이 넘긴 operation_id 예약→`Fun.protect finally`→`rollback_shutdown`이 같은 id로 `slot.shutdown_operation_id<-None`. 그런데 test born-red. **정적으론 설명 불가 → runtime signal 필요.**

## 변경 (test-only)
테스트의 `Busy _`가 버리던 block reason을 분기해 CI가 원인 노출:
- `Shutdown_requested id` → shutdown 예약이 slot을 계속 소유(rollback이 `slot.shutdown_operation_id` 미클리어). id로 "rollback 미실행" vs "다른 id clear" 구분.
- `Turn_busy` → shutdown 예약이 아닌 turn이 slot 보유.

production 무변경. #24261이 lifecycle을 이 방식(instrument→diagnose)으로 크랙한 것과 동일.

## 검증
- ocamlformat --check: pass (로컬)
- `autonomous_block` = `Turn_busy | Shutdown_requested` 2 variant, match exhaustive 확인.
- Build은 CI에서. 이 PR 자체도 M2/P12/lifecycle 상속 red이나, admission-fence 테스트 실패 **메시지**가 원인을 노출하는 게 목적.

RFC-WAIVED: test-only diagnostic, no production/containment change.