### PR TITLE
feat(task): Gate 0 — require evidence_refs for Done_action completions (task-2280)

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -430,6 +430,26 @@ let evidence_refs =
         | Some h -> h.evidence_refs
         | None -> []
       in
+      (* Gate 0: Done_action requires at least one evidence_ref.
+         RFC-0323: bare result text without a locally-validatable artifact
+         (file path, commit hash, or trace ref) is insufficient. *)
+      let evidence_refs_gate =
+        if (=) action Masc_domain.Done_action && not force
+        && Stdlib.List.length evidence_refs = 0
+        then
+          Some
+            "Done action requires at least one evidence_ref \
+             (file path, commit hash, or trace ref). Result text, \
+             URLs, and PR numbers alone do not satisfy the gate."
+        else
+          None
+      in
+      match evidence_refs_gate with
+      | Some reason ->
+        Tool_result.error
+          ~failure_class:(Some Tool_result.Workflow_rejection)
+          ~tool_name ~start_time reason
+      | None ->
       let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
       if not completion_owned_by_caller then


### PR DESCRIPTION
## Summary

Adds Gate 0 fast-fail in `handle_transition`: when a `Done_action` is requested with empty `evidence_refs`, reject immediately before the LLM review gate.

### Change

`lib/task/tool_task.ml` — inserts `evidence_refs_gate` check after extracting evidence_refs from handoff_context, before `review_gate_rejection`:
- If `action = Done_action` AND `not force` AND `evidence_refs = []` → return `Workflow_rejection` error
- Otherwise → continue to existing review gate

### Why

RFC-0323: bare result text without a locally-validatable artifact (file path, commit hash, trace ref) is insufficient evidence of task completion. This prevents keepers from closing tasks with only URLs or PR numbers.

### Prior attempts

- #24249 — closed without merge (design iteration)
- #24265 — closed without merge (design iteration)

This PR uses the minimal insertion approach from #24265 with verified anchor text on current main.

### Testing

CI will verify compilation and existing tests. Gate 0 is a pure guard clause — no behavioral change for tasks that already provide evidence_refs.