### PR TITLE
fix(dashboard): separate intermediate tool narration

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2388,6 +2388,48 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(bundle?.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('곧 답합니다')
   })
 
+  it('renders intermediate assistant text as compact progress without fabricating Chat', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'assistant-progress',
+            text: '',
+            role: 'assistant',
+            source: 'direct_assistant',
+            delivery: 'error',
+            traceSteps: [
+              {
+                kind: 'progress',
+                text: 'PR 목록을 확인하고 리뷰 상태를 보겠다.',
+                oasBlockIndex: 2,
+              },
+              {
+                kind: 'tool',
+                name: 'Execute',
+                toolCallId: 'tc-progress',
+                status: 'err',
+              },
+            ],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+
+    const trace = container.querySelector('[data-chat-work-trace]')
+    expect(trace?.textContent).toContain('Progress 1')
+    expect(trace?.textContent).not.toContain('Chat 1')
+    expect(container.textContent).not.toContain('(empty reply)')
+    expect(trace?.querySelector('[data-chat-trace-step="chat"]')).toBeNull()
+    const progress = trace?.querySelector('[data-chat-trace-step="progress"]') as HTMLElement
+    expect(progress.getAttribute('data-chat-trace-provenance')).toBe('intermediate_text')
+    expect(progress.getAttribute('data-chat-trace-oas-block-index')).toBe('2')
+    expect(progress.textContent).toContain('PR 목록을 확인하고 리뷰 상태를 보겠다.')
+  })
+
   it('badges turn timeline rows with field-level provenance', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -108,6 +108,15 @@ function traceSourceBadge(step: ChatTraceStep): TraceSourceBadgeInfo {
       tone: 'stream',
     }
   }
