### PR TITLE
fix(keeper): preserve typed OAS session conflicts

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -127,6 +127,7 @@ type runtime_exhaustion_reason = Keeper_internal_error.runtime_exhaustion_reason
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Session_conflict
   | Structural_attempt_timeout of { detail : string }
   | Capacity_exhausted
   | Other_detail of string
@@ -261,6 +262,8 @@ let runtime_exhaustion_summary = function
     "Runtime exhausted after provider candidates were filtered; inspect candidate filter reasons."
   | Max_turns_exceeded ->
     "Runtime exhausted after a provider hit its per-call turn budget."
+  | Session_conflict ->
+    "Runtime exhausted because another process owns the provider session lease."
   | Structural_attempt_timeout _ ->
     "Runtime exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
   | Capacity_exhausted ->

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -133,6 +133,9 @@ type runtime_exhaustion_reason = Keeper_internal_error.runtime_exhaustion_reason
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Session_conflict
+      (** The provider session lease is owned by another process. This remains
+          terminal for automatic retry and is never inferred from message text. *)
   | Structural_attempt_timeout of { detail : string }
       (** Agent SDK [with_optional_timeout] wrapper fired its per-OAS-call
           ceiling ([max_execution_time_s]). Distinct from transport-level
@@ -183,9 +186,9 @@ val runtime_exhaustion_summary :
 val runtime_exhaustion_reason_retryable : runtime_exhaustion_reason -> bool
 (** Total typed retryability per reason variant. Transient/connectivity
     reasons and bounded-cycle/turn/capacity exhaustion are retryable;
-    [Other_detail] (unknown free-text) is not. Replaces a string-prefix
-    reparse with a [_ -> false] catch-all that mis-biased transient faults
-    to terminal. *)
+    [Session_conflict] and [Other_detail] (unknown free-text) are not. Replaces
+    a string-prefix reparse with a [_ -> false] catch-all that mis-biased
+    transient faults to terminal. *)
 
 val blocker_class_continue_gate : blocker_class -> bool
 (** [blocker_class_continue_gate b] is [true] iff the supervisor

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -23,6 +23,7 @@ let blocker_reason_of_turn_driver_reason
   | Keeper_turn_driver.Candidates_filtered_after_cycles ->
     Candidates_filtered_after_cycles
   | Keeper_turn_driver.Max_turns_exceeded -> Max_turns_exceeded
+  | Keeper_turn_driver.Session_conflict -> Session_conflict
   | Keeper_turn_driver.Structural_attempt_timeout { detail } ->
     Structural_attempt_timeout { detail }
   | Keeper_turn_driver.Capacity_exhausted -> Capacity_exhausted

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -180,12 +180,10 @@ let runtime_exhaustion_reason_of_http_error
     Keeper_internal_error.Max_turns_exceeded
   | Some
       (Llm_provider.Http_client.ProviderTerminal
-         { kind = Llm_provider.Http_client.Session_conflict; message }) ->
-    (* The provider terminal kind is matched directly, so this never reparses
-       provider prose. [runtime_exhaustion_reason] has no session-conflict
-       constructor yet; retain the provider's structured message as terminal
-       detail rather than pretending that it is retryable transport failure. *)
-    Keeper_internal_error.Other_detail message
+         { kind = Llm_provider.Http_client.Session_conflict; _ }) ->
+    (* Preserve the closed provider kind through MASC policy and persistence;
+       no provider prose is parsed or collapsed into [Other_detail]. *)
+    Keeper_internal_error.Session_conflict
   | Some (Llm_provider.Http_client.ProviderTerminal { kind = Llm_provider.Http_client.Other _; message }) ->
     Keeper_internal_error.Other_detail message
   | Some

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -52,6 +52,7 @@ let runtime_reason_is_structural_attempt_timeout
   | Keeper_turn_driver.All_providers_failed
   | Keeper_turn_driver.Candidates_filtered_after_cycles
   | Keeper_turn_driver.Max_turns_exceeded
