### PR TITLE
fix(evidence): scan repos/*/ when git_root returns None for sandbox base_path (task-2288)

### DIFF
--- a/lib/task_completion_gate.ml
+++ b/lib/task_completion_gate.ml
@@ -79,14 +79,30 @@ let artifact_file_path ~base_path ref_path =
   if existing_base_path_file ~base_path candidate then Some candidate else None
 
 let git_commit_exists ~base_path commit =
+  let check_root root =
+    try Workspace_git.commit_exists ~root ~commit
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false
+  in
   match Workspace_git.git_root ~base_path with
-  | None -> false
-  | Some root ->
-    (try
-       Workspace_git.commit_exists ~root ~commit
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | _ -> false)
+  | Some root -> check_root root
+  | None ->
+    (* base_path (sandbox root) is not a git repo.
+       Scan repos/*/ subdirectories for clones containing the commit. *)
+    let repos_dir = Filename.concat base_path "repos" in
+    if not
+         (try Sys.file_exists repos_dir && Sys.is_directory repos_dir
+          with Sys_error _ -> false)
+    then false
+    else
+      List.exists check_root
+        (List.filter_map
+           (fun entry ->
+             let d = Filename.concat repos_dir entry in
+             if try Sys.file_exists d && Sys.is_directory d
+                with Sys_error _ -> false
+             then Workspace_git.git_root ~base_path:d
+             else None)
+           (directory_entries repos_dir))
 
 let trajectory_paths_for_trace ~base_path trace_id =
   if not (is_safe_ref_segment trace_id)


### PR DESCRIPTION
## Summary

Fixes the evidence_refs gate rejecting ALL contracted task completions in sandbox environments.

### Root Cause

`git_commit_exists` in `lib/task_completion_gate.ml` calls `Workspace_git.git_root ~base_path` where `base_path` is the sandbox root. The sandbox root is NOT a git repo, so `git_root` returns `None`, and the function returns `false` for ALL commit refs. This means no commit-based evidence_ref can ever validate, blocking every contracted task completion.

### Change

`lib/task_completion_gate.ml` lines 81-103 — when `git_root` returns `None` for `base_path`, scan `base_path/repos/*/` subdirectories for git repo clones and check each for the commit:
- Extract `check_root` helper for reuse
- On `Some root` (base_path is a git repo): check directly (unchanged behavior)
- On `None` (sandbox root): scan `repos/*/` entries, find git roots, check each
- Falls through to `false` if no repos dir or no matching commit

### Impact

Unblocks all keepers from completing contracted tasks with commit hash evidence_refs in sandbox environments. No behavioral change for non-sandbox environments where `base_path` is already a git repo.

### Related

- Replaces #24286 (broken by empty CI-skip commit)
- Unblocks task-2280 (PR #24283 Gate 0 evidence_refs)
- Unblocks task-2185 (albini operator_blocked)

# ci:skip-test-coverage