### PR TITLE
feat: operator_blocked task state (task-2185 v4) — P2 fix

### DIFF
--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -288,6 +288,7 @@ let task_operation_status (task : Masc_domain.task) =
   (* RFC-0323 G-6: awaiting verification is the normal completion lane,
      not a pause — the operation is still moving (verifier's turn). *)
   | Masc_domain.AwaitingVerification _ -> Some "active"
+  | Masc_domain.OperatorBlocked _ -> Some "active"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_updated_at (task : Masc_domain.task) =
@@ -297,6 +298,7 @@ let task_operation_updated_at (task : Masc_domain.task) =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 
 let task_operation_links (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -513,6 +513,7 @@ let task_updated_at (task : Masc_domain.task) =
   | Masc_domain.InProgress { started_at; _ } -> started_at
   | Masc_domain.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Masc_domain.Claimed { claimed_at; _ } -> claimed_at
+  | Masc_domain.OperatorBlocked { blocked_at; _ } -> blocked_at
   | Masc_domain.Todo -> task.created_at
 ;;
 
@@ -523,7 +524,8 @@ let task_completed_at (task : Masc_domain.task) =
   | Masc_domain.Todo
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
-  | Masc_domain.AwaitingVerification _ -> None
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.OperatorBlocked _ -> None
 ;;
 
 let task_execution_links_json (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -46,7 +46,8 @@ let keeper_action_stale_sec = Env_config.Dashboard.keeper_action_stale_sec
 let task_assignee (task : Masc_domain.task) =
   match task.task_status with
   | Claimed { assignee; _ } | InProgress { assignee; _ }
-  | AwaitingVerification { assignee; _ } | Done { assignee; _ } ->
+  | AwaitingVerification { assignee; _ } | Done { assignee; _ }
+  | OperatorBlocked { assignee; _ } ->
       Some assignee
   | Todo | Cancelled _ -> None
 
@@ -364,13 +365,14 @@ let task_operation_status (task : Masc_domain.task) =
   (* RFC-0323 G-6: awaiting verification is the normal completion lane,
      not a pause — the operation is still moving (verifier's turn). *)
   | Masc_domain.AwaitingVerification _ -> Some "active"
+  | Masc_domain.OperatorBlocked _ -> Some "active"
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 
 let task_operation_severity (task : Masc_domain.task) =
   match task.task_status with
   (* RFC-0323 G-6: verification pending is not a warning tone. *)
   | Masc_domain.AwaitingVerification _ -> Tone_ok
-  | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> Tone_ok
+  | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.OperatorBlocked _ -> Tone_ok
   | Masc_domain.Done _ | Masc_domain.Cancelled _ -> Tone_ok
 
 let task_operation_updated_at (task : Masc_domain.task) =

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -350,7 +350,7 @@ let rec build_tree context goals goal =
         match task.task_status with
         | Masc_domain.AwaitingVerification _ -> true
         | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.Done _
-        | Masc_domain.Cancelled _ ->
+        | Masc_domain.Cancelled _ | Masc_domain.OperatorBlocked _ ->
             false)
       linked_tasks
   in

--- a/lib/task/task_dispatch.ml
+++ b/lib/task/task_dispatch.ml
@@ -81,7 +81,7 @@ let list_tasks config ?(include_done=false) ?(include_cancelled=false) () =
         let dominated = match t.task_status with
           | Done _ -> not include_done
           | Cancelled _ -> not include_cancelled
-          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+          | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | OperatorBlocked _ -> false
         in
         not dominated
       ) backlog.tasks in

--- a/lib/task/task_transition_state.ml
+++ b/lib/task/task_transition_state.ml
@@ -17,6 +17,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 type transition_action =
   | Claim
@@ -27,6 +28,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 type family =
   | Invalid_transition of
@@ -62,6 +65,7 @@ let status_kind_to_string = function
   | AwaitingVerification_kind -> "awaiting_verification"
   | Done_kind -> "done"
   | Cancelled_kind -> "cancelled"
+  | OperatorBlocked_kind -> "operator_blocked"
 
 let transition_action_to_string = function
   | Claim -> "claim"
@@ -72,6 +76,8 @@ let transition_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve_verification"
   | Reject_verification -> "reject_verification"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 let family_to_string = function
   | Invalid_transition { from_status; action } ->
@@ -98,6 +104,7 @@ let all_status_kinds : status_kind list =
   ; AwaitingVerification_kind
   ; Done_kind
   ; Cancelled_kind
+  ; OperatorBlocked_kind
   ]
 
 let all_transition_actions : transition_action list =
@@ -109,6 +116,8 @@ let all_transition_actions : transition_action list =
   ; Submit_for_verification
   ; Approve_verification
   ; Reject_verification
+  ; Block_for_operator
+  ; Unblock
   ]
 
 let all_families : family list =

--- a/lib/task/task_transition_state.mli
+++ b/lib/task/task_transition_state.mli
@@ -81,6 +81,7 @@ type status_kind =
   | AwaitingVerification_kind
   | Done_kind
   | Cancelled_kind
+  | OperatorBlocked_kind
 
 (** Closed-enum mirror of [Types_core.task_action]. Adding a new action
     upstream forces an arm here. Used for both fingerprinting and the
@@ -94,6 +95,8 @@ type transition_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 
 (** Closed-enum classification of the [InvalidState] error message.
     Derived from the [Tool_task.validate_transition] surface and the

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -229,6 +229,7 @@ let todo_task_has_completed_deliverable_conflict (ctx : context) (task : Masc_do
   | Masc_domain.Claimed _
   | Masc_domain.InProgress _
   | Masc_domain.AwaitingVerification _
+  | Masc_domain.OperatorBlocked _
   | Masc_domain.Done _
   | Masc_domain.Cancelled _ -> false
 ;;
@@ -420,6 +421,13 @@ let status_summary_string (ctx : context) =
          | Masc_domain.Done _ ->
            active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt + 1, cancelled_cnt
          | Masc_domain.AwaitingVerification _ ->
+           ( task :: active
+           , todo_cnt
+           , claimed_cnt
+           , in_progress_cnt + 1
+           , done_cnt
+           , cancelled_cnt )
+         | Masc_domain.OperatorBlocked _ ->
            ( task :: active
            , todo_cnt
            , claimed_cnt

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -352,6 +352,7 @@ let string_of_task_status = task_status_to_string
 let task_status_icon = function
   | Todo -> "📋"
   | Claimed _ | InProgress _ -> "🔄"
+  | OperatorBlocked _ -> "🚧"
   | AwaitingVerification _ -> "🔍"
   | Done _ -> "✅"
   | Cancelled _ -> "🚫"

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -320,7 +320,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
-  | OperatorBlocked of { assignee: string; blocked_at: string; reason: string option }
+  | OperatorBlocked of { assignee: string; blocked_at: string; reason: string }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -313,6 +313,7 @@ type task_status =
     }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
+  | OperatorBlocked of { assignee: string; blocked_at: string; reason: string option }
 [@@deriving show]
 
 (** RFC-0220 §3.5: the [task_status] of an [AwaitingVerification] obligation
@@ -369,14 +370,14 @@ let task_assignee_of_status = function
     Exhaustive match — adding a constructor forces an update here. *)
 let task_status_is_terminal = function
   | Done _ | Cancelled _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | OperatorBlocked _ -> false
 
 (** Completed state: [Done]. Distinct from [task_status_is_terminal] which
     also includes [Cancelled]. Use this when only successful completion
     matters (e.g. convergence ratios, reputation counting). *)
 let task_status_is_done = function
   | Done _ -> true
-  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ -> false
+  | Todo | Claimed _ | InProgress _ | AwaitingVerification _ | Cancelled _ | OperatorBlocked _ -> false
 
 (** Issue #8354 + 2026-05-27 follow-up: schema enums for [task_status]
     used to be hand-rolled in [tool_shard.ml] and [mcp_server.ml],

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -372,6 +372,7 @@ let task_assignee_of_status = function
   | Claimed { assignee; _ } -> Some assignee
   | InProgress { assignee; _ } -> Some assignee
   | AwaitingVerification { assignee; _ } -> Some assignee
+  | OperatorBlocked { assignee; _ } -> Some assignee
   | Todo | Done _ | Cancelled _ -> None
 
 (** Terminal states: [Done] or [Cancelled]. No further transitions possible.

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -233,6 +233,8 @@ type task_action =
   | Submit_for_verification
   | Approve_verification
   | Reject_verification
+  | Block_for_operator
+  | Unblock
 [@@deriving show]
 
 (** RFC-0262: who authorizes a transition that would otherwise require the
@@ -269,6 +271,8 @@ let task_action_of_string s =
   | "submit_for_verification" -> Ok Submit_for_verification
   | "approve" -> Ok Approve_verification
   | "reject" -> Ok Reject_verification
+  | "block_for_operator" -> Ok Block_for_operator
+  | "unblock" -> Ok Unblock
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -280,11 +284,14 @@ let task_action_to_string = function
   | Submit_for_verification -> "submit_for_verification"
   | Approve_verification -> "approve"
   | Reject_verification -> "reject"
+  | Block_for_operator -> "block_for_operator"
+  | Unblock -> "unblock"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
 let all_task_actions =
   [ Claim; Start; Done_action; Cancel; Release;
-    Submit_for_verification; Approve_verification; Reject_verification ]
+    Submit_for_verification; Approve_verification; Reject_verification;
+    Block_for_operator; Unblock ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 (* RFC-0220: the verification sub-state (previously a separate request_status

--- a/lib/workspace/workspace_gc.ml
+++ b/lib/workspace/workspace_gc.ml
@@ -181,7 +181,8 @@ let cleanup_zombies
                    ("ts", `String (now_iso ()));
                  ]))
         | Masc_domain.Claimed _ | Masc_domain.InProgress _
-        | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ()
+        | Todo | AwaitingVerification _ | OperatorBlocked _
+        | Done _ | Cancelled _ -> ()
       ) backlog.tasks;
 
       (* Phase 4: Delete files — skip agents with release failures *)

--- a/lib/workspace/workspace_task_classify.ml
+++ b/lib/workspace/workspace_task_classify.ml
@@ -55,7 +55,8 @@ let classify_completion_path
   | Masc_domain.Approve_verification -> "via_verification"
   | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action
   | Masc_domain.Cancel | Masc_domain.Release
-  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification ->
+  | Masc_domain.Submit_for_verification | Masc_domain.Reject_verification
+  | Masc_domain.Block_for_operator | Masc_domain.Unblock ->
     if force then "forced_done"
     else (match drift with
           | Some Workspace_task_lifecycle.Claimed_to_done_skip -> "claimed_to_done_skip"
@@ -85,6 +86,7 @@ let working_agents config =
       (fun (t : task) ->
          match t.task_status with
          | Claimed { assignee; _ } | InProgress { assignee; _ } -> Some assignee
+         | OperatorBlocked { assignee; _ } -> Some assignee
          | Todo | Done _ | Cancelled _ | AwaitingVerification _ -> None)
       backlog.tasks
     |> List.sort_uniq String.compare

--- a/lib/workspace/workspace_task_lifecycle.ml
+++ b/lib/workspace/workspace_task_lifecycle.ml
@@ -70,7 +70,8 @@ let resolve_claim ~same_actor ~agent_name ~now (task : Masc_domain.task) =
       Verifier_claim
         (Masc_domain.bind_verifier
            ~verifier:agent_name ~assignee ~submitted_at ~verification_id)
-  | Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ } ->
+  | Masc_domain.Claimed { assignee; _ } | Masc_domain.InProgress { assignee; _ }
+  | Masc_domain.OperatorBlocked { assignee; _ } ->
     if same_actor assignee then Self_owned else Held_by_other assignee
   | Masc_domain.Done _ ->
     (* RFC-0323: a completed task is terminal for every actor — the #23632

--- a/lib/workspace/workspace_task_schedule.ml
+++ b/lib/workspace/workspace_task_schedule.ml
@@ -20,6 +20,7 @@ let task_status_label (status : Masc_domain.task_status) : string =
   | Claimed _ -> "claimed"
   | InProgress _ -> "in_progress"
   | AwaitingVerification _ -> "awaiting_verification"
+  | OperatorBlocked _ -> "operator_blocked"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
 ;;
@@ -60,7 +61,7 @@ let active_task_assignees_by_task_id backlog =
        match task.task_status with
        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
          Hashtbl.replace table task.id assignee
-       | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
+       | Todo | AwaitingVerification _ | OperatorBlocked _ | Done _ | Cancelled _ -> ())
     backlog.tasks;
   table
 ;;

--- a/lib/workspace/workspace_task_transition_executor.ml
+++ b/lib/workspace/workspace_task_transition_executor.ml
@@ -21,7 +21,9 @@ let action_persists_handoff_context = function
   | Masc_domain.Start
   | Masc_domain.Cancel
   | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
+  | Masc_domain.Reject_verification
+  | Masc_domain.Block_for_operator
+  | Masc_domain.Unblock ->
     true
 ;;
 
@@ -30,6 +32,8 @@ let normalize_task_before_status ~action task =
   | Masc_domain.Claim ->
     Workspace_task_claim.clear_reclaim_decision task
   | Masc_domain.Release -> task
+  | Masc_domain.Block_for_operator
+  | Masc_domain.Unblock -> task
   | Masc_domain.Start
   | Masc_domain.Done_action
   | Masc_domain.Cancel
@@ -57,7 +61,9 @@ let release_counters ~action task handoff_context =
   | Masc_domain.Done_action
   | Masc_domain.Submit_for_verification
   | Masc_domain.Approve_verification
-  | Masc_domain.Reject_verification ->
+  | Masc_domain.Reject_verification
+  | Masc_domain.Block_for_operator
+  | Masc_domain.Unblock ->
     task.cycle_count, task.reclaim_policy, task.do_not_reclaim_reason
 ;;
 

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -87,7 +87,9 @@ let transition_task_outcome_r
           | Masc_domain.Claim
           | Masc_domain.Start
           | Masc_domain.Cancel
-          | Masc_domain.Release -> Ok ()
+          | Masc_domain.Release
+          | Masc_domain.Block_for_operator
+          | Masc_domain.Unblock -> Ok ()
           | Masc_domain.Done_action
           | Masc_domain.Submit_for_verification ->
             (* #23719 evidence gate, scoped to the RFC-0323 Phase A predicate

--- a/lib/workspace_status_rendering.ml
+++ b/lib/workspace_status_rendering.ml
@@ -44,6 +44,7 @@ let task_status_badge = function
   | Masc_domain.Claimed _ -> ("🟡", "claimed")
   | Masc_domain.InProgress _ -> ("🟢", "in_progress")
   | Masc_domain.AwaitingVerification _ -> ("🔍", "awaiting_verification")
+  | Masc_domain.OperatorBlocked _ -> ("🚧", "operator_blocked")
   | Masc_domain.Done _ -> ("✅", "done")
   | Masc_domain.Cancelled _ -> ("🚫", "cancelled")
 
@@ -51,6 +52,7 @@ let task_assignee = function
   | Masc_domain.Claimed { assignee; _ }
   | Masc_domain.InProgress { assignee; _ }
   | Masc_domain.AwaitingVerification { assignee; _ }
+  | Masc_domain.OperatorBlocked { assignee; _ }
   | Masc_domain.Done { assignee; _ } -> assignee
   | Masc_domain.Cancelled { cancelled_by; _ } -> cancelled_by
   | Masc_domain.Todo -> "unclaimed"
@@ -58,7 +60,8 @@ let task_assignee = function
 let active_task_assignee = function
   | Masc_domain.Claimed { assignee; _ }
   | Masc_domain.InProgress { assignee; _ }
-  | Masc_domain.AwaitingVerification { assignee; _ } ->
+  | Masc_domain.AwaitingVerification { assignee; _ }
+  | Masc_domain.OperatorBlocked { assignee; _ } ->
       Some assignee
   | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
 


### PR DESCRIPTION
## Summary

Implements `OperatorBlocked` task state with mandatory reason (string, not option).

### Changes

- Added `OperatorBlocked of { assignee: string; blocked_at: string; reason: string }` to `task_status` type
- Added `Block_for_operator` and `Unblock` transitions in workspace_task_transition_executor.ml
- Updated all exhaustive pattern matches across 16 source files
- **P2 fix**: `reason` is now `string` (mandatory), not `string option`

### What's new in v4

- Addresses P2 from jeong-sik review on PR #24288: reason field is mandatory, not optional. Reason-less blocks are under-specified — operator/UI cannot determine why a task was blocked.

### CI

Lint, Test Coverage, PR Sync, PR Live Gate, Detect Changed Surfaces — all green on v3. This is a single-field type change.

### Why

Unassignable P0 tasks currently cycle: someone claims → can't work → unclaims → someone else claims → repeat. `OperatorBlocked` lets an operator mark a task as blocked by policy, breaking the cycle.