+  | Keeper_turn_driver.Session_conflict
   | Keeper_turn_driver.Capacity_exhausted
   | Keeper_turn_driver.Other_detail _ -> false
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -103,6 +103,7 @@ let runtime_exhaustion_reason_code
   | Keeper_internal_error.Candidates_filtered_after_cycles ->
     "runtime_exhausted_candidates_filtered"
   | Keeper_internal_error.Max_turns_exceeded -> "runtime_exhausted_max_turns"
+  | Keeper_internal_error.Session_conflict -> "runtime_exhausted_session_conflict"
   | Keeper_internal_error.Structural_attempt_timeout _ ->
     "runtime_exhausted_structural_attempt_timeout"
   | Keeper_internal_error.Capacity_exhausted -> "runtime_exhausted_capacity_exhausted"
@@ -124,6 +125,8 @@ let registry_reason_of_internal_reason
     Keeper_meta_contract.Candidates_filtered_after_cycles
   | Keeper_internal_error.Max_turns_exceeded ->
     Keeper_meta_contract.Max_turns_exceeded
+  | Keeper_internal_error.Session_conflict ->
+    Keeper_meta_contract.Session_conflict
   | Keeper_internal_error.Structural_attempt_timeout { detail } ->
     Keeper_meta_contract.Structural_attempt_timeout { detail }
   | Keeper_internal_error.Capacity_exhausted ->

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -111,6 +111,7 @@ type runtime_exhaustion_reason =
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Session_conflict
   | Structural_attempt_timeout of { detail : string }
   | Capacity_exhausted
   | Other_detail of string
@@ -121,7 +122,7 @@ let runtime_exhaustion_reason_retryable = function
   | Connection_refused | Dns_failure | No_providers_available | All_providers_failed ->
     true
   | Structural_attempt_timeout _ -> true
-  | Other_detail _ -> false
+  | Session_conflict | Other_detail _ -> false
 
 let runtime_exhaustion_label_payload_max_bytes = 200
 
@@ -146,6 +147,7 @@ let runtime_exhaustion_reason_to_label = function
   | All_providers_failed -> "all_providers_failed"
   | Candidates_filtered_after_cycles -> "candidates_filtered_after_cycles"
   | Max_turns_exceeded -> "max_turns_exceeded"
+  | Session_conflict -> "session_conflict"
   | Structural_attempt_timeout { detail } ->
     Printf.sprintf "structural_attempt_timeout(%s)"
       (runtime_exhaustion_label_payload detail)
@@ -160,6 +162,7 @@ let runtime_exhaustion_reason_to_json = function
   | All_providers_failed -> `String "all_providers_failed"
   | Candidates_filtered_after_cycles -> `String "candidates_filtered_after_cycles"
   | Max_turns_exceeded -> `String "max_turns_exceeded"
+  | Session_conflict -> `String "session_conflict"
   | Structural_attempt_timeout { detail } ->
     `Assoc [ "tag", `String "structural_attempt_timeout"; "detail", `String detail ]
   | Capacity_exhausted -> `String "capacity_exhausted"
