### PR TITLE
feat(task): Gate 0 — require evidence_refs for all Done_action completions

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -430,6 +430,26 @@ let evidence_refs =
         | Some h -> h.evidence_refs
         | None -> []
       in
+      (* Gate 0: Done_action requires at least one evidence_ref.
+         RFC-0323: bare result text without a locally-validatable artifact
+         (file path, commit hash, or trace ref) is insufficient. *)
+      let evidence_refs_gate =
+        if (=) action Masc_domain.Done_action && not force
+        && Stdlib.List.length evidence_refs = 0
+        then
+          Some
+            "Done action requires at least one evidence_ref \
+             (file path, commit hash, or trace ref). Result text, \
+             URLs, and PR numbers alone do not satisfy the gate."
+        else
+          None
+      in
+      match evidence_refs_gate with
+      | Some reason ->
+        Tool_result.error
+          ~failure_class:(Some Tool_result.Workflow_rejection)
+          ~tool_name ~start_time reason
+      | None ->
       let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -3178,6 +3178,46 @@ let () = test "rfc_0034_v2_capacity_check_returns_some_at_limit" (fun () ->
    | None ->
        failwith "expected capacity_error at the per-goal limit"))
 
+(* Gate 0 coverage: handle_transition action=done rejects empty evidence_refs.
+   This gate lives in [Tool_task.handle_transition] (the masc_transition tool
+   path), before the completion review gate. *)
+let () = test "handle_transition_gate0_rejects_done_with_empty_evidence_refs" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("title", `String "Gate 0 coverage task")]) in
+  let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("task_id", `String "task-001")]) in
+  let result = Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [
+      ("task_id", `String "task-001");
+      ("action", `String "done");
+      ("notes", `String "Done but no evidence.");
+      ("evidence_refs", `List []);
+    ]) in
+  assert (not (Tool_result.is_success result));
+  assert (str_contains (Tool_result.message result)
+    "Done action requires at least one evidence_ref"))
+
+let () = test "handle_transition_gate0_allows_done_with_evidence_ref" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("title", `String "Gate 0 pass task")]) in
+  let _ = Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [("task_id", `String "task-001")]) in
+  (* Will fail past Gate 0 at the completion review gate, but Gate 0 itself
+     should NOT reject — the evidence_ref is present. *)
+  let result = Task.Tool.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
+    (`Assoc [
+      ("task_id", `String "task-001");
+      ("action", `String "done");
+      ("notes", `String "Done with evidence.");
+      ("evidence_refs", `List [ `String "lib/task/tool_task.ml" ]);
+    ]) in
+  (* Gate 0 should not be the rejection reason; if it is, the test fails. *)
+  if not (Tool_result.is_success result) then
+    assert (not (str_contains (Tool_result.message result)
+      "Done action requires at least one evidence_ref")))
+
 let () =
   ensure_test_runtime ();
   Alcotest.run "Task.Tool"


### PR DESCRIPTION
## Summary

Task-2280: Require at least one locally-validatable evidence_ref for every `Done` action in `handle_transition` (the `masc_transition` tool path).

RFC-0323: bare result text without a file path, commit hash, or trace ref is insufficient — URLs and PR numbers alone do not satisfy the gate.

## Changes

- `lib/task/tool_task.ml`: Gate 0 check before the completion review gate. Rejects `Done_action` with empty `evidence_refs` (unless `force=true`).
- `test/test_tool_task_coverage.ml`: 2 coverage tests — rejection case (empty evidence_refs) and acceptance case (with evidence_ref).

## Scope

60 insertions, 0 deletions across 2 files.

Closes task-2280