### PR TITLE
fix: git_root fallback to parent-walk .git marker when rev-parse fails in sandbox

### DIFF
--- a/lib/workspace/workspace_git.ml
+++ b/lib/workspace/workspace_git.ml
@@ -70,22 +70,37 @@ let is_valid_branch_name s =
 (* Git Repository Utilities                     *)
 (* ============================================ *)
 
+(** Walk parent directories to find the git work-tree root.
+    Returns [Some dir] where [.git] exists, or [None].
+    Avoids spawning a subprocess when clearly not in a git repo. *)
+let find_git_marker_root path =
+  let rec walk dir =
+    let marker = Filename.concat dir ".git" in
+    if Sys.file_exists marker then Some dir
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then None else walk parent
+  in
+  try walk path with Sys_error _ -> None
+
 (** Fast check for .git marker by walking parent directories.
     Avoids spawning a subprocess when clearly not in a git repo. *)
 let has_git_marker path =
-  let rec walk dir =
-    let marker = Filename.concat dir ".git" in
-    if Sys.file_exists marker then true
-    else
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then false else walk parent
-  in
-  try walk path with Sys_error _ -> false
+  match find_git_marker_root path with
+  | Some _ -> true
+  | None -> false
 
-(** Get git root directory *)
+(** Get git root directory.
+    Tries [rev-parse --show-toplevel] first; falls back to the
+    parent-walk [.git] marker when the subprocess is unavailable
+    (e.g. sandbox exec gate). *)
 let git_root ~base_path =
-  if not (has_git_marker base_path) then None
-  else git_first_line ~repo_path:base_path [ "rev-parse"; "--show-toplevel" ]
+  match find_git_marker_root base_path with
+  | None -> None
+  | Some marker_root ->
+    (match git_first_line ~repo_path:base_path [ "rev-parse"; "--show-toplevel" ] with
+     | Some _ as root -> root
+     | None -> Some marker_root)
 
 (** Check if directory is a git repository *)
 let is_git_repo ~base_path =

--- a/test/test_workspace_git_coverage.ml
+++ b/test/test_workspace_git_coverage.ml
@@ -58,6 +58,23 @@ let test_git_root_is_directory () =
   | Some root -> check bool "root is directory" true (Sys.is_directory root)
   | None -> fail "expected git root"
 
+let test_git_root_falls_back_to_parent_marker () =
+  let root = Filename.temp_dir "workspace-git-fallback" "" in
+  let child = Filename.concat root "nested" in
+  let marker = Filename.concat root ".git" in
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists marker then Unix.unlink marker;
+      if Sys.file_exists child then Unix.rmdir child;
+      if Sys.file_exists root then Unix.rmdir root)
+    (fun () ->
+      Unix.mkdir child 0o700;
+      let missing_git_dir = Filename.concat root "missing-git-dir" in
+      Fs_compat.save_file marker ("gitdir: " ^ missing_git_dir ^ "\n");
+      check (option string) "failed rev-parse falls back to marker root"
+        (Some root)
+        (Workspace_git.git_root ~base_path:child))
+
 (* ============================================================
    is_git_repo Tests
    ============================================================ *)
@@ -192,6 +209,8 @@ let () =
       test_case "tmp" `Quick test_git_root_tmp;
       test_case "current nonempty" `Quick test_git_root_current_nonempty;
       test_case "is directory" `Quick test_git_root_is_directory;
+      test_case "rev-parse failure uses parent marker" `Quick
+        test_git_root_falls_back_to_parent_marker;
     ];
     "is_git_repo", [
       test_case "current" `Quick test_is_git_repo_current;


### PR DESCRIPTION
## Problem

`Workspace_git.git_root` returns `None` in sandbox because `rev-parse --show-toplevel` fails through the exec gate. This blocks contracted task completions — evidence_refs with commit hashes are always rejected by the evidence gate.

## Root Cause

`git_root` called `rev-parse` first and returned `None` on failure, even though a parent `.git` marker was still observable.

## Fix

- Extract `find_git_marker_root` returning the exact repository root.
- Keep `rev-parse` as the primary source and fall back to parent marker discovery only when the command fails.
- Add a deterministic regression where the `.git` marker exists, its target is intentionally unavailable, and nested-path `rev-parse` fails.

## Validation

Exact head: `44fa790ddbefd5c6aeb2af4f67af4f16a9b5f689`

- changed OCaml parser and `ocamlformat --check`: pass
- `git diff --check`: pass
- blocking PR lint: 31/31 pass
- local Dune was not run; PR CI is the build and test authority

Resolves task-2288. Linked to goal-evidence-gate-fix-2026-07.

Supersedes closed PR #24272.
