### PR TITLE
fix(test): inspect dashboard purge admission fence directly

### DIFF
--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2557,14 +2557,15 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
         "delivered dashboard purge receipt prevents duplicate event"
         0
         (List.length (Agent_sdk.Event_bus.drain completion_subscription));
-      match
-        Masc.Keeper_turn_admission.run_if_free
+      let admission =
+        Masc.Keeper_turn_admission.snapshot_for
           ~base_path:config.base_path
           ~keeper_name:meta.name
-          (fun () -> ())
-      with
-      | `Ran () -> ()
-      | `Busy _ -> fail "delivered dashboard purge left admission fenced")
+      in
+      check bool
+        "delivered dashboard purge released admission fence"
+        true
+        (Option.is_none admission.snapshot_shutdown_operation_id))
 ;;
 
 let test_keeper_shutdown_cleanup_replays_after_meta_removal () =


### PR DESCRIPTION
## 문제

`test_heartbeat_integration`의 dashboard purge test는 shutdown admission fence 해제를 검증하려고 `Keeper_turn_admission.run_if_free`를 호출합니다. 하지만 이 API는 chat persistence가 구성되지 않은 isolated test에서도 의도적으로 fail-closed `Busy`를 반환하므로, fence가 정상 해제돼도 테스트가 실패합니다.

## 수정

- purge 완료 뒤 `Keeper_turn_admission.snapshot_for`의 `snapshot_shutdown_operation_id`를 직접 검사합니다.
- production 경로와 admission 정책은 변경하지 않습니다.
- 서로 다른 chat-persistence gate와 shutdown fence를 분리해 원래 계약만 검증합니다.

## 검증

- `git diff --check`
- `ocamlformat --check test/test_heartbeat_integration.ml`
- `scripts/dune-local.sh build test/test_heartbeat_integration.exe`
- `test_heartbeat_integration direct_keepalive/17`: PASS

Closes #24309
