### PR TITLE
fix(tool): require total Keeper execution policy

### DIFF
--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -783,13 +783,22 @@ let dispatch_stream_if_free
 (* Tool_spec registration                                           *)
 (* ================================================================ *)
 
-let tool_spec_read_only =
-  [ "masc_persona_list"; "masc_keeper_list";
-    "masc_keeper_status"; "masc_keeper_persona_audit";
-    "masc_keeper_sandbox_status"; "masc_keeper_msg_queue";
-    "masc_keeper_adversarial_review" ]
+exception Keeper_surface_registration_error of Tool_catalog.execution_policy_error
+
+let () =
+  Printexc.register_printer (function
+    | Keeper_surface_registration_error error ->
+      Some (Tool_catalog.execution_policy_error_to_string error)
+    | _ -> None)
+;;
 
 let register_keeper_surface_schema (s : Masc_domain.tool_schema) =
+  let metadata = Tool_catalog.metadata s.name in
+  let policy =
+    match Tool_catalog.execution_policy_of_metadata ~tool_name:s.name metadata with
+    | Ok policy -> policy
+    | Error error -> raise (Keeper_surface_registration_error error)
+  in
   Tool_spec.register
     (Tool_spec.create
        ~name:s.name
@@ -797,9 +806,18 @@ let register_keeper_surface_schema (s : Masc_domain.tool_schema) =
        ~module_tag:Tool_dispatch.Mod_external
        ~input_schema:s.input_schema
        ~handler_binding:Tag_dispatch
-       ~is_read_only:(List.mem s.name tool_spec_read_only)
-       ~is_idempotent:(List.mem s.name tool_spec_read_only)
-       ~is_destructive:(String.equal s.name "masc_keeper_clear")
+       ~is_read_only:policy.is_read_only
+       ~mcp_context_required:policy.mcp_context_required
+       ~is_idempotent:policy.is_idempotent
+       ~is_destructive:policy.is_destructive
+       ~visibility:metadata.visibility
+       ~implementation_status:metadata.implementation_status
+       ?canonical_name:metadata.canonical_name
+       ?replacement:metadata.replacement
+       ?reason:metadata.reason
+       ~allow_direct_call_when_hidden:metadata.allow_direct_call_when_hidden
+       ?effect_domain:metadata.effect_domain
+       ?requires_actor_binding:metadata.requires_actor_binding
        ())
 let () =
   List.iter register_keeper_surface_schema schemas

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -72,6 +72,66 @@ type metadata = {
   requires_actor_binding : bool option;
 }
 
+type execution_policy_axis =
+  | Read_only_axis
+  | Idempotent_axis
+  | Destructive_axis
+  | Mcp_context_required_axis
+
+type execution_policy = {
+  is_read_only : bool;
+  is_idempotent : bool;
+  is_destructive : bool;
+  mcp_context_required : bool;
+}
+
+type execution_policy_error =
+  | Missing_execution_policy of
+      { tool_name : string
+      ; missing_axes : execution_policy_axis list
+      }
+
+let execution_policy_axis_to_string = function
+  | Read_only_axis -> "readonly"
+  | Idempotent_axis -> "idempotent"
+  | Destructive_axis -> "destructive"
+  | Mcp_context_required_axis -> "mcp_context_required"
+;;
+
+let execution_policy_error_to_string = function
+  | Missing_execution_policy { tool_name; missing_axes } ->
+    Printf.sprintf
+      "tool %s is missing required execution policy metadata: %s"
+      tool_name
+      (missing_axes
+       |> List.map execution_policy_axis_to_string
+       |> String.concat ", ")
+;;
+
+let execution_policy_of_metadata ~tool_name (metadata : metadata) =
+  match
+    ( metadata.readonly
+    , metadata.idempotent
+    , metadata.destructive
+    , metadata.mcp_context_required )
+  with
+  | Some is_read_only, Some is_idempotent, Some is_destructive, Some mcp_context_required ->
+    Ok { is_read_only; is_idempotent; is_destructive; mcp_context_required }
+  | readonly, idempotent, destructive, mcp_context_required ->
+    let missing_axes =
+      [ Option.fold ~none:(Some Read_only_axis) ~some:(fun _ -> None) readonly
+      ; Option.fold ~none:(Some Idempotent_axis) ~some:(fun _ -> None) idempotent
+      ; Option.fold ~none:(Some Destructive_axis) ~some:(fun _ -> None) destructive
+      ; Option.fold
+          ~none:(Some Mcp_context_required_axis)
+          ~some:(fun _ -> None)
+          mcp_context_required
+      ]
+      |> List.filter_map Fun.id
+    in
+    Error (Missing_execution_policy { tool_name; missing_axes })
+;;
+
 (* ================================================================ *)
 (* Metadata constructors                                            *)
 (* ================================================================ *)
