### PR TITLE
test(reqd): drop obsolete KS3b source string-match anchor

### DIFF
--- a/test/test_reqd_invalid_state_swallow.ml
+++ b/test/test_reqd_invalid_state_swallow.ml
@@ -307,10 +307,12 @@ let () =
     ~label:"KS3a: worker owns connector user-line recording decision"
     keeper_stream_src
     "process_single_turn ~connector_user_line_recorded_upstream:false";
-  assert_contains
-    ~label:"KS3b: worker uses server switch"
-    keeper_stream_src
-    "~state ~clock ~sw";
+  (* KS3b removed: it string-matched the literal "~state ~clock ~sw", an
+     obsolete worker signature. The worker now takes "~state ~clock ~auth_token
+     ..." (keeper_stream.ml:1244) and threads the switch via
+     ~client_disconnects:(Some (stream_sw, _)) — still asserted by KS4 below.
+     The switch/structured-concurrency invariant holds; the anchor was a
+     brittle source string-match that false-positived on the signature change. *)
   assert_contains
     ~label:"KS4: disconnect watcher uses stream switch"
     keeper_stream_src


### PR DESCRIPTION
## 개선점
main-suite Build 실패 5개 중 하나인 **KS3b 앵커**를 제거해용 (커밋 `00507fc5e0`).

`test_reqd_invalid_state_swallow.ml`의 KS3b는 `server_routes_http_keeper_stream.ml` 소스에 리터럴 `"~state ~clock ~sw"`가 있는지 검사하는 **string-match anchor**였어용. worker 시그니처가 `~state ~clock ~auth_token ...`(`keeper_stream.ml:1244`)로 바뀌면서 그 리터럴이 사라져 Build가 fail했어용.

**검증(적대적 판단)**: switch/structured-concurrency 불변식은 **여전히 유지**돼용 — worker는 `~client_disconnects:(Some (stream_sw, _))`로 switch를 받고, 그건 바로 아래 **KS4 앵커가 계속 검사**해용. 즉 KS3b는 obsolete 시그니처를 검사하던 stale anchor라 regression을 숨기지 않아용. goal 기준 "노 스트링 매치 · 불필요 테스트 적극 제거"에 부합해용.

## P0/P1/P2/P3
- **P0/P1/P2/P3**: 없어용. (테스트 앵커 1개 제거, prod 무변경)

## 남은점
main-suite Build의 나머지 4개 실패(board_post 8 / direct_keepalive 0 / keeper_msg_async 5 / executor_pool 34)는 별도 root라 이 PR 범위 밖이에용.

## 병합 가능성
prod 코드 무변경, 앵커 1개 제거. CI(Build and Test)에서 KS3b fail 해소 확인 후 병합 가능해용. 로컬 dune 대신 CI로 검증해용.

관련: #24261 Build 진단 코멘트(issuecomment-4950023580)에서 식별한 5개 실패 중 KS3b 건.
