### PR TITLE
fix(gate): search repos/ subdirs when base_path is not a git root

### DIFF
--- a/lib/task_completion_gate.ml
+++ b/lib/task_completion_gate.ml
@@ -80,13 +80,26 @@ let artifact_file_path ~base_path ref_path =
 
 let git_commit_exists ~base_path commit =
   match Workspace_git.git_root ~base_path with
-  | None -> false
   | Some root ->
+    (try Workspace_git.commit_exists ~root ~commit
+     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false)
+  | None ->
+    (* Sandbox base_path may not be a git root itself.
+       Search repos/ subdirectories for a repo containing the commit. *)
+    let repos_dir = Filename.concat base_path "repos" in
     (try
-       Workspace_git.commit_exists ~root ~commit
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | _ -> false)
+       directory_entries repos_dir
+       |> List.filter_map (fun name ->
+         let repo = Filename.concat repos_dir name in
+         match Workspace_git.git_root ~base_path:repo with
+         | Some root ->
+           (try
+              if Workspace_git.commit_exists ~root ~commit then Some true
+              else None
+            with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+         | None -> None)
+       |> List.exists (fun x -> x)
+     with _ -> false)
 
 let trajectory_paths_for_trace ~base_path trace_id =
   if not (is_safe_ref_segment trace_id)


### PR DESCRIPTION
## Problem
`Workspace_git.git_root` returns `None` when sandbox `base_path` has no `.git`, causing `git_commit_exists` in `task_completion_gate.ml` to always return `false`. This blocks ALL contracted task completions (390 tasks unclaimable).

## Fix
`git_commit_exists` now falls back to searching `repos/` subdirectories when `base_path` is not a git root.

## Files changed
- `lib/task_completion_gate.ml:81` — added `repos/` subdir discovery fallback

## Unblocks
- task-2288 (this fix)
- task-1903 (RFC-0327 §A1, commit `56449328a7`)
- All 390 remaining unclaimed tasks

Task-2288