### PR TITLE
fix(keeper): observe bootstrap launch outcomes

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1009,7 +1009,21 @@ let start_keeper_loops
                 ; net = state.net
                 }
               in
-              Keeper_keepalive.start_keepalive ~proactive_warmup_sec:warmup ctx m;
+              let launch_outcome =
+                Keeper_keepalive.start_keepalive
+                  ~proactive_warmup_sec:warmup
+                  ctx
+                  m
+              in
+              (match launch_outcome with
+               | Keeper_keepalive.Keepalive_started _
+               | Keeper_keepalive.Keepalive_already_registered _ -> ()
+               | outcome ->
+                 Log.Keeper.warn
+                   "%s: start_keepalive rejected %s: %s"
+                   log_prefix
+                   m.name
+                   (Keeper_keepalive.start_keepalive_outcome_to_string outcome));
               (* start_keepalive registers the keeper synchronously via
                  register_offline and then forks the keepalive fiber.  The
                  fiber flips the registry to running asynchronously on the

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -15,6 +15,7 @@
 open Alcotest
 
 module R = Masc.Keeper_registry
+module Workspace = Masc.Workspace
 module Keeper_types_profile = Masc.Keeper_types_profile
 module Sup = Masc.Keeper_supervisor
 module KT = Keeper_types


### PR DESCRIPTION
## 요약\n\n#24155 병합 후 CI가 확인한 컴파일 오류 두 건을 수정했어용.\n\n- bootstrap에서 typed `start_keepalive` outcome을 명시적으로 관측·로그 처리했어용.\n- heartbeat integration fixture의 `Workspace`를 `Masc.Workspace` 별칭으로 고정했어용.\n\n## 검증\n\n- 변경 OCaml 포맷·파싱\n- diff check\n- ignore 정적 가드\n- 실제 Dune type/build는 PR CI가 검증해용.