@@ -144,15 +204,43 @@ let with_semantic_flags ?readonly ?mcp_context_required
       | None -> meta.requires_actor_binding);
   }
 
+let with_execution_policy
+    ~readonly
+    ~idempotent
+    ~destructive
+    ?(mcp_context_required = false)
+    meta
+  =
+  with_semantic_flags
+    ~readonly
+    ~idempotent
+    ~destructive
+    ~mcp_context_required
+    meta
+;;
+
 let readonly_tool =
-  with_semantic_flags ~readonly:true ~idempotent:true
-    ~effect_domain:Read_only default_metadata
+  with_execution_policy
+    ~readonly:true
+    ~idempotent:true
+    ~destructive:false
+    default_metadata
+  |> with_semantic_flags ~effect_domain:Read_only
 
 let destructive_tool =
-  with_semantic_flags ~destructive:true default_metadata
+  with_execution_policy
+    ~readonly:false
+    ~idempotent:false
+    ~destructive:true
+    default_metadata
 
 let masc_workspace_tool =
-  with_semantic_flags ~effect_domain:Masc_workspace default_metadata
+  with_execution_policy
+    ~readonly:false
+    ~idempotent:false
+    ~destructive:false
+    default_metadata
+  |> with_semantic_flags ~effect_domain:Masc_workspace
 
 let actor_bound_masc_workspace_tool =
   with_semantic_flags ~requires_actor_binding:true masc_workspace_tool
@@ -247,11 +335,25 @@ let explicit_metadata : (string * metadata) list =
     ("masc_plan_update", broadcast_tool);
     ("masc_keeper_list", read_state_tool);
     ("masc_keeper_status", read_state_tool);
+    ( "masc_keeper_sandbox_start",
+      with_semantic_flags ~effect_domain:Playground_write broadcast_tool );
+    ( "masc_keeper_sandbox_stop",
+      with_semantic_flags ~effect_domain:Playground_write destructive_tool );
+    ("masc_keeper_create_from_persona", broadcast_tool);
+    ("masc_keeper_msg", broadcast_tool);
+    ("masc_keeper_msg_result", read_state_tool);
+    ("masc_keeper_msg_cancel", broadcast_tool);
+    ("masc_keeper_msg_queue", read_state_tool);
+    ("masc_keeper_persona_audit", read_state_tool);
+    ("masc_keeper_sandbox_status", read_state_tool);
+    ("masc_keeper_adversarial_review", read_state_tool);
     ("masc_keeper_waiting_inventory", read_state_tool);
     ("masc_keeper_up", broadcast_tool);
     ( "masc_keeper_down",
-      with_semantic_flags ~destructive:true ~effect_domain:Masc_workspace
-        default_metadata );
+      with_semantic_flags ~effect_domain:Masc_workspace destructive_tool );
+    ("masc_keeper_compact", broadcast_tool);
+    ("masc_keeper_clear", destructive_tool);
+    ("masc_keeper_reset", destructive_tool);
     ("masc_plan_get_task", read_state_tool);
     ("masc_plan_clear_task", actor_broadcast_tool);
     ("masc_note_add", broadcast_tool);

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -38,6 +38,25 @@ type metadata = {
   requires_actor_binding : bool option;
 }
 
+type execution_policy_axis =
+  | Read_only_axis
+  | Idempotent_axis
+  | Destructive_axis
+  | Mcp_context_required_axis
+
+type execution_policy = {
+  is_read_only : bool;
+  is_idempotent : bool;
+  is_destructive : bool;
+  mcp_context_required : bool;
+}
+
+type execution_policy_error =
+  | Missing_execution_policy of
+      { tool_name : string
+      ; missing_axes : execution_policy_axis list
+      }
+
 (** {1 Configuration} *)
 
 val default_metadata : metadata
