### PR TITLE
fix(keeper): reconcile queued delivery without redispatch

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -240,8 +240,9 @@ let log_deferred_turn ~keeper_name
          in_flight=%b; returning the leased receipt to Pending"
         keeper_name waiting (Option.is_some in_flight)
 
-let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id ~queued =
-  match handle_turn ~sw ~keeper_name ~queued_message:queued with
+let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
+    ~delivery_key ~queued =
+  match handle_turn ~sw ~keeper_name ~delivery_key ~queued_message:queued with
   | Deferred { rejection } ->
       log_deferred_turn ~keeper_name rejection;
       nack_or_warn state ~keeper_name ~lease_id
@@ -267,11 +268,11 @@ let run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id ~queued
            })
 
 let dispatch_queued_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
-    ~queued =
+    ~delivery_key ~queued =
   Eio.Fiber.fork ~sw (fun () ->
       try
         run_leased_turn state ~sw ~clock ~handle_turn ~keeper_name ~lease_id
-          ~queued;
+          ~delivery_key ~queued;
         clear_dispatching state keeper_name
       with
       | Eio.Cancel.Cancelled _ as e ->
@@ -366,6 +367,16 @@ let start ~sw ~clock ~base_path ~handle_turn =
                           nack_or_warn dispatch_state ~keeper_name ~lease_id;
                           clear_dispatching dispatch_state keeper_name
                       | Some queued ->
+                          let delivery_key =
+                            List.map
+                              (fun (item : Keeper_chat_queue.leased_message) ->
+                                 item.receipt_id)
+                              items
+                            |> Keeper_chat_delivery_identity.Receipt_ids.of_list
+                            |> Result.map (fun receipt_ids ->
+                              Keeper_chat_delivery_identity.Queue_receipts
+                                receipt_ids)
+                          in
                           let admission =
                             Keeper_turn_admission.snapshot_for ~base_path
                               ~keeper_name
@@ -378,25 +389,38 @@ let start ~sw ~clock ~base_path ~handle_turn =
                                nack_or_warn dispatch_state ~keeper_name ~lease_id;
                                clear_dispatching dispatch_state keeper_name
                            | None, None ->
-                               (try
-                                  dispatch_queued_turn dispatch_state ~sw ~clock
-                                    ~handle_turn ~keeper_name ~lease_id ~queued
-                                with
-                                | Eio.Cancel.Cancelled _ as e ->
-                                    Eio.Cancel.protect (fun () ->
-                                        nack_or_warn dispatch_state ~keeper_name
-                                          ~lease_id);
-                                    clear_dispatching dispatch_state keeper_name;
-                                    raise e
-                                | exn ->
-                                    nack_or_warn dispatch_state ~keeper_name
-                                      ~lease_id;
-                                    clear_dispatching dispatch_state keeper_name;
-                                    Log.Keeper.warn
-                                      "keeper_chat_consumer: dispatch fork failed for \
-                                       keeper=%s: %s"
-                                      keeper_name
-                                      (Printexc.to_string exn)))))
+                               (match delivery_key with
+                                | Error detail ->
+                                  finalize_or_warn dispatch_state ~keeper_name
+                                    ~lease_id
+                                    (Keeper_chat_queue.Mark_failed
+                                       { completed_at = Eio.Time.now clock
+                                       ; kind = Keeper_chat_queue.Internal_error
+                                       ; detail
+                                       ; outcome_ref = None
+                                       });
+                                  clear_dispatching dispatch_state keeper_name
+                                | Ok delivery_key ->
+                                  (try
+                                     dispatch_queued_turn dispatch_state ~sw ~clock
+                                       ~handle_turn ~keeper_name ~lease_id
+                                       ~delivery_key ~queued
+                                   with
+                                   | Eio.Cancel.Cancelled _ as e ->
+                                       Eio.Cancel.protect (fun () ->
+                                           nack_or_warn dispatch_state ~keeper_name
+                                             ~lease_id);
+                                       clear_dispatching dispatch_state keeper_name;
+                                       raise e
+                                   | exn ->
+                                       nack_or_warn dispatch_state ~keeper_name
+                                         ~lease_id;
+                                       clear_dispatching dispatch_state keeper_name;
+                                       Log.Keeper.warn
+                                         "keeper_chat_consumer: dispatch fork failed for \
+                                          keeper=%s: %s"
+                                         keeper_name
+                                         (Printexc.to_string exn))))))
                else
                  Log.Keeper.warn
                    "keeper_chat_consumer: duplicate dispatch suppressed for \

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -376,6 +376,8 @@ let start ~sw ~clock ~base_path ~handle_turn =
                             |> Result.map (fun receipt_ids ->
                               Keeper_chat_delivery_identity.Queue_receipts
                                 receipt_ids)
+                            |> Result.map_error
+                                 Keeper_chat_delivery_identity.Receipt_ids.error_to_string
                           in
                           let admission =
                             Keeper_turn_admission.snapshot_for ~base_path

--- a/lib/keeper/keeper_chat_consumer.mli
+++ b/lib/keeper/keeper_chat_consumer.mli
@@ -62,7 +62,7 @@ val start :
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   base_path:string ->
-  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> queued_message:Keeper_chat_queue.queued_message -> turn_outcome) ->
+  handle_turn:(sw:Eio.Switch.t -> keeper_name:string -> delivery_key:Keeper_chat_delivery_identity.delivery_key -> queued_message:Keeper_chat_queue.queued_message -> turn_outcome) ->
   unit
 
 module For_testing : sig

--- a/lib/keeper/keeper_chat_delivery_identity.ml
+++ b/lib/keeper/keeper_chat_delivery_identity.ml
@@ -65,10 +65,15 @@ end
 
 module Receipt_ids = struct
   type t = Receipt_id.t * Receipt_id.t list
+  type error = Empty
 
   let of_list = function
-    | [] -> Error "queue delivery identity requires at least one receipt id"
+    | [] -> Error Empty
     | first :: rest -> Ok (first, rest)
+  ;;
+
+  let error_to_string = function
+    | Empty -> "queue delivery identity requires at least one receipt id"
   ;;
 
   let to_list (first, rest) = first :: rest
@@ -171,7 +176,11 @@ let delivery_key_of_yojson = function
              (Ok [])
          | _ -> Error "delivery identity receipt_ids must be a list"
        in
-       let* receipt_ids = Receipt_ids.of_list receipt_ids in
+       let* receipt_ids =
+         match Receipt_ids.of_list receipt_ids with
+         | Ok receipt_ids -> Ok receipt_ids
+         | Error error -> Error (Receipt_ids.error_to_string error)
+       in
        Ok (Queue_receipts receipt_ids)
      | _ -> Error (Printf.sprintf "unsupported delivery identity kind %S" kind))
   | _ -> Error "delivery identity must be an object"

--- a/lib/keeper/keeper_chat_delivery_identity.mli
+++ b/lib/keeper/keeper_chat_delivery_identity.mli
@@ -21,8 +21,10 @@ end
 
 module Receipt_ids : sig
   type t
+  type error = Empty
 
-  val of_list : Receipt_id.t list -> (t, string) result
+  val of_list : Receipt_id.t list -> (t, error) result
+  val error_to_string : error -> string
   val to_list : t -> Receipt_id.t list
 end
 

