### PR TITLE
fix(test): repair heartbeat integration compile drift

### DIFF
--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2769,7 +2769,13 @@ let test_start_keepalive_denies_dead_tombstone_before_registration () =
         ; net = None
         }
       in
-      Masc.Keeper_keepalive.start_keepalive ctx meta;
+      (match Masc.Keeper_keepalive.start_keepalive ctx meta with
+       | Masc.Keeper_keepalive.Keepalive_lifecycle_denied
+           Keeper_lifecycle_admission.Autonomous_dead_tombstone -> ()
+       | outcome ->
+         failf
+           "dead tombstone returned unexpected launch outcome: %s"
+           (Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
       check bool "dead keeper never reaches registry registration" false
         (R.is_registered ~base_path:config.base_path keeper_name))
 let test_start_keepalive_preserves_unresolved_failing_entry () =

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2383,7 +2383,7 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
       in
       write_file agent_path "{}";
       let agent_metrics_dir =
-        Metrics_store_eio.agent_metrics_dir config meta.agent_name
+        Masc.Metrics_store_eio.agent_metrics_dir config meta.agent_name
       in
       write_file (Filename.concat agent_metrics_dir "fixture.jsonl") "{}\n";
       let unrelated_path =


### PR DESCRIPTION
## 문제

현재 main의 test_heartbeat_integration에 두 개의 typed API drift가 남아 Health compile을 막습니다.

1. wrapped masc library의 Metrics_store_eio를 bare module로 참조해 Unbound module 오류가 납니다.
2. start_keepalive가 typed launch outcome을 반환하도록 바뀌었지만 dead-tombstone 테스트가 결과를 버려 warning 10이 error로 승격됩니다.

#24243 exact-head Health job 86635118475와 #24307 job 86635993288에서 순서대로 확인했습니다.

## 수정

- Masc.Metrics_store_eio.agent_metrics_dir로 library ownership을 명시합니다.
- dead-tombstone 시작이 Keepalive_lifecycle_denied Autonomous_dead_tombstone인지 typed pattern으로 검증합니다. 결과를 ignore하거나 문자열로 판정하지 않습니다.

## 검증

- ocamlc -stop-after parsing 통과
- ocamlformat --check 통과
- git diff --check 통과
- blocking-pr lint 31개 통과
- full Dune build/test는 CI를 권위로 사용합니다.