### PR TITLE
test(keeper): cover terminal session conflict exhaustion

### DIFF
--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2474,6 +2474,39 @@ let test_capacity_failure_exhaustion_classifies_as_capacity_exhausted () =
     Alcotest.failf "expected typed keeper error, got %s"
       (Agent_sdk.Error.to_string mapped)
 
+let test_session_conflict_exhaustion_preserves_terminal_detail () =
+  let session_conflict =
+    Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Session_conflict
+      ; message = "session is owned by another process"
+      }
+  in
+  let mapped =
+    Masc.Keeper_turn_driver.For_testing.sdk_error_of_exhausted
+      ~runtime_id:"runtime.session-conflict"
+      (Some session_conflict)
+  in
+  match Keeper_internal_error.classify_masc_internal_error mapped with
+  | Some (Keeper_internal_error.Runtime_exhausted { reason; _ }) ->
+    Alcotest.(check bool)
+      "session conflict stays terminal"
+      false
+      (Keeper_internal_error.runtime_exhaustion_reason_retryable reason);
+    Alcotest.(check bool)
+      "session conflict is not auto-recoverable"
+      false
+      (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped);
+    Alcotest.(check bool)
+      "provider terminal detail is preserved"
+      true
+      (reason = Keeper_internal_error.Other_detail "session is owned by another process")
+  | Some other ->
+    Alcotest.failf "expected Runtime_exhausted, got %s"
+      (Keeper_internal_error.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "expected typed keeper error, got %s"
+      (Agent_sdk.Error.to_string mapped)
+
 let test_runtime_exhaustion_label_caps_free_text_detail () =
   let detail = String.make 260 'x' ^ "\nwith newline\tand spacing" in
   let label =
@@ -2659,6 +2692,10 @@ let () =
             "capacity exhaustion classifies as retryable Runtime_exhausted"
             `Quick
             test_capacity_failure_exhaustion_classifies_as_capacity_exhausted;
+          Alcotest.test_case
+            "session conflict exhaustion stays terminal"
+            `Quick
+            test_session_conflict_exhaustion_preserves_terminal_detail;
           Alcotest.test_case
             "runtime exhaustion labels cap free-text detail"
             `Quick


### PR DESCRIPTION
## 요약\n\n#24303에서 추가된 typed `ProviderTerminal.Session_conflict` 처리의 회귀 테스트예요.\n\n- provider terminal input이 terminal runtime exhaustion으로 유지되는지 검증해용.\n- 자동 복구/재시도 대상으로 오분류되지 않는지 검증해용.\n\n실제 test/build는 CI에서 확인해용.