### PR TITLE
fix(keeper): complete typed wakeup callers

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -334,14 +334,31 @@ let wake_keeper_on_fusion_completion
     ignore (Fusion_wake_route.take ~run_id);
     Log.Keeper.info "fusion completion wake: keeper=%s run_id=%s ok=%b" keeper run_id ok;
     (* Best-effort wake hint: the payload is already durable, so a withheld or
-       failed hint only defers pickup to the keeper's next turn. The Running-gate
-       outcome is intentionally discarded (typed [_] so a signature change surfaces
-       here), and a hint exception is logged — not swallowed — then dropped. *)
+       failed hint only defers pickup to the keeper's next turn. The typed outcome
+       remains observable; an exception is logged and does not roll back the
+       durable completion. *)
     (try
-       let (_ : Keeper_registry.wakeup_running_outcome) =
-         Keeper_registry.wakeup_running ~base_path:base_dir keeper
-       in
-       ()
+       match
+         Keeper_registry.wakeup_running
+           ~intent:Keeper_registry.Reactive_signal
+           ~base_path:base_dir
+           keeper
+       with
+       | Keeper_registry.Signaled -> ()
+       | Keeper_registry.Deferred_unregistered ->
+         Log.Keeper.info ~keeper_name:keeper
+           "fusion completion wake deferred: keeper is no longer registered run_id=%s"
+           run_id
+       | Keeper_registry.Deferred_not_running phase ->
+         Log.Keeper.info ~keeper_name:keeper
+           "fusion completion wake deferred: phase=%s run_id=%s"
+           (Keeper_state_machine.phase_to_string phase)
+           run_id
+       | Keeper_registry.Deferred_lifecycle denial ->
+         Log.Keeper.info ~keeper_name:keeper
+           "fusion completion wake deferred by lifecycle: reason=%s run_id=%s"
+           (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
+           run_id
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -303,7 +303,25 @@ let wakeup_keeper ?base_path ?stimulus name =
               value)
          stimulus;
        if entry.phase = Keeper_state_machine.Running
-       then Keeper_registry.wakeup ~base_path:entry.base_path name
+       then (
+         match
+           Keeper_registry.wakeup
+             ~intent:Keeper_registry.Reactive_signal
+             ~base_path:entry.base_path
+             name
+         with
+         | Keeper_registry.Signaled -> ()
+         | Keeper_registry.Deferred_unregistered ->
+           Log.Keeper.info ~keeper_name:name
+             "wakeup_keeper: wake deferred after registry removal"
+         | Keeper_registry.Deferred_not_running phase ->
+           Log.Keeper.info ~keeper_name:name
+             "wakeup_keeper: wake deferred after phase change phase=%s"
+             (Keeper_state_machine.phase_to_string phase)
+         | Keeper_registry.Deferred_lifecycle denial ->
+           Log.Keeper.info ~keeper_name:name
+             "wakeup_keeper: wake deferred by lifecycle reason=%s"
+             (Keeper_lifecycle_admission.autonomous_denial_to_wire denial))
        else
          Log.Keeper.info ~keeper_name:name
            "wakeup_keeper: stimulus queued; wake hint withheld phase=%s stimulus=%s"
@@ -320,12 +338,12 @@ let wakeup_keeper ?base_path ?stimulus name =
     [None] preserves the legacy global wakeup behavior. *)
 let wakeup_all_keepers ?base_path () =
   match base_path with
-  | None -> Keeper_registry.wakeup_all ()
+  | None -> Keeper_registry.wakeup_all ~intent:Keeper_registry.Broadcast_signal ()
   | Some expected ->
-      Keeper_registry.all ~base_path:expected ()
-      |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
-           if entry.phase = Keeper_state_machine.Running then
-             Keeper_registry.wakeup ~base_path:entry.base_path entry.name)
+    Keeper_registry.wakeup_all
+      ~intent:Keeper_registry.Broadcast_signal
+      ~base_path:expected
+      ()
 
 (* ── Board-reactive policy constants ── *)
 
@@ -602,7 +620,24 @@ let board_signal_wake_paused_keeper
       ~base_path:config.base_path
       resumed_meta.name
       stimulus;
-    Keeper_registry.wakeup ~base_path:config.base_path resumed_meta.name;
+    (match
+       Keeper_registry.wakeup
+         ~intent:Keeper_registry.Supervisor_resume
+         ~base_path:config.base_path
+         resumed_meta.name
+     with
+     | Keeper_registry.Signaled -> ()
+     | Keeper_registry.Deferred_unregistered ->
+       Log.Keeper.info ~keeper_name:resumed_meta.name
+         "board signal resume committed but wake deferred: keeper unregistered"
+     | Keeper_registry.Deferred_not_running phase ->
+       Log.Keeper.info ~keeper_name:resumed_meta.name
+         "board signal resume committed but wake deferred: phase=%s"
+         (Keeper_state_machine.phase_to_string phase)
+     | Keeper_registry.Deferred_lifecycle denial ->
+       Log.Keeper.info ~keeper_name:resumed_meta.name
+         "board signal resume committed but wake deferred by lifecycle: reason=%s"
+         (Keeper_lifecycle_admission.autonomous_denial_to_wire denial));
     Ok ()
   | Error err ->
     Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -178,6 +178,14 @@ let runtime_exhaustion_reason_of_http_error
     Keeper_internal_error.Other_detail reason
   | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
     Keeper_internal_error.Max_turns_exceeded
+  | Some
+      (Llm_provider.Http_client.ProviderTerminal
+         { kind = Llm_provider.Http_client.Session_conflict; message }) ->
+    (* The provider terminal kind is matched directly, so this never reparses
+       provider prose. [runtime_exhaustion_reason] has no session-conflict
+       constructor yet; retain the provider's structured message as terminal
+       detail rather than pretending that it is retryable transport failure. *)
+    Keeper_internal_error.Other_detail message
   | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Other _; message }) ->
     Keeper_internal_error.Other_detail message
   | Some


### PR DESCRIPTION
## 요약\n\n누적 병합 뒤 깨진 typed wakeup/provider terminal 호출 계약을 복구했어용.\n\n- 모든 누락 `wakeup`/`wakeup_all` 호출에 의미별 intent를 연결했어용.\n- fusion·reactive·resume wake의 deferred outcome을 로그로 관측했어용.\n- `ProviderTerminal.Session_conflict`를 typed variant로 명시 처리했어용.\n\n## 검증\n\n- 변경 OCaml 포맷·파싱\n- 호출자 전수 검색\n- diff/ignore/TLA 정적 가드\n- 실제 OCaml 5.4/5.5 build/test는 CI가 검증해용.