@@ -172,6 +175,7 @@ let runtime_exhaustion_reason_of_json = function
   | `String "all_providers_failed" -> Some All_providers_failed
   | `String "candidates_filtered_after_cycles" -> Some Candidates_filtered_after_cycles
   | `String "max_turns_exceeded" -> Some Max_turns_exceeded
+  | `String "session_conflict" -> Some Session_conflict
   | `String "capacity_exhausted" -> Some Capacity_exhausted
   | `Assoc fields ->
     (match List.assoc_opt "tag" fields with

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -56,6 +56,7 @@ type runtime_exhaustion_reason =
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Session_conflict
   | Structural_attempt_timeout of { detail : string }
   | Capacity_exhausted
   | Other_detail of string

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -109,6 +109,7 @@ let route_of_masc_internal ~err (internal : Keeper_internal_error.masc_internal_
      | Keeper_internal_error.No_providers_available
      | Keeper_internal_error.All_providers_failed
      | Keeper_internal_error.Max_turns_exceeded
+     | Keeper_internal_error.Session_conflict
      | Keeper_internal_error.Other_detail _ ->
        rotate Runtime_exhausted)
   | Keeper_internal_error.Accept_rejected _ ->

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -24,6 +24,7 @@ let all_variants : blocker_class list =
   ; Runtime_exhausted All_providers_failed
   ; Runtime_exhausted Candidates_filtered_after_cycles
   ; Runtime_exhausted Max_turns_exceeded
+  ; Runtime_exhausted Session_conflict
   ; Runtime_exhausted (Structural_attempt_timeout { detail = "30" })
   ; Runtime_exhausted Capacity_exhausted
   ; Capacity_backpressure
@@ -106,7 +107,7 @@ let test_unknown_string () =
 (** Pin the variant count so additions are visible in diffs.  When adding a
     new [blocker_class] variant, bump this number and add the variant to
     [all_variants]. *)
-let expected_variant_count = 32
+let expected_variant_count = 33
 
 let test_variant_count () =
   let count = List.length all_variants in

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -39,6 +39,7 @@ let non_overflow_classes_are_not_matched () =
     Keeper_meta_contract.Runtime_exhausted Keeper_meta_contract.No_providers_available;
     Keeper_meta_contract.Runtime_exhausted Keeper_meta_contract.All_providers_failed;
     Keeper_meta_contract.Runtime_exhausted Keeper_meta_contract.Max_turns_exceeded;
+    Keeper_meta_contract.Runtime_exhausted Keeper_meta_contract.Session_conflict;
     Keeper_meta_contract.Capacity_backpressure;
     Keeper_meta_contract.Ambiguous_post_commit_timeout;
     Keeper_meta_contract.Ambiguous_post_commit_failure;

--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -196,7 +196,13 @@ let test_masc_internal_judgment_classes () =
        { pacing = KFR.Capacity_backpressure; retry_after = None })
     (internal_err
        (Keeper_internal_error.Runtime_exhausted
-          { runtime_id = "r"; reason = Keeper_internal_error.Capacity_exhausted }))
+          { runtime_id = "r"; reason = Keeper_internal_error.Capacity_exhausted }));
+  check_masc_route
+    "session conflict rotates without retry pacing"
+    (KFR.Rotate_now { rotate = KFR.Runtime_exhausted })
+    (internal_err
+       (Keeper_internal_error.Runtime_exhausted
+          { runtime_id = "r"; reason = Keeper_internal_error.Session_conflict }))
 
 let test_non_provider_families_judge () =
   let raw_internal = Agent_sdk.Error.Internal "boom" in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -277,7 +277,9 @@ let test_supervisor_policy_runtime_exhausted_retryable_reasons () =
 
 let test_supervisor_policy_runtime_exhausted_terminal_reasons () =
   let terminal_reasons =