+  if (step.kind === 'progress') {
+    return {
+      label: 'intermediate_text',
+      title: step.oasBlockIndex === undefined
+        ? 'source: TEXT_MESSAGE_CONTENT followed by TOOL_CALL_START'
+        : `source: TEXT_MESSAGE_CONTENT block ${step.oasBlockIndex}, followed by TOOL_CALL_START`,
+      tone: 'stream',
+    }
+  }
   const callId = step.toolCallId?.trim()
   if (callId) {
     return {
@@ -1645,6 +1654,41 @@ function ChatTraceStep({
     `
   }
 
+  if (step.kind === 'progress') {
+    return html`
+      <div
+        class="chat-block-tstep progress ${open ? 'exp' : ''}"
+        data-chat-trace-step="progress"
+        data-chat-turn-order-index=${orderIndex ?? undefined}
+        data-chat-turn-order-kind="trace"
+        data-chat-trace-provenance=${sourceBadge.label}
+        data-chat-trace-oas-block-index=${step.oasBlockIndex ?? undefined}
+        data-chat-trace-ts=${step.ts ?? undefined}
+      >
+        <span class="chat-block-tnode"></span>
+        <div class="min-w-0 flex-1">
+          <button
+            type="button"
+            class="chat-block-tstep-row click w-full text-left"
+            aria-expanded=${open}
+            onClick=${() => setOpen((o) => !o)}
+          >
+            <span class="chat-block-tstep-kind">Progress</span>
+            <${TraceSourceBadge} info=${sourceBadge} />
+            <span class="chat-block-tstep-text min-w-0 flex-1 truncate">${step.text}</span>
+            <span class="chat-block-tstep-chev">${open ? '▼' : '▶'}</span>
+          </button>
+          ${open
+            ? html`<${AsyncMarkdownDiv}
+                text=${step.text}
+                className="chat-block-reason-detail markdown-body whitespace-pre-wrap break-words"
+              />`
+            : null}
+        </div>
+      </div>
+    `
+  }
+
   const statusUi = traceToolStatusUi(step.status)
 
   return html`
@@ -2403,6 +2447,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     entry.delivery === 'transport_failure' && !!entry.error?.trim()
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
+  const traceOwnsIntermediateText = !hasRealText && (entry.traceSteps?.length ?? 0) > 0
   const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))
   const shouldParseRichBlocks =
     !isFailureMessage
@@ -2650,6 +2695,8 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                 />`
               : hasEffectiveBlocks
               ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`
+              : traceOwnsIntermediateText
+              ? null
               : html`
                   <div
                     class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
@@ -3226,7 +3273,10 @@ function ToolTraceCard({
     )
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
     turnComplete && coverageStateForEntry(entry) === 'covered'
-  const ordered = assistant
+  const hasChatResponse = assistant !== null
+    && assistant.delivery !== 'no_reply'
+    && assistant.text.trim().length > 0
+  const ordered = hasChatResponse && assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
   const orderSignature = ordered.map((item) => {
@@ -3237,6 +3287,7 @@ function ToolTraceCard({
   }).join('|')
   const orderedToolSteps = ordered.filter(isToolOrderItem)
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
+  const progressN = traceSteps.filter((step) => step.kind === 'progress').length
   const failN = orderedToolSteps.filter(
     (s) =>
       (s.output !== null && (s.output.success === false || s.output.semantic_success === false))
@@ -3261,7 +3312,7 @@ function ToolTraceCard({
     0,
   )
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
-  const chatN = assistant ? 1 : 0
+  const chatN = hasChatResponse ? 1 : 0
   const stepN = ordered.length
 
   return html`
@@ -3299,6 +3350,7 @@ function ToolTraceCard({
         <span class="chat-block-trace-count">${stepN}단계</span>
         <span class="chat-block-trace-meta">
           ${thinkN > 0 ? html`<span>Think ${thinkN}</span>` : null}
+          ${progressN > 0 ? html`<span>Progress ${progressN}</span>` : null}
           ${orderedToolSteps.length > 0 ? html`<span>도구 ${orderedToolSteps.length}</span>` : null}
           ${chatN > 0 ? html`<span>Chat ${chatN}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
@@ -3615,6 +3667,7 @@ function traceStepsSignature(entry: KeeperConversationEntry): string {
   return steps.map((step) => {
     if (step.kind === 'think') return `think:${step.text.length}:${step.ts ?? ''}`
     if (step.kind === 'reason') return `reason:${step.text.length}:${step.detail?.length ?? 0}:${step.ts ?? ''}`
+    if (step.kind === 'progress') return `progress:${step.text.length}:${step.ts ?? ''}`
     return `tool:${step.name}:${step.status ?? ''}:${step.dur ?? ''}:${step.result?.length ?? 0}`
   }).join(',')
 }

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1328,7 +1328,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     await sendPromise
   })
 
-  it('persists the live assistant draft while the stream is in flight', async () => {
+  it('persists intermediate narration as progress while the stream is in flight', async () => {
     let resolveStream: (outcome: { terminal: boolean }) => void = () => {}
     streamKeeperMessage.mockImplementation(async (
       _name: string,
@@ -1356,10 +1356,15 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     await Promise.resolve()
 
     const [pending] = pendingKeeperChatRequestsForKeeper('echo')
-    expect(pending?.assistantDraft?.text).toBe('부분 응답')
+    expect(pending?.assistantDraft?.text).toBe('')
+    expect(pending?.assistantDraft?.rawText).toBe('')
     expect(pending?.assistantDraft?.delivery).toBe('streaming')
     expect(pending?.assistantDraft?.streamState).toBe('streaming')
     expect(pending?.assistantDraft?.traceSteps).toEqual([
+      expect.objectContaining({
+        kind: 'progress',
+        text: '부분 응답',
+      }),
       expect.objectContaining({
         kind: 'tool',
         name: 'keeper_board_list',

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -109,6 +109,16 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
     if (ts !== undefined) step.ts = ts
     return step
   }
+  if (kind === 'progress') {
+    const text = stringValue(raw.text)
+    if (text === undefined) return null
+    const step: ChatTraceStep = { kind, text }
+    const ts = stringValue(raw.ts)
+    const oasBlockIndex = numberValue(raw.oasBlockIndex)
+    if (ts !== undefined) step.ts = ts
+    if (oasBlockIndex !== undefined) step.oasBlockIndex = oasBlockIndex
+    return step
+  }
   if (kind === 'tool') {
     const name = stringValue(raw.name)
     if (name === undefined) return null

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1040,8 +1040,8 @@ export function promoteAssistantTextToProgress(
   meta: { oasBlockIndex?: number } = {},
 ): void {
   updateThreadEntry(name, entryId, entry => {
-    const text = entry.text.trim()
-    if (!text) return entry
+    const text = entry.rawText ?? entry.text
+    if (!text.trim()) return entry
     const progress = withoutUndefined({
       kind: 'progress' as const,
       text,

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -434,6 +434,17 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
       ? withoutUndefined({ kind: 'reason', text, detail: asString(raw.detail) ?? undefined, ts: asString(raw.ts) })
       : null
   }
+  if (kind === 'progress') {
+    const text = asString(raw.text)
+    return text !== undefined
+      ? withoutUndefined({
+          kind: 'progress',
+          text,
+          ts: asString(raw.ts),
+          oasBlockIndex: asNumber(raw.oasBlockIndex) ?? asNumber(raw.oas_block_index) ?? undefined,
+        })
+      : null
+  }
   if (kind === 'tool') {
     const name = asString(raw.name)
     if (name === undefined) return null
@@ -1017,6 +1028,34 @@ export function appendAssistantDelta(name: string, entryId: string, delta: strin
       deliveryReceipt: 'client_observed_sse_event',
     }),
   }))
+}
+
+/** Move assistant text that is structurally followed by a tool call out of
+ *  the final reply and into the turn timeline. The following TOOL_CALL_START
+ *  is the protocol proof that this text belonged to an intermediate assistant
+ *  round; no text-content or similarity classification participates. */
+export function promoteAssistantTextToProgress(
+  name: string,
+  entryId: string,
+  meta: { oasBlockIndex?: number } = {},
+): void {
+  updateThreadEntry(name, entryId, entry => {
+    const text = entry.text.trim()
+    if (!text) return entry
+    const progress = withoutUndefined({
+      kind: 'progress' as const,
+      text,
+      ts: new Date().toISOString(),
+      oasBlockIndex: meta.oasBlockIndex,
+    })
+    return {
+      ...entry,
+      text: '',
+      rawText: '',
+      blocks: [],
+      traceSteps: [...(entry.traceSteps ?? []), progress],
+    }
+  })
 }
 
 function writeAssistantThinkingText(

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -886,6 +886,100 @@ describe('applyKeeperStreamEvent tool calls', () => {
     ])
   })
 
+  it('promotes text followed by a tool call and keeps only terminal text as Chat', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CONTENT_BLOCK_START',
+      value: { index: 2, content_type: 'text' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: 'PR 목록을 확인하겠다.',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_END' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-progress',
+      toolCallName: 'Execute',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 'tc-progress',
+      delta: '{"argv":["pr","list"]}',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_END',
+      toolCallId: 'tc-progress',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: '최종 결과다.',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'RUN_FINISHED' })
+
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.text).toBe('최종 결과다.')
+    expect(reply?.rawText).toBe('최종 결과다.')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'progress',
+        text: 'PR 목록을 확인하겠다.',
+        ts: expect.any(String),
+        oasBlockIndex: 2,
+      },
+      {
+        kind: 'tool',
+        name: 'Execute',
+        toolCallId: 'tc-progress',
+        status: 'ok',
+        args: '{"argv":["pr","list"]}',
+        ts: expect.any(String),
+      },
+    ])
+  })
+
+  it('keeps repeated intermediate rounds as progress when the run times out', () => {
+    assistantEntry()
+    for (const [index, text] of [
+      [2, 'PR 목록을 확인하겠다.'],
+      [4, 'cwd를 설정해서 다시 보겠다.'],
+    ] as const) {
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'CUSTOM',
+        name: 'KEEPER_CONTENT_BLOCK_START',
+        value: { index, content_type: 'text' },
+      })
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'TEXT_MESSAGE_CONTENT',
+        delta: text,
+      })
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'TOOL_CALL_START',
+        toolCallId: `tc-progress-${index}`,
+        toolCallName: 'Execute',
+      })
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
+        type: 'TOOL_CALL_END',
+        toolCallId: `tc-progress-${index}`,
+      })
+    }
+
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'RUN_ERROR',
+      value: { message: 'request exceeded timeout_sec=300.000 before completion' },
+    })).toBe('request exceeded timeout_sec=300.000 before completion')
+
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.text).toBe('')
+    expect(reply?.rawText).toBe('')
+    expect(reply?.traceSteps?.filter(step => step.kind === 'progress')).toEqual([
+      expect.objectContaining({ kind: 'progress', text: 'PR 목록을 확인하겠다.', oasBlockIndex: 2 }),
+      expect.objectContaining({ kind: 'progress', text: 'cwd를 설정해서 다시 보겠다.', oasBlockIndex: 4 }),
+    ])
+  })
+
   it('preserves OAS content block index on tool trace steps', () => {
     assistantEntry()
     applyKeeperStreamEvent('sangsu', 'reply-1', {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -896,7 +896,7 @@ describe('applyKeeperStreamEvent tool calls', () => {
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_START' })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_CONTENT',
-      delta: 'PR 목록을 확인하겠다.',
+      delta: '  PR 목록을 확인하겠다.\n',
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_END' })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
@@ -925,7 +925,7 @@ describe('applyKeeperStreamEvent tool calls', () => {
     expect(reply?.traceSteps).toEqual([
       {
         kind: 'progress',
-        text: 'PR 목록을 확인하겠다.',
+        text: '  PR 목록을 확인하겠다.\n',
         ts: expect.any(String),
         oasBlockIndex: 2,
       },

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -8,6 +8,7 @@ import type { KeeperChatStreamEvent } from './api'
 import type { KeeperConversationDetails } from './types'
 import {
   appendAssistantDelta,
+  promoteAssistantTextToProgress,
   appendAssistantToolTraceArgsDelta,
   setAssistantToolTraceArgsSnapshot,
   appendAssistantToolTraceStep,
@@ -41,6 +42,7 @@ export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'canc
 export const KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS = 100
 
 const pendingOasToolBlockIndexes = new Map<string, number>()
+const pendingOasTextBlockIndexes = new Map<string, number>()
 type ScheduledFlushHandle = ReturnType<typeof setTimeout>
 interface PendingThinkingState {
   chunks: string[]
@@ -180,6 +182,7 @@ export function _resetKeeperStreamBuffersForTests(): void {
   }
   pendingThinkingDeltas.clear()
   pendingOasToolBlockIndexes.clear()
+  pendingOasTextBlockIndexes.clear()
 }
 
 export interface KeeperThreadAbortResult {
@@ -278,6 +281,26 @@ function clearPendingOasToolBlockIndexesForEntry(keeperName: string, assistantEn
   }
 }
 
+function rememberOasTextBlockIndex(
+  keeperName: string,
+  assistantEntryId: string,
+  index: number | undefined,
+): void {
+  if (index === undefined) return
+  pendingOasTextBlockIndexes.set(streamEntryKey(keeperName, assistantEntryId), index)
+}
+
+function takeOasTextBlockIndex(keeperName: string, assistantEntryId: string): number | undefined {
+  const key = streamEntryKey(keeperName, assistantEntryId)
+  const index = pendingOasTextBlockIndexes.get(key)
+  pendingOasTextBlockIndexes.delete(key)
+  return index
+}
+
+function clearPendingOasTextBlockIndex(keeperName: string, assistantEntryId: string): void {
+  pendingOasTextBlockIndexes.delete(streamEntryKey(keeperName, assistantEntryId))
+}
+
 function normalizeStreamUsage(raw: unknown): NonNullable<KeeperConversationDetails['usage']> | null {
   if (!isRecord(raw)) return null
   const usage: NonNullable<KeeperConversationDetails['usage']> = {
@@ -333,6 +356,7 @@ export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult 
       timestamp: new Date().toISOString(),
     })
     clearPendingOasToolBlockIndexesForEntry(keeperName, entryId)
+    clearPendingOasTextBlockIndex(keeperName, entryId)
   }
   clearActiveStream(keeperName)
   setRecordValue(keeperSending, keeperName, false)
@@ -415,6 +439,9 @@ export function applyKeeperStreamEvent(
         )
         return null
       }
+      promoteAssistantTextToProgress(keeperName, assistantEntryId, {
+        oasBlockIndex: takeOasTextBlockIndex(keeperName, assistantEntryId),
+      })
       appendAssistantToolTraceStep(keeperName, assistantEntryId, {
         toolCallId,
         name: toolName,
@@ -543,8 +570,12 @@ export function applyKeeperStreamEvent(
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const value = isRecord(event.value) ? event.value : null
         const oasBlockIndex = asNumber(value?.index) ?? asNumber(value?.block_index)
+        const contentType = asString(value?.content_type)
         const toolCallId = asString(value?.tool_call_id)
         const toolName = asString(value?.tool_call_name)
+        if (contentType === 'text') {
+          rememberOasTextBlockIndex(keeperName, assistantEntryId, oasBlockIndex)
+        }
         if (toolCallId && toolName) {
           rememberOasToolBlockIndex(keeperName, assistantEntryId, toolCallId, oasBlockIndex)
         }
@@ -840,10 +871,12 @@ export function applyKeeperStreamEvent(
     case 'RUN_FINISHED':
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
+      clearPendingOasTextBlockIndex(keeperName, assistantEntryId)
       return null
     case 'RUN_ERROR':
       flushPendingThinkingDeltas(keeperName, assistantEntryId)
       clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
+      clearPendingOasTextBlockIndex(keeperName, assistantEntryId)
       return typeof event.value === 'string'
         ? event.value
         : (isRecord(event.value) ? asString(event.value.message) : null) ?? 'Keeper stream failed'

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -906,6 +906,7 @@ export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string 
 // timestamps and still render in stored order.
 export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string; oasBlockIndex?: number }
 export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string; ts?: string }
+export type ChatTraceProgressStep = { kind: 'progress'; text: string; ts?: string; oasBlockIndex?: number }
 export type ChatTraceToolStep = {
   kind: 'tool'
   name: string
@@ -917,7 +918,7 @@ export type ChatTraceToolStep = {
   ts?: string
   oasBlockIndex?: number
 }
-export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep
+export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceProgressStep | ChatTraceToolStep
 export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }
 
 export type ChatLinkBlock = { t: 'link'; url: string; title: string; desc?: string; meta?: string; fav?: string; kind?: string }


### PR DESCRIPTION
## Problem

Assistant text emitted before a following tool call was accumulated into the final Chat bubble. Repeated tool rounds therefore appeared as a repetitive final answer, and timeout turns fabricated a Chat row from partial intermediate narration.

## Contract

- Classify by stream structure only: text followed by a valid TOOL_CALL_START is intermediate progress.
- Do not use text similarity, repetition counts, provider names, or model-specific strings.
- Preserve intermediate text and its OAS block index as an observable Progress trace row.
- Keep only terminal assistant text in Chat.
- On trace-only errors, retain the error surface without rendering an empty reply or Chat count.

## Verification

- TypeScript: dashboard tsc --noEmit passed.
- Focused Vitest: keeper-stream and chat primitives, 173 tests passed.
- Regression covers multiple repeated progress rounds followed by request timeout.