### PR TITLE
fix(keeper): make chat transcript settlement durable

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -662,6 +662,254 @@ let reset_fd_cache_for_testing () = Fd_cache.reset_for_testing ()
 
 let with_cached_writer_for_testing path f = Fd_cache.with_writer path f
 
+let rec read_fd_chunks fd buffer =
+  let chunk = Bytes.create 65536 in
+  match Unix.read fd chunk 0 (Bytes.length chunk) with
+  | 0 -> Buffer.contents buffer
+  | count ->
+    Buffer.add_subbytes buffer chunk 0 count;
+    read_fd_chunks fd buffer
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_fd_chunks fd buffer
+
+type durable_append_operation =
+  | Write
+  | Append_fsync
+  | Rollback_truncate
+  | Rollback_fsync
+
+type durable_append_failure =
+  | Unix_error of
+      { operation : durable_append_operation
+      ; error : Unix.error
+      ; function_name : string
+      ; argument : string
+      }
+  | No_write_progress
+
+type durable_append_error =
+  { append_failure : durable_append_failure
+  ; rollback_failures : durable_append_failure list
+  }
+
+let durable_append_operation_to_string = function
+  | Write -> "write"
+  | Append_fsync -> "append fsync"
+  | Rollback_truncate -> "rollback truncate"
+  | Rollback_fsync -> "rollback fsync"
+;;
+
+let durable_append_failure_to_string = function
+  | No_write_progress -> "write made no progress"
+  | Unix_error { operation; error; function_name; argument } ->
+    Printf.sprintf
+      "%s failed: %s (function=%S argument=%S)"
+      (durable_append_operation_to_string operation)
+      (Unix.error_message error)
+      function_name
+      argument
+;;
+
+let durable_append_error_to_string { append_failure; rollback_failures } =
+  let append = durable_append_failure_to_string append_failure in
+  match rollback_failures with
+  | [] -> Printf.sprintf "durable append failed and rollback succeeded: %s" append
+  | failures ->
+    Printf.sprintf
+      "durable append failed: %s; rollback failed: %s"
+      append
+      (failures
+       |> List.map durable_append_failure_to_string
+       |> String.concat "; ")
+;;
+
+type durable_append_io_for_testing =
+  { write : Unix.file_descr -> bytes -> int -> int -> int
+  ; ftruncate : Unix.file_descr -> int -> unit
+  ; fsync : Unix.file_descr -> unit
+  }
+
+let unix_failure ~operation error function_name argument =
+  Unix_error { operation; error; function_name; argument }
+;;
+
+let rec write_fd_all ~write fd bytes offset remaining =
+  if remaining = 0
+  then Ok ()
+  else
+    match write fd bytes offset remaining with
+    | 0 -> Error No_write_progress
+    | written -> write_fd_all ~write fd bytes (offset + written) (remaining - written)
+    | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+      write_fd_all ~write fd bytes offset remaining
+    | exception Unix.Unix_error (error, function_name, argument) ->
+      Error (unix_failure ~operation:Write error function_name argument)
+;;
+
+let rec run_unix_io ~operation f =
+  match f () with
+  | () -> Ok ()
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> run_unix_io ~operation f
+  | exception Unix.Unix_error (error, function_name, argument) ->
+    Error (unix_failure ~operation error function_name argument)
+;;
+
+let rollback_durable_append ~io ~fd ~original_length =
+  let truncate_result =
+    run_unix_io ~operation:Rollback_truncate (fun () ->
+      io.ftruncate fd original_length)
+  in
+  let fsync_result =
+    run_unix_io ~operation:Rollback_fsync (fun () -> io.fsync fd)
+  in
+  [ truncate_result; fsync_result ]
+  |> List.filter_map (function
+    | Ok () -> None
+    | Error failure -> Some failure)
+;;
+
+let append_fd_durable ~io ~fd ~original_length suffix =
+  let bytes = Bytes.of_string suffix in
+  let append_result =
+    match write_fd_all ~write:io.write fd bytes 0 (Bytes.length bytes) with
+    | Error _ as error -> error
+    | Ok () -> run_unix_io ~operation:Append_fsync (fun () -> io.fsync fd)
+  in
+  match append_result with
+  | Ok () -> Ok ()
+  | Error append_failure ->
+    let rollback_failures = rollback_durable_append ~io ~fd ~original_length in
+    Error { append_failure; rollback_failures }
+;;
+
+let append_fd_durable_for_testing = append_fd_durable
+
+let durable_append_unix_io =
+  { write = Unix.write; ftruncate = Unix.ftruncate; fsync = Unix.fsync }
+;;
+
+let fsync_parent_directory dir =
+  let fd = Unix.openfile dir [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> Unix.fsync fd)
+;;
+
+let rec lock_whole_file fd =
+  match Unix.lockf fd Unix.F_LOCK 0 with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> lock_whole_file fd
+;;
+
+let run_blocking_durable_append ~path f =
+  with_fs_or_fallback
+    ~path
+    ~fallback:f
+    (fun _fs ->
+       Eio_unix.run_in_systhread ~label:"fs-compat-durable-append" f)
+;;
+
+let update_private_file_durable_locked_result path decide =
+  test_exec_home_guard ~op:"update_private_file_durable_locked" path;
+  let dir = Filename.dirname path in
+  mkdir_p_memoized dir;
+  let path_mu = get_append_path_mutex path in
+  run_blocking_durable_append ~path (fun () ->
+    Stdlib.Mutex.protect path_mu (fun () ->
+      let fd =
+        Unix.openfile path
+          [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
+          0o600
+      in
+      Fun.protect
+        ~finally:(fun () -> Unix.close fd)
+        (fun () ->
+           Unix.fchmod fd 0o600;
+           fsync_parent_directory dir;
+           (* See Unix.lseek: only the file-position side effect is required. *)
+           ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+           lock_whole_file fd;
+           (* See Unix.lseek: only the file-position side effect is required. *)
+           ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+           let existing = read_fd_chunks fd (Buffer.create 4096) in
+           let suffix, result = decide existing in
+           match suffix with
+            | None -> Ok result
+            | Some suffix ->
+              (* See Unix.lseek: only the file-position side effect is required. *)
+              let original_length = Unix.lseek fd 0 Unix.SEEK_END in
+              append_fd_durable
+                ~io:durable_append_unix_io
+                ~fd
+                ~original_length
+                suffix
+              |> Result.map (fun () -> result))))
+;;
+
+type private_jsonl_append_error =
+  | Incomplete_jsonl_tail
+  | Invalid_jsonl_suffix
+  | Durable_jsonl_append_failed of durable_append_error
+
+let private_jsonl_append_error_to_string = function
+  | Incomplete_jsonl_tail ->
+    "existing JSONL file ends with an incomplete row"
+  | Invalid_jsonl_suffix ->
+    "JSONL append suffix must be non-empty and newline-terminated"
+  | Durable_jsonl_append_failed error -> durable_append_error_to_string error
+;;
+
+let append_private_jsonl_durable_locked_result path suffix =
+  if String.equal suffix ""
+     || not (Char.equal suffix.[String.length suffix - 1] '\n')
+  then Error Invalid_jsonl_suffix
+  else (
+    test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
+    let dir = Filename.dirname path in
+    mkdir_p_memoized dir;
+    let path_mu = get_append_path_mutex path in
+    run_blocking_durable_append ~path (fun () ->
+      Stdlib.Mutex.protect path_mu (fun () ->
+        let fd =
+          Unix.openfile path
+            [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
+            0o600
+        in
+        Fun.protect
+          ~finally:(fun () -> Unix.close fd)
+          (fun () ->
+             Unix.fchmod fd 0o600;
+             fsync_parent_directory dir;
+             (* See Unix.lseek: only the file-position side effect is required. *)
+             ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+             lock_whole_file fd;
+             let original_length = Unix.lseek fd 0 Unix.SEEK_END in
+             let tail_is_complete =
+               if original_length = 0
+               then true
+               else (
+                 ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
+                 let byte = Bytes.create 1 in
+                 let rec read_tail () =
+                   match Unix.read fd byte 0 1 with
+                   | 1 -> Char.equal (Bytes.get byte 0) '\n'
+                   | 0 -> false
+                   | _ -> false
+                   | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
+                 in
+                 read_tail ())
+             in
+             if not tail_is_complete
+             then Error Incomplete_jsonl_tail
+             else (
+               ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+               append_fd_durable
+                 ~io:durable_append_unix_io
+                 ~fd
+                 ~original_length
+                 suffix
+               |> Result.map_error (fun error -> Durable_jsonl_append_failed error))))))
+;;
+
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   test_exec_home_guard ~op:"append_jsonl" path;
   let dir = Stdlib.Filename.dirname path in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -887,6 +887,7 @@ let append_private_jsonl_durable_locked_result path suffix =
                if original_length = 0
                then true
                else (
+                 (* See Unix.lseek: only the file-position side effect is required. *)
                  ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
                  let byte = Bytes.create 1 in
                  let rec read_tail () =
@@ -901,6 +902,7 @@ let append_private_jsonl_durable_locked_result path suffix =
              if not tail_is_complete
              then Error Incomplete_jsonl_tail
              else (
+               (* See Unix.lseek: only the file-position side effect is required. *)
                ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
                append_fd_durable
                  ~io:durable_append_unix_io

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -177,6 +177,82 @@ val fold_appended_lines
   -> f:('acc -> string -> 'acc)
   -> 'acc * int
 
+type durable_append_operation =
+  | Write
+  | Append_fsync
+  | Rollback_truncate
+  | Rollback_fsync
+
+type durable_append_failure =
+  | Unix_error of
+      { operation : durable_append_operation
+      ; error : Unix.error
+      ; function_name : string
+      ; argument : string
+      }
+  | No_write_progress
+
+type durable_append_error =
+  { append_failure : durable_append_failure
+  ; rollback_failures : durable_append_failure list
+  }
+
+(** Render a structured durable-append failure without discarding the original
+    [Unix.error] or rollback failures. *)
+val durable_append_error_to_string : durable_append_error -> string
+
+(** [update_private_file_durable_locked_result path decide] serializes in-process
+    callers with the shared per-path append mutex, takes a cross-process file
+    lock, reads the exact existing bytes, and calls [decide]. [Some suffix]
+    appends the complete suffix and fsyncs it before returning [Ok]; [None]
+    performs no write. If writing or the append fsync fails, the file is
+    truncated to its original length and that rollback is fsynced. [Error]
+    preserves the append failure and every rollback failure. Setup, read, and
+    [decide] exceptions still propagate. The file is created with mode [0600],
+    and every transaction fsyncs its parent directory before touching payload
+    bytes so a failed creation can be retried without silently skipping that
+    durability boundary. Filesystems that reject directory fsync fail
+    explicitly. The shared path mutex serializes this operation with cached
+    JSONL writers without closing their already-flushed descriptors. When the
+    Eio filesystem is active, the transaction and [decide] run in a system
+    thread so a contended file cannot stop unrelated fibers; [decide] therefore
+    must not perform Eio effects. *)
+val update_private_file_durable_locked_result :
+  string -> (string -> string option * 'a) -> ('a, durable_append_error) result
+
+type private_jsonl_append_error =
+  | Incomplete_jsonl_tail
+  | Invalid_jsonl_suffix
+  | Durable_jsonl_append_failed of durable_append_error
+
+(** Append one or more complete JSONL rows without reading the existing file.
+    The operation holds the same in-process and cross-process path locks as
+    {!update_private_file_durable_locked_result}, verifies only that an existing
+    file ends at a newline boundary, then appends and fsyncs with rollback on
+    failure. Every transaction also fsyncs the parent directory. Runtime cost
+    is proportional to [suffix], not to historical file size. When the Eio
+    filesystem is active, the entire blocking lock/write/fsync transaction runs
+    in a system thread so one contended file cannot stop unrelated fibers. *)
+val append_private_jsonl_durable_locked_result :
+  string -> string -> (unit, private_jsonl_append_error) result
+
+val private_jsonl_append_error_to_string : private_jsonl_append_error -> string
+
+type durable_append_io_for_testing =
+  { write : Unix.file_descr -> bytes -> int -> int -> int
+  ; ftruncate : Unix.file_descr -> int -> unit
+  ; fsync : Unix.file_descr -> unit
+  }
+
+(** Direct fd-level seam for deterministic partial-write and rollback tests.
+    Production code uses the same implementation with [Unix] operations. *)
+val append_fd_durable_for_testing :
+  io:durable_append_io_for_testing ->
+  fd:Unix.file_descr ->
+  original_length:int ->
+  string ->
+  (unit, durable_append_error) result
+
 (** Append JSON value as line to JSONL file.
 
     Backed by a process-local per-path fd cache (RFC-0162 §3.4).

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -612,43 +612,6 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
   in
   Yojson.Safe.to_string (`Assoc all_fields)
 
-type writer_lock =
-  { mutex : Stdlib.Mutex.t
-  ; mutable users : int
-  }
-
-let writer_locks : (string, writer_lock) Hashtbl.t = Hashtbl.create 16
-let writer_locks_mutex = Stdlib.Mutex.create ()
-
-let acquire_writer_lock path =
-  Stdlib.Mutex.protect writer_locks_mutex (fun () ->
-    match Hashtbl.find_opt writer_locks path with
-    | Some lock ->
-      lock.users <- lock.users + 1;
-      lock
-    | None ->
-      let lock = { mutex = Stdlib.Mutex.create (); users = 1 } in
-      Hashtbl.add writer_locks path lock;
-      lock)
-;;
-
-let release_writer_lock path lock =
-  Stdlib.Mutex.protect writer_locks_mutex (fun () ->
-    lock.users <- lock.users - 1;
-    if lock.users = 0
-    then
-      match Hashtbl.find_opt writer_locks path with
-      | Some current when current == lock -> Hashtbl.remove writer_locks path
-      | Some _ | None -> ())
-;;
-
-let with_writer_lock path f =
-  let lock = acquire_writer_lock path in
-  Fun.protect
-    ~finally:(fun () -> release_writer_lock path lock)
-    (fun () -> Stdlib.Mutex.protect lock.mutex f)
-;;
-
 let provenance_of_line ~line_number line =
   let fail detail =
     Error
@@ -685,61 +648,65 @@ let provenance_of_line ~line_number line =
   | Yojson.Json_error detail -> fail detail
 ;;
 
-let find_provenance_unlocked path ~delivery_key ~transcript_slot =
-  if not (Fs_compat.file_exists path)
-  then Ok None
-  else
-    try
-      let lines =
-        Fs_compat.load_file path
-        |> String.split_on_char '\n'
-        |> List.mapi (fun index line -> index + 1, line)
-      in
-      List.fold_left
-           (fun result (line_number, line) ->
-              let ( let* ) = Result.bind in
-              let* found = result in
-              if String.equal line ""
-              then Ok found
-              else
-                let* provenance = provenance_of_line ~line_number line in
-                match provenance, found with
-                | None, _ -> Ok found
-                | Some (candidate_key, candidate_slot, row_id), None
-                  when
-                    Keeper_chat_delivery_identity.delivery_key_equal
-                      delivery_key
-                      candidate_key
-                    && Keeper_chat_delivery_identity.transcript_slot_equal
-                         transcript_slot
-                         candidate_slot ->
-                  Ok (Some row_id)
-                | Some (candidate_key, candidate_slot, _), Some _
-                  when
-                    Keeper_chat_delivery_identity.delivery_key_equal
-                      delivery_key
-                      candidate_key
-                    && Keeper_chat_delivery_identity.transcript_slot_equal
-                         transcript_slot
-                         candidate_slot ->
-                  Error "duplicate Keeper chat delivery provenance rows"
-                | Some _, _ -> Ok found)
-           (Ok None)
-           lines
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Printexc.to_string exn)
+let find_provenance existing ~delivery_key ~transcript_slot =
+  existing
+  |> String.split_on_char '\n'
+  |> List.mapi (fun index line -> index + 1, line)
+  |> List.fold_left
+       (fun result (line_number, line) ->
+          let ( let* ) = Result.bind in
+          let* found = result in
+          if String.equal line ""
+          then Ok found
+          else
+            let* provenance = provenance_of_line ~line_number line in
+            match provenance, found with
+            | None, _ -> Ok found
+            | Some (candidate_key, candidate_slot, row_id), None
+              when
+                Keeper_chat_delivery_identity.delivery_key_equal
+                  delivery_key
+                  candidate_key
+                && Keeper_chat_delivery_identity.transcript_slot_equal
+                     transcript_slot
+                     candidate_slot ->
+              Ok (Some row_id)
+            | Some (candidate_key, candidate_slot, _), Some _
+              when
+                Keeper_chat_delivery_identity.delivery_key_equal
+                  delivery_key
+                  candidate_key
+                && Keeper_chat_delivery_identity.transcript_slot_equal
+                     transcript_slot
+                     candidate_slot ->
+              Error "duplicate Keeper chat delivery provenance rows"
+            | Some _, _ -> Ok found)
+       (Ok None)
 ;;
 
 let append_line_once path ~delivery_key ~transcript_slot ~row_id line =
-  with_writer_lock path (fun () ->
-    match find_provenance_unlocked path ~delivery_key ~transcript_slot with
-    | Error _ as error -> error
-    | Ok (Some existing_row_id) ->
-      Ok (Already_present { row_id = existing_row_id })
-    | Ok None ->
-      Fs_compat.append_file path (line ^ "\n");
-      Ok (Appended { row_id }))
+  match
+    Fs_compat.update_private_file_durable_locked_result path (fun existing ->
+      match find_provenance existing ~delivery_key ~transcript_slot with
+      | Error detail -> None, Error detail
+      | Ok (Some existing_row_id) ->
+        None, Ok (Already_present { row_id = existing_row_id })
+      | Ok None -> Some (line ^ "\n"), Ok (Appended { row_id }))
+  with
+  | Ok result -> result
+  | Error error -> Error (Fs_compat.durable_append_error_to_string error)
+;;
+
+let append_chat_payload_durable path payload =
+  match Fs_compat.append_private_jsonl_durable_locked_result path payload with
+  | Ok () -> ()
+  | Error error ->
+    raise
+      (Sys_error
+         (Printf.sprintf
+            "%s: %s"
+            path
+            (Fs_compat.private_jsonl_append_error_to_string error)))
 ;;
 
 (* Tool calls with empty accumulated arguments are normalised to "{}" so
@@ -814,7 +781,7 @@ let append_turn_result ~base_dir ~keeper_name ~(user_content : string)
     let payload =
       String.concat "\n" ((user_line :: tool_lines) @ [ asst_line ]) ^ "\n"
     in
-    Fs_compat.append_file path payload;
+    append_chat_payload_durable path payload;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -862,7 +829,7 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
       encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
         ?audio ?blocks ?turn_ref ?stream_lifecycle ()
     in
-    Fs_compat.append_file path (line ^ "\n");
+    append_chat_payload_durable path (line ^ "\n");
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -961,7 +928,7 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
         ?external_message_id ?speaker
         ~mentions:(user_line_mentions ~extra_mentions content) ()
     in
-    Fs_compat.append_file path (line ^ "\n")
+    append_chat_payload_durable path (line ^ "\n")
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->

--- a/test/dune
+++ b/test/dune
@@ -1979,6 +1979,8 @@
 
 (include stanzas/test_fs_compat_append_jsonl_atomicity.inc)
 
+(include stanzas/test_fs_compat_durable_append.inc)
+
 (include stanzas/test_fs_compat_home_guard.inc)
 
 (include stanzas/test_fs_compat_mkdir_memo.inc)

--- a/test/stanzas/test_fs_compat_durable_append.inc
+++ b/test/stanzas/test_fs_compat_durable_append.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_fs_compat_durable_append)
+ (modules test_fs_compat_durable_append)
+ (libraries fs_compat alcotest unix))

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -1,0 +1,300 @@
+open Alcotest
+
+let with_durable_append_fd ~original f =
+  let path = Filename.temp_file "masc_durable_append_" ".log" in
+  let output = open_out_bin path in
+  output_string output original;
+  close_out output;
+  let fd =
+    Unix.openfile path [ Unix.O_RDWR; Unix.O_APPEND; Unix.O_CLOEXEC ] 0o600
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close fd;
+      Sys.remove path)
+    (fun () -> f path fd)
+;;
+
+let check_unix_failure ~label ~operation ~error = function
+  | Fs_compat.Unix_error failure ->
+    check bool (label ^ " operation") true (failure.operation = operation);
+    check bool (label ^ " Unix.error") true (failure.error = error)
+  | Fs_compat.No_write_progress -> fail (label ^ " lost the typed Unix.error")
+;;
+
+let partial_write_then_error ~path error =
+  let write_calls = ref 0 in
+  fun fd bytes offset remaining ->
+    incr write_calls;
+    if !write_calls = 1
+    then Unix.single_write fd bytes offset (min 3 remaining)
+    else raise (Unix.Unix_error (error, "injected_write", path))
+;;
+
+let test_success_fsyncs () =
+  with_durable_append_fd ~original:"before"
+  @@ fun path fd ->
+  let fsync_calls = ref 0 in
+  let io : Fs_compat.durable_append_io_for_testing =
+    { write = Unix.write
+    ; ftruncate = Unix.ftruncate
+    ; fsync =
+        (fun fd ->
+          incr fsync_calls;
+          Unix.fsync fd)
+    }
+  in
+  let original_length = (Unix.fstat fd).Unix.st_size in
+  (match
+     Fs_compat.append_fd_durable_for_testing
+       ~io
+       ~fd
+       ~original_length
+       "-after"
+   with
+   | Ok () -> ()
+   | Error error -> fail (Fs_compat.durable_append_error_to_string error));
+  check int "successful append fsync count" 1 !fsync_calls;
+  check string "successful durable append" "before-after" (Fs_compat.load_file path)
+;;
+
+let test_partial_write_rolls_back error =
+  with_durable_append_fd ~original:"stable"
+  @@ fun path fd ->
+  let truncate_calls = ref 0 in
+  let fsync_calls = ref 0 in
+  let io : Fs_compat.durable_append_io_for_testing =
+    { write = partial_write_then_error ~path error
+    ; ftruncate =
+        (fun fd length ->
+          incr truncate_calls;
+          Unix.ftruncate fd length)
+    ; fsync =
+        (fun fd ->
+          incr fsync_calls;
+          Unix.fsync fd)
+    }
+  in
+  let original_length = (Unix.fstat fd).Unix.st_size in
+  (match
+     Fs_compat.append_fd_durable_for_testing
+       ~io
+       ~fd
+       ~original_length
+       "-partial-suffix"
+   with
+   | Ok () -> fail "partial write unexpectedly succeeded"
+   | Error { append_failure; rollback_failures } ->
+     check_unix_failure
+       ~label:"append failure"
+       ~operation:Fs_compat.Write
+       ~error
+       append_failure;
+     check int "rollback failures" 0 (List.length rollback_failures));
+  check int "rollback truncate count" 1 !truncate_calls;
+  check int "rollback fsync count" 1 !fsync_calls;
+  check int "original file length restored" original_length (Unix.fstat fd).Unix.st_size;
+  check string "partial suffix removed" "stable" (Fs_compat.load_file path)
+;;
+
+let test_partial_enospc_rolls_back () = test_partial_write_rolls_back Unix.ENOSPC
+let test_partial_eio_rolls_back () = test_partial_write_rolls_back Unix.EIO
+
+let test_append_fsync_failure_rolls_back () =
+  with_durable_append_fd ~original:"stable"
+  @@ fun path fd ->
+  let fsync_calls = ref 0 in
+  let io : Fs_compat.durable_append_io_for_testing =
+    { write = Unix.write
+    ; ftruncate = Unix.ftruncate
+    ; fsync =
+        (fun fd ->
+          incr fsync_calls;
+          if !fsync_calls = 1
+          then raise (Unix.Unix_error (Unix.EIO, "injected_append_fsync", path))
+          else Unix.fsync fd)
+    }
+  in
+  let original_length = (Unix.fstat fd).Unix.st_size in
+  (match
+     Fs_compat.append_fd_durable_for_testing
+       ~io
+       ~fd
+       ~original_length
+       "-complete-but-not-durable"
+   with
+   | Ok () -> fail "failed append fsync unexpectedly succeeded"
+   | Error { append_failure; rollback_failures } ->
+     check_unix_failure
+       ~label:"append fsync failure"
+       ~operation:Fs_compat.Append_fsync
+       ~error:Unix.EIO
+       append_failure;
+     check int "rollback failures" 0 (List.length rollback_failures));
+  check int "append and rollback fsync calls" 2 !fsync_calls;
+  check int "original file length restored" original_length (Unix.fstat fd).Unix.st_size;
+  check string "complete suffix rolled back" "stable" (Fs_compat.load_file path)
+;;
+
+let test_rollback_truncate_failure_is_explicit_and_still_fsyncs () =
+  with_durable_append_fd ~original:"stable"
+  @@ fun path fd ->
+  let rollback_fsync_calls = ref 0 in
+  let io : Fs_compat.durable_append_io_for_testing =
+    { write = partial_write_then_error ~path Unix.ENOSPC
+    ; ftruncate =
+        (fun _fd _length ->
+          raise (Unix.Unix_error (Unix.EIO, "injected_ftruncate", path)))
+    ; fsync =
+        (fun fd ->
+          incr rollback_fsync_calls;
+          Unix.fsync fd)
+    }
+  in
+  let original_length = (Unix.fstat fd).Unix.st_size in
+  (match
+     Fs_compat.append_fd_durable_for_testing
+       ~io
+       ~fd
+       ~original_length
+       "-partial-suffix"
+   with
+   | Ok () -> fail "append with failed rollback unexpectedly succeeded"
+   | Error { append_failure; rollback_failures } ->
+     check_unix_failure
+       ~label:"original append failure"
+       ~operation:Fs_compat.Write
+       ~error:Unix.ENOSPC
+       append_failure;
+     (match rollback_failures with
+      | [ rollback_failure ] ->
+        check_unix_failure
+          ~label:"rollback truncate failure"
+          ~operation:Fs_compat.Rollback_truncate
+          ~error:Unix.EIO
+          rollback_failure
+      | failures ->
+        failf "expected one rollback failure, got %d" (List.length failures)));
+  check int "rollback fsync still attempted" 1 !rollback_fsync_calls
+;;
+
+let test_rollback_fsync_failure_is_explicit () =
+  with_durable_append_fd ~original:"stable"
+  @@ fun path fd ->
+  let io : Fs_compat.durable_append_io_for_testing =
+    { write = partial_write_then_error ~path Unix.ENOSPC
+    ; ftruncate = Unix.ftruncate
+    ; fsync =
+        (fun _fd -> raise (Unix.Unix_error (Unix.EIO, "injected_fsync", path)))
+    }
+  in
+  let original_length = (Unix.fstat fd).Unix.st_size in
+  (match
+     Fs_compat.append_fd_durable_for_testing
+       ~io
+       ~fd
+       ~original_length
+       "-partial-suffix"
+   with
+   | Ok () -> fail "append with failed rollback fsync unexpectedly succeeded"
+   | Error { append_failure; rollback_failures } ->
+     check_unix_failure
+       ~label:"original append failure"
+       ~operation:Fs_compat.Write
+       ~error:Unix.ENOSPC
+       append_failure;
+     (match rollback_failures with
+      | [ rollback_failure ] ->
+        check_unix_failure
+          ~label:"rollback fsync failure"
+          ~operation:Fs_compat.Rollback_fsync
+          ~error:Unix.EIO
+          rollback_failure
+      | failures ->
+        failf "expected one rollback failure, got %d" (List.length failures)));
+  check int "truncate restored original length" original_length (Unix.fstat fd).Unix.st_size;
+  check string "partial suffix removed before failed fsync" "stable" (Fs_compat.load_file path)
+;;
+
+let with_temp_jsonl original f =
+  let path = Filename.temp_file "masc_private_jsonl_" ".jsonl" in
+  let output = open_out_bin path in
+  output_string output original;
+  close_out output;
+  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+;;
+
+let test_private_jsonl_append_preserves_complete_history () =
+  with_temp_jsonl "{\"row\":1}\n" @@ fun path ->
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_result
+       path
+       "{\"row\":2}\n{\"row\":3}\n"
+   with
+   | Ok () -> ()
+   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+  check string
+    "complete rows appended"
+    "{\"row\":1}\n{\"row\":2}\n{\"row\":3}\n"
+    (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_append_rejects_incomplete_tail () =
+  with_temp_jsonl "{\"row\":1}" @@ fun path ->
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":2}\n"
+   with
+   | Error Fs_compat.Incomplete_jsonl_tail -> ()
+   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Ok () -> fail "append accepted an incomplete existing JSONL row");
+  check string "incomplete bytes unchanged" "{\"row\":1}" (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_append_rejects_incomplete_suffix () =
+  with_temp_jsonl "" @@ fun path ->
+  match Fs_compat.append_private_jsonl_durable_locked_result path "{\"row\":1}" with
+  | Error Fs_compat.Invalid_jsonl_suffix -> ()
+  | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
+  | Ok () -> fail "append accepted a non-terminated JSONL suffix"
+;;
+
+let () =
+  run
+    "fs_compat durable append"
+    [ ( "durable_append"
+      , [ test_case "success fsyncs" `Quick test_success_fsyncs
+        ; test_case
+            "partial ENOSPC rolls back and fsyncs"
+            `Quick
+            test_partial_enospc_rolls_back
+        ; test_case
+            "partial EIO rolls back and fsyncs"
+            `Quick
+            test_partial_eio_rolls_back
+        ; test_case
+            "append fsync failure rolls back and fsyncs"
+            `Quick
+            test_append_fsync_failure_rolls_back
+        ; test_case
+            "rollback truncate failure stays explicit"
+            `Quick
+            test_rollback_truncate_failure_is_explicit_and_still_fsyncs
+        ; test_case
+            "rollback fsync failure stays explicit"
+            `Quick
+            test_rollback_fsync_failure_is_explicit
+        ; test_case
+            "private JSONL append preserves complete history"
+            `Quick
+            test_private_jsonl_append_preserves_complete_history
+        ; test_case
+            "private JSONL append rejects incomplete tail"
+            `Quick
+            test_private_jsonl_append_rejects_incomplete_tail
+        ; test_case
+            "private JSONL append rejects incomplete suffix"
+            `Quick
+            test_private_jsonl_append_rejects_incomplete_suffix
+        ] )
+    ]
+;;

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -287,6 +287,90 @@ let test_chat_append_once_converges () =
     check int "one user and one terminal row" 2 (List.length history))
 ;;
 
+let test_chat_append_once_converges_across_processes () =
+  with_temp_dir (fun base_path ->
+    let delivery_key = direct_key () in
+    let seed =
+      Keeper_chat_store.append_assistant_message_result
+        ~base_dir:base_path
+        ~keeper_name:"sangsu"
+        ~content:"seed"
+        ()
+    in
+    (match seed with
+     | Ok () -> ()
+     | Error detail -> fail detail);
+    let ready_read, ready_write = Unix.pipe () in
+    let append_child () =
+      Unix.close ready_write;
+      let byte = Bytes.create 1 in
+      let rec await_start () =
+        match Unix.read ready_read byte 0 1 with
+        | 1 -> ()
+        | 0 -> exit 2
+        | _ -> await_start ()
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> await_start ()
+      in
+      await_start ();
+      let result =
+        Keeper_chat_store.append_user_message_once
+          ~base_dir:base_path
+          ~keeper_name:"sangsu"
+          ~delivery_key
+          ~content:"cross-process request"
+          ~surface:
+            (Surface_ref.Dashboard { session_id = Some "dashboard-session" })
+          ~speaker:(payload ()).speaker
+          ()
+      in
+      Unix.close ready_read;
+      exit (if Result.is_ok result then 0 else 3)
+    in
+    let spawn () =
+      match Unix.fork () with
+      | 0 -> append_child ()
+      | pid -> pid
+    in
+    let first = spawn () in
+    let second = spawn () in
+    Unix.close ready_read;
+    let rec release_children offset =
+      if offset = 2
+      then ()
+      else
+        match Unix.write_substring ready_write "xy" offset (2 - offset) with
+        | 0 -> fail "cross-process start barrier made no write progress"
+        | written -> release_children (offset + written)
+        | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+          release_children offset
+    in
+    release_children 0;
+    Unix.close ready_write;
+    let await_child pid =
+      match Unix.waitpid [] pid with
+      | _, Unix.WEXITED 0 -> ()
+      | _, status ->
+        failf
+          "cross-process append child failed: %s"
+          (match status with
+           | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+           | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+           | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal)
+    in
+    await_child first;
+    await_child second;
+    let matching_rows =
+      Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu"
+      |> List.filter (fun row ->
+           Keeper_chat_store.Role.equal row.role Keeper_chat_store.Role.User
+           && String.equal row.content "cross-process request")
+    in
+    check int
+      "cross-process retries persist one provenance row"
+      1
+      (List.length matching_rows))
+;;
+
 let test_restart_recovery_converges_without_duplicate_rows () =
   with_temp_dir (fun base_path ->
     let key = direct_key () in
@@ -590,6 +674,10 @@ let () =
             "chat append-once converges"
             `Quick
             test_chat_append_once_converges
+        ; test_case
+            "chat append-once converges across processes"
+            `Quick
+            test_chat_append_once_converges_across_processes
         ; test_case
             "restart recovery converges"
             `Quick

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -23,6 +23,13 @@ let rec remove_tree path =
 
 let keeper_name = "chat-store-append-keeper"
 
+let persisted_path base_dir =
+  Filename.concat
+    (Filename.concat
+       (Masc.Common.masc_dir_from_base_path ~base_path:base_dir)
+       "keeper_chat")
+    (keeper_name ^ ".jsonl")
+
 let test_ok_on_writable_dir () =
   let base_dir = temp_base_path "keeper-chat-store-ok" in
   Fun.protect
@@ -53,6 +60,59 @@ let test_error_when_path_under_a_file () =
         "append under a non-directory path is Error" true
         (Result.is_error result))
 
+let test_append_is_owner_only_and_durable () =
+  let base_dir = temp_base_path "keeper-chat-store-private" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let result =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"private durable row" ()
+      in
+      Alcotest.(check bool) "durable append succeeds" true (Result.is_ok result);
+      let path = persisted_path base_dir in
+      Alcotest.(check int)
+        "chat history is owner-only"
+        0o600
+        ((Unix.stat path).Unix.st_perm land 0o777);
+      match S.load ~base_dir ~keeper_name with
+      | [ row ] ->
+        Alcotest.(check string)
+          "durable row is readable"
+          "private durable row"
+          row.content
+      | rows ->
+        Alcotest.failf "expected one readable row, got %d" (List.length rows))
+
+let test_incomplete_tail_fails_closed_without_rewrite () =
+  let base_dir = temp_base_path "keeper-chat-store-incomplete" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let initial =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"seed" ()
+      in
+      Alcotest.(check bool) "seed append succeeds" true (Result.is_ok initial);
+      let path = persisted_path base_dir in
+      let corrupt = "{\"role\":\"assistant\"" in
+      let output = open_out_bin path in
+      output_string output corrupt;
+      close_out output;
+      let result =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"must not append" ()
+      in
+      Alcotest.(check bool)
+        "incomplete tail is explicit" true (Result.is_error result);
+      let input = open_in_bin path in
+      let persisted = really_input_string input (in_channel_length input) in
+      close_in input;
+      Alcotest.(check string)
+        "incomplete bytes remain untouched"
+        corrupt
+        persisted)
+
 let () =
   Alcotest.run "keeper_chat_store_append_result"
     [
@@ -61,5 +121,9 @@ let () =
           Alcotest.test_case "writable dir -> Ok" `Quick test_ok_on_writable_dir;
           Alcotest.test_case "path under a file -> Error" `Quick
             test_error_when_path_under_a_file;
+          Alcotest.test_case "owner-only durable append" `Quick
+            test_append_is_owner_only_and_durable;
+          Alcotest.test_case "incomplete tail fails closed" `Quick
+            test_incomplete_tail_fails_closed_without_rewrite;
         ] );
     ]

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -26,7 +26,7 @@ let keeper_name = "chat-store-append-keeper"
 let persisted_path base_dir =
   Filename.concat
     (Filename.concat
-       (Masc.Common.masc_dir_from_base_path ~base_path:base_dir)
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
        "keeper_chat")
     (keeper_name ^ ".jsonl")
 


### PR DESCRIPTION
## 요약
- 현행 keeper chat JSONL SSOT에 typed durable append 경계를 추가합니다.
- partial write 또는 fsync 실패 시 원래 길이로 rollback하고, append/rollback 실패를 모두 보존합니다.
- append-once의 provenance 확인과 append를 동일한 process mutex + cross-process file lock 트랜잭션으로 묶습니다.
- blocking lock/write/fsync는 Eio system thread에서 실행해 한 Keeper의 파일 경합이 다른 lane을 멈추지 않게 합니다.
- chat 파일은 0600을 강제하고, parent directory fsync 실패도 명시적으로 표면화합니다.

## 범위
- 닫힌 #24266/#24298의 typed-v3 hard cut 또는 legacy delivery migration을 재도입하지 않습니다.
- 현재 main의 keeper_chat 및 keeper_chat_delivery_journal 권위를 유지한 채 durability 전제만 보강합니다.

## 검증
- 변경 OCaml 파일 parser check 통과
- ocamlformat --check 통과
- git diff --check 통과
- blocking lint 26개 통과
- stringly-boundary ratchet 통과
- silent-failure ratchet 및 critical scan 통과
- full Dune build/test는 CI를 권위로 사용합니다.