@@ -70,6 +89,9 @@ val full_surface_override : unit -> bool
 (** {1 Metadata lookup} *)
 
 val metadata : string -> metadata
+val execution_policy_of_metadata :
+  tool_name:string -> metadata -> (execution_policy, execution_policy_error) result
+val execution_policy_error_to_string : execution_policy_error -> string
 val implementation_status : string -> implementation_status
 val effect_domain : string -> effect_domain option
 val requires_actor_binding : string -> bool

--- a/test/test_tool_registry_consistency.ml
+++ b/test/test_tool_registry_consistency.ml
@@ -161,6 +161,40 @@ let test_workspace_schemas_have_tool_spec_metadata () =
     workspace_names
 ;;
 
+let test_default_metadata_has_no_implicit_execution_policy () =
+  match
+    Tool_catalog.execution_policy_of_metadata
+      ~tool_name:"__unregistered_tool"
+      Tool_catalog.default_metadata
+  with
+  | Ok _ -> Alcotest.fail "default metadata must not invent an execution policy"
+  | Error (Tool_catalog.Missing_execution_policy { tool_name; missing_axes }) ->
+    Alcotest.(check string) "diagnostic keeps tool name" "__unregistered_tool" tool_name;
+    Alcotest.(check int) "all execution axes are absent" 4 (List.length missing_axes)
+;;
+
+let test_keeper_schemas_have_explicit_execution_policy () =
+  let errors =
+    Keeper_schema.schemas
+    |> List.filter_map (fun (schema : Masc_domain.tool_schema) ->
+      match List.assoc_opt schema.name Tool_catalog.explicit_metadata with
+      | None -> Some (Printf.sprintf "%s: missing explicit metadata" schema.name)
+      | Some metadata ->
+        (match
+           Tool_catalog.execution_policy_of_metadata
+             ~tool_name:schema.name
+             metadata
+         with
+         | Ok _ -> None
+         | Error error ->
+           Some (Tool_catalog.execution_policy_error_to_string error)))
+  in
+  Alcotest.(check (list string))
+    "every Keeper schema has total catalog-owned execution policy"
+    []
+    errors
+;;
+
 let test_retired_tools_are_absent () =
   init ();
   (* Only fully retired tools — no live dispatch handler and no keeper
@@ -225,6 +259,16 @@ let () =
             test_workspace_schemas_match_dispatch_bindings
         ; test_case "workspace schemas have ToolSpec metadata" `Quick
             test_workspace_schemas_have_tool_spec_metadata
+        ] )
+    ; ( "keeper_tool_policy"
+      , [ test_case
+            "default metadata does not invent execution policy"
+            `Quick
+            test_default_metadata_has_no_implicit_execution_policy
+        ; test_case
+            "Keeper schemas have explicit execution policy"
+            `Quick
+            test_keeper_schemas_have_explicit_execution_policy
         ] )
     ; ( "retired_tools"
       , [ test_case "retired tools are absent" `Quick test_retired_tools_are_absent


### PR DESCRIPTION
## 요약

#24243의 200-file hard-cut에서 독립 가능한 Tool policy SSOT 개선만 최신 main에 포팅합니다.

- Keeper Tool_spec 등록의 로컬 이름 allowlist와 string equality 분기를 제거합니다.
- readonly, idempotent, destructive, mcp_context_required 네 축을 typed execution_policy로 묶습니다.
- Tool_catalog metadata에 축이 하나라도 없으면 typed Missing_execution_policy로 startup registration을 중단합니다.
- visibility, implementation status, canonical/replacement, reason, direct-call, effect domain, actor binding projection을 그대로 보존합니다.
- current main에서 이미 분리된 permission ownership은 되살리거나 변경하지 않습니다.

## 테스트

- default metadata가 실행정책을 발명하지 않는 음성 테스트
- Keeper_schema.schemas 전체가 explicit catalog policy 네 축을 갖는 전수 테스트

## 검증

- 변경 OCaml parser check 통과
- ocamlformat --check 통과
- git diff --check 통과
- blocking-pr lint 31개 통과
- stringly-boundary ratchet 통과
- silent-failure ratchet 및 critical scan 통과
- full Dune build/test는 CI를 권위로 사용합니다.