-    [ Keeper_meta_contract.Other_detail "opaque free-text" ]
+    [ Keeper_meta_contract.Session_conflict
+    ; Keeper_meta_contract.Other_detail "opaque free-text"
+    ]
   in
   List.iter
     (fun reason ->

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2474,32 +2474,32 @@ let test_capacity_failure_exhaustion_classifies_as_capacity_exhausted () =
     Alcotest.failf "expected typed keeper error, got %s"
       (Agent_sdk.Error.to_string mapped)
 
-let test_session_conflict_exhaustion_preserves_terminal_detail () =
-  let session_conflict =
+let test_session_conflict_exhaustion_preserves_typed_terminal_reason () =
+  let conflict_err =
     Llm_provider.Http_client.ProviderTerminal
       { kind = Llm_provider.Http_client.Session_conflict
-      ; message = "session is owned by another process"
+      ; message = "provider prose is not a MASC policy input"
       }
   in
   let mapped =
     Masc.Keeper_turn_driver.For_testing.sdk_error_of_exhausted
       ~runtime_id:"runtime.session-conflict"
-      (Some session_conflict)
+      (Some conflict_err)
   in
   match Keeper_internal_error.classify_masc_internal_error mapped with
   | Some (Keeper_internal_error.Runtime_exhausted { reason; _ }) ->
     Alcotest.(check bool)
-      "session conflict stays terminal"
+      "reason is Session_conflict"
+      true
+      (reason = Keeper_internal_error.Session_conflict);
+    Alcotest.(check bool)
+      "session conflict is not automatically retryable"
       false
       (Keeper_internal_error.runtime_exhaustion_reason_retryable reason);
     Alcotest.(check bool)
       "session conflict is not auto-recoverable"
       false
-      (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped);
-    Alcotest.(check bool)
-      "provider terminal detail is preserved"
-      true
-      (reason = Keeper_internal_error.Other_detail "session is owned by another process")
+      (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped)
   | Some other ->
     Alcotest.failf "expected Runtime_exhausted, got %s"
       (Keeper_internal_error.kind_of_masc_internal_error other)
@@ -2693,9 +2693,9 @@ let () =
             `Quick
             test_capacity_failure_exhaustion_classifies_as_capacity_exhausted;
           Alcotest.test_case
-            "session conflict exhaustion stays terminal"
+            "session conflict preserves typed terminal exhaustion"
             `Quick
-            test_session_conflict_exhaustion_preserves_terminal_detail;
+            test_session_conflict_exhaustion_preserves_typed_terminal_reason;
           Alcotest.test_case
             "runtime exhaustion labels cap free-text detail"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -2496,6 +2496,16 @@ let test_session_conflict_exhaustion_preserves_typed_terminal_reason () =
       "session conflict is not automatically retryable"
       false
       (Keeper_internal_error.runtime_exhaustion_reason_retryable reason);
+    Alcotest.(check string)
+      "session conflict has a stable observation label"
+      "session_conflict"
+      (Keeper_internal_error.runtime_exhaustion_reason_to_label reason);
+    let encoded = Keeper_internal_error.runtime_exhaustion_reason_to_json reason in
+    Alcotest.(check bool)
+      "session conflict survives persistence round-trip"
+      true
+      (Keeper_internal_error.runtime_exhaustion_reason_of_json encoded
+       = Some Keeper_internal_error.Session_conflict);
     Alcotest.(check bool)
       "session conflict is not auto-recoverable"
       false


### PR DESCRIPTION
## 문제

OAS v0.211.8은 provider session lease 충돌을 폐쇄형 `ProviderTerminal.Session_conflict`로 노출합니다. MASC #24303은 컴파일 누락을 막았지만 이를 `Other_detail message`로 축소했고, #24305는 정확한 provider 문구를 테스트 기대값으로 고정했습니다. 그 결과 typed SSOT가 persistence, registry, routing 경계에서 사라집니다.

## 수정

- MASC `runtime_exhaustion_reason`에 전용 `Session_conflict`를 추가합니다.
- OAS constructor를 provider prose와 무관하게 직접 매핑합니다.
- retryability는 terminal/non-retryable로 유지합니다.
- label/JSON decode, meta contract summary, unified code, blocker projection, rollover gate, runtime route까지 같은 typed reason을 전파합니다.
- #24305의 free-text 기대값을 typed constructor + non-retryable + non-auto-recoverable 검증으로 교체합니다.
- exhaustiveness count/round-trip과 route/supervisor 테스트를 갱신합니다.

## 검증

- `git diff --check origin/main...HEAD`
- `ocamlformat --check <changed .ml/.mli>`
- `scripts/dune-local.sh build @install` — 통과
- focused build 5개 — 통과
- `test_keeper_turn_driver_accept`: 48/48
- `test_keeper_runtime_failure_route`: 14/14
- `test_keeper_supervisor` failure-policy case: 1/1
- `test_blocker_class_exhaustiveness`: 16/16
- `test_keeper_rollover_gate`: 11/11
- `test_heartbeat_integration.exe` compile + `direct_keepalive/20`: 통과
- `scripts/check-oas-pin.sh --local-only`: 통과
- `scripts/check-oas-pin.sh`: 통과
- `scripts/oas-drift-check.sh`: API fingerprint 일치

## 참고

OAS pin 자체(v0.211.8, `677a7eed6a8c8529e822d1d8ce95100e920f0b9e`)는 #24302에서 이미 main에 들어갔습니다. 이 PR은 그 pin으로 드러난 downstream typed-consumer 손실을 마무리합니다.