--- a/lib/keeper/keeper_chat_delivery_journal.ml
+++ b/lib/keeper/keeper_chat_delivery_journal.ml
@@ -3,6 +3,7 @@ module Identity = Keeper_chat_delivery_identity
 type user_row_origin =
   | Needs_append
   | Already_persisted of { row_id : string }
+  | Already_persisted_upstream
 
 type accepted_payload =
   { keeper_name : string
@@ -25,7 +26,9 @@ type terminal_delivery =
   | Transport_failure of { content : string }
   | No_assistant_reply of { reason : no_assistant_reply_reason }
 
-and no_assistant_reply_reason = Continuation_checkpoint
+and no_assistant_reply_reason =
+  | Continuation_checkpoint
+  | Queued_for_later of { receipt_id : Identity.Receipt_id.t }
 
 type terminal_result =
   { ok : bool
@@ -35,11 +38,11 @@ type terminal_result =
 
 type phase =
   | Prepared
-  | Accepted of { user_row_id : string }
-  | Running of { user_row_id : string }
+  | Accepted of { user_row_id : string option }
+  | Running of { user_row_id : string option }
   | Terminal_pending of
       { terminal : terminal_result
-      ; user_row_id : string
+      ; user_row_id : string option
       }
   | Transcript_committed of
       { terminal : terminal_result
@@ -76,6 +79,7 @@ type error =
       ; actual : string
       }
   | Transcript_error of string
+  | Invalid_terminal of string
 
 let schema_version = 1
 let ( let* ) = Result.bind
@@ -109,6 +113,17 @@ let error_to_string = function
       actual
   | Transcript_error detail ->
     "chat delivery transcript persistence failed: " ^ detail
+  | Invalid_terminal detail -> "chat delivery terminal is invalid: " ^ detail
+;;
+
+let validate_terminal terminal =
+  match terminal.ok, terminal.delivery with
+  | true, (Assistant_reply _ | No_assistant_reply _) -> Ok ()
+  | false, Transport_failure _ -> Ok ()
+  | true, Transport_failure _ ->
+    Error (Invalid_terminal "successful status cannot carry a transport failure")
+  | false, (Assistant_reply _ | No_assistant_reply _) ->
+    Error (Invalid_terminal "failed status cannot carry a successful delivery")
 ;;
 
 type operation_lock =
@@ -205,6 +220,8 @@ let user_row_origin_to_yojson = function
   | Already_persisted { row_id } ->
     `Assoc
       [ "kind", `String "already_persisted"; "row_id", `String row_id ]
+  | Already_persisted_upstream ->
+    `Assoc [ "kind", `String "already_persisted_upstream" ]
 ;;
 
 let payload_to_yojson payload =
@@ -242,6 +259,12 @@ let terminal_delivery_to_yojson = function
       [ "kind", `String "no_assistant_reply"
       ; "reason", `String "continuation_checkpoint"
       ]
+  | No_assistant_reply { reason = Queued_for_later { receipt_id } } ->
+    `Assoc
+      [ "kind", `String "no_assistant_reply"
+      ; "reason", `String "queued_for_later"
+      ; "receipt_id", `String (Identity.Receipt_id.to_string receipt_id)
+      ]
 ;;
 
 let terminal_to_yojson terminal =
@@ -256,15 +279,19 @@ let phase_to_yojson = function
   | Prepared -> `Assoc [ "kind", `String "prepared" ]
   | Accepted { user_row_id } ->
     `Assoc
-      [ "kind", `String "accepted"; "user_row_id", `String user_row_id ]
+      [ "kind", `String "accepted"
+      ; "user_row_id", string_option_to_yojson user_row_id
+      ]
   | Running { user_row_id } ->
     `Assoc
-      [ "kind", `String "running"; "user_row_id", `String user_row_id ]
+      [ "kind", `String "running"
+      ; "user_row_id", string_option_to_yojson user_row_id
+      ]
   | Terminal_pending { terminal; user_row_id } ->
     `Assoc
       [ "kind", `String "terminal_pending"
       ; "terminal", terminal_to_yojson terminal
-      ; "user_row_id", `String user_row_id
+      ; "user_row_id", string_option_to_yojson user_row_id
       ]
   | Transcript_committed { terminal; transcript_row_id } ->
     `Assoc
@@ -427,6 +454,14 @@ let user_row_origin_of_yojson = function
        in
        let* row_id = string "row_id" fields in
        Ok (Already_persisted { row_id })
+     | "already_persisted_upstream" ->
+       let* () =
+         validate_fields
+           ~context:"upstream persisted user row origin"
+           ~expected:[ "kind" ]
+           fields
+       in
+       Ok Already_persisted_upstream
      | _ -> Error (Decode_error (Printf.sprintf "unknown user row origin %S" kind)))
   | _ -> Error (Decode_error "user_row_origin must be an object")
 ;;
@@ -519,16 +554,29 @@ let terminal_delivery_of_yojson = function
        let* content = string "content" fields in
        Ok (Transport_failure { content })
      | "no_assistant_reply" ->
-       let* () =
-         validate_fields
-           ~context:"no-assistant terminal delivery"
-           ~expected:[ "kind"; "reason" ]
-           fields
-       in
        let* reason = string "reason" fields in
        (match reason with
         | "continuation_checkpoint" ->
+          let* () =
+            validate_fields
+              ~context:"checkpoint no-assistant terminal delivery"
+              ~expected:[ "kind"; "reason" ]
+              fields
+          in
           Ok (No_assistant_reply { reason = Continuation_checkpoint })
+        | "queued_for_later" ->
+          let* () =
+            validate_fields
+              ~context:"queued no-assistant terminal delivery"
+              ~expected:[ "kind"; "reason"; "receipt_id" ]
+              fields
+          in
+          let* receipt_id = string "receipt_id" fields in
+          let* receipt_id =
+            Identity.Receipt_id.of_string receipt_id
+            |> Result.map_error (fun detail -> Decode_error detail)
+          in
+          Ok (No_assistant_reply { reason = Queued_for_later { receipt_id } })
         | _ ->
           Error
             (Decode_error
@@ -549,7 +597,9 @@ let terminal_of_yojson = function
     let* poll_body = string "poll_body" fields in
     let* delivery_json = assoc "delivery" fields in
     let* delivery = terminal_delivery_of_yojson delivery_json in
-    Ok { ok; poll_body; delivery }
+    let terminal = { ok; poll_body; delivery } in
+    let* () = validate_terminal terminal in
+    Ok terminal
   | _ -> Error (Decode_error "terminal result must be an object")
 ;;
 
@@ -569,7 +619,7 @@ let phase_of_yojson = function
            ~expected:[ "kind"; "user_row_id" ]
            fields
        in
-       let* user_row_id = string "user_row_id" fields in
+       let* user_row_id = string_option "user_row_id" fields in
        Ok (Accepted { user_row_id })
      | "running" ->
        let* () =
@@ -578,7 +628,7 @@ let phase_of_yojson = function
            ~expected:[ "kind"; "user_row_id" ]
            fields
        in
-       let* user_row_id = string "user_row_id" fields in
+       let* user_row_id = string_option "user_row_id" fields in
        Ok (Running { user_row_id })
      | "terminal_pending" ->
        let* () =
@@ -589,7 +639,7 @@ let phase_of_yojson = function
        in
        let* terminal_json = assoc "terminal" fields in
        let* terminal = terminal_of_yojson terminal_json in
-       let* user_row_id = string "user_row_id" fields in
+       let* user_row_id = string_option "user_row_id" fields in
        Ok (Terminal_pending { terminal; user_row_id })
      | "transcript_committed" | "final" ->
        let* () =
@@ -798,6 +848,7 @@ let mark_terminal_pending
       ~terminal
       ~now
   =
+  let* () = validate_terminal terminal in
   replace
     ~base_path
     ~expected_revision
@@ -857,6 +908,7 @@ let mark_recovery_terminal_pending
       ~terminal
       ~now
   =
+  let* () = validate_terminal terminal in
   replace
     ~base_path
     ~expected_revision
@@ -879,7 +931,8 @@ let row_id_of_append_once = function
 
 let append_accepted_user ~base_path journal =
   match journal.payload.user_row_origin with
-  | Already_persisted { row_id } -> Ok row_id
+  | Already_persisted { row_id } -> Ok (Some row_id)
+  | Already_persisted_upstream -> Ok None
   | Needs_append ->
     Keeper_chat_store.append_user_message_once
       ~base_dir:base_path
@@ -892,7 +945,7 @@ let append_accepted_user ~base_path journal =
       ?external_message_id:journal.payload.external_message_id
       ~speaker:journal.payload.speaker
       ()
-    |> Result.map row_id_of_append_once
+    |> Result.map (fun result -> Some (row_id_of_append_once result))
     |> Result.map_error (fun detail -> Transcript_error detail)
 ;;
 
@@ -935,7 +988,14 @@ let append_terminal ~base_path journal ~user_row_id terminal =
       ()
     |> Result.map row_id_of_append_once
     |> Result.map_error (fun detail -> Transcript_error detail)
-  | No_assistant_reply { reason = Continuation_checkpoint } -> Ok user_row_id
+  | No_assistant_reply
+      { reason = Continuation_checkpoint | Queued_for_later _ } ->
+    (match user_row_id with
+     | Some user_row_id -> Ok user_row_id
+     | None ->
+       Error
+         (Transcript_error
+            "continuation checkpoint requires an accepted user transcript row"))
 ;;
 
 let interrupted_terminal journal =
@@ -1057,6 +1117,46 @@ let list_for_keeper ~base_path ~keeper_name =
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn -> Error (Io_error (Printexc.to_string exn))
+;;
+
+let dashboard_queue_user_row_origin ~base_path ~keeper_name receipt_ids =
+  let* records = list_for_keeper ~base_path ~keeper_name in
+  let handed_off_receipts =
+    List.filter_map
+      (fun journal ->
+         match journal.phase with
+         | Final
+             { terminal =
+                 { delivery =
+                     No_assistant_reply
+                       { reason = Queued_for_later { receipt_id } }
+                 ; _
+                 }
+             ; _
+             } -> Some receipt_id
+         | Prepared
+         | Accepted _
+         | Running _
+         | Terminal_pending _
+         | Transcript_committed _
+         | Final _ -> None)
+      records
+  in
+  let provenance =
+    Identity.Receipt_ids.to_list receipt_ids
+    |> List.map (fun receipt_id ->
+      List.exists
+        (fun candidate -> Identity.Receipt_id.equal receipt_id candidate)
+        handed_off_receipts)
+  in
+  if List.for_all Fun.id provenance
+  then Ok Already_persisted_upstream
+  else if List.for_all (fun present -> not present) provenance
+  then Ok Needs_append
+  else
+    Error
+      (Transcript_error
+         "dashboard queue batch mixes journaled and legacy user-row provenance")
 ;;
 
 let recover_all ~base_path ~now =

--- a/lib/keeper/keeper_chat_delivery_journal.mli
+++ b/lib/keeper/keeper_chat_delivery_journal.mli
@@ -9,6 +9,7 @@ module Identity = Keeper_chat_delivery_identity
 type user_row_origin =
   | Needs_append
   | Already_persisted of { row_id : string }
+  | Already_persisted_upstream
 
 type accepted_payload =
   { keeper_name : string
@@ -31,7 +32,9 @@ type terminal_delivery =
   | Transport_failure of { content : string }
   | No_assistant_reply of { reason : no_assistant_reply_reason }
 
-and no_assistant_reply_reason = Continuation_checkpoint
+and no_assistant_reply_reason =
+  | Continuation_checkpoint
+  | Queued_for_later of { receipt_id : Identity.Receipt_id.t }
 
 type terminal_result =
   { ok : bool
@@ -41,11 +44,11 @@ type terminal_result =
 
 type phase =
   | Prepared
-  | Accepted of { user_row_id : string }
-  | Running of { user_row_id : string }
+  | Accepted of { user_row_id : string option }
+  | Running of { user_row_id : string option }
   | Terminal_pending of
       { terminal : terminal_result
-      ; user_row_id : string
+      ; user_row_id : string option
       }
   | Transcript_committed of
       { terminal : terminal_result
@@ -82,6 +85,7 @@ type error =
       ; actual : string
       }
   | Transcript_error of string
+  | Invalid_terminal of string
 
 val error_to_string : error -> string
 val phase_to_string : phase -> string
@@ -97,7 +101,7 @@ val mark_accepted :
   base_path:string ->
   expected_revision:int ->
   identity:t ->
-  user_row_id:string ->
+  user_row_id:string option ->
   now:float ->
   (t, error) result
 
@@ -141,6 +145,15 @@ val list_for_keeper :
   base_path:string ->
   keeper_name:string ->
   (t list, error) result
+
+(** Resolve Dashboard queue user-row ownership from exact typed direct-request
+    handoff journals. All receipts must agree; a mixed legacy/current batch is
+    an explicit error instead of a duplicate or missing transcript row. *)
+val dashboard_queue_user_row_origin :
+  base_path:string ->
+  keeper_name:string ->
+  Identity.Receipt_ids.t ->
+  (user_row_origin, error) result
 
 (** Complete every durable non-final delivery without re-running inference.
     Recovery is lane-local: one malformed Keeper journal is reported without

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -777,41 +777,23 @@ let recovered_queue_terminal ~base_path ~keeper_name receipts =
      | Ok
          { Keeper_chat_delivery_journal.phase =
              Keeper_chat_delivery_journal.Final { terminal; _ }
-          ; updated_at
-          ; _
-          } ->
-       if terminal.ok
-       then
-         (match terminal.delivery with
-          | Keeper_chat_delivery_journal.Assistant_reply
-              { turn_ref = Some turn_ref; _ } ->
-            Ok
-              (Some
-                 (Stored_delivered
-                    { completed_at = updated_at
-                    ; outcome_ref = Some (Ids.Turn_ref.to_string turn_ref)
-                    }))
-          | Keeper_chat_delivery_journal.Assistant_reply { turn_ref = None; _ }
-          | Keeper_chat_delivery_journal.No_assistant_reply _
-          | Keeper_chat_delivery_journal.Transport_failure _ ->
-            Ok
-              (Some
-                 (Stored_failed
-                    { completed_at = updated_at
-                    ; kind = Internal_error
-                    ; detail =
-                        "recovered queue delivery lacks a canonical successful turn_ref"
-                    ; outcome_ref = None
-                    })))
-       else
-         Ok
-           (Some
-              (Stored_failed
-                 { completed_at = updated_at
-                 ; kind = Recovery_interrupted
-                 ; detail = terminal.poll_body
-                 ; outcome_ref = None
-                 }))
+         ; updated_at
+         ; _
+         } ->
+       let detail =
+         if terminal.ok
+         then
+           "queue transcript committed before restart, but terminal connector delivery was not durably proven"
+         else terminal.poll_body
+       in
+       Ok
+         (Some
+            (Stored_failed
+               { completed_at = updated_at
+               ; kind = Recovery_interrupted
+               ; detail
+               ; outcome_ref = None
+               }))
      | Ok journal ->
        Error
          (Printf.sprintf

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -35,6 +35,7 @@ type failure_kind =
   | Delivery_failed
   | Cancelled
   | Internal_error
+  | Recovery_interrupted
 
 type failure = {
   completed_at : float;
@@ -476,6 +477,7 @@ let failure_kind_to_string = function
   | Delivery_failed -> "delivery_failed"
   | Cancelled -> "cancelled"
   | Internal_error -> "internal_error"
+  | Recovery_interrupted -> "recovery_interrupted"
 
 let failure_kind_of_string = function
   | "turn_failed" -> Ok Turn_failed
@@ -486,6 +488,7 @@ let failure_kind_of_string = function
   | "delivery_failed" -> Ok Delivery_failed
   | "cancelled" -> Ok Cancelled
   | "internal_error" -> Ok Internal_error
+  | "recovery_interrupted" -> Ok Recovery_interrupted
   | value -> Error (Printf.sprintf "unknown chat queue failure kind: %s" value)
 
 let completion_fields (completion : completion) =
@@ -746,7 +749,76 @@ type loaded_snapshot = {
 
 let load_error kind ?path message = { kind; path; message }
 
-let recover_inflight path ~revision receipts =
+let recovered_queue_terminal ~base_path ~keeper_name receipts =
+  let inflight_ids =
+    List.filter_map
+      (fun receipt ->
+         match receipt.state with
+         | Stored_inflight _ -> Some receipt.receipt_id
+         | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> None)
+      receipts
+  in
+  match Keeper_chat_delivery_identity.Receipt_ids.of_list inflight_ids with
+  | Error _ -> Ok None
+  | Ok receipt_ids ->
+    let delivery_key =
+      Keeper_chat_delivery_identity.Queue_receipts receipt_ids
+    in
+    (match
+       Keeper_chat_delivery_journal.load
+         ~base_path
+         ~keeper_name
+         delivery_key
+     with
+     | Error (Keeper_chat_delivery_journal.Not_found _) -> Ok None
+     | Error error ->
+       Error
+         (Keeper_chat_delivery_journal.error_to_string error)
+     | Ok
+         { Keeper_chat_delivery_journal.phase =
+             Keeper_chat_delivery_journal.Final { terminal; _ }
+          ; updated_at
+          ; _
+          } ->
+       if terminal.ok
+       then
+         (match terminal.delivery with
+          | Keeper_chat_delivery_journal.Assistant_reply
+              { turn_ref = Some turn_ref; _ } ->
+            Ok
+              (Some
+                 (Stored_delivered
+                    { completed_at = updated_at
+                    ; outcome_ref = Some (Ids.Turn_ref.to_string turn_ref)
+                    }))
+          | Keeper_chat_delivery_journal.Assistant_reply { turn_ref = None; _ }
+          | Keeper_chat_delivery_journal.No_assistant_reply _
+          | Keeper_chat_delivery_journal.Transport_failure _ ->
+            Ok
+              (Some
+                 (Stored_failed
+                    { completed_at = updated_at
+                    ; kind = Internal_error
+                    ; detail =
+                        "recovered queue delivery lacks a canonical successful turn_ref"
+                    ; outcome_ref = None
+                    })))
+       else
+         Ok
+           (Some
+              (Stored_failed
+                 { completed_at = updated_at
+                 ; kind = Recovery_interrupted
+                 ; detail = terminal.poll_body
+                 ; outcome_ref = None
+                 }))
+     | Ok journal ->
+       Error
+         (Printf.sprintf
+            "queue delivery journal remained non-final after startup recovery: %s"
+            (Keeper_chat_delivery_journal.phase_to_string journal.phase)))
+
+let recover_inflight ~base_path ~keeper_name path ~revision receipts =
   let recovered_count =
     List.fold_left
       (fun count receipt ->
@@ -758,14 +830,23 @@ let recover_inflight path ~revision receipts =
   if recovered_count = 0
   then Ok { revision; receipts; migrated = false; recovered_count = 0 }
   else
+    let recovered_terminal =
+      recovered_queue_terminal ~base_path ~keeper_name receipts
+    in
     let receipts =
-      List.map
-        (fun receipt ->
-           match receipt.state with
-           | Stored_inflight { message; _ } ->
-             { receipt with state = Stored_pending message }
-           | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> receipt)
-        receipts
+      Result.map
+        (fun recovered_terminal ->
+           List.map
+             (fun receipt ->
+                match receipt.state, recovered_terminal with
+                | Stored_inflight _, Some terminal_state ->
+                  { receipt with state = terminal_state }
+                | Stored_inflight { message; _ }, None ->
+                  { receipt with state = Stored_pending message }
+                | (Stored_pending _ | Stored_delivered _ | Stored_failed _), _ ->
+                  receipt)
+             receipts)
+        recovered_terminal
     in
     if Int64.compare revision max_revision >= 0
     then
@@ -774,12 +855,18 @@ let recover_inflight path ~revision receipts =
            "cannot persist restart recovery: chat queue revision domain is exhausted")
     else
       let revision = Int64.succ revision in
-      match persist_snapshot_to_path path ~revision receipts with
-      | Ok () -> Ok { revision; receipts; migrated = false; recovered_count }
+      match receipts with
       | Error error ->
         Error
           (load_error Recovery_failed ~path
-             ("failed to persist restart recovery: " ^ error))
+             ("failed to reconcile delivery journal: " ^ error))
+      | Ok receipts ->
+        (match persist_snapshot_to_path path ~revision receipts with
+         | Ok () -> Ok { revision; receipts; migrated = false; recovered_count }
+         | Error error ->
+           Error
+             (load_error Recovery_failed ~path
+                ("failed to persist restart recovery: " ^ error)))
 
 let load_snapshot ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name with
@@ -797,7 +884,13 @@ let load_snapshot ~base_path ~keeper_name =
            (match parse_v2 json with
             | Error message -> Error (load_error Parse_failed ~path message)
             | Ok (revision, receipts) ->
-              Result.map Option.some (recover_inflight path ~revision receipts))
+              Result.map Option.some
+                (recover_inflight
+                   ~base_path
+                   ~keeper_name
+                   path
+                   ~revision
+                   receipts))
          | Ok schema when String.equal schema schema_v1 ->
            (match migrate_v1_to_v2 path json with
             | Ok (revision, receipts) ->

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -759,7 +759,7 @@ let recovered_queue_terminal ~base_path ~keeper_name receipts =
       receipts
   in
   match Keeper_chat_delivery_identity.Receipt_ids.of_list inflight_ids with
-  | Error _ -> Ok None
+  | Error Keeper_chat_delivery_identity.Receipt_ids.Empty -> Ok None
   | Ok receipt_ids ->
     let delivery_key =
       Keeper_chat_delivery_identity.Queue_receipts receipt_ids

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -780,6 +780,11 @@ let recovered_queue_terminal ~base_path ~keeper_name receipts =
          ; updated_at
          ; _
          } ->
+       (* The journal proves transcript commit, not Discord/Slack delivery.
+          If the queue snapshot is still Inflight, no durable connector receipt
+          exists. Fail explicitly and never redispatch inference; #24180's
+          connector outbox is the boundary that can later make outbound delivery
+          itself resumable. *)
        let detail =
          if terminal.ok
          then

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -30,13 +30,7 @@ type queued_message = {
   source : message_source;
 }
 
-module Receipt_id : sig
-  type t
-
-  val of_string : string -> (t, string) result
-  val to_string : t -> string
-  val equal : t -> t -> bool
-end
+module Receipt_id = Keeper_chat_delivery_identity.Receipt_id
 
 type completion = {
   completed_at : float;
@@ -52,6 +46,7 @@ type failure_kind =
   | Delivery_failed
   | Cancelled
   | Internal_error
+  | Recovery_interrupted
 
 val failure_kind_to_string : failure_kind -> string
 

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -728,6 +728,7 @@ let dispatch_stream
       ?on_event
       ?continuation_channel
       ?on_admission_rejected
+      ?on_admitted
       ctx
       ~name
       ~args
@@ -745,6 +746,7 @@ let dispatch_stream
               ?on_event
               ?continuation_channel
               ?on_admission_rejected
+              ?on_admitted
               ctx
               args))
   | _ -> None

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -46,6 +46,7 @@ val dispatch_stream :
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
+  ?on_admitted:(unit -> (unit, string) result) ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 (** Non-blocking streaming dispatch for direct chat admission. The Keeper turn

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -857,6 +857,7 @@ let handle_keeper_msg_stream
       ?on_event
       ?continuation_channel
       ?on_admission_rejected
+      ?on_admitted
       ctx
       args
   : tool_result
@@ -874,6 +875,7 @@ let handle_keeper_msg_stream
         ?event_bus
         ?continuation_channel
         ?on_admission_rejected
+        ?on_admitted
         ctx
         resolved_args
     in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1328,6 +1328,7 @@ let handle_keeper_msg
       ?event_bus
       ?continuation_channel
       ?on_admission_rejected
+      ?on_admitted
       ctx
       args
   : tool_result
@@ -1354,13 +1355,28 @@ let handle_keeper_msg
         ~base_path:ctx.config.base_path
         ~keeper_name:name
         (fun () ->
-          run_keeper_msg_turn_admitted
-            ?on_text_delta
-            ?on_event
-            ?event_bus
-            ?continuation_channel
-            ctx
-            args)
+          match on_admitted with
+          | Some notify ->
+            (match notify () with
+             | Ok () ->
+               run_keeper_msg_turn_admitted
+                 ?on_text_delta
+                 ?on_event
+                 ?event_bus
+                 ?continuation_channel
+                 ctx
+                 args
+             | Error detail ->
+               tool_result_error
+                 ("keeper turn admission persistence failed: " ^ detail))
+          | None ->
+            run_keeper_msg_turn_admitted
+              ?on_text_delta
+              ?on_event
+              ?event_bus
+              ?continuation_channel
+              ctx
+              args)
     with
     | `Ran result -> result
     | `Rejected

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -140,6 +140,7 @@ val handle_keeper_msg :
   ?event_bus:Agent_sdk.Event_bus.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
+  ?on_admitted:(unit -> (unit, string) result) ->
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 (** [event_bus] is captured at the handler boundary and reused by the admitted
     turn body. Callers that omit it keep the legacy process/domain fallback, but

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -230,8 +230,9 @@ let connector_user_line_recorded_upstream_of_source
   (* RFC-connector-deferred-reply-via-chat-queue §3.4: connector sources (Discord/Slack) had their user
      line recorded at the gate inbound boundary before the message was
      enqueued, so the turn records the assistant reply only and does not
-     re-write the user line. Dashboard-source queue messages have no
-     upstream recorder, so the turn records both sides. *)
+     re-write the user line. Dashboard ownership is resolved later from exact
+     direct-request handoff journals, allowing legacy receipts to append their
+     missing user row without duplicating current receipts. *)
   match source with
   | Keeper_chat_queue.Discord _ | Keeper_chat_queue.Slack _ -> true
   | Keeper_chat_queue.Dashboard -> false
@@ -1168,7 +1169,7 @@ let start_keeper_loops
            queue_report.load_errors;
          Keeper_chat_consumer.start ~sw ~clock
            ~base_path
-           ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
+           ~handle_turn:(fun ~sw ~keeper_name ~delivery_key ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in
              let run_id =
@@ -1329,6 +1330,7 @@ let start_keeper_loops
                match
                  process_single_turn ~connector_user_line_recorded_upstream
                    ~queued_turn:true
+                   ~delivery_key:(Some delivery_key)
                    ~state ~clock ~auth_token:None
                    ~thread_id ~continuation_channel ~closed
                    ~client_disconnects:None

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -790,6 +790,7 @@ let execute_keeper_stream_tool_streaming
       ~clock
       ?auth_token:_
       ?on_event
+      ?on_admitted
       state
       ~agent_name
       ~arguments
@@ -814,6 +815,7 @@ let execute_keeper_stream_tool_streaming
         Keeper_tool_surface.dispatch_stream ~on_text_delta ?on_event
           ~on_admission_rejected:(fun rejection ->
             admission_rejection := Some rejection)
+          ?on_admitted
           keeper_ctx
           ~continuation_channel
           ~name:"masc_keeper_msg"
@@ -1241,6 +1243,7 @@ let translate_oas_stream_event = Keeper_chat_oas_stream_bridge.translate
    the user line, and whether this turn was dispatched from the queue
    consumer. *)
 let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
+    ~delivery_key
     ~state ~clock ~auth_token ~thread_id ~continuation_channel ~closed
     ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name ~submitted_by
@@ -1388,7 +1391,87 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~base_path
         ~expected_revision:prepared.revision
         ~identity:prepared
-        ~user_row_id:(row_id_of_append_once user_row)
+        ~user_row_id:(Some (row_id_of_append_once user_row))
+        ~now:(Time_compat.now ())
+      |> Result.map_error journal_error
+    in
+    ignore (set_direct_delivery_journal accepted : Keeper_chat_delivery_journal.t);
+    let* running =
+      Keeper_chat_delivery_journal.mark_running
+        ~base_path
+        ~expected_revision:accepted.revision
+        ~identity:accepted
+        ~now:(Time_compat.now ())
+      |> Result.map_error journal_error
+    in
+    ignore (set_direct_delivery_journal running : Keeper_chat_delivery_journal.t);
+    Ok ()
+  in
+  let on_queue_turn_admitted () =
+    let ( let* ) = Result.bind in
+    let* delivery_key, receipt_ids =
+      match delivery_key with
+      | Some (Keeper_chat_delivery_identity.Queue_receipts receipt_ids as key) ->
+        Ok (key, receipt_ids)
+      | Some (Keeper_chat_delivery_identity.Direct_request _) ->
+        Error "queued Keeper turn received a direct-request delivery identity"
+      | None -> Error "queued Keeper turn is missing its receipt delivery identity"
+    in
+    let user_row_origin =
+      if connector_user_line_recorded_upstream
+      then Ok Keeper_chat_delivery_journal.Already_persisted_upstream
+      else
+        Keeper_chat_delivery_journal.dashboard_queue_user_row_origin
+          ~base_path
+          ~keeper_name:payload.name
+          receipt_ids
+        |> Result.map_error journal_error
+    in
+    let* user_row_origin = user_row_origin in
+    let accepted_payload : Keeper_chat_delivery_journal.accepted_payload =
+      { keeper_name = payload.name
+      ; submitted_by
+      ; user_content = payload.message
+      ; user_attachments = payload.attachments
+      ; surface = chat_surface
+      ; conversation_id = None
+      ; external_message_id = None
+      ; speaker = chat_speaker
+      ; user_row_origin
+      }
+    in
+    let* prepared =
+      Keeper_chat_delivery_journal.prepare
+        ~base_path
+        ~delivery_key
+        ~payload:accepted_payload
+        ~now:(Time_compat.now ())
+      |> Result.map_error journal_error
+    in
+    ignore (set_direct_delivery_journal prepared : Keeper_chat_delivery_journal.t);
+    let* user_row_id =
+      match user_row_origin with
+      | Keeper_chat_delivery_journal.Already_persisted_upstream -> Ok None
+      | Keeper_chat_delivery_journal.Already_persisted { row_id } ->
+        Ok (Some row_id)
+      | Keeper_chat_delivery_journal.Needs_append ->
+        Keeper_chat_store.append_user_message_once
+          ~base_dir:base_path
+          ~keeper_name:payload.name
+          ~delivery_key
+          ~content:payload.message
+          ~attachments:payload.attachments
+          ~surface:chat_surface
+          ~speaker:chat_speaker
+          ()
+        |> Result.map (fun result -> Some (row_id_of_append_once result))
+    in
+    let* accepted =
+      Keeper_chat_delivery_journal.mark_accepted
+        ~base_path
+        ~expected_revision:prepared.revision
+        ~identity:prepared
+        ~user_row_id
         ~now:(Time_compat.now ())
       |> Result.map_error journal_error
     in
@@ -1451,8 +1534,15 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               ()
             |> Result.map row_id_of_append_once
           | Keeper_chat_delivery_journal.No_assistant_reply
-              { reason = Keeper_chat_delivery_journal.Continuation_checkpoint } ->
-            Ok user_row_id
+              { reason =
+                  ( Keeper_chat_delivery_journal.Continuation_checkpoint
+                  | Keeper_chat_delivery_journal.Queued_for_later _ )
+              } ->
+            (match user_row_id with
+             | Some user_row_id -> Ok user_row_id
+             | None ->
+               Error
+                 "continuation checkpoint requires an accepted user transcript row")
         in
         let* committed =
           Keeper_chat_delivery_journal.mark_transcript_committed
@@ -1645,6 +1735,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~keeper_name:payload.name
         ~f:(fun request_sw ->
         let start_time = Time_compat.now () in
+        let on_admitted =
+          if queued_turn then Some on_queue_turn_admitted else None
+        in
         let dispatch_result =
           try
             if dashboard_direct_stream then
@@ -1658,11 +1751,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               | `Ran result -> Ok (`Ran result)
               | `Busy rejection ->
                   (match
-                     dashboard_deferred_chat_of_rejection ~clock payload rejection
+                   dashboard_deferred_chat_of_rejection ~clock payload rejection
                    with
-                   | Ok queued ->
-                       push_worker_event (Stream_dashboard_queued queued);
-                       Ok (`Queued queued)
+                   | Ok queued -> Ok (`Queued queued)
                    | Error message -> Error message)
             else
               (match
@@ -1672,6 +1763,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                    ?auth_token
                    state ~agent_name ~arguments:args ~on_event
                    ~continuation_channel ~on_text_delta:(fun _ -> ())
+                   ?on_admitted
                with
                | `Ran result -> Ok (`Ran result)
                | `Deferred rejection -> Ok (`Deferred rejection))
@@ -1681,7 +1773,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               Log.Keeper.warn
                 "keeper_stream: streaming dispatch raised: %s"
                 (Printexc.to_string exn);
-              if dashboard_direct_stream then Error (Printexc.to_string exn)
+              if dashboard_direct_stream || queued_turn
+              then Error (Printexc.to_string exn)
               else
                 (try
                    Ok
@@ -1706,11 +1799,39 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                     ; ("admission", admission_rejection_to_json rejection)
                     ]))
         | Ok (`Queued queued) ->
-            Tool_result.ok
-              ~tool_name:"masc_keeper_msg"
-              ~start_time
-              (Yojson.Safe.to_string
-                 (dashboard_deferred_chat_to_json ~keeper_name:payload.name queued))
+            let body =
+              Yojson.Safe.to_string
+                (dashboard_deferred_chat_to_json ~keeper_name:payload.name queued)
+            in
+            let committed =
+              let ( let* ) = Result.bind in
+              let* receipt_id =
+                Keeper_chat_delivery_identity.Receipt_id.of_string
+                  queued.receipt_id
+              in
+              commit_direct_terminal
+                { ok = true
+                ; poll_body = body
+                ; delivery =
+                    Keeper_chat_delivery_journal.No_assistant_reply
+                      { reason =
+                          Keeper_chat_delivery_journal.Queued_for_later
+                            { receipt_id }
+                      }
+                }
+            in
+            (match committed with
+             | Ok () ->
+               push_worker_event (Stream_dashboard_queued queued);
+               Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body
+             | Error detail ->
+               push_worker_event
+                 (Stream_terminal
+                    { status = Stream_error
+                    ; body = detail
+                    ; queued_outcome = None
+                    });
+               Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail)
         | Ok (`Ran (true, body)) ->
             let payload_json_opt, visible_reply = extract_visible_reply body in
             let streamed_text =
@@ -2550,7 +2671,7 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
                 user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
              ignore
                (process_single_turn ~connector_user_line_recorded_upstream:false
-                  ~queued_turn:false
+                  ~queued_turn:false ~delivery_key:None
                   ~state ~clock
                   ~auth_token:(auth_token_from_request request)
                   ~thread_id ~continuation_channel ~closed

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -184,6 +184,7 @@ val queued_turn_failure_kind_to_string : queued_turn_failure_kind -> string
 val process_single_turn :
   connector_user_line_recorded_upstream:bool ->
   queued_turn:bool ->
+  delivery_key:Keeper_chat_delivery_identity.delivery_key option ->
   state:Mcp_server.server_state ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   auth_token:string option ->

--- a/test/test_keeper_chat_consumer_delivery.ml
+++ b/test/test_keeper_chat_consumer_delivery.ml
@@ -160,7 +160,7 @@ let test_delivery_finalizes_terminal_receipt () =
     | None -> ()
     | Some accepted ->
       let captured = ref None in
-      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message =
+      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~delivery_key:_ ~queued_message =
         captured := Some (dispatched_keeper, queued_message);
         Keeper_chat_consumer.Delivered
           { outcome_ref = "trace-delivered#1" }
@@ -206,7 +206,7 @@ let test_explicit_failure_finalizes_failed_receipt () =
     with
     | None -> ()
     | Some accepted ->
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         Keeper_chat_consumer.Failed
           { kind = Keeper_chat_queue.Delivery_failed
           ; detail = "connector rejected outbound delivery"
@@ -247,7 +247,7 @@ let test_structured_cancellation_nacks_and_preserves_receipt () =
     | Some accepted ->
       let started, resolve_started = Eio.Promise.create () in
       let never, _resolve_never = Eio.Promise.create () in
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         Eio.Promise.resolve resolve_started ();
         Eio.Promise.await never
       in
@@ -308,7 +308,7 @@ let test_dispatch_is_concurrent_per_keeper () =
       let first_started, resolve_first_started = Eio.Promise.create () in
       let release_first, resolve_release_first = Eio.Promise.create () in
       let second_started, resolve_second_started = Eio.Promise.create () in
-      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:dispatched_keeper ~delivery_key:_ ~queued_message:_ =
         incr calls;
         match !first_keeper with
         | None ->
@@ -379,7 +379,7 @@ let test_finalization_persistence_retry_does_not_redeliver () =
     | None -> ()
     | Some accepted ->
       let calls = ref 0 in
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         incr calls;
         Keeper_chat_queue.For_testing.fail_next_persist ();
         Keeper_chat_consumer.Delivered
@@ -415,7 +415,7 @@ let test_invalid_delivered_turn_ref_fails_closed () =
     with
     | None -> ()
     | Some accepted ->
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         Keeper_chat_consumer.Delivered { outcome_ref = "trace#0042" }
       in
       with_consumer_switch (fun sw ->
@@ -450,7 +450,7 @@ let test_invalid_delivery_diagnostic_does_not_block_lane () =
       let calls = ref 0 in
       let first_started, resolve_first_started = Eio.Promise.create () in
       let release_first, resolve_release_first = Eio.Promise.create () in
-      let handle_turn ~sw:_ ~keeper_name:_
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_
           ~(queued_message : Keeper_chat_queue.queued_message) =
         incr calls;
         if String.equal queued_message.content "invalid diagnostic"
@@ -518,7 +518,7 @@ let test_shutdown_fence_keeps_receipt_pending_until_rollback () =
            ~operation_id
           : Keeper_turn_admission.begin_shutdown_result);
       let calls = ref 0 in
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         incr calls;
         Keeper_chat_consumer.Delivered
           { outcome_ref = "trace-shutdown-rollback#1" }
@@ -572,7 +572,7 @@ let test_typed_admission_race_nacks_then_retries () =
       let first_deferred, resolve_first_deferred = Eio.Promise.create () in
       let second_started, resolve_second_started = Eio.Promise.create () in
       let release_second, resolve_release_second = Eio.Promise.create () in
-      let handle_turn ~sw:_ ~keeper_name:_ ~queued_message:_ =
+      let handle_turn ~sw:_ ~keeper_name:_ ~delivery_key:_ ~queued_message:_ =
         incr calls;
         if !calls = 1
         then (

--- a/test/test_keeper_chat_delivery_identity.ml
+++ b/test/test_keeper_chat_delivery_identity.ml
@@ -27,14 +27,18 @@ let test_direct_roundtrip () =
 
 let test_queue_requires_nonempty_receipts () =
   (match Identity.Receipt_ids.of_list [] with
-   | Error _ -> ()
+   | Error Identity.Receipt_ids.Empty -> ()
    | Ok _ -> fail "empty receipt list was accepted");
   let receipt_id =
     Identity.Receipt_id.of_string
       "chatq_123e4567-e89b-12d3-a456-426614174000"
     |> expect_ok
   in
-  let receipt_ids = Identity.Receipt_ids.of_list [ receipt_id ] |> expect_ok in
+  let receipt_ids =
+    Identity.Receipt_ids.of_list [ receipt_id ]
+    |> Result.map_error Identity.Receipt_ids.error_to_string
+    |> expect_ok
+  in
   let key = Identity.Queue_receipts receipt_ids in
   let decoded =
     Identity.delivery_key_to_yojson key

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -413,7 +413,7 @@ let test_queue_restart_finalizes_receipt_without_redispatch () =
           |> Identity.Receipt_ids.of_list
           |> function
           | Ok receipt_ids -> receipt_ids
-          | Error detail -> fail detail
+          | Error error -> fail (Identity.Receipt_ids.error_to_string error)
         in
         Identity.Queue_receipts receipt_ids
       | `Empty -> fail "queue was empty after enqueue"
@@ -548,7 +548,7 @@ let test_dashboard_queue_origin_uses_typed_handoff_journal () =
     let origin receipt_ids =
       Identity.Receipt_ids.of_list receipt_ids
       |> function
-      | Error detail -> fail detail
+      | Error error -> fail (Identity.Receipt_ids.error_to_string error)
       | Ok receipt_ids ->
         Journal.dashboard_queue_user_row_origin
           ~base_path

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Identity = Masc.Keeper_chat_delivery_identity
 module Journal = Masc.Keeper_chat_delivery_journal
 module Keeper_chat_store = Masc.Keeper_chat_store
+module Keeper_chat_queue = Masc.Keeper_chat_queue
 module Surface_ref = Masc.Surface_ref
 
 let expect_ok = function
@@ -78,7 +79,7 @@ let test_full_transition_and_reload () =
         ~base_path
         ~expected_revision:prepared.revision
         ~identity:prepared
-        ~user_row_id:"msg-user"
+        ~user_row_id:(Some "msg-user")
         ~now:2.0
       |> expect_ok
     in
@@ -148,7 +149,7 @@ let test_stale_revision_and_phase_fail_closed () =
         ~base_path
         ~expected_revision:0
         ~identity:prepared
-        ~user_row_id:"msg-user"
+        ~user_row_id:(Some "msg-user")
         ~now:2.0
       |> expect_ok
     in
@@ -342,7 +343,7 @@ let test_checkpoint_commits_without_fake_assistant_row () =
         ~base_path
         ~expected_revision:prepared.revision
         ~identity:prepared
-        ~user_row_id
+        ~user_row_id:(Some user_row_id)
         ~now:2.0
       |> expect_ok
     in
@@ -382,6 +383,192 @@ let test_checkpoint_commits_without_fake_assistant_row () =
     check int "checkpoint adds no fake assistant row" 1 (List.length history))
 ;;
 
+let test_queue_restart_finalizes_receipt_without_redispatch () =
+  Eio_main.run @@ fun _env ->
+  with_temp_dir (fun base_path ->
+    Keeper_chat_queue.For_testing.reset ();
+    ignore
+      (Keeper_chat_queue.configure_persistence ~base_path
+        : Keeper_chat_queue.configure_report);
+    let queued_message : Keeper_chat_queue.queued_message =
+      { content = "queued source check"
+      ; user_blocks = []
+      ; attachments = []
+      ; timestamp = 1.0
+      ; source = Keeper_chat_queue.Dashboard
+      }
+    in
+    let receipt =
+      match Keeper_chat_queue.enqueue ~keeper_name:"sangsu" queued_message with
+      | Ok receipt -> receipt
+      | Error error -> fail (Keeper_chat_queue.mutation_error_to_string error)
+    in
+    let delivery_key =
+      match Keeper_chat_queue.lease_batch ~keeper_name:"sangsu" with
+      | `Leased { items; _ } ->
+        let receipt_ids =
+          List.map
+            (fun (item : Keeper_chat_queue.leased_message) -> item.receipt_id)
+            items
+          |> Identity.Receipt_ids.of_list
+          |> function
+          | Ok receipt_ids -> receipt_ids
+          | Error detail -> fail detail
+        in
+        Identity.Queue_receipts receipt_ids
+      | `Empty -> fail "queue was empty after enqueue"
+      | `Already_leased lease_id -> failf "unexpected existing lease %s" lease_id
+      | `Error error -> fail (Keeper_chat_queue.mutation_error_to_string error)
+    in
+    ignore
+      (Journal.prepare
+         ~base_path
+         ~delivery_key
+         ~payload:
+           { (payload ()) with
+             user_content = queued_message.content
+           ; user_row_origin = Journal.Needs_append
+           }
+         ~now:2.0
+       |> expect_ok
+        : Journal.t);
+    Keeper_chat_queue.For_testing.reset ();
+    let recovery = Journal.recover_all ~base_path ~now:3.0 in
+    check int "queue journal recovered" 1 recovery.recovered;
+    let queue_recovery = Keeper_chat_queue.configure_persistence ~base_path in
+    check int "one inflight receipt reconciled" 1 queue_recovery.recovered_receipt_count;
+    (match
+       Keeper_chat_queue.lookup_receipt
+         ~keeper_name:"sangsu"
+         ~receipt_id:receipt.receipt_id
+     with
+     | Ok
+         { receipt =
+             Some
+               { state =
+                   Keeper_chat_queue.Failed
+                     { kind = Keeper_chat_queue.Recovery_interrupted; _ }
+               ; _
+               }
+         ; _
+         } -> ()
+     | Ok _ -> fail "recovered receipt was not terminal Recovery_interrupted"
+     | Error error -> fail (Keeper_chat_queue.mutation_error_to_string error));
+    let history = Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu" in
+    check int "queue restart writes one user and one failure row" 2 (List.length history);
+    Keeper_chat_queue.For_testing.reset ())
+;;
+
+let test_dashboard_queue_origin_uses_typed_handoff_journal () =
+  with_temp_dir (fun base_path ->
+    let receipt_id =
+      Identity.Receipt_id.of_string
+        "chatq_123e4567-e89b-12d3-a456-426614174000"
+      |> function
+      | Ok receipt_id -> receipt_id
+      | Error detail -> fail detail
+    in
+    let unknown_receipt_id =
+      Identity.Receipt_id.of_string
+        "chatq_123e4567-e89b-12d3-a456-426614174001"
+      |> function
+      | Ok receipt_id -> receipt_id
+      | Error detail -> fail detail
+    in
+    let key = direct_key () in
+    let prepared =
+      Journal.prepare
+        ~base_path
+        ~delivery_key:key
+        ~payload:(payload ())
+        ~now:1.0
+      |> expect_ok
+    in
+    let user_row =
+      Keeper_chat_store.append_user_message_once
+        ~base_dir:base_path
+        ~keeper_name:"sangsu"
+        ~delivery_key:key
+        ~content:prepared.payload.user_content
+        ~surface:prepared.payload.surface
+        ~speaker:prepared.payload.speaker
+        ()
+      |> expect_chat_ok
+    in
+    let user_row_id = row_id user_row in
+    let accepted =
+      Journal.mark_accepted
+        ~base_path
+        ~expected_revision:prepared.revision
+        ~identity:prepared
+        ~user_row_id:(Some user_row_id)
+        ~now:2.0
+      |> expect_ok
+    in
+    let running =
+      Journal.mark_running
+        ~base_path
+        ~expected_revision:accepted.revision
+        ~identity:accepted
+        ~now:3.0
+      |> expect_ok
+    in
+    let pending =
+      Journal.mark_terminal_pending
+        ~base_path
+        ~expected_revision:running.revision
+        ~identity:running
+        ~terminal:
+          { ok = true
+          ; poll_body = "queued"
+          ; delivery =
+              Journal.No_assistant_reply
+                { reason = Journal.Queued_for_later { receipt_id } }
+          }
+        ~now:4.0
+      |> expect_ok
+    in
+    let committed =
+      Journal.mark_transcript_committed
+        ~base_path
+        ~expected_revision:pending.revision
+        ~identity:pending
+        ~transcript_row_id:user_row_id
+        ~now:5.0
+      |> expect_ok
+    in
+    ignore
+      (Journal.mark_final
+         ~base_path
+         ~expected_revision:committed.revision
+         ~identity:committed
+         ~now:6.0
+       |> expect_ok
+        : Journal.t);
+    let origin receipt_ids =
+      Identity.Receipt_ids.of_list receipt_ids
+      |> function
+      | Error detail -> fail detail
+      | Ok receipt_ids ->
+        Journal.dashboard_queue_user_row_origin
+          ~base_path
+          ~keeper_name:"sangsu"
+          receipt_ids
+    in
+    (match origin [ receipt_id ] with
+     | Ok Journal.Already_persisted_upstream -> ()
+     | Ok _ -> fail "journaled Dashboard receipt was treated as legacy"
+     | Error error -> fail (Journal.error_to_string error));
+    (match origin [ unknown_receipt_id ] with
+     | Ok Journal.Needs_append -> ()
+     | Ok _ -> fail "legacy Dashboard receipt did not request a user append"
+     | Error error -> fail (Journal.error_to_string error));
+    match origin [ receipt_id; unknown_receipt_id ] with
+    | Error (Journal.Transcript_error _) -> ()
+    | Error error -> fail (Journal.error_to_string error)
+    | Ok _ -> fail "mixed Dashboard provenance was accepted")
+;;
+
 let () =
   run
     "keeper chat delivery journal"
@@ -411,6 +598,14 @@ let () =
             "checkpoint has no fake reply"
             `Quick
             test_checkpoint_commits_without_fake_assistant_row
+        ; test_case
+            "queue restart finalizes without redispatch"
+            `Quick
+            test_queue_restart_finalizes_receipt_without_redispatch
+        ; test_case
+            "Dashboard queue origin is typed"
+            `Quick
+            test_dashboard_queue_origin_uses_typed_handoff_journal
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- bind each leased queue batch to the shared typed delivery identity at the actual Keeper admission boundary
- leave typed admission deferrals Pending without opening a journal
- recover an interrupted Inflight journal to an append-once terminal transcript before queue snapshot recovery
- finalize recovered Inflight receipts as Recovery_interrupted instead of re-running inference or falsely inferring connector delivery from transcript success
- preserve Dashboard user-row ownership through typed direct-to-queue handoff journals; fail closed on mixed provenance
- commit the direct busy handoff before publishing queued request status
- represent nonempty receipt identity construction failure as the closed `Receipt_ids.Empty` variant and match it exhaustively at recovery boundaries

## Boundary
Stacked on #24277, which is stacked on #24241. This PR completes the queued half of #24191 while Keeper_chat_queue remains the receipt-state SSOT and the delivery journal remains the transcript-commit SSOT. A transcript commit is deliberately not treated as Discord/Slack delivery proof.

## Verification
- scripts/dune-local.sh build test/test_keeper_chat_delivery_identity.exe test/test_keeper_chat_consumer_delivery.exe test/test_keeper_chat_delivery_journal.exe lib/masc.cmxa
- test_keeper_chat_delivery_identity.exe: 4 passed
- test_keeper_chat_consumer_delivery.exe: all receipt checks passed
- test_keeper_chat_delivery_journal.exe: 9 passed, including restart no-redispatch and typed Dashboard provenance
- ocamlformat on all touched OCaml files
- git